### PR TITLE
Made never autoplay video option available to all curriculum

### DIFF
--- a/dashboard/app/views/levels/editors/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/_blockly.html.haml
@@ -15,8 +15,6 @@
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :is_k1, description: "Is K1 level"}
 .field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :never_autoplay_video, description: "Never autoplay video"}
-.field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :use_modal_function_editor, description: "Use modal function editor"}
 .field
   = f.label :open_function_definition, 'Auto-open function definition'

--- a/dashboard/app/views/levels/editors/_curriculum_specific.html.haml
+++ b/dashboard/app/views/levels/editors/_curriculum_specific.html.haml
@@ -1,4 +1,7 @@
 .field
+  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :never_autoplay_video, description: "Never autoplay video"}
+
+.field
   = f.label :thumbnail_url, 'Optional thumbnail URL (overrides default thumbnail)'
   = f.text_field :thumbnail_url
 


### PR DESCRIPTION
Never Autoplay video was missing from the non-blockly editor partials. Moved it to the curriculum-specific one so it shows up for all curriculum. The curriculum team needs this very soon. 

**Before:**
![image](https://user-images.githubusercontent.com/14324873/45507571-5287e980-b747-11e8-87a0-eb2b860329ab.png)


**After:**
![image](https://user-images.githubusercontent.com/14324873/45507556-469c2780-b747-11e8-8371-166c0bf77553.png)
