### PR TITLE
Remove Safari Skip Tag in Pixelation Feature

### DIFF
--- a/dashboard/test/ui/features/pixelation.feature
+++ b/dashboard/test/ui/features/pixelation.feature
@@ -1,6 +1,5 @@
 @dashboard_db_access
 @no_mobile
-@no_safari_yosemite
 Feature: Pixelation levels
   # Brad (2018-11-14) Skip on IE due to blocked pop-ups
   @no_ie


### PR DESCRIPTION
Tag initially added here: https://github.com/code-dot-org/code-dot-org/pull/7102
No context on reason.

After removing tag, the tests passed locally on SauceLabs safari.
Planning to re-enable and monitor for flakiness or failures.