### PR TITLE
Revert to remove validation from authored hints field

### DIFF
--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -10,7 +10,7 @@
         %input.tts_url{type: 'hidden', value: 'general'}
         .row
           .span10
-            %input.hint_id{type: 'text', placeholder: 'hint_id', required: true}
+            %input.hint_id{type: 'text', placeholder: 'hint_id'}
             %select.hint_class
               %option{value: 'content'} Content Hint
               %option{value: 'pointer'} Pointer Hint


### PR DESCRIPTION
See [PR# 26295](https://github.com/code-dot-org/code-dot-org/pull/26295)

PR reverted due to content editors being unable to edit and publish a level.