### PR TITLE
Course versioning redirect feedback

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverview.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverview.jsx
@@ -17,6 +17,7 @@ import { resourceShape } from '@cdo/apps/templates/courseOverview/resourceType';
 import { hasLockableStages } from '@cdo/apps/code-studio/progressRedux';
 import ScriptOverviewHeader from './ScriptOverviewHeader';
 import { isScriptHiddenForSection } from '@cdo/apps/code-studio/hiddenStageRedux';
+import dismissVersionRedirect from '@cdo/apps/util/dismissVersionRedirect';
 
 /**
  * Stage progress component used in level header and script overview.
@@ -63,6 +64,7 @@ class ScriptOverview extends React.Component {
   }
 
   onCloseRedirectDialog = () => {
+    dismissVersionRedirect.onDismissRedirectDialog(this.props.scriptName);
     this.setState({
       showRedirectDialog: false,
     });
@@ -108,7 +110,7 @@ class ScriptOverview extends React.Component {
       <div>
         {onOverviewPage && (
           <div>
-            {redirectScriptUrl &&
+            {redirectScriptUrl && !dismissVersionRedirect.dismissedRedirectDialog(scriptName) &&
               <RedirectDialog
                 isOpen={this.state.showRedirectDialog}
                 details={i18n.assignedToNewerVersion()}

--- a/apps/src/code-studio/components/progress/ScriptOverview.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverview.jsx
@@ -17,7 +17,7 @@ import { resourceShape } from '@cdo/apps/templates/courseOverview/resourceType';
 import { hasLockableStages } from '@cdo/apps/code-studio/progressRedux';
 import ScriptOverviewHeader from './ScriptOverviewHeader';
 import { isScriptHiddenForSection } from '@cdo/apps/code-studio/hiddenStageRedux';
-import dismissVersionRedirect from '@cdo/apps/util/dismissVersionRedirect';
+import { onDismissRedirectDialog, dismissedRedirectDialog } from '@cdo/apps/util/dismissVersionRedirect';
 
 /**
  * Stage progress component used in level header and script overview.
@@ -67,7 +67,7 @@ class ScriptOverview extends React.Component {
   onCloseRedirectDialog = () => {
     const {courseName, scriptName} = this.props;
     // Use course name if available, and script name if not.
-    dismissVersionRedirect.onDismissRedirectDialog(courseName || scriptName);
+    onDismissRedirectDialog(courseName || scriptName);
     this.setState({
       showRedirectDialog: false,
     });
@@ -100,7 +100,7 @@ class ScriptOverview extends React.Component {
       courseName,
     } = this.props;
 
-    const displayRedirectDialog = redirectScriptUrl && !dismissVersionRedirect.dismissedRedirectDialog(courseName || scriptName);
+    const displayRedirectDialog = redirectScriptUrl && !dismissedRedirectDialog(courseName || scriptName);
 
     let scriptProgress = NOT_STARTED;
     if (scriptCompleted) {

--- a/apps/src/code-studio/components/progress/ScriptOverview.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverview.jsx
@@ -36,6 +36,7 @@ class ScriptOverview extends React.Component {
       version_year: PropTypes.string.isRequired,
       version_title: PropTypes.string.isRequired,
     })).isRequired,
+    courseName: PropTypes.string,
 
     // redux provided
     perLevelProgress: PropTypes.object.isRequired,
@@ -64,7 +65,9 @@ class ScriptOverview extends React.Component {
   }
 
   onCloseRedirectDialog = () => {
-    dismissVersionRedirect.onDismissRedirectDialog(this.props.scriptName);
+    const {courseName, scriptName} = this.props;
+    // Use course name if available, and script name if not.
+    dismissVersionRedirect.onDismissRedirectDialog(courseName || scriptName);
     this.setState({
       showRedirectDialog: false,
     });
@@ -94,7 +97,10 @@ class ScriptOverview extends React.Component {
       versions,
       hiddenStageState,
       selectedSectionId,
+      courseName,
     } = this.props;
+
+    const displayRedirectDialog = redirectScriptUrl && !dismissVersionRedirect.dismissedRedirectDialog(courseName || scriptName);
 
     let scriptProgress = NOT_STARTED;
     if (scriptCompleted) {
@@ -110,7 +116,7 @@ class ScriptOverview extends React.Component {
       <div>
         {onOverviewPage && (
           <div>
-            {redirectScriptUrl && !dismissVersionRedirect.dismissedRedirectDialog(scriptName) &&
+            {displayRedirectDialog &&
               <RedirectDialog
                 isOpen={this.state.showRedirectDialog}
                 details={i18n.assignedToNewerVersion()}
@@ -125,6 +131,7 @@ class ScriptOverview extends React.Component {
               showRedirectWarning={showRedirectWarning}
               showHiddenUnitWarning={isHiddenUnit}
               versions={versions}
+              courseName={courseName}
             />
             {!professionalLearningCourse && viewAs === ViewType.Teacher &&
                 (scriptHasLockableStages || scriptAllowsHiddenStages) &&

--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -10,7 +10,7 @@ import { announcementShape, VisibilityType } from '@cdo/apps/code-studio/scriptA
 import Notification, { NotificationType } from '@cdo/apps/templates/Notification';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
-import dismissVersionRedirect from '@cdo/apps/util/dismissVersionRedirect';
+import { dismissedRedirectWarning, onDismissRedirectWarning } from '@cdo/apps/util/dismissVersionRedirect';
 
 const SCRIPT_OVERVIEW_WIDTH = 1100;
 
@@ -153,7 +153,7 @@ class ScriptOverviewHeader extends Component {
       courseName,
     } = this.props;
 
-    const displayVersionWarning = showRedirectWarning && !dismissVersionRedirect.dismissedRedirectWarning(courseName || scriptName);
+    const displayVersionWarning = showRedirectWarning && !dismissedRedirectWarning(courseName || scriptName);
 
     let versionWarningDetails;
     if (showCourseUnitVersionWarning) {
@@ -183,7 +183,7 @@ class ScriptOverviewHeader extends Component {
             details={i18n.redirectCourseVersionWarningDetails()}
             dismissible={true}
             width={SCRIPT_OVERVIEW_WIDTH}
-            onDismiss={() => dismissVersionRedirect.onDismissRedirectWarning(courseName || scriptName)}
+            onDismiss={() => onDismissRedirectWarning(courseName || scriptName)}
           />
         }
         {versionWarningDetails &&

--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -10,10 +10,7 @@ import { announcementShape, VisibilityType } from '@cdo/apps/code-studio/scriptA
 import Notification, { NotificationType } from '@cdo/apps/templates/Notification';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
-
-// A session variable storing a comma-delimited list of course/script names for which
-// the user has already dismissed the version redirect warning.
-const DISMISSED_REDIRECT_WARNINGS_SESSION_KEY = 'dismissedRedirectWarnings';
+import dismissVersionRedirect from '@cdo/apps/util/dismissVersionRedirect';
 
 const SCRIPT_OVERVIEW_WIDTH = 1100;
 
@@ -138,21 +135,6 @@ class ScriptOverviewHeader extends Component {
     return currentAnnouncements;
   };
 
-    dismissedRedirectWarning = () => {
-      const dismissedRedirectWarnings = sessionStorage.getItem(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY);
-      return (dismissedRedirectWarnings || '').includes(this.props.scriptName);
-    };
-
-    onDismissRedirectWarning = () => {
-      let dismissedRedirectWarnings = sessionStorage.getItem(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY);
-      if (dismissedRedirectWarnings) {
-        dismissedRedirectWarnings += `,${this.props.scriptName}`;
-      } else {
-        dismissedRedirectWarnings = this.props.scriptName;
-      }
-      sessionStorage.setItem(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY, dismissedRedirectWarnings);
-    };
-
   render() {
     const {
       plcHeaderProps,
@@ -192,14 +174,14 @@ class ScriptOverviewHeader extends Component {
             width={SCRIPT_OVERVIEW_WIDTH}
           />
         }
-        {(showRedirectWarning && !this.dismissedRedirectWarning()) &&
+        {(showRedirectWarning && !dismissVersionRedirect.dismissedRedirectWarning(scriptName)) &&
           <Notification
             type={NotificationType.warning}
             notice=""
             details={i18n.redirectCourseVersionWarningDetails()}
             dismissible={true}
             width={SCRIPT_OVERVIEW_WIDTH}
-            onDismiss={this.onDismissRedirectWarning}
+            onDismiss={() => dismissVersionRedirect.onDismissRedirectWarning(scriptName)}
           />
         }
         {versionWarningDetails &&

--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -76,6 +76,7 @@ class ScriptOverviewHeader extends Component {
       version_title: PropTypes.string.isRequired,
     })).isRequired,
     showHiddenUnitWarning: PropTypes.bool,
+    courseName: PropTypes.string,
   };
 
   componentDidMount() {
@@ -149,9 +150,10 @@ class ScriptOverviewHeader extends Component {
       showRedirectWarning,
       versions,
       showHiddenUnitWarning,
+      courseName,
     } = this.props;
 
-
+    const displayVersionWarning = showRedirectWarning && !dismissVersionRedirect.dismissedRedirectWarning(courseName || scriptName);
 
     let versionWarningDetails;
     if (showCourseUnitVersionWarning) {
@@ -174,14 +176,14 @@ class ScriptOverviewHeader extends Component {
             width={SCRIPT_OVERVIEW_WIDTH}
           />
         }
-        {(showRedirectWarning && !dismissVersionRedirect.dismissedRedirectWarning(scriptName)) &&
+        {displayVersionWarning &&
           <Notification
             type={NotificationType.warning}
             notice=""
             details={i18n.redirectCourseVersionWarningDetails()}
             dismissible={true}
             width={SCRIPT_OVERVIEW_WIDTH}
-            onDismiss={() => dismissVersionRedirect.onDismissRedirectWarning(scriptName)}
+            onDismiss={() => dismissVersionRedirect.onDismissRedirectWarning(courseName || scriptName)}
           />
         }
         {versionWarningDetails &&

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -150,6 +150,7 @@ progress.renderCourseProgress = function (scriptData) {
         showRedirectWarning={scriptData.show_redirect_warning}
         redirectScriptUrl={scriptData.redirect_script_url}
         versions={scriptData.versions}
+        courseName={scriptData.course_name}
       />
     </Provider>,
     mountPoint

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -10,7 +10,12 @@ import VerifiedResourcesNotification from './VerifiedResourcesNotification';
 import * as utils from '../../utils';
 import { queryParams } from '../../code-studio/utils';
 import i18n from '@cdo/locale';
-import dismissVersionRedirect from '@cdo/apps/util/dismissVersionRedirect';
+import {
+  onDismissRedirectDialog,
+  dismissedRedirectDialog,
+  onDismissRedirectWarning,
+  dismissedRedirectWarning
+} from '@cdo/apps/util/dismissVersionRedirect';
 import RedirectDialog from '@cdo/apps/code-studio/components/RedirectDialog';
 import Notification, { NotificationType } from '@cdo/apps/templates/Notification';
 import color from '@cdo/apps/util/color';
@@ -107,7 +112,7 @@ export default class CourseOverview extends Component {
   };
 
   onCloseRedirectDialog = () => {
-    dismissVersionRedirect.onDismissRedirectDialog(this.props.name);
+    onDismissRedirectDialog(this.props.name);
     this.setState({
       showRedirectDialog: false,
     });
@@ -147,7 +152,7 @@ export default class CourseOverview extends Component {
 
     return (
       <div style={mainStyle}>
-        {redirectToCourseUrl && !dismissVersionRedirect.dismissedRedirectDialog(name) &&
+        {redirectToCourseUrl && !dismissedRedirectDialog(name) &&
           <RedirectDialog
             isOpen={this.state.showRedirectDialog}
             details={i18n.assignedToNewerVersion()}
@@ -156,13 +161,13 @@ export default class CourseOverview extends Component {
             redirectButtonText={i18n.goToAssignedVersion()}
           />
         }
-        {(showRedirectWarning && !dismissVersionRedirect.dismissedRedirectWarning(name)) &&
+        {(showRedirectWarning && !dismissedRedirectWarning(name)) &&
           <Notification
             type={NotificationType.warning}
             notice=""
             details={i18n.redirectCourseVersionWarningDetails()}
             dismissible={true}
-            onDismiss={() => dismissVersionRedirect.onDismissRedirectWarning(name)}
+            onDismiss={() => onDismissRedirectWarning(name)}
           />
         }
         {showVersionWarning &&

--- a/apps/src/util/dismissVersionRedirect.js
+++ b/apps/src/util/dismissVersionRedirect.js
@@ -1,25 +1,23 @@
-const dismissVersionRedirect = module.exports;
-
 // A session variable storing a comma-delimited list of course/script names for which:
 // ...the user has already dismissed the version redirect warning.
 const DISMISSED_REDIRECT_WARNINGS_SESSION_KEY = 'dismissedRedirectWarnings';
 // ...the user has already dismissed the version redirect dialog (<RedirectDialog/> component).
 const DISMISSED_REDIRECT_DIALOGS_SESSION_KEY = 'dismissedRedirectDialogs';
 
-dismissVersionRedirect.dismissedRedirect = function (sessionKey, name) {
+export const dismissedRedirect = (sessionKey, name) => {
   const dismissedRedirects = sessionStorage.getItem(sessionKey);
-  return (dismissedRedirects || '').includes(name);
+  return (dismissedRedirects || '').split(',').includes(name);
 };
 
-dismissVersionRedirect.dismissedRedirectWarning = function (name) {
-  return this.dismissedRedirect(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY, name);
+export const dismissedRedirectWarning = (name) => {
+  return dismissedRedirect(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY, name);
 };
 
-dismissVersionRedirect.dismissedRedirectDialog = function (name) {
-  return this.dismissedRedirect(DISMISSED_REDIRECT_DIALOGS_SESSION_KEY, name);
+export const dismissedRedirectDialog = (name) => {
+  return dismissedRedirect(DISMISSED_REDIRECT_DIALOGS_SESSION_KEY, name);
 };
 
-dismissVersionRedirect.onDismissRedirect = function (sessionKey, name) {
+export const onDismissRedirect = (sessionKey, name) => {
   let dismissedRedirects = sessionStorage.getItem(sessionKey);
   if (dismissedRedirects) {
     dismissedRedirects += `,${name}`;
@@ -29,10 +27,10 @@ dismissVersionRedirect.onDismissRedirect = function (sessionKey, name) {
   sessionStorage.setItem(sessionKey, dismissedRedirects);
 };
 
-dismissVersionRedirect.onDismissRedirectWarning = function (name) {
-  return this.onDismissRedirect(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY, name);
+export const onDismissRedirectWarning = (name) => {
+  return onDismissRedirect(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY, name);
 };
 
-dismissVersionRedirect.onDismissRedirectDialog = function (name) {
-  return this.onDismissRedirect(DISMISSED_REDIRECT_DIALOGS_SESSION_KEY, name);
+export const onDismissRedirectDialog = (name) => {
+  return onDismissRedirect(DISMISSED_REDIRECT_DIALOGS_SESSION_KEY, name);
 };

--- a/apps/src/util/dismissVersionRedirect.js
+++ b/apps/src/util/dismissVersionRedirect.js
@@ -1,0 +1,38 @@
+const dismissVersionRedirect = module.exports;
+
+// A session variable storing a comma-delimited list of course/script names for which:
+// ...the user has already dismissed the version redirect warning.
+const DISMISSED_REDIRECT_WARNINGS_SESSION_KEY = 'dismissedRedirectWarnings';
+// ...the user has already dismissed the version redirect dialog (<RedirectDialog/> component).
+const DISMISSED_REDIRECT_DIALOGS_SESSION_KEY = 'dismissedRedirectDialogs';
+
+dismissVersionRedirect.dismissedRedirect = function (sessionKey, name) {
+  const dismissedRedirects = sessionStorage.getItem(sessionKey);
+  return (dismissedRedirects || '').includes(name);
+};
+
+dismissVersionRedirect.dismissedRedirectWarning = function (name) {
+  return this.dismissedRedirect(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY, name);
+};
+
+dismissVersionRedirect.dismissedRedirectDialog = function (name) {
+  return this.dismissedRedirect(DISMISSED_REDIRECT_DIALOGS_SESSION_KEY, name);
+};
+
+dismissVersionRedirect.onDismissRedirect = function (sessionKey, name) {
+  let dismissedRedirects = sessionStorage.getItem(sessionKey);
+  if (dismissedRedirects) {
+    dismissedRedirects += `,${name}`;
+  } else {
+    dismissedRedirects = name;
+  }
+  sessionStorage.setItem(sessionKey, dismissedRedirects);
+};
+
+dismissVersionRedirect.onDismissRedirectWarning = function (name) {
+  return this.onDismissRedirect(DISMISSED_REDIRECT_WARNINGS_SESSION_KEY, name);
+};
+
+dismissVersionRedirect.onDismissRedirectDialog = function (name) {
+  return this.onDismissRedirect(DISMISSED_REDIRECT_DIALOGS_SESSION_KEY, name);
+};

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -375,7 +375,6 @@ export function trySetLocalStorage(item, value) {
   } catch (e) {
     return false;
   }
-
 }
 
 export function tryGetSessionStorage(key, defaultValue) {

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -1,5 +1,5 @@
 -# This variable will get any data we need to pass along to scriptOverview.js
-- script_data = @script.summarize(true, current_user).merge({show_redirect_warning: show_redirect_warning, redirect_script_url: redirect_script_url})
+- script_data = @script.summarize(true, current_user).merge({course_name: @script.course&.name, show_redirect_warning: show_redirect_warning, redirect_script_url: redirect_script_url})
 - scriptOverviewData = { scriptData: script_data }
 - if @script.professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
   -  scriptOverviewData[:plcBreadcrumb] = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.get_url_name)}


### PR DESCRIPTION
### What it does
- Refactors helpers for dismissing version warnings/dialogs into a helper in utils
- Stores a session cookie when a user dismisses a version dialog
- We want the dismissal of a script version dialog to count for all scripts in that course, so store the course name in the session cookie wherever possible

Implements the following feedback (from [this doc](https://docs.google.com/document/d/1DfYNku2iC5QuBd9EX2OxDY0nhLbCyfhGJPmNuzXrMO8/edit?usp=sharing)):
- Make sure that the above “you’re not in the right place” dialog doesn’t show up again when I dig further into the course / unit. It is currently (needs a session cookie?)
- (P2) Go to old version of CSP (2017) and saw the version warning (correct), but when I clicked on a unit, still saw the warning on the unit page. Expected: The warning should be hidden at this point because I didn’t try to go to the old version.