### PR TITLE
Proof of concept: React Tooltips

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -209,6 +209,7 @@
     "jszip": "3.0.0",
     "object-fit-images": "^3.2.3",
     "query-string": "4.1.0",
+    "rc-tooltip": "^3.7.0",
     "react-dom-confetti": "^0.0.8",
     "react-hot-loader": "^1.3.1",
     "selectize": "^0.12.4",

--- a/apps/src/lib/ui/Tooltip.js
+++ b/apps/src/lib/ui/Tooltip.js
@@ -1,0 +1,103 @@
+import React, { PropTypes, Component } from 'react';
+import RCTooltip from 'rc-tooltip';
+
+// Note: rc-tooltip generally expects classNames to be used for styling. I've
+// managed to replicate the styling from node_modules/rc-tooltip/assets/bootstrap.css
+// However, it currently only has styles for top placement
+
+// TODO: doesnt work in header
+
+const styles = {
+  // Does the work of .rc-tooltip and .rc-tooltip-placement-*
+  tooltip: {
+    position: 'absolute',
+    // TODO: zIndex 1070 may or may not be the right zIndex for us
+    zIndex: 1070,
+    display: 'block',
+    visibility: 'visible',
+    fontSize: 12,
+    lineHeight: 1.5,
+    opacity: 0.9,
+
+    // placement-top
+    padding: '5px 0 9px 0'
+  }
+};
+
+// Positions the arrow in the tooltip. Does the work of .rc-tooltip-arrow and
+// .rc-tooltip-placement-*
+const ArrowContent = () => (
+  <div
+    style={{
+      position: 'absolute',
+      width: 0,
+      height: 0,
+      borderColor: 'transparent',
+      borderStyle: 'solid',
+
+      // placement-top
+      bottom: 4,
+      marginLeft: -5,
+      borderWidth: '5px 5px 0',
+      borderTopColor: '#373737',
+      left: '50%'
+    }}
+  />
+);
+
+// Styling for the content of the tooltip. Does the work of .rc-tooltip-inner.
+const Overlay = ({children}) => (
+  <div
+    style={{
+      padding: '8px 10px',
+      color: '#fff',
+      textAlign: 'left',
+      textDecoration: 'none',
+      backgroundColor: '#373737',
+      borderRadius: 6,
+      boxShadow: '0 0 4px rgba(0,0,0,0.17)',
+      minHeight: 34,
+    }}
+  >
+    {children}
+  </div>
+);
+Overlay.propTypes = {
+  children: PropTypes.element.isRequired,
+};
+
+export default class ToolTip extends Component {
+  static propTypes = {
+    // Adding support for other placements will mean more flexible styles
+    placement: PropTypes.oneOf(['top']),
+    // can be used with aria-describedby on child for a11y
+    id: PropTypes.string,
+    overlay: PropTypes.node.isRequired,
+    children: PropTypes.element.isRequired,
+  };
+
+  render() {
+    const placement = this.props.placement || "top";
+
+    const overlay = (
+      <Overlay>
+        {this.props.overlay}
+      </Overlay>
+    );
+
+    // Note: destroyTooltipOnHide doesn't actually work in current versions
+    return (
+      <RCTooltip
+        overlayStyle={styles.tooltip}
+        arrowContent={<ArrowContent/>}
+        placement={placement}
+        overlay={overlay}
+        id={this.props.id}
+        mouseLeaveDelay={0}
+        destroyTooltipOnHide={true}
+      >
+        {this.props.children}
+      </RCTooltip>
+    );
+  }
+}

--- a/apps/src/lib/ui/Tooltip.js
+++ b/apps/src/lib/ui/Tooltip.js
@@ -4,11 +4,11 @@ import RCTooltip from 'rc-tooltip';
 // Note: rc-tooltip generally expects classNames to be used for styling. I've
 // managed to replicate the styling from node_modules/rc-tooltip/assets/bootstrap.css
 // However, it currently only has styles for top placement
