### PR TITLE
Geocode hoc activity: fix for three-letter state codes on levelbuilder

### DIFF
--- a/bin/cron/geocode_hoc_activity
+++ b/bin/cron/geocode_hoc_activity
@@ -31,14 +31,18 @@ def main
       if location.latitude && location.longitude
         position = "#{location.latitude}, #{location.longitude}"
       end
-      DB[:hoc_activity].where(id: row[:id]).update(
-        country: location.country,
-        country_code: location.country_code,
-        state: location.state,
-        state_code: location.state_code,
-        city: location.city,
-        location: position,
-      )
+      if location.state_code.length > 2
+        puts "Skipping #{row[:id]} with state_code #{location.state_code}"
+      else
+        DB[:hoc_activity].where(id: row[:id]).update(
+          country: location.country,
+          country_code: location.country_code,
+          state: location.state,
+          state_code: location.state_code,
+          city: location.city,
+          location: position,
+        )
+      end
     end
 
     last_index = row[:id]


### PR DESCRIPTION
Honeybadger noted some errors in the `geocode_hoc_activity` cron job that runs every minute, on levelbuilder of all environments.  Not yet understood why, but the Geocoder was returning results with three-characters that we were attempting to store as two-character state codes, which was failing.

The fix was to make this change temporarily on levelbuilder to help it skip over the offending entries (which included three-character strings such as CMX, PAC, and ANT).