### PR TITLE
Upgrade to AWS-tuned kernel package on EC2 instances

### DIFF
--- a/cookbooks/Berksfile.lock
+++ b/cookbooks/Berksfile.lock
@@ -56,7 +56,7 @@ DEPENDENCIES
     branch: update_rubygems_fix
   ixgbevf
     git: https://github.com/wjordan/chef-ixgbevf.git
-    revision: 969318033aecd49dbbd57d9dafd03a84959d7736
+    revision: fb14d4f0e4caf21dd835739e58d372c66dca8a6e
     branch: cdo
   ntp (~> 1.8.6)
   sudo-user
@@ -114,7 +114,7 @@ GRAPH
     build-essential (>= 0.0.0)
   cdo-mysql (0.1.11)
     apt (~> 2.6.0)
-  cdo-networking (0.1.1)
+  cdo-networking (0.1.2)
     ixgbevf (>= 0.0.0)
   cdo-newrelic (0.1.18)
     apt (>= 0.0.0)
@@ -176,6 +176,4 @@ GRAPH
   ulimit (0.4.0)
   windows (1.39.1)
     chef_handler (>= 0.0.0)
-  yum (3.10.0)
-  yum-epel (0.6.5)
-    yum (~> 3.2)
+  yum-epel (3.2.0)

--- a/cookbooks/cdo-networking/README.md
+++ b/cookbooks/cdo-networking/README.md
@@ -1,7 +1,9 @@
 # cdo-networking
 
 Wraps the [ixgbevf](https://github.com/PaytmLabs/chef-ixgbevf) cookbook supporting [Enhanced Networking](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html) on Ubuntu EC2 instances
-by updating the "Intel 10 Gigabit Virtual Function" (`ixgbevf`) Network Driver kernel module to the latest version.
+by updating the "Intel 10 Gigabit Virtual Function" (`ixgbevf`) Network Driver kernel module to a recent version.
 
 AWS [recommends](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enhanced-networking-ubuntu)
 that the `ixgbevf` module be version `2.14.2` or higher for the best performance.
+
+Also installs the `linux-aws` kernel package for the latest AWS-tuned kernel images.

--- a/cookbooks/cdo-networking/attributes/default.rb
+++ b/cookbooks/cdo-networking/attributes/default.rb
@@ -1,3 +1,1 @@
 default['cdo-networking'] = {}
-default['ixgbevf']['version'] = '3.1.2'
-default['ixgbevf']['checksum'] = "845f37a16a5acc491b5e6bdf6d3fe580724d82b7cf88ac080e3c8f9ceeea79ee"

--- a/cookbooks/cdo-networking/metadata.rb
+++ b/cookbooks/cdo-networking/metadata.rb
@@ -1,4 +1,4 @@
 name             'cdo-networking'
-version          '0.1.1'
+version          '0.1.2'
 
 depends 'ixgbevf'

--- a/cookbooks/cdo-networking/recipes/default.rb
+++ b/cookbooks/cdo-networking/recipes/default.rb
@@ -1,2 +1,6 @@
 # Only apply recipe to EC2 instances.
-include_recipe 'ixgbevf' if node[:ec2]
+if node[:ec2]
+  # Upgrade to AWS-tuned kernel package on EC2 instances.
+  apt_package 'linux-aws'
+  include_recipe 'ixgbevf'
+end


### PR DESCRIPTION
This PR adds the [`linux-aws`](https://packages.ubuntu.com/trusty/linux-aws) package to our chef provisioning, which will install the linux-tuned kernel on all Chef-managed EC2 instances.

It also updates the `ixgbevf` cookbook with a fix allowing the enhanced-networking module to compile correctly on the AWS-tuned kernel. (See [bug discussion on StackOverflow](https://stackoverflow.com/q/44833346/2518355) for details.)

I've tested/verified this kernel is working properly on an adhoc instance.

More details on the aws-tuned kernel here:
https://blog.ubuntu.com/2017/04/05/ubuntu-on-aws-gets-serious-performance-boost-with-aws-tuned-kernel