### PR TITLE
Use Puma web-application server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,6 @@ gem 'rack-mini-profiler'
 group :development do
   gem 'annotate'
   gem 'ruby-progressbar', require: false
-  gem 'thin'
   gem 'web-console'
 end
 
@@ -78,6 +77,7 @@ group :development, :test do
   gem 'ruby_dep', '~> 1.3.1'
 
   gem 'shotgun'
+  gem 'thin'
   # Use debugger
   #gem 'debugger' unless ENV['RM_INFO']
 
@@ -131,6 +131,7 @@ gem 'open_uri_redirections', require: false, group: [:development, :staging, :te
 
 # Ref: https://github.com/tmm1/gctools/pull/17
 gem 'gctools', github: 'wjordan/gctools', ref: 'ruby-2.5'
+gem 'puma'
 gem 'unicorn', '~> 5.1.0'
 
 gem 'chronic', '~> 0.10.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -618,6 +618,7 @@ GEM
     powerpack (0.1.1)
     progress (3.3.1)
     public_suffix (3.0.2)
+    puma (3.12.0)
     pusher (1.3.1)
       httpclient (~> 2.7)
       multi_json (~> 1.0)
@@ -970,6 +971,7 @@ DEPENDENCIES
   petit!
   pg
   phantomjs (~> 1.9.7.1)
+  puma
   pusher (~> 1.3.1)
   rack-cache
   rack-mini-profiler

--- a/cookbooks/cdo-apps/attributes/default.rb
+++ b/cookbooks/cdo-apps/attributes/default.rb
@@ -18,6 +18,7 @@ default['cdo-apps'] = {
       'en' => 'English',
     },
   },
-  'nginx_enabled' => true
+  'nginx_enabled' => true,
+  'app_server' => 'unicorn'
 }
 default['omnibus_updater']['version'] = '12.7.2'

