### PR TITLE
Modify Report Abuse UI test 

### DIFF
--- a/dashboard/test/ui/features/report_abuse.feature
+++ b/dashboard/test/ui/features/report_abuse.feature
@@ -6,7 +6,7 @@ Feature: Report Abuse Form
     And I select the "Other" option in dropdown "uitest-abuse-type"
     And I type "Mudblood is an offensive term" into "#uitest-abuse-detail"
     Then I click selector "#uitest-submit-report-abuse" once I see it
-    Then check that the URL matches "https://support.code.org/hc/en-us"
+    Then I wait until current URL contains "support.code.org"
 
   Scenario: Reporting abuse as a signed-in student
     Given I create a student named "Harry"
@@ -17,7 +17,7 @@ Feature: Report Abuse Form
     And I select the "Other" option in dropdown "uitest-abuse-type"
     And I type "Mudblood is an offensive term" into "#uitest-abuse-detail"
     Then I click selector "#uitest-submit-report-abuse" once I see it
-    Then check that the URL matches "https://support.code.org/hc/en-us"
+    Then I wait until current URL contains "support.code.org"
 
   Scenario: Reporting abuse as a signed-in teacher
     Given I create a teacher named "Dumbledore"
@@ -28,4 +28,4 @@ Feature: Report Abuse Form
     And I select the "Other" option in dropdown "uitest-abuse-type"
     And I type "Mudblood is an offensive term" into "#uitest-abuse-detail"
     Then I click selector "#uitest-submit-report-abuse" once I see it
-    Then check that the URL matches "https://support.code.org/hc/en-us"
+    Then I wait until current URL contains "support.code.org"


### PR DESCRIPTION
When run on the test machine for the first time, the new `report_abuse.feature` tests failed on iPad, IE11Win10 and SafariYosemite despite passing on other browsers.  These tests failed on the last step - checking that form submission caused a redirect to the support page.  When I watched the Saucelabs playback for these failed cases, the test appears to end up on the correct page 🤔. I'm hoping that by building in some more resiliency with the wait time in this new step as well as some flexibility by only checking for the core of the new url "support.code.org" rather than the full url with language code appendage, these tests will be more reliable across browsers.   