### PR TITLE
Draw sticker size bug

### DIFF
--- a/apps/src/turtle/turtle.js
+++ b/apps/src/turtle/turtle.js
@@ -1616,7 +1616,7 @@ Artist.prototype.step = function (command, values, options) {
  */
 function scaleToBoundingBox(maxSize, width, height) {
   if (width < maxSize && height < maxSize) {
-    return {width: width, height: height};
+    return {width: maxSize, height: maxSize};
   }
 
   var newWidth;

--- a/apps/test/unit/turtle/turtleTest.js
+++ b/apps/test/unit/turtle/turtleTest.js
@@ -152,7 +152,7 @@ describe('Artist', () => {
       artist.stickers = {Alien:img};
       artist.step('sticker', ['Alien', size, blockId], options);
 
-      expect(setStickerSize).to.be.have.been.calledWith(img, 0, 0, 100, 100, -50, -100, 100, 100);
+      expect(setStickerSize).to.be.have.been.calledWith(img, 0, 0, 100, 100, -100, -200, 200, 200);
 
       setStickerSize.restore();
     });


### PR DESCRIPTION
This PR shows the solution that allows users to draw a sticker to any size.

Bug:
Sticker sizes larger than 100 are capped at 100.

![max-size-sticker-bug-v1](https://user-images.githubusercontent.com/30066710/38152953-295367d4-341f-11e8-97bc-9b2722382fa5.gif)

Solution:
-Check the dimensions of all the sticker assets 
-Since all the sticker assets have a width and height of 100, a condition to account for if the width or height is different is not required.  
-When a size greater than a 100 is entered, the width and height of the sticker is set to the size in the scaleToBoundingBox function and drawn to the new setting. 

![max-size-sticker-bug-fix](https://user-images.githubusercontent.com/30066710/38152957-2ddec082-341f-11e8-88fb-f41c8d5e7286.gif)
