### PR TITLE
show unsubmit button when level is submitted but not submittable

### DIFF
--- a/apps/src/templates/CompletionButton.jsx
+++ b/apps/src/templates/CompletionButton.jsx
@@ -41,7 +41,7 @@ class CompletionButton extends Component {
       return <div/>;
     }
 
-    if (this.props.isSubmittable) {
+    if (this.props.isSubmittable || this.props.isSubmitted) {
       if (this.props.isSubmitted) {
         id = 'unsubmitButton';
         contents = msg.unsubmit();

--- a/apps/test/unit/applab/CompletionButtonTest.js
+++ b/apps/test/unit/applab/CompletionButtonTest.js
@@ -33,6 +33,22 @@ describe('CompletionButton', () => {
     expect(button.text()).to.equal('Unsubmit');
   });
 
+  // It is possible for users to get into a state where the level is submitted
+  // but not submittable. Make sure we show the Unsubmit button in this case.
+  it('non-project level, is not submittable, but is submitted', () => {
+    const completionButton = mount(
+      <CompletionButton
+        isProjectLevel={false}
+        isSubmittable={false}
+        isSubmitted={true}
+      />
+    );
+    const button = completionButton.find('button');
+    expect(button).to.have.length(1);
+    expect(button.props().id).to.equal('unsubmitButton');
+    expect(button.text()).to.equal('Unsubmit');
+  });
+
   it('non-project level, cant submit', () => {
     const completionButton = mount(
       <CompletionButton


### PR DESCRIPTION
Addresses https://codeorg.zendesk.com/agent/tickets/224195 . The user cannot see the unsubmit button because we only show submit/unsubmit if the user belongs to a section (EDIT: updated bad link): https://github.com/code-dot-org/code-dot-org/blob/a855633cac7dfd0bad5c9022eda08deee3ef37cf/dashboard/app/helpers/levels_helper.rb#L576-L578

The solution here is to show the unsubmit button if the level has been submitted, even if it is not "submittable". 