### PR TITLE
Update asset_path for pegasus_skip_asset_map

### DIFF
--- a/pegasus/helpers/asset_helpers.rb
+++ b/pegasus/helpers/asset_helpers.rb
@@ -20,7 +20,7 @@ class AssetMap
 
   def asset_path(asset)
     # Don't require developers or unit tests to precompile assets.
-    return CDO.studio_url("/assets/#{asset}") if CDO.pegasus_skip_asset_map
+    return CDO.studio_url("/blockly/#{asset}") if CDO.pegasus_skip_asset_map
     raise "Asset map not initialized" unless @asset_map
     asset_path = @asset_map[asset]
     raise "Asset not found in asset map: '#{asset}'" unless asset_path

--- a/pegasus/test/test_asset_helpers.rb
+++ b/pegasus/test/test_asset_helpers.rb
@@ -3,14 +3,14 @@ require_relative '../helpers/asset_helpers'
 
 class AssetHelpersTest < Minitest::Test
   UNMINIFIED_ASSET_NAME = 'js/public/abcxyz/index.js'.freeze
-  UNDIGESTED_ASSET_PATH = "#{CDO.studio_url}/assets/js/public/abcxyz/index.js".freeze
+  UNDIGESTED_ASSET_PATH = "#{CDO.studio_url}/blockly/js/public/abcxyz/index.js".freeze
   UNMINIFIED_ASSET_PATH = "#{CDO.studio_url}/assets/js/public/abcxyz/"\
     'index-ef90e2acd9003ff8b8bac522e6ce107da641d3b85aba5f58c77d5d28f77a496a.js'.freeze
   MINIFIED_ASSET_PATH = "#{CDO.studio_url}/assets/js/public/abcxyz/"\
     'index.min-5bb3b68c6f92cf8409eb7d0649cf572ffa0c66fca1b02b887b4454cab553daef.js'.freeze
   UNMINIFIED_ASSET_NOT_IN_MAP = 'foo.js'.freeze
   MINIFIED_ASSET_NOT_IN_MAP = 'foo.min.js'.freeze
-  UNDIGESTED_ASSET_PATH_NOT_IN_MAP = "#{CDO.studio_url}/assets/foo.js".freeze
+  UNDIGESTED_ASSET_PATH_NOT_IN_MAP = "#{CDO.studio_url}/blockly/foo.js".freeze
 
   def setup
     CDO.stubs(:pegasus_skip_asset_map).returns(false)


### PR DESCRIPTION
When `pegasus_skip_asset_map` is true (developers/unit tests), `asset_path` should resolve to `/blockly/` (symlink to the current apps build) rather than `/assets` (latest precompiled assets).

This fixes an issue where running `asset:precompile` was necessary to see updated results in bundles linked by the `asset_path` or `minifiable_asset_path` tag helpers.