### PR TITLE
Reorganized the Gamelab and Sprite Lab Level Editor templates

### DIFF
--- a/apps/style/code-studio/levelbuilder.scss
+++ b/apps/style/code-studio/levelbuilder.scss
@@ -188,20 +188,25 @@ table.checkboxes {
 }
 .audit_log{
   width: 100%;
-  
+
   tr:nth-child(odd){
     background-color: #f9cb81;
   }
-  
+
   td{
     padding: 2%;
   }
-  
+
   .aud_date{
     width: 25%;
   }
-  
+
   .aud_person{
     width: 43%;
   }
+}
+
+.levelTypeHeader{
+  font-weight: bold;
+  padding: 2% 2% 2% 0%;
 }

--- a/dashboard/app/views/levels/editors/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/_blockly.html.haml
@@ -5,9 +5,10 @@
     = javascript_include_tag "js/en_us/common_locale"
     = javascript_include_tag "js/en_us/#{@level.game.app}_locale"
 
+%legend.control-legend.levelTypeHeader
+  Blockly Options
 = render partial: 'levels/editors/authored_hints', locals: {f: f}
-.field
-  = f.label :edit_code,'Blockly level'
+
 = render partial: 'levels/editors/ani_gif', locals: {f: f}
 .field
   = f.label :skin

--- a/dashboard/app/views/levels/editors/_gamelab.html.haml
+++ b/dashboard/app/views/levels/editors/_gamelab.html.haml
@@ -7,19 +7,25 @@
     }
   %script{src: minifiable_asset_path('js/levelbuilder_gamelab.js')}
 
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_animation_mode, description: "Hide the Animation Tab (you can still seed a level with animations)"}
+%legend.control-legend.levelTypeHeader
+  Game Lab Options
 
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :start_in_animation_tab, description: "Start in the Animation Tab"}
+= render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'gamelab'}
 
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :all_animations_single_frame, description: "All animations should be a single frame. If it has multiple frames, only show the first frame as a still image."}
+= render partial: 'levels/editors/teacher_only_markdown', locals: {f: f}
 
-.field
+%legend.control-legend{data: {toggle: "collapse", target: "#debuggingTools"}}
+  Debugging
+
+#debuggingTools.collapse
+
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :expand_debugger, description: "Expand Debugger by Default"}
 
-= render partial: 'levels/editors/watchers_ui', locals: {f: f}
+  = render partial: 'levels/editors/watchers_ui', locals: {f: f}
+
+  .field.aligned-input-group
+    = boolean_check_box f, :debugger_disabled
+    =f.label 'Disable code debugger (Console is still enabled)'
 
 .field
   = f.label :soft_buttons, 'Controls buttons'
@@ -58,10 +64,6 @@
   = boolean_check_box f, :hide_view_data_button
   = f.label 'Hide View Data Button'
 
-.field.aligned-input-group
-  = boolean_check_box f, :debugger_disabled
-  =f.label 'Disable code debugger (Console is still enabled)'
-
 .field
   = f.label 'Immediately show the results of setup code changes in the playspace?'
   :ruby
@@ -85,65 +87,85 @@
     (shift-click or cmd-click to select multiple).
   = f.select :helper_libraries, (Library.distinct.pluck(:name) + (@level.helper_libraries || [])).uniq.sort, {}, {multiple: true}
 
-.field
-  = f.label 'Validation code'
+%legend.control-legend{data: {toggle: "collapse", target: "#validation"}}
+  Validation
+
+#validation.collapse
   %p
     This is a snippet of javascript that is run after every draw loop. Call levelSuccess() in here to stop the level as a success. You can also pass a number into levelSuccess() to give the student a non-perfect test result (see <a href="https://github.com/code-dot-org/code-dot-org/blob/101fbfd2dcdd635d7359e991559ba782f9fd00be/apps/src/constants.js#L33-L106">TestResults</a> for the list of valid test results). There is also a `validationProps` object that you can stick arbitrary properties on to track state across draw loops.
   = f.text_area :validation_code
 
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: 'pause_animations_by_default', description: "Animations are paused by default"}
+%legend.control-legend{data: {toggle: "collapse", target: "#animations"}}
+  Animations
 
-  %p
-    If checked, the sprite animation will always be paused after a <tt>setAnimation</tt> call.
-    Otherwise, it will be playing after a <tt>setAnimation</tt> call.
+#animations.collapse
 
