### PR TITLE
Fix teacher resources button for non English locales

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/dance-landing/dance-teacher-resources.css
+++ b/pegasus/sites.v3/code.org/public/css/dance-landing/dance-teacher-resources.css
@@ -34,6 +34,14 @@
   color: white;
   font-family: 'Gotham 7r', sans-serif;
   margin-bottom: 20px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.resource-title:hover {
+  overflow: visible;
+  white-space: normal;
 }
 
 .resource-description {
@@ -68,6 +76,10 @@
     float: none;
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .resource-title {
+    margin-bottom: 0px;
   }
 
   .resource-gif {

--- a/pegasus/sites.v3/code.org/public/css/dance-landing/dance-teacher-resources.css
+++ b/pegasus/sites.v3/code.org/public/css/dance-landing/dance-teacher-resources.css
@@ -46,6 +46,8 @@
   background-color: #e7e8ea;
   border-color: #e7e8ea;
   color: #5b6770;
+  height: auto;
+  white-space: normal;
 }
 
 #teacher-resources .col-50:nth-child(2) {


### PR DESCRIPTION
This PR is to adjust the button in the  teacher resources' cards for non-English languages.  Long translated titles are truncated.  This is a temporary fix is to improve user experience during hoc.  Additional work will be done post hoc.

### Before
- Desktop (Italian)
<img width="1033" alt="screen shot 2018-11-28 at 8 23 31 pm" src="https://user-images.githubusercontent.com/30066710/49199258-b20b9380-f34b-11e8-9b4e-09ff3f949228.png">

- Mobile
<img width="341" alt="screen shot 2018-11-28 at 8 23 52 pm" src="https://user-images.githubusercontent.com/30066710/49199259-b2a42a00-f34b-11e8-8493-16708b29a153.png">

- Tablet
<img width="568" alt="screen shot 2018-11-28 at 8 24 02 pm" src="https://user-images.githubusercontent.com/30066710/49199260-b2a42a00-f34b-11e8-8803-caa7d69a2e9f.png">


### After

- Desktop
![ellipsis](https://user-images.githubusercontent.com/30066710/49199169-59d49180-f34b-11e8-83a7-a74be20ecd46.gif)

- Mobile
<img width="353" alt="screen shot 2018-11-28 at 8 21 20 pm" src="https://user-images.githubusercontent.com/30066710/49199511-fe0b0800-f34c-11e8-908a-8c628b6c5c28.png">



<img width="352" alt="screen shot 2018-11-28 at 7 10 55 pm" src="https://user-images.githubusercontent.com/30066710/49199099-0a8e6100-f34b-11e8-87b0-2b6908cefbc7.png">

- Tablet
<img width="616" alt="screen shot 2018-11-28 at 7 58 25 pm" src="https://user-images.githubusercontent.com/30066710/49199100-0a8e6100-f34b-11e8-9752-b3d54bd5d787.png">
