### PR TITLE
Principal approval per partner

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_application_specific_questions.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_application_specific_questions.jsx
@@ -13,6 +13,7 @@ import {
   LabelOverrides as FacilitatorLabelOverrides,
   NumberedQuestions
 } from '@cdo/apps/generated/pd/facilitator1819ApplicationConstants';
+import SendPrincipalApprovalButton from './send_principal_approval_button';
 
 const TEACHER = 'Teacher';
 const FACILITATOR = 'Facilitator';
@@ -27,12 +28,14 @@ const paneledQuestions = {
 
 export default class DetailViewApplicationSpecificQuestions extends React.Component {
   static propTypes = {
+    id: PropTypes.string,
     formResponses: PropTypes.object.isRequired,
     applicationType: PropTypes.oneOf([TEACHER, FACILITATOR]).isRequired,
     editing: PropTypes.bool,
     scores: PropTypes.object,
     handleScoreChange: PropTypes.func,
-    applicationGuid: PropTypes.string
+    applicationGuid: PropTypes.string,
+    principalApprovalState: PropTypes.oneOf(['not_sent', 'sent', 'received'])
   };
 
   constructor(props) {
@@ -60,18 +63,31 @@ export default class DetailViewApplicationSpecificQuestions extends React.Compon
   renderResponsesForSection(section) {
     // Lame edge case but has to be done
     if (section === 'detailViewPrincipalApproval' && !this.props.formResponses['principalApproval']) {
-      return (
-        <span>
-          <h4>
-            Not yet submitted
-          </h4>
+      if (this.props.principalApprovalState === 'not_sent') {
+        return (
+          <div>
+            <h4>
+              Not required - request not sent to principal
+            </h4>
+            <SendPrincipalApprovalButton
+              id={this.props.id}
+            />
+          </div>
+        );
+      } else {
+        return (
           <span>
-            Link to principal approval form: (<a href={`/pd/application/principal_approval/${this.props.applicationGuid}`} target="_blank">
-             {`http://studio.code.org/pd/application/principal_approval/${this.props.applicationGuid}`}
-            </a>)
+            <h4>
+              Not yet submitted
+            </h4>
+            <span>
+              Link to principal approval form: (<a href={`/pd/application/principal_approval/${this.props.applicationGuid}`} target="_blank">
+               {`http://studio.code.org/pd/application/principal_approval/${this.props.applicationGuid}`}
+              </a>)
+            </span>
           </span>
-        </span>
-      );
+        );
+      }
     } else {
       return Object.keys(this.pageLabels[section]).map((question, j) => {
         return (

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -97,7 +97,8 @@ export class DetailViewContents extends React.Component {
       application_guid: PropTypes.string,
       registered_teachercon: PropTypes.bool,
       registered_fit_weekend: PropTypes.bool,
-      attending_teachercon: PropTypes.bool
+      attending_teachercon: PropTypes.bool,
+      principal_approval_state: PropTypes.oneOf(['not_sent', 'sent', 'received'])
     }).isRequired,
     viewType: PropTypes.oneOf(['teacher', 'facilitator']).isRequired,
     onUpdate: PropTypes.func,
@@ -636,12 +637,14 @@ export class DetailViewContents extends React.Component {
   renderQuestions = () => {
     return (
       <DetailViewApplicationSpecificQuestions
+        id={this.props.applicationId}
         formResponses={this.props.applicationData.form_data}
         applicationType={this.props.applicationData.application_type}
         editing={this.state.editing}
         scores={this.state.response_scores}
         handleScoreChange={this.handleScoreChange}
         applicationGuid={this.props.applicationData.application_guid}
+        principalApprovalState={this.props.applicationData.principal_approval_state}
       />
     );
   };

--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -249,7 +249,7 @@ export class QuickViewTable extends React.Component {
         </Button>
         <br/>
         {
-          ['waitlisted', 'pending', 'unreviewed'].includes(props['rowData']['status']) && (
+          props['rowData']['principal_approval'] === 'No approval sent' && (
             <SendPrincipalApprovalButton id={id}/>
           )
         }

--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
 import {Table, sort} from 'reactabular';
 import color from '@cdo/apps/util/color';
-import {Button, ButtonGroup} from 'react-bootstrap';
+import {Button} from 'react-bootstrap';
 import _, {orderBy} from 'lodash';
 import { StatusColors } from './constants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';

--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -7,7 +7,7 @@ import {Button} from 'react-bootstrap';
 import _, {orderBy} from 'lodash';
 import { StatusColors } from './constants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
-import {SendPrincipalApprovalButton} from "./send_principal_approval_button";
+import SendPrincipalApprovalButton from './send_principal_approval_button';
 
 const styles = {
   table: {

--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -3,10 +3,11 @@ import { connect } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
 import {Table, sort} from 'reactabular';
 import color from '@cdo/apps/util/color';
-import {Button} from 'react-bootstrap';
+import {Button, ButtonGroup} from 'react-bootstrap';
 import _, {orderBy} from 'lodash';
 import { StatusColors } from './constants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
+import {SendPrincipalApprovalButton} from "./send_principal_approval_button";
 
 const styles = {
   table: {
@@ -179,10 +180,10 @@ export class QuickViewTable extends React.Component {
     },{
       property: 'id',
       header: {
-        label: 'View Application',
+        label: 'Actions',
       },
       cell: {
-        format: this.formatViewButton
+        format: this.formatActionsCell
       }
     });
 
@@ -236,15 +237,23 @@ export class QuickViewTable extends React.Component {
     );
   };
 
-  formatViewButton = (id) => {
+  formatActionsCell = (id, props) => {
     return (
-      <Button
-        bsSize="xsmall"
-        target="_blank"
-        href={this.context.router.createHref(`/${this.props.path}/${id}`)}
-      >
-        View Application
-      </Button>
+      <div>
+        <Button
+          bsSize="xsmall"
+          target="_blank"
+          href={this.context.router.createHref(`/${this.props.path}/${id}`)}
+        >
+          View Application
+        </Button>
+        <br/>
+        {
+          ['waitlisted', 'pending', 'unreviewed'].includes(props['rowData']['status']) && (
+            <SendPrincipalApprovalButton id={id}/>
+          )
+        }
+      </div>
     );
   };
 

--- a/apps/src/code-studio/pd/application_dashboard/send_principal_approval_button.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/send_principal_approval_button.jsx
@@ -1,0 +1,57 @@
+import React, {PropTypes} from 'react';
+import Spinner from '../components/spinner.jsx'
+import $ from 'jquery';
+import {Button} from 'react-bootstrap';
+
+export class SendPrincipalApprovalButton extends React.Component {
+  static propTypes = {
+    id: PropTypes.number.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      requestSending: false,
+      requestSent: false
+    }
+  }
+
+  sendPrincipalApproval = () => {
+    this.setState({
+      requestSending: true
+    })
+
+    $.ajax({
+      method: 'POST',
+      url: `/api/v1/pd/application/resend_principal_approval/${this.props.id}`
+    }).
+    done(data => {
+      this.setState({
+        requestSent: true
+      })
+    });
+  }
+
+  render() {
+    if (this.state.requestSent) {
+      return (
+        <span>
+          Email sent!
+        </span>
+      )
+    } else if (this.state.requestSending) {
+      return (<Spinner size="small"/>)
+    } else {
+      return (
+        <Button
+          bsSize="xsmall"
+          target="_blank"
+          onClick={this.sendPrincipalApproval}
+        >
+          Send Principal Approval
+        </Button>
+      )
+    }
+  }
+}

--- a/apps/src/code-studio/pd/application_dashboard/send_principal_approval_button.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/send_principal_approval_button.jsx
@@ -3,9 +3,9 @@ import Spinner from '../components/spinner.jsx';
 import $ from 'jquery';
 import {Button} from 'react-bootstrap';
 
-export class SendPrincipalApprovalButton extends React.Component {
+export default class SendPrincipalApprovalButton extends React.Component {
   static propTypes = {
-    id: PropTypes.number.isRequired
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
   };
 
   constructor(props) {

--- a/apps/src/code-studio/pd/application_dashboard/send_principal_approval_button.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/send_principal_approval_button.jsx
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react';
-import Spinner from '../components/spinner.jsx'
+import Spinner from '../components/spinner.jsx';
 import $ from 'jquery';
 import {Button} from 'react-bootstrap';
 
@@ -14,24 +14,23 @@ export class SendPrincipalApprovalButton extends React.Component {
     this.state = {
       requestSending: false,
       requestSent: false
-    }
+    };
   }
 
   sendPrincipalApproval = () => {
     this.setState({
       requestSending: true
-    })
+    });
 
     $.ajax({
       method: 'POST',
       url: `/api/v1/pd/application/resend_principal_approval/${this.props.id}`
-    }).
-    done(data => {
+    }).done(data => {
       this.setState({
         requestSent: true
-      })
+      });
     });
-  }
+  };
 
   render() {
     if (this.state.requestSent) {
@@ -39,9 +38,9 @@ export class SendPrincipalApprovalButton extends React.Component {
         <span>
           Email sent!
         </span>
-      )
+      );
     } else if (this.state.requestSending) {
-      return (<Spinner size="small"/>)
+      return (<Spinner size="small"/>);
     } else {
       return (
         <Button
@@ -49,9 +48,9 @@ export class SendPrincipalApprovalButton extends React.Component {
           target="_blank"
           onClick={this.sendPrincipalApproval}
         >
-          Send Principal Approval
+          Send email to principal
         </Button>
-      )
+      );
     }
   }
 }

--- a/apps/src/code-studio/pd/components/spinner.jsx
+++ b/apps/src/code-studio/pd/components/spinner.jsx
@@ -2,13 +2,14 @@
  * Loading spinner.
  */
 
-import React, {PropTypes}from 'react';
+import React, {PropTypes} from 'react';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 export default class Spinner extends React.Component {
   static propTypes = {
     size: PropTypes.oneOf(['small', 'large'])
-  }
+  };
+
   render() {
     return <FontAwesome icon="spinner" className={`fa-pulse ${this.props.size !== 'small' ? 'fa-3x' : ''}`}/>;
   }

--- a/apps/src/code-studio/pd/components/spinner.jsx
+++ b/apps/src/code-studio/pd/components/spinner.jsx
@@ -2,11 +2,14 @@
  * Loading spinner.
  */
 
-import React from 'react';
+import React, {PropTypes}from 'react';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 export default class Spinner extends React.Component {
+  static propTypes = {
+    size: PropTypes.oneOf(['small', 'large'])
+  }
   render() {
-    return <FontAwesome icon="spinner" className="fa-pulse fa-3x"/>;
+    return <FontAwesome icon="spinner" className={`fa-pulse ${this.props.size !== 'small' ? 'fa-3x' : ''}`}/>;
   }
 }

--- a/dashboard/app/controllers/api/v1/pd/application/principal_approval_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/principal_approval_applications_controller.rb
@@ -1,9 +1,7 @@
 module Api::V1::Pd::Application
   class PrincipalApprovalApplicationsController < Api::V1::Pd::FormsController
     def new_form
-      @application = Pd::Application::PrincipalApproval1819Application.new(
-        # current_user may not exist but might as well record it
-        user: current_user,
+      @application = Pd::Application::PrincipalApproval1819Application.find_or_create_by(
         application_guid: params.require(:application_guid)
       )
     end

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -8,6 +8,10 @@ module Api::V1::Pd::Application
       )
     end
 
+    def resend_principal_approval
+      ::Pd::Application::Teacher1819ApplicationMailer.principal_approval(Pd::Application::Teacher1819Application.find(params[:id])).deliver_now
+    end
+
     protected
 
     def on_successful_create

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -16,7 +16,10 @@ module Api::V1::Pd::Application
       @application.update_user_school_info!
 
       ::Pd::Application::Teacher1819ApplicationMailer.confirmation(@application).deliver_now
-      ::Pd::Application::Teacher1819ApplicationMailer.principal_approval(@application).deliver_now
+
+      unless @application.regional_partner&.principal_approval == RegionalPartner::SELECTIVE_APPROVAL
+        ::Pd::Application::Teacher1819ApplicationMailer.principal_approval(@application).deliver_now
+      end
     end
   end
 end

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -9,7 +9,9 @@ module Api::V1::Pd::Application
     end
 
     def resend_principal_approval
-      ::Pd::Application::Teacher1819ApplicationMailer.principal_approval(Pd::Application::Teacher1819Application.find(params[:id])).deliver_now
+      ::Pd::Application::PrincipalApproval1819Application.create_placeholder_and_send_mail(
+        Pd::Application::Teacher1819Application.find(params[:id])
+      )
     end
 
     protected
@@ -22,7 +24,7 @@ module Api::V1::Pd::Application
       ::Pd::Application::Teacher1819ApplicationMailer.confirmation(@application).deliver_now
 
       unless @application.regional_partner&.principal_approval == RegionalPartner::SELECTIVE_APPROVAL
-        ::Pd::Application::Teacher1819ApplicationMailer.principal_approval(@application).deliver_now
+        ::Pd::Application::PrincipalApproval1819Application.create_placeholder_and_send_mail(@application)
       end
     end
   end

--- a/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
@@ -23,8 +23,12 @@ module Pd::Application
         principal_email: application_hash[:principal_email]
       }
 
-      # Submitted only if answers are nonempty
-      unless Pd::Application::PrincipalApproval1819Application.find_by(application_guid: params[:application_guid])&.placeholder?
+      # Return submitted if the approval exists and is not a placeholder
+      # Rather annoyingly, we can't say "unless existing_approval&.placeholder?" because
+      # if there is no approval, (handling legacy case and proper fallback behavior
+      # in case we fail to create placeholders) we'd be rendering submitted
+      existing_approval = Pd::Application::PrincipalApproval1819Application.find_by(application_guid: params[:application_guid])
+      if existing_approval && !existing_approval.placeholder?
         return render :submitted
       end
 

--- a/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
@@ -23,7 +23,8 @@ module Pd::Application
         principal_email: application_hash[:principal_email]
       }
 
-      if Pd::Application::PrincipalApproval1819Application.exists?(application_guid: params[:application_guid])
+      # Submitted only if answers are nonempty
+      unless Pd::Application::PrincipalApproval1819Application.find_by(application_guid: params[:application_guid])&.placeholder?
         return render :submitted
       end
 

--- a/dashboard/app/models/pd/application/principal_approval1819_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval1819_application.rb
@@ -181,8 +181,9 @@ module Pd::Application
 
     # @override
     def check_idempotency
-      # only one per teacher application (guid)
-      !Pd::Application::PrincipalApproval1819Application.find_by(application_guid: application_guid).placeholder?
+      existing_application = Pd::Application::PrincipalApproval1819Application.find_by(application_guid: application_guid)
+
+      (!existing_application || existing_application.placeholder?) ? nil : existing_application
     end
   end
 end

--- a/dashboard/app/models/pd/application/principal_approval1819_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval1819_application.rb
@@ -101,43 +101,43 @@ module Pd::Application
       }
     end
 
-    def self.required_fields
-      %i(
-        first_name
-        last_name
-        email
-        do_you_approve
-        confirm_principal
-      )
-    end
-
     def dynamic_required_fields(hash)
       [].tap do |required|
-        unless hash[:do_you_approve] == NO
+        unless hash.empty?
           required.concat [
-            :total_student_enrollment,
-            :free_lunch_percent,
-            :white,
-            :black,
-            :hispanic,
-            :asian,
-            :pacific_islander,
-            :american_indian,
-            :other,
-            :committed_to_master_schedule,
-            :hours_per_year,
-            :terms_per_year,
-            :replace_course,
-            :committed_to_diversity,
-            :understand_fee,
-            :pay_fee
+            :first_name,
+            :last_name,
+            :email,
+            :do_you_approve,
+            :confirm_principal
           ]
 
-          if hash[:replace_course] == YES
-            if course == 'csd'
-              required << :replace_which_course_csd
-            elsif course == 'csp'
-              required << :replace_which_course_csp
+          unless hash[:do_you_approve] == NO
+            required.concat [
+              :total_student_enrollment,
+              :free_lunch_percent,
+              :white,
+              :black,
+              :hispanic,
+              :asian,
+              :pacific_islander,
+              :american_indian,
+              :other,
+              :committed_to_master_schedule,
+              :hours_per_year,
+              :terms_per_year,
+              :replace_course,
+              :committed_to_diversity,
+              :understand_fee,
+              :pay_fee
+            ]
+
+            if hash[:replace_course] == YES
+              if course == 'csd'
+                required << :replace_which_course_csd
+              elsif course == 'csp'
+                required << :replace_which_course_csp
+              end
             end
           end
         end
@@ -166,10 +166,23 @@ module Pd::Application
       end.values.map(&:to_f).reduce(:+)
     end
 
+    def self.create_placeholder_and_send_mail(teacher_application)
+      ::Pd::Application::Teacher1819ApplicationMailer.principal_approval(teacher_application).deliver_now
+
+      Pd::Application::PrincipalApproval1819Application.create(
+        form_data: {}.to_json,
+        application_guid: teacher_application.application_guid
+      )
+    end
+
+    def placeholder?
+      JSON.parse(form_data).empty?
+    end
+
     # @override
     def check_idempotency
       # only one per teacher application (guid)
-      Pd::Application::PrincipalApproval1819Application.find_by(application_guid: application_guid)
+      !Pd::Application::PrincipalApproval1819Application.find_by(application_guid: application_guid).placeholder?
     end
   end
 end

--- a/dashboard/app/models/pd/application/teacher_application_base.rb
+++ b/dashboard/app/models/pd/application/teacher_application_base.rb
@@ -500,7 +500,17 @@ module Pd::Application
     end
 
     def principal_approval
-      sanitize_form_data_hash[:principal_approval] || ''
+      principal_approval = Pd::Application::PrincipalApproval1819Application.find_by(application_guid: application_guid)
+
+      if principal_approval
+        if principal_approval.placeholder?
+          'Sent'
+        else
+          sanitize_form_data_hash[:principal_approval]
+        end
+      else
+        'No approval sent'
+      end
     end
 
     # @override

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -48,6 +48,11 @@ class RegionalPartner < ActiveRecord::Base
     principal_approval
   )
 
+  PRINCIPAL_APPROVAL_TYPES = [
+    ALL_REQUIRE_APPROVAL = 'all_teachers_required'.freeze,
+    SELECTIVE_APPROVAL = 'required_per_teacher'.freeze
+  ].freeze
+
   # Upcoming and not ended
   def future_pd_workshops_organized
     pd_workshops_organized.future
@@ -62,6 +67,7 @@ class RegionalPartner < ActiveRecord::Base
   validates_format_of :phone_number, with: PHONE_NUMBER_VALIDATION_REGEX, if: -> {phone_number.present?}
   validates :zip_code, us_zip_code: true, if: -> {zip_code.present?}
   validates_inclusion_of :state, in: STATE_ABBR_WITH_DC_HASH.keys.map(&:to_s), if: -> {state.present?}
+  validates_inclusion_of :principal_approval, in: PRINCIPAL_APPROVAL_TYPES, if: -> {principal_approval.present?}
 
   # assign a program manager to a regional partner
   def program_manager=(program_manager_id)

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -6,7 +6,8 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
     :meets_criteria, :bonus_points, :pd_workshop_id, :fit_workshop_name, :fit_workshop_url,
     :meets_criteria, :bonus_points, :pd_workshop_id, :pd_workshop_name, :pd_workshop_url,
     :fit_workshop_id, :fit_workshop_name, :fit_workshop_url, :application_guid,
-    :registered_teachercon, :registered_fit_weekend, :attending_teachercon
+    :registered_teachercon, :registered_fit_weekend, :attending_teachercon,
+    :principal_approval_state
 
   def email
     object.user.email
@@ -69,5 +70,14 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
 
   def attending_teachercon
     object&.workshop&.teachercon?
+  end
+
+  def principal_approval_state
+    approval = Pd::Application::PrincipalApproval1819Application.find_by(application_guid: object.application_guid)
+    if approval
+      approval.placeholder? ? 'sent' : 'received'
+    else
+      'not_sent'
+    end
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -419,6 +419,7 @@ Dashboard::Application.routes.draw do
       namespace :application do
         post :facilitator, to: 'facilitator_applications#create'
         post :teacher, to: 'teacher_applications#create'
+        post 'resend_principal_approval/:id', to: 'teacher_applications#resend_principal_approval'
         post :principal_approval, to: 'principal_approval_applications#create'
       end
 

--- a/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
@@ -30,10 +30,9 @@ module Api::V1::Pd::Application
         assert_response :success
       end
 
-      application = Pd::Application::PrincipalApproval1819Application.find_by!(
+      Pd::Application::PrincipalApproval1819Application.find_by!(
         application_guid: @teacher_application.application_guid
       )
-      assert_equal principal, application.user
 
       @teacher_application.reload
       expected_principal_fields = {

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -52,12 +52,16 @@ module Api::V1::Pd::Application
       )
     end
 
-    test 'do not send principal approval email on successful create' do
+    test 'do not send principal approval email on successful create if RP has selective principal approval' do
       Pd::Application::Teacher1819ApplicationMailer.expects(:confirmation).
         with(instance_of(Pd::Application::Teacher1819Application)).
         returns(mock {|mail| mail.expects(:deliver_now)})
 
       Pd::Application::Teacher1819ApplicationMailer.expects(:principal_approval).never
+
+      regional_partner = create :regional_partner, principal_approval: RegionalPartner::ALL_REQUIRE_APPROVAL
+
+      Pd::Application::Teacher1819Application.any_instance.stubs(:regional_partner).returns(regional_partner)
 
       sign_in @applicant
 

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -16,9 +16,8 @@ module Api::V1::Pd::Application
       Pd::Application::Teacher1819ApplicationMailer.stubs(:confirmation).returns(
         mock {|mail| mail.stubs(:deliver_now)}
       )
-      Pd::Application::Teacher1819ApplicationMailer.stubs(:principal_approval).returns(
-        mock {|mail| mail.stubs(:deliver_now)}
-      )
+
+      Pd::Application::PrincipalApproval1819Application.stubs(:create_placeholder_and_send_mail)
     end
 
     test_redirect_to_sign_in_for :create
@@ -30,9 +29,7 @@ module Api::V1::Pd::Application
         with(instance_of(Pd::Application::Teacher1819Application)).
         returns(mock {|mail| mail.expects(:deliver_now)})
 
-      Pd::Application::Teacher1819ApplicationMailer.expects(:principal_approval).
-        with(instance_of(Pd::Application::Teacher1819Application)).
-        returns(mock {|mail| mail.expects(:deliver_now)})
+      Pd::Application::PrincipalApproval1819Application.expects(:create_placeholder_and_send_mail)
 
       sign_in @applicant
 
@@ -57,7 +54,7 @@ module Api::V1::Pd::Application
         with(instance_of(Pd::Application::Teacher1819Application)).
         returns(mock {|mail| mail.expects(:deliver_now)})
 
-      Pd::Application::Teacher1819ApplicationMailer.expects(:principal_approval).never
+      Pd::Application::PrincipalApproval1819Application.expects(:create_placeholder_and_send_mail).never
 
       regional_partner = create :regional_partner, principal_approval: RegionalPartner::ALL_REQUIRE_APPROVAL
 
@@ -71,7 +68,8 @@ module Api::V1::Pd::Application
 
     test 'does not send confirmation mail on unsuccessful create' do
       Pd::Application::Teacher1819ApplicationMailer.expects(:confirmation).never
-      Pd::Application::Teacher1819ApplicationMailer.expects(:principal_approval).never
+      Pd::Application::PrincipalApproval1819Application.expects(:create_placeholder_and_send_mail).never
+
       sign_in @applicant
 
       put :create, params: {form_data: {firstName: ''}}

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -52,6 +52,19 @@ module Api::V1::Pd::Application
       )
     end
 
+    test 'do not send principal approval email on successful create' do
+      Pd::Application::Teacher1819ApplicationMailer.expects(:confirmation).
+        with(instance_of(Pd::Application::Teacher1819Application)).
+        returns(mock {|mail| mail.expects(:deliver_now)})
+
+      Pd::Application::Teacher1819ApplicationMailer.expects(:principal_approval).never
+
+      sign_in @applicant
+
+      put :create, params: @test_params
+      assert_response :success
+    end
+
     test 'does not send confirmation mail on unsuccessful create' do
       Pd::Application::Teacher1819ApplicationMailer.expects(:confirmation).never
       Pd::Application::Teacher1819ApplicationMailer.expects(:principal_approval).never

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -256,4 +256,10 @@ class RegionalPartnerTest < ActiveSupport::TestCase
     end
     assert_equal "No date found for either course csp or role facilitator for regional partner id #{regional_partner.id}", error.message
   end
+
+  test 'principal_approval must be valid' do
+    regional_partner = build :regional_partner, principal_approval: 'Invalid principal_approval'
+    refute regional_partner.valid?
+    assert_equal ["Principal approval is not included in the list"], regional_partner.errors.full_messages
+  end
 end


### PR DESCRIPTION
First iteration of Principal Approval changes
- [ ] Don't send the principal approval if the regional partner 
- [ ] Create a placeholder Principal Approval (similar to what we do for JotForm) when we send the email, so we know that we've sent principals an email
- [ ] Make a "send principal approval button" that turns into a spinner when sending email
- [ ] Change the way the principal approval shows up in detail and list view