### PR TITLE
Rename primary_authentication_option to primary_contact_info

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -125,12 +125,12 @@ class RegistrationsController < Devise::RegistrationsController
           false
         elsif needs_password?(current_user, params)
           if current_user.valid_password?(params[:user][:current_password])
-            current_user.update_primary_authentication_option(user: set_email_params)
+            current_user.update_primary_contact_info(user: set_email_params)
           else
             false
           end
         else
-          current_user.update_primary_authentication_option(user: set_email_params)
+          current_user.update_primary_contact_info(user: set_email_params)
         end
       else
         if forbidden_change?(current_user, params)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2,53 +2,53 @@
 #
 # Table name: users
 #
-#  id                               :integer          not null, primary key
-#  studio_person_id                 :integer
-#  email                            :string(255)      default(""), not null
-#  parent_email                     :string(255)
-#  encrypted_password               :string(255)      default("")
-#  reset_password_token             :string(255)
-#  reset_password_sent_at           :datetime
-#  remember_created_at              :datetime
-#  sign_in_count                    :integer          default(0)
-#  current_sign_in_at               :datetime
-#  last_sign_in_at                  :datetime
-#  current_sign_in_ip               :string(255)
-#  last_sign_in_ip                  :string(255)
-#  created_at                       :datetime
-#  updated_at                       :datetime
-#  username                         :string(255)
-#  provider                         :string(255)
-#  uid                              :string(255)
-#  admin                            :boolean
-#  gender                           :string(1)
-#  name                             :string(255)
-#  locale                           :string(10)       default("en-US"), not null
-#  birthday                         :date
-#  user_type                        :string(16)
-#  school                           :string(255)
-#  full_address                     :string(1024)
-#  school_info_id                   :integer
-#  total_lines                      :integer          default(0), not null
-#  secret_picture_id                :integer
-#  active                           :boolean          default(TRUE), not null
-#  hashed_email                     :string(255)
-#  deleted_at                       :datetime
-#  purged_at                        :datetime
-#  secret_words                     :string(255)
-#  properties                       :text(65535)
-#  invitation_token                 :string(255)
-#  invitation_created_at            :datetime
-#  invitation_sent_at               :datetime
-#  invitation_accepted_at           :datetime
-#  invitation_limit                 :integer
-#  invited_by_id                    :integer
-#  invited_by_type                  :string(255)
-#  invitations_count                :integer          default(0)
-#  terms_of_service_version         :integer
-#  urm                              :boolean
-#  races                            :string(255)
-#  primary_authentication_option_id :integer
+#  id                       :integer          not null, primary key
+#  studio_person_id         :integer
+#  email                    :string(255)      default(""), not null
+#  parent_email             :string(255)
+#  encrypted_password       :string(255)      default("")
+#  reset_password_token     :string(255)
+#  reset_password_sent_at   :datetime
+#  remember_created_at      :datetime
+#  sign_in_count            :integer          default(0)
+#  current_sign_in_at       :datetime
+#  last_sign_in_at          :datetime
+#  current_sign_in_ip       :string(255)
+#  last_sign_in_ip          :string(255)
+#  created_at               :datetime
+#  updated_at               :datetime
+#  username                 :string(255)
+#  provider                 :string(255)
+#  uid                      :string(255)
+#  admin                    :boolean
+#  gender                   :string(1)
+#  name                     :string(255)
+#  locale                   :string(10)       default("en-US"), not null
+#  birthday                 :date
+#  user_type                :string(16)
+#  school                   :string(255)
+#  full_address             :string(1024)
+#  school_info_id           :integer
+#  total_lines              :integer          default(0), not null
+#  secret_picture_id        :integer
+#  active                   :boolean          default(TRUE), not null
+#  hashed_email             :string(255)
+#  deleted_at               :datetime
+#  purged_at                :datetime
+#  secret_words             :string(255)
+#  properties               :text(65535)
+#  invitation_token         :string(255)
+#  invitation_created_at    :datetime
+#  invitation_sent_at       :datetime
+#  invitation_accepted_at   :datetime
+#  invitation_limit         :integer
+#  invited_by_id            :integer
+#  invited_by_type          :string(255)
+#  invitations_count        :integer          default(0)
+#  terms_of_service_version :integer
+#  urm                      :boolean
+#  races                    :string(255)
+#  primary_contact_info_id  :integer
 #
 # Indexes
 #
