### PR TITLE
Track how often TTS is played

### DIFF
--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -4,6 +4,7 @@ import React, {PropTypes} from 'react';
 import { connect } from 'react-redux';
 import trackEvent from '../../util/trackEvent';
 import color from '../../util/color';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 // TODO (elijah): have these constants shared w/dashboard
 const VOICES = {
@@ -88,7 +89,12 @@ class InlineAudio extends React.Component {
     textToSpeechEnabled: PropTypes.bool,
     src: PropTypes.string,
     message: PropTypes.string,
-    style: PropTypes.object
+    style: PropTypes.object,
+
+    // Provided by redux
+    // To Log TTS usage
+    puzzleNumber: PropTypes.number,
+    userId: PropTypes.number
   };
 
   state = {
@@ -169,6 +175,19 @@ class InlineAudio extends React.Component {
   playAudio() {
     this.getAudioElement().play();
     this.setState({ playing: true });
+    firehoseClient.putRecord(
+      {
+        study: 'tts-play',
+        study_group: 'v1',
+        event: 'play',
+        data_string: this.props.src,
+        data_json: JSON.stringify({
+          userId: this.props.userId,
+          puzzleNumber: this.props.puzzleNumber,
+          src: this.props.src
+        }),
+      }
+    );
   }
 
   pauseAudio() {
@@ -221,5 +240,7 @@ export default connect(function propsFromStore(state) {
     assetUrl: state.pageConstants.assetUrl,
     textToSpeechEnabled: state.pageConstants.textToSpeechEnabled || state.pageConstants.isK1,
     locale: state.pageConstants.locale,
+    userId: state.pageConstants.userId,
+    puzzleNumber: state.pageConstants.puzzleNumber
   };
 })(StatelessInlineAudio);


### PR DESCRIPTION
We have anecdotal evidence that TTS is used by students and teachers have requested more of it.
This change will help us build a set of data to support or refute these anecdotes, answer questions about TTS usage, and measure changes in TTS behavior as we extend TTS support.

This change tracks when a user selects play on a TTS audio file and records which file got played (which is associated with a single level), the puzzle number it was played on (in case a single level is used in multiple scripts), and the user id of who played it.

cc: @ryansloan 