### PR TITLE
prevent UserLevel#most_recent_driver query unless user can pair

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -83,6 +83,7 @@ class UserLevel < ActiveRecord::Base
   end
 
   def self.most_recent_driver(script, level, user)
+    return nil unless user.can_pair?
     most_recent = find_by(script: script, level: level, user: user).try(:driver_user_levels).try(:last)
     return nil unless most_recent
 

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -223,8 +223,8 @@ class LevelsHelperTest < ActionView::TestCase
   test 'applab levels should include pairing_driver and pairing_channel_id when viewed by navigator' do
     @level = create :applab
 
-    @driver = create :student, name: 'DriverName'
-    @navigator = create :student
+    @driver = create :student_in_word_section, name: 'DriverName'
+    @navigator = create :student_in_word_section
 
     @driver_user_level = create :user_level, user: @driver, level: @level
     @navigator_user_level = create :user_level, user: @navigator, level: @level

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -51,7 +51,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level.id
     )
 
-    assert_cached_queries(7) do
+    assert_cached_queries(6) do
       get user_progress_path,
         headers: {'HTTP_USER_AGENT': 'test'}
       assert_response :success

--- a/dashboard/test/models/user_level_test.rb
+++ b/dashboard/test/models/user_level_test.rb
@@ -7,8 +7,8 @@ class UserLevelTest < ActiveSupport::TestCase
     @user = create(:user)
     @level = create(:level)
 
-    @driver = create :student, name: 'DriverName'
-    @navigator = create :student
+    @driver = create :student_in_word_section, name: 'DriverName'
+    @navigator = create :student_in_word_section
     @driver_user_level = create :user_level, user: @driver, level: @level
     @navigator_user_level = create :user_level, user: @navigator, level: @level
     @driver_user_level.navigator_user_levels << @navigator_user_level


### PR DESCRIPTION
This optimization prevents the following DB query from occurring in all `Api#user_progress` (performed on every signed-in puzzle-page load) actions:

<code>SELECT  &#96;user_levels&#96;.* FROM &#96;user_levels&#96; INNER JOIN &#96;paired_user_levels&#96; ON &#96;user_levels&#96;.&#96;id&#96; = &#96;paired_user_levels&#96;.&#96;driver_user_level_id&#96; WHERE &#96;paired_user_levels&#96;.&#96;navigator_user_level_id&#96; = 4 ORDER BY &#96;user_levels&#96;.&#96;id&#96; DESC LIMIT 1</code>

Following this change, `UserLevel#most_recent_driver` will return `nil` unless `User#can_pair?` is true (if the user is in a section where pairing is enabled). This might be a _slight_ behavior change (see the added unit-test changes) since it's theoretically possible that a user logged pair-programming `UserLevel`s from a section where pairing was previously enabled but is now disabled, so `#most_recent_driver` might return different values on some weird edge cases like that. For this reason I'd like someone familiar with this pair-programming feature (@joshlory?) to make sure this PR behavior is an acceptable tradeoff for the DB-performance gain.

Part of ActiveRecord query optimization pass (see #18390). This query accounts for ~4-6% of our current DB load.