### PR TITLE
Remove skip tag from GDPR test

### DIFF
--- a/dashboard/test/ui/features/gdpr_dialog.feature
+++ b/dashboard/test/ui/features/gdpr_dialog.feature
@@ -3,7 +3,6 @@
 
 Feature: GDPR Dialog - data transfer agreement
 
-  @skip
   Scenario: EU user sees the GDPR Dialog on dashboard, opt out
     Given I am a teacher
     Given I am on "http://studio.code.org/home?force_in_eu=1"


### PR DESCRIPTION
Part of the dev-prod-sprint testing improvements goal to remove skip tags.

These tags originally added here: https://github.com/code-dot-org/code-dot-org/pull/22900 and the issue was potentially fixed here: https://github.com/code-dot-org/code-dot-org/pull/22905

Running locally (through SauceLabs) these tests no longer fail, so I'm removing this tag to see if the errors re-surface on the test machine.
