### PR TITLE
Honeybadger reporting fixes

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -1,6 +1,5 @@
 require 'cdo/aws/cloudfront'
 require 'google/apis/classroom_v1'
-require 'honeybadger'
 
 class ApiController < ApplicationController
   layout false

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -1,5 +1,5 @@
 require 'cdo/shared_cache'
-require 'honeybadger'
+require 'honeybadger/ruby'
 
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include UsersHelper

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -1,7 +1,7 @@
 require 'cdo/activity_constants'
 require 'cdo/shared_constants'
 require 'cdo/firehose'
-require 'honeybadger'
+require 'honeybadger/ruby'
 
 module UsersHelper
   include ApplicationHelper

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -1,7 +1,6 @@
 path = File.expand_path('../../deployment.rb', __FILE__)
 path = File.expand_path('../../../deployment.rb', __FILE__) unless File.file?(path)
 require path
-require 'cdo/aws/metrics'
 
 if CDO.dashboard_sock
   bind "unix://#{CDO.dashboard_sock}"
@@ -31,6 +30,8 @@ before_fork do
   # NOTE: before_fork runs on the parent puma process, so complete restart of the web application services on all
   # front end instances is required for a change of this Gatekeeper flag to take effect:
   #   sudo service dashboard upgrade && sudo service pegasus upgrade
+  require 'dynamic_config/gatekeeper'
+  require 'dynamic_config/dcdo'
   if Gatekeeper.allows('enableWebServiceProcessRollingRestart')
     require 'puma_worker_killer'
 
@@ -40,6 +41,7 @@ before_fork do
 end
 
 on_worker_boot do |_index|
