### PR TITLE
Teacher Dashboard: render Section Projects with real data

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/index.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/index.js
@@ -7,6 +7,7 @@ import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashbo
 const script = document.querySelector('script[data-dashboard]');
 const scriptData = JSON.parse(script.dataset.dashboard);
 const sectionId = scriptData.section_id;
+const studioUrlPrefix = scriptData.studio_url;
 const baseUrl = `/teacher_dashboard/sections/${sectionId}`;
 
 $(document).ready(function () {
@@ -15,7 +16,7 @@ $(document).ready(function () {
       <Router basename={baseUrl}>
         <Route
           path="/"
-          component={props => <TeacherDashboard {...props} sectionId={sectionId}/>}
+          component={props => <TeacherDashboard {...props} sectionId={sectionId} studioUrlPrefix={studioUrlPrefix}/>}
         />
       </Router>
     </div>

--- a/apps/src/sites/studio/pages/teacher_dashboard/index.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/index.js
@@ -7,7 +7,6 @@ import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashbo
 const script = document.querySelector('script[data-dashboard]');
 const scriptData = JSON.parse(script.dataset.dashboard);
 const sectionId = scriptData.section_id;
-const studioUrlPrefix = scriptData.studio_url;
 const baseUrl = `/teacher_dashboard/sections/${sectionId}`;
 
 $(document).ready(function () {
@@ -16,7 +15,7 @@ $(document).ready(function () {
       <Router basename={baseUrl}>
         <Route
           path="/"
-          component={props => <TeacherDashboard {...props} sectionId={sectionId} studioUrlPrefix={studioUrlPrefix}/>}
+          component={props => <TeacherDashboard {...props} sectionId={sectionId} studioUrlPrefix=""/>}
         />
       </Router>
     </div>

--- a/apps/src/templates/projects/SectionProjectsListWithData.jsx
+++ b/apps/src/templates/projects/SectionProjectsListWithData.jsx
@@ -1,0 +1,51 @@
+import React, {Component, PropTypes} from 'react';
+import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
+import SectionProjectsList from './SectionProjectsList';
+
+class SectionProjectsListWithData extends Component {
+  static propTypes = {
+    sectionId: PropTypes.string,
+    studioUrlPrefix: PropTypes.string
+  };
+
+  state = {
+    projectsData: {},
+    isLoading: true
+  };
+
+  componentDidMount() {
+    const projectsDataUrl = `/dashboardapi/v1/projects/section/${this.props.sectionId}`;
+    $.ajax({
+      url: projectsDataUrl,
+      method: 'GET',
+      dataType: 'json'
+    }).done(projectsData => {
+      this.setState({
+        projectsData: projectsData,
+        isLoading: false
+      });
+    });
+  }
+
+  render() {
+    const {studioUrlPrefix} = this.props;
+    const {projectsData} = this.state;
+
+    return (
+      <div>
+        {this.state.isLoading &&
+          <Spinner/>
+        }
+        {!this.state.isLoading &&
+          <SectionProjectsList
+            projectsData={projectsData}
+            studioUrlPrefix={studioUrlPrefix}
+            showProjectThumbnails={true}
+          />
+        }
+      </div>
+    );
+  }
+}
+
+export default SectionProjectsListWithData;

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -2,14 +2,16 @@ import React, {PropTypes, Component} from 'react';
 import {Route, Switch} from 'react-router-dom';
 import TeacherDashboardNavigation from './TeacherDashboardNavigation';
 import StatsTableWithData from './StatsTableWithData';
+import SectionProjectsListWithData from '@cdo/apps/templates/projects/SectionProjectsListWithData';
 
 export default class TeacherDashboard extends Component {
   static propTypes = {
-    sectionId: PropTypes.string
+    sectionId: PropTypes.string,
+    studioUrlPrefix: PropTypes.string
   };
 
   render() {
-    const {sectionId} = this.props;
+    const {sectionId, studioUrlPrefix} = this.props;
 
     return (
       <div>
@@ -29,7 +31,7 @@ export default class TeacherDashboard extends Component {
           />
           <Route
             path="/projects"
-            component={props => <div>Projects content goes here!</div>}
+            component={props => <SectionProjectsListWithData {...props} sectionId={sectionId} studioUrlPrefix={studioUrlPrefix}/>}
           />
           <Route
             path="/text_responses"

--- a/dashboard/app/views/teacher_dashboard/index.html.haml
+++ b/dashboard/app/views/teacher_dashboard/index.html.haml
@@ -1,6 +1,7 @@
 :ruby
   teacher_dashboard_data = {}
   teacher_dashboard_data[:section_id] = @section_id
+  teacher_dashboard_data[:studio_url] = CDO.studio_url
 
 %script{src: minifiable_asset_path('js/teacher_dashboard/index.js'), data: {dashboard: teacher_dashboard_data.to_json}}
 

--- a/dashboard/app/views/teacher_dashboard/index.html.haml
+++ b/dashboard/app/views/teacher_dashboard/index.html.haml
@@ -1,7 +1,6 @@
 :ruby
   teacher_dashboard_data = {}
   teacher_dashboard_data[:section_id] = @section_id
-  teacher_dashboard_data[:studio_url] = CDO.studio_url
 
 %script{src: minifiable_asset_path('js/teacher_dashboard/index.js'), data: {dashboard: teacher_dashboard_data.to_json}}
 


### PR DESCRIPTION
Similar to #26401

Teacher Dashboard on Dashboard now renders a `SectionProjectsListWithData` which displays a table of projects that belong to the students enrolled in the section. 

![projects](https://user-images.githubusercontent.com/12300669/50182592-9816fe00-02c4-11e9-8a27-7859f7e26133.gif)

To do in follow up work: 

- [ ] gracefully handle when the section id is invalid, right now you get 403 errors and an infinite spinner 