### PR TITLE
Refactor Starwars tutorial haml to be more generalizable

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/starwars.css
+++ b/pegasus/sites.v3/code.org/public/css/starwars.css
@@ -1,7 +1,3 @@
-#starwars-mobile-image {
-  background-image: url(/images/fit-520/starwars_carousel_background.jpg);
-}
-
 .starwars-container {
   width: 100%;
   padding-left: 5px;
@@ -81,6 +77,10 @@
 }
 
 @media screen and (min-width: 0px) and (max-width: 970px) {
+  #starwars-mobile-image {
+    background-image: url(/images/fit-520/starwars_carousel_background.jpg);
+  }
+
   .starwars-container .tutorial-box h2 {
     font-size: 17px;
   }

--- a/pegasus/sites.v3/code.org/public/css/starwars.css
+++ b/pegasus/sites.v3/code.org/public/css/starwars.css
@@ -1,3 +1,7 @@
+#starwars-mobile-image {
+  background-image: url(/images/fit-520/starwars_carousel_background.jpg);
+}
+
 .starwars-container {
   width: 100%;
   padding-left: 5px;

--- a/pegasus/sites.v3/code.org/public/css/tutorial-promo.css
+++ b/pegasus/sites.v3/code.org/public/css/tutorial-promo.css
@@ -81,10 +81,6 @@
   .img-container {
     padding: 0px 5px;
   }
-
-  #starwars-mobile-image {
-    background-image: url(/images/fit-520/starwars_carousel_background.jpg);
-  }
 }
 
 @media screen and (min-width: 500px) and (max-width: 600px) {

--- a/pegasus/sites.v3/code.org/public/css/tutorial-promo.css
+++ b/pegasus/sites.v3/code.org/public/css/tutorial-promo.css
@@ -1,0 +1,113 @@
+.tutorial-promo-container {
+  width: 100%;
+  padding-left: 5px;
+  position: relative;
+}
+
+.background-img {
+  width: 100%;
+  border-radius: 5px;
+}
+
+.tutorial-heading {
+  margin-top: 0px;
+  margin-bottom: 10px;
+  color: white;
+  position: absolute;
+  top: 20px;
+  left: 470px;
+}
+
+.specific-tutorial {
+  position: absolute;
+  height: 330px;
+  padding: 5px;
+  top: 70px;
+}
+
+.left-tutorial {
+  right: 20px;
+}
+
+.right-tutorial {
+  right: 270px;
+}
+
+.tutorial-promo-container .tutorial-box {
+  background-color: rgba(0, 0, 0, 0.4);
+  color: white;
+  padding: 20px;
+  border-radius: 5px;
+}
+
+.specific-tutorial-heading {
+  margin-top: 0px;
+  margin-bottom: 10px;
+  color: white;
+}
+
+.tutorial-info {
+  height: 100px;
+}
+
+.tutorial-specs {
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.tutorial-button {
+  font-size: 18px;
+  height: 40px;
+}
+
+@media screen and (min-width: 0px) and (max-width: 970px) {
+  .tutorial-promo-container .tutorial-box h2 {
+    font-size: 17px;
+  }
+
+  .specific-tutorial {
+    width: 100%;
+    height: 220px;
+    padding: 5px;
+    position: static;
+    margin-bottom: 10px;
+  }
+
+  .tutorial-heading {
+    top: 15px;
+    left: 290px;
+  }
+
+  .img-container {
+    padding: 0px 5px;
+  }
+
+  #starwars-mobile-image {
+    background-image: url(/images/fit-520/starwars_carousel_background.jpg);
+  }
+}
+
+@media screen and (min-width: 500px) and (max-width: 600px) {
+  .tutorial-promo-container .tutorial-box h2 {
+    font-size: 14px;
+  }
+}
+
+@media screen and (min-width: 0px) and (max-width: 512px) {
+  .specific-tutorial {
+    width: 100%;
+    height: 220px;
+    position: static;
+  }
+
+  .tutorial-heading {
+    position: static;
+    color: #00adbc;
+    text-align: center;
+  }
+
+  .tutorial-promo-container .tutorial-box {
+    /* Ensure background doesn't repeat in the wider box */
+    background-size: cover;
+  }
+}

--- a/pegasus/sites.v3/code.org/public/starwars.haml
+++ b/pegasus/sites.v3/code.org/public/starwars.haml
@@ -43,7 +43,7 @@ style_min: true
     display_second_tutorial: display_second_tutorial
   }
 
-=view :tutorial_promo, tutorial: tutorial
+= view :tutorial_promo, tutorial: tutorial
 
 %div{style: "clear:both"}
 

