### PR TITLE
rename unencrypted channel_id to storage_app_id

### DIFF
--- a/bin/grep-applab-source
+++ b/bin/grep-applab-source
@@ -57,9 +57,9 @@ puts "Scanning #{applab_channels.length} source files in S3 using #{MAX_THREADS}
 
 applab_channels.each_slice(MAX_THREADS) do |chunk|
   threads = []
-  chunk.each do |owner_storage_id, channel_id|
+  chunk.each do |owner_storage_id, storage_app_id|
     threads << Thread.new do
-      s3_filename = "#{base_dir}/#{owner_storage_id}/#{channel_id}/main.json"
+      s3_filename = "#{base_dir}/#{owner_storage_id}/#{storage_app_id}/main.json"
       begin
         body = s3.get_object(bucket: bucket, key: s3_filename)[:body].read
       rescue Aws::S3::Errors::NoSuchKey
@@ -71,7 +71,7 @@ applab_channels.each_slice(MAX_THREADS) do |chunk|
       if source
         commands.each do |regex, filename|
           source.scan(regex).each do |match|
-            channel = storage_encrypt_channel_id(owner_storage_id, channel_id)
+            channel = storage_encrypt_channel_id(owner_storage_id, storage_app_id)
             project_url = "https://#{CDO.dashboard_hostname}/projects/applab/#{channel}/view"
 
             File.open(filename, 'a') do |file|

--- a/dashboard/app/controllers/featured_projects_controller.rb
+++ b/dashboard/app/controllers/featured_projects_controller.rb
@@ -2,16 +2,16 @@ class FeaturedProjectsController < ApplicationController
   authorize_resource
 
   def feature
-    _, channel_id = storage_decrypt_channel_id(params[:project_id])
-    return render_404 unless channel_id
-    @featured_project = FeaturedProject.find_or_create_by!(storage_app_id: channel_id)
+    _, storage_app_id = storage_decrypt_channel_id(params[:project_id])
+    return render_404 unless storage_app_id
+    @featured_project = FeaturedProject.find_or_create_by!(storage_app_id: storage_app_id)
     @featured_project.update! unfeatured_at: nil, featured_at: DateTime.now
   end
 
   def unfeature
-    _, channel_id = storage_decrypt_channel_id(params[:project_id])
-    return render_404 unless channel_id
-    @featured_project = FeaturedProject.find_by! storage_app_id: channel_id
+    _, storage_app_id = storage_decrypt_channel_id(params[:project_id])
+    return render_404 unless storage_app_id
+    @featured_project = FeaturedProject.find_by! storage_app_id: storage_app_id
     @featured_project.update! unfeatured_at: DateTime.now
   end
 end

--- a/dashboard/app/models/featured_project.rb
+++ b/dashboard/app/models/featured_project.rb
@@ -20,15 +20,15 @@ class FeaturedProject < ApplicationRecord
   end
 
   # Determines if a project is currently featured by decrypting the provided
-  # encrypted_channel_id, using the decrypted channel id to check for a
+  # encrypted_channel_id, using the storage_app_id to check for a
   # FeaturedProject with the corresponding storage_app_id.  If there is a
   # FeaturedProject with that storage_app_id, check if it is currently featured.
   # @param encrypted_channel_id [string]
   # @return [Boolean] whether the project associated with the given
   # encrypted_channel_id is currently featured
   def self.featured_channel_id?(encrypted_channel_id)
-    _, channel_id = storage_decrypt_channel_id encrypted_channel_id
-    find_by(storage_app_id: channel_id)&.featured?
+    _, storage_app_id = storage_decrypt_channel_id encrypted_channel_id
+    find_by(storage_app_id: storage_app_id)&.featured?
   rescue ArgumentError
     false
   end

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1747,15 +1747,15 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
   test "soft-deletes all of a soft-deleted user's projects" do
     student = create :student
-    with_channel_for student do |channel_id, storage_id|
-      assert_equal 'active', storage_apps.where(id: channel_id).first[:state]
+    with_channel_for student do |storage_app_id, storage_id|
+      assert_equal 'active', storage_apps.where(id: storage_app_id).first[:state]
       storage_apps.where(storage_id: storage_id).each do |app|
         assert_equal 'active', app[:state]
       end
 
       student.destroy
 
