### PR TITLE
remove code preventing accessing facilitator app on prod

### DIFF
--- a/dashboard/app/controllers/pd/application/facilitator_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/facilitator_application_controller.rb
@@ -6,12 +6,6 @@ module Pd::Application
     end
 
     def new
-      # Block on production until we're ready to release and publicize the url
-      # TODO: Andrew - remove this, and the associated Gatekeeper key, after we go live
-      if Rails.env.production? && !current_user.try(:workshop_admin?) && Gatekeeper.disallows('pd_facilitator_application')
-        return head :not_found
-      end
-
       return render :logged_out unless current_user
       return render :not_teacher unless current_user.teacher?
 


### PR DESCRIPTION
To be merged after the Gatekeeper key has been turned off. (or do we want to leave this in place for next year, and just turn the Gatekeeper key back on sometime after applications close? they will close automatically anyway, but this way we won't have to re-add this piece of code next year)