### PR TITLE
Cloudfront static error page fallback

### DIFF
--- a/cookbooks/cdo-varnish/Berksfile.lock
+++ b/cookbooks/cdo-varnish/Berksfile.lock
@@ -13,7 +13,7 @@ GRAPH
   ark (0.9.0)
     7-zip (>= 0.0.0)
     windows (>= 0.0.0)
-  cdo-varnish (0.3.2)
+  cdo-varnish (0.3.6)
     apt (>= 0.0.0)
   chef_handler (1.2.0)
   varnish_test (0.1.0)

--- a/cookbooks/cdo-varnish/libraries/helpers.rb
+++ b/cookbooks/cdo-varnish/libraries/helpers.rb
@@ -183,6 +183,8 @@ end
 # 'pegasus' or 'dashboard' are the only supported values.
 def process_proxy(behavior, app)
   proxy = (behavior[:proxy] || app).to_s
+  # TODO implement full 'proxy' support for cloudfront+varnish
+  proxy = app.to_s if proxy == 'error'
   unless %w(pegasus dashboard).include? proxy
     raise ArgumentError.new("Invalid proxy: #{proxy}")
   end

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -93,6 +93,12 @@ class HttpCache
       dashboard: {
         behaviors: [
           {
+            path: '/500.html',
+            headers: [],
+            cookies: 'none',
+            proxy: 'error'
+          },
+          {
             path: '/v3/assets/*',
             headers: LANGUAGE_HEADER,
             cookies: whitelisted_cookies

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -35,6 +35,12 @@ class HttpCache
       pegasus: {
         behaviors: [
           {
+            path: '/500.html',
+            headers: [],
+            cookies: 'none',
+            proxy: 'error'
+          },
+          {
             path: '/api/hour/*',
             headers: LANGUAGE_HEADER,
             cookies: whitelisted_cookies

--- a/cookbooks/cdo-varnish/metadata.rb
+++ b/cookbooks/cdo-varnish/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'geoffrey@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-varnish'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.5'
+version          '0.3.6'
 
 depends 'apt'

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -157,7 +157,7 @@ module AWS
             },
             {
               id: 'error', # required
-              domain_name: 'cdo-error.s3-website-us-east-1.amazonaws.com', # required
+              domain_name: 'cdo-error.s3.amazonaws.com', # required
               origin_path: '',
               s3_origin_config: {
                 origin_access_identity: '', # required
@@ -185,7 +185,7 @@ module AWS
           end + redirect_error_codes.map do |error|
             {
               error_code: error,
-              response_code: '',
+              response_code: '200',
               response_page_path: '/500.html',
               error_caching_min_ttl: 0
             }


### PR DESCRIPTION
Adds a static error page fallback to CloudFront distribution. Response with a static html page when the origin server responds with a 502, 503 or 504 error. Error responses are not cached so as soon as the site responds with a non-error response code again, the static html page will go away.