-.field
-  %p{data: {toggle: "collapse", target: "#animation_json_output"}}
-    Starting Animation JSON
-  %p
-    This should be equivalent to the animation JSON created by the animation tab.
-    <a href="#" onClick="toggleBlock('start_animations_more'); return false">Read more...</a>
-  %p
-    Learn how to preload starting animations
-    = link_to 'here', 'https://github.com/code-dot-org/code-dot-org/wiki/%5BLevelbuilder%5D-Adding-Preloaded-Animations-to-a-Level-in-Game-Lab', target: '_blank'
-  #start_animations_more{style: 'display: none'}
+  - if (@level.is_a? GamelabJr)
+    .field
+      = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :use_default_sprites, description: "Use default sprites as starting animation JSON"}
+      
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_animation_mode, description: "Hide the Animation Tab (you can still seed a level with animations)"}
+
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :start_in_animation_tab, description: "Start in the Animation Tab"}
+
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :all_animations_single_frame, description: "All animations should be a single frame. If it has multiple frames, only show the first frame as a still image."}
+
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: 'pause_animations_by_default', description: "Animations are paused by default"}
+
     %p
-      You can generate this by getting the animation tab into the desired state,
-      opening the developer console, and running <tt>viewExportableAnimationList()</tt>;
-      or, you can compose it by hand.
-      Here is an example.
-    %pre
-      :preserve
-        {
-          "orderedKeys": ["animation1"],
-          "propsByKey": {
-            "animation1": {
-              "name": "asterisk_circle",
-              "sourceUrl": "/blockly/media/gamelab/library/asterisk_circle.png",
-              "frameSize": {"x":132, "y": 126},
-              "frameCount": 9,
-              "frameDelay": 2,
-              "looping": true
+      If checked, the sprite animation will always be paused after a <tt>setAnimation</tt> call.
+      Otherwise, it will be playing after a <tt>setAnimation</tt> call.
+
+  .field
+    %p{data: {toggle: "collapse", target: "#animation_json_output"}}
+      Starting Animation JSON
+    %p
+      This should be equivalent to the animation JSON created by the animation tab.
+      <a href="#" onClick="toggleBlock('start_animations_more'); return false">Read more...</a>
+    %p
+      Learn how to preload starting animations
+      = link_to 'here', 'https://github.com/code-dot-org/code-dot-org/wiki/%5BLevelbuilder%5D-Adding-Preloaded-Animations-to-a-Level-in-Game-Lab', target: '_blank'
+    #start_animations_more{style: 'display: none'}
+      %p
+        You can generate this by getting the animation tab into the desired state,
+        opening the developer console, and running <tt>viewExportableAnimationList()</tt>;
+        or, you can compose it by hand.
+        Here is an example.
+      %pre
+        :preserve
+          {
+            "orderedKeys": ["animation1"],
+            "propsByKey": {
+              "animation1": {
+                "name": "asterisk_circle",
+                "sourceUrl": "/blockly/media/gamelab/library/asterisk_circle.png",
+                "frameSize": {"x":132, "y": 126},
+                "frameCount": 9,
+                "frameDelay": 2,
+                "looping": true
+              }
             }
           }
-        }
-    %p
-      Some considerations:
-    %ul
-      %li <tt>orderedKeys</tt> defines the order the animations are listed in the animation tab, and each key must reference a set of props in <tt>propsByKey</tt>
-      %li <tt>name</tt>, <tt>sourceUrl</tt>, <tt>frameSize</tt>, <tt>frameCount</tt>, <tt>frameDelay</tt>, and <tt>looping</tt> are all required.
-      %li <tt>name</tt> is used to refer to the animation in code; the "animation key" is never visible to the student.
-      %li
-        <tt>sourceUrl</tt> can take absolute URLs (which will run through our media proxy, so you can refer to almost anything)
-        or domain-relative URLs for the limited set of animations in the current library,
-        <a href="https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/gamelab/animationLibrary.js">which you can find here.</a>
-        The sourceUrl should point to an image or spritesheet - not an animated gif.
-      %li <tt>frameDelay</tt> can be from slowest to fastest: 60, 45, 30, 20, 15, 10, 5, 4, 3, 2, 1.
-      %li <tt>looping</tt> is true is if the animation plays repeatedly or false if it plays once.
-  #animation_json_output.collapse.in
-    ~ f.text_area :start_animations, placeholder: 'Starting animations JSON', rows: 4, value: @level.start_animations
-    #level-start-animations-validation
+      %p
+        Some considerations:
+      %ul
+        %li <tt>orderedKeys</tt> defines the order the animations are listed in the animation tab, and each key must reference a set of props in <tt>propsByKey</tt>
+        %li <tt>name</tt>, <tt>sourceUrl</tt>, <tt>frameSize</tt>, <tt>frameCount</tt>, <tt>frameDelay</tt>, and <tt>looping</tt> are all required.
+        %li <tt>name</tt> is used to refer to the animation in code; the "animation key" is never visible to the student.
+        %li
+          <tt>sourceUrl</tt> can take absolute URLs (which will run through our media proxy, so you can refer to almost anything)
+          or domain-relative URLs for the limited set of animations in the current library,
+          <a href="https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/gamelab/animationLibrary.js">which you can find here.</a>
+          The sourceUrl should point to an image or spritesheet - not an animated gif.
+        %li <tt>frameDelay</tt> can be from slowest to fastest: 60, 45, 30, 20, 15, 10, 5, 4, 3, 2, 1.
+        %li <tt>looping</tt> is true is if the animation plays repeatedly or false if it plays once.
+    #animation_json_output.collapse.in
+      ~ f.text_area :start_animations, placeholder: 'Starting animations JSON', rows: 4, value: @level.start_animations
+      #level-start-animations-validation
 
 :javascript
   window.toggleBlock = function (elementId) {
@@ -152,7 +174,3 @@
       element.style.display = element.style.display === 'none' ? 'block' : 'none';
     }
   };
-
-= render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'gamelab'}
-
-= render partial: 'levels/editors/teacher_only_markdown', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_gamelab_jr.html.haml
+++ b/dashboard/app/views/levels/editors/_gamelab_jr.html.haml
@@ -1,8 +1,7 @@
+%legend.control-legend.levelTypeHeader
+  Sprite Lab Options
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :include_shared_functions, description: "Make shared functions and behaviors available"}
-
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :use_default_sprites, description: "Use default sprites as starting animation JSON"}
 
 .field
   %p{data: {toggle: "collapse", target: "#custom_blocks_output"}}
