### PR TITLE
Disable Eyes logging

### DIFF
--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -5,7 +5,6 @@ require 'open-uri'
 require 'json'
 require 'rinku'
 require_relative '../../utils/selenium_constants'
-require 'logger'
 
 # Override default match timeout (2 seconds) to help prevent laggy UI from breaking eyes tests.
 # See http://support.applitools.com/customer/en/portal/articles/2099488-match-timeout
@@ -76,5 +75,4 @@ def ensure_eyes_available
   # Force eyes to use a consistent host OS identifier for now
   # BrowserStack was reporting Windows 6.0 and 6.1, causing different baselines
   @eyes.host_os = ENV['APPLITOOLS_HOST_OS']
-  @eyes.log_handler = Logger.new('../../log/eyes.log')
 end


### PR DESCRIPTION
@mehalshah and I enabled Eyes logging to diagnose HTTP 408 errors being returned by the Applitools web service in early August.  This logging is no longer needed and can be disabled.