### PR TITLE
Reenable IE11 tests that were failing due to blocked pop-up

### DIFF
--- a/dashboard/test/ui/features/gdpr_dialog.feature
+++ b/dashboard/test/ui/features/gdpr_dialog.feature
@@ -57,8 +57,6 @@ Feature: GDPR Dialog - data transfer agreement
     Given I am on "http://studio.code.org/home?force_in_eu=1"
     Then element ".ui-test-gdpr-dialog" is not visible
 
-  # Brad (2018-11-14) Skip on IE due to blocked pop-ups
-  @no_ie
   Scenario: GDPR Dialog privacy link works from dashboard
     Given I am a teacher
     Given I am on "http://studio.code.org/home?force_in_eu=1"

--- a/dashboard/test/ui/features/manage_assets.feature
+++ b/dashboard/test/ui/features/manage_assets.feature
@@ -23,8 +23,7 @@ Feature: Manage Assets
     And element ".assetThumbnail" is visible
     And element ".fa-play-circle" is visible
 
-  # Brad (2018-11-14) Skip on IE due to blocked pop-ups
-  @no_safari_yosemite @no_ie
+  @no_safari_yosemite
   Scenario: The manage assets dialog displays an image thumbnail and opens in a new tab when clicked
     Given I am a student
     And I start a new Game Lab project

--- a/dashboard/test/ui/features/pixelation.feature
+++ b/dashboard/test/ui/features/pixelation.feature
@@ -2,8 +2,6 @@
 @no_mobile
 @no_safari_yosemite
 Feature: Pixelation levels
-  # Brad (2018-11-14) Skip on IE due to blocked pop-ups
-  @no_ie
   @no_circle
   @as_student
   Scenario: Pixelation version 2 in black and white with no sliders
@@ -21,8 +19,6 @@ Feature: Pixelation levels
     And I save pixelation data and reload
     Then pixelation data has text "0000 0011 0000 0010 0 1 0 1 1 1 1 1"
 
-  # Brad (2018-11-14) Skip on IE due to blocked pop-ups
-  @no_ie
   @no_circle
   @as_student
   Scenario: Pixelation version 3 in color with sliders
@@ -40,8 +36,6 @@ Feature: Pixelation levels
     And I save pixelation data and reload
     Then pixelation data has text "0000 0100 0000 0010 0000 0011 000 111 100 010 001 110 111 000 111 000 01"
 
-  # Brad (2018-11-14) Skip on IE due to blocked pop-ups
-  @no_ie
   @no_circle
   @as_student
   Scenario: Pixelation version 3 in color with sliders starting in hex mode


### PR DESCRIPTION
Heard back from SauceLabs:

> The internal bug for the issue where the IE popup blocker was causing the tests to fail has been resolved. Please try running your tests and let me know if you still face issues.

This PR reverses _some_ of the changes in https://github.com/code-dot-org/code-dot-org/pull/26078, experimentally checking if we can re-enable these tests.  Note, some of them (pixelation.feature in particular) are marked `@no_circle` so we may want to check these directly on test before merging too.

`[skip unit] [skip chrome] [test ie]`