@@ -219,7 +219,7 @@ class User < ActiveRecord::Base
   has_many :districts, through: :districts_users
 
   has_many :authentication_options, dependent: :destroy
-  belongs_to :primary_authentication_option, class_name: 'AuthenticationOption'
+  belongs_to :primary_contact_info, class_name: 'AuthenticationOption'
 
   belongs_to :school_info
   accepts_nested_attributes_for :school_info, reject_if: :preprocess_school_info
@@ -288,12 +288,12 @@ class User < ActiveRecord::Base
 
   def email
     return read_attribute(:email) unless migrated?
-    primary_authentication_option.try(:email) || ''
+    primary_contact_info.try(:email) || ''
   end
 
   def hashed_email
     return read_attribute(:hashed_email) unless migrated?
-    primary_authentication_option.try(:hashed_email) || ''
+    primary_contact_info.try(:hashed_email) || ''
   end
 
   def facilitator?
@@ -839,7 +839,7 @@ class User < ActiveRecord::Base
     end
   end
 
-  def update_primary_authentication_option(user: {email: nil, hashed_email: nil})
+  def update_primary_contact_info(user: {email: nil, hashed_email: nil})
     email = user[:email]
     hashed_email = user[:hashed_email]
 
@@ -853,14 +853,14 @@ class User < ActiveRecord::Base
     # If an auth option exists with same email, set it to the user's primary authentication option
     existing_auth_option = authentication_options.find {|ao| ao.email == email || ao.hashed_email == hashed_email}
     if existing_auth_option
-      self.primary_authentication_option = existing_auth_option
+      self.primary_contact_info = existing_auth_option
       return save
     end
 
     params = {credential_type: 'email', user: self}
     params[:email] = email unless email.nil?
     params[:hashed_email] = hashed_email if email.nil?
-    self.primary_authentication_option = AuthenticationOption.new(params)
+    self.primary_contact_info = AuthenticationOption.new(params)
     return save
   end
 

--- a/dashboard/app/serializers/user_serializer.rb
+++ b/dashboard/app/serializers/user_serializer.rb
@@ -2,53 +2,53 @@
 #
 # Table name: users
 #
