### PR TITLE
Dance Landing: remove Starwars classnames and CSS from dance tutorial

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/dance-landing/dance.css
+++ b/pegasus/sites.v3/code.org/public/css/dance-landing/dance.css
@@ -14,13 +14,13 @@
   display: none;
 }
 
-.starwars-tutorial.dance-tutorial {
+.dance-tutorial {
   top: 15px;
 }
 
 .dance-try-button {
-  font-size:18px;
-  height:40px;
+  font-size: 18px;
+  height: 40px;
   background-color: white;
   border-color: white;
   color: #4d575f;
@@ -36,6 +36,11 @@
   font-family: 'Gotham 5r', sans-serif;
   line-height: 19px;
   padding: 5px 10px;
+}
+
+.foot-note-heading {
+  margin-bottom: 5px;
+  font-family: 'Gotham 7r', sans-serif;
 }
 
 .img-wrapper img {
@@ -105,6 +110,10 @@ a:hover {
   margin-right: 18%;
 }
 
+.artist-name, .and-more {
+  white-space: nowrap;
+}
+
 @media screen and (min-width: 0px) and (max-width: 512px) {
   .sponsor-logo-with-text {
     flex-direction: column;
@@ -128,6 +137,17 @@ a:hover {
 
 /* Tablet and mobile */
 @media screen and (max-width: 970px) {
+  .dance-party-container .tutorial-box {
+    background-image: url(/images/fit-1940/dance-hoc/dance_party_landing_main_nophotos.png)
+  }
+
+  .img-container {
+    background: url(/images/dance-hoc/dance_party_tutorial_hero.png);
+    margin: 5px;
+    border-radius: 5px;
+    background-size: cover;
+  }
+
   .foot-note-text {
     position: static;
     color: #00adbc;
@@ -179,12 +199,12 @@ a:hover {
     position: relative;
   }
 
-  .starwars-tutorial.dance-tutorial {
+  .dance-tutorial {
     float: left;
     width: 50%;
   }
 
-  .img-container img {
+  .background-img img {
     margin-bottom: 5px
   }
 }
@@ -195,7 +215,7 @@ a:hover {
     display: block;
   }
 
-  .img-container {
+  .background-img {
     background: url(/images/dance-hoc/dance_party_tutorial_hero.png);
     margin: 5px;
     border-radius: 5px;

--- a/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
+++ b/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
@@ -1,38 +1,39 @@
 - hide_keep_on_dancing_tile = DCDO.get('hide_dance_followup', nil)
-%link{href: "/css/starwars.css", type: "text/css", rel: "stylesheet"}
 
-%div{style: "clear:both"}
-.starwars-container.dance-party-container
+%link{href: "/css/tutorial-promo.css", type: "text/css", rel: "stylesheet"}
+
+.dance-clear-element
+.tutorial-promo-container.dance-party-container
   .img-container
-    %img.starwars-img.desktop-only.tablet-only{src:"/images/dance-hoc/dance_party_tutorial_hero_400px.png"}
+    %img.background-img.desktop-only.tablet-only{src:"/images/dance-hoc/dance_party_tutorial_hero_400px.png"}
     %img.img-dance-stars.desktop-only{src: "/images/fit-300x300/homepage/hoc2018_dance_stars_mobile.png"}
     %img.img-dance-stars.tablet-only{src: "/images/fit-520/homepage/hoc2018_dance_stars.png"}
     %img.img-dance-stars.mobile-only{src: "/images/fit-300x300/homepage/hoc2018_dance_stars_mobile.png"}
-  .col-25.starwars-tutorial.starwars-blocks-tutorial.dance-tutorial
+  .col-25.specific-tutorial.right-tutorial.dance-tutorial
     .tutorial-box
-      %h2.sw-h2.dance-party-h2= I18n.t(:hoc2018_dance_party_box_title)
-      .sw-tutorial-info
-        %p.sw-tutorial-description= I18n.t(:hoc2018_dance_party_box_description)
-      %a{:href => CDO.studio_url('/s/dance/reset'), :target=>'_self'}
-        %button.sw-try-button.dance-try-button= I18n.t(:hoc2018_dance_party_button)
-  .col-25.starwars-tutorial.starwars-js-tutorial.dance-tutorial
+      %h2.specific-tutorial-heading.dance-party-h2= I18n.t(:hoc2018_dance_party_box_title)
+      .tutorial-details
+        %p.tutorial-description= I18n.t(:hoc2018_dance_party_box_description)
+      %a{href: CDO.studio_url('/s/dance/reset'), target: '_self'}
+        %button.tutorial-button.dance-try-button= I18n.t(:hoc2018_dance_party_button)
+  .col-25.specific-tutorial.left-tutorial.dance-tutorial
     - unless hide_keep_on_dancing_tile
       .tutorial-box
-        %h2.sw-h2.dance-party-h2= I18n.t(:hoc2018_dance_keep_on_dancing_box_title)
-        .sw-tutorial-info
-          %p.sw-tutorial-description= I18n.t(:hoc2018_dance_keep_on_dancing_description)
-        %a{:href => CDO.studio_url('/s/dance-extras/reset'), :target=>'_self'}
-          %button.sw-try-button.dance-try-button= I18n.t(:hoc2018_dance_keep_on_dancing_button)
+        %h2.specific-tutorial-heading.dance-party-h2= I18n.t(:hoc2018_dance_keep_on_dancing_box_title)
+        .tutorial-details
+          %p.tutorial-description= I18n.t(:hoc2018_dance_keep_on_dancing_description)
+        %a{href: CDO.studio_url('/s/dance-extras/reset'), target: '_self'}
+          %button.tutorial-button.dance-try-button= I18n.t(:hoc2018_dance_keep_on_dancing_button)
   .dance-text-icon-container.tablet-only.mobile-only
     %a.translate-link{href: "/translate/dance"}
       .dance-translate-link-text
         =I18n.t(:hoc2018_dance_party_subheading)
       %i.fa.fa-chevron-right.dance-chevron-icon
-  %div.foot-note-text
-    %div{style: "margin-bottom: 5px; font-weight: bold;"}= hoc_s(:codeorg_homepage_hoc2018_musician_before)
-    %div
+  .foot-note-text
+    .foot-note-heading= hoc_s(:codeorg_homepage_hoc2018_musician_before)
+    .artist-names
       - Homepage.get_dance_stars.each do |star|
-        %span{style: "white-space: nowrap"}= star
+        %span.artist-name= star
         &nbsp; &nbsp;
-      %span{style: "white-space: nowrap"}= hoc_s(:codeorg_homepage_hoc2018_musician_after)
-%div{style: "clear:both"}
+      %span.and-more= hoc_s(:codeorg_homepage_hoc2018_musician_after)
+.dance-clear-element


### PR DESCRIPTION
Continuation of #26289.

The Dance Party tutorial promotion section has some elements (the small circles for the star photos, differently colored buttons, the footer text, etc) that would've made it difficult to entirely reuse `tutorial_promo.haml` without overloading that component with conditionals.  However, by renaming the haml elements in `dance_tutorial_section` to be consistent with `tutorial-promo.css` I was able to re-use tutorial promo styles and eliminate the need to import `starwars.css`.  Other clean-up changes includes removing inline styles, updating => syntax and adding spaces where needed. 

No user impact.

After the refactor:
![dance-tutorial-refactor](https://user-images.githubusercontent.com/12300669/49545144-9e9f8180-f891-11e8-912c-256a160b3692.gif)
