### PR TITLE
Update CrossHairOverlayTest to use Enzyme

### DIFF
--- a/apps/test/unit/templates/CrosshairOverlayTest.js
+++ b/apps/test/unit/templates/CrosshairOverlayTest.js
@@ -1,14 +1,13 @@
-import {expect} from '../../util/configuredChai';
 import React from 'react';
-import ReactTestUtils from 'react-addons-test-utils';
+import {expect} from '../../util/configuredChai';
+import {mount} from 'enzyme';
 import CrosshairOverlay, { CROSSHAIR_MARGIN, styles } from '@cdo/apps/templates/CrosshairOverlay';
 
 describe('CrosshairOverlay', () => {
   const TEST_APP_WIDTH = 300, TEST_APP_HEIGHT = 200;
 
   function renderAtMousePosition(x, y) {
-    let renderer = ReactTestUtils.createRenderer();
-    renderer.render(
+    const crosshairOverlay = mount(
         <CrosshairOverlay
           width={TEST_APP_WIDTH}
           height={TEST_APP_HEIGHT}
@@ -16,35 +15,32 @@ describe('CrosshairOverlay', () => {
           mouseY={y}
         />
     );
-    return renderer.getRenderOutput();
+    return crosshairOverlay;
   }
 
   function checkRenderAtMousePosition(x, y) {
-    expect(renderAtMousePosition(x, y)).to.deep.equal(
-        <g className="crosshair-overlay">
-          <line
-            x1={x}
-            y1={0}
-            x2={x}
-            y2={y - CROSSHAIR_MARGIN}
-            style={styles.line}
-          />
-          <line
-            x1={0}
-            y1={y}
-            x2={x - CROSSHAIR_MARGIN}
-            y2={y}
-            style={styles.line}
-          />
-        </g>
-    );
+    const crosshairOverlay = renderAtMousePosition(x,y);
+    expect(crosshairOverlay.find('g')).to.have.length(1);
+    expect(crosshairOverlay.find('line')).to.have.length(2);
+    const firstLine = crosshairOverlay.find('line').first();
+    expect(firstLine.props().x1).to.equal(x);
+    expect(firstLine.props().y1).to.equal(0);
+    expect(firstLine.props().x2).to.equal(x);
+    expect(firstLine.props().y2).to.equal(y - CROSSHAIR_MARGIN);
+    expect(firstLine.props().style).to.equal(styles.line);
+    const secondLine = crosshairOverlay.find('line').last();
+    expect(secondLine.props().x1).to.equal(0);
+    expect(secondLine.props().y1).to.equal(y);
+    expect(secondLine.props().x2).to.equal(x - CROSSHAIR_MARGIN);
+    expect(secondLine.props().y2).to.equal(y);
+    expect(secondLine.props().style).to.equal(styles.line);
   }
 
   it('renders null if mouse is out of bounds', () => {
-    expect(renderAtMousePosition(-1, 0)).to.be.null;
-    expect(renderAtMousePosition(0, -1)).to.be.null;
-    expect(renderAtMousePosition(TEST_APP_WIDTH + 1, TEST_APP_HEIGHT)).to.be.null;
-    expect(renderAtMousePosition(TEST_APP_WIDTH, TEST_APP_HEIGHT + 1)).to.be.null;
+    expect(renderAtMousePosition(-1, 0).html()).to.be.null;
+    expect(renderAtMousePosition(0, -1).html()).to.be.null;
+    expect(renderAtMousePosition(TEST_APP_WIDTH + 1, TEST_APP_HEIGHT).html()).to.be.null;
+    expect(renderAtMousePosition(TEST_APP_WIDTH, TEST_APP_HEIGHT + 1).html()).to.be.null;
   });
 
   it('renders lines converging at mouse position if mouse is in bounds', () => {


### PR DESCRIPTION
Continuation of the work outlined in #26536. This is a re-write of `CrossHairOverlayTest` to use Enzyme, which is more compatible with the upcoming React upgrade.