### PR TITLE
Implement versioning feedback

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1059,7 +1059,6 @@
   "recording": "Recording",
   "recordAudio": "Record Audio",
   "redirectCourseVersionWarningDetails": "It looks like you accidentally went to an outdated version of the course. You've been redirected to the recommended version or the version assigned by your teacher.",
-  "redirectScriptVersionWarningDetails": "It looks like you accidentally went to an outdated version of the script. You've been redirected to the recommended version or the version assigned by your teacher.",
   "reloadPage": "Reload Page",
   "relockStage": "Re-lock stage",
   "relockStageInstructions": "\"Re-lock stage\" to prevent sharing of answers with other classes/schools.",

--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -196,7 +196,7 @@ class ScriptOverviewHeader extends Component {
           <Notification
             type={NotificationType.warning}
             notice=""
-            details={i18n.redirectScriptVersionWarningDetails()}
+            details={i18n.redirectCourseVersionWarningDetails()}
             dismissible={true}
             width={SCRIPT_OVERVIEW_WIDTH}
             onDismiss={this.onDismissRedirectWarning}

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -360,7 +360,7 @@ class Course < ApplicationRecord
     # Redirect user to the latest assigned course in this course family,
     # if one exists and it is newer than the current course.
     latest_assigned_version = Course.latest_assigned_version(family_name, user)
-    return nil if latest_assigned_version.nil? || latest_assigned_version.version_year < version_year
+    return nil unless latest_assigned_version.present? && latest_assigned_version.version_year > version_year
     latest_assigned_version.link
   end
 

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -352,12 +352,16 @@ class Course < ApplicationRecord
   # @param user [User]
   # @return [String] URL to the course the user should be redirected to.
   def redirect_to_course_url(user)
+    # Only redirect students.
+    return nil unless user && user.student?
     # No redirect unless user is allowed to view this course version and they are not assigned to the course.
     return nil unless can_view_version?(user) && !user.assigned_course?(self)
 
-    # Redirect user to the latest assigned course in this course family, if one exists.
+    # Redirect user to the latest assigned course in this course family,
+    # if one exists and it is newer than the current course.
     latest_assigned_version = Course.latest_assigned_version(family_name, user)
-    latest_assigned_version&.link
+    return nil if latest_assigned_version.nil? || latest_assigned_version.version_year < version_year
+    latest_assigned_version.link
   end
 
   # @param user [User]

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -354,13 +354,15 @@ class Course < ApplicationRecord
   def redirect_to_course_url(user)
     # Only redirect students.
     return nil unless user && user.student?
-    # No redirect unless user is allowed to view this course version and they are not assigned to the course.
-    return nil unless can_view_version?(user) && !user.assigned_course?(self)
+    # No redirect unless user is allowed to view this course version, they are not assigned to the course,
+    # and it is versioned.
+    return nil unless can_view_version?(user) && !user.assigned_course?(self) && version_year
 
     # Redirect user to the latest assigned course in this course family,
     # if one exists and it is newer than the current course.
     latest_assigned_version = Course.latest_assigned_version(family_name, user)
-    return nil unless latest_assigned_version.present? && latest_assigned_version.version_year > version_year
+    latest_assigned_version_year = latest_assigned_version&.version_year
+    return nil unless latest_assigned_version_year && latest_assigned_version_year > version_year
     latest_assigned_version.link
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -451,11 +451,14 @@ class Script < ActiveRecord::Base
     return true unless user.student?
 
     # A student can view the script version if...
-    # it is the latest stable version, they are assigned to it, or they have progress in it.
-    latest_script_version = Script.latest_stable_version(family_name, locale: locale)
+    # 1) it is the latest stable version in English, 2) it is the latest stable version in their locale,
+    # 3) they are assigned to it, 4) or they have progress in it.
+    return true if Script.latest_stable_version(family_name) == self
+
+    latest_stable_version_in_locale = Script.latest_stable_version(family_name, locale: locale)
     has_progress = user.scripts.include?(self)
 
-    latest_script_version == self || user.assigned_script?(self) || has_progress
+    latest_stable_version_in_locale == self || user.assigned_script?(self) || has_progress
   end
 
   # @param family_name [String] The family name for a script family.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -434,11 +434,15 @@ class Script < ActiveRecord::Base
     # No redirect unless user is allowed to view this script version and they are not already assigned to this script
     # or the course it belongs to.
     return nil unless can_view_version?(user, locale: locale) && !user.assigned_script?(self)
+    # No redirect if script or its course are not versioned.
+    current_version_year = version_year || course&.version_year
+    return nil unless current_version_year.present?
 
     # Redirect user to the latest assigned script in this family,
     # if one exists and it is newer than the current script.
     latest_assigned_version = Script.latest_assigned_version(family_name, user)
-    return nil unless latest_assigned_version.present? && latest_assigned_version.version_year > version_year
+    latest_assigned_version_year = latest_assigned_version&.version_year || latest_assigned_version&.course&.version_year
+    return nil unless latest_assigned_version_year && latest_assigned_version_year > current_version_year
     latest_assigned_version.link
   end
 

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -298,6 +298,15 @@ class CourseTest < ActiveSupport::TestCase
       section.students << student
       assert_equal csp_2018.link, @csp_2017.redirect_to_course_url(student)
     end
+
+    test 'returns nil if latest assigned course is an older version than the current course' do
+      Course.any_instance.stubs(:can_view_version?).returns(true)
+      csp_2018 = create(:course, name: 'csp-2018', family_name: 'csp', version_year: '2018')
+      section = create :section, course: @csp_2017
+      student = create :student
+      section.students << student
+      assert_nil csp_2018.redirect_to_course_url(student)
+    end
   end
 
   class CanViewVersion < ActiveSupport::TestCase

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -414,14 +414,25 @@ class ScriptTest < ActiveSupport::TestCase
     assert_nil script.redirect_to_script_url(student)
   end
 
+  test 'returns nil if latest assigned script is an older version than the current script' do
+    Script.any_instance.stubs(:can_view_version?).returns(true)
+    student = create :student
+    csp1_2017 = create(:script, name: 'csp1-2017', family_name: 'csp', version_year: '2017')
+    csp1_2018 = create(:script, name: 'csp1-2018', family_name: 'csp', version_year: '2018')
+    section = create :section, script: csp1_2017
+    section.students << student
+
+    assert_nil csp1_2018.redirect_to_script_url(student)
+  end
+
   test 'redirect_to_script_url returns script url of latest assigned script version in family for script belonging to course family' do
     Script.any_instance.stubs(:can_view_version?).returns(true)
     student = create :student
     csp_2017 = create(:course, name: 'csp-2017', family_name: 'csp', version_year: '2017')
-    csp1_2017 = create(:script, name: 'csp1-2017', family_name: 'csp')
+    csp1_2017 = create(:script, name: 'csp1-2017', family_name: 'csp', version_year: '2017')
     create :course_script, course: csp_2017, script: csp1_2017, position: 1
     csp_2018 = create(:course, name: 'csp-2018', family_name: 'csp', version_year: '2018')
-    csp1_2018 = create(:script, name: 'csp1-2018', family_name: 'csp')
+    csp1_2018 = create(:script, name: 'csp1-2018', family_name: 'csp', version_year: '2018')
     create :course_script, course: csp_2018, script: csp1_2018, position: 1
     section = create :section, course: csp_2018
     section.students << student

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -429,10 +429,10 @@ class ScriptTest < ActiveSupport::TestCase
     Script.any_instance.stubs(:can_view_version?).returns(true)
     student = create :student
     csp_2017 = create(:course, name: 'csp-2017', family_name: 'csp', version_year: '2017')
-    csp1_2017 = create(:script, name: 'csp1-2017', family_name: 'csp', version_year: '2017')
+    csp1_2017 = create(:script, name: 'csp1-2017', family_name: 'csp')
     create :course_script, course: csp_2017, script: csp1_2017, position: 1
     csp_2018 = create(:course, name: 'csp-2018', family_name: 'csp', version_year: '2018')
-    csp1_2018 = create(:script, name: 'csp1-2018', family_name: 'csp', version_year: '2018')
+    csp1_2018 = create(:script, name: 'csp1-2018', family_name: 'csp')
     create :course_script, course: csp_2018, script: csp1_2018, position: 1
     section = create :section, course: csp_2018
     section.students << student

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -446,12 +446,13 @@ class ScriptTest < ActiveSupport::TestCase
     assert script.can_view_version?(teacher)
   end
 
-  test 'can_view_version? is true if script is latest stable version in student locale' do
-    script = create :script, name: 'my-script'
-    Script.stubs(:latest_stable_version).returns(script)
+  test 'can_view_version? is true if script is latest stable version in student locale or in English' do
+    latest_in_english = create :script, name: 'english-only-script', family_name: 'courseg', version_year: '2018', is_stable: true, supported_locales: []
+    latest_in_locale = create :script, name: 'localized-script', family_name: 'courseg', version_year: '2017', is_stable: true, supported_locales: ['it-it']
     student = create :student
 
-    script.can_view_version?(student)
+    assert latest_in_english.can_view_version?(student, locale: 'it-it')
+    assert latest_in_locale.can_view_version?(student, locale: 'it-it')
   end
 
   test 'can_view_version? is true if student is assigned to script' do
@@ -459,7 +460,7 @@ class ScriptTest < ActiveSupport::TestCase
     student = create :student
     student.expects(:assigned_script?).returns(true)
 
-    script.can_view_version?(student)
+    assert script.can_view_version?(student)
   end
 
   test 'can_view_version? is true if student has progress in script' do
@@ -467,7 +468,7 @@ class ScriptTest < ActiveSupport::TestCase
     student = create :student
     student.scripts << script
 
-    script.can_view_version?(student)
+    assert script.can_view_version?(student)
   end
 
   test 'self.latest_stable_version is nil if no script versions in family are stable in locale' do


### PR DESCRIPTION
Implements the following feedback from Amanda & Poorva (also outlined in [this doc](https://docs.google.com/document/d/1DfYNku2iC5QuBd9EX2OxDY0nhLbCyfhGJPmNuzXrMO8/edit?usp=sharing)):
- Redirect notification is using “internal” language “script.” Expected: “It looks like you accidentally went to an outdated version of the course...”
- Always allow students to visit the latest stable version of a course/script, even if it isn't supported in their locale. Examples:
  - If I am in spanish and go directly to the newest version of Course A (2018), this redirects to Course A 2017 Spanish (which is the latest stable for Spanish). Expected: we should take you to the 2018 version even if we need to fall-back to english to give you that version. 
  - I was assigned to the 2017 version of CSP, i’m in a lesson and i try to go to csp 2018 and I get the blocking dialog. Expected: I should always be able to go to the newer version if i type it in manually.

Basically, we only ever want to redirect (or ask the user to redirect) to a _newer_ version of a course/script -- never an older one.