### PR TITLE
Course show page versioning redirects

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1054,6 +1054,7 @@
   "record": "Record",
   "recording": "Recording",
   "recordAudio": "Record Audio",
+  "redirectCourseVersionWarningDetails": "It looks like you accidentally went to an outdated version of the course. You've been redirected to the recommended version or the version assigned by your teacher.",
   "reloadPage": "Reload Page",
   "relockStage": "Re-lock stage",
   "relockStageInstructions": "\"Re-lock stage\" to prevent sharing of answers with other classes/schools.",

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -68,6 +68,7 @@ function showCourseOverview() {
         hasVerifiedResources={!!courseSummary.has_verified_resources}
         versions={versions}
         showVersionWarning={!!scriptData.show_version_warning && versions.length > 1}
+        showRedirectWarning={scriptData.show_redirect_warning}
       />
     </Provider>,
   document.getElementById('course_overview'));

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -109,7 +109,7 @@ export default class CourseOverview extends Component {
   onDismissRedirectWarning = () => {
     let dismissedRedirectWarnings = sessionStorage.getItem(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY);
     if (dismissedRedirectWarnings) {
-        dismissedRedirectWarnings += `,${this.props.name}`;
+      dismissedRedirectWarnings += `,${this.props.name}`;
     } else {
       dismissedRedirectWarnings = this.props.name;
     }

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -65,6 +65,7 @@ export default class CourseOverview extends Component {
       version_year: PropTypes.string.isRequired
     })).isRequired,
     showVersionWarning: PropTypes.bool,
