### PR TITLE
Update ToggleButtonTest to be more compatible with recent React versions

### DIFF
--- a/apps/test/unit/templates/ToggleButtonTest.js
+++ b/apps/test/unit/templates/ToggleButtonTest.js
@@ -1,42 +1,36 @@
-import {assert} from '../../util/configuredChai';
-var testUtils = require('./../../util/testUtils');
-var React = require('react');
-var ReactTestUtils = require('react-addons-test-utils');
+import React from 'react';
+import {expect} from '../../util/configuredChai';
+import {mount} from 'enzyme';
+import ToggleButton from '@cdo/apps/templates/ToggleButton';
 
-describe('ToggleButton', function () {
-
-  testUtils.setExternalGlobals();
-
-  var ToggleButton = require('@cdo/apps/templates/ToggleButton');
-  var renderer;
-
-  beforeEach(function () {
-    renderer = ReactTestUtils.createRenderer();
+describe('ToggleButton', () => {
+  it('renders a "button" element', () => {
+    const toggleButton = mount(
+      <ToggleButton
+        active={true}
+        first={true}
+        last={false}
+        onClick={()=>{}}
+      >
+        <div>click me!</div>
+      </ToggleButton>
+    );
+    expect(toggleButton.find('button')).to.have.length(1);
   });
 
-  it('generates a "button" element', function () {
-    var button = React.createElement(ToggleButton, {
-      active: true,
-      onClick: function () {}
-    }, 'buttonText');
-
-    renderer.render(button);
-    var result = renderer.getRenderOutput();
-
-    assert.equal(result.type, 'button');
-    assert.equal(result.props.children, 'buttonText');
-  });
-
-  it('applies id to the element if provided', function () {
-    var button = React.createElement(ToggleButton, {
-      id: 'buttonElementId',
-      active: true,
-      onClick: function () {}
-    }, 'buttonText');
-
-    renderer.render(button);
-    var result = renderer.getRenderOutput();
-
-    assert.equal(result.props.id, 'buttonElementId');
+  it('applies id to the element if provided', () => {
+    const id = "ButtonId";
+    const toggleButton = mount(
+      <ToggleButton
+        id={id}
+        active={true}
+        first={true}
+        last={false}
+        onClick={()=>{}}
+      >
+        <div>click me!</div>
+      </ToggleButton>
+    );
+    expect(toggleButton.props().id).to.equal(id);
   });
 });


### PR DESCRIPTION
We are currently on React version 15.4. As an intermediate step to the ultimate goal of moving to React 16.0, I'd like to upgrade to 15.6. According to the [React upgrading docs](https://reactjs.org/blog/2017/09/26/react-v16.0.html#upgrading) if our app works in 15.6, it will most likely make a smooth jump up to 16.0.

The `react-addons-test-utils` package [is deprecated as of React version 15.5](https://www.npmjs.com/package/react-addons-test-utils).  Currently, [14 of our React component tests](https://github.com/code-dot-org/code-dot-org/search?q=react-addons-test-utils&unscoped_q=react-addons-test-utils) rely on this package. As a step towards upgrading, I think we need to update the testing of these components.  I've started here with `ToggleButtonTest`. 