### PR TITLE
allow zeros in percent fields

### DIFF
--- a/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Component.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Component.jsx
@@ -354,7 +354,7 @@ export default class PrincipalApproval1920Component extends LabeledFormComponent
     // Sanitize numeric fields (necessary for older browsers that don't
     // automatically enforce numeric inputs)
     ['freeLunchPercent', ...RACE_LIST].forEach((field) => {
-      changes[field] = parseFloat(data[field]);
+      changes[field] = parseFloat(data[field]).toString();
     });
 
     return changes;


### PR DESCRIPTION
In https://github.com/code-dot-org/code-dot-org/pull/26633, I added a step to cast strings input in percent fields to floats, so when principals on browsers that don't enforce `type="number"` input fields enter things like "59%", the `%` sign gets parsed out.

Unfortunately, this means that the data changed from strings to floats; this still works fine except in cases where the teachers enter "0", in which case the falsy data gets stripped from the form.

The simple fix is to just convert the string input to a float then back to a string.