### PR TITLE
add production RDS DB parameter group to Data stack template

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -5,7 +5,7 @@ require 'active_support/core_ext/numeric/time'
 -%>
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: Data layer for Tableau including RedShift cluster configuration and synchronization with RDS instance.
+Description: Data layer including RedShift cluster configuration and synchronization with RDS instance.
 # Parameters can be provided via CDO.underscored_parameter, e.g. via locals.yml:
 # redshift_password: abcdef
 # Parameters are only required for initial stack creation, and reused if not provided on stack update.
@@ -118,62 +118,18 @@ Resources:
       TableMappings: !Sub |
         <%= table_mappings.to_json %>
 <% end -%>
+  PrimaryDBParameters:
+    Type: AWS::RDS::DBParameterGroup
+    Properties:
+      Description: !Sub "Primary Database Parameters for ${AWS::StackName}."
+      Family: mysql5.7
+      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['Primary'].compact.to_json %>
   ReportingDBParameters:
     Type: AWS::RDS::DBParameterGroup
     Properties:
       Description: !Sub "Reporting Read Replica DB Parameters for ${AWS::StackName}."
       Family: mysql5.7
-      Parameters:
-        # Allow redo log to grow larger before flushing for better write I/O efficiency.
-        innodb_adaptive_flushing_lwm: 40
-        # Improve insert/update concurrency for autoincrement tables.
-        innodb_autoinc_lock_mode: 2
-        # Reduce durability for better performance.
-        innodb_flush_log_at_trx_commit: 0
-        # Neighbor flushing reduces performance without any benefit on SSD.
-        innodb_flush_neighbors: 0
-        # IO capacity controls background flushing rate (IO/sec).
-        innodb_io_capacity: 1000
-        # IO capacity max controls maximum background flushing rate when certain thresholds are reached.
-        innodb_io_capacity_max: 3000
-        # Larger log buffer size allows larger transactions without writing to disk.
-        innodb_log_buffer_size: <%=16.megabytes%>
-        # Larger redo log file size allows write combining for better write I/O efficiency.
-        innodb_log_file_size: <%=2.gigabytes%>
-        # LRU scan depth controls LRU flushing rate (IO/sec).
-        innodb_lru_scan_depth: 1000
-        # Enable all InnoDB performance schema monitors for better debugging.
-        innodb_monitor_enable: all
-        # Random read ahead can improve overall read-query performance, important for reporting.
-        innodb_random_read_ahead: 1
-        # Increase number of threads for background reads (read-ahead)
-        innodb_read_io_threads: 8
-        # Increase sample pages for more accurate statistics for query plans.
-        innodb_stats_persistent_sample_pages: 60
-        # 'Splits an internal data structure used to coordinate threads, for higher concurrency in workloads with large numbers of waiting threads.'
-        # AWS recommended increasing to max (1024).
-        innodb_sync_array_size: 1024
-        # Number of threads for background writes
-        innodb_write_io_threads: 8
-        # Reporting DB currently needs write access for contact rollup staging table.
-        read_only: 0
-        # Don't resolve DNS on usernames.
-        skip_name_resolve: 1
-        # Use compression for replication.
-        slave_compressed_protocol: 1
-        # Enable slow query log.
-        slow_query_log: 1
-        # Reduce durability for better performance.
-        sync_binlog: 0
-        # Fully cache all open tables and table definitions.
-        table_definition_cache: 20000
-        table_open_cache: 20000
-        # Relax transaction isolation for improved concurrency under load.
-        tx_isolation: READ-COMMITTED
-        # Requirements for DMS Change Data Capture.
-        # Ref: https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-        binlog_format: ROW
-        binlog_checksum: NONE
+      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['Replica'].compact.to_json %>
 <%
   # Add CloudWatch Logs Metric Filters for RDS Enhanced Monitoring metrics.
   # Ref: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#w2ab1c20c23c17b7b5

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -1,0 +1,139 @@
+---
+# Database parameter group template
+# Reference documentation:
+# https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html
+# https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html
+# https://dev.mysql.com/doc/refman/5.7/en/replication-options-slave.html
+# https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html
+
+# System variables used by primary RDS instance.
+Primary: &primary
+  # Enable Performance Schema.
+  performance_schema: 1
+
+  # Server System Variables:
+  # https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html
+
+  # Number of equality ranges in an equality comparison condition when the optimizer should switch from using index dives
+  # to index statistics in estimating the number of qualifying rows.
+  # Preserve 5.6 default of 10 (in 5.7 the default increased to 200).
+  eq_range_index_dive_limit: 10
+  # Store query logs in files to avoid database overhead.
+  log_output: FILE
+  # Set global execution timeout for SELECT statements, in milliseconds.
+  max_execution_time: 30000
+  # Skip resolving DNS on hostnames for improved performance.
+  skip_name_resolve: 1 # not dynamic
+  # Enable slow query log.
+  slow_query_log: 1
+  # Fully cache all table definitions.
+  table_definition_cache: 20000
+  # Set table_open_cache equal to max_connections.
+  # Ref: https://dev.mysql.com/doc/refman/5.7/en/table-cache.html
+  table_open_cache: '{DBInstanceClassMemory/12582880}'
+  # Relax transaction isolation for improved concurrency under load.
+  tx_isolation: READ-COMMITTED
+
+  # InnoDB System Variables:
+  # https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html
+
+  # Improve insert/update concurrency for autoincrement tables.
+  innodb_autoinc_lock_mode: 2 # not dynamic
+  # With a setting of 0, logs are written and flushed to disk once per second.
+  # Transactions for which logs have not been flushed can be lost in a crash.
+  # Reduces durability for better performance.
+  innodb_flush_log_at_trx_commit: 0
+  # Neighbor flushing reduces performance without any benefit on SSD. (Default changes to 0 in >= 8.0.3)
+  innodb_flush_neighbors: 0
+  # IO capacity controls background flushing rate (IO/sec).
+  innodb_io_capacity: 4000
+  # IO capacity max controls maximum background flushing rate when certain thresholds are reached.
+  innodb_io_capacity_max: 9000
+  # Larger log buffer size allows larger transactions without writing to disk.
+  innodb_log_buffer_size: <%=16.megabytes%> # not dynamic
+  # Larger redo log file size allows write combining for better write I/O efficiency.
+  innodb_log_file_size: <%=2.gigabytes%> # not dynamic
+  # Controls max page-cleaner LRU-flush rate per second, per buffer pool instance.
+  # IO/sec = innodb_lru_scan_depth * innodb_buffer_pool_instances (8).
+  innodb_lru_scan_depth: 2048
+  # Enable all InnoDB performance schema monitors for better debugging.
+  innodb_monitor_enable: all
+  # Increase number of page cleaner threads for flushing dirty pages from the buffer pool.
+  # Recommended one thread per buffer pool instance (8).
+  innodb_page_cleaners: 8 # not dynamic
+  # Random read ahead can improve overall read-query performance.
+  innodb_random_read_ahead: 1
+  # Increase number of threads for background reads (read-ahead).
+  # Each background thread can handle up to 256 pending I/O requests.
+  innodb_read_io_threads: 8 # not dynamic
+  # Increase sample pages for more accurate statistics for query plans.
+  innodb_stats_persistent_sample_pages: 60
+  # Size of the mutex/lock wait array which splits the internal data structure used to coordinate threads.
+  # Increasing the value is recommended for higher concurrency with large numbers of waiting threads (> 768).
+  # AWS recommended increasing to max (1024).
+  innodb_sync_array_size: 1024 # not dynamic
+  # Tries to keep the number of OS threads concurrently inside InnoDB less than or equal to this value.
+  # AWS recommended increasing to max (1000).
+  innodb_thread_concurrency: 1000
+  # Increase number of threads for background writes.
+  # Each background thread can handle up to 256 pending I/O requests.
+  innodb_write_io_threads: 8 # not dynamic
+
+  # Binary Logging Variables
+  # https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html
+
+  # When using row-based logging, the master writes events to the binary log that indicate how individual table rows are changed.
+  # Replication of the master to the slave works by copying the events representing the changes to the table rows to the slave.
+  # ROW required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  binlog_format: ROW
+  # When enabled (default), transactions are externalized in the same order as they are written to the binary log.
+  # If disabled, transactions may be committed in parallel.
+  # In some cases, disabling this variable might produce a performance increment.
+  binlog_order_commits: 0
+  # Log only changed columns, and columns needed to identify rows.
+  binlog_row_image: minimal
+  # Disable synchronization of the binary log to disk.
+  # Reduces durability for better performance.
+  sync_binlog: 0
+
+  # Replication Slave Variables
+  # https://dev.mysql.com/doc/refman/5.7/en/replication-options-slave.html
+
+  # Use compression on the replication protocol.
+  slave_compressed_protocol: 1
+
+# System variables used by read-replica RDS instance.
+Replica:
+  # Merge all primary variables into replica.
+  <<: *primary
+
+  # Performance Schema not needed on reporting DB.
+  performance_schema: null
+  # No max execution time on reporting DB.
+  max_execution_time: null
+  # Reporting DB currently needs write access for contact rollup staging table.
+  read_only: 0
+
+  # Binary Logging Variables
+  # https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html
+
+  # When enabled, this variable causes the master to write a checksum for each event in the binary log.
+  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
+  # NONE required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  binlog_checksum: NONE
+  # Log all columns.
+  # FULL required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.CustomerManaged
+  binlog_row_image: FULL
+
+  # Replication Slave Variables
+  # https://dev.mysql.com/doc/refman/5.7/en/replication-options-slave.html
+
+  # Apply transactions that are part of the same binary-log group-commit in parallel.
+  slave_parallel_type: LOGICAL_CLOCK
+  # Set to 1 (single-thread) as long as binlog_order_commits is disabled (0), to ensure commit-order consistency.
+  slave_parallel_workers: 1
+  # Ensure transactions are externalized in the same order as they appear in the replica's relay log.
+  slave_preserve_commit_order: 1


