### PR TITLE
join #infra-production when running bin/dotd script

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -515,6 +515,7 @@ def main
   Slack.join_room('deploy-status')
   Slack.join_room('infra-staging')
   Slack.join_room('infra-test')
+  Slack.join_room('infra-production')
   Slack.join_room('levelbuilder')
 
   puts_script_intro


### PR DESCRIPTION
this will make it so that the DOTD will see the `@` mention in slack when a Deploy To Production fails.