### PR TITLE
convert ResizablePanes component to es6 class syntax

### DIFF
--- a/apps/src/templates/ResizablePanes.jsx
+++ b/apps/src/templates/ResizablePanes.jsx
@@ -4,7 +4,7 @@
  *  and works with React 0.14.7.
  *  @see https://github.com/tomkp/react-split-pane
  */
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Component} from 'react';
 var ReactDOM = require('react-dom');
 var _ = require('lodash');
 import Radium from 'radium';
@@ -35,41 +35,39 @@ const styles = {
 /**
  * Wraps its children to display them in a flexbox layout.
  */
-var ResizablePanes = Radium(React.createClass({
-  propTypes: {
+class ResizablePanes extends Component {
+  static propTypes = {
     style: PropTypes.object,
     columnSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
     onChange: PropTypes.func.isRequired,
     children: PropTypes.node,
     lockedColumns: PropTypes.arrayOf(PropTypes.number)
-  },
+  };
 
-  getInitialState: function () {
-    return {
-      dragging: false,
-      index: 0
-    };
-  },
+  state = {
+    dragging: false,
+    index: 0
+  };
 
   componentDidMount() {
     document.addEventListener('mousemove', this.onMouseMove);
     document.addEventListener('mouseup', this.onMouseUp);
-  },
+  }
 
   componentWillUnmount() {
     document.removeEventListener('mousemove', this.onMouseMove);
     document.removeEventListener('mouseup', this.onMouseUp);
-  },
+  }
 
-  onResizerMouseDown: function (event) {
+  onResizerMouseDown = event => {
     this.unFocus();
     this.setState({
       dragging: true,
       index: parseInt(event.target.dataset.resizerIndex, 10)
     });
-  },
+  };
 
-  onMouseMove(event) {
+  onMouseMove = event => {
     if (!this.state.dragging) {
       return;
     }
@@ -89,23 +87,23 @@ var ResizablePanes = Radium(React.createClass({
     let newSizes = this.props.columnSizes.slice();
     newSizes[this.state.index] = event.clientX - boundingRect.left;
     this.props.onChange(newSizes);
-  },
+  };
 
-  onMouseUp() {
+  onMouseUp = () => {
     if (this.state.dragging) {
       this.setState({ dragging: false });
     }
-  },
+  };
 
-  unFocus: function () {
+  unFocus = () => {
     if (document.selection) {
       document.selection.empty();
     } else {
       window.getSelection().removeAllRanges();
     }
-  },
+  };
 
-  getClonedChild: function (child, index) {
+  getClonedChild(child, index) {
     var columnSize = this.props.columnSizes[index];
     var style = _.assign(
         {flex: '1'},
@@ -118,9 +116,9 @@ var ResizablePanes = Radium(React.createClass({
       key: "pane-" + index,
       style: style
     });
-  },
+  }
 
-  getResizer: function (index) {
+  getResizer(index) {
     return (
       <div
         key={"resizer-" + index}
@@ -129,17 +127,17 @@ var ResizablePanes = Radium(React.createClass({
         onMouseDown={this.onResizerMouseDown}
       />
     );
-  },
+  }
 
-  isColumnLocked: function (index) {
+  isColumnLocked = index => {
     if (!this.props.lockedColumns) {
       return false;
     }
 
     return this.props.lockedColumns.indexOf(index) >= 0;
-  },
+  };
 
-  getChildren: function () {
+  getChildren() {
     var childCount = React.Children.count(this.props.children);
     var computedChildren = [];
     React.Children.forEach(this.props.children, function (child, index) {
@@ -154,9 +152,9 @@ var ResizablePanes = Radium(React.createClass({
       }
     }, this);
     return computedChildren;
-  },
+  }
 
-  render: function () {
+  render() {
     var styles = {
       root: _.assign({
         display: 'flex',
@@ -171,6 +169,6 @@ var ResizablePanes = Radium(React.createClass({
       </div>
     );
   }
-}));
+}
 
-export default ResizablePanes;
+export default Radium(ResizablePanes);

--- a/apps/src/templates/ResizablePanes.jsx
+++ b/apps/src/templates/ResizablePanes.jsx
@@ -5,8 +5,8 @@
  *  @see https://github.com/tomkp/react-split-pane
  */
 import React, {PropTypes, Component} from 'react';
-var ReactDOM = require('react-dom');
-var _ = require('lodash');
+import ReactDOM from 'react-dom';
+import _ from 'lodash';
 import Radium from 'radium';
 
 const styles = {
@@ -18,7 +18,7 @@ const styles = {
     backgroundColor: '#000',
     backgroundClip: 'padding-box',
     userSelect: 'text',
-    width: 11,
+    width: 31,
     margin: '0 -5px',
     borderLeft: '5px solid',
     borderRight: '5px solid',
@@ -72,12 +72,12 @@ class ResizablePanes extends Component {
       return;
     }
     this.unFocus();
-    var resizingPane = this.refs['pane-' + this.state.index];
+    const resizingPane = this.refs[`pane-${this.state.index}`];
     if (!resizingPane) {
       return;
     }
 
-    var resizingPaneDOMNode = ReactDOM.findDOMNode(resizingPane);
+    const resizingPaneDOMNode = ReactDOM.findDOMNode(resizingPane);
     if (!resizingPaneDOMNode.getBoundingClientRect) {
       return;
     }
@@ -104,24 +104,24 @@ class ResizablePanes extends Component {
   };
 
   getClonedChild(child, index) {
-    var columnSize = this.props.columnSizes[index];
-    var style = _.assign(
+    const columnSize = this.props.columnSizes[index];
+    const style = _.assign(
         {flex: '1'},
         child.props.style,
-        (typeof columnSize !== 'undefined' ? {flex: '0 0 ' + columnSize + 'px'} : undefined)
+        (typeof columnSize !== 'undefined' ? {flex: `0 0 ${columnSize}px`} : undefined)
     );
 
     return React.cloneElement(child, {
-      ref: "pane-" + index,
-      key: "pane-" + index,
-      style: style
+      ref: `pane-${index}`,
+      key: `pane-${index}`,
+      style,
     });
   }
 
   getResizer(index) {
     return (
       <div
-        key={"resizer-" + index}
+        key={`resizer-${index}`}
         data-resizer-index={index}
         style={styles.resizer}
         onMouseDown={this.onResizerMouseDown}
@@ -138,9 +138,9 @@ class ResizablePanes extends Component {
   };
 
   getChildren() {
-    var childCount = React.Children.count(this.props.children);
-    var computedChildren = [];
-    React.Children.forEach(this.props.children, function (child, index) {
+    const childCount = React.Children.count(this.props.children);
+    const computedChildren = [];
+    React.Children.forEach(this.props.children, (child, index) => {
       if (!child) {
         return;
       }
@@ -155,7 +155,7 @@ class ResizablePanes extends Component {
   }
 
   render() {
-    var styles = {
+    const styles = {
       root: _.assign({
         display: 'flex',
         flexDirection: 'row',


### PR DESCRIPTION
There is no test coverage for this component. Ideas for an effective way to test it are welcome, otherwise I'll plan to leave them out and rely on manual testing.

Dragging to the right is a little janky in that it stops working if you go fast (more than 5px at a time):
![janky-dragging](https://user-images.githubusercontent.com/8001765/50249929-463da900-0394-11e9-9148-bbf9a20a277f.gif)

However, this is not a regression. It is due to the fact that the right pane is an iframe and therefore swallows the mousemove events. I could not find an easy fix for this.