### PR TITLE
show alternate scripts for teacher with experiment enabled

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -14,7 +14,7 @@ class CoursesController < ApplicationController
         @header_banner_image_filename = !@is_teacher ? "courses-hero-student" : "courses-hero-teacher"
       end
       format.json do
-        render json: Course.valid_courses
+        render json: Course.valid_courses(current_user)
       end
     end
   end

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -255,10 +255,10 @@ class Course < ApplicationRecord
   # @return [CourseScript]
   def select_course_script(user, default_course_script)
     alternates = alternate_course_scripts.where(default_script: default_course_script.script).all
-    alternates.each do |cs|
-      return cs if SingleUserExperiment.enabled?(user: user, experiment_name: cs.experiment_name)
+    alternate_course_script = alternates.find do |cs|
+      SingleUserExperiment.enabled?(user: user, experiment_name: cs.experiment_name)
     end
-    return default_course_script
+    alternate_course_script || default_course_script
   end
 
   @@course_cache = nil

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -196,7 +196,7 @@ class Course < ApplicationRecord
   def self.valid_courses(user = nil)
     # Do not cache if the user might have an experiment enabled which puts them
     # on an alternate script.
-    return Course.valid_courses_for_user(user) if CourseScript.has_any_experiment?(user)
+    return Course.courses_for_user_with_experiments(user) if CourseScript.has_any_experiment?(user)
     Rails.cache.fetch("valid_courses/#{I18n.locale}") do
       Course.
         all.
@@ -207,7 +207,7 @@ class Course < ApplicationRecord
 
   # Get the set of valid courses for the dropdown in our sections table, using
   # any alternate scripts based on any experiments the user belongs to.
-  def self.valid_courses_for_user(user)
+  def self.courses_for_user_with_experiments(user)
     Course.
       all.
       select {|course| ScriptConstants.script_in_category?(:full_course, course[:name])}.

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -193,7 +193,7 @@ class Course < ApplicationRecord
   # Get the set of valid courses for the dropdown in our sections table. This
   # should be static data for users without experiments enabled, but contains
   # localized strings so we can only cache on a per locale basis.
-  def self.valid_courses(user)
+  def self.valid_courses(user = nil)
     # Do not cache if the user might have an experiment enabled which puts them
     # on an alternate script.
     return Course.valid_courses_for_user(user) if CourseScript.has_any_experiment?(user)
@@ -220,7 +220,7 @@ class Course < ApplicationRecord
     valid_courses.any? {|course| course[:id] == course_id.to_i}
   end
 