--- a/cookbooks/cdo-apps/templates/default/puma.sh.erb
+++ b/cookbooks/cdo-apps/templates/default/puma.sh.erb
@@ -1,0 +1,135 @@
+#!/bin/sh
+###
+# Puma init script
+# Derived from unicorn init script, with changed signals.
+###
+
+set -e
+
+TIMEOUT=${TIMEOUT-600}
+APP_ROOT=<%= @app_root %>
+PID=<%= @pid_file %>
+CMD="cd $APP_ROOT; LANG=en_US.UTF-8 bundle exec puma -d -C <%= @src_file %> -e <%= @env %>"
+AS_USER=<%= @user %>
+<%= @export_env ? @export_env.map{|k,v|"export #{k}=#{v}"}.join("\n") : '' %>
+UPGRADE_DELAY=${UPGRADE_DELAY-30}
+SOCKET_PATH=<%= @socket_path %>
+
+action="$1"
+set -u
+
+cd $APP_ROOT || exit 1
+
+sig () {
+        test -s "$PID" && kill -$1 $(cat $PID)
+}
+
+run () {
+  if [ -n $SOCKET_PATH ] &&
+     [ ! -d $SOCKET_PATH ]
+  then
+      mkdir -p $SOCKET_PATH; chown ${AS_USER}: $SOCKET_PATH
+  fi
+
+  if [ "$(id -un)" = "$AS_USER" ]; then
+    eval $1
+  else
+    su -c "$1" $AS_USER
+  fi
+}
+
+get_workers () {
+  pgrep -P $(cat $PID 2>&-)
+}
+
+case $action in
+start)
+        sig 0 && echo >&2 "Already running" && exit 0
+        run "$CMD"
+        ;;
+stop)
+        if sig TERM
+        then
+          while sig 0
+          do
+            echo "Stopping..."
+            sleep 2
+          done
+          exit 0
+        fi
+        echo >&2 "Not running"
+        ;;
+stop-with-status)
+        if sig TERM
+        then
+          # give up with error status if the process doesn't stop within 20 seconds
+          for i in `seq 1 10`;
+          do
+            sig 0 || exit 0
+            echo "Stopping..."
+            sleep 2
+          done
+          echo >&2 "Failed to stop"
+          exit 1
+        fi
+        echo >&2 "Not running"
+        ;;
+force-stop)
+        sig QUIT && exit 0
+        echo >&2 "Not running"
+        ;;
+restart)
+        # Stop current process and wait for it to complete.
+        sig TERM
+        while sig 0; do sleep 2; done
+        # Start a new process.
+        run "$CMD"
+        ;;
+reload)
+        sig USR2 && echo reloaded OK && exit 0
+        echo >&2 "Couldn't reload, starting '$CMD' instead"
+        run "$CMD"
+        ;;
+upgrade)
+        # Signal USR2 to current process.
+        if sig 0 &&
+          old_workers=$(get_workers) &&
+          sig USR2
+        then
+                # Wait $UPGRADE_DELAY seconds for the old workers to exit.
+                n=$UPGRADE_DELAY
+                while test $n -ge 0 &&
+                      test x"$old_workers" = x"$(get_workers)"
+                do
+                        printf '.' && sleep 1 && n=$(( $n - 1 ))
+                done
+                if test $n -lt 0; then
+                        echo >&2 "Old workers still exist after $UPGRADE_DELAY seconds"
+                        exit 1
+                fi
+
+                # Wait $TIMEOUT seconds for new workers to spawn.
+                n=$TIMEOUT
+                while test $n -ge 0 &&
+                      test -z "$(get_workers)"
+                do
+                        printf '.' && sleep 1 && n=$(( $n - 1 ))
+                done
+
+                if test $n -lt 0; then
+                        echo >&2 "New workers don't exist after $TIMEOUT seconds"
+                        exit 1
+                fi
+                exit 0
+        fi
+        echo >&2 "Couldn't upgrade, starting '$CMD' instead"
+        run "$CMD"
+        ;;
+reopen-logs)
+        sig HUP
+        ;;
+*)
+        echo >&2 "Usage: $0 <start|stop|restart|upgrade|force-stop|reopen-logs>"
+        exit 1
+        ;;
+esac

