### PR TITLE
Pegasus: cope with numerical directory in image-resize URLs

### DIFF
--- a/lib/cdo/pegasus/graphics.rb
+++ b/lib/cdo/pegasus/graphics.rb
@@ -49,7 +49,7 @@ def process_image(path, ext_names, language=nil, site=nil)
   manipulated = false
 
   # Manipulated?
-  if (m = dirname.match /^(?<basedir>.*)\/(?<mode>fit-|fill-)?(?<width>\d*)x?(?<height>\d*)(\/(?<dir>.*))?$/m)
+  if (m = dirname.match /^(?<basedir>.*?)\/(?<mode>fit-|fill-)?(?<width>\d*)x?(?<height>\d*)(\/(?<dir>.*))?$/m)
     mode = m[:mode][0..-2].to_sym unless m[:mode].nil_or_empty?
     width = m[:width].to_i unless m[:width].nil_or_empty?
     height = m[:height].to_i unless m[:height].nil_or_empty?


### PR DESCRIPTION
A URL like this was failing to load: /images/fill-480x360/tutorials/2017/myimage.png

Because the basedir capture group was greedy (as is the default), the regular expression decided 2017 was the width, rather than 480.

The solution is to make the basedir capture group lazy.