### PR TITLE
[WIP] Internet Simulator: Manage Redis clusters with CloudFormation

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -44,6 +44,18 @@ cat <<JSON > $FIRST_BOOT
     "redis_primary": "${GeocoderGroup.PrimaryEndPoint.Address}:${GeocoderGroup.PrimaryEndPoint.Port}",
     "redis_read_addresses": "${GeocoderGroup.ReadEndPoint.Addresses}",
     "redis_read_ports": "${GeocoderGroup.ReadEndPoint.Ports}",
+    "netsim_redis_groups": [
+      <%= (0...netsim_number_of_clusters).each do |shard_index| -%>
+      {
+        master: "redis://${NetSimGroup<%= shard_index %>.PrimaryEndPoint.Address}:${NetSimGroup<%= shard_index %>.PrimaryEndPoint.Port}",
+        read_replicas: [
+          <% (1...netsim_nodes_per_cluster).each do |node_index| -%>
+          "redis://${NetSimGroup<%= shard_index %>.ReadEndPoint.Addresses[<%= node_index %>]}:${NetSimGroup<%= shard_index %>.ReadEndPoint.Ports[<%= node_index %>]}",
+          <% end -%>
+        ]
+      },
+      <% end -%>
+    ],
 <% end -%>
 <% if environment == :adhoc && TEMPLATE == 'cloud_formation_stack.yml.erb' -%>
     "db_writer": "mysql://${DatabaseUsername}:${DatabasePassword}@${Database.Endpoint.Address}:${Database.Endpoint.Port}/",

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -404,6 +404,33 @@ Resources:
       AZMode: cross-az
       PreferredAvailabilityZones: <%= availability_zones.first(2).to_json %>
       VpcSecurityGroupIds: [!ImportValue VPC-MemcachedSecurityGroup]
+  # Internet Simulator Redis cluster configuration
+  NetSimSubnetGroup:
+    Type: AWS::ElastiCache::SubnetGroup
+    Properties:
+      Description: Internet Simulator Subnet Group
+      SubnetIds: <%= subnets.to_json %>
+  NetSimParameterGroup:
+    Type: AWS::ElastiCache::ParameterGroup
+    Properties:
+      CacheParameterGroupFamily: redis3.2
+      Description: Configuration for NetSim Redis nodes. Only change from default parameters is adding an idle client timeout.
+      Properties:
+        timeout: 3600
+  <% (0...netsim_number_of_clusters).each do |shard_index| -%>
+  NetSimGroup<%= shard_index %>:
+    Type: AWS::ElastiCache::ReplicationGroup
+    Properties:
+      ReplicationGroupDescription: Internet Simulator Simulation State Shard
+      NumCacheClusters: <%= netsim_nodes_per_cluster %>
+      Engine: redis
+      CacheNodeType: <%= netsim_node_type %>
+      CacheParameterGroupName: !Ref NetSimParameterGroup
+      CacheSubnetGroupName: !Ref NetSimSubnetGroup
+      SecurityGroupIds: [!ImportValue VPC-RedisSecurityGroup]
+      AZMode: cross-az
+      PreferredAvailabilityZones: <%= availability_zones.first(netsim_nodes_per_cluster).to_json %>
+  <% end -%>
 <% end -%>
   ActivitiesQueue:
     Type: AWS::SQS::Queue

--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -357,7 +357,10 @@ module AWS
           update_certs: method(:update_certs),
           update_cookbooks: method(:update_cookbooks),
           update_bootstrap_script: method(:update_bootstrap_script),
-          log_name: LOG_NAME
+          log_name: LOG_NAME,
+          netsim_number_of_clusters: rack_env?(:production) ? 2 : 1,
+          netsim_nodes_per_cluster: rack_env?(:production) ? 3 : 1,
+          netsim_node_type: rack_env?(:production) ? 'cache.m3.medium' : 'cache.t2.micro'
         )
         erb_eval(template_string, filename)
       end


### PR DESCRIPTION
I'm going to need Will's help to finish this, but thought I'd make a first pass.  Now that NetSim has its own Redis nodes, we'd like to set them up using our CloudFormation templates (instead of manually, like I did the first time).

### References:
- [Implementation nodes from manually setting up NetSim Redis](https://docs.google.com/document/d/1nHACJgvBH0YbLU3SrIslz_4jNjGu5_3eD26mayFnNa8/edit#heading=h.yuikp1lgrdcl)