### PR TITLE
test apps package with multiple CPUs

### DIFF
--- a/apps/test-low-memory.sh
+++ b/apps/test-low-memory.sh
@@ -1,43 +1,59 @@
 #!/bin/bash
 set -e
 
-# 'npm test' normally does all three of these things.
-# We break them up here so they each run in isolation.
-GRUNT_CMD="node --max_old_space_size=4096 `npm bin`/grunt"
+MEM_PER_PROCESS=4096
+GRUNT_CMD="node --max_old_space_size=${MEM_PER_PROCESS} `npm bin`/grunt"
 
 if [ -n "$CIRCLECI" ]; then
+  NPROC=4
   mkdir -p log
-
-  curl -s https://codecov.io/bash > /tmp/codecov.sh
-  chmod +x /tmp/codecov.sh
-
-  $GRUNT_CMD preconcat
-
-  echo "###################################################################"
-  echo "#                                                                 #"
-  echo "#   See 'apps-test-log' under the artifacts tab for test output   #"
-  echo "#                                                                 #"
-  echo "###################################################################"
-
-  SHELL=/bin/bash parallel -j 4 --joblog - ::: "npm run lint" \
-  "(PORT=9876 $GRUNT_CMD unitTest && /tmp/codecov.sh -cF unit) > log/unitTest.log" \
-  "(PORT=9877 $GRUNT_CMD storybookTest && /tmp/codecov.sh -cF storybook) > log/storybookTest.log" \
-  "(PORT=9878 $GRUNT_CMD scratchTest && /tmp/codecov.sh -cF scratch) > log/scratchTest.log" \
-  "(PORT=9879 LEVEL_TYPE='turtle' $GRUNT_CMD karma:integration && \
-    /tmp/codecov.sh -cF integration) > log/turtleTest.log" \
-  "(PORT=9880 LEVEL_TYPE='maze|bounce|calc|eval|flappy|studio' $GRUNT_CMD karma:integration && \
-    /tmp/codecov.sh -cF integration) > log/integrationTest.log" \
-  "(PORT=9881 LEVEL_TYPE='applab|gamelab' $GRUNT_CMD karma:integration && \
-    /tmp/codecov.sh -cF integration) > log/appLabgameLabTest.log" \
-  "(PORT=9882 LEVEL_TYPE='craft' $GRUNT_CMD karma:integration && \
-    /tmp/codecov.sh -cF integration) > log/craftTest.log"
+  cat <<STR
+###################################################################
+#                                                                 #
+#   See 'apps-test-log' under the artifacts tab for test output   #
+#                                                                 #
+###################################################################
+STR
+  CODECOV=/tmp/codecov.sh
+  curl -s https://codecov.io/bash > ${CODECOV}
+  chmod +x ${CODECOV}
+  LOG=">"
 else
-  npm run lint
-  $GRUNT_CMD unitTest
-  $GRUNT_CMD storybookTest
-  $GRUNT_CMD scratchTest
-  LEVEL_TYPE='turtle' $GRUNT_CMD integrationTest
-  LEVEL_TYPE='maze|bounce|calc|eval|flappy|studio' $GRUNT_CMD integrationTest
-  LEVEL_TYPE='applab|gamelab' $GRUNT_CMD integrationTest
-  LEVEL_TYPE='craft' $GRUNT_CMD integrationTest
+  # For non-Circle runs, stub-out codecov and logging to files.
+  NPROC=$(nproc)
+  CODECOV=: # stub
+  LOG='&& :' # stub
 fi
+
+# Don't run more processes than can fit in free memory.
+MEM_PROCS=$(awk "/MemFree/ {printf \"%d\", \$2/1024/${MEM_PER_PROCESS}}" /proc/meminfo)
+PROCS=$(( ${MEM_PROCS} < ${NPROC} ? ${MEM_PROCS} : ${NPROC} ))
+
+if [ $PROCS -eq 0 ]; then
+  echo "Error: Not enough available memory available to run tests"
+  exit 1
+fi
+
+$GRUNT_CMD preconcat
+
+export SHELL=/bin/bash
+if command -v parallel 2>/dev/null; then
+  PARALLEL="parallel --will-cite --halt 2 -j ${PROCS} --joblog - :::"
+else
+  PARALLEL="xargs -P${PROCS} -d\n -L1 -n1 ${SHELL} -c"
+fi
+
+${PARALLEL} <<SCRIPT
+npm run lint
+(PORT=9876 ${GRUNT_CMD} unitTest && ${CODECOV} -cF unit) ${LOG} log/unitTest.log
+(PORT=9877 $GRUNT_CMD storybookTest && ${CODECOV} -cF storybook) ${LOG} log/storybookTest.log
+(PORT=9878 $GRUNT_CMD scratchTest && ${CODECOV} -cF scratch) ${LOG} log/scratchTest.log
+(PORT=9879 LEVEL_TYPE='turtle' $GRUNT_CMD karma:integration && \
+  ${CODECOV} -cF integration) ${LOG} log/turtleTest.log
+(PORT=9880 LEVEL_TYPE='maze|bounce|calc|eval|flappy|studio' $GRUNT_CMD karma:integration && \
+  ${CODECOV} -cF integration) ${LOG} log/integrationTest.log
+(PORT=9881 LEVEL_TYPE='applab|gamelab' $GRUNT_CMD karma:integration && \
+  ${CODECOV} -cF integration) ${LOG} log/appLabgameLabTest.log
+(PORT=9882 LEVEL_TYPE='craft' $GRUNT_CMD karma:integration && \
+  ${CODECOV} -cF integration) ${LOG} log/craftTest.log
+SCRIPT


### PR DESCRIPTION
Improves build/test times for apps-package artifacts:
- Use uglifyjs-webpack-plugin v1.3.0 with `parallel` option
- refactor test-low-memory.sh script to run tests using parallel/xargs even in non-circleci environments.
- small changes to Rakefile build/package scripts for clearer logging output