### PR TITLE
update Expo SDK to 32.0.0

### DIFF
--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -569,7 +569,7 @@ export default {
       sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
       files,
       name: project.getCurrentName(),
-      sdkVersion: '28.0.0',
+      sdkVersion: '32.0.0',
     });
 
     // Important that index.html comes first:

--- a/apps/src/gamelab/Exporter.js
+++ b/apps/src/gamelab/Exporter.js
@@ -291,7 +291,7 @@ export default {
       sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
       files,
       name: project.getCurrentName(),
-      sdkVersion: '28.0.0',
+      sdkVersion: '32.0.0',
     });
 
     // Important that index.html comes first:

--- a/apps/src/templates/export/expo/App.js.ejs
+++ b/apps/src/templates/export/expo/App.js.ejs
@@ -106,6 +106,7 @@ export default class App extends React.Component {
       <View onLayout={this.onLayout} style={styles.container}>
         {height && <View style={this.webViewContainerStyle()}>
           <WebView
+            originWhitelist={['*']}
             source={{uri: indexUri}}
             style={styles.webView}
             javaScriptEnabled={true}

--- a/apps/src/templates/export/expo/App.js.ejs
+++ b/apps/src/templates/export/expo/App.js.ejs
@@ -107,9 +107,10 @@ export default class App extends React.Component {
         {height && <View style={this.webViewContainerStyle()}>
           <WebView
             originWhitelist={['*']}
+            allowFileAccess
             source={{uri: indexUri}}
             style={styles.webView}
-            javaScriptEnabled={true}
+            javaScriptEnabled
             mediaPlaybackRequiresUserAction={false}
             scrollEnabled={false}
             bounces={false}
@@ -134,7 +135,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'black',
   },
   webView: {
-    backgroundColor: 'black',
+    backgroundColor: 'white',
     flex: 1,
   }
 });

--- a/apps/src/templates/export/expo/CustomAsset.exported_js
+++ b/apps/src/templates/export/expo/CustomAsset.exported_js
@@ -1,213 +1,51 @@
-import { NativeModules, PixelRatio, Platform } from 'react-native';
-import AssetRegistry from 'AssetRegistry';
-import AssetSourceResolver from 'AssetSourceResolver';
-
-// On Android we pass the manifest in JSON form so this step is necessary
-const { ExponentConstants } = NativeModules;
-
-let manifest;
-if (ExponentConstants) {
-  manifest = ExponentConstants.manifest;
-  if (typeof manifest === 'string') {
-    manifest = JSON.parse(manifest);
-  }
-}
-
-const Constants = {
-  ...ExponentConstants,
-  manifest,
-};
-
-const FS = NativeModules.ExponentFileSystem;
-
-// Fast lookup check if assets are available in the local bundle.
-const bundledAssets = new Set(FS.bundledAssets || []);
-
-// Return { uri, hash } for an asset's file, picking the correct scale, based on its React Native
-// metadata. If the asset isn't an image just picks the first file.
-const pickScale = meta => {
-  // This logic is based on that in AssetSourceResolver.js, we just do it with our own tweaks for
-  // Expo
-
-  const scale =
-    meta.scales.length > 1 ? AssetSourceResolver.pickScale(meta.scales, PixelRatio.get()) : 1;
-  const index = meta.scales.findIndex(s => s === scale);
-  const hash = meta.fileHashes[index] || meta.fileHashes[0];
-
-  const suffix =
-    '/' +
-    meta.name +
-    (scale === 1 ? '' : '@' + scale + 'x') +
-    '.' +
-    meta.type +
-    '?platform=' +
-    Platform.OS +
-    '&hash=' +
-    meta.hash;
-
-  // Allow asset processors to directly provide the URL that will be loaded
-  if (meta.uri) {
-    return {
-      uri: meta.uri,
-      hash,
-    };
-  }
-
-  if (/^https?:/.test(meta.httpServerLocation)) {
-    // This is a full URL, so we avoid prepending bundle URL/cloudfront
-    // This usually means Asset is on a different server, and the URL is present in the bundle
-    return {
-      uri: meta.httpServerLocation + suffix,
-      hash,
-    };
-  }
-
-  if (Constants.manifest.xde) {
-    // Development server URI is pieced together
-    return {
-      uri:
-        Constants.manifest.bundleUrl.match(/^https?:\/\/.*?\//)[0] +
-        meta.httpServerLocation.replace(/^\/?/, '') +
-        suffix,
-      hash,
-    };
-  }
-
-  // CDN URI is based directly on the hash
-  return {
-    uri: 'https://d1wp6m56sqw74a.cloudfront.net/~assets/' + hash,
-    hash,
-  };
-};
-
-// Returns the uri of an asset from its hash and type or null if the asset is
-// not included in the app bundle.
-const getUriInBundle = (hash, type) => {
-  const assetName = 'asset_' + hash + (type ? '.' + type : '');
-  if (Constants.appOwnership !== 'standalone' || !bundledAssets.has(assetName)) {
-    return null;
-  }
-  return `${FS.bundleDirectory}${assetName}`;
-};
+import { Asset, FileSystem } from 'expo';
 
 export default class CustomAsset {
-  static byHash = {};
-
-  constructor({ name, type, hash, uri, width, height }) {
-    this.name = name;
-    this.type = type;
-    this.hash = hash;
-    this.uri = uri;
-    if (typeof width === 'number') {
-      this.width = width;
-    }
-    if (typeof height === 'number') {
-      this.height = height;
-    }
-
-    this.downloading = false;
-    this.downloaded = false;
-    this.downloadCallbacks = [];
+  constructor({ asset, fileName }) {
+    this.asset = asset;
+    this.fileName = fileName;
   }
 
-  static loadAsync(moduleId) {
-    let moduleIds = typeof moduleId === 'number' ? [moduleId] : moduleId;
-    return Promise.all(moduleIds.map(m => CustomAsset.fromModule(m).downloadAsync()));
+  static fromModule(moduleId, fileName) {
+    const asset = Asset.fromModule(moduleId);
+    return new CustomAsset({asset, fileName});
   }
 
   static loadAsyncAssets(assets) {
     return Promise.all(assets.map(a => a.downloadAsync()));
   }
 
-  static fromModule(moduleId, fileName) {
-    const meta = AssetRegistry.getAssetByID(moduleId);
-    const asset = CustomAsset.fromMetadata(meta);
-    asset.name = fileName;
-    return asset;
-  }
-
-  static fromMetadata(meta) {
-    // The hash of the whole asset, not to confuse with the hash of a specific
-    // file returned from `pickScale`.
-    const metaHash = meta.hash;
-    if (CustomAsset.byHash[metaHash]) {
-      return CustomAsset.byHash[metaHash];
-    }
-
-    const { uri, hash } = pickScale(meta);
-
-    const asset = new CustomAsset({
-      name: meta.name,
-      type: meta.type,
-      hash,
-      uri,
-      width: meta.width,
-      height: meta.height,
-    });
-    CustomAsset.byHash[metaHash] = asset;
-    return asset;
-  }
-
   async downloadAsync() {
-    if (this.downloaded) {
-      return;
-    }
-    if (this.downloading) {
-      await new Promise((resolve, reject) => this.downloadCallbacks.push({ resolve, reject }));
-      return;
-    }
-    this.downloading = true;
-    try {
-      const localUri = `${FS.cacheDirectory}${encodeURI(this.name)}`;
-      let exists, md5;
-      ({ exists, md5 } = await FS.getInfoAsync(localUri, {
-        cache: true,
-        md5: true,
-      }));
-      if (!exists || md5 !== this.hash) {
-        const dirName = localUri.substring(0, localUri.lastIndexOf('/'));
-        if (`${dirName}/` !== FS.cacheDirectory) {
-          try {
-            await FS.makeDirectoryAsync(dirName, {
-              intermediates: true,
-            });
-          } catch (e) {
-            // Ignore this because it throws if the dir already exists on Android
-          }
-        }
-        const bundleUri = getUriInBundle(this.hash, this.type);
-        if (bundleUri) {
-          await FS.copyAsync({
-            from: bundleUri,
-            to: localUri,
+    const localUri = `${FileSystem.cacheDirectory}${encodeURI(this.fileName)}`;
+    let exists, md5;
+    ({ exists, md5 } = await FileSystem.getInfoAsync(localUri, {
+      cache: true,
+      md5: true,
+    }));
+    if (!exists || md5 !== this.asset.hash) {
+      const dirName = localUri.substring(0, localUri.lastIndexOf('/'));
+      if (`${dirName}/` !== FileSystem.cacheDirectory) {
+        try {
+          await FileSystem.makeDirectoryAsync(dirName, {
+            intermediates: true,
           });
-          ({ md5 } = await FS.getInfoAsync(localUri, {
-            cache: true,
-            md5: true,
-          }));
-        }
-        ({ md5 } = await FS.downloadAsync(this.uri, localUri, {
-          cache: true,
-          md5: true,
-        }));
-        if (md5 !== this.hash) {
-          throw new Error(
-            `Downloaded file for asset '${this.name} ` +
-              `Located at ${this.uri} ` +
-              `failed MD5 integrity check`
-          );
+        } catch (e) {
+          // Ignore this because it throws if the dir already exists on Android
         }
       }
-
-      this.localUri = localUri;
-      this.downloaded = true;
-      this.downloadCallbacks.forEach(({ resolve }) => resolve());
-    } catch (e) {
-      this.downloadCallbacks.forEach(({ reject }) => reject(e));
-      throw e;
-    } finally {
-      this.downloading = false;
-      this.downloadCallbacks = [];
+      ({ md5 } = await FileSystem.downloadAsync(this.asset.uri, localUri, {
+          cache: true,
+          md5: true,
+      }));
+      if (md5 !== this.asset.hash) {
+        throw new Error(
+          `Downloaded file for asset '${this.fileName} ` +
+            `Located at ${this.asset.localUri} ` +
+            `failed MD5 integrity check`
+        );
+      }
     }
+    this.localUri = localUri;
+    this.downloaded = true;
   }
 }

--- a/apps/src/templates/export/expo/app.json.ejs
+++ b/apps/src/templates/export/expo/app.json.ejs
@@ -4,7 +4,7 @@
     "description": "<%- appName %> from Code.org Code Studio.",
     "slug": "<%- appName.replace(/([^a-zA-Z0-9_\-]+)/gi, '-') %>",
     "privacy": "public",
-    "sdkVersion": "28.0.0",
+    "sdkVersion": "32.0.0",
     "platforms": ["ios", "android"],
     "version": "1.0.0",
     "orientation": "portrait",

--- a/apps/src/templates/export/expo/package.exported_json
+++ b/apps/src/templates/export/expo/package.exported_json
@@ -8,9 +8,9 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^28.0.0",
+    "expo": "^32.0.0",
     "expo-cli": "^2.6.14",
-    "react": "16.3.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-28.0.0.tar.gz"
+    "react": "16.5.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz"
   }
 }


### PR DESCRIPTION
* Rewrote our `CustomAsset` react-native class to wrap Expo's `Asset` instead of providing a replacement. `CustomAsset` now stores a `fileName` alongside an `asset`. It has its own `downloadAsync()` implementation that uses Expo's `FileSystem` to create a local directory structure underneath the `CacheDirectory` so we can invoke `WebView` with a local `index.html` and all relative references from that file work as expected
* Minor tweaks to the `App.js` to work with Expo SDK 32.0.0