### PR TITLE
fix grid checkbox and isShareView

### DIFF
--- a/apps/src/gamelab/GameLabVisualizationColumn.jsx
+++ b/apps/src/gamelab/GameLabVisualizationColumn.jsx
@@ -168,7 +168,7 @@ class GameLabVisualizationColumn extends React.Component {
 
           <CompletionButton />
 
-          {!spriteLab && isShareView && this.renderGridCheckbox()}
+          {!spriteLab && !isShareView && this.renderGridCheckbox()}
         </GameButtons>
         {!spriteLab && this.renderAppSpaceCoordinates()}
         <ProtectedStatefulDiv


### PR DESCRIPTION
* Previous PR had a typo in it: https://github.com/code-dot-org/code-dot-org/pull/26444/files#diff-4c349716b5402ccc3b147049dfc2a9bcL181
* `!isShareView` became `isShareView` accidentally. Fixed!