### PR TITLE
Fixing NoMethodError: undefined method `+' for nil:NilClass

### DIFF
--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -99,7 +99,20 @@ class SchoolStatsByYear < ActiveRecord::Base
   end
 
   def urm_percent
-    percent_of_students(student_am_count + student_hi_count + student_bl_count + student_hp_count)
+    total_urm_students = 0
+    if student_am_count.present?
+      total_urm_students += student_am_count
+    end
+    if student_hi_count.present?
+      total_urm_students += student_hi_count
+    end
+    if student_bl_count.present?
+      total_urm_students += student_bl_count
+    end
+    if student_hp_count.present?
+      total_urm_students += student_hp_count
+    end
+    percent_of_students(total_urm_students)
   end
 
   # returns what percent "count" is of the total student enrollment

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -99,20 +99,7 @@ class SchoolStatsByYear < ActiveRecord::Base
   end
 
   def urm_percent
-    total_urm_students = 0
-    if student_am_count.present?
-      total_urm_students += student_am_count
-    end
-    if student_hi_count.present?
-      total_urm_students += student_hi_count
-    end
-    if student_bl_count.present?
-      total_urm_students += student_bl_count
-    end
-    if student_hp_count.present?
-      total_urm_students += student_hp_count
-    end
-    percent_of_students(total_urm_students)
+    percent_of_students([student_am_count, student_hi_count, student_bl_count, student_hp_count].compact.reduce(:+))
   end
 
   # returns what percent "count" is of the total student enrollment

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -104,6 +104,19 @@ class SchoolTest < ActiveSupport::TestCase
     assert_equal(true, school.high_needs?)
   end
 
+  test 'urm school stats missing counts' do
+    school = create :school
+    stats_by_year =
+      school.school_stats_by_year << SchoolStatsByYear.new(
+        school_id: school.id,
+        school_year: '1998-1999',
+        students_total: 4,
+        student_bl_count: 2, 
+      )
+    school.save!
+    assert_equal(50.0,stats_by_year.first.urm_percent)
+  end
+
   test 'normalize_school_id works for short ids without leading zeros' do
     normalized_id = School.normalize_school_id("123456")
     assert_equal "123456", normalized_id

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -111,10 +111,10 @@ class SchoolTest < ActiveSupport::TestCase
         school_id: school.id,
         school_year: '1998-1999',
         students_total: 4,
-        student_bl_count: 2, 
+        student_bl_count: 2
       )
     school.save!
-    assert_equal(50.0,stats_by_year.first.urm_percent)
+    assert_equal(50.0, stats_by_year.first.urm_percent)
   end
 
   test 'normalize_school_id works for short ids without leading zeros' do


### PR DESCRIPTION
Fixing Honeybadger error that occurs when trying to generate a csv when some student counts are nil and some aren't.