### PR TITLE
Cache script_structure API responses

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -71,6 +71,7 @@ class ApiController < ApplicationController
 
   def script_structure
     script = Script.get_from_cache(params[:script_name])
+    configure_caching
     render json: script.summarize
   end
 
@@ -255,6 +256,15 @@ class ApiController < ApplicationController
   end
 
   private
+
+  ONE_HOUR = 3600
+
+  def configure_caching
+    return unless Script.should_cache?
+    max_age = DCDO.get('pegasus_document_max_age', ONE_HOUR * 4)
+    proxy_max_age = DCDO.get('pegasus_document_proxy_max_age', ONE_HOUR * 2)
+    response.headers['Cache-Control'] = "public,max-age=#{max_age},s-maxage=#{proxy_max_age}"
+  end
 
   def load_student
     @student = User.find(params[:student_id])

--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -69,7 +69,8 @@ class Stage < ActiveRecord::Base
   end
 
   def summarize
-    stage_summary = Rails.cache.fetch("#{cache_key}/stage_summary/#{I18n.locale}") do
+    summary_cache_key = "#{script.cache_key}/#{cache_key}/stage_summary/#{I18n.backend.cache_key}"
+    Rails.cache.fetch(summary_cache_key) do
       stage_data = {
           script_id: script.id,
           script_name: script.name,
@@ -111,7 +112,6 @@ class Stage < ActiveRecord::Base
       end
 
       stage_data
-    end
-    stage_summary.freeze
+    end.freeze
   end
 end

--- a/dashboard/config/initializers/fast_localization.rb
+++ b/dashboard/config/initializers/fast_localization.rb
@@ -13,3 +13,11 @@ Dashboard::Application.config.after_initialize do |_|
   I18n.backend.init_translations if I18n.backend.respond_to? :init_translations
   I18n.t 'hello'
 end
+
+# Provides a cache key based on the current locale and contents of all localized strings.
+module I18n::Backend::CacheKey
+  def cache_key
+    "#{I18n.locale}-#{translations.hash}"
+  end
+end
+I18n::Backend::Simple.include(I18n::Backend::CacheKey)


### PR DESCRIPTION
Followup to #8774 with one improvement and two fixes:
## Improvement:
- add public caching headers to `ApiController#script_structure`. Will not apply on levelbuilder server, where `Script.should_cache?` is `false`.

This allows client browsers as well as CloudFront/Varnish to cache the value of this static script structure for a configurable period of time, equivalent to the amount we currently cache Pegasus document pages in each environment.

The http cache configuration for this path already properly includes the current locale in the cache key. The user session cookie is also included (not ideal), so this will only currently be cached in the CDN/http-proxies for anonymous requests and not logged-in users. So this change will mainly be helpful to browser-side caching, however proxy cacheability can be improved in the future with a change to the http cache configuration.

This sets the stage for performant and scalable uses of the `script_structure` API moving forward (as outlined in my [comment](https://github.com/code-dot-org/code-dot-org/pull/8774#issuecomment-224408143)).
## Fixes:

(to allow the cached objects to invalidate correctly on levelbuilder when levels/stage content is updated)
- Add `I18n.backend.cache_key` helper method to include localization contents along with the current locale in the `Stage#summarize` cache key. This will invalidate the cached object whenever any I18n localized strings are modified.
- Add `script.cache_key` to the `Stage#summarize` cache key, because some of the contents depend on the stage's parent `Script` contents, and so the cached object should be invalidated whenever the script itself is updated.
