### PR TITLE
Remove no_firefox tag for flakiness

### DIFF
--- a/dashboard/test/ui/features/big_game_remix.feature
+++ b/dashboard/test/ui/features/big_game_remix.feature
@@ -1,4 +1,3 @@
-@no_firefox
 @dashboard_db_access
 @as_student
 Feature: Big Game Remix

--- a/dashboard/test/ui/features/level_group_multi_page.feature
+++ b/dashboard/test/ui/features/level_group_multi_page.feature
@@ -1,4 +1,3 @@
-@no_firefox
 @no_mobile
 @as_taught_student
 Feature: Level Group


### PR DESCRIPTION
WIP  - address Firefox sign-out issue

no_firefox tag was added in this PR: https://github.com/code-dot-org/code-dot-org/commit/76aa12e7d229a97baa534d0fc009048dabb2b797 to mitigate flakiness
Issue was documented in known issues, but has since been removed.
Re-adding test with plans to monitor for flakiness.
