### PR TITLE
Remove pineapple from block in feedback message

### DIFF
--- a/apps/i18n/dance/en_us.json
+++ b/apps/i18n/dance/en_us.json
@@ -5,7 +5,7 @@
   "danceFeedbackTooManyDancers": "Be careful! If you put `make a new` block inside `every 2 measures`, you will create a lot of dancers.",
   "danceFeedbackUseSetSize": "Use the `set backup_dancer2 size` block to make that dancer smaller.",
   "danceFeedbackUseSetTint": "Use the `set tint` block to change a dancer's tint.",
-  "danceFeedbackUseStartMapping": "Try adding the <xml><block type=\"Dancelab_startMapping\"><title name=\"SPRITE\">right_pineapple</title><title name=\"PROPERTY\">\"scale\"</title><title name=\"RANGE\">\"bass\"</title></block></xml> block to your program.",
+  "danceFeedbackUseStartMapping": "Try adding the <xml><block type=\"Dancelab_startMapping\"><title name=\"SPRITE\">right_unicorn</title><title name=\"PROPERTY\">\"scale\"</title><title name=\"RANGE\">\"bass\"</title></block></xml> block to your program.",
   "danceFeedbackStartNewMove": "Your dancer wasn't doing a new move after the fourth measure.",
   "danceFeedbackNeedDifferentDance": "You need to use a different dance.",
   "danceFeedbackNeedEveryTwoMeasures": "Make sure you are using the `every 2 measures` block",


### PR DESCRIPTION
We are removing all required/in-puzzle references to the pineapple and alien in case we have to cut them. In this case, the word "pineapple" didn't appear in the feedback message, but it did appear in the block description. @Hamms , I'm not sure if we need to push out a new loc string or not based on this.