### PR TITLE
Rename instructions in properties blob

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -53,8 +53,6 @@ class Level < ActiveRecord::Base
     video_key
     embed
     callout_json
-    instructions
-    markdown_instructions
     authored_hints
     instructions_important
     display_name
@@ -68,28 +66,38 @@ class Level < ActiveRecord::Base
   # Temporary aliases while we transition between naming schemes.
   # TODO: elijah: migrate the data to these new field names and remove these
   def short_instructions
-    read_attribute('properties')['instructions']
+    read_attribute('properties')['short_instructions'] || read_attribute('properties')['instructions']
   end
+  alias_method :instructions, :short_instructions
 
   def short_instructions=(value)
-    read_attribute('properties')['instructions'] = value
+    read_attribute('properties')['short_instructions'] = value
+    read_attribute('properties')['instructions'] = nil
   end
+  alias_method :instructions=, :short_instructions=
 
   def short_instructions?
+    !!JSONValue.value(read_attribute('properties')['short_instructions']) ||
     !!JSONValue.value(read_attribute('properties')['instructions'])
   end
+  alias_method :instructions?, :short_instructions?
 
   def long_instructions
-    read_attribute('properties')['markdown_instructions']
+    read_attribute('properties')['long_instructions'] || read_attribute('properties')['markdown_instructions']
   end
+  alias_method :markdown_instructions, :long_instructions
 
   def long_instructions=(value)
-    read_attribute('properties')['markdown_instructions'] = value
+    read_attribute('properties')['long_instructions'] = value
+    read_attribute('properties')['markdown_instructions'] = nil
   end
+  alias_method :markdown_instructions=, :long_instructions=
 
   def long_instructions?
+    !!JSONValue.value(read_attribute('properties')['long_instructions']) ||
     !!JSONValue.value(read_attribute('properties')['markdown_instructions'])
   end
+  alias_method :markdown_instructions?, :long_instructions?
 
   def self.permitted_params
     super.concat(['short_instructions', 'long_instructions'])
@@ -113,11 +121,11 @@ class Level < ActiveRecord::Base
     attributes = new_attributes.stringify_keys
 
     # TODO: elijah: migrate the data to these new field names and remove these
-    if attributes.key?('short_instructions')
-      attributes['instructions'] = attributes.delete('short_instructions')
+    if attributes.key?('instructions')
+      attributes['short_instructions'] = attributes.delete('instructions')
     end
-    if attributes.key?('long_instructions')
-      attributes['markdown_instructions'] = attributes.delete('long_instructions')
+    if attributes.key?('markdown_instructions')
+      attributes['long_instructions'] = attributes.delete('markdown_instructions')
     end
 
     concept_difficulty_attributes = attributes.delete('level_concept_difficulty')

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -67,12 +67,30 @@ class Level < ActiveRecord::Base
 
   # Temporary aliases while we transition between naming schemes.
   # TODO: elijah: migrate the data to these new field names and remove these
-  define_method('short_instructions') {read_attribute('properties')['instructions']}
-  define_method('short_instructions=') {|value| read_attribute('properties')['instructions'] = value}
-  define_method('short_instructions?') {!!JSONValue.value(read_attribute('properties')['instructions'])}
-  define_method('long_instructions') {read_attribute('properties')['markdown_instructions']}
-  define_method('long_instructions=') {|value| read_attribute('properties')['markdown_instructions'] = value}
-  define_method('long_instructions?') {!!JSONValue.value(read_attribute('properties')['markdown_instructions'])}
+  def short_instructions
+    read_attribute('properties')['instructions']
+  end
+
+  def short_instructions=(value)
+    read_attribute('properties')['instructions'] = value
+  end
+
+  def short_instructions?
+    !!JSONValue.value(read_attribute('properties')['instructions'])
+  end
+
+  def long_instructions
+    read_attribute('properties')['markdown_instructions']
+  end
+
+  def long_instructions=(value)
+    read_attribute('properties')['markdown_instructions'] = value
+  end
+
+  def long_instructions?
+    !!JSONValue.value(read_attribute('properties')['markdown_instructions'])
+  end
+
   def self.permitted_params
     super.concat(['short_instructions', 'long_instructions'])
   end

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -6,9 +6,9 @@ class LevelTest < ActiveSupport::TestCase
   STUB_ENCRYPTION_KEY = SecureRandom.base64(Encryption::KEY_LENGTH / 8)
 
   setup do
-    @turtle_data = {game_id: 23, name: "__bob4", level_num: "custom", skin: "artist", instructions: "sdfdfs", type: 'Artist'}
+    @turtle_data = {game_id: 23, name: "__bob4", level_num: "custom", skin: "artist", short_instructions: "sdfdfs", type: 'Artist'}
     @custom_turtle_data = {user_id: 1}
