### PR TITLE
Hotfix: restore redacted i18n files that got skipped in the last sync

### DIFF
--- a/dashboard/config/locales/blocks.ar-SA.yml
+++ b/dashboard/config/locales/blocks.ar-SA.yml
@@ -3,20 +3,20 @@ ar:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: وبعد [TIMESTAMP][0] [UNIT][1]
+        text: وبعد {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': اجرائات
             '"seconds"': ثوان
       Dancelab_changeColorBy:
-        text: تغيير [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: تغيير {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"hue"': صبغة
             '"saturation"': تشبع
             '"brightness"': السطوع
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] نفذ هذا [MOVE][1] [DIR][2] إلى الأبد"
+        text: "{GROUP} نفذ هذا {MOVE} {DIR} إلى الأبد"
         options:
           GROUP:
             sprites: الكل
@@ -50,7 +50,7 @@ ar:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] نفذ هذا [MOVE][1][DIR][2] الى الابد"
+        text: "{SPRITE} نفذ هذا {MOVE}{DIR} الى الابد"
         options:
           MOVE:
             '"next"': "(التالي)"
@@ -71,7 +71,7 @@ ar:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: تغيير [SPRITE][0] [PROPERTY][1] [VAL][2]
+        text: تغيير {SPRITE} {PROPERTY} {VAL}
         options:
           PROPERTY:
             '"scale"': الحجم
@@ -80,7 +80,7 @@ ar:
             '"x"': بشكل أفقي
             '"y"': بشكل عمودي
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] نفذ هذا [MOVE][1] [DIR][2] مرة واحدة"
+        text: "{GROUP} نفذ هذا {MOVE} {DIR} مرة واحدة"
         options:
           GROUP:
             sprites: الكل
@@ -112,7 +112,7 @@ ar:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] نفذ هذا [MOVE][1] [DIR][2] مرة واحدة"
+        text: "{SPRITE} نفذ هذا {MOVE} {DIR} مرة واحدة"
         options:
           MOVE:
             '"rand"': "(عشوائي)"
@@ -131,34 +131,34 @@ ar:
             '1': "→"
             "-1": "←"
       Dancelab_eval:
-        text: تقييم[CODE][0]
+        text: تقييم{CODE}
       Dancelab_everySeconds:
-        text: 'كلما [N][0] [UNIT][1] '
+        text: 'كلما {N} {UNIT} '
         options:
           UNIT:
             '"measures"': اجرائات
             '"seconds"': ثوان
       Dancelab_everySecondsRange:
-        text: 'كلما [N][0] [UNIT][1] من [START][2] الى [STOP][3] '
+        text: 'كلما {N} {UNIT} من {START} الى {STOP} '
         options:
           UNIT:
             measures: اجرائات
             seconds: ثانية
       Dancelab_everyVerseChorus:
-        text: 'كلما [UNIT][0] '
+        text: 'كلما {UNIT} '
         options:
           UNIT:
             '"verse"': مقطع
             '"chorus"': دورة
       Dancelab_getEnergy:
-        text: الحصول على [RANGE][0]
+        text: الحصول على {RANGE}
         options:
           RANGE:
             '"low"': صوت عميق
             '"mid"': نصف
             '"high"': ثلاث
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': الحجم
@@ -168,13 +168,13 @@ ar:
             '"y"': بشكل عمودي
             '"tint"': لون
       Dancelab_getTime:
-        text: "[UNIT][0] منقضي"
+        text: "{UNIT} منقضي"
         options:
           UNIT:
             '"measures"': اجرائات
             '"seconds"': ثوان
       Dancelab_ifDanceIs:
-        text: إذا كان [SPRITE][0] يقوم بِ[DANCE][1][DO1][2] [DO2][3]
+        text: إذا كان {SPRITE} يقوم بِ{DANCE}{DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: تصفيق عالي
@@ -194,7 +194,7 @@ ar:
             '"measures"': اجرائات
             '"seconds"': ثوان
       Dancelab_jumpTo:
-        text: "[SPRITE][0] اقفز الى [LOCATION][1]"
+        text: "{SPRITE} اقفز الى {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": أعلى
@@ -264,7 +264,7 @@ ar:
       Dancelab_randomColor:
         text: لون عشوائي
       Dancelab_setBackgroundEffect:
-        text: عيّن تأثيرات الخلفية [EFFECT][0]
+        text: عيّن تأثيرات الخلفية {EFFECT}
         options:
           EFFECT:
             '"circles"': نفق
@@ -283,7 +283,7 @@ ar:
             '"vintage"': عتيق
             '"warm"': الأحمر بدرجاته
       Dancelab_setBackgroundEffectWithPalette:
-        text: عيّن تأثيرات الخلفية [EFFECT][0] [PALETTE][1]
+        text: عيّن تأثيرات الخلفية {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"rand"': "(عشوائي)"
@@ -404,7 +404,7 @@ ar:
             '"ROBOT"': كل الروبوتات
             '"SHARK"': كل القروش
       Dancelab_setVisible:
-        text: اضبط [SPRITE][0] على مرئي لـ [VISIBILITY][1]
+        text: اضبط {SPRITE} على مرئي لـ {VISIBILITY}
         options:
           VISIBILITY:
             'false': غير مرئي
@@ -426,7 +426,7 @@ ar:
           VISIBILITY:
             'false': غير مرئي
       Dancelab_startMapping:
-        text: "[SPRITE][0] بدأ [PROPERTY][1] بالتالي [RANGE][2]"
+        text: "{SPRITE} بدأ {PROPERTY} بالتالي {RANGE}"
         options:
           PROPERTY:
             '"scale"': الحجم
@@ -440,7 +440,7 @@ ar:
             '"mid"': نصف
             '"treble"': ثلاث
       Dancelab_stopMapping:
-        text: "[SPRITE][0] توقع [PROPERTY][1] بالتالي [RANGE][2]"
+        text: "{SPRITE} توقع {PROPERTY} بالتالي {RANGE}"
         options:
           PROPERTY:
             '"scale"': الحجم
@@ -470,19 +470,19 @@ ar:
             '1': نصف
             '2': ثلاث
       gamelab_changeColor:
-        text: تغيير [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: تغيير {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"tint"': لون
       gamelab_changeColorBy:
-        text: تغيير [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: تغيير {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"hue"': صبغة
             '"saturation"': تشبع
             '"brightness"': السطوع
       gamelab_changePropBy:
-        text: تغيير [SPRITE][0] [PROPERTY][1] [VAL][2]
+        text: تغيير {SPRITE} {PROPERTY} {VAL}
         options:
           PROPERTY:
             '"scale"': الحجم
@@ -496,9 +496,9 @@ ar:
             'true': صحيح
             'false': خطأ
       gamelab_eval:
-        text: تقييم[CODE][0]
+        text: تقييم{CODE}
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': الحجم
@@ -508,7 +508,7 @@ ar:
             '"direction"': اتجاه الحركة
             '"tint"': لون
       gamelab_jumpTo:
-        text: "[SPRITE][0] اقفز الى [LOCATION][1]"
+        text: "{SPRITE} اقفز الى {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -600,7 +600,7 @@ ar:
             "{x: 100, y: 200}": اليسار
             "{x: 300, y: 200}": اليمين
       Mikelab_eval:
-        text: تقييم[CODE][0]
+        text: تقييم{CODE}
       Mikelab_getProp:
         options:
           PROPERTY:
@@ -669,7 +669,7 @@ ar:
           SELECT:
             '"all"': الكل
       Mikelab_ifDanceIs:
-        text: إذا كان [SPRITE][0] يقوم بِ[DANCE][1][DO1][2] [DO2][3]
+        text: إذا كان {SPRITE} يقوم بِ{DANCE}{DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: تصفيق عالي

--- a/dashboard/config/locales/blocks.bg-BG.yml
+++ b/dashboard/config/locales/blocks.bg-BG.yml
@@ -3,20 +3,20 @@ bg:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: след [TIMESTAMP][0] [UNIT][1]
+        text: след {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': мерки
             '"seconds"': секунди
       Dancelab_changeColorBy:
-        text: промяна на [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: промяна на {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"hue"': оттенък
             '"saturation"': наситеност
             '"brightness"': яркост
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] направи [MOVE][1] [DIR][2] завинаги"
+        text: "{GROUP} направи {MOVE} {DIR} завинаги"
         options:
           GROUP:
             sprites: всички
@@ -49,7 +49,7 @@ bg:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] направи [MOVE][1] [DIR][2] завинаги"
+        text: "{SPRITE} направи {MOVE} {DIR} завинаги"
         options:
           MOVE:
             '"next"': "(Следващ)"
@@ -70,7 +70,7 @@ bg:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: промяна на [SPRITE][0] [PROPERTY][1] с [VAL][2]
+        text: промяна на {SPRITE} {PROPERTY} с {VAL}
         options:
           PROPERTY:
             '"scale"': размер
@@ -79,7 +79,7 @@ bg:
             '"x"': хоризонтално положение
             '"y"': вертикално положение
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] направи [MOVE][1] [DIR][2] веднъж"
+        text: "{GROUP} направи {MOVE} {DIR} веднъж"
         options:
           GROUP:
             sprites: всички
@@ -110,7 +110,7 @@ bg:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] направи [MOVE][1] [DIR][2] веднъж"
+        text: "{SPRITE} направи {MOVE} {DIR} веднъж"
         options:
           MOVE:
             '"rand"': Случаен
@@ -128,25 +128,25 @@ bg:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'всеки [N][0] [UNIT][1] '
+        text: 'всеки {N} {UNIT} '
         options:
           UNIT:
             '"measures"': мерки
             '"seconds"': секунди
       Dancelab_everySecondsRange:
-        text: 'всеки [N][0] [UNIT][1] от [START],[2] до [STOP][3] '
+        text: 'всеки {N} {UNIT} от [START],[2] до {STOP} '
         options:
           UNIT:
             measures: Измерване
             seconds: Секунди
       Dancelab_everyVerseChorus:
-        text: 'всеки [UNIT][0] '
+        text: 'всеки {UNIT} '
         options:
           UNIT:
             '"verse"': стих
             '"chorus"': припев
       Dancelab_getEnergy:
-        text: взима [RANGE][0]
+        text: взима {RANGE}
         options:
           RANGE:
             '"low"': бас
@@ -345,7 +345,7 @@ bg:
             '"spotlight"': Прожектор
             '"raining_tacos"': Такос
       Dancelab_setProp:
-        text: промяна на [SPRITE][0] [PROPERTY][1] с [VAL][2]
+        text: промяна на {SPRITE} {PROPERTY} с {VAL}
         options:
           PROPERTY:
             '"scale"': размер
@@ -448,7 +448,7 @@ bg:
             '"bass"': бас
             '"treble"': сопрано
       Dancelab_whenKey:
-        text: когато [KEY][0] е натиснат
+        text: когато {KEY} е натиснат
         options:
           KEY:
             '"up"': нагоре
@@ -469,21 +469,21 @@ bg:
             '1': mid
             '2': сопрано
       gamelab_changeColor:
-        text: промяна на [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: промяна на {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"tint"': оттенък
             '"tone"': тон
             '"shade"': сянка
       gamelab_changeColorBy:
-        text: промяна на [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: промяна на {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"hue"': оттенък
             '"saturation"': наситеност
             '"brightness"': яркост
       gamelab_changePropBy:
-        text: промяна на [SPRITE][0] [PROPERTY][1] с [VAL][2]
+        text: промяна на {SPRITE} {PROPERTY} с {VAL}
         options:
           PROPERTY:
             '"scale"': размер
@@ -533,15 +533,15 @@ bg:
       gamelab_locationNorth:
         text: север
       gamelab_locationOf:
-        text: разположение на [SPRITE][0]
+        text: разположение на {SPRITE}
       gamelab_locationSouth:
         text: юг
       gamelab_locationWest:
         text: запад
       gamelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       gamelab_location_variable_get:
-        text: разположение на [VAR][0]
+        text: разположение на {VAR}
       gamelab_makeNewGroup:
         text: създай нова група
       gamelab_mirrorSprite:
@@ -562,7 +562,7 @@ bg:
           POSITION:
             '"random"': случаен
       gamelab_setProp:
-        text: промяна на [SPRITE][0] [PROPERTY][1] с [VAL][2]
+        text: промяна на {SPRITE} {PROPERTY} с {VAL}
         options:
           PROPERTY:
             '"scale"': размер
@@ -598,7 +598,7 @@ bg:
             '"right"': надясно
             '"left"': наляво
       gamelab_whenKey:
-        text: когато [KEY][0] е натиснат
+        text: когато {KEY} е натиснат
         options:
           KEY:
             '"up"': нагоре
@@ -630,7 +630,7 @@ bg:
             '"s"': s
             '"d"': d
       Mikelab_changePropBy:
-        text: промяна на [SPRITE][0] [PROPERTY][1] с [VAL][2]
+        text: промяна на {PROPERTY} {SPRITE} с {VAL}
         options:
           PROPERTY:
             '"scale"': размер
@@ -728,7 +728,7 @@ bg:
             MOVES.ThisOrThat: Това или онова
             MOVES.Rest: Без
       Mikelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       Mikelab_randomColor:
         text: случаен цвят
       Mikelab_setBG:
@@ -736,7 +736,7 @@ bg:
           BG:
             '"https://studio.code.org/api/v1/animation-library/04L4sdTODkNZF1OHf4qO_I.Al3QP43wA/category_backgrounds/city.png"': град
       Mikelab_setProp:
-        text: промяна на [SPRITE][0] [PROPERTY][1] с [VAL][2]
+        text: промяна на {PROPERTY} {SPRITE} с {VAL}
         options:
           PROPERTY:
             '"scale"': размер
@@ -758,7 +758,7 @@ bg:
             "{x: 300, y: 200}": надясно
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": Случаен
       Mikelab_whenKeyPressed:
-        text: когато [KEY][0] е натиснат
+        text: когато {KEY} е натиснат
         options:
           KEY:
             '"up"': стрелка нагоре
@@ -819,7 +819,7 @@ bg:
             '"left"': наляво
             '"right"': надясно
       binary_whenKey:
-        text: когато [KEY][0] е натиснат
+        text: когато {KEY} е натиснат
         options:
           KEY:
             '"up"': нагоре
@@ -833,8 +833,8 @@ bg:
             '"d"': d
       craft_ifPath:
         text: |-
-          ако пътят [DIR][0]
-          [STATEMENT][1]
+          ако пътят {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": отпред
@@ -842,8 +842,8 @@ bg:
             "'left'": вляво
       craft_ifStandingOn:
         text: |-
-          ако стоиш на [TYPE][0]
-          [STATEMENT][1]
+          ако стоиш на {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": син корал
@@ -854,8 +854,8 @@ bg:
             "'seaLantern'": морски фенер
       craft_ifStandingOnLimit:
         text: |-
-          ако стоиш на [TYPE][0]
-          [STATEMENT][1]
+          ако стоиш на {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": пясък
@@ -864,7 +864,7 @@ bg:
       craft_moveForward:
         text: върви напред
       craft_placeBlock:
-        text: място [blockType][0]
+        text: място {blockType}
         options:
           blockType:
             '"strippedOak"': отрязан дъб
@@ -897,11 +897,11 @@ bg:
       craft_placeTorch:
         text: постави факел
       craft_repeatUntilConduit:
-        text: повтаряй докато водопроводът е завършен [STATEMENT][0]
+        text: повтаряй докато водопроводът е завършен {STATEMENT}
       craft_repeatUntilGoal:
-        text: повтаряй до достигане на цел [STATEMENT][0]
+        text: повтаряй до достигане на цел {STATEMENT}
       craft_spawnEntity:
-        text: хайвер [ENTITY][0]
+        text: хайвер {ENTITY}
         options:
           ENTITY:
             '"cod"': треска
@@ -911,7 +911,7 @@ bg:
             '"squid"': калмар
             '"tropicalFish"': тропическа риба
       craft_turn:
-        text: обърни се [DIR][0]
+        text: обърни се {DIR}
         options:
           DIR:
             right: дясно ↻

--- a/dashboard/config/locales/blocks.bs-BA.yml
+++ b/dashboard/config/locales/blocks.bs-BA.yml
@@ -3,20 +3,20 @@ bs:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: nakon [TIMESTAMP][0] [UNIT][1]
+        text: nakon {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': taktovi
             '"seconds"': sekunde
       Dancelab_changeColorBy:
-        text: izmjeni [COLOR][0] [METHOD][1] za [AMOUNT][2]
+        text: izmjeni {COLOR} {METHOD} za {AMOUNT}
         options:
           METHOD:
             '"hue"': nijansa
             '"saturation"': zasićenje
             '"brightness"': osvjetljenost
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] radi [MOVE][1] [DIR][2] zauvijek"
+        text: "{GROUP} radi {MOVE} {DIR} zauvijek"
         options:
           GROUP:
             '"ALIEN"': svi vanzemaljci
@@ -49,7 +49,7 @@ bs:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] radi [MOVE][1] [DIR][2] zauvijek"
+        text: "{SPRITE} radi {MOVE} {DIR} zauvijek"
         options:
           MOVE:
             '"next"': "(Sljedeća)"
@@ -70,7 +70,7 @@ bs:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: izmjeni [SPRITE][0] [PROPERTY][1] za [VAL][2]
+        text: izmjeni {SPRITE} {PROPERTY} za {VAL}
         options:
           PROPERTY:
             '"scale"': veličina
@@ -80,7 +80,7 @@ bs:
             '"x"': vodoravna pozicija
             '"y"': uspravna pozicija
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] uradi [MOVE][1] [DIR][2] jednom"
+        text: "{GROUP} uradi {MOVE} {DIR} jednom"
         options:
           GROUP:
             '"ALIEN"': svi vanzemaljci
@@ -123,7 +123,7 @@ bs:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] uradi [MOVE][1] [DIR][2] jednom"
+        text: "{SPRITE} uradi {MOVE} {DIR} jednom"
         options:
           MOVE:
             '"rand"': "(Slučajna)"
@@ -154,32 +154,32 @@ bs:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'svako [N][0] [UNIT][1] '
+        text: 'svako {N} {UNIT} '
         options:
           UNIT:
             '"measures"': taktovi
             '"seconds"': sekunde
       Dancelab_everySecondsRange:
-        text: 'svako [N][0] [UNIT][1] od [START][2] do [STOP][3] '
+        text: 'svako {N} {UNIT} od {START} do {STOP} '
         options:
           UNIT:
             measures: Taktovi
             seconds: Sekunde
       Dancelab_everyVerseChorus:
-        text: 'svako [UNIT][0] '
+        text: 'svako {UNIT} '
         options:
           UNIT:
             '"verse"': protiv
             '"chorus"': korus
       Dancelab_getEnergy:
-        text: vrati [RANGE][0]
+        text: vrati {RANGE}
         options:
           RANGE:
             '"low"': basovi
             '"mid"': mid
             '"high"': trebl
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': veličina
@@ -190,15 +190,15 @@ bs:
             '"y"': uspravna pozicija
             '"tint"': nijanse
       Dancelab_getTime:
-        text: trenutno vrijeme u [UNIT][0]
+        text: trenutno vrijeme u {UNIT}
         options:
           UNIT:
             '"measures"': taktovi
             '"seconds"': sekunde
       Dancelab_ifDanceIs:
         text: |-
-          ako [SPRITE][0] čini [DANCE][1]
-          [DO1][2] [DO2][3]
+          ako {SPRITE} čini {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Klapni visoko
@@ -214,14 +214,14 @@ bs:
             MOVES.Rest: Nijedno
       Dancelab_ifTime:
         text: |-
-          ako [UNIT][0] je [OP][1] [N][2]
-          [DO1][3] [DO2][4]
+          ako {UNIT} je {OP} {N}
+          {DO1} {DO2}
         options:
           UNIT:
             '"measures"': taktovi
             '"seconds"': sekunde
       Dancelab_jumpTo:
-        text: "[SPRITE][0] skoči na [LOCATION][1]"
+        text: "{SPRITE} skoči na {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": vrh
@@ -235,7 +235,7 @@ bs:
             "{x: 300, y: 300}": donja desna
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": slučajno odabran
       Dancelab_layoutSprites:
-        text: postavka [GROUP][0] kao [FORMAT][1]
+        text: postavka {GROUP} kao {FORMAT}
         options:
           GROUP:
             '"ALIEN"': svi vanzemaljci
@@ -261,8 +261,8 @@ bs:
             '"random"': slučajno odabran
       Dancelab_makeNewDanceSprite:
         text: |-
-          kreiraj novi [COSTUME][0]
-          nazvan [NAME][1] na [LOCATION][2]
+          kreiraj novi {COSTUME}
+          nazvan {NAME} na {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Vanzemaljac
@@ -289,8 +289,8 @@ bs:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": slučajno odabran
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          napravi [N][0] novi [COSTUME][1]
-          unutar [LAYOUT][2]
+          napravi {N} novi {COSTUME}
+          unutar {LAYOUT}
         options:
           N:
             '2': '2'
@@ -335,9 +335,9 @@ bs:
             '"plus"': plus
             '"random"': slučajno odabran
       Dancelab_mixColors:
-        text: miks [COLOR1][0] i [COLOR2][1]
+        text: miks {COLOR1} i {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] takta/ova"
+        text: "{N} takta/ova"
       Dancelab_onPointerDown:
         text: na pritisak pokazivača
       Dancelab_onPointerDrag:
@@ -347,9 +347,9 @@ bs:
       Dancelab_randomColor:
         text: nasumična boja
       Dancelab_setBackground:
-        text: podesi boju pozadine [COLOR][0]
+        text: podesi boju pozadine {COLOR}
       Dancelab_setBackgroundEffect:
-        text: podesi efekat pozadine [EFFECT][0]
+        text: podesi efekat pozadine {EFFECT}
         options:
           EFFECT:
             '"none"': Nijedno
@@ -382,7 +382,7 @@ bs:
       Dancelab_setBackgroundEffectWithPalette:
         text: |-
           podesi efekat pozadine
-          [EFFECT][0] [PALETTE][1]
+          {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Nijedno
@@ -414,7 +414,7 @@ bs:
             '"vintage"': Starinsko
             '"warm"': Vruće
       Dancelab_setDanceSpeed:
-        text: podesi [SPRITE][0] brzinu plesa [SPEED][1]
+        text: podesi {SPRITE} brzinu plesa {SPEED}
         options:
           SPEED:
             '1': normal
@@ -423,7 +423,7 @@ bs:
             '0.5': sporo
             '0.25': vrlo sporo
       Dancelab_setDanceSpeedEach:
-        text: podesi [GROUP][0] brzinu plesa [SPEED][1]
+        text: podesi {GROUP} brzinu plesa {SPEED}
         options:
           GROUP:
             '"ALIEN"': svi vanzemaljci
@@ -444,7 +444,7 @@ bs:
             '0.5': sporo
             '0.25': vrlo sporo
       Dancelab_setForegroundEffect:
-        text: podesi efekat sprijeda [EFFECT][0]
+        text: podesi efekat sprijeda {EFFECT}
         options:
           EFFECT:
             '"none"': Nijedno
@@ -462,7 +462,7 @@ bs:
             '"color_lights"': Rasvjeta bine
             '"raining_tacos"': Takosi
       Dancelab_setForegroundEffectExtended:
-        text: podesi efekat sprijeda [EFFECT][0]
+        text: podesi efekat sprijeda {EFFECT}
         options:
           EFFECT:
             '"none"': Nijedno
@@ -481,7 +481,7 @@ bs:
             '"color_lights"': Rasvjeta bine
             '"raining_tacos"': Takosi
       Dancelab_setProp:
-        text: 'podesi [SPRITE][0] [PROPERTY][1] na[VAL][2] '
+        text: 'podesi {SPRITE} {PROPERTY} na{VAL} '
         options:
           PROPERTY:
             '"scale"': veličina
@@ -492,7 +492,7 @@ bs:
             '"y"': uspravna pozicija
             '"tint"': nijanse
       Dancelab_setPropEach:
-        text: podesi [GROUP][0] [PROPERTY][1] na [VAL][2]
+        text: podesi {GROUP} {PROPERTY} na {VAL}
         options:
           GROUP:
             '"ALIEN"': svi vanzemaljci
@@ -515,7 +515,7 @@ bs:
             '"y"': uspravna pozicija
             '"tint"': nijanse
       Dancelab_setPropRandom:
-        text: nasumično [SPRITE][0] [PROPERTY][1]
+        text: nasumično {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': veličina
@@ -526,9 +526,9 @@ bs:
             '"y"': uspravna pozicija
             '"tint"': nijanse
       Dancelab_setTint:
-        text: podesi [SPRITE][0] nijanse na [VAL][1]
+        text: podesi {SPRITE} nijanse na {VAL}
       Dancelab_setTintEach:
-        text: podesi [THIS][0] nijanse na [VAL][1]
+        text: podesi {THIS} nijanse na {VAL}
         options:
           THIS:
             '"ALIEN"': svi vanzemaljci
@@ -542,15 +542,15 @@ bs:
             '"ROBOT"': svi roboti
             '"SHARK"': sve ajkule
       Dancelab_setTintInline:
-        text: podesi [SPRITE][0] nijanse na [VAL][1]
+        text: podesi {SPRITE} nijanse na {VAL}
       Dancelab_setVisible:
-        text: podesi [SPRITE][0] nijanse na [VISIBILITY][1]
+        text: podesi {SPRITE} nijanse na {VISIBILITY}
         options:
           VISIBILITY:
             'true': vidljivo
             'false': nevidljivo
       Dancelab_setVisibleEach:
-        text: podesi [THIS][0] vidljivost na [VISIBILITY][1]
+        text: podesi {THIS} vidljivost na {VISIBILITY}
         options:
           THIS:
             '"ALIEN"': svi vanzemaljci
@@ -568,7 +568,7 @@ bs:
             'true': vidljivo
             'false': nevidljivo
       Dancelab_startMapping:
-        text: "[SPRITE][0] pokreni [PROPERTY][1] isprati [RANGE][2]"
+        text: "{SPRITE} pokreni {PROPERTY} isprati {RANGE}"
         options:
           PROPERTY:
             '"scale"': veličina
@@ -583,7 +583,7 @@ bs:
             '"mid"': mid
             '"treble"': trebl
       Dancelab_stopMapping:
-        text: "[SPRITE][0] zaustavi [PROPERTY][1] isprati [RANGE][2]"
+        text: "{SPRITE} zaustavi {PROPERTY} isprati {RANGE}"
         options:
           PROPERTY:
             '"scale"': veličina
@@ -599,7 +599,7 @@ bs:
             '"mid"': mid
             '"treble"': trebl
       Dancelab_whenKey:
-        text: kada je pritisnuta [KEY][0] tipka
+        text: kada je pritisnuta {KEY} tipka
         options:
           KEY:
             '"up"': gore
@@ -628,7 +628,7 @@ bs:
             '"x"': x
             '"z"': z
       Dancelab_whenPeak:
-        text: kada [RANGE][0] vrhunac
+        text: kada {RANGE} vrhunac
         options:
           RANGE:
             '0': basovi
@@ -637,19 +637,19 @@ bs:
       Dancelab_whenSetup:
         text: postavka
       gamelab_changeColor:
-        text: izmjeni [COLOR][0] [METHOD][1] za [AMOUNT][2]
+        text: izmjeni {COLOR} {METHOD} za {AMOUNT}
         options:
           METHOD:
             '"tint"': nijanse
       gamelab_changeColorBy:
-        text: izmjeni [COLOR][0] [METHOD][1] za [AMOUNT][2]
+        text: izmjeni {COLOR} {METHOD} za {AMOUNT}
         options:
           METHOD:
             '"hue"': nijansa
             '"saturation"': zasićenje
             '"brightness"': osvjetljenost
       gamelab_changePropBy:
-        text: izmjeni [SPRITE][0] [PROPERTY][1] za [VAL][2]
+        text: izmjeni {SPRITE} {PROPERTY} za {VAL}
         options:
           PROPERTY:
             '"scale"': veličina
@@ -661,7 +661,7 @@ bs:
             'true': istinito
             'false': neistinito
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': veličina
@@ -669,7 +669,7 @@ bs:
             '"direction"': smijer kretanja
             '"tint"': nijanse
       gamelab_jumpTo:
-        text: "[SPRITE][0] skoči na [LOCATION][1]"
+        text: "{SPRITE} skoči na {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -680,15 +680,15 @@ bs:
             '"right"': desno
             '"left"': lijevo
       gamelab_mixColors:
-        text: miks [COLOR1][0] i [COLOR2][1]
+        text: miks {COLOR1} i {COLOR2}
       gamelab_randColor:
         text: nasumična boja
       gamelab_randomColor:
         text: nasumična boja
       gamelab_setBackground:
-        text: podesi boju pozadine [COLOR][0]
+        text: podesi boju pozadine {COLOR}
       gamelab_setPosition:
-        text: pomjeri [THIS][0] na [POSITION][1] poziciju
+        text: pomjeri {THIS} na {POSITION} poziciju
         options:
           POSITION:
             "{x: 50, y: 50}": gornja lijeva
@@ -734,7 +734,7 @@ bs:
             '"right"': desno
             '"left"': lijevo
       gamelab_whenKey:
-        text: kada je pritisnuta [KEY][0] tipka
+        text: kada je pritisnuta {KEY} tipka
         options:
           KEY:
             '"up"': gore
@@ -821,8 +821,8 @@ bs:
             '"direction"': smijer kretanja
       Mikelab_ifDanceIs:
         text: |-
-          ako [SPRITE][0] čini [DANCE][1]
-          [DO1][2] [DO2][3]
+          ako {SPRITE} čini {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Klapni visoko
@@ -866,7 +866,7 @@ bs:
             "{x: 100, y: 300}": donja lijeva
             "{x: 300, y: 300}": donja desna
       Mikelab_whenKeyPressed:
-        text: kada je pritisnuta [KEY][0] tipka
+        text: kada je pritisnuta {KEY} tipka
         options:
           KEY:
             '"up"': strelica gore
@@ -919,7 +919,7 @@ bs:
             '"left"': lijevo
             '"right"': desno
       binary_whenKey:
-        text: kada je pritisnuta [KEY][0] tipka
+        text: kada je pritisnuta {KEY} tipka
         options:
           KEY:
             '"up"': gore

--- a/dashboard/config/locales/blocks.ca-ES.yml
+++ b/dashboard/config/locales/blocks.ca-ES.yml
@@ -3,20 +3,20 @@ ca:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: després de [TIMESTAMP][0] [UNIT][1]
+        text: després de {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': mesures
             '"seconds"': segons
       Dancelab_changeColorBy:
-        text: canvi [COLOR][0] [METHOD][1] per [AMOUNT][2]
+        text: canvi {COLOR} {METHOD} per {AMOUNT}
         options:
           METHOD:
             '"hue"': matís
             '"saturation"': saturació
             '"brightness"': lluïssor
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] fer [MOVE][1] [DIR][2] per sempre"
+        text: "{GROUP} fer {MOVE} {DIR} per sempre"
         options:
           GROUP:
             '"ALIEN"': tots els extraterrestres
@@ -49,7 +49,7 @@ ca:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] fer [MOVE][1] [DIR][2] per sempre"
+        text: "{SPRITE} fer {MOVE} {DIR} per sempre"
         options:
           MOVE:
             '"next"': "(Següent)"
@@ -70,7 +70,7 @@ ca:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: canvi [SPRITE][0] [PROPERTY][1] per [VAL][2]
+        text: canvi {SPRITE} {PROPERTY} per {VAL}
         options:
           PROPERTY:
             '"scale"': mida
@@ -80,7 +80,7 @@ ca:
             '"x"': posició horitzontal
             '"y"': posició vertical
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] fer [MOVE][1] [DIR][2] un cop"
+        text: "{GROUP} fer {MOVE} {DIR} un cop"
         options:
           GROUP:
             '"ALIEN"': tots els extraterrestres
@@ -111,7 +111,7 @@ ca:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] fer [MOVE][1] [DIR][2] un cop"
+        text: "{SPRITE} fer {MOVE} {DIR} un cop"
         options:
           MOVE:
             '"rand"': "(Aleatori)"
@@ -130,25 +130,25 @@ ca:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'cada [N][0] [UNIT][1] '
+        text: 'cada {N} {UNIT} '
         options:
           UNIT:
             '"measures"': mesures
             '"seconds"': segons
       Dancelab_everySecondsRange:
-        text: 'cada [N][0] [UNIT][1] des de [START][2] a [STOP][3] '
+        text: 'cada {N} {UNIT} des de {START} a {STOP} '
         options:
           UNIT:
             measures: Mesures
             seconds: Segons
       Dancelab_everyVerseChorus:
-        text: 'cada [UNIT][0] '
+        text: 'cada {UNIT} '
         options:
           UNIT:
             '"verse"': vers
             '"chorus"': tornada
       Dancelab_getEnergy:
-        text: obtenir [RANGE][0]
+        text: obtenir {RANGE}
         options:
           RANGE:
             '"low"': baix
@@ -164,15 +164,15 @@ ca:
             '"x"': posició horitzontal
             '"y"': posició vertical
       Dancelab_getTime:
-        text: "[UNIT][0] transcorregut"
+        text: "{UNIT} transcorregut"
         options:
           UNIT:
             '"measures"': mesures
             '"seconds"': segons
       Dancelab_ifDanceIs:
         text: |-
-          si [SPRITE][0] està fent [DANCE][1]
-          [DO1][2] [DO2][3]
+          si {SPRITE} està fent {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: aplaudir ben fort
@@ -192,7 +192,7 @@ ca:
             '"measures"': mesures
             '"seconds"': segons
       Dancelab_jumpTo:
-        text: "[SPRITE][0] salta a [LOCATION][1]"
+        text: "{SPRITE} salta a {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": part superior
@@ -206,7 +206,7 @@ ca:
             "{x: 300, y: 300}": part inferior dreta
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": atzar
       Dancelab_layoutSprites:
-        text: disposició [GROUP][0] com a [FORMAT][1]
+        text: disposició {GROUP} com a {FORMAT}
         options:
           GROUP:
             '"ALIEN"': tots els extraterrestres
@@ -232,8 +232,8 @@ ca:
             '"random"': atzar
       Dancelab_makeNewDanceSprite:
         text: |-
-          fer un nou [COSTUME][0]
-          anomenat [NAME][1] a [LOCATION][2]
+          fer un nou {COSTUME}
+          anomenat {NAME} a {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Extraterrestre
@@ -258,8 +258,8 @@ ca:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": atzar
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          fer [N][0] nou [COSTUME][1]
-          en una [LAYOUT][2]
+          fer {N} nou {COSTUME}
+          en una {LAYOUT}
         options:
           N:
             '2': '2'
@@ -302,9 +302,9 @@ ca:
             '"plus"': més
             '"random"': atzar
       Dancelab_mixColors:
-        text: barrejar [COLOR1][0] i [COLOR2][1]
+        text: barrejar {COLOR1} i {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] mesures"
+        text: "{N} mesures"
       Dancelab_onPointerDown:
         text: amb el punter cap avall
       Dancelab_onPointerDrag:
@@ -314,9 +314,9 @@ ca:
       Dancelab_randomColor:
         text: color aleatori
       Dancelab_setBackground:
-        text: definir el color de fons [COLOR][0]
+        text: definir el color de fons {COLOR}
       Dancelab_setBackgroundEffect:
-        text: definir l'efecte de fons [EFFECT][0]
+        text: definir l'efecte de fons {EFFECT}
         options:
           EFFECT:
             '"none"': Cap
@@ -337,7 +337,7 @@ ca:
             '"neon"': Neó
             '"warm"': Vermells
       Dancelab_setBackgroundEffectWithPalette:
-        text: definir l'efecte de fons [EFFECT][0] [PALETTE][1]
+        text: definir l'efecte de fons {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Cap
@@ -360,7 +360,7 @@ ca:
             '"neon"': Neó
             '"warm"': Vermells
       Dancelab_setDanceSpeed:
-        text: canviar [SPRITE][0] velocitat de dansa a [SPEED][1]
+        text: canviar {SPRITE} velocitat de dansa a {SPEED}
         options:
           SPEED:
             '1': normal
@@ -389,7 +389,7 @@ ca:
             '0.5': lent
             '0.25': molt lent
       Dancelab_setForegroundEffect:
-        text: definir l'efecte de fons [EFFECT][0]
+        text: definir l'efecte de fons {EFFECT}
         options:
           EFFECT:
             '"none"': Cap
@@ -402,7 +402,7 @@ ca:
             '"floating_rainbows"': Arc de Sant Martí
             '"raining_tacos"': Tacs
       Dancelab_setForegroundEffectExtended:
-        text: definir l'efecte de fons [EFFECT][0]
+        text: definir l'efecte de fons {EFFECT}
         options:
           EFFECT:
             '"none"': Cap
@@ -416,7 +416,7 @@ ca:
             '"floating_rainbows"': Arc de Sant Martí
             '"raining_tacos"': Tacs
       Dancelab_setProp:
-        text: 'configurar [SPRITE][0] [PROPERTY][1] a [VAL][2] '
+        text: 'configurar {SPRITE} {PROPERTY} a {VAL} '
         options:
           PROPERTY:
             '"scale"': mida
@@ -426,7 +426,7 @@ ca:
             '"x"': posició horitzontal
             '"y"': posició vertical
       Dancelab_setPropEach:
-        text: configurar [GROUP][0] [PROPERTY][1] a [VAL][2]
+        text: configurar {GROUP} {PROPERTY} a {VAL}
         options:
           GROUP:
             '"ALIEN"': tots els extraterrestres
@@ -448,7 +448,7 @@ ca:
             '"x"': posició horitzontal
             '"y"': posició vertical
       Dancelab_setPropRandom:
-        text: aleatoritzar [SPRITE][0] [PROPERTY][1]
+        text: aleatoritzar {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': mida
@@ -458,7 +458,7 @@ ca:
             '"x"': posició horitzontal
             '"y"': posició vertical
       Dancelab_setTint:
-        text: configurar [SPRITE][0] tint a [VAL][1]
+        text: configurar {SPRITE} tint a {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -473,11 +473,11 @@ ca:
             '"ROBOT"': tots els robots
             '"SHARK"': tots els taurons
       Dancelab_setTintInline:
-        text: configurar [SPRITE][0] tint a [VAL][1]
+        text: configurar {SPRITE} tint a {VAL}
       Dancelab_setVisible:
-        text: conjunt [SPRITE][0] visible per [visibilitat][1]
+        text: conjunt {SPRITE} visible per {VISIBILITY}
       Dancelab_setVisibleEach:
-        text: configurar [THIS][0] visibilitat a [VISIBILITY][1]
+        text: configurar {THIS} visibilitat a {VISIBILITY}
         options:
           THIS:
             '"ALIEN"': tots els extraterrestres
@@ -492,7 +492,7 @@ ca:
             '"SHARK"': tots els taurons
             '"UNICORN"': tots els unicorns
       Dancelab_startMapping:
-        text: "[SPRITE][0] comença a [PROPERTY][1] seguit de [RANGE][2]"
+        text: "{SPRITE} comença a {PROPERTY} seguit de {RANGE}"
         options:
           PROPERTY:
             '"scale"': mida
@@ -506,7 +506,7 @@ ca:
             '"mid"': mig
             '"treble"': agut
       Dancelab_stopMapping:
-        text: "[SPRITE][0] s'atura a [PROPERTY][1] seguit [RANGE][2]"
+        text: "{SPRITE} s'atura a {PROPERTY} seguit {RANGE}"
         options:
           PROPERTY:
             '"scale"': mida
@@ -521,7 +521,7 @@ ca:
             '"mid"': mig
             '"treble"': agut
       Dancelab_whenKey:
-        text: quan la [KEY][0] és premuda
+        text: quan la {KEY} és premuda
         options:
           KEY:
             '"up"': cap amunt
@@ -531,7 +531,7 @@ ca:
             '"space"': espai
             '"x"': x
       Dancelab_whenPeak:
-        text: quan al pic de [RANGE][0]
+        text: quan al pic de {RANGE}
         options:
           RANGE:
             '0': baix
@@ -540,16 +540,16 @@ ca:
       Dancelab_whenSetup:
         text: configuració
       gamelab_changeColor:
-        text: canvi [COLOR][0] [METHOD][1] per [AMOUNT][2]
+        text: canvi {COLOR} {METHOD} per {AMOUNT}
       gamelab_changeColorBy:
-        text: canvi [COLOR][0] [METHOD][1] per [AMOUNT][2]
+        text: canvi {COLOR} {METHOD} per {AMOUNT}
         options:
           METHOD:
             '"hue"': matís
             '"saturation"': saturació
             '"brightness"': lluïssor
       gamelab_changePropBy:
-        text: canvi [SPRITE][0] [PROPERTY][1] per [VAL][2]
+        text: canvi {SPRITE} {PROPERTY} per {VAL}
         options:
           PROPERTY:
             '"scale"': mida
@@ -567,7 +567,7 @@ ca:
             '"rotation"': rotació
             '"direction"': direcció del moviment
       gamelab_jumpTo:
-        text: "[SPRITE][0] salta a [LOCATION][1]"
+        text: "{SPRITE} salta a {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -578,15 +578,15 @@ ca:
             '"right"': dret
             '"left"': esquerra
       gamelab_mixColors:
-        text: barrejar [COLOR1][0] i [COLOR2][1]
+        text: barrejar {COLOR1} i {COLOR2}
       gamelab_randColor:
         text: color aleatori
       gamelab_randomColor:
         text: color aleatori
       gamelab_setBackground:
-        text: definir el color de fons [COLOR][0]
+        text: definir el color de fons {COLOR}
       gamelab_setPosition:
-        text: moure [THIS][0] a la posició [POSITION][1]
+        text: moure {THIS} a la posició {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": part superior esquerra
@@ -630,7 +630,7 @@ ca:
             '"right"': dret
             '"left"': esquerra
       gamelab_whenKey:
-        text: quan la [KEY][0] és premuda
+        text: quan la {KEY} és premuda
         options:
           KEY:
             '"up"': cap amunt
@@ -709,8 +709,8 @@ ca:
             '"direction"': direcció del moviment
       Mikelab_ifDanceIs:
         text: |-
-          si [SPRITE][0] està fent [DANCE][1]
-          [DO1][2] [DO2][3]
+          si {SPRITE} està fent {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: aplaudir ben fort
@@ -754,7 +754,7 @@ ca:
             "{x: 100, y: 300}": part inferior esquerra
             "{x: 300, y: 300}": part inferior dreta
       Mikelab_whenKeyPressed:
-        text: quan la [KEY][0] és premuda
+        text: quan la {KEY} és premuda
         options:
           KEY:
             '"up"': fletxa cap amunt
@@ -806,7 +806,7 @@ ca:
             '"left"': esquerra
             '"right"': dret
       binary_whenKey:
-        text: quan la [KEY][0] és premuda
+        text: quan la {KEY} és premuda
         options:
           KEY:
             '"up"': cap amunt

--- a/dashboard/config/locales/blocks.cs-CZ.yml
+++ b/dashboard/config/locales/blocks.cs-CZ.yml
@@ -3,20 +3,20 @@ cs:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: po [ČASOVÉ RAZÍTKO][0] [JEDNOTKA][1]
+        text: po {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekund
       Dancelab_changeColorBy:
-        text: změnit [BARVA][0] [METODA][1] o [MNOŽSTVÍ][2]
+        text: změnit {COLOR} {METHOD} o {AMOUNT}
         options:
           METHOD:
             '"hue"': odstín
             '"saturation"': sytost
             '"brightness"': jas
       Dancelab_changeMoveEachLR:
-        text: "[SKUPINA][0] dělá [POHYB][1] [SMĚR][2] navždy"
+        text: "{GROUP} dělá {MOVE} {DIR} navždy"
         options:
           GROUP:
             sprites: vše
@@ -50,7 +50,7 @@ cs:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SKŘÍTEK][0] dělá [POHYB][1] [SMĚR][2] navždy"
+        text: "{SPRITE} dělá {MOVE} {DIR} navždy"
         options:
           MOVE:
             '"next"': "(Další)"
@@ -72,7 +72,7 @@ cs:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: změnit [SKŘÍTEK][0] [VLASTNOST][1] o [HODNOTA][2]
+        text: změnit {SPRITE} {PROPERTY} o {VAL}
         options:
           PROPERTY:
             '"scale"': velikost
@@ -82,7 +82,7 @@ cs:
             '"x"': vodorovná pozice
             '"y"': svislá pozice
       Dancelab_doMoveEachLR:
-        text: "[SKUPINA][0] dělá [POHYB][1] [SMĚR][2] jednou"
+        text: "{GROUP} dělá {MOVE} {DIR} jednou"
         options:
           GROUP:
             sprites: vše
@@ -114,7 +114,7 @@ cs:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SKŘÍTEK][0] dělá [POHYB][1] [SMĚR][2] jednou"
+        text: "{SPRITE} dělá {MOVE} {DIR} jednou"
         options:
           MOVE:
             '"rand"': "(Náhodně)"
@@ -133,32 +133,32 @@ cs:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'každé [N][0] [JEDNOTKA][1] '
+        text: 'každé {N} {UNIT} '
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekund
       Dancelab_everySecondsRange:
-        text: 'každá [N][0] [JEDNOTKA][1] z [ZAČÁTEK][2] na [ZASTAVENÍ][3] '
+        text: 'každá {N} {UNIT} z {START} na {STOP} '
         options:
           UNIT:
             measures: Takty
             seconds: Sekundy
       Dancelab_everyVerseChorus:
-        text: 'každá [UNIT][0] '
+        text: 'každá {UNIT} '
         options:
           UNIT:
             '"verse"': verš
             '"chorus"': sbor
       Dancelab_getEnergy:
-        text: získat [ROZSAH][0]
+        text: získat {RANGE}
         options:
           RANGE:
             '"low"': basy
             '"mid"': středy
             '"high"': výšky
       Dancelab_getProp:
-        text: "[SKŘÍTEK][0] [VLASTNOST][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': velikost
@@ -169,15 +169,15 @@ cs:
             '"y"': svislá pozice
             '"tint"': odstín
       Dancelab_getTime:
-        text: aktuální čas v [UNIT][0]
+        text: aktuální čas v {UNIT}
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekund
       Dancelab_ifDanceIs:
         text: |-
-          když [SPRITE][0] dělá [DANCE][1]
-          [DO1][2] [DO2][3]
+          když {SPRITE} dělá {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Clap High
@@ -193,14 +193,14 @@ cs:
             MOVES.Rest: Žádný
       Dancelab_ifTime:
         text: |-
-          když [UNIT][0] je [OP][1] [N][2]
-          [DO1][3] [DO2][4]
+          když {UNIT} je {OP} {N}
+          {DO1} {DO2}
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekund
       Dancelab_jumpTo:
-        text: "[SPRITE][0] skoč na [LOCATION][1]"
+        text: "{SPRITE} skoč na {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": nahoře
@@ -214,7 +214,7 @@ cs:
             "{x: 300, y: 300}": dole vpravo
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": náhodně
       Dancelab_layoutSprites:
-        text: uspořádat [GROUP][0] jako [FORMAT][1]
+        text: uspořádat {GROUP} jako {FORMAT}
         options:
           GROUP:
             sprites: vše
@@ -241,8 +241,8 @@ cs:
             '"random"': náhodně
       Dancelab_makeNewDanceSprite:
         text: |-
-          vytvořit nový [COSTUME][0]
-          nazvaný [NAME][1] kde [LOCATION][2]
+          vytvořit nový {COSTUME}
+          nazvaný {NAME} kde {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Vetřelec
@@ -269,8 +269,8 @@ cs:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": náhodně
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          vytvoř [N][0] nový [COSTUME][1]
-          v uspořádání [LAYOUT][2]
+          vytvoř {N} nový {COSTUME}
+          v uspořádání {LAYOUT}
         options:
           N:
             '2': '2'
@@ -315,9 +315,9 @@ cs:
             '"plus"': plus
             '"random"': náhodně
       Dancelab_mixColors:
-        text: smíchat [BARVA1][0] a [BARVA2][1]
+        text: smíchat {COLOR1} a {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] takty"
+        text: "{N} takty"
       Dancelab_onPointerDown:
         text: na ukazatel dolů
       Dancelab_onPointerDrag:
@@ -327,9 +327,9 @@ cs:
       Dancelab_randomColor:
         text: náhodná barva
       Dancelab_setBackground:
-        text: nastavit barvu pozadí [BARVA][0]
+        text: nastavit barvu pozadí {COLOR}
       Dancelab_setBackgroundEffect:
-        text: nastavit efekt pozadí [EFEKT][0]
+        text: nastavit efekt pozadí {EFFECT}
         options:
           EFFECT:
             '"none"': Žádný
@@ -355,7 +355,7 @@ cs:
             '"tropical"': Tropické
             '"warm"': Červené
       Dancelab_setBackgroundEffectWithPalette:
-        text: nastavit efekt pozadí [EFFECT][0] [PALETTE][1]
+        text: nastavit efekt pozadí {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Žádný
@@ -382,7 +382,7 @@ cs:
             '"tropical"': Tropické
             '"warm"': Červené
       Dancelab_setDanceSpeed:
-        text: změnit [SKŘÍTEK][0] rychlost tance na [RYCHLOST][1]
+        text: změnit {SPRITE} rychlost tance na {SPEED}
         options:
           SPEED:
             '1': normální
@@ -391,7 +391,7 @@ cs:
             '0.5': pomalá
             '0.25': velmi pomalá
       Dancelab_setDanceSpeedEach:
-        text: nastav [GROUP][0] rychlost tance na [SPEED][1]
+        text: nastav {GROUP} rychlost tance na {SPEED}
         options:
           GROUP:
             sprites: vše
@@ -413,7 +413,7 @@ cs:
             '0.5': pomalá
             '0.25': velmi pomalá
       Dancelab_setForegroundEffect:
-        text: nastavit efekt popředí [EFEKT][0]
+        text: nastavit efekt popředí {EFFECT}
         options:
           EFFECT:
             '"none"': Žádný
@@ -428,7 +428,7 @@ cs:
             '"spotlight"': Bodový reflektor
             '"raining_tacos"': Tacos
       Dancelab_setForegroundEffectExtended:
-        text: nastavit efekt popředí [EFEKT][0]
+        text: nastavit efekt popředí {EFFECT}
         options:
           EFFECT:
             '"none"': Žádný
@@ -444,7 +444,7 @@ cs:
             '"spotlight"': Bodový reflektor
             '"raining_tacos"': Tacos
       Dancelab_setProp:
-        text: 'nastavit [SKŘÍTEK][0] [VLASTNOSTI][1] na [HODNOTA][2] '
+        text: 'nastavit {SPRITE} {PROPERTY} na {VAL} '
         options:
           PROPERTY:
             '"scale"': velikost
@@ -455,7 +455,7 @@ cs:
             '"y"': svislá pozice
             '"tint"': odstín
       Dancelab_setPropEach:
-        text: nastavit [SKUPINA][0] [VLASTNOST][1] na [HODNOTA][2]
+        text: nastavit {GROUP} {PROPERTY} na {VAL}
         options:
           GROUP:
             sprites: vše
@@ -479,7 +479,7 @@ cs:
             '"y"': svislá pozice
             '"tint"': odstín
       Dancelab_setPropRandom:
-        text: náhodně vybrat [SKŘÍTEK][0] [VLASTNOST][1]
+        text: náhodně vybrat {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': velikost
@@ -490,9 +490,9 @@ cs:
             '"y"': svislá pozice
             '"tint"': odstín
       Dancelab_setTint:
-        text: nastavit [SKŘÍTEK][0] odstín na [HODNOTA][1]
+        text: nastavit {SPRITE} odstín na {VAL}
       Dancelab_setTintEach:
-        text: nastav odstín [THIS][0] na [VAL][1]
+        text: nastav odstín {THIS} na {VAL}
         options:
           THIS:
             sprites: vše
@@ -507,15 +507,15 @@ cs:
             '"ROBOT"': všichni roboti
             '"SHARK"': všichni žraloci
       Dancelab_setTintInline:
-        text: nastavit [SKŘÍTEK][0] odstín na [HODNOTA][1]
+        text: nastavit {SPRITE} odstín na {VAL}
       Dancelab_setVisible:
-        text: nastavit [SPRITE][0] viditelný pro [VISIBILITY][1]
+        text: nastavit {SPRITE} viditelný pro {VISIBILITY}
         options:
           VISIBILITY:
             'true': viditelný
             'false': neviditelný
       Dancelab_setVisibleEach:
-        text: nastavit [TOTO][0] viditelnost na [VIDITELNOST][1]
+        text: nastavit {THIS} viditelnost na {VISIBILITY}
         options:
           THIS:
             sprites: vše
@@ -534,7 +534,7 @@ cs:
             'true': viditelný
             'false': neviditelný
       Dancelab_startMapping:
-        text: "[SPRITE][0] začne [PROPERTY][1] podle [RANGE][2]"
+        text: "{SPRITE} začne {PROPERTY} podle {RANGE}"
         options:
           PROPERTY:
             '"scale"': velikost
@@ -549,7 +549,7 @@ cs:
             '"mid"': středy
             '"treble"': výšky
       Dancelab_stopMapping:
-        text: "[SKŘÍTEK][0] zastavuje [VLASTNOST][1] sledující [ROZSAH][2]"
+        text: "{SPRITE} zastavuje {PROPERTY} sledující {RANGE}"
         options:
           PROPERTY:
             '"scale"': velikost
@@ -565,7 +565,7 @@ cs:
             '"mid"': středy
             '"treble"': výšky
       Dancelab_whenKey:
-        text: když je stisknuta [KLÁVESA][0]
+        text: když je stisknuta {KEY}
         options:
           KEY:
             '"up"': nahoru
@@ -594,7 +594,7 @@ cs:
             '"y"': y
             '"z"': z
       Dancelab_whenPeak:
-        text: když je [ROZSAH][0] na vrcholu
+        text: když je {RANGE} na vrcholu
         options:
           RANGE:
             '0': basy
@@ -603,19 +603,19 @@ cs:
       Dancelab_whenSetup:
         text: nastavení
       gamelab_changeColor:
-        text: změnit [BARVA][0] [METODA][1] o [MNOŽSTVÍ][2]
+        text: změnit {COLOR} {METHOD} o {AMOUNT}
         options:
           METHOD:
             '"tint"': odstín
       gamelab_changeColorBy:
-        text: změnit [BARVA][0] [METODA][1] o [MNOŽSTVÍ][2]
+        text: změnit {COLOR} {METHOD} o {AMOUNT}
         options:
           METHOD:
             '"hue"': odstín
             '"saturation"': sytost
             '"brightness"': jas
       gamelab_changePropBy:
-        text: změnit [SKŘÍTEK][0] [VLASTNOST][1] o [HODNOTA][2]
+        text: změnit {SPRITE} {PROPERTY} o {VAL}
         options:
           PROPERTY:
             '"scale"': velikost
@@ -624,15 +624,15 @@ cs:
             '"y"': souřadnice Y
             '"direction"': směr pohybu
       gamelab_createNewSprite:
-        text: "vytvořit novou postavu \n nazvanou [NAME][0] \n s kostýmem [COSTUME][1]
-          \n kde [LOCATION][2]"
+        text: "vytvořit novou postavu \n nazvanou {NAME} \n s kostýmem {COSTUME} \n
+          kde {LOCATION}"
       gamelab_debugSprite:
         options:
           VAL:
             'true': pravda
             'false': záporné
       gamelab_getProp:
-        text: "[SKŘÍTEK][0] [VLASTNOST][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': velikost
@@ -642,7 +642,7 @@ cs:
             '"direction"': směr pohybu
             '"tint"': odstín
       gamelab_jumpTo:
-        text: "[SPRITE][0] skoč na [LOCATION][1]"
+        text: "{SPRITE} skoč na {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -653,19 +653,19 @@ cs:
             '"right"': vpravo
             '"left"': vlevo
       gamelab_mixColors:
-        text: smíchat [BARVA1][0] a [BARVA2][1]
+        text: smíchat {COLOR1} a {COLOR2}
       gamelab_randColor:
         text: náhodná barva
       gamelab_randomColor:
         text: náhodná barva
       gamelab_removeAllBehaviors:
-        text: "[SPRITE][0] vše zastaví"
+        text: "{SPRITE} vše zastaví"
       gamelab_removeBehaviorSimple:
-        text: postava [SPRITE][0] zastaví [BEHAVIOR][1]
+        text: postava {SPRITE} zastaví {BEHAVIOR}
       gamelab_setBackground:
-        text: nastavit barvu pozadí [BARVA][0]
+        text: nastavit barvu pozadí {COLOR}
       gamelab_setPosition:
-        text: přesunout [TOTO][0] na pozici [POZICE][1]
+        text: přesunout {THIS} na pozici {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": nahoře vlevo
@@ -718,7 +718,7 @@ cs:
             '"right"': vpravo
             '"left"': vlevo
       gamelab_whenKey:
-        text: když je stisknuta [KLÁVESA][0]
+        text: když je stisknuta {KEY}
         options:
           KEY:
             '"up"': nahoru
@@ -739,8 +739,8 @@ cs:
             "'right'": vpravo
       gamelab_whenStartAndStopTouching:
         text: |-
-          když [SPRITE1][0] se začne dotýkat [SPRITE2][1] [STATEMENT1][2]když se přestanou dotýkat
-          [STATEMENT2][3]
+          když {SPRITE1} se začne dotýkat {SPRITE2} {STATEMENT1}když se přestanou dotýkat
+          {STATEMENT2}
       gamelab_whileKey:
         options:
           KEY:
@@ -847,8 +847,8 @@ cs:
             '"all"': vše
       Mikelab_ifDanceIs:
         text: |-
-          když [SPRITE][0] dělá [DANCE][1]
-          [DO1][2] [DO2][3]
+          když {SPRITE} dělá {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Clap High
@@ -865,7 +865,7 @@ cs:
       Mikelab_randomColor:
         text: náhodná barva
       Mikelab_removeBehaviorSimple:
-        text: postava [SPRITE][0] zastaví [BEHAVIOR][1]
+        text: postava {SPRITE} zastaví {BEHAVIOR}
       Mikelab_setBG:
         options:
           BG:
@@ -896,7 +896,7 @@ cs:
             "{x: 100, y: 300}": dole vlevo
             "{x: 300, y: 300}": dole vpravo
       Mikelab_whenKeyPressed:
-        text: když je stisknuta [KLÁVESA][0]
+        text: když je stisknuta {KEY}
         options:
           KEY:
             '"up"': šipka nahoru
@@ -957,7 +957,7 @@ cs:
             '"left"': vlevo
             '"right"': vpravo
       binary_whenKey:
-        text: když je stisknuta [KLÁVESA][0]
+        text: když je stisknuta {KEY}
         options:
           KEY:
             '"up"': nahoru
@@ -971,8 +971,8 @@ cs:
             '"d"': d
       craft_ifPath:
         text: |-
-          pokud cesta [SMĚR][0]
-          [PŘÍKAZ][1]
+          pokud cesta {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": před sebe
@@ -980,8 +980,8 @@ cs:
             "'left'": vlevo
       craft_ifStandingOn:
         text: |-
-          pokud stojí na [TYP][0]
-          [PŘÍKAZ][1]
+          pokud stojí na {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": modrý korál
@@ -992,8 +992,8 @@ cs:
             "'seaLantern'": mořská lucerna
       craft_ifStandingOnLimit:
         text: |-
-          pokud stojí na [TYP][0]
-          [PŘÍKAZ][1]
+          pokud stojí na {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": písek
@@ -1002,7 +1002,7 @@ cs:
       craft_moveForward:
         text: posunout vpřed
       craft_placeBlock:
-        text: polož [TypBloku][0]
+        text: polož {blockType}
         options:
           blockType:
             '"strippedOak"': holý dub
@@ -1037,13 +1037,13 @@ cs:
       craft_repeatUntilConduit:
         text: |-
           opakuj dokud není dokončeno
-          [PŘÍKAZ][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           opakuj dokud není cíl
-          [PŘÍKAZ][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: vytvořit [JEDNOTKA][0]
+        text: vytvořit {ENTITY}
         options:
           ENTITY:
             '"cod"': treska
@@ -1053,7 +1053,7 @@ cs:
             '"squid"': chobotnice
             '"tropicalFish"': tropická ryba
       craft_turn:
-        text: otočit [SMĚR][0]
+        text: otočit {DIR}
         options:
           DIR:
             right: vpravo ↻

--- a/dashboard/config/locales/blocks.da-DK.yml
+++ b/dashboard/config/locales/blocks.da-DK.yml
@@ -130,7 +130,7 @@ da:
       Dancelab_randomColor:
         text: tilfældig farve
       Dancelab_setBackgroundEffect:
-        text: indstil baggrundseffekt [EFFECT][0]
+        text: indstil baggrundseffekt {EFFECT}
         options:
           EFFECT:
             '"circles"': Tunnel
@@ -147,7 +147,7 @@ da:
             '"tropical"': Tropisk
             '"warm"': Rød
       Dancelab_setBackgroundEffectWithPalette:
-        text: indstil baggrundseffekt [EFFECT][0] [PALETTE][1]
+        text: indstil baggrundseffekt {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"circles"': Tunnel
@@ -222,7 +222,7 @@ da:
           THIS:
             sprites: alle
       Dancelab_setVisible:
-        text: indstil [SPRITE][0] synlighed til [VISIBILITY][1]
+        text: indstil {SPRITE} synlighed til {VISIBILITY}
       Dancelab_setVisibleEach:
         options:
           THIS:

--- a/dashboard/config/locales/blocks.de-DE.yml
+++ b/dashboard/config/locales/blocks.de-DE.yml
@@ -3,20 +3,20 @@ de:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: nach [TIMESTAMP][0] [UNIT][1]
+        text: nach {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': Takte
             '"seconds"': Sekunden
       Dancelab_changeColorBy:
-        text: ändern [COLOR][0] [METHOD][1] um [AMOUNT][2]
+        text: ändern {COLOR} {METHOD} um {AMOUNT}
         options:
           METHOD:
             '"hue"': Farbton
             '"saturation"': Sättigung
             '"brightness"': Helligkeit
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] tut [MOVE][1] [DIR][2] für immer"
+        text: "{GROUP} tut {MOVE} {DIR} für immer"
         options:
           GROUP:
             sprites: Alle
@@ -44,7 +44,7 @@ de:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] tut [MOVE][1] [DIR][2] für immer"
+        text: "{SPRITE} tut {MOVE} {DIR} für immer"
         options:
           MOVE:
             '"next"': "(nächster)"
@@ -59,7 +59,7 @@ de:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: Änderung [SPRITE][0] [Eigenschaft][1] bis [VAL][2].
+        text: Änderung {SPRITE} {PROPERTY} bis {VAL}.
         options:
           PROPERTY:
             '"scale"': Größe
@@ -69,7 +69,7 @@ de:
             '"x"': horizontale Position
             '"y"': vertikale Position
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] tut [MOVE][1] [DIR][2] einmal"
+        text: "{GROUP} tut {MOVE} {DIR} einmal"
         options:
           GROUP:
             sprites: Alle
@@ -95,7 +95,7 @@ de:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] tut [MOVE][1] [DIR][2] einmal"
+        text: "{SPRITE} tut {MOVE} {DIR} einmal"
         options:
           MOVE:
             '"rand"': "(zufällig)"
@@ -108,25 +108,25 @@ de:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'jede [N][0] [UNIT][1] '
+        text: 'jede {N} {UNIT} '
         options:
           UNIT:
             '"measures"': Takte
             '"seconds"': Sekunden
       Dancelab_everySecondsRange:
-        text: 'jede [N][0] [UNIT][1] von [START][2] bis [STOP][3] '
+        text: 'jede {N} {UNIT} von {START} bis {STOP} '
         options:
           UNIT:
             measures: Takte
             seconds: Sekunden
       Dancelab_everyVerseChorus:
-        text: 'jede [UNIT][0] '
+        text: 'jede {UNIT} '
         options:
           UNIT:
             '"verse"': Strophe
             '"chorus"': Refrain
       Dancelab_getEnergy:
-        text: erhalten [RANGE][0]
+        text: erhalten {RANGE}
         options:
           RANGE:
             '"low"': Bässe
@@ -143,15 +143,15 @@ de:
             '"y"': vertikale Position
             '"tint"': Farbton
       Dancelab_getTime:
-        text: "[UNIT][0] vergangen"
+        text: "{UNIT} vergangen"
         options:
           UNIT:
             '"measures"': Takte
             '"seconds"': Sekunden
       Dancelab_ifDanceIs:
         text: |-
-          wenn [SPRITE][0] [DANCE][1] tut
-          [DO1][2] [DO2][3]
+          wenn {SPRITE} {DANCE} tut
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.Clown: Clown
@@ -165,7 +165,7 @@ de:
             '"measures"': Takte
             '"seconds"': Sekunden
       Dancelab_jumpTo:
-        text: "[SPRITE][0] springen Sie zu [LOCATION][1]"
+        text: "{SPRITE} springen Sie zu {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": oben
@@ -179,7 +179,7 @@ de:
             "{x: 300, y: 300}": unten rechts
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": zufällig
       Dancelab_layoutSprites:
-        text: Layout [GROUP][0] als ein [FORMAT][1]
+        text: Layout {GROUP} als ein {FORMAT}
         options:
           GROUP:
             sprites: Alle
@@ -205,8 +205,8 @@ de:
             '"random"': zufällig
       Dancelab_makeNewDanceSprite:
         text: |-
-          machen Sie ein neues [COSTUME][0]
-          genannt [NAME][1] in [LOCATION][2]
+          machen Sie ein neues {COSTUME}
+          genannt {NAME} in {LOCATION}
         options:
           COSTUME:
             '"BEAR"': Bär
@@ -232,8 +232,8 @@ de:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": zufällig
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          machen Sie [N][0] neues [COSTUME][1]
-          in einem [LAYOUT][2]
+          machen Sie {N} neues {COSTUME}
+          in einem {LAYOUT}
         options:
           N:
             '2': '2'
@@ -276,9 +276,9 @@ de:
             '"x"': kreuz und quer
             '"random"': zufällig
       Dancelab_mixColors:
-        text: Mischen Sie [COLOR1][0] und [COLOR2][1]
+        text: Mischen Sie {COLOR1} und {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] Takte"
+        text: "{N} Takte"
       Dancelab_onPointerDown:
         text: auf Zeiger nach unten
       Dancelab_onPointerDrag:
@@ -288,9 +288,9 @@ de:
       Dancelab_randomColor:
         text: zufällige Farbe
       Dancelab_setBackground:
-        text: Hintergrundfarbe einstellen [COLOR][0]
+        text: Hintergrundfarbe einstellen {COLOR}
       Dancelab_setBackgroundEffect:
-        text: Hintergrundeffekt einstellen [EFFECT][0]
+        text: Hintergrundeffekt einstellen {EFFECT}
         options:
           EFFECT:
             '"none"': Keiner
@@ -311,7 +311,7 @@ de:
             '"tropical"': Tropisch
             '"warm"': Rots
       Dancelab_setBackgroundEffectWithPalette:
-        text: Hintergrundeffekt einstellen [EFFECT][0] [PALETTE][1]
+        text: Hintergrundeffekt einstellen {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Keiner
@@ -334,7 +334,7 @@ de:
             '"tropical"': Tropisch
             '"warm"': Rots
       Dancelab_setDanceSpeed:
-        text: verändern Sie die [SPRITE][0] Tanzgeschwindigkeit zu [SPEED][1]
+        text: verändern Sie die {SPRITE} Tanzgeschwindigkeit zu {SPEED}
         options:
           SPEED:
             '1': Normal
@@ -364,7 +364,7 @@ de:
             '0.5': langsam
             '0.25': sehr langsam
       Dancelab_setForegroundEffect:
-        text: Vordergrundeffekt einstellen [EFFECT][0]
+        text: Vordergrundeffekt einstellen {EFFECT}
         options:
           EFFECT:
             '"none"': Keiner
@@ -376,7 +376,7 @@ de:
             '"rain"': Regen
             '"floating_rainbows"': Regenbogen
       Dancelab_setForegroundEffectExtended:
-        text: Vordergrundeffekt einstellen [EFFECT][0]
+        text: Vordergrundeffekt einstellen {EFFECT}
         options:
           EFFECT:
             '"none"': Keiner
@@ -389,7 +389,7 @@ de:
             '"rain"': Regen
             '"floating_rainbows"': Regenbogen
       Dancelab_setProp:
-        text: 'stellen Sie [SPRITE][0] [PROPERTY][1] auf [VAL][2] '
+        text: 'stellen Sie {SPRITE} {PROPERTY} auf {VAL} '
         options:
           PROPERTY:
             '"scale"': Größe
@@ -400,7 +400,7 @@ de:
             '"y"': vertikale Position
             '"tint"': Farbton
       Dancelab_setPropEach:
-        text: stellen Sie [GROUP][0] [PROPERTY][1] auf [VAL][2]
+        text: stellen Sie {GROUP} {PROPERTY} auf {VAL}
         options:
           GROUP:
             sprites: Alle
@@ -424,7 +424,7 @@ de:
             '"y"': vertikale Position
             '"tint"': Farbton
       Dancelab_setPropRandom:
-        text: randomisieren Sie [SPRITE][0] [PROPERTY][1]
+        text: randomisieren Sie {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': Größe
@@ -435,7 +435,7 @@ de:
             '"y"': vertikale Position
             '"tint"': Farbton
       Dancelab_setTint:
-        text: stellen Sie [SPRITE][0] Farbton auf [VAL][1]
+        text: stellen Sie {SPRITE} Farbton auf {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -451,15 +451,15 @@ de:
             '"ROBOT"': alle Roboter
             '"SHARK"': alle Haie
       Dancelab_setTintInline:
-        text: stellen Sie [SPRITE][0] Farbton auf [VAL][1]
+        text: stellen Sie {SPRITE} Farbton auf {VAL}
       Dancelab_setVisible:
-        text: "[SPRITE][0] für [VISIBILITY][1] sichtbar machen"
+        text: "{SPRITE} für {VISIBILITY} sichtbar machen"
         options:
           VISIBILITY:
             'true': sichtbar
             'false': unsichtbar
       Dancelab_setVisibleEach:
-        text: stellen Sie [THIS][0] Sichtbarkeit auf [VISIBILITY][1]
+        text: stellen Sie {THIS} Sichtbarkeit auf {VISIBILITY}
         options:
           THIS:
             sprites: Alle
@@ -478,7 +478,7 @@ de:
             'true': sichtbar
             'false': unsichtbar
       Dancelab_startMapping:
-        text: "[SPRITE][0] beginnt [PROPERTY][1] nach [RANGE][2]"
+        text: "{SPRITE} beginnt {PROPERTY} nach {RANGE}"
         options:
           PROPERTY:
             '"scale"': Größe
@@ -493,7 +493,7 @@ de:
             '"mid"': Mitten
             '"treble"': Höhen
       Dancelab_stopMapping:
-        text: "[SPRITE][0] stoppt [PROPERTY][1] nach [RANGE][2]"
+        text: "{SPRITE} stoppt {PROPERTY} nach {RANGE}"
         options:
           PROPERTY:
             '"scale"': Größe
@@ -509,7 +509,7 @@ de:
             '"mid"': Mitten
             '"treble"': Höhen
       Dancelab_whenKey:
-        text: wenn [KEY][0] gedrückt
+        text: wenn {KEY} gedrückt
         options:
           KEY:
             '"up"': hoch
@@ -520,7 +520,7 @@ de:
             '"x"': x
             '"y"': y
       Dancelab_whenPeak:
-        text: wenn [RANGE][0] Höhepunkt
+        text: wenn {RANGE} Höhepunkt
         options:
           RANGE:
             '0': Bässe
@@ -529,19 +529,19 @@ de:
       Dancelab_whenSetup:
         text: Setup
       gamelab_changeColor:
-        text: ändern [COLOR][0] [METHOD][1] um [AMOUNT][2]
+        text: ändern {COLOR} {METHOD} um {AMOUNT}
         options:
           METHOD:
             '"tint"': Farbton
       gamelab_changeColorBy:
-        text: ändern [COLOR][0] [METHOD][1] um [AMOUNT][2]
+        text: ändern {COLOR} {METHOD} um {AMOUNT}
         options:
           METHOD:
             '"hue"': Farbton
             '"saturation"': Sättigung
             '"brightness"': Helligkeit
       gamelab_changePropBy:
-        text: Änderung [SPRITE][0] [Eigenschaft][1] bis [VAL][2].
+        text: Änderung {SPRITE} {PROPERTY} bis {VAL}.
         options:
           PROPERTY:
             '"scale"': Größe
@@ -564,7 +564,7 @@ de:
             '"direction"': Bewegungsrichtung
             '"tint"': Farbton
       gamelab_jumpTo:
-        text: "[SPRITE][0] springen Sie zu [LOCATION][1]"
+        text: "{SPRITE} springen Sie zu {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -575,15 +575,15 @@ de:
             '"right"': rechts
             '"left"': links
       gamelab_mixColors:
-        text: Mischen Sie [COLOR1][0] und [COLOR2][1]
+        text: Mischen Sie {COLOR1} und {COLOR2}
       gamelab_randColor:
         text: zufällige Farbe
       gamelab_randomColor:
         text: zufällige Farbe
       gamelab_setBackground:
-        text: Hintergrundfarbe einstellen [COLOR][0]
+        text: Hintergrundfarbe einstellen {COLOR}
       gamelab_setPosition:
-        text: verschieben Sie [THIS][0] auf die Position [POSITION][1]
+        text: verschieben Sie {THIS} auf die Position {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": oben links
@@ -636,7 +636,7 @@ de:
             '"right"': rechts
             '"left"': links
       gamelab_whenKey:
-        text: wenn [KEY][0] gedrückt
+        text: wenn {KEY} gedrückt
         options:
           KEY:
             '"up"': hoch
@@ -753,8 +753,8 @@ de:
             '"all"': Alle
       Mikelab_ifDanceIs:
         text: |-
-          wenn [SPRITE][0] [DANCE][1] tut
-          [DO1][2] [DO2][3]
+          wenn {SPRITE} {DANCE} tut
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.Clown: Clown
@@ -794,7 +794,7 @@ de:
             "{x: 100, y: 300}": unten links
             "{x: 300, y: 300}": unten rechts
       Mikelab_whenKeyPressed:
-        text: wenn [KEY][0] gedrückt
+        text: wenn {KEY} gedrückt
         options:
           KEY:
             '"up"': Pfeil-nach-oben
@@ -855,7 +855,7 @@ de:
             '"left"': links
             '"right"': rechts
       binary_whenKey:
-        text: wenn [KEY][0] gedrückt
+        text: wenn {KEY} gedrückt
         options:
           KEY:
             '"up"': hoch
@@ -865,8 +865,8 @@ de:
             '"space"': Weltall
       craft_ifPath:
         text: |-
-          wenn Weg [DIR][0]
-          [STATEMENT][1]
+          wenn Weg {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": voraus
@@ -874,8 +874,8 @@ de:
             "'left'": nach links
       craft_ifStandingOn:
         text: |-
-          wenn auf [TYPE][0]
-          [STATEMENT][1]
+          wenn auf {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": blaue Koralle
@@ -886,8 +886,8 @@ de:
             "'seaLantern'": Seelaterne
       craft_ifStandingOnLimit:
         text: |-
-          wenn auf [TYPE][0]
-          [STATEMENT][1]
+          wenn auf {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": Sand
@@ -903,4 +903,4 @@ de:
       craft_repeatUntilGoal:
         text: |-
           bis Ziel wiederholen
-          [STATEMENT][0]
+          {STATEMENT}

--- a/dashboard/config/locales/blocks.el-GR.yml
+++ b/dashboard/config/locales/blocks.el-GR.yml
@@ -3,20 +3,20 @@ el:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: μετά [TIMESTAMP][0] [UNIT][1]
+        text: μετά {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': μέτρα
             '"seconds"': δευτερόλεπτα
       Dancelab_changeColorBy:
-        text: αλλαγή [COLOR][0] [METHOD][1] με [AMOUNT][2]
+        text: αλλαγή {COLOR} {METHOD} με {AMOUNT}
         options:
           METHOD:
             '"hue"': χροιά
             '"saturation"': ένταση
             '"brightness"': φωτεινότητα
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] κάνε [MOVE][1] [DIR][2] για πάντα"
+        text: "{GROUP} κάνε {MOVE} {DIR} για πάντα"
         options:
           GROUP:
             sprites: όλα
@@ -47,7 +47,7 @@ el:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] κάνε [MOVE][1] [DIR][2] για πάντα"
+        text: "{SPRITE} κάνε {MOVE} {DIR} για πάντα"
         options:
           MOVE:
             '"next"': "(Επόμενο)"
@@ -65,7 +65,7 @@ el:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: αλλαγή [SPRITE][0] [PROPERTY][1] με [VAL][2]
+        text: αλλαγή {SPRITE} {PROPERTY} με {VAL}
         options:
           PROPERTY:
             '"scale"': μέγεθος
@@ -75,7 +75,7 @@ el:
             '"x"': οριζόντια θέση
             '"y"': κάθετη θέση
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] κάνε [MOVE][1] [DIR][2] μία φορά"
+        text: "{GROUP} κάνε {MOVE} {DIR} μία φορά"
         options:
           GROUP:
             sprites: όλα
@@ -104,7 +104,7 @@ el:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] κάνε [MOVE][1] [DIR][2] μία φορά"
+        text: "{SPRITE} κάνε {MOVE} {DIR} μία φορά"
         options:
           MOVE:
             '"rand"': "(Τυχαίο)"
@@ -120,25 +120,25 @@ el:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'κάθε [N][0] [UNIT][1] '
+        text: 'κάθε {N} {UNIT} '
         options:
           UNIT:
             '"measures"': μέτρα
             '"seconds"': δευτερόλεπτα
       Dancelab_everySecondsRange:
-        text: 'κάθε [N][0] [UNIT][1] από [START][2] να [STOP][3] '
+        text: 'κάθε {N} {UNIT} από {START} να {STOP} '
         options:
           UNIT:
             measures: Μέτρα
             seconds: Δευτερόλεπτα
       Dancelab_everyVerseChorus:
-        text: 'κάθε [UNIT][0] '
+        text: 'κάθε {UNIT} '
         options:
           UNIT:
             '"verse"': στροφή
             '"chorus"': ρεφρέν
       Dancelab_getEnergy:
-        text: πάρε [RANGE][0]
+        text: πάρε {RANGE}
         options:
           RANGE:
             '"low"': μπάσα
@@ -155,15 +155,15 @@ el:
             '"y"': κάθετη θέση
             '"tint"': απόχρωση
       Dancelab_getTime:
-        text: "[UNIT][0] πέρασε"
+        text: "{UNIT} πέρασε"
         options:
           UNIT:
             '"measures"': μέτρα
             '"seconds"': δευτερόλεπτα
       Dancelab_ifDanceIs:
         text: |-
-          εάν [SPRITE][0] κάνει [DANCE][1]
-          [DO1][2] [DO2][3]
+          εάν {SPRITE} κάνει {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Παλαμάκια Ψηλά
@@ -180,7 +180,7 @@ el:
             '"measures"': μέτρα
             '"seconds"': δευτερόλεπτα
       Dancelab_jumpTo:
-        text: "[SPRITE][0] μετάβαση σε [LOCATION][1]"
+        text: "{SPRITE} μετάβαση σε {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": πάνω
@@ -194,7 +194,7 @@ el:
             "{x: 300, y: 300}": κάτω δεξιά
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": τυχαίο
       Dancelab_layoutSprites:
-        text: διάταξη [GROUP][0] ως [FORMAT][1]
+        text: διάταξη {GROUP} ως {FORMAT}
         options:
           GROUP:
             sprites: όλα
@@ -221,8 +221,8 @@ el:
             '"random"': τυχαίο
       Dancelab_makeNewDanceSprite:
         text: |-
-          φτιάξε ένα νέο [COSTUME][0]
-          ονομάζεται [NAME][1] στην [LOCATION][2]
+          φτιάξε ένα νέο {COSTUME}
+          ονομάζεται {NAME} στην {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Εξωγήινος
@@ -249,8 +249,8 @@ el:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": τυχαίο
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          φτιάξε [N][0] νέο [COSTUME][1]
-          σε μία [LAYOUT][2]
+          φτιάξε {N} νέο {COSTUME}
+          σε μία {LAYOUT}
         options:
           N:
             '2': '2'
@@ -295,9 +295,9 @@ el:
             '"plus"': συν
             '"random"': τυχαίο
       Dancelab_mixColors:
-        text: ανακάτεψε [COLOR1][0] και [COLOR2][1]
+        text: ανακάτεψε {COLOR1} και {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] μέτρα"
+        text: "{N} μέτρα"
       Dancelab_onPointerDown:
         text: με τον δείκτη του ποντικιού προς τα κάτω
       Dancelab_onPointerDrag:
@@ -307,9 +307,9 @@ el:
       Dancelab_randomColor:
         text: τυχαίο χρώμα
       Dancelab_setBackground:
-        text: ορισμός χρώματος φόντου [COLOR][0]
+        text: ορισμός χρώματος φόντου {COLOR}
       Dancelab_setBackgroundEffect:
-        text: ορισμός εφέ φόντου [EFFECT][0]
+        text: ορισμός εφέ φόντου {EFFECT}
         options:
           EFFECT:
             '"none"': Κανένα
@@ -332,7 +332,7 @@ el:
             '"vintage"': Βίντατζ
             '"warm"': Κόκκινα
       Dancelab_setBackgroundEffectWithPalette:
-        text: ορισμός εφέ φόντου [EFFECT][0] [PALETTE][1]
+        text: ορισμός εφέ φόντου {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Κανένα
@@ -357,7 +357,7 @@ el:
             '"vintage"': Βίντατζ
             '"warm"': Κόκκινα
       Dancelab_setDanceSpeed:
-        text: αλλαγή [SPRITE][0] ταχύτητας χορού σε [SPEED][1]
+        text: αλλαγή {SPRITE} ταχύτητας χορού σε {SPEED}
         options:
           SPEED:
             '1': κανονικό
@@ -387,7 +387,7 @@ el:
             '0.5': αργή
             '0.25': πολύ αργή
       Dancelab_setForegroundEffect:
-        text: ορισμός εφέ προσκηνίου [EFFECT][0]
+        text: ορισμός εφέ προσκηνίου {EFFECT}
         options:
           EFFECT:
             '"none"': Κανένα
@@ -400,7 +400,7 @@ el:
             '"floating_rainbows"': Ουράνιο τόξο
             '"raining_tacos"': Τάκο
       Dancelab_setForegroundEffectExtended:
-        text: ορισμός εφέ προσκηνίου [EFFECT][0]
+        text: ορισμός εφέ προσκηνίου {EFFECT}
         options:
           EFFECT:
             '"none"': Κανένα
@@ -414,7 +414,7 @@ el:
             '"floating_rainbows"': Ουράνιο τόξο
             '"raining_tacos"': Τάκο
       Dancelab_setProp:
-        text: 'ορισμός [SPRITE][0] [PROPERTY][1] σε [VAL][2] '
+        text: 'ορισμός {SPRITE} {PROPERTY} σε {VAL} '
         options:
           PROPERTY:
             '"scale"': μέγεθος
@@ -425,7 +425,7 @@ el:
             '"y"': κάθετη θέση
             '"tint"': απόχρωση
       Dancelab_setPropEach:
-        text: ορισμός [GROUP][0] [PROPERTY][1] σε [VAL][2]
+        text: ορισμός {GROUP} {PROPERTY} σε {VAL}
         options:
           GROUP:
             sprites: όλα
@@ -449,7 +449,7 @@ el:
             '"y"': κάθετη θέση
             '"tint"': απόχρωση
       Dancelab_setPropRandom:
-        text: τυχαίοποίηση [SPRITE][0] [PROPERTY][1]
+        text: τυχαίοποίηση {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': μέγεθος
@@ -460,7 +460,7 @@ el:
             '"y"': κάθετη θέση
             '"tint"': απόχρωση
       Dancelab_setTint:
-        text: ορισμός [SPRITE][0] απόχρωσης σε [VAL][1]
+        text: ορισμός {SPRITE} απόχρωσης σε {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -476,15 +476,15 @@ el:
             '"ROBOT"': όλα τα ρομπότ
             '"SHARK"': όλοι οι καρχαρίες
       Dancelab_setTintInline:
-        text: ορισμός [SPRITE][0] απόχρωσης σε [VAL][1]
+        text: ορισμός {SPRITE} απόχρωσης σε {VAL}
       Dancelab_setVisible:
-        text: ορίστε [SPRITE][0] ως ορατό σε [VISIBILITY][1]
+        text: ορίστε {SPRITE} ως ορατό σε {VISIBILITY}
         options:
           VISIBILITY:
             'true': ορατό
             'false': αόρατο
       Dancelab_setVisibleEach:
-        text: ορισμός [THIS][0] ορατότητας σε [VISIBILITY][1]
+        text: ορισμός {THIS} ορατότητας σε {VISIBILITY}
         options:
           THIS:
             sprites: όλα
@@ -503,7 +503,7 @@ el:
             'true': ορατό
             'false': αόρατο
       Dancelab_startMapping:
-        text: "[SPRITE][0] αρχίζει [PROPERTY][1] μετά[RANGE][2]"
+        text: "{SPRITE} αρχίζει {PROPERTY} μετά{RANGE}"
         options:
           PROPERTY:
             '"scale"': μέγεθος
@@ -518,7 +518,7 @@ el:
             '"mid"': μεσαία
             '"treble"': πρίμα
       Dancelab_stopMapping:
-        text: "[SPRITE][0] αρχίζει [PROPERTY][1] μετά [RANGE][2]"
+        text: "{SPRITE} αρχίζει {PROPERTY} μετά {RANGE}"
         options:
           PROPERTY:
             '"scale"': μέγεθος
@@ -534,7 +534,7 @@ el:
             '"mid"': μεσαία
             '"treble"': πρίμα
       Dancelab_whenKey:
-        text: όταν πιέζεται [KEY][0]
+        text: όταν πιέζεται {KEY}
         options:
           KEY:
             '"up"': επάνω
@@ -544,7 +544,7 @@ el:
             '"space"': διάστημα
             '"x"': x
       Dancelab_whenPeak:
-        text: όταν κορυφώνεται [RANGE][0]
+        text: όταν κορυφώνεται {RANGE}
         options:
           RANGE:
             '0': μπάσα
@@ -553,19 +553,19 @@ el:
       Dancelab_whenSetup:
         text: εγκατάσταση (setup)
       gamelab_changeColor:
-        text: αλλαγή [COLOR][0] [METHOD][1] με [AMOUNT][2]
+        text: αλλαγή {COLOR} {METHOD} με {AMOUNT}
         options:
           METHOD:
             '"tint"': απόχρωση
       gamelab_changeColorBy:
-        text: αλλαγή [COLOR][0] [METHOD][1] με [AMOUNT][2]
+        text: αλλαγή {COLOR} {METHOD} με {AMOUNT}
         options:
           METHOD:
             '"hue"': χροιά
             '"saturation"': ένταση
             '"brightness"': φωτεινότητα
       gamelab_changePropBy:
-        text: αλλαγή [SPRITE][0] [PROPERTY][1] με [VAL][2]
+        text: αλλαγή {SPRITE} {PROPERTY} με {VAL}
         options:
           PROPERTY:
             '"scale"': μέγεθος
@@ -588,7 +588,7 @@ el:
             '"direction"': κατεύθυνση κίνησης
             '"tint"': απόχρωση
       gamelab_jumpTo:
-        text: "[SPRITE][0] μετάβαση σε [LOCATION][1]"
+        text: "{SPRITE} μετάβαση σε {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -599,15 +599,15 @@ el:
             '"right"': δεξιά
             '"left"': αριστερά
       gamelab_mixColors:
-        text: ανακάτεψε [COLOR1][0] και [COLOR2][1]
+        text: ανακάτεψε {COLOR1} και {COLOR2}
       gamelab_randColor:
         text: τυχαίο χρώμα
       gamelab_randomColor:
         text: τυχαίο χρώμα
       gamelab_setBackground:
-        text: ορισμός χρώματος φόντου [COLOR][0]
+        text: ορισμός χρώματος φόντου {COLOR}
       gamelab_setPosition:
-        text: προχώρησε μπροστά [THIS][0] στη θέση [POSITION][1]
+        text: προχώρησε μπροστά {THIS} στη θέση {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": πάνω αριστερά
@@ -660,7 +660,7 @@ el:
             '"right"': δεξιά
             '"left"': αριστερά
       gamelab_whenKey:
-        text: όταν πιέζεται [KEY][0]
+        text: όταν πιέζεται {KEY}
         options:
           KEY:
             '"up"': επάνω
@@ -777,8 +777,8 @@ el:
             '"all"': όλα
       Mikelab_ifDanceIs:
         text: |-
-          εάν [SPRITE][0] κάνει [DANCE][1]
-          [DO1][2] [DO2][3]
+          εάν {SPRITE} κάνει {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Παλαμάκια Ψηλά
@@ -821,7 +821,7 @@ el:
             "{x: 100, y: 300}": κάτω αριστερά
             "{x: 300, y: 300}": κάτω δεξιά
       Mikelab_whenKeyPressed:
-        text: όταν πιέζεται [KEY][0]
+        text: όταν πιέζεται {KEY}
         options:
           KEY:
             '"up"': επάνω βέλος
@@ -882,7 +882,7 @@ el:
             '"left"': αριστερά
             '"right"': δεξιά
       binary_whenKey:
-        text: όταν πιέζεται [KEY][0]
+        text: όταν πιέζεται {KEY}
         options:
           KEY:
             '"up"': επάνω
@@ -892,8 +892,8 @@ el:
             '"space"': διάστημα
       craft_ifPath:
         text: |-
-          αν διαδρομή [ΚΑΤ][0]
-          [ΕΝΤΟΛΗ][1]
+          αν διαδρομή {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": μπροστά
@@ -901,8 +901,8 @@ el:
             "'left'": προς τα αριστερά
       craft_ifStandingOn:
         text: |-
-          Εάν στέκεστε επάνω σε [ΠΛΗΚΤΡΟΛΟΓΗΣΤΕ][0]
-          [ΕΝΤΟΛΗ][1]
+          Εάν στέκεστε επάνω σε {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": μπλε κοράλλι
@@ -913,8 +913,8 @@ el:
             "'seaLantern'": θαλάσσιο φανάρι
       craft_ifStandingOnLimit:
         text: |-
-          Εάν στέκεστε επάνω σε [ΠΛΗΚΤΡΟΛΟΓΗΣΤΕ][0]
-          [ΕΝΤΟΛΗ][1]
+          Εάν στέκεστε επάνω σε {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": άμμος
@@ -923,7 +923,7 @@ el:
       craft_moveForward:
         text: προχώρησε μπροστά
       craft_placeBlock:
-        text: Τοποθετήστε [τύποςΜπλοκ][0]
+        text: Τοποθετήστε {blockType}
         options:
           blockType:
             '"strippedOak"': αποφλοιωμένη βελανιδιά
@@ -958,13 +958,13 @@ el:
       craft_repeatUntilConduit:
         text: |-
           επαναλάβετε μέχρις ότου ολοκληρωθεί ο αγωγός μετάδοσης
-          [ΔΗΛΩΣΗ][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           επαναλάβετε μέχρι τον στόχο
-          [ΔΗΛΩΣΗ][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: Φύτεψε [ΟΝΤΟΤΗΤΑ][0]
+        text: Φύτεψε {ENTITY}
         options:
           ENTITY:
             '"cod"': βακαλάος
@@ -974,7 +974,7 @@ el:
             '"squid"': καλαμάρι
             '"tropicalFish"': τροπικό ψάρι
       craft_turn:
-        text: στρίψε [ΚΑΤ][0]
+        text: στρίψε {DIR}
         options:
           DIR:
             right: δεξιά ↻

--- a/dashboard/config/locales/blocks.es-ES.yml
+++ b/dashboard/config/locales/blocks.es-ES.yml
@@ -3,20 +3,20 @@ es:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: después de [TIMESTAMP][0] [UNIT][1]
+        text: después de {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': compases
             '"seconds"': segundos
       Dancelab_changeColorBy:
-        text: cambiar [COLOR][0] [METHOD][1] por [AMOUNT][2]
+        text: cambiar {COLOR} {METHOD} por {AMOUNT}
         options:
           METHOD:
             '"hue"': tono
             '"saturation"': saturación
             '"brightness"': brillo
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] hacer [MOVE][1] [DIR][2] siempre"
+        text: "{GROUP} hacer {MOVE} {DIR} siempre"
         options:
           GROUP:
             sprites: todo
@@ -46,7 +46,7 @@ es:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] hacer [MOVE][1] [DIR][2] siempre"
+        text: "{SPRITE} hacer {MOVE} {DIR} siempre"
         options:
           MOVE:
             '"next"': "(Siguiente)"
@@ -63,7 +63,7 @@ es:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: cambiar [SPRITE][0] [PROPERTY][1] por [VAL][2]
+        text: cambiar {SPRITE} {PROPERTY} por {VAL}
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -73,7 +73,7 @@ es:
             '"x"': posición horizontal
             '"y"': posición vertical
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] hacer [MOVE][1] [DIR][2] una vez"
+        text: "{GROUP} hacer {MOVE} {DIR} una vez"
         options:
           GROUP:
             sprites: todo
@@ -101,7 +101,7 @@ es:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] hacer [MOVE][1] [DIR][2] una vez"
+        text: "{SPRITE} hacer {MOVE} {DIR} una vez"
         options:
           MOVE:
             '"rand"': "(Aleatorio)"
@@ -116,25 +116,25 @@ es:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'cada [N][0] [UNIT][1] '
+        text: 'cada {N} {UNIT} '
         options:
           UNIT:
             '"measures"': compases
             '"seconds"': segundos
       Dancelab_everySecondsRange:
-        text: 'cada [N][0] [UNIT][1] de [START][2] a [STOP][3] '
+        text: 'cada {N} {UNIT} de {START} a {STOP} '
         options:
           UNIT:
             measures: Compases
             seconds: Segundos
       Dancelab_everyVerseChorus:
-        text: 'cada [UNIT][0] '
+        text: 'cada {UNIT} '
         options:
           UNIT:
             '"verse"': estrofa
             '"chorus"': estribillo
       Dancelab_getEnergy:
-        text: obtener [RANGE][0]
+        text: obtener {RANGE}
         options:
           RANGE:
             '"low"': bajo
@@ -151,15 +151,15 @@ es:
             '"y"': posición vertical
             '"tint"': tonalidad
       Dancelab_getTime:
-        text: "[UNIT][0] transcurridos"
+        text: "{UNIT} transcurridos"
         options:
           UNIT:
             '"measures"': compases
             '"seconds"': segundos
       Dancelab_ifDanceIs:
         text: |-
-          si [SPRITE][0] hace [DANCE][1]
-          [DO1][2] [DO2][3]
+          si {SPRITE} hace {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Palmas hacia arriba
@@ -175,7 +175,7 @@ es:
             '"measures"': compases
             '"seconds"': segundos
       Dancelab_jumpTo:
-        text: "[SPRITE][0] saltar a [LOCATION][1]"
+        text: "{SPRITE} saltar a {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": arriba
@@ -189,7 +189,7 @@ es:
             "{x: 300, y: 300}": abajo a la derecha
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": aleatorio
       Dancelab_layoutSprites:
-        text: diseño [GROUP][0] como [FORMAT][1]
+        text: diseño {GROUP} como {FORMAT}
         options:
           GROUP:
             sprites: todo
@@ -216,8 +216,8 @@ es:
             '"random"': aleatorio
       Dancelab_makeNewDanceSprite:
         text: |-
-          crea un nuevo [COSTUME][0]
-          llamado [NAME][1] en [LOCATION][2]
+          crea un nuevo {COSTUME}
+          llamado {NAME} en {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Extraterrestre
@@ -244,8 +244,8 @@ es:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": aleatorio
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          crear [N][0] nuevo [COSTUME][1]
-          en un [LAYOUT][2]
+          crear {N} nuevo {COSTUME}
+          en un {LAYOUT}
         options:
           N:
             '2': '2'
@@ -290,9 +290,9 @@ es:
             '"plus"': signo más
             '"random"': aleatorio
       Dancelab_mixColors:
-        text: mezclar [COLOR1][0] y [COLOR2][1]
+        text: mezclar {COLOR1} y {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] compases"
+        text: "{N} compases"
       Dancelab_onPointerDown:
         text: el puntero hacia abajo
       Dancelab_onPointerDrag:
@@ -302,9 +302,9 @@ es:
       Dancelab_randomColor:
         text: color aleatorio
       Dancelab_setBackground:
-        text: establecer color de fondo [COLOR][0]
+        text: establecer color de fondo {COLOR}
       Dancelab_setBackgroundEffect:
-        text: stablecer efecto de fondo [EFFECT][0]
+        text: stablecer efecto de fondo {EFFECT}
         options:
           EFFECT:
             '"none"': Ninguno
@@ -330,7 +330,7 @@ es:
             '"neon"': Neón
             '"warm"': Rojos
       Dancelab_setBackgroundEffectWithPalette:
-        text: stablecer efecto de fondo [EFFECT][0] [PALETTE][1]
+        text: stablecer efecto de fondo {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Ninguno
@@ -357,7 +357,7 @@ es:
             '"neon"': Neón
             '"warm"': Rojos
       Dancelab_setDanceSpeed:
-        text: cambiar velocidad de danza de [SPRITE][0] a [SPEED][1]
+        text: cambiar velocidad de danza de {SPRITE} a {SPEED}
         options:
           SPEED:
             '1': normal
@@ -387,7 +387,7 @@ es:
             '0.5': lento
             '0.25': muy lento
       Dancelab_setForegroundEffect:
-        text: establecer efecto de primer plano [EFFECT][0]
+        text: establecer efecto de primer plano {EFFECT}
         options:
           EFFECT:
             '"none"': Ninguno
@@ -402,7 +402,7 @@ es:
             '"spotlight"': Destacado
             '"raining_tacos"': Tacos
       Dancelab_setForegroundEffectExtended:
-        text: establecer efecto de primer plano [EFFECT][0]
+        text: establecer efecto de primer plano {EFFECT}
         options:
           EFFECT:
             '"none"': Ninguno
@@ -418,7 +418,7 @@ es:
             '"spotlight"': Destacado
             '"raining_tacos"': Tacos
       Dancelab_setProp:
-        text: 'establecer [SPRITE][0] [PROPERTY][1] a [VAL][2] '
+        text: 'establecer {SPRITE} {PROPERTY} a {VAL} '
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -429,7 +429,7 @@ es:
             '"y"': posición vertical
             '"tint"': tonalidad
       Dancelab_setPropEach:
-        text: establecer [GROUP][0] [PROPERTY][1] a [VAL][2]
+        text: establecer {GROUP} {PROPERTY} a {VAL}
         options:
           GROUP:
             sprites: todo
@@ -453,7 +453,7 @@ es:
             '"y"': posición vertical
             '"tint"': tonalidad
       Dancelab_setPropRandom:
-        text: aleatorizar [SPRITE][0] [PROPERTY][1]
+        text: aleatorizar {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -464,7 +464,7 @@ es:
             '"y"': posición vertical
             '"tint"': tonalidad
       Dancelab_setTint:
-        text: establecer tonalidad [SPRITE][0] a [VAL][1]
+        text: establecer tonalidad {SPRITE} a {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -480,15 +480,15 @@ es:
             '"ROBOT"': todos los robots
             '"SHARK"': todos los tiburones
       Dancelab_setTintInline:
-        text: establecer tonalidad [SPRITE][0] a [VAL][1]
+        text: establecer tonalidad {SPRITE} a {VAL}
       Dancelab_setVisible:
-        text: establecer [SPRITE][0] visible en [VISIBILITY][1]
+        text: establecer {SPRITE} visible en {VISIBILITY}
         options:
           VISIBILITY:
             'true': visible
             'false': invisible
       Dancelab_setVisibleEach:
-        text: establecer visibilidad [THIS][0] a [VISIBILITY][1]
+        text: establecer visibilidad {THIS} a {VISIBILITY}
         options:
           THIS:
             sprites: todo
@@ -507,7 +507,7 @@ es:
             'true': visible
             'false': invisible
       Dancelab_startMapping:
-        text: "[SPRITE][0] comienza [PROPERTY][1] después de [RANGE][2]"
+        text: "{SPRITE} comienza {PROPERTY} después de {RANGE}"
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -522,7 +522,7 @@ es:
             '"mid"': medio
             '"treble"': tiple
       Dancelab_stopMapping:
-        text: "[SPRITE][0] para [PROPERTY][1] después de [RANGE][2]"
+        text: "{SPRITE} para {PROPERTY} después de {RANGE}"
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -538,7 +538,7 @@ es:
             '"mid"': medio
             '"treble"': tiple
       Dancelab_whenKey:
-        text: al pulsar [KEY][0]
+        text: al pulsar {KEY}
         options:
           KEY:
             '"up"': arriba
@@ -567,7 +567,7 @@ es:
             '"y"': y
             '"z"': z
       Dancelab_whenPeak:
-        text: cuando [RANGE][0] llega al punto máximo
+        text: cuando {RANGE} llega al punto máximo
         options:
           RANGE:
             '0': bajo
@@ -576,19 +576,19 @@ es:
       Dancelab_whenSetup:
         text: establecer
       gamelab_changeColor:
-        text: cambiar [COLOR][0] [METHOD][1] por [AMOUNT][2]
+        text: cambiar {COLOR} {METHOD} por {AMOUNT}
         options:
           METHOD:
             '"tint"': tonalidad
       gamelab_changeColorBy:
-        text: cambiar [COLOR][0] [METHOD][1] por [AMOUNT][2]
+        text: cambiar {COLOR} {METHOD} por {AMOUNT}
         options:
           METHOD:
             '"hue"': tono
             '"saturation"': saturación
             '"brightness"': brillo
       gamelab_changePropBy:
-        text: cambiar [SPRITE][0] [PROPERTY][1] por [VAL][2]
+        text: cambiar {SPRITE} {PROPERTY} por {VAL}
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -611,7 +611,7 @@ es:
             '"direction"': dirección del movimiento
             '"tint"': tonalidad
       gamelab_jumpTo:
-        text: "[SPRITE][0] saltar a [LOCATION][1]"
+        text: "{SPRITE} saltar a {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -622,15 +622,15 @@ es:
             '"right"': derecha
             '"left"': izquierda
       gamelab_mixColors:
-        text: mezclar [COLOR1][0] y [COLOR2][1]
+        text: mezclar {COLOR1} y {COLOR2}
       gamelab_randColor:
         text: color aleatorio
       gamelab_randomColor:
         text: color aleatorio
       gamelab_setBackground:
-        text: establecer color de fondo [COLOR][0]
+        text: establecer color de fondo {COLOR}
       gamelab_setPosition:
-        text: mover [THIS][0] a la posición [POSITION][1]
+        text: mover {THIS} a la posición {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": arriba a la izquierda
@@ -683,7 +683,7 @@ es:
             '"right"': derecha
             '"left"': izquierda
       gamelab_whenKey:
-        text: al pulsar [KEY][0]
+        text: al pulsar {KEY}
         options:
           KEY:
             '"up"': arriba
@@ -808,8 +808,8 @@ es:
             '"all"': todo
       Mikelab_ifDanceIs:
         text: |-
-          si [SPRITE][0] hace [DANCE][1]
-          [DO1][2] [DO2][3]
+          si {SPRITE} hace {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Palmas hacia arriba
@@ -851,7 +851,7 @@ es:
             "{x: 100, y: 300}": abajo a la izquierda
             "{x: 300, y: 300}": abajo a la derecha
       Mikelab_whenKeyPressed:
-        text: al pulsar [KEY][0]
+        text: al pulsar {KEY}
         options:
           KEY:
             '"up"': flecha hacia arriba
@@ -912,7 +912,7 @@ es:
             '"left"': izquierda
             '"right"': derecha
       binary_whenKey:
-        text: al pulsar [KEY][0]
+        text: al pulsar {KEY}
         options:
           KEY:
             '"up"': arriba
@@ -926,8 +926,8 @@ es:
             '"d"': d
       craft_ifPath:
         text: |-
-          si en ruta [DIR][0]
-          [STATEMENT][1]
+          si en ruta {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": delante
@@ -935,8 +935,8 @@ es:
             "'left'": hacia la izquierda
       craft_ifStandingOn:
         text: |-
-          si de pie en [TYPE][0]
-          [STATEMENT][1]
+          si de pie en {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": coral azul
@@ -947,8 +947,8 @@ es:
             "'seaLantern'": linterna del mar
       craft_ifStandingOnLimit:
         text: |-
-          si de pie en [TYPE][0]
-          [STATEMENT][1]
+          si de pie en {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": arena
@@ -957,7 +957,7 @@ es:
       craft_moveForward:
         text: avanzar
       craft_placeBlock:
-        text: colocar [blockType][0]
+        text: colocar {blockType}
         options:
           blockType:
             '"strippedOak"': tronco de roble sin corteza
@@ -992,13 +992,13 @@ es:
       craft_repeatUntilConduit:
         text: |-
           repetir hasta completar conducto
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           repetir hasta meta
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: generar [ENTITY][0]
+        text: generar {ENTITY}
         options:
           ENTITY:
             '"cod"': merluc
@@ -1008,7 +1008,7 @@ es:
             '"squid"': kallamar
             '"tropicalFish"': peshk tropikal
       craft_turn:
-        text: girar [DIR][0]
+        text: girar {DIR}
         options:
           DIR:
             right: derecha ↻

--- a/dashboard/config/locales/blocks.es-MX.yml
+++ b/dashboard/config/locales/blocks.es-MX.yml
@@ -3,20 +3,20 @@ es-MX:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: después [TIMESTAMP][0] [UNIT][1]
+        text: después {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': medidas
             '"seconds"': segundos
       Dancelab_changeColorBy:
-        text: cambiar [COLOR][0] [METHOD][1] por [AMOUNT][2]
+        text: cambiar {COLOR} {METHOD} por {AMOUNT}
         options:
           METHOD:
             '"hue"': matiz
             '"saturation"': saturación
             '"brightness"': brillo
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] hacer [MOVE][1] [DIR][2] siempre"
+        text: "{GROUP} hacer {MOVE} {DIR} siempre"
         options:
           GROUP:
             sprites: todo
@@ -50,7 +50,7 @@ es-MX:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] hacer [MOVE][1] [DIR][2] siempre"
+        text: "{SPRITE} hacer {MOVE} {DIR} siempre"
         options:
           MOVE:
             '"next"': "(Siguiente)"
@@ -72,7 +72,7 @@ es-MX:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: cambiar [SPRITE][0] [PROPERTY][1] por [VAL][2].
+        text: cambiar {SPRITE} {PROPERTY} por {VAL}.
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -82,7 +82,7 @@ es-MX:
             '"x"': posición horizontal
             '"y"': posición vertical
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] hacer [MOVE][1] [DIR][2] una vez"
+        text: "{GROUP} hacer {MOVE} {DIR} una vez"
         options:
           GROUP:
             sprites: todo
@@ -114,7 +114,7 @@ es-MX:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] hacer [MOVE][1] [DIR][2] una vez"
+        text: "{SPRITE} hacer {MOVE} {DIR} una vez"
         options:
           MOVE:
             '"rand"': "(Al azar)"
@@ -133,32 +133,32 @@ es-MX:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'cada [N][0] [UNIT][1] '
+        text: 'cada {N} {UNIT} '
         options:
           UNIT:
             '"measures"': medidas
             '"seconds"': segundos
       Dancelab_everySecondsRange:
-        text: 'cada [N][0] [UNIT][1] desde [START][2] hasta [STOP][3] '
+        text: 'cada {N} {UNIT} desde {START} hasta {STOP} '
         options:
           UNIT:
             measures: Medidas
             seconds: Segundos
       Dancelab_everyVerseChorus:
-        text: 'cada [UNIT][0] '
+        text: 'cada {UNIT} '
         options:
           UNIT:
             '"verse"': verso
             '"chorus"': coro
       Dancelab_getEnergy:
-        text: obtener [RANGE][0]
+        text: obtener {RANGE}
         options:
           RANGE:
             '"low"': bajo
             '"mid"': med
             '"high"': agudos
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -169,15 +169,15 @@ es-MX:
             '"y"': posición vertical
             '"tint"': tinte
       Dancelab_getTime:
-        text: "[UNIT][0] transcurrido"
+        text: "{UNIT} transcurrido"
         options:
           UNIT:
             '"measures"': medidas
             '"seconds"': segundos
       Dancelab_ifDanceIs:
         text: |-
-          Si [SPRITE][0] está haciendo [DANCE][1]
-          [DO1][2] [DO2][3]
+          Si {SPRITE} está haciendo {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Aplauso alto
@@ -197,7 +197,7 @@ es-MX:
             '"measures"': medidas
             '"seconds"': segundos
       Dancelab_jumpTo:
-        text: "[SPRITE][0] saltar a [LOCATION][1]"
+        text: "{SPRITE} saltar a {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": arriba
@@ -211,7 +211,7 @@ es-MX:
             "{x: 300, y: 300}": abajo a la derecha
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": al azar
       Dancelab_layoutSprites:
-        text: diseño [GROUP][0] como un [FORMAT][1]
+        text: diseño {GROUP} como un {FORMAT}
         options:
           GROUP:
             sprites: todo
@@ -238,8 +238,8 @@ es-MX:
             '"random"': al azar
       Dancelab_makeNewDanceSprite:
         text: |-
-          Haz un nuevo [COSTUME][0]
-          llamado [NAME][1] en [LOCATION][2]
+          Haz un nuevo {COSTUME}
+          llamado {NAME} en {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Extranjero
@@ -266,8 +266,8 @@ es-MX:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": al azar
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          Hacer [N][0] nuevo [COSTUME][1]
-          en un [LAYOUT][2]
+          Hacer {N} nuevo {COSTUME}
+          en un {LAYOUT}
         options:
           N:
             '2': '2'
@@ -312,9 +312,9 @@ es-MX:
             '"plus"': más
             '"random"': al azar
       Dancelab_mixColors:
-        text: mezclar [COLOR1][0] y [COLOR2][1]
+        text: mezclar {COLOR1} y {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] medidas"
+        text: "{N} medidas"
       Dancelab_onPointerDown:
         text: puntero hacia abajo
       Dancelab_onPointerDrag:
@@ -324,9 +324,9 @@ es-MX:
       Dancelab_randomColor:
         text: color al azar
       Dancelab_setBackground:
-        text: establecer color de fondo [COLOR][0]
+        text: establecer color de fondo {COLOR}
       Dancelab_setBackgroundEffect:
-        text: establecer efecto de fondo [EFFECT][0]
+        text: establecer efecto de fondo {EFFECT}
         options:
           EFFECT:
             '"none"': Ninguna
@@ -352,7 +352,7 @@ es-MX:
             '"neon"': Neón
             '"warm"': Rojos
       Dancelab_setBackgroundEffectWithPalette:
-        text: establecer efecto de fondo [EFFECT][0] [PALETTE][1]
+        text: establecer efecto de fondo {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Ninguna
@@ -379,7 +379,7 @@ es-MX:
             '"neon"': Neón
             '"warm"': Rojos
       Dancelab_setDanceSpeed:
-        text: cambiar velocidad de danza [SPRITE][0] a [velocidad][1]
+        text: cambiar velocidad de danza {SPRITE} a {SPEED}
         options:
           SPEED:
             '1': normal
@@ -409,7 +409,7 @@ es-MX:
             '0.5': lento
             '0.25': muy lento
       Dancelab_setForegroundEffect:
-        text: establecer efecto de primer plano [EFFECT][0]
+        text: establecer efecto de primer plano {EFFECT}
         options:
           EFFECT:
             '"none"': Ninguna
@@ -424,7 +424,7 @@ es-MX:
             '"spotlight"': Destacado
             '"raining_tacos"': Tacos
       Dancelab_setForegroundEffectExtended:
-        text: establecer efecto de primer plano [EFFECT][0]
+        text: establecer efecto de primer plano {EFFECT}
         options:
           EFFECT:
             '"none"': Ninguna
@@ -440,7 +440,7 @@ es-MX:
             '"spotlight"': Destacado
             '"raining_tacos"': Tacos
       Dancelab_setProp:
-        text: 'definir [SPRITE][0] [PROPERTY][1] a [VAL][2] '
+        text: 'definir {SPRITE} {PROPERTY} a {VAL} '
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -451,7 +451,7 @@ es-MX:
             '"y"': posición vertical
             '"tint"': tinte
       Dancelab_setPropEach:
-        text: definir [GROUP][0] [PROPERTY][1] a [VAL][2]
+        text: definir {GROUP} {PROPERTY} a {VAL}
         options:
           GROUP:
             sprites: todo
@@ -475,7 +475,7 @@ es-MX:
             '"y"': posición vertical
             '"tint"': tinte
       Dancelab_setPropRandom:
-        text: aleatorizar [SPRITE][0] [PROPERTY][1]
+        text: aleatorizar {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -486,7 +486,7 @@ es-MX:
             '"y"': posición vertical
             '"tint"': tinte
       Dancelab_setTint:
-        text: definir tinte [SPRITE][0] a [VAL][1]
+        text: definir tinte {SPRITE} a {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -502,15 +502,15 @@ es-MX:
             '"ROBOT"': todos los robots
             '"SHARK"': todos los tiburones
       Dancelab_setTintInline:
-        text: definir tinte [SPRITE][0] a [VAL][1]
+        text: definir tinte {SPRITE} a {VAL}
       Dancelab_setVisible:
-        text: establecer [SPRITE][0] visible para [VISIBILITY][1]
+        text: establecer {SPRITE} visible para {VISIBILITY}
         options:
           VISIBILITY:
             'true': visible
             'false': invisible
       Dancelab_setVisibleEach:
-        text: definir [THIS][0] visibilidad a [VISIBILITY][1]
+        text: definir {THIS} visibilidad a {VISIBILITY}
         options:
           THIS:
             sprites: todo
@@ -529,7 +529,7 @@ es-MX:
             'true': visible
             'false': invisible
       Dancelab_startMapping:
-        text: "[SPRITE][0] comienza [PROPERTY][1] siguiendo [RANGE][2]"
+        text: "{SPRITE} comienza {PROPERTY} siguiendo {RANGE}"
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -544,7 +544,7 @@ es-MX:
             '"mid"': med
             '"treble"': agudos
       Dancelab_stopMapping:
-        text: "[SPRITE][0] detiene [PROPERTY][1] siguiendo [RANGE][2]"
+        text: "{SPRITE} detiene {PROPERTY} siguiendo {RANGE}"
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -560,7 +560,7 @@ es-MX:
             '"mid"': med
             '"treble"': agudos
       Dancelab_whenKey:
-        text: al pulsar [KEY][0]
+        text: al pulsar {KEY}
         options:
           KEY:
             '"up"': arriba
@@ -589,7 +589,7 @@ es-MX:
             '"y"': y
             '"z"': z
       Dancelab_whenPeak:
-        text: Cuando [RANGE][0] alcance
+        text: Cuando {RANGE} alcance
         options:
           RANGE:
             '0': bajo
@@ -598,31 +598,31 @@ es-MX:
       Dancelab_whenSetup:
         text: instalación
       gamelab_add:
-        text: añadir [SPRITE][0] al grupo [THIS][1]
+        text: añadir {SPRITE} al grupo {THIS}
       gamelab_addBehaviorSimple:
-        text: gráfico [SPRITE][0] inicia [BEHAVIOR][1]
+        text: gráfico {SPRITE} inicia {BEHAVIOR}
       gamelab_beginBehavior:
-        text: empiezo [BEHAVIOR][0]
+        text: empiezo {BEHAVIOR}
       gamelab_bounceOff:
-        text: "[SPRITE][0] rebota el apagado de [TARGET][1]"
+        text: "{SPRITE} rebota el apagado de {TARGET}"
       gamelab_bounceOffEdges:
-        text: "[SPRITE][0] rebota en los limites"
+        text: "{SPRITE} rebota en los limites"
       gamelab_changeColor:
-        text: cambiar [COLOR][0] [METHOD][1] por [AMOUNT][2]
+        text: cambiar {COLOR} {METHOD} por {AMOUNT}
         options:
           METHOD:
             '"tint"': tinte
             '"tone"': tono
             '"shade"': cortina
       gamelab_changeColorBy:
-        text: cambiar [COLOR][0] [METHOD][1] por [AMOUNT][2]
+        text: cambiar {COLOR} {METHOD} por {AMOUNT}
         options:
           METHOD:
             '"hue"': matiz
             '"saturation"': saturación
             '"brightness"': brillo
       gamelab_changePropBy:
-        text: cambiar [SPRITE][0] [PROPERTY][1] por [VAL][2].
+        text: cambiar {SPRITE} {PROPERTY} por {VAL}.
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -631,46 +631,46 @@ es-MX:
             '"y"': posición y
             '"direction"': dirección de movimiento
       gamelab_clickedOn:
-        text: cuando [SPRITE][0] haz clic
+        text: cuando {SPRITE} haz clic
       gamelab_comment:
-        text: 'comentario: [COMMENT][0]'
+        text: 'comentario: {COMMENT}'
       gamelab_console.log:
-        text: registro de mensaje [MESSAGE][0]
+        text: registro de mensaje {MESSAGE}
       gamelab_createNewSprite:
-        text: "haz un gráfico nuevo\n llamado [NAME][0] \n con disfraz [COSTUME][1]
-          \n en [LOCATION][2]"
+        text: "haz un gráfico nuevo\n llamado {NAME} \n con disfraz {COSTUME} \n en
+          {LOCATION}"
       gamelab_debugSprite:
-        text: limpia [SPRITE][0] [VAL][1]
+        text: limpia {SPRITE} {VAL}
         options:
           VAL:
             'true': verdadero
             'false': falso
       gamelab_destroy:
-        text: remueva [THIS][0]
+        text: remueva {THIS}
       gamelab_displace:
-        text: "[THIS][0] bloquea [SPRITE][1] movilidad"
+        text: "{THIS} bloquea {SPRITE} movilidad"
       gamelab_distance:
-        text: distancia de [LOCATION1][0] a [LOCATION2][1]
+        text: distancia de {LOCATION1} a {LOCATION2}
       gamelab_draggable:
         text: poder arrastrastrarlos
       gamelab_edgesDisplace:
-        text: limitacion de bloque [SPRITE][0] para moverse
+        text: limitacion de bloque {SPRITE} para moverse
       gamelab_enableDebug:
         text: activar la depuración
       gamelab_firstTouched:
         text: primer grafico tocado
       gamelab_forEachSpriteWithCostume:
         text: |-
-          para cada [VALUE][0] grafico
-          hacer [STATEMENT][1]
+          para cada {VALUE} grafico
+          hacer {STATEMENT}
       gamelab_getAnim:
-        text: "[SPRITE][0] [COSTUME][1]"
+        text: "{SPRITE} {COSTUME}"
       gamelab_getDirection:
-        text: "[SPRITE][0] direccion del movimiento"
+        text: "{SPRITE} direccion del movimiento"
       gamelab_getFrameDelay:
-        text: "[THIS][0] retraso de marco"
+        text: "{THIS} retraso de marco"
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': tamaño
@@ -680,11 +680,11 @@ es-MX:
             '"direction"': dirección de movimiento
             '"tint"': tinte
       gamelab_groupLength:
-        text: número de graficos en [THIS][0]
+        text: número de graficos en {THIS}
       gamelab_hasBehavior:
-        text: "[SPRITE][0] actualmente es [BEHAVIOR][1]"
+        text: "{SPRITE} actualmente es {BEHAVIOR}"
       gamelab_jumpTo:
-        text: "[SPRITE][0] saltar a [LOCATION][1]"
+        text: "{SPRITE} saltar a {LOCATION}"
       gamelab_locationConstant:
         options:
           DIR:
@@ -707,7 +707,7 @@ es-MX:
       gamelab_locationNorth:
         text: norte
       gamelab_locationOf:
-        text: posición de [SPRITE][0]
+        text: posición de {SPRITE}
       gamelab_locationSouth:
         text: sur
       gamelab_locationWest:
@@ -718,7 +718,7 @@ es-MX:
             '"right"': derecha
             '"left"': izquierda
       gamelab_mixColors:
-        text: mezclar [COLOR1][0] y [COLOR2][1]
+        text: mezclar {COLOR1} y {COLOR2}
       gamelab_mouseLocation:
         text: posición del ratón
       gamelab_randColor:
@@ -726,9 +726,9 @@ es-MX:
       gamelab_randomColor:
         text: color al azar
       gamelab_setBackground:
-        text: establecer color de fondo [COLOR][0]
+        text: establecer color de fondo {COLOR}
       gamelab_setPosition:
-        text: mover [THIS][0] a la posición [POSITION][1]
+        text: mover {THIS} a la posición {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": arriba a la izquierda
@@ -776,14 +776,14 @@ es-MX:
             '"direction"': dirección de movimiento
             '"tint"': tinte
       gamelab_thisBeginsBehaviorSimple:
-        text: gráfico [SPRITE][0] inicia [BEHAVIOR][1]
+        text: gráfico {SPRITE} inicia {BEHAVIOR}
       gamelab_turn:
         options:
           DIRECTION:
             '"right"': derecha
             '"left"': izquierda
       gamelab_whenKey:
-        text: al pulsar [KEY][0]
+        text: al pulsar {KEY}
         options:
           KEY:
             '"up"': arriba
@@ -815,7 +815,7 @@ es-MX:
             '"s"': s
             '"d"': d
       Mikelab_addBehaviorSimple:
-        text: gráfico [SPRITE][0] inicia [BEHAVIOR][1]
+        text: gráfico {SPRITE} inicia {BEHAVIOR}
       Mikelab_changePropBy:
         options:
           PROPERTY:
@@ -909,11 +909,11 @@ es-MX:
           SELECT:
             '"all"': todo
       Mikelab_hasBehavior:
-        text: "[SPRITE][0] actualmente es [BEHAVIOR][1]"
+        text: "{SPRITE} actualmente es {BEHAVIOR}"
       Mikelab_ifDanceIs:
         text: |-
-          Si [SPRITE][0] está haciendo [DANCE][1]
-          [DO1][2] [DO2][3]
+          Si {SPRITE} está haciendo {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Aplauso alto
@@ -959,9 +959,9 @@ es-MX:
             "{x: 100, y: 300}": abajo a la izquierda
             "{x: 300, y: 300}": abajo a la derecha
       Mikelab_whenClickedOn:
-        text: cuando [SPRITE][0] haz clic
+        text: cuando {SPRITE} haz clic
       Mikelab_whenKeyPressed:
-        text: al pulsar [KEY][0]
+        text: al pulsar {KEY}
         options:
           KEY:
             '"up"': flecha hacia arriba
@@ -997,7 +997,7 @@ es-MX:
       RyanLab_turnRight:
         text: girar a la derecha
       Vector_log:
-        text: registro de mensaje [MESSAGE][0]
+        text: registro de mensaje {MESSAGE}
       Vector_positionCenter:
         text: centro
       Vector_vectorNorth:
@@ -1026,7 +1026,7 @@ es-MX:
             '"left"': izquierda
             '"right"': derecha
       binary_whenKey:
-        text: al pulsar [KEY][0]
+        text: al pulsar {KEY}
         options:
           KEY:
             '"up"': arriba
@@ -1040,8 +1040,8 @@ es-MX:
             '"d"': d
       craft_ifPath:
         text: |-
-          si el camino es [DIR][0]
-          [STATEMENT][1]
+          si el camino es {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": delante
@@ -1049,8 +1049,8 @@ es-MX:
             "'left'": hacia la izquierda
       craft_ifStandingOn:
         text: |-
-          al pararse sobre [TYPE][0]
-          [STATEMENT][1]
+          al pararse sobre {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": coral azul
@@ -1061,19 +1061,19 @@ es-MX:
             "'seaLantern'": linterna marina
       craft_ifStandingOnLimit:
         text: |-
-          al pararse sobre [TYPE][0]
-          [STATEMENT][1]
+          al pararse sobre {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": arena
             "'darkPrismarine'": prismarina oscura
             "'seaLantern'": linterna marina
       craft_log:
-        text: registro de mensaje [MESSAGE][0]
+        text: registro de mensaje {MESSAGE}
       craft_moveForward:
         text: avanzar
       craft_placeBlock:
-        text: colocar [blockType][0]
+        text: colocar {blockType}
         options:
           blockType:
             '"strippedOak"': roble sin corteza
@@ -1108,13 +1108,13 @@ es-MX:
       craft_repeatUntilConduit:
         text: |-
           repetir hasta completar conducto
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           repetir hasta lograr meta
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: generar [ENTITY][0]
+        text: generar {ENTITY}
         options:
           ENTITY:
             '"cod"': merluc
@@ -1124,7 +1124,7 @@ es-MX:
             '"squid"': kallamar
             '"tropicalFish"': peshk tropikal
       craft_turn:
-        text: girar a la [DIR][0]
+        text: girar a la {DIR}
         options:
           DIR:
             right: derecha ↻

--- a/dashboard/config/locales/blocks.et-EE.yml
+++ b/dashboard/config/locales/blocks.et-EE.yml
@@ -3,20 +3,20 @@ et:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: pärast [TIMESTAMP][0] [UNIT][1]
+        text: pärast {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': ühikud
             '"seconds"': sekundit
       Dancelab_changeColorBy:
-        text: muuda [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: muuda {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"hue"': värvitoon
             '"saturation"': küllastus
             '"brightness"': heledus
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] [MOVE][1] [DIR][2] tee igavesti"
+        text: "{GROUP} {MOVE} {DIR} tee igavesti"
         options:
           GROUP:
             sprites: kõik
@@ -50,7 +50,7 @@ et:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] tee [MOVE][1] [DIR][2] igavesti"
+        text: "{SPRITE} tee {MOVE} {DIR} igavesti"
         options:
           MOVE:
             '"next"': "(Järgmine)"
@@ -72,7 +72,7 @@ et:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: muuda [SPRITE][0] [PROPERTY][1] [VAL][2] võrra
+        text: muuda {SPRITE} {PROPERTY} {VAL} võrra
         options:
           PROPERTY:
             '"scale"': suurus
@@ -82,7 +82,7 @@ et:
             '"x"': horisontaalne asend
             '"y"': vertikaalne asend
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] tee [MOVE][1] [DIR][2] üks kord"
+        text: "{GROUP} tee {MOVE} {DIR} üks kord"
         options:
           GROUP:
             sprites: kõik
@@ -114,7 +114,7 @@ et:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] tee [MOVE][1] [DIR][2] üks kord"
+        text: "{SPRITE} tee {MOVE} {DIR} üks kord"
         options:
           MOVE:
             '"rand"': "(Juhuslik)"
@@ -133,32 +133,32 @@ et:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'iga [N][0] [UNIT][1] '
+        text: 'iga {N} {UNIT} '
         options:
           UNIT:
             '"measures"': ühikud
             '"seconds"': sekundit
       Dancelab_everySecondsRange:
-        text: 'iga [N][0] [UNIT][1] alates [START][2] kuni [STOP][3] '
+        text: 'iga {N} {UNIT} alates {START} kuni {STOP} '
         options:
           UNIT:
             measures: Ühikud
             seconds: Sekundid
       Dancelab_everyVerseChorus:
-        text: 'iga [UNIT][0] '
+        text: 'iga {UNIT} '
         options:
           UNIT:
             '"verse"': salm
             '"chorus"': refrään
       Dancelab_getEnergy:
-        text: saa [RANGE][0]
+        text: saa {RANGE}
         options:
           RANGE:
             '"low"': bass
             '"mid"': keskel
             '"high"': kõrged helid
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': suurus
@@ -169,15 +169,15 @@ et:
             '"y"': vertikaalne asend
             '"tint"': toon
       Dancelab_getTime:
-        text: aeg käesolevas peatükis [UNIT][0]
+        text: aeg käesolevas peatükis {UNIT}
         options:
           UNIT:
             '"measures"': ühikud
             '"seconds"': sekundit
       Dancelab_ifDanceIs:
         text: |-
-          kui [SPRITE][0] teeb [DANCE][1]
-          [DO1][2] [DO2][3]
+          kui {SPRITE} teeb {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Kõrge plaks
@@ -193,14 +193,14 @@ et:
             MOVES.Rest: Mitte ükski
       Dancelab_ifTime:
         text: |-
-          kui [UNIT][0] on [OP][1] [N][2]
-          [DO1][3] [DO2][4]
+          kui {UNIT} on {OP} {N}
+          {DO1} {DO2}
         options:
           UNIT:
             '"measures"': ühikud
             '"seconds"': sekundit
       Dancelab_jumpTo:
-        text: "[SPRITE][0] hüppavad [LOCATION][1]"
+        text: "{SPRITE} hüppavad {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": üleval
@@ -214,7 +214,7 @@ et:
             "{x: 300, y: 300}": all paremal
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": juhuslik
       Dancelab_layoutSprites:
-        text: paigutus [GROUP][0] nagu [FORMAT][1]
+        text: paigutus {GROUP} nagu {FORMAT}
         options:
           GROUP:
             sprites: kõik
@@ -241,8 +241,8 @@ et:
             '"random"': juhuslik
       Dancelab_makeNewDanceSprite:
         text: |-
-          tee uus [COSTUME][0]
-          mille nimi on [NAME][1] ekraani [LOCATION][2]
+          tee uus {COSTUME}
+          mille nimi on {NAME} ekraani {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Tulnukas
@@ -268,8 +268,8 @@ et:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": juhuslik
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          tee [N][0] uus [COSTUME][1]
-          erkraani [LAYOUT][2]
+          tee {N} uus {COSTUME}
+          erkraani {LAYOUT}
         options:
           N:
             '2': '2'
@@ -314,9 +314,9 @@ et:
             '"plus"': pluss
             '"random"': juhuslik
       Dancelab_mixColors:
-        text: segad [COLOR1][0] ja [COLOR2][1]
+        text: segad {COLOR1} ja {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] ühikud"
+        text: "{N} ühikud"
       Dancelab_onPointerDown:
         text: kui kursor on suunatud alla
       Dancelab_onPointerDrag:
@@ -326,9 +326,9 @@ et:
       Dancelab_randomColor:
         text: juhuslik värv
       Dancelab_setBackground:
-        text: määra taustavärv [COLOR][0]
+        text: määra taustavärv {COLOR}
       Dancelab_setBackgroundEffect:
-        text: määra taustaefekt [EFFECT][0]
+        text: määra taustaefekt {EFFECT}
         options:
           EFFECT:
             '"none"': Mitte ükski
@@ -354,7 +354,7 @@ et:
             '"spiral"': Spiraal
             '"disco"': Ruudud
       Dancelab_setDanceSpeed:
-        text: sea [SPEED][0] tantsu kiirus [SPRITE][1]
+        text: sea {SPRITE} tantsu kiirus {SPEED}
         options:
           SPEED:
             '1': tavaline
@@ -363,7 +363,7 @@ et:
             '0.5': aeglane
             '0.25': väga aeglane
       Dancelab_setDanceSpeedEach:
-        text: sea [GROUP][0] tantsu kiirus [SPEED][1]
+        text: sea {GROUP} tantsu kiirus {SPEED}
         options:
           GROUP:
             sprites: kõik
@@ -385,7 +385,7 @@ et:
             '0.5': aeglane
             '0.25': väga aeglane
       Dancelab_setForegroundEffect:
-        text: määra esiplaani efekt [EFFECT][0]
+        text: määra esiplaani efekt {EFFECT}
         options:
           EFFECT:
             '"none"': Mitte ükski
@@ -395,7 +395,7 @@ et:
             '"spotlight"': Punktvalgus
             '"raining_tacos"': Tacod
       Dancelab_setForegroundEffectExtended:
-        text: määra esiplaani efekt [EFFECT][0]
+        text: määra esiplaani efekt {EFFECT}
         options:
           EFFECT:
             '"none"': Mitte ükski
@@ -406,7 +406,7 @@ et:
             '"spotlight"': Punktvalgus
             '"raining_tacos"': Tacod
       Dancelab_setProp:
-        text: 'muuda [SPRITE][0] [PROPERTY][1] [VAL][2] '
+        text: 'muuda {SPRITE} {PROPERTY} {VAL} '
         options:
           PROPERTY:
             '"scale"': suurus
@@ -417,7 +417,7 @@ et:
             '"y"': vertikaalne asend
             '"tint"': toon
       Dancelab_setPropEach:
-        text: muuda [GROUP][0] [PROPERTY][1] [VAL][2]
+        text: muuda {GROUP} {PROPERTY} {VAL}
         options:
           GROUP:
             sprites: kõik
@@ -441,7 +441,7 @@ et:
             '"y"': vertikaalne asend
             '"tint"': toon
       Dancelab_setPropRandom:
-        text: juhusliku valiku alusel [SPRITE][0] [PROPERTY][1]
+        text: juhusliku valiku alusel {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': suurus
@@ -452,9 +452,9 @@ et:
             '"y"': vertikaalne asend
             '"tint"': toon
       Dancelab_setTint:
-        text: määra [SPRITE][0] toon [VAL][1]
+        text: määra {SPRITE} toon {VAL}
       Dancelab_setTintEach:
-        text: määra [THIS][0] toon [VAL][1]
+        text: määra {THIS} toon {VAL}
         options:
           THIS:
             sprites: kõik
@@ -469,15 +469,15 @@ et:
             '"ROBOT"': kõik robotid
             '"SHARK"': kõik haid
       Dancelab_setTintInline:
-        text: määra [SPRITE][0] toon [VAL][1]
+        text: määra {SPRITE} toon {VAL}
       Dancelab_setVisible:
-        text: määra [SPRITE][0] nähtavus [VISIBILITY][1]
+        text: määra {SPRITE} nähtavus {VISIBILITY}
         options:
           VISIBILITY:
             'true': nähtav
             'false': nähtamatu
       Dancelab_setVisibleEach:
-        text: määra [THIS][0] nähtavus [VISIBILITY][1]
+        text: määra {THIS} nähtavus {VISIBILITY}
         options:
           THIS:
             sprites: kõik
@@ -496,7 +496,7 @@ et:
             'true': nähtav
             'false': nähtamatu
       Dancelab_startMapping:
-        text: "[SPRITE][0] hakkab [PROPERTY][1] järgnema [RANGE][2]"
+        text: "{SPRITE} hakkab {PROPERTY} järgnema {RANGE}"
         options:
           PROPERTY:
             '"scale"': suurus
@@ -511,7 +511,7 @@ et:
             '"mid"': keskel
             '"treble"': kõrged helid
       Dancelab_stopMapping:
-        text: "[SPRITE][0] lõpetab [PROPERTY][1] järgnemise [RANGE][2]"
+        text: "{SPRITE} lõpetab {PROPERTY} järgnemise {RANGE}"
         options:
           PROPERTY:
             '"scale"': suurus
@@ -527,7 +527,7 @@ et:
             '"mid"': keskel
             '"treble"': kõrged helid
       Dancelab_whenKey:
-        text: kui vajutad [KEY][0]
+        text: kui vajutad {KEY}
         options:
           KEY:
             '"up"': üles
@@ -555,7 +555,7 @@ et:
             '"x"': x
             '"z"': z
       Dancelab_whenPeak:
-        text: kui [RANGE][0] tipneb
+        text: kui {RANGE} tipneb
         options:
           RANGE:
             '0': bass
@@ -564,19 +564,19 @@ et:
       Dancelab_whenSetup:
         text: seadistus
       gamelab_changeColor:
-        text: muuda [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: muuda {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"tint"': toon
       gamelab_changeColorBy:
-        text: muuda [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: muuda {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"hue"': värvitoon
             '"saturation"': küllastus
             '"brightness"': heledus
       gamelab_changePropBy:
-        text: muuda [SPRITE][0] [PROPERTY][1] [VAL][2] võrra
+        text: muuda {SPRITE} {PROPERTY} {VAL} võrra
         options:
           PROPERTY:
             '"scale"': suurus
@@ -590,7 +590,7 @@ et:
             'true': tõene
             'false': väär
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': suurus
@@ -600,7 +600,7 @@ et:
             '"direction"': liikumise suund
             '"tint"': toon
       gamelab_jumpTo:
-        text: "[SPRITE][0] hüppavad [LOCATION][1]"
+        text: "{SPRITE} hüppavad {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -611,15 +611,15 @@ et:
             '"right"': paremale
             '"left"': vasakule
       gamelab_mixColors:
-        text: segad [COLOR1][0] ja [COLOR2][1]
+        text: segad {COLOR1} ja {COLOR2}
       gamelab_randColor:
         text: juhuslik värv
       gamelab_randomColor:
         text: juhuslik värv
       gamelab_setBackground:
-        text: määra taustavärv [COLOR][0]
+        text: määra taustavärv {COLOR}
       gamelab_setPosition:
-        text: liiguta [THIS][0] [POSITION][1] asendisse
+        text: liiguta {THIS} {POSITION} asendisse
         options:
           POSITION:
             "{x: 50, y: 50}": üleval vasakul
@@ -671,7 +671,7 @@ et:
             '"right"': paremale
             '"left"': vasakule
       gamelab_whenKey:
-        text: kui vajutad [KEY][0]
+        text: kui vajutad {KEY}
         options:
           KEY:
             '"up"': üles
@@ -796,8 +796,8 @@ et:
             '"all"': kõik
       Mikelab_ifDanceIs:
         text: |-
-          kui [SPRITE][0] teeb [DANCE][1]
-          [DO1][2] [DO2][3]
+          kui {SPRITE} teeb {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Kõrge plaks
@@ -843,7 +843,7 @@ et:
             "{x: 100, y: 300}": keskel vasakul
             "{x: 300, y: 300}": all paremal
       Mikelab_whenKeyPressed:
-        text: kui vajutad [KEY][0]
+        text: kui vajutad {KEY}
         options:
           KEY:
             '"up"': nool üles
@@ -904,7 +904,7 @@ et:
             '"left"': vasakule
             '"right"': paremale
       binary_whenKey:
-        text: kui vajutad [KEY][0]
+        text: kui vajutad {KEY}
         options:
           KEY:
             '"up"': üles
@@ -918,8 +918,8 @@ et:
             '"d"': d
       craft_ifPath:
         text: |-
-          kui rada [DIR][0]
-          [STATEMENT][1]
+          kui rada {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": ees
@@ -927,8 +927,8 @@ et:
             "'left'": vasakule
       craft_ifStandingOn:
         text: |-
-          kui seisad [TYPE][0]
-          [STATEMENT][1]
+          kui seisad {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": sinine korall
@@ -939,8 +939,8 @@ et:
             "'seaLantern'": merelatern
       craft_ifStandingOnLimit:
         text: |-
-          kui seisad [TYPE][0]
-          [STATEMENT][1]
+          kui seisad {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": liiv
@@ -949,7 +949,7 @@ et:
       craft_moveForward:
         text: liigu edasi
       craft_placeBlock:
-        text: paiguta [blockType][0]
+        text: paiguta {blockType}
         options:
           blockType:
             '"strippedOak"': kooritud tamm
@@ -984,13 +984,13 @@ et:
       craft_repeatUntilConduit:
         text: |-
           korda kuni kanal valmis
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           korda kuni eemärgini
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: loo [ENTITY][0]
+        text: loo {ENTITY}
         options:
           ENTITY:
             '"cod"': tursk
@@ -1000,7 +1000,7 @@ et:
             '"squid"': kalmaar
             '"tropicalFish"': troopiline kala
       craft_turn:
-        text: keera [DIR][0]
+        text: keera {DIR}
         options:
           DIR:
             right: paremale ↻

--- a/dashboard/config/locales/blocks.eu-ES.yml
+++ b/dashboard/config/locales/blocks.eu-ES.yml
@@ -3,20 +3,20 @@ eu:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: "[TIMESTAMP][0] ondoren [UNIT][1]"
+        text: "{TIMESTAMP} ondoren {UNIT}"
         options:
           UNIT:
             '"measures"': neurriak
             '"seconds"': segundu
       Dancelab_changeColorBy:
-        text: aldatu [COLOR][0] [METHOD][1] [AMOUNT][2] erabiliaz
+        text: aldatu {COLOR} {METHOD} {AMOUNT} erabiliaz
         options:
           METHOD:
             '"hue"': tonua
             '"saturation"': saturazioa
             '"brightness"': distira
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] egin [MOVE][1] [DIR][2] betirako"
+        text: "{GROUP} egin {MOVE} {DIR} betirako"
         options:
           GROUP:
             '"ALIEN"': estralurtar guztiak
@@ -45,7 +45,7 @@ eu:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] egin [MOVE][1] [DIR][2] betirako"
+        text: "{SPRITE} egin {MOVE} {DIR} betirako"
         options:
           MOVE:
             '"rand"': Ausazkoa
@@ -63,7 +63,7 @@ eu:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: aldatu [SPRITE][0] [PROPERTY][1] honekin [VAL][2]
+        text: aldatu {SPRITE} {PROPERTY} honekin {VAL}
         options:
           PROPERTY:
             '"scale"': tamaina
@@ -72,7 +72,7 @@ eu:
             '"x"': posizio horizontala
             '"y"': posizio bertikala
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] egin [MOVE][1] [DIR][2] behin"
+        text: "{GROUP} egin {MOVE} {DIR} behin"
         options:
           GROUP:
             '"ALIEN"': estralurtar guztiak
@@ -101,7 +101,7 @@ eu:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] egin [MOVE][1] [DIR][2] behin"
+        text: "{SPRITE} egin {MOVE} {DIR} behin"
         options:
           MOVE:
             '"rand"': Ausazkoa
@@ -119,32 +119,32 @@ eu:
             '1': "→"
             "-1": "←"
       Dancelab_eval:
-        text: ebal [CODE][0]
+        text: ebal {CODE}
       Dancelab_everySeconds:
-        text: "[N][0] [UNIT][1] aldiro "
+        text: "{N} {UNIT} aldiro "
         options:
           UNIT:
             '"measures"': neurriak
             '"seconds"': segundu
       Dancelab_everySecondsRange:
-        text: "[N][0] [UNIT][1] aldiro, [START][2] tik [STOP][3] ra "
+        text: "{N} {UNIT} aldiro, {START} tik {STOP} ra "
         options:
           UNIT:
             measures: Neurriak
             seconds: Segunduak
       Dancelab_everyVerseChorus:
-        text: "[UNIT][0] guztietan "
+        text: "{UNIT} guztietan "
         options:
           UNIT:
             '"verse"': versus
             '"chorus"': koruak
       Dancelab_getEnergy:
-        text: hartu [RANGE][0]
+        text: hartu {RANGE}
         options:
           RANGE:
             '"mid"': erdi
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': tamaina
@@ -335,7 +335,7 @@ eu:
           VISIBILITY:
             'false': ikusezin
       Dancelab_startMapping:
-        text: "[SPRITE][0] hasi [PROPERTY][1] jarraituz [RANGE][2]"
+        text: "{SPRITE} hasi {PROPERTY} jarraituz {RANGE}"
         options:
           PROPERTY:
             '"scale"': tamaina
@@ -347,7 +347,7 @@ eu:
           RANGE:
             '"mid"': erdi
       Dancelab_stopMapping:
-        text: "[SPRITE][0] gelditu [PROPERTY][1] jarraituz [RANGE][2]"
+        text: "{SPRITE} gelditu {PROPERTY} jarraituz {RANGE}"
         options:
           PROPERTY:
             '"scale"': tamaina
@@ -360,7 +360,7 @@ eu:
           RANGE:
             '"mid"': erdi
       Dancelab_whenKey:
-        text: "[KEY][0] zapaltzean"
+        text: "{KEY} zapaltzean"
         options:
           KEY:
             '"up"': gora
@@ -386,26 +386,26 @@ eu:
             '"hammer"': MC Hammer - U Can't Touch This
             '"peas"': The Black Eyed Peas - I Got a Feeling
       gamelab_add:
-        text: gehitu [SPRITE][0], [THIS][1] taldera
+        text: gehitu {SPRITE}, {THIS} taldera
       gamelab_addBehaviorSimple:
-        text: sprite [SPRITE][0] hasi [BEHAVIOR][1]
+        text: sprite {SPRITE} hasi {BEHAVIOR}
       gamelab_beginBehavior:
-        text: hasi [BEHAVIOR][0]
+        text: hasi {BEHAVIOR}
       gamelab_changeColor:
-        text: aldatu [COLOR][0] [METHOD][1] [AMOUNT][2] erabiliaz
+        text: aldatu {COLOR} {METHOD} {AMOUNT} erabiliaz
         options:
           METHOD:
             '"tint"': tinta
             '"tone"': tonua
       gamelab_changeColorBy:
-        text: aldatu [COLOR][0] [METHOD][1] [AMOUNT][2] erabiliaz
+        text: aldatu {COLOR} {METHOD} {AMOUNT} erabiliaz
         options:
           METHOD:
             '"hue"': tonua
             '"saturation"': saturazioa
             '"brightness"': distira
       gamelab_changePropBy:
-        text: aldatu [SPRITE][0] [PROPERTY][1] honekin [VAL][2]
+        text: aldatu {SPRITE} {PROPERTY} honekin {VAL}
         options:
           PROPERTY:
             '"scale"': tamaina
@@ -414,20 +414,20 @@ eu:
             '"y"': y posizioa
             '"direction"': mugimentuaren norantza
       gamelab_clickedOn:
-        text: "[SPRITE][0] klik egitean"
+        text: "{SPRITE} klik egitean"
       gamelab_comment:
-        text: 'iruzkina: [COMMENT][0]'
+        text: 'iruzkina: {COMMENT}'
       gamelab_debugSprite:
         options:
           VAL:
             'true': egia
             'false': gezurra
       gamelab_destroy:
-        text: ezabatu [THIS][0]
+        text: ezabatu {THIS}
       gamelab_eval:
-        text: ebal [CODE][0]
+        text: ebal {CODE}
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': tamaina
@@ -484,14 +484,14 @@ eu:
             '"direction"': mugimentuaren norantza
             '"tint"': tinta
       gamelab_thisBeginsBehaviorSimple:
-        text: sprite [SPRITE][0] hasi [BEHAVIOR][1]
+        text: sprite {SPRITE} hasi {BEHAVIOR}
       gamelab_turn:
         options:
           DIRECTION:
             '"right"': eskuinera
             '"left"': ezkerrera
       gamelab_whenKey:
-        text: "[KEY][0] zapaltzean"
+        text: "{KEY} zapaltzean"
         options:
           KEY:
             '"up"': gora
@@ -523,7 +523,7 @@ eu:
             '"s"': s
             '"d"': d
       Mikelab_addBehaviorSimple:
-        text: sprite [SPRITE][0] hasi [BEHAVIOR][1]
+        text: sprite {SPRITE} hasi {BEHAVIOR}
       Mikelab_changePropBy:
         options:
           PROPERTY:
@@ -539,7 +539,7 @@ eu:
             "{x: 300, y: 200}": eskuinera
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": Ausazkoa
       Mikelab_eval:
-        text: ebal [CODE][0]
+        text: ebal {CODE}
       Mikelab_getProp:
         options:
           PROPERTY:
@@ -617,9 +617,9 @@ eu:
             "{x: 300, y: 200}": eskuinera
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": Ausazkoa
       Mikelab_whenClickedOn:
-        text: "[SPRITE][0] klik egitean"
+        text: "{SPRITE} klik egitean"
       Mikelab_whenKeyPressed:
-        text: "[KEY][0] zapaltzean"
+        text: "{KEY} zapaltzean"
         options:
           KEY:
             '"up"': gora gezia
@@ -678,7 +678,7 @@ eu:
             '"left"': ezkerrera
             '"right"': eskuinera
       binary_whenKey:
-        text: "[KEY][0] zapaltzean"
+        text: "{KEY} zapaltzean"
         options:
           KEY:
             '"up"': gora

--- a/dashboard/config/locales/blocks.fi-FI.yml
+++ b/dashboard/config/locales/blocks.fi-FI.yml
@@ -434,16 +434,16 @@ fi:
             '"y"': y:n paikka
             '"direction"': liikkeen suunta
       gamelab_clickedOn:
-        text: kun [SPRITE][0] klikataan
+        text: kun {SPRITE} klikataan
       gamelab_comment:
-        text: 'kommentti: [COMMENT][0]'
+        text: 'kommentti: {COMMENT}'
       gamelab_debugSprite:
         options:
           VAL:
             'true': tosi
             'false': epätosi
       gamelab_destroy:
-        text: poista [THIS][0]
+        text: poista {THIS}
       gamelab_getAnim:
         options:
           COSTUME:
@@ -719,7 +719,7 @@ fi:
             "{x: 100, y: 300}": alhaalla vasemmalla
             "{x: 300, y: 300}": alhaalla oikealla
       Mikelab_whenClickedOn:
-        text: kun [SPRITE][0] klikataan
+        text: kun {SPRITE} klikataan
       Mikelab_whenKeyPressed:
         options:
           KEY:

--- a/dashboard/config/locales/blocks.fr-FR.yml
+++ b/dashboard/config/locales/blocks.fr-FR.yml
@@ -3,20 +3,20 @@ fr:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: après [TIMESTAMP][0] [UNIT][1]
+        text: après {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': mesures
             '"seconds"': des secondes
       Dancelab_changeColorBy:
-        text: changer [COLOR][0] [METHOD][1] par [AMOUNT][2]
+        text: changer {COLOR} {METHOD} par {AMOUNT}
         options:
           METHOD:
             '"hue"': teinte
             '"saturation"': saturation
             '"brightness"': luminosité
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] faire [MOVE][1] [DIR][2] pour toujours"
+        text: "{GROUP} faire {MOVE} {DIR} pour toujours"
         options:
           GROUP:
             sprites: tout
@@ -46,7 +46,7 @@ fr:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] faire [MOVE][1] [DIR][2] pour toujours"
+        text: "{SPRITE} faire {MOVE} {DIR} pour toujours"
         options:
           MOVE:
             '"next"': "(Suivant)"
@@ -63,7 +63,7 @@ fr:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: changer [SPRITE][0] [PROPERTY][1] par [VAL][2]
+        text: changer {SPRITE} {PROPERTY} par {VAL}
         options:
           PROPERTY:
             '"scale"': taille
@@ -72,7 +72,7 @@ fr:
             '"x"': position horizontale
             '"y"': position verticale
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] faire [MOVE][1] [DIR][2] une fois"
+        text: "{GROUP} faire {MOVE} {DIR} une fois"
         options:
           GROUP:
             sprites: tout
@@ -100,7 +100,7 @@ fr:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] faire [MOVE][1] [DIR][2] une fois"
+        text: "{SPRITE} faire {MOVE} {DIR} une fois"
         options:
           MOVE:
             '"rand"': "(Aléatoire)"
@@ -115,25 +115,25 @@ fr:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'chaque [N][0] [UNIT][1] '
+        text: 'chaque {N} {UNIT} '
         options:
           UNIT:
             '"measures"': mesures
             '"seconds"': des secondes
       Dancelab_everySecondsRange:
-        text: 'chaque [N][0] [UNIT][1] de [START][2] à [STOP][3] '
+        text: 'chaque {N} {UNIT} de {START} à {STOP} '
         options:
           UNIT:
             measures: Mesures
             seconds: Secondes
       Dancelab_everyVerseChorus:
-        text: 'chaque [UNIT][0] '
+        text: 'chaque {UNIT} '
         options:
           UNIT:
             '"verse"': verset
             '"chorus"': chœur
       Dancelab_getEnergy:
-        text: obtenir [RANGE][0]
+        text: obtenir {RANGE}
         options:
           RANGE:
             '"low"': grave
@@ -149,15 +149,15 @@ fr:
             '"y"': position verticale
             '"tint"': nuance
       Dancelab_getTime:
-        text: "[UNIT][0] s’est écoulé"
+        text: "{UNIT} s’est écoulé"
         options:
           UNIT:
             '"measures"': mesures
             '"seconds"': des secondes
       Dancelab_ifDanceIs:
         text: |-
-          Si [SPRITE][0] exécute [DANCE][1]
-          [DO1][2] [DO2][3]
+          Si {SPRITE} exécute {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Tapez des mains en haut
@@ -173,7 +173,7 @@ fr:
             '"measures"': mesures
             '"seconds"': des secondes
       Dancelab_jumpTo:
-        text: "[SPRITE][0] passer à [LOCATION][1]"
+        text: "{SPRITE} passer à {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": vers le haut
@@ -187,7 +187,7 @@ fr:
             "{x: 300, y: 300}": vers le haut à droite
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": aléatoire
       Dancelab_layoutSprites:
-        text: afficher [GROUP][0] en tant que [FORMAT][1]
+        text: afficher {GROUP} en tant que {FORMAT}
         options:
           GROUP:
             sprites: tout
@@ -212,8 +212,8 @@ fr:
             '"random"': aléatoire
       Dancelab_makeNewDanceSprite:
         text: |-
-          faire un nouvel [COSTUME][0]
-          appelé [NAME][1] à [LOCATION][2]
+          faire un nouvel {COSTUME}
+          appelé {NAME} à {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Extraterrestre
@@ -239,8 +239,8 @@ fr:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": aléatoire
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          faire [N][0] nouveau [COSTUME][1]
-          dans un [LAYOUT][2]
+          faire {N} nouveau {COSTUME}
+          dans un {LAYOUT}
         options:
           N:
             '2': '2'
@@ -282,9 +282,9 @@ fr:
             '"column"': colonne
             '"random"': aléatoire
       Dancelab_mixColors:
-        text: mélanger [COLOR1][0] et [COLOR2][1]
+        text: mélanger {COLOR1} et {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] mesures"
+        text: "{N} mesures"
       Dancelab_onPointerDown:
         text: sur le pointeur vers le bas
       Dancelab_onPointerDrag:
@@ -294,9 +294,9 @@ fr:
       Dancelab_randomColor:
         text: couleur aléatoire
       Dancelab_setBackground:
-        text: définir la couleur de fond [COLOR][0]
+        text: définir la couleur de fond {COLOR}
       Dancelab_setBackgroundEffect:
-        text: définir l’effet de fond [EFFECT][0]
+        text: définir l’effet de fond {EFFECT}
         options:
           EFFECT:
             '"none"': Aucun
@@ -316,7 +316,7 @@ fr:
             '"neon"': Néon
             '"warm"': Rouges
       Dancelab_setBackgroundEffectWithPalette:
-        text: définir l’effet de fond [EFFECT][0] [PALETTE][1]
+        text: définir l’effet de fond {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Aucun
@@ -338,7 +338,7 @@ fr:
             '"neon"': Néon
             '"warm"': Rouges
       Dancelab_setDanceSpeed:
-        text: changer la vitesse de la danse à [SPEED][1] pour [SPRITE][0]
+        text: changer la vitesse de la danse à {SPEED} pour {SPRITE}
         options:
           SPEED:
             '1': normal
@@ -368,7 +368,7 @@ fr:
             '0.5': lent
             '0.25': très lent
       Dancelab_setForegroundEffect:
-        text: définir l’effet de premier plan [EFFECT][0]
+        text: définir l’effet de premier plan {EFFECT}
         options:
           EFFECT:
             '"none"': Aucun
@@ -379,7 +379,7 @@ fr:
             '"rain"': Pluie
             '"floating_rainbows"': Arc-en-ciel
       Dancelab_setForegroundEffectExtended:
-        text: définir l’effet de premier plan [EFFECT][0]
+        text: définir l’effet de premier plan {EFFECT}
         options:
           EFFECT:
             '"none"': Aucun
@@ -391,7 +391,7 @@ fr:
             '"rain"': Pluie
             '"floating_rainbows"': Arc-en-ciel
       Dancelab_setProp:
-        text: 'définir [SPRITE][0] [PROPERTY][1] à [VAL][2] '
+        text: 'définir {SPRITE} {PROPERTY} à {VAL} '
         options:
           PROPERTY:
             '"scale"': taille
@@ -401,7 +401,7 @@ fr:
             '"y"': position verticale
             '"tint"': nuance
       Dancelab_setPropEach:
-        text: définir [GROUP][0] [PROPERTY][1] à [VAL][2]
+        text: définir {GROUP} {PROPERTY} à {VAL}
         options:
           GROUP:
             sprites: tout
@@ -424,7 +424,7 @@ fr:
             '"y"': position verticale
             '"tint"': nuance
       Dancelab_setPropRandom:
-        text: randomiser [SPRITE][0] [PROPERTY][1]
+        text: randomiser {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': taille
@@ -434,7 +434,7 @@ fr:
             '"y"': position verticale
             '"tint"': nuance
       Dancelab_setTint:
-        text: définir la nuance de [SPRITE][0] à [VAL][1]
+        text: définir la nuance de {SPRITE} à {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -450,11 +450,11 @@ fr:
             '"ROBOT"': tous les robots
             '"SHARK"': tous les requins
       Dancelab_setTintInline:
-        text: définir la nuance de [SPRITE][0] à [VAL][1]
+        text: définir la nuance de {SPRITE} à {VAL}
       Dancelab_setVisible:
-        text: régler [SPRITE][0] visible à [VISIBILITY][1]
+        text: régler {SPRITE} visible à {VISIBILITY}
       Dancelab_setVisibleEach:
-        text: définir [THIS][0] visibilité à [VISIBILITY][1]
+        text: définir {THIS} visibilité à {VISIBILITY}
         options:
           THIS:
             sprites: tout
@@ -470,7 +470,7 @@ fr:
             '"SHARK"': tous les requins
             '"UNICORN"': Toutes les licornes
       Dancelab_startMapping:
-        text: "[SPRITE][0] commence [PROPERTY][1] suivant [RANGE][2]"
+        text: "{SPRITE} commence {PROPERTY} suivant {RANGE}"
         options:
           PROPERTY:
             '"scale"': taille
@@ -484,7 +484,7 @@ fr:
             '"mid"': médium
             '"treble"': aigu
       Dancelab_stopMapping:
-        text: "[SPRITE][0] arrête [PROPERTY][1] suivant [RANGE][2]"
+        text: "{SPRITE} arrête {PROPERTY} suivant {RANGE}"
         options:
           PROPERTY:
             '"scale"': taille
@@ -499,7 +499,7 @@ fr:
             '"mid"': médium
             '"treble"': aigu
       Dancelab_whenKey:
-        text: En appuyant sur [KEY][0]
+        text: En appuyant sur {KEY}
         options:
           KEY:
             '"up"': vers le haut
@@ -510,7 +510,7 @@ fr:
             '"x"': x
             '"y"': y
       Dancelab_whenPeak:
-        text: Lorsque [RANGE][0] pic
+        text: Lorsque {RANGE} pic
         options:
           RANGE:
             '0': grave
@@ -519,19 +519,19 @@ fr:
       Dancelab_whenSetup:
         text: configuration
       gamelab_changeColor:
-        text: changer [COLOR][0] [METHOD][1] par [AMOUNT][2]
+        text: changer {COLOR} {METHOD} par {AMOUNT}
         options:
           METHOD:
             '"tint"': nuance
       gamelab_changeColorBy:
-        text: changer [COLOR][0] [METHOD][1] par [AMOUNT][2]
+        text: changer {COLOR} {METHOD} par {AMOUNT}
         options:
           METHOD:
             '"hue"': teinte
             '"saturation"': saturation
             '"brightness"': luminosité
       gamelab_changePropBy:
-        text: changer [SPRITE][0] [PROPERTY][1] par [VAL][2]
+        text: changer {SPRITE} {PROPERTY} par {VAL}
         options:
           PROPERTY:
             '"scale"': taille
@@ -552,7 +552,7 @@ fr:
             '"direction"': direction du mouvement
             '"tint"': nuance
       gamelab_jumpTo:
-        text: "[SPRITE][0] passer à [LOCATION][1]"
+        text: "{SPRITE} passer à {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -563,15 +563,15 @@ fr:
             '"right"': vers la droite
             '"left"': vers la gauche
       gamelab_mixColors:
-        text: mélanger [COLOR1][0] et [COLOR2][1]
+        text: mélanger {COLOR1} et {COLOR2}
       gamelab_randColor:
         text: couleur aléatoire
       gamelab_randomColor:
         text: couleur aléatoire
       gamelab_setBackground:
-        text: définir la couleur de fond [COLOR][0]
+        text: définir la couleur de fond {COLOR}
       gamelab_setPosition:
-        text: déplacer [THIS][0] à la position [POSITION][1]
+        text: déplacer {THIS} à la position {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": vers le haut à gauche
@@ -623,7 +623,7 @@ fr:
             '"right"': vers la droite
             '"left"': vers la gauche
       gamelab_whenKey:
-        text: En appuyant sur [KEY][0]
+        text: En appuyant sur {KEY}
         options:
           KEY:
             '"up"': vers le haut
@@ -735,8 +735,8 @@ fr:
             '"all"': tout
       Mikelab_ifDanceIs:
         text: |-
-          Si [SPRITE][0] exécute [DANCE][1]
-          [DO1][2] [DO2][3]
+          Si {SPRITE} exécute {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Tapez des mains en haut
@@ -777,7 +777,7 @@ fr:
             "{x: 100, y: 300}": vers le bas à gauche
             "{x: 300, y: 300}": vers le haut à droite
       Mikelab_whenKeyPressed:
-        text: En appuyant sur [KEY][0]
+        text: En appuyant sur {KEY}
         options:
           KEY:
             '"up"': flèche « vers le haut »
@@ -837,7 +837,7 @@ fr:
             '"left"': vers la gauche
             '"right"': vers la droite
       binary_whenKey:
-        text: En appuyant sur [KEY][0]
+        text: En appuyant sur {KEY}
         options:
           KEY:
             '"up"': vers le haut
@@ -847,8 +847,8 @@ fr:
             '"space"': espace
       craft_ifPath:
         text: |-
-          si chemin [DIR][0]
-          [STATEMENT][1]
+          si chemin {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": devant
@@ -856,8 +856,8 @@ fr:
             "'left'": à gauche
       craft_ifStandingOn:
         text: |-
-          si debout sur [TYPE][0]
-          [STATEMENT][1]
+          si debout sur {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": corail bleu
@@ -868,8 +868,8 @@ fr:
             "'seaLantern'": lanterne aquatique
       craft_ifStandingOnLimit:
         text: |-
-          si debout sur [TYPE][0]
-          [STATEMENT][1]
+          si debout sur {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": sable
@@ -878,7 +878,7 @@ fr:
       craft_moveForward:
         text: avancer plus
       craft_placeBlock:
-        text: placer [blockType][0]
+        text: placer {blockType}
         options:
           blockType:
             '"strippedOak"': chêne écorcé
@@ -910,15 +910,15 @@ fr:
       craft_repeatUntilConduit:
         text: |-
           répéter jusqu'à ce que le conduit soit terminé
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           répéter jusqu'au bout
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: œuf [ENTITY][0]
+        text: œuf {ENTITY}
       craft_turn:
-        text: tourner [DIR][0]
+        text: tourner {DIR}
         options:
           DIR:
             right: droite ↻

--- a/dashboard/config/locales/blocks.he-IL.yml
+++ b/dashboard/config/locales/blocks.he-IL.yml
@@ -3,20 +3,20 @@ he:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: אחרי [TIMESTAMP][0] [UNIT][1]
+        text: אחרי {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': תיבות
             '"seconds"': שניות
       Dancelab_changeColorBy:
-        text: שנה [COLOR][0] [METHOD][1] ב [AMOUNT][2]
+        text: שנה {COLOR} {METHOD} ב {AMOUNT}
         options:
           METHOD:
             '"hue"': גוון
             '"saturation"': רוויה
             '"brightness"': בהירות
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] עושים [MOVE][1] [DIR][2] לנצח"
+        text: "{GROUP} עושים {MOVE} {DIR} לנצח"
         options:
           GROUP:
             sprites: כולם
@@ -50,7 +50,7 @@ he:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] עושה [MOVE][1] [DIR][2] לנצח"
+        text: "{SPRITE} עושה {MOVE} {DIR} לנצח"
         options:
           MOVE:
             '"next"': "(הבא)"
@@ -71,7 +71,7 @@ he:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: שנה [PROPERTY][1] של [SPRITE][0] ב [VAL][2]
+        text: שנה {PROPERTY} של {SPRITE} ב {VAL}
         options:
           PROPERTY:
             '"scale"': גודל
@@ -81,7 +81,7 @@ he:
             '"x"': מיקום אופקי
             '"y"': מיקום אנכי
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] עושים [MOVE][1] [DIR][2] פעם אחת"
+        text: "{GROUP} עושים {MOVE} {DIR} פעם אחת"
         options:
           GROUP:
             sprites: כולם
@@ -125,7 +125,7 @@ he:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] עושה [MOVE][1] [DIR][2] פעם אחת"
+        text: "{SPRITE} עושה {MOVE} {DIR} פעם אחת"
         options:
           MOVE:
             '"rand"': "(רנדומלי)"
@@ -156,32 +156,32 @@ he:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'כל [N][0] [UNIT][1] '
+        text: 'כל {N} {UNIT} '
         options:
           UNIT:
             '"measures"': תיבות
             '"seconds"': שניות
       Dancelab_everySecondsRange:
-        text: 'כל [N][0] [UNIT][1] מ-[START][2] ועד [STOP][3] '
+        text: 'כל {N} {UNIT} מ-{START} ועד {STOP} '
         options:
           UNIT:
             measures: תיבות
             seconds: שניות
       Dancelab_everyVerseChorus:
-        text: 'כל [UNIT][0] '
+        text: 'כל {UNIT} '
         options:
           UNIT:
             '"verse"': בית
             '"chorus"': פזמון
       Dancelab_getEnergy:
-        text: קבל [RANGE][0]
+        text: קבל {RANGE}
         options:
           RANGE:
             '"low"': באס
             '"mid"': אמצע
             '"high"': טְרֶבֶּל
       Dancelab_getProp:
-        text: "[PROPERTY][1] של [SPRITE][0]"
+        text: "{PROPERTY} של {SPRITE}"
         options:
           PROPERTY:
             '"scale"': גודל
@@ -192,15 +192,15 @@ he:
             '"y"': מיקום אנכי
             '"tint"': גוון
       Dancelab_getTime:
-        text: זמן נוכחי ב [UNIT][0]
+        text: זמן נוכחי ב {UNIT}
         options:
           UNIT:
             '"measures"': תיבות
             '"seconds"': שניות
       Dancelab_ifDanceIs:
         text: |-
-          אם [SPRITE][0] עושה [DANCE][1]
-          [DO1][2] [DO2][3]
+          אם {SPRITE} עושה {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: קלאפ היי
@@ -216,8 +216,8 @@ he:
             MOVES.Rest: כלום
       Dancelab_ifTime:
         text: |-
-          אם [UNIT][0] הוא [OP][1] [N][2]
-          [DO1][3] [DO2][4]
+          אם {UNIT} הוא {OP} {N}
+          {DO1} {DO2}
         options:
           UNIT:
             '"measures"': תיבות
@@ -227,7 +227,7 @@ he:
             '"<"': "\\<"
             '"="': "="
       Dancelab_jumpTo:
-        text: "[SPRITE][0] קפוץ למיקום [LOCATION][1]"
+        text: "{SPRITE} קפוץ למיקום {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": עליון
@@ -241,7 +241,7 @@ he:
             "{x: 300, y: 300}": למטה מימין
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": אקראי
       Dancelab_layoutSprites:
-        text: סידור [GROUP][0] כ [FORMAT][1]
+        text: סידור {GROUP} כ {FORMAT}
         options:
           GROUP:
             sprites: כולם
@@ -268,8 +268,8 @@ he:
             '"random"': אקראי
       Dancelab_makeNewDanceSprite:
         text: |-
-          צור [COSTUME][0] חדש
-          בשם [NAME][1] ב [LOCATION][2]
+          צור {COSTUME} חדש
+          בשם {NAME} ב {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': חייזר
@@ -296,8 +296,8 @@ he:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": אקראי
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          צור [N][0] [COSTUME][1] חדשים
-          ב [LAYOUT][2]
+          צור {N} {COSTUME} חדשים
+          ב {LAYOUT}
         options:
           N:
             '2': '2'
@@ -342,9 +342,9 @@ he:
             '"plus"': פלוס
             '"random"': אקראי
       Dancelab_mixColors:
-        text: ערבב [COLOR1][0] עם [COLOR2][1]
+        text: ערבב {COLOR1} עם {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] תיבות"
+        text: "{N} תיבות"
       Dancelab_onPointerDown:
         text: כאשר הלחצן יורד
       Dancelab_onPointerDrag:
@@ -354,9 +354,9 @@ he:
       Dancelab_randomColor:
         text: צבע אקראי
       Dancelab_setBackground:
-        text: קבע צבע רקע [COLOR][0]
+        text: קבע צבע רקע {COLOR}
       Dancelab_setBackgroundEffect:
-        text: קבעו אפקט רקע [EFFECT][0]
+        text: קבעו אפקט רקע {EFFECT}
         options:
           EFFECT:
             '"none"': כלום
@@ -382,7 +382,7 @@ he:
             '"spiral"': ספירלה
             '"disco"': ריבועים
       Dancelab_setDanceSpeed:
-        text: קבע [SPRITE][0] מהירות ריקוד ל [SPEED][1]
+        text: קבע {SPRITE} מהירות ריקוד ל {SPEED}
         options:
           SPEED:
             '1': רגיל
@@ -391,7 +391,7 @@ he:
             '0.5': איטי
             '0.25': מאוד איטי
       Dancelab_setDanceSpeedEach:
-        text: קבע [GROUP][0] מהירות ריקוד ל [SPEED][1]
+        text: קבע {GROUP} מהירות ריקוד ל {SPEED}
         options:
           GROUP:
             sprites: כולם
@@ -413,7 +413,7 @@ he:
             '0.5': איטי
             '0.25': מאוד איטי
       Dancelab_setForegroundEffect:
-        text: קבע אפקט חזית [EFFECT][0]
+        text: קבע אפקט חזית {EFFECT}
         options:
           EFFECT:
             '"none"': כלום
@@ -423,7 +423,7 @@ he:
             '"spotlight"': זרקור
             '"raining_tacos"': טָאקוֹ
       Dancelab_setForegroundEffectExtended:
-        text: קבע אפקט חזית [EFFECT][0]
+        text: קבע אפקט חזית {EFFECT}
         options:
           EFFECT:
             '"none"': כלום
@@ -434,7 +434,7 @@ he:
             '"spotlight"': זרקור
             '"raining_tacos"': טָאקוֹ
       Dancelab_setProp:
-        text: 'קבע [PROPERTY][1] של [SPRITE][0] ל [VAL][2] '
+        text: 'קבע {PROPERTY} של {SPRITE} ל {VAL} '
         options:
           PROPERTY:
             '"scale"': גודל
@@ -445,7 +445,7 @@ he:
             '"y"': מיקום אנכי
             '"tint"': גוון
       Dancelab_setPropEach:
-        text: קבע [PROPERTY][1] של [GROUP][0] ל [VAL][2]
+        text: קבע {PROPERTY} של {GROUP} ל {VAL}
         options:
           GROUP:
             sprites: כולם
@@ -469,7 +469,7 @@ he:
             '"y"': מיקום אנכי
             '"tint"': גוון
       Dancelab_setPropRandom:
-        text: קבע באקראי את [PROPERTY][1] של [SPRITE][0]
+        text: קבע באקראי את {PROPERTY} של {SPRITE}
         options:
           PROPERTY:
             '"scale"': גודל
@@ -480,9 +480,9 @@ he:
             '"y"': מיקום אנכי
             '"tint"': גוון
       Dancelab_setTint:
-        text: קבע גוון של [SPRITE][0] ל [VAL][1]
+        text: קבע גוון של {SPRITE} ל {VAL}
       Dancelab_setTintEach:
-        text: קבע גוון של [THIS][0] ל [VAL][1]
+        text: קבע גוון של {THIS} ל {VAL}
         options:
           THIS:
             sprites: כולם
@@ -497,15 +497,15 @@ he:
             '"ROBOT"': כל הרובוטים
             '"SHARK"': כל הכרישים
       Dancelab_setTintInline:
-        text: קבע גוון של [SPRITE][0] ל [VAL][1]
+        text: קבע גוון של {SPRITE} ל {VAL}
       Dancelab_setVisible:
-        text: קבע את הנראות של [SPRITE][0] ל [VISIBILITY][1]
+        text: קבע את הנראות של {SPRITE} ל {VISIBILITY}
         options:
           VISIBILITY:
             'true': נראה
             'false': בלתי נראה
       Dancelab_setVisibleEach:
-        text: שנה את הנראות של [THIS][0] ל [VISIBILITY][1]
+        text: שנה את הנראות של {THIS} ל {VISIBILITY}
         options:
           THIS:
             sprites: כולם
@@ -524,7 +524,7 @@ he:
             'true': נראה
             'false': בלתי נראה
       Dancelab_startMapping:
-        text: "[PROPERTY][1] של [SPRITE][0] מתחיל לעקוב אחרי [RANGE][2]"
+        text: "{PROPERTY} של {SPRITE} מתחיל לעקוב אחרי {RANGE}"
         options:
           PROPERTY:
             '"scale"': גודל
@@ -539,7 +539,7 @@ he:
             '"mid"': אמצע
             '"treble"': טְרֶבֶּל
       Dancelab_stopMapping:
-        text: "[PROPERTY][1] של [SPRITE][0] מפסיק לעקוב אחרי [RANGE][2]"
+        text: "{PROPERTY} של {SPRITE} מפסיק לעקוב אחרי {RANGE}"
         options:
           PROPERTY:
             '"scale"': גודל
@@ -555,7 +555,7 @@ he:
             '"mid"': אמצע
             '"treble"': טְרֶבֶּל
       Dancelab_whenKey:
-        text: כשמקש [KEY][0] לחוץ
+        text: כשמקש {KEY} לחוץ
         options:
           KEY:
             '"up"': למעלה
@@ -588,7 +588,7 @@ he:
             '"z"': z
             '"0"': '0'
       Dancelab_whenPeak:
-        text: כאשר [RANGE][0] מגיע לשיא
+        text: כאשר {RANGE} מגיע לשיא
         options:
           RANGE:
             '0': באס
@@ -597,21 +597,21 @@ he:
       Dancelab_whenSetup:
         text: הגדרה
       gamelab_beginBehavior:
-        text: התחל [BEHAVIOR][0]
+        text: התחל {BEHAVIOR}
       gamelab_changeColor:
-        text: שנה [COLOR][0] [METHOD][1] ב [AMOUNT][2]
+        text: שנה {COLOR} {METHOD} ב {AMOUNT}
         options:
           METHOD:
             '"tint"': גוון
       gamelab_changeColorBy:
-        text: שנה [COLOR][0] [METHOD][1] ב [AMOUNT][2]
+        text: שנה {COLOR} {METHOD} ב {AMOUNT}
         options:
           METHOD:
             '"hue"': גוון
             '"saturation"': רוויה
             '"brightness"': בהירות
       gamelab_changePropBy:
-        text: שנה [PROPERTY][1] של [SPRITE][0] ב [VAL][2]
+        text: שנה {PROPERTY} של {SPRITE} ב {VAL}
         options:
           PROPERTY:
             '"scale"': גודל
@@ -620,20 +620,20 @@ he:
             '"y"': מיקום בציר y
             '"direction"': כיוון תנועה
       gamelab_clickedOn:
-        text: כאשר [SPRITE][0] נלחץ
+        text: כאשר {SPRITE} נלחץ
       gamelab_comment:
-        text: 'הערה: [COMMENT][0]'
+        text: 'הערה: {COMMENT}'
       gamelab_console.log:
-        text: הודעת לוג [MESSAGE][0]
+        text: הודעת לוג {MESSAGE}
       gamelab_debugSprite:
         options:
           VAL:
             'true': נכון
             'false': שגוי
       gamelab_destroy:
-        text: הסר את [THIS][0]
+        text: הסר את {THIS}
       gamelab_distance:
-        text: מרחק מנקודה [LOCATION1][0] לנקודה [LOCATION2][1]
+        text: מרחק מנקודה {LOCATION1} לנקודה {LOCATION2}
       gamelab_enableDebug:
         text: הדלק דיבוג
       gamelab_getAnim:
@@ -641,7 +641,7 @@ he:
           COSTUME:
             '"costume"': תחפושת
       gamelab_getProp:
-        text: "[PROPERTY][1] של [SPRITE][0]"
+        text: "{PROPERTY} של {SPRITE}"
         options:
           PROPERTY:
             '"scale"': גודל
@@ -653,16 +653,16 @@ he:
       gamelab_hideTitleScreen:
         text: הסתר כותרת מסך
       gamelab_jumpTo:
-        text: "[SPRITE][0] קפוץ למיקום [LOCATION][1]"
+        text: "{SPRITE} קפוץ למיקום {LOCATION}"
       gamelab_keyDown:
-        text: כפתור [KEY][0] לחוץ
+        text: כפתור {KEY} לחוץ
       gamelab_locationAdd:
         options:
           OPERATOR:
             "'plus'": "\\+"
             "'minus'": "\\-"
       gamelab_locationConstant:
-        text: "[DIR][0]"
+        text: "{DIR}"
         options:
           DIR:
             "'north'": צפון
@@ -684,17 +684,17 @@ he:
       gamelab_locationNorth:
         text: צפון
       gamelab_locationOf:
-        text: מיקום [SPRITE][0]
+        text: מיקום {SPRITE}
       gamelab_locationSouth:
         text: דרום
       gamelab_locationWest:
         text: מערב
       gamelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       gamelab_location_variable_get:
-        text: מיקום [VAR][0]
+        text: מיקום {VAR}
       gamelab_location_variable_set:
-        text: שנה מיקום של [VAR][0] ל-[VAL][1]
+        text: שנה מיקום של {VAR} ל-{VAL}
       gamelab_makeNewGroup:
         text: צור קבוצה חדשה
       gamelab_mirrorSprite:
@@ -703,7 +703,7 @@ he:
             '"right"': ימינה
             '"left"': שמאלה
       gamelab_mixColors:
-        text: ערבב [COLOR1][0] עם [COLOR2][1]
+        text: ערבב {COLOR1} עם {COLOR2}
       gamelab_mouseLocation:
         text: מיקום עכבר
       gamelab_randColor:
@@ -711,9 +711,9 @@ he:
       gamelab_randomColor:
         text: צבע אקראי
       gamelab_setBackground:
-        text: קבע צבע רקע [COLOR][0]
+        text: קבע צבע רקע {COLOR}
       gamelab_setPosition:
-        text: העבר את [THIS][0] לעמדה [POSITION][1]
+        text: העבר את {THIS} לעמדה {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": למעלה משמאל
@@ -742,13 +742,13 @@ he:
             '"width"': רוחב
             '"height"': גובה
       gamelab_setTint:
-        text: שנה צבע של [THIS][0] ל-[COLOR][1]
+        text: שנה צבע של {THIS} ל-{COLOR}
       gamelab_setup:
         text: הגדרה
       gamelab_spriteCostume:
-        text: "[COSTUME][0]"
+        text: "{COSTUME}"
       gamelab_spriteDirection:
-        text: "[DIRECTION][0]"
+        text: "{DIRECTION}"
       gamelab_spritesWhere:
         options:
           PROPERTY:
@@ -779,7 +779,7 @@ he:
             '"right"': ימינה
             '"left"': שמאלה
       gamelab_whenKey:
-        text: כשמקש [KEY][0] לחוץ
+        text: כשמקש {KEY} לחוץ
         options:
           KEY:
             '"up"': למעלה
@@ -904,8 +904,8 @@ he:
             '"all"': כולם
       Mikelab_ifDanceIs:
         text: |-
-          אם [SPRITE][0] עושה [DANCE][1]
-          [DO1][2] [DO2][3]
+          אם {SPRITE} עושה {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: קלאפ היי
@@ -920,7 +920,7 @@ he:
             MOVES.ThisOrThat: זה או ההוא
             MOVES.Rest: כלום
       Mikelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       Mikelab_randomColor:
         text: צבע אקראי
       Mikelab_setBG:
@@ -953,9 +953,9 @@ he:
             "{x: 100, y: 300}": למטה משמאל
             "{x: 300, y: 300}": למטה מימין
       Mikelab_whenClickedOn:
-        text: כאשר [SPRITE][0] נלחץ
+        text: כאשר {SPRITE} נלחץ
       Mikelab_whenKeyPressed:
-        text: כשמקש [KEY][0] לחוץ
+        text: כשמקש {KEY} לחוץ
         options:
           KEY:
             '"up"': חץ למעלה
@@ -991,7 +991,7 @@ he:
       RyanLab_turnRight:
         text: פנה ימינה
       Vector_log:
-        text: הודעת לוג [MESSAGE][0]
+        text: הודעת לוג {MESSAGE}
       Vector_positionCenter:
         text: באמצע
       Vector_vectorNorth:
@@ -1026,7 +1026,7 @@ he:
             '"left"': שמאלה
             '"right"': ימינה
       binary_whenKey:
-        text: כשמקש [KEY][0] לחוץ
+        text: כשמקש {KEY} לחוץ
         options:
           KEY:
             '"up"': למעלה
@@ -1040,8 +1040,8 @@ he:
             '"d"': d
       craft_ifPath:
         text: |-
-          אם יש נתיב [DIR][0]
-          [STATEMENT][1]
+          אם יש נתיב {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": קדימה
@@ -1049,8 +1049,8 @@ he:
             "'left'": שמאלה
       craft_ifStandingOn:
         text: |-
-          אם עומדים מעל [TYPE][0]
-          [STATEMENT][1]
+          אם עומדים מעל {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": שונית כחולה
@@ -1061,19 +1061,19 @@ he:
             "'seaLantern'": פנס ימי
       craft_ifStandingOnLimit:
         text: |-
-          אם עומדים מעל [TYPE][0]
-          [STATEMENT][1]
+          אם עומדים מעל {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": חול
             "'darkPrismarine'": פריזמרינה כהה
             "'seaLantern'": פנס ימי
       craft_log:
-        text: הודעת לוג [MESSAGE][0]
+        text: הודעת לוג {MESSAGE}
       craft_moveForward:
         text: זוז קדימה
       craft_placeBlock:
-        text: הנח [blockType][0]
+        text: הנח {blockType}
         options:
           blockType:
             '"strippedOak"': עץ אלון מקולף
@@ -1108,13 +1108,13 @@ he:
       craft_repeatUntilConduit:
         text: |-
           חזור עד שהמגדלור התת-ימי מושלם
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           חזור עד המטרה
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: צור [ENTITY][0]
+        text: צור {ENTITY}
         options:
           ENTITY:
             '"cod"': דג
@@ -1124,7 +1124,7 @@ he:
             '"squid"': דיונון
             '"tropicalFish"': דג טרופי
       craft_turn:
-        text: פנה [DIR][0]
+        text: פנה {DIR}
         options:
           DIR:
             right: ימינה

--- a/dashboard/config/locales/blocks.hu-HU.yml
+++ b/dashboard/config/locales/blocks.hu-HU.yml
@@ -3,20 +3,20 @@ hu:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: "[TIMESTAMP][0] [UNIT][1] után"
+        text: "{TIMESTAMP} {UNIT} után"
         options:
           UNIT:
             '"measures"': ütem
             '"seconds"': másodperc
       Dancelab_changeColorBy:
-        text: 'módosítás: [COLOR][0] [METHOD][1], ennyivel: [AMOUNT][2]'
+        text: 'módosítás: {COLOR} {METHOD}, ennyivel: {AMOUNT}'
         options:
           METHOD:
             '"hue"': színárnyalat
             '"saturation"': telítettség
             '"brightness"': fényerő
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] csináld [MOVE][1] [DIR][2] örökké"
+        text: "{GROUP} csináld {MOVE} {DIR} örökké"
         options:
           GROUP:
             sprites: összes
@@ -48,7 +48,7 @@ hu:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] csináld [MOVE][1] [DIR][2] örökké"
+        text: "{SPRITE} csináld {MOVE} {DIR} örökké"
         options:
           MOVE:
             '"next"': "(Következő)"
@@ -67,7 +67,7 @@ hu:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: 'módosítás: [SPRITE][0] [PROPERTY][1] ennyivel: [VAL][2]'
+        text: 'módosítás: {SPRITE} {PROPERTY} ennyivel: {VAL}'
         options:
           PROPERTY:
             '"scale"': méret
@@ -77,7 +77,7 @@ hu:
             '"x"': vízszintes helyzet
             '"y"': függőleges helyzet
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] csináld [MOVE][1] [DIR][2] egyszer"
+        text: "{GROUP} csináld {MOVE} {DIR} egyszer"
         options:
           GROUP:
             sprites: összes
@@ -107,7 +107,7 @@ hu:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] csináld [MOVE][1] [DIR][2] egyszer"
+        text: "{SPRITE} csináld {MOVE} {DIR} egyszer"
         options:
           MOVE:
             '"rand"': "(Véletlen)"
@@ -124,25 +124,25 @@ hu:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'minden [N][0] [UNIT][1] '
+        text: 'minden {N} {UNIT} '
         options:
           UNIT:
             '"measures"': ütem
             '"seconds"': másodperc
       Dancelab_everySecondsRange:
-        text: 'minden [N][0] [UNIT][1] ettől: [START][2], eddig: [STOP][3] '
+        text: 'minden {N} {UNIT} ettől: {START}, eddig: {STOP} '
         options:
           UNIT:
             measures: Ütem
             seconds: Másodperc
       Dancelab_everyVerseChorus:
-        text: 'minden [UNIT][0] '
+        text: 'minden {UNIT} '
         options:
           UNIT:
             '"verse"': verze
             '"chorus"': refrén
       Dancelab_getEnergy:
-        text: 'beolvasás: [RANGE][0]'
+        text: 'beolvasás: {RANGE}'
         options:
           RANGE:
             '"low"': basszus
@@ -159,15 +159,15 @@ hu:
             '"y"': függőleges helyzet
             '"tint"': árnyalat
       Dancelab_getTime:
-        text: "[UNIT][0] eltelt"
+        text: "{UNIT} eltelt"
         options:
           UNIT:
             '"measures"': ütem
             '"seconds"': másodperc
       Dancelab_ifDanceIs:
         text: |-
-          ha [SPRITE][0] csinálja [DANCE][1]
-          [DO1][2] [DO2][3]
+          ha {SPRITE} csinálja {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Taps fent
@@ -185,7 +185,7 @@ hu:
             '"measures"': ütem
             '"seconds"': másodperc
       Dancelab_jumpTo:
-        text: "[SPRITE][0] ugrás: [LOCATION][1]"
+        text: "{SPRITE} ugrás: {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": fent
@@ -199,7 +199,7 @@ hu:
             "{x: 300, y: 300}": jobbra lent
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": véletlen
       Dancelab_layoutSprites:
-        text: "[GROUP][0] elrendezése így: [FORMAT][1]"
+        text: "{GROUP} elrendezése így: {FORMAT}"
         options:
           GROUP:
             sprites: összes
@@ -226,8 +226,8 @@ hu:
             '"random"': véletlen
       Dancelab_makeNewDanceSprite:
         text: |-
-          új [COSTUME][0] készítése
-          [NAME][1] néven itt: [LOCATION][2]
+          új {COSTUME} készítése
+          {NAME} néven itt: {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Földönkívüli
@@ -253,8 +253,8 @@ hu:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": véletlen
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          készíts [N][0] új [COSTUME][1] elemet
-          [LAYOUT][2] elrendezésben
+          készíts {N} új {COSTUME} elemet
+          {LAYOUT} elrendezésben
         options:
           N:
             '2': '2'
@@ -299,9 +299,9 @@ hu:
             '"plus"': plusz
             '"random"': véletlen
       Dancelab_mixColors:
-        text: "[COLOR1][0] és [COLOR2][1] keverése"
+        text: "{COLOR1} és {COLOR2} keverése"
       Dancelab_nMeasures:
-        text: "[N][0] ütem"
+        text: "{N} ütem"
       Dancelab_onPointerDown:
         text: mutató lefelé mozgatásakor
       Dancelab_onPointerDrag:
@@ -311,9 +311,9 @@ hu:
       Dancelab_randomColor:
         text: Véletlen szín
       Dancelab_setBackground:
-        text: 'háttérszín beállítása: [COLOR][0]'
+        text: 'háttérszín beállítása: {COLOR}'
       Dancelab_setBackgroundEffect:
-        text: háttéreffekt beállítása [EFFECT][0]
+        text: háttéreffekt beállítása {EFFECT}
         options:
           EFFECT:
             '"none"': Egyik sem
@@ -335,7 +335,7 @@ hu:
             '"vintage"': Régi
             '"warm"': Vörösek
       Dancelab_setBackgroundEffectWithPalette:
-        text: háttéreffekt beállítása [EFFECT][0] [PALETTE][1]
+        text: háttéreffekt beállítása {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Egyik sem
@@ -359,7 +359,7 @@ hu:
             '"vintage"': Régi
             '"warm"': Vörösek
       Dancelab_setDanceSpeed:
-        text: "[SPRITE][0] táncolási sebességének módosítása: [SPEED][1]"
+        text: "{SPRITE} táncolási sebességének módosítása: {SPEED}"
         options:
           SPEED:
             '1': normál
@@ -389,7 +389,7 @@ hu:
             '0.5': lassú
             '0.25': nagyon lassú
       Dancelab_setForegroundEffect:
-        text: 'előtéreffekt beállítása: [EFFECT][0]'
+        text: 'előtéreffekt beállítása: {EFFECT}'
         options:
           EFFECT:
             '"none"': Egyik sem
@@ -402,7 +402,7 @@ hu:
             '"floating_rainbows"': Szivárvány
             '"raining_tacos"': Taco
       Dancelab_setForegroundEffectExtended:
-        text: 'előtéreffekt beállítása: [EFFECT][0]'
+        text: 'előtéreffekt beállítása: {EFFECT}'
         options:
           EFFECT:
             '"none"': Egyik sem
@@ -416,7 +416,7 @@ hu:
             '"floating_rainbows"': Szivárvány
             '"raining_tacos"': Taco
       Dancelab_setProp:
-        text: "[SPRITE][0] [PROPERTY][1] tulajdonságának beállítása: [VAL][2] "
+        text: "{SPRITE} {PROPERTY} tulajdonságának beállítása: {VAL} "
         options:
           PROPERTY:
             '"scale"': méret
@@ -427,7 +427,7 @@ hu:
             '"y"': függőleges helyzet
             '"tint"': árnyalat
       Dancelab_setPropEach:
-        text: "[GROUP][0] [PROPERTY][1] tulajdonságának beállítása: [VAL][2]"
+        text: "{GROUP} {PROPERTY} tulajdonságának beállítása: {VAL}"
         options:
           GROUP:
             sprites: összes
@@ -451,7 +451,7 @@ hu:
             '"y"': függőleges helyzet
             '"tint"': árnyalat
       Dancelab_setPropRandom:
-        text: "[SPRITE][0] [PROPERTY][1] legyen véletlenszerű"
+        text: "{SPRITE} {PROPERTY} legyen véletlenszerű"
         options:
           PROPERTY:
             '"scale"': méret
@@ -462,7 +462,7 @@ hu:
             '"y"': függőleges helyzet
             '"tint"': árnyalat
       Dancelab_setTint:
-        text: "[SPRITE][0] árnyalatának beállítása: [VAL][1]"
+        text: "{SPRITE} árnyalatának beállítása: {VAL}"
       Dancelab_setTintEach:
         options:
           THIS:
@@ -478,15 +478,15 @@ hu:
             '"ROBOT"': összes robot
             '"SHARK"': összes cápa
       Dancelab_setTintInline:
-        text: "[SPRITE][0] árnyalatának beállítása: [VAL][1]"
+        text: "{SPRITE} árnyalatának beállítása: {VAL}"
       Dancelab_setVisible:
-        text: "[SPRITE][0] beállítása láthatónak: [VISIBILITY][1]"
+        text: "{SPRITE} beállítása láthatónak: {VISIBILITY}"
         options:
           VISIBILITY:
             'true': látható
             'false': láthatatlan
       Dancelab_setVisibleEach:
-        text: "[THIS][0] láthatóságának beállítása: [VISIBILITY][1]"
+        text: "{THIS} láthatóságának beállítása: {VISIBILITY}"
         options:
           THIS:
             sprites: összes
@@ -505,7 +505,7 @@ hu:
             'true': látható
             'false': láthatatlan
       Dancelab_startMapping:
-        text: "[SPRITE][0] [PROPERTY][1] tulajdonságot kezdi [RANGE][2] után"
+        text: "{SPRITE} {PROPERTY} tulajdonságot kezdi {RANGE} után"
         options:
           PROPERTY:
             '"scale"': méret
@@ -520,7 +520,7 @@ hu:
             '"mid"': közepes
             '"treble"': magas
       Dancelab_stopMapping:
-        text: "[SPRITE][0] [PROPERTY][1] tulajdonságot befejezi [RANGE][2] után"
+        text: "{SPRITE} {PROPERTY} tulajdonságot befejezi {RANGE} után"
         options:
           PROPERTY:
             '"scale"': méret
@@ -536,7 +536,7 @@ hu:
             '"mid"': közepes
             '"treble"': magas
       Dancelab_whenKey:
-        text: "[KEY][0] lenyomásakor"
+        text: "{KEY} lenyomásakor"
         options:
           KEY:
             '"up"': fel
@@ -546,7 +546,7 @@ hu:
             '"space"': világűr
             '"x"': x
       Dancelab_whenPeak:
-        text: "[RANGE][0] csúcsértékekor"
+        text: "{RANGE} csúcsértékekor"
         options:
           RANGE:
             '0': basszus
@@ -555,19 +555,19 @@ hu:
       Dancelab_whenSetup:
         text: beállítás
       gamelab_changeColor:
-        text: 'módosítás: [COLOR][0] [METHOD][1], ennyivel: [AMOUNT][2]'
+        text: 'módosítás: {COLOR} {METHOD}, ennyivel: {AMOUNT}'
         options:
           METHOD:
             '"tint"': árnyalat
       gamelab_changeColorBy:
-        text: 'módosítás: [COLOR][0] [METHOD][1], ennyivel: [AMOUNT][2]'
+        text: 'módosítás: {COLOR} {METHOD}, ennyivel: {AMOUNT}'
         options:
           METHOD:
             '"hue"': színárnyalat
             '"saturation"': telítettség
             '"brightness"': fényerő
       gamelab_changePropBy:
-        text: 'módosítás: [SPRITE][0] [PROPERTY][1] ennyivel: [VAL][2]'
+        text: 'módosítás: {SPRITE} {PROPERTY} ennyivel: {VAL}'
         options:
           PROPERTY:
             '"scale"': méret
@@ -590,7 +590,7 @@ hu:
             '"direction"': mozgás iránya
             '"tint"': árnyalat
       gamelab_jumpTo:
-        text: "[SPRITE][0] ugrás: [LOCATION][1]"
+        text: "{SPRITE} ugrás: {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -601,15 +601,15 @@ hu:
             '"right"': jobbra
             '"left"': balra
       gamelab_mixColors:
-        text: "[COLOR1][0] és [COLOR2][1] keverése"
+        text: "{COLOR1} és {COLOR2} keverése"
       gamelab_randColor:
         text: Véletlen szín
       gamelab_randomColor:
         text: Véletlen szín
       gamelab_setBackground:
-        text: 'háttérszín beállítása: [COLOR][0]'
+        text: 'háttérszín beállítása: {COLOR}'
       gamelab_setPosition:
-        text: "[THIS][0] mozgatása [POSITION][1] pozícióba"
+        text: "{THIS} mozgatása {POSITION} pozícióba"
         options:
           POSITION:
             "{x: 50, y: 50}": balra fent
@@ -662,7 +662,7 @@ hu:
             '"right"': jobbra
             '"left"': balra
       gamelab_whenKey:
-        text: "[KEY][0] lenyomásakor"
+        text: "{KEY} lenyomásakor"
         options:
           KEY:
             '"up"': fel
@@ -779,8 +779,8 @@ hu:
             '"all"': összes
       Mikelab_ifDanceIs:
         text: |-
-          ha [SPRITE][0] csinálja [DANCE][1]
-          [DO1][2] [DO2][3]
+          ha {SPRITE} csinálja {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Taps fent
@@ -824,7 +824,7 @@ hu:
             "{x: 100, y: 300}": balra lent
             "{x: 300, y: 300}": jobbra lent
       Mikelab_whenKeyPressed:
-        text: "[KEY][0] lenyomásakor"
+        text: "{KEY} lenyomásakor"
         options:
           KEY:
             '"up"': felfelé nyíl
@@ -885,7 +885,7 @@ hu:
             '"left"': balra
             '"right"': jobbra
       binary_whenKey:
-        text: "[KEY][0] lenyomásakor"
+        text: "{KEY} lenyomásakor"
         options:
           KEY:
             '"up"': fel

--- a/dashboard/config/locales/blocks.id-ID.yml
+++ b/dashboard/config/locales/blocks.id-ID.yml
@@ -3,19 +3,19 @@ id:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: setelah [TIMESTAMP][0][UNIT][1]
+        text: setelah {TIMESTAMP}{UNIT}
         options:
           UNIT:
             '"seconds"': detik
       Dancelab_changeColorBy:
-        text: ubah [COLOR][0][METHOD][1] dengan [AMOUNT][2]
+        text: ubah {COLOR}{METHOD} dengan {AMOUNT}
         options:
           METHOD:
             '"hue"': Corak warna warni
             '"saturation"': Saturasi
             '"brightness"': Kecerahan
       Dancelab_changeMoveEachLR:
-        text: lakukan [GROUP][0] [MOVE][1] [DIR][2] selamanya
+        text: lakukan {GROUP} {MOVE} {DIR} selamanya
         options:
           GROUP:
             sprites: semua
@@ -330,14 +330,14 @@ id:
             '1': Sedang
             '2': Besar
       gamelab_changeColor:
-        text: ubah [COLOR][0][METHOD][1] dengan [AMOUNT][2]
+        text: ubah {COLOR}{METHOD} dengan {AMOUNT}
         options:
           METHOD:
             '"tint"': Mewarnai
             '"tone"': Nada
             '"shade"': Corak
       gamelab_changeColorBy:
-        text: ubah [COLOR][0][METHOD][1] dengan [AMOUNT][2]
+        text: ubah {COLOR}{METHOD} dengan {AMOUNT}
         options:
           METHOD:
             '"hue"': Corak warna warni

--- a/dashboard/config/locales/blocks.is-IS.yml
+++ b/dashboard/config/locales/blocks.is-IS.yml
@@ -3,7 +3,7 @@ is:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: eftir [TIMESTAMP][0] [UNIT][1]
+        text: eftir {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': taktar
@@ -272,7 +272,7 @@ is:
             '"default"': Ljós
             '"neon"': Neon
       Dancelab_setBackgroundEffectWithPalette:
-        text: stilla bakgrunn [EFFECT][0] [PALETTE][1]
+        text: stilla bakgrunn {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Ekkert
@@ -357,7 +357,7 @@ is:
             '"smile_face"': Bros
             '"color_lights"': Sviðsljós
       Dancelab_setProp:
-        text: 'stilla [SPRITE][0] [PROPERTY][1] í [VAL][2] '
+        text: 'stilla {SPRITE} {PROPERTY} í {VAL} '
         options:
           PROPERTY:
             '"scale"': stærð
@@ -461,7 +461,7 @@ is:
             '"mid"': miðja
             '"treble"': hátíðni
       Dancelab_whenKey:
-        text: þegar ýtt er á [KEY][0]
+        text: þegar ýtt er á {KEY}
         options:
           KEY:
             '"up"': uppi
@@ -556,7 +556,7 @@ is:
             '"right"': hægri
             '"left"': vinstri
       gamelab_whenKey:
-        text: þegar ýtt er á [KEY][0]
+        text: þegar ýtt er á {KEY}
         options:
           KEY:
             '"up"': uppi
@@ -685,7 +685,7 @@ is:
             "{x: 100, y: 200}": vinstri
             "{x: 300, y: 200}": hægri
       Mikelab_whenKeyPressed:
-        text: þegar ýtt er á [KEY][0]
+        text: þegar ýtt er á {KEY}
         options:
           KEY:
             '"up"': upp ör
@@ -738,7 +738,7 @@ is:
             '"left"': vinstri
             '"right"': hægri
       binary_whenKey:
-        text: þegar ýtt er á [KEY][0]
+        text: þegar ýtt er á {KEY}
         options:
           KEY:
             '"up"': uppi

--- a/dashboard/config/locales/blocks.it-IT.yml
+++ b/dashboard/config/locales/blocks.it-IT.yml
@@ -3,20 +3,20 @@ it:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: dopo [TIMESTAMP][0] [UNIT][1]
+        text: dopo {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': battute
             '"seconds"': secondi
       Dancelab_changeColorBy:
-        text: modifica [COLOR][0] [METHOD][1] di [AMOUNT][2]
+        text: modifica {COLOR} {METHOD} di {AMOUNT}
         options:
           METHOD:
             '"hue"': tonalità
             '"saturation"': saturazione
             '"brightness"': luminosità
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] eseguono ininterrottamente la mossa [MOVE][1] [DIR][2]"
+        text: "{GROUP} eseguono ininterrottamente la mossa {MOVE} {DIR}"
         options:
           GROUP:
             sprites: tutto
@@ -51,7 +51,7 @@ it:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] esegue ininterrottamente la mossa [MOVE][1] [DIR][2]"
+        text: "{SPRITE} esegue ininterrottamente la mossa {MOVE} {DIR}"
         options:
           MOVE:
             '"next"': "(Successiva)"
@@ -73,7 +73,7 @@ it:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: modifica la [PROPERTY][1] di [SPRITE][0] di [VAL][2]
+        text: modifica la {PROPERTY} di {SPRITE} di {VAL}
         options:
           PROPERTY:
             '"scale"': dimensione
@@ -83,7 +83,7 @@ it:
             '"x"': posizione orizzontale
             '"y"': posizione verticale
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] eseguono la mossa [MOVE][1] [DIR][2] una volta"
+        text: "{GROUP} eseguono la mossa {MOVE} {DIR} una volta"
         options:
           GROUP:
             sprites: tutti
@@ -128,7 +128,7 @@ it:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] esegue la mossa [MOVE][1] [DIR][2] una volta"
+        text: "{SPRITE} esegue la mossa {MOVE} {DIR} una volta"
         options:
           MOVE:
             '"rand"': "(Casuale)"
@@ -160,32 +160,32 @@ it:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'ogni [N][0] [UNIT][1] '
+        text: 'ogni {N} {UNIT} '
         options:
           UNIT:
             '"measures"': battute
             '"seconds"': secondi
       Dancelab_everySecondsRange:
-        text: 'ogni [N][0] [UNIT][1] da [START][2] fino a [STOP][3] '
+        text: 'ogni {N} {UNIT} da {START} fino a {STOP} '
         options:
           UNIT:
             measures: Battute
             seconds: Secondi
       Dancelab_everyVerseChorus:
-        text: 'ogni [unità][0] '
+        text: 'ogni {UNIT} '
         options:
           UNIT:
             '"verse"': strofa
             '"chorus"': ritornello
       Dancelab_getEnergy:
-        text: ottieni i [RANGE][0]
+        text: ottieni i {RANGE}
         options:
           RANGE:
             '"low"': toni bassi
             '"mid"': toni medi
             '"high"': toni acuti
       Dancelab_getProp:
-        text: "[PROPERTY][1] [SPRITE][0]"
+        text: "{PROPERTY} {SPRITE}"
         options:
           PROPERTY:
             '"scale"': dimensione
@@ -196,15 +196,15 @@ it:
             '"y"': posizione verticale
             '"tint"': tonalità
       Dancelab_getTime:
-        text: "[UNIT][0] trascorse/i"
+        text: "{UNIT} trascorse/i"
         options:
           UNIT:
             '"measures"': battute
             '"seconds"': secondi
       Dancelab_ifDanceIs:
         text: |-
-          se [SPRITE][0] sta eseguendo la mossa [DANCE][1]
-          [DO1][2] [DO2][3]
+          se {SPRITE} sta eseguendo la mossa {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Applauso alto
@@ -221,8 +221,8 @@ it:
             MOVES.Rest: Nessuno
       Dancelab_ifTime:
         text: |-
-          se [UNIT][0] è [OP][1] [N][2]
-          [DO1][3] [DO2][4]
+          se {UNIT} è {OP} {N}
+          {DO1} {DO2}
         options:
           UNIT:
             '"measures"': battute
@@ -232,7 +232,7 @@ it:
             '"<"': "\\<"
             '"="': "="
       Dancelab_jumpTo:
-        text: "[SPRITE][0] salta [LOCATION][1]"
+        text: "{SPRITE} salta {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": in alto
@@ -246,7 +246,7 @@ it:
             "{x: 300, y: 300}": in basso a destra
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": in un punto casuale
       Dancelab_layoutSprites:
-        text: disponi [GROUP][0] in [FORMAT][1]
+        text: disponi {GROUP} in {FORMAT}
         options:
           GROUP:
             sprites: tutto
@@ -272,8 +272,8 @@ it:
             '"random"': a caso
       Dancelab_makeNewDanceSprite:
         text: |-
-          crea un nuovo [COSTUME][0]
-          chiamato [NAME][1][LOCATION][2]
+          crea un nuovo {COSTUME}
+          chiamato {NAME}{LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Alieno
@@ -300,8 +300,8 @@ it:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": in un punto casuale
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          Disponi [N][0] nuovi [COSTUME][1]
-          in [LAYOUT][2]
+          Disponi {N} nuovi {COSTUME}
+          in {LAYOUT}
         options:
           N:
             '2': '2'
@@ -345,9 +345,9 @@ it:
             '"plus"': più
             '"random"': a caso
       Dancelab_mixColors:
-        text: mescola [COLOR1][0] e [COLOR2][1]
+        text: mescola {COLOR1} e {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] battute"
+        text: "{N} battute"
       Dancelab_onPointerDown:
         text: col puntatore in basso
       Dancelab_onPointerDrag:
@@ -357,9 +357,9 @@ it:
       Dancelab_randomColor:
         text: colore scelto a caso
       Dancelab_setBackground:
-        text: imposta il colore dello sfondo [COLOR][0]
+        text: imposta il colore dello sfondo {COLOR}
       Dancelab_setBackgroundEffect:
-        text: imposta sfondo con effetto [EFFECT][0]
+        text: imposta sfondo con effetto {EFFECT}
         options:
           EFFECT:
             '"none"': Nessuno
@@ -390,7 +390,7 @@ it:
             '"vintage"': Vintage
             '"warm"': Rossi
       Dancelab_setBackgroundEffectWithPalette:
-        text: imposta effetto di sfondo [EFFECT][0] [PALETTE][1]
+        text: imposta effetto di sfondo {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Nessuno
@@ -422,7 +422,7 @@ it:
             '"vintage"': Vintage
             '"warm"': Rossi
       Dancelab_setDanceSpeed:
-        text: imposta la velocità di ballo del [SPRITE][0] a [SPEED][1]
+        text: imposta la velocità di ballo del {SPRITE} a {SPEED}
         options:
           SPEED:
             '1': normale
@@ -431,7 +431,7 @@ it:
             '0.5': lenta
             '0.25': molto lenta
       Dancelab_setDanceSpeedEach:
-        text: imposta [GROUP][0] a velocità di ballo [SPEED][1]
+        text: imposta {GROUP} a velocità di ballo {SPEED}
         options:
           GROUP:
             sprites: tutto
@@ -453,7 +453,7 @@ it:
             '0.5': lenta
             '0.25': molto lenta
       Dancelab_setForegroundEffect:
-        text: imposta effetto di primo piano [EFFECT][0]
+        text: imposta effetto di primo piano {EFFECT}
         options:
           EFFECT:
             '"none"': Nessuno
@@ -471,7 +471,7 @@ it:
             '"color_lights"': Luci del palco
             '"raining_tacos"': Tacos
       Dancelab_setForegroundEffectExtended:
-        text: imposta effetto di primo piano [EFFECT][0]
+        text: imposta effetto di primo piano {EFFECT}
         options:
           EFFECT:
             '"none"': Nessuno
@@ -490,7 +490,7 @@ it:
             '"color_lights"': Luci del palco
             '"raining_tacos"': Tacos
       Dancelab_setProp:
-        text: 'imposta la [PROPERTY][1] di [SPRITE][0] a [VAL][2] '
+        text: 'imposta la {PROPERTY} di {SPRITE} a {VAL} '
         options:
           PROPERTY:
             '"scale"': dimensione
@@ -501,7 +501,7 @@ it:
             '"y"': posizione verticale
             '"tint"': tonalità
       Dancelab_setPropEach:
-        text: imposta la [PROPERTY][1] di [GROUP][0] a [VAL][2]
+        text: imposta la {PROPERTY} di {GROUP} a {VAL}
         options:
           GROUP:
             sprites: tutto
@@ -525,7 +525,7 @@ it:
             '"y"': posizione verticale
             '"tint"': tonalità
       Dancelab_setPropRandom:
-        text: modifica a caso la [PROPERTY][1] di [SPRITE][0]
+        text: modifica a caso la {PROPERTY} di {SPRITE}
         options:
           PROPERTY:
             '"scale"': dimensione
@@ -536,7 +536,7 @@ it:
             '"y"': posizione verticale
             '"tint"': tonalità
       Dancelab_setTint:
-        text: imposta la tonalità di [SPRITE][0] a [VAL][1]
+        text: imposta la tonalità di {SPRITE} a {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -552,15 +552,15 @@ it:
             '"ROBOT"': tutti i robot
             '"SHARK"': tutti gli squali
       Dancelab_setTintInline:
-        text: imposta la tonalità di [SPRITE][0] a [VAL][1]
+        text: imposta la tonalità di {SPRITE} a {VAL}
       Dancelab_setVisible:
-        text: imposta visibilità [SPRITE][0] su [VISIBILITY][1]
+        text: imposta visibilità {SPRITE} su {VISIBILITY}
         options:
           VISIBILITY:
             'true': visibile
             'false': invisibile
       Dancelab_setVisibleEach:
-        text: imposta visibilità [THIS][0] su [VISIBILITY][1]
+        text: imposta visibilità {THIS} su {VISIBILITY}
         options:
           THIS:
             sprites: tutto
@@ -579,7 +579,7 @@ it:
             'true': visibile
             'false': invisibile
       Dancelab_startMapping:
-        text: "[SPRITE][0] modifica la [PROPERTY][1] seguendo i [RANGE][2]"
+        text: "{SPRITE} modifica la {PROPERTY} seguendo i {RANGE}"
         options:
           PROPERTY:
             '"scale"': dimensione
@@ -594,7 +594,7 @@ it:
             '"mid"': toni medi
             '"treble"': toni acuti
       Dancelab_stopMapping:
-        text: "[SPRITE][0] smette di modificare la [PROPERTY][1] seguendo i [RANGE][2]"
+        text: "{SPRITE} smette di modificare la {PROPERTY} seguendo i {RANGE}"
         options:
           PROPERTY:
             '"scale"': dimensione
@@ -610,7 +610,7 @@ it:
             '"mid"': toni medi
             '"treble"': toni acuti
       Dancelab_whenKey:
-        text: quando si preme [KEY][0]
+        text: quando si preme {KEY}
         options:
           KEY:
             '"up"': in alto
@@ -641,7 +641,7 @@ it:
             '"z"': z
             '"0"': '0'
       Dancelab_whenPeak:
-        text: quando i [RANGE][0] raggiungono il picco
+        text: quando i {RANGE} raggiungono il picco
         options:
           RANGE:
             '0': toni bassi
@@ -650,20 +650,20 @@ it:
       Dancelab_whenSetup:
         text: quando si clicca su "Esegui"
       gamelab_changeColor:
-        text: modifica [COLOR][0] [METHOD][1] di [AMOUNT][2]
+        text: modifica {COLOR} {METHOD} di {AMOUNT}
         options:
           METHOD:
             '"tint"': tonalità
             '"tone"': tonalità
       gamelab_changeColorBy:
-        text: modifica [COLOR][0] [METHOD][1] di [AMOUNT][2]
+        text: modifica {COLOR} {METHOD} di {AMOUNT}
         options:
           METHOD:
             '"hue"': tonalità
             '"saturation"': saturazione
             '"brightness"': luminosità
       gamelab_changePropBy:
-        text: modifica la [PROPERTY][1] di [SPRITE][0] di [VAL][2]
+        text: modifica la {PROPERTY} di {SPRITE} di {VAL}
         options:
           PROPERTY:
             '"scale"': dimensione
@@ -677,12 +677,12 @@ it:
             'true': vero
             'false': falso
       gamelab_getAnim:
-        text: "[SPRITE][0] [COSTUME][1]"
+        text: "{SPRITE} {COSTUME}"
         options:
           COSTUME:
             '"costume"': costume
       gamelab_getProp:
-        text: "[PROPERTY][1] [SPRITE][0]"
+        text: "{PROPERTY} {SPRITE}"
         options:
           PROPERTY:
             '"scale"': dimensione
@@ -692,32 +692,32 @@ it:
             '"direction"': direzione del movimento
             '"tint"': tonalità
       gamelab_isTouching:
-        text: "[THIS][0] sta toccando [TARGET][1]"
+        text: "{THIS} sta toccando {TARGET}"
       gamelab_jumpTo:
-        text: "[SPRITE][0] salta [LOCATION][1]"
+        text: "{SPRITE} salta {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
             "'random'": a caso
       gamelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       gamelab_mirrorSprite:
         options:
           DIRECTION:
             '"right"': a destra
             '"left"': a sinistra
       gamelab_mixColors:
-        text: mescola [COLOR1][0] e [COLOR2][1]
+        text: mescola {COLOR1} e {COLOR2}
       gamelab_moveInDirection2:
-        text: sposta [SPRITE][0] di [DISTANCE][1] pixel verso [DIRECTION][2]
+        text: sposta {SPRITE} di {DISTANCE} pixel verso {DIRECTION}
       gamelab_randColor:
         text: colore scelto a caso
       gamelab_randomColor:
         text: colore scelto a caso
       gamelab_setBackground:
-        text: imposta il colore dello sfondo [COLOR][0]
+        text: imposta il colore dello sfondo {COLOR}
       gamelab_setPosition:
-        text: sposta [THIS][0] [POSITION][1]
+        text: sposta {THIS} {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": in alto a sinistra
@@ -778,7 +778,7 @@ it:
             '"right"': a destra
             '"left"': a sinistra
       gamelab_whenKey:
-        text: quando si preme [KEY][0]
+        text: quando si preme {KEY}
         options:
           KEY:
             '"up"': in alto
@@ -798,9 +798,9 @@ it:
             "'left'": a sinistra
             "'right'": a destra
       gamelab_whenTouching:
-        text: quando [SPRITE1][0] tocca [SPRITE2][1]
+        text: quando {SPRITE1} tocca {SPRITE2}
       gamelab_whileKey:
-        text: quando [KEY][0] è premuto
+        text: quando {KEY} è premuto
         options:
           KEY:
             '"up"': in alto
@@ -813,7 +813,7 @@ it:
             '"s"': s
             '"d"': d
       gamelab_whileTouching:
-        text: quando [SPRITE1][0] sta toccando [SPRITE2][1]
+        text: quando {SPRITE1} sta toccando {SPRITE2}
       Mikelab_changePropBy:
         options:
           PROPERTY:
@@ -836,9 +836,9 @@ it:
             "{x: 300, y: 300}": in basso a destra
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": Casuale
       Mikelab_getAnim:
-        text: "[SPRITE][0] [COSTUME][1]"
+        text: "{SPRITE} [COSTUME][1]"
       Mikelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': dimensione
@@ -913,8 +913,8 @@ it:
             '"all"': tutto
       Mikelab_ifDanceIs:
         text: |-
-          se [SPRITE][0] sta eseguendo la mossa [DANCE][1]
-          [DO1][2] [DO2][3]
+          se {SPRITE} sta eseguendo la mossa {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Applauso alto
@@ -930,9 +930,9 @@ it:
             MOVES.Thriller: Zombie
             MOVES.Rest: Nessuno
       Mikelab_isAnim:
-        text: "[SPRITE][0] [COSTUME][1]"
+        text: "{SPRITE} {COSTUME}"
       Mikelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       Mikelab_randomColor:
         text: colore scelto a caso
       Mikelab_setBG:
@@ -966,7 +966,7 @@ it:
             "{x: 300, y: 300}": in basso a destra
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": Casuale
       Mikelab_whenKeyPressed:
-        text: quando si preme [KEY][0]
+        text: quando si preme {KEY}
         options:
           KEY:
             '"up"': si preme sulla freccia verso l'alto
@@ -1004,13 +1004,13 @@ it:
       Vector_positionCenter:
         text: al centro
       Vector_push:
-        text: imposta velocità [VECTOR][0]
+        text: imposta velocità {VECTOR}
       Vector_setColor:
-        text: imposta colore a [COLOR][0]
+        text: imposta colore a {COLOR}
       Vector_setSize:
-        text: imposta larghezza [WIDTH][0] altezza [HEIGHT][1]
+        text: imposta larghezza {WIDTH} altezza {HEIGHT}
       Vector_where:
-        text: per ogni personaggio dove [PROPERTY][0] è [VALUE][1] esegui [STATEMENT][2]
+        text: per ogni personaggio dove {PROPERTY} è {VALUE} esegui {STATEMENT}
         options:
           PROPERTY:
             "'shapeColor'": colore
@@ -1023,8 +1023,8 @@ it:
             '"y"': posizione y
             '"direction"': direzione del movimento
       aalab_createPropertyGroup:
-        text: crea un nuovo gruppo di personaggi chiamato [VAR][0] tutto composto
-          da [COSTUME][1]
+        text: crea un nuovo gruppo di personaggi chiamato {VAR} tutto composto da
+          {COSTUME}
       aalab_spritesWhere:
         options:
           PROPERTY:
@@ -1043,7 +1043,7 @@ it:
             '"left"': a sinistra
             '"right"': a destra
       binary_whenKey:
-        text: quando si preme [KEY][0]
+        text: quando si preme {KEY}
         options:
           KEY:
             '"up"': in alto
@@ -1057,8 +1057,8 @@ it:
             '"d"': d
       craft_ifPath:
         text: |-
-          se c'è strada [DIR][0]
-          [STATEMENT][1]
+          se c'è strada {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": davanti
@@ -1066,8 +1066,8 @@ it:
             "'left'": a sinistra
       craft_ifStandingOn:
         text: |-
-          se sei sopra a [TYPE][0]
-          [STATEMENT][1]
+          se sei sopra a {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": corallo blu
@@ -1078,8 +1078,8 @@ it:
             "'seaLantern'": lanterna marina
       craft_ifStandingOnLimit:
         text: |-
-          se sei sopra a [TYPE][0]
-          [STATEMENT][1]
+          se sei sopra a {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": sabbia
@@ -1088,7 +1088,7 @@ it:
       craft_moveForward:
         text: vai avanti
       craft_placeBlock:
-        text: colloca [blockType][0]
+        text: colloca {blockType}
         options:
           blockType:
             '"strippedOak"': quercia scortecciata
@@ -1123,13 +1123,13 @@ it:
       craft_repeatUntilConduit:
         text: |-
           ripeti fino al completamento del condotto
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           ripeti fino all'obiettivo
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: genera [ENTITY][0]
+        text: genera {ENTITY}
         options:
           ENTITY:
             '"cod"': merluzzo
@@ -1139,7 +1139,7 @@ it:
             '"squid"': calamaro
             '"tropicalFish"': pesce tropicale
       craft_turn:
-        text: gira a [DIR][0]
+        text: gira a {DIR}
         options:
           DIR:
             right: destra ↻

--- a/dashboard/config/locales/blocks.ja-JP.yml
+++ b/dashboard/config/locales/blocks.ja-JP.yml
@@ -3,20 +3,20 @@ ja:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: "[TIMESTAMP][0] [UNIT][1] 後"
+        text: "{TIMESTAMP} {UNIT} 後"
         options:
           UNIT:
             '"measures"': 小節
             '"seconds"': 秒
       Dancelab_changeColorBy:
-        text: "[COLOR][0] [METHOD][1] を [AMOUNT][2] 変更 "
+        text: "{COLOR} {METHOD} を {AMOUNT} 変更 "
         options:
           METHOD:
             '"hue"': 色相
             '"saturation"': 彩度
             '"brightness"': 明るさ
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] で実行 [MOVE][1] [DIR][2] ずっとくりかえす"
+        text: "{GROUP} で実行 {MOVE} {DIR} ずっとくりかえす"
         options:
           GROUP:
             sprites: すべて
@@ -50,7 +50,7 @@ ja:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[GROUP][0] で実行 [MOVE][1] [DIR][2] ずっとくりかえす"
+        text: "{SPRITE} で実行 {MOVE} {DIR} ずっとくりかえす"
         options:
           MOVE:
             '"next"': "(次へ)"
@@ -71,7 +71,7 @@ ja:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: "[SPRITE][0] [PROPERTY][1] を [VAL][2] 変更"
+        text: "{SPRITE} {PROPERTY} を {VAL} 変更"
         options:
           PROPERTY:
             '"scale"': おおきさ
@@ -81,7 +81,7 @@ ja:
             '"x"': 水平方向の位置
             '"y"': 垂直方向の位置
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] で実行 [MOVE][1] [DIR][2] いちどだけ"
+        text: "{GROUP} で実行 {MOVE} {DIR} いちどだけ"
         options:
           GROUP:
             sprites: すべて
@@ -113,7 +113,7 @@ ja:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[GROUP][0] で実行 [MOVE][1] [DIR][2] いちどだけ"
+        text: "{SPRITE} で実行 {MOVE} {DIR} いちどだけ"
         options:
           MOVE:
             '"rand"': "(ランダム)"
@@ -132,25 +132,25 @@ ja:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'すべての [N][0] [UNIT][1] '
+        text: 'すべての {N} {UNIT} '
         options:
           UNIT:
             '"measures"': 小節
             '"seconds"': 秒
       Dancelab_everySecondsRange:
-        text: 'すべての [N][0] [UNIT][1] [START][2] から [STOP][3] まで '
+        text: 'すべての {N} {UNIT} {START} から {STOP} まで '
         options:
           UNIT:
             measures: 小節
             seconds: 秒
       Dancelab_everyVerseChorus:
-        text: 'すべての [UNIT][0] '
+        text: 'すべての {UNIT} '
         options:
           UNIT:
             '"verse"': Aメロ・Bメロ
             '"chorus"': サビ
       Dancelab_getEnergy:
-        text: 取得 [RANGE][0]
+        text: 取得 {RANGE}
         options:
           RANGE:
             '"low"': ベース
@@ -167,15 +167,15 @@ ja:
             '"y"': 垂直方向の位置
             '"tint"': 色合い
       Dancelab_getTime:
-        text: "[UNIT][0] 経過"
+        text: "{UNIT} 経過"
         options:
           UNIT:
             '"measures"': 小節
             '"seconds"': 秒
       Dancelab_ifDanceIs:
         text: |-
-          もし [SPRITE][0] が [DANCE][1] をしてたら
-          [DO1][2] [DO2][3]
+          もし {SPRITE} が {DANCE} をしてたら
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: 手を高く上げてたたく
@@ -195,7 +195,7 @@ ja:
             '"measures"': 小節
             '"seconds"': 秒
       Dancelab_jumpTo:
-        text: "[SPRITE][0]　[LOCATION][1]にとぶ"
+        text: "{SPRITE}　{LOCATION}にとぶ"
         options:
           LOCATION:
             "{x: 200, y: 100}": 上
@@ -209,7 +209,7 @@ ja:
             "{x: 300, y: 300}": 右下
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": ランダム に
       Dancelab_layoutSprites:
-        text: "[GROUP][0] を [FORMAT][1] にレイアウト"
+        text: "{GROUP} を {FORMAT} にレイアウト"
         options:
           GROUP:
             sprites: すべて
@@ -236,8 +236,8 @@ ja:
             '"random"': ランダム に
       Dancelab_makeNewDanceSprite:
         text: |-
-          [COSTUME][0] を新しくつくる
-          名前は [NAME][1] 場所は [LOCATION][2]
+          {COSTUME} を新しくつくる
+          名前は {NAME} 場所は {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': エイリアン
@@ -264,8 +264,8 @@ ja:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": ランダム に
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          [N][0] を新しい [COSTUME][1] にする
-          [LAYOUT][2] で
+          {N} を新しい {COSTUME} にする
+          {LAYOUT} で
         options:
           N:
             '2': '2'
@@ -310,9 +310,9 @@ ja:
             '"plus"': プラス
             '"random"': ランダム に
       Dancelab_mixColors:
-        text: "[COLOR1][0] と [COLOR2][1] をまぜる"
+        text: "{COLOR1} と {COLOR2} をまぜる"
       Dancelab_nMeasures:
-        text: "[N][0] 小節"
+        text: "{N} 小節"
       Dancelab_onPointerDown:
         text: ポインターを下げたとき
       Dancelab_onPointerDrag:
@@ -322,9 +322,9 @@ ja:
       Dancelab_randomColor:
         text: てきとうな色
       Dancelab_setBackground:
-        text: 背景色を [COLOR][0] にセット
+        text: 背景色を {COLOR} にセット
       Dancelab_setBackgroundEffect:
-        text: 背景エフェクトを [EFFECT][0] にセット
+        text: 背景エフェクトを {EFFECT} にセット
         options:
           EFFECT:
             '"none"': 設定なし
@@ -347,7 +347,7 @@ ja:
             '"vintage"': ヴィンテージ
             '"warm"': 赤
       Dancelab_setBackgroundEffectWithPalette:
-        text: 背景エフェクトを [EFFECT][0] [PALETTE][1] にセット
+        text: 背景エフェクトを {EFFECT} {PALETTE} にセット
         options:
           EFFECT:
             '"none"': 設定なし
@@ -372,7 +372,7 @@ ja:
             '"vintage"': ヴィンテージ
             '"warm"': 赤
       Dancelab_setDanceSpeed:
-        text: "[SPRITE][0] のダンスの速さを [SPEED][1] に変更"
+        text: "{SPRITE} のダンスの速さを {SPEED} に変更"
         options:
           SPEED:
             '1': ノーマル
@@ -402,7 +402,7 @@ ja:
             '0.5': おそい
             '0.25': すごくおそい
       Dancelab_setForegroundEffect:
-        text: 前景エフェクトを [EFFECT][0] にセット
+        text: 前景エフェクトを {EFFECT} にセット
         options:
           EFFECT:
             '"none"': 設定なし
@@ -415,7 +415,7 @@ ja:
             '"floating_rainbows"': 虹
             '"raining_tacos"': タコス
       Dancelab_setForegroundEffectExtended:
-        text: 前景エフェクトを [EFFECT][0] にセット
+        text: 前景エフェクトを {EFFECT} にセット
         options:
           EFFECT:
             '"none"': 設定なし
@@ -429,7 +429,7 @@ ja:
             '"floating_rainbows"': 虹
             '"raining_tacos"': タコス
       Dancelab_setProp:
-        text: "[SPRITE][0] [PROPERTY][1] を [VAL][2] にセット "
+        text: "{SPRITE} {PROPERTY} を {VAL} にセット "
         options:
           PROPERTY:
             '"scale"': おおきさ
@@ -440,7 +440,7 @@ ja:
             '"y"': 垂直方向の位置
             '"tint"': 色合い
       Dancelab_setPropEach:
-        text: "[GROUP][0] [PROPERTY][1] を [VAL][2] にセット"
+        text: "{GROUP} {PROPERTY} を {VAL} にセット"
         options:
           GROUP:
             sprites: すべて
@@ -464,7 +464,7 @@ ja:
             '"y"': 垂直方向の位置
             '"tint"': 色合い
       Dancelab_setPropRandom:
-        text: ランダムにする [SPRITE][0] [PROPERTY][1]
+        text: ランダムにする {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': おおきさ
@@ -475,7 +475,7 @@ ja:
             '"y"': 垂直方向の位置
             '"tint"': 色合い
       Dancelab_setTint:
-        text: "[SPRITE][0] の色合いを [VAL][1] にセット"
+        text: "{SPRITE} の色合いを {VAL} にセット"
       Dancelab_setTintEach:
         options:
           THIS:
@@ -491,15 +491,15 @@ ja:
             '"ROBOT"': すべてのロボット
             '"SHARK"': すべてのサメ
       Dancelab_setTintInline:
-        text: "[SPRITE][0] の色合いを [VAL][1] にセット"
+        text: "{SPRITE} の色合いを {VAL} にセット"
       Dancelab_setVisible:
-        text: "[SPRITE][0] 可視を[VISIBILITY][1] に設定"
+        text: "{SPRITE} 可視を{VISIBILITY} に設定"
         options:
           VISIBILITY:
             'true': 見える
             'false': 見えない
       Dancelab_setVisibleEach:
-        text: "[THIS][0] の見え方を [VISIBILITY][1] にセット"
+        text: "{THIS} の見え方を {VISIBILITY} にセット"
         options:
           THIS:
             sprites: すべて
@@ -518,7 +518,7 @@ ja:
             'true': 見える
             'false': 見えない
       Dancelab_startMapping:
-        text: "[SPRITE][0] が [PROPERTY][1] をはじめる、[RANGE][2] のあとに"
+        text: "{SPRITE} が {PROPERTY} をはじめる、{RANGE} のあとに"
         options:
           PROPERTY:
             '"scale"': おおきさ
@@ -533,7 +533,7 @@ ja:
             '"mid"': ミドル
             '"treble"': トレブル
       Dancelab_stopMapping:
-        text: "[SPRITE][0] が [PROPERTY][1] をやめる、[RANGE][2] のあとに"
+        text: "{SPRITE} が {PROPERTY} をやめる、{RANGE} のあとに"
         options:
           PROPERTY:
             '"scale"': おおきさ
@@ -549,7 +549,7 @@ ja:
             '"mid"': ミドル
             '"treble"': トレブル
       Dancelab_whenKey:
-        text: "[KEY][0] が押されたとき"
+        text: "{KEY} が押されたとき"
         options:
           KEY:
             '"up"': 上 に
@@ -559,7 +559,7 @@ ja:
             '"space"': うちゅう
             '"x"': x
       Dancelab_whenPeak:
-        text: "[RANGE][0] がいちばん大きいとき"
+        text: "{RANGE} がいちばん大きいとき"
         options:
           RANGE:
             '0': ベース
@@ -568,19 +568,19 @@ ja:
       Dancelab_whenSetup:
         text: セットアップ
       gamelab_changeColor:
-        text: "[COLOR][0] [METHOD][1] を [AMOUNT][2] 変更 "
+        text: "{COLOR} {METHOD} を {AMOUNT} 変更 "
         options:
           METHOD:
             '"tint"': 色合い
       gamelab_changeColorBy:
-        text: "[COLOR][0] [METHOD][1] を [AMOUNT][2] 変更 "
+        text: "{COLOR} {METHOD} を {AMOUNT} 変更 "
         options:
           METHOD:
             '"hue"': 色相
             '"saturation"': 彩度
             '"brightness"': 明るさ
       gamelab_changePropBy:
-        text: "[SPRITE][0] [PROPERTY][1] を [VAL][2] 変更"
+        text: "{SPRITE} {PROPERTY} を {VAL} 変更"
         options:
           PROPERTY:
             '"scale"': おおきさ
@@ -603,7 +603,7 @@ ja:
             '"direction"': 動きの方向
             '"tint"': 色合い
       gamelab_jumpTo:
-        text: "[SPRITE][0]　[LOCATION][1]にとぶ"
+        text: "{SPRITE}　{LOCATION}にとぶ"
       gamelab_locationDelta:
         options:
           DIR:
@@ -614,15 +614,15 @@ ja:
             '"right"': 右 に
             '"left"': 左 に
       gamelab_mixColors:
-        text: "[COLOR1][0] と [COLOR2][1] をまぜる"
+        text: "{COLOR1} と {COLOR2} をまぜる"
       gamelab_randColor:
         text: てきとうな色
       gamelab_randomColor:
         text: てきとうな色
       gamelab_setBackground:
-        text: 背景色を [COLOR][0] にセット
+        text: 背景色を {COLOR} にセット
       gamelab_setPosition:
-        text: "[THIS][0] を [POSITION][1] の位置に移動"
+        text: "{THIS} を {POSITION} の位置に移動"
         options:
           POSITION:
             "{x: 50, y: 50}": 左上
@@ -675,7 +675,7 @@ ja:
             '"right"': 右 に
             '"left"': 左 に
       gamelab_whenKey:
-        text: "[KEY][0] が押されたとき"
+        text: "{KEY} が押されたとき"
         options:
           KEY:
             '"up"': 上 に
@@ -792,8 +792,8 @@ ja:
             '"all"': すべて
       Mikelab_ifDanceIs:
         text: |-
-          もし [SPRITE][0] が [DANCE][1] をしてたら
-          [DO1][2] [DO2][3]
+          もし {SPRITE} が {DANCE} をしてたら
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: 手を高く上げてたたく
@@ -839,7 +839,7 @@ ja:
             "{x: 100, y: 300}": 左下
             "{x: 300, y: 300}": 右下
       Mikelab_whenKeyPressed:
-        text: "[KEY][0] が押されたとき"
+        text: "{KEY} が押されたとき"
         options:
           KEY:
             '"up"': 上矢じるしキーが おされたら
@@ -900,7 +900,7 @@ ja:
             '"left"': 左 に
             '"right"': 右 に
       binary_whenKey:
-        text: "[KEY][0] が押されたとき"
+        text: "{KEY} が押されたとき"
         options:
           KEY:
             '"up"': 上 に
@@ -910,8 +910,8 @@ ja:
             '"space"': うちゅう
       craft_ifPath:
         text: |-
-          [DIR][0]に道がある時
-          [STATEMENT][1]
+          {DIR}に道がある時
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": その前に
@@ -919,8 +919,8 @@ ja:
             "'left'": 左
       craft_ifStandingOn:
         text: |-
-          [TYPE][0]の上にいる時
-          [STATEMENT][1]
+          {TYPE}の上にいる時
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": 青色のサンゴ
@@ -931,8 +931,8 @@ ja:
             "'seaLantern'": 海のランタン
       craft_ifStandingOnLimit:
         text: |-
-          [TYPE][0]の上にいる時
-          [STATEMENT][1]
+          {TYPE}の上にいる時
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": 砂
@@ -941,7 +941,7 @@ ja:
       craft_moveForward:
         text: 前に すすむ
       craft_placeBlock:
-        text: "[blockType][0]を置く"
+        text: "{blockType}を置く"
         options:
           blockType:
             '"strippedOak"': 樹皮を剥いだオーク
@@ -976,13 +976,13 @@ ja:
       craft_repeatUntilConduit:
         text: |-
           コンジットができるまでリピート
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           ゴールまでリピート
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: "[ENTITY][0]を産む"
+        text: "{ENTITY}を産む"
         options:
           ENTITY:
             '"cod"': タラ
@@ -992,7 +992,7 @@ ja:
             '"squid"': イカ
             '"tropicalFish"': 熱帯魚
       craft_turn:
-        text: "[DIR][0]を向く"
+        text: "{DIR}を向く"
         options:
           DIR:
             right: 右↻

--- a/dashboard/config/locales/blocks.ko-KR.yml
+++ b/dashboard/config/locales/blocks.ko-KR.yml
@@ -3,20 +3,20 @@ ko:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: "[TIMESTAMP][0] [UNIT][1] 이후"
+        text: "{TIMESTAMP} {UNIT} 이후"
         options:
           UNIT:
             '"measures"': 마디
             '"seconds"': "~초 기다리기"
       Dancelab_changeColorBy:
-        text: "[COLOR][0] [METHOD][1]을(를) [AMOUNT][2]만큼 변경하기"
+        text: "{COLOR} {METHOD}을(를) {AMOUNT}만큼 변경하기"
         options:
           METHOD:
             '"hue"': 색조
             '"saturation"': 채도
             '"brightness"': 명도
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0]이(가) [MOVE][1] [DIR][2]을(를) 영원히 실행"
+        text: "{GROUP}이(가) {MOVE} {DIR}을(를) 영원히 실행"
         options:
           GROUP:
             sprites: 모두
@@ -50,7 +50,7 @@ ko:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0]이(가) [MOVE][1][DIR][2]을(를) 영원히 실행"
+        text: "{SPRITE}이(가) {MOVE}{DIR}을(를) 영원히 실행"
         options:
           MOVE:
             '"next"': "(다음)"
@@ -71,7 +71,7 @@ ko:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: "[SPRITE][0][PROPERTY][1]을(를) [VAL][2]만큼 변경"
+        text: "{SPRITE}{PROPERTY}을(를) {VAL}만큼 변경"
         options:
           PROPERTY:
             '"scale"': 크기
@@ -81,7 +81,7 @@ ko:
             '"x"': 수평 위치
             '"y"': 수직 위치
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0]이(가) [MOVE][1][DIR][2]을(를) 한 번 실행"
+        text: "{GROUP}이(가) {MOVE}{DIR}을(를) 한 번 실행"
         options:
           GROUP:
             sprites: 모두
@@ -113,7 +113,7 @@ ko:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0]이(가) [MOVE][1][DIR][2]을(를) 한 번 실행"
+        text: "{SPRITE}이(가) {MOVE}{DIR}을(를) 한 번 실행"
         options:
           MOVE:
             '"rand"': "(임의)"
@@ -132,25 +132,25 @@ ko:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: '매 [N][0] [UNIT][1] '
+        text: '매 {N} {UNIT} '
         options:
           UNIT:
             '"measures"': 마디
             '"seconds"': "~초 기다리기"
       Dancelab_everySecondsRange:
-        text: '매 [N][0] [UNIT][1]마다 [START][2]에서 [STOP][3]까지 '
+        text: '매 {N} {UNIT}마다 {START}에서 {STOP}까지 '
         options:
           UNIT:
             measures: 마디
             seconds: 초
       Dancelab_everyVerseChorus:
-        text: '매 [UNIT][0] '
+        text: '매 {UNIT} '
         options:
           UNIT:
             '"verse"': 절
             '"chorus"': 후렴
       Dancelab_getEnergy:
-        text: "[RANGE][0] 가져오기"
+        text: "{RANGE} 가져오기"
         options:
           RANGE:
             '"low"': 베이스
@@ -167,15 +167,15 @@ ko:
             '"y"': 수직 위치
             '"tint"': 색조
       Dancelab_getTime:
-        text: "[UNIT][0] 경과됨"
+        text: "{UNIT} 경과됨"
         options:
           UNIT:
             '"measures"': 마디
             '"seconds"': "~초 기다리기"
       Dancelab_ifDanceIs:
         text: |-
-          만약 [SPRITE][0]이(가) [DANCE][1]을(를) 하고 있을 경우
-          [DO1][2] [DO2][3]
+          만약 {SPRITE}이(가) {DANCE}을(를) 하고 있을 경우
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: 높이 손뼉치기
@@ -195,7 +195,7 @@ ko:
             '"measures"': 마디
             '"seconds"': "~초 기다리기"
       Dancelab_jumpTo:
-        text: "[SPRITE][0]이(가) [LOCATION][1](으)로 점프"
+        text: "{SPRITE}이(가) {LOCATION}(으)로 점프"
         options:
           LOCATION:
             "{x: 200, y: 100}": 맨 위로
@@ -209,7 +209,7 @@ ko:
             "{x: 300, y: 300}": 오른쪽 아래
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": random(랜덤)
       Dancelab_layoutSprites:
-        text: "[GROUP][0](을)를 [FORMAT][1](으)로 레이아웃"
+        text: "{GROUP}(을)를 {FORMAT}(으)로 레이아웃"
         options:
           GROUP:
             sprites: 모두
@@ -236,8 +236,8 @@ ko:
             '"random"': random(랜덤)
       Dancelab_makeNewDanceSprite:
         text: |-
-          새로운 [COSTUME][0] 만들기
-          [NAME][1](이)라는 이름으로 [LOCATION][2]에서
+          새로운 {COSTUME} 만들기
+          {NAME}(이)라는 이름으로 {LOCATION}에서
         options:
           COSTUME:
             '"ALIEN"': 외계인
@@ -264,8 +264,8 @@ ko:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": random(랜덤)
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          [N][0]을(를) 새로운 [COSTUME][1](으)로 만들기
-          [LAYOUT][2]에서
+          {N}을(를) 새로운 {COSTUME}(으)로 만들기
+          {LAYOUT}에서
         options:
           N:
             '2': '2'
@@ -310,9 +310,9 @@ ko:
             '"plus"': 더하기
             '"random"': random(랜덤)
       Dancelab_mixColors:
-        text: "[COLOR1][0] 및 [COLOR2][1] 혼합"
+        text: "{COLOR1} 및 {COLOR2} 혼합"
       Dancelab_nMeasures:
-        text: "[N][0] 마디"
+        text: "{N} 마디"
       Dancelab_onPointerDown:
         text: 포인터 아래로 할 때
       Dancelab_onPointerDrag:
@@ -322,9 +322,9 @@ ko:
       Dancelab_randomColor:
         text: 랜덤 색
       Dancelab_setBackground:
-        text: 배경색 [COLOR][0] 설정
+        text: 배경색 {COLOR} 설정
       Dancelab_setBackgroundEffect:
-        text: 배경 효과 [EFFECT][0] 설정
+        text: 배경 효과 {EFFECT} 설정
         options:
           EFFECT:
             '"none"': 없음
@@ -347,7 +347,7 @@ ko:
             '"vintage"': 빈티지
             '"warm"': 빨간색
       Dancelab_setBackgroundEffectWithPalette:
-        text: 배경 효과 [EFFECT][0] [PALETTE][1] 설정
+        text: 배경 효과 {EFFECT} {PALETTE} 설정
         options:
           EFFECT:
             '"none"': 없음
@@ -372,7 +372,7 @@ ko:
             '"vintage"': 빈티지
             '"warm"': 빨간색
       Dancelab_setDanceSpeed:
-        text: "[SPRITE][0] 댄스 속도를 [SPEED][1](으)로 변경하기"
+        text: "{SPRITE} 댄스 속도를 {SPEED}(으)로 변경하기"
         options:
           SPEED:
             '1': 보통
@@ -402,7 +402,7 @@ ko:
             '0.5': 느리게
             '0.25': 매우 느리게
       Dancelab_setForegroundEffect:
-        text: 전경 효과 [EFFECT][0] 설정
+        text: 전경 효과 {EFFECT} 설정
         options:
           EFFECT:
             '"none"': 없음
@@ -415,7 +415,7 @@ ko:
             '"floating_rainbows"': 무지개
             '"raining_tacos"': 타코
       Dancelab_setForegroundEffectExtended:
-        text: 전경 효과 [EFFECT][0] 설정
+        text: 전경 효과 {EFFECT} 설정
         options:
           EFFECT:
             '"none"': 없음
@@ -429,7 +429,7 @@ ko:
             '"floating_rainbows"': 무지개
             '"raining_tacos"': 타코
       Dancelab_setProp:
-        text: "[SPRITE][0] [PROPERTY][1]을(를) [VAL][2](으)로 설정 "
+        text: "{SPRITE} {PROPERTY}을(를) {VAL}(으)로 설정 "
         options:
           PROPERTY:
             '"scale"': 크기
@@ -440,7 +440,7 @@ ko:
             '"y"': 수직 위치
             '"tint"': 색조
       Dancelab_setPropEach:
-        text: "[GROUP][0] [PROPERTY][1]을(를) [VAL][2](으)로 설정"
+        text: "{GROUP} {PROPERTY}을(를) {VAL}(으)로 설정"
         options:
           GROUP:
             sprites: 모두
@@ -464,7 +464,7 @@ ko:
             '"y"': 수직 위치
             '"tint"': 색조
       Dancelab_setPropRandom:
-        text: "[SPRITE][0] [PROPERTY][1] 무작위로 하기"
+        text: "{SPRITE} {PROPERTY} 무작위로 하기"
         options:
           PROPERTY:
             '"scale"': 크기
@@ -475,7 +475,7 @@ ko:
             '"y"': 수직 위치
             '"tint"': 색조
       Dancelab_setTint:
-        text: "[SPRITE][0] 색조를 [VAL][1](으)로 설정하기"
+        text: "{SPRITE} 색조를 {VAL}(으)로 설정하기"
       Dancelab_setTintEach:
         options:
           THIS:
@@ -491,15 +491,15 @@ ko:
             '"ROBOT"': 모든 로봇
             '"SHARK"': 모든 상어
       Dancelab_setTintInline:
-        text: "[SPRITE][0] 색조를 [VAL][1](으)로 설정하기"
+        text: "{SPRITE} 색조를 {VAL}(으)로 설정하기"
       Dancelab_setVisible:
-        text: "[VISIBILITY][1]에서 보이도록 [SPRITE][0] 설정"
+        text: "{VISIBILITY}에서 보이도록 {SPRITE} 설정"
         options:
           VISIBILITY:
             'true': 보이기
             'false': 보이지 않기
       Dancelab_setVisibleEach:
-        text: "[THIS][0] 가시도를 [VISIBILITY][1](으)로 설정하기"
+        text: "{THIS} 가시도를 {VISIBILITY}(으)로 설정하기"
         options:
           THIS:
             sprites: 모두
@@ -518,7 +518,7 @@ ko:
             'true': 보이기
             'false': 보이지 않기
       Dancelab_startMapping:
-        text: "[SPRITE][0]이(가)[RANGE][2]을(를) 따르는 [PROPERTY][1]을(를) 시작하기"
+        text: "{SPRITE}이(가){RANGE}을(를) 따르는 {PROPERTY}을(를) 시작하기"
         options:
           PROPERTY:
             '"scale"': 크기
@@ -533,7 +533,7 @@ ko:
             '"mid"': 중간음
             '"treble"': 고음
       Dancelab_stopMapping:
-        text: "[SPRITE][0]이(가) [RANGE][2]을(를) 따르는 [PROPERTY][1]을(를) 중지하기"
+        text: "{SPRITE}이(가) {RANGE}을(를) 따르는 {PROPERTY}을(를) 중지하기"
         options:
           PROPERTY:
             '"scale"': 크기
@@ -549,7 +549,7 @@ ko:
             '"mid"': 중간음
             '"treble"': 고음
       Dancelab_whenKey:
-        text: "[KEY][0] 누를 때"
+        text: "{KEY} 누를 때"
         options:
           KEY:
             '"up"': 위로
@@ -560,7 +560,7 @@ ko:
             '"x"': x
             '"y"': 예
       Dancelab_whenPeak:
-        text: "[RANGE][0] 피크일 때"
+        text: "{RANGE} 피크일 때"
         options:
           RANGE:
             '0': 베이스
@@ -569,19 +569,19 @@ ko:
       Dancelab_whenSetup:
         text: 설정
       gamelab_changeColor:
-        text: "[COLOR][0] [METHOD][1]을(를) [AMOUNT][2]만큼 변경하기"
+        text: "{COLOR} {METHOD}을(를) {AMOUNT}만큼 변경하기"
         options:
           METHOD:
             '"tint"': 색조
       gamelab_changeColorBy:
-        text: "[COLOR][0] [METHOD][1]을(를) [AMOUNT][2]만큼 변경하기"
+        text: "{COLOR} {METHOD}을(를) {AMOUNT}만큼 변경하기"
         options:
           METHOD:
             '"hue"': 색조
             '"saturation"': 채도
             '"brightness"': 명도
       gamelab_changePropBy:
-        text: "[SPRITE][0][PROPERTY][1]을(를) [VAL][2]만큼 변경"
+        text: "{SPRITE}{PROPERTY}을(를) {VAL}만큼 변경"
         options:
           PROPERTY:
             '"scale"': 크기
@@ -604,7 +604,7 @@ ko:
             '"direction"': 움직임 방향
             '"tint"': 색조
       gamelab_jumpTo:
-        text: "[SPRITE][0]이(가) [LOCATION][1](으)로 점프"
+        text: "{SPRITE}이(가) {LOCATION}(으)로 점프"
       gamelab_locationDelta:
         options:
           DIR:
@@ -615,15 +615,15 @@ ko:
             '"right"': 오른쪽으로
             '"left"': 왼쪽으로
       gamelab_mixColors:
-        text: "[COLOR1][0] 및 [COLOR2][1] 혼합"
+        text: "{COLOR1} 및 {COLOR2} 혼합"
       gamelab_randColor:
         text: 랜덤 색
       gamelab_randomColor:
         text: 랜덤 색
       gamelab_setBackground:
-        text: 배경색 [COLOR][0] 설정
+        text: 배경색 {COLOR} 설정
       gamelab_setPosition:
-        text: "[THIS][0]을(를) [POSITION][1] 위치로 이동"
+        text: "{THIS}을(를) {POSITION} 위치로 이동"
         options:
           POSITION:
             "{x: 50, y: 50}": 왼쪽 위
@@ -676,7 +676,7 @@ ko:
             '"right"': 오른쪽으로
             '"left"': 왼쪽으로
       gamelab_whenKey:
-        text: "[KEY][0] 누를 때"
+        text: "{KEY} 누를 때"
         options:
           KEY:
             '"up"': 위로
@@ -793,8 +793,8 @@ ko:
             '"all"': 모두
       Mikelab_ifDanceIs:
         text: |-
-          만약 [SPRITE][0]이(가) [DANCE][1]을(를) 하고 있을 경우
-          [DO1][2] [DO2][3]
+          만약 {SPRITE}이(가) {DANCE}을(를) 하고 있을 경우
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: 높이 손뼉치기
@@ -840,7 +840,7 @@ ko:
             "{x: 100, y: 300}": 왼쪽 아래
             "{x: 300, y: 300}": 오른쪽 아래
       Mikelab_whenKeyPressed:
-        text: "[KEY][0] 누를 때"
+        text: "{KEY} 누를 때"
         options:
           KEY:
             '"up"': 위쪽 방향키를 누르면
@@ -901,7 +901,7 @@ ko:
             '"left"': 왼쪽으로
             '"right"': 오른쪽으로
       binary_whenKey:
-        text: "[KEY][0] 누를 때"
+        text: "{KEY} 누를 때"
         options:
           KEY:
             '"up"': 위로
@@ -911,8 +911,8 @@ ko:
             '"space"': 우주
       craft_ifPath:
         text: |-
-          [DIR][0]에 길이 있을 경우
-          [STATEMENT][1]
+          {DIR}에 길이 있을 경우
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": 정면
@@ -920,8 +920,8 @@ ko:
             "'left'": 왼쪽
       craft_ifStandingOn:
         text: |-
-          [TYPE][0] 위에 서 있을 경우
-          [STATEMENT][1]
+          {TYPE} 위에 서 있을 경우
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": 파란색 산호
@@ -932,8 +932,8 @@ ko:
             "'seaLantern'": 바다 랜턴
       craft_ifStandingOnLimit:
         text: |-
-          [TYPE][0] 위에 서 있을 경우
-          [STATEMENT][1]
+          {TYPE} 위에 서 있을 경우
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": 모래
@@ -949,4 +949,4 @@ ko:
       craft_repeatUntilGoal:
         text: |-
           목표까지 반복하기
-          [STATEMENT][0]
+          {STATEMENT}

--- a/dashboard/config/locales/blocks.mi-NZ.yml
+++ b/dashboard/config/locales/blocks.mi-NZ.yml
@@ -354,8 +354,8 @@ mi:
             '"space"': tuarangi
       craft_ifPath:
         text: |-
-          mena he ara  [DIR][0]
-          [STATEMENT][1]
+          mena he ara  {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": ki mua
@@ -363,8 +363,8 @@ mi:
             "'left'": ki te taha maui
       craft_ifStandingOn:
         text: |-
-          mena e tu ana ki runga [TYPE][0]
-          [STATEMENT][1]
+          mena e tu ana ki runga {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": punga moana kikorangi
@@ -375,19 +375,19 @@ mi:
             "'seaLantern'": rama moana
       craft_ifStandingOnLimit:
         text: |-
-          mena e tu ana ki runga [TYPE][0]
-          [STATEMENT][1]
+          mena e tu ana ki runga {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": oneone
             "'darkPrismarine'": poromoana uriuri
             "'seaLantern'": rama moana
       craft_log:
-        text: kārere takiputa [KĀRERE][0]
+        text: kārere takiputa {MESSAGE}
       craft_moveForward:
         text: neke ki mua
       craft_placeBlock:
-        text: waiho [blockType][0]
+        text: waiho {blockType}
         options:
           blockType:
             '"strippedOak"': ōki horea
@@ -420,13 +420,13 @@ mi:
       craft_placeTorch:
         text: hoatu rama
       craft_repeatUntilConduit:
-        text: "mahia tonu kia mutu ai te roma \n[STATEMENT][0]"
+        text: "mahia tonu kia mutu ai te roma \n{STATEMENT}"
       craft_repeatUntilGoal:
         text: |-
           mahia tonu kia whiwhi whāinga
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: whakawhānau [ENTITY][0]
+        text: whakawhānau {ENTITY}
         options:
           ENTITY:
             '"cod"': pātutuki
@@ -436,7 +436,7 @@ mi:
             '"squid"': wheke
             '"tropicalFish"': ika pārūrū
       craft_turn:
-        text: hurihia [DIR][0]
+        text: hurihia {DIR}
         options:
           DIR:
             right: matau ↻

--- a/dashboard/config/locales/blocks.nl-NL.yml
+++ b/dashboard/config/locales/blocks.nl-NL.yml
@@ -3,20 +3,20 @@ nl:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: na [TIMESTAMP][0] [UNIT][1]
+        text: na {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': maten
             '"seconds"': seconden
       Dancelab_changeColorBy:
-        text: verander [COLOR][0] [METHOD][1] met [AMOUNT][2]
+        text: verander {COLOR} {METHOD} met {AMOUNT}
         options:
           METHOD:
             '"hue"': tint
             '"saturation"': verzadiging
             '"brightness"': helderheid
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] doe [MOVE][1] [DIR][2] voor altijd"
+        text: "{GROUP} doe {MOVE} {DIR} voor altijd"
         options:
           GROUP:
             sprites: alles
@@ -47,7 +47,7 @@ nl:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] doe [MOVE][1] [DIR][2] voor altijd"
+        text: "{SPRITE} doe {MOVE} {DIR} voor altijd"
         options:
           MOVE:
             '"next"': "(Volgende)"
@@ -65,7 +65,7 @@ nl:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: wijzig [SPRITE][0] [PROPERTY][1] met [VAL][2]
+        text: wijzig {SPRITE} {PROPERTY} met {VAL}
         options:
           PROPERTY:
             '"scale"': grootte
@@ -75,7 +75,7 @@ nl:
             '"x"': horizontale positie
             '"y"': verticale positie
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] doe [MOVE][1] [DIR][2] een keer"
+        text: "{GROUP} doe {MOVE} {DIR} een keer"
         options:
           GROUP:
             sprites: alles
@@ -104,7 +104,7 @@ nl:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] doe [MOVE][1] [DIR][2] een keer"
+        text: "{SPRITE} doe {MOVE} {DIR} een keer"
         options:
           MOVE:
             '"rand"': "(Willekeurig)"
@@ -120,25 +120,25 @@ nl:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'elke [N][0] [UNIT][1] '
+        text: 'elke {N} {UNIT} '
         options:
           UNIT:
             '"measures"': maten
             '"seconds"': seconden
       Dancelab_everySecondsRange:
-        text: 'elke [N][0] [UNIT][1] van [START][2] tot [STOP][3] '
+        text: 'elke {N} {UNIT} van {START} tot {STOP} '
         options:
           UNIT:
             measures: Maten
             seconds: Seconden
       Dancelab_everyVerseChorus:
-        text: 'elke [UNIT][0] '
+        text: 'elke {UNIT} '
         options:
           UNIT:
             '"verse"': couplet
             '"chorus"': refrein
       Dancelab_getEnergy:
-        text: krijg [RANGE][0]
+        text: krijg {RANGE}
       Dancelab_getProp:
         options:
           PROPERTY:
@@ -149,15 +149,15 @@ nl:
             '"x"': horizontale positie
             '"y"': verticale positie
       Dancelab_getTime:
-        text: "[UNIT][0] verstreken"
+        text: "{UNIT} verstreken"
         options:
           UNIT:
             '"measures"': maten
             '"seconds"': seconden
       Dancelab_ifDanceIs:
         text: |-
-          als [SPRITE][0] [DANCE][1] doet
-          [DO1][2] [DO2][3]
+          als {SPRITE} {DANCE} doet
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Hoog klappen
@@ -174,7 +174,7 @@ nl:
             '"measures"': maten
             '"seconds"': seconden
       Dancelab_jumpTo:
-        text: "[SPRITE][0] ga naar [LOCATION][1]"
+        text: "{SPRITE} ga naar {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": boven
@@ -188,7 +188,7 @@ nl:
             "{x: 300, y: 300}": rechtsonder
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": willekeurig
       Dancelab_layoutSprites:
-        text: "[GROUP][0] indelen als een [FORMAT][1]"
+        text: "{GROUP} indelen als een {FORMAT}"
         options:
           GROUP:
             sprites: alles
@@ -214,8 +214,8 @@ nl:
             '"random"': willekeurig
       Dancelab_makeNewDanceSprite:
         text: |-
-          maak een nieuw [COSTUME][0]
-          genaamd [NAME][1] op [LOCATION][2]
+          maak een nieuw {COSTUME}
+          genaamd {NAME} op {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Buitenaards wezen
@@ -241,8 +241,8 @@ nl:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": willekeurig
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          Maak [N][0] nieuw [COSTUME][1]
-          in een [LAYOUT][2]
+          Maak {N} nieuw {COSTUME}
+          in een {LAYOUT}
         options:
           N:
             '2': '2'
@@ -285,9 +285,9 @@ nl:
             '"x"': kriskras
             '"random"': willekeurig
       Dancelab_mixColors:
-        text: Meng [COLOR1][0] en [COLOR2][1]
+        text: Meng {COLOR1} en {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] maten"
+        text: "{N} maten"
       Dancelab_onPointerDown:
         text: op aanwijzer omlaag
       Dancelab_onPointerDrag:
@@ -297,9 +297,9 @@ nl:
       Dancelab_randomColor:
         text: willekeurige kleur
       Dancelab_setBackground:
-        text: stel [COLOR][0] in als achtergrondkleur
+        text: stel {COLOR} in als achtergrondkleur
       Dancelab_setBackgroundEffect:
-        text: stel [EFFECT][0] in als achtergrondeffect
+        text: stel {EFFECT} in als achtergrondeffect
         options:
           EFFECT:
             '"none"': Geen
@@ -320,7 +320,7 @@ nl:
             '"tropical"': Tropisch
             '"warm"': Rood
       Dancelab_setBackgroundEffectWithPalette:
-        text: stel [EFFECT][0] [PALETTE][1] in als achtergrondeffect
+        text: stel {EFFECT} {PALETTE} in als achtergrondeffect
         options:
           EFFECT:
             '"none"': Geen
@@ -343,7 +343,7 @@ nl:
             '"tropical"': Tropisch
             '"warm"': Rood
       Dancelab_setDanceSpeed:
-        text: verander de danssnelheid van [SPRITE][0] naar [SPEED][1]
+        text: verander de danssnelheid van {SPRITE} naar {SPEED}
         options:
           SPEED:
             '1': normaal
@@ -373,7 +373,7 @@ nl:
             '0.5': langzaam
             '0.25': heel langzaam
       Dancelab_setForegroundEffect:
-        text: stel [EFFECT][0] in als voorgrondeffect
+        text: stel {EFFECT} in als voorgrondeffect
         options:
           EFFECT:
             '"none"': Geen
@@ -385,7 +385,7 @@ nl:
             '"floating_rainbows"': Regenboog
             '"raining_tacos"': Taco‘s
       Dancelab_setForegroundEffectExtended:
-        text: stel [EFFECT][0] in als voorgrondeffect
+        text: stel {EFFECT} in als voorgrondeffect
         options:
           EFFECT:
             '"none"': Geen
@@ -398,7 +398,7 @@ nl:
             '"floating_rainbows"': Regenboog
             '"raining_tacos"': Taco‘s
       Dancelab_setProp:
-        text: 'stel [SPRITE][0] [PROPERTY][1] in op [VAL][2] '
+        text: 'stel {SPRITE} {PROPERTY} in op {VAL} '
         options:
           PROPERTY:
             '"scale"': grootte
@@ -408,7 +408,7 @@ nl:
             '"x"': horizontale positie
             '"y"': verticale positie
       Dancelab_setPropEach:
-        text: stel [GROUP][0] [PROPERTY][1] in op [VAL][2]
+        text: stel {GROUP} {PROPERTY} in op {VAL}
         options:
           GROUP:
             sprites: alles
@@ -431,7 +431,7 @@ nl:
             '"x"': horizontale positie
             '"y"': verticale positie
       Dancelab_setPropRandom:
-        text: maak [SPRITE][0] [PROPERTY][1] willekeurig
+        text: maak {SPRITE} {PROPERTY} willekeurig
         options:
           PROPERTY:
             '"scale"': grootte
@@ -441,7 +441,7 @@ nl:
             '"x"': horizontale positie
             '"y"': verticale positie
       Dancelab_setTint:
-        text: stel de tint van [SPRITE][0] in op [VAL][1]
+        text: stel de tint van {SPRITE} in op {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -457,15 +457,15 @@ nl:
             '"ROBOT"': alle robots
             '"SHARK"': alle haaien
       Dancelab_setTintInline:
-        text: stel de tint van [SPRITE][0] in op [VAL][1]
+        text: stel de tint van {SPRITE} in op {VAL}
       Dancelab_setVisible:
-        text: stel [SPRITE][0] zichtbaarheid in op [VISIBILITY][1]
+        text: stel {SPRITE} zichtbaarheid in op {VISIBILITY}
         options:
           VISIBILITY:
             'true': zichtbaar
             'false': onzichtbaar
       Dancelab_setVisibleEach:
-        text: stel [THIS][0] zichtbaarheid in op [VISIBILITY][1]
+        text: stel {THIS} zichtbaarheid in op {VISIBILITY}
         options:
           THIS:
             sprites: alles
@@ -484,7 +484,7 @@ nl:
             'true': zichtbaar
             'false': onzichtbaar
       Dancelab_startMapping:
-        text: "[SPRITE][0] begint [PROPERTY][1] volgens [RANGE][2]"
+        text: "{SPRITE} begint {PROPERTY} volgens {RANGE}"
         options:
           PROPERTY:
             '"scale"': grootte
@@ -494,7 +494,7 @@ nl:
             '"x"': horizontale positie
             '"y"': verticale positie
       Dancelab_stopMapping:
-        text: "[SPRITE][0] stopt [PROPERTY][1] volgens [RANGE][2]"
+        text: "{SPRITE} stopt {PROPERTY} volgens {RANGE}"
         options:
           PROPERTY:
             '"scale"': grootte
@@ -505,7 +505,7 @@ nl:
             '"y"': verticale positie
             '"direction"': bewegingsrichting
       Dancelab_whenKey:
-        text: als [KEY][0] ingedrukt
+        text: als {KEY} ingedrukt
         options:
           KEY:
             '"up"': omhoog
@@ -516,18 +516,18 @@ nl:
             '"x"': x
             '"y"': y
       Dancelab_whenPeak:
-        text: als [RANGE][0] piek
+        text: als {RANGE} piek
       gamelab_changeColor:
-        text: verander [COLOR][0] [METHOD][1] met [AMOUNT][2]
+        text: verander {COLOR} {METHOD} met {AMOUNT}
       gamelab_changeColorBy:
-        text: verander [COLOR][0] [METHOD][1] met [AMOUNT][2]
+        text: verander {COLOR} {METHOD} met {AMOUNT}
         options:
           METHOD:
             '"hue"': tint
             '"saturation"': verzadiging
             '"brightness"': helderheid
       gamelab_changePropBy:
-        text: wijzig [SPRITE][0] [PROPERTY][1] met [VAL][2]
+        text: wijzig {SPRITE} {PROPERTY} met {VAL}
         options:
           PROPERTY:
             '"scale"': grootte
@@ -549,7 +549,7 @@ nl:
             '"y"': y positie
             '"direction"': bewegingsrichting
       gamelab_jumpTo:
-        text: "[SPRITE][0] ga naar [LOCATION][1]"
+        text: "{SPRITE} ga naar {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -560,15 +560,15 @@ nl:
             '"right"': rechts
             '"left"': links
       gamelab_mixColors:
-        text: Meng [COLOR1][0] en [COLOR2][1]
+        text: Meng {COLOR1} en {COLOR2}
       gamelab_randColor:
         text: willekeurige kleur
       gamelab_randomColor:
         text: willekeurige kleur
       gamelab_setBackground:
-        text: stel [COLOR][0] in als achtergrondkleur
+        text: stel {COLOR} in als achtergrondkleur
       gamelab_setPosition:
-        text: verplaats [THIS][0] naar de positie [POSITION][1]
+        text: verplaats {THIS} naar de positie {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": linksboven
@@ -616,7 +616,7 @@ nl:
             '"right"': rechts
             '"left"': links
       gamelab_whenKey:
-        text: als [KEY][0] ingedrukt
+        text: als {KEY} ingedrukt
         options:
           KEY:
             '"up"': omhoog
@@ -733,8 +733,8 @@ nl:
             '"all"': alles
       Mikelab_ifDanceIs:
         text: |-
-          als [SPRITE][0] [DANCE][1] doet
-          [DO1][2] [DO2][3]
+          als {SPRITE} {DANCE} doet
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Hoog klappen
@@ -777,7 +777,7 @@ nl:
             "{x: 100, y: 300}": linksonder
             "{x: 300, y: 300}": rechtsonder
       Mikelab_whenKeyPressed:
-        text: als [KEY][0] ingedrukt
+        text: als {KEY} ingedrukt
         options:
           KEY:
             '"up"': pijltje naar boven
@@ -837,7 +837,7 @@ nl:
             '"left"': links
             '"right"': rechts
       binary_whenKey:
-        text: als [KEY][0] ingedrukt
+        text: als {KEY} ingedrukt
         options:
           KEY:
             '"up"': omhoog
@@ -847,8 +847,8 @@ nl:
             '"space"': ruimte
       craft_ifPath:
         text: |-
-          als pad [DIR][0]
-          [STATEMENT][1]
+          als pad {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": voor
@@ -856,8 +856,8 @@ nl:
             "'left'": naar links
       craft_ifStandingOn:
         text: |-
-          als staande op [TYPE][0]
-          [STATEMENT][1]
+          als staande op {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": blauw koraal
@@ -868,8 +868,8 @@ nl:
             "'seaLantern'": zeelantaarn
       craft_ifStandingOnLimit:
         text: |-
-          als staande op [TYPE][0]
-          [STATEMENT][1]
+          als staande op {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": zand
@@ -878,7 +878,7 @@ nl:
       craft_moveForward:
         text: beweeg vooruit
       craft_placeBlock:
-        text: plaats [blockType][0]
+        text: plaats {blockType}
         options:
           blockType:
             '"strippedOak"': geschaafd eikenhout
@@ -913,11 +913,11 @@ nl:
       craft_repeatUntilConduit:
         text: |-
           herhaal totdat kracht van de zee voltooid is
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           herhalen tot doel
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
         options:
           ENTITY:
@@ -928,7 +928,7 @@ nl:
             '"squid"': inktvis
             '"tropicalFish"': tropische vis
       craft_turn:
-        text: draai [DIR][0]
+        text: draai {DIR}
         options:
           DIR:
             right: rechtsom ↻

--- a/dashboard/config/locales/blocks.nn-NO.yml
+++ b/dashboard/config/locales/blocks.nn-NO.yml
@@ -3,20 +3,20 @@ nn:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: etter [TIMESTAMP][0] [UNIT][1]
+        text: etter {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': taktar
             '"seconds"': sekund
       Dancelab_changeColorBy:
-        text: endre [COLOR][0] [METHOD][1] med [AMOUNT][2]
+        text: endre {COLOR} {METHOD} med {AMOUNT}
         options:
           METHOD:
             '"hue"': nyanse
             '"saturation"': metning
             '"brightness"': lysstyrke
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] gjør [MOVE][1] [DIR][2] for alltid"
+        text: "{GROUP} gjør {MOVE} {DIR} for alltid"
         options:
           GROUP:
             sprites: alle
@@ -49,7 +49,7 @@ nn:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] gjer [MOVE][1] [DIR][2] for alltid"
+        text: "{SPRITE} gjer {MOVE} {DIR} for alltid"
         options:
           MOVE:
             '"next"': "(Neste)"
@@ -69,7 +69,7 @@ nn:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: endre [SPRITE][0] [PROPERTY][1] med [VAL][2]
+        text: endre {SPRITE} {PROPERTY} med {VAL}
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -79,7 +79,7 @@ nn:
             '"x"': horisontal posisjon
             '"y"': vertikal posisjon
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] gjør [MOVE][1] [DIR][2] for alltid"
+        text: "{GROUP} gjør {MOVE} {DIR} for alltid"
         options:
           GROUP:
             sprites: alle
@@ -110,7 +110,7 @@ nn:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] gjør [MOVE][1] [DIR][2] for alltid"
+        text: "{SPRITE} gjør {MOVE} {DIR} for alltid"
         options:
           MOVE:
             '"rand"': "(Tilfeldig)"
@@ -128,32 +128,32 @@ nn:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'etter [N][0] [UNIT][1] '
+        text: 'etter {N} {UNIT} '
         options:
           UNIT:
             '"measures"': taktar
             '"seconds"': sekund
       Dancelab_everySecondsRange:
-        text: 'kvar [N][0] [UNIT][1] frå [START][2] til [STOP][3] '
+        text: 'kvar {N} {UNIT} frå {START} til {STOP} '
         options:
           UNIT:
             measures: Taktar
             seconds: Sekunder
       Dancelab_everyVerseChorus:
-        text: 'kvar [UNIT][0] '
+        text: 'kvar {UNIT} '
         options:
           UNIT:
             '"verse"': vers
             '"chorus"': refreng
       Dancelab_getEnergy:
-        text: få [RANGE][0]
+        text: få {RANGE}
         options:
           RANGE:
             '"low"': bass
             '"mid"': mellomtone
             '"high"': diskant
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -164,15 +164,15 @@ nn:
             '"y"': vertikal posisjon
             '"tint"': farge
       Dancelab_getTime:
-        text: gjeldande klokkeslett i [UNIT][0]
+        text: gjeldande klokkeslett i {UNIT}
         options:
           UNIT:
             '"measures"': taktar
             '"seconds"': sekund
       Dancelab_ifDanceIs:
         text: |-
-          dersom [SPRITE][0] gjer [DANCE][1]
-          [DO1][2] [DO2][3]
+          dersom {SPRITE} gjer {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Klapp høyt
@@ -191,7 +191,7 @@ nn:
             '"measures"': taktar
             '"seconds"': sekund
       Dancelab_jumpTo:
-        text: "[SPRITE][0] hoppar til [LOCATION][1]"
+        text: "{SPRITE} hoppar til {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": øvst
@@ -205,7 +205,7 @@ nn:
             "{x: 300, y: 300}": nedst til høgre
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": tilfeldig
       Dancelab_layoutSprites:
-        text: oppsett [GROUP][0] som [FORMAT][1]
+        text: oppsett {GROUP} som {FORMAT}
         options:
           GROUP:
             sprites: alle
@@ -232,8 +232,8 @@ nn:
             '"random"': tilfeldig
       Dancelab_makeNewDanceSprite:
         text: |-
-          lag ei ny [COSTUME][0]
-          som heiter [NAME][1] på [LOCATION][2]
+          lag ei ny {COSTUME}
+          som heiter {NAME} på {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Romvesen
@@ -259,8 +259,8 @@ nn:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": tilfeldig
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          lag [N][0] ny [COSTUME][1]
-          i ei [LAYOUT][2]
+          lag {N} ny {COSTUME}
+          i ei {LAYOUT}
         options:
           N:
             '2': '2'
@@ -305,9 +305,9 @@ nn:
             '"plus"': pluss
             '"random"': tilfeldig
       Dancelab_mixColors:
-        text: bland [COLOR1][0] og [COLOR2][1]
+        text: bland {COLOR1} og {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] taktar"
+        text: "{N} taktar"
       Dancelab_onPointerDown:
         text: når peikar ned
       Dancelab_onPointerDrag:
@@ -317,9 +317,9 @@ nn:
       Dancelab_randomColor:
         text: tilfeldig farge
       Dancelab_setBackground:
-        text: vel bakgrunnsfarge [COLOR][0]
+        text: vel bakgrunnsfarge {COLOR}
       Dancelab_setBackgroundEffect:
-        text: vel bakgrunnseffekt [EFFECT][0]
+        text: vel bakgrunnseffekt {EFFECT}
         options:
           EFFECT:
             '"none"': Ingen
@@ -346,7 +346,7 @@ nn:
             '"vintage"': Retro
             '"warm"': Rødfarger
       Dancelab_setBackgroundEffectWithPalette:
-        text: velg bakgrunnseffekt [EFFECT][0] [PALETTE][1]
+        text: velg bakgrunnseffekt {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Ingen
@@ -374,7 +374,7 @@ nn:
             '"vintage"': Retro
             '"warm"': Rødfarger
       Dancelab_setDanceSpeed:
-        text: endre dansefarten til [SPRITE][0] til [SPEED][1]
+        text: endre dansefarten til {SPRITE} til {SPEED}
         options:
           SPEED:
             '1': normal
@@ -383,7 +383,7 @@ nn:
             '0.5': sakte
             '0.25': veldig sakte
       Dancelab_setDanceSpeedEach:
-        text: sett [GROUP][0] dansehastighet til [SPEED][1]
+        text: sett {GROUP} dansehastighet til {SPEED}
         options:
           GROUP:
             sprites: alle
@@ -405,7 +405,7 @@ nn:
             '0.5': sakte
             '0.25': veldig sakte
       Dancelab_setForegroundEffect:
-        text: velg forgrunnseffekt [EFFECT][0]
+        text: velg forgrunnseffekt {EFFECT}
         options:
           EFFECT:
             '"none"': Ingen
@@ -420,7 +420,7 @@ nn:
             '"spotlight"': Spotlight
             '"raining_tacos"': Taco
       Dancelab_setForegroundEffectExtended:
-        text: velg forgrunnseffekt [EFFECT][0]
+        text: velg forgrunnseffekt {EFFECT}
         options:
           EFFECT:
             '"none"': Ingen
@@ -436,7 +436,7 @@ nn:
             '"spotlight"': Spotlight
             '"raining_tacos"': Taco
       Dancelab_setProp:
-        text: 'sett [SPRITE][0] [PROPERTY][1] til [VAL][2] '
+        text: 'sett {SPRITE} {PROPERTY} til {VAL} '
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -447,7 +447,7 @@ nn:
             '"y"': vertikal posisjon
             '"tint"': farge
       Dancelab_setPropEach:
-        text: sett [GROUP][0] [PROPERTY][1] til [VAL][2]
+        text: sett {GROUP} {PROPERTY} til {VAL}
         options:
           GROUP:
             sprites: alle
@@ -471,7 +471,7 @@ nn:
             '"y"': vertikal posisjon
             '"tint"': farge
       Dancelab_setPropRandom:
-        text: gjer [SPRITE][0] [PROPERTY][1] tilfeldig
+        text: gjer {SPRITE} {PROPERTY} tilfeldig
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -482,9 +482,9 @@ nn:
             '"y"': vertikal posisjon
             '"tint"': farge
       Dancelab_setTint:
-        text: sett fargen på [SPRITE][0] til [VAL][1]
+        text: sett fargen på {SPRITE} til {VAL}
       Dancelab_setTintEach:
-        text: sett [THIS][0] fargetone til [VAL][1]
+        text: sett {THIS} fargetone til {VAL}
         options:
           THIS:
             sprites: alle
@@ -499,15 +499,15 @@ nn:
             '"ROBOT"': alle roboter
             '"SHARK"': alle haier
       Dancelab_setTintInline:
-        text: sett fargen på [SPRITE][0] til [VAL][1]
+        text: sett fargen på {SPRITE} til {VAL}
       Dancelab_setVisible:
-        text: sett [SPRITE][0] synlighet til [VISIBILITY][1]
+        text: sett {SPRITE} synlighet til {VISIBILITY}
         options:
           VISIBILITY:
             'true': synleg
             'false': usynleg
       Dancelab_setVisibleEach:
-        text: sett synlegheita for [THIS][0] til [VISIBILITY][1]
+        text: sett synlegheita for {THIS} til {VISIBILITY}
         options:
           THIS:
             sprites: alle
@@ -526,7 +526,7 @@ nn:
             'true': synleg
             'false': usynleg
       Dancelab_startMapping:
-        text: "[SPRITE][0] startar med [PROPERTY][1] etter [RANGE][2]"
+        text: "{SPRITE} startar med {PROPERTY} etter {RANGE}"
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -541,7 +541,7 @@ nn:
             '"mid"': mellomtone
             '"treble"': diskant
       Dancelab_stopMapping:
-        text: "[SPRITE][0] sluttar med [PROPERTY][1] etter [RANGE][2]"
+        text: "{SPRITE} sluttar med {PROPERTY} etter {RANGE}"
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -557,7 +557,7 @@ nn:
             '"mid"': mellomtone
             '"treble"': diskant
       Dancelab_whenKey:
-        text: når [KEY][0] blir trykka ned
+        text: når {KEY} blir trykka ned
         options:
           KEY:
             '"up"': opp
@@ -584,7 +584,7 @@ nn:
             '"x"': x
             '"y"': y
       Dancelab_whenPeak:
-        text: når [RANGE][0] er på sitt største
+        text: når {RANGE} er på sitt største
         options:
           RANGE:
             '0': bass
@@ -593,19 +593,19 @@ nn:
       Dancelab_whenSetup:
         text: oppsett
       gamelab_changeColor:
-        text: endre [COLOR][0] [METHOD][1] med [AMOUNT][2]
+        text: endre {COLOR} {METHOD} med {AMOUNT}
         options:
           METHOD:
             '"tint"': farge
       gamelab_changeColorBy:
-        text: endre [COLOR][0] [METHOD][1] med [AMOUNT][2]
+        text: endre {COLOR} {METHOD} med {AMOUNT}
         options:
           METHOD:
             '"hue"': nyanse
             '"saturation"': metning
             '"brightness"': lysstyrke
       gamelab_changePropBy:
-        text: endre [SPRITE][0] [PROPERTY][1] med [VAL][2]
+        text: endre {SPRITE} {PROPERTY} med {VAL}
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -621,23 +621,23 @@ nn:
       gamelab_draggable:
         text: er flyttbar
       gamelab_edgesDisplace:
-        text: kantene blokkerer [SPRITE][0] fra å flytte seg
+        text: kantene blokkerer {SPRITE} fra å flytte seg
       gamelab_enableDebug:
         text: aktivere feilsøking
       gamelab_firstTouched:
         text: første berørte figur
       gamelab_forEachSpriteWithCostume:
         text: |-
-          for hver [VALUE][0] figur
-          gjør [STATEMENT][1]
+          for hver {VALUE} figur
+          gjør {STATEMENT}
       gamelab_getAnim:
-        text: "[SPRITE][0] [COSTUME][1]"
+        text: "{SPRITE} {COSTUME}"
       gamelab_getDirection:
-        text: "[SPRITE][0] bevegelsesretning"
+        text: "{SPRITE} bevegelsesretning"
       gamelab_getFrameDelay:
-        text: "[THIS][0] forsinkelse"
+        text: "{THIS} forsinkelse"
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -647,33 +647,33 @@ nn:
             '"direction"': retninga til rørsla
             '"tint"': farge
       gamelab_groupLength:
-        text: antall figurer i [THIS][0]
+        text: antall figurer i {THIS}
       gamelab_hasBehavior:
-        text: "[SPRITE][0] er foreløpig [BEHAVIOR][1]"
+        text: "{SPRITE} er foreløpig {BEHAVIOR}"
       gamelab_hideTitleScreen:
         text: skjul tittelskjerm
       gamelab_jumpTo:
-        text: "[SPRITE][0] hoppar til [LOCATION][1]"
+        text: "{SPRITE} hoppar til {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
             "'random'": tilfeldig
       gamelab_mirrorSprite:
-        text: "[SPRITE][0] se til [DIRECTION][1]"
+        text: "{SPRITE} se til {DIRECTION}"
         options:
           DIRECTION:
             '"right"': høgre
             '"left"': venstre
       gamelab_mixColors:
-        text: bland [COLOR1][0] og [COLOR2][1]
+        text: bland {COLOR1} og {COLOR2}
       gamelab_mouseDown:
         text: museknapp er nede
       gamelab_moveDown:
-        text: "[THIS][0] gå ned"
+        text: "{THIS} gå ned"
       gamelab_moveForward:
-        text: gå [SPRITE][0] [DISTANCE][1] piksler fremover
+        text: gå {SPRITE} {DISTANCE} piksler fremover
       gamelab_moveInDirection:
-        text: gå [SPRITE][0] [DISTANCE][1] piksler [DIRECTION][2]
+        text: gå {SPRITE} {DISTANCE} piksler {DIRECTION}
         options:
           DIRECTION:
             '"North"': Nord
@@ -681,17 +681,17 @@ nn:
             '"South"': Sør
             '"West"': Vest
       gamelab_moveInDirection2:
-        text: gå [SPRITE][0] piksler [DISTANCE][1] mot [DIRECTION][2]
+        text: gå {SPRITE} piksler {DISTANCE} mot {DIRECTION}
       gamelab_moveLeft:
-        text: "[THIS][0] gå venstre"
+        text: "{THIS} gå venstre"
       gamelab_moveRight:
-        text: "[THIS][0] gå høyre"
+        text: "{THIS} gå høyre"
       gamelab_moveToward:
-        text: gå [SPRITE][0] distanse [DISTANCE][1] mot [TARGET][2]
+        text: gå {SPRITE} distanse {DISTANCE} mot {TARGET}
       gamelab_moveUp:
-        text: "[THIS][0] gå opp"
+        text: "{THIS} gå opp"
       gamelab_pointInDirection:
-        text: pek [SPRITE][0] [DIRECTION][1]
+        text: pek {SPRITE} {DIRECTION}
         options:
           DIRECTION:
             '"North"': Nord
@@ -699,7 +699,7 @@ nn:
             '"South"': Sør
             '"West"': Vest
       gamelab_pointToward:
-        text: pek [SPRITE][0] mot [LOCATION][1]
+        text: pek {SPRITE} mot {LOCATION}
       gamelab_randColor:
         text: tilfeldig farge
       gamelab_randomColor:
@@ -707,15 +707,15 @@ nn:
       gamelab_randomLocation:
         text: tilfeldig sted
       gamelab_removeAllBehaviors:
-        text: "[SPRITE][0] stopper alt"
+        text: "{SPRITE} stopper alt"
       gamelab_removeBehaviorSimple:
-        text: figur [SPRITE][0] stopper [BEHAVIOR][1]
+        text: figur {SPRITE} stopper {BEHAVIOR}
       gamelab_removeTint:
-        text: fjern farge fra [THIS][0]
+        text: fjern farge fra {THIS}
       gamelab_setBackground:
-        text: vel bakgrunnsfarge [COLOR][0]
+        text: vel bakgrunnsfarge {COLOR}
       gamelab_setPosition:
-        text: flytt [THIS][0] til [POSITION][1]
+        text: flytt {THIS} til {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": øvst til venstre
@@ -775,7 +775,7 @@ nn:
             '"right"': høgre
             '"left"': venstre
       gamelab_whenKey:
-        text: når [KEY][0] blir trykka ned
+        text: når {KEY} blir trykka ned
         options:
           KEY:
             '"up"': opp
@@ -897,11 +897,11 @@ nn:
           SELECT:
             '"all"': alle
       Mikelab_hasBehavior:
-        text: "[SPRITE][0] er foreløpig [BEHAVIOR][1]"
+        text: "{SPRITE} er foreløpig {BEHAVIOR}"
       Mikelab_ifDanceIs:
         text: |-
-          dersom [SPRITE][0] gjer [DANCE][1]
-          [DO1][2] [DO2][3]
+          dersom {SPRITE} gjer {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Klapp høyt
@@ -917,7 +917,7 @@ nn:
       Mikelab_randomColor:
         text: tilfeldig farge
       Mikelab_removeBehaviorSimple:
-        text: figur [SPRITE][0] stopper [BEHAVIOR][1]
+        text: figur {SPRITE} stopper {BEHAVIOR}
       Mikelab_setBG:
         options:
           BG:
@@ -948,7 +948,7 @@ nn:
             "{x: 100, y: 300}": nedst til venstre
             "{x: 300, y: 300}": nedst til høgre
       Mikelab_whenKeyPressed:
-        text: når [KEY][0] blir trykka ned
+        text: når {KEY} blir trykka ned
         options:
           KEY:
             '"up"': pil opp
@@ -1011,7 +1011,7 @@ nn:
             '"left"': venstre
             '"right"': høgre
       binary_whenKey:
-        text: når [KEY][0] blir trykka ned
+        text: når {KEY} blir trykka ned
         options:
           KEY:
             '"up"': opp
@@ -1024,8 +1024,8 @@ nn:
             '"d"': d
       craft_ifPath:
         text: |-
-          dersom veien [DIR][0]
-          [STATEMENT][1]
+          dersom veien {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": foran
@@ -1033,8 +1033,8 @@ nn:
             "'left'": til venstre
       craft_ifStandingOn:
         text: |-
-          dersom du står på [TYPE][0]
-          [STATEMENT][1]
+          dersom du står på {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": blå korall
@@ -1045,8 +1045,8 @@ nn:
             "'seaLantern'": sjølanterne
       craft_ifStandingOnLimit:
         text: |-
-          dersom du står på [TYPE][0]
-          [STATEMENT][1]
+          dersom du står på {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": sand
@@ -1055,7 +1055,7 @@ nn:
       craft_moveForward:
         text: gå framover
       craft_placeBlock:
-        text: plassar [blockType][0]
+        text: plassar {blockType}
         options:
           blockType:
             '"strippedOak"': strippa eik
@@ -1090,13 +1090,13 @@ nn:
       craft_repeatUntilConduit:
         text: |-
           gjenta til kanalen er fullført
-          [STATEMENT][0][0]
+          {STATEMENT}[0]
       craft_repeatUntilGoal:
         text: |-
           gjenta til målet
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: rogn [ENTITY][0]
+        text: rogn {ENTITY}
         options:
           ENTITY:
             '"cod"': torsk
@@ -1106,7 +1106,7 @@ nn:
             '"squid"': blekksprut
             '"tropicalFish"': tropisk fisk
       craft_turn:
-        text: snu [DIR][0]
+        text: snu {DIR}
         options:
           DIR:
             right: høgre ↻

--- a/dashboard/config/locales/blocks.no-NO.yml
+++ b/dashboard/config/locales/blocks.no-NO.yml
@@ -3,20 +3,20 @@
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: etter [TIMESTAMP][0] [UNIT][1]
+        text: etter {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': takter
             '"seconds"': sekunder
       Dancelab_changeColorBy:
-        text: endre [COLOR][0] [METHOD][1] av [AMOUNT]-[2]
+        text: endre {COLOR} {METHOD} av [AMOUNT]-[2]
         options:
           METHOD:
             '"hue"': fargetone
             '"saturation"': metning
             '"brightness"': lysstyrke
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] gjør [MOVE][1] [DIR][2] for alltid"
+        text: "{GROUP} gjør {MOVE} {DIR} for alltid"
         options:
           GROUP:
             sprites: alle
@@ -47,7 +47,7 @@
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] gjør [MOVE][1] [DIR][2] for alltid"
+        text: "{SPRITE} gjør {MOVE} {DIR} for alltid"
         options:
           MOVE:
             '"next"': "(Neste)"
@@ -65,7 +65,7 @@
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: endre [SPRITE][0] [PROPERTY][1] med [VAL][2]
+        text: endre {SPRITE} {PROPERTY} med {VAL}
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -74,7 +74,7 @@
             '"x"': horisontal posisjon
             '"y"': vertikal posisjon
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] gjør [MOVE][1] [DIR][2] en gang"
+        text: "{GROUP} gjør {MOVE} {DIR} en gang"
         options:
           GROUP:
             sprites: alle
@@ -103,7 +103,7 @@
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] gjør [MOVE][1] [DIR][2] en gang"
+        text: "{SPRITE} gjør {MOVE} {DIR} en gang"
         options:
           MOVE:
             '"rand"': "(Tilfeldig)"
@@ -119,32 +119,32 @@
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'hver [N][0] [UNIT][1] '
+        text: 'hver {N} {UNIT} '
         options:
           UNIT:
             '"measures"': takter
             '"seconds"': sekunder
       Dancelab_everySecondsRange:
-        text: 'hver [N][0] [UNIT][1] fra [START][2] til [STOP][3] '
+        text: 'hver {N} {UNIT} fra {START} til {STOP} '
         options:
           UNIT:
             measures: Takter
             seconds: Sekunder
       Dancelab_everyVerseChorus:
-        text: 'hver [UNIT][0] '
+        text: 'hver {UNIT} '
         options:
           UNIT:
             '"verse"': vers
             '"chorus"': refreng
       Dancelab_getEnergy:
-        text: hent [RANGE][0]
+        text: hent {RANGE}
         options:
           RANGE:
             '"low"': bass
             '"mid"': midt
             '"high"': diskant
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -249,9 +249,9 @@
             '"plus"': pluss
             '"random"': tilfeldig
       Dancelab_mixColors:
-        text: bland [COLOR1][0] og [COLOR2][1]
+        text: bland {COLOR1} og {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] takt"
+        text: "{N} takt"
       Dancelab_onPointerDown:
         text: på musepeker ned
       Dancelab_onPointerDrag:
@@ -261,9 +261,9 @@
       Dancelab_randomColor:
         text: tilfeldig farge
       Dancelab_setBackground:
-        text: sett bakgrunnsfarge [COLOR][0]
+        text: sett bakgrunnsfarge {COLOR}
       Dancelab_setBackgroundEffect:
-        text: velg bakgrunnseffekt [EFFECT][0]
+        text: velg bakgrunnseffekt {EFFECT}
         options:
           EFFECT:
             '"none"': Ingen
@@ -290,7 +290,7 @@
             '"vintage"': Retro
             '"warm"': Rødfarger
       Dancelab_setBackgroundEffectWithPalette:
-        text: velg bakgrunnseffekt [EFFECT][0] [PALETTE][1]
+        text: velg bakgrunnseffekt {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Ingen
@@ -318,7 +318,7 @@
             '"vintage"': Retro
             '"warm"': Rødfarger
       Dancelab_setDanceSpeed:
-        text: sett [SPRITE][0] dansehastighet til [SPEED][1]
+        text: sett {SPRITE} dansehastighet til {SPEED}
         options:
           SPEED:
             '1': normal
@@ -327,7 +327,7 @@
             '0.5': sakte
             '0.25': veldig sakte
       Dancelab_setDanceSpeedEach:
-        text: sett [GROUP][0] dansehastighet til [SPEED][1]
+        text: sett {GROUP} dansehastighet til {SPEED}
         options:
           GROUP:
             sprites: alle
@@ -349,7 +349,7 @@
             '0.5': sakte
             '0.25': veldig sakte
       Dancelab_setForegroundEffect:
-        text: sett forgrunneffekt [EFFECT][0]
+        text: sett forgrunneffekt {EFFECT}
         options:
           EFFECT:
             '"none"': Ingen
@@ -364,7 +364,7 @@
             '"spotlight"': Spotlight
             '"raining_tacos"': Taco
       Dancelab_setForegroundEffectExtended:
-        text: sett forgrunneffekt [EFFECT][0]
+        text: sett forgrunneffekt {EFFECT}
         options:
           EFFECT:
             '"none"': Ingen
@@ -380,7 +380,7 @@
             '"spotlight"': Spotlight
             '"raining_tacos"': Taco
       Dancelab_setProp:
-        text: 'sett [SPRITE][0] [PROPERTY][1] til [VAL][2] '
+        text: 'sett {SPRITE} {PROPERTY} til {VAL} '
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -390,7 +390,7 @@
             '"y"': vertikal posisjon
             '"tint"': fargetone
       Dancelab_setPropEach:
-        text: sett [GROUP][0] [PROPERTY][1] til [VAL][2]
+        text: sett {GROUP} {PROPERTY} til {VAL}
         options:
           GROUP:
             sprites: alle
@@ -413,7 +413,7 @@
             '"y"': vertikal posisjon
             '"tint"': fargetone
       Dancelab_setPropRandom:
-        text: tilfeldig [SPRITE][0] [PROPERTY][1]
+        text: tilfeldig {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -423,9 +423,9 @@
             '"y"': vertikal posisjon
             '"tint"': fargetone
       Dancelab_setTint:
-        text: sett [SPRITE][0] fargetone til [VAL][1]
+        text: sett {SPRITE} fargetone til {VAL}
       Dancelab_setTintEach:
-        text: sett [THIS][0] fargetone til [VAL][1]
+        text: sett {THIS} fargetone til {VAL}
         options:
           THIS:
             sprites: alle
@@ -440,15 +440,15 @@
             '"ROBOT"': alle roboter
             '"SHARK"': alle haier
       Dancelab_setTintInline:
-        text: sett [SPRITE][0] fargetone til [VAL][1]
+        text: sett {SPRITE} fargetone til {VAL}
       Dancelab_setVisible:
-        text: sett [SPRITE][0] synlighet til [VISIBILITY][1]
+        text: sett {SPRITE} synlighet til {VISIBILITY}
         options:
           VISIBILITY:
             'true': synlig
             'false': usynlig
       Dancelab_setVisibleEach:
-        text: sett [THIS][0] synlighet til [VISIBILITY][1]
+        text: sett {THIS} synlighet til {VISIBILITY}
         options:
           THIS:
             sprites: alle
@@ -467,7 +467,7 @@
             'true': synlig
             'false': usynlig
       Dancelab_startMapping:
-        text: "[SPRITE][0] begynner [PROPERTY][1] etter [RANGE][2]"
+        text: "{SPRITE} begynner {PROPERTY} etter {RANGE}"
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -481,7 +481,7 @@
             '"mid"': midt
             '"treble"': diskant
       Dancelab_stopMapping:
-        text: "[SPRITE][0] stopper [PROPERTY][1] etter [RANGE][2]"
+        text: "{SPRITE} stopper {PROPERTY} etter {RANGE}"
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -496,7 +496,7 @@
             '"mid"': midt
             '"treble"': diskant
       Dancelab_whenKey:
-        text: når [KEY][0] trykkes
+        text: når {KEY} trykkes
         options:
           KEY:
             '"up"': opp
@@ -528,19 +528,19 @@
             '1': midt
             '2': diskant
       gamelab_changeColor:
-        text: endre [COLOR][0] [METHOD][1] av [AMOUNT]-[2]
+        text: endre {COLOR} {METHOD} av [AMOUNT]-[2]
         options:
           METHOD:
             '"tint"': fargetone
       gamelab_changeColorBy:
-        text: endre [COLOR][0] [METHOD][1] av [AMOUNT]-[2]
+        text: endre {COLOR} {METHOD} av [AMOUNT]-[2]
         options:
           METHOD:
             '"hue"': fargetone
             '"saturation"': metning
             '"brightness"': lysstyrke
       gamelab_changePropBy:
-        text: endre [SPRITE][0] [PROPERTY][1] med [VAL][2]
+        text: endre {SPRITE} {PROPERTY} med {VAL}
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -556,23 +556,23 @@
       gamelab_draggable:
         text: er flyttbar
       gamelab_edgesDisplace:
-        text: kantene blokkerer [SPRITE][0] fra å flytte seg
+        text: kantene blokkerer {SPRITE} fra å flytte seg
       gamelab_enableDebug:
         text: aktivere feilsøking
       gamelab_firstTouched:
         text: første berørte figur
       gamelab_forEachSpriteWithCostume:
         text: |-
-          for hver [VALUE][0] figur
-          gjør [STATEMENT][1]
+          for hver {VALUE} figur
+          gjør {STATEMENT}
       gamelab_getAnim:
-        text: "[SPRITE][0] [COSTUME][1]"
+        text: "{SPRITE} {COSTUME}"
       gamelab_getDirection:
-        text: "[SPRITE][0] bevegelsesretning"
+        text: "{SPRITE} bevegelsesretning"
       gamelab_getFrameDelay:
-        text: "[THIS][0] forsinkelse"
+        text: "{THIS} forsinkelse"
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': størrelse
@@ -582,9 +582,9 @@
             '"direction"': bevegelsesretning
             '"tint"': fargetone
       gamelab_groupLength:
-        text: antall figurer i [THIS][0]
+        text: antall figurer i {THIS}
       gamelab_hasBehavior:
-        text: "[SPRITE][0] er foreløpig [BEHAVIOR][1]"
+        text: "{SPRITE} er foreløpig {BEHAVIOR}"
       gamelab_hideTitleScreen:
         text: skjul tittelskjerm
       gamelab_locationDelta:
@@ -592,21 +592,21 @@
           DIR:
             "'random'": tilfeldig
       gamelab_mirrorSprite:
-        text: "[SPRITE][0] se til [DIRECTION][1]"
+        text: "{SPRITE} se til {DIRECTION}"
         options:
           DIRECTION:
             '"right"': høyre
             '"left"': venstre
       gamelab_mixColors:
-        text: bland [COLOR1][0] og [COLOR2][1]
+        text: bland {COLOR1} og {COLOR2}
       gamelab_mouseDown:
         text: museknapp er nede
       gamelab_moveDown:
-        text: "[THIS][0] gå ned"
+        text: "{THIS} gå ned"
       gamelab_moveForward:
-        text: gå [SPRITE][0] [DISTANCE][1] piksler fremover
+        text: gå {SPRITE} {DISTANCE} piksler fremover
       gamelab_moveInDirection:
-        text: gå [SPRITE][0] [DISTANCE][1] piksler [DIRECTION][2]
+        text: gå {SPRITE} {DISTANCE} piksler {DIRECTION}
         options:
           DIRECTION:
             '"North"': Nord
@@ -614,17 +614,17 @@
             '"South"': Sør
             '"West"': Vest
       gamelab_moveInDirection2:
-        text: gå [SPRITE][0] piksler [DISTANCE][1] mot [DIRECTION][2]
+        text: gå {SPRITE} piksler {DISTANCE} mot {DIRECTION}
       gamelab_moveLeft:
-        text: "[THIS][0] gå venstre"
+        text: "{THIS} gå venstre"
       gamelab_moveRight:
-        text: "[THIS][0] gå høyre"
+        text: "{THIS} gå høyre"
       gamelab_moveToward:
-        text: gå [SPRITE][0] distanse [DISTANCE][1] mot [TARGET][2]
+        text: gå {SPRITE} distanse {DISTANCE} mot {TARGET}
       gamelab_moveUp:
-        text: "[THIS][0] gå opp"
+        text: "{THIS} gå opp"
       gamelab_pointInDirection:
-        text: pek [SPRITE][0] [DIRECTION][1]
+        text: pek {SPRITE} {DIRECTION}
         options:
           DIRECTION:
             '"North"': Nord
@@ -632,7 +632,7 @@
             '"South"': Sør
             '"West"': Vest
       gamelab_pointToward:
-        text: pek [SPRITE][0] mot [LOCATION][1]
+        text: pek {SPRITE} mot {LOCATION}
       gamelab_randColor:
         text: tilfeldig farge
       gamelab_randomColor:
@@ -640,13 +640,13 @@
       gamelab_randomLocation:
         text: tilfeldig sted
       gamelab_removeAllBehaviors:
-        text: "[SPRITE][0] stopper alt"
+        text: "{SPRITE} stopper alt"
       gamelab_removeBehaviorSimple:
-        text: figur [SPRITE][0] stopper [BEHAVIOR][1]
+        text: figur {SPRITE} stopper {BEHAVIOR}
       gamelab_removeTint:
-        text: fjern farge fra [THIS][0]
+        text: fjern farge fra {THIS}
       gamelab_setBackground:
-        text: sett bakgrunnsfarge [COLOR][0]
+        text: sett bakgrunnsfarge {COLOR}
       gamelab_setPosition:
         options:
           POSITION:
@@ -694,7 +694,7 @@
             '"right"': høyre
             '"left"': venstre
       gamelab_whenKey:
-        text: når [KEY][0] trykkes
+        text: når {KEY} trykkes
         options:
           KEY:
             '"up"': opp
@@ -802,7 +802,7 @@
           SELECT:
             '"all"': alle
       Mikelab_hasBehavior:
-        text: "[SPRITE][0] er foreløpig [BEHAVIOR][1]"
+        text: "{SPRITE} er foreløpig {BEHAVIOR}"
       Mikelab_ifDanceIs:
         options:
           DANCE:
@@ -817,7 +817,7 @@
       Mikelab_randomColor:
         text: tilfeldig farge
       Mikelab_removeBehaviorSimple:
-        text: figur [SPRITE][0] stopper [BEHAVIOR][1]
+        text: figur {SPRITE} stopper {BEHAVIOR}
       Mikelab_setBG:
         options:
           BG:
@@ -841,7 +841,7 @@
             "{x: 100, y: 200}": venstre
             "{x: 300, y: 200}": høyre
       Mikelab_whenKeyPressed:
-        text: når [KEY][0] trykkes
+        text: når {KEY} trykkes
         options:
           KEY:
             '"up"': pil opp
@@ -902,7 +902,7 @@
             '"left"': venstre
             '"right"': høyre
       binary_whenKey:
-        text: når [KEY][0] trykkes
+        text: når {KEY} trykkes
         options:
           KEY:
             '"up"': opp

--- a/dashboard/config/locales/blocks.pl-PL.yml
+++ b/dashboard/config/locales/blocks.pl-PL.yml
@@ -3,20 +3,20 @@ pl:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: po [TIMESTAMP][0] [UNIT][1]
+        text: po {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekundy
       Dancelab_changeColorBy:
-        text: zmień [COLOR][0] [METHOD][1] o [AMOUNT][2]
+        text: zmień {COLOR} {METHOD} o {AMOUNT}
         options:
           METHOD:
             '"hue"': zabarwienie
             '"saturation"': nasycenie
             '"brightness"': jasność
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] wykonuje [MOVE][1] [DIR][2] bez końca"
+        text: "{GROUP} wykonuje {MOVE} {DIR} bez końca"
         options:
           GROUP:
             sprites: wszystkie
@@ -51,7 +51,7 @@ pl:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] rób [MOVE][1] [DIR][2] bez końca"
+        text: "{SPRITE} rób {MOVE} {DIR} bez końca"
         options:
           MOVE:
             '"next"': "(Następny)"
@@ -73,7 +73,7 @@ pl:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: zamień [SPRITE][0] [PROPERTY][1] przez [VAL][2]
+        text: zamień {SPRITE} {PROPERTY} przez {VAL}
         options:
           PROPERTY:
             '"scale"': rozmiar
@@ -83,7 +83,7 @@ pl:
             '"x"': pozycja pozioma
             '"y"': pozycja pionowa
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] zrób [MOVE][1] [DIR][2] raz"
+        text: "{GROUP} zrób {MOVE} {DIR} raz"
         options:
           GROUP:
             sprites: wszystkie
@@ -128,7 +128,7 @@ pl:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[GROUP][0] zrób [MOVE][1] [DIR][2] raz"
+        text: "{SPRITE} zrób {MOVE} {DIR} raz"
         options:
           MOVE:
             '"rand"': "(Losowy)"
@@ -160,34 +160,34 @@ pl:
             '1': "→"
             "-1": "←"
       Dancelab_eval:
-        text: oceń [CODE][0]
+        text: oceń {CODE}
       Dancelab_everySeconds:
-        text: 'co [N][0] [UNIT][1] '
+        text: 'co {N} {UNIT} '
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekundy
       Dancelab_everySecondsRange:
-        text: 'co [N][0] [UNIT][1] od [START][2] do [STOP][3] '
+        text: 'co {N} {UNIT} od {START} do {STOP} '
         options:
           UNIT:
             measures: Takty
             seconds: Sekundy
       Dancelab_everyVerseChorus:
-        text: 'co [UNIT][0] '
+        text: 'co {UNIT} '
         options:
           UNIT:
             '"verse"': zwrotka
             '"chorus"': chór
       Dancelab_getEnergy:
-        text: uzyskaj [RANGE][0]
+        text: uzyskaj {RANGE}
         options:
           RANGE:
             '"low"': niski ton
             '"mid"': średni ton
             '"high"': wysoki ton
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': rozmiar
@@ -198,15 +198,15 @@ pl:
             '"y"': pozycja pionowa
             '"tint"': odcień
       Dancelab_getTime:
-        text: aktualny czas [UNIT][0]
+        text: aktualny czas {UNIT}
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekundy
       Dancelab_ifDanceIs:
         text: |-
-          jeśli [SPRITE][0] wykonuje [DANCE][1]
-          [DO1][2] [DO2][3]
+          jeśli {SPRITE} wykonuje {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Clap high
@@ -223,8 +223,8 @@ pl:
             MOVES.Rest: Żaden
       Dancelab_ifTime:
         text: |-
-          jeśli [UNIT][0] jest [OP][1] [N][2]
-          [DO1][3] [DO2][4]
+          jeśli {UNIT} jest {OP} {N}
+          {DO1} {DO2}
         options:
           UNIT:
             '"measures"': takty
@@ -234,7 +234,7 @@ pl:
             '"<"': "\\<"
             '"="': "="
       Dancelab_jumpTo:
-        text: "[SPRITE][0] skocz do [LOCATION][1]"
+        text: "{SPRITE} skocz do {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": u góry
@@ -248,7 +248,7 @@ pl:
             "{x: 300, y: 300}": dolny prawy róg
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": losowy
       Dancelab_layoutSprites:
-        text: formacja [GROUP][0] jako [FORMAT][1]
+        text: formacja {GROUP} jako {FORMAT}
         options:
           GROUP:
             sprites: wszystkie
@@ -275,8 +275,8 @@ pl:
             '"random"': losowy
       Dancelab_makeNewDanceSprite:
         text: |-
-          zrób nowy [COSTUME][0]
-          nazywany [NAME][1] w [LOCATION][2]
+          zrób nowy {COSTUME}
+          nazywany {NAME} w {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Obcy
@@ -303,8 +303,8 @@ pl:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": losowy
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          zrób [N][0] nowy [COSTUME][1]
-          w [LAYOUT][2]
+          zrób {N} nowy {COSTUME}
+          w {LAYOUT}
         options:
           N:
             '2': '2'
@@ -349,9 +349,9 @@ pl:
             '"plus"': plus
             '"random"': losowy
       Dancelab_mixColors:
-        text: zmieszaj [COLOR1][0] z [COLOR2][1]
+        text: zmieszaj {COLOR1} z {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] taktów"
+        text: "{N} taktów"
       Dancelab_onPointerDown:
         text: przy wskaźniku w dół
       Dancelab_onPointerDrag:
@@ -361,9 +361,9 @@ pl:
       Dancelab_randomColor:
         text: losowy kolor
       Dancelab_setBackground:
-        text: ustaw kolor tła [COLOR][0]
+        text: ustaw kolor tła {COLOR}
       Dancelab_setBackgroundEffect:
-        text: ustaw efekt tła [EFFECT][0]
+        text: ustaw efekt tła {EFFECT}
         options:
           EFFECT:
             '"none"': Żaden
@@ -394,7 +394,7 @@ pl:
             '"vintage"': Starocie
             '"warm"': Czerwone
       Dancelab_setBackgroundEffectWithPalette:
-        text: ustaw efekt tła [EFFECT][0] [PALETTE][1]
+        text: ustaw efekt tła {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Żaden
@@ -426,7 +426,7 @@ pl:
             '"vintage"': Starocie
             '"warm"': Czerwone
       Dancelab_setDanceSpeed:
-        text: ustaw prędkość tańca [SPRITE][0] na [SPEED][1]
+        text: ustaw prędkość tańca {SPRITE} na {SPEED}
         options:
           SPEED:
             '1': normalny
@@ -435,7 +435,7 @@ pl:
             '0.5': powoli
             '0.25': bardzo powoli
       Dancelab_setDanceSpeedEach:
-        text: ustaw prędkość tańca [GROUP][0] na [SPEED][1]
+        text: ustaw prędkość tańca {GROUP} na {SPEED}
         options:
           GROUP:
             sprites: wszystkie
@@ -457,7 +457,7 @@ pl:
             '0.5': powoli
             '0.25': bardzo powoli
       Dancelab_setForegroundEffect:
-        text: ustaw efekt pierwszego planu [EFFECT][0]
+        text: ustaw efekt pierwszego planu {EFFECT}
         options:
           EFFECT:
             '"none"': Żaden
@@ -475,7 +475,7 @@ pl:
             '"color_lights"': Światła rampy
             '"raining_tacos"': Taco
       Dancelab_setForegroundEffectExtended:
-        text: ustaw efekt pierwszego planu [EFFECT][0]
+        text: ustaw efekt pierwszego planu {EFFECT}
         options:
           EFFECT:
             '"none"': Żaden
@@ -494,7 +494,7 @@ pl:
             '"color_lights"': Światła rampy
             '"raining_tacos"': Taco
       Dancelab_setProp:
-        text: 'ustaw [SPRITE][0] [PROPERTY][1] na [VAL][2] '
+        text: 'ustaw {SPRITE} {PROPERTY} na {VAL} '
         options:
           PROPERTY:
             '"scale"': rozmiar
@@ -505,7 +505,7 @@ pl:
             '"y"': pozycja pionowa
             '"tint"': odcień
       Dancelab_setPropEach:
-        text: ustaw [GROUP][0] [PROPERTY][1] na [VAL][2]
+        text: ustaw {GROUP} {PROPERTY} na {VAL}
         options:
           GROUP:
             sprites: wszystkie
@@ -529,7 +529,7 @@ pl:
             '"y"': pozycja pionowa
             '"tint"': odcień
       Dancelab_setPropRandom:
-        text: losuj [SPRITE][0] [PROPERTY][1]
+        text: losuj {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': rozmiar
@@ -540,9 +540,9 @@ pl:
             '"y"': pozycja pionowa
             '"tint"': odcień
       Dancelab_setTint:
-        text: ustaw [SPRITE][0] odcień na [VAL][1]
+        text: ustaw {SPRITE} odcień na {VAL}
       Dancelab_setTintEach:
-        text: ustaw odcień [THIS][0] na [VAL][1]
+        text: ustaw odcień {THIS} na {VAL}
         options:
           THIS:
             sprites: wszystkie
@@ -557,15 +557,15 @@ pl:
             '"ROBOT"': wszystkie roboty
             '"SHARK"': wszystkie rekiny
       Dancelab_setTintInline:
-        text: ustaw [SPRITE][0] odcień na [VAL][1]
+        text: ustaw {SPRITE} odcień na {VAL}
       Dancelab_setVisible:
-        text: ustaw widoczność [SPRITE][0] na [VISIBILITY][1]
+        text: ustaw widoczność {SPRITE} na {VISIBILITY}
         options:
           VISIBILITY:
             'true': widoczny
             'false': niewidoczny
       Dancelab_setVisibleEach:
-        text: ustaw widoczność [THIS][0] na [VISIBILITY][1]
+        text: ustaw widoczność {THIS} na {VISIBILITY}
         options:
           THIS:
             sprites: wszystkie
@@ -584,7 +584,7 @@ pl:
             'true': widoczny
             'false': niewidoczny
       Dancelab_startMapping:
-        text: "[SPRITE][0] zaczyna [PROPERTY][1] po [RANGE][2]"
+        text: "{SPRITE} zaczyna {PROPERTY} po {RANGE}"
         options:
           PROPERTY:
             '"scale"': rozmiar
@@ -599,7 +599,7 @@ pl:
             '"mid"': średni ton
             '"treble"': wysoki ton
       Dancelab_stopMapping:
-        text: "[SPRITE][0] zatrzymuje [PROPERTY][1] po [RANGE][2]"
+        text: "{SPRITE} zatrzymuje {PROPERTY} po {RANGE}"
         options:
           PROPERTY:
             '"scale"': rozmiar
@@ -615,7 +615,7 @@ pl:
             '"mid"': średni ton
             '"treble"': wysoki ton
       Dancelab_whenKey:
-        text: po naciśnięciu [KEY][0]
+        text: po naciśnięciu {KEY}
         options:
           KEY:
             '"up"': do góry
@@ -661,7 +661,7 @@ pl:
             '"8"': '8'
             '"9"': '9'
       Dancelab_whenPeak:
-        text: podczas szczytu [RANGE][0]
+        text: podczas szczytu {RANGE}
         options:
           RANGE:
             '0': niski ton
@@ -670,26 +670,26 @@ pl:
       Dancelab_whenSetup:
         text: układ
       Dancelab_whenSetupSong:
-        text: 'ustaw [SONG][0] '
+        text: 'ustaw {SONG} '
         options:
           SONG:
             '"macklemore90"': Macklemore - Can't Hold Us
             '"hammer"': MC Hammer - U Can't Touch This
             '"peas"': The Black Eyed Peas - I Got a Feeling
       gamelab_changeColor:
-        text: zmień [COLOR][0] [METHOD][1] o [AMOUNT][2]
+        text: zmień {COLOR} {METHOD} o {AMOUNT}
         options:
           METHOD:
             '"tint"': odcień
       gamelab_changeColorBy:
-        text: zmień [COLOR][0] [METHOD][1] o [AMOUNT][2]
+        text: zmień {COLOR} {METHOD} o {AMOUNT}
         options:
           METHOD:
             '"hue"': zabarwienie
             '"saturation"': nasycenie
             '"brightness"': jasność
       gamelab_changePropBy:
-        text: zamień [SPRITE][0] [PROPERTY][1] przez [VAL][2]
+        text: zamień {SPRITE} {PROPERTY} przez {VAL}
         options:
           PROPERTY:
             '"scale"': rozmiar
@@ -703,9 +703,9 @@ pl:
             'true': prawda
             'false': fałsz
       gamelab_eval:
-        text: oceń [CODE][0]
+        text: oceń {CODE}
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': rozmiar
@@ -715,7 +715,7 @@ pl:
             '"direction"': kierunku ruchu
             '"tint"': odcień
       gamelab_jumpTo:
-        text: "[SPRITE][0] skocz do [LOCATION][1]"
+        text: "{SPRITE} skocz do {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -726,15 +726,15 @@ pl:
             '"right"': w prawo
             '"left"': w lewo
       gamelab_mixColors:
-        text: zmieszaj [COLOR1][0] z [COLOR2][1]
+        text: zmieszaj {COLOR1} z {COLOR2}
       gamelab_randColor:
         text: losowy kolor
       gamelab_randomColor:
         text: losowy kolor
       gamelab_setBackground:
-        text: ustaw kolor tła [COLOR][0]
+        text: ustaw kolor tła {COLOR}
       gamelab_setPosition:
-        text: przenieś [THIS][0] do położenia [POSITION][1]
+        text: przenieś {THIS} do położenia {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": górny lewy róg
@@ -787,7 +787,7 @@ pl:
             '"right"': w prawo
             '"left"': w lewo
       gamelab_whenKey:
-        text: po naciśnięciu [KEY][0]
+        text: po naciśnięciu {KEY}
         options:
           KEY:
             '"up"': do góry
@@ -839,7 +839,7 @@ pl:
             "{x: 100, y: 300}": dolny lewy róg
             "{x: 300, y: 300}": dolny prawy róg
       Mikelab_eval:
-        text: oceń [CODE][0]
+        text: oceń {CODE}
       Mikelab_getProp:
         options:
           PROPERTY:
@@ -914,8 +914,8 @@ pl:
             '"all"': wszystkie
       Mikelab_ifDanceIs:
         text: |-
-          jeśli [SPRITE][0] wykonuje [DANCE][1]
-          [DO1][2] [DO2][3]
+          jeśli {SPRITE} wykonuje {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Clap high
@@ -962,7 +962,7 @@ pl:
             "{x: 100, y: 300}": dolny lewy róg
             "{x: 300, y: 300}": dolny prawy róg
       Mikelab_whenKeyPressed:
-        text: po naciśnięciu [KEY][0]
+        text: po naciśnięciu {KEY}
         options:
           KEY:
             '"up"': strzałka w górę
@@ -1023,7 +1023,7 @@ pl:
             '"left"': w lewo
             '"right"': w prawo
       binary_whenKey:
-        text: po naciśnięciu [KEY][0]
+        text: po naciśnięciu {KEY}
         options:
           KEY:
             '"up"': do góry
@@ -1037,8 +1037,8 @@ pl:
             '"d"': d
       craft_ifPath:
         text: |-
-          jeśli jest ścieżka [DIR][0]
-          [STATEMENT][1]
+          jeśli jest ścieżka {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": z przodu jest
@@ -1046,8 +1046,8 @@ pl:
             "'left'": w lewo
       craft_ifStandingOn:
         text: |-
-          jeśli stojąc na [TYPE][0]
-          [STATEMENT][1]
+          jeśli stojąc na {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": niebieski koral
@@ -1058,19 +1058,19 @@ pl:
             "'seaLantern'": latarnia morska
       craft_ifStandingOnLimit:
         text: |-
-          jeśli stojąc na [TYPE][0]
-          [STATEMENT][1]
+          jeśli stojąc na {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": piasek
             "'darkPrismarine'": ciemny pryzmaryn
             "'seaLantern'": latarnia morska
       craft_log:
-        text: zaloguj wiadomości [MESSAGE][0]
+        text: zaloguj wiadomości {MESSAGE}
       craft_moveForward:
         text: idź do przodu
       craft_placeBlock:
-        text: umieść [blockType][0]
+        text: umieść {blockType}
         options:
           blockType:
             '"strippedOak"': okorowany dąb
@@ -1105,13 +1105,13 @@ pl:
       craft_repeatUntilConduit:
         text: |-
           powtarzaj do ukończenia kanału
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           powtarzaj do osiągnięcia celu
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: tarło [ENTITY][0]
+        text: tarło {ENTITY}
         options:
           ENTITY:
             '"cod"': dorsz
@@ -1121,7 +1121,7 @@ pl:
             '"squid"': kałamarnica
             '"tropicalFish"': ryba tropikalna
       craft_turn:
-        text: skręt [DIR][0]
+        text: skręt {DIR}
         options:
           DIR:
             right: w prawo ↻

--- a/dashboard/config/locales/blocks.pt-BR.yml
+++ b/dashboard/config/locales/blocks.pt-BR.yml
@@ -3,20 +3,20 @@ pt-BR:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: após [TIMESTAMP][0] [UNIT][1]
+        text: após {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': compassos
             '"seconds"': segundos
       Dancelab_changeColorBy:
-        text: alterar [COLOR][0] [METHOD][1] por [AMOUNT][2]
+        text: alterar {COLOR} {METHOD} por {AMOUNT}
         options:
           METHOD:
             '"hue"': tonalidade
             '"saturation"': saturação
             '"brightness"': brilho
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] executa [MOVE][1] [DIR][2] para sempre"
+        text: "{GROUP} executa {MOVE} {DIR} para sempre"
         options:
           GROUP:
             sprites: todos
@@ -50,7 +50,7 @@ pt-BR:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] executa [MOVE][1] [DIR][2] para sempre"
+        text: "{SPRITE} executa {MOVE} {DIR} para sempre"
         options:
           MOVE:
             '"next"': "(Próximo)"
@@ -71,7 +71,7 @@ pt-BR:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: alterar [SPRITE][0] [PROPERTY][1] por [VAL][2]
+        text: alterar {SPRITE} {PROPERTY} por {VAL}
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -81,7 +81,7 @@ pt-BR:
             '"x"': posição horizontal
             '"y"': posição vertical
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] executa [MOVE][1] [DIR][2] uma vez"
+        text: "{GROUP} executa {MOVE} {DIR} uma vez"
         options:
           GROUP:
             sprites: todos
@@ -119,7 +119,7 @@ pt-BR:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] executa [MOVE][1] [DIR][2] uma vez"
+        text: "{SPRITE} executa {MOVE} {DIR} uma vez"
         options:
           MOVE:
             '"rand"': "(Aleatório)"
@@ -144,32 +144,32 @@ pt-BR:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'cada [N][0] [UNIT][1] '
+        text: 'cada {N} {UNIT} '
         options:
           UNIT:
             '"measures"': compassos
             '"seconds"': segundos
       Dancelab_everySecondsRange:
-        text: 'cada [N][0] [UNIT][1] de [START][2] até [STOP][3] '
+        text: 'cada {N} {UNIT} de {START} até {STOP} '
         options:
           UNIT:
             measures: Compassos
             seconds: Segundos
       Dancelab_everyVerseChorus:
-        text: 'cada [UNIT][0] '
+        text: 'cada {UNIT} '
         options:
           UNIT:
             '"verse"': verso
             '"chorus"': refrão
       Dancelab_getEnergy:
-        text: obter [RANGE][0]
+        text: obter {RANGE}
         options:
           RANGE:
             '"low"': grave
             '"mid"': médio
             '"high"': agudo
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -180,15 +180,15 @@ pt-BR:
             '"y"': posição vertical
             '"tint"': tonalidade
       Dancelab_getTime:
-        text: "[UNIT][0] decorrido"
+        text: "{UNIT} decorrido"
         options:
           UNIT:
             '"measures"': compassos
             '"seconds"': segundos
       Dancelab_ifDanceIs:
         text: |-
-          se [SPRITE][0] está fazendo [DANCE][1]
-          [DO1][2] [DO2][3]
+          se {SPRITE} está fazendo {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Bater palmas
@@ -203,7 +203,7 @@ pt-BR:
             MOVES.ThisOrThat: Isso ou Aquilo
             MOVES.Rest: Nenhum
       Dancelab_ifTime:
-        text: se [UNIT][0] é [OP][1] [N][2] [DO1][3] [DO2][4]
+        text: se {UNIT} é {OP} {N} {DO1} {DO2}
         options:
           UNIT:
             '"measures"': compassos
@@ -213,7 +213,7 @@ pt-BR:
             '"<"': "\\<"
             '"="': "="
       Dancelab_jumpTo:
-        text: "[SPRITE][0] pular para [LOCATION][1]"
+        text: "{SPRITE} pular para {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": parte de cima
@@ -227,7 +227,7 @@ pt-BR:
             "{x: 300, y: 300}": canto inferior direito
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": aleatório
       Dancelab_layoutSprites:
-        text: layout [GROUP][0] como um [FORMAT][1]
+        text: layout {GROUP} como um {FORMAT}
         options:
           GROUP:
             sprites: todos
@@ -254,8 +254,8 @@ pt-BR:
             '"random"': aleatório
       Dancelab_makeNewDanceSprite:
         text: |-
-          Crie uma nova [COSTUME][0]
-          chamada [NAME][1] em [LOCATION][2]
+          Crie uma nova {COSTUME}
+          chamada {NAME} em {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Alienígena
@@ -282,8 +282,8 @@ pt-BR:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": aleatório
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          criar [N][0] nova [COSTUME][1]
-          em um [LAYOUT][2]
+          criar {N} nova {COSTUME}
+          em um {LAYOUT}
         options:
           N:
             '2': '2'
@@ -328,9 +328,9 @@ pt-BR:
             '"plus"': mais
             '"random"': aleatório
       Dancelab_mixColors:
-        text: Mesclar [COLOR1][0] e [COLOR2][1]
+        text: Mesclar {COLOR1} e {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] compassos"
+        text: "{N} compassos"
       Dancelab_onPointerDown:
         text: No cursor para baixo
       Dancelab_onPointerDrag:
@@ -340,9 +340,9 @@ pt-BR:
       Dancelab_randomColor:
         text: cor aleatória
       Dancelab_setBackground:
-        text: definir a cor do plano de fundo [COLOR][0]
+        text: definir a cor do plano de fundo {COLOR}
       Dancelab_setBackgroundEffect:
-        text: definir o efeito do plano de fundo [EFFECT][0]
+        text: definir o efeito do plano de fundo {EFFECT}
         options:
           EFFECT:
             '"none"': Nenhum
@@ -374,7 +374,7 @@ pt-BR:
             '"vintage"': Vintage
             '"warm"': Tons de vermelho
       Dancelab_setBackgroundEffectWithPalette:
-        text: definir o efeito do plano de fundo [EFFECT][0] [PALETTE][1]
+        text: definir o efeito do plano de fundo {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Nenhum
@@ -407,7 +407,7 @@ pt-BR:
             '"vintage"': Vintage
             '"warm"': Tons de vermelho
       Dancelab_setDanceSpeed:
-        text: alterar a velocidade da dança de [SPRITE][0] para [SPEED][1]
+        text: alterar a velocidade da dança de {SPRITE} para {SPEED}
         options:
           SPEED:
             '1': normal
@@ -416,7 +416,7 @@ pt-BR:
             '0.5': devagar
             '0.25': muito devagar
       Dancelab_setDanceSpeedEach:
-        text: definir velocidade de dança de [GROUP][0] para [SPEED][1]
+        text: definir velocidade de dança de {GROUP} para {SPEED}
         options:
           GROUP:
             sprites: todos
@@ -438,7 +438,7 @@ pt-BR:
             '0.5': devagar
             '0.25': muito devagar
       Dancelab_setForegroundEffect:
-        text: definir o efeito do primeiro plano [EFFECT][0]
+        text: definir o efeito do primeiro plano {EFFECT}
         options:
           EFFECT:
             '"none"': Nenhum
@@ -455,7 +455,7 @@ pt-BR:
             '"color_lights"': Luzes de palco
             '"raining_tacos"': Tacos
       Dancelab_setForegroundEffectExtended:
-        text: definir o efeito do primeiro plano [EFFECT][0]
+        text: definir o efeito do primeiro plano {EFFECT}
         options:
           EFFECT:
             '"none"': Nenhum
@@ -473,7 +473,7 @@ pt-BR:
             '"color_lights"': Luzes de palco
             '"raining_tacos"': Tacos
       Dancelab_setProp:
-        text: 'Definir [SPRITE][0] [PROPERTY][1] para [VAL][2] '
+        text: 'Definir {SPRITE} {PROPERTY} para {VAL} '
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -484,7 +484,7 @@ pt-BR:
             '"y"': posição vertical
             '"tint"': tonalidade
       Dancelab_setPropEach:
-        text: definir [GROUP][0] [PROPERTY][1] para [VAL][2]
+        text: definir {GROUP} {PROPERTY} para {VAL}
         options:
           GROUP:
             sprites: todos
@@ -508,7 +508,7 @@ pt-BR:
             '"y"': posição vertical
             '"tint"': tonalidade
       Dancelab_setPropRandom:
-        text: aleatorizar [SPRITE][0] [PROPERTY][1]
+        text: aleatorizar {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -519,9 +519,9 @@ pt-BR:
             '"y"': posição vertical
             '"tint"': tonalidade
       Dancelab_setTint:
-        text: definir tonalidade [SPRITE][0] para [VAL][1]
+        text: definir tonalidade {SPRITE} para {VAL}
       Dancelab_setTintEach:
-        text: definir tonalidade de [THIS][0] para [VAL][1]
+        text: definir tonalidade de {THIS} para {VAL}
         options:
           THIS:
             sprites: todos
@@ -536,15 +536,15 @@ pt-BR:
             '"ROBOT"': todos os robôs
             '"SHARK"': todos os tubarões
       Dancelab_setTintInline:
-        text: definir tonalidade [SPRITE][0] para [VAL][1]
+        text: definir tonalidade {SPRITE} para {VAL}
       Dancelab_setVisible:
-        text: definir [SPRITE][0] como visível para [VISIBILITY][1]
+        text: definir {SPRITE} como visível para {VISIBILITY}
         options:
           VISIBILITY:
             'true': visível
             'false': invisível
       Dancelab_setVisibleEach:
-        text: definir visibilidade [THIS][0] para [VISIBILITY][1]
+        text: definir visibilidade {THIS} para {VISIBILITY}
         options:
           THIS:
             sprites: todos
@@ -563,7 +563,7 @@ pt-BR:
             'true': visível
             'false': invisível
       Dancelab_startMapping:
-        text: "[SPRITE][0] começa a [PROPERTY][1] seguir [RANGE][2]"
+        text: "{SPRITE} começa a {PROPERTY} seguir {RANGE}"
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -578,7 +578,7 @@ pt-BR:
             '"mid"': médio
             '"treble"': agudo
       Dancelab_stopMapping:
-        text: "[SPRITE][0] para de [PROPERTY][1] seguir [RANGE][2]"
+        text: "{SPRITE} para de {PROPERTY} seguir {RANGE}"
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -594,7 +594,7 @@ pt-BR:
             '"mid"': médio
             '"treble"': agudo
       Dancelab_whenKey:
-        text: quando [KEY][0] for pressionado
+        text: quando {KEY} for pressionado
         options:
           KEY:
             '"up"': para cima
@@ -640,7 +640,7 @@ pt-BR:
             '"8"': '8'
             '"9"': '9'
       Dancelab_whenPeak:
-        text: Quando [RANGE][0] atingir o ponto máximo
+        text: Quando {RANGE} atingir o ponto máximo
         options:
           RANGE:
             '0': grave
@@ -654,31 +654,31 @@ pt-BR:
             '"hammer"': MC Hammer - U Can't Touch This
             '"peas"': The Black Eyed Peas - I Got a Feeling
       gamelab_add:
-        text: adicionar [SPRITE][0] ao grupo [THIS][1]
+        text: adicionar {SPRITE} ao grupo {THIS}
       gamelab_addBehaviorSimple:
-        text: sprite [SPRITE][0] começa a [BEHAVIOR][1]
+        text: sprite {SPRITE} começa a {BEHAVIOR}
       gamelab_beginBehavior:
-        text: começar [BEHAVIOR][0]
+        text: começar {BEHAVIOR}
       gamelab_bounceOff:
-        text: "[SPRITE][0] salta fora de [TARGET][1]"
+        text: "{SPRITE} salta fora de {TARGET}"
       gamelab_bounceOffEdges:
-        text: "[SPRITE][0] salta pra fora das bordas"
+        text: "{SPRITE} salta pra fora das bordas"
       gamelab_changeColor:
-        text: alterar [COLOR][0] [METHOD][1] por [AMOUNT][2]
+        text: alterar {COLOR} {METHOD} por {AMOUNT}
         options:
           METHOD:
             '"tint"': tonalidade
             '"tone"': tonalidade
             '"shade"': sombra
       gamelab_changeColorBy:
-        text: alterar [COLOR][0] [METHOD][1] por [AMOUNT][2]
+        text: alterar {COLOR} {METHOD} por {AMOUNT}
         options:
           METHOD:
             '"hue"': tonalidade
             '"saturation"': saturação
             '"brightness"': brilho
       gamelab_changePropBy:
-        text: alterar [SPRITE][0] [PROPERTY][1] por [VAL][2]
+        text: alterar {SPRITE} {PROPERTY} por {VAL}
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -687,49 +687,49 @@ pt-BR:
             '"y"': posição y
             '"direction"': direção do movimento
       gamelab_clickedOn:
-        text: quando [SPRITE][0] for clicado
+        text: quando {SPRITE} for clicado
       gamelab_comment:
-        text: 'comentário: [COMMENT][0]'
+        text: 'comentário: {COMMENT}'
       gamelab_console.log:
-        text: mostra mensagem [MESSAGE][0]
+        text: mostra mensagem {MESSAGE}
       gamelab_createNewSprite:
-        text: "faça um novo sprite\n chamado [NAME][0] \n com fantasia [COSTUME][1]
-          \n em [LOCATION][2]"
+        text: "faça um novo sprite\n chamado {NAME} \n com fantasia {COSTUME} \n em
+          {LOCATION}"
       gamelab_debugSprite:
-        text: depurar [SPRITE][0] [VAL][1]
+        text: depurar {SPRITE} {VAL}
         options:
           VAL:
             'true': verdadeiro
             'false': falso
       gamelab_destroy:
-        text: remover [THIS][0]
+        text: remover {THIS}
       gamelab_displace:
-        text: "[THIS][0] bloqueia [SPRITE][1] de se mover"
+        text: "{THIS} bloqueia {SPRITE} de se mover"
       gamelab_distance:
-        text: distância de [LOCATION1][0] até [LOCATION2][1]
+        text: distância de {LOCATION1} até {LOCATION2}
       gamelab_draggable:
         text: ser arrastável
       gamelab_edgesDisplace:
-        text: bordas bloqueiam [SPRITE][0] de se mover
+        text: bordas bloqueiam {SPRITE} de se mover
       gamelab_enableDebug:
         text: habilitar a depuração
       gamelab_firstTouched:
         text: primeiro sprite tocado
       gamelab_forEachSpriteWithCostume:
         text: |-
-          para cada [VALUE][0] sprite
-          faça [STATEMENT][1]
+          para cada {VALUE} sprite
+          faça {STATEMENT}
       gamelab_getAnim:
-        text: "[SPRITE][0] [COSTUME][1]"
+        text: "{SPRITE} {COSTUME}"
         options:
           COSTUME:
             '"costume"': fantasia
       gamelab_getDirection:
-        text: direção do movimento de [SPRITE][0]
+        text: direção do movimento de {SPRITE}
       gamelab_getFrameDelay:
-        text: atraso do quadro [THIS][0]
+        text: atraso do quadro {THIS}
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -739,33 +739,33 @@ pt-BR:
             '"direction"': direção do movimento
             '"tint"': tonalidade
       gamelab_groupLength:
-        text: número de personagens em [THIS][0]
+        text: número de personagens em {THIS}
       gamelab_hasBehavior:
-        text: "[SPRITE][0] está [BEHAVIOR][1]"
+        text: "{SPRITE} está {BEHAVIOR}"
       gamelab_hideTitleScreen:
         text: esconder a tela do título
       gamelab_hsbColor:
-        text: "Cor HSB \nH[HUE][0]S[SATURATION][1]B[BRIGHTNESS][2]"
+        text: "Cor HSB \nH{HUE}S{SATURATION}B{BRIGHTNESS}"
       gamelab_isTouching:
-        text: "[THIS][0] está tocando [TARGET][1]"
+        text: "{THIS} está tocando {TARGET}"
       gamelab_isTouchingEdges:
-        text: "[SPRITE][0] está tocando as bordas"
+        text: "{SPRITE} está tocando as bordas"
       gamelab_joystickDirection:
         text: direção do joystick
       gamelab_jumpTo:
-        text: "[SPRITE][0] pular para [LOCATION][1]"
+        text: "{SPRITE} pular para {LOCATION}"
       gamelab_keyDown:
-        text: tecla está pressionada [KEY][0]
+        text: tecla está pressionada {KEY}
       gamelab_locationAdd:
-        text: "[LOC1][0] [OPERATOR][1] [LOC2][2]"
+        text: "{LOC1} {OPERATOR} {LOC2}"
         options:
           OPERATOR:
             "'plus'": "\\+"
             "'minus'": "\\-"
       gamelab_locationAt:
-        text: 'localização x: [X][0] y: [Y][1]'
+        text: 'localização x: {X} y: {Y}'
       gamelab_locationConstant:
-        text: "[DIR][0]"
+        text: "{DIR}"
         options:
           DIR:
             "'north'": norte
@@ -773,7 +773,7 @@ pt-BR:
             "'east'": leste
             "'west'": oeste
       gamelab_locationDelta:
-        text: "[DISTANCE][0] pixels [DIR][1] de [LOCATION][2]"
+        text: "{DISTANCE} pixels {DIR} de {LOCATION}"
         options:
           DIR:
             "'north'": norte
@@ -788,37 +788,37 @@ pt-BR:
       gamelab_locationNorth:
         text: norte
       gamelab_locationOf:
-        text: localização de [SPRITE][0]
+        text: localização de {SPRITE}
       gamelab_locationSouth:
         text: sul
       gamelab_locationWest:
         text: oeste
       gamelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       gamelab_location_variable_get:
-        text: localização de [VAR][0]
+        text: localização de {VAR}
       gamelab_location_variable_set:
-        text: definir localização de [VAR][0] para [VAL][1]
+        text: definir localização de {VAR} para {VAL}
       gamelab_makeNewGroup:
         text: criar um novo grupo
       gamelab_mirrorSprite:
-        text: "[SPRITE][0] vira para [DIRECTION][1]"
+        text: "{SPRITE} vira para {DIRECTION}"
         options:
           DIRECTION:
             '"right"': para direita
             '"left"': para esquerda
       gamelab_mixColors:
-        text: Mesclar [COLOR1][0] e [COLOR2][1]
+        text: Mesclar {COLOR1} e {COLOR2}
       gamelab_mouseDown:
         text: mouse está parado
       gamelab_mouseLocation:
         text: posição do mouse
       gamelab_moveDown:
-        text: "[THIS][0] move para baixo"
+        text: "{THIS} move para baixo"
       gamelab_moveForward:
-        text: mover [SPRITE][0] [DISTANCE][1] pixels pra frente
+        text: mover {SPRITE} {DISTANCE} pixels pra frente
       gamelab_moveInDirection:
-        text: mover [SPRITE][0] [DISTANCE][1] pixels [DIRECTION][2]
+        text: mover {SPRITE} {DISTANCE} pixels {DIRECTION}
         options:
           DIRECTION:
             '"North"': Norte
@@ -826,17 +826,17 @@ pt-BR:
             '"South"': Sul
             '"West"': Oeste
       gamelab_moveInDirection2:
-        text: mover [SPRITE][0] pixels [DISTANCE][1] na direção de [DIRECTION][2]
+        text: mover {SPRITE} pixels {DISTANCE} na direção de {DIRECTION}
       gamelab_moveLeft:
-        text: "[THIS][0] mover pra esquerda"
+        text: "{THIS} mover pra esquerda"
       gamelab_moveRight:
-        text: "[THIS][0] mover pra direita"
+        text: "{THIS} mover pra direita"
       gamelab_moveToward:
-        text: mover [SPRITE][0] distância [DISTANCE][1] em direção a [TARGET][2]
+        text: mover {SPRITE} distância {DISTANCE} em direção a {TARGET}
       gamelab_moveUp:
-        text: "[THIS][0] move pra cima"
+        text: "{THIS} move pra cima"
       gamelab_pointInDirection:
-        text: aponte [SPRITE][0] [DIRECTION][1]
+        text: aponte {SPRITE} {DIRECTION}
         options:
           DIRECTION:
             '"North"': Norte
@@ -844,7 +844,7 @@ pt-BR:
             '"South"': Sul
             '"West"': Oeste
       gamelab_pointToward:
-        text: aponte [SPRITE][0] para [LOCATION][1]
+        text: aponte {SPRITE} para {LOCATION}
       gamelab_randColor:
         text: cor aleatória
       gamelab_randomColor:
@@ -852,23 +852,23 @@ pt-BR:
       gamelab_randomLocation:
         text: posição aleatória
       gamelab_removeAllBehaviors:
-        text: "[SPRITE][0] para tudo"
+        text: "{SPRITE} para tudo"
       gamelab_removeBehaviorSimple:
-        text: personagem [SPRITE][0] para [BEHAVIOR][1]
+        text: personagem {SPRITE} para {BEHAVIOR}
       gamelab_removeTint:
-        text: retirar cor de [THIS][0]
+        text: retirar cor de {THIS}
       gamelab_secondTouched:
         text: segunda fada a ser tocada
       gamelab_setAnimation:
-        text: alterar fantasia de [THIS][0] para [ANIMATION][1]
+        text: alterar fantasia de {THIS} para {ANIMATION}
       gamelab_setBackground:
-        text: definir a cor do plano de fundo [COLOR][0]
+        text: definir a cor do plano de fundo {COLOR}
       gamelab_setDirection:
-        text: definir [SPRITE][0] direção de movimento [DIRECTION][1]
+        text: definir {SPRITE} direção de movimento {DIRECTION}
       gamelab_setFrameDelay:
-        text: definir [THIS][0] atraso do quadro [VAL][1]
+        text: definir {THIS} atraso do quadro {VAL}
       gamelab_setPosition:
-        text: mover [THIS][0] para a posição [POSITION][1]
+        text: mover {THIS} para a posição {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": canto superior esquerdo
@@ -882,7 +882,7 @@ pt-BR:
             "{x: 350, y: 350}": canto inferior direito
             '"random"': aleatório
       gamelab_setProp:
-        text: definir [SPRITE][0] [PROPERTY][1] para [VAL][2]
+        text: definir {SPRITE} {PROPERTY} para {VAL}
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -892,22 +892,22 @@ pt-BR:
             '"direction"': direção do movimento
             '"tint"': tonalidade
       gamelab_setSizes:
-        text: definir [SPRITE][0] [PROPERTY][1] para [N][2]%
+        text: definir {SPRITE} {PROPERTY} para {N}%
         options:
           PROPERTY:
             '"scale"': tamanho
             '"width"': largura
             '"height"': altura
       gamelab_setTint:
-        text: mudar a cor de [THIS][0] para [COLOR][1]
+        text: mudar a cor de {THIS} para {COLOR}
       gamelab_setup:
         text: configuração
       gamelab_showTitleScreen:
-        text: mostrar tela de título [BREAK][0] título [TITLE][1] texto [SUBTITLE][2]
+        text: mostrar tela de título {BREAK} título {TITLE} texto {SUBTITLE}
       gamelab_spriteCostume:
-        text: "[COSTUME][0]"
+        text: "{COSTUME}"
       gamelab_spriteDirection:
-        text: "[DIRECTION][0]"
+        text: "{DIRECTION}"
         options:
           DIRECTION:
             '"North"': Norte
@@ -915,7 +915,7 @@ pt-BR:
             '"South"': Sul
             '"West"': Oeste
       gamelab_spritesWhere:
-        text: personagens onde [PROPERTY][0] é [VALUE][1]
+        text: personagens onde {PROPERTY} é {VALUE}
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -926,9 +926,9 @@ pt-BR:
             '"rotation"': rotação ou direção
             '"tint"': tonalidade
       gamelab_spritesWhereFirst:
-        text: primeiro [VALUE][0]
+        text: primeiro {VALUE}
       gamelab_spritesWhereGenerator:
-        text: personagens onde [PROPERTY][0] [OP][1] [VALUE][2]
+        text: personagens onde {PROPERTY} {OP} {VALUE}
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -943,16 +943,16 @@ pt-BR:
             '">"': ">"
             '"<"': "\\<"
       gamelab_spritesWhereLast:
-        text: último [VALUE][0]
+        text: último {VALUE}
       gamelab_spritesWhereRandom:
-        text: aleatório no grupo [VALUE][0]
+        text: aleatório no grupo {VALUE}
       gamelab_thisBeginsBehaviorSimple:
-        text: sprite [SPRITE][0] começa a [BEHAVIOR][1]
+        text: sprite {SPRITE} começa a {BEHAVIOR}
         options:
           SPRITE:
             abc: este personagem
       gamelab_turn:
-        text: "[SPRITE][0] gira [DIRECTION][1] [N][2] graus"
+        text: "{SPRITE} gira {DIRECTION} {N} graus"
         options:
           DIRECTION:
             '"right"': para direita
@@ -962,7 +962,7 @@ pt-BR:
       gamelab_whenJoystick:
         text: quando o joystick
       gamelab_whenKey:
-        text: quando [KEY][0] for pressionado
+        text: quando {KEY} for pressionado
         options:
           KEY:
             '"up"': para cima
@@ -979,7 +979,7 @@ pt-BR:
       gamelab_whenMouseClicked:
         text: quando o personagem for clicado
       gamelab_whenPressedAndReleased:
-        text: "quando [DIR][0] pressionado \n[STATEMENT1][1]quando liberado\n[STATEMENT2][2]"
+        text: "quando {DIR} pressionado \n{STATEMENT1}quando liberado\n{STATEMENT2}"
         options:
           DIR:
             "'up'": para cima
@@ -990,14 +990,14 @@ pt-BR:
         text: quando a seta para direita for pressionada
       gamelab_whenStartAndStopTouching:
         text: |-
-          quando [SPRITE1][0] começar a encostar em [SPRITE2][1] [STATEMENT1][2]quando eles param de se encostar
-          [STATEMENT2][3]
+          quando {SPRITE1} começar a encostar em {SPRITE2} {STATEMENT1}quando eles param de se encostar
+          {STATEMENT2}
       gamelab_whenTouching:
-        text: quando [SPRITE1][0] encostar [SPRITE2][1]
+        text: quando {SPRITE1} encostar {SPRITE2}
       gamelab_whenTouchingAny:
-        text: quando [SPRITE][0] encosta em qualquer [GROUP][1]
+        text: quando {SPRITE} encosta em qualquer {GROUP}
       gamelab_whenTrue:
-        text: quando [CONDITION][0] for verdadeiro
+        text: quando {CONDITION} for verdadeiro
       gamelab_whenUpArrow:
         text: quando a seta para cima for pressionada
       gamelab_whileDownArrow:
@@ -1005,7 +1005,7 @@ pt-BR:
       gamelab_whileJoystick:
         text: enquanto o joystick
       gamelab_whileKey:
-        text: enquanto [KEY][0] estiver pressionado
+        text: enquanto {KEY} estiver pressionado
         options:
           KEY:
             '"up"': para cima
@@ -1022,15 +1022,15 @@ pt-BR:
       gamelab_whileRightArrow:
         text: enquanto a seta para a direita estiver pressionada
       gamelab_whileTouching:
-        text: enquanto [SPRITE1][0] estiver tocando [SPRITE2][1]
+        text: enquanto {SPRITE1} estiver tocando {SPRITE2}
       gamelab_whileUpArrow:
         text: enquanto a seta para cima estiver pressionada
       gamelab_xLocationOf:
-        text: coordenada x do [SPRITE][0]
+        text: coordenada x do {SPRITE}
       gamelab_yLocationOf:
-        text: coordenada y do [SPRITE][0]
+        text: coordenada y do {SPRITE}
       Mikelab_addBehaviorSimple:
-        text: sprite [SPRITE][0] começa a [BEHAVIOR][1]
+        text: sprite {SPRITE} começa a {BEHAVIOR}
       Mikelab_changePropBy:
         options:
           PROPERTY:
@@ -1053,7 +1053,7 @@ pt-BR:
             "{x: 300, y: 300}": canto inferior direito
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": Aleatório
       Mikelab_destroy:
-        text: remover [SPRITE][0]
+        text: remover {SPRITE}
       Mikelab_getProp:
         options:
           PROPERTY:
@@ -1128,11 +1128,11 @@ pt-BR:
           SELECT:
             '"all"': todos
       Mikelab_hasBehavior:
-        text: "[SPRITE][0] está [BEHAVIOR][1]"
+        text: "{SPRITE} está {BEHAVIOR}"
       Mikelab_ifDanceIs:
         text: |-
-          se [SPRITE][0] está fazendo [DANCE][1]
-          [DO1][2] [DO2][3]
+          se {SPRITE} está fazendo {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Bater palmas
@@ -1147,13 +1147,13 @@ pt-BR:
             MOVES.ThisOrThat: Isso ou Aquilo
             MOVES.Rest: Nenhum
       Mikelab_locationAt:
-        text: 'localização x: [X][0] y: [Y][1]'
+        text: 'localização x: {X} y: {Y}'
       Mikelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       Mikelab_randomColor:
         text: cor aleatória
       Mikelab_removeBehaviorSimple:
-        text: personagem [SPRITE][0] para [BEHAVIOR][1]
+        text: personagem {SPRITE} para {BEHAVIOR}
       Mikelab_setBG:
         options:
           BG:
@@ -1185,9 +1185,9 @@ pt-BR:
             "{x: 300, y: 300}": canto inferior direito
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": Aleatório
       Mikelab_whenClickedOn:
-        text: quando [SPRITE][0] for clicado
+        text: quando {SPRITE} for clicado
       Mikelab_whenKeyPressed:
-        text: quando [KEY][0] for pressionado
+        text: quando {KEY} for pressionado
         options:
           KEY:
             '"up"': seta para cima
@@ -1219,9 +1219,9 @@ pt-BR:
             '"left"': seta para a esquerda
             '"right"': seta para a direita
       Mikelab_xLocationOf:
-        text: coordenada x do [SPRITE][0]
+        text: coordenada x do {SPRITE}
       Mikelab_yLocationOf:
-        text: coordenada y do [SPRITE][0]
+        text: coordenada y do {SPRITE}
       RyanLab_moveForward:
         text: avance
       RyanLab_turnLeft:
@@ -1231,32 +1231,32 @@ pt-BR:
       Vector_createSpriteWith:
         text: |-
           criar um personagem
-          faça[STATEMENT][0]
+          faça{STATEMENT}
       Vector_log:
-        text: mostra mensagem [MESSAGE][0]
+        text: mostra mensagem {MESSAGE}
       Vector_positionCenter:
         text: centro
       Vector_push:
-        text: definir velocidade [VECTOR][0]
+        text: definir velocidade {VECTOR}
       Vector_randomLocation:
         text: posição aleatória
       Vector_setColor:
-        text: definir cor para [COLOR][0]
+        text: definir cor para {COLOR}
       Vector_setSize:
-        text: definir largura [WIDTH][0] altura [HEIGHT][1]
+        text: definir largura {WIDTH} altura {HEIGHT}
       Vector_teleportTo:
-        text: definir posição [POSITION][0]
+        text: definir posição {POSITION}
       Vector_vectorNorth:
         text: norte
       Vector_where:
-        text: cada personagem onde [PROPERTY][0] é [VALUE][1] faça[STATEMENT][2]
+        text: cada personagem onde {PROPERTY} é {VALUE} faça{STATEMENT}
         options:
           PROPERTY:
             "'shapeColor'": cor
       aalab_addToSpriteGroup:
-        text: adicionar personagem [SPRITE][0] ao grupo [GROUP][1]
+        text: adicionar personagem {SPRITE} ao grupo {GROUP}
       aalab_changeGroupPropBy:
-        text: mude o grupo [GROUP][0] [PROPERTY][1] por [VAL][2]
+        text: mude o grupo {GROUP} {PROPERTY} por {VAL}
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -1266,12 +1266,12 @@ pt-BR:
             '"direction"': direção do movimento
       aalab_createPropertyGroup:
         text: |-
-          faça um novo grupo de sprite chamado [VAR][0]
-          de todos os sprites [COSTUME][1]
+          faça um novo grupo de sprite chamado {VAR}
+          de todos os sprites {COSTUME}
       aalab_createSpriteGroup:
-        text: faça um novo grupo de personagens chamado [VAR][0]
+        text: faça um novo grupo de personagens chamado {VAR}
       aalab_spritesWhere:
-        text: personagens onde [PROPERTY][0] é [VALUE][1]
+        text: personagens onde {PROPERTY} é {VALUE}
         options:
           PROPERTY:
             '"scale"': tamanho
@@ -1289,7 +1289,7 @@ pt-BR:
             '"left"': para esquerda
             '"right"': para direita
       binary_whenKey:
-        text: quando [KEY][0] for pressionado
+        text: quando {KEY} for pressionado
         options:
           KEY:
             '"up"': para cima
@@ -1303,8 +1303,8 @@ pt-BR:
             '"d"': d
       craft_ifPath:
         text: |-
-          se o caminho estiver [DIR][0]
-          [STATEMENT][1]
+          se o caminho estiver {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": adiante
@@ -1312,8 +1312,8 @@ pt-BR:
             "'left'": à esquerda
       craft_ifStandingOn:
         text: |-
-          se estiver em cima de [TYPE][0]
-          [STATEMENT][1]
+          se estiver em cima de {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": coral azul
@@ -1324,19 +1324,19 @@ pt-BR:
             "'seaLantern'": lanterna do mar
       craft_ifStandingOnLimit:
         text: |-
-          se estiver em cima de [TYPE][0]
-          [STATEMENT][1]
+          se estiver em cima de {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": areia
             "'darkPrismarine'": prismarinho escuro
             "'seaLantern'": lanterna do mar
       craft_log:
-        text: mostra mensagem [MESSAGE][0]
+        text: mostra mensagem {MESSAGE}
       craft_moveForward:
         text: avance
       craft_placeBlock:
-        text: colocar [blockType][0]
+        text: colocar {blockType}
         options:
           blockType:
             '"strippedOak"': carvalho descascado
@@ -1371,13 +1371,13 @@ pt-BR:
       craft_repeatUntilConduit:
         text: |-
           repetir até concluir o canal
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           repetir até o objetivo
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: invocar [ENTITY][0]
+        text: invocar {ENTITY}
         options:
           ENTITY:
             '"cod"': bacalhau
@@ -1387,7 +1387,7 @@ pt-BR:
             '"squid"': lula
             '"tropicalFish"': peixe tropical
       craft_turn:
-        text: virar [DIR][0]
+        text: virar {DIR}
         options:
           DIR:
             right: à direita ↻

--- a/dashboard/config/locales/blocks.pt-PT.yml
+++ b/dashboard/config/locales/blocks.pt-PT.yml
@@ -398,8 +398,8 @@ pt:
             '"space"': espaço
       craft_ifPath:
         text: |-
-          se o caminho seguir para [DIR][0]
-          [STATEMENT][1]
+          se o caminho seguir para {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": à frente
@@ -407,8 +407,8 @@ pt:
             "'left'": a esquerda
       craft_ifStandingOn:
         text: |-
-          se em cima de [TYPE][0]
-          [STATEMENT][1]
+          se em cima de {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": coral azul
@@ -419,8 +419,8 @@ pt:
             "'seaLantern'": lanterna aquática
       craft_ifStandingOnLimit:
         text: |-
-          se em cima de [TYPE][0]
-          [STATEMENT][1]
+          se em cima de {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": areia
@@ -429,7 +429,7 @@ pt:
       craft_moveForward:
         text: segue em frente
       craft_placeBlock:
-        text: colocar [blockType][0]
+        text: colocar {blockType}
         options:
           blockType:
             '"strippedOak"': carvalho despojado
@@ -461,15 +461,15 @@ pt:
       craft_repeatUntilConduit:
         text: |-
           repetir até conclusão do canal
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           repetir até ao objetivo
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: gerar [ENTITY][0]
+        text: gerar {ENTITY}
       craft_turn:
-        text: virar [DIR][0]
+        text: virar {DIR}
         options:
           DIR:
             right: direita ↻

--- a/dashboard/config/locales/blocks.ru-RU.yml
+++ b/dashboard/config/locales/blocks.ru-RU.yml
@@ -3,20 +3,20 @@ ru:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: после [TIMESTAMP][0] [UNIT][1]
+        text: после {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': такты
             '"seconds"': секунд
       Dancelab_changeColorBy:
-        text: изменить [COLOR][0] [METHOD][1] на [AMOUNT][2]
+        text: изменить {COLOR} {METHOD} на {AMOUNT}
         options:
           METHOD:
             '"hue"': оттенок
             '"saturation"': насыщенность
             '"brightness"': яркость
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] делать [MOVE][1] [DIR][2] всегда"
+        text: "{GROUP} делать {MOVE} {DIR} всегда"
         options:
           GROUP:
             sprites: все
@@ -50,7 +50,7 @@ ru:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] делать [MOVE][1] [DIR][2] всегда"
+        text: "{SPRITE} делать {MOVE} {DIR} всегда"
         options:
           MOVE:
             '"next"': "(Следующий)"
@@ -71,7 +71,7 @@ ru:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: изменить [SPRITE][0] [PROPERTY][1] на [VAL][2]
+        text: изменить {SPRITE} {PROPERTY} на {VAL}
         options:
           PROPERTY:
             '"scale"': размер
@@ -81,7 +81,7 @@ ru:
             '"x"': горизонтальное положение
             '"y"': вертикальное положение
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] делать [MOVE][1] [DIR][2] один раз"
+        text: "{GROUP} делать {MOVE} {DIR} один раз"
         options:
           GROUP:
             sprites: все
@@ -113,7 +113,7 @@ ru:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] делать [MOVE][1] [DIR][2] один раз"
+        text: "{SPRITE} делать {MOVE} {DIR} один раз"
         options:
           MOVE:
             '"rand"': "(Случайный)"
@@ -132,25 +132,25 @@ ru:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'каждые [N][0] [UNIT][1] '
+        text: 'каждые {N} {UNIT} '
         options:
           UNIT:
             '"measures"': такты
             '"seconds"': секунд
       Dancelab_everySecondsRange:
-        text: 'каждые [N][0] [UNIT][1] от [START][2] до [STOP][3] '
+        text: 'каждые {N} {UNIT} от {START} до {STOP} '
         options:
           UNIT:
             measures: Такты
             seconds: Секунды
       Dancelab_everyVerseChorus:
-        text: 'каждые [UNIT][0] '
+        text: 'каждые {UNIT} '
         options:
           UNIT:
             '"verse"': куплет
             '"chorus"': припев
       Dancelab_getEnergy:
-        text: получить [RANGE][0]
+        text: получить {RANGE}
         options:
           RANGE:
             '"low"': бас
@@ -167,15 +167,15 @@ ru:
             '"y"': вертикальное положение
             '"tint"': оттенок
       Dancelab_getTime:
-        text: прошло [UNIT][0]
+        text: прошло {UNIT}
         options:
           UNIT:
             '"measures"': такты
             '"seconds"': секунд
       Dancelab_ifDanceIs:
         text: |-
-          если [SPRITE][0] выполняет [DANCE][1]
-          [DO1][2] [DO2][3]
+          если {SPRITE} выполняет {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Высокий хлопок
@@ -195,7 +195,7 @@ ru:
             '"measures"': такты
             '"seconds"': секунд
       Dancelab_jumpTo:
-        text: "[SPRITE][0] перейти к [LOCATION][1]"
+        text: "{SPRITE} перейти к {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": верх
@@ -209,7 +209,7 @@ ru:
             "{x: 300, y: 300}": внизу справа
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": случайный
       Dancelab_layoutSprites:
-        text: расстановка [GROUP][0] как [FORMAT][1]
+        text: расстановка {GROUP} как {FORMAT}
         options:
           GROUP:
             sprites: все
@@ -236,8 +236,8 @@ ru:
             '"random"': случайный
       Dancelab_makeNewDanceSprite:
         text: |-
-          создать новый [COSTUME][0]
-          вызов [NAME][1] в [LOCATION][2]
+          создать новый {COSTUME}
+          вызов {NAME} в {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Инопланетянин
@@ -264,8 +264,8 @@ ru:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": случайный
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          создать [N][0] новых [COSTUME][1]
-          в [LAYOUT][2]
+          создать {N} новых {COSTUME}
+          в {LAYOUT}
         options:
           N:
             '2': '2'
@@ -310,9 +310,9 @@ ru:
             '"plus"': плюс
             '"random"': случайный
       Dancelab_mixColors:
-        text: смешайте [COLOR1][0] и [COLOR2][1]
+        text: смешайте {COLOR1} и {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] тактов"
+        text: "{N} тактов"
       Dancelab_onPointerDown:
         text: при перемещении указателя вниз
       Dancelab_onPointerDrag:
@@ -322,9 +322,9 @@ ru:
       Dancelab_randomColor:
         text: случайный цвет
       Dancelab_setBackground:
-        text: задать цвет фона [COLOR][0]
+        text: задать цвет фона {COLOR}
       Dancelab_setBackgroundEffect:
-        text: задать фоновый эффект [EFFECT][0]
+        text: задать фоновый эффект {EFFECT}
         options:
           EFFECT:
             '"none"': Нет
@@ -347,7 +347,7 @@ ru:
             '"vintage"': Винтаж
             '"warm"': Красный
       Dancelab_setBackgroundEffectWithPalette:
-        text: задать фоновый эффект [EFFECT][0] [PALETTE][1]
+        text: задать фоновый эффект {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Нет
@@ -372,7 +372,7 @@ ru:
             '"vintage"': Винтаж
             '"warm"': Красный
       Dancelab_setDanceSpeed:
-        text: измените скорость танца [SPRITE][0] на [SPEED][1]
+        text: измените скорость танца {SPRITE} на {SPEED}
         options:
           SPEED:
             '1': норма
@@ -402,7 +402,7 @@ ru:
             '0.5': медленно
             '0.25': очень медленно
       Dancelab_setForegroundEffect:
-        text: задать эффект переднего плана [EFFECT][0]
+        text: задать эффект переднего плана {EFFECT}
         options:
           EFFECT:
             '"none"': Нет
@@ -415,7 +415,7 @@ ru:
             '"floating_rainbows"': Радуга
             '"raining_tacos"': Тако
       Dancelab_setForegroundEffectExtended:
-        text: задать эффект переднего плана [EFFECT][0]
+        text: задать эффект переднего плана {EFFECT}
         options:
           EFFECT:
             '"none"': Нет
@@ -429,7 +429,7 @@ ru:
             '"floating_rainbows"': Радуга
             '"raining_tacos"': Тако
       Dancelab_setProp:
-        text: 'установить [SPRITE][0] [PROPERTY][1] на [VAL][2] '
+        text: 'установить {SPRITE} {PROPERTY} на {VAL} '
         options:
           PROPERTY:
             '"scale"': размер
@@ -440,7 +440,7 @@ ru:
             '"y"': вертикальное положение
             '"tint"': оттенок
       Dancelab_setPropEach:
-        text: установить [GROUP][0] [PROPERTY][1] на [VAL][2]
+        text: установить {GROUP} {PROPERTY} на {VAL}
         options:
           GROUP:
             sprites: все
@@ -464,7 +464,7 @@ ru:
             '"y"': вертикальное положение
             '"tint"': оттенок
       Dancelab_setPropRandom:
-        text: рандомизировать [SPRITE][0] [PROPERTY][1]
+        text: рандомизировать {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': размер
@@ -475,7 +475,7 @@ ru:
             '"y"': вертикальное положение
             '"tint"': оттенок
       Dancelab_setTint:
-        text: установить оттенок [SPRITE][0] на [VAL][1]
+        text: установить оттенок {SPRITE} на {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -491,15 +491,15 @@ ru:
             '"ROBOT"': все роботы
             '"SHARK"': все акулы
       Dancelab_setTintInline:
-        text: установить оттенок [SPRITE][0] на [VAL][1]
+        text: установить оттенок {SPRITE} на {VAL}
       Dancelab_setVisible:
-        text: установить видимость [SPRITE][0] на [VISIBILITY][1]
+        text: установить видимость {SPRITE} на {VISIBILITY}
         options:
           VISIBILITY:
             'true': видимый
             'false': невидимый
       Dancelab_setVisibleEach:
-        text: установить видимость [THIS][0] на [VISIBILITY][1]
+        text: установить видимость {THIS} на {VISIBILITY}
         options:
           THIS:
             sprites: все
@@ -518,7 +518,7 @@ ru:
             'true': видимый
             'false': невидимый
       Dancelab_startMapping:
-        text: "[SPRITE][0] начинает [PROPERTY][1] после [RANGE][2]"
+        text: "{SPRITE} начинает {PROPERTY} после {RANGE}"
         options:
           PROPERTY:
             '"scale"': размер
@@ -533,7 +533,7 @@ ru:
             '"mid"': средние
             '"treble"': высокие
       Dancelab_stopMapping:
-        text: "[SPRITE][0] останавливает [PROPERTY][1] после [RANGE][2]"
+        text: "{SPRITE} останавливает {PROPERTY} после {RANGE}"
         options:
           PROPERTY:
             '"scale"': размер
@@ -549,7 +549,7 @@ ru:
             '"mid"': средние
             '"treble"': высокие
       Dancelab_whenKey:
-        text: при нажатии [KEY][0]
+        text: при нажатии {KEY}
         options:
           KEY:
             '"up"': вверх
@@ -560,7 +560,7 @@ ru:
             '"x"': x
             '"y"': у
       Dancelab_whenPeak:
-        text: при максимуме [RANGE][0]
+        text: при максимуме {RANGE}
         options:
           RANGE:
             '0': бас
@@ -569,19 +569,19 @@ ru:
       Dancelab_whenSetup:
         text: установка
       gamelab_changeColor:
-        text: изменить [COLOR][0] [METHOD][1] на [AMOUNT][2]
+        text: изменить {COLOR} {METHOD} на {AMOUNT}
         options:
           METHOD:
             '"tint"': оттенок
       gamelab_changeColorBy:
-        text: изменить [COLOR][0] [METHOD][1] на [AMOUNT][2]
+        text: изменить {COLOR} {METHOD} на {AMOUNT}
         options:
           METHOD:
             '"hue"': оттенок
             '"saturation"': насыщенность
             '"brightness"': яркость
       gamelab_changePropBy:
-        text: изменить [SPRITE][0] [PROPERTY][1] на [VAL][2]
+        text: изменить {SPRITE} {PROPERTY} на {VAL}
         options:
           PROPERTY:
             '"scale"': размер
@@ -604,7 +604,7 @@ ru:
             '"direction"': направление движения
             '"tint"': оттенок
       gamelab_jumpTo:
-        text: "[SPRITE][0] перейти к [LOCATION][1]"
+        text: "{SPRITE} перейти к {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -615,15 +615,15 @@ ru:
             '"right"': вправо
             '"left"': влево
       gamelab_mixColors:
-        text: смешайте [COLOR1][0] и [COLOR2][1]
+        text: смешайте {COLOR1} и {COLOR2}
       gamelab_randColor:
         text: случайный цвет
       gamelab_randomColor:
         text: случайный цвет
       gamelab_setBackground:
-        text: задать цвет фона [COLOR][0]
+        text: задать цвет фона {COLOR}
       gamelab_setPosition:
-        text: переместить [THIS][0] в положение [POSITION][1]
+        text: переместить {THIS} в положение {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": вверху слева
@@ -676,7 +676,7 @@ ru:
             '"right"': вправо
             '"left"': влево
       gamelab_whenKey:
-        text: при нажатии [KEY][0]
+        text: при нажатии {KEY}
         options:
           KEY:
             '"up"': вверх
@@ -793,8 +793,8 @@ ru:
             '"all"': все
       Mikelab_ifDanceIs:
         text: |-
-          если [SPRITE][0] выполняет [DANCE][1]
-          [DO1][2] [DO2][3]
+          если {SPRITE} выполняет {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Высокий хлопок
@@ -840,7 +840,7 @@ ru:
             "{x: 100, y: 300}": внизу слева
             "{x: 300, y: 300}": внизу справа
       Mikelab_whenKeyPressed:
-        text: при нажатии [KEY][0]
+        text: при нажатии {KEY}
         options:
           KEY:
             '"up"': клавиша со стрелкой вверх
@@ -901,7 +901,7 @@ ru:
             '"left"': влево
             '"right"': вправо
       binary_whenKey:
-        text: при нажатии [KEY][0]
+        text: при нажатии {KEY}
         options:
           KEY:
             '"up"': вверх
@@ -911,8 +911,8 @@ ru:
             '"space"': космос
       craft_ifPath:
         text: |-
-          если путь [DIR][0]
-          [STATEMENT][1]
+          если путь {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": вперед
@@ -920,8 +920,8 @@ ru:
             "'left'": слева
       craft_ifStandingOn:
         text: |-
-          стоя на [TYPE][0]
-          [STATEMENT][1]
+          стоя на {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": синем коралле
@@ -932,8 +932,8 @@ ru:
             "'seaLantern'": морском фонаре
       craft_ifStandingOnLimit:
         text: |-
-          стоя на [TYPE][0]
-          [STATEMENT][1]
+          стоя на {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": песок
@@ -942,7 +942,7 @@ ru:
       craft_moveForward:
         text: двигаться вперед
       craft_placeBlock:
-        text: разместить [blockType][0]
+        text: разместить {blockType}
         options:
           blockType:
             '"strippedOak"': очищенный дуб
@@ -975,15 +975,15 @@ ru:
       craft_repeatUntilConduit:
         text: |-
           повторить до завершения проводника
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           повторить до достижения цели
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: создать [ENTITY][0]
+        text: создать {ENTITY}
       craft_turn:
-        text: повернуть [DIR][0]
+        text: повернуть {DIR}
         options:
           DIR:
             right: направо ↻

--- a/dashboard/config/locales/blocks.sk-SK.yml
+++ b/dashboard/config/locales/blocks.sk-SK.yml
@@ -3,20 +3,20 @@ sk:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: po [TIMESTAMP][0] [UNIT][1]
+        text: po {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekundy
       Dancelab_changeColorBy:
-        text: zmeň [COLOR][0] [METHOD][1] o [AMOUNT][2]
+        text: zmeň {COLOR} {METHOD} o {AMOUNT}
         options:
           METHOD:
             '"hue"': odtieň
             '"saturation"': sýtosť
             '"brightness"': jas
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] urobte [MOVE][1] \n[DIR][2] nekonečne krát"
+        text: "{GROUP} urobte {MOVE} \n{DIR} nekonečne krát"
         options:
           GROUP:
             sprites: všetky
@@ -50,7 +50,7 @@ sk:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] urob [MOVE][1] \n[DIR][2] nekonečne krát"
+        text: "{SPRITE} urob {MOVE} \n{DIR} nekonečne krát"
         options:
           MOVE:
             '"next"': "(Ďalší)"
@@ -71,7 +71,7 @@ sk:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: zmeň [SPRITE][0] [PROPERTY][1] o [VAL][2]
+        text: zmeň {SPRITE} {PROPERTY} o {VAL}
         options:
           PROPERTY:
             '"scale"': veľkosť
@@ -81,7 +81,7 @@ sk:
             '"x"': horizontálna pozícia
             '"y"': vertikálna pozícia
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] urobte [MOVE][1] \n[DIR][2] jeden krát"
+        text: "{GROUP} urobte {MOVE} \n{DIR} jeden krát"
         options:
           GROUP:
             sprites: všetky
@@ -125,7 +125,7 @@ sk:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] urob [MOVE][1] \n[DIR][2] jeden krát"
+        text: "{SPRITE} urob {MOVE} \n{DIR} jeden krát"
         options:
           MOVE:
             '"rand"': "(Náhodné)"
@@ -156,32 +156,32 @@ sk:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'každé [N][0] [UNIT][1] '
+        text: 'každé {N} {UNIT} '
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekundy
       Dancelab_everySecondsRange:
-        text: 'každé [N][0] [UNIT][1] od [START][2] do [STOP][3] '
+        text: 'každé {N} {UNIT} od {START} do {STOP} '
         options:
           UNIT:
             measures: Takty
             seconds: Sekundy
       Dancelab_everyVerseChorus:
-        text: 'každý [UNIT][0] '
+        text: 'každý {UNIT} '
         options:
           UNIT:
             '"verse"': verš
             '"chorus"': refrén
       Dancelab_getEnergy:
-        text: získaj [RANGE][0]
+        text: získaj {RANGE}
         options:
           RANGE:
             '"low"': basy
             '"mid"': stredy
             '"high"': výšky
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': veľkosť
@@ -192,15 +192,15 @@ sk:
             '"y"': vertikálna pozícia
             '"tint"': sfarbenie
       Dancelab_getTime:
-        text: aktuálny čas v [UNIT][0]
+        text: aktuálny čas v {UNIT}
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekundy
       Dancelab_ifDanceIs:
         text: |-
-          ak [SPRITE][0] robí [DANCE][1]
-          [DO1][2] [DO2][3]
+          ak {SPRITE} robí {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Vysoký Tlesk
@@ -216,14 +216,14 @@ sk:
             MOVES.Rest: Žiadne
       Dancelab_ifTime:
         text: |-
-          ak [UNIT][0] je [OP][1] [N][2]
-          [DO1][3] [DO2][4]
+          ak {UNIT} je {OP} {N}
+          {DO1} {DO2}
         options:
           UNIT:
             '"measures"': takty
             '"seconds"': sekundy
       Dancelab_jumpTo:
-        text: "[SPRITE][0] skoč [LOCATION][1]"
+        text: "{SPRITE} skoč {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": hore
@@ -237,7 +237,7 @@ sk:
             "{x: 300, y: 300}": vpravo dole
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": náhodný
       Dancelab_layoutSprites:
-        text: rozmiestni [GROUP][0] ako [FORMAT][1]
+        text: rozmiestni {GROUP} ako {FORMAT}
         options:
           GROUP:
             sprites: všetky
@@ -263,7 +263,7 @@ sk:
             '"plus"': plus
             '"random"': náhodný
       Dancelab_makeNewDanceSprite:
-        text: vytvor [COSTUME][0] s menom [NAME][1] s umiestnením [LOCATION][2]
+        text: vytvor {COSTUME} s menom {NAME} s umiestnením {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Mimozemšťan
@@ -289,7 +289,7 @@ sk:
             "{x: 300, y: 300}": vpravo dole
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": náhodný
       Dancelab_makeNewDanceSpriteGroup:
-        text: "vytvor [N][0] nových [COSTUME][1] \ns usporiadaním [LAYOUT][2]"
+        text: "vytvor {N} nových {COSTUME} \ns usporiadaním {LAYOUT}"
         options:
           N:
             '2': '2'
@@ -334,9 +334,9 @@ sk:
             '"plus"': plus
             '"random"': náhodný
       Dancelab_mixColors:
-        text: zmiešaj [COLOR1][0] a [COLOR2][1]
+        text: zmiešaj {COLOR1} a {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] taktoch"
+        text: "{N} taktoch"
       Dancelab_onPointerDown:
         text: na stlačenie myši
       Dancelab_onPointerDrag:
@@ -346,9 +346,9 @@ sk:
       Dancelab_randomColor:
         text: náhodná farba
       Dancelab_setBackground:
-        text: nastav farbu pozadia [COLOR][0]
+        text: nastav farbu pozadia {COLOR}
       Dancelab_setBackgroundEffect:
-        text: nastav efekt pozadia [EFFECT][0]
+        text: nastav efekt pozadia {EFFECT}
         options:
           EFFECT:
             '"none"': Žiadne
@@ -381,7 +381,7 @@ sk:
       Dancelab_setBackgroundEffectWithPalette:
         text: |-
           nastav efekt pozadia
-          [EFFECT][0] [PALETTE][1]
+          {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Žiadne
@@ -413,7 +413,7 @@ sk:
             '"vintage"': Vintage
             '"warm"': Teplý
       Dancelab_setDanceSpeed:
-        text: nastav [SPRITE][0] rýchlosť tanca na [SPEED][1]
+        text: nastav {SPRITE} rýchlosť tanca na {SPEED}
         options:
           SPEED:
             '1': normálny
@@ -422,7 +422,7 @@ sk:
             '0.5': pomaly
             '0.25': veľmi pomaly
       Dancelab_setDanceSpeedEach:
-        text: nastav [GROUP][0] rýchlosť tanca na [SPEED][1]
+        text: nastav {GROUP} rýchlosť tanca na {SPEED}
         options:
           GROUP:
             sprites: všetky
@@ -444,7 +444,7 @@ sk:
             '0.5': pomaly
             '0.25': veľmi pomaly
       Dancelab_setForegroundEffect:
-        text: nastav efekt popredia [EFFECT][0]
+        text: nastav efekt popredia {EFFECT}
         options:
           EFFECT:
             '"none"': Žiadne
@@ -462,7 +462,7 @@ sk:
             '"color_lights"': Javiskové svetlá
             '"raining_tacos"': Tacos
       Dancelab_setForegroundEffectExtended:
-        text: nastav efekt popredia [EFFECT][0]
+        text: nastav efekt popredia {EFFECT}
         options:
           EFFECT:
             '"none"': Žiadne
@@ -481,7 +481,7 @@ sk:
             '"color_lights"': Javiskové svetlá
             '"raining_tacos"': Tacos
       Dancelab_setProp:
-        text: 'nastav [SPRITE][0] [PROPERTY][1] na [VAL][2] '
+        text: 'nastav {SPRITE} {PROPERTY} na {VAL} '
         options:
           PROPERTY:
             '"scale"': veľkosť
@@ -492,7 +492,7 @@ sk:
             '"y"': vertikálna pozícia
             '"tint"': sfarbenie
       Dancelab_setPropEach:
-        text: nastav [GROUP][0] [PROPERTY][1] na [VAL][2]
+        text: nastav {GROUP} {PROPERTY} na {VAL}
         options:
           GROUP:
             sprites: všetky
@@ -516,7 +516,7 @@ sk:
             '"y"': vertikálna pozícia
             '"tint"': sfarbenie
       Dancelab_setPropRandom:
-        text: nastav náhodne [SPRITE][0] [PROPERTY][1]
+        text: nastav náhodne {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': veľkosť
@@ -527,9 +527,9 @@ sk:
             '"y"': vertikálna pozícia
             '"tint"': sfarbenie
       Dancelab_setTint:
-        text: nastav [SPRITE][0] sfarbenie na [VAL][1]
+        text: nastav {SPRITE} sfarbenie na {VAL}
       Dancelab_setTintEach:
-        text: nastav [THIS][0] sfarbenie na [VAL][1]
+        text: nastav {THIS} sfarbenie na {VAL}
         options:
           THIS:
             sprites: všetky
@@ -544,15 +544,15 @@ sk:
             '"ROBOT"': všetci roboti
             '"SHARK"': všetky žraloky
       Dancelab_setTintInline:
-        text: nastav [SPRITE][0] sfarbenie na [VAL][1]
+        text: nastav {SPRITE} sfarbenie na {VAL}
       Dancelab_setVisible:
-        text: nastav [SPRITE][0] viditeľnosť na [VISIBILITY][1]
+        text: nastav {SPRITE} viditeľnosť na {VISIBILITY}
         options:
           VISIBILITY:
             'true': viditeľný
             'false': neviditeľný
       Dancelab_setVisibleEach:
-        text: nastav [THIS][0] viditeľnosť na [VISIBILITY][1]
+        text: nastav {THIS} viditeľnosť na {VISIBILITY}
         options:
           THIS:
             sprites: všetky
@@ -571,7 +571,7 @@ sk:
             'true': viditeľný
             'false': neviditeľný
       Dancelab_startMapping:
-        text: "[SPRITE][0] začne [PROPERTY][1] nasledovať [RANGE][2]"
+        text: "{SPRITE} začne {PROPERTY} nasledovať {RANGE}"
         options:
           PROPERTY:
             '"scale"': veľkosť
@@ -586,7 +586,7 @@ sk:
             '"mid"': stredy
             '"treble"': výšky
       Dancelab_stopMapping:
-        text: "[SPRITE][0] prestane [PROPERTY][1] nasledovať [RANGE][2]"
+        text: "{SPRITE} prestane {PROPERTY} nasledovať {RANGE}"
         options:
           PROPERTY:
             '"scale"': veľkosť
@@ -602,7 +602,7 @@ sk:
             '"mid"': stredy
             '"treble"': výšky
       Dancelab_whenKey:
-        text: keď [KEY][0] stlačený
+        text: keď {KEY} stlačený
         options:
           KEY:
             '"up"': hore
@@ -631,7 +631,7 @@ sk:
             '"y"': y
             '"z"': z
       Dancelab_whenPeak:
-        text: keď [RANGE][0] vrcholia
+        text: keď {RANGE} vrcholia
         options:
           RANGE:
             '0': basy
@@ -640,19 +640,19 @@ sk:
       Dancelab_whenSetup:
         text: nastavenie
       gamelab_changeColor:
-        text: zmeň [COLOR][0] [METHOD][1] o [AMOUNT][2]
+        text: zmeň {COLOR} {METHOD} o {AMOUNT}
         options:
           METHOD:
             '"tint"': sfarbenie
       gamelab_changeColorBy:
-        text: zmeň [COLOR][0] [METHOD][1] o [AMOUNT][2]
+        text: zmeň {COLOR} {METHOD} o {AMOUNT}
         options:
           METHOD:
             '"hue"': odtieň
             '"saturation"': sýtosť
             '"brightness"': jas
       gamelab_changePropBy:
-        text: zmeň [SPRITE][0] [PROPERTY][1] o [VAL][2]
+        text: zmeň {SPRITE} {PROPERTY} o {VAL}
         options:
           PROPERTY:
             '"scale"': veľkosť
@@ -666,7 +666,7 @@ sk:
             'true': pravda
             'false': nepravda
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': veľkosť
@@ -676,7 +676,7 @@ sk:
             '"direction"': smeru pohybu
             '"tint"': sfarbenie
       gamelab_jumpTo:
-        text: "[SPRITE][0] skoč [LOCATION][1]"
+        text: "{SPRITE} skoč {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -687,13 +687,13 @@ sk:
             '"right"': vpravo
             '"left"': vľavo
       gamelab_mixColors:
-        text: zmiešaj [COLOR1][0] a [COLOR2][1]
+        text: zmiešaj {COLOR1} a {COLOR2}
       gamelab_randColor:
         text: náhodná farba
       gamelab_randomColor:
         text: náhodná farba
       gamelab_setBackground:
-        text: nastav farbu pozadia [COLOR][0]
+        text: nastav farbu pozadia {COLOR}
       gamelab_setPosition:
         options:
           POSITION:
@@ -742,7 +742,7 @@ sk:
             '"right"': vpravo
             '"left"': vľavo
       gamelab_whenKey:
-        text: keď [KEY][0] stlačený
+        text: keď {KEY} stlačený
         options:
           KEY:
             '"up"': hore
@@ -867,8 +867,8 @@ sk:
             '"all"': všetky
       Mikelab_ifDanceIs:
         text: |-
-          ak [SPRITE][0] robí [DANCE][1]
-          [DO1][2] [DO2][3]
+          ak {SPRITE} robí {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Vysoký Tlesk
@@ -914,7 +914,7 @@ sk:
             "{x: 100, y: 300}": vľavo dole
             "{x: 300, y: 300}": vpravo dole
       Mikelab_whenKeyPressed:
-        text: keď [KEY][0] stlačený
+        text: keď {KEY} stlačený
         options:
           KEY:
             '"up"': šípka hore
@@ -975,7 +975,7 @@ sk:
             '"left"': vľavo
             '"right"': vpravo
       binary_whenKey:
-        text: keď [KEY][0] stlačený
+        text: keď {KEY} stlačený
         options:
           KEY:
             '"up"': hore

--- a/dashboard/config/locales/blocks.sl-SI.yml
+++ b/dashboard/config/locales/blocks.sl-SI.yml
@@ -355,8 +355,8 @@ sl:
             "'ahead'": spredaj
       craft_ifStandingOn:
         text: |-
-          če stojiš na [TYPE][0]
-          [STATEMENT][1]
+          če stojiš na {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": moder koral
@@ -367,8 +367,8 @@ sl:
             "'seaLantern'": morska svetilka
       craft_ifStandingOnLimit:
         text: |-
-          če stojiš na [TYPE][0]
-          [STATEMENT][1]
+          če stojiš na {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": pesek

--- a/dashboard/config/locales/blocks.sq-AL.yml
+++ b/dashboard/config/locales/blocks.sq-AL.yml
@@ -321,8 +321,8 @@ sq:
             '"space"': hapësirë
       craft_ifPath:
         text: |-
-          nëse shtegu [DIR][0]
-          [STATEMENT][1]
+          nëse shtegu {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": përpara
@@ -330,8 +330,8 @@ sq:
             "'left'": në të majtë
       craft_ifStandingOn:
         text: |-
-          nëse je ngritur [TYPE][0]
-          [STATEMENT][1]
+          nëse je ngritur {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": korali blu
@@ -342,8 +342,8 @@ sq:
             "'seaLantern'": fari i detit
       craft_ifStandingOnLimit:
         text: |-
-          nëse je ngritur [TYPE][0]
-          [STATEMENT][1]
+          nëse je ngritur {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": rërë
@@ -352,7 +352,7 @@ sq:
       craft_moveForward:
         text: lëviz përpara
       craft_placeBlock:
-        text: vendos [blockType][0]
+        text: vendos {blockType}
         options:
           blockType:
             '"strippedOak"': lis i zhveshur
@@ -387,13 +387,13 @@ sq:
       craft_repeatUntilConduit:
         text: |-
           përsërite deri sa tubi të mbarojë
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           përsërit deri te pikësynimi
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: vezë peshku [ENTITY][0]
+        text: vezë peshku {ENTITY}
         options:
           ENTITY:
             '"cod"': merluc
@@ -403,7 +403,7 @@ sq:
             '"squid"': kallamar
             '"tropicalFish"': peshk tropikal
       craft_turn:
-        text: kthehu [DIR][0]
+        text: kthehu {DIR}
         options:
           DIR:
             right: djathtas ↻

--- a/dashboard/config/locales/blocks.sv-SE.yml
+++ b/dashboard/config/locales/blocks.sv-SE.yml
@@ -3,20 +3,20 @@ sv:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: efter [TIMESTAMP][0] [UNIT][1]
+        text: efter {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': åtgärder
             '"seconds"': sekunder
       Dancelab_changeColorBy:
-        text: ändra [COLOR][0] [METHOD][1] via [AMOUNT][2]
+        text: ändra {COLOR} {METHOD} via {AMOUNT}
         options:
           METHOD:
             '"hue"': nyans
             '"saturation"': färgmättnad
             '"brightness"': ljusstyrka
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] gör [MOVE][1] [DIR][2] för alltid"
+        text: "{GROUP} gör {MOVE} {DIR} för alltid"
         options:
           GROUP:
             sprites: alla
@@ -50,7 +50,7 @@ sv:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] gör [MOVE][1] [DIR][2] för alltid"
+        text: "{SPRITE} gör {MOVE} {DIR} för alltid"
         options:
           MOVE:
             '"next"': "(Nästa)"
@@ -71,7 +71,7 @@ sv:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: ändra [SPRITE][0] [PROPERTY][1] via [VAL][2]
+        text: ändra {SPRITE} {PROPERTY} via {VAL}
         options:
           PROPERTY:
             '"scale"': storlek
@@ -80,7 +80,7 @@ sv:
             '"x"': horisontellt läge
             '"y"': vertikalt läge
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] gör [MOVE][1] [DIR][2] en gång"
+        text: "{GROUP} gör {MOVE} {DIR} en gång"
         options:
           GROUP:
             sprites: alla
@@ -112,7 +112,7 @@ sv:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] gör [MOVE][1] [DIR][2] en gång"
+        text: "{SPRITE} gör {MOVE} {DIR} en gång"
         options:
           MOVE:
             '"rand"': "(Slumpad)"
@@ -131,25 +131,25 @@ sv:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'varje [N][0] [UNIT][1] '
+        text: 'varje {N} {UNIT} '
         options:
           UNIT:
             '"measures"': åtgärder
             '"seconds"': sekunder
       Dancelab_everySecondsRange:
-        text: 'varje [N][0] [UNIT][1] från [START][2] till [STOP][3] '
+        text: 'varje {N} {UNIT} från {START} till {STOP} '
         options:
           UNIT:
             measures: Åtgärder
             seconds: Sekunder
       Dancelab_everyVerseChorus:
-        text: 'varje [UNIT][0] '
+        text: 'varje {UNIT} '
         options:
           UNIT:
             '"verse"': vers
             '"chorus"': refräng
       Dancelab_getEnergy:
-        text: få [RANGE][0]
+        text: få {RANGE}
         options:
           RANGE:
             '"low"': bas
@@ -165,15 +165,15 @@ sv:
             '"y"': vertikalt läge
             '"tint"': färgton
       Dancelab_getTime:
-        text: "[UNIT][0] har passerat"
+        text: "{UNIT} har passerat"
         options:
           UNIT:
             '"measures"': åtgärder
             '"seconds"': sekunder
       Dancelab_ifDanceIs:
         text: |-
-          om [SPRITE][0] gör [DANCE][1]
-          [DO1][2] [DO2][3]
+          om {SPRITE} gör {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Klappa högt
@@ -193,7 +193,7 @@ sv:
             '"measures"': åtgärder
             '"seconds"': sekunder
       Dancelab_jumpTo:
-        text: "[SPRITE][0] hoppa till [LOCATION][1]"
+        text: "{SPRITE} hoppa till {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": topp
@@ -207,7 +207,7 @@ sv:
             "{x: 300, y: 300}": nederst till höger
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": slumpad
       Dancelab_layoutSprites:
-        text: utforma [GROUP][0] som en/ett [FORMAT][1]
+        text: utforma {GROUP} som en/ett {FORMAT}
         options:
           GROUP:
             sprites: alla
@@ -233,8 +233,8 @@ sv:
             '"random"': slumpad
       Dancelab_makeNewDanceSprite:
         text: |-
-          gör en ny [COSTUME][0]
-          kallade [NAME][1] till [LOCATION][2]
+          gör en ny {COSTUME}
+          kallade {NAME} till {LOCATION}
         options:
           COSTUME:
             '"BEAR"': Björn
@@ -259,8 +259,8 @@ sv:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": slumpad
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          gör [N][0] ny [COSTUME][1]
-          i en [LAYOUT][2]
+          gör {N} ny {COSTUME}
+          i en {LAYOUT}
         options:
           N:
             '2': '2'
@@ -303,9 +303,9 @@ sv:
             '"x"': korsvis
             '"random"': slumpad
       Dancelab_mixColors:
-        text: blanda [COLOR1][0] och [COLOR2][1]
+        text: blanda {COLOR1} och {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] åtgärder"
+        text: "{N} åtgärder"
       Dancelab_onPointerDown:
         text: på pekaren för ned
       Dancelab_onPointerDrag:
@@ -315,9 +315,9 @@ sv:
       Dancelab_randomColor:
         text: slumpad färg
       Dancelab_setBackground:
-        text: ange bakgrundsfärg [COLOR][0]
+        text: ange bakgrundsfärg {COLOR}
       Dancelab_setBackgroundEffect:
-        text: täll in bakgrundseffekt [EFFECT][0]
+        text: täll in bakgrundseffekt {EFFECT}
         options:
           EFFECT:
             '"none"': Ingen
@@ -338,7 +338,7 @@ sv:
             '"tropical"': Tropisk
             '"warm"': Röda
       Dancelab_setBackgroundEffectWithPalette:
-        text: täll in bakgrundseffekt [EFFECT][0] [PALETTE][1]
+        text: täll in bakgrundseffekt {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Ingen
@@ -361,7 +361,7 @@ sv:
             '"tropical"': Tropisk
             '"warm"': Röda
       Dancelab_setDanceSpeed:
-        text: ändra danshastigheten av [SPRITE][0] till [SPEED][1]
+        text: ändra danshastigheten av {SPRITE} till {SPEED}
         options:
           SPEED:
             '1': normal
@@ -391,7 +391,7 @@ sv:
             '0.5': långsam
             '0.25': väldigt långsam
       Dancelab_setForegroundEffect:
-        text: ställ in förgrundseffekt [EFFECT][0]
+        text: ställ in förgrundseffekt {EFFECT}
         options:
           EFFECT:
             '"none"': Ingen
@@ -403,7 +403,7 @@ sv:
             '"rain"': Regn
             '"floating_rainbows"': Regnbåge
       Dancelab_setForegroundEffectExtended:
-        text: ställ in förgrundseffekt [EFFECT][0]
+        text: ställ in förgrundseffekt {EFFECT}
         options:
           EFFECT:
             '"none"': Ingen
@@ -416,7 +416,7 @@ sv:
             '"rain"': Regn
             '"floating_rainbows"': Regnbåge
       Dancelab_setProp:
-        text: 'Ställ in [SPRITE][0] [PROPERTY][1] till [VAL][2] '
+        text: 'Ställ in {SPRITE} {PROPERTY} till {VAL} '
         options:
           PROPERTY:
             '"scale"': storlek
@@ -426,7 +426,7 @@ sv:
             '"y"': vertikalt läge
             '"tint"': färgton
       Dancelab_setPropEach:
-        text: ställ in [GROUP][0] [PROPERTY][1] till [VAL][2]
+        text: ställ in {GROUP} {PROPERTY} till {VAL}
         options:
           GROUP:
             sprites: alla
@@ -449,7 +449,7 @@ sv:
             '"y"': vertikalt läge
             '"tint"': färgton
       Dancelab_setPropRandom:
-        text: slumpa [SPRITE][0] [PROPERTY][1]
+        text: slumpa {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': storlek
@@ -459,7 +459,7 @@ sv:
             '"y"': vertikalt läge
             '"tint"': färgton
       Dancelab_setTint:
-        text: Ställ in [SPRITE][0]s färgton till [VAL][1]
+        text: Ställ in {SPRITE}s färgton till {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -475,15 +475,15 @@ sv:
             '"ROBOT"': alla robotar
             '"SHARK"': alla hajar
       Dancelab_setTintInline:
-        text: Ställ in [SPRITE][0]s färgton till [VAL][1]
+        text: Ställ in {SPRITE}s färgton till {VAL}
       Dancelab_setVisible:
-        text: ställ in synligheten på [SPRITE][0] till [VISIBILITY][1]
+        text: ställ in synligheten på {SPRITE} till {VISIBILITY}
         options:
           VISIBILITY:
             'true': synlig
             'false': osynlig
       Dancelab_setVisibleEach:
-        text: Ställ in [THIS][0]s synlighetsgrad till [VISIBILITY][1]
+        text: Ställ in {THIS}s synlighetsgrad till {VISIBILITY}
         options:
           THIS:
             sprites: alla
@@ -502,7 +502,7 @@ sv:
             'true': synlig
             'false': osynlig
       Dancelab_startMapping:
-        text: "[SPRITE][0] påbörjar [PROPERTY][1] följandes [RANGE][2]"
+        text: "{SPRITE} påbörjar {PROPERTY} följandes {RANGE}"
         options:
           PROPERTY:
             '"scale"': storlek
@@ -516,7 +516,7 @@ sv:
             '"mid"': mellan
             '"treble"': diskant
       Dancelab_stopMapping:
-        text: "[SPRITE][0] stoppar [PROPERTY][1] följandes [RANGE][2]"
+        text: "{SPRITE} stoppar {PROPERTY} följandes {RANGE}"
         options:
           PROPERTY:
             '"scale"': storlek
@@ -531,7 +531,7 @@ sv:
             '"mid"': mellan
             '"treble"': diskant
       Dancelab_whenKey:
-        text: när [KEY][0] är intryckt
+        text: när {KEY} är intryckt
         options:
           KEY:
             '"up"': upp
@@ -541,7 +541,7 @@ sv:
             '"space"': rymden
             '"x"': x
       Dancelab_whenPeak:
-        text: När [RANGE][0] är maximal
+        text: När {RANGE} är maximal
         options:
           RANGE:
             '0': bas
@@ -550,19 +550,19 @@ sv:
       Dancelab_whenSetup:
         text: ställ in
       gamelab_changeColor:
-        text: ändra [COLOR][0] [METHOD][1] via [AMOUNT][2]
+        text: ändra {COLOR} {METHOD} via {AMOUNT}
         options:
           METHOD:
             '"tint"': färgton
       gamelab_changeColorBy:
-        text: ändra [COLOR][0] [METHOD][1] via [AMOUNT][2]
+        text: ändra {COLOR} {METHOD} via {AMOUNT}
         options:
           METHOD:
             '"hue"': nyans
             '"saturation"': färgmättnad
             '"brightness"': ljusstyrka
       gamelab_changePropBy:
-        text: ändra [SPRITE][0] [PROPERTY][1] via [VAL][2]
+        text: ändra {SPRITE} {PROPERTY} via {VAL}
         options:
           PROPERTY:
             '"scale"': storlek
@@ -583,7 +583,7 @@ sv:
             '"direction"': rörelseriktning
             '"tint"': färgton
       gamelab_jumpTo:
-        text: "[SPRITE][0] hoppa till [LOCATION][1]"
+        text: "{SPRITE} hoppa till {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -594,15 +594,15 @@ sv:
             '"right"': höger
             '"left"': vänster
       gamelab_mixColors:
-        text: blanda [COLOR1][0] och [COLOR2][1]
+        text: blanda {COLOR1} och {COLOR2}
       gamelab_randColor:
         text: slumpad färg
       gamelab_randomColor:
         text: slumpad färg
       gamelab_setBackground:
-        text: ange bakgrundsfärg [COLOR][0]
+        text: ange bakgrundsfärg {COLOR}
       gamelab_setPosition:
-        text: flytta [THIS][0] till positionen av [POSITION][1]
+        text: flytta {THIS} till positionen av {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": längst upp till vänster
@@ -654,7 +654,7 @@ sv:
             '"right"': höger
             '"left"': vänster
       gamelab_whenKey:
-        text: när [KEY][0] är intryckt
+        text: när {KEY} är intryckt
         options:
           KEY:
             '"up"': upp
@@ -766,8 +766,8 @@ sv:
             '"all"': alla
       Mikelab_ifDanceIs:
         text: |-
-          om [SPRITE][0] gör [DANCE][1]
-          [DO1][2] [DO2][3]
+          om {SPRITE} gör {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Klappa högt
@@ -812,7 +812,7 @@ sv:
             "{x: 100, y: 300}": nederst till vänster
             "{x: 300, y: 300}": nederst till höger
       Mikelab_whenKeyPressed:
-        text: när [KEY][0] är intryckt
+        text: när {KEY} är intryckt
         options:
           KEY:
             '"up"': pil upp
@@ -868,7 +868,7 @@ sv:
             '"left"': vänster
             '"right"': höger
       binary_whenKey:
-        text: när [KEY][0] är intryckt
+        text: när {KEY} är intryckt
         options:
           KEY:
             '"up"': upp
@@ -878,8 +878,8 @@ sv:
             '"space"': rymden
       craft_ifPath:
         text: |-
-          Vid väg [DIR][0]
-          [STATEMENT][1]
+          Vid väg {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": framåt
@@ -887,8 +887,8 @@ sv:
             "'left'": till vänster
       craft_ifStandingOn:
         text: |-
-          om du står på [TYPE][0]
-          [STATEMENT][1]
+          om du står på {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": blå korall
@@ -899,8 +899,8 @@ sv:
             "'seaLantern'": havslykta
       craft_ifStandingOnLimit:
         text: |-
-          om du står på [TYPE][0]
-          [STATEMENT][1]
+          om du står på {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": sand
@@ -909,7 +909,7 @@ sv:
       craft_moveForward:
         text: gå framåt
       craft_placeBlock:
-        text: placera [blockType][0]
+        text: placera {blockType}
         options:
           blockType:
             '"strippedOak"': avskalad ek
@@ -943,13 +943,13 @@ sv:
       craft_repeatUntilConduit:
         text: |-
           upprepa tills kanalen är klar
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           upprepa till målet
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: skapa [ENTITY][0]
+        text: skapa {ENTITY}
         options:
           ENTITY:
             '"cod"': torsk
@@ -959,7 +959,7 @@ sv:
             '"squid"': bläckfisk
             '"tropicalFish"': tropisk fisk
       craft_turn:
-        text: sväng [DIR][0]
+        text: sväng {DIR}
         options:
           DIR:
             right: höger ↻

--- a/dashboard/config/locales/blocks.th-TH.yml
+++ b/dashboard/config/locales/blocks.th-TH.yml
@@ -3,20 +3,20 @@ th:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: หลังจาก [TIMESTAMP][0] [UNIT][1]
+        text: หลังจาก {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': ห้องดนตรี
             '"seconds"': วินาที
       Dancelab_changeColorBy:
-        text: เปลี่ยน [COLOR][0] [METHOD][1] จำนวน [AMOUNT][2]
+        text: เปลี่ยน {COLOR} {METHOD} จำนวน {AMOUNT}
         options:
           METHOD:
             '"hue"': สีสัน
             '"saturation"': ความอิ่มตัวของสี
             '"brightness"': ความสว่าง
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] ทำ [MOVE][1] [DIR][2] ตลอดไป"
+        text: "{GROUP} ทำ {MOVE} {DIR} ตลอดไป"
         options:
           GROUP:
             sprites: ทั้งหมด
@@ -50,7 +50,7 @@ th:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[GROUP][0] ทำ [MOVE][1] [DIR][2] ตลอดไป"
+        text: "{SPRITE} ทำ {MOVE} {DIR} ตลอดไป"
         options:
           MOVE:
             '"next"': "(ถัดไป)"
@@ -71,7 +71,7 @@ th:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: เปลี่ยน [SPRITE][0] [PROPERTY][1] โดย [VAL][2]
+        text: เปลี่ยน {SPRITE} {PROPERTY} โดย {VAL}
         options:
           PROPERTY:
             '"scale"': ขนาด
@@ -81,7 +81,7 @@ th:
             '"x"': ตำแหน่งแนวนอน
             '"y"': ตำแหน่งแนวตั้ง
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] ทำ [MOVE][1] [DIR][2] ตลอดไป"
+        text: "{GROUP} ทำ {MOVE} {DIR} ตลอดไป"
         options:
           GROUP:
             sprites: ทั้งหมด
@@ -113,7 +113,7 @@ th:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] ทำ [MOVE][1] [DIR][2] ครั้งเดียว"
+        text: "{SPRITE} ทำ {MOVE} {DIR} ครั้งเดียว"
         options:
           MOVE:
             '"rand"': "(สุ่ม)"
@@ -132,25 +132,25 @@ th:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'ทุกๆ [N][0] [UNIT][1] '
+        text: 'ทุกๆ {N} {UNIT} '
         options:
           UNIT:
             '"measures"': ห้องดนตรี
             '"seconds"': วินาที
       Dancelab_everySecondsRange:
-        text: 'ทุก [N][0] [UNIT][1] จาก [START][2] ถึง [STOP][3] '
+        text: 'ทุก {N} {UNIT} จาก {START} ถึง {STOP} '
         options:
           UNIT:
             measures: ห้องดนตรี
             seconds: ขั้นคู่สอง
       Dancelab_everyVerseChorus:
-        text: 'ทุก [หน่วย][0] '
+        text: 'ทุก {UNIT} '
         options:
           UNIT:
             '"verse"': ท่อนร้อง
             '"chorus"': ประสานเสียง
       Dancelab_getEnergy:
-        text: รับ [RANGE][0]
+        text: รับ {RANGE}
         options:
           RANGE:
             '"low"': เสียงต่ำ
@@ -167,15 +167,15 @@ th:
             '"y"': อยู่ที่แกน Y
             '"tint"': ระดับอ่อนสี
       Dancelab_getTime:
-        text: "[หน่วย][0] ล่วงผ่าน"
+        text: "{UNIT} ล่วงผ่าน"
         options:
           UNIT:
             '"measures"': ห้องดนตรี
             '"seconds"': วินาที
       Dancelab_ifDanceIs:
         text: |-
-          ถ้า [SPRITE][0] กำลัง [DANCE][1]
-          [DO1][2] [DO2][3]
+          ถ้า {SPRITE} กำลัง {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: ปรบมือสูง
@@ -195,7 +195,7 @@ th:
             '"measures"': ห้องดนตรี
             '"seconds"': วินาที
       Dancelab_jumpTo:
-        text: "[SPRITE][0] ข้ามไปที่ [LOCATION][1]"
+        text: "{SPRITE} ข้ามไปที่ {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": ด้านบน
@@ -209,7 +209,7 @@ th:
             "{x: 300, y: 300}": ขวาล่าง
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": สุ่ม
       Dancelab_layoutSprites:
-        text: วางผัง [GROUP][0] เป็น [FORMAT][1]
+        text: วางผัง {GROUP} เป็น {FORMAT}
         options:
           GROUP:
             sprites: ทั้งหมด
@@ -236,8 +236,8 @@ th:
             '"random"': สุ่ม
       Dancelab_makeNewDanceSprite:
         text: |-
-          ทำใหม่ [COSTUME][0]
-          เรียก [NAME][1] ที่ [LOCATION][2]
+          ทำใหม่ {COSTUME}
+          เรียก {NAME} ที่ {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': มนุษย์ต่างดาว
@@ -264,8 +264,8 @@ th:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": สุ่ม
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          ทำ [N][0] ใหม่ [COSTUME][1]
-          ใน [LAYOUT][2]
+          ทำ {N} ใหม่ {COSTUME}
+          ใน {LAYOUT}
         options:
           N:
             '2': '2'
@@ -310,9 +310,9 @@ th:
             '"plus"': เครื่องหมายบวก
             '"random"': สุ่ม
       Dancelab_mixColors:
-        text: ผสม[COLOR1][0] กับ [COLOR2][1]
+        text: ผสม{COLOR1} กับ {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] ห้องดนตรี"
+        text: "{N} ห้องดนตรี"
       Dancelab_onPointerDown:
         text: ที่ตัวชี้ลง
       Dancelab_onPointerDrag:
@@ -322,9 +322,9 @@ th:
       Dancelab_randomColor:
         text: สุ่มสี
       Dancelab_setBackground:
-        text: กำหนดสีแบ็กกราวนด์ [COLOR][0]
+        text: กำหนดสีแบ็กกราวนด์ {COLOR}
       Dancelab_setBackgroundEffect:
-        text: กำหนดแบ็กกราวนด์เอฟเฟกต์ [EFFECT][0]
+        text: กำหนดแบ็กกราวนด์เอฟเฟกต์ {EFFECT}
         options:
           EFFECT:
             '"none"': ไม่มี
@@ -347,7 +347,7 @@ th:
             '"vintage"': วินเทจ
             '"warm"': แดง
       Dancelab_setBackgroundEffectWithPalette:
-        text: กำหนดแบ็กกราวนด์เอฟเฟกต์ [EFFECT][0] [PALETTE][1]
+        text: กำหนดแบ็กกราวนด์เอฟเฟกต์ {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': ไม่มี
@@ -372,7 +372,7 @@ th:
             '"vintage"': วินเทจ
             '"warm"': แดง
       Dancelab_setDanceSpeed:
-        text: เปลี่ยน [SPRITE][0] ความเร็วของการเต้นเป็น [SPEED][1]
+        text: เปลี่ยน {SPRITE} ความเร็วของการเต้นเป็น {SPEED}
         options:
           SPEED:
             '1': ธรรมดา
@@ -402,7 +402,7 @@ th:
             '0.5': ช้า
             '0.25': ช้ามาก
       Dancelab_setForegroundEffect:
-        text: กำหนดโฟร์กราวด์เอฟเฟค [EFFECT][0]
+        text: กำหนดโฟร์กราวด์เอฟเฟค {EFFECT}
         options:
           EFFECT:
             '"none"': ไม่มี
@@ -415,7 +415,7 @@ th:
             '"floating_rainbows"': สายรุ้ง
             '"raining_tacos"': ทาโก้
       Dancelab_setForegroundEffectExtended:
-        text: กำหนดโฟร์กราวด์เอฟเฟค [EFFECT][0]
+        text: กำหนดโฟร์กราวด์เอฟเฟค {EFFECT}
         options:
           EFFECT:
             '"none"': ไม่มี
@@ -429,7 +429,7 @@ th:
             '"floating_rainbows"': สายรุ้ง
             '"raining_tacos"': ทาโก้
       Dancelab_setProp:
-        text: 'กำหนด [SPRITE][0] [PROPERTY][1] เป็น [VAL][2] '
+        text: 'กำหนด {SPRITE} {PROPERTY} เป็น {VAL} '
         options:
           PROPERTY:
             '"scale"': ขนาด
@@ -440,7 +440,7 @@ th:
             '"y"': อยู่ที่แกน Y
             '"tint"': ระดับอ่อนสี
       Dancelab_setPropEach:
-        text: กำหนด [GROUP][0] [PROPERTY][1] เป็น [VAL][2]
+        text: กำหนด {GROUP} {PROPERTY} เป็น {VAL}
         options:
           GROUP:
             sprites: ทั้งหมด
@@ -464,7 +464,7 @@ th:
             '"y"': ตำแหน่งแนวตั้ง
             '"tint"': ระดับอ่อนสี
       Dancelab_setPropRandom:
-        text: การสุ่ม [SPRITE][0] [PROPERTY][1]
+        text: การสุ่ม {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': ขนาด
@@ -475,7 +475,7 @@ th:
             '"y"': ตำแหน่งแนวตั้ง
             '"tint"': ระดับอ่อนสี
       Dancelab_setTint:
-        text: กำหนด [SPRITE][0] ระดับอ่อนสีเป็น [VAL][1]
+        text: กำหนด {SPRITE} ระดับอ่อนสีเป็น {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -491,15 +491,15 @@ th:
             '"ROBOT"': หุ่นยนต์ทั้งหมด
             '"SHARK"': ฉลามทั้งหมด
       Dancelab_setTintInline:
-        text: กำหนด [SPRITE][0] ระดับอ่อนสีเป็น [VAL][1]
+        text: กำหนด {SPRITE} ระดับอ่อนสีเป็น {VAL}
       Dancelab_setVisible:
-        text: ตั้งค่า [SPRITE][0] การมองเห็นเป็น [VISIBILITY][1]
+        text: ตั้งค่า {SPRITE} การมองเห็นเป็น {VISIBILITY}
         options:
           VISIBILITY:
             'true': มองเห็นได้
             'false': มองไม่เห็น
       Dancelab_setVisibleEach:
-        text: กำหนด [THIS][0] สภาพมองเห็นได้เป็น [VISIBILITY][1]
+        text: กำหนด {THIS} สภาพมองเห็นได้เป็น {VISIBILITY}
         options:
           THIS:
             sprites: ทั้งหมด
@@ -518,7 +518,7 @@ th:
             'true': มองเห็นได้
             'false': มองไม่เห็น
       Dancelab_startMapping:
-        text: "[SPRITE][0] เริ่ม [PROPERTY][1] หลังจาก [RANGE][2]"
+        text: "{SPRITE} เริ่ม {PROPERTY} หลังจาก {RANGE}"
         options:
           PROPERTY:
             '"scale"': ขนาด
@@ -533,7 +533,7 @@ th:
             '"mid"': เสียงกลาง
             '"treble"': เสียงสูง
       Dancelab_stopMapping:
-        text: "[SPRITE][0] หยุด [PROPERTY][1] หลังจาก [RANGE][2]"
+        text: "{SPRITE} หยุด {PROPERTY} หลังจาก {RANGE}"
         options:
           PROPERTY:
             '"scale"': ขนาด
@@ -549,7 +549,7 @@ th:
             '"mid"': เสียงกลาง
             '"treble"': เสียงสูง
       Dancelab_whenKey:
-        text: เมื่อ [KEY][0] ถูกกด
+        text: เมื่อ {KEY} ถูกกด
         options:
           KEY:
             '"up"': ขึ้นข้างบน
@@ -559,7 +559,7 @@ th:
             '"space"': อวกาศ
             '"x"': x
       Dancelab_whenPeak:
-        text: เมื่อ [RANGE][0] สูงสุด
+        text: เมื่อ {RANGE} สูงสุด
         options:
           RANGE:
             '0': เสียงต่ำ
@@ -568,19 +568,19 @@ th:
       Dancelab_whenSetup:
         text: การตั้งค่า
       gamelab_changeColor:
-        text: เปลี่ยน [COLOR][0] [METHOD][1] จำนวน [AMOUNT][2]
+        text: เปลี่ยน {COLOR} {METHOD} จำนวน {AMOUNT}
         options:
           METHOD:
             '"tint"': ระดับอ่อนสี
       gamelab_changeColorBy:
-        text: เปลี่ยน [COLOR][0] [METHOD][1] จำนวน [AMOUNT][2]
+        text: เปลี่ยน {COLOR} {METHOD} จำนวน {AMOUNT}
         options:
           METHOD:
             '"hue"': สีสัน
             '"saturation"': ความอิ่มตัวของสี
             '"brightness"': ความสว่าง
       gamelab_changePropBy:
-        text: เปลี่ยน [SPRITE][0] [PROPERTY][1] โดย [VAL][2]
+        text: เปลี่ยน {SPRITE} {PROPERTY} โดย {VAL}
         options:
           PROPERTY:
             '"scale"': ขนาด
@@ -603,7 +603,7 @@ th:
             '"direction"': ทิศทางการเคลื่อนไหว
             '"tint"': ระดับอ่อนสี
       gamelab_jumpTo:
-        text: "[SPRITE][0] ข้ามไปที่ [LOCATION][1]"
+        text: "{SPRITE} ข้ามไปที่ {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -614,15 +614,15 @@ th:
             '"right"': ขวา
             '"left"': ซ้าย
       gamelab_mixColors:
-        text: ผสม[COLOR1][0] กับ [COLOR2][1]
+        text: ผสม{COLOR1} กับ {COLOR2}
       gamelab_randColor:
         text: สุ่มสี
       gamelab_randomColor:
         text: สุ่มสี
       gamelab_setBackground:
-        text: กำหนดสีแบ็กกราวนด์ [COLOR][0]
+        text: กำหนดสีแบ็กกราวนด์ {COLOR}
       gamelab_setPosition:
-        text: ย้าย [THIS][0] ไป [POSITION][1] ตำแหน่ง
+        text: ย้าย {THIS} ไป {POSITION} ตำแหน่ง
         options:
           POSITION:
             "{x: 50, y: 50}": ซ้ายบน
@@ -675,7 +675,7 @@ th:
             '"right"': ขวา
             '"left"': ซ้าย
       gamelab_whenKey:
-        text: เมื่อ [KEY][0] ถูกกด
+        text: เมื่อ {KEY} ถูกกด
         options:
           KEY:
             '"up"': ขึ้นข้างบน
@@ -792,8 +792,8 @@ th:
             '"all"': ทั้งหมด
       Mikelab_ifDanceIs:
         text: |-
-          ถ้า [SPRITE][0] กำลัง [DANCE][1]
-          [DO1][2] [DO2][3]
+          ถ้า {SPRITE} กำลัง {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: ปรบมือสูง
@@ -839,7 +839,7 @@ th:
             "{x: 100, y: 300}": ซ้ายล่าง
             "{x: 300, y: 300}": ขวาล่าง
       Mikelab_whenKeyPressed:
-        text: เมื่อ [KEY][0] ถูกกด
+        text: เมื่อ {KEY} ถูกกด
         options:
           KEY:
             '"up"': ลูกศรชี้ขึ้น
@@ -896,7 +896,7 @@ th:
             '"left"': ซ้าย
             '"right"': ขวา
       binary_whenKey:
-        text: เมื่อ [KEY][0] ถูกกด
+        text: เมื่อ {KEY} ถูกกด
         options:
           KEY:
             '"up"': ขึ้นข้างบน
@@ -906,8 +906,8 @@ th:
             '"space"': อวกาศ
       craft_ifPath:
         text: |-
-          ถ้ามีเส้นทาง [DIR][0]
-          [STATEMENT][1]
+          ถ้ามีเส้นทาง {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": ข้างหน้า
@@ -915,8 +915,8 @@ th:
             "'left'": ไปทางซ้าย
       craft_ifStandingOn:
         text: |-
-          ถ้าหากยืนอยู่บน [TYPE][0]
-          [STATEMENT][1]
+          ถ้าหากยืนอยู่บน {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": ปะการังสีฟ้า
@@ -927,8 +927,8 @@ th:
             "'seaLantern'": โคมทะเล
       craft_ifStandingOnLimit:
         text: |-
-          ถ้าหากยืนอยู่บน [TYPE][0]
-          [STATEMENT][1]
+          ถ้าหากยืนอยู่บน {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": ทราย
@@ -937,7 +937,7 @@ th:
       craft_moveForward:
         text: ไปข้างหน้า
       craft_placeBlock:
-        text: วาง [blockType][0]
+        text: วาง {blockType}
         options:
           blockType:
             '"strippedOak"': ชิ้นไม้โอ็ค
@@ -972,11 +972,11 @@ th:
       craft_repeatUntilConduit:
         text: |-
           ทำซ้ำจนกว่าน้ำพุจะสร้างเสร็จ
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
-        text: ทำซ้ำจนสำเร็จ[STATEMENT][0]
+        text: ทำซ้ำจนสำเร็จ{STATEMENT}
       craft_spawnEntity:
-        text: แพร่พันธ์ุ [ENTITY][0]
+        text: แพร่พันธ์ุ {ENTITY}
         options:
           ENTITY:
             '"cod"': ปลาคอด
@@ -986,7 +986,7 @@ th:
             '"squid"': ปลาหมึก
             '"tropicalFish"': ปลาทรอปปิค
       craft_turn:
-        text: หัน [DIR][0]
+        text: หัน {DIR}
         options:
           DIR:
             right: ไปทางขวา ↻

--- a/dashboard/config/locales/blocks.tr-TR.yml
+++ b/dashboard/config/locales/blocks.tr-TR.yml
@@ -3,20 +3,20 @@ tr:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: "[TIMESTAMP][0] [UNIT][1] sonra"
+        text: "{TIMESTAMP} {UNIT} sonra"
         options:
           UNIT:
             '"measures"': ölçü
             '"seconds"': saniye
       Dancelab_changeColorBy:
-        text: "[COLOR][0] [METHOD][1]’u [AMOUNT][2] kadar değiştir"
+        text: "{COLOR} {METHOD}’u {AMOUNT} kadar değiştir"
         options:
           METHOD:
             '"hue"': renk tonu
             '"saturation"': doygunluk
             '"brightness"': parlaklık
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] sürekli [MOVE][1] [DIR][2] yap"
+        text: "{GROUP} sürekli {MOVE} {DIR} yap"
         options:
           GROUP:
             sprites: tüm
@@ -46,7 +46,7 @@ tr:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] sürekli [MOVE][1] [DIR][2] yap"
+        text: "{SPRITE} sürekli {MOVE} {DIR} yap"
         options:
           MOVE:
             '"next"': "(Sonraki)"
@@ -63,7 +63,7 @@ tr:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: "[SPRITE][0] [PROPERTY][1]’i [VAL][2] kadar değiştir"
+        text: "{SPRITE} {PROPERTY}’i {VAL} kadar değiştir"
         options:
           PROPERTY:
             '"scale"': boyut
@@ -73,7 +73,7 @@ tr:
             '"x"': yatay konum
             '"y"': dikey konum
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] bir kere [MOVE][1] [DIR][2] yap"
+        text: "{GROUP} bir kere {MOVE} {DIR} yap"
         options:
           GROUP:
             sprites: tüm
@@ -101,7 +101,7 @@ tr:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] bir kere [MOVE][1] [DIR][2] yap"
+        text: "{SPRITE} bir kere {MOVE} {DIR} yap"
         options:
           MOVE:
             '"rand"': "(Rastgele)"
@@ -116,25 +116,25 @@ tr:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'her [N][0] [UNIT][1]’de bir '
+        text: 'her {N} {UNIT}’de bir '
         options:
           UNIT:
             '"measures"': ölçü
             '"seconds"': saniye
       Dancelab_everySecondsRange:
-        text: "[START][2]’den [STOP][3]’e her [N][0] [UNIT][1]’de bir "
+        text: "{START}’den {STOP}’e her {N} {UNIT}’de bir "
         options:
           UNIT:
             measures: Ölçü
             seconds: Saniye
       Dancelab_everyVerseChorus:
-        text: 'her [UNIT][0]’de bir '
+        text: 'her {UNIT}’de bir '
         options:
           UNIT:
             '"verse"': dize
             '"chorus"': koro
       Dancelab_getEnergy:
-        text: "[RANGE][0]’i al"
+        text: "{RANGE}’i al"
         options:
           RANGE:
             '"low"': bas
@@ -151,15 +151,15 @@ tr:
             '"y"': dikey konum
             '"tint"': renk tonu
       Dancelab_getTime:
-        text: "[UNIT][0] geçti"
+        text: "{UNIT} geçti"
         options:
           UNIT:
             '"measures"': ölçü
             '"seconds"': saniye
       Dancelab_ifDanceIs:
         text: |-
-          eğer [SPRITE][0] [DANCE][1] yapıyorsa
-          [DO1][2] [DO2][3]
+          eğer {SPRITE} {DANCE} yapıyorsa
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Yüksek Alkış
@@ -175,7 +175,7 @@ tr:
             '"measures"': ölçü
             '"seconds"': saniye
       Dancelab_jumpTo:
-        text: "[SPRITE][0] [LOCATION][1]’a atla"
+        text: "{SPRITE} {LOCATION}’a atla"
         options:
           LOCATION:
             "{x: 200, y: 100}": üst
@@ -189,7 +189,7 @@ tr:
             "{x: 300, y: 300}": sağ alt
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": gelişigüzel
       Dancelab_layoutSprites:
-        text: "[GROUP][0]’i bir [FORMAT][1] olarak düzenle"
+        text: "{GROUP}’i bir {FORMAT} olarak düzenle"
         options:
           GROUP:
             sprites: tüm
@@ -216,8 +216,8 @@ tr:
             '"random"': gelişigüzel
       Dancelab_makeNewDanceSprite:
         text: |-
-          yeni bir [COSTUME][0] yap
-          [LOCATION][2]’de [NAME][1] çağrıldı
+          yeni bir {COSTUME} yap
+          {LOCATION}’de {NAME} çağrıldı
         options:
           COSTUME:
             '"ALIEN"': Uzaylı
@@ -243,8 +243,8 @@ tr:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": gelişigüzel
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          Bir [LAYOUT][2]’de
-          [N][0]’e yeni [COSTUME][1] yap
+          Bir {LAYOUT}’de
+          {N}’e yeni {COSTUME} yap
         options:
           N:
             '2': '2'
@@ -289,9 +289,9 @@ tr:
             '"plus"': artı
             '"random"': gelişigüzel
       Dancelab_mixColors:
-        text: "[COLOR1][0] ve [COLOR2][1]’yi karıştır"
+        text: "{COLOR1} ve {COLOR2}’yi karıştır"
       Dancelab_nMeasures:
-        text: "[N][0] ölçü"
+        text: "{N} ölçü"
       Dancelab_onPointerDown:
         text: işaretçi aşağıya çekildiğinde
       Dancelab_onPointerDrag:
@@ -301,9 +301,9 @@ tr:
       Dancelab_randomColor:
         text: rastgele renk
       Dancelab_setBackground:
-        text: arka plan rengini [COLOR][0] olarak ayarla
+        text: arka plan rengini {COLOR} olarak ayarla
       Dancelab_setBackgroundEffect:
-        text: arka plan efektini [EFFECT][0] olarak ayarla
+        text: arka plan efektini {EFFECT} olarak ayarla
         options:
           EFFECT:
             '"none"': Hiçbiri
@@ -324,7 +324,7 @@ tr:
             '"tropical"': Tropikal
             '"warm"': Kırmızılar
       Dancelab_setBackgroundEffectWithPalette:
-        text: arka plan efektini [EFFECT][0] [PALETTE][1] olarak ayarla
+        text: arka plan efektini {EFFECT} {PALETTE} olarak ayarla
         options:
           EFFECT:
             '"none"': Hiçbiri
@@ -347,7 +347,7 @@ tr:
             '"tropical"': Tropikal
             '"warm"': Kırmızılar
       Dancelab_setDanceSpeed:
-        text: "[SPRITE][0] dans hızını [SPEED][1] olarak değiştir"
+        text: "{SPRITE} dans hızını {SPEED} olarak değiştir"
         options:
           SPEED:
             '1': normal
@@ -377,7 +377,7 @@ tr:
             '0.5': yavaş
             '0.25': çok yavaş
       Dancelab_setForegroundEffect:
-        text: ön plan efektini [EFFECT][0] olarak ayarla
+        text: ön plan efektini {EFFECT} olarak ayarla
         options:
           EFFECT:
             '"none"': Hiçbiri
@@ -390,7 +390,7 @@ tr:
             '"floating_rainbows"': Gökkuşağı
             '"raining_tacos"': Tacolar
       Dancelab_setForegroundEffectExtended:
-        text: ön plan efektini [EFFECT][0] olarak ayarla
+        text: ön plan efektini {EFFECT} olarak ayarla
         options:
           EFFECT:
             '"none"': Hiçbiri
@@ -404,7 +404,7 @@ tr:
             '"floating_rainbows"': Gökkuşağı
             '"raining_tacos"': Tacolar
       Dancelab_setProp:
-        text: "[SPRITE][0] [PROPERTY][1]’i [VAL][2] olarak ayarla "
+        text: "{SPRITE} {PROPERTY}’i {VAL} olarak ayarla "
         options:
           PROPERTY:
             '"scale"': boyut
@@ -415,7 +415,7 @@ tr:
             '"y"': dikey konum
             '"tint"': renk tonu
       Dancelab_setPropEach:
-        text: "[GROUP][0] [PROPERTY][1]’i [VAL][2] olarak ayarla"
+        text: "{GROUP} {PROPERTY}’i {VAL} olarak ayarla"
         options:
           GROUP:
             sprites: tüm
@@ -439,7 +439,7 @@ tr:
             '"y"': dikey konum
             '"tint"': renk tonu
       Dancelab_setPropRandom:
-        text: "[SPRITE][0] [PROPERTY][1]’i rastgele yap"
+        text: "{SPRITE} {PROPERTY}’i rastgele yap"
         options:
           PROPERTY:
             '"scale"': boyut
@@ -450,7 +450,7 @@ tr:
             '"y"': dikey konum
             '"tint"': renk tonu
       Dancelab_setTint:
-        text: "[SPRITE][0] renk tonunu [VAL][1] olarak ayarla"
+        text: "{SPRITE} renk tonunu {VAL} olarak ayarla"
       Dancelab_setTintEach:
         options:
           THIS:
@@ -466,15 +466,15 @@ tr:
             '"ROBOT"': tüm robotlar
             '"SHARK"': tüm köpekbalıkları
       Dancelab_setTintInline:
-        text: "[SPRITE][0] renk tonunu [VAL][1] olarak ayarla"
+        text: "{SPRITE} renk tonunu {VAL} olarak ayarla"
       Dancelab_setVisible:
-        text: "[SPRITE][0] görünürlüğünü [VISIBILITY][1] olarak ayarla"
+        text: "{SPRITE} görünürlüğünü {VISIBILITY} olarak ayarla"
         options:
           VISIBILITY:
             'true': görünür
             'false': görünmez
       Dancelab_setVisibleEach:
-        text: "[THIS][0] görünürlüğünü [VISIBILITY][1] olarak ayarla"
+        text: "{THIS} görünürlüğünü {VISIBILITY} olarak ayarla"
         options:
           THIS:
             sprites: tüm
@@ -493,7 +493,7 @@ tr:
             'true': görünür
             'false': görünmez
       Dancelab_startMapping:
-        text: "[SPRITE][0] [RANGE][2]’i takiben [PROPERTY][1]’e başlar"
+        text: "{SPRITE} {RANGE}’i takiben {PROPERTY}’e başlar"
         options:
           PROPERTY:
             '"scale"': boyut
@@ -508,7 +508,7 @@ tr:
             '"mid"': orta
             '"treble"': tiz
       Dancelab_stopMapping:
-        text: "[SPRITE][0] [RANGE][2]’i takiben [PROPERTY][1]’i durdurur"
+        text: "{SPRITE} {RANGE}’i takiben {PROPERTY}’i durdurur"
         options:
           PROPERTY:
             '"scale"': boyut
@@ -524,7 +524,7 @@ tr:
             '"mid"': orta
             '"treble"': tiz
       Dancelab_whenKey:
-        text: "[KEY][0] basıldığında"
+        text: "{KEY} basıldığında"
         options:
           KEY:
             '"up"': yukarı
@@ -535,7 +535,7 @@ tr:
             '"x"': x
             '"y"': y
       Dancelab_whenPeak:
-        text: "[RANGE][0] en üst seviyedeyken"
+        text: "{RANGE} en üst seviyedeyken"
         options:
           RANGE:
             '0': bas
@@ -544,19 +544,19 @@ tr:
       Dancelab_whenSetup:
         text: kurulum
       gamelab_changeColor:
-        text: "[COLOR][0] [METHOD][1]’u [AMOUNT][2] kadar değiştir"
+        text: "{COLOR} {METHOD}’u {AMOUNT} kadar değiştir"
         options:
           METHOD:
             '"tint"': renk tonu
       gamelab_changeColorBy:
-        text: "[COLOR][0] [METHOD][1]’u [AMOUNT][2] kadar değiştir"
+        text: "{COLOR} {METHOD}’u {AMOUNT} kadar değiştir"
         options:
           METHOD:
             '"hue"': renk tonu
             '"saturation"': doygunluk
             '"brightness"': parlaklık
       gamelab_changePropBy:
-        text: "[SPRITE][0] [PROPERTY][1]’i [VAL][2] kadar değiştir"
+        text: "{SPRITE} {PROPERTY}’i {VAL} kadar değiştir"
         options:
           PROPERTY:
             '"scale"': boyut
@@ -579,7 +579,7 @@ tr:
             '"direction"': hareket yönü
             '"tint"': renk tonu
       gamelab_jumpTo:
-        text: "[SPRITE][0] [LOCATION][1]’a atla"
+        text: "{SPRITE} {LOCATION}’a atla"
       gamelab_locationDelta:
         options:
           DIR:
@@ -590,15 +590,15 @@ tr:
             '"right"': sağ
             '"left"': sol
       gamelab_mixColors:
-        text: "[COLOR1][0] ve [COLOR2][1]’yi karıştır"
+        text: "{COLOR1} ve {COLOR2}’yi karıştır"
       gamelab_randColor:
         text: rastgele renk
       gamelab_randomColor:
         text: rastgele renk
       gamelab_setBackground:
-        text: arka plan rengini [COLOR][0] olarak ayarla
+        text: arka plan rengini {COLOR} olarak ayarla
       gamelab_setPosition:
-        text: "[THIS][0]’i [POSITION][1] konuma getir"
+        text: "{THIS}’i {POSITION} konuma getir"
         options:
           POSITION:
             "{x: 50, y: 50}": sol üst
@@ -651,7 +651,7 @@ tr:
             '"right"': sağ
             '"left"': sol
       gamelab_whenKey:
-        text: "[KEY][0] basıldığında"
+        text: "{KEY} basıldığında"
         options:
           KEY:
             '"up"': yukarı
@@ -768,8 +768,8 @@ tr:
             '"all"': tüm
       Mikelab_ifDanceIs:
         text: |-
-          eğer [SPRITE][0] [DANCE][1] yapıyorsa
-          [DO1][2] [DO2][3]
+          eğer {SPRITE} {DANCE} yapıyorsa
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Yüksek Alkış
@@ -811,7 +811,7 @@ tr:
             "{x: 100, y: 300}": sol alt
             "{x: 300, y: 300}": sağ alt
       Mikelab_whenKeyPressed:
-        text: "[KEY][0] basıldığında"
+        text: "{KEY} basıldığında"
         options:
           KEY:
             '"up"': yukarı ok
@@ -872,7 +872,7 @@ tr:
             '"left"': sol
             '"right"': sağ
       binary_whenKey:
-        text: "[KEY][0] basıldığında"
+        text: "{KEY} basıldığında"
         options:
           KEY:
             '"up"': yukarı
@@ -882,8 +882,8 @@ tr:
             '"space"': uzay
       craft_ifPath:
         text: |-
-          eğer yol [DIR][0]
-          [STATEMENT][1]
+          eğer yol {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": ileri
@@ -891,8 +891,8 @@ tr:
             "'left'": sola giderse
       craft_ifStandingOn:
         text: |-
-          eğer altındaki blok [TYPE][0]
-          [STATEMENT][1]
+          eğer altındaki blok {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": mavi mercan ise
@@ -903,8 +903,8 @@ tr:
             "'seaLantern'": deniz ışığı ise
       craft_ifStandingOnLimit:
         text: |-
-          eğer altındaki blok [TYPE][0]
-          [STATEMENT][1]
+          eğer altındaki blok {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": kum
@@ -913,7 +913,7 @@ tr:
       craft_moveForward:
         text: ilerle
       craft_placeBlock:
-        text: yerleştir [blockType][0]
+        text: yerleştir {blockType}
         options:
           blockType:
             '"strippedOak"': soyulmuş meşe
@@ -947,13 +947,13 @@ tr:
       craft_repeatUntilConduit:
         text: |-
           su yolu tamamlanana kadar tekrarla
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           hedefe kadar tekrarla
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: 'oluştur: [ENTITY][0]'
+        text: 'oluştur: {ENTITY}'
         options:
           ENTITY:
             '"cod"': morina
@@ -963,7 +963,7 @@ tr:
             '"squid"': kalamar
             '"tropicalFish"': tropikal balık
       craft_turn:
-        text: dön [DIR][0]
+        text: dön {DIR}
         options:
           DIR:
             right: sağa ↻

--- a/dashboard/config/locales/blocks.uk-UA.yml
+++ b/dashboard/config/locales/blocks.uk-UA.yml
@@ -3,20 +3,20 @@ uk:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: після [TIMESTAMP][0] [UNIT][1]
+        text: після {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': кроків
             '"seconds"': секунди
       Dancelab_changeColorBy:
-        text: змінити [COLOR][0] [METHOD][1] на [AMOUNT][2]
+        text: змінити {COLOR} {METHOD} на {AMOUNT}
         options:
           METHOD:
             '"hue"': відтінок
             '"saturation"': насиченість
             '"brightness"': яскравість
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] виконувати рух [MOVE][1] [DIR][2] завжди"
+        text: "{GROUP} виконувати рух {MOVE} {DIR} завжди"
         options:
           GROUP:
             sprites: усі
@@ -39,7 +39,7 @@ uk:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] виконувати рух [MOVE][1] [DIR][2] завжди"
+        text: "{SPRITE} виконувати рух {MOVE} {DIR} завжди"
         options:
           MOVE:
             '"next"': "(Наступний)"
@@ -49,7 +49,7 @@ uk:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: змінити [SPRITE][0] [PROPERTY][1] на [VAL][2]
+        text: змінити {SPRITE} {PROPERTY} на {VAL}
         options:
           PROPERTY:
             '"scale"': розмір
@@ -59,7 +59,7 @@ uk:
             '"x"': горизонтальне положення
             '"y"': вертикальне положення
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] виконує рух [MOVE][1] [DIR][2] один раз"
+        text: "{GROUP} виконує рух {MOVE} {DIR} один раз"
         options:
           GROUP:
             sprites: усі
@@ -80,7 +80,7 @@ uk:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] виконує рух [MOVE][1] [DIR][2] один раз"
+        text: "{SPRITE} виконує рух {MOVE} {DIR} один раз"
         options:
           MOVE:
             '"rand"': "(Випадковий)"
@@ -88,25 +88,25 @@ uk:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'кожні [N][0] [UNIT][1] '
+        text: 'кожні {N} {UNIT} '
         options:
           UNIT:
             '"measures"': кроків
             '"seconds"': секунди
       Dancelab_everySecondsRange:
-        text: 'кожні [N][0] [UNIT][1] з [START][2] до [STOP][3] '
+        text: 'кожні {N} {UNIT} з {START} до {STOP} '
         options:
           UNIT:
             measures: Кроки
             seconds: Секунди
       Dancelab_everyVerseChorus:
-        text: 'кожні [UNIT][0] '
+        text: 'кожні {UNIT} '
         options:
           UNIT:
             '"verse"': куплет
             '"chorus"': приспів
       Dancelab_getEnergy:
-        text: отримати [RANGE][0]
+        text: отримати {RANGE}
         options:
           RANGE:
             '"low"': низькі тони
@@ -123,25 +123,25 @@ uk:
             '"y"': вертикальне положення
             '"tint"': відтінок
       Dancelab_getTime:
-        text: "[UNIT][0] минуло"
+        text: "{UNIT} минуло"
         options:
           UNIT:
             '"measures"': кроків
             '"seconds"': секунди
       Dancelab_ifDanceIs:
         text: |-
-          якщо [SPRITE][0] виконує рух [DANCE][1]
-          [DO1][2] [DO2][3]
+          якщо {SPRITE} виконує рух {DANCE}
+          {DO1} {DO2}
       Dancelab_ifTime:
         text: |-
-          якщо [UNIT][0] має значення [OP][1] [N][2]
-          [DO1][3] [DO2][4]
+          якщо {UNIT} має значення {OP} {N}
+          {DO1} {DO2}
         options:
           UNIT:
             '"measures"': кроків
             '"seconds"': секунди
       Dancelab_jumpTo:
-        text: "[SPRITE][0] стрибає до [LOCATION][1]"
+        text: "{SPRITE} стрибає до {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": вгорі
@@ -155,7 +155,7 @@ uk:
             "{x: 300, y: 300}": нижній правий кут
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": випадковий
       Dancelab_layoutSprites:
-        text: розмістити [GROUP][0] у формі [FORMAT][1]
+        text: розмістити {GROUP} у формі {FORMAT}
         options:
           GROUP:
             sprites: усі
@@ -182,8 +182,8 @@ uk:
             '"random"': випадковий
       Dancelab_makeNewDanceSprite:
         text: |-
-          створити новий [COSTUME][0]
-          з іменем [NAME][1] розмістивши у [LOCATION][2]
+          створити новий {COSTUME}
+          з іменем {NAME} розмістивши у {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Прибулець
@@ -210,8 +210,8 @@ uk:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": випадковий
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          створити [N][0] нових [COSTUME][1]
-          у [LAYOUT][2]
+          створити {N} нових {COSTUME}
+          у {LAYOUT}
         options:
           N:
             '2': '2'
@@ -256,9 +256,9 @@ uk:
             '"plus"': плюс
             '"random"': випадковий
       Dancelab_mixColors:
-        text: змішати [COLOR1][0] та [COLOR2][1]
+        text: змішати {COLOR1} та {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] кроків"
+        text: "{N} кроків"
       Dancelab_onPointerDown:
         text: коли вказівник вниз
       Dancelab_onPointerDrag:
@@ -268,9 +268,9 @@ uk:
       Dancelab_randomColor:
         text: випадковий колір
       Dancelab_setBackground:
-        text: встановити колір тла [COLOR][0]
+        text: встановити колір тла {COLOR}
       Dancelab_setBackgroundEffect:
-        text: встановити ефект тла [EFFECT][0]
+        text: встановити ефект тла {EFFECT}
         options:
           EFFECT:
             '"color_cycle"': Кольори
@@ -296,7 +296,7 @@ uk:
             '"spiral"': Спіраль
             '"disco"': Квадрати
       Dancelab_setDanceSpeed:
-        text: змінити для [SPRITE][0] швидкість танцю на [SPEED][1]
+        text: змінити для {SPRITE} швидкість танцю на {SPEED}
         options:
           SPEED:
             '1': нормальний
@@ -305,7 +305,7 @@ uk:
             '0.5': повільно
             '0.25': дуже повільно
       Dancelab_setDanceSpeedEach:
-        text: встановити для [GROUP][0] швидкість танцю в [SPEED][1]
+        text: встановити для {GROUP} швидкість танцю в {SPEED}
         options:
           GROUP:
             sprites: усі
@@ -327,7 +327,7 @@ uk:
             '0.5': повільно
             '0.25': дуже повільно
       Dancelab_setForegroundEffect:
-        text: встановити ефект переднього плану [EFFECT][0]
+        text: встановити ефект переднього плану {EFFECT}
         options:
           EFFECT:
             '"bubbles"': Бульбашки
@@ -335,7 +335,7 @@ uk:
             '"rain"': Дощ
             '"raining_tacos"': Тако
       Dancelab_setForegroundEffectExtended:
-        text: встановити ефект переднього плану [EFFECT][0]
+        text: встановити ефект переднього плану {EFFECT}
         options:
           EFFECT:
             '"rand"': "(Випадковий)"
@@ -344,7 +344,7 @@ uk:
             '"rain"': Дощ
             '"raining_tacos"': Тако
       Dancelab_setProp:
-        text: 'встановити [SPRITE][0] [PROPERTY][1] у [VAL][2] '
+        text: 'встановити {SPRITE} {PROPERTY} у {VAL} '
         options:
           PROPERTY:
             '"scale"': розмір
@@ -355,7 +355,7 @@ uk:
             '"y"': вертикальне положення
             '"tint"': відтінок
       Dancelab_setPropEach:
-        text: встановити [GROUP][0] [PROPERTY][1] у [VAL][2]
+        text: встановити {GROUP} {PROPERTY} у {VAL}
         options:
           GROUP:
             sprites: усі
@@ -379,7 +379,7 @@ uk:
             '"y"': вертикальне положення
             '"tint"': відтінок
       Dancelab_setPropRandom:
-        text: випадково [SPRITE][0] [PROPERTY][1]
+        text: випадково {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': розмір
@@ -390,9 +390,9 @@ uk:
             '"y"': вертикальне положення
             '"tint"': відтінок
       Dancelab_setTint:
-        text: встановити для [SPRITE][0] відтінок [VAL][1]
+        text: встановити для {SPRITE} відтінок {VAL}
       Dancelab_setTintEach:
-        text: встановити для [THIS][0] відтінок у [VAL][1]
+        text: встановити для {THIS} відтінок у {VAL}
         options:
           THIS:
             sprites: усі
@@ -407,15 +407,15 @@ uk:
             '"ROBOT"': всі роботи
             '"SHARK"': всі акули
       Dancelab_setTintInline:
-        text: встановити для [SPRITE][0] відтінок [VAL][1]
+        text: встановити для {SPRITE} відтінок {VAL}
       Dancelab_setVisible:
-        text: встановити для [SPRITE][0] видимість у [VISIBILITY][1]
+        text: встановити для {SPRITE} видимість у {VISIBILITY}
         options:
           VISIBILITY:
             'true': видимий
             'false': невидимий
       Dancelab_setVisibleEach:
-        text: встановити для [THIS][0] видимість [VISIBILITY][1]
+        text: встановити для {THIS} видимість {VISIBILITY}
         options:
           THIS:
             sprites: усі
@@ -434,7 +434,7 @@ uk:
             'true': видимий
             'false': невидимий
       Dancelab_startMapping:
-        text: "[SPRITE][0] змінює [PROPERTY][1] відповідно [RANGE][2]"
+        text: "{SPRITE} змінює {PROPERTY} відповідно {RANGE}"
         options:
           PROPERTY:
             '"scale"': розмір
@@ -449,7 +449,7 @@ uk:
             '"mid"': середні тони
             '"treble"': високі тони
       Dancelab_stopMapping:
-        text: "[SPRITE][0] припиняє [PROPERTY][1] після [RANGE][2]"
+        text: "{SPRITE} припиняє {PROPERTY} після {RANGE}"
         options:
           PROPERTY:
             '"scale"': розмір
@@ -465,7 +465,7 @@ uk:
             '"mid"': середні тони
             '"treble"': високі тони
       Dancelab_whenKey:
-        text: коли натиснуто [KEY][0]
+        text: коли натиснуто {KEY}
         options:
           KEY:
             '"up"': вгору
@@ -475,7 +475,7 @@ uk:
             '"space"': космос
             '"x"': x
       Dancelab_whenPeak:
-        text: коли досягаємо кінця [RANGE][0]
+        text: коли досягаємо кінця {RANGE}
         options:
           RANGE:
             '0': низькі тони
@@ -484,21 +484,21 @@ uk:
       Dancelab_whenSetup:
         text: налаштування
       gamelab_changeColor:
-        text: змінити [COLOR][0] [METHOD][1] на [AMOUNT][2]
+        text: змінити {COLOR} {METHOD} на {AMOUNT}
         options:
           METHOD:
             '"tint"': відтінок
             '"tone"': тон
             '"shade"': відтінок
       gamelab_changeColorBy:
-        text: змінити [COLOR][0] [METHOD][1] на [AMOUNT][2]
+        text: змінити {COLOR} {METHOD} на {AMOUNT}
         options:
           METHOD:
             '"hue"': відтінок
             '"saturation"': насиченість
             '"brightness"': яскравість
       gamelab_changePropBy:
-        text: змінити [SPRITE][0] [PROPERTY][1] на [VAL][2]
+        text: змінити {SPRITE} {PROPERTY} на {VAL}
         options:
           PROPERTY:
             '"scale"': розмір
@@ -507,7 +507,7 @@ uk:
             '"y"': позиція по осі y
             '"direction"': напрямок руху
       gamelab_clickedOn:
-        text: коли клацнули [SPRITE][0]
+        text: коли клацнули {SPRITE}
       gamelab_debugSprite:
         options:
           VAL:
@@ -523,7 +523,7 @@ uk:
             '"direction"': напрямок руху
             '"tint"': відтінок
       gamelab_jumpTo:
-        text: "[SPRITE][0] стрибає до [LOCATION][1]"
+        text: "{SPRITE} стрибає до {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -534,15 +534,15 @@ uk:
             '"right"': праворуч
             '"left"': ліворуч
       gamelab_mixColors:
-        text: змішати [COLOR1][0] та [COLOR2][1]
+        text: змішати {COLOR1} та {COLOR2}
       gamelab_randColor:
         text: випадковий колір
       gamelab_randomColor:
         text: випадковий колір
       gamelab_setBackground:
-        text: встановити колір тла [COLOR][0]
+        text: встановити колір тла {COLOR}
       gamelab_setPosition:
-        text: перемістити [THIS][0] у позицію [POSITION][1]
+        text: перемістити {THIS} у позицію {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": верхній лівий кут
@@ -594,7 +594,7 @@ uk:
             '"right"': праворуч
             '"left"': ліворуч
       gamelab_whenKey:
-        text: коли натиснуто [KEY][0]
+        text: коли натиснуто {KEY}
         options:
           KEY:
             '"up"': вгору
@@ -711,8 +711,8 @@ uk:
             '"all"': усі
       Mikelab_ifDanceIs:
         text: |-
-          якщо [SPRITE][0] виконує рух [DANCE][1]
-          [DO1][2] [DO2][3]
+          якщо {SPRITE} виконує рух {DANCE}
+          {DO1} {DO2}
       Mikelab_randomColor:
         text: випадковий колір
       Mikelab_setBG:
@@ -745,9 +745,9 @@ uk:
             "{x: 100, y: 300}": нижній лівий кут
             "{x: 300, y: 300}": нижній правий кут
       Mikelab_whenClickedOn:
-        text: коли клацнули [SPRITE][0]
+        text: коли клацнули {SPRITE}
       Mikelab_whenKeyPressed:
-        text: коли натиснуто [KEY][0]
+        text: коли натиснуто {KEY}
         options:
           KEY:
             '"up"': стрілка вгору
@@ -785,7 +785,7 @@ uk:
       Vector_positionCenter:
         text: посередині
       Vector_setSize:
-        text: встановити ширину [WIDTH][0] висоту [HEIGHT][1]
+        text: встановити ширину {WIDTH} висоту {HEIGHT}
       aalab_changeGroupPropBy:
         options:
           PROPERTY:
@@ -810,7 +810,7 @@ uk:
             '"left"': ліворуч
             '"right"': праворуч
       binary_whenKey:
-        text: коли натиснуто [KEY][0]
+        text: коли натиснуто {KEY}
         options:
           KEY:
             '"up"': вгору
@@ -820,8 +820,8 @@ uk:
             '"space"': космос
       craft_ifPath:
         text: |-
-          якщо є шлях [DIR][0]
-          [STATEMENT][1]
+          якщо є шлях {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": попереду
@@ -829,8 +829,8 @@ uk:
             "'left'": ліворуч
       craft_ifStandingOn:
         text: |-
-          якщо стою на [TYPE][0]
-          [STATEMENT][1]
+          якщо стою на {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": синій корал
@@ -841,8 +841,8 @@ uk:
             "'seaLantern'": морський ліхтар
       craft_ifStandingOnLimit:
         text: |-
-          якщо стою на [TYPE][0]
-          [STATEMENT][1]
+          якщо стою на {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": пісок
@@ -851,7 +851,7 @@ uk:
       craft_moveForward:
         text: рухатись вперед
       craft_placeBlock:
-        text: постав [blockType][0]
+        text: постав {blockType}
         options:
           blockType:
             '"strippedOak"': очищений дуб
@@ -886,13 +886,13 @@ uk:
       craft_repeatUntilConduit:
         text: |-
           повторювати до завершення трубопроводу
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           повторювати до досягнення цілі
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: плодити [ENTITY][0]
+        text: плодити {ENTITY}
         options:
           ENTITY:
             '"cod"': тріска
@@ -902,7 +902,7 @@ uk:
             '"squid"': кальмар
             '"tropicalFish"': тропічна риба
       craft_turn:
-        text: повернути [DIR][0]
+        text: повернути {DIR}
         options:
           DIR:
             right: праворуч ↻

--- a/dashboard/config/locales/blocks.vi-VN.yml
+++ b/dashboard/config/locales/blocks.vi-VN.yml
@@ -3,20 +3,20 @@ vi:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: sau [TIMESTAMP][0] [UNIT][1]
+        text: sau {TIMESTAMP} {UNIT}
         options:
           UNIT:
             '"measures"': nhịp
             '"seconds"': giây
       Dancelab_changeColorBy:
-        text: thay đổi [COLOR][0] [METHOD][1] thành [AMOUNT][2]
+        text: thay đổi {COLOR} {METHOD} thành {AMOUNT}
         options:
           METHOD:
             '"hue"': sắc màu
             '"saturation"': độ bão hòa
             '"brightness"': độ sáng
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] [MOVE][1] [DIR][2] mãi mãi"
+        text: "{GROUP} {MOVE} {DIR} mãi mãi"
         options:
           GROUP:
             sprites: tất cả
@@ -47,7 +47,7 @@ vi:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] [MOVE][1] [DIR][2] mãi mãi"
+        text: "{SPRITE} {MOVE} {DIR} mãi mãi"
         options:
           MOVE:
             '"next"': "(Tiếp theo)"
@@ -65,7 +65,7 @@ vi:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: thay đổi [PROPERTY][1] [SPRITE][0] theo [VAL][2]
+        text: thay đổi {PROPERTY} {SPRITE} theo {VAL}
         options:
           PROPERTY:
             '"scale"': kích cỡ
@@ -75,7 +75,7 @@ vi:
             '"x"': vị trí ngang
             '"y"': vị trí dọc
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] [MOVE][1] [DIR][2] một lần"
+        text: "{GROUP} {MOVE} {DIR} một lần"
         options:
           GROUP:
             sprites: tất cả
@@ -104,7 +104,7 @@ vi:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] [MOVE][1] [DIR][2] một lần"
+        text: "{SPRITE} {MOVE} {DIR} một lần"
         options:
           MOVE:
             '"rand"': "(Ngẫu nhiên)"
@@ -120,32 +120,32 @@ vi:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: 'mỗi [N][0] [UNIT][1] '
+        text: 'mỗi {N} {UNIT} '
         options:
           UNIT:
             '"measures"': nhịp
             '"seconds"': giây
       Dancelab_everySecondsRange:
-        text: 'mỗi [N][0] [UNIT][1] từ [START][2] đến [STOP][3] '
+        text: 'mỗi {N} {UNIT} từ {START} đến {STOP} '
         options:
           UNIT:
             measures: Nhịp
             seconds: Giây
       Dancelab_everyVerseChorus:
-        text: 'mỗi [UNIT][0] '
+        text: 'mỗi {UNIT} '
         options:
           UNIT:
             '"verse"': khổ
             '"chorus"': điệp khúc
       Dancelab_getEnergy:
-        text: có [RANGE][0]
+        text: có {RANGE}
         options:
           RANGE:
             '"low"': âm trầm
             '"mid"': âm trung
             '"high"': âm cao
       Dancelab_getProp:
-        text: "[PROPERTY][1] [SPRITE][0]"
+        text: "{PROPERTY} {SPRITE}"
         options:
           PROPERTY:
             '"scale"': kích cỡ
@@ -156,15 +156,15 @@ vi:
             '"y"': vị trí dọc
             '"tint"': sắc thái
       Dancelab_getTime:
-        text: Hết [UNIT][0]
+        text: Hết {UNIT}
         options:
           UNIT:
             '"measures"': nhịp
             '"seconds"': giây
       Dancelab_ifDanceIs:
         text: |-
-          nếu [SPRITE][0] đang [DANCE][1]
-          [DO1][2] [DO2][3]
+          nếu {SPRITE} đang {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Vỗ tay cao
@@ -181,7 +181,7 @@ vi:
             '"measures"': nhịp
             '"seconds"': giây
       Dancelab_jumpTo:
-        text: "[SPRITE][0] nhảy đến [LOCATION][1]"
+        text: "{SPRITE} nhảy đến {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": trên
@@ -195,7 +195,7 @@ vi:
             "{x: 300, y: 300}": dưới phải
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": ngẫu nhiên
       Dancelab_layoutSprites:
-        text: bố trí [GROUP][0] như là [FORMAT][1]
+        text: bố trí {GROUP} như là {FORMAT}
         options:
           GROUP:
             sprites: tất cả
@@ -221,8 +221,8 @@ vi:
             '"random"': ngẫu nhiên
       Dancelab_makeNewDanceSprite:
         text: |-
-          tạo một [COSTUME][0] mới
-          gọi [NAME][1] ở [LOCATION][2]
+          tạo một {COSTUME} mới
+          gọi {NAME} ở {LOCATION}
         options:
           COSTUME:
             '"ALIEN"': Người ngoài hành tinh
@@ -248,8 +248,8 @@ vi:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": ngẫu nhiên
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          làm [N][0] [COSTUME][1] mới
-          trong [LAYOUT][2]
+          làm {N} {COSTUME} mới
+          trong {LAYOUT}
         options:
           N:
             '2': '2'
@@ -293,9 +293,9 @@ vi:
             '"plus"': cộng
             '"random"': ngẫu nhiên
       Dancelab_mixColors:
-        text: trộn [COLOR1][0] và [COLOR2][1]
+        text: trộn {COLOR1} và {COLOR2}
       Dancelab_nMeasures:
-        text: Nhịp [N][0]
+        text: Nhịp {N}
       Dancelab_onPointerDown:
         text: con trỏ nhấn
       Dancelab_onPointerDrag:
@@ -305,9 +305,9 @@ vi:
       Dancelab_randomColor:
         text: màu ngẫu nhiên
       Dancelab_setBackground:
-        text: thiết lập màu nền [COLOR][0]
+        text: thiết lập màu nền {COLOR}
       Dancelab_setBackgroundEffect:
-        text: thiết lập hiệu ứng nền [EFFECT][0]
+        text: thiết lập hiệu ứng nền {EFFECT}
         options:
           EFFECT:
             '"none"': Không có
@@ -329,7 +329,7 @@ vi:
             '"vintage"': Cổ điển
             '"warm"': Đỏ
       Dancelab_setBackgroundEffectWithPalette:
-        text: thiết lập hiệu ứng nền [EFFECT][0] [PALETTE][1]
+        text: thiết lập hiệu ứng nền {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': Không có
@@ -353,7 +353,7 @@ vi:
             '"vintage"': Cổ điển
             '"warm"': Đỏ
       Dancelab_setDanceSpeed:
-        text: thay đổi tốc độ nhảy của [SPRITE][0] thành [SPEED][1]
+        text: thay đổi tốc độ nhảy của {SPRITE} thành {SPEED}
         options:
           SPEED:
             '1': bình thường
@@ -383,7 +383,7 @@ vi:
             '0.5': chậm
             '0.25': rất chậm
       Dancelab_setForegroundEffect:
-        text: thiết lập hiệu ứng tiền cảnh [EFFECT][0]
+        text: thiết lập hiệu ứng tiền cảnh {EFFECT}
         options:
           EFFECT:
             '"none"': Không có
@@ -396,7 +396,7 @@ vi:
             '"floating_rainbows"': Cầu vồng
             '"raining_tacos"': Taco
       Dancelab_setForegroundEffectExtended:
-        text: thiết lập hiệu ứng tiền cảnh [EFFECT][0]
+        text: thiết lập hiệu ứng tiền cảnh {EFFECT}
         options:
           EFFECT:
             '"none"': Không có
@@ -410,7 +410,7 @@ vi:
             '"floating_rainbows"': Cầu vồng
             '"raining_tacos"': Taco
       Dancelab_setProp:
-        text: 'thiết lập [PROPERTY][1] [SPRITE][0] thành [VAL][2] '
+        text: 'thiết lập {PROPERTY} {SPRITE} thành {VAL} '
         options:
           PROPERTY:
             '"scale"': kích cỡ
@@ -421,7 +421,7 @@ vi:
             '"y"': vị trí dọc
             '"tint"': sắc thái
       Dancelab_setPropEach:
-        text: thiết lập [PROPERTY][1] [GROUP][0] thành [VAL][2]
+        text: thiết lập {PROPERTY} {GROUP} thành {VAL}
         options:
           GROUP:
             sprites: tất cả
@@ -445,7 +445,7 @@ vi:
             '"y"': vị trí dọc
             '"tint"': sắc thái
       Dancelab_setPropRandom:
-        text: ngẫu nhiên hóa [PROPERTY][1] [SPRITE][0]
+        text: ngẫu nhiên hóa {PROPERTY} {SPRITE}
         options:
           PROPERTY:
             '"scale"': kích cỡ
@@ -456,7 +456,7 @@ vi:
             '"y"': vị trí dọc
             '"tint"': sắc thái
       Dancelab_setTint:
-        text: thiết lập sắc thái [SPRITE][0] thành [VAL][1]
+        text: thiết lập sắc thái {SPRITE} thành {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -472,15 +472,15 @@ vi:
             '"ROBOT"': tất cả robot
             '"SHARK"': tất cả cá mập
       Dancelab_setTintInline:
-        text: thiết lập sắc thái [SPRITE][0] thành [VAL][1]
+        text: thiết lập sắc thái {SPRITE} thành {VAL}
       Dancelab_setVisible:
-        text: thiết lập [SPRITE][0] có thể nhìn thấy với [VISIBILITY][1]
+        text: thiết lập {SPRITE} có thể nhìn thấy với {VISIBILITY}
         options:
           VISIBILITY:
             'true': có thể nhìn thấy
             'false': không thể nhìn thấy
       Dancelab_setVisibleEach:
-        text: thiết lập khả năng hiển thị [THIS][0] thành [VISIBILITY][1]
+        text: thiết lập khả năng hiển thị {THIS} thành {VISIBILITY}
         options:
           THIS:
             sprites: tất cả
@@ -499,7 +499,7 @@ vi:
             'true': có thể nhìn thấy
             'false': không thể nhìn thấy
       Dancelab_startMapping:
-        text: "[SPRITE][0] bắt đầu [PROPERTY][1] theo [RANGE][2]"
+        text: "{SPRITE} bắt đầu {PROPERTY} theo {RANGE}"
         options:
           PROPERTY:
             '"scale"': kích cỡ
@@ -514,7 +514,7 @@ vi:
             '"mid"': âm trung
             '"treble"': âm cao
       Dancelab_stopMapping:
-        text: "[SPRITE][0] dừng [PROPERTY][1] theo [RANGE][2]"
+        text: "{SPRITE} dừng {PROPERTY} theo {RANGE}"
         options:
           PROPERTY:
             '"scale"': kích cỡ
@@ -530,7 +530,7 @@ vi:
             '"mid"': âm trung
             '"treble"': âm cao
       Dancelab_whenKey:
-        text: khi nhấn [KEY][0]
+        text: khi nhấn {KEY}
         options:
           KEY:
             '"up"': trên
@@ -540,7 +540,7 @@ vi:
             '"space"': vũ trụ
             '"x"': x
       Dancelab_whenPeak:
-        text: khi đỉnh [RANGE][0]
+        text: khi đỉnh {RANGE}
         options:
           RANGE:
             '0': âm trầm
@@ -549,19 +549,19 @@ vi:
       Dancelab_whenSetup:
         text: thiết lập
       gamelab_changeColor:
-        text: thay đổi [COLOR][0] [METHOD][1] thành [AMOUNT][2]
+        text: thay đổi {COLOR} {METHOD} thành {AMOUNT}
         options:
           METHOD:
             '"tint"': sắc thái
       gamelab_changeColorBy:
-        text: thay đổi [COLOR][0] [METHOD][1] thành [AMOUNT][2]
+        text: thay đổi {COLOR} {METHOD} thành {AMOUNT}
         options:
           METHOD:
             '"hue"': sắc màu
             '"saturation"': độ bão hòa
             '"brightness"': độ sáng
       gamelab_changePropBy:
-        text: thay đổi [PROPERTY][1] [SPRITE][0] theo [VAL][2]
+        text: thay đổi {PROPERTY} {SPRITE} theo {VAL}
         options:
           PROPERTY:
             '"scale"': kích cỡ
@@ -575,7 +575,7 @@ vi:
             'true': đúng
             'false': sai
       gamelab_getProp:
-        text: "[PROPERTY][1] [SPRITE][0]"
+        text: "{PROPERTY} {SPRITE}"
         options:
           PROPERTY:
             '"scale"': kích cỡ
@@ -585,7 +585,7 @@ vi:
             '"direction"': phương hướng chuyển động
             '"tint"': sắc thái
       gamelab_jumpTo:
-        text: "[SPRITE][0] nhảy đến [LOCATION][1]"
+        text: "{SPRITE} nhảy đến {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -596,15 +596,15 @@ vi:
             '"right"': phải
             '"left"': trái
       gamelab_mixColors:
-        text: trộn [COLOR1][0] và [COLOR2][1]
+        text: trộn {COLOR1} và {COLOR2}
       gamelab_randColor:
         text: màu ngẫu nhiên
       gamelab_randomColor:
         text: màu ngẫu nhiên
       gamelab_setBackground:
-        text: thiết lập màu nền [COLOR][0]
+        text: thiết lập màu nền {COLOR}
       gamelab_setPosition:
-        text: di chuyển [THIS][0] đến vị trí [POSITION][1]
+        text: di chuyển {THIS} đến vị trí {POSITION}
         options:
           POSITION:
             "{x: 50, y: 50}": trên trái
@@ -657,7 +657,7 @@ vi:
             '"right"': phải
             '"left"': trái
       gamelab_whenKey:
-        text: khi nhấn [KEY][0]
+        text: khi nhấn {KEY}
         options:
           KEY:
             '"up"': trên
@@ -774,8 +774,8 @@ vi:
             '"all"': tất cả
       Mikelab_ifDanceIs:
         text: |-
-          nếu [SPRITE][0] đang [DANCE][1]
-          [DO1][2] [DO2][3]
+          nếu {SPRITE} đang {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: Vỗ tay cao
@@ -819,7 +819,7 @@ vi:
             "{x: 100, y: 300}": dưới trái
             "{x: 300, y: 300}": dưới phải
       Mikelab_whenKeyPressed:
-        text: khi nhấn [KEY][0]
+        text: khi nhấn {KEY}
         options:
           KEY:
             '"up"': mũi tên lên trên
@@ -880,7 +880,7 @@ vi:
             '"left"': trái
             '"right"': phải
       binary_whenKey:
-        text: khi nhấn [KEY][0]
+        text: khi nhấn {KEY}
         options:
           KEY:
             '"up"': trên
@@ -890,8 +890,8 @@ vi:
             '"space"': vũ trụ
       craft_ifPath:
         text: |-
-          nếu có đường dẫn [DIR][0]
-          [STATEMENT][1]
+          nếu có đường dẫn {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": phía trước
@@ -899,8 +899,8 @@ vi:
             "'left'": sang bên trái
       craft_ifStandingOn:
         text: |-
-          nếu đứng trên [TYPE][0]
-          [STATEMENT][1]
+          nếu đứng trên {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": san hô màu xanh
@@ -911,19 +911,19 @@ vi:
             "'seaLantern'": ngọn đèn biển
       craft_ifStandingOnLimit:
         text: |-
-          nếu đứng trên [TYPE][0]
-          [STATEMENT][1]
+          nếu đứng trên {TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": cát
             "'darkPrismarine'": prismarine màu tối
             "'seaLantern'": ngọn đèn biển
       craft_log:
-        text: đăng nhập thư [MESSAGE][0]
+        text: đăng nhập thư {MESSAGE}
       craft_moveForward:
         text: đi thẳng
       craft_placeBlock:
-        text: đặt [blockType][0]
+        text: đặt {blockType}
         options:
           blockType:
             '"strippedOak"': gỗ sồi được tước
@@ -958,13 +958,13 @@ vi:
       craft_repeatUntilConduit:
         text: |-
           lặp lại cho đến khi hoàn thành ống dẫn
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           lặp lại đến khi đạt mục tiêu
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: đẻ trứng [ENTITY][0]
+        text: đẻ trứng {ENTITY}
         options:
           ENTITY:
             '"cod"': cá tuyết
@@ -974,7 +974,7 @@ vi:
             '"squid"': mực ống
             '"tropicalFish"': cá nhiệt đới
       craft_turn:
-        text: rẽ [DIR][0]
+        text: rẽ {DIR}
         options:
           DIR:
             right: phải ↻

--- a/dashboard/config/locales/blocks.zh-CN.yml
+++ b/dashboard/config/locales/blocks.zh-CN.yml
@@ -3,20 +3,20 @@ zh-CN:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: 在 [TIMESTAMP][0] [UNIT][1] 后
+        text: 在 {TIMESTAMP} {UNIT} 后
         options:
           UNIT:
             '"measures"': 节拍
             '"seconds"': " 秒"
       Dancelab_changeColorBy:
-        text: 将 [COLOR][0] [METHOD][1] 改动 [AMOUNT][2]
+        text: 将 {COLOR} {METHOD} 改动 {AMOUNT}
         options:
           METHOD:
             '"hue"': 色调
             '"saturation"': 饱和度
             '"brightness"': 亮度
       Dancelab_changeMoveEachLR:
-        text: '在 GROUP[0] 中，进行 循环查找   [MOVE][1] [DIR][2] '
+        text: '在 GROUP[0] 中，进行 循环查找   {MOVE} {DIR} '
         options:
           GROUP:
             sprites: 所有
@@ -50,7 +50,7 @@ zh-CN:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] 一直重复 [MOVE][1] [DIR][2]"
+        text: "{SPRITE} 一直重复 {MOVE} {DIR}"
         options:
           MOVE:
             '"next"': "(下一步)"
@@ -72,7 +72,7 @@ zh-CN:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: 将 [SPRITE][0] [PROPERTY][1] 改为 [VAL][2]
+        text: 将 {SPRITE} {PROPERTY} 改为 {VAL}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -82,7 +82,7 @@ zh-CN:
             '"x"': 水平位置
             '"y"': 垂直位置
       Dancelab_doMoveEachLR:
-        text: 在 [GROUP][0] 中，进行 [MOVE][1] [DIR][2] 一次
+        text: 在 {GROUP} 中，进行 {MOVE} {DIR} 一次
         options:
           GROUP:
             sprites: 所有
@@ -114,7 +114,7 @@ zh-CN:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] 重复 [MOVE][1] [DIR][2] 一次"
+        text: "{SPRITE} 重复 {MOVE} {DIR} 一次"
         options:
           MOVE:
             '"rand"': 随机
@@ -133,34 +133,34 @@ zh-CN:
             '1': "→"
             "-1": "←"
       Dancelab_eval:
-        text: 执行 [CODE][0]
+        text: 执行 {CODE}
       Dancelab_everySeconds:
-        text: '每次 [N][0] [UNIT][1] '
+        text: '每次 {N} {UNIT} '
         options:
           UNIT:
             '"measures"': 节拍
             '"seconds"': " 秒"
       Dancelab_everySecondsRange:
-        text: 每个 [N][0] [UNIT][1] 要从 [START][2] 到 [STOP][3]
+        text: 每个 {N} {UNIT} 要从 {START} 到 {STOP}
         options:
           UNIT:
             measures: 节拍
             seconds: 秒
       Dancelab_everyVerseChorus:
-        text: '每个 [UNIT][0] '
+        text: '每个 {UNIT} '
         options:
           UNIT:
             '"verse"': 诗歌
             '"chorus"': 合唱
       Dancelab_getEnergy:
-        text: 获得 [RANGE][0]
+        text: 获得 {RANGE}
         options:
           RANGE:
             '"low"': 低音
             '"mid"': 中音音量
             '"high"': 高音音量
       Dancelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': 大小
@@ -171,15 +171,15 @@ zh-CN:
             '"y"': 垂直位置
             '"tint"': 色调
       Dancelab_getTime:
-        text: "[UNIT][0] 当前时间"
+        text: "{UNIT} 当前时间"
         options:
           UNIT:
             '"measures"': 节拍
             '"seconds"': " 秒"
       Dancelab_ifDanceIs:
         text: |-
-          如果 [SPRITE][0] 正在 [DANCE][1]
-          [DO1][2] [DO2][3]
+          如果 {SPRITE} 正在 {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: 用力鼓掌
@@ -195,8 +195,8 @@ zh-CN:
             MOVES.Rest: 没有
       Dancelab_ifTime:
         text: |-
-          如果 [UNIT][0] 是 [OP][1] [N][2]
-          [DO1][3] [DO2][4]
+          如果 {UNIT} 是 {OP} {N}
+          {DO1} {DO2}
         options:
           UNIT:
             '"measures"': 节拍
@@ -206,7 +206,7 @@ zh-CN:
             '"<"': "\\<"
             '"="': "="
       Dancelab_jumpTo:
-        text: "[SPRITE][0] 跳到 [LOCATION][1]"
+        text: "{SPRITE} 跳到 {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": 顶部
@@ -220,7 +220,7 @@ zh-CN:
             "{x: 300, y: 300}": 右下
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": 随机
       Dancelab_layoutSprites:
-        text: 输出 [GROUP][0] 精灵为 [FORMAT][1]
+        text: 输出 {GROUP} 精灵为 {FORMAT}
         options:
           GROUP:
             sprites: 所有
@@ -246,7 +246,7 @@ zh-CN:
             '"plus"': 添加
             '"random"': 随机
       Dancelab_makeNewDanceSprite:
-        text: 在 [LOCATION][2] 创建一个叫做 [NAME][1] 的新 [COSTUME][0]
+        text: 在 {LOCATION} 创建一个叫做 {NAME} 的新 {COSTUME}
         options:
           COSTUME:
             '"ALIEN"': 外星人
@@ -272,7 +272,7 @@ zh-CN:
             "{x: 300, y: 300}": 右下
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": 随机
       Dancelab_makeNewDanceSpriteGroup:
-        text: 在 [LAYOUT][2] 创造 [N][0] 新的 [COSTUME][1]
+        text: 在 {LAYOUT} 创造 {N} 新的 {COSTUME}
         options:
           N:
             '2': '2'
@@ -317,9 +317,9 @@ zh-CN:
             '"plus"': 添加
             '"random"': 随机
       Dancelab_mixColors:
-        text: 混合 [COLOR1][0] 和 [COLOR2][1]
+        text: 混合 {COLOR1} 和 {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] 个节拍"
+        text: "{N} 个节拍"
       Dancelab_onPointerDown:
         text: 当指针按下时
       Dancelab_onPointerDrag:
@@ -329,9 +329,9 @@ zh-CN:
       Dancelab_randomColor:
         text: 随机颜色
       Dancelab_setBackground:
-        text: 设置背景颜色为 [COLOR][0]
+        text: 设置背景颜色为 {COLOR}
       Dancelab_setBackgroundEffect:
-        text: 设置背景效果 [EFFECT][0]
+        text: 设置背景效果 {EFFECT}
         options:
           EFFECT:
             '"none"': 没有
@@ -359,7 +359,7 @@ zh-CN:
             '"vintage"': 复古
             '"warm"': 红色
       Dancelab_setBackgroundEffectWithPalette:
-        text: 设置背景效果 [EFFECT][0] [PALETTE][1]
+        text: 设置背景效果 {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': 没有
@@ -388,7 +388,7 @@ zh-CN:
             '"vintage"': 复古
             '"warm"': 红色
       Dancelab_setDanceSpeed:
-        text: 将 [SPRITE][0] 跳舞速度改为 [SPEED][1]
+        text: 将 {SPRITE} 跳舞速度改为 {SPEED}
         options:
           SPEED:
             '1': 正常
@@ -397,7 +397,7 @@ zh-CN:
             '0.5': 慢
             '0.25': 非常慢
       Dancelab_setDanceSpeedEach:
-        text: 将 [GROUP][0] 跳舞速度改为 [SPEED][1]
+        text: 将 {GROUP} 跳舞速度改为 {SPEED}
         options:
           GROUP:
             sprites: 所有
@@ -419,7 +419,7 @@ zh-CN:
             '0.5': 慢
             '0.25': 非常慢
       Dancelab_setForegroundEffect:
-        text: 设置前景效果为 [EFFECT][0]
+        text: 设置前景效果为 {EFFECT}
         options:
           EFFECT:
             '"none"': 没有
@@ -434,7 +434,7 @@ zh-CN:
             '"spotlight"': 聚光灯
             '"raining_tacos"': 玉米卷
       Dancelab_setForegroundEffectExtended:
-        text: 设置前景效果为 [EFFECT][0]
+        text: 设置前景效果为 {EFFECT}
         options:
           EFFECT:
             '"none"': 没有
@@ -450,7 +450,7 @@ zh-CN:
             '"spotlight"': 聚光灯
             '"raining_tacos"': 玉米卷
       Dancelab_setProp:
-        text: 设置 [SPRITE][0] [PROPERTY][1] 为 [VAL][2]
+        text: 设置 {SPRITE} {PROPERTY} 为 {VAL}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -461,7 +461,7 @@ zh-CN:
             '"y"': 垂直位置
             '"tint"': 色调
       Dancelab_setPropEach:
-        text: 设置 [GROUP][0] [PROPERTY][1] 为 [VAL][2]
+        text: 设置 {GROUP} {PROPERTY} 为 {VAL}
         options:
           GROUP:
             sprites: 所有
@@ -485,7 +485,7 @@ zh-CN:
             '"y"': 垂直位置
             '"tint"': 色调
       Dancelab_setPropRandom:
-        text: 随机 [SPRITE][0] [PROPERTY][1]
+        text: 随机 {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -496,9 +496,9 @@ zh-CN:
             '"y"': 垂直位置
             '"tint"': 色调
       Dancelab_setTint:
-        text: 设置 [SPRITE][0] 色调为 [VAL][1]
+        text: 设置 {SPRITE} 色调为 {VAL}
       Dancelab_setTintEach:
-        text: 设置 [THIS][0] 色调为 [VAL][1]
+        text: 设置 {THIS} 色调为 {VAL}
         options:
           THIS:
             sprites: 所有
@@ -513,15 +513,15 @@ zh-CN:
             '"ROBOT"': 所有机器人
             '"SHARK"': 所有鲨鱼
       Dancelab_setTintInline:
-        text: 设置 [SPRITE][0] 色调为 [VAL][1]
+        text: 设置 {SPRITE} 色调为 {VAL}
       Dancelab_setVisible:
-        text: 设置 [SPRITE][0] 可见度为 [VISIBILITY][1]
+        text: 设置 {SPRITE} 可见度为 {VISIBILITY}
         options:
           VISIBILITY:
             'true': 可见
             'false': 隐藏
       Dancelab_setVisibleEach:
-        text: 设置 [THIS][0] 可见度为 [VISIBILITY][1]
+        text: 设置 {THIS} 可见度为 {VISIBILITY}
         options:
           THIS:
             sprites: 所有
@@ -540,7 +540,7 @@ zh-CN:
             'true': 可见
             'false': 隐藏
       Dancelab_startMapping:
-        text: "[SPRITE][0] 开始 [PROPERTY][1] 为 [RANGE][2]"
+        text: "{SPRITE} 开始 {PROPERTY} 为 {RANGE}"
         options:
           PROPERTY:
             '"scale"': 大小
@@ -555,7 +555,7 @@ zh-CN:
             '"mid"': 中音音量
             '"treble"': 高音音量
       Dancelab_stopMapping:
-        text: "[SPRITE][0] 停止 [PROPERTY][1] 为 [RANGE][2]"
+        text: "{SPRITE} 停止 {PROPERTY} 为 {RANGE}"
         options:
           PROPERTY:
             '"scale"': 大小
@@ -571,7 +571,7 @@ zh-CN:
             '"mid"': 中音音量
             '"treble"': 高音音量
       Dancelab_whenKey:
-        text: 当 [KEY][0] 按下时
+        text: 当 {KEY} 按下时
         options:
           KEY:
             '"up"': 向上
@@ -600,7 +600,7 @@ zh-CN:
             '"y"': y
             '"z"': z
       Dancelab_whenPeak:
-        text: 当 [RANGE][0] 达到最高
+        text: 当 {RANGE} 达到最高
         options:
           RANGE:
             '0': 低音
@@ -613,31 +613,31 @@ zh-CN:
           SONG:
             '"peas"': 黑眼豆豆合唱团 - 我有一种感觉
       gamelab_add:
-        text: 将 [SPRITE][0] 加入组 [THIS][1]
+        text: 将 {SPRITE} 加入组 {THIS}
       gamelab_addBehaviorSimple:
-        text: 精灵 [SPRITE][0] 开始 [BEHAVIOR][1]
+        text: 精灵 {SPRITE} 开始 {BEHAVIOR}
       gamelab_beginBehavior:
-        text: 开始 [BEHAVIOR][0]
+        text: 开始 {BEHAVIOR}
       gamelab_bounceOff:
-        text: "[SPRITE][0] 弹离 [TARGET][1]"
+        text: "{SPRITE} 弹离 {TARGET}"
       gamelab_bounceOffEdges:
-        text: "[SPRITE][0] 弹离边缘"
+        text: "{SPRITE} 弹离边缘"
       gamelab_changeColor:
-        text: 将 [COLOR][0] [METHOD][1] 改动 [AMOUNT][2]
+        text: 将 {COLOR} {METHOD} 改动 {AMOUNT}
         options:
           METHOD:
             '"tint"': 色调
             '"tone"': 语气
             '"shade"': 色度
       gamelab_changeColorBy:
-        text: 将 [COLOR][0] [METHOD][1] 改动 [AMOUNT][2]
+        text: 将 {COLOR} {METHOD} 改动 {AMOUNT}
         options:
           METHOD:
             '"hue"': 色调
             '"saturation"': 饱和度
             '"brightness"': 亮度
       gamelab_changePropBy:
-        text: 将 [SPRITE][0] [PROPERTY][1] 改为 [VAL][2]
+        text: 将 {SPRITE} {PROPERTY} 改为 {VAL}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -646,50 +646,50 @@ zh-CN:
             '"y"': y位置
             '"direction"': 移动方向
       gamelab_clickedOn:
-        text: 当 [SPRITE][0] 被点击时
+        text: 当 {SPRITE} 被点击时
       gamelab_comment:
-        text: '注释: [COMMENT][0]'
+        text: '注释: {COMMENT}'
       gamelab_console.log:
-        text: 日志消息 [MESSAGE][0]
+        text: 日志消息 {MESSAGE}
       gamelab_createNewSprite:
-        text: "制作一个新的精灵 \n 叫做 [NAME][0] \n 服装为 [COSTUME][1] \n 位于 [LOCATION][2]"
+        text: "制作一个新的精灵 \n 叫做 {NAME} \n 服装为 {COSTUME} \n 位于 {LOCATION}"
       gamelab_debugSprite:
-        text: 调试 [SPRITE][0] [VAL][1]
+        text: 调试 {SPRITE} {VAL}
         options:
           VAL:
             'true': 真
             'false': 错
       gamelab_destroy:
-        text: 移除 [THIS][0]
+        text: 移除 {THIS}
       gamelab_displace:
-        text: "[THIS][0] 模块阻止了 [SPRITE][1] 移动"
+        text: "{THIS} 模块阻止了 {SPRITE} 移动"
       gamelab_distance:
-        text: 从 [LOCATION1][0] 到 [LOCATION2][1] 的距离
+        text: 从 {LOCATION1} 到 {LOCATION2} 的距离
       gamelab_draggable:
         text: 可拖拽
       gamelab_edgesDisplace:
-        text: 边缘模块阻止了 [SPRITE][0] 移动
+        text: 边缘模块阻止了 {SPRITE} 移动
       gamelab_enableDebug:
         text: 启用调试
       gamelab_eval:
-        text: 执行 [CODE][0]
+        text: 执行 {CODE}
       gamelab_firstTouched:
         text: 首先碰到的精灵
       gamelab_forEachSpriteWithCostume:
         text: |-
-          每个 [VALUE][0] 精灵
-          执行 [STATEMENT][1]
+          每个 {VALUE} 精灵
+          执行 {STATEMENT}
       gamelab_getAnim:
-        text: "[SPRITE][0] [COSTUME][1]"
+        text: "{SPRITE} {COSTUME}"
         options:
           COSTUME:
             '"costume"': 服装
       gamelab_getDirection:
-        text: "[SPRITE][0] 移动方向"
+        text: "{SPRITE} 移动方向"
       gamelab_getFrameDelay:
-        text: "[THIS][0] 帧延迟"
+        text: "{THIS} 帧延迟"
       gamelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': 大小
@@ -699,35 +699,35 @@ zh-CN:
             '"direction"': 移动方向
             '"tint"': 色调
       gamelab_groupLength:
-        text: "[THIS][0] 中的精灵数量"
+        text: "{THIS} 中的精灵数量"
       gamelab_hasBehavior:
-        text: "[SPRITE][0] 当前在 [BEHAVIOR][1]"
+        text: "{SPRITE} 当前在 {BEHAVIOR}"
       gamelab_hideTitleScreen:
         text: 隐藏标题屏幕
       gamelab_hsbColor:
         text: |-
           HSB 颜色
-          H[HUE][0]S[SATURATION][1]B[BRIGHTNESS][2]
+          H{HUE}S{SATURATION}B{BRIGHTNESS}
       gamelab_isTouching:
-        text: "[THIS][0] 正在触碰 [TARGET][1]"
+        text: "{THIS} 正在触碰 {TARGET}"
       gamelab_isTouchingEdges:
-        text: "[SPRITE][0] 正在触碰边缘"
+        text: "{SPRITE} 正在触碰边缘"
       gamelab_joystickDirection:
         text: 游戏杆方向
       gamelab_jumpTo:
-        text: "[SPRITE][0] 跳到 [LOCATION][1]"
+        text: "{SPRITE} 跳到 {LOCATION}"
       gamelab_keyDown:
-        text: 键被按下 [KEY][0]
+        text: 键被按下 {KEY}
       gamelab_locationAdd:
-        text: "[LOC1][0] [OPERATOR][1] [LOC2][2]"
+        text: "{LOC1} {OPERATOR} {LOC2}"
         options:
           OPERATOR:
             "'plus'": "\\+"
             "'minus'": "\\-"
       gamelab_locationAt:
-        text: '位置 x: [X][0] y: [Y][1]'
+        text: '位置 x: {X} y: {Y}'
       gamelab_locationConstant:
-        text: "[DIR][0]"
+        text: "{DIR}"
         options:
           DIR:
             "'north'": 北
@@ -735,7 +735,7 @@ zh-CN:
             "'east'": 东
             "'west'": 西
       gamelab_locationDelta:
-        text: "[LOCATION][2] 的 [DIR][1] [DISTANCE][0] 像素"
+        text: "{LOCATION} 的 {DIR} {DISTANCE} 像素"
         options:
           DIR:
             "'north'": 北
@@ -750,37 +750,37 @@ zh-CN:
       gamelab_locationNorth:
         text: 北
       gamelab_locationOf:
-        text: "[SPRITE][0] 的位置"
+        text: "{SPRITE} 的位置"
       gamelab_locationSouth:
         text: 南
       gamelab_locationWest:
         text: 西
       gamelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       gamelab_location_variable_get:
-        text: "[VAR][0] 的位置"
+        text: "{VAR} 的位置"
       gamelab_location_variable_set:
-        text: 设置 [VAR][0] 的位置到 [VAL][1]
+        text: 设置 {VAR} 的位置到 {VAL}
       gamelab_makeNewGroup:
         text: 创建新组
       gamelab_mirrorSprite:
-        text: "[SPRITE][0] 面向 [DIRECTION][1]"
+        text: "{SPRITE} 面向 {DIRECTION}"
         options:
           DIRECTION:
             '"right"': 向右
             '"left"': 向左
       gamelab_mixColors:
-        text: 混合 [COLOR1][0] 和 [COLOR2][1]
+        text: 混合 {COLOR1} 和 {COLOR2}
       gamelab_mouseDown:
         text: 鼠标已按下
       gamelab_mouseLocation:
         text: 鼠标位置
       gamelab_moveDown:
-        text: "[THIS][0] 向下移动"
+        text: "{THIS} 向下移动"
       gamelab_moveForward:
-        text: 向前移动 [SPRITE][0] [DISTANCE][1] 像素
+        text: 向前移动 {SPRITE} {DISTANCE} 像素
       gamelab_moveInDirection:
-        text: 移动 [SPRITE][0] [DISTANCE][1] 像素，方向 [DIRECTION][2]
+        text: 移动 {SPRITE} {DISTANCE} 像素，方向 {DIRECTION}
         options:
           DIRECTION:
             '"North"': 北
@@ -788,17 +788,17 @@ zh-CN:
             '"South"': 南
             '"West"': 西
       gamelab_moveInDirection2:
-        text: 移动 [SPRITE][0] [DISTANCE][1] 像素，方向 [DIRECTION][2]
+        text: 移动 {SPRITE} {DISTANCE} 像素，方向 {DIRECTION}
       gamelab_moveLeft:
-        text: "[THIS][0] 向左移动"
+        text: "{THIS} 向左移动"
       gamelab_moveRight:
-        text: "[THIS][0] 向右移动"
+        text: "{THIS} 向右移动"
       gamelab_moveToward:
-        text: 朝 [TARGET][2] 移动 [SPRITE][0] 距离 [DISTANCE][1]
+        text: 朝 {TARGET} 移动 {SPRITE} 距离 {DISTANCE}
       gamelab_moveUp:
-        text: "[THIS][0] 向上移动"
+        text: "{THIS} 向上移动"
       gamelab_pointInDirection:
-        text: 指向 [SPRITE][0] [DIRECTION][1]
+        text: 指向 {SPRITE} {DIRECTION}
         options:
           DIRECTION:
             '"North"': 北
@@ -806,7 +806,7 @@ zh-CN:
             '"South"': 南
             '"West"': 西
       gamelab_pointToward:
-        text: 将 [SPRITE][0] 朝向 [LOCATION][1]
+        text: 将 {SPRITE} 朝向 {LOCATION}
       gamelab_randColor:
         text: 随机颜色
       gamelab_randomColor:
@@ -814,23 +814,23 @@ zh-CN:
       gamelab_randomLocation:
         text: 随机位置
       gamelab_removeAllBehaviors:
-        text: "[SPRITE][0] 停止所有事情"
+        text: "{SPRITE} 停止所有事情"
       gamelab_removeBehaviorSimple:
-        text: 精灵 [SPRITE][0] 停止 [BEHAVIOR][1]
+        text: 精灵 {SPRITE} 停止 {BEHAVIOR}
       gamelab_removeTint:
-        text: 从 [THIS][0] 删除颜色
+        text: 从 {THIS} 删除颜色
       gamelab_secondTouched:
         text: 第二次碰到精灵
       gamelab_setAnimation:
-        text: 将 [THIS][0] 的服装改为 [ANIMATION][1]
+        text: 将 {THIS} 的服装改为 {ANIMATION}
       gamelab_setBackground:
-        text: 设置背景颜色为 [COLOR][0]
+        text: 设置背景颜色为 {COLOR}
       gamelab_setDirection:
-        text: 设置 [SPRITE][0] 移动方向为 [DIRECTION][1]
+        text: 设置 {SPRITE} 移动方向为 {DIRECTION}
       gamelab_setFrameDelay:
-        text: 设置 [THIS][0] 帧延迟 [VAL][1]
+        text: 设置 {THIS} 帧延迟 {VAL}
       gamelab_setPosition:
-        text: 将 [THIS][0] 移动到 [POSITION][1] 位置
+        text: 将 {THIS} 移动到 {POSITION} 位置
         options:
           POSITION:
             "{x: 50, y: 50}": 左上
@@ -844,7 +844,7 @@ zh-CN:
             "{x: 350, y: 350}": 右下
             '"random"': 随机
       gamelab_setProp:
-        text: 设置 [SPRITE][0] [PROPERTY][1] 为 [VAL][2]
+        text: 设置 {SPRITE} {PROPERTY} 为 {VAL}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -854,22 +854,22 @@ zh-CN:
             '"direction"': 移动方向
             '"tint"': 色调
       gamelab_setSizes:
-        text: 设置 [SPRITE][0] [PROPERTY][1] 为 [N][2]%
+        text: 设置 {SPRITE} {PROPERTY} 为 {N}%
         options:
           PROPERTY:
             '"scale"': 大小
             '"width"': 宽度
             '"height"': 高度
       gamelab_setTint:
-        text: 将 [THIS][0] 的颜色改为 [COLOR][1]
+        text: 将 {THIS} 的颜色改为 {COLOR}
       gamelab_setup:
         text: 设置
       gamelab_showTitleScreen:
-        text: 显示标题屏幕 [BREAK][0] 标题 [TITLE][1] 文本 [SUBTITLE][2]
+        text: 显示标题屏幕 {BREAK} 标题 {TITLE} 文本 {SUBTITLE}
       gamelab_spriteCostume:
-        text: "[COSTUME][0]"
+        text: "{COSTUME}"
       gamelab_spriteDirection:
-        text: "[DIRECTION][0]"
+        text: "{DIRECTION}"
         options:
           DIRECTION:
             '"North"': 北
@@ -877,7 +877,7 @@ zh-CN:
             '"South"': 南
             '"West"': 西
       gamelab_spritesWhere:
-        text: 精灵的 [PROPERTY][0] 为 [VALUE][1]
+        text: 精灵的 {PROPERTY} 为 {VALUE}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -888,9 +888,9 @@ zh-CN:
             '"rotation"': 旋转或方向
             '"tint"': 色调
       gamelab_spritesWhereFirst:
-        text: 第一个 [VALUE][0]
+        text: 第一个 {VALUE}
       gamelab_spritesWhereGenerator:
-        text: 精灵的 [PROPERTY][0] [OP][1] [VALUE][2]
+        text: 精灵的 {PROPERTY} {OP} {VALUE}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -905,16 +905,16 @@ zh-CN:
             '">"': ">"
             '"<"': "\\<"
       gamelab_spritesWhereLast:
-        text: 最后一个 [VALUE][0]
+        text: 最后一个 {VALUE}
       gamelab_spritesWhereRandom:
-        text: 在组 [VALUE][0] 中随机
+        text: 在组 {VALUE} 中随机
       gamelab_thisBeginsBehaviorSimple:
-        text: 精灵 [SPRITE][0] 开始 [BEHAVIOR][1]
+        text: 精灵 {SPRITE} 开始 {BEHAVIOR}
         options:
           SPRITE:
             abc: 这个精灵
       gamelab_turn:
-        text: "[SPRITE][0] 转 [DIRECTION][1] [N][2] 度"
+        text: "{SPRITE} 转 {DIRECTION} {N} 度"
         options:
           DIRECTION:
             '"right"': 向右
@@ -924,7 +924,7 @@ zh-CN:
       gamelab_whenJoystick:
         text: 当使用游戏杆时
       gamelab_whenKey:
-        text: 当 [KEY][0] 按下时
+        text: 当 {KEY} 按下时
         options:
           KEY:
             '"up"': 向上
@@ -941,7 +941,7 @@ zh-CN:
       gamelab_whenMouseClicked:
         text: 当鼠标点击时
       gamelab_whenPressedAndReleased:
-        text: "当 [DIR][0] 按下\n[STATEMENT1][1] 当释放 \n[STATEMENT2][2]"
+        text: "当 {DIR} 按下\n{STATEMENT1} 当释放 \n{STATEMENT2}"
         options:
           DIR:
             "'up'": 向上
@@ -952,14 +952,14 @@ zh-CN:
         text: 当按右方向键时
       gamelab_whenStartAndStopTouching:
         text: |-
-          当 [SPRITE1][0] 开始碰到 [SPRITE2][1] [STATEMENT1][2] 当它们不再接触
-          [STATEMENT2][3]
+          当 {SPRITE1} 开始碰到 {SPRITE2} {STATEMENT1} 当它们不再接触
+          {STATEMENT2}
       gamelab_whenTouching:
-        text: 当 [SPRITE1][0] 碰到 [SPRITE2][1]
+        text: 当 {SPRITE1} 碰到 {SPRITE2}
       gamelab_whenTouchingAny:
-        text: 当 [SPRITE][0] 碰到任何 [GROUP][1]
+        text: 当 {SPRITE} 碰到任何 {GROUP}
       gamelab_whenTrue:
-        text: 当 [CONDITION][0] 为真时
+        text: 当 {CONDITION} 为真时
       gamelab_whenUpArrow:
         text: 当上方向键按下时
       gamelab_whileDownArrow:
@@ -967,7 +967,7 @@ zh-CN:
       gamelab_whileJoystick:
         text: 当使用游戏杆时
       gamelab_whileKey:
-        text: 当 [KEY][0] 按下时
+        text: 当 {KEY} 按下时
         options:
           KEY:
             '"up"': 向上
@@ -984,17 +984,17 @@ zh-CN:
       gamelab_whileRightArrow:
         text: 当按右方向键时
       gamelab_whileTouching:
-        text: 当 [SPRITE1][0] 碰到 [SPRITE2][1]
+        text: 当 {SPRITE1} 碰到 {SPRITE2}
       gamelab_whileUpArrow:
         text: 当上方向键按下时
       gamelab_xLocationOf:
-        text: "[SPRITE][0] 的x轴坐标"
+        text: "{SPRITE} 的x轴坐标"
       gamelab_yLocationOf:
-        text: "[SPRITE][0] 的y坐标"
+        text: "{SPRITE} 的y坐标"
       Mikelab_addBehaviorSimple:
-        text: 精灵 [SPRITE][0] 开始 [BEHAVIOR][1]
+        text: 精灵 {SPRITE} 开始 {BEHAVIOR}
       Mikelab_changePropBy:
-        text: 将 [SPRITE][0] [PROPERTY][1] 改为 [VAL][2]
+        text: 将 {PROPERTY} {SPRITE} 改为 {VAL}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -1003,7 +1003,7 @@ zh-CN:
             '"y"': y位置
             '"direction"': 移动方向
       Mikelab_createNewSprite:
-        text: "制作一个新的精灵 \n 叫做 [NAME][0] \n 服装为 [COSTUME][1] \n 位于 [LOCATION][2]"
+        text: "制作一个新的精灵 \n 叫做 {COSTUME} \n 服装为 {NAME} \n 位于 {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": 顶部
@@ -1017,9 +1017,9 @@ zh-CN:
             "{x: 300, y: 300}": 右下
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": 随机
       Mikelab_eval:
-        text: 执行 [CODE][0]
+        text: 执行 {CODE}
       Mikelab_getProp:
-        text: "[SPRITE][0] [PROPERTY][1]"
+        text: "{SPRITE} {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': 大小
@@ -1093,11 +1093,11 @@ zh-CN:
           SELECT:
             '"all"': 所有
       Mikelab_hasBehavior:
-        text: "[SPRITE][0] 当前在 [BEHAVIOR][1]"
+        text: "{SPRITE} 当前在 {BEHAVIOR}"
       Mikelab_ifDanceIs:
         text: |-
-          如果 [SPRITE][0] 正在 [DANCE][1]
-          [DO1][2] [DO2][3]
+          如果 {SPRITE} 正在 {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: 用力鼓掌
@@ -1112,19 +1112,19 @@ zh-CN:
             MOVES.ThisOrThat: 交替摆臂
             MOVES.Rest: 没有
       Mikelab_locationAt:
-        text: '位置 x: [X][0] y: [Y][1]'
+        text: '位置 x: {X} y: {Y}'
       Mikelab_location_picker:
-        text: "[LOCATION][0]"
+        text: "{LOCATION}"
       Mikelab_randomColor:
         text: 随机颜色
       Mikelab_removeBehaviorSimple:
-        text: 精灵 [SPRITE][0] 停止 [BEHAVIOR][1]
+        text: 精灵 {SPRITE} 停止 {BEHAVIOR}
       Mikelab_setBG:
         options:
           BG:
             '"https://studio.code.org/api/v1/animation-library/04L4sdTODkNZF1OHf4qO_I.Al3QP43wA/category_backgrounds/city.png"': 城市
       Mikelab_setProp:
-        text: 设置 [SPRITE][0] [PROPERTY][1] 为 [VAL][2]
+        text: 设置 {PROPERTY} {SPRITE} 为 {VAL}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -1133,7 +1133,7 @@ zh-CN:
             '"y"': y位置
             '"direction"': 移动方向
       Mikelab_setTint:
-        text: 将 [THIS][0] 的颜色改为 [COLOR][1]
+        text: 将 {SPRITE} 的颜色改为 {COLOR}
       Mikelab_showScoreboard:
         options:
           CORNER:
@@ -1153,9 +1153,9 @@ zh-CN:
             "{x: 300, y: 300}": 右下
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": 随机
       Mikelab_whenClickedOn:
-        text: 当 [SPRITE][0] 被点击时
+        text: 当 {SPRITE} 被点击时
       Mikelab_whenKeyPressed:
-        text: 当 [KEY][0] 按下时
+        text: 当 {KEY} 按下时
         options:
           KEY:
             '"up"': 上方向键
@@ -1180,7 +1180,7 @@ zh-CN:
       Mikelab_whenMouseClicked:
         text: 当鼠标点击时
       Mikelab_whenTouchesAny:
-        text: 当[TARGET][0] 触及任何精灵时
+        text: 当{SPRITE} 触及任何精灵时
       Mikelab_whileKeyPressed:
         options:
           KEY:
@@ -1190,12 +1190,12 @@ zh-CN:
             '"right"': 右方向键
       Mikelab_whileTouchingAny:
         text: |-
-          当[TARGET][0] 碰到任何精灵
-          [STATEMENT][1]
+          当{SPRITE} 碰到任何精灵
+          {STATEMENT}
       Mikelab_xLocationOf:
-        text: "[SPRITE][0] 的x轴坐标"
+        text: "{SPRITE} 的x轴坐标"
       Mikelab_yLocationOf:
-        text: "[SPRITE][0] 的y坐标"
+        text: "{SPRITE} 的y坐标"
       RyanLab_moveForward:
         text: 向前移动
       RyanLab_turnLeft:
@@ -1205,32 +1205,32 @@ zh-CN:
       Vector_createSpriteWith:
         text: |-
           创建精灵
-          执行 [STATEMENT][0]
+          执行 {STATEMENT}
       Vector_log:
-        text: 日志消息 [MESSAGE][0]
+        text: 日志消息 {MESSAGE}
       Vector_positionCenter:
         text: 中央
       Vector_push:
-        text: 设置速度为 [VECTOR][0]
+        text: 设置速度为 {VECTOR}
       Vector_randomLocation:
         text: 随机位置
       Vector_setColor:
-        text: 设置颜色为 [COLOR][0]
+        text: 设置颜色为 {COLOR}
       Vector_setSize:
-        text: 设置宽度为 [WIDTH][0] 高度为 [HEIGHT][1]
+        text: 设置宽度为 {WIDTH} 高度为 {HEIGHT}
       Vector_teleportTo:
-        text: 设置位置为 [POSITION][0]
+        text: 设置位置为 {POSITION}
       Vector_vectorNorth:
         text: 北
       Vector_where:
-        text: 当每个的 [PROPERTY][0] 为 [VALUE][1] 时执行 [STATEMENT][2]
+        text: 当每个的 {PROPERTY} 为 {VALUE} 时执行 {STATEMENT}
         options:
           PROPERTY:
             "'shapeColor'": 颜色
       aalab_addToSpriteGroup:
-        text: 向组 [GROUP][1] 添加精灵 [SPRITE][0]
+        text: 向组 {GROUP} 添加精灵 {SPRITE}
       aalab_changeGroupPropBy:
-        text: 将组 [GROUP][0] [PROPERTY][1] 改为 [VAL][2]
+        text: 将组 {GROUP} {PROPERTY} 改为 {VAL}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -1240,12 +1240,12 @@ zh-CN:
             '"direction"': 移动方向
       aalab_createPropertyGroup:
         text: |-
-          创建一个叫做 [VAR][0] 的精灵组
-          包括所有的 [COSTUME][1] 精灵
+          创建一个叫做 {VAR} 的精灵组
+          包括所有的 {COSTUME} 精灵
       aalab_createSpriteGroup:
-        text: 创造一个叫做 [VAR][0] 的新精灵组
+        text: 创造一个叫做 {VAR} 的新精灵组
       aalab_spritesWhere:
-        text: 精灵的 [PROPERTY][0] 为 [VALUE][1]
+        text: 精灵的 {PROPERTY} 为 {VALUE}
         options:
           PROPERTY:
             '"scale"': 大小
@@ -1263,7 +1263,7 @@ zh-CN:
             '"left"': 向左
             '"right"': 向右
       binary_whenKey:
-        text: 当 [KEY][0] 按下时
+        text: 当 {KEY} 按下时
         options:
           KEY:
             '"up"': 向上
@@ -1277,8 +1277,8 @@ zh-CN:
             '"d"': d
       craft_ifPath:
         text: |-
-          如果路径 [DIR][0]
-          [STATEMENT][1]
+          如果路径 {DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": 前面
@@ -1286,8 +1286,8 @@ zh-CN:
             "'left'": 向左转
       craft_ifStandingOn:
         text: |-
-          站在[TYPE][0]
-          [STATEMENT][1]
+          站在{TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": 蓝色珊瑚
@@ -1298,19 +1298,19 @@ zh-CN:
             "'seaLantern'": 海晶灯
       craft_ifStandingOnLimit:
         text: |-
-          站在[TYPE][0]
-          [STATEMENT][1]
+          站在{TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": 沙子
             "'darkPrismarine'": 暗海晶石
             "'seaLantern'": 海晶灯
       craft_log:
-        text: 日志消息 [MESSAGE][0]
+        text: 日志消息 {MESSAGE}
       craft_moveForward:
         text: 向前移动
       craft_placeBlock:
-        text: 放下[blockType][0]
+        text: 放下{blockType}
         options:
           blockType:
             '"strippedOak"': 去皮橡树
@@ -1345,13 +1345,13 @@ zh-CN:
       craft_repeatUntilConduit:
         text: |-
           重复，直至导管完成
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           重复，直至目标达成
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: 生成[ENTITY][0]
+        text: 生成{ENTITY}
         options:
           ENTITY:
             '"cod"': 鳕鱼
@@ -1361,7 +1361,7 @@ zh-CN:
             '"squid"': 鱿鱼
             '"tropicalFish"': 热带鱼
       craft_turn:
-        text: 转向[DIR][0]
+        text: 转向{DIR}
         options:
           DIR:
             right: 右 ↻

--- a/dashboard/config/locales/blocks.zh-TW.yml
+++ b/dashboard/config/locales/blocks.zh-TW.yml
@@ -3,20 +3,20 @@ zh-TW:
   data:
     blocks:
       Dancelab_atTimestamp:
-        text: "[TIMESTAMP][0] [UNIT][1] 之後"
+        text: "{TIMESTAMP} {UNIT} 之後"
         options:
           UNIT:
             '"measures"': 小節
             '"seconds"': 秒
       Dancelab_changeColorBy:
-        text: 變更 [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: 變更 {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"hue"': 色調
             '"saturation"': 飽和度
             '"brightness"': 亮度
       Dancelab_changeMoveEachLR:
-        text: "[GROUP][0] 永遠進行 [MOVE][1] [DIR][2]"
+        text: "{GROUP} 永遠進行 {MOVE} {DIR}"
         options:
           GROUP:
             sprites: 全部
@@ -50,7 +50,7 @@ zh-TW:
             '1': "→"
             "-1": "←"
       Dancelab_changeMoveLR:
-        text: "[SPRITE][0] 永遠進行 [MOVE][1] [DIR][2]"
+        text: "{SPRITE} 永遠進行 {MOVE} {DIR}"
         options:
           MOVE:
             '"next"': "（下一個）"
@@ -71,7 +71,7 @@ zh-TW:
             '1': "→"
             "-1": "←"
       Dancelab_changePropBy:
-        text: 依 [VAL][2] 變更 [SPRITE][0] [PROPERTY][1]
+        text: 依 {VAL} 變更 {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': 尺寸
@@ -81,7 +81,7 @@ zh-TW:
             '"x"': 水平位置
             '"y"': 垂直位置
       Dancelab_doMoveEachLR:
-        text: "[GROUP][0] 進行一次 [MOVE][1] [DIR][2]"
+        text: "{GROUP} 進行一次 {MOVE} {DIR}"
         options:
           GROUP:
             sprites: 全部
@@ -113,7 +113,7 @@ zh-TW:
             '1': "→"
             "-1": "←"
       Dancelab_doMoveLR:
-        text: "[SPRITE][0] 進行一次 [MOVE][1] [DIR][2]"
+        text: "{SPRITE} 進行一次 {MOVE} {DIR}"
         options:
           MOVE:
             '"rand"': "（隨機）"
@@ -132,25 +132,25 @@ zh-TW:
             '1': "→"
             "-1": "←"
       Dancelab_everySeconds:
-        text: '每個 [N][0] [UNIT][1] '
+        text: '每個 {N} {UNIT} '
         options:
           UNIT:
             '"measures"': 小節
             '"seconds"': 秒
       Dancelab_everySecondsRange:
-        text: '從 [START][2] 到 [STOP][3] 的每個 [N][0] [UNIT][1] '
+        text: '從 {START} 到 {STOP} 的每個 {N} {UNIT} '
         options:
           UNIT:
             measures: 小節
             seconds: 秒
       Dancelab_everyVerseChorus:
-        text: '每個 [UNIT][0] '
+        text: '每個 {UNIT} '
         options:
           UNIT:
             '"verse"': 詩歌
             '"chorus"': 合唱
       Dancelab_getEnergy:
-        text: 取得 [RANGE][0]
+        text: 取得 {RANGE}
         options:
           RANGE:
             '"low"': 低音
@@ -167,15 +167,15 @@ zh-TW:
             '"y"': 垂直位置
             '"tint"': 色調
       Dancelab_getTime:
-        text: 經過 [UNIT][0]
+        text: 經過 {UNIT}
         options:
           UNIT:
             '"measures"': 小節
             '"seconds"': 秒
       Dancelab_ifDanceIs:
         text: |-
-          如果 [SPRITE][0] 正在進行 [DANCE][1]
-          [DO1][2] [DO2][3]
+          如果 {SPRITE} 正在進行 {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: 高舉擊掌
@@ -195,7 +195,7 @@ zh-TW:
             '"measures"': 小節
             '"seconds"': 秒
       Dancelab_jumpTo:
-        text: "[SPRITE][0] 跳至 [LOCATION][1]"
+        text: "{SPRITE} 跳至 {LOCATION}"
         options:
           LOCATION:
             "{x: 200, y: 100}": 頂端
@@ -209,7 +209,7 @@ zh-TW:
             "{x: 300, y: 300}": 右下
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": 隨機
       Dancelab_layoutSprites:
-        text: 配置 [GROUP][0] 作為 [FORMAT][1]
+        text: 配置 {GROUP} 作為 {FORMAT}
         options:
           GROUP:
             sprites: 全部
@@ -236,8 +236,8 @@ zh-TW:
             '"random"': 隨機
       Dancelab_makeNewDanceSprite:
         text: |-
-          製作新的 [COSTUME][0]
-          在 [LOCATION][2] 稱為 [NAME][1]
+          製作新的 {COSTUME}
+          在 {LOCATION} 稱為 {NAME}
         options:
           COSTUME:
             '"ALIEN"': 外星人
@@ -264,8 +264,8 @@ zh-TW:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": 隨機
       Dancelab_makeNewDanceSpriteGroup:
         text: |-
-          讓 [N][0] 成為新的 [COSTUME][1]
-          在 [LAYOUT][2]
+          讓 {N} 成為新的 {COSTUME}
+          在 {LAYOUT}
         options:
           N:
             '2': '2'
@@ -310,9 +310,9 @@ zh-TW:
             '"plus"': 添加
             '"random"': 隨機
       Dancelab_mixColors:
-        text: 混合 [COLOR1][0] 和 [COLOR2][1]
+        text: 混合 {COLOR1} 和 {COLOR2}
       Dancelab_nMeasures:
-        text: "[N][0] 小節"
+        text: "{N} 小節"
       Dancelab_onPointerDown:
         text: 在向下指標
       Dancelab_onPointerDrag:
@@ -322,9 +322,9 @@ zh-TW:
       Dancelab_randomColor:
         text: 隨機顏色
       Dancelab_setBackground:
-        text: 設定背景顏色 [COLOR][0]
+        text: 設定背景顏色 {COLOR}
       Dancelab_setBackgroundEffect:
-        text: 設定背景效果 [EFFECT][0]
+        text: 設定背景效果 {EFFECT}
         options:
           EFFECT:
             '"none"': 無
@@ -347,7 +347,7 @@ zh-TW:
             '"vintage"': 復古
             '"warm"': 紅色
       Dancelab_setBackgroundEffectWithPalette:
-        text: 設定背景效果 [EFFECT][0] [PALETTE][1]
+        text: 設定背景效果 {EFFECT} {PALETTE}
         options:
           EFFECT:
             '"none"': 無
@@ -372,7 +372,7 @@ zh-TW:
             '"vintage"': 復古
             '"warm"': 紅色
       Dancelab_setDanceSpeed:
-        text: 將 [SPRITE][0] 舞蹈速度變更為 [SPEED][1]
+        text: 將 {SPRITE} 舞蹈速度變更為 {SPEED}
         options:
           SPEED:
             '1': 普通
@@ -402,7 +402,7 @@ zh-TW:
             '0.5': 慢
             '0.25': 非常慢
       Dancelab_setForegroundEffect:
-        text: 設定前景效果 [EFFECT][0]
+        text: 設定前景效果 {EFFECT}
         options:
           EFFECT:
             '"none"': 無
@@ -415,7 +415,7 @@ zh-TW:
             '"floating_rainbows"': 彩虹
             '"raining_tacos"': 墨西哥捲餅
       Dancelab_setForegroundEffectExtended:
-        text: 設定前景效果 [EFFECT][0]
+        text: 設定前景效果 {EFFECT}
         options:
           EFFECT:
             '"none"': 無
@@ -429,7 +429,7 @@ zh-TW:
             '"floating_rainbows"': 彩虹
             '"raining_tacos"': 墨西哥捲餅
       Dancelab_setProp:
-        text: '將 [SPRITE][0] [PROPERTY][1] 設定為 [VAL][2] '
+        text: '將 {SPRITE} {PROPERTY} 設定為 {VAL} '
         options:
           PROPERTY:
             '"scale"': 尺寸
@@ -440,7 +440,7 @@ zh-TW:
             '"y"': 垂直位置
             '"tint"': 色調
       Dancelab_setPropEach:
-        text: 將 [GROUP][0] [PROPERTY][1] 設定為 [VAL][2]
+        text: 將 {GROUP} {PROPERTY} 設定為 {VAL}
         options:
           GROUP:
             sprites: 全部
@@ -464,7 +464,7 @@ zh-TW:
             '"y"': 垂直位置
             '"tint"': 色調
       Dancelab_setPropRandom:
-        text: 隨機安排 [SPRITE][0] [PROPERTY][1]
+        text: 隨機安排 {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': 尺寸
@@ -475,7 +475,7 @@ zh-TW:
             '"y"': 垂直位置
             '"tint"': 色調
       Dancelab_setTint:
-        text: 將 [SPRITE][0] 色調設定為 [VAL][1]
+        text: 將 {SPRITE} 色調設定為 {VAL}
       Dancelab_setTintEach:
         options:
           THIS:
@@ -491,15 +491,15 @@ zh-TW:
             '"ROBOT"': 所有機器人
             '"SHARK"': 所有鯊魚
       Dancelab_setTintInline:
-        text: 將 [SPRITE][0] 色調設定為 [VAL][1]
+        text: 將 {SPRITE} 色調設定為 {VAL}
       Dancelab_setVisible:
-        text: 將 [SPRITE][0] 可見設置為 [VISIBILITY][1]
+        text: 將 {SPRITE} 可見設置為 {VISIBILITY}
         options:
           VISIBILITY:
             'true': 可見
             'false': 不可見
       Dancelab_setVisibleEach:
-        text: 將 [THIS][0] 可見度設定為 [VISIBILITY][1]
+        text: 將 {THIS} 可見度設定為 {VISIBILITY}
         options:
           THIS:
             sprites: 全部
@@ -518,7 +518,7 @@ zh-TW:
             'true': 可見
             'false': 不可見
       Dancelab_startMapping:
-        text: "[SPRITE][0] 隨著 [RANGE][2] 開始 [PROPERTY][1]"
+        text: "{SPRITE} 隨著 {RANGE} 開始 {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': 尺寸
@@ -533,7 +533,7 @@ zh-TW:
             '"mid"': 中音
             '"treble"': 高音
       Dancelab_stopMapping:
-        text: "[SPRITE][0] 隨著 [RANGE][2] 停止 [PROPERTY][1]"
+        text: "{SPRITE} 隨著 {RANGE} 停止 {PROPERTY}"
         options:
           PROPERTY:
             '"scale"': 尺寸
@@ -549,7 +549,7 @@ zh-TW:
             '"mid"': 中音
             '"treble"': 高音
       Dancelab_whenKey:
-        text: 按下 [KEY][0] 時
+        text: 按下 {KEY} 時
         options:
           KEY:
             '"up"': 到上方
@@ -559,7 +559,7 @@ zh-TW:
             '"space"': 太空
             '"x"': x
       Dancelab_whenPeak:
-        text: 當 [RANGE][0] 處於峰值時
+        text: 當 {RANGE} 處於峰值時
         options:
           RANGE:
             '0': 低音
@@ -568,19 +568,19 @@ zh-TW:
       Dancelab_whenSetup:
         text: 設定
       gamelab_changeColor:
-        text: 變更 [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: 變更 {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"tint"': 色調
       gamelab_changeColorBy:
-        text: 變更 [COLOR][0] [METHOD][1] [AMOUNT][2]
+        text: 變更 {COLOR} {METHOD} {AMOUNT}
         options:
           METHOD:
             '"hue"': 色調
             '"saturation"': 飽和度
             '"brightness"': 亮度
       gamelab_changePropBy:
-        text: 依 [VAL][2] 變更 [SPRITE][0] [PROPERTY][1]
+        text: 依 {VAL} 變更 {SPRITE} {PROPERTY}
         options:
           PROPERTY:
             '"scale"': 尺寸
@@ -603,7 +603,7 @@ zh-TW:
             '"direction"': 移動方向
             '"tint"': 色調
       gamelab_jumpTo:
-        text: "[SPRITE][0] 跳至 [LOCATION][1]"
+        text: "{SPRITE} 跳至 {LOCATION}"
       gamelab_locationDelta:
         options:
           DIR:
@@ -614,15 +614,15 @@ zh-TW:
             '"right"': 到右方
             '"left"': 到左方
       gamelab_mixColors:
-        text: 混合 [COLOR1][0] 和 [COLOR2][1]
+        text: 混合 {COLOR1} 和 {COLOR2}
       gamelab_randColor:
         text: 隨機顏色
       gamelab_randomColor:
         text: 隨機顏色
       gamelab_setBackground:
-        text: 設定背景顏色 [COLOR][0]
+        text: 設定背景顏色 {COLOR}
       gamelab_setPosition:
-        text: 將 [THIS][0] 移動到 [POSITION][1] 位置
+        text: 將 {THIS} 移動到 {POSITION} 位置
         options:
           POSITION:
             "{x: 50, y: 50}": 左上
@@ -675,7 +675,7 @@ zh-TW:
             '"right"': 到右方
             '"left"': 到左方
       gamelab_whenKey:
-        text: 按下 [KEY][0] 時
+        text: 按下 {KEY} 時
         options:
           KEY:
             '"up"': 到上方
@@ -792,8 +792,8 @@ zh-TW:
             '"all"': 全部
       Mikelab_ifDanceIs:
         text: |-
-          如果 [SPRITE][0] 正在進行 [DANCE][1]
-          [DO1][2] [DO2][3]
+          如果 {SPRITE} 正在進行 {DANCE}
+          {DO1} {DO2}
         options:
           DANCE:
             MOVES.ClapHigh: 高舉擊掌
@@ -839,7 +839,7 @@ zh-TW:
             "{x: 100, y: 300}": 左下
             "{x: 300, y: 300}": 右下
       Mikelab_whenKeyPressed:
-        text: 按下 [KEY][0] 時
+        text: 按下 {KEY} 時
         options:
           KEY:
             '"up"': 向上鍵
@@ -900,7 +900,7 @@ zh-TW:
             '"left"': 到左方
             '"right"': 到右方
       binary_whenKey:
-        text: 按下 [KEY][0] 時
+        text: 按下 {KEY} 時
         options:
           KEY:
             '"up"': 到上方
@@ -910,8 +910,8 @@ zh-TW:
             '"space"': 太空
       craft_ifPath:
         text: |-
-          如果路徑[DIR][0]
-          [STATEMENT][1]
+          如果路徑{DIR}
+          {STATEMENT}
         options:
           DIR:
             "'ahead'": 到前方
@@ -919,8 +919,8 @@ zh-TW:
             "'left'": 往左
       craft_ifStandingOn:
         text: |-
-          如果站在[TYPE][0]
-          [STATEMENT][1]
+          如果站在{TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'blueCoralBlock'": 藍色珊瑚
@@ -931,8 +931,8 @@ zh-TW:
             "'seaLantern'": 海燈籠
       craft_ifStandingOnLimit:
         text: |-
-          如果站在[TYPE][0]
-          [STATEMENT][1]
+          如果站在{TYPE}
+          {STATEMENT}
         options:
           TYPE:
             "'sand'": 沙
@@ -941,7 +941,7 @@ zh-TW:
       craft_moveForward:
         text: 移動-向前
       craft_placeBlock:
-        text: 放置[blockType][0]
+        text: 放置{blockType}
         options:
           blockType:
             '"strippedOak"': 條紋橡樹
@@ -974,15 +974,15 @@ zh-TW:
       craft_repeatUntilConduit:
         text: |-
           重複直到導管完成
-          [STATEMENT][0]
+          {STATEMENT}
       craft_repeatUntilGoal:
         text: |-
           重複直到抵達目的地
-          [STATEMENT][0]
+          {STATEMENT}
       craft_spawnEntity:
-        text: 增生[ENTITY][0]
+        text: 增生{ENTITY}
       craft_turn:
-        text: 轉向[DIR][0]
+        text: 轉向{DIR}
         options:
           DIR:
             right: 右 ↻


### PR DESCRIPTION
The i18n sync out process [looks for redacted files](https://github.com/code-dot-org/code-dot-org/blob/9fa9340b61a43171d6ec4f59b4f14b664efc062c/bin/i18n/sync-codeorg-out.rb#L49) to decide what to restore; unfortunately, it's relatively easy for that directory to go missing, since it's not stored in git. When that happens, the sync process doesn't bother to restore the files and we get redacted i18n in our system:

![image](https://user-images.githubusercontent.com/244100/50803072-f3258a80-129d-11e9-8fa5-08701ae29683.png)