### PR TITLE
The answer column was too narrow for long email addresses, which was …

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -79,10 +79,10 @@ const styles = {
     width: '80%'
   },
   questionColumn: {
-    width: '60%'
+    width: '50%'
   },
   answerColumn: {
-    width: '20%'
+    width: '30%'
   },
   scoringColumn: {
     width: '20%'


### PR DESCRIPTION
…causing eyes tests to generate unneeded diffs. Widen the column