-      assert_equal 'deleted', storage_apps.where(id: channel_id).first[:state]
+      assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
       storage_apps.where(storage_id: storage_id).each do |app|
         assert_equal 'deleted', app[:state]
       end
@@ -1764,15 +1764,15 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
   test "soft-deletes all of a purged user's projects" do
     student = create :student
-    with_channel_for student do |channel_id, storage_id|
-      assert_equal 'active', storage_apps.where(id: channel_id).first[:state]
+    with_channel_for student do |storage_app_id, storage_id|
+      assert_equal 'active', storage_apps.where(id: storage_app_id).first[:state]
       storage_apps.where(storage_id: storage_id).each do |app|
         assert_equal 'active', app[:state]
       end
 
       purge_user student
 
-      assert_equal 'deleted', storage_apps.where(id: channel_id).first[:state]
+      assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
       storage_apps.where(storage_id: storage_id).each do |app|
         assert_equal 'deleted', app[:state]
       end
@@ -1784,15 +1784,15 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "does not soft-delete anyone else's projects" do
     student_a = create :student
     student_b = create :student
-    with_channel_for student_a do |channel_id_a|
-      with_channel_for student_b do |channel_id_b|
-        assert_equal 'active', storage_apps.where(id: channel_id_a).first[:state]
-        assert_equal 'active', storage_apps.where(id: channel_id_b).first[:state]
+    with_channel_for student_a do |storage_app_id_a|
+      with_channel_for student_b do |storage_app_id_b|
+        assert_equal 'active', storage_apps.where(id: storage_app_id_a).first[:state]
+        assert_equal 'active', storage_apps.where(id: storage_app_id_b).first[:state]
 
         purge_user student_a
 
-        assert_equal 'deleted', storage_apps.where(id: channel_id_a).first[:state]
-        assert_equal 'active', storage_apps.where(id: channel_id_b).first[:state]
+        assert_equal 'deleted', storage_apps.where(id: storage_app_id_a).first[:state]
+        assert_equal 'active', storage_apps.where(id: storage_app_id_b).first[:state]
       end
     end
   end
@@ -1800,17 +1800,17 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "sets updated_at when soft-deleting projects" do
     student = create :student
     Timecop.freeze do
-      with_channel_for student do |channel_id|
-        assert_equal 'active', storage_apps.where(id: channel_id).first[:state]
-        original_updated_at = storage_apps.where(id: channel_id).first[:updated_at]
+      with_channel_for student do |storage_app_id|
+        assert_equal 'active', storage_apps.where(id: storage_app_id).first[:state]
+        original_updated_at = storage_apps.where(id: storage_app_id).first[:updated_at]
 
         Timecop.travel 10
 
         student.destroy
 
-        assert_equal 'deleted', storage_apps.where(id: channel_id).first[:state]
+        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
         refute_equal original_updated_at.utc.to_s,
-          storage_apps.where(id: channel_id).first[:updated_at].utc.to_s
+          storage_apps.where(id: storage_app_id).first[:updated_at].utc.to_s
       end
     end
   end
@@ -1818,19 +1818,19 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "soft-delete does not set updated_at on already soft-deleted projects" do
     student = create :student
     Timecop.freeze do
-      with_channel_for student do |channel_id|
-        storage_apps.where(id: channel_id).update(state: 'deleted', updated_at: Time.now)
+      with_channel_for student do |storage_app_id|
+        storage_apps.where(id: storage_app_id).update(state: 'deleted', updated_at: Time.now)
 
-        assert_equal 'deleted', storage_apps.where(id: channel_id).first[:state]
-        original_updated_at = storage_apps.where(id: channel_id).first[:updated_at]
+        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
+        original_updated_at = storage_apps.where(id: storage_app_id).first[:updated_at]
 
         Timecop.travel 10
 
         student.destroy
 
-        assert_equal 'deleted', storage_apps.where(id: channel_id).first[:state]
+        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
         assert_equal original_updated_at.utc.to_s,
