### PR TITLE
add applab predictive free response ui test [test ui]

### DIFF
--- a/dashboard/test/ui/features/applab/predictiveFreeResponse.feature
+++ b/dashboard/test/ui/features/applab/predictiveFreeResponse.feature
@@ -1,0 +1,20 @@
+@no_mobile
+@dashboard_db_access
+@as_student
+Feature: App Lab Scenarios
+
+  Scenario: Predictive free response level
+    # A level that asks for a prediction using a contained free response level
+    Given I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/15?noautoplay=true"
+    And I rotate to landscape
+    And I wait to see "#runButton"
+    And I wait to see ".response"
+    And element "#runButton" is disabled
+
+    Then I type "test answer" into ".response"
+    And element "#runButton" is enabled
+    And I press "runButton"
+    And element "#finishButton" is visible
+    And I press "finishButton"
+    And I wait to see ".congrats"
+    And element ".congrats" is visible

--- a/dashboard/test/ui/step_definitions/steps.rb
+++ b/dashboard/test/ui/step_definitions/steps.rb
@@ -305,6 +305,7 @@ end
 When /^I type "([^"]*)" into "([^"]*)"$/ do |input_text, selector|
   @browser.execute_script("$('" + selector + "').val('" + input_text + "')")
   @browser.execute_script("$('" + selector + "').keyup()")
+  @browser.execute_script("$('" + selector + "').trigger('input')")
   @browser.execute_script("$('" + selector + "').change()")
 end
 


### PR DESCRIPTION
- Modify `steps.rb` for `I type <> into <>` so that it triggers an `input` event in addition to a `change` event.
- Add a `Predictive free response level` scenario to the `App Lab Scenarios` ui tests - it opens the example level in `allthethings`, verifies that the Run button is disabled, "types" an answer, verifies that the Run button is enabled, presses the Finish button, and verifies that `.congrats` is visible
