### PR TITLE
Simple regex to better handle hyphens in course names

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -42,7 +42,7 @@ class CoursesController < ApplicationController
     unless course
       # PLC courses have different ways of getting to name. ideally this goes
       # away eventually
-      course_name = params[:course_name].tr('-', '_').titleize
+      course_name = params[:course_name].tr('-', '_').titleize.gsub /(\d+) (\d+)/, '\1-\2'
       course = Course.get_from_cache(course_name)
       # only support this alternative course name for plc courses
       raise ActiveRecord::RecordNotFound unless course.try(:plc_course)

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -32,6 +32,8 @@ require_relative './utils/selenium_constants'
 
 require 'active_support/core_ext/object/blank'
 
+require 'logger'
+
 ENV['BUILD'] = `git rev-parse --short HEAD`
 
 GIT_BRANCH = GitUtils.current_branch

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -32,8 +32,6 @@ require_relative './utils/selenium_constants'
 
 require 'active_support/core_ext/object/blank'
 
-require 'logger'
-
 ENV['BUILD'] = `git rev-parse --short HEAD`
 
 GIT_BRANCH = GitUtils.current_branch


### PR DESCRIPTION
A little hacky but it works - bring back hyphens in the course name via the power of regex.

The problem was that plc courses with names like "CSD Training 2018-2019" were getting titlecased to "Csd Training 2018 2019" and they weren't found in the cache. This is a workaround for it.