-          storage_apps.where(id: channel_id).first[:updated_at].utc.to_s
+          storage_apps.where(id: storage_app_id).first[:updated_at].utc.to_s
       end
     end
   end
@@ -1838,34 +1838,34 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "user purge does set updated_at on already soft-deleted projects" do
     student = create :student
     Timecop.freeze do
-      with_channel_for student do |channel_id|
-        storage_apps.where(id: channel_id).update(state: 'deleted', updated_at: Time.now)
+      with_channel_for student do |storage_app_id|
+        storage_apps.where(id: storage_app_id).update(state: 'deleted', updated_at: Time.now)
 
-        assert_equal 'deleted', storage_apps.where(id: channel_id).first[:state]
-        original_updated_at = storage_apps.where(id: channel_id).first[:updated_at]
+        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
+        original_updated_at = storage_apps.where(id: storage_app_id).first[:updated_at]
 
         Timecop.travel 10
 
         purge_user student
 
-        assert_equal 'deleted', storage_apps.where(id: channel_id).first[:state]
+        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
         refute_equal original_updated_at.utc.to_s,
-          storage_apps.where(id: channel_id).first[:updated_at].utc.to_s
+          storage_apps.where(id: storage_app_id).first[:updated_at].utc.to_s
       end
     end
   end
 
   test "clears 'value' for all of a purged user's projects" do
     student = create :student
-    with_channel_for student do |channel_id, storage_id|
-      refute_nil storage_apps.where(id: channel_id).first[:value]
+    with_channel_for student do |storage_app_id, storage_id|
+      refute_nil storage_apps.where(id: storage_app_id).first[:value]
       storage_apps.where(storage_id: storage_id).each do |app|
         refute_nil app[:value]
       end
 
       purge_user student
 
-      assert_nil storage_apps.where(id: channel_id).first[:value]
+      assert_nil storage_apps.where(id: storage_app_id).first[:value]
       storage_apps.where(storage_id: storage_id).each do |app|
         assert_nil app[:value]
       end
@@ -1874,15 +1874,15 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
   test "clears 'updated_ip' for all of a purged user's projects" do
     student = create :student
-    with_channel_for student do |channel_id, storage_id|
-      refute_empty storage_apps.where(id: channel_id).first[:updated_ip]
+    with_channel_for student do |storage_app_id, storage_id|
+      refute_empty storage_apps.where(id: storage_app_id).first[:updated_ip]
       storage_apps.where(storage_id: storage_id).each do |app|
         refute_empty app[:updated_ip]
       end
 
       purge_user student
 
-      assert_empty storage_apps.where(id: channel_id).first[:updated_ip]
+      assert_empty storage_apps.where(id: storage_app_id).first[:updated_ip]
       storage_apps.where(storage_id: storage_id).each do |app|
         assert_empty app[:updated_ip]
       end
@@ -1895,9 +1895,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
   test "unfeatures any featured projects owned by soft-deleted user" do
     student = create :student
-    with_channel_for student do |channel_id|
+    with_channel_for student do |storage_app_id|
       featured_project = create :featured_project,
-        storage_app_id: channel_id,
+        storage_app_id: storage_app_id,
         featured_at: Time.now
 
       assert featured_project.featured?
@@ -1911,9 +1911,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
   test "unfeatures any featured projects owned by purged user" do
     student = create :student
-    with_channel_for student do |channel_id|
+    with_channel_for student do |storage_app_id|
       featured_project = create :featured_project,
-        storage_app_id: channel_id,
+        storage_app_id: storage_app_id,
         featured_at: Time.now
 
       assert featured_project.featured?
@@ -1929,9 +1929,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     student = create :student
     featured_time = Time.now - 20
     unfeatured_time = Time.now - 10
-    with_channel_for student do |channel_id|
+    with_channel_for student do |storage_app_id|
       featured_project = create :featured_project,
-        storage_app_id: channel_id,
+        storage_app_id: storage_app_id,
         featured_at: featured_time,
         unfeatured_at: unfeatured_time
 
@@ -1980,16 +1980,16 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     # in this test, we depend on the unit tests for the particular buckets to
     # verify correct hard-delete behavior for that bucket.
     student = create :student
