### PR TITLE
Volunteer: fix unsubscribe for users without email preference

### DIFF
--- a/pegasus/sites.v3/code.org/public/js/volunteer-unsubscribe.js
+++ b/pegasus/sites.v3/code.org/public/js/volunteer-unsubscribe.js
@@ -14,6 +14,8 @@ function processVolunteerUnsubscribeError(data) {
       'Please certify that you are at least 18 years old to update your preferences. ' +
       'If you are not yet 18, please request to remove yourself from the volunteer list by ' +
       '<a href="https://support.code.org/hc/en-us/requests/new" target="_blank">contacting support</a>.';
+    } else if (errors[i] === "email_preference_opt_in_s") {
+      errorMessage = 'Please select an email preference below.';
     }
   }
 

--- a/pegasus/sites.v3/code.org/public/volunteer/engineer/edit/splat.haml
+++ b/pegasus/sites.v3/code.org/public/volunteer/engineer/edit/splat.haml
@@ -33,23 +33,35 @@ theme: responsive
     .radio-row
       %div
         %label.radio-inline
-          %input#unsubscribe-volunteer-annual{name: "unsubscribed_s", type: "radio", xrequired: true, value: "untilhoc", checked: form.data['unsubscribed_s'] == 'untilhoc'}/
+          %input#unsubscribe-volunteer-annual{name: "unsubscribed_s", type: "radio", value: "untilhoc", checked: form.data['unsubscribed_s'] == 'untilhoc'}/
           Stop sending me teacher requests until the next Hour of Code
       %div
         %label.radio-inline
-          %input#unsubscribe-volunteer-annual{name: "unsubscribed_s", type: "radio", xrequired: true, value: "forever", checked: form.data['unsubscribed_s'] == 'forever'}/
+          %input#unsubscribe-volunteer-annual{name: "unsubscribed_s", type: "radio", value: "forever", checked: form.data['unsubscribed_s'] == 'forever'}/
           Stop sending me teacher requests forever
       %div
         %label.radio-inline
-          %input#unsubscribe-volunteer-annual{name: "unsubscribed_s", type: "radio", xrequired: true, value: "resubscribe", checked: form.data['unsubscribed_s'] == 'resubscribe'}/
+          %input#unsubscribe-volunteer-annual{name: "unsubscribed_s", type: "radio", value: "resubscribe", checked: form.data['unsubscribed_s'] == 'resubscribe'}/
           Send me teacher requests again
 
   - if form.data['age_18_plus_b'] != '1'
     .form-group
       %div
         %label{style: 'font-weight: normal; cursor: pointer'}
-          %input#volunteer-age-18-plus-unsubscribe{name: 'age_18_plus_b', type: 'checkbox', value: '1', xrequired: true, checked: true}
+          %input#volunteer-age-18-plus-unsubscribe{name: 'age_18_plus_b', type: 'checkbox', value: '1', checked: true}
             = I18n.t(:volunteer_engineer_submission_checkbox_age_18_plus)
+
+  .form-group
+    %label.control-label{for: "volunteer-email-preference"}
+      = I18n.t(:volunteer_engineer_submission_field_email_preference)
+      %a{href: '/privacy', target: '_blank'}
+        = I18n.t(:volunteer_engineer_submission_field_email_preference_privacy)
+      %span.form-required-field *
+    %div
+      %select#volunteer-email-preference.form-control{name: "email_preference_opt_in_s", type: "select", xrequired: true}
+        %option{value: "", selected: true, disabled: true}
+        %option{value: "yes"}= I18n.t(:volunteer_engineer_submission_field_email_preference_yes)
+        %option{value: "no"}= I18n.t(:volunteer_engineer_submission_field_email_preference_no)
 
   #volunteer-secret{style: 'display: none'}= secret
   %button.primary.btn-submit Confirm

--- a/pegasus/sites.v3/code.org/public/volunteer/engineer/edit/splat.haml
+++ b/pegasus/sites.v3/code.org/public/volunteer/engineer/edit/splat.haml
@@ -50,15 +50,17 @@ theme: responsive
         %label{style: 'font-weight: normal; cursor: pointer'}
           %input#volunteer-age-18-plus-unsubscribe{name: 'age_18_plus_b', type: 'checkbox', value: '1', checked: true}
             = I18n.t(:volunteer_engineer_submission_checkbox_age_18_plus)
+          %span.form-required-field *
 
   .form-group
     %label.control-label{for: "volunteer-email-preference"}
       = I18n.t(:volunteer_engineer_submission_field_email_preference)
       %a{href: '/privacy', target: '_blank'}
         = I18n.t(:volunteer_engineer_submission_field_email_preference_privacy)
-      %span.form-required-field *
+      -unless form.data['email_preference_opt_in_s']
+        %span.form-required-field *
     %div
-      %select#volunteer-email-preference.form-control{name: "email_preference_opt_in_s", type: "select", xrequired: true}
+      %select#volunteer-email-preference.form-control{name: "email_preference_opt_in_s", type: "select"}
         %option{value: "", selected: true, disabled: true}
         %option{value: "yes"}= I18n.t(:volunteer_engineer_submission_field_email_preference_yes)
         %option{value: "no"}= I18n.t(:volunteer_engineer_submission_field_email_preference_no)

--- a/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
@@ -120,7 +120,7 @@
         = I18n.t(:volunteer_engineer_submission_field_email_preference_privacy)
       %span.form-required-field *
     %div
-      %select#volunteer-email-preference.form-control{name: "email_preference_opt_in_s", type: "select", required: true}
+      %select#volunteer-email-preference.form-control{name: "email_preference_opt_in_s", type: "select"}
         %option{value: "", selected: true, disabled: true}
         %option{value: "yes"}= I18n.t(:volunteer_engineer_submission_field_email_preference_yes)
         %option{value: "no"}= I18n.t(:volunteer_engineer_submission_field_email_preference_no)


### PR DESCRIPTION
Users who had volunteered before we added the email preference weren't able to modify subscription preferences because the server was enforcing a requirement that there be an email preference.

This adds the email preference dropdown to the "Update email preferences" UI.

![screenshot 2018-11-18 12 45 42](https://user-images.githubusercontent.com/2205926/48667680-e7d0a100-eb2f-11e8-90f3-1ca1b119846c.png)

It's not mandatory if the user already has an email preference, but if they don't, submitting the form will give an error that a value needs to be provided.

![screenshot 2018-11-16 08 57 52](https://user-images.githubusercontent.com/2205926/48584872-093e5b00-e97f-11e8-8049-9ff1d94943d6.png)

(Also, the red asterisk next to email preference is only shown if we don't already have one on record.)

This is similar to the 18+ fix made in https://github.com/code-dot-org/code-dot-org/pull/14622.

Also made a couple small fixes to `/volunteer/local`: when contacting a volunteer, the initiating user's `age_18_plus_b` value is now written properly in the `VolunteerContact2015` form, and fields highlighted for errors are returned to normal when the form is submitted successfully.
