### PR TITLE
Specify AWS CLI and SDK metadata service timeout

### DIFF
--- a/cookbooks/cdo-awscli/templates/default/config.erb
+++ b/cookbooks/cdo-awscli/templates/default/config.erb
@@ -4,6 +4,8 @@ cwlogs = cwlogs
 [default]
 region = <%= node['cdo-awscli']['region'] || 'us-east-1' %>
 metadata_service_num_attempts = 30
+metadata_service_timeout = 30 # seconds
+
 
 <% if node['cdo-awscli']['access_key_id'] &&
     node['cdo-awscli']['access_key_secret']

--- a/lib/cdo/aws/cdo_google_credentials.rb
+++ b/lib/cdo/aws/cdo_google_credentials.rb
@@ -25,12 +25,19 @@ module Cdo
 end
 Aws::CredentialProviderChain.prepend Cdo::CdoCredentialProvider
 
-# Set `instance_profile_credentials_retries` from the AWS config variable
-# `metadata_service_num_attempts`, if provided.
+# Set `instance_profile_credentials_retries` and `instance_profile_credentials_timeout` from the AWS config variables
+# `metadata_service_num_attempts` and `metadata_service_timeout`, if provided.
 # Ref: https://github.com/aws/aws-sdk-ruby/issues/717
 if (retries = Aws.shared_config.
   instance_variable_get(:@parsed_config)&.
   dig(Aws.shared_config.profile_name, 'metadata_service_num_attempts'))
 
   Aws.config.update(instance_profile_credentials_retries: retries)
+end
+
+if (timeout = Aws.shared_config.
+    instance_variable_get(:@parsed_config)&.
+    dig(Aws.shared_config.profile_name, 'metadata_service_timeout'))
+
+  Aws.config.update(instance_profile_credentials_timeout: timeout)
 end


### PR DESCRIPTION
Increase timeout when AWS Command Line Interface (CLI) or AWS SDK query the EC2 Instance metadata service due to issues where certain Instance Types do not respond on the first request to get the instance's IAM credentials.  #25797 increased the number of retries, but we are still seeing Autoscale EC2 Instance launches fail to get IAM credentials when invoking the AWS CLI to invoke the Autoscale lifecycle event.