### PR TITLE
change Spanish (Mexico) to Spanish (Latin America) in language dropdown

### DIFF
--- a/dashboard/config/locales.yml
+++ b/dashboard/config/locales.yml
@@ -98,8 +98,8 @@
   native: "Español (España)"
 
 "es-MX":
-  english: "Spanish (LATAM)"
-  native: "Español (LATAM)"
+  english: "Spanish (Latin America)"
+  native: "Español (Latinoamérica)"
 
 "et": "et-EE"
 "et-EE":

--- a/dashboard/config/locales.yml
+++ b/dashboard/config/locales.yml
@@ -98,8 +98,8 @@
   native: "Español (España)"
 
 "es-MX":
-  english: "Spanish (Mexico)"
-  native: "Español (México)"
+  english: "Spanish (LATAM)"
+  native: "Español (LATAM)"
 
 "et": "et-EE"
 "et-EE":


### PR DESCRIPTION
I changed this in the cdo-languages gsheet for pegasus. This change is for the dashboard dropdown.