-  def summarize(user)
+  def summarize(user = nil)
     {
       name: name,
       id: id,

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -195,7 +195,7 @@ class Course < ApplicationRecord
     valid_courses.any? {|course| course[:id] == course_id.to_i}
   end
 
-  def summarize
+  def summarize(user)
     {
       name: name,
       id: id,
@@ -203,13 +203,40 @@ class Course < ApplicationRecord
       description_short: I18n.t("data.course.name.#{name}.description_short", default: ''),
       description_student: I18n.t("data.course.name.#{name}.description_student", default: ''),
       description_teacher: I18n.t("data.course.name.#{name}.description_teacher", default: ''),
-      scripts: default_course_scripts.map(&:script).map do |script|
+      scripts: scripts_for_user(user).map do |script|
         include_stages = false
         script.summarize(include_stages).merge!(script.summarize_i18n(include_stages))
       end,
       teacher_resources: teacher_resources,
       has_verified_resources: has_verified_resources?
     }
+  end
+
+  # If a user has no experiments enabled, return the default set of scripts.
+  # If a user has an experiment enabled corresponding to an alternate script in
+  # this course, use the alternate script in place of the default script with
+  # the same position.
+  # @param user [User]
+  # @return [Array<Script>]
+  def scripts_for_user(user)
+    return default_scripts unless user
+    default_course_scripts.map do |cs|
+      select_course_script(user, cs).script
+    end
+  end
+
+  # Return the first alternate course script with the same position as the
+  # default course script and which the user has the corresponding experiment
+  # enabled, if one exists. Otherwise return the default course script.
+  # @param user [User]
+  # @param default_course_script [CourseScript]
+  # @return [CourseScript]
+  def select_course_script(user, default_course_script)
+    alternates = alternate_course_scripts.where(default_script: default_course_script.script).all
+    alternates.each do |cs|
+      return cs if SingleUserExperiment.enabled?(user: user, experiment_name: cs.experiment_name)
+    end
+    return default_course_script
   end
 
   @@course_cache = nil

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -250,9 +250,10 @@ class Course < ApplicationRecord
     end
   end
 
-  # Return the first alternate course script with the same position as the
-  # default course script and which the user has the corresponding experiment
-  # enabled, if one exists. Otherwise return the default course script.
+  # Return the first alternate course script with a default script matching
+  # default_course_script, and for which the user has the corresponding
+  # experiment enabled, if one exists. Otherwise return the default course
+  # script.
   # @param user [User]
   # @param default_course_script [CourseScript]
   # @return [CourseScript]

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -167,26 +167,15 @@ class Course < ApplicationRecord
 
   # Get the assignable info for this course, then update translations
   # @return AssignableInfo
-  def assignable_info
+  def assignable_info(user = nil)
     info = ScriptConstants.assignable_info(self)
     # ScriptConstants gives us untranslated versions of our course name, and the
     # category it's in. Set translated strings here
     info[:name] = localized_title
     info[:category] = I18n.t('courses_category')
-    info[:script_ids] = default_course_scripts.map(&:script_id)
-    info
-  end
-
-  # Get the assignable info for this course, substituting any alternate scripts
-  # based on any experiments this user has enabled, then update translations.
-  # @return AssignableInfo
-  def assignable_info_for_user(user)
-    info = ScriptConstants.assignable_info(self)
-    # ScriptConstants gives us untranslated versions of our course name, and the
-    # category it's in. Set translated strings here
-    info[:name] = localized_title
-    info[:category] = I18n.t('courses_category')
-    info[:script_ids] = scripts_for_user(user).map(&:id)
+    info[:script_ids] = user ?
+      scripts_for_user(user).map(&:id) :
+      default_course_scripts.map(&:script_id)
     info
   end
 
@@ -211,7 +200,7 @@ class Course < ApplicationRecord
     Course.
       all.
       select {|course| ScriptConstants.script_in_category?(:full_course, course[:name])}.
-      map {|course| course.assignable_info_for_user(user)}
+      map {|course| course.assignable_info(user)}
   end
 
   # @param course_id [String] id of the course we're checking the validity of

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -185,7 +185,7 @@ class Course < ApplicationRecord
   def self.valid_courses(user = nil)
     # Do not cache if the user might have an experiment enabled which puts them
     # on an alternate script.
-    return Course.courses_for_user_with_experiments(user) if has_any_course_experiments?(user)
+    return Course.courses_for_user_with_experiments(user) if user && has_any_course_experiments?(user)
     Rails.cache.fetch("valid_courses/#{I18n.locale}") do
       Course.
         all.

--- a/dashboard/app/models/course_script.rb
+++ b/dashboard/app/models/course_script.rb
@@ -23,4 +23,17 @@ class CourseScript < ApplicationRecord
   # The script will replace the default_script when the user has
   # the experiment_name enabled.
   belongs_to :default_script, class_name: 'Script'
+
+  def self.has_any_experiment?(user)
+    CourseScript.experiments.each do |experiment|
+      return true if SingleUserExperiment.enabled?(user: user, experiment_name: experiment)
+    end
+    false
+  end
+
+  def self.experiments
+    Rails.cache.fetch("course_script_experiments") do
+      CourseScript.where.not(experiment_name: nil).map(&:experiment_name)
+    end
+  end
 end

--- a/dashboard/app/models/course_script.rb
+++ b/dashboard/app/models/course_script.rb
@@ -24,13 +24,6 @@ class CourseScript < ApplicationRecord
   # the experiment_name enabled.
   belongs_to :default_script, class_name: 'Script'
 
-  def self.has_any_experiment?(user)
-    CourseScript.experiments.each do |experiment|
-      return true if SingleUserExperiment.enabled?(user: user, experiment_name: experiment)
-    end
-    false
-  end
-
   def self.experiments
     Rails.cache.fetch("course_script_experiments") do
       CourseScript.where.not(experiment_name: nil).map(&:experiment_name)

--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -73,7 +73,7 @@ class Experiment < ApplicationRecord
   # @param experiment_names [Array[String]]
   # @returns [Boolean]
   def self.any_enabled?(user: nil, section: nil, script: nil, experiment_names: [])
-    !!experiment_names.find do |experiment_name|
+    experiment_names.any? do |experiment_name|
       get_all_enabled(
         user: user,
         section: section,

--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -49,6 +49,13 @@ class Experiment < ApplicationRecord
     end
   end
 
+  # Returns whether the experiment_name is enabled for the specified user,
+  # section and/or script.
+  # @param user [User]
+  # @param section [Section]
+  # @param script [Script]
+  # @param experiment_name [String]
+  # @returns [Boolean]
   def self.enabled?(user: nil, section: nil, script: nil, experiment_name: nil)
     get_all_enabled(
       user: user,
@@ -56,6 +63,24 @@ class Experiment < ApplicationRecord
       script: script,
       experiment_name: experiment_name
     ).any?
+  end
+
+  # Returns whether any of experiment_names are enabled for the specified user,
+  # section and/or script.
+  # @param user [User]
+  # @param section [Section]
+  # @param script [Script]
+  # @param experiment_names [Array[String]]
+  # @returns [Boolean]
+  def self.any_enabled?(user: nil, section: nil, script: nil, experiment_names: [])
+    !!experiment_names.find do |experiment_name|
+      get_all_enabled(
+        user: user,
+        section: section,
+        script: script,
+        experiment_name: experiment_name
+      ).any?
+    end
   end
 
   def self.update_cache

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -1,7 +1,7 @@
 - course = local_assigns[:course]
 
 - data = {}
-- data[:course_summary] = course.summarize
+- data[:course_summary] = course.summarize(@current_user)
 - data[:sections] = @current_user.try{|u| u.sections.where(hidden: false).select(:id, :name)} || []
 - data[:is_teacher] = @current_user.try(:teacher?) || false
 - data[:is_verified_teacher] = @current_user.try(:authorized_teacher?) || false

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -6215,9 +6215,11 @@ en:
           stages:
             new stage:
               name: new stage
+            'CSP3A: Using Simple Commands':
+              name: 'CSP3A: Using Simple Commands'
           title: CSP Unit 3 - Subgoals Group A
           description_audience: ''
-          description_short: Alternate version of CSP Unit 3 for subgoal labels experiment
+          description_short: Alternate version of CSP Unit 3 for subgoal labels experiment group A.
           description: This unit introduces the foundational concepts of computer programming, for students in Subgoals Group A.
         new-express:
           stages:

--- a/dashboard/config/scripts/csp3-a.script
+++ b/dashboard/config/scripts/csp3-a.script
@@ -1,2 +1,5 @@
-
-
+stage 'CSP3A: Using Simple Commands', flex_category: 'csp3_1'
+level 'subgoal v2 U3L04 Student Lesson Introduction'
+level 'subgoal U3L2 Using Simple Commands'
+level 'subgoal U3 L4 introducing subgoal labels'
+level 'subgoalU3L2_TurtleSquare_right'

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -230,12 +230,20 @@ class CourseTest < ActiveSupport::TestCase
     csp = create(:course, name: 'csp')
     csp1 = create(:script, name: 'csp1')
     csp2 = create(:script, name: 'csp2')
+    csp2_alt = create(:script, name: 'csp2-alt', hidden: true)
     csp3 = create(:script, name: 'csp3')
     csd = create(:course, name: 'csd')
     create(:course, name: 'madeup')
 
     create(:course_script, position: 1, course: csp, script: csp1)
     create(:course_script, position: 2, course: csp, script: csp2)
+    create(:course_script,
+      position: 2,
+      course: csp,
+      script: csp2_alt,
+      experiment_name: 'csp2-alt-experiment',
+      default_script: csp2
+    )
     create(:course_script, position: 3, course: csp, script: csp3)
 
     courses = Course.valid_courses
@@ -259,6 +267,21 @@ class CourseTest < ActiveSupport::TestCase
 
     # has script_ids
     assert_equal [csp1.id, csp2.id, csp3.id], csp_assign_info[:script_ids]
+
+    # user without experiment has default script_ids
+    user = create(:user)
+    courses = Course.valid_courses(user)
+    assert_equal csp.id, courses[0][:id]
+    csp_assign_info = courses[0]
+    assert_equal [csp1.id, csp2.id, csp3.id], csp_assign_info[:script_ids]
+
+    # user with experiment has alternate script_ids
+    user_with_experiment = create(:user)
+    create(:single_user_experiment, name: 'csp2-alt-experiment', min_user_id: user_with_experiment.id)
+    courses = Course.valid_courses(user_with_experiment)
+    assert_equal csp.id, courses[0][:id]
+    csp_assign_info = courses[0]
+    assert_equal [csp1.id, csp2_alt.id, csp3.id], csp_assign_info[:script_ids]
   end
 
   test "update_teacher_resources" do

--- a/pegasus/helpers/section_api_helpers.rb
+++ b/pegasus/helpers/section_api_helpers.rb
@@ -221,6 +221,7 @@ class DashboardSection
     @@course_cache = {}
     @@course_experiments = nil
     @@course_experiment_map = nil
+    @@alternate_course_scripts_map = {}
   end
 
   # @typedef AssignableInfo Hash
@@ -312,6 +313,21 @@ class DashboardSection
           map[user_id][row[:name]] = true
         end
     end
+  end
+
+  # [Hash[Array[row]]] A map from course name to an array of rows from the
+  # course_scripts table.
+  @@alternate_course_scripts_map = {}
+
+  # Fetches, caches, and returns the course script rows for the specified course
+  # which have experiments enabled.
+  # course_id [Integer] The id of the course to look up.
+  # Array[row]] Array of rows from the course_scripts table.
+  def self.alternate_course_scripts(course_id)
+    @@alternate_course_scripts_map[course] ||= Dashboard.db[:course_scripts].
+      where(course_id: course_id).
+      exclude(experiment_name: nil).
+      all
   end
 
   @@course_cache = {}

--- a/pegasus/helpers/section_api_helpers.rb
+++ b/pegasus/helpers/section_api_helpers.rb
@@ -315,6 +315,15 @@ class DashboardSection
     end
   end
 
+  def self.has_experiment?(user_id, experiment_name)
+    raise "experiment_name is required" unless experiment_name && !experiment_name.empty?
+    !!course_experiment_map[user_id] && course_experiment_map[user_id][experiment_name]
+  end
+
+  def self.has_any_experiment?(user_id)
+    !!course_experiment_map[user_id]
+  end
+
   # [Hash[Array[row]]] A map from course name to an array of rows from the
   # course_scripts table.
   @@alternate_course_scripts_map = {}

--- a/pegasus/helpers/section_api_helpers.rb
+++ b/pegasus/helpers/section_api_helpers.rb
@@ -257,6 +257,10 @@ class DashboardSection
   # @param user_id [Integer]
   # @return AssignableInfo[]
   def self.valid_scripts(user_id = nil)
+    return valid_default_scripts(user_id)
+  end
+
+  def self.valid_default_scripts(user_id)
     # some users can see all scripts, even those marked hidden
     script_cache_key = I18n.locale.to_s +
       ((user_id && Dashboard.hidden_script_access?(user_id)) ? "-all" : "-valid")

--- a/pegasus/test/fixtures/fake_dashboard.rb
+++ b/pegasus/test/fixtures/fake_dashboard.rb
@@ -118,30 +118,32 @@ module FakeDashboard
       name: 'flappy',
       hidden: 0
     },
+    SCRIPT_CSP1 = {
+      id: 31,
+      name: 'csp1',
+      hidden: 0,
+    },
+    SCRIPT_CSP2 = {
+      id: 32,
+      name: 'csp2',
+      hidden: 0,
+    },
+    SCRIPT_CSP3 = {
+      id: 34,
+      name: 'csp3',
+      hidden: 0,
+    },
+    # put the hidden scripts at the end and give them higher ids, to make
+    # unit testing slightly easier.
     SCRIPT_ALLTHETHINGS = {
       id: 45,
       name: 'allthehiddenthings',
       hidden: 1
     },
-    SCRIPT_CSP1 = {
-      id: 51,
-      name: 'csp1',
-      hidden: 0,
-    },
-    SCRIPT_CSP2 = {
-      id: 52,
-      name: 'csp2',
-      hidden: 0,
-    },
     SCRIPT_CSP2_ALT = {
       id: 53,
       name: 'csp2-alt',
       hidden: 1
-    },
-    SCRIPT_CSP3 = {
-      id: 54,
-      name: 'csp3',
-      hidden: 0,
     },
   ]
 

