### PR TITLE
Format twitter url differently from Share Allowed Dialog

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -264,8 +264,8 @@ class ShareAllowedDialog extends React.Component {
                           "&amp;hashtags=HourOfCode&amp;related=codeorg";
     // Check out the dance I made featuring @artist on @codeorg! URL #HourOfCode
     const twitterShareUrlDance = "https://twitter.com/intent/tweet?url=" +
-                          "&amp;text=Check%20out%20the%20dance%20I%20made%20featuring%20@" + artistTwitterHandle + "%20on%20@codeorg!%20" +
                           encodeURIComponent(this.props.shareUrl) +
+                          "&amp;text=Check%20out%20the%20dance%20I%20made%20featuring%20@" + artistTwitterHandle + "%20on%20@codeorg!%20" +
                           "&amp;hashtags=HourOfCode&amp;related=codeorg";
 
     const twitterShareUrl = artistTwitterHandle ?


### PR DESCRIPTION
Related to[ Dance Party Issue 502](https://github.com/code-dot-org/dance-party/issues/502) - there are a few more notes in that issue.  

Tweeting from the Share Dialog of a Dance Party project doesn't have an image. 
<img width="578" alt="screen shot 2018-11-29 at 9 25 54 am" src="https://user-images.githubusercontent.com/12300669/49240966-5d076600-f3bb-11e8-8f50-57cb600440f8.png">

Tweeting from the Share Dialog or the Finish Dialog of a Dance Party level does have an image, and a differently formatted card. 
<img width="525" alt="screen shot 2018-11-29 at 9 18 31 am" src="https://user-images.githubusercontent.com/12300669/49241014-7c05f800-f3bb-11e8-8abe-42fa56045f2f.png">

Tweeting from the Share Dialog of a Minecraft project does have an image on production.
https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost-studio.code.org%3A3000%2Fprojects%2Fminecraft_aquatic%2F2yEPja9PTH4oi51mNwTaLA&amp;text=Check%20out%20what%20I%20made%20@codeorg&amp;hashtags=HourOfCode&amp;related=codeorg
<img width="582" alt="screen shot 2018-11-29 at 9 55 23 am" src="https://user-images.githubusercontent.com/12300669/49241559-03a03680-f3bd-11e8-93cc-1f404cc58016.png">

One notable difference is how the Twitter link is being formatted.  Currently, the Dance Party project tweet doesn't include the url in the url section of the link. 

The other difference is where we pull the share image from: https://studio.code.org/assets/craft_sharing_drawing-0c44b72723ec99761f50eb399e489c6cb071d9367079161ef9e48cfa8cefb50b.png

BEFORE:
https://twitter.com/intent/tweet?url=&amp;text=Check%20out%20the%20dance%20I%20made%20featuring%20@codeorg%20on%20@codeorg!%20http%3A%2F%2Flocalhost-studio.code.org%3A3000%2Fprojects%2Fdance%2FiAKraM_MXxv6Dk2BxrpCbw&amp;hashtags=HourOfCode&amp;related=codeorg

<img width="663" alt="local share before" src="https://user-images.githubusercontent.com/12300669/49240600-6fcd6b00-f3ba-11e8-9ed6-6242db95dc00.png">

I rearranged the order of information in the Tweet link for Dance Party projects so the url is include, which is more consistent with how Minecraft project tweets are formatted. 

AFTER: 
https://twitter.com/intent/tweet?url=http%3A%2F%2Flocalhost-studio.code.org%3A3000%2Fprojects%2Fdance%2FiAKraM_MXxv6Dk2BxrpCbw&amp;text=Check%20out%20the%20dance%20I%20made%20featuring%20@codeorg%20on%20@codeorg!%20&amp;hashtags=HourOfCode&amp;related=codeorg
<img width="706" alt="screen shot 2018-11-29 at 9 40 00 am" src="https://user-images.githubusercontent.com/12300669/49240735-ce92e480-f3ba-11e8-8a8d-ab972748b19e.png">


