### PR TITLE
Dance page - open new tab when playlist thumbnail is clicked

### DIFF
--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -27,7 +27,7 @@ theme: responsive
     .col-50.dance-add-padding
       .videothumbnail
         .thumbnail-wrapper
-          %a{href: "https://www.youtube.com/playlist?list=PLzdnOPI1iJNcXMS80NRhQd0NA3po1swJf"}
+          %a{href: "https://www.youtube.com/playlist?list=PLzdnOPI1iJNcXMS80NRhQd0NA3po1swJf", target: "_blank"}
             %img.dance_thumbnail-tile-img{src:"/images/dance-hoc/dance_playlist_thumbnail.png"}
           .dance_thumbnail-tile-subtitle= I18n.t(:hoc2018_dance_view_creativity_video_playlist)
 


### PR DESCRIPTION
A new tab opens when the playlist thumbnail is clicked since a user will be redirected to youtube.


![playlist_thumbnail](https://user-images.githubusercontent.com/30066710/48309479-ddab1300-e52f-11e8-8786-c4d5079ebcfc.gif)