--- a/pegasus/sites.v3/code.org/public/starwars.haml
+++ b/pegasus/sites.v3/code.org/public/starwars.haml
@@ -23,30 +23,27 @@ style_min: true
 
 %link{href: "/css/starwars.css", rel: "stylesheet"}
 
-%div{style: "clear:both"}
+:ruby
+  display_second_tutorial = !("#{request.locale}" == "en-US") ? 'none' : ''
 
-.starwars-container
-  .img-container
-    %img.starwars-img{src:"/images/fit-1940/sw_landingpage.jpg"}
-  %h1.starwars-heading= I18n.t(:starwars_subtitle)
+  tutorial = {
+    heading: I18n.t(:starwars_subtitle),
+    background_image: "/images/fit-1940/sw_landingpage.jpg",
+    left_heading: I18n.t(:starwars_javascript_title),
+    left_description: I18n.t(:starwars_javascript_description),
+    left_specs: I18n.t(:starwars_javascript_specs),
+    left_button_link: '/api/hour/begin/starwars',
+    left_button_text: I18n.t(:try_now),
+    right_heading:  I18n.t(:starwars_blocks_title),
+    right_description: I18n.t(:starwars_blocks_description),
+    right_specs: I18n.t(:starwars_blocks_specs),
+    right_button_link: '/api/hour/begin/starwarsblocks',
+    right_button_text: I18n.t(:try_now),
+    id_for_mobile_image: "starwars-mobile-image",
+    display_second_tutorial: display_second_tutorial
+  }
 
-  .col-25.starwars-tutorial.starwars-js-tutorial{style: "display: none"}
-    .tutorial-box
-      %h2.sw-h2= I18n.t(:starwars_javascript_title)
-      .sw-tutorial-info
-        %p.sw-tutorial-description= I18n.t(:starwars_javascript_description)
-        %p.sw-tutorial-specs= I18n.t(:starwars_javascript_specs)
-      %a{:href => '/api/hour/begin/starwars', :target=>'_self'}
-        %button.sw-try-button= I18n.t(:try_now)
-
-  .col-25.starwars-tutorial.starwars-blocks-tutorial
-    .tutorial-box
-      %h2.sw-h2= I18n.t(:starwars_blocks_title)
-      .sw-tutorial-info
-        %p.sw-tutorial-description= I18n.t(:starwars_blocks_description)
-        %p.sw-tutorial-specs= I18n.t(:starwars_blocks_specs)
-      %a{:href => '/api/hour/begin/starwarsblocks', :target=>'_self'}
-        %button.sw-try-button= I18n.t(:try_now)
+=view :tutorial_promo, tutorial: tutorial
 
 %div{style: "clear:both"}
 
@@ -65,13 +62,3 @@ style_min: true
 %h2.sw-header2
   = I18n.t(:speak_another_language)
   %a{href: "/translate/starwars"}= I18n.t(:help_translate)
-
-= view 'mobilecheck.js'
-
-:javascript
-
-  $(document).ready(function() {
-    if (!window.mobilecheck() && "#{request.locale}" == "en-US") {
-      $('.starwars-js-tutorial').show();
-    }
-  });

--- a/pegasus/sites.v3/code.org/views/tutorial_promo.haml
+++ b/pegasus/sites.v3/code.org/views/tutorial_promo.haml
@@ -1,0 +1,24 @@
+%link{href: "/css/tutorial-promo.css", rel: "stylesheet"}
+
+.tutorial-promo-container
+  .img-container
+    %img.background-img{src: tutorial[:background_image]}
+  %h1.tutorial-heading=tutorial[:heading]
+
+  .col-25.specific-tutorial.left-tutorial{style: "display: #{tutorial[:display_second_tutorial]}"}
+    .tutorial-box{id: tutorial[:id_for_mobile_image]}
+      %h2.specific-tutorial-heading=tutorial[:left_heading]
+      .tutorial-info
+        %p.tutorial-description=tutorial[:left_description]
+        %p.tutorial-specs=tutorial[:left_specs]
+      %a{:href => tutorial[:left_button_link], :target=>'_self'}
+        %button.tutorial-button= tutorial[:left_button_text]
+
+  .col-25.specific-tutorial.right-tutorial
+    .tutorial-box{id: tutorial[:id_for_mobile_image]}
+      %h2.specific-tutorial-heading=tutorial[:right_heading]
+      .tutorial-info
+        %p.tutorial-description=tutorial[:right_description]
+        %p.tutorial-specs=tutorial[:right_specs]
+      %a{:href => tutorial[:right_button_link], :target=>'_self'}
+        %button.tutorial-button= tutorial[:right_button_text]

--- a/pegasus/sites.v3/code.org/views/tutorial_promo.haml
+++ b/pegasus/sites.v3/code.org/views/tutorial_promo.haml
@@ -3,22 +3,22 @@
 .tutorial-promo-container
   .img-container
     %img.background-img{src: tutorial[:background_image]}
