### PR TITLE
DB read-replica fallback support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
           name: taking these out of dockerfile to see if that fixes build issues
           command: |
             sudo mv /usr/bin/parallel /usr/bin/gnu_parallel
+            sudo apt-get update
             sudo apt-get install -y libicu-dev enscript moreutils pdftk libmysqlclient-dev libsqlite3-dev
             sudo mv /usr/bin/gnu_parallel /usr/bin/parallel
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,8 @@ gem 'sinatra', '~> 2.0.0.beta2', require: 'sinatra/base'
 gem 'mysql2', '~> 0.3.13'
 # Ref: https://github.com/bdurand/seamless_database_pool/issues/38
 # Ref: https://github.com/bdurand/seamless_database_pool/pull/39
-gem 'seamless_database_pool', github: 'wjordan/seamless_database_pool', ref: 'cdo'
+# Include read-only fallback logic.
+gem 'seamless_database_pool', github: 'wjordan/seamless_database_pool', ref: 'fallback'
 
 gem 'dalli' # memcached
 gem 'dalli-elasticache' # ElastiCache Auto Discovery memcached nodes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,8 +128,8 @@ GIT
 
 GIT
   remote: https://github.com/wjordan/seamless_database_pool.git
-  revision: c9a5c2bc92efc1f87a2aa065283e15283dbb9425
-  ref: cdo
+  revision: a2ce938ffe9356802bffdd712c02e1ef259aeba4
+  ref: fallback
   specs:
     seamless_database_pool (1.0.19)
       activerecord (>= 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GIT
 
 GIT
   remote: https://github.com/wjordan/seamless_database_pool.git
-  revision: a2ce938ffe9356802bffdd712c02e1ef259aeba4
+  revision: f6ac06becd69bcb2ed958cf0ae79b98c96a48d6f
   ref: fallback
   specs:
     seamless_database_pool (1.0.19)

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -15,6 +15,7 @@ mysql_defaults: &mysql_defaults
   encoding: utf8
   collation: utf8_unicode_ci
   pool: 5
+  reconnect: true
   connect_timeout: 2
   default_group: 'cdo'
   master:
@@ -22,7 +23,7 @@ mysql_defaults: &mysql_defaults
     password: <%= writer.password || '' %>
     host: <%= writer.host || 'localhost' %>
     database: <%= writer.path.sub(%r{^/},"") || "dashboard_#{Rails.env}" %>
-  <% if reader && reader.host != writer.host %>
+  <% if reader && reader != writer %>
     # When there is a separate read-only database configured, do NOT
     # include the master database in the read pool.
     # Ref: https://github.com/bdurand/seamless_database_pool#the-master-connection

--- a/lib/sequel/extensions/server_fallback.rb
+++ b/lib/sequel/extensions/server_fallback.rb
@@ -1,22 +1,48 @@
+require 'active_support/core_ext/numeric/time'
+
 # Sequel extension to serve read-only requests from a replica shard
 # when the primary database is down.
-# Wait 10 seconds before attempting to read from the primary database again.
+# Throttle reconnection attempts to once every 10 seconds.
 module ServerFallback
   def self.extended(db)
     db.instance_variable_set(:@suppress_master_until, Time.now)
+    db.extend_datasets(Dataset)
   end
+
+  attr_accessor :suppress_master_until
 
   def execute(sql, opts=OPTS, &block)
     if opts[:server] == :read_only && @suppress_master_until > Time.now
       opts[:server] = :fallback
     end
     super
-  rescue Sequel::DatabaseDisconnectError, *@error_classes => e
-    if opts[:server] == :read_only && pool.disconnect_error?(e)
+  rescue Sequel::DatabaseDisconnectError, *database_error_classes => e
+    if opts[:server] == :read_only && disconnect_error?(e, opts)
       @suppress_master_until = 10.seconds.from_now
       retry
     else
       raise e
+    end
+  end
+
+  # Treat "Access denied" message as a disconnect error for testing purposes.
+  def disconnect_error?(e, _)
+    super || /Access denied for user/.match(e.message)
+  end
+
+  # MySQL adapter uses an active connection for escaping SQL strings,
+  # so use same fallback as other read-only queries.
+  module Dataset
+    def literal_string_append(sql, v)
+      @opts[:server] = :fallback if db.suppress_master_until > Time.now
+      super
+    rescue Sequel::DatabaseDisconnectError => e
+      if @opts[:server] != :fallback
+        db.suppress_master_until = 10.seconds.from_now
+        retry
+      else
+        raise e
+      end
     end
   end
 end

--- a/lib/sequel/extensions/server_fallback.rb
+++ b/lib/sequel/extensions/server_fallback.rb
@@ -1,0 +1,23 @@
+# Sequel extension to serve read-only requests from a replica shard
+# when the primary database is down.
+# Wait 10 seconds before attempting to read from the primary database again.
+module ServerFallback
+  def self.extended(db)
+    db.instance_variable_set(:@suppress_master_until, Time.now)
+  end
+
+  def execute(sql, opts=OPTS, &block)
+    if opts[:server] == :read_only && @suppress_master_until > Time.now
+      opts[:server] = :fallback
+    end
+    super
+  rescue Sequel::DatabaseDisconnectError, *@error_classes => e
+    if opts[:server] == :read_only && pool.disconnect_error?(e)
+      @suppress_master_until = 10.seconds.from_now
+      retry
+    else
+      raise e
+    end
+  end
+end
+Sequel::Database.register_extension(:server_fallback, ServerFallback)


### PR DESCRIPTION
This PR adds logic to our database adapters (both ActiveRecord and Sequel) to use the configured read-replica connection (`reporting` database) as a fallback for read-only queries when the primary DB is down/unavailable, to provide a graceful fallback for read-only parts of the web-application.

This should provide a less-catastrophic failure scenario for primary-database process/instance restarts, and might even gracefully handle partial/full primary-db outages to some extent. Instead of any database query causing the associated request/page-load to return a 5xx error, following this PR, only queries that actually attempt to write data will return an error, while read-only queries will be served by the read-replica. Once it eventually comes back online, the primary database will resume handling all read queries again.

A cool-off period is provided in both adapters so that the server will only attempt a single reconnect request every 10 seconds per connection, rather than every time a new query is attempted.

See also related code changes to the `seamless_database_pool` forked-branch with this diff: [`cdo...fallback`](https://github.com/wjordan/seamless_database_pool/compare/cdo...wjordan:fallback?expand=1&w=1)

I've done a bit of manual testing in development so far with simulated failure conditions. Currently testing on an adhoc instance ([`adhoc-db-fallback`](https://adhoc-db-fallback.cdn-code.org)).