### PR TITLE
recover gracefully when admin views deleted project

### DIFF
--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -210,7 +210,7 @@ class StorageApps
     _owner, storage_app_id = storage_decrypt_channel_id(channel_id)
 
     row = @table.where(id: storage_app_id).exclude(state: 'deleted').first
-    raise NotFound, "channel `#{channel_id}` not found" unless row
+    return false unless row
 
     row[:skip_content_moderation]
   end


### PR DESCRIPTION
### Background

https://app.honeybadger.io/projects/3240/faults/44663286 indicates that admins are getting 500 when following urls to deleted projects. This is because the admin panel displays content moderation info https://github.com/code-dot-org/code-dot-org/blob/f9bf7c898ebe16d0426175c7188151691f28cc5b/dashboard/app/views/levels/_admin.html.haml#L88-L90 and the content moderation logic raises if you check whether a deleted project requires moderation: https://github.com/code-dot-org/code-dot-org/blob/a23e3ca0a096dd07fc94c7e71677a3063f920eed/shared/middleware/helpers/storage_apps.rb#L209-L213

### Description

The solution is to not raise for deleted projects. In the admin panel this suppresses any errors long enough for the page to redirect. This is also harmless for non-admins in production, since an earlier lookup to the project would 404 prior to any 404 being generated by the line modified in this PR: https://github.com/code-dot-org/code-dot-org/blob/6269b4bd42aba22c90b47d3061ff148a635ee69b/shared/middleware/files_api.rb#L875

### Testing

Manually verified that when an admin views a deleted project, they now get redirected to their latest project of that type instead of seeing a 500 error.