### PR TITLE
Set a max height and vertical scroll bar for the copy to screen menu.

### DIFF
--- a/apps/src/applab/designElements/CopyElementToScreenButton.jsx
+++ b/apps/src/applab/designElements/CopyElementToScreenButton.jsx
@@ -13,6 +13,10 @@ const styles = {
   },
   screen: {
   },
+  menu: {
+    maxHeight: '200px',
+    overflowY: 'scroll',
+  },
 };
 
 /**
@@ -104,6 +108,7 @@ class CopyElementToScreenButton extends React.Component {
               targetPoint={targetPoint}
               offset={{x: 0, y: 0}}
               beforeClose={this.beforeClose}
+              style={styles.menu}
             >
               {otherScreens}
             </PopUpMenu>

--- a/apps/src/applab/designElements/CopyElementToScreenButton.jsx
+++ b/apps/src/applab/designElements/CopyElementToScreenButton.jsx
@@ -15,7 +15,7 @@ const styles = {
   },
   menu: {
     maxHeight: '200px',
-    overflowY: 'scroll',
+    overflowY: 'auto',
   },
 };
 


### PR DESCRIPTION
If the user has created too many screens, when selecting an element and clicking the dropdown to copy that element to another screen, the dropdown height will now be limited to a maximum height, and scrollable within that area.
![scrolling copy to screen dropdown](https://user-images.githubusercontent.com/11651276/51767662-ef15ad00-2092-11e9-843b-55d45bad63d5.png)