-    with_channel_for student do |channel_id_a, _|
-      with_channel_for student do |channel_id_b, storage_id|
-        storage_apps.where(id: channel_id_a).update(state: 'deleted')
+    with_channel_for student do |storage_app_id_a, _|
+      with_channel_for student do |storage_app_id_b, storage_id|
+        storage_apps.where(id: storage_app_id_a).update(state: 'deleted')
 
         bucket.any_instance.
           expects(:hard_delete_channel_content).
-          with(storage_encrypt_channel_id(storage_id, channel_id_a))
+          with(storage_encrypt_channel_id(storage_id, storage_app_id_a))
         bucket.any_instance.
           expects(:hard_delete_channel_content).
-          with(storage_encrypt_channel_id(storage_id, channel_id_b))
+          with(storage_encrypt_channel_id(storage_id, storage_app_id_b))
 
         purge_user student
       end
@@ -2002,16 +2002,16 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
   test "Firebase: deletes content for all of user's channels" do
     student = create :student
-    with_channel_for student do |channel_id_a, _|
-      with_channel_for student do |channel_id_b, storage_id|
-        storage_apps.where(id: channel_id_a).update(state: 'deleted')
+    with_channel_for student do |storage_app_id_a, _|
+      with_channel_for student do |storage_app_id_b, storage_id|
+        storage_apps.where(id: storage_app_id_a).update(state: 'deleted')
 
         FirebaseHelper.
           expects(:delete_channel).
-          with(storage_encrypt_channel_id(storage_id, channel_id_a))
+          with(storage_encrypt_channel_id(storage_id, storage_app_id_a))
         FirebaseHelper.
           expects(:delete_channel).
-          with(storage_encrypt_channel_id(storage_id, channel_id_b))
+          with(storage_encrypt_channel_id(storage_id, storage_app_id_b))
 
         purge_user student
       end
@@ -2084,8 +2084,8 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     with_storage_id_for student do |storage_id|
       assert_empty storage_apps.where(storage_id: storage_id)
 
-      with_channel_for student do |channel_id|
-        assert_equal channel_id, storage_apps.where(storage_id: storage_id).first[:id]
+      with_channel_for student do |storage_app_id|
+        assert_equal storage_app_id, storage_apps.where(storage_id: storage_id).first[:id]
       end
 
       assert_empty storage_apps.where(storage_id: storage_id)

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4082,16 +4082,16 @@ class UserTest < ActiveSupport::TestCase
 
   test 'find_channel_owner finds channel owner' do
     student = create :student
-    with_channel_for student do |channel_id, storage_id|
-      encrypted_channel_id = storage_encrypt_channel_id storage_id, channel_id
+    with_channel_for student do |storage_app_id, storage_id|
+      encrypted_channel_id = storage_encrypt_channel_id storage_id, storage_app_id
       result = User.find_channel_owner encrypted_channel_id
       assert_equal student, result
     end
   end
 
   test 'find_channel_owner returns nil for channel with no owner' do
-    with_anonymous_channel do |channel_id, storage_id|
-      encrypted_channel_id = storage_encrypt_channel_id storage_id, channel_id
+    with_anonymous_channel do |storage_app_id, storage_id|
+      encrypted_channel_id = storage_encrypt_channel_id storage_id, storage_app_id
       result = User.find_channel_owner encrypted_channel_id
       assert_nil result
     end

--- a/dashboard/test/testing/storage_apps_test_utils.rb
+++ b/dashboard/test/testing/storage_apps_test_utils.rb
@@ -7,14 +7,14 @@ module StorageAppsTestUtils
   def with_channel_for(owner)
     with_storage_id_for owner do |storage_id|
       encrypted_channel_id = StorageApps.new(storage_id).create({projectType: 'applab'}, ip: 123)
-      _, id = storage_decrypt_channel_id encrypted_channel_id
-      yield id, storage_id
+      _, storage_app_id = storage_decrypt_channel_id encrypted_channel_id
+      yield storage_app_id, storage_id
     ensure
-      storage_apps.where(id: id).delete if id
+      storage_apps.where(id: storage_app_id).delete if storage_app_id
     end
   end
 