-
-// TODO: doesnt work in header
+// It might be possible to just import the css instead and have it end up in our
+// JS bundle, which might end up being a cleaner solution.
 
 const styles = {
-  // Does the work of .rc-tooltip and .rc-tooltip-placement-*
+  // Does the work of .rc-tooltip
   tooltip: {
     position: 'absolute',
     // TODO: zIndex 1070 may or may not be the right zIndex for us
@@ -18,34 +18,57 @@ const styles = {
     fontSize: 12,
     lineHeight: 1.5,
     opacity: 0.9,
-
-    // placement-top
-    padding: '5px 0 9px 0'
-  }
-};
-
-// Positions the arrow in the tooltip. Does the work of .rc-tooltip-arrow and
-// .rc-tooltip-placement-*
-const ArrowContent = () => (
-  <div
-    style={{
-      position: 'absolute',
-      width: 0,
-      height: 0,
-      borderColor: 'transparent',
-      borderStyle: 'solid',
-
-      // placement-top
+  },
+  // .rc-tooltip-placement-*
+  tooltipPlacement: {
+    top: {
+      padding: '5px 0 9px 0'
+    },
+    bottom: {
+      padding: '9px 0 5px 0'
+    }
+  },
+  // .rc-tooltip-arrow
+  arrowContent: {
+    position: 'absolute',
+    width: 0,
+    height: 0,
+    borderColor: 'transparent',
+    borderStyle: 'solid',
+  },
+  // .rc-tooltip-placement-*
+  arrowContentPlacement: {
+    top: {
       bottom: 4,
       marginLeft: -5,
       borderWidth: '5px 5px 0',
       borderTopColor: '#373737',
       left: '50%'
+    },
+    bottom: {
+      top: 4,
+      marginLeft: -5,
+      borderWidth: '0 5px 5px',
+      borderBottomColor: '#373737',
+      left: '50%'
+    }
+  }
+};
+
+// Positions the arrow in the tooltip.
+const ArrowContent = ({placement}) => (
+  <div
+    style={{
+      ...styles.arrowContent,
+      ...styles.arrowContentPlacement[placement],
     }}
   />
 );
+ArrowContent.propTypes = {
+  placement: PropTypes.oneOf(['top', 'bottom']),
+};
 
-// Styling for the content of the tooltip. Does the work of .rc-tooltip-inner.
+// Styling for the content of the tooltip.
 const Overlay = ({children}) => (
   <div
     style={{
@@ -69,32 +92,60 @@ Overlay.propTypes = {
 export default class ToolTip extends Component {
   static propTypes = {
     // Adding support for other placements will mean more flexible styles
-    placement: PropTypes.oneOf(['top']),
+    placement: PropTypes.oneOf(['top', 'bottom']),
     // can be used with aria-describedby on child for a11y
     id: PropTypes.string,
     overlay: PropTypes.node.isRequired,
     children: PropTypes.element.isRequired,
   };
 
-  render() {
-    const placement = this.props.placement || "top";
+  constructor(props) {
+    super(props);
+    this.state = {
+      placement: props.placement || 'top'
+    };
+  }
 
+  /**
+   * This is perhaps slightly hacky, but seems to work. Sometimes when we ask for
+   * a particular placement (such as top), we don't have enough room for a tooltip
+   * there. The library seems to be smart enough to then flip the placement for us
+   * and give us a bottom tip. Because we're doing our styling inlined instead
+   * of uses classes, we now need to flip our styling as well.
+   */
+  onPopupAlign = (node, align) => {
+    const match = /rc-tooltip-placement-(.*)$/.exec(node.className);
+    if (match) {
+      const placement = match[1].trim();
+      if (placement !== this.state.placement) {
+        this.setState({placement});
+      }
+    }
+  }
+
+  render() {
     const overlay = (
       <Overlay>
         {this.props.overlay}
       </Overlay>
     );
 
+    const { placement } = this.state;
+
     // Note: destroyTooltipOnHide doesn't actually work in current versions
     return (
       <RCTooltip
-        overlayStyle={styles.tooltip}
-        arrowContent={<ArrowContent/>}
+        overlayStyle={{
+          ...styles.tooltip,
+          ...styles.tooltipPlacement[placement]
+        }}
+        arrowContent={<ArrowContent placement={placement}/>}
         placement={placement}
         overlay={overlay}
         id={this.props.id}
         mouseLeaveDelay={0}
         destroyTooltipOnHide={true}
+        onPopupAlign={this.onPopupAlign}
       >
         {this.props.children}
       </RCTooltip>

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -16,6 +16,7 @@ import {
 } from './progressStyles';
 import ProgressPill from '@cdo/apps/templates/progress/ProgressPill';
 import TooltipWithIcon from './TooltipWithIcon';
+import Tooltip from '@cdo/apps/lib/ui/Tooltip';
 
 /**
  * A ProgressBubble represents progress for a specific level. It can be a circle
@@ -75,6 +76,13 @@ const styles = {
     // undo the rotation from the parent
     transform: 'rotate(-45deg)'
   },
+  arrow: {
+    position: 'absolute',
+    width: 0,
+    height: 0,
+    borderColor: 'transparent',
+    borderStyle: 'solid',
+  }
 };
 
 class ProgressBubble extends React.Component {
@@ -121,6 +129,7 @@ class ProgressBubble extends React.Component {
         text={tooltipText}
       />
     );
+    // const tooltip = undefined;
 
     if (level.isUnplugged && !smallBubble) {
       return (
@@ -128,7 +137,7 @@ class ProgressBubble extends React.Component {
           levels={[level]}
           text={i18n.unpluggedActivity()}
           fontSize={16}
-          tooltip={tooltip}
+          tooltip={undefined}
         />
       );
     }
@@ -136,38 +145,41 @@ class ProgressBubble extends React.Component {
     // Outer div here is used to make sure our bubbles all take up equivalent
     // amounts of space, whether they're diamonds or circles
     let bubble = (
-      <div
-        style={{
-          // two pixles on each side for border, 2 pixels on each side for margin
-          width: (smallBubble ? SMALL_DOT_SIZE : DOT_SIZE) + 8,
-          display: 'flex',
-          justifyContent: 'center'
-        }}
+      <Tooltip
+        overlay={tooltip}
+        id={tooltipId}
       >
         <div
-          style={style}
-          data-tip data-for={tooltipId}
           aria-describedby={tooltipId}
+          style={{
+            // two pixles on each side for border, 2 pixels on each side for margin
+            width: (smallBubble ? SMALL_DOT_SIZE : DOT_SIZE) + 8,
+            display: 'flex',
+            justifyContent: 'center'
+          }}
         >
           <div
-            style={{
-              ...styles.contents,
-              ...(level.isConceptLevel && styles.diamondContents)
-            }}
+            style={style}
           >
-            {levelIcon === 'lock' && <FontAwesome icon="lock"/>}
-            {levelIcon !== 'lock' && (
-              <span>
-                {/*Text will not show up for smallBubble, but it's presence
-                  causes bubble to be properly aligned vertically
-                  */}
-                {smallBubble ? '' : number}
-              </span>
-            )}
-            {tooltip}
+            <div
+              style={{
+                ...styles.contents,
+                ...(level.isConceptLevel && styles.diamondContents)
+              }}
+            >
+              {levelIcon === 'lock' && <FontAwesome icon="lock"/>}
+              {levelIcon !== 'lock' && (
+                <span>
+                  {/*Text will not show up for smallBubble, but it's presence
+                    causes bubble to be properly aligned vertically
+                    */}
+                  {smallBubble ? '' : number}
+                </span>
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      </Tooltip>
     );
 
     // If we have an href, wrap in an achor tag

--- a/apps/src/templates/progress/TooltipWithIcon.jsx
+++ b/apps/src/templates/progress/TooltipWithIcon.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes, Component } from 'react';
-import ReactTooltip from 'react-tooltip';
+// import ReactTooltip from 'react-tooltip';
 import FontAwesome from '../FontAwesome';
 import { DOT_SIZE } from './progressStyles';
 
@@ -20,24 +20,24 @@ const styles = {
  */
 export default class TooltipWithIcon extends Component {
   static propTypes = {
-    tooltipId: PropTypes.string.isRequired,
+    // tooltipId: PropTypes.string.isRequired,
     icon: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
   };
   render() {
-    const { tooltipId, icon, text } = this.props;
+    const { icon, text } = this.props;
     return (
-      <ReactTooltip
-        id={tooltipId}
-        role="tooltip"
-        wrapper="span"
-        effect="solid"
-      >
+      // <ReactTooltip
+      //   id={tooltipId}
+      //   role="tooltip"
+      //   wrapper="span"
+      //   effect="solid"
+      // >
         <div style={styles.tooltip}>
           <FontAwesome icon={icon} style={styles.tooltipIcon}/>
           {text}
         </div>
-      </ReactTooltip>
+      // </ReactTooltip>
     );
   }
 }

--- a/apps/src/templates/teacherDashboard/SectionScriptProgress.js
+++ b/apps/src/templates/teacherDashboard/SectionScriptProgress.js
@@ -57,8 +57,21 @@ export default class SectionScriptProgress extends Component {
     return levelsByLesson(fakeState);
   }
 
+  // TODO: temporary logging to help debugging
+  componentDidMount() {
+    const now = new Date();
+    console.log('cDM', now - this.renderTime);
+  }
+
+  componentDidUpdate() {
+    const now = new Date();
+    console.log('cDU', now - this.renderTime);
+  }
+
   render() {
     const { section, scriptData } = this.props;
+    console.log('render');
+    this.renderTime = new Date();
 
     return (
       <div>

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -327,6 +327,12 @@ acorn@^5.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
 
+add-dom-event-listener@1.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz#8faed2c41008721cf111da1d30d995b85be42bed"
+  dependencies:
+    object-assign "4.x"
+
 adm-zip@^0.4.7:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.7.tgz#8606c2cbf1c426ce8c8ec00174447fd49b6eafc1"
@@ -2110,7 +2116,7 @@ babel-register@^6.9.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@6.x.x, babel-runtime@^6.18.0, babel-runtime@^6.26.0, babel-runtime@^6.9.1, babel-runtime@^6.9.2:
+babel-runtime@6.x, babel-runtime@6.x.x, babel-runtime@^6.18.0, babel-runtime@^6.26.0, babel-runtime@^6.9.1, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -3137,6 +3143,12 @@ component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
 
+component-classes@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/component-classes/-/component-classes-1.2.6.tgz#c642394c3618a4d8b0b8919efccbbd930e5cd691"
+  dependencies:
+    component-indexof "0.0.3"
+
 component-emitter@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
@@ -3144,6 +3156,10 @@ component-emitter@1.1.2:
 component-emitter@1.2.1, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
+component-indexof@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-indexof/-/component-indexof-0.0.3.tgz#11d091312239eb8f32c8f25ae9cb002ffe8d3c24"
 
 component-inherit@0.0.3:
   version "0.0.3"
@@ -3369,7 +3385,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.6.2:
+create-react-class@15.x, create-react-class@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
   dependencies:
@@ -3439,6 +3455,13 @@ crypto-random-string@^1.0.0:
 csextends@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/csextends/-/csextends-1.0.3.tgz#df41407bfddb1837ecc2dd28587725d6af9550f8"
+
+css-animation@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/css-animation/-/css-animation-1.4.1.tgz#5b8813125de0fbbbb0bbe1b472ae84221469b7a8"
+  dependencies:
+    babel-runtime "6.x"
+    component-classes "^1.2.5"
 
 css-color-names@0.0.4:
   version "0.0.4"
@@ -3904,6 +3927,10 @@ doctrine@^2.0.0:
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+dom-align@1.x:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.6.7.tgz#6858138efb6b77405ce99146d0be5e4f7282813f"
 
 dom-confetti@~0.0.7:
   version "0.0.8"
@@ -8461,13 +8488,13 @@ object-assign@4.1.0, object-assign@^4.0.0, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
+object-assign@4.x, object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
 object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
-
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-component@0.0.3:
   version "0.0.3"
@@ -9398,20 +9425,20 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8:
-  version "15.5.10"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-
-prop-types@^15.5.6, prop-types@^15.5.9, prop-types@^15.6.0:
+prop-types@15.x, prop-types@^15.5.6, prop-types@^15.5.9, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 proxy-addr@~2.0.2:
   version "2.0.2"
@@ -9609,6 +9636,51 @@ raw-body@~2.2.0:
 raw-loader@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
+
+rc-align@2.x:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-2.3.5.tgz#5085cfa4d685ee9d030b9afd2971eb370c5e80a1"
+  dependencies:
+    babel-runtime "^6.26.0"
+    dom-align "1.x"
+    prop-types "^15.5.8"
+    rc-util "^4.0.4"
+
+rc-animate@2.x:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.4.4.tgz#a05a784c747beef140d99ff52b6117711bef4b1e"
+  dependencies:
+    babel-runtime "6.x"
+    css-animation "^1.3.2"
+    prop-types "15.x"
+
+rc-tooltip@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-3.7.0.tgz#3afbf109865f7cdcfe43752f3f3f501f7be37aaa"
+  dependencies:
+    babel-runtime "6.x"
+    prop-types "^15.5.8"
+    rc-trigger "^2.2.2"
+
+rc-trigger@^2.2.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-2.3.3.tgz#406c5ddea594aca71d067852f27d91a5f3a653b8"
+  dependencies:
+    babel-runtime "6.x"
+    create-react-class "15.x"
+    prop-types "15.x"
+    rc-align "2.x"
+    rc-animate "2.x"
+    rc-util "^4.3.0"
+
+rc-util@^4.0.4, rc-util@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.3.1.tgz#79f0adb30f449c1b29d7c5cdb2d82c193920c362"
+  dependencies:
+    add-dom-event-listener "1.x"
+    babel-runtime "6.x"
+    prop-types "^15.5.10"
+    shallowequal "^0.2.2"
 
 rc@~1.1.6:
   version "1.1.6"


### PR DESCRIPTION
We currently use https://github.com/wwayne/react-tooltip for our tooltip needs. I've never loved the pattern used for tooltips with this library, but it has worked well enough for us.

Recently we did some initial work to use React's ProgressBubbles in in teacher dashboard progress tab. This means rendering a lot more ProgressBubbles at once than we have in the past. Doing so for lots of students reveal some serious performance issues, specifically with the ReactTooltip component.  Specifically, for a section with 89 students, we spent 45s figuring out what to render when using ReactTooltip, but 6-9s when we removed the tooltip.

This led to me exploring other options. There aren't a lot of tooltip libraries out there, but one that I like the look of better is http://react-component.github.io/tooltip/.

Instead of doing something like this:
```jsx
<div data-for="my-tooltip">Interesting text that you should mouse over</div>
<Tooltip id="my-tooltip">This is what you see if you mouse over</div>
```
it allows you to do this
```jsx
<Tooltip
  overlay={<div>This is what you see if you mouse over</div>}
/>
  Interesting text that you should mouse over
</Tooltip>
```

For me, this is much easier to reason about - especially since in example one, there's no guarantee the two components are actually co-located. It also has the benefit of making it so that we don't have to do a `querySelector` when rendering our tooltip to find the matching parent. It is this query that was causing our perf issues.

I've also validated that we don't have the same perf issues with this library.

### Drawbacks
rc-tooltip has a preference for using classNames/css for styling. They provide a css file that you can use to make this easy, but we don't have any great ways of integrating this into our build system. We could stick this css somewhere like `user-progres.scss`, which seems to be loaded by both dashboard and pegasus, but in general our system doesn't have a great way of ensuring that certain CSS exists for certain JS.

I've managed to semi-hack my way around this by transferring some of the styling into inlined styles. Right now it only supports `top` arrows, but it shouldn't be too too difficult to support others as well.

This brings me to the second drawback, which is positioning our tooltip. Our currently library has some logic to flip from being on top to being below if it doesn't fit. I think that is what the code here is doing https://github.com/wwayne/react-tooltip/blob/master/src/index.js#L389. Our new library does not have that logic, which becomes an issue in our header:
![image](https://user-images.githubusercontent.com/1767466/35127309-6c52d042-fc66-11e7-8bcb-5dd9595f55e5.png)