### PR DESCRIPTION
This PR updates the CloudFormation-managed RDS DB parameter group currently used by our read-replica `reporting` instance, and also creates a new parameter group intended for use by our primary production instance (which is currently using a manually-managed parameter group).

Switching to a CFn-managed parameter group for our primary instance will help us better track our evolving database configuration within our application codebase, and give us a place to add comments and references to further discussion on the various tuning parameters.

As part of this, I've done a pass to try and combine the `reporting` group already in `data` stack template with the current parameter group on production, to set us up with a set of stable, documented set of non-default variable values for us to use moving forward. Here's the diff between the current `production` parameter group (`upgrade-replica`) and the one created by this template (`primarydbparameters`):

Parameter | upgrade-replica | primarydbparameters
-- | -- | --
binlog_format | MIXED | ROW
binlog_row_image | <engine-default> | minimal
innodb_buffer_pool_dump_at_shutdown | 1 | <engine-default>
innodb_buffer_pool_load_at_startup | 1 | <engine-default>
innodb_page_cleaners | <engine-default> | 8
innodb_random_read_ahead | 0 | 1
join_buffer_size | 1048576 | <engine-default>
log_queries_not_using_indexes | 0 | <engine-default>
log_throttle_queries_not_using_indexes | 1 | <engine-default>
performance_schema | 0 | 1
slave_compressed_protocol | <engine-default> | 1
sort_buffer_size | 1048576 | <engine-default>
table_open_cache | 40000 | {DBInstanceClassMemory/12582880}