-  # @param [User] user - may be nil for anonymouse storage id
+  # @param [User] user - may be nil for anonymous storage id
   def with_storage_id_for(user)
     owns_storage_id = false
     user_id = user&.id

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -35,15 +35,15 @@ class DeleteAccountsHelper
 
     @log.puts "Deleting project backed progress"
 
-    channel_ids = @pegasus_db[:storage_apps].where(storage_id: user.user_storage_id).map(:id)
-    channel_count = channel_ids.count
-    encrypted_channel_ids = channel_ids.map do |id|
-      storage_encrypt_channel_id user.user_storage_id, id
+    storage_app_ids = @pegasus_db[:storage_apps].where(storage_id: user.user_storage_id).map(:id)
+    channel_count = storage_app_ids.count
+    encrypted_channel_ids = storage_app_ids.map do |storage_app_id|
+      storage_encrypt_channel_id user.user_storage_id, storage_app_id
     end
 
     # Clear potential PII from user's channels
     @pegasus_db[:storage_apps].
-      where(id: channel_ids).
+      where(id: storage_app_ids).
       update(value: nil, updated_ip: '', updated_at: Time.now)
 
     # Clear S3 contents for user's channels

--- a/shared/middleware/helpers/bucket_helper.rb
+++ b/shared/middleware/helpers/bucket_helper.rb
@@ -49,8 +49,8 @@ class BucketHelper
   end
 
   def app_size(encrypted_channel_id)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    prefix = s3_path owner_id, channel_id
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    prefix = s3_path owner_id, storage_app_id
     track_list_operation 'BucketHelper.app_size'
     s3.list_objects(bucket: @bucket, prefix: prefix).contents.map(&:size).reduce(:+).to_i
   end
@@ -64,10 +64,10 @@ class BucketHelper
   #                 object whose size we should return.
   # @return [[Int, Int]] size of target_object and size of entire app
   def object_and_app_size(encrypted_channel_id, target_object)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
 
-    app_prefix = s3_path owner_id, channel_id
-    target_object_prefix = s3_path owner_id, channel_id, target_object
+    app_prefix = s3_path owner_id, storage_app_id
+    target_object_prefix = s3_path owner_id, storage_app_id, target_object
 
     track_list_operation 'BucketHelper.object_and_app_size'
     objects = s3.list_objects(bucket: @bucket, prefix: app_prefix).contents
