### PR TITLE
 facilitator app: gender and race are required on the client

### DIFF
--- a/apps/src/code-studio/pd/application/facilitator1920/Section6Submission.jsx
+++ b/apps/src/code-studio/pd/application/facilitator1920/Section6Submission.jsx
@@ -11,7 +11,9 @@ export default class Section6Submission extends LabeledFormComponent {
   static labels = {...PageLabels.section6Submission, ...PageLabels.section1AboutYou};
 
   static associatedFields = [
-    ...Object.keys(PageLabels.section6Submission)
+    ...Object.keys(PageLabels.section6Submission),
+    "genderIdentity",
+    "race"
   ];
 
   render() {


### PR DESCRIPTION
Previously we were only checking for them on the server side. Now they are required on the client, before you can leave that page of the application or submit it.

<img width="1043" alt="screen shot 2019-01-14 at 11 05 24 pm" src="https://user-images.githubusercontent.com/224089/51164261-3f9a3880-1851-11e9-98ba-3a585120b295.png">


