### PR TITLE
Filter query-string based on http-cache configuration setting

### DIFF
--- a/cookbooks/cdo-varnish/README.md
+++ b/cookbooks/cdo-varnish/README.md
@@ -36,6 +36,7 @@ HTTP cache layers.
     - Note: Objects are already cached based on the `Host` header by default.
     - Note: `headers` is currently only used by CloudFront, while Varnish
       caches objects based on the `Vary` HTTP response header.
+  - `query`: Forward query strings to the origin. If so, specify `true`; if not, specify `false`.
   - `cookies`: A whitelist array of HTTP cookie keys to pass to the origin and
     include in the cache key.
     To whitelist all cookies for the path, pass `'all'`.

--- a/cookbooks/cdo-varnish/libraries/helpers.rb
+++ b/cookbooks/cdo-varnish/libraries/helpers.rb
@@ -156,6 +156,9 @@ def process_request(behavior, _)
       cookies.map {|c| extract_cookie(c)}.join + "cookie.filter_except(\"#{cookies.join(',')}\");"
     end
   )
+  unless behavior[:query]
+    out << "\n" + 'set req.url = regsub(req.url, "\?.*$", "");'
+  end
   REMOVED_HEADERS.each do |remove_header|
     name, value = remove_header.split ':'
     next if behavior[:headers].include? name

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -72,6 +72,7 @@ class HttpCache
           {
             path: '/api/hour/*',
             headers: LANGUAGE_HEADER,
+            query: true,
             # Allow the company cookie to be read and set to track company users for tutorials.
             cookies: whitelisted_cookies + ['company']
           },
@@ -99,13 +100,30 @@ class HttpCache
               /poste*
             ),
             headers: LANGUAGE_HEADER,
