### PR TITLE
hourofcode.com: fix US total event counts

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/events/2014/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/2014/index.haml
@@ -9,12 +9,13 @@ nav: events_nav
   KIND = "HocSignup#{HOC_YEAR}".freeze
   events = Forms.events_by_country(KIND)
   us_events = Forms.events_by_state(KIND)
+  us_events_count = us_events.inject(0) {|result, element| result + element[:count]}
 
 %h1= hoc_s(:events_all_old_title).gsub(/\@year/, HOC_YEAR.to_s)
 
 %ul
   %li{class: "hoc-event-country"}
-    %span{style: "font-weight: bold;"}= "United States (#{us_events.count rescue '0'} #{hoc_s(:events)})"
+    %span{style: "font-weight: bold;"}= "United States (#{us_events_count} #{hoc_s(:events)})"
     %ul{style: "margin-top: 0; margin-bottom: 0;"}
       -us_events.each do |event|
         %li{class: "hoc-event-state"}

--- a/pegasus/sites.v3/hourofcode.com/public/events/2015/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/2015/index.haml
@@ -9,12 +9,13 @@ nav: events_nav
   KIND = "HocSignup#{HOC_YEAR}".freeze
   events = Forms.events_by_country(KIND)
   us_events = Forms.events_by_state(KIND)
+  us_events_count = us_events.inject(0) {|result, element| result + element[:count]}
 
 %h1= hoc_s(:events_all_old_title).gsub(/\@year/, HOC_YEAR.to_s)
 
 %ul
   %li{class: "hoc-event-country"}
-    %span{style: "font-weight: bold;"}= "United States (#{us_events.count rescue '0'} #{hoc_s(:events)})"
+    %span{style: "font-weight: bold;"}= "United States (#{us_events_count} #{hoc_s(:events)})"
     %ul{style: "margin-top: 0; margin-bottom: 0;"}
       -us_events.each do |event|
         %li{class: "hoc-event-state"}

--- a/pegasus/sites.v3/hourofcode.com/public/events/2016/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/2016/index.haml
@@ -9,12 +9,13 @@ nav: events_nav
   KIND = "HocSignup#{HOC_YEAR}".freeze
   events = Forms.events_by_country(KIND)
   us_events = Forms.events_by_state(KIND)
+  us_events_count = us_events.inject(0) {|result, element| result + element[:count]}
 
 %h1= hoc_s(:events_all_old_title).gsub(/\@year/, HOC_YEAR.to_s)
 
 %ul
   %li{class: "hoc-event-country"}
-    %span{style: "font-weight: bold;"}= "United States (#{us_events.count rescue '0'} #{hoc_s(:events)})"
+    %span{style: "font-weight: bold;"}= "United States (#{us_events_count} #{hoc_s(:events)})"
     %ul{style: "margin-top: 0; margin-bottom: 0;"}
       -us_events.each do |event|
         %li{class: "hoc-event-state"}

--- a/pegasus/sites.v3/hourofcode.com/public/events/all/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/all/index.haml
@@ -9,12 +9,13 @@ nav: events_nav
   KIND = "HocSignup#{hoc_year}".freeze
   events = Forms.events_by_country(KIND)
   us_events = Forms.events_by_state(KIND)
+  us_events_count = us_events.inject(0) {|result, element| result + element[:count]}
 
 %h1= hoc_s(:events_all_title)
 
 %ul
   %li{class: "hoc-event-country"}
-    %span{style: "font-weight: bold;"}= "United States (#{us_events.count rescue '0'} #{hoc_s(:events)})"
+    %span{style: "font-weight: bold;"}= "United States (#{us_events_count} #{hoc_s(:events)})"
     %ul{style: "margin-top: 0; margin-bottom: 0;"}
       -us_events.each do |event|
         %li{class: "hoc-event-state"}


### PR DESCRIPTION
This fixes the total US event count to once again show the total number of events, rather than just the count of states and territories, on the following pages:

https://hourofcode.com/au/events/2014
https://hourofcode.com/au/events/2015
https://hourofcode.com/au/events/2016
https://hourofcode.com/au/events/all