### PR TITLE
sanitize percentage inputs in principal approval

### DIFF
--- a/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Component.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Component.jsx
@@ -351,6 +351,12 @@ export default class PrincipalApproval1920Component extends LabeledFormComponent
       fieldsToClear.add(REPLACE_COURSE_FIELDS);
     }
 
+    // Sanitize numeric fields (necessary for older browsers that don't
+    // automatically enforce numeric inputs)
+    ['freeLunchPercent', ...RACE_LIST].forEach((field) => {
+      changes[field] = parseFloat(data[field]);
+    });
+
     return changes;
   }
 }


### PR DESCRIPTION
We do some work in the application to verify that the inputs can be parsed as floats, but that unfortunately includes constructs like "15%", which can be parsed by JS as the float `15`, but will still end up being posted as the string `"15%"`.

With this, the values received by the server will be appropriately sanitized.