### PR TITLE
Add back empty `GoBeyond` model

### DIFF
--- a/dashboard/app/models/levels/go_beyond.rb
+++ b/dashboard/app/models/levels/go_beyond.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: levels
+#
+#  id                       :integer          not null, primary key
+#  game_id                  :integer
+#  name                     :string(255)      not null
+#  created_at               :datetime
+#  updated_at               :datetime
+#  level_num                :string(255)
+#  ideal_level_source_id    :integer
+#  solution_level_source_id :integer
+#  user_id                  :integer
+#  properties               :text(65535)
+#  type                     :string(255)
+#  md5                      :string(255)
+#  published                :boolean          default(FALSE), not null
+#  notes                    :text(65535)
+#  audit_log                :text(65535)
+#
+# Indexes
+#
+#  index_levels_on_game_id  (game_id)
+#  index_levels_on_name     (name)
+#
+
+class GoBeyond < Level
+end


### PR DESCRIPTION
Avoid migration errors in development environments until everyone has updated.