### PR TITLE
check jqXHR before referencing when fetching project source

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1380,7 +1380,7 @@ function fetchSource(channelData, callback, version, sourcesApi) {
           animations: ''
         };
       }
-      currentSourceVersionId = jqXHR.getResponseHeader('S3-Version-Id');
+      currentSourceVersionId = jqXHR && jqXHR.getResponseHeader('S3-Version-Id');
       unpackSources(data);
       callback();
     });


### PR DESCRIPTION
https://codeorg.zendesk.com/agent/tickets/225181 reported a student project failing to load. The problem was due to a js error which is fixed by this PR. The problem can be seen in this remix of the user-reported project: https://studio.code.org/projects/applab/AESue8h3AyOObSDMNwuctQ It can also be reproduced by using chrome dev tools to block /v3/sources/.../main.json from loading.

With this fix, a project whose source fails to load will appear to have no code in it, however the code can be recovered using the Version History feature.