### PR TITLE
Remove educate box

### DIFF
--- a/pegasus/sites.v3/code.org/views/educate_box.haml
+++ b/pegasus/sites.v3/code.org/views/educate_box.haml
@@ -1,9 +1,0 @@
--color ||= "#59b9dc"
--item[:button_s] ||= 'Learn more'
-.educate-container.col-32
-  .educate-box{style: "background-color: #{color};"}
-    %h1.educate-h1= item[:title_s]
-    %p.educate-p= item[:description_t]
-    - unless item[:url_s].nil_or_empty?
-      %a{:href => item[:url_s]}
-        %button.educate-button= item[:button_s]


### PR DESCRIPTION
follow-up to https://github.com/code-dot-org/code-dot-org/pull/26592, https://github.com/code-dot-org/code-dot-org/pull/26594, and https://github.com/code-dot-org/code-dot-org/pull/26597