+            query: true,
             cookies: whitelisted_cookies
           },
           {
             path: '/dashboardapi/*',
             proxy: 'dashboard',
             headers: LANGUAGE_HEADER,
+            query: true,
             cookies: whitelisted_cookies
+          },
+          # Cached paths that vary based on query-parameters.
+          {
+            path: %w(
+              /curriculum/*
+              /advocacy*
+              /yourschool
+              /certificates
+              /congrats
+              /custom-certificates
+              /printcertificate*
+            ),
+            query: true,
+            headers: LANGUAGE_HEADER,
+            cookies: default_cookies
           }
         ],
         # Remaining Pegasus paths are cached, and vary only on language and default cookies.
@@ -131,6 +149,7 @@ class HttpCache
               /v3/files/*
             ),
             headers: LANGUAGE_HEADER,
+            query: true,
             cookies: whitelisted_cookies
           },
           {
@@ -143,6 +162,7 @@ class HttpCache
               /milestone/*
             ),
             headers: LANGUAGE_HEADER + ['User-Agent'],
+            query: true,
             cookies: whitelisted_cookies
           },
           {
@@ -158,6 +178,7 @@ class HttpCache
           {
             path: '/api/*',
             headers: LANGUAGE_HEADER,
+            query: true,
             cookies: whitelisted_cookies
           },
           {
@@ -170,6 +191,7 @@ class HttpCache
             path: '/v2/*',
             proxy: 'pegasus',
             headers: LANGUAGE_HEADER,
+            query: true,
             cookies: whitelisted_cookies
           },
           {
@@ -181,6 +203,7 @@ class HttpCache
         # Default Dashboard paths are session-specific, whitelist all session cookies and language header.
         default: {
           headers: LANGUAGE_HEADER,
+          query: true,
           cookies: whitelisted_cookies
         }
       }

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -217,7 +217,7 @@ module AWS
           Cookies: cookie_config,
           # Always explicitly include Host and CloudFront-Forwarded-Proto headers in CloudFront's cache key, to match Varnish defaults.
           Headers: headers,
-          QueryString: true
+          QueryString: !!behavior_config[:query]
         },
         MaxTTL: 31_536_000, # =1 year,
         MinTTL: 0,

--- a/lib/cdo/rack/whitelist.rb
+++ b/lib/cdo/rack/whitelist.rb
@@ -27,7 +27,7 @@ module Rack
         unless behavior[:query]
           env[Rack::RACK_REQUEST_QUERY_STRING] = ''
           env[Rack::QUERY_STRING] = ''
-          env[Rack::RACK_REQUEST_QUERY_HASH].clear
+          env[Rack::RACK_REQUEST_QUERY_HASH]&.clear
         end
 
         # Filter whitelisted request headers.

--- a/lib/cdo/rack/whitelist.rb
+++ b/lib/cdo/rack/whitelist.rb
@@ -7,7 +7,7 @@ require 'cdo/aws/cloudfront'
 
 module Rack
   module Whitelist
-    # Downstream middleware filters out unwanted HTTP request headers and cookies,
+    # Downstream middleware filters out unwanted HTTP request headers, query parameters and cookies,
     # and extracts cookies into HTTP headers before the request reaches the cache.
     class Downstream
       attr_reader :config
@@ -22,6 +22,13 @@ module Rack
         request = Rack::Request.new(env)
         path = request.path
         behavior = behavior_for_path((config[:behaviors] + [config[:default]]), path)
+
+        # Filter query string.
+        unless behavior[:query]
+          env[Rack::RACK_REQUEST_QUERY_STRING] = ''
+          env[Rack::QUERY_STRING] = ''
+          env[Rack::RACK_REQUEST_QUERY_HASH].clear
+        end
 
         # Filter whitelisted request headers.
         headers = behavior[:headers]

--- a/shared/test/test_varnish_helpers.rb
+++ b/shared/test/test_varnish_helpers.rb
@@ -74,18 +74,20 @@ STR
   BEHAVIOR = {
     dashboard: {
       behaviors: [],
-      default: {cookies: 'all', headers: HEADERS}
+      default: {cookies: 'all', query: true, headers: HEADERS}
     },
     pegasus: {
       behaviors: [
         {
           path: '/api/*',
           headers: HEADERS,
+          query: true,
           cookies: 'all'
         },
         {
           path: '/',
           headers: HEADERS,
+          query: true,
           cookies: ['1']
         }
       ],
@@ -108,6 +110,7 @@ if (req.http.host ~ "(dashboard|studio)") {
     cookie.filter_except("1");
   } else {
     cookie.filter_except("NO_CACHE");
+    set req.url = regsub(req.url, \"\\?.*$\", \"\");
   }
 }
 STR


### PR DESCRIPTION
This PR adds a new http-cache configuration behavior parameter (`query`) that specifies whether query-strings should be forwarded to the origin and included in the http-cache key.

In general, cached pages usually don't vary their response based on provided query parameters, so we can simply filter out the query string where pages are cached.

Searching through our current site content, I found a small handful of pages that _do_ vary cached content based on query parameters (e.g., `pdf_version` on `curriculum`/`advocacy` pages, and various parameters on HoC-certificate pages), so I've added a separate set of cache-behaviors for these exceptions.

 I've added a query-string filter based on the `query` behavior parameter to all three of our http-cache implementations (Rack, Varnish, and CloudFront (using the [`QueryString`](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ForwardedValues.html#cloudfront-Type-ForwardedValues-QueryString) CloudFront-distribution configuration option)).

This will improve cacheability, and also mitigate against [HTTP flood/cache-busting (layer 7) attacks](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html#types-of-ddos-attacks) on these cached endpoints:

> With an HTTP flood, including GET and POST floods, an attacker sends multiple HTTP requests that appear to be from a real user of the web application. Cache-busting attacks are a type of HTTP flood that uses variations in the HTTP request's query string that prevent use of edge-located cached content and forces the content to be served from the origin web server, causing additional and potentially damaging strain on the origin web server.

See Also:
- [A Web Developers Guide to Defeating an Application Layer DDoS Attack: Aggressive Caching](https://blog.cloudflare.com/the-new-ddos-landscape/#aggressivecaching) (CloudFlare Blog, Nov 2017)
- [AWS Shield: Types of DDoS Attacks](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html#types-of-ddos-attacks)
- [AWS Best Practices for DDos Resiliency](https://d0.awsstatic.com/whitepapers/Security/DDoS_White_Paper.pdf) (June 2016)