### PR TITLE
Fix up Dance free play level

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -338,6 +338,7 @@
   "decideLater": "Decide later",
   "defaultTwitterText": "Check out what I made",
   "defaultProjectNameAppLab": "App Lab Project",
+  "defaultProjectNameDance": "Dance Project",
   "defaultProjectNameGameLab": "Game Lab Project",
   "defaultProjectNameWebLab": "Web Lab Project",
   "defaultProjectNameArtist": "Artist Project",

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -642,12 +642,16 @@ var projects = module.exports = {
     }
     switch (appOptions.app) {
       case 'applab':
-        return 'applab';
+      case 'calc':
+      case 'dance':
+      case 'eval':
+      case 'flappy':
+      case 'scratch':
+      case 'weblab':
+        return appOptions.app; // Pass through type exactly
       case 'gamelab':
         if (appOptions.droplet) {
           return 'gamelab';
-        } else if (appOptions.level.isDanceLab) {
-          return 'dance';
         }
         return 'spritelab';
       case 'turtle':
@@ -657,8 +661,6 @@ var projects = module.exports = {
           return 'artist_k1';
         }
         return 'artist';
-      case 'calc':
-        return 'calc';
       case 'craft':
         if (appOptions.level.isAgentLevel) {
           return 'minecraft_hero';
@@ -668,8 +670,6 @@ var projects = module.exports = {
           return 'minecraft_codebuilder';
         }
         return 'minecraft_adventurer';
-      case 'eval':
-        return 'eval';
       case 'studio':
         if (appOptions.level.useContractEditor) {
           return 'algebra_game';
@@ -689,12 +689,6 @@ var projects = module.exports = {
           return 'playlab_k1';
         }
         return 'playlab';
-      case 'weblab':
-        return 'weblab';
-      case 'flappy':
-        return 'flappy';
-      case 'scratch':
-        return 'scratch';
       case 'bounce':
         if (appOptions.skinId === 'sports') {
           return 'sports';

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -627,6 +627,8 @@ var projects = module.exports = {
           return msg.defaultProjectNameBasketball();
         }
         return msg.defaultProjectNameBounce();
+      case 'dance':
+        return msg.defaultProjectNameDance();
     }
     return msg.defaultProjectName();
   },

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -87,7 +87,7 @@ Dance.prototype.init = function (config) {
 
     const finishButton = document.getElementById('finishButton');
     if (finishButton) {
-      dom.addClickTouchEvent(finishButton, () => this.onPuzzleComplete());
+      dom.addClickTouchEvent(finishButton, () => this.onPuzzleComplete(true));
     }
   };
 

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
@@ -12,6 +11,7 @@ import Sounds from '../Sounds';
 import {TestResults} from '../constants';
 import DanceParty from '@code-dot-org/dance-party/src/p5.dance';
 import {reducers, setSong} from './redux';
+import {SignInState} from '../code-studio/progressRedux';
 
 const ButtonState = {
   UP: 0,
@@ -92,7 +92,6 @@ Dance.prototype.init = function (config) {
   };
 
   const showFinishButton = !this.level.isProjectLevel && !this.level.validationCode;
-  const finishButtonFirstLine = _.isEmpty(this.level.softButtons);
 
   this.studioApp_.setPageConstants(config, {
     channelId: config.channel,
@@ -118,7 +117,7 @@ Dance.prototype.init = function (config) {
       <AppView
         visualizationColumn={
           <DanceVisualizationColumn
-            showFinishButton={finishButtonFirstLine && showFinishButton}
+            showFinishButton={showFinishButton}
           />
         }
         onMount={onMount}
@@ -486,12 +485,15 @@ Dance.prototype.onP5Draw = function () {
  * this.studioApp_.displayFeedback when appropriate
  */
 Dance.prototype.displayFeedback_ = function () {
+  const isSignedIn = getStore().getState().progress.signInState === SignInState.SignedIn;
   this.studioApp_.displayFeedback({
     feedbackType: this.testResults,
     message: this.message,
     response: this.response,
     level: this.level,
     showingSharing: this.shouldShowSharing(),
+    saveToProjectGallery: true,
+    disableSaveToGallery: !isSignedIn,
     appStrings: {
       reinfFeedbackMsg: 'TODO: localized feedback message.',
     },

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -5,6 +5,7 @@ import * as utils from '@cdo/apps/utils';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {files as filesApi} from '@cdo/apps/clientApi';
 import header from '@cdo/apps/code-studio/header';
+import msg from '@cdo/locale';
 
 describe('project.js', () => {
   let sourceHandler;
@@ -22,6 +23,120 @@ describe('project.js', () => {
     header.showMinimalProjectHeader.restore();
     header.updateTimestamp.restore();
     restoreAppOptions();
+  });
+
+  describe('getNewProjectName()', () => {
+    it('for applab', () => {
+      window.appOptions.app = 'applab';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameAppLab());
+    });
+
+    it('for gamelab', () => {
+      window.appOptions.app = 'gamelab';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameGameLab());
+    });
+
+    it('for weblab', () => {
+      window.appOptions.app = 'weblab';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameWebLab());
+    });
+
+    it('for artist', () => {
+      window.appOptions.app = 'turtle';
+      window.appOptions.skinId = 'artist';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameArtist());
+    });
+
+    it('for artist_zombie', () => {
+      window.appOptions.app = 'turtle';
+      window.appOptions.skinId = 'artist_zombie';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameArtist());
+    });
+
+    it('for anna', () => {
+      window.appOptions.app = 'turtle';
+      window.appOptions.skinId = 'anna';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameFrozen());
+    });
+
+    it('for elsa', () => {
+      window.appOptions.app = 'turtle';
+      window.appOptions.skinId = 'elsa';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameFrozen());
+    });
+
+    it('for Big Game', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.level = {useContractEditor: true};
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameBigGame());
+    });
+
+    it('for Play Lab', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'studio';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNamePlayLab());
+    });
+
+    it('for infinity', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'infinity';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameInfinity());
+    });
+
+    it('for gumball', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'gumball';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameGumball());
+    });
+
+    it('for iceage', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'iceage';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameIceAge());
+    });
+
+    it('for Star Wars', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'hoc2015';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameStarWars());
+    });
+
+    it('for craft', () => {
+      window.appOptions.app = 'craft';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameMinecraft());
+    });
+
+    it('for flappy', () => {
+      window.appOptions.app = 'flappy';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameFlappy());
+    });
+
+    it('for bounce', () => {
+      window.appOptions.app = 'bounce';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameBounce());
+    });
+
+    it('for sports', () => {
+      window.appOptions.app = 'bounce';
+      window.appOptions.skinId = 'sports';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameSports());
+    });
+
+    it('for basketball', () => {
+      window.appOptions.app = 'bounce';
+      window.appOptions.skinId = 'basketball';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameBasketball());
+    });
+
+    it('for dance', () => {
+      window.appOptions.app = 'dance';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectNameDance());
+    });
+
+    it('default case', () => {
+      window.appOptions.app = 'someOtherType';
+      expect(project.getNewProjectName()).to.equal(msg.defaultProjectName());
+    });
   });
 
   describe('project.getProjectUrl', function () {

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {expect} from '../../../util/configuredChai';
 import sinon from 'sinon';
 import {replaceOnWindow, restoreOnWindow} from '../../../util/testUtils';
@@ -136,6 +137,171 @@ describe('project.js', () => {
     it('default case', () => {
       window.appOptions.app = 'someOtherType';
       expect(project.getNewProjectName()).to.equal(msg.defaultProjectName());
+    });
+  });
+
+  describe('getStandaloneApp()', () => {
+    it('for any level with a predefined project type', () => {
+      window.appOptions.level = {projectType: 'foobar'};
+      expect(project.getStandaloneApp()).to.equal('foobar');
+    });
+
+    it('for applab', () => {
+      window.appOptions.app = 'applab';
+      expect(project.getStandaloneApp()).to.equal('applab');
+    });
+
+    it('for calc', () => {
+      window.appOptions.app = 'calc';
+      expect(project.getStandaloneApp()).to.equal('calc');
+    });
+
+    it('for dance', () => {
+      window.appOptions.app = 'dance';
+      expect(project.getStandaloneApp()).to.equal('dance');
+    });
+
+    it('for eval', () => {
+      window.appOptions.app = 'eval';
+      expect(project.getStandaloneApp()).to.equal('eval');
+    });
+
+    it('for flappy', () => {
+      window.appOptions.app = 'flappy';
+      expect(project.getStandaloneApp()).to.equal('flappy');
+    });
+
+    it('for scratch', () => {
+      window.appOptions.app = 'scratch';
+      expect(project.getStandaloneApp()).to.equal('scratch');
+    });
+
+    it('for weblab', () => {
+      window.appOptions.app = 'weblab';
+      expect(project.getStandaloneApp()).to.equal('weblab');
+    });
+
+    it('for gamelab', () => {
+      window.appOptions.app = 'gamelab';
+      window.appOptions.droplet = true;
+      expect(project.getStandaloneApp()).to.equal('gamelab');
+    });
+
+    it('for spritelab', () => {
+      window.appOptions.app = 'gamelab';
+      window.appOptions.droplet = false;
+      expect(project.getStandaloneApp()).to.equal('spritelab');
+    });
+
+    it('for artist', () => {
+      window.appOptions.app = 'turtle';
+      expect(project.getStandaloneApp()).to.equal('artist');
+    });
+
+    it('for artist_k1', () => {
+      window.appOptions.app = 'turtle';
+      window.appOptions.level = {isK1: true};
+      expect(project.getStandaloneApp()).to.equal('artist_k1');
+    });
+
+    it('for frozen', () => {
+      window.appOptions.app = 'turtle';
+      window.appOptions.skinId = _.sample(['anna', 'elsa']);
+      expect(project.getStandaloneApp()).to.equal('frozen');
+    });
+
+    it('for minecraft_adventurer', () => {
+      window.appOptions.app = 'craft';
+      expect(project.getStandaloneApp()).to.equal('minecraft_adventurer');
+    });
+
+    it('for minecraft_hero', () => {
+      window.appOptions.app = 'craft';
+      window.appOptions.level = {isAgentLevel: true};
+      expect(project.getStandaloneApp()).to.equal('minecraft_hero');
+    });
+
+    it('for minecraft_designer', () => {
+      window.appOptions.app = 'craft';
+      window.appOptions.level = {isEventLevel: true};
+      expect(project.getStandaloneApp()).to.equal('minecraft_designer');
+    });
+
+    it('for minecraft_codebuilder', () => {
+      window.appOptions.app = 'craft';
+      window.appOptions.level = {isConnectionLevel: true};
+      expect(project.getStandaloneApp()).to.equal('minecraft_codebuilder');
+    });
+
+    it('for playlab', () => {
+      window.appOptions.app = 'studio';
+      expect(project.getStandaloneApp()).to.equal('playlab');
+    });
+
+    it('for playlab_k1', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.level = {isK1: true};
+      expect(project.getStandaloneApp()).to.equal('playlab_k1');
+    });
+
+    it('for algebra_game', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.level = {useContractEditor: true};
+      expect(project.getStandaloneApp()).to.equal('algebra_game');
+    });
+
+    it('for starwars', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'hoc2015';
+      window.appOptions.droplet = true;
+      expect(project.getStandaloneApp()).to.equal('starwars');
+    });
+
+    it('for starwarsblocks_hour', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'hoc2015';
+      window.appOptions.droplet = false;
+      expect(project.getStandaloneApp()).to.equal('starwarsblocks_hour');
+    });
+
+    it('for iceage', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'iceage';
+      expect(project.getStandaloneApp()).to.equal('iceage');
+    });
+
+    it('for infinity', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'infinity';
+      expect(project.getStandaloneApp()).to.equal('infinity');
+    });
+
+    it('for gumball', () => {
+      window.appOptions.app = 'studio';
+      window.appOptions.skinId = 'gumball';
+      expect(project.getStandaloneApp()).to.equal('gumball');
+    });
+
+    it('for bounce', () => {
+      window.appOptions.app = 'bounce';
+      expect(project.getStandaloneApp()).to.equal('bounce');
+    });
+
+    it('for sports', () => {
+      window.appOptions.app = 'bounce';
+      window.appOptions.skinId = 'sports';
+      expect(project.getStandaloneApp()).to.equal('sports');
+    });
+
+    it('for basketball', () => {
+      window.appOptions.app = 'bounce';
+      window.appOptions.skinId = 'basketball';
+      expect(project.getStandaloneApp()).to.equal('basketball');
+    });
+
+    it('default case', () => {
+      window.appOptions.app = 'someothertype';
+      expect(project.getStandaloneApp()).to.be.null;
     });
   });
 

