### PR TITLE
Projects: update count to 35M

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1023,7 +1023,7 @@
   "projectsViewAll": "View all projects",
   "projectsViewProjectGallery": "View projects",
   "projects": "Projects",
-  "projectsSubHeading": "Over 25 million projects created",
+  "projectsSubHeading": "Over 35 million projects created",
   "print": "Print",
   "privacyPolicy": "Privacy Policy",
   "projectWarning": "Note: You are on a level that is part of a longer project. Changes made on this level will also appear in other levels in the project.",


### PR DESCRIPTION
https://studio.code.org/projects/public has 35M projects mentioned in its header now.

![screenshot 2019-01-09 06 56 53](https://user-images.githubusercontent.com/2205926/50855805-07bc6c80-13dd-11e9-998d-d9ba380ff0b7.png)
