### PR TITLE
Perf improvement for disco effect

### DIFF
--- a/apps/src/dance/Effects.js
+++ b/apps/src/dance/Effects.js
@@ -30,32 +30,27 @@ export default class Effects {
     };
 
     this.disco = {
-      colors: [],
+      bg: undefined,
+      init: function () {
+        this.bg = createGraphics(World.width, World.height);
+        this.bg.noStroke();
+        for (let i = 0; i < 16; i++) {
+          this.bg.fill(
+            p5.color("hsla(" + randomNumber(0, 359) + ", 100%, 80%, " + alpha + ")"));
+          this.bg.rect((i % 4) * 50, Math.floor(i / 4) * 50, 50, 50);
+        }
+      },
       update: function () {
-        if (this.colors.length < 16) {
-          this.colors = [];
-          for (let i = 0; i < 16; i++) {
-            this.colors.push(
-              p5.color("hsla(" + randomNumber(0, 359) + ", 100%, 80%, " + alpha + ")"));
-          }
-        } else {
-          for (let j = randomNumber(5, 10); j > 0; j--) {
-            this.colors[randomNumber(0, this.colors.length - 1)] =
-              p5.color("hsla(" + randomNumber(0, 359) + ", 100%, 80%, " + alpha + ")");
-          }
+        for (let i = randomNumber(5, 10); i > 0; i--) {
+          let loc = randomNumber(0, 15);
+          this.bg.fill(p5.color("hsla(" + randomNumber(0, 359) + ", 100%, 80%, " + alpha + ")"));
+          this.bg.rect((loc % 4) * 50, Math.floor(i / 4) * 50, 50, 50);
         }
       },
       draw: function ({isPeak}) {
-        if (isPeak || this.colors.length < 1) {
-          this.update();
-        }
-        p5.push();
-        p5.noStroke();
-        for (let i = 0; i < this.colors.length; i++) {
-          p5.fill(this.colors[i]);
-          p5.rect((i % 4) * 100, Math.floor(i / 4) * 100, 100, 100);
-        }
-        p5.pop();
+        if (!this.bg) this.init();
+        if (isPeak) this.update();
+        p5.image(this.bg, 0, 0);
       }
     };
 

--- a/apps/src/dance/Effects.js
+++ b/apps/src/dance/Effects.js
@@ -44,7 +44,7 @@ export default class Effects {
         for (let i = randomNumber(5, 10); i > 0; i--) {
           let loc = randomNumber(0, 15);
           this.bg.fill(p5.color("hsla(" + randomNumber(0, 359) + ", 100%, 80%, " + alpha + ")"));
-          this.bg.rect((loc % 4) * 50, Math.floor(i / 4) * 50, 50, 50);
+          this.bg.rect((loc % 4) * 50, Math.floor(loc / 4) * 50, 50, 50);
         }
       },
       draw: function ({isPeak}) {

--- a/apps/src/dance/Effects.js
+++ b/apps/src/dance/Effects.js
@@ -32,7 +32,7 @@ export default class Effects {
     this.disco = {
       bg: undefined,
       init: function () {
-        this.bg = createGraphics(World.width, World.height);
+        this.bg = p5.createGraphics(p5.width, p5.height);
         this.bg.noStroke();
         for (let i = 0; i < 16; i++) {
           this.bg.fill(
@@ -48,8 +48,12 @@ export default class Effects {
         }
       },
       draw: function ({isPeak}) {
-        if (!this.bg) this.init();
-        if (isPeak) this.update();
+        if (!this.bg) {
+          this.init();
+        }
+        if (isPeak) {
+          this.update();
+        }
         p5.image(this.bg, 0, 0);
       }
     };


### PR DESCRIPTION
I've been experimenting with drawing effects to an offscreen buffer so that we can update the existing buffer instead of redrawing the whole thing every tick. Note that I haven't tested this as my local instance is in a bad state. This technique won't work for every effect, but if it works it should be easier to create a class of effects that I've avoided thus far due to bad performance.