### PR TITLE
reduce user_levels queries in script_levels#show

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -255,10 +255,7 @@ class ScriptLevelsController < ApplicationController
       readonly_view_options
     elsif current_user
       # load user's previous attempt at this puzzle.
-      @last_activity = current_user.last_attempt(@level)
-      level_source = @last_activity.try(:level_source)
-
-      user_level = current_user.user_level_for(@script_level, @level)
+      user_level = current_user.user_levels_by_level(@script)[@level.id]
       if user_level && user_level.submitted?
         level_view_options(
           @level.id,
@@ -268,6 +265,7 @@ class ScriptLevelsController < ApplicationController
         readonly_view_options
       end
       readonly_view_options if user_level && user_level.readonly_answers?
+      level_source = user_level.try(:level_source)
     end
 
     @last_attempt = level_source.try(:data)

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -255,7 +255,10 @@ class ScriptLevelsController < ApplicationController
       readonly_view_options
     elsif current_user
       # load user's previous attempt at this puzzle.
-      user_level = current_user.user_levels_by_level(@script)[@level.id]
+      @last_activity = current_user.user_levels_by_level(@script)[@level.id]
+      level_source = @last_activity.try(:level_source)
+
+      user_level = @last_activity
       if user_level && user_level.submitted?
         level_view_options(
           @level.id,
@@ -265,7 +268,6 @@ class ScriptLevelsController < ApplicationController
         readonly_view_options
       end
       readonly_view_options if user_level && user_level.readonly_answers?
-      level_source = user_level.try(:level_source)
     end
 
     @last_attempt = level_source.try(:data)

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -787,7 +787,12 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     last_attempt_data = 'test'
     level = @custom_s1_l1.level
     level_source = LevelSource.find_identical_or_create(level, last_attempt_data)
-    UserLevel.create!(level: level, user: @student, level_source: level_source)
+    UserLevel.create!(
+      script: @custom_s1_l1.script,
+      level: level,
+      user: @student,
+      level_source: level_source
+    )
 
     get :show, params: {
       script_id: @custom_script,

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -20,7 +20,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level,
       level_source: create(:level_source, level: level)
 
-    assert_cached_queries(22) do
+    assert_cached_queries(20) do
       get script_stage_script_level_path(
         script_id: script.name,
         stage_position: 1,


### PR DESCRIPTION
This optimization removes the following DB queries from `ScriptLevel#show` actions (every signed-in puzzle-page load, on non-scale-mode scripts):

<code>SELECT  `user_levels`.* FROM `user_levels` WHERE `user_levels`.`user_id` = [user] AND `user_levels`.`level_id` = [level] ORDER BY updated_at DESC LIMIT 1</code>
<code>SELECT  `user_levels`.* FROM `user_levels` WHERE `user_levels`.`user_id` = [user] AND `user_levels`.`script_id` = [script] AND `user_levels`.`level_id` = [level] ORDER BY id desc LIMIT 1</code>

The optimization reuses the existing `user_levels_by_level` query (automatically cached within the current request by the ActiveRecord Query Cache), both for getting the most recent attempt and for getting the most recent `UserLevel`.

Part of ActiveRecord query optimization pass (see #18390).