### PR TITLE
Update Vagrantfile to use chef_apply, fully deploy a development CDO environment, and implement latest README setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 .dropbox
 .idea/
+.vagrant
 /.bundle
 /.gdrive_session
 /crontab

--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ Many Windows developers have found that setting up an Ubuntu virtual machine is 
 * Option B: Use vagrant ([install](https://docs.vagrantup.com/v2/installation/)):
   1. Just download the project's [Vagrantfile](https://github.com/code-dot-org/code-dot-org/raw/staging/Vagrantfile) (you will be able to skip all Ubuntu and common setup instructions) to your desired code-dot-org project directory
   1. In the directory where you downloaded the Vagrantfile:
+    1. [Open an elevated command prompt](http://windows.microsoft.com/en-us/windows/command-prompt-faq) (or elevated terminal application of your choice). This is important for Virtualbox to be able to create symlinks in your Windows filesystem.
     1. `vagrant up` (Note that on first run this could take up to an hour depending on connection bandwidth and machine speed; subsequent runs should be very much faster)
     1. `vagrant ssh`
     1. Dashboard and Pegasus are setup/built by default, to run them both in the development environment execute the following in the Vagrant SSH session:
-      1. `cd code-dot-org`
+      1. `cd repo/code-dot-org` (Note that in the guest VM, the path to the Code.org source code is located at ~/repo/code-dot-org)
       1. `bin/dashboard-server`
   1. On your host machine you can now visit [Dashboard](http://localhost.studio.code.org:3000/) and [Pegasus](http://localhost.code.org:3000/)
+  1. You can use an editor or IDE of your choice to modify project files from your host machine in the code-dot-org subdirectory that is created in the directory where you downloaded the project's Vagrantfile. Changes you make on the host machine will be synced to the Ubunutu guest VM. Git operations may work more smoothly from inside a Vagrant ssh session, but you can also try git operations on the files that are synced to the Windows host.
 * Option C: Use AWS EC2: [launch Ubuntu 14.04 AMI](https://console.aws.amazon.com/ec2/home?region=ap-northeast-1#launchAmi=ami-d9fdddd8)
 
 ## Common setup

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Many Windows developers have found that setting up an Ubuntu virtual machine is 
 
 * Option A: Use [VMWare Player](https://my.vmware.com/web/vmware/free#desktop_end_user_computing/vmware_player/4_0) and an [Ubuntu 14.04 iso image](http://releases.ubuntu.com/14.04.1/ubuntu-14.04.1-desktop-amd64.iso)
 * Option B: Use vagrant ([install](https://docs.vagrantup.com/v2/installation/)):
-  1. Just download the project's [Vagrantfile](https://github.com/code-dot-org/code-dot-org/raw/staging/Vagrantfile) (you will be able to skip all Ubuntu and common setup instructions) to your desired code-dot-org project directory
+  1. Just download the project's [Vagrantfile](https://github.com/code-dot-org/code-dot-org/raw/staging/Vagrantfile) (you will be able to skip all Ubuntu and common setup instructions) to your desired code-dot-org project parent directory
   1. In the directory where you downloaded the Vagrantfile:
     1. [Open an elevated command prompt](http://windows.microsoft.com/en-us/windows/command-prompt-faq) (or elevated terminal application of your choice). This is important for Virtualbox to be able to create symlinks in your Windows filesystem.
     1. `vagrant up` (Note that on first run this could take up to an hour depending on connection bandwidth and machine speed; subsequent runs should be very much faster)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
 1. `sudo aptitude upgrade`
 1. `sudo aptitude install -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-7-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk ruby2.0 ruby2.0-dev`
   * **Hit enter and select default options for any configuration popups**
-1. Upgrade npm to 2.0. If `npm -v` says less than 2.0,
-  * `sudo add-apt-repository ppa:chris-lea/node.js  `
-  * `sudo apt-get update`
-  * `sudo apt-get install nodejs`
 1. Either setup RBENV or configure your default ruby and gem version to 2.0
   1. Option A - RBENV: ([instructions](https://github.com/sstephenson/rbenv#installation))
     1. Install RBENV and ruby-build
@@ -41,7 +37,11 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
   1. Option B - Symlinks:
     1. Ruby: `sudo ln -sf /usr/bin/ruby2.0 /usr/bin/ruby`
     1. Gem: `sudo ln -sf /usr/bin/gem2.0 /usr/bin/gem`
-    1. <code>sudo chown \`whoami\` /usr/bin/gem/</code>`
+    1. To install gems without sudo you will also need to do the following:
+      1. `sudo chown $(whoami) /usr/bin/gem/`
+      1. Create the gems directory if it doesn't already exist: `[ ! -d /var/lib/gems ] && sudo mkdir /var/lib/gems`
+      1. `sudo chown $(whoami) /var/lib/gems/`
+      1. `sudo chown $(whoami) /usr/local/bin/`
 1. Install Node.js 0.12.4 and npm 2.10.1
   1. Option A - nodesource repository
     1. `curl -sL https://deb.nodesource.com/setup | sudo bash -`
@@ -55,17 +55,20 @@ Many Windows developers have found that setting up an Ubuntu virtual machine is 
 
 * Option A: Use [VMWare Player](https://my.vmware.com/web/vmware/free#desktop_end_user_computing/vmware_player/4_0) and an [Ubuntu 14.04 iso image](http://releases.ubuntu.com/14.04.1/ubuntu-14.04.1-desktop-amd64.iso)
 * Option B: Use vagrant ([install](https://docs.vagrantup.com/v2/installation/)):
-  1. First clone the code.org git repo to get the provided Vagrantfile (you will be able to skip step 1 of the common setup instructions): `git clone https://github.com/code-dot-org/code-dot-org.git`
-  1. `cd code-dot-org`
-  1. `vagrant up`
-  1. `vagrant ssh`
-  1. Goto step 2 of the common setup instructions
+  1. Just download the project's [Vagrantfile](https://github.com/code-dot-org/code-dot-org/raw/staging/Vagrantfile) (you will be able to skip all Ubuntu and common setup instructions) to your desired code-dot-org project directory
+  1. In the directory where you downloaded the Vagrantfile:
+    1. `vagrant up`
+    1. `vagrant ssh`
+    1. Dashboard and Pegasus are setup/built by default, to run them both in the development environment execute the following in the Vagrant SSH session:
+      1. `cd code-dot-org`
+      1. `bin/dashboard-server`
+  1. On your host machine you can now visit [Dashboard](http://localhost.studio.code.org:3000/) and [Pegasus](http://localhost.code.org:3000/)
 * Option C: Use AWS EC2: [launch Ubuntu 14.04 AMI](https://console.aws.amazon.com/ec2/home?region=ap-northeast-1#launchAmi=ami-d9fdddd8)
 
 ## Common setup
 
 1. `git clone https://github.com/code-dot-org/code-dot-org.git`
-1. `gem install bundler -v 1.10.4`
+1. `gem install bundler -v 1.10.4` (if you have permission issues you can use sudo or take ownership of the gem directories)
 1. `rbenv rehash` (if using rbenv)
 1. `cd code-dot-org/aws`
 1. `bundle install`
@@ -92,7 +95,7 @@ Our code is segmented into four parts:
 1. `cd code-dot-org`
 2. `rake build:dashboard` (Generally, do this after each pull)
 3. `bin/dashboard-server`
-4. Visit [http://localhost.studio.code.org:3000/](http://localhost.studio.code.org:3000/)
+4. Visit [http://localhost.studio.code.org:3000/](http://localhost.studio.code.org:3000/) (note that in the development environment, by default Pegasus will also be running and can be reached at [http://localhost.code.org:3000/](http://localhost.code.org:3000/))
 
 ## Running Pegasus
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Many Windows developers have found that setting up an Ubuntu virtual machine is 
 * Option B: Use vagrant ([install](https://docs.vagrantup.com/v2/installation/)):
   1. Just download the project's [Vagrantfile](https://github.com/code-dot-org/code-dot-org/raw/staging/Vagrantfile) (you will be able to skip all Ubuntu and common setup instructions) to your desired code-dot-org project directory
   1. In the directory where you downloaded the Vagrantfile:
-    1. `vagrant up`
+    1. `vagrant up` (Note that on first run this could take up to an hour depending on connection bandwidth and machine speed; subsequent runs should be very much faster)
     1. `vagrant ssh`
     1. Dashboard and Pegasus are setup/built by default, to run them both in the development environment execute the following in the Vagrant SSH session:
       1. `cd code-dot-org`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,11 +37,32 @@ Vagrant.configure(2) do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", inline: <<-SHELL
-    aptitude update
-    aptitude upgrade
-    DEBIAN_FRONTEND=noninteractive aptitude install -q -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev nodejs npm openjdk-7-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk ruby2.0 ruby2.0-dev
-    ln -sf /usr/bin/ruby2.0 /usr/bin/ruby
-    ln -sf /usr/bin/gem2.0 /usr/bin/gem
-  SHELL
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL1
+    sudo aptitude update
+    sudo aptitude upgrade
+    DEBIAN_FRONTEND=noninteractive sudo -E aptitude install -q -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-7-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk ruby2.0 ruby2.0-dev
+    sudo ln -sf /usr/bin/ruby2.0 /usr/bin/ruby
+    sudo ln -sf /usr/bin/gem2.0 /usr/bin/gem
+    sudo chown $(whoami) /usr/bin/gem/
+    curl -sL https://deb.nodesource.com/setup | sudo bash -
+    sudo aptitude install -y nodejs
+    git clone https://github.com/code-dot-org/code-dot-org.git
+
+    [ ! -d /var/lib/gems ] && sudo mkdir /var/lib/gems
+    sudo chown $(whoami) /var/lib/gems
+    sudo chown $(whoami) /usr/local/bin
+    gem install bundler -v 1.10.4
+    cd code-dot-org/aws
+    bundle install
+    cd ..
+    sudo chown $(whoami) $HOME/.npm
+    rake install
+  SHELL1
+
+  config.vm.provision "shell", run: "always", privileged: false, inline: <<-SHELL2
+    cd code-dot-org
+    git fetch
+    rake build:dashboard
+    rake build:pegasus
+  SHELL2
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(2) do |config|
   # View the documentation for the provider you are using for more
   # information on available options.
   config.vm.provision "chef_apply", recipe: <<-RECIPE1
-    execute 'updateAndUpgradePackages' do
+    execute 'update-and-upgrade-packages' do
       command 'aptitude update && aptitude upgrade -y'
       retries 5
       retry_delay 5
@@ -54,11 +54,11 @@ Vagrant.configure(2) do |config|
       to "/usr/bin/gem2.0"
     end
 
-    execute 'chownGemDirectories' do
+    execute 'chown-gem-directories' do
       command 'chown vagrant /usr/bin/gem; chown -R vagrant /usr/local/bin; [ ! -d /var/lib/gems ] && mkdir /var/lib/gems; chown -R vagrant /var/lib/gems'
     end
 
-    execute 'downloadAndInstallNode' do
+    execute 'download-and-install-node' do
       command 'curl -sSL https://deb.nodesource.com/setup | bash - && aptitude install -y nodejs'
       retries 5
       retry_delay 5


### PR DESCRIPTION
The Vagrantfile has been rewritten to use chef_apply as a more robust substitute for some parts of the previous version's shell script provisioning. This means that if there is a network issue during package/gem installation etc, chef will automatically retry the operation a few times. On top of that, I've expanded the scope of the Vagrantfile provisioning from just getting the Ubuntu system prepared to cover everything from system setup, source cloning from git, install, and setup. After running `vagrant up` and then `vagrant ssh` someone should be able to immediately run the development environment dashboard and pegasus servers. I noticed that there are a few new instructions in the README file for Ubuntu and common setup that weren't covered by the old Vagrantfile and these steps have been included in this version.

Additionally I've made some changes in the README file for clarification (like removing one of the two sections in the Ubuntu section about installing nodejs and npm as this only needs to be done once) and also to reflect the new scope of the Vagrantfile.

Thanks,
-David