Notes on each of these diffs:

- `binlog_format`: `MIXED` uses `STATEMENT` format when possible, and `ROW` otherwise. Statement-based logging is the legacy format with various limitations (I suspect most/all of our commits already use ROW format anyway, since statement-based logging is disallowed for commits in `READ_COMMITTED` isolation mode according to the documentation). `ROW` is also the new MySQL default as of 5.7.7.
- `binlog_row_image`: `minimal` reduces the size of the binary log events for replication efficiency.
- `innodb_buffer_pool_dump_at_shutdown` / `innodb_buffer_pool_load_at_startup`: the `engine-default` is now `1` for these in 5.7, so remove the overrides for simplicity.
- `innodb_page_cleaners`: default is `4`, but increasing to `8` (to match buffer pool instance count) is recommended.
- `innodb_random_read_ahead`: enabling this feature can improve read performance.
- `join_buffer_size` / `sort_buffer_size`: The default is **256kb**. These are legacy settings that were changed a long time ago- I suspect these overrides to **1mb** either make no difference or adversely affect performance (by increasing memory usage per-connection). The documentation suggests that it is better to keep these global settings small and change to a larger setting only in specific sessions that are doing large joins / sorts.
- `log_queries_not_using_indexes` / `log_throttle_queries_not_using_indexes`: This is currently disabled which is the default (Performance schema has newer ways to profile queries missing indexes), so remove the overrides for simplicity.
- `performance_schema`: This needs to be on (`1`) for Performance Insights to work; not sure why this was disabled (`0`) in the existing parameter group (it's still currently enabled on the instance anyway).
- `slave_compressed_protocol`: Use compression for replication efficiency.
- `table_open_cache`: The recommendation is to keep this value >= `max_connections`, so this uses the same expression used by default to set `max_connections` (`{DBInstanceClassMemory/12582880}`).