### PR TITLE
[Work In Progress] Disable spellchecker in Chrome during UI test

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -52,7 +52,7 @@ def saucelabs_browser
       http_client.timeout = 5.minutes
 
       options = Selenium::WebDriver::Chrome::Options.new
-      options.add_argument('disable-multilingual-spellchecker')
+      options.add_argument('--disable-multilingual-spellchecker')
 
       browser = Selenium::WebDriver.for(:remote,
         url: url,

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -51,10 +51,14 @@ def saucelabs_browser
       # Longer overall timeout, because iOS takes more time. This must be set before initializing Selenium::WebDriver.
       http_client.timeout = 5.minutes
 
+      options = Selenium::WebDriver::Chrome::Options.new
+      options.add_argument('disable-multilingual-spellchecker')
+
       browser = Selenium::WebDriver.for(:remote,
         url: url,
         desired_capabilities: capabilities,
-        http_client: http_client
+        http_client: http_client,
+        options: options
       )
 
       # Shorter idle_timeout to avoid "too many connection resets" error


### PR DESCRIPTION
The Chrome spellchecker sometimes displays a curly underline beneath text in forms, which can cause visual differences caught by Eyes between feature tests executed on different systems (test server vs CircleCI).