### PR TITLE
Dance landing page tutorial section

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/dance-landing/dance.css
+++ b/pegasus/sites.v3/code.org/public/css/dance-landing/dance.css
@@ -1,0 +1,13 @@
+.dance-subheading {
+  float: right;
+}
+
+.dance-party-h2 {
+  font-size: 20px;
+}
+
+.dance-img-placeholder {
+  border-radius: 5px;
+  background-color: grey;
+  opacity: 0.2;
+}

--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -1,4 +1,8 @@
+%link{href: "/css/dance-landing/dance.css", type: "text/css", rel: "stylesheet"}
+%link{href: "/css/starwars.css", type: "text/css", rel: "stylesheet"}
+
 %h1= I18n.t(:hoc2018_dance_party_main_heading)
+=view :dance_tutorial_section
 
 %h1= I18n.t(:hoc2018_dance_teacher_resources_title)
 

--- a/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
+++ b/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
@@ -1,0 +1,22 @@
+.dance-subheading
+  %a{href: "https://code.org/translate/dance"}= I18n.t(:hoc2018_dance_party_subheading)
+
+%div{style: "clear:both"}
+.starwars-container
+  .img-container.dance-img-placeholder
+  %h1.starwars-heading= I18n.t(:hoc2018_dance_create_your_own_dance_title)
+  .col-25.starwars-tutorial.starwars-blocks-tutorial
+    .tutorial-box
+      %h2.sw-h2.dance-party-h2= I18n.t(:hoc2018_dance_party_box_title)
+      .sw-tutorial-info
+        %p.sw-tutorial-description= I18n.t(:hoc2018_dance_party_box_description)
+      %a{:href => '/api/hour/begin/dance', :target=>'_self'}
+        %button.sw-try-button= I18n.t(:hoc2018_dance_party_button)
+  .col-25.starwars-tutorial.starwars-js-tutorial
+    .tutorial-box
+      %h2.sw-h2.dance-party-h2= I18n.t(:hoc2018_dance_keep_on_dancing_box_title)
+      .sw-tutorial-info
+        %p.sw-tutorial-description= I18n.t(:hoc2018_dance_keep_on_dancing_description)
+      %a{:href => '/api/hour/begin/dance-extras', :target=>'_self'}
+        %button.sw-try-button= I18n.t(:hoc2018_dance_keep_on_dancing_button)
+%div{style: "clear:both"}


### PR DESCRIPTION
This PR is to display the dance tutorial section that includes a lin to dance hoc and second hour of code.  The background will be updated once asset is ready.

### Implemented
- Added tutorial section view partial
- Adjusted font size of the each of tile titles and section sub-heading
- A grey background placeholder

Future work includes: 
- [ ] Add chevron icon to tutorial section subheading
- [ ] i18n for hardcoded strings 
- [ ] creating view partials for each section
- [ ] Updating dance landing page skeleton with view partials
- [ ] Making landing page responsive
- [ ] style tweaks when we see it in the context of the page 

### Screen shot
<img width="1045" alt="screen shot 2018-11-05 at 4 52 40 pm" src="https://user-images.githubusercontent.com/30066710/48036008-430b9800-e11b-11e8-9e5f-4a8530c80957.png">
