### PR TITLE
implement Request#gdpr?

### DIFF
--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -7,6 +7,8 @@ class HttpCache
 
   # Language header and cookie are needed to separately cache language-specific pages.
   LANGUAGE_HEADER = %w(Accept-Language).freeze
+  COUNTRY_HEADER = %w(CloudFront-Viewer-Country).freeze
+  WHITELISTED_HEADERS = LANGUAGE_HEADER + COUNTRY_HEADER
 
   DEFAULT_COOKIES = [
     # Language drop-down selection.
@@ -71,7 +73,7 @@ class HttpCache
         behaviors: [
           {
             path: '/api/hour/*',
-            headers: LANGUAGE_HEADER,
+            headers: WHITELISTED_HEADERS,
             # Allow the company cookie to be read and set to track company users for tutorials.
             cookies: whitelisted_cookies + ['company']
           },
@@ -98,13 +100,13 @@ class HttpCache
               /pd-program-registration*
               /poste*
             ),
-            headers: LANGUAGE_HEADER,
+            headers: WHITELISTED_HEADERS,
             cookies: whitelisted_cookies
           },
           {
             path: '/dashboardapi/*',
             proxy: 'dashboard',
-            headers: LANGUAGE_HEADER,
+            headers: WHITELISTED_HEADERS,
             cookies: whitelisted_cookies
           }
         ],
@@ -130,7 +132,7 @@ class HttpCache
               /v3/animations/*
               /v3/files/*
             ),
-            headers: LANGUAGE_HEADER,
+            headers: WHITELISTED_HEADERS,
             cookies: whitelisted_cookies
           },
           {
@@ -142,12 +144,12 @@ class HttpCache
               /api/user_progress/*
               /milestone/*
             ),
-            headers: LANGUAGE_HEADER + ['User-Agent'],
+            headers: WHITELISTED_HEADERS + ['User-Agent'],
             cookies: whitelisted_cookies
           },
           {
             path: CACHED_SCRIPTS_MAP.values,
-            headers: LANGUAGE_HEADER,
+            headers: WHITELISTED_HEADERS,
             cookies: default_cookies
           },
           {
@@ -157,7 +159,7 @@ class HttpCache
           },
           {
             path: '/api/*',
-            headers: LANGUAGE_HEADER,
+            headers: WHITELISTED_HEADERS,
             cookies: whitelisted_cookies
           },
           {
@@ -169,7 +171,7 @@ class HttpCache
           {
             path: '/v2/*',
             proxy: 'pegasus',
-            headers: LANGUAGE_HEADER,
+            headers: WHITELISTED_HEADERS,
             cookies: whitelisted_cookies
           },
           {
@@ -180,7 +182,7 @@ class HttpCache
         ],
         # Default Dashboard paths are session-specific, whitelist all session cookies and language header.
         default: {
-          headers: LANGUAGE_HEADER,
+          headers: WHITELISTED_HEADERS,
           cookies: whitelisted_cookies
         }
       }

--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -1,6 +1,7 @@
 require 'rack/request'
 require 'ipaddr'
 require 'json'
+require 'country_codes'
 
 module Cdo
   module RequestExtension
@@ -100,6 +101,15 @@ module Cdo
       warden.first.first
     rescue
       return nil
+    end
+
+    def country
+      env['HTTP_CLOUDFRONT_VIEWER_COUNTRY'] ||
+        location&.country_code
+    end
+
+    def gdpr?
+      gdpr_country_code?(country)
     end
   end
 end

--- a/lib/country_codes.rb
+++ b/lib/country_codes.rb
@@ -250,6 +250,40 @@ COUNTRY_CODE_TO_COUNTRY_NAME = {
   "ZW" => "Zimbabwe",
 }.freeze
 
+# ISO 3166 alpha-2 country codes for Member States of the European Union.
+# Source: http://publications.europa.eu/code/pdf/370000en.htm
+# ISO codes for Greece (GR) and United Kingdom (GB) are listed instead of their recommended abbreviations (EL and UK).
+EU_COUNTRY_CODES = %w(
+  AT
+  BE
+  BG
+  CY
+  CZ
+  DE
+  DK
+  EE
+  ES
+  FI
+  FR
+  GB
+  GR
+  HR
+  HU
+  IE
+  IT
+  LT
+  LU
+  LV
+  MT
+  NL
+  PL
+  PT
+  RO
+  SE
+  SI
+  SK
+).freeze
+
 # Returns the name of the country whose two character country code is code.
 # If code is not a valid two character country code, returns code.
 def country_name_from_code(code)
@@ -263,4 +297,11 @@ end
 
 def valid_country_code?(code)
   return COUNTRY_CODE_TO_COUNTRY_NAME[code.to_s.strip.upcase].present?
+end
+
+# @return true if the provided alpha-2 country code represents a
+# member state of the European Union covered by the GDPR.
+def gdpr_country_code?(code)
+  return false if code.nil?
+  EU_COUNTRY_CODES.include?(code.to_s.strip.upcase)
 end

--- a/lib/country_codes.rb
+++ b/lib/country_codes.rb
@@ -284,6 +284,14 @@ EU_COUNTRY_CODES = %w(
   SK
 ).freeze
 
+# EEA = EU + Iceland, Liechtenstein and Norway.
+EEA_COUNTRY_CODES = EU_COUNTRY_CODES +
+  %w(
+    IS
+    LI
+    NO
+  )
+
 # Returns the name of the country whose two character country code is code.
 # If code is not a valid two character country code, returns code.
 def country_name_from_code(code)
@@ -303,5 +311,5 @@ end
 # member state of the European Union covered by the GDPR.
 def gdpr_country_code?(code)
   return false if code.nil?
-  EU_COUNTRY_CODES.include?(code.to_s.strip.upcase)
+  EEA_COUNTRY_CODES.include?(code.to_s.strip.upcase)
 end

--- a/pegasus/routes/v2_geocoder_routes.rb
+++ b/pegasus/routes/v2_geocoder_routes.rb
@@ -21,3 +21,12 @@ get '/v2/client-location' do
   content_type :json
   JSON.pretty_generate(location)
 end
+
+get '/v2/country' do
+  dont_cache
+  content_type :json
+  JSON.pretty_generate(
+    country: request.country,
+    gdpr: request.gdpr?
+  )
+end


### PR DESCRIPTION
Adds a `request.gdpr?` method that inspects the [`CloudFront-Viewer-Country`](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html#header-caching-web-location) HTTP request header, using our own IP-based geolocation as a fallback if this header is not available.

In addition:
- Adds a `EU_COUNTRY_CODES` constant containing the alpha-2 country codes of all 28 [EU member states](http://publications.europa.eu/code/pdf/370000en.htm) (This list will need to be maintained over time if/when EU membership ever changes), along with a `gdpr_country_code?` helper method that maps country code to a 'gdpr jurisdiction' boolean.
- Adds a `request.country` method that returns the alpha-2 country code of the current request which might be useful in other country-filtering contexts beyond gdpr inclusion.
- Whitelists the `CloudFront-Viewer-Country` header in all non-cached CloudFront path behaviors so the header is included in all requests to these paths.
- Adds a `/v2/country` JSON API, for testing and checking via client-side XHR on static/cached pages.