-#  id                               :integer          not null, primary key
-#  studio_person_id                 :integer
-#  email                            :string(255)      default(""), not null
-#  parent_email                     :string(255)
-#  encrypted_password               :string(255)      default("")
-#  reset_password_token             :string(255)
-#  reset_password_sent_at           :datetime
-#  remember_created_at              :datetime
-#  sign_in_count                    :integer          default(0)
-#  current_sign_in_at               :datetime
-#  last_sign_in_at                  :datetime
-#  current_sign_in_ip               :string(255)
-#  last_sign_in_ip                  :string(255)
-#  created_at                       :datetime
-#  updated_at                       :datetime
-#  username                         :string(255)
-#  provider                         :string(255)
-#  uid                              :string(255)
-#  admin                            :boolean
-#  gender                           :string(1)
-#  name                             :string(255)
-#  locale                           :string(10)       default("en-US"), not null
-#  birthday                         :date
-#  user_type                        :string(16)
-#  school                           :string(255)
-#  full_address                     :string(1024)
-#  school_info_id                   :integer
-#  total_lines                      :integer          default(0), not null
-#  secret_picture_id                :integer
-#  active                           :boolean          default(TRUE), not null
-#  hashed_email                     :string(255)
-#  deleted_at                       :datetime
-#  purged_at                        :datetime
-#  secret_words                     :string(255)
-#  properties                       :text(65535)
-#  invitation_token                 :string(255)
-#  invitation_created_at            :datetime
-#  invitation_sent_at               :datetime
-#  invitation_accepted_at           :datetime
-#  invitation_limit                 :integer
-#  invited_by_id                    :integer
-#  invited_by_type                  :string(255)
-#  invitations_count                :integer          default(0)
-#  terms_of_service_version         :integer
-#  urm                              :boolean
-#  races                            :string(255)
-#  primary_authentication_option_id :integer
+#  id                       :integer          not null, primary key
+#  studio_person_id         :integer
+#  email                    :string(255)      default(""), not null
+#  parent_email             :string(255)
+#  encrypted_password       :string(255)      default("")
+#  reset_password_token     :string(255)
+#  reset_password_sent_at   :datetime
+#  remember_created_at      :datetime
+#  sign_in_count            :integer          default(0)
+#  current_sign_in_at       :datetime
+#  last_sign_in_at          :datetime
+#  current_sign_in_ip       :string(255)
+#  last_sign_in_ip          :string(255)
+#  created_at               :datetime
+#  updated_at               :datetime
+#  username                 :string(255)
+#  provider                 :string(255)
+#  uid                      :string(255)
+#  admin                    :boolean
+#  gender                   :string(1)
+#  name                     :string(255)
+#  locale                   :string(10)       default("en-US"), not null
+#  birthday                 :date
+#  user_type                :string(16)
+#  school                   :string(255)
+#  full_address             :string(1024)
+#  school_info_id           :integer
+#  total_lines              :integer          default(0), not null
+#  secret_picture_id        :integer
+#  active                   :boolean          default(TRUE), not null
+#  hashed_email             :string(255)
+#  deleted_at               :datetime
+#  purged_at                :datetime
+#  secret_words             :string(255)
+#  properties               :text(65535)
+#  invitation_token         :string(255)
+#  invitation_created_at    :datetime
+#  invitation_sent_at       :datetime
+#  invitation_accepted_at   :datetime
+#  invitation_limit         :integer
+#  invited_by_id            :integer
+#  invited_by_type          :string(255)
+#  invitations_count        :integer          default(0)
+#  terms_of_service_version :integer
+#  urm                      :boolean
+#  races                    :string(255)
+#  primary_contact_info_id  :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20180621001650_rename_primary_authentication_option.rb
+++ b/dashboard/db/migrate/20180621001650_rename_primary_authentication_option.rb
@@ -1,0 +1,5 @@
+class RenamePrimaryAuthenticationOption < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :users, :primary_authentication_option_id, :primary_contact_info_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180607153724) do
+ActiveRecord::Schema.define(version: 20180621001650) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1459,13 +1459,13 @@ ActiveRecord::Schema.define(version: 20180607153724) do
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "studio_person_id"
-    t.string   "email",                                          default: "",      null: false
+    t.string   "email",                                  default: "",      null: false
     t.string   "parent_email"
-    t.string   "encrypted_password",                             default: ""
+    t.string   "encrypted_password",                     default: ""
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                                  default: 0
+    t.integer  "sign_in_count",                          default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -1476,22 +1476,22 @@ ActiveRecord::Schema.define(version: 20180607153724) do
     t.string   "provider"
     t.string   "uid"
     t.boolean  "admin"
-    t.string   "gender",                           limit: 1
+    t.string   "gender",                   limit: 1
     t.string   "name"
-    t.string   "locale",                           limit: 10,    default: "en-US", null: false
+    t.string   "locale",                   limit: 10,    default: "en-US", null: false
     t.date     "birthday"
-    t.string   "user_type",                        limit: 16
+    t.string   "user_type",                limit: 16
     t.string   "school"
-    t.string   "full_address",                     limit: 1024
+    t.string   "full_address",             limit: 1024
     t.integer  "school_info_id"
-    t.integer  "total_lines",                                    default: 0,       null: false
+    t.integer  "total_lines",                            default: 0,       null: false
     t.integer  "secret_picture_id"
-    t.boolean  "active",                                         default: true,    null: false
+    t.boolean  "active",                                 default: true,    null: false
     t.string   "hashed_email"
     t.datetime "deleted_at"
     t.datetime "purged_at"
     t.string   "secret_words"
-    t.text     "properties",                       limit: 65535
+    t.text     "properties",               limit: 65535
     t.string   "invitation_token"
     t.datetime "invitation_created_at"
     t.datetime "invitation_sent_at"
