### PR TITLE
Selenium - update deprecated timeout step

### DIFF
--- a/dashboard/test/ui/features/step_definitions/applab.rb
+++ b/dashboard/test/ui/features/step_definitions/applab.rb
@@ -61,17 +61,17 @@ When /^I switch to code mode$/ do
 end
 
 And /^I wait to see Applab design mode$/ do
-  wait = Selenium::WebDriver::Wait.new(timeout: 10)
+  wait = Selenium::WebDriver::Wait.new(open_timeout: 10)
   wait.until {@browser.execute_script("return $('#designWorkspace').css('display') == 'block';")}
 end
 
 And /^I wait to see Applab data mode$/ do
-  wait = Selenium::WebDriver::Wait.new(timeout: 10)
+  wait = Selenium::WebDriver::Wait.new(open_timeout: 10)
   wait.until {@browser.execute_script("return $('#dataWorkspaceWrapper').css('display') == 'block';")}
 end
 
 And /^I wait to see Applab code mode$/ do
-  wait = Selenium::WebDriver::Wait.new(timeout: 30)
+  wait = Selenium::WebDriver::Wait.new(open_timeout: 30)
   wait.until {@browser.execute_script("return $('#codeWorkspaceWrapper').css('display') == 'block';")}
 end
 


### PR DESCRIPTION
While DoTD today I hit this warning: "2019-01-10 17:37:54 WARN Selenium [DEPRECATION] :timeout= is deprecated. Use #read_timeout= and #open_timeout= instead." when running `applab/level_options.feature`.  So I updated the relevant steps that use "timeout".  This might not be strictly necessary, but were we ever to upgrade Selenium or if it enforced this warning more strictly we could run into issues. 