### PR TITLE
enable i18n tests on circle

### DIFF
--- a/dashboard/test/ui/features/i18n.feature
+++ b/dashboard/test/ui/features/i18n.feature
@@ -1,4 +1,3 @@
-@no_circle
 Feature: Hour of Code, Frozen, and Minecraft:Agent tutorials in various languages
 
 Scenario: HoC tutorial in Spanish
@@ -71,7 +70,6 @@ Scenario: HoC tutorial in Portuguese
   Given I am on "http://studio.code.org/reset_session/lang/en"
   And I wait for 2 seconds
 
-@no_circle
 Scenario: Frozen tutorial in Portuguese
   Given I am on "http://studio.code.org/s/frozen/stage/1/puzzle/2/lang/pt-br"
   And I rotate to landscape


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/19714

Now that i18n changes are no longer reliant on going through staging, we can reliably test i18n features on circle.