### PR TITLE
New Workshop Form: add "Deep Dive" as CSF subject option

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -412,6 +412,9 @@ export class WorkshopForm extends React.Component {
 
   renderWorkshopTypeOptions(validation) {
     const isCsf = this.state.course === 'CS Fundamentals';
+    const isDeepDive = this.state.subject === "Deep Dive";
+    const showMapChoice = isCsf && !isDeepDive;
+
     return (
       <FormGroup>
         <ControlLabel>
@@ -434,7 +437,7 @@ export class WorkshopForm extends React.Component {
         }
         <Row>
           <Col smOffset={1}>
-            {isCsf && this.renderOnMapRadios(validation)}
+            {showMapChoice && this.renderOnMapRadios(validation)}
             {this.renderFundedSelect(validation)}
           </Col>
         </Row>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -504,12 +504,7 @@ export class WorkshopForm extends React.Component {
 
   renderSubjectSelect(validation) {
     if (this.shouldRenderSubject()) {
-      // TODO(tanya): Show 201 subject in workshop dashboard UI
-      // Temporarily hiding CSF 201 subject from the workshop dashboard
-      // until the pilot is over in winter 2018
-      const included_subjects = Subjects[this.state.course]
-        .filter(subject => subject !== "Deep Dive");
-      const options = included_subjects.map((subject, i) => {
+      const options = Subjects[this.state.course].map((subject, i) => {
         return (<option key={i} value={subject}>{subject}</option>);
       });
       const placeHolder = this.state.subject ? null : <option />;


### PR DESCRIPTION
Follow up to #23190.

Now that the pilot is over, we would like to permanently add "Deep Dive" as a subject option if CS Fundamentals is selected as the course when a new workshop is being created. This PR includes "Deep Dive" in the subject options dropdown if "CS Fundamentals" is the selected course and hides the map option for this case. 

BEFORE
<img width="677" alt="screen shot 2018-12-11 at 10 08 53 am" src="https://user-images.githubusercontent.com/12300669/49821421-3dfbc300-fd2f-11e8-85d9-4e1d86077024.png">

AFTER
![deep-dive](https://user-images.githubusercontent.com/12300669/49821418-3cca9600-fd2f-11e8-950f-f01af1be9353.gif)
