### PR TITLE
more robust html processing in ProcessHtml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,8 @@ gem 'haml'
 
 gem 'jquery-ui-rails', '~> 5.0.3'
 
-gem 'nokogiri', '1.6.1'
+gem 'nokogiri', '1.6.1'     # libxml2 (HTML4 parser) bindings
+gem 'nokogumbo', '~> 1.4.2' # Gumbo (Spec-compliant HTML5 parser) bindings
 
 gem 'highline', '~> 1.6.21'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
     newrelic_rpm (3.10.0.279)
     nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
+    nokogumbo (1.4.2)
+      nokogiri
     oauth (0.4.7)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
@@ -454,6 +456,7 @@ DEPENDENCIES
   naturally
   newrelic_rpm (~> 3.10.0.279)
   nokogiri (= 1.6.1)
+  nokogumbo (~> 1.4.2)
   omniauth-clever!
   omniauth-facebook
   omniauth-google-oauth2

--- a/lib/cdo/rack/process_html.rb
+++ b/lib/cdo/rack/process_html.rb
@@ -1,6 +1,6 @@
 # Base Rack middleware class for processing html through a Nokogiri filter on every request.
 require 'rack/utils'
-require 'nokogiri'
+require 'nokogumbo'
 require 'cdo/pegasus/string'
 
 module Rack
@@ -39,11 +39,9 @@ module Rack
       content = ''
       body.each{|x|content += x}
       body.close if body.respond_to? :close
-      doc = ::Nokogiri::HTML(content)
-      process_doc(doc)
-      content = doc.to_html
+      content = process_doc(::Nokogiri::HTML5(content)).to_html if content.include?('<html')
       # Update content-length after transform
-      headers['content-length'] = content.bytesize.to_s
+      headers['Content-Length'] = content.bytesize.to_s
       response = [content]
 
       [status, headers, response]
@@ -55,6 +53,7 @@ module Rack
       nodes = ::Nokogiri::XML::NodeSet.new(doc)
       nodes += doc.xpath(@xpath) unless @xpath.nil?
       @block.call(nodes) unless nodes.empty?
+      doc
     end
 
     def should_process?(env, status, headers, body)


### PR DESCRIPTION
- beyond content-type='text/html', use a simple failsafe check to ensure the body contains a valid html-document string: `content.include?('<html')` - this should cover any remaining instances similar to #2837 where we're using text/html content-type for non-html documents
- use Gumbo (HTML5) instead of libxml2 (HTML4) for parsing+rendering html document (fixes issue with invalid `<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">` being added to html; should be more future-proof)
