### PR TITLE
Fetch with_associated_models in Script#get_without_cache

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -378,7 +378,7 @@ class Script < ActiveRecord::Base
     # names which are strings that may contain numbers (eg. 2-3)
     is_id = id_or_name.to_i.to_s == id_or_name.to_s
     find_by = is_id ? :id : :name
-    script = Script.find_by(find_by => id_or_name)
+    script = Script.with_associated_models.find_by(find_by => id_or_name)
     return script if script
 
     unless is_id


### PR DESCRIPTION
### Issue

Since #22887, the `version_year` parameter is added to script-cache fetches from `ScriptLevelsController#show`. These fetches do not use the pre-loaded script entries, but instead are fetched individually from `get_without_cache`. However, the implementation of `get_without_cache` only currently fetches the `script` model alone, without the `with_associated_models` scope currently used by the pre-loaded models, causing extra queries to be generated at runtime when using these models.

The fix is to add `with_associated_models` to the `get_without_cache` code path.