@@ -29,7 +28,7 @@
     %ul
       %li <code>returnType</code> and <code>args[].type</code> can be any of 'String', 'Number', 'Image', 'Boolean', 'Function', 'Colour', or 'Array'. If none of those apply, or you don't want to enforce a type, just use 'None'
       %li <code>blockText</code> must contain a placeholder for every argument in the <code>args</code> list
-  #custom_blocks_output.collapse.in
+  #custom_blocks_output.collapse
     ~ f.text_area :custom_blocks, placeholder: 'Custom blocks', rows: 4, value: @level.custom_blocks
     #custom-blocks-validation
 .field


### PR DESCRIPTION
- Reorganized different options in GameLab and Sprite Lab
- Put grouped items in collapsible containers
- Added clear headers for what options belong to which level type

**Before:**
![image](https://user-images.githubusercontent.com/14324873/45904558-4d0f4c80-bda2-11e8-8d15-39e94cfdc5af.png)

![image](https://user-images.githubusercontent.com/14324873/45904572-58627800-bda2-11e8-896f-7dcf5410401e.png)

![image](https://user-images.githubusercontent.com/14324873/45904595-64e6d080-bda2-11e8-9f2d-1b72b5120eae.png)

![image](https://user-images.githubusercontent.com/14324873/45904606-6dd7a200-bda2-11e8-9038-69e23135296e.png)


**After**:
![image](https://user-images.githubusercontent.com/14324873/45904633-7d56eb00-bda2-11e8-8e43-1ac9ef7d49b1.png)

![image](https://user-images.githubusercontent.com/14324873/45904650-8778e980-bda2-11e8-8baf-938579ace3cd.png)

![image](https://user-images.githubusercontent.com/14324873/45904665-92cc1500-bda2-11e8-96a1-6bea61f9a9f9.png)

![image](https://user-images.githubusercontent.com/14324873/45904740-c0b15980-bda2-11e8-9f6b-cd141d4b3473.png)

![image](https://user-images.githubusercontent.com/14324873/45904753-cb6bee80-bda2-11e8-9b87-ad2b33cd50c5.png)

![image](https://user-images.githubusercontent.com/14324873/45904762-d6268380-bda2-11e8-8586-061974e17b04.png)