--- a/pegasus/test/fixtures/fake_dashboard.rb
+++ b/pegasus/test/fixtures/fake_dashboard.rb
@@ -122,6 +122,59 @@ module FakeDashboard
       id: 45,
       name: 'allthehiddenthings',
       hidden: 1
+    },
+    SCRIPT_CSP1 = {
+      id: 51,
+      name: 'csp1',
+      hidden: 0,
+    },
+    SCRIPT_CSP2 = {
+      id: 52,
+      name: 'csp2',
+      hidden: 0,
+    },
+    SCRIPT_CSP2_ALT = {
+      id: 53,
+      name: 'csp2-alt',
+      hidden: 1
+    },
+    SCRIPT_CSP3 = {
+      id: 54,
+      name: 'csp3',
+      hidden: 0,
+    },
+  ]
+
+  COURSE_SCRIPTS = [
+    {
+      course_id: COURSE_CSP[:id],
+      script_id: SCRIPT_CSP1[:id],
+      position: 1
+    },
+    {
+      course_id: COURSE_CSP[:id],
+      script_id: SCRIPT_CSP2[:id],
+      position: 2
+    },
+    {
+      course_id: COURSE_CSP[:id],
+      script_id: SCRIPT_CSP2_ALT[:id],
+      position: 2,
+      experiment_name: 'csp2-alt-experiment',
+      default_script_id: SCRIPT_CSP2[:id]
+    },
+    {
+      course_id: COURSE_CSP[:id],
+      script_id: SCRIPT_CSP3[:id],
+      position: 3
+    },
+  ]
+
+  EXPERIMENTS = [
+    CSP2_ALT_EXPERIMENT = {
+      name: 'csp2-alt-experiment',
+      type: 'SingleUserExperiment',
+      min_user_id: 17
     }
   ]
 
