### PR TITLE
Application timestamp logs assigning and unassigning workshops

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/application/facilitator_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/facilitator_applications_controller.rb
@@ -13,6 +13,7 @@ module Api::V1::Pd::Application
 
     def on_successful_create
       @application.queue_email :confirmation, deliver_now: true
+      @application.update_status_timestamp_change_log(current_user)
     end
   end
 end

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -172,6 +172,14 @@ module Api::V1::Pd
         status_changed = true
       end
 
+      if application_data[:fit_workshop_id] != @application.try(:fit_workshop_id)
+        fit_workshop_changed = true
+      end
+
+      if application_data[:pd_workshop_id] != @application.pd_workshop_id
+        summer_workshop_changed = true
+      end
+
       if application_data[:response_scores]
         application_data[:response_scores] = JSON.parse(application_data[:response_scores]).transform_keys {|x| x.to_s.underscore}.to_json
       end
@@ -209,6 +217,8 @@ module Api::V1::Pd
       end
 
       @application.update_status_timestamp_change_log(current_user) if status_changed
+      @application.log_fit_workshop_change(current_user) if fit_workshop_changed
+      @application.log_summer_workshop_change(current_user) if summer_workshop_changed
 
       render json: @application, serializer: ApplicationSerializer
     end

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -393,9 +393,9 @@ module Pd::Application
     # Record when the status changes and who changed it
     # Ideally we'd implement this as an after_save action, but since we want the current
     # user to be included, this needs to be explicitly passed in in the controller
