### PR TITLE
Fix RTL hamburger

### DIFF
--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -42,6 +42,7 @@
     cursor: pointer;
     padding: 10px 35px 16px 0;
     height: 20px;
+    width: 20px;
     vertical-align: middle;
     text-decoration: none;
     float: right;


### PR DESCRIPTION
https://trello.com/c/4EnuG6vi/242-investigate-hamburger-not-working-properly-in-rtl-languages

Before the hamburger click area when viewing in a RTL language was shifted away from the hamburger icon: 
![arabic-before](https://user-images.githubusercontent.com/12300669/46323235-4357c700-c5a2-11e8-8b7d-7ad1234a3c23.gif)

By forcing the hamburger icon to take up a defined width, the click target is over the actual icon now for RTL languages. Shown here with Arabic. 

dashboard mobile: 
![dashboard-mobile](https://user-images.githubusercontent.com/12300669/46323301-74d09280-c5a2-11e8-8548-f325991b11cd.gif)

dashboard desktop: 
![dashboard-desktop](https://user-images.githubusercontent.com/12300669/46323296-726e3880-c5a2-11e8-870e-f869a419ea9d.gif)

pegasus mobile: 
![pegasus-mobile](https://user-images.githubusercontent.com/12300669/46323294-6edab180-c5a2-11e8-972f-4f9995f8d7d7.gif)

pegasus desktop: 
![pegasus-desktop](https://user-images.githubusercontent.com/12300669/46323291-6d10ee00-c5a2-11e8-87aa-a738a747c82e.gif)

No change for LTR languages. 