### PR TITLE
Optimize S3 assets:sync task

### DIFF
--- a/dashboard/lib/tasks/asset_sync.rake
+++ b/dashboard/lib/tasks/asset_sync.rake
@@ -22,7 +22,12 @@ namespace :assets do
     require 'parallel'
     bucket = Aws::S3::Resource.new.bucket(CDO.assets_bucket)
     Parallel.each(changed_paths, in_threads: 16) do |key, path|
-      bucket.object("#{CDO.assets_bucket_prefix}/assets/#{key}").upload_file(path, acl: 'public-read', cache_control: 'max-age=31536000')
+      bucket.object("#{CDO.assets_bucket_prefix}/assets/#{key}").upload_file(
+        path,
+        acl: 'public-read',
+        cache_control: 'max-age=31536000',
+        content_type: Rack::Mime.mime_type(File.extname(key))
+      )
     end
   rescue
     if m && changed_paths


### PR DESCRIPTION
This PR changes `assets:sync` to track and upload only newly-added Sprockets assets to S3, instead of running [`aws s3 sync`](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html) from the AWS CLI, which first lists all existing S3 objects in the bucket/prefix before deciding which new ones to upload, and which takes a long time on bucket/prefix paths with a large number of files.

I've also added an exception-handler which will `rm` the newly-added assets if the process fails during the S3 upload, so the upload will be re-tried when regenerated in a future run.

This change reduces the time taken by `assets:precompile` from ~3 minutes to ~30 seconds on `staging`.