--- a/cookbooks/cdo-apps/templates/default/unicorn.sh.erb
+++ b/cookbooks/cdo-apps/templates/default/unicorn.sh.erb
@@ -34,9 +34,9 @@ oldsig () {
 
 run () {
 <% if node['cdo-apps']['nginx_enabled'] %>
-  if [ ! -d "/run/unicorn" ]
+  if [ ! -d "<%= @socket_path %>" ]
   then
-      mkdir -p /run/unicorn; chown ${AS_USER}: /run/unicorn
+      mkdir -p <%= @socket_path %>; chown ${AS_USER}: <%= @socket_path %>
   fi
 <% end %>
   if [ "$(id -un)" = "$AS_USER" ]; then

--- a/cookbooks/cdo-nginx/attributes/default.rb
+++ b/cookbooks/cdo-nginx/attributes/default.rb
@@ -2,5 +2,6 @@ default['cdo-nginx'] = {
   common_name: 'cdn-code.org',
   ssl_key: {content: ''},
   ssl_cert: {content: ''},
-  ssl_chain: {content: ''}
+  ssl_chain: {content: ''},
+  socket_path: '/run/unicorn'
 }

--- a/cookbooks/cdo-nginx/recipes/default.rb
+++ b/cookbooks/cdo-nginx/recipes/default.rb
@@ -6,9 +6,8 @@ end
 
 apt_package 'nginx'
 
-run_unicorn = '/run/unicorn'
 %w(dashboard pegasus).each do |app|
-  socket_path = File.join run_unicorn, "#{app}.sock"
+  socket_path = File.join node['cdo-nginx']['socket_path'], "#{app}.sock"
   # Ensure stale socket-files are cleaned up
   # (in case OS doesn't automatically remove them, e.g., due to an aborted process)
   file socket_path do
@@ -41,7 +40,7 @@ template '/etc/nginx/nginx.conf' do
   mode '0644'
   variables ssl_key: cert.key_path,
     ssl_cert: cert.chain_combined_path,
-    run_dir: run_unicorn
+    run_dir: node['cdo-nginx']['socket_path']
   notifies :reload, 'service[nginx]', :immediately
 end
 

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -1,0 +1,27 @@
+path = File.expand_path('../../deployment.rb', __FILE__)
+path = File.expand_path('../../../deployment.rb', __FILE__) unless File.file?(path)
+require path
+
+if CDO.dashboard_sock
+  bind "unix://#{CDO.dashboard_sock}"
+else
+  bind "tcp://#{CDO.dashboard_host}:#{CDO.dashboard_port}"
+end
+workers CDO.dashboard_workers unless CDO.dashboard_workers.to_i < 2
+threads 8, 16
+
+pidfile "#{File.expand_path(__FILE__)}.pid"
+preload_app!
+stdout_redirect dashboard_dir('log', 'puma_stdout.log'), dashboard_dir('log', 'puma_stderr.log'), true
+directory deploy_dir('dashboard')
+
+before_fork do
+  ActiveRecord::Base.connection_pool.disconnect!
+end
+
+on_worker_boot do |_index|
+  require 'dynamic_config/gatekeeper'
+  require 'dynamic_config/dcdo'
+  Gatekeeper.after_fork
+  DCDO.after_fork
+end

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -91,7 +91,7 @@ namespace :circle do
     RakeUtils.system_stream_output 'mkdir -p $CIRCLE_TEST_REPORTS/cucumber'
 
     Dir.chdir('dashboard') do
-      RakeUtils.exec_in_background "RAILS_ENV=test bundle exec unicorn -c config/unicorn.rb -E test -l #{CDO.dashboard_port}"
+      RakeUtils.exec_in_background 'RAILS_ENV=test bundle exec puma -e test'
     end
     ui_test_browsers = browsers_to_run
     use_saucelabs = !ui_test_browsers.empty?

--- a/pegasus/config/puma.rb
+++ b/pegasus/config/puma.rb
@@ -1,0 +1,24 @@
+require File.join(File.expand_path(__FILE__), '../../../deployment')
+
+if CDO.pegasus_sock
+  bind "unix://#{CDO.pegasus_sock}"
+else
+  bind "tcp://#{CDO.pegasus_host}:#{CDO.pegasus_port}"
+end
+
+workers CDO.pegasus_workers unless CDO.pegasus_workers.to_i < 2
+threads 8, 16
+
+pidfile "#{File.expand_path(__FILE__)}.pid"
+
+preload_app!
+
+stdout_redirect pegasus_dir('log', 'puma_stdout.log'), pegasus_dir('log', 'puma_stderr.log'), true
+directory deploy_dir('pegasus')
+
+on_worker_boot do |_index|
+  require 'dynamic_config/gatekeeper'
+  require 'dynamic_config/dcdo'
+  Gatekeeper.after_fork
+  DCDO.after_fork
+end


### PR DESCRIPTION
[Puma](http://puma.io/) web-application server offers multi-thread as well as multi-process concurrency, so it has the potential for much greater concurrency without any added memory requirements, which will help alleviate queuing requests when workers are I/O bound (database queries, other third-party service requests, etc), our most common cascading-failure type of scenario.

This PR adds `puma` to our `Gemfile`, and uses it as the default web-application server for CircleCI tests. It also adds a Chef attribute `'cdo-apps.app_server'` (default `unicorn`), allowing the current app server to be swappable (with some added logic to ensure the app service is stopped/started cleanly between updates).

Once this is deployed, I plan to override the `app_server` attribute to `puma` for non-production environments, then begin testing out the change on a canary front-end. If/when these tests are successful, I'll roll-out the change everywhere by merging a follow-up PR setting `puma` as the new attribute default.