### PR TITLE
Web Lab: Serve Bramble from downloads.code.org

### DIFF
--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -500,7 +500,7 @@ function load(Bramble) {
   bramble_ = Bramble;
 
   Bramble.load("#bramble", {
-    url: "//downloads.computinginthecore.org/bramble_0.1.26/index.html?disableExtensions=bramble-move-file",
+    url: "//downloads.code.org/weblab/bramble_0.1.26/index.html?disableExtensions=bramble-move-file",
     // DEVMODE: INSECURE (local) url: "../blockly/js/bramble/index.html?disableExtensions=bramble-move-file",
     // DEVMODE: INSECURE url: "http://127.0.0.1:8000/src/index.html?disableExtensions=bramble-move-file",
     useLocationSearch: true,

--- a/pegasus/sites.v3/code.org/public/educate/it.md
+++ b/pegasus/sites.v3/code.org/public/educate/it.md
@@ -19,7 +19,7 @@ We use [YouTube](https://www.youtube.com) to embed videos into Code.org and our 
 | **To use YouTube hosted videos** <br/>(Deprecated late July 2018)| `https://s.youtube.com/*`<br/>`https://www.youtube.com/*`<br/>`https://*.googlevideo.com/*`<br/>`https://*.ytimg.com/*`                                |
 | **To use Code.org hosted videos**                                                  | **Unblock:**<br/>`https://videos.code.org`<br/>**Block:**<br/>`https://www.youtube.com/favicon.ico`<br/>`https://www.youtube-nocookie.com/favicon.ico` |
 | **To use Internet Simulator**   | `https://api.pusherapp.com`<br/>`wss://ws.pusherapp.com:443`                                                                                           |
-| **To use Web Lab** | `https://downloads.computinginthecore.org`<br/>`https://codeprojects.org`                                                                              |
+| **To use Web Lab** | `https://codeprojects.org`                                                                              |
 
 ### Hardware
 


### PR DESCRIPTION
We currently serve [code-dot-org/bramble](https://github.com/code-dot-org/bramble), the HTML/CSS editor at the heart of Web Lab, as a static application from `downloads.computinginthecore.org`, backed by an S3 bucket.

Since Web Lab launched, we've had a trickle of support issues caused by schools/districts blocking `downloads.computinginthecore.org`.  We list this origin on our [IT Requirements Page](https://code.org/educate/it) but it's not surprising that many districts allow-list `*.code.org` and leave it at that.  We had [another support ticket today](https://codeorg.zendesk.com/agent/tickets/209443) probably running into this issue.

I propose we start serving Bramble from `downloads.code.org` to sidestep this problem in the future.  It's also backed by an S3 bucket.  I've already copied the latest Bramble assets over in S3:

![image](https://user-images.githubusercontent.com/1615761/45773746-f833d080-bbff-11e8-808b-a047c550f050.png)

This PR updates the Web Lab wrapper code to look in the new location for the Bramble download, and removes the `downloads.computinginthecore.org` requirement from Web Lab on our IT requirements page.