### PR TITLE
[WIP] Include contained dsl in i18n sync

### DIFF
--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -56,6 +56,15 @@ class DSLDefined < Level
     dsl_class.parse(str, filename, name)
   end
 
+  def should_write_i18n?
+    # As of August 2018, we only want to internationalize DSL levels that are
+    # used in the CSF courses, either directly or as a contained level
+    return true if script_levels.any? {|sl| sl.script.csf?}
+    return true if containing_levels.collect(&:script_levels).flatten.any? {|sl| sl.script.csf?}
+
+    false
+  end
+
   def self.create_from_level_builder(params, level_params, old_name = nil)
     text = level_params[:dsl_text] || params[:dsl_text]
     transaction do
@@ -76,7 +85,7 @@ class DSLDefined < Level
         level.rewrite_dsl_file(text)
         # Only bother saving levels in scripts that we want to internationalize.
         # As of August 2018, that's just the CSF levels.
-        rewrite_i18n_file(i18n) if level.script_levels.any? {|sl| sl.script.csf?}
+        rewrite_i18n_file(i18n) if level.should_write_i18n?
       end
 
       level

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -482,6 +482,12 @@ class Level < ActiveRecord::Base
     end
   end
 
+  # Returns an array of all levels which contain this level
+  # WARNING this is a heavy SQL query; do not use this for view operations
+  def containing_levels
+    Level.where("JSON_CONTAINS(properties, :name, '$.contained_level_names')", name: name.inspect)
+  end
+
   def summarize
     {
       level_id: id,


### PR DESCRIPTION
Right now, we aren't internationalizing DSL content like http://localhost-studio.code.org:3000/s/coursee-2017/stage/8/puzzle/4 that is _contained_ in a CSF script but not a part of the script directly.

To fix that, we have a couple options:

1. Give contained levels an awareness of their containing levels, the approach currently in this PR. This is the _simplest_ change, but it includes introducing a fairly expensive (~800ms) SQL query to every DSL-defined `save` operation`.
2. Move the responsibility for syncing i18n onto the save operation on the containing level. This would be cheap, but a bit fragile, and involves a pollution of responsibilities that I don't love.
3. Refactor the syncing of dsl-defined data to happen not on save but on `sync-in`, like our other level content. This is probably the _best_ option, but the one that would require by far the most work. Additionally, our existing i18n sync doesn't have a concept of script-specific operations, so even that would have to be refactored to accommodate this new requirement.