### PR TITLE
Split assessment tab UI test scenarios to speed up re-runs

### DIFF
--- a/dashboard/test/ui/features/teacher_dashboard_assessments1.feature
+++ b/dashboard/test/ui/features/teacher_dashboard_assessments1.feature
@@ -1,0 +1,33 @@
+@no_ie
+@no_mobile
+@dashboard_db_access
+@pegasus_db_access
+Feature: Using the assessments tab in the teacher dashboard
+
+  Scenario: Assessments tab initialization
+    Given I create an authorized teacher-associated student named "Sally"
+    And I give user "Teacher_Sally" hidden script access
+    And I sign out
+
+    # Assign a script with a survey but no assessment
+    When I sign in as "Teacher_Sally"
+    And I am on "http://studio.code.org/home"
+    And I click selector ".ui-test-section-dropdown" once I see it
+    And I click selector ".edit-section-details-link"
+    And I wait until element "#uitest-assignment-family" is visible
+    And I select the "Computer Science Principles" option in dropdown "uitest-assignment-family"
+    And I wait until element "#assignment-version-year" is visible
+    And I press "assignment-version-year"
+    And I click selector ".assignment-version-title:contains('17-'18)" once I see it
+    And I select the "CSP Student Post-Course Survey ('17-'18)" option in dropdown "uitest-secondary-assignment"
+    And I press the first ".uitest-saveButton" element
+    And I wait until element ".modal-backdrop" is gone
+
+    # Progress tab
+    When I click selector "a:contains('Untitled Section')" once I see it
+    And I wait until element "#uitest-course-dropdown" is visible
+
+    # Assessments tab
+    When I click selector "#learn-tabs a:contains('Assessments/Surveys')" once I see it
+    And I wait until element "#uitest-course-dropdown" is visible
+    Then I wait until element "h3:contains(this survey is anonymous)" is visible

--- a/dashboard/test/ui/features/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_dashboard_assessments2.feature
@@ -4,34 +4,6 @@
 @pegasus_db_access
 Feature: Using the assessments tab in the teacher dashboard
 
-  Scenario: Assessments tab initialization
-    Given I create an authorized teacher-associated student named "Sally"
-    And I give user "Teacher_Sally" hidden script access
-    And I sign out
-
-    # Assign a script with a survey but no assessment
-    When I sign in as "Teacher_Sally"
-    And I am on "http://studio.code.org/home"
-    And I click selector ".ui-test-section-dropdown" once I see it
-    And I click selector ".edit-section-details-link"
-    And I wait until element "#uitest-assignment-family" is visible
-    And I select the "Computer Science Principles" option in dropdown "uitest-assignment-family"
-    And I wait until element "#assignment-version-year" is visible
-    And I press "assignment-version-year"
-    And I click selector ".assignment-version-title:contains('17-'18)" once I see it
-    And I select the "CSP Student Post-Course Survey ('17-'18)" option in dropdown "uitest-secondary-assignment"
-    And I press the first ".uitest-saveButton" element
-    And I wait until element ".modal-backdrop" is gone
-
-    # Progress tab
-    When I click selector "a:contains('Untitled Section')" once I see it
-    And I wait until element "#uitest-course-dropdown" is visible
-
-    # Assessments tab
-    When I click selector "#learn-tabs a:contains('Assessments/Surveys')" once I see it
-    And I wait until element "#uitest-course-dropdown" is visible
-    Then I wait until element "h3:contains(this survey is anonymous)" is visible
-
   Scenario: Assessments tab survey submissions
     Given I create an authorized teacher-associated student named "Sally"
     And I give user "Teacher_Sally" hidden script access


### PR DESCRIPTION
As DotD today, I needed to re-run `teacher_dashboard_assessments.feature` and it took 20 minutes to fail! It only takes 6 minutes to pass, but since it has many steps where waiting for elements is required, re-runs can be time consuming. 

<img width="1114" alt="screen shot 2019-01-10 at 3 59 27 pm" src="https://user-images.githubusercontent.com/12300669/51006350-9ae9c500-14f7-11e9-9ad9-d589367c8b8b.png">

Since the test's 2 scenarios are not dependent on one another, I split them into two files to expedite both the initial runs and any re-runs that need to occur. This is consistent with other files that have been split for expediency ([example](https://github.com/code-dot-org/code-dot-org/pull/26220)) as a lightweight mitigation for long running tests. 