@@ -233,6 +286,18 @@ module FakeDashboard
     SCRIPTS.each do |script|
       new_id = @@fake_db[:scripts].insert(script)
       script.merge! @@fake_db[:scripts][id: new_id]
+    end
+
+    COURSE_SCRIPTS.each do |course_script|
+      new_id = @@fake_db[:course_scripts].insert(course_script)
+      course_script.merge! @@fake_db[:course_scripts][id: new_id]
+    end
+
+    EXPERIMENTS.each do |experiment|
+      experiment[:created_at] ||= Time.now
+      experiment[:updated_at] ||= Time.now
+      new_id = @@fake_db[:experiments].insert(experiment)
+      experiment.merge! @@fake_db[:experiments][id: new_id]
     end
 
     TEACHER_SECTIONS.each do |section|

--- a/pegasus/test/fixtures/fake_dashboard.rb
+++ b/pegasus/test/fixtures/fake_dashboard.rb
@@ -252,6 +252,10 @@ module FakeDashboard
     @@fake_db
   end
 
+  def self.stub_database
+    Dashboard.stubs(:db)
+  end
+
   # Lazy-creates sqlite database using Dashboard's real ActiveRecord schema,
   # and populates it with some simple test data.
   # We might want to extract the test data to individual tests in the future,

