### PR TITLE
Add step to check for multiple css properties

### DIFF
--- a/dashboard/test/ui/features/level_swap.feature
+++ b/dashboard/test/ui/features/level_swap.feature
@@ -1,5 +1,4 @@
 @no_firefox
-@no_ie
 
 Feature: Swapped levels
   Scenario: Signed-out user sees active version

--- a/dashboard/test/ui/features/level_swap.feature
+++ b/dashboard/test/ui/features/level_swap.feature
@@ -1,5 +1,3 @@
-@no_firefox
-
 Feature: Swapped levels
   Scenario: Signed-out user sees active version
     When I am on "http://studio.code.org/s/allthethings/stage/29/puzzle/1"

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -43,7 +43,7 @@ def verify_bubble_type(selector, type)
   end
   steps %{
     And I wait until element "#{selector}" is in the DOM
-    And element "#{selector}" has css property "border-radius" equal to "#{border_radius}"
+    And element "#{selector}" has one of css properties "border-radius,-webkit-border-radius" equal to "#{border_radius}"
   }
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -546,6 +546,12 @@ Then /^element "([^"]*)" has css property "([^"]*)" equal to "([^"]*)"$/ do |sel
   element_has_css(selector, property, expected_value)
 end
 
+# Example use case: checking webkit and moz overrides for css properties
+Then /^element "([^"]*)" has one of css properties "([^"]*)" equal to "([^"]*)"$/ do |selectors, properties, expected_value|
+  properties = properties.split(',')
+  element_has_css_multiple_properties(selectors, properties, expected_value)
+end
+
 Then /^I wait up to ([\d\.]+) seconds for element "([^"]*)" to have css property "([^"]*)" equal to "([^"]*)"$/ do |seconds, selector, property, expected_value|
   Selenium::WebDriver::Wait.new(timeout: seconds.to_f).until do
     element_css_value(selector, property) == expected_value

--- a/dashboard/test/ui/features/support/browser_helpers.rb
+++ b/dashboard/test/ui/features/support/browser_helpers.rb
@@ -54,6 +54,14 @@ module BrowserHelpers
     expect(element_css_value(selector, property)).to eq(expected_value)
   end
 
+  def element_has_css_multiple_properties(selector, properties, expected_value)
+    expected = false
+    properties.each do |property|
+      expected ||= (element_css_value(selector, property) === (expected_value))
+    end
+    expected
+  end
+
   def element_css_value(selector, property)
     @browser.execute_script("return $(\"#{selector}\").css(\"#{property}\");")
   end


### PR DESCRIPTION
Test disabled on IE here: https://github.com/code-dot-org/code-dot-org/pull/19259

This test was disabled for IE because it was failing when checking the css for the border radius.
I added a step that checks if any of an array of properties is equal to the expected value.