### PR TITLE
Add "Code.org - Markdown" Crowdin project to standard i18n sync

### DIFF
--- a/bin/i18n/sync-codeorg-all.rb
+++ b/bin/i18n/sync-codeorg-all.rb
@@ -121,6 +121,13 @@ def create_down_out_pr
     "pegasus i18n updates"
   )
 
+  git_add_and_commit(
+    [
+      "pegasus/sites.v3/code.org/i18n",
+    ],
+    "pegasus i18n markdown updates"
+  )
+
   # Break up the dashboard changes, since they frequently end up being large
   # enough to have trouble viewing in github
   Languages.get_crowdin_name_and_locale.each do |prop|

--- a/bin/i18n/sync-codeorg-down.rb
+++ b/bin/i18n/sync-codeorg-down.rb
@@ -1,13 +1,14 @@
 #!/usr/bin/env ruby
 
-# Downloads all translations from Crowdin Code.org
-# project to i18n/locales.
+# Downloads all translations from Crowdin Code.org and Code.org-Markdown
+# projects to i18n/locales.
 # https://crowdin.com/project/codeorg
 
 require_relative 'i18n_script_utils'
 
 def sync_down
-  system "crowdin --config #{CODEORG_CONFIG_FILE} --identity #{CODEORG_IDENTITY_FILE} download"
+  system "crowdin --config #{CODEORG_CONFIG_FILE} --identity #{CODEORG_IDENTITY_FILE} download translations"
+  system "crowdin --config #{CODEORG_MARKDOWN_CONFIG_FILE} --identity #{CODEORG_MARKDOWN_IDENTITY_FILE} download translations"
 end
 
 sync_down if __FILE__ == $0

--- a/bin/i18n/sync-codeorg-in.rb
+++ b/bin/i18n/sync-codeorg-in.rb
@@ -17,32 +17,9 @@ def sync_in
   localize_level_content
   localize_block_content
   run_bash_script "bin/i18n-codeorg/in.sh"
-  localize_pegasus_markdown_content
   # disable redaction of level content until the switch to remark is complete
   #redact_level_content
   redact_block_content
-end
-
-def localize_pegasus_markdown_content
-  # The in script grabs all the serialized pegasus strings, but we also want to
-  # localize some markdown pages. As of September 2018, there is exactly one
-  # page we want to localize, but we expect there to be more eventually.
-  markdown_to_localize = %w(
-    educate/curriculum/csf-transition-guide
-  ).freeze
-
-  src_dir = 'pegasus/sites.v3/code.org/public'.freeze
-  dest_dir = 'i18n/locales/source/pegasus/public'.freeze
-
-  # If we wanted to preprocess the markdown before it goes into crowdin (for
-  # example, to strip out the YAML header or perform redaction), right here is
-  # where we would likely do it.
-  markdown_to_localize.each do |md|
-    src_file = File.join src_dir, "#{md}.md"
-    dest_file = File.join dest_dir, "#{md}.md"
-    FileUtils.mkdir_p File.dirname(dest_file)
-    FileUtils.cp src_file, dest_file
-  end
 end
 
 def copy_to_yml(label, data)

--- a/bin/i18n/sync-codeorg-markdown-down.rb
+++ b/bin/i18n/sync-codeorg-markdown-down.rb
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-require_relative 'i18n_script_utils'
-
-def sync_down
-  system "crowdin --config #{CODEORG_MARKDOWN_CONFIG_FILE} --identity #{CODEORG_MARKDOWN_IDENTITY_FILE} download translations"
-end
-
-sync_down if __FILE__ == $0

--- a/bin/i18n/sync-codeorg-up.rb
+++ b/bin/i18n/sync-codeorg-up.rb
@@ -1,13 +1,15 @@
 #!/usr/bin/env ruby
 
-# Uploads all English source files from i18n/locales/source
-# to Code.org project on Crowdin for translation.
+# Uploads all English source files from i18n/locales/source to Code.org
+# project, and all source files from pegasus/sites.v3/code.org/public to
+# Code.org - Markdown project on Crowdin.
 # https://crowdin.com/project/codeorg
 
 require_relative 'i18n_script_utils'
 
 def sync_up
   system "crowdin --config #{CODEORG_CONFIG_FILE} --identity #{CODEORG_IDENTITY_FILE} upload sources"
+  system "crowdin --config #{CODEORG_MARKDOWN_CONFIG_FILE} --identity #{CODEORG_MARKDOWN_IDENTITY_FILE} upload sources"
 end
 
 sync_up if __FILE__ == $0


### PR DESCRIPTION
Rather than having it be a separate sync pathway