### PR TITLE
Fix Gatekeeper adapter on test

### DIFF
--- a/lib/dynamic_config/gatekeeper.rb
+++ b/lib/dynamic_config/gatekeeper.rb
@@ -107,7 +107,7 @@ class GatekeeperBase
     cache_expiration = 5
 
     # Use the memory adapter if we're running tests, but not if we running the test Rails server.
-    if env == 'test' && File.basename($0) != 'unicorn'
+    if env == 'test' && File.basename($0) != 'puma'
       adapter = MemoryAdapter.new
     elsif env == 'production'
       cache_expiration = 30


### PR DESCRIPTION
Gatekeeper uses a non-persistent in-memory datastore in Rails test environments, except on the managed test server.  The check for whether this the test server was still looking for unicorn, even after we switched to puma.