### PR TITLE
re-enable Pegasus page rendering test

### DIFF
--- a/pegasus/test/test_pegasus_documents.rb
+++ b/pegasus/test/test_pegasus_documents.rb
@@ -88,9 +88,6 @@ class PegasusTest < Minitest::Test
   ]
 
   def test_render_pegasus_documents
-    # TODO: (@brendan) re-enable this test after resolving Advocacy pages
-    skip 'temporarily skip this test because changes to the Advocacy site are failing.  Brendan will re-enable'
-
     all_documents = app.helpers.all_documents.reject do |page|
       # 'Splat' documents not yet handled.
       page[:uri].end_with?('/splat') ||


### PR DESCRIPTION
This test was disabled on Thursday 4/5 due to a problem with a page in the Pegasus Advocacy site