### PR TITLE
Remove unused edit UI for Concepts on Level Builder

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -268,7 +268,6 @@ class LevelsController < ApplicationController
       :encrypted,
       :published,
       {poems: []},
-      {concept_ids: []},
       {level_concept_difficulty_attributes: [:id] + LevelConceptDifficulty::CONCEPTS},
       {soft_buttons: []},
       {contained_level_names: []},

--- a/dashboard/app/models/concept.rb
+++ b/dashboard/app/models/concept.rb
@@ -20,20 +20,9 @@ class Concept < ActiveRecord::Base
   include Seeded
   has_and_belongs_to_many :levels
   belongs_to :video
-  # Can't call static from filter. Leaving in place for fixing later
-  #after_save :expire_cache
 
   def self.by_name(name)
     (@@name_cache ||= Concept.all.index_by(&:name))[name].try(:id)
-  end
-
-  def self.cached
-    @@all_cache ||= Concept.all
-  end
-
-  def self.expire_cache
-    @@all_cache = nil
-    @@name_cache = nil
   end
 
   CONCEPT_NAMES_BY_INDEX = %w(

--- a/dashboard/app/views/levels/editors/_all.html.haml
+++ b/dashboard/app/views/levels/editors/_all.html.haml
@@ -21,16 +21,6 @@
       Notes for yourself or other Levelbuilders. Viewable here and here alone.
     = f.text_area :notes, rows: 6, class: "input-block-level"
 
-.field
-  = f.label 'concepts'
-  %p
-    Select
-    %a.select_all{href: '#'} all
-    \/
-    %a.select_none{href: '#'} none
-    (shift-click or cmd-click to select multiple).
-  = f.collection_select :concept_ids, Concept.cached, :id, :name, { :selected => @level.concept_ids }, { :multiple => true, :name => 'level[concept_ids][]', :size => Concept.cached.length }
-
 -# We can only save a related LevelConceptDifficulty object for a level that's already been created, not for a new level about to be created
 - if @level && @level.id
   .field


### PR DESCRIPTION
Concepts are only set via `.script` files. No custom `.level` files specify any concepts:

```ruby
irb(main):001:0> Concept.all.map{ |c| c.levels.select{ |l| l.level_num == 'custom' }}.flatten.count
=> 0
```