-  %h1.tutorial-heading=tutorial[:heading]
+  %h1.tutorial-heading= tutorial[:heading]
 
   .col-25.specific-tutorial.left-tutorial{style: "display: #{tutorial[:display_second_tutorial]}"}
     .tutorial-box{id: tutorial[:id_for_mobile_image]}
-      %h2.specific-tutorial-heading=tutorial[:left_heading]
+      %h2.specific-tutorial-heading= tutorial[:left_heading]
       .tutorial-info
-        %p.tutorial-description=tutorial[:left_description]
-        %p.tutorial-specs=tutorial[:left_specs]
-      %a{:href => tutorial[:left_button_link], :target=>'_self'}
+        %p.tutorial-description= tutorial[:left_description]
+        %p.tutorial-specs= tutorial[:left_specs]
+      %a{href: tutorial[:left_button_link], target: '_self'}
         %button.tutorial-button= tutorial[:left_button_text]
 
   .col-25.specific-tutorial.right-tutorial
     .tutorial-box{id: tutorial[:id_for_mobile_image]}
-      %h2.specific-tutorial-heading=tutorial[:right_heading]
+      %h2.specific-tutorial-heading= tutorial[:right_heading]
       .tutorial-info
-        %p.tutorial-description=tutorial[:right_description]
-        %p.tutorial-specs=tutorial[:right_specs]
-      %a{:href => tutorial[:right_button_link], :target=>'_self'}
+        %p.tutorial-description= tutorial[:right_description]
+        %p.tutorial-specs= tutorial[:right_specs]
+      %a{href: tutorial[:right_button_link], target: '_self'}
         %button.tutorial-button= tutorial[:right_button_text]


### PR DESCRIPTION
On our tutorial landing pages we have 3 very similar components that are all currently using [Starwars styling and selectors](https://github.com/code-dot-org/code-dot-org/pull/25528/files#r228708365) since they were built quickly to hit HoC deadlines: 

**Starwars**
<img width="985" alt="screen shot 2018-11-30 at 5 32 26 pm" src="https://user-images.githubusercontent.com/12300669/49409080-ec8e7b00-f713-11e8-9a31-670c805d2baa.png">

**Minecraft** 
<img width="1014" alt="screen shot 2018-11-30 at 5 33 21 pm" src="https://user-images.githubusercontent.com/12300669/49409077-ea2c2100-f713-11e8-9422-eee140f287ba.png">

**Dance** 
<img width="987" alt="screen shot 2018-11-30 at 5 32 48 pm" src="https://user-images.githubusercontent.com/12300669/49409057-dbde0500-f713-11e8-8c00-5285e321875e.png">

It's also very likely that we will want to use a similar component in the future. 

This PR is the first in a series to extract the skeleton of the Starwars version of the component and its stylings into a more general, reusable haml partial. This PR affects only code.org/starwars. Follow up PR will address the other 2 components and delete the styles duplication. 

There should be no user impact with this refactor, and there are eyes tests on the Starwars landing page, which should catch any regressions. 

English // Desktop // Before 
<img width="1170" alt="english desktop prod" src="https://user-images.githubusercontent.com/12300669/49409230-89511880-f714-11e8-8265-de18048a3b22.png">

English // Desktop // After 
<img width="1233" alt="english desktop after" src="https://user-images.githubusercontent.com/12300669/49409233-8eae6300-f714-11e8-8c4e-bf0c67d38483.png">

English // Mobile // Before 
<img width="399" alt="english mobile before" src="https://user-images.githubusercontent.com/12300669/49409239-93731700-f714-11e8-8546-9b94eb7c1795.png">

English // Mobile // After 
<img width="396" alt="english mobile after" src="https://user-images.githubusercontent.com/12300669/49409241-97069e00-f714-11e8-88a1-d2fe8a4502f1.png">

non-English // Desktop // Before 
<img width="1170" alt="spanish desktop prod" src="https://user-images.githubusercontent.com/12300669/49409248-9f5ed900-f714-11e8-85b8-d1a896f2fcea.png">

non-English // Desktop // After 
<img width="1234" alt="spanish desktop after" src="https://user-images.githubusercontent.com/12300669/49409255-a7b71400-f714-11e8-82cf-1967919816bd.png">

non-English // Mobile // Before 
<img width="402" alt="spanish mobile before" src="https://user-images.githubusercontent.com/12300669/49409259-aede2200-f714-11e8-8370-aec2628ff33d.png">

non-English // Mobile // After 
<img width="398" alt="spanish mobile after" src="https://user-images.githubusercontent.com/12300669/49409267-b271a900-f714-11e8-9aac-0085b3acac84.png">