-    def update_status_timestamp_change_log(user)
+    def update_status_timestamp_change_log(user, title = status)
       log_entry = {
-        title: status,
+        title: title,
         changing_user_id: user.try(:id),
         changing_user_name: user.try(:name) || user.try(:email),
         time: Time.zone.now

--- a/dashboard/app/models/pd/application/facilitator_application_base.rb
+++ b/dashboard/app/models/pd/application/facilitator_application_base.rb
@@ -96,6 +96,10 @@ module Pd::Application
       fit_workshop.try(&:date_and_location_name)
     end
 
+    def log_fit_workshop_change(user)
+      update_status_timestamp_change_log(user, "Fit Workshop: #{fit_workshop_date_and_location || 'Unassigned'}")
+    end
+
     def registered_fit_workshop?
       # inspect the cached fit_workshop.enrollments rather than querying the DB
       fit_workshop.enrollments.any? {|e| e.user_id == user.id} if fit_workshop_id

--- a/dashboard/app/models/pd/application/facilitator_application_base.rb
+++ b/dashboard/app/models/pd/application/facilitator_application_base.rb
@@ -97,7 +97,7 @@ module Pd::Application
     end
 
     def log_fit_workshop_change(user)
-      update_status_timestamp_change_log(user, "Fit Workshop: #{fit_workshop_date_and_location || 'Unassigned'}")
+      update_status_timestamp_change_log(user, "Fit Workshop: #{fit_workshop_id ? fit_workshop_date_and_location : 'Unassigned'}")
     end
 
     def registered_fit_workshop?

--- a/dashboard/app/models/pd/application/workshop_autoenrolled_application.rb
+++ b/dashboard/app/models/pd/application/workshop_autoenrolled_application.rb
@@ -96,7 +96,7 @@ module Pd::Application
     end
 
     def log_summer_workshop_change(user)
-      update_status_timestamp_change_log(user, "Summer Workshop: #{workshop_date_and_location || 'Unassigned'}")
+      update_status_timestamp_change_log(user, "Summer Workshop: #{pd_workshop_id ? workshop_date_and_location : 'Unassigned'}")
     end
 
     # override

--- a/dashboard/app/models/pd/application/workshop_autoenrolled_application.rb
+++ b/dashboard/app/models/pd/application/workshop_autoenrolled_application.rb
@@ -95,6 +95,10 @@ module Pd::Application
       workshop.try(&:date_and_location_name)
     end
 
+    def log_summer_workshop_change(user)
+      update_status_timestamp_change_log(user, "Summer Workshop: #{workshop_date_and_location || 'Unassigned'}")
+    end
+
     # override
     def lock!
       return if locked?

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -39,7 +39,7 @@ module Api::V1::Pd
       @csd_teacher_application = create TEACHER_APPLICATION_FACTORY, course: 'csd'
       @csd_teacher_application_with_partner = create TEACHER_APPLICATION_FACTORY, course: 'csd', regional_partner: @regional_partner
       @csp_teacher_application = create TEACHER_APPLICATION_FACTORY, course: 'csp'
-      @csp_facilitator_application = create FACILITATOR_APPLICATION_FACTORY, course: 'csp'
+      @csp_facilitator_application = create FACILITATOR_APPLICATION_FACTORY, course: 'csp', regional_partner: @regional_partner
 
       @serializing_teacher = create(:teacher,
         email: 'minerva@hogwarts.edu',
@@ -301,7 +301,7 @@ module Api::V1::Pd
       assert_equal({regional_partner_name: 'Yes'}, application.response_scores_hash)
     end
 
-    test 'update appends to the status changed log if status is changed' do
+    test 'update appends to the timestamp log if status is changed' do
       sign_in @program_manager
 
       assert_equal [], @csd_teacher_application_with_partner.sanitize_status_timestamp_change_log
@@ -319,7 +319,7 @@ module Api::V1::Pd
       ], @csd_teacher_application_with_partner.sanitize_status_timestamp_change_log
     end
 
-    test 'update does not append to the status changed log if status is unchanged' do
+    test 'update does not append to the timestamp log if status is unchanged' do
       sign_in @program_manager
       @csd_teacher_application_with_partner.update(status_timestamp_change_log: '[]')
       @csd_teacher_application_with_partner.reload
@@ -330,6 +330,46 @@ module Api::V1::Pd
       @csd_teacher_application_with_partner.reload
 
       assert_equal [], @csd_teacher_application_with_partner.sanitize_status_timestamp_change_log
+    end
+
+    test 'update appends to the timestamp log if fit workshop is changed' do
+      sign_in @program_manager
+      @csp_facilitator_application.update(status_timestamp_change_log: '[]')
+      @csp_facilitator_application.reload
+
+      assert_equal [], @csp_facilitator_application.sanitize_status_timestamp_change_log
+
+      post :update, params: {id: @csp_facilitator_application.id, application: {fit_workshop_id: @fit_workshop.id, status: @csp_facilitator_application.status}}
+      @csp_facilitator_application.reload
+
+      assert_equal [
+        {
+          title: "Fit Workshop: #{@csp_facilitator_application.fit_workshop_date_and_location}",
+          changing_user_id: @program_manager.id,
+          changing_user_name: @program_manager.name,
+          time: Time.zone.now
+        }
+      ], @csp_facilitator_application.sanitize_status_timestamp_change_log
+    end
+
+    test 'update appends to the timestamp log if summer workshop is changed' do
+      sign_in @program_manager
+      @csp_facilitator_application.update(status_timestamp_change_log: '[]')
+      @csp_facilitator_application.reload
+
+      assert_equal [], @csp_facilitator_application.sanitize_status_timestamp_change_log
+
+      post :update, params: {id: @csp_facilitator_application.id, application: {pd_workshop_id: @summer_workshop.id, status: @csp_facilitator_application.status}}
+      @csp_facilitator_application.reload
+
+      assert_equal [
+        {
+          title: "Summer Workshop: #{@csp_facilitator_application.workshop_date_and_location}",
+          changing_user_id: @program_manager.id,
+          changing_user_name: @program_manager.name,
+          time: Time.zone.now
+        }
+      ], @csp_facilitator_application.sanitize_status_timestamp_change_log
     end
 
     test 'workshop admins can lock and unlock applications' do

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -52,6 +52,9 @@ module Api::V1::Pd
         )
       )
 
+      @summer_workshop = create :pd_workshop, :local_summer_workshop, num_sessions: 5, sessions_from: Date.new(2019, 6, 1), processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+      @fit_workshop = create :pd_workshop, :fit, num_sessions: 3, sessions_from: Date.new(2019, 6, 1), processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+
       @markdown = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
     end
 

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     association :organizer, factory: :workshop_organizer
     funded false
     on_map true
+    location_name 'Hogwarts School of Witchcraft and Wizardry'
     course Pd::Workshop::COURSES.first
     subject {Pd::Workshop::SUBJECTS[course].try(&:first)}
     trait :teachercon do


### PR DESCRIPTION
Teacher app logs summer workshop changes, Facilitator app logs summer and FiT workshop changes

note: nothing is logged about workshops until one is assigned - this is just a partial screenshot which is why it shows 'Unassigned' first

<img width="1323" alt="screen shot 2019-01-11 at 3 47 08 pm" src="https://user-images.githubusercontent.com/224089/51065194-70ac0c00-15b8-11e9-9be9-8ee1b816fb88.png">
