### PR TITLE
Try running Sauce Connect tunnel shared across containers ("high availability" mode)

### DIFF
--- a/dashboard/test/ui/support/connect.rb
+++ b/dashboard/test/ui/support/connect.rb
@@ -34,7 +34,7 @@ def saucelabs_browser
   end
 
   capabilities[:javascript_enabled] = 'true'
-  circle_run_identifier = ENV['CIRCLE_BUILD_NUM'] ? "CIRCLE-BUILD-#{ENV['CIRCLE_BUILD_NUM']}-#{ENV['CIRCLE_NODE_INDEX']}" : nil
+  circle_run_identifier = ENV['CIRCLE_BUILD_NUM'] ? "CIRCLE-BUILD-#{ENV['CIRCLE_BUILD_NUM']}" : nil
   capabilities[:tunnelIdentifier] = circle_run_identifier if circle_run_identifier
   capabilities[:name] = ENV['TEST_RUN_NAME']
   capabilities[:build] = circle_run_identifier || ENV['BUILD']

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -23,7 +23,7 @@ namespace :circle do
     RakeUtils.system_stream_output 'tar -xzf sc-4.4.0-rc2-linux.tar.gz'
     Dir.chdir(Dir.glob('sc-*-linux')[0]) do
       # Run sauce connect a second time on failure, known periodic "Error bringing up tunnel VM." disconnection-after-connect issue, e.g. https://circleci.com/gh/code-dot-org/code-dot-org/20930
-      RakeUtils.exec_in_background 'for i in 1 2; do ./bin/sc -vv -l $CIRCLE_ARTIFACTS/sc.log -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -i CIRCLE-BUILD-$CIRCLE_BUILD_NUM-$CIRCLE_NODE_INDEX --tunnel-domains localhost-studio.code.org,localhost.code.org && break; done'
+      RakeUtils.exec_in_background 'for i in 1 2; do ./bin/sc -vv -l $CIRCLE_ARTIFACTS/sc.log -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -i CIRCLE-BUILD-$CIRCLE_BUILD_NUM --tunnel-domains localhost-studio.code.org,localhost.code.org --wait-tunnel-shutdown --no-remove-colliding-tunnels && break; done'
     end
     RakeUtils.system_stream_output 'until $(curl --output /dev/null --silent --head --fail http://localhost.studio.code.org:3000); do sleep 5; done'
     Dir.chdir('dashboard/test/ui') do


### PR DESCRIPTION
We're running up against the 30 tunnel limit during the peak of daily development.

This branch tests using [Sauce Connect's "High Availability"](https://wiki.saucelabs.com/display/DOCS/High+Availability+Sauce+Connect+Setup) mode and sharing tunnels across builds.

In this mode, the two UI test CircleCI containers would share a single tunnel, with `--no-remove-colliding-tunnels` and `--wait-tunnel-shutdown` set.

Potential concerns:

(1) whether our containers terminating at different times might cause a test in progress to lose connection if it was load-balanced to the other container
(2) whether when the docs say “load balance”, it (A) means it will connect to a given container instance for the duration of a given test VM instance :+1: or (B) that each request might hit a different tunnel, which would be :-1: because we have separate DBs running across the instances and tests with test users might be affected.
