### PR TITLE
Dance page - fix video bug

### DIFF
--- a/pegasus/sites.v3/code.org/views/dance_creativity_video.haml
+++ b/pegasus/sites.v3/code.org/views/dance_creativity_video.haml
@@ -1,5 +1,5 @@
 - videos = []
-- videos << { id: 'creativity-is',  code: 'VYqHGIR7a_k', text: I18n.t(:hoc2018_dance_video_title_what_is_creativity),  duration: I18n.t(:video_1min), download: "//videos.code.org/social/creativity-is.mp4"}
+- videos << { id: 'creativity_is',  code: 'VYqHGIR7a_k', text: I18n.t(:hoc2018_dance_video_title_what_is_creativity),  duration: I18n.t(:video_1min), download: "//videos.code.org/social/creativity-is.mp4"}
 
 - videos.each do |video|
   .col-50{style: "float:left; padding:10px"}


### PR DESCRIPTION
Bug: The creativity video does not play when the play button is clicked.

Error:  Uncaught reference error (video id was not found)

Fix:  The naming convention used for the video id was incorrect.  The video id (creativity-is), does not match the convention used to find a video which requires an underscore if there are multiple words used for the video id.  New video id name: creativity_is

![creativity_video](https://user-images.githubusercontent.com/30066710/48309759-42b53780-e535-11e8-8c62-8938bf8cbfdb.gif)
