### PR TITLE
Modified styles such that the Create menu will expand to accommodate any length of text.

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -378,39 +378,40 @@ img.video_thumbnail {
       top: 55px;
       right: 55px;
       background-color: $white;
-      width: 260px;
+      width: max-content;
       z-index: 10000;
+      border: 1px solid $charcoal;
+      border-bottom: 0;
       a {
         color: $teal;
-        font-family: $gotham-bold;
-        height: 70px;
-        width: 258px;
+        font-family: 'Gotham 5r', sans-serif;
+        min-width: 240px;
         font-size: 14px;
-        float: left;
-        border-left: 1px solid $charcoal;
-        border-right: 1px solid $charcoal;
-        border-top: 1px solid $charcoal;
+        border-bottom: 1px solid $charcoal;
+        box-sizing: content-box;
+        white-space: nowrap;
       }
       a:hover {
         color: $teal;
-        font-family: $gotham-bold;
+        font-weight: 900;
         background-color: $white;
         cursor: pointer;
       }
       img {
         height: 70px;
         width: 70px;
-        float: left;
+      }
+      .project_link_box {
+        display: block;
       }
       .project_link {
-        padding-left: 10px;
-        line-height: 70px;
-        float: left;
+        display: inline-block;
+        padding: 0 10px 0 4px;
+        line-height: 67px;
       }
       #view_all_projects {
-        width: 248px;
         height: 70px;
-        border-bottom: 1px solid $charcoal;
+        padding-left: 10px;
       }
     }
 
@@ -464,6 +465,18 @@ img.video_thumbnail {
   .project_list {
     float: left;
     margin-top: 6px;
+  }
+}
+
+#language_dir.rtl #pageheader-wrapper {
+  .create_options {
+    direction: rtl;
+    .project_link {
+      padding: 0 4px 0 10px;
+    }
+    #view_all_projects {
+      padding-right: 10px;
+    }
   }
 }
 

--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -163,18 +163,18 @@
     top: 55px;
     right: 55px;
     background-color: $white;
-    width: 260px;
+    width: max-content;
     z-index: 10000;
+    border: 1px solid $charcoal;
+    border-bottom: 0;
     a {
       color: $teal;
       font-family: 'Gotham 5r', sans-serif;
-      width: 258px;
+      min-width: 240px;
       font-size: 14px;
-      float: left;
-      border-left: 1px solid $charcoal;
-      border-right: 1px solid $charcoal;
-      border-top: 1px solid $charcoal;
+      border-bottom: 1px solid $charcoal;
       box-sizing: content-box;
+      white-space: nowrap;
     }
     a:hover {
       color: $teal;
@@ -185,16 +185,18 @@
     img {
       height: 70px;
       width: 70px;
-      float: left;
+    }
+    .project_link_box {
+      display: block;
     }
     .project_link {
-      padding-left: 10px;
-      line-height: 70px;
-      float: left;
+      display: inline-block;
+      padding: 0 10px 0 4px;
+      line-height: 67px;
     }
     #view_all_projects {
       height: 70px;
-      border-bottom: 1px solid $charcoal;
+      padding-left: 10px;
     }
   }
 
@@ -212,19 +214,19 @@
       display: none !important;
     }
     #signin_button {
-     margin-top: -4px !important;
-   }
+      margin-top: -4px !important;
+    }
   }
 }
 
 #language_dir.rtl #pageheader-wrapper {
   .create_options {
-    img {
-      float: right;
-    }
+    direction: rtl;
     .project_link {
+      padding: 0 4px 0 10px;
+    }
+    #view_all_projects {
       padding-right: 10px;
-      float: right;
     }
   }
 }


### PR DESCRIPTION
Verified at both /home and /help.

Note that I made the changes in header.scss, and then copied the styles to application.scss so they would be consistent. However, they weren't consistent originally, which accounts for some of the extra changes, like from $gotham-bold to 'Gotham 5r', sans-serif. Let me know if they should both be $gotham-bold instead.

The following images were made by adjusting the DOM in the development console, to add text to the menu item and to switch to RTL for the bottom one.

![image](https://user-images.githubusercontent.com/11651276/50024757-44d93e80-ff98-11e8-8baa-d4b10aabbc9e.png)

![image](https://user-images.githubusercontent.com/11651276/50024772-502c6a00-ff98-11e8-8aee-cd83c33e89e5.png)