@@ -80,8 +80,8 @@ class BucketHelper
   end
 
   def list(encrypted_channel_id)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    prefix = s3_path owner_id, channel_id
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    prefix = s3_path owner_id, storage_app_id
     track_list_operation 'BucketHelper.list'
     s3.list_objects(bucket: @bucket, prefix: prefix).contents.map do |fileinfo|
       filename = %r{#{prefix}(.+)$}.match(fileinfo.key)[1]
@@ -94,11 +94,11 @@ class BucketHelper
   def get(encrypted_channel_id, filename, if_modified_since = nil, version = nil)
     if_modified_since = nil if if_modified_since == ''
     begin
-      owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
+      owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       return {status: 'NOT_FOUND'}
     end
-    key = s3_path owner_id, channel_id, filename
+    key = s3_path owner_id, storage_app_id, filename
     begin
       s3_object = s3_get_object(key, if_modified_since, version)
       {status: 'FOUND', body: s3_object.body, version_id: s3_object.version_id, last_modified: s3_object.last_modified, metadata: s3_object.metadata}
@@ -125,10 +125,10 @@ class BucketHelper
   end
 
   def copy_files(src_channel, dest_channel, options={})
-    src_owner_id, src_channel_id = storage_decrypt_channel_id(src_channel)
-    dest_owner_id, dest_channel_id = storage_decrypt_channel_id(dest_channel)
+    src_owner_id, src_storage_app_id = storage_decrypt_channel_id(src_channel)
+    dest_owner_id, dest_storage_app_id = storage_decrypt_channel_id(dest_channel)
 
-    src_prefix = s3_path src_owner_id, src_channel_id
+    src_prefix = s3_path src_owner_id, src_storage_app_id
     track_list_operation 'BucketHelper.copy_files'
     result = s3.list_objects(bucket: @bucket, prefix: src_prefix).contents.map do |fileinfo|
       filename = %r{#{src_prefix}(.+)$}.match(fileinfo.key)[1]
@@ -137,7 +137,7 @@ class BucketHelper
       category = mime_type.split('/').first  # e.g. 'image' or 'audio'
 
       src = "#{@bucket}/#{src_prefix}#{filename}"
-      dest = s3_path dest_owner_id, dest_channel_id, filename
+      dest = s3_path dest_owner_id, dest_storage_app_id, filename
 
       # Temporary: Add additional context to exceptions reported here, to help
       # diagnose a recurring issue where we pass a bad copy_source to the S3
@@ -158,23 +158,23 @@ class BucketHelper
   end
 
   def restore_file_version(encrypted_channel_id, filename, version)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, filename
 
     s3.copy_object(bucket: @bucket, copy_source: URI.encode("#{@bucket}/#{key}?versionId=#{version}"), key: key, metadata_directive: 'REPLACE')
   end
 
   def replace_abuse_score(encrypted_channel_id, filename, abuse_score)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, filename
 
     s3.copy_object(bucket: @bucket, copy_source: URI.encode("#{@bucket}/#{key}"), key: key, metadata: {abuse_score: abuse_score.to_s}, metadata_directive: 'REPLACE')
   end
 
   def create_or_replace(encrypted_channel_id, filename, body, version = nil, abuse_score = 0)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
 
-    key = s3_path owner_id, channel_id, filename
+    key = s3_path owner_id, storage_app_id, filename
     response = s3.put_object(bucket: @bucket, key: key, body: body, metadata: {abuse_score: abuse_score.to_s})
 
     # Delete the old version, if doing an in-place replace
@@ -203,8 +203,8 @@ class BucketHelper
   def check_current_version(encrypted_channel_id, filename, current_version, should_replace, timestamp, tab_id, user_id)
     return true unless filename == 'main.json' && @bucket == CDO.sources_s3_bucket && current_version
 
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, filename
 
     begin
       latest = s3.head_object(bucket: @bucket, key: key).version_id
@@ -276,10 +276,10 @@ class BucketHelper
   # @param [String] version - Version of destination object to replace
   # @return [Hash] S3 response from copy operation
   def copy(encrypted_channel_id, filename, source_filename, version = nil)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
 
-    key = s3_path owner_id, channel_id, filename
-    copy_source = @bucket + '/' + s3_path(owner_id, channel_id, source_filename)
+    key = s3_path owner_id, storage_app_id, filename
+    copy_source = @bucket + '/' + s3_path(owner_id, storage_app_id, source_filename)
     response = s3.copy_object(bucket: @bucket, key: key, copy_source: copy_source)
 
     # TODO: (bbuchanan) Handle abuse_score metadata for animations.
@@ -293,15 +293,15 @@ class BucketHelper
   end
 
   def delete(encrypted_channel_id, filename)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, filename
 
     s3.delete_object(bucket: @bucket, key: key)
   end
 
   def delete_multiple(encrypted_channel_id, filenames)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    objects = filenames.map {|filename| {key: s3_path(owner_id, channel_id, filename)}}
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    objects = filenames.map {|filename| {key: s3_path(owner_id, storage_app_id, filename)}}
 
     s3.delete_objects(bucket: @bucket, delete: {objects: objects, quiet: true})
   end
@@ -315,9 +315,9 @@ class BucketHelper
   # @return [Integer] the number of objects deleted
   def hard_delete_channel_content(encrypted_channel_id)
     # TODO: Handle pagination in the S3 APIs
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
     # Find all versions of all objects
-    channel_prefix = s3_path owner_id, channel_id
+    channel_prefix = s3_path owner_id, storage_app_id
     track_list_operation 'BucketHelper.hard_delete_channel_content'
     version_list = s3.list_object_versions(bucket: @bucket, prefix: channel_prefix)
     return 0 if version_list.versions.empty? && version_list.delete_markers.empty?
@@ -340,8 +340,8 @@ class BucketHelper
   end
 
   def list_versions(encrypted_channel_id, filename)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, filename
 
     track_list_operation 'BucketHelper.list_versions'
     s3.list_object_versions(bucket: @bucket, prefix: key).
@@ -357,8 +357,8 @@ class BucketHelper
 
   # Used for testing
   def list_delete_markers(encrypted_channel_id, filename)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, filename
 
     track_list_operation 'BucketHelper.list_delete_markers'
     s3.list_object_versions(bucket: @bucket, prefix: key).
@@ -375,8 +375,8 @@ class BucketHelper
   # Copies the given version of the file to make it the current revision.
   # (All intermediate versions are preserved.)
   def restore_previous_version(encrypted_channel_id, filename, version_id, user_id)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, filename
 
     version_restored = false
 
@@ -464,8 +464,8 @@ class BucketHelper
   end
 
   def log_restored_file(project_id:, user_id:, filename:, source_version_id:, new_version_id:)
-    owner_id, channel_id = storage_decrypt_channel_id(project_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(project_id)
+    key = s3_path owner_id, storage_app_id, filename
     FirehoseClient.instance.put_record(
       study: 'project-data-integrity',
       study_group: 'v4',
@@ -493,8 +493,8 @@ class BucketHelper
     false
   end
 
-  def s3_path(owner_id, channel_id, filename = nil)
-    "#{@base_dir}/#{owner_id}/#{channel_id}/#{Addressable::URI.unencode(filename)}"
+  def s3_path(owner_id, storage_app_id, filename = nil)
+    "#{@base_dir}/#{owner_id}/#{storage_app_id}/#{Addressable::URI.unencode(filename)}"
   end
 
   # Extracted so we can override with special behavior in AnimationBucket.

--- a/shared/middleware/helpers/file_bucket.rb
+++ b/shared/middleware/helpers/file_bucket.rb
@@ -53,8 +53,8 @@ class FileBucket < BucketHelper
   # expiration.
   #
   def make_temporary_public_url(encrypted_channel_id, filename, expires_in = 5.minutes)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, filename
     Aws::S3::Presigner.new(client: s3).presigned_url(
       :get_object,
       {

--- a/shared/middleware/helpers/source_bucket.rb
+++ b/shared/middleware/helpers/source_bucket.rb
@@ -31,8 +31,8 @@ class SourceBucket < BucketHelper
     # In most cases fall back on the generic restore behavior.
     return super(encrypted_channel_id, filename, version_id, user_id) unless MAIN_JSON_FILENAME == filename
 
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, filename
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, filename
 
     source_object = s3.get_object(bucket: @bucket, key: key, version_id: version_id)
     source_body = source_object.body.read
@@ -75,11 +75,11 @@ class SourceBucket < BucketHelper
   # in dest_channel
   # Note: this function assumes that the animations have already been copied
   def remix_source(src_channel, dest_channel, animation_list)
-    src_owner_id, src_channel_id = storage_decrypt_channel_id(src_channel)
-    dest_owner_id, dest_channel_id = storage_decrypt_channel_id(dest_channel)
+    src_owner_id, src_storage_app_id = storage_decrypt_channel_id(src_channel)
+    dest_owner_id, dest_storage_app_id = storage_decrypt_channel_id(dest_channel)
 
-    src = s3_path src_owner_id, src_channel_id, MAIN_JSON_FILENAME
-    dest = s3_path dest_owner_id, dest_channel_id, MAIN_JSON_FILENAME
+    src = s3_path src_owner_id, src_storage_app_id, MAIN_JSON_FILENAME
+    dest = s3_path dest_owner_id, dest_storage_app_id, MAIN_JSON_FILENAME
 
     # Get animation manifest
     src_object = s3.get_object(bucket: @bucket, key: src)
@@ -113,8 +113,8 @@ class SourceBucket < BucketHelper
   # bucket will be called main.json.
   # This avoids a potentially expensive LIST request to S3.
   def app_size(encrypted_channel_id)
-    owner_id, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, channel_id, MAIN_JSON_FILENAME
+    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    key = s3_path owner_id, storage_app_id, MAIN_JSON_FILENAME
     s3.head_object(bucket: @bucket, key: key).content_length.to_i
   rescue Aws::S3::Errors::NotFound
     0

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -50,10 +50,10 @@ def storage_decrypt_channel_id(encrypted)
   raise ArgumentError, "`encrypted` must be a string" unless encrypted.is_a? String
   # pad to a multiple of 4 characters to make a valid base64 string.
   encrypted += '=' * ((4 - encrypted.length % 4) % 4)
-  storage_id, channel_id = storage_decrypt(Base64.urlsafe_decode64(encrypted)).split(':').map(&:to_i)
+  storage_id, storage_app_id = storage_decrypt(Base64.urlsafe_decode64(encrypted)).split(':').map(&:to_i)
   raise ArgumentError, "`storage_id` must be an integer > 0" unless storage_id > 0
-  raise ArgumentError, "`channel_id` must be an integer > 0" unless channel_id > 0
-  [storage_id, channel_id]
+  raise ArgumentError, "`storage_app_id` must be an integer > 0" unless storage_app_id > 0
+  [storage_id, storage_app_id]
 end
 
 def valid_encrypted_channel_id(encrypted)
@@ -79,12 +79,12 @@ def storage_encrypt_id(id)
   storage_encrypt("#{SecureRandom.random_number(65536)}:#{id}:#{SecureRandom.random_number(65536)}")
 end
 
-def storage_encrypt_channel_id(storage_id, channel_id)
+def storage_encrypt_channel_id(storage_id, storage_app_id)
   storage_id = storage_id.to_i
   raise ArgumentError, "`storage_id` must be an integer > 0" unless storage_id > 0
-  channel_id = channel_id.to_i
-  raise ArgumentError, "`channel_id` must be an integer > 0" unless channel_id > 0
-  Base64.urlsafe_encode64(storage_encrypt("#{storage_id}:#{channel_id}")).tr('=', '')
+  storage_app_id = storage_app_id.to_i
+  raise ArgumentError, "`storage_app_id` must be an integer > 0" unless storage_app_id > 0
+  Base64.urlsafe_encode64(storage_encrypt("#{storage_id}:#{storage_app_id}")).tr('=', '')
 end
 
 def storage_id(endpoint)

--- a/shared/test/test_channels.rb
+++ b/shared/test/test_channels.rb
@@ -425,20 +425,20 @@ class ChannelsTest < Minitest::Test
     assert last_request.url.end_with? "/#{response['id']}"
     assert_equal 456, response['def']
 
-    _, channel_id = storage_decrypt_channel_id(response['id'])
-    _, parent_channel_id = storage_decrypt_channel_id(encrypted_parent_channel_id)
-    assert_equal parent_channel_id, PEGASUS_DB[:storage_apps].where(id: channel_id).first[:remix_parent_id]
+    _, storage_app_id = storage_decrypt_channel_id(response['id'])
+    _, parent_storage_app_id = storage_decrypt_channel_id(encrypted_parent_channel_id)
+    assert_equal parent_storage_app_id, PEGASUS_DB[:storage_apps].where(id: storage_app_id).first[:remix_parent_id]
   end
 
   def test_update_project_type
     post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     encrypted_channel_id = last_response.location.split('/').last
-    _, channel_id = storage_decrypt_channel_id(encrypted_channel_id)
-    assert_nil PEGASUS_DB[:storage_apps].where(id: channel_id).first[:project_type]
+    _, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    assert_nil PEGASUS_DB[:storage_apps].where(id: storage_app_id).first[:project_type]
 
     post "/v3/channels/#{encrypted_channel_id}", {projectType: 'gamelab'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     assert last_response.successful?
-    assert_equal 'gamelab', PEGASUS_DB[:storage_apps].where(id: channel_id).first[:project_type]
+    assert_equal 'gamelab', PEGASUS_DB[:storage_apps].where(id: storage_app_id).first[:project_type]
   end
 
   private


### PR DESCRIPTION
ensure all instances of `storage_app_id` are named properly in the codebase, as outlined in the [project resource naming proposal](https://docs.google.com/document/d/1iuJMhSsl9s9m-Y0hypKxDlwv52vaRBLjFHaL2hsH4mE/edit).