--- a/dashboard/config/scripts/levels/Dance_Party_12.level
+++ b/dashboard/config/scripts/levels/Dance_Party_12.level
@@ -40,7 +40,6 @@
     "skip_autosave": true,
     "default_song": "hammer",
     "long_instructions": "Get your groove on! Create a dance of your own to share with your friends.",
-    "is_project_level": true,
     "soft_buttons": [
       "leftButton",
       "rightButton",

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -70,6 +70,7 @@ module ScriptConstants
       BASKETBALL_NAME = 'basketball'.freeze,
       SPORTS_NAME = 'sports'.freeze,
       HOC_NAME = 'hourofcode'.freeze, # 2014 hour of code
+      DANCE_PARTY_NAME = 'dance'.freeze, # 2018 hour of code
     ],
     csf_international: [
       COURSE1_NAME = 'course1'.freeze,


### PR DESCRIPTION
This is the "project-backed native dance" work, although I think we may pivot away from that to doing what we've done in the past: A level-source-backed free-play level with a "Add to my projects" feature behind the "Finish" button which remixes the level-source-backed work into a dance-type project.

FYI @cpirich I'll be pushing relevant changes here as I go.

**Fixes:**
- Last level of dance script gets a **Finish** button.
- Finish dialog shows **Add to Projects** and **Publish** options (if you're signed in).
  ![image](https://user-images.githubusercontent.com/1615761/47396303-06817a80-d6df-11e8-87e7-c788d66f74a6.png)
- **Add to Projects** correctly makes a project at `/projects/dance/...` with the student's previous work.
- Clicking **Continue** in the finish dialog correctly navigates to `<pegasus>/api/hour/finish/dance`

**Still needed:**
- Styling and updated strings for the finish dialog.
- Save a project thumbnail when saving to gallery.
- Selected song is not saved into the created project.
- `<pegasus>/api/hour/finish/dance` is not found (depends on an update to the tutorials Gsheet)
- Integration tests for these features.