### PR TITLE
whitelist Authorization header via SharedVarnishConstants

### DIFF
--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -1,10 +1,10 @@
-require File.expand_path('../../../../lib/cdo/shared_constants.rb', __FILE__)
+require_relative 'shared_varnish_constants'
 
 # HTTP Cache configuration.
 #
 # See cdo-varnish/README.md for more information on the configuration format.
 class HttpCache
-  include SharedConstants
+  include SharedVarnishConstants
 
   # Paths for files that are always cached based on their extension.
   STATIC_ASSET_EXTENSION_PATHS = %w(css js mp3 jpg png).map {|ext| "/*.#{ext}"}.freeze

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -1,7 +1,11 @@
+require File.expand_path('../../../../lib/cdo/shared_constants.rb', __FILE__)
+
 # HTTP Cache configuration.
 #
 # See cdo-varnish/README.md for more information on the configuration format.
 class HttpCache
+  include SharedConstants
+
   # Paths for files that are always cached based on their extension.
   STATIC_ASSET_EXTENSION_PATHS = %w(css js mp3 jpg png).map {|ext| "/*.#{ext}"}.freeze
 
@@ -222,6 +226,11 @@ class HttpCache
             ),
             headers: [],
             cookies: 'none'
+          },
+          {
+            path: '/xhr*',
+            headers: WHITELISTED_HEADERS + ALLOWED_WEB_REQUEST_HEADERS,
+            cookies: whitelisted_cookies
           },
         ],
         # Default Dashboard paths are session-specific, whitelist all session cookies and language header.

--- a/cookbooks/cdo-varnish/libraries/shared_varnish_constants.rb
+++ b/cookbooks/cdo-varnish/libraries/shared_varnish_constants.rb
@@ -1,0 +1,9 @@
+# module containing varnish-related constants which need to be shared between
+# chef and application server code. Storing constants here allows them to be
+# accessed without pulling in anything else in HttpCache.
+
+module SharedVarnishConstants
+  ALLOWED_WEB_REQUEST_HEADERS = %w(
+    Authorization
+  )
+end

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -1,4 +1,5 @@
 require 'json'
+require_relative '../../cookbooks/cdo-varnish/libraries/shared_varnish_constants'
 
 # This is the source of truth for a set of constants that are shared between JS
 # and ruby code. generateSharedConstants.rb is the file that processes this and
@@ -9,6 +10,8 @@ require 'json'
 # result in changes to these other files.
 
 module SharedConstants
+  include SharedVarnishConstants
+
   # Used to communicate different types of levels
   LEVEL_KIND = OpenStruct.new(
     {
@@ -550,8 +553,4 @@ module SharedConstants
       "comment": null
     }
   JSON
-
-  ALLOWED_WEB_REQUEST_HEADERS = %w(
-    Authorization
-  )
 end


### PR DESCRIPTION
follow-on to https://github.com/code-dot-org/code-dot-org/pull/26383 to allow `Authorization` header through Varnish and CloudFront. HttpCache cannot depend on SharedConstants because that file is not available in chef, so we have to jump through some extra hoops.