### PR TITLE
Remove Safari Skip in Big Game Versions

### DIFF
--- a/dashboard/test/ui/features/big_game_versions.feature
+++ b/dashboard/test/ui/features/big_game_versions.feature
@@ -12,7 +12,6 @@ Feature: Big Game Versions
     And I close callout "0"
     And callout "0" is hidden
 
-  @no_safari_yosemite
   @no_mobile
   Scenario: Big Game Versions
 


### PR DESCRIPTION
Skip tag added in this PR: https://github.com/code-dot-org/code-dot-org/pull/10378
No documentation on reason for skip tag
Test passes locally in SauceLab safari
Re-adding test with plans to monitor for flakiness 