### PR TITLE
use monitored-frontend role for cloudformation stack

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -51,7 +51,7 @@ Resources:
           resource_id: "AMICreate#{ami}",
           node_name: 'ami-${INSTANCE_ID}',
           run_list: [
-            local_mode ? 'recipe[cdo-apps]' : 'role[unmonitored-frontend]'
+            local_mode ? 'recipe[cdo-apps]' : 'role[front-end]'
           ],
           commit: commit,
           shutdown: true


### PR DESCRIPTION
this updated role will include `recipe[cdo-newrelic]` to the AMI-created frontend instance, which will install `newrelic-sysmond` and the `cdo-newrelic` script for automatically adding/removing the specified frontend from the production alert policy on startup/shutdown.

This is needed for immutable frontend instances to report `Server` information to New Relic using the `nerelic-sysmond` agent.