### PR TITLE
Free Response Details Dialog - update markdown component

### DIFF
--- a/apps/src/templates/sectionAssessments/FreeResponseDetailsDialog.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponseDetailsDialog.jsx
@@ -5,9 +5,8 @@ import Button from '@cdo/apps/templates/Button';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import i18n from "@cdo/locale";
 import DialogFooter from "@cdo/apps/templates/teacherDashboard/DialogFooter";
-import processMarkdown from 'marked';
-import renderer from "@cdo/apps/util/StylelessRenderer";
 import {getCurrentQuestion} from "./sectionAssessmentsRedux";
+import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 
 const styles = {
   dialog: {
@@ -29,7 +28,6 @@ class FreeResponseDetailsDialog extends Component {
 
   render() {
     // Questions are in markdown format and should not display as plain text in the dialog.
-    const renderedMarkdown = processMarkdown(this.props.questionAndAnswers.question, { renderer });
 
     return (
       <BaseDialog
@@ -41,8 +39,11 @@ class FreeResponseDetailsDialog extends Component {
         <h2>{i18n.questionText()}</h2>
         <div
           style={styles.instructions}
-          dangerouslySetInnerHTML={{ __html: renderedMarkdown }}
-        />
+        >
+          <UnsafeRenderedMarkdown
+            markdown={this.props.questionAndAnswers.question}
+          />
+        </div>
         <DialogFooter>
           <Button
             text={i18n.done()}


### PR DESCRIPTION
This PR is to update free response details dialog with the new markdown component to display questions as formatted text.

### Screen shots
Before Implementation
<img width="740" alt="screen shot 2018-09-21 at 3 45 53 pm" src="https://user-images.githubusercontent.com/30066710/45909229-856c5600-bdb5-11e8-90c3-d252e6e44fdf.png">

After Implementation
<img width="737" alt="screen shot 2018-09-21 at 3 42 36 pm" src="https://user-images.githubusercontent.com/30066710/45909174-3faf8d80-bdb5-11e8-98b2-4af8cda3beb5.png">
