### PR TITLE
Workaround step definiton for entering text in safari textarea

### DIFF
--- a/dashboard/test/ui/features/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/applab/shared_apps.feature
@@ -91,7 +91,6 @@ Feature: App Lab Scenarios
   # typing into a contenteditable div (which is what our Applab textareas are)
   # See https://code.google.com/p/selenium/issues/detail?id=4467
   # Also doesnt seem to be working for ie
-  @no_safari_yosemite
   @no_ie
   @no_mobile
   Scenario: Can type in textarea on share page
@@ -100,5 +99,5 @@ Feature: App Lab Scenarios
     When I navigate to the shared version of my project
     And I wait until element ".screen > #text_area1" is visible
     And I press the first ".screen > #text_area1" element
-    And I press keys "XYZZY" for element ".screen > #text_area1"
+    And I use jquery to set the text of "#screen1 > #text_area1" to "XYZZY"
     Then element ".screen > #text_area1" contains text "XYZZY"

--- a/dashboard/test/ui/features/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/applab/shared_apps.feature
@@ -87,10 +87,6 @@ Feature: App Lab Scenarios
     And I press keys "GLULX" for element ".screen > input"
     Then element ".screen > input" has value "GLULX"
 
-  # Known limitation of Selenium's Safari driver: Cannot use sendKeys to simulate
-  # typing into a contenteditable div (which is what our Applab textareas are)
-  # See https://code.google.com/p/selenium/issues/detail?id=4467
-  # Also doesnt seem to be working for ie
   @no_ie
   @no_mobile
   Scenario: Can type in textarea on share page

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -649,6 +649,10 @@ Then /^element "([^"]*)" is (not )?checked$/ do |selector, negation|
   expect(value).to eq(negation.nil?)
 end
 
+Then /^I use jquery to set the text of "([^"]*)" to "([^"]*)"$/ do |selector, value|
+  @browser.execute_script("$(\"#{selector}\").text(\"#{value}\");")
+end
+
 Then /^element "([^"]*)" has attribute "((?:[^"\\]|\\.)*)" equal to "((?:[^"\\]|\\.)*)"$/ do |selector, attribute, expected_text|
   element_has_attribute(selector, attribute, replace_hostname(expected_text))
 end


### PR DESCRIPTION
Context on Safari send_keys issue: https://github.com/SeleniumHQ/selenium/issues/4361

Adding a step that circumvents the send_keys and uses jquery to set the text of a field. Removing the safari skip tag.