### PR TITLE
App Lab: Expose selectionStart and selectionEnd on event objects

### DIFF
--- a/apps/src/applab/EventSandboxer.js
+++ b/apps/src/applab/EventSandboxer.js
@@ -129,6 +129,16 @@ EventSandboxer.prototype.sandboxEvent = function (event) {
         }
       });
 
+  // Pull selectionStart and selectionEnd from the target element, if available,
+  // and expose them on the sandboxed event object
+  if (event.target) {
+    ['selectionStart', 'selectionEnd'].forEach((eventTargetPropName) => {
+      if (event.target[eventTargetPropName] !== undefined) {
+        newEvent[eventTargetPropName] = event.target[eventTargetPropName];
+      }
+    });
+  }
+
   // Attempt to polyfill DOM element ID properties
   // Of our six DOM properties, only three are standard.
   var fillProperty = function (to, from) {

--- a/apps/test/unit/applab/EventSandboxerTest.js
+++ b/apps/test/unit/applab/EventSandboxerTest.js
@@ -386,6 +386,27 @@ describe('EventSandboxer', function () {
     });
   });
 
+  describe('hoisted event target properties', () => {
+    it('copies "selectionStart" from the original event target to the new event', () => {
+      const originalEvent = {target: {selectionStart: Math.random()}};
+      const newEvent = sandboxer.sandboxEvent(originalEvent);
+      assert.equal(newEvent.selectionStart, originalEvent.target.selectionStart);
+    });
+
+    it('copies "selectionEnd" from the original event target to the new event', () => {
+      const originalEvent = {target: {selectionEnd: Math.random()}};
+      const newEvent = sandboxer.sandboxEvent(originalEvent);
+      assert.equal(newEvent.selectionEnd, originalEvent.target.selectionEnd);
+    });
+
+    it('does not add selectionStart or selectionEnd to the new event if they are missing or undefined', () => {
+      const originalEvent = {target: {selectionEnd: undefined}};
+      const newEvent = sandboxer.sandboxEvent(originalEvent);
+      assert.isFalse(newEvent.hasOwnProperty('selectionStart'));
+      assert.isFalse(newEvent.hasOwnProperty('selectionEnd'));
+    });
+  });
+
   describe('DOM element substitution', function () {
     function assertPropertyElementToElementId(originalName) {
       var randomId = Math.random();


### PR DESCRIPTION
We've had a few requests to get access to the cursor position within fields in App Lab - [here's the latest](http://forum.code.org/t/applab-getelementbyid-id-possible/13574).

The easiest way to do this is probably with the [`selectionStart`](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Property/selectionStart) and [`selectionEnd`](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Property/selectionEnd) properties, which [have excellent cross-browser support](https://caniuse.com/#feat=input-selection).  Normally one could call these in an event handler via `event.target.selectionStart`, but [our `EventSandboxer`](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/applab/EventSandboxer.js) strips out the `target` property of events so we don't accidentally expose general access to the DOM.

I'm hoisting these two integer properties from the `target` onto the new event during sandboxing, making them available to App Lab users wherever they would normally exist outside of our sandbox.

## Example App
```js
textInput("myInput", "text");
textLabel("selectionStart", "text");
textLabel("selectionEnd", "text");

function readSelection(event) {
  setText("selectionStart", event.selectionStart);
  setText("selectionEnd", event.selectionEnd);
}

onEvent("myInput", "keyup", readSelection);
onEvent("myInput", "mousemove", readSelection);
```
![out](https://user-images.githubusercontent.com/1615761/34841119-fd0e1ee4-f6bb-11e7-9960-5d118144f9bc.gif)
