### PR TITLE
Add link to Japanese Hour of Code Campaign site

### DIFF
--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -86,6 +86,9 @@
                 %a.learnoption{style: "color: white; cursor: pointer; margin-right:35px", href: CDO.studio_url} Code Studio
                 %a.learnoption{style: "color: white; cursor: pointer; margin-right:35px", href: "/learn/beyond"} Other Courses
                 %a.learnoption{style: "color: white; cursor: pointer; margin-right:10px", href: "/learn/local"} Local Classes
+        -# Japanese Campaign Site
+        -if request.language == "ja"
+          %a.headerlink{:href=>"http://hourofcode.jp/"}国内開催情報
 
     #clear{:style=>'clear:both'}
 

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -102,6 +102,11 @@
               = I18n.t(entry[:text1_s])
           .actiongap
             &nbsp;
+      -# Japanese Campaign Site
+      - if request.language == "ja"
+        .action{style: "display: block; opacity: 0;"}
+          %a(href="http://hourofcode.jp/")
+            %button{style: "font-weight: 500; font-size: 20px; height: 50px;"} 日本での開催情報
 
 :javascript
   var petition;


### PR DESCRIPTION
# Summary

Add link to Hour of Code Japanese Campaign Site.
Anchor text means "Information with in Japan"
![2015-10-20 15 41 00](https://cloud.githubusercontent.com/assets/932230/10600809/311e4452-7748-11e5-8c3f-ea6d10d92ee2.png)
