### PR TITLE
[On Hold] Web Lab: Serve Bramble from static.codeprojects.org

### DIFF
--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -498,7 +498,7 @@ function load(Bramble) {
   bramble_ = Bramble;
 
   Bramble.load("#bramble", {
-    url: "//downloads.computinginthecore.org/bramble_0.1.26/index.html?disableExtensions=bramble-move-file",
+    url: "https://static.codeprojects.org/bramble_0.1.26/index.html?disableExtensions=bramble-move-file",
     // DEVMODE: INSECURE (local) url: "../blockly/js/bramble/index.html?disableExtensions=bramble-move-file",
     // DEVMODE: INSECURE url: "http://127.0.0.1:8000/src/index.html?disableExtensions=bramble-move-file",
     useLocationSearch: true,

--- a/pegasus/sites.v3/code.org/public/educate/it.md
+++ b/pegasus/sites.v3/code.org/public/educate/it.md
@@ -38,7 +38,7 @@ For the very best experience with all Code.org content, we recommend consulting 
 | **To use YouTube hosted videos** <br/>(Deprecated late July 2018)| `https://s.youtube.com/*`<br/>`https://www.youtube.com/*`<br/>`https://*.googlevideo.com/*`<br/>`https://*.ytimg.com/*`                                |
 | **To use Code.org hosted videos**                                                  | **Unblock:**<br/>`https://videos.code.org`<br/>**Block:**<br/>`https://www.youtube.com/favicon.ico`<br/>`https://www.youtube-nocookie.com/favicon.ico` |
 | **To use Internet Simulator**   | `https://api.pusherapp.com`<br/>`wss://ws.pusherapp.com:443`                                                                                           |
-| **To use Web Lab** | `https://downloads.computinginthecore.org`<br/>`https://codeprojects.org`                                                                              |
+| **To use Web Lab** | `https://codeprojects.org`<br/>`https://*.codeprojects.org`                                                                              |
 
 ## Videos
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#26385, restores https://github.com/code-dot-org/code-dot-org/pull/26299.

We tried replacing `downloads.computinginthecore.org` with `static.codeprojects.org` in [v2018-12-13.0](https://github.com/code-dot-org/code-dot-org/releases/tag/v2018-12-13.0) and got some complaints, which is expected and (somewhat) unavoidable.  But we don't want to drop this change on teachers without warning, so we reverted the change in [v2018-12-17.0](https://github.com/code-dot-org/code-dot-org/releases/tag/v2018-12-17.0) and will proactively communicate about it when we actually do it.

If we really want to minimize impact we'll have to wait until next summer. CSD2 traffic is distributed pretty evenly across the school year. I'd rather not wait that long, but if we think this is inevitably disruptive to classrooms maybe we need to. Dave proposed we could detect access to `static.codeprojects.org` with a tracking pixel and display a warning for a while before we roll out this change. That would also let us gather metrics on how many students are actually affected. I like this idea but don't have time to implement it before the break.

So: I propose the following:

**Late January** we ship
- A tracking pixel and metrics for static.codeprojects.org in Web Lab.
- A warning banner (shown only when static.codeprojects.org is unreachable)
- A support article about the upcoming change (linked to from the warning banner)
- A change to code.org/educate/it mentioning the upcoming change.

**May 3** we ship
- A warning banner in Web Lab (shown to everyone) mentioning the upcoming change and linking to the support article.

**May 31** we ship
- Change Web Lab to depend on static.codeprojects.org.
- Remove banner shown to everyone.
- Leave reachability metrics and banner for unreachable domain in place (it's a good idea anyway).
- Update banner to point at code.org/educate/it.
- Update code.org/educate/it to only mention the new requirements. (edited) 