--- a/pegasus/test/test_section_api_helpers.rb
+++ b/pegasus/test/test_section_api_helpers.rb
@@ -230,6 +230,38 @@ class SectionApiHelperTest < SequelTestCase
         }
         assert_equal expected, flappy_script
       end
+
+      it 'includes default csp scripts' do
+        script_ids = DashboardSection.valid_scripts.map {|script| script[:script_name]}
+        assert_includes script_ids, 'csp1'
+        assert_includes script_ids, 'csp2'
+        refute_includes script_ids, 'csp2-alt'
+        assert_includes script_ids, 'csp3'
+      end
+
+      it 'includes default csp scripts for user without experiment' do
+        user_id = 1
+        valid_scripts = DashboardSection.valid_scripts(user_id)
+        script_names = valid_scripts.map {|script| script[:script_name]}
+        assert_includes script_names, 'csp1'
+        assert_includes script_names, 'csp2'
+        refute_includes script_names, 'csp2-alt'
+        assert_includes script_names, 'csp3'
+
+        assert_equal 'Unit 2: Digital Information', valid_scripts.find {|s| s[:script_name] == 'csp2'}[:name]
+      end
+
+      it 'includes alternate csp scripts for user with experiment' do
+        user_id = FakeDashboard::CSP2_ALT_EXPERIMENT[:min_user_id]
+        valid_scripts = DashboardSection.valid_scripts(user_id)
+        script_names = valid_scripts.map {|script| script[:script_name]}
+        assert_includes script_names, 'csp1'
+        refute_includes script_names, 'csp2'
+        assert_includes script_names, 'csp2-alt'
+        assert_includes script_names, 'csp3'
+
+        assert_equal 'Unit 2: Digital Information', valid_scripts.find {|s| s[:script_name] == 'csp2-alt'}[:name]
+      end
     end
 
     describe 'valid courses' do

