### PR TITLE
localized_shared_blocks test - return default value

### DIFF
--- a/dashboard/test/models/blockly_test.rb
+++ b/dashboard/test/models/blockly_test.rb
@@ -209,6 +209,55 @@ XML
     assert_equal localized_custom_block, translated_block
   end
 
+  test 'return default value if string is not translated' do
+    test_locale = :"te-ST"
+    I18n.locale = test_locale
+    custom_i18n = {
+      "data" => {
+        "blocks" => {
+          "DanceLab_jumpTo" => {
+            "text" => "springen naar {TIMESTAMP} {DIRECTION}",
+            "options" => {
+              "DIRECTION" => {
+                "right": "",
+                "left": "",
+              }
+            }
+          }
+        }
+      }
+    }
+
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    level = create(:level, :blockly, level_num: 'level1_2_3')
+
+    custom_block =
+      [{
+        name: "DanceLab_jumpTo",
+        pool: "SelectDirection",
+        category: "Events",
+        config:
+          {
+            "color" => [140, 1, 0.74],
+            "func" => "atDirection",
+            "blockText" => "jump to {TIMESTAMP} {DIRECTION}",
+            "args" => [
+              {"name" => "TIMESTAMP", "type" => "Number", "field" => true},
+              {"name" => "DIRECTION", "options" => [["right", "right"], ["left", "left"]]}
+            ],
+            "eventBlock" => true
+          },
+        helperCode: nil
+      }]
+
+    translated_block = level.localized_shared_blocks(custom_block)
+
+    assert_equal translated_block[0][:config]["blockText"], "springen naar {TIMESTAMP} {DIRECTION}"
+    assert_equal translated_block[0][:config]["args"][1]["options"][0][1], "right"
+    assert_equal translated_block[0][:config]["args"][1]["options"][1][1], "left"
+  end
+
   test 'original object is not mutated' do
     test_locale = :"te-ST"
     I18n.locale = test_locale


### PR DESCRIPTION
When a block text or option string is not translated, a default string is displayed.

Previously, a default value was not returned if a string was not translated.  See image below.

<img width="1270" alt="screen shot 2018-11-13 at 6 44 52 pm" src="https://user-images.githubusercontent.com/30066710/48456573-3ff45580-e774-11e8-833e-7c0dbfe40402.png">

[PR #25816](https://github.com/code-dot-org/code-dot-org/pull/25816) resolved this issue.  There is an added step to check if the translated string exists.  If the translated string exists, the translated string is displayed.  If the translated string does not exist, the default value is displayed (English string).

