### PR TITLE
Control project sharing dialog - mark down conversion

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -958,7 +958,7 @@
   "projectSharingColumnHeader": "Sharing",
   "projectSharingDialogButton": "Show project sharing column",
   "projectSharingDialogHeader": "Control sharing for App Lab / Game Lab / Web Lab projects",
-  "projectSharingDialogInstructions1": "App Lab, Game Lab and Web Lab are programming environments that allow students to personalize and customize their creations through writing free-form text, uploading images and sounds, etc. By default, students under the age of 13 are not able to share their projects with others, but students aged 13 and over are.\n\n If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the orange button below.",
+  "projectSharingDialogInstructions": "App Lab, Game Lab and Web Lab are programming environments that allow students to personalize and customize their creations through writing free-form text, uploading images and sounds, etc. By default, students under the age of 13 are not able to share their projects with others, but students aged 13 and over are.\n\n If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the orange button below.",
   "projectSharingDisableAll": "Disable all",
   "projectSharingEnableAll": "Enable all",
   "projectStartNew": "Start a new project",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -959,7 +959,6 @@
   "projectSharingDialogButton": "Show project sharing column",
   "projectSharingDialogHeader": "Control sharing for App Lab / Game Lab / Web Lab projects",
   "projectSharingDialogInstructions1": "App Lab, Game Lab and Web Lab are programming environments that allow students to personalize and customize their creations through writing free-form text, uploading images and sounds, etc. By default, students under the age of 13 are not able to share their projects with others, but students aged 13 and over are.\n\n If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the orange button below.",
-  "projectSharingDialogInstructions2": "If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the orange button below.",
   "projectSharingDisableAll": "Disable all",
   "projectSharingEnableAll": "Enable all",
   "projectStartNew": "Start a new project",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -958,7 +958,7 @@
   "projectSharingColumnHeader": "Sharing",
   "projectSharingDialogButton": "Show project sharing column",
   "projectSharingDialogHeader": "Control sharing for App Lab / Game Lab / Web Lab projects",
-  "projectSharingDialogInstructions1": "App Lab, Game Lab and Web Lab are programming environments that allow students to personalize and customize their creations through writing free-form text, uploading images and sounds, etc. By default, students under the age of 13 are not able to share their projects with others, but students aged 13 and over are.",
+  "projectSharingDialogInstructions1": "App Lab, Game Lab and Web Lab are programming environments that allow students to personalize and customize their creations through writing free-form text, uploading images and sounds, etc. By default, students under the age of 13 are not able to share their projects with others, but students aged 13 and over are.\n\n If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the orange button below.",
   "projectSharingDialogInstructions2": "If you want to be able to manage exactly which students can and can not share these project types, you can show the project sharing column by clicking the orange button below.",
   "projectSharingDisableAll": "Disable all",
   "projectSharingEnableAll": "Enable all",

--- a/apps/src/templates/manageStudents/ControlProjectSharingDialog.jsx
+++ b/apps/src/templates/manageStudents/ControlProjectSharingDialog.jsx
@@ -43,7 +43,7 @@ class ControlProjectSharingDialog extends Component {
         >
           <h2>{i18n.projectSharingDialogHeader()}</h2>
           <div>
-            <UnsafeRenderedMarkdown markdown={i18n.projectSharingDialogInstructions1()} />
+            <UnsafeRenderedMarkdown markdown={i18n.projectSharingDialogInstructions()} />
           </div>
           <DialogFooter>
             <Button

--- a/apps/src/templates/manageStudents/ControlProjectSharingDialog.jsx
+++ b/apps/src/templates/manageStudents/ControlProjectSharingDialog.jsx
@@ -5,15 +5,13 @@ import Button from '../Button';
 import i18n from "@cdo/locale";
 import BaseDialog from '../BaseDialog';
 import DialogFooter from "../teacherDashboard/DialogFooter";
+import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 
 const styles = {
   dialog: {
     paddingLeft: 20,
     paddingRight: 20,
     paddingBottom: 20
-  },
-  instructions: {
-    marginTop: 20
   }
 };
 
@@ -45,10 +43,7 @@ class ControlProjectSharingDialog extends Component {
         >
           <h2>{i18n.projectSharingDialogHeader()}</h2>
           <div>
-            {i18n.projectSharingDialogInstructions1()}
-          </div>
-          <div style={styles.instructions}>
-            {i18n.projectSharingDialogInstructions2()}
+            <UnsafeRenderedMarkdown markdown={i18n.projectSharingDialogInstructions1()} />
           </div>
           <DialogFooter>
             <Button


### PR DESCRIPTION
This PR is to convert strings used in the control project sharing dialog to markdown.  Two strings were merged.

### Screen shot
Before Change
<img width="740" alt="screen shot 2018-09-21 at 3 40 41 pm" src="https://user-images.githubusercontent.com/30066710/45909075-c6179f80-bdb4-11e8-853d-35802cf39b5b.png">

After Change
<img width="739" alt="screen shot 2018-09-21 at 12 59 46 pm" src="https://user-images.githubusercontent.com/30066710/45903352-44b51280-bd9e-11e8-926c-07dbdf5b092b.png">
