### PR TITLE
Dance: Force playspace to be LTR

### DIFF
--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -134,6 +134,7 @@ class DanceVisualizationColumn extends React.Component {
             <div
               id="divDance"
               style={divDanceStyle}
+              dir="ltr"
             >
               <div id="p5_loading" style={p5LoadingStyle}>
                 <img src="//curriculum.code.org/images/DancePartyLoading.gif" style={p5LoadingGifStyle}/>


### PR DESCRIPTION
The "Measures: X" text was rendered mostly off-screen for RTL users.  This simple fix forces the playspace to always be LTR, making the text look the same for both LTR and RTL users.

Care should be taken to ensure this doesn't interfere with any other visuals in the dance party.

Before, for "Measure: 10":

![screenshot 2018-11-22 11 27 29](https://user-images.githubusercontent.com/2205926/48973391-68445400-f092-11e8-87fd-6e2a2d9ed5ea.png)
