### PR TITLE
Save hashed email from forms

### DIFF
--- a/pegasus/helpers/form_helpers.rb
+++ b/pegasus/helpers/form_helpers.rb
@@ -1,3 +1,5 @@
+require 'digest/md5'
+
 def validate_form(kind, data)
   def csv_multivalue(value)
     return value if value.class == FieldError
@@ -129,10 +131,11 @@ def insert_form(kind, data, options={})
 
   timestamp = DateTime.now
 
+  normalized_email = data[:email_s].to_s.strip.downcase
   row = {
     secret: SecureRandom.hex,
     parent_id: options[:parent_id],
-    email: data[:email_s].to_s.strip.downcase,
+    email: normalized_email,
     name: data[:name_s].to_s.strip,
     kind: kind,
     data: data.to_json,
@@ -140,6 +143,7 @@ def insert_form(kind, data, options={})
     created_ip: request.ip,
     updated_at: timestamp,
     updated_ip: request.ip,
+    hashed_email: Digest::MD5.hexdigest(normalized_email),
   }
   row[:user_id] = dashboard_user ? dashboard_user[:id] : data[:user_id_i]
 
@@ -195,6 +199,7 @@ def update_form(kind, secret, data)
   form[:reviewed_at] = nil
   form[:reviewed_by] = nil
   form[:reviewed_ip] = nil
+  form[:hashed_email] = Digest::MD5.hexdigest(form[:email]) if data.key?(:email_s)
   DB[:forms].where(id: form[:id]).update(form)
 
   form

--- a/pegasus/migrations/106_populate_forms_hashed_email.rb
+++ b/pegasus/migrations/106_populate_forms_hashed_email.rb
@@ -1,0 +1,23 @@
+require 'digest/md5'
+
+# Based off of 097_populate_contacts_hashed_email.rb
+Sequel.migration do
+  up do
+    from(:forms).where(hashed_email: nil).each do |form|
+      hashed_email = Digest::MD5.hexdigest(form[:email])
+      from(:forms).
+          where(id: form[:id]).
+          update(hashed_email: hashed_email)
+    end
+
+    alter_table(:forms) do
+      set_column_not_null :hashed_email
+    end
+  end
+
+  down do
+    alter_table(:forms) do
+      set_column_allow_null :hashed_email
+    end
+  end
+end


### PR DESCRIPTION
Step 4 in the comment at https://github.com/code-dot-org/code-dot-org/pull/11400#issuecomment-256695027, which has a live Ruby migration to populate remaining null hashed_email fields (as opposed to an offline one), sets the hashed_email to non-null, and starts filling it when new form records are added.

This directly depends on step 1 (https://github.com/code-dot-org/code-dot-org/pull/11424) but also must wait until the script in step 3 (https://github.com/code-dot-org/code-dot-org/pull/11427) has been run in production, otherwise it will take a really, really long time to run.

(This has not been tested yet, I'll do that once step 1 is on staging)