@@ -1499,11 +1499,11 @@ ActiveRecord::Schema.define(version: 20180607153724) do
     t.integer  "invitation_limit"
     t.integer  "invited_by_id"
     t.string   "invited_by_type"
-    t.integer  "invitations_count",                              default: 0
+    t.integer  "invitations_count",                      default: 0
     t.integer  "terms_of_service_version"
     t.boolean  "urm"
     t.string   "races"
-    t.integer  "primary_authentication_option_id"
+    t.integer  "primary_contact_info_id"
     t.index ["birthday"], name: "index_users_on_birthday", using: :btree
     t.index ["current_sign_in_at"], name: "index_users_on_current_sign_in_at", using: :btree
     t.index ["deleted_at"], name: "index_users_on_deleted_at", using: :btree

--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -6,7 +6,7 @@ module UserMultiAuthHelper
     return true if migrated?
 
     unless sponsored?
-      self.primary_authentication_option =
+      self.primary_contact_info =
         if provider == 'google_oauth2'
           AuthenticationOption.new(
             user: self,

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -273,7 +273,7 @@ FactoryGirl.define do
           authentication_id: 'abcd123'
         )
         user.update!(
-          primary_authentication_option: ao,
+          primary_contact_info: ao,
           provider: User::PROVIDER_MIGRATED
         )
       end
@@ -313,7 +313,7 @@ FactoryGirl.define do
           authentication_id: user.hashed_email
         )
         user.update!(
-          primary_authentication_option: ao,
+          primary_contact_info: ao,
           provider: User::PROVIDER_MIGRATED
         )
       end

--- a/dashboard/test/lib/user_multi_auth_helper_test.rb
+++ b/dashboard/test/lib/user_multi_auth_helper_test.rb
@@ -34,7 +34,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
 
     assert_user user,
       sponsored?: true,
-      primary_authentication_option: nil,
+      primary_contact_info: nil,
       authentication_options: :empty
   end
 
@@ -61,7 +61,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
       hashed_email: '',
       username: :not_empty,
       encrypted_password: :not_empty,
-      primary_authentication_option: nil,
+      primary_contact_info: nil,
       authentication_options: :empty
   end
 
@@ -91,7 +91,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
       username: :not_empty,
       encrypted_password: :not_empty,
       parent_email: :not_empty,
-      primary_authentication_option: nil,
+      primary_contact_info: nil,
       authentication_options: :empty
   end
 
@@ -100,7 +100,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
     assert_empty user.email
     assert_convert_email_user user
     assert_empty user.email
-    assert_empty user.primary_authentication_option.email
+    assert_empty user.primary_contact_info.email
   end
 
   test 'convert email+password teacher' do
@@ -108,7 +108,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
     refute_empty user.email
     assert_convert_email_user user
     refute_empty user.email
-    refute_empty user.primary_authentication_option.email
+    refute_empty user.primary_contact_info.email
   end
 
   def assert_convert_email_user(user)
@@ -126,7 +126,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
       email: original_email,
       hashed_email: original_hashed_email,
       encrypted_password: :not_empty,
