### PR TITLE
Use dance-party@0.0.28

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -43,7 +43,7 @@
     "@code-dot-org/blockly": "3.1.8",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.1.24",
-    "@code-dot-org/dance-party": "0.0.27",
+    "@code-dot-org/dance-party": "0.0.28",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -58,9 +58,9 @@
   version "0.1.24"
   resolved "https://registry.yarnpkg.com/@code-dot-org/craft/-/craft-0.1.24.tgz#d5d6e383bffb613c5b5a85b351bb6a154a2f6024"
 
-"@code-dot-org/dance-party@0.0.27":
-  version "0.0.27"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/dance-party/-/dance-party-0.0.27.tgz#4a3467e70cd637ebb57ce47e36a7e6313271c99b"
+"@code-dot-org/dance-party@0.0.28":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/dance-party/-/dance-party-0.0.28.tgz#8f98be835e8d326f9e80696f21c18c5a558e3bcd"
 
 "@code-dot-org/johnny-five@0.11.1-cdo.2":
   version "0.11.1-cdo.2"


### PR DESCRIPTION
Pick up these changes:
- `p5.play@1.3.8-cdo` https://github.com/code-dot-org/dance-party/pull/254
  - Smaller temporary canvas for tint https://github.com/code-dot-org/p5.play/pull/48
  - Set character fillStyle to tint value https://github.com/code-dot-org/p5.play/pull/46
- Combine spritesheets and json to minimize requests https://github.com/code-dot-org/dance-party/pull/241
- Changes to event system https://github.com/code-dot-org/dance-party/pull/222