### PR TITLE
cache-extend CSS files

### DIFF
--- a/lib/cdo/rack/content_digest.rb
+++ b/lib/cdo/rack/content_digest.rb
@@ -1,0 +1,36 @@
+# Rack middleware for cache-extending relative references by inserting a content digest in the path.
+# Currently rewrites stylesheet hrefs, but can be extended to cache-extend other references.
+
+require 'cdo/rack/process_html'
+require 'net/http'
+
+module Rack
+  class ContentDigest < ProcessHtml
+    attr_reader :request
+
+    def initialize(app)
+      super(
+        app,
+        xpath: '//link[@href[starts-with(.,"/")] and @rel="stylesheet"]'
+      ) do |nodes, env|
+        @request = Request.new(env)
+        nodes.each do |node|
+          process(node)
+        end
+      end
+    end
+
+    private
+
+    def process(node)
+      href = node['href'].to_s
+      url = URI(CDO.site_url(request.site, href, CDO.default_scheme))
+      headers = Net::HTTP.start(url.host, url.port, use_ssl: url.scheme == 'https').head(url.path).to_hash
+      if (content_tag = headers['etag'] || headers['last-modified'])
+        digest = Digest::MD5.hexdigest(content_tag.last)
+        ext = ::File.extname(href)
+        node['href'] = "#{href.chomp(ext)}-#{digest}#{ext}"
+      end
+    end
+  end
+end

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -72,8 +72,8 @@ class Documents < Sinatra::Base
 
   # Use dynamic config for max_age settings, with the provided default as fallback.
   def self.set_max_age(type, default)
-    default /= 10 if rack_env? :staging
-    default /= 60 if rack_env? :development
+    default /= 360 if rack_env? :staging
+    default /= ONE_HOUR if rack_env? :development
     set "#{type}_max_age", proc {DCDO.get("pegasus_#{type}_max_age", default)}
   end
 

--- a/shared/middleware/shared_resources.rb
+++ b/shared/middleware/shared_resources.rb
@@ -9,7 +9,9 @@ class SharedResources < Sinatra::Base
 
   # Use dynamic config for max_age settings, with the provided default as fallback.
   def self.set_max_age(type, default)
-    set "#{type}_max_age", proc {[:development, :staging].include?(rack_env) ? 0 : DCDO.get("pegasus_#{type}_max_age", default)}
+    default /= 360 if rack_env? :staging
+    default /= ONE_HOUR if rack_env? :development
+    set "#{type}_max_age", proc {DCDO.get("pegasus_#{type}_max_age", default)}
   end
 
   ONE_HOUR = 3600

--- a/shared/middleware/shared_resources.rb
+++ b/shared/middleware/shared_resources.rb
@@ -68,9 +68,11 @@ class SharedResources < Sinatra::Base
       path = pegasus_dir('cache', 'css', uri)
       pass unless File.file?(path)
     end
+    last_modified = ::File.mtime(path)
+    pass if md5 && md5.to_s != "-#{Digest::MD5.hexdigest(last_modified.httpdate)}"
 
     content_type :css
-    send_file(path)
+    send_file(path, last_modified: last_modified)
   end
 
   # JavaScripts


### PR DESCRIPTION
This html-rewriting Rack middleware will cache-extend CSS by adding a content digest in the path for all relative stylesheet references. This has two benefits:

- Allow us to serve CSS files with long cache lifetimes
- No longer serve stale CSS after updating files in-place

This works by performing an HTTP HEAD request for all local CSS references in the HTML response. If the response headers contain either `etag` or `last-modified`, use that to calculate an MD5 digest appended to the path (but before any file-extension).

The Pegasus router is updated to filter the MD5 content-hash from the path when performing file lookup, and send the response with a long cache lifetime if the content-hash is present.

This PR should be enough to address the current issue of stale CSS content, though I have two future extensions to this approach in mind:

- extend the html-rewriting to cover various other HTML references to static content (Javascript `script src`, image `img src`, etc)
- Cache the content-digests (using path as cache-key), so that the HEAD request only needs to be performed once for each unique path per deploy.