### PR TITLE
Add small dot between artist names on /dance

### DIFF
--- a/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
+++ b/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
@@ -33,6 +33,6 @@
     %div
       - Homepage.get_dance_stars.each do |star|
         %span{style: "white-space: nowrap"}= star
-        &nbsp; &nbsp;
+        &nbsp;&middot;&nbsp;
       %span{style: "white-space: nowrap"}= hoc_s(:codeorg_homepage_hoc2018_musician_after)
 %div{style: "clear:both"}


### PR DESCRIPTION
Resolves https://github.com/code-dot-org/dance-party/issues/386.

I didn't make the same change on the homepage, although we could if we wanted to.  That code is here:

https://github.com/code-dot-org/code-dot-org/blob/769c46e96babe4e4e0b3a4057f5776c99b4b3992/pegasus/sites.v3/code.org/views/homepage_hero.haml#L121-L123

Before:

![image](https://user-images.githubusercontent.com/413693/49249683-be3a3400-f3d1-11e8-8c23-0624aa35a26e.png)

After:

![image](https://user-images.githubusercontent.com/413693/49249605-8206d380-f3d1-11e8-88d9-e741bbb06681.png)