-      primary_authentication_option: {
+      primary_contact_info: {
         credential_type: 'email',
         authentication_id: original_hashed_email,
         email: original_email,
@@ -162,7 +162,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
     assert_user user,
       email: initial_email,
       hashed_email: initial_hashed_email,
-      primary_authentication_option: {
+      primary_contact_info: {
         credential_type: 'google_oauth2',
         authentication_id: initial_authentication_id,
         email: initial_email,
@@ -193,18 +193,18 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   #
   # Assert a set of attributes about a user.
   # See assert_attributes for details.
-  # Has special handling for :primary_authentication_option
+  # Has special handling for :primary_contact_info
   #
   def assert_user(user, expected_values)
     refute_nil user
-    expected_primary_option = expected_values.delete(:primary_authentication_option)
+    expected_primary_option = expected_values.delete(:primary_contact_info)
 
     assert_attributes user, expected_values
 
     if expected_primary_option.nil?
-      assert_nil user.primary_authentication_option
+      assert_nil user.primary_contact_info
     elsif expected_primary_option
-      assert_authentication_option user.primary_authentication_option, expected_primary_option
+      assert_authentication_option user.primary_contact_info, expected_primary_option
     end
   end
 

--- a/dashboard/test/models/authentication_option_test.rb
+++ b/dashboard/test/models/authentication_option_test.rb
@@ -6,8 +6,8 @@ class AuthenticationOptionTest < ActiveSupport::TestCase
     new_teacher_email = 'awesometeacher@xyz.foo'
     teacher = create(:teacher, email: original_teacher_email)
     email_auth = create(:email_authentication_option, user: teacher, email: new_teacher_email)
-    teacher.update(primary_authentication_option: email_auth, provider: 'migrated')
-    assert_equal teacher.primary_authentication_option_id, email_auth.id
+    teacher.update(primary_contact_info: email_auth, provider: 'migrated')
+    assert_equal teacher.primary_contact_info_id, email_auth.id
     assert_equal new_teacher_email, teacher.email
     assert_equal AuthenticationOption.hash_email(new_teacher_email), teacher.hashed_email
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1360,137 +1360,137 @@ class UserTest < ActiveSupport::TestCase
     assert_equal name, student.name
   end
 
-  test 'update_primary_authentication_option is false if email and hashed_email are nil' do
+  test 'update_primary_contact_info is false if email and hashed_email are nil' do
     user = create :user
-    successful_save = user.update_primary_authentication_option(user: {email: nil, hashed_email: nil})
+    successful_save = user.update_primary_contact_info(user: {email: nil, hashed_email: nil})
     refute successful_save
   end
 
-  test 'update_primary_authentication_option is false if email is nil for teacher' do
+  test 'update_primary_contact_info is false if email is nil for teacher' do
     teacher = create :teacher
-    successful_save = teacher.update_primary_authentication_option(user: {email: nil})
+    successful_save = teacher.update_primary_contact_info(user: {email: nil})
     refute successful_save
   end
 
-  test 'update_primary_authentication_option adds new email option for teacher if no matches exist' do
+  test 'update_primary_contact_info adds new email option for teacher if no matches exist' do
     teacher = create :teacher, :with_migrated_google_authentication_option
 
     assert_equal 1, teacher.authentication_options.count
-    refute_nil teacher.primary_authentication_option
+    refute_nil teacher.primary_contact_info
 
-    successful_save = teacher.update_primary_authentication_option(user: {email: 'example@email.com'})
+    successful_save = teacher.update_primary_contact_info(user: {email: 'example@email.com'})
     teacher.reload
     assert successful_save
     assert_equal 2, teacher.authentication_options.count
-    assert_equal 'example@email.com', teacher.primary_authentication_option.email
+    assert_equal 'example@email.com', teacher.primary_contact_info.email
   end
 
-  test 'update_primary_authentication_option replaces email option for teacher if one already exists' do
+  test 'update_primary_contact_info replaces email option for teacher if one already exists' do
     teacher = create :teacher, :with_migrated_email_authentication_option
 
     assert_equal 1, teacher.authentication_options.count
-    refute_nil teacher.primary_authentication_option
+    refute_nil teacher.primary_contact_info
 
-    successful_save = teacher.update_primary_authentication_option(user: {email: 'second@email.com'})
+    successful_save = teacher.update_primary_contact_info(user: {email: 'second@email.com'})
     teacher.reload
     assert successful_save
     assert_equal 1, teacher.authentication_options.count
-    assert_equal 'second@email.com', teacher.primary_authentication_option.email
+    assert_equal 'second@email.com', teacher.primary_contact_info.email
   end
 
-  test 'update_primary_authentication_option oauth option replaces any existing email options for teacher' do
+  test 'update_primary_contact_info oauth option replaces any existing email options for teacher' do
     teacher = create :teacher, :with_migrated_google_authentication_option
-    existing_email = teacher.primary_authentication_option.email
+    existing_email = teacher.primary_contact_info.email
 
     assert_equal 1, teacher.authentication_options.count
-    refute_nil teacher.primary_authentication_option
+    refute_nil teacher.primary_contact_info
 
     # Update primary to a different email
-    teacher.update_primary_authentication_option(user: {email: 'example@email.com'})
+    teacher.update_primary_contact_info(user: {email: 'example@email.com'})
     teacher.reload
     assert_equal 2, teacher.authentication_options.count
-    assert_equal 'example@email.com', teacher.primary_authentication_option.email
+    assert_equal 'example@email.com', teacher.primary_contact_info.email
 
     # Change back to original oauth email
-    successful_save = teacher.update_primary_authentication_option(user: {email: existing_email})
+    successful_save = teacher.update_primary_contact_info(user: {email: existing_email})
     teacher.reload
     assert successful_save
     assert_equal 1, teacher.authentication_options.count
-    assert_equal existing_email, teacher.primary_authentication_option.email
+    assert_equal existing_email, teacher.primary_contact_info.email
   end
 
-  test 'update_primary_authentication_option recalculates hashed_email if both email and hashed_email are supplied for teacher' do
+  test 'update_primary_contact_info recalculates hashed_email if both email and hashed_email are supplied for teacher' do
     teacher = create :teacher, :with_migrated_email_authentication_option
 
     assert_equal 1, teacher.authentication_options.count
-    refute_nil teacher.primary_authentication_option
+    refute_nil teacher.primary_contact_info
 
-    successful_save = teacher.update_primary_authentication_option(user: {email: 'first@email.com', hashed_email: User.hash_email('second@email.com')})
+    successful_save = teacher.update_primary_contact_info(user: {email: 'first@email.com', hashed_email: User.hash_email('second@email.com')})
     assert successful_save
     assert_equal 1, teacher.authentication_options.count
-    assert_equal User.hash_email('first@email.com'), teacher.primary_authentication_option.hashed_email
+    assert_equal User.hash_email('first@email.com'), teacher.primary_contact_info.hashed_email
   end
 
-  test 'update_primary_authentication_option adds new email option for student if no matches exist' do
+  test 'update_primary_contact_info adds new email option for student if no matches exist' do
     student = create :student, :with_migrated_google_authentication_option
 
     assert_equal 1, student.authentication_options.count
-    refute_nil student.primary_authentication_option
+    refute_nil student.primary_contact_info
 
     hashed_new_email = User.hash_email('example@email.com')
-    successful_save = student.update_primary_authentication_option(user: {hashed_email: hashed_new_email})
+    successful_save = student.update_primary_contact_info(user: {hashed_email: hashed_new_email})
     student.reload
     assert successful_save
     assert_equal 2, student.authentication_options.count
-    assert_equal hashed_new_email, student.primary_authentication_option.hashed_email
+    assert_equal hashed_new_email, student.primary_contact_info.hashed_email
   end
 
-  test 'update_primary_authentication_option replaces email option for student if one already exists' do
+  test 'update_primary_contact_info replaces email option for student if one already exists' do
     student = create :student, :with_migrated_email_authentication_option
 
     assert_equal 1, student.authentication_options.count
-    refute_nil student.primary_authentication_option
+    refute_nil student.primary_contact_info
 
     hashed_new_email = User.hash_email('second@email.com')
-    successful_save = student.update_primary_authentication_option(user: {hashed_email: hashed_new_email})
+    successful_save = student.update_primary_contact_info(user: {hashed_email: hashed_new_email})
     student.reload
     assert successful_save
     assert_equal 1, student.authentication_options.count
-    assert_equal hashed_new_email, student.primary_authentication_option.hashed_email
+    assert_equal hashed_new_email, student.primary_contact_info.hashed_email
   end
 
-  test 'update_primary_authentication_option oauth option replaces any existing email options for student' do
+  test 'update_primary_contact_info oauth option replaces any existing email options for student' do
     student = create :student, :with_migrated_google_authentication_option, email: 'student@email.com'
-    existing_hashed_email = student.primary_authentication_option.hashed_email
+    existing_hashed_email = student.primary_contact_info.hashed_email
 
     assert_equal 1, student.authentication_options.count
-    refute_nil student.primary_authentication_option
+    refute_nil student.primary_contact_info
 
     # Update primary to a different email
     hashed_new_email = User.hash_email('example@email.com')
-    student.update_primary_authentication_option(user: {hashed_email: hashed_new_email})
+    student.update_primary_contact_info(user: {hashed_email: hashed_new_email})
     student.reload
     assert_equal 2, student.authentication_options.count
-    assert_equal hashed_new_email, student.primary_authentication_option.hashed_email
+    assert_equal hashed_new_email, student.primary_contact_info.hashed_email
 
     # Change back to original oauth email
-    successful_save = student.update_primary_authentication_option(user: {hashed_email: existing_hashed_email})
+    successful_save = student.update_primary_contact_info(user: {hashed_email: existing_hashed_email})
     student.reload
     assert successful_save
     assert_equal 1, student.authentication_options.count
-    assert_equal existing_hashed_email, student.primary_authentication_option.hashed_email
+    assert_equal existing_hashed_email, student.primary_contact_info.hashed_email
   end
 
-  test 'update_primary_authentication_option recalculates hashed_email if both email and hashed_email are supplied for student' do
+  test 'update_primary_contact_info recalculates hashed_email if both email and hashed_email are supplied for student' do
     student = create :student, :with_migrated_email_authentication_option
 
     assert_equal 1, student.authentication_options.count
-    refute_nil student.primary_authentication_option
+    refute_nil student.primary_contact_info
 
-    successful_save = student.update_primary_authentication_option(user: {email: 'first@email.com', hashed_email: User.hash_email('second@email.com')})
+    successful_save = student.update_primary_contact_info(user: {email: 'first@email.com', hashed_email: User.hash_email('second@email.com')})
     assert successful_save
     assert_equal 1, student.authentication_options.count
-    assert_equal User.hash_email('first@email.com'), student.primary_authentication_option.hashed_email
+    assert_equal User.hash_email('first@email.com'), student.primary_contact_info.hashed_email
   end
 
   test 'track_proficiency adds proficiency if necessary and no hint used' do
@@ -3005,20 +3005,20 @@ class UserTest < ActiveSupport::TestCase
 
   test 'primary email for migrated user is readable from user model' do
     user = create(:teacher, :with_email_authentication_option)
-    user.primary_authentication_option = user.authentication_options.first
+    user.primary_contact_info = user.authentication_options.first
     user.provider = 'migrated'
-    user.primary_authentication_option.update(email: 'eric@code.org')
+    user.primary_contact_info.update(email: 'eric@code.org')
     assert_equal user.email, user.authentication_options.first.email
-    assert_equal user.email, user.primary_authentication_option.email
+    assert_equal user.email, user.primary_contact_info.email
   end
 
   test 'primary email for non-migrated user is not readable from user model' do
     user = create(:teacher, :with_email_authentication_option)
-    user.primary_authentication_option = user.authentication_options.first
-    user.primary_authentication_option.update(email: 'eric@code.org')
+    user.primary_contact_info = user.authentication_options.first
+    user.primary_contact_info.update(email: 'eric@code.org')
     assert_not_equal user.email, user.authentication_options.first.email
-    assert_not_equal user.email, user.primary_authentication_option.email
-    assert_equal user.primary_authentication_option.email, user.authentication_options.first.email
+    assert_not_equal user.email, user.primary_contact_info.email
+    assert_equal user.primary_contact_info.email, user.authentication_options.first.email
   end
 
   test 'within_united_states? is false without UserGeo record' do


### PR DESCRIPTION
We decided `primary_contact_info` more accurately reflects what this field is used for.

Because this code is not actively used, it should be safe to deploy the code changes at the same time as the renaming without risking significant downtime, however because this is a user table migration, it will require a few minutes of downtime. I'm going to coordinate when exactly to merge and deploy this so that we don't disrupt TeacherCon, maybe it'll have to go out after-hours at some point.

I verified that there are no remaining usages of `primary_authentication_option` other than in the migrations:

<img width="1070" alt="screen shot 2018-06-20 at 5 31 27 pm" src="https://user-images.githubusercontent.com/70630/41691758-3c656d86-74b1-11e8-84a2-7bb9ec3130f7.png">
