### PR TITLE
Update rest-client to 2.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -271,7 +271,11 @@ gem 'net-scp'
 gem 'net-ssh'
 gem 'oj'
 
-gem 'rest-client', '~> 2.0'
+gem 'rest-client', '~> 2.0.1'
+
+# A rest-client dependency
+# This is the latest version that's installing successfully
+gem 'unf_ext', '0.0.7.2'
 
 # Generate SSL certificates.
 gem 'acmesmith', '~> 0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,7 +398,7 @@ GEM
       devise (>= 3.2.0)
     diff-lcs (1.3)
     docile (1.1.5)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     eventmachine (1.2.5)
@@ -483,7 +483,7 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     httparty (0.13.7)
       json (~> 1.8)
@@ -716,7 +716,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rest-client (2.0.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -1006,7 +1006,7 @@ DEPENDENCIES
   require_all
   rerun
   responders (~> 2.0)
-  rest-client (~> 2.0)
+  rest-client (~> 2.0.1)
   retryable
   rinku
   rmagick
@@ -1037,6 +1037,7 @@ DEPENDENCIES
   timecop
   twilio-ruby
   uglifier (>= 1.3.0)
+  unf_ext (= 0.0.7.2)
   unicorn (~> 5.1.0)
   user_agent_parser
   validates_email_format_of


### PR DESCRIPTION
While attempting reproduce the case where tests exited early on localhost, I hit this possibly-related exception in the `rest-client` gem while retrieving flakiness information from SauceLabs:

```
     5: from /home/brad/Projects/code-dot-org/code-dot-org/lib/cdo/test_flakiness.rb:46:in `block in summarize_by_job'
     4: from /home/brad/Projects/code-dot-org/code-dot-org/lib/cdo/test_flakiness.rb:30:in `get_jobs'
     3: from /home/brad/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rest-client-2.0.0/lib/restclient/request.rb:52:in `execute'
     2: from /home/brad/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rest-client-2.0.0/lib/restclient/request.rb:52:in `new'
     1: from /home/brad/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rest-client-2.0.0/lib/restclient/request.rb:198:in `initialize'
/home/brad/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rest-client-2.0.0/lib/restclient/request.rb:198:in `fetch': key not found: :ciphers (KeyError)
```

We are depending on `rest-client@2.0.0` but apparently [this particular error has been fixed in `rest-client@2.0.1`](https://github.com/rest-client/rest-client/issues/612#issuecomment-313034465).

I'm setting our dependency to `~> 2.0.1` to make sure we pick up the fix, but we're actually upgrading to 2.0.2 with this change.  The [changes in these two versions](https://github.com/rest-client/rest-client/blob/master/history.md#202) look quite small so I'm not particularly concerned about the upgrade.

### Change footprint

We use `rest-client` for four things:

- [Asking SauceLabs for flakiness info](https://github.com/code-dot-org/code-dot-org/blob/1e42fe6eb6eee7c2c1bedbd0abce6b73fe0ae9c0/lib/cdo/test_flakiness.rb#L30)
- [Talking to Mimeo](https://github.com/code-dot-org/code-dot-org/blob/70431bd70ae9d71fdb104db167728400a4a98bca/dashboard/lib/pd/mimeo_rest_client.rb#L31)
- [Talking to JotForm](https://github.com/code-dot-org/code-dot-org/blob/f8bcb7276ae87f4f8a9fc52ea85149b54e6f9e5f/dashboard/lib/pd/jot_form/jot_form_rest_client.rb#L16)
- [Talking to Clever for class rostering](https://github.com/code-dot-org/code-dot-org/blob/0138b1a743450f26e829a127c95d5b949b33abfb/dashboard/app/controllers/api_controller.rb#L13)

I'm not sure our test coverage for these things is particularly good, so I consider this change risky in the sense that it depends on manual testing.

### Locking unf_ext

I ran into one issue during this upgrade, which was building native dependencies for the `unf_ext` gem that `rest-client` (eventually) depends upon.  I found a number of reports of problems building this gem ([example](https://github.com/rest-client/rest-client/issues/473)).  This worries me a bit, and I decided the safest course of action would be to lock our `unf_ext` version to the one (0.0.7.2) that is building successfully (on my machine and, presumably, everywhere else) instead of upgrading to the newest one (0.0.7.5) which was giving me trouble, and might be a problem elsewhere too.  I verified all the intermediate dependencies are loose enough to work fine with the existing `unf_ext` version.
