### PR TITLE
follow all symlinks in RakeUtils#git folder hash

### DIFF
--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -107,7 +107,11 @@ module RakeUtils
   # full revision history needed to find the original commit SHA.
   def self.git_folder_hash(dir)
     Dir.chdir(File.expand_path(dir)) do
-      Digest::SHA2.hexdigest(`git ls-tree -r HEAD`)
+      Digest::SHA2.hexdigest(
+        `git ls-tree -r HEAD` +
+        # Follow all symlinks (=file mode 12000) and append their `git ls-tree` contents to the digest.
+        `git ls-tree -r HEAD | grep '^12000' | cut -f2 | xargs readlink -f | xargs git ls-tree HEAD`
+      )
     end
   end
 


### PR DESCRIPTION
This PR should properly treat git-committed symlinks as s3-packaging dependencies.
Not sure if all of the unix utilities used by this one-liner (readlink, grep, cut, xargs) are fully cross-platform compatible in the way they're used here, could use testing on OSX to make sure it works correctly before merging.
