### PR TITLE
Abuse scores for Featured Projects 

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -275,12 +275,38 @@ var projects = module.exports = {
   /**
    * Sets abuse score to zero, saves the project, and reloads the page
    */
-  adminResetAbuseScore(new_score = 0) {
+  adminResetAbuseScore() {
     var id = this.getCurrentId();
     if (!id) {
       return;
     }
     channels.delete(id + '/abuse', function (err, result) {
+      if (err) {
+        throw err;
+      }
+      assets.patchAll(id, 'abuse_score=0', null, function (err, result) {
+        if (err) {
+          throw err;
+        }
+      });
+      files.patchAll(id, 'abuse_score=0', null, function (err, result) {
+        if (err) {
+          throw err;
+        }
+      });
+    });
+    $('.admin-abuse-score').text(0);
+  },
+
+  /**
+   * Sets abuse score to -1000, saves the project, and reloads the page. This is used when a project is featured to prevent false abuse reports from hiding the project.
+   */
+  setFeaturedAbuseScore(new_score = -1000) {
+    var id = this.getCurrentId();
+    if (!id) {
+      return;
+    }
+    channels.update(id + '/featured-abuse', function (err, result) {
       if (err) {
         throw err;
       }
@@ -293,11 +319,9 @@ var projects = module.exports = {
         if (err) {
           throw err;
         }
-        $('.admin-abuse-score').text(new_score);
       });
     });
-
-    console.log("abuse score", this.getAbuseScore())
+    $('.admin-abuse-score').text(new_score);
   },
 
   /**

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -275,7 +275,7 @@ var projects = module.exports = {
   /**
    * Sets abuse score to zero, saves the project, and reloads the page
    */
-  adminResetAbuseScore() {
+  adminResetAbuseScore(new_score = 0) {
     var id = this.getCurrentId();
     if (!id) {
       return;
@@ -284,18 +284,20 @@ var projects = module.exports = {
       if (err) {
         throw err;
       }
-      assets.patchAll(id, 'abuse_score=0', null, function (err, result) {
+      assets.patchAll(id, `abuse_score=${new_score}`, null, function (err, result) {
         if (err) {
           throw err;
         }
       });
-      files.patchAll(id, 'abuse_score=0', null, function (err, result) {
+      files.patchAll(id, `abuse_score=${new_score}`, null, function (err, result) {
         if (err) {
           throw err;
         }
-        $('.admin-abuse-score').text(0);
+        $('.admin-abuse-score').text(new_score);
       });
     });
+
+    console.log("abuse score", this.getAbuseScore())
   },
 
   /**

--- a/apps/src/code-studio/showProjectAdmin.js
+++ b/apps/src/code-studio/showProjectAdmin.js
@@ -39,6 +39,7 @@ export default (project) => {
         type:'PUT',
         dataType:'json',
         success:function (data) {
+          project.adminResetAbuseScore(-100);
           $('#unfeature_project').show();
           $('#feature_project').hide();
         },

--- a/apps/src/code-studio/showProjectAdmin.js
+++ b/apps/src/code-studio/showProjectAdmin.js
@@ -39,7 +39,7 @@ export default (project) => {
         type:'PUT',
         dataType:'json',
         success:function (data) {
-          project.adminResetAbuseScore(-100);
+          project.setFeaturedAbuseScore();
           $('#unfeature_project').show();
           $('#feature_project').hide();
         },

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -112,11 +112,12 @@
 
     - if current_user.project_validator?
       %br
-      .admin-abuse
+      .admin-abuse{ style: 'display: inline-block;' }
         Abuse score:
-      %span.admin-abuse-score
-        = link_to 'Reset', '#', { class: 'admin-abuse-reset' }
-      .admin-report-abuse{ style: 'display: none;' }
+      .admin-abuse-score{ style: 'display: inline-block;' }
+      .admin-reset-abuse
+        = link_to 'Reset Abuse', '#', { class: 'admin-abuse-reset' }
+      .admin-report-abuse
         = link_to 'Report Abuse', '/report_abuse'
 
       #disable-auto-moderation{'style' => ('display: none;' if content_moderation_disabled)}

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -112,9 +112,9 @@
 
     - if current_user.project_validator?
       %br
-      %div.admin-abuse{ :style => "display: none" }
+      .admin-abuse
         Abuse score:
-        %span.admin-abuse-score
+      %span.admin-abuse-score
         = link_to 'Reset', '#', { class: 'admin-abuse-reset' }
       .admin-report-abuse{ style: 'display: none;' }
         = link_to 'Report Abuse', '/report_abuse'

--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -194,16 +194,25 @@ class StorageApps
     new_score
   end
 
-  def reset_abuse(channel_id)
+  def set_featured_abuse_score(channel_id)
+    _owner, id = storage_decrypt_channel_id(channel_id)
+    row = @table.where(id: id).exclude(state: 'deleted').first
+    raise NotFound, "channel `#{channel_id}` not found" unless row
+
+    update_count = @table.where(id: id).exclude(state: 'deleted').update({abuse_score: -1000})
+    raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
+  end
+
+  def set_abuse(channel_id, new_score = 0)
     _owner, id = storage_decrypt_channel_id(channel_id)
 
     row = @table.where(id: id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
 
-    update_count = @table.where(id: id).exclude(state: 'deleted').update({abuse_score: 0})
+    update_count = @table.where(id: id).exclude(state: 'deleted').update({abuse_score: new_score})
     raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
 
-    0
+    new_score
   end
 
   def content_moderation_disabled?(channel_id)


### PR DESCRIPTION
Project abuse scores start at 0. If abuse is reported on a project, the abuse score increments by 10 and at 10 the project is hidden from the public gallery.  Featured projects are hand selected for their quality and display prominently in the public gallery.  Users will often report abuse on featured projects even though they aren't abusive. As a preventative measure, this change sets the abuse score to -1000 when a project is featured. 

- unfeaturing a previously featured project does not affect the abuse score
- reporting abuse on a featured project still increments the abuse score by 10 
- reseting the abuse score still sets the score to 0 even if the project is featured

![feature-abuse-score-2](https://user-images.githubusercontent.com/12300669/48524763-785c6800-e836-11e8-875f-7e848828321f.gif)
