### PR TITLE
Removing skip and reference to bug

### DIFF
--- a/dashboard/test/ui/features/contract_examples.feature
+++ b/dashboard/test/ui/features/contract_examples.feature
@@ -36,8 +36,6 @@ Scenario: Expected failure to hotkey-delete function definition block
   And I press delete
   Then block "function definition" has not been deleted
 
-# Skip due to bug: https://www.pivotaltracker.com/story/show/102630766
-@skip
 @no_mobile
 Scenario: Deleting an example block via delete key
   When I click block "second example"


### PR DESCRIPTION
Part of the dev-prod-sprint testing improvements goal to remove skip tags.

This tag was added in 2015 and references a bug that is not accessible in pivotal tracker anymore. Since I'm not sure what the referenced bug is and removing the tag doesn't seem to cause errors, I propose just removing the tag.