+  require 'cdo/aws/metrics'
   Cdo::Metrics.push(
     'App Server',
     [

--- a/lib/cdo/app_server_metrics.rb
+++ b/lib/cdo/app_server_metrics.rb
@@ -1,6 +1,6 @@
 require 'raindrops'
 require 'cdo/aws/metrics'
-require 'honeybadger'
+require 'honeybadger/ruby'
 require 'concurrent/timer_task'
 require 'active_support/core_ext/module/attribute_accessors'
 

--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -1,7 +1,7 @@
 require 'aws-sdk-cloudwatch'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'concurrent/async'
-require 'honeybadger'
+require 'honeybadger/ruby'
 
 module Cdo
   # Singleton interface for asynchronously sending a collection of CloudWatch metrics in batches.

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -2,7 +2,7 @@ require 'aws-sdk-s3'
 require 'tempfile'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/hash/slice'
-require 'honeybadger'
+require 'honeybadger/ruby'
 require 'dynamic_config/dcdo'
 
 module AWS

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -1,5 +1,5 @@
 require 'cdo/azure_content_moderator'
-require 'honeybadger'
+require 'honeybadger/ruby'
 
 module ImageModeration
   # Returns a content rating from an external service.

--- a/lib/cdo/pegasus/donor.rb
+++ b/lib/cdo/pegasus/donor.rb
@@ -1,3 +1,5 @@
+require 'honeybadger/ruby'
+
 # Returns a random donor's twitter handle.
 def get_random_donor_twitter
   weight = SecureRandom.random_number

--- a/lib/cdo/shared_cache.rb
+++ b/lib/cdo/shared_cache.rb
@@ -1,6 +1,6 @@
 require 'active_support/cache'
 require 'active_support/core_ext/object/blank'
-require 'honeybadger'
+require 'honeybadger/ruby'
 require 'dalli/elasticache'
 
 # Provide a long-lived, cross-instance shared cache.

--- a/lib/dynamic_config/datastore_cache.rb
+++ b/lib/dynamic_config/datastore_cache.rb
@@ -1,4 +1,4 @@
-require 'honeybadger'
+require 'honeybadger/ruby'
 
 # A caching layer that sits in front of a datastore that
 # implements get and set

--- a/pegasus/config.ru
+++ b/pegasus/config.ru
@@ -48,6 +48,10 @@ if CDO.image_optim
   use Rack::Optimize
 end
 
+# Disable Sinatra auto-initialization.
+# Add Honeybadger::Rack::ErrorNotifier to Rack middleware directly.
+use Honeybadger::Rack::ErrorNotifier
+
 require 'files_api'
 use FilesApi
 

--- a/pegasus/config/puma.rb
+++ b/pegasus/config/puma.rb
@@ -1,5 +1,4 @@
 require File.join(File.expand_path(__FILE__), '../../../deployment')
-require 'cdo/aws/metrics'
 
 if CDO.pegasus_sock
   bind "unix://#{CDO.pegasus_sock}"
@@ -31,6 +30,8 @@ before_fork do
   # NOTE: before_fork runs on the parent puma process, so complete restart of the web application services on all
   # front end instances is required for a change of this Gatekeeper flag to take effect:
   #   sudo service dashboard upgrade && sudo service pegasus upgrade
+  require 'dynamic_config/gatekeeper'
+  require 'dynamic_config/dcdo'
   if Gatekeeper.allows('enableWebServiceProcessRollingRestart')
     require 'puma_worker_killer'
 
@@ -40,6 +41,7 @@ before_fork do
 end
 
 on_worker_boot do |_index|
+  require 'cdo/aws/metrics'
   Cdo::Metrics.push(
     'App Server',
     [

--- a/pegasus/forms/hoc_signup_2014.rb
+++ b/pegasus/forms/hoc_signup_2014.rb
@@ -1,4 +1,4 @@
-require 'honeybadger'
+require 'honeybadger/ruby'
 require_relative '../helpers/hourofcode_helpers'
 
 class HocSignup2014 < Form

--- a/pegasus/helpers/page_helpers.rb
+++ b/pegasus/helpers/page_helpers.rb
@@ -1,5 +1,4 @@
 require 'active_support/core_ext/string/indent'
-require 'honeybadger'
 require 'cdo/pegasus/donor'
 
 def page_title_with_tagline

--- a/pegasus/honeybadger.yml
+++ b/pegasus/honeybadger.yml
@@ -3,3 +3,7 @@ api_key: <%=CDO.pegasus_honeybadger_api_key%>
 exceptions:
   ignore: <%= %w(Sinatra).map{|x| "#{x}::NotFound"}.to_json%>
   notify_at_exit: false
+# Disable Sinatra auto-initialization.
+# Add Honeybadger::Rack::ErrorNotifier to Rack middleware directly.
+sinatra:
+  enabled: false

--- a/pegasus/routes/v2_user_routes.rb
+++ b/pegasus/routes/v2_user_routes.rb
@@ -1,4 +1,4 @@
-require 'honeybadger'
+require 'honeybadger/ruby'
 
 get '/v2/user' do
   only_for 'code.org'

--- a/shared/middleware/helpers/bucket_helper.rb
+++ b/shared/middleware/helpers/bucket_helper.rb
@@ -2,7 +2,7 @@ require 'addressable'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'cdo/aws/s3'
-require 'honeybadger'
+require 'honeybadger/ruby'
 require 'cdo/firehose'
 
 #


### PR DESCRIPTION
Several fixes to Honeybadger integration, to resolve the issue where Pegasus errors were no longer being reported:

- Move `require 'cdo/aws/metrics'` inside the `on_worker_boot` block, so it gets loaded later in the initialization process. This was the narrowest fix for the issue (because `require 'honeybadger'` was being run within `cdo/aws/metrics`).
- Refactor uses of `require 'honeybadger'` (which initializes HB, including all global framework auto-detection) to `require 'honeybadger/ruby'`, which more narrowly makes the API available for library uses (see docs on [Plain Ruby Mode](https://docs.honeybadger.io/ruby/getting-started/plain-ruby-mode.html)).
- Disable Sinatra auto-initialization, adding `Honeybadger::Rack::ErrorNotifier` to Rack middleware directly, preventing duplicate Honeybadger notices due to multiple `Sinatra::Base` middlewares concatenated in a single Rack application.