### PR TITLE
use quotes to prevent ActionMailer from choking on commas in names

### DIFF
--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -386,11 +386,11 @@ module Pd::Application
       return nil unless regional_partner&.contact_email_with_backup.present?
 
       if regional_partner.contact_name.present? && regional_partner.contact_email.present?
-        "#{regional_partner.contact_name} <#{regional_partner.contact_email}>"
+        "\"#{regional_partner.contact_name}\" <#{regional_partner.contact_email}>"
       elsif regional_partner.program_managers&.first.present?
-        "#{regional_partner.program_managers.first.name} <#{regional_partner.program_managers.first.email}>"
+        "\"#{regional_partner.program_managers.first.name}\" <#{regional_partner.program_managers.first.email}>"
       elsif regional_partner.contact&.email.present?
-        "#{regional_partner.contact.name} <#{regional_partner.contact.email}>"
+        "\"#{regional_partner.contact.name}\" <#{regional_partner.contact.email}>"
       end
     end
 

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -144,11 +144,11 @@ module Pd::Application
     end
 
     def formatted_teacher_email
-      "#{teacher_full_name} <#{user.email}>"
+      "\"#{teacher_full_name}\" <#{user.email}>"
     end
 
     def formatted_principal_email
-      "#{principal_greeting} <#{principal_email}>"
+      "\"#{principal_greeting}\" <#{principal_email}>"
     end
 
     def effective_regional_partner_name

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181128012054) do
+ActiveRecord::Schema.define(version: 20190111004745) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -326,16 +326,16 @@ module Pd::Application
 
       # old contact field
       partner.contact = contact
-      assert_equal "#{contact.name} <#{contact.email}>", application.formatted_partner_contact_email
+      assert_equal "\"#{contact.name}\" <#{contact.email}>", application.formatted_partner_contact_email
 
       # program manager but no contact_name or contact_email
       program_manager = (create :regional_partner_program_manager, regional_partner: partner).program_manager
-      assert_equal "#{program_manager.name} <#{program_manager.email}>", application.formatted_partner_contact_email
+      assert_equal "\"#{program_manager.name}\" <#{program_manager.email}>", application.formatted_partner_contact_email
 
       # name and email
       partner.contact_name = 'We Teach Code'
       partner.contact_email = 'we_teach_code@ex.net'
-      assert_equal 'We Teach Code <we_teach_code@ex.net>', application.formatted_partner_contact_email
+      assert_equal "\"We Teach Code\" <we_teach_code@ex.net>", application.formatted_partner_contact_email
     end
   end
 end

--- a/dashboard/test/models/pd/application/teacher1920_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher1920_application_test.rb
@@ -529,16 +529,16 @@ module Pd::Application
 
       # old contact field
       partner.contact = contact
-      assert_equal "#{contact.name} <#{contact.email}>", application.formatted_partner_contact_email
+      assert_equal "\"#{contact.name}\" <#{contact.email}>", application.formatted_partner_contact_email
 
       # program manager but no contact_name or contact_email
       program_manager = (create :regional_partner_program_manager, regional_partner: partner).program_manager
-      assert_equal "#{program_manager.name} <#{program_manager.email}>", application.formatted_partner_contact_email
+      assert_equal "\"#{program_manager.name}\" <#{program_manager.email}>", application.formatted_partner_contact_email
 
       # name and email
       partner.contact_name = 'We Teach Code'
       partner.contact_email = 'we_teach_code@ex.net'
-      assert_equal 'We Teach Code <we_teach_code@ex.net>', application.formatted_partner_contact_email
+      assert_equal "\"We Teach Code\" <we_teach_code@ex.net>", application.formatted_partner_contact_email
     end
 
     test 'test non course dynamically required fields' do


### PR DESCRIPTION
Fix for this HB error: https://app.honeybadger.io/projects/3240/faults/43493291/5fa0ac12-1906-11e9-8f2a-6369fca72b51#notice-summary