+    showRedirectWarning: PropTypes.bool,
   };
 
   onChangeVersion = event => {
@@ -113,6 +114,7 @@ export default class CourseOverview extends Component {
       hasVerifiedResources,
       versions,
       showVersionWarning,
+      showRedirectWarning,
     } = this.props;
 
     // We currently set .container.main to have a width of 940 at a pretty high
@@ -128,6 +130,15 @@ export default class CourseOverview extends Component {
 
     return (
       <div style={mainStyle}>
+        {showRedirectWarning &&
+          <Notification
+            type={NotificationType.warning}
+            notice=""
+            details={i18n.redirectCourseVersionWarningDetails()}
+            dismissible={true}
+            onDismiss={() => {console.log('dismissed');}}
+          />
+        }
         {showVersionWarning &&
           <Notification
             type={NotificationType.warning}

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -13,6 +13,10 @@ import i18n from '@cdo/locale';
 import Notification, { NotificationType } from '@cdo/apps/templates/Notification';
 import color from '@cdo/apps/util/color';
 
+// A session variable storing a comma-delimited list of course names for which
+// the user has already dismissed the course version redirect warning.
+const DISMISSED_REDIRECT_WARNINGS_SESSION_KEY = 'dismissedRedirectWarnings';
+
 const styles = {
   main: {
     width: styleConstants['content-width'],
@@ -97,6 +101,21 @@ export default class CourseOverview extends Component {
     });
   };
 
+  dismissedRedirectWarning = () => {
+    const dismissedRedirectWarnings = sessionStorage.getItem(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY);
+    return (dismissedRedirectWarnings || '').includes(this.props.name);
+  };
+
+  onDismissRedirectWarning = () => {
+    let dismissedRedirectWarnings = sessionStorage.getItem(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY);
+    if (dismissedRedirectWarnings) {
+        dismissedRedirectWarnings += `,${this.props.name}`;
+    } else {
+      dismissedRedirectWarnings = this.props.name;
+    }
+    sessionStorage.setItem(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY, dismissedRedirectWarnings);
+  };
+
   render() {
     const {
       name,
@@ -130,13 +149,13 @@ export default class CourseOverview extends Component {
 
     return (
       <div style={mainStyle}>
-        {showRedirectWarning &&
+        {(showRedirectWarning && !this.dismissedRedirectWarning()) &&
           <Notification
             type={NotificationType.warning}
             notice=""
             details={i18n.redirectCourseVersionWarningDetails()}
             dismissible={true}
-            onDismiss={() => {console.log('dismissed');}}
+            onDismiss={this.onDismissRedirectWarning}
           />
         }
         {showVersionWarning &&

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -61,9 +61,9 @@ class CoursesController < ApplicationController
       return
     end
 
-    # Attempt to redirect students if we think they ended up on the wrong course overview page.
-    if student_redirect_course = student_redirect_course(course)
-      redirect_to "/courses/#{student_redirect_course.name}/?redirect_warning=true"
+    # Attempt to redirect user if we think they ended up on the wrong course overview page.
+    if redirect_course = redirect_course(course)
+      redirect_to "/courses/#{redirect_course.name}/?redirect_warning=true"
       return
     end
 
@@ -109,8 +109,8 @@ class CoursesController < ApplicationController
 
   private
 
-  def student_redirect_course(course)
-    # Return nil if course is nil or we know the student can view the version requested.
+  def redirect_course(course)
+    # Return nil if course is nil or we know the user can view the version requested.
     return nil if !course || course.can_view_version?(current_user)
 
     # Redirect the user to the latest assigned course in this family, or to the latest course in this family if none

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -62,13 +62,12 @@ class CoursesController < ApplicationController
     end
 
     # Attempt to redirect students if we think they ended up on the wrong course overview page.
-    if student_redirect_path = student_redirect_path(course)
-      # TODO: add param to show redirect warning
-      redirect_to student_redirect_path
+    if student_redirect_course = student_redirect_course(course)
+      redirect_to "/courses/#{student_redirect_course.name}/?redirect_warning=true"
       return
     end
 
-    render 'show', locals: {course: course}
+    render 'show', locals: {course: course, redirect_warning: params[:redirect_warning] == 'true'}
   end
 
   def new
@@ -110,10 +109,9 @@ class CoursesController < ApplicationController
 
   private
 
-  def student_redirect_path(course)
-    # Return nil if there isn't a course, the user is a teacher, or we know the student can view the version
-    # requested.
-    return nil if !course || current_user&.teacher? || course.can_view_version?(current_user)
+  def student_redirect_course(course)
+    # Return nil if course is nil or we know the student can view the version requested.
+    return nil if !course || course.can_view_version?(current_user)
 
     # Redirect the user to the latest assigned course in this family, or to the latest course in this family if none
     # are assigned.
@@ -123,6 +121,6 @@ class CoursesController < ApplicationController
     # Do not redirect if we are already on the correct course.
     return nil if redirect_course == course
 
-    course_path(redirect_course)
+    redirect_course
   end
 end

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -365,11 +365,11 @@ class Course < ApplicationRecord
     return nil unless family_name.present?
 
     Course.
-        # select only courses in the same course family.
-        where("properties -> '$.family_name' = ?", family_name).
-        # order by version year.
-        order("properties -> '$.version_year' DESC")&.
-        first
+      # select only courses in the same course family.
+      where("properties -> '$.family_name' = ?", family_name).
+      # order by version year.
+      order("properties -> '$.version_year' DESC")&.
+      first
   end
 
   # @param family_name [String] The family name for a course family.
@@ -380,13 +380,13 @@ class Course < ApplicationRecord
     assigned_course_ids = user.section_courses.pluck(:id)
 
     Course.
-        # select only courses assigned to this user.
-        where(id: assigned_course_ids).
-        # select only courses in the same course family.
-        where("properties -> '$.family_name' = ?", family_name).
-        # order by version year.
-        order("properties -> '$.version_year' DESC")&.
-        first
+      # select only courses assigned to this user.
+      where(id: assigned_course_ids).
+      # select only courses in the same course family.
+      where("properties -> '$.family_name' = ?", family_name).
+      # order by version year.
+      order("properties -> '$.version_year' DESC")&.
+      first
   end
 
   # @param user [User]

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -346,7 +346,7 @@ class Course < ApplicationRecord
   end
 
   # @param user [User]
-  # @return [Boolean] Whether the user can view the current course.
+  # @return [Boolean] Whether the user can view the course.
   def can_view_version?(user)
     return nil unless user
     # Restrictions only apply to students.

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -7,6 +7,7 @@
 - data[:is_verified_teacher] = @current_user.try(:authorized_teacher?) || false
 - data[:hidden_scripts] = @current_user.try(:get_hidden_script_ids, course)
 - data[:show_version_warning] = course.has_older_version_progress?(@current_user) && !course.has_dismissed_version_warning?(@current_user)
+- data[:show_redirect_warning] = redirect_warning
 
 - content_for(:head) do
   %script{ src: minifiable_asset_path('js/courses/show.js'), data: {courses_show: data.to_json}}

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -74,6 +74,8 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to '/courses/csd-2018'
   end
 
+  # Right now, all course versions are considered stable, but in the future, we will track an is_stable property for
+  # each course, and the following tests regarding "latest stable version" need be updated.
   test "show: redirect to latest stable version in course family for logged out user" do
     sign_out @teacher
     create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017'

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -74,6 +74,58 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to '/courses/csd-2018'
   end
 
+  test "show: redirect to latest stable version in course family for logged out user" do
+    sign_out @teacher
+    create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017'
+    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018'
+
+    get :show, params: {course_name: 'csp-2017'}
+
+    assert_redirected_to '/courses/csp-2018/?redirect_warning=true'
+  end
+
+  test "show: redirect to latest stable version in course family for student" do
+    create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017'
+    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018'
+
+    sign_in create(:student)
+    get :show, params: {course_name: 'csp-2017'}
+
+    assert_redirected_to '/courses/csp-2018/?redirect_warning=true'
+  end
+
+  test "show: do not redirect student to latest stable version in course family if they have progress" do
+    create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017'
+    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018'
+
+    Course.any_instance.stubs(:has_progress?).returns(true)
+    sign_in create(:student)
+    get :show, params: {course_name: 'csp-2017'}
+
+    assert_response :ok
+  end
+
+  test "show: do not redirect student to latest stable version in course family if they are assigned" do
+    student = create :student
+    csp2017 = create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017'
+    create :follower, section: create(:section, course: csp2017), student_user: student
+    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018'
+
+    sign_in student
+    get :show, params: {course_name: 'csp-2017'}
+
+    assert_response :ok
+  end
+
+  test "show: do not redirect teacher to latest stable version in course family" do
+    create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017'
+    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018'
+
+    get :show, params: {course_name: 'csp-2017'}
+
+    assert_response :ok
+  end
+
   # Tests for create
 
   test "create: fails without levelbuilder permission" do

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -262,7 +262,62 @@ class CourseTest < ActiveSupport::TestCase
     end
   end
 
-  class OtherVersionProgressTests < ActiveSupport::TestCase
+  class CanViewVersion < ActiveSupport::TestCase
+    setup do
+      @csp_2017 = create(:course, name: 'csp-2017', family_name: 'csp', version_year: '2017')
+      @csp1_2017 = create(:script, name: 'csp1-2017')
+      create :course_script, course: @csp_2017, script: @csp1_2017, position: 1
+      @csp_2018 = create(:course, name: 'csp-2018', family_name: 'csp', version_year: '2018')
+      @student = create :student
+    end
+
+    test 'teacher can always view version' do
+      assert @csp_2017.can_view_version?(create(:teacher))
+    end
+
+    test 'student can view version if it is the latest version in course family' do
+      assert @csp_2018.can_view_version?(@student)
+      refute @csp_2017.can_view_version?(@student)
+    end
+
+    test 'student can view version if it is assigned to them' do
+      create :follower, section: create(:section, course: @csp_2018), student_user: @student
+      create :follower, section: create(:section, course: @csp_2017), student_user: @student
+
+      assert @csp_2018.can_view_version?(@student)
+      assert @csp_2017.can_view_version?(@student)
+    end
+
+    test 'student can view version if they have progress in it' do
+      create :user_script, user: @student, script: @csp1_2017
+      assert @csp_2017.can_view_version?(@student)
+    end
+  end
+
+  class LatestVersionTests < ActiveSupport::TestCase
+    setup do
+      @csp_2017 = create(:course, name: 'csp-2017', family_name: 'csp', version_year: '2017')
+      @csp_2018 = create(:course, name: 'csp-2018', family_name: 'csp', version_year: '2018')
+      @student = create :student
+    end
+
+    test 'latest version returns nil if course family does not exist' do
+      assert_nil Course.latest_version('fake-family')
+    end
+
+    test 'latest version returns latest course version' do
+      latest_version = Course.latest_version('csp')
+      assert_equal @csp_2018, latest_version
+    end
+
+    test 'latest assigned version returns latest version in family assigned to student' do
+      create :follower, section: create(:section, course: @csp_2017), student_user: @student
+      latest_assigned_version = Course.latest_assigned_version('csp', @student)
+      assert_equal @csp_2017, latest_assigned_version
+    end
+  end
+
+  class ProgressTests < ActiveSupport::TestCase
     setup do
       @csp_2017 = create(:course, name: 'csp-2017', family_name: 'csp', version_year: '2017')
       @csp1_2017 = create(:script, name: 'csp1-2017')
@@ -287,6 +342,18 @@ class CourseTest < ActiveSupport::TestCase
       assert_equal 2, @csp_2017.default_scripts.count
       assert_equal 2, @csp_2018.default_scripts.count
       assert_equal 1, @csd.default_scripts.count
+    end
+
+    test 'student with no progress has no progress' do
+      refute @csp_2017.has_progress?(@student)
+      refute @csp_2018.has_progress?(@student)
+    end
+
+    test 'student with progress in course has progress' do
+      create :user_script, user: @student, script: @csp1_2017
+
+      assert @csp_2017.has_progress?(@student)
+      refute @csp_2018.has_progress?(@student)
     end
 
     test 'student with no progress does not have older version progress' do


### PR DESCRIPTION
[Corresponding spec](https://docs.google.com/document/d/17pIPHJJ4eJP69KDyy_KM7PRIDbziknY4iQyJoMTKjK4/edit?usp=sharing) - it may be easiest to look at this

If we think a student made their way to an older version of a course by accident (i.e., this is not a version the student has been assigned, has progress in, or is the latest version of the course), we want to redirect them to the latest course overview page with a redirect warning:

<img width="988" alt="screen shot 2018-12-19 at 5 14 22 pm" src="https://user-images.githubusercontent.com/9812299/50257763-8d866280-03b1-11e9-8edd-292ca8293b40.png">

We only want to show the user this warning once per session per course, so we accumulate the dismissed course warnings in a `dismissedRedirectWarnings` session variable, which contains a comma-delimited list of course warnings already dismissed this session.

`dismissedRedirectWarnings: csp-2018,csd-2018` - means the user has been redirected to CSP 2018 and CSD 2018 already this session and dismissed the warnings, so they will not be shown again until a new session is started.