### PR TITLE
Re-usable AgeDropdown on ReportAbuseForm

### DIFF
--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -92,7 +92,7 @@ export default class ReportAbuseForm extends React.Component {
           <input type="hidden" name="name" value={this.props.name}/>
           <div style={{display: this.props.email ? 'none' : 'block'}}>
             <div>{i18n.t('activerecord.attributes.user.email')}</div>
-            <input type="text" style={{width: INPUT_WIDTH}} defaultValue={this.props.email} name="email" ref="email"/>
+            <input type="text" style={{width: INPUT_WIDTH}} defaultValue={this.props.email} name="email" ref="email" id="uitest-email"/>
           </div>
 
           <div style={{display: this.props.age ? 'none' : 'block'}}>
@@ -100,6 +100,7 @@ export default class ReportAbuseForm extends React.Component {
             <AgeDropdown
               style={{width: DROPDOWN_WIDTH}}
               ref="age"
+              age={this.props.age}
             />
           </div>
 
@@ -115,7 +116,7 @@ export default class ReportAbuseForm extends React.Component {
               })
             }}
           />
-          <select style={{width: DROPDOWN_WIDTH}} name="abuse_type" ref="abuse_type">
+        <select style={{width: DROPDOWN_WIDTH}} name="abuse_type" ref="abuse_type" id="uitest-abuse-type">
             <option value=""></option>
             <option value="harassment">{i18n.t('project.abuse.report_abuse_form.abuse_type.harassment')}</option>
             <option value="offensive">{i18n.t('project.abuse.report_abuse_form.abuse_type.offensive')}</option>
@@ -124,7 +125,7 @@ export default class ReportAbuseForm extends React.Component {
           </select>
 
           <div>{i18n.t('project.abuse.report_abuse_form.detail')}</div>
-          <textarea style={{width: INPUT_WIDTH, height: 100}} name="abuse_detail" ref="abuse_detail"/>
+          <textarea style={{width: INPUT_WIDTH, height: 100}} name="abuse_detail" ref="abuse_detail" id="uitest-abuse-detail"/>
 
           {/* we dangerouslySetInnerHTML because our string has html in it*/}
           <div
@@ -136,7 +137,10 @@ export default class ReportAbuseForm extends React.Component {
               })
             }}
           />
