### PR TITLE
Cleaned up XML block editors within the editor

### DIFF
--- a/dashboard/app/views/levels/editors/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/_blockly.html.haml
@@ -55,30 +55,25 @@
   = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'toolbox'}
 
 .field
-  - if @level.uses_droplet?
-    = f.label :start_blocks, 'Edit Starting JavaScript Program'
-  - else
-    = link_to 'Edit Start Blocks', level_edit_blocks_path(@level, :start_blocks) unless @level.new_record?
-    = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'start'}
+  = link_to 'Edit Start Blocks', level_edit_blocks_path(@level, :start_blocks) unless @level.new_record?
+  = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'start'}
 
 .field
-  - if @level.uses_droplet?
-    = f.label :required_blocks,'Edit Required Blocks'
-  - else
-    = link_to 'Edit Required Blocks', level_edit_blocks_path(@level, :required_blocks) unless @level.new_record?
-    = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'required'}
+  = link_to 'Edit Required Blocks', level_edit_blocks_path(@level, :required_blocks) unless @level.new_record?
+  = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'required'}
 
 .field
-  - if @level.uses_droplet?
-    = f.label :recommended_blocks, 'Edit Recommended Blocks'
-  - else
-    = link_to 'Edit Recommended Blocks', level_edit_blocks_path(@level, :recommended_blocks) unless @level.new_record?
-    = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'recommended'}
+  = link_to 'Edit Recommended Blocks', level_edit_blocks_path(@level, :recommended_blocks) unless @level.new_record?
+  = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'recommended'}
 
-- unless @level.uses_droplet?
+.field
+  = link_to 'Edit Initialization Blocks', level_edit_blocks_path(@level, :initialization_blocks) unless @level.new_record?
+  = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'initialization'}
+
+-if @level.respond_to? :solution_blocks
   .field
-    = link_to 'Edit Initialization Blocks', level_edit_blocks_path(@level, :initialization_blocks) unless @level.new_record?
-    = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'initialization'}
+    = link_to 'Edit Solution Blocks', level_edit_blocks_path(@level, :solution_blocks) unless @level.new_record?
+    = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'solution'}
 
 .field
   = f.label :ideal, 'Ideal block number'
@@ -90,14 +85,6 @@
   = f.label :step_speed, 'Step speed'
   %p Number is a multiplier for how long each step takes (so higher numbers are slower). Default is 5 for Maze, 2 for Bee.
   = f.number_field :step_speed
-
--if @level.respond_to? :solution_blocks
-  .field
-    - if @level.uses_droplet?
-      = f.label :solution_blocks, 'Edit Solution Blocks'
-    - else
-      = link_to 'Edit Solution Blocks', level_edit_blocks_path(@level, :solution_blocks) unless @level.new_record?
-      = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'solution'}
 
 :ruby
   script_data = {

--- a/dashboard/app/views/levels/editors/_collapsible_block_editor.html.haml
+++ b/dashboard/app/views/levels/editors/_collapsible_block_editor.html.haml
@@ -3,7 +3,7 @@
 
 %div{data: {toggle: "collapse", target: "##{collapse_xml}"}}
   Open/Close
-.row.collapse.in{id: collapse_xml}
+.row.collapse{id: collapse_xml}
   .span8
     ~ f.text_area :"#{xml_id}_blocks", placeholder: "#{xml_id} blocks", rows: 4, value: @level.pretty_block(xml_id)
   .span4{id: xml_id + '-preview'}


### PR DESCRIPTION
**Changes:** 

- Removed unnecessary code that brought the XML block editors up if the level wasn't a droplet level. Now that droplet and blockly code live happily in their own partials there's no need for checks like this anymore. 
- Moved the solution block xml editor to the same area as the other xml block editors.
- Made XML block editors collapsed by default (Requested by Mike Harvey)

**Before:**
![image](https://user-images.githubusercontent.com/14324873/45123499-f8ba6a80-b11b-11e8-9e58-ebdbb40bc199.png)
![image](https://user-images.githubusercontent.com/14324873/45123512-0374ff80-b11c-11e8-80ef-52de36c51006.png)
![image](https://user-images.githubusercontent.com/14324873/45123521-0f60c180-b11c-11e8-9712-6de2e9db4706.png)
![image](https://user-images.githubusercontent.com/14324873/45123487-ec361200-b11b-11e8-9860-e13e94d08ea9.png)

**After:**
![image](https://user-images.githubusercontent.com/14324873/45123533-1be51a00-b11c-11e8-8bb4-b88c60949ab4.png)
