### PR TITLE
Update our estimates of how much memory each Dashboard and Pegasus pr…

### DIFF
--- a/cookbooks/cdo-apps/Berksfile
+++ b/cookbooks/cdo-apps/Berksfile
@@ -13,6 +13,7 @@ metadata
   nodejs
   java-7
   networking
+  cloudwatch-extra-metrics
 ).map{|x| "cdo-#{x}"}.
   push('sudo-user').
   each do |dep|

--- a/cookbooks/cdo-apps/recipes/workers.rb
+++ b/cookbooks/cdo-apps/recipes/workers.rb
@@ -3,13 +3,15 @@
 # but the defaults should usually be used (or tweaked/fixed).
 
 # Approximate max Dashboard memory usage per process
-DASHBOARD_USAGE = 800 * 1024
+DASHBOARD_USAGE = 1400 * 1024
 
 # Approximate max Pegasus memory usage per process
-PEGASUS_USAGE = 400 * 1024
+PEGASUS_USAGE = 450 * 1024
 
 # Ratio of Pegasus to Dashboard worker processes
 PEGASUS_DASHBOARD_RATIO = 0.5.to_f
+
+# How much of our total memory we want these processes to take up
 MEMORY_RATIO = 0.8.to_f
 
 # Parse Varnish storage backend allocation from existing Chef attribute.

--- a/cookbooks/cdo-apps/spec/workers_spec.rb
+++ b/cookbooks/cdo-apps/spec/workers_spec.rb
@@ -28,22 +28,22 @@ describe 'cdo-apps::workers' do
   # Test various cpu/ram/varnish configurations and the number of workers calculated
   #        context          cpu mem dash peg varn
   run_test 'cpu-bound',     32, 64, 32,  16
-  run_test 'memory-bound',  32,  8,  6,   3
+  run_test 'memory-bound',  32,  8,  4,   2
   run_test 'varnish-bound', 32,  8,  1,   1, 4
   # staging server
-  run_test 'c3.2xlarge',     8, 15,  8,   4, 0.5
+  run_test 'c3.2xlarge',     8, 15,  6,   3, 0.5
   # ccpu-bound front-end
-  run_test 'c3.8xlarge',    32, 60, 32,  16, 4
+  run_test 'c3.8xlarge',    32, 60, 21,  10, 4
   # memory-bound next-gen front-end (with current conservative calculations)
-  run_test 'c4.8xlarge',    36, 60, 33,  16, 4
+  run_test 'c4.8xlarge',    36, 60, 22,  11, 4
 
   context 'varnish mebibyte suffix' do
     let(:varnish_suffix){'M'}
-    run_test 'varnish using mebibytes', 32, 8, 4, 2, 1024
+    run_test 'varnish using mebibytes', 32, 8, 2, 1, 1024
   end
 
   context 'varnish no suffix' do
     let(:varnish_suffix){''}
-    run_test 'varnish using bytes', 32, 8, 4, 2, 1024 * 1024 * 1024
+    run_test 'varnish using bytes', 32, 8, 2, 1, 1024 * 1024 * 1024
   end
 end


### PR DESCRIPTION
This updates our per-process memory estimates for Dashboard and Pegasus, which are used to set the number of processes allowed on each server. It also updates the tests, and adds a missing Berksfile entry required to run them. The new estimates are:

DASHBOARD_USAGE = 1400 * 1024 (kb)
PEGASUS_USAGE = 450 * 1024 (kb)

This is based on some estimates that Will put together from watching servers for a while:

- `varnish`: *8429472*
- `unicorn`-`dashboard`: *1351656* max [32 worker processes + 1 master]
- `unicorn`-`pegasus`: *426600* current max [16 worker processes + 1 master]