-    @maze_data = {game_id: 25, name: "__bob4", level_num: "custom", skin: "birds", instructions: "sdfdfs", type: 'Maze'}
+    @maze_data = {game_id: 25, name: "__bob4", level_num: "custom", skin: "birds", short_instructions: "sdfdfs", type: 'Maze'}
     @custom_maze_data = @maze_data.merge(user_id: 1)
     @gamelab_data = {game_id: 48, name: 'some gamelab level', level_num: 'custom', type: 'Gamelab'}
     @custom_level = Level.create(@custom_maze_data.dup)
@@ -34,7 +34,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'create level' do
-    Level.create(game_id: 25, name: "__bob4", level_num: "custom", skin: "birds", instructions: "sdfdfs", type: 'Maze')
+    Level.create(game_id: 25, name: "__bob4", level_num: "custom", skin: "birds", short_instructions: "sdfdfs", type: 'Maze')
   end
 
   test "throws argument error on bad data" do
@@ -112,7 +112,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test "get_question_text returns question text for free response level" do
-    free_response_level = create :level, name: 'A question', markdown_instructions: 'Answer this question.',
+    free_response_level = create :level, name: 'A question', long_instructions: 'Answer this question.',
       type: 'FreeResponse'
     assert_equal free_response_level.get_question_text, 'Answer this question.'
   end
@@ -157,27 +157,27 @@ class LevelTest < ActiveSupport::TestCase
 
   test 'serialize properties' do
     level = Blockly.new
-    level.instructions = 'test!'
-    assert_equal 'test!', level.properties['instructions']
-    assert_equal level.instructions, level.properties['instructions']
+    level.short_instructions = 'test!'
+    assert_equal 'test!', level.properties['short_instructions']
+    assert_equal level.short_instructions, level.properties['short_instructions']
   end
 
   test 'create with serialized properties' do
-    level = Blockly.create(instructions: 'test')
-    assert_equal 'test', level.instructions
-    level.instructions = 'test2'
-    assert_equal 'test2', level.instructions
+    level = Blockly.create(short_instructions: 'test')
+    assert_equal 'test', level.short_instructions
+    level.short_instructions = 'test2'
+    assert_equal 'test2', level.short_instructions
   end
 
   test 'update serialized column with properties hash' do
-    level = Blockly.create(instructions: 'test')
-    level.update(instructions: 'test2', properties: {skin: 'skin'})
-    assert_equal 'test2', level.instructions
+    level = Blockly.create(short_instructions: 'test')
+    level.update(short_instructions: 'test2', properties: {skin: 'skin'})
+    assert_equal 'test2', level.short_instructions
     assert_equal 'skin', level.skin
   end
 
   test 'cannot have non-existent properties' do
-    level = Blockly.create(instructions: 'test')
+    level = Blockly.create(short_instructions: 'test')
     level.update(properties: {property_that_does_not_exist: 'impossible value storage'})
     assert_raises(NoMethodError) do
       level.property_that_does_not_exist
@@ -185,7 +185,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'can have video key' do
-    level = Blockly.create(instructions: 'test')
+    level = Blockly.create(short_instructions: 'test')
     video = create(:video)
     level.update(properties: {video_key: video.key})
     assert_equal video.key, level.video_key
@@ -224,7 +224,7 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test 'prioritize property over column data in merged update' do
-    level = Level.create(instructions: 'test', type: 'Maze')
+    level = Level.create(short_instructions: 'test', type: 'Maze')
     level.update(maze: '', properties: {maze: 'maze'})
     assert_equal 'maze', level.maze
   end
@@ -328,7 +328,7 @@ EOS
   end
 
   test 'delete removed level properties on import' do
-    level = Level.create(name: 'test delete properties', instructions: 'test', type: 'Studio', embed: true)
+    level = Level.create(name: 'test delete properties', short_instructions: 'test', type: 'Studio', embed: true)
 
     assert_equal true, level.embed
 
@@ -659,14 +659,14 @@ EOS
     assert_equal 9360, JSON.parse(level.audit_log).length
 
     # add a new entry that will put us over the limit
-    level.instructions = "new actual instructions"
+    level.short_instructions = "new actual instructions"
     level.log_changes
 
     # audit log should have dropped off several entries in order get back under
     # the limit, since the test entries are individually much smaller than the
     # new actual entry
-    assert_equal 65533, level.audit_log.length
-    assert_equal 9351, JSON.parse(level.audit_log).length
+    assert_equal 65532, level.audit_log.length
+    assert_equal 9350, JSON.parse(level.audit_log).length
   end
 
   test "can validate XML field with valid XML" do


### PR DESCRIPTION
For the penultimate step is fully renaming instructions and markdown instructions, we preserve both old and new means of accessing the data, but switch the method of updating the data to move it over to the new location.

This means we will, for a period of time, have the data stored internally in both locations, but be consistently relying on the new location as the canonical one. The next step is to then trigger the swap from old to new on all levels and remove the old accessors.