### PR TITLE
sync IO for Cucumber formatters

### DIFF
--- a/dashboard/test/ui/run_cucumber
+++ b/dashboard/test/ui/run_cucumber
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+require 'bundler/setup'
+require 'cucumber/formatter/io'
+module Cucumber
+  module Formatter
+    module SyncIO
+      def ensure_io(path_or_io)
+        super.tap {|io| io.sync = true}
+      end
+    end
+    Io.prepend SyncIO
+  end
+end
+
+require 'cucumber/cli/main'
+Cucumber::Cli::Main.new(ARGV.dup).execute!

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -305,7 +305,7 @@ end
 
 def run_tests(env, feature, arguments, log_prefix)
   start_time = Time.now
-  cmd = "cucumber #{feature} #{arguments}"
+  cmd = "#{__dir__}/run_cucumber #{feature} #{arguments}"
   puts "#{log_prefix}#{cmd}"
   Open3.popen3(env, cmd) do |stdin, stdout, stderr, wait_thr|
     stdin.close


### PR DESCRIPTION
This PR patches [`Cucumber::Formatter:IO`](https://github.com/cucumber/cucumber-ruby/blob/v2.4.0/lib/cucumber/formatter/io.rb) before launching `cucumber` to add `io.sync = true` to the IO objects used for writing HTML file output, in order to ensure the output files are always completely flushed so that we can examine UI test failures in detail.