--- a/pegasus/test/test_section_api_helpers.rb
+++ b/pegasus/test/test_section_api_helpers.rb
@@ -251,6 +251,16 @@ class SectionApiHelperTest < SequelTestCase
         assert_equal 'Unit 2: Digital Information', valid_scripts.find {|s| s[:script_name] == 'csp2'}[:name]
       end
 
+      it 'only hits the database to check hidden script access on subsequent requests without experiment' do
+        user_id = 1
+        DashboardSection.valid_scripts(user_id)
+        Dashboard.stubs(:hidden_script_access?).returns(false)
+        FakeDashboard.stub_database.raises('unexpected call to fake dashboard DB')
+        DashboardSection.valid_scripts
+        DashboardSection.valid_scripts(user_id)
+        DashboardSection.valid_scripts(user_id + 1)
+      end
+
       it 'includes alternate csp scripts for user with experiment' do
         user_id = FakeDashboard::CSP2_ALT_EXPERIMENT[:min_user_id]
         valid_scripts = DashboardSection.valid_scripts(user_id)

--- a/pegasus/test/test_v2_section_routes.rb
+++ b/pegasus/test/test_v2_section_routes.rb
@@ -355,7 +355,31 @@ class V2SectionRoutesTest < SequelTestCase
             "category" => "Hour of Code",
             "position" => 4,
             "category_priority" => 2
-          }
+          },
+          {
+            "id" => 31,
+            "name" => "Unit 1: The Internet",
+            "script_name" => "csp1",
+            "category" => "CS Principles",
+            "position" => 0,
+            "category_priority" => 9
+          },
+          {
+            "id" => 32,
+            "name" => "Unit 2: Digital Information",
+            "script_name" => "csp2",
+            "category" => "CS Principles",
+            "position" => 1,
+            "category_priority" => 9
+          },
+          {
+            "id" => 34,
+            "name" => "Unit 3: Algorithms and Programming",
+            "script_name" => "csp3",
+            "category" => "CS Principles",
+            "position" => 2,
+            "category_priority" => 9
+          },
         ]
       end
 
@@ -391,6 +415,13 @@ class V2SectionRoutesTest < SequelTestCase
             'category' => 'other',
             'position' => nil,
             'category_priority' => 15
+          } << {
+            "id" => 53,
+            "name" => "csp2-alt *",
+            "script_name" => "csp2-alt",
+            "category" => "other",
+            "position" => nil,
+            "category_priority" => 15
           },
           JSON.parse(@pegasus.last_response.body)
         )


### PR DESCRIPTION
### Background
* ~[axosoft item](https://codeorg.axosoft.com/viewitem?id=1015&type=features&force_use_number=true) (click through to parent for spec)~
* [spec](https://docs.google.com/document/d/1BrYi9nzIwrOkrCGl1ibx1ZdbHme04mEjSZyNOgAMevs/edit?tab=t.0#heading=h.zs1cbf275w7)
* [work items](https://docs.google.com/document/d/1vmnLwUaZLzSuPvepW4KI15FUKPwtJxcgKK-wErTZsms/edit#heading=h.47njzgyhcx7b) in dev doc

To summarize: 
* the config for alternate course scripts has been persisted to the database in past PRs
* the experience for teachers is implemented in this PR
* the experience for students will be implemented next

### Description

For teachers with a course script experiment enabled, show the corresponding alternate script in the following places:
* on the course page (https://studio.code.org/courses/csp)
* in the course unit selector on teacher homepage
* in the progress script selector in teacher dashboard

These 3 places can all be seen in this screencap:
![subgoals-teacher-experiment](https://user-images.githubusercontent.com/8001765/30922536-4a767af2-a35e-11e7-8956-d15a1115ee76.gif)

### Caveats

Unfortunately, the logic for retrieving scripts, courses and sections via server APIs is split between pegasus and dashboard. This PR updates /dashboardapi/courses (in dashboard) and /v2/sections/valid_scripts (in pegasus). I really wanted to move `valid_scripts` over to dashboard, but I didn't want to risk going too far down a rabbit hole with an upcoming deadline. 

The first hurdle I ran into in attempting to move `valid_scripts` over to dashboard was that I couldn't access pegasus i18n strings from dashboard. There may be other stumbling blocks as well. A good next step (after this feature's deadline) may be to solve the i18n issue and see if there are any other blocking issues.