-          <button onClick={this.handleSubmit}>
+          <button
+            onClick={this.handleSubmit}
+            id="uitest-submit-report-abuse"
+          >
             {i18n.t('submit')}
           </button>
         </form>

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -99,7 +99,6 @@ export default class ReportAbuseForm extends React.Component {
             <div>{i18n.t('activerecord.attributes.user.age')}</div>
             <AgeDropdown
               style={{width: DROPDOWN_WIDTH}}
-              age={this.props.age}
               ref="age"
             />
           </div>

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-danger */
 import React, {PropTypes} from 'react';
 import ReactDOM from 'react-dom';
-import _ from 'lodash';
+import AgeDropdown from '@cdo/apps/templates/AgeDropdown';
 
 /**
  * A component containing some text/links for projects that have had abuse
@@ -29,39 +29,6 @@ export const getChannelIdFromUrl = function (abuseUrl) {
   }
   return match && match[1];
 };
-
-/**
- * A dropdown with the set of ages we use across our site (4-20, 21+)
- */
-class AgeDropdown extends React.Component {
-  static propTypes = {
-    age: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
-    style: PropTypes.object
-  };
-
-  render() {
-    const style = _.assign({}, {width: DROPDOWN_WIDTH}, this.props.style);
-
-    const age = this.props.age && this.props.age.toString();
-    const ages = ['', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14',
-      '15', '16', '17', '18', '19', '20', '21+'];
-
-    if (this.props.age !== null && ages.indexOf(age) === -1) {
-      throw new Error('Invalid age: ' + age);
-    }
-
-    return (
-      <select name="age" style={style} defaultValue={age}>{
-        ages.map(function (age) {
-          return <option key={age} value={age}>{age}</option>;
-        })
-      }</select>
-    );
-  }
-}
 
 export default class ReportAbuseForm extends React.Component {
   static propTypes = {
@@ -130,7 +97,11 @@ export default class ReportAbuseForm extends React.Component {
 
           <div style={{display: this.props.age ? 'none' : 'block'}}>
             <div>{i18n.t('activerecord.attributes.user.age')}</div>
-            <AgeDropdown age={this.props.age} ref="age"/>
+            <AgeDropdown
+              style={{width: DROPDOWN_WIDTH}}
+              age={this.props.age}
+              ref="age"
+            />
           </div>
 
           <div>{i18n.t('project.abuse.report_abuse_form.abusive_url')}</div>

--- a/apps/src/templates/AgeDropdown.jsx
+++ b/apps/src/templates/AgeDropdown.jsx
@@ -11,6 +11,10 @@ export const ages = ['', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '
 export default class AgeDropdown extends Component {
   static propTypes = {
     style: PropTypes.object,
+    age: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ])
   };
 
   /**
@@ -21,12 +25,15 @@ export default class AgeDropdown extends Component {
   }
 
   render() {
+    const age = this.props.age && this.props.age.toString();
+
     return (
       <select
         ref={element => this.root = element}
         name="age"
         style={this.props.style}
         id="uitest-age-selector"
+        defaultValue={age}
       >
        {ages.map(age => <option key={age} value={age}>{age}</option>)}
       </select>

--- a/apps/src/templates/AgeDropdown.jsx
+++ b/apps/src/templates/AgeDropdown.jsx
@@ -11,10 +11,6 @@ export const ages = ['', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '
 export default class AgeDropdown extends Component {
   static propTypes = {
     style: PropTypes.object,
-    age: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ])
   };
 
   /**
@@ -25,19 +21,12 @@ export default class AgeDropdown extends Component {
   }
 
   render() {
-    const age = this.props.age && this.props.age.toString();
-
-    if (this.props.age !== null && ages.indexOf(age) === -1) {
-      throw new Error('Invalid age: ' + age);
-    }
-
     return (
       <select
         ref={element => this.root = element}
         name="age"
         style={this.props.style}
         id="uitest-age-selector"
-        defaultValue={age}
       >
        {ages.map(age => <option key={age} value={age}>{age}</option>)}
       </select>

--- a/apps/src/templates/AgeDropdown.jsx
+++ b/apps/src/templates/AgeDropdown.jsx
@@ -6,14 +6,15 @@ export const ages = ['', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '
 
 /**
  * A dropdown with the set of ages we use across our site (4-20, 21+)
- * NOTE: this is pretty similarly to a component in dashboard's
- * ReportAbuseForm.jsx. In an ideal world, we would have a better way of
- * sharing components between dashboard/apps and have any difference between
- * the two version controlled by props.
- */
+**/
+
 export default class AgeDropdown extends Component {
   static propTypes = {
-    style: PropTypes.object
+    style: PropTypes.object,
+    age: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ])
   };
 
   /**
@@ -24,12 +25,19 @@ export default class AgeDropdown extends Component {
   }
 
   render() {
+    const age = this.props.age && this.props.age.toString();
+
+    if (this.props.age !== null && ages.indexOf(age) === -1) {
+      throw new Error('Invalid age: ' + age);
+    }
+
     return (
       <select
         ref={element => this.root = element}
         name="age"
         style={this.props.style}
         id="uitest-age-selector"
+        defaultValue={age}
       >
        {ages.map(age => <option key={age} value={age}>{age}</option>)}
       </select>

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -20,7 +20,7 @@ class ReportAbuseController < ApplicationController
   AGE_CUSTOM_FIELD_ID = 24_024_923
 
   def report_abuse
-    unless Rails.env.development?
+    unless Rails.env.development? || Rails.env.test?
       subject = FeaturedProject.featured_channel_id?(params[:channel_id]) ?
         'Featured Project: Abuse Reported' :
         'Abuse Reported'

--- a/dashboard/test/ui/features/report_abuse.feature
+++ b/dashboard/test/ui/features/report_abuse.feature
@@ -1,0 +1,31 @@
+Feature: Report Abuse Form
+  Scenario: Reporting abuse while signed-out
+    Given I am on "http://studio.code.org/report_abuse"
+    And I type "harry@hogwarts.edu" into "#uitest-email"
+    And I select the "13" option in dropdown "uitest-age-selector"
+    And I select the "Other" option in dropdown "uitest-abuse-type"
+    And I type "Mudblood is an offensive term" into "#uitest-abuse-detail"
+    Then I click selector "#uitest-submit-report-abuse" once I see it
+    Then check that the URL matches "https://support.code.org/hc/en-us"
+
+  Scenario: Reporting abuse as a signed-in student
+    Given I create a student named "Harry"
+    Given I am on "http://studio.code.org/report_abuse"
+    And I type "harry@hogwarts.edu" into "#uitest-email"
+    # Age is are already known and passed to the form
+    And I wait until element "#uitest-age-selector" is not visible
+    And I select the "Other" option in dropdown "uitest-abuse-type"
+    And I type "Mudblood is an offensive term" into "#uitest-abuse-detail"
+    Then I click selector "#uitest-submit-report-abuse" once I see it
+    Then check that the URL matches "https://support.code.org/hc/en-us"
+
+  Scenario: Reporting abuse as a signed-in teacher
+    Given I create a teacher named "Dumbledore"
+    Given I am on "http://studio.code.org/report_abuse"
+    # Email and age are already known and passed to the form
+    And I wait until element "#uitest-email" is not visible
+    And I wait until element "#uitest-age-selector" is not visible
+    And I select the "Other" option in dropdown "uitest-abuse-type"
+    And I type "Mudblood is an offensive term" into "#uitest-abuse-detail"
+    Then I click selector "#uitest-submit-report-abuse" once I see it
+    Then check that the URL matches "https://support.code.org/hc/en-us"


### PR DESCRIPTION
There was a `AgeDropdown` component baked into the `ReportAbuseForm` as well as a nearly identical `AgeDropdown` component that we re-use in various places across the site.  I imported the re-usable `AgeDropdown` and deleted the version that was within the `ReportAbuseForm`.