### PR TITLE
Display nectar and honey counts in RTL languages

### DIFF
--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -530,6 +530,10 @@ html[dir='rtl'] div#visualizationResizeBar {
   cursor: default;
 }
 
+html[dir='rtl'] .karel-counter-text {
+  text-anchor: start;
+}
+
 /* Shrink the visualization area on small displays. */
 
 #visualization.responsive > * {

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -528,10 +528,10 @@ html[dir='rtl'] div#visualizationResizeBar {
   stroke: black;
   stroke-width: 1;
   cursor: default;
-}
 
-html[dir='rtl'] .karel-counter-text {
-  text-anchor: start;
+  html[dir='RTL'] & {
+    text-anchor: start;
+  }
 }
 
 /* Shrink the visualization area on small displays. */


### PR DESCRIPTION
Nectar and Honey counts in Bee do not display in RTL languages.

### Fix
- Changed the value of text-anchor attribute from "end" to "start" when a RTL language is selected.

### Screen shots
#### Before
- Persian
<img width="427" alt="screen shot 2018-12-12 at 6 36 47 pm" src="https://user-images.githubusercontent.com/30066710/49914822-9e7e2380-fe47-11e8-8b0a-782bb9b6800b.png">

- Hebrew
<img width="432" alt="screen shot 2018-12-12 at 6 47 54 pm" src="https://user-images.githubusercontent.com/30066710/49914823-9e7e2380-fe47-11e8-99c9-33c08bf7b34d.png">

#### After
- Hebrew
<img width="441" alt="screen shot 2018-12-12 at 6 49 06 pm" src="https://user-images.githubusercontent.com/30066710/49914824-9e7e2380-fe47-11e8-9111-986f5311715a.png">

- Arabic
<img width="440" alt="screen shot 2018-12-12 at 6 49 49 pm" src="https://user-images.githubusercontent.com/30066710/49914825-9e7e2380-fe47-11e8-94c7-00584f544d8a.png">

- Persian
<img width="432" alt="screen shot 2018-12-12 at 7 05 43 pm" src="https://user-images.githubusercontent.com/30066710/49914826-9e7e2380-fe47-11e8-80fb-d105c99e0911.png">
