### PR TITLE
Fix links to CB

### DIFF
--- a/deployment.rb
+++ b/deployment.rb
@@ -272,7 +272,7 @@ class CDOImpl < OpenStruct
   def curriculum_url(locale, path = '')
     locale = locale.downcase.to_s
     uri = URI("https://curriculum.code.org")
-    uri += locale if CURRICULUM_LANGUAGES.include? locale
+    path = File.join(locale, path) if CURRICULUM_LANGUAGES.include? locale
     uri += path
     uri.to_s
   end


### PR DESCRIPTION
Right now, they're linking to English even in es-MX.

This is because URI += doesn't work as you would expect; each time you use it, it overwrites the value added last, meaning that we were adding the locale string, then overwriting it with the path.

Using File.join to construct the path as a whole is apparently how we're supposed to do this.

https://blog.honeybadger.io/why-is-uri-join-so-counterintuitive/