### PR TITLE
implement interpreter Array.sort properly

### DIFF
--- a/apps/src/JSInterpreter.js
+++ b/apps/src/JSInterpreter.js
@@ -8,6 +8,7 @@
 var codegen = require('./codegen');
 var ObservableEvent = require('./ObservableEvent');
 var utils = require('./utils');
+var jsArray = require('./jsArray');
 
 /**
  * Create a JSInterpreter object. This object wraps an Interpreter object and
@@ -113,6 +114,10 @@ JSInterpreter.prototype.parse = function (options) {
     self.interpreter = interpreter;
     // Store globalScope on JSInterpreter
     self.globalScope = scope;
+
+    // Override some of the built-in JS functions provided by the Interpreter:
+    self.overrideInterpreterJSFunctions();
+
     // Override Interpreter's get/set Property functions with JSInterpreter
     interpreter.getProperty = self.getProperty.bind(
         self,
@@ -165,6 +170,22 @@ JSInterpreter.prototype.parse = function (options) {
     this.handleError(err);
   }
 
+};
+
+/**
+ * Override the implementations of specific built-in JavaScript functions from
+ * the Interpreter object.
+ */
+JSInterpreter.prototype.overrideInterpreterJSFunctions = function () {
+
+  var arraySort = jsArray.generateSort(this);
+
+  this.interpreter.setProperty(
+      this.interpreter.ARRAY.properties.prototype,
+      'sort',
+      this.interpreter.createNativeFunction(arraySort),
+      false,
+      true);
 };
 
 /**

--- a/apps/src/codegen.js
+++ b/apps/src/codegen.js
@@ -358,7 +358,7 @@ exports.marshalInterpreterToNative = function (interpreter, interpreterVar) {
  * from native to interpreter before calling the supplied callback.
  *
  * @param {Object} opts Options block with interpreter and maxDepth provided
- * @param {function} callback The interpreter supplied callback function
+ * @param {Function} callback The interpreter supplied callback function
  */
 var createNativeCallbackForAsyncFunction = function (opts, callback) {
   return function (nativeValue) {
@@ -376,32 +376,41 @@ var createNativeCallbackForAsyncFunction = function (opts, callback) {
  * invoked by a special native function that can execute these callbacks inline
  * on the interpreter stack.
  *
- * @param {Object} opts Options block with interpreter and maxDepth provided
- * @param {function} intFunc The interpreter supplied callback function
+ * @param {!Object} opts Options block
+ * @param {!Interpreter} opts.interpreter Interpreter instance
+ * @param {number} [opts.maxDepth] Maximum depth to marshal objects
+ * @param {boolean} [opts.dontMarshal] Do not marshal parameters if true
+ * @param {Object} [opts.callbackState] callback state object, which will
+          hold the unmarshaled return value as a 'value' property later.
+ * @param {Function} intFunc The interpreter supplied callback function
  */
-var createNativeInterpreterCallback = function (opts, intFunc) {
+exports.createNativeInterpreterCallback = function (opts, intFunc) {
   return function (nativeValue) {
     var args = Array.prototype.slice.call(arguments);
-    var intArgs = [];
-    for (var i = 0; i < args.length; i++) {
-      intArgs[i] = exports.marshalNativeToInterpreter(
-          opts.interpreter,
-          args[i],
-          null,
-          opts.maxDepth);
+    var intArgs;
+    if (opts.dontMarshal) {
+      intArgs = args;
+    } else {
+      for (var i = 0; i < args.length; i++) {
+        intArgs[i] = exports.marshalNativeToInterpreter(
+            opts.interpreter,
+            args[i],
+            null,
+            opts.maxDepth);
+      }
     }
     // Shift a CallExpression node on the stack that already has its func_,
     // arguments, and other state populated:
-    var state = {
-      node: {
-        type: 'CallExpression',
-        arguments: intArgs /* this just needs to be array of the same size */
-        },
-      doneCallee_: true,
-      func_: intFunc,
-      arguments: intArgs,
-      n_: intArgs.length
+    var state = opts.callbackState || {};
+    state.node = {
+      type: 'CallExpression',
+      arguments: intArgs /* this just needs to be an array of the same size */
     };
+    state.doneCallee_ = true;
+    state.func_ = intFunc;
+    state.arguments = intArgs;
+    state.n_ = intArgs.length;
+
     opts.interpreter.stateStack.unshift(state);
   };
 };
@@ -432,7 +441,7 @@ exports.makeNativeMemberFunction = function (opts) {
           // A select class of native functions is aware of the interpreter and
           // capable of calling the interpreter on the stack immediately. We
           // marshal these differently:
-          nativeArgs[i] = createNativeInterpreterCallback(opts, arguments[i]);
+          nativeArgs[i] = exports.createNativeInterpreterCallback(opts, arguments[i]);
         } else {
           nativeArgs[i] = exports.marshalInterpreterToNative(opts.interpreter, arguments[i]);
         }

--- a/apps/src/jsArray.js
+++ b/apps/src/jsArray.js
@@ -1,0 +1,113 @@
+// Strict linting: Absorb into global config when possible
+/* jshint
+ unused: true,
+ eqeqeq: true,
+ maxlen: 120
+ */
+
+var codegen = require('./codegen');
+
+// Array.sort
+// iterative quicksort based on:
+// http://www.stoimen.com/blog/2010/06/18/friday-algorithms-iterative-quicksort/
+// (modified as a stateful native function to support callbacks)
+exports.generateSort = function (jsInterpreter) {
+  return function (opt_compFunc) {
+    if (this.length <= 1) {
+      return this;
+    }
+    var interpreter = jsInterpreter.interpreter;
+    var i;
+    var state = jsInterpreter.getCurrentState();
+    var useCompareFunc = (typeof opt_compFunc !== 'undefined') &&
+        (opt_compFunc !== interpreter.UNDEFINED);
+    if (typeof state.__i === 'undefined') {
+      state.__jsList = [];
+      for (i = 0; i < this.length; i++) {
+        state.__jsList[i] = this.properties[i];
+      }
+      if (useCompareFunc) {
+        state.__sortStack = [state.__jsList];
+        state.__sortedList = [];
+      }
+    }
+    if (!useCompareFunc) {
+      // No compare function supplied, use the native JS sort(), but supply
+      // a compare function that marshals the interpreter values back to native
+      // before comparing them.
+      state.__jsList.sort(function (a, b) {
+        var nativeA = codegen.marshalInterpreterToNative(interpreter, a);
+        var nativeB = codegen.marshalInterpreterToNative(interpreter, b);
+        return (nativeA < nativeB) ? -1 : (nativeA > nativeB ? 1 : 0);
+      });
+    } else {
+      state.doneExec = false;
+
+      var thisArray = this;
+      var invokeCompare = function () {
+        state.__callbackState = {};
+        var nativeCompFunc = codegen.createNativeInterpreterCallback({
+            interpreter: interpreter,
+            dontMarshal: true,
+            callbackState: state.__callbackState
+          },
+          opt_compFunc);
+
+        nativeCompFunc.call(thisArray, state.__temp[state.__i], state.__pivot);
+      };
+
+      if (typeof state.__temp !== 'undefined') {
+        if (state.__callbackState.value !== interpreter.UNDEFINED &&
+            state.__callbackState.value.data < 0) {
+          state.__left.push(state.__temp[state.__i]);
+        } else {
+          state.__right.push(state.__temp[state.__i]);
+        }
+        state.__i++;
+        if (state.__i < state.__temp.length) {
+          invokeCompare();
+        } else {
+          state.__left.push(state.__pivot);
+
+          if (state.__right.length) {
+            state.__sortStack.push(state.__right);
+          }
+          if (state.__left.length) {
+            state.__sortStack.push(state.__left);
+          }
+          delete state.__temp;
+        }
+      }
+
+      if (typeof state.__temp === 'undefined') {
+        if (state.__sortStack.length) {
+          state.__temp = state.__sortStack.pop();
+          state.__pivot = state.__temp[0];
+
+          if (state.__temp.length === 1) {
+            state.__sortedList.push(state.__pivot);
+            delete state.__temp;
+          } else {
+            state.__i = 1;
+            state.__left = [];
+            state.__right = [];
+
+            invokeCompare();
+          }
+        } else {
+          state.doneExec = true;
+        }
+      }
+    }
+    if (state.doneExec) {
+      for (i = 0; i < state.__jsList.length; i++) {
+        interpreter.setProperty(
+            this,
+            i,
+            useCompareFunc ? state.__sortedList[i] : state.__jsList[i]);
+      }
+    }
+    return this;
+  };
+};
+


### PR DESCRIPTION
`Array.sort` has been missing from the interpreter since the dawn of time. Last year, there was an attempt to add it, but it didn't really work: https://github.com/NeilFraser/JS-Interpreter/pull/17 . One of the hard parts has been dealing with the optional comparison function, since native functions couldn't call interpreter functions directly. Since I created `codegen.createNativeInterpreterCallback()` last week, I thought it would be worth revisiting this. Today, I got it working as a patch to the `Interpreter` instance when `JSInterpreter` is initialized.

When the `sort` function sees no `opt_compFunc` parameter, it simply uses a native `Array` copy of the interpreter array `properties` to execute the JS native sort function, with a supplied compare function that marshals the interpreter values back to native before comparing them.

When the `sort` function sees an `opt_compFunc` parameter, it executes an iterative quicksort implementation that I've adapted into a "stateful native function". The `while` and `for` loops in the original quicksort implementation have been replaced with comparisons against various values that are tacked onto the `state` object. Every time the interpreter comparison function is executed, `sort()` goes asynchronous until it is called again, at which point it can retrieve the return value from the interpreter code. The return value retrieval is a small tweak on last week's initial implementation of `codegen.createNativeInterpreterCallback()` - now, you can pass `opts.callbackState` and effectively own the `state` object that is used to invoke the interpreter callback. That gives you the ability to check `state.value` later to see what the return value happened to be.
