### PR TITLE
Circuit Playground Discount code fixes

### DIFF
--- a/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
@@ -143,7 +143,7 @@ export default class EligibilityChecklist extends React.Component {
               stepName={i18n.eligibilityReqPD()}
               stepStatus={this.props.statusPD}
             >
-              <UnsafeRenderedMarkdown markdown={eligibilityReqPDFail('faketeacheremailTODO@example.com')}/>
+              <UnsafeRenderedMarkdown markdown={eligibilityReqPDFail}/>
             </ValidationStep>
             <ValidationStep
               stepName={i18n.eligibilityReqStudentCount()}
@@ -218,9 +218,9 @@ If you believe the data that we have on your school is inaccurate, please email 
 lunch data from your school.
 `;
 
-const eligibilityReqPDFail = (teacherEmail) => `
-We did not find the email address associated with this account (\`${teacherEmail}\`) under the list of
-people who meet this requirement.
+const eligibilityReqPDFail = `
+We did not find the email address associated with this account under the list of people who meet
+this requirement.
 If you think this is incorrect, please email us at [teacher@code.org](mailto:teacher@code.org).
 `;
 

--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -121,6 +121,7 @@ class MakerController < ApplicationController
   def application_status
     return head :forbidden unless current_user.admin?
     user = User.from_identifier(params.require(:user))
+    return head :not_found unless user
 
     render json: {application: CircuitPlaygroundDiscountApplication.admin_application_status(user)}
   end

--- a/dashboard/app/models/circuit_playground_discount_application.rb
+++ b/dashboard/app/models/circuit_playground_discount_application.rb
@@ -87,7 +87,8 @@ class CircuitPlaygroundDiscountApplication < ApplicationRecord
   # Looks to see if any of the users associated with this studio_person_id are eligibile
   # for our circuit playground discount
   def self.studio_person_pd_eligible?(user)
-    User.where(studio_person_id: user.studio_person_id).any? {|associated_user| user_pd_eligible?(associated_user)}
+    accounts = user.studio_person_id.nil? ? [user] : User.where(studio_person_id: user.studio_person_id)
+    accounts.any? {|associated_user| user_pd_eligible?(associated_user)}
   end
 
   # @return {boolean} true if we have at least one section that meets our eligibility

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -349,6 +349,10 @@ class User < ActiveRecord::Base
     (identifier.to_i.to_s == identifier && where(id: identifier).first) ||
       where(username: identifier).first ||
       find_by_email_or_hashed_email(identifier)
+  rescue ActiveModel::RangeError
+    # Given too large of a user id this can produce a range error
+    # @see https://app.honeybadger.io/projects/3240/faults/44740400
+    nil
   end
 
   def self.find_or_create_teacher(params, invited_by_user, permission = nil)

--- a/dashboard/test/models/circuit_playground_discount_application_test.rb
+++ b/dashboard/test/models/circuit_playground_discount_application_test.rb
@@ -149,6 +149,12 @@ class CircuitPlaygroundDiscountApplicationTest < ActiveSupport::TestCase
     assert_equal true, CircuitPlaygroundDiscountApplication.studio_person_pd_eligible?(user2)
   end
 
+  test 'studio_person_pd_eligible? just checks the one user if they have no studio_person_id' do
+    student = create :student
+    CircuitPlaygroundDiscountApplication.expects(:user_pd_eligible?).with(student).once
+    refute CircuitPlaygroundDiscountApplication.studio_person_pd_eligible?(student)
+  end
+
   test 'application_status for unstarted application' do
     teacher = create :teacher
 

--- a/dashboard/test/models/circuit_playground_discount_application_test.rb
+++ b/dashboard/test/models/circuit_playground_discount_application_test.rb
@@ -134,6 +134,21 @@ class CircuitPlaygroundDiscountApplicationTest < ActiveSupport::TestCase
     assert_equal true, CircuitPlaygroundDiscountApplication.studio_person_pd_eligible?(user2)
   end
 
+  test 'studio_person_pd_eligible? returns true if studio_person_id associated User is approved facilitator' do
+    user1 = create :teacher
+    user2 = create :teacher, studio_person_id: user1.studio_person_id
+
+    DCDO.stubs(:get).
+      with('facilitator_ids_eligible_for_maker_discount', []).
+      returns([user1.id])
+
+    assert_equal true, CircuitPlaygroundDiscountApplication.user_pd_eligible?(user1)
+    assert_equal false, CircuitPlaygroundDiscountApplication.user_pd_eligible?(user2)
+
+    assert_equal true, CircuitPlaygroundDiscountApplication.studio_person_pd_eligible?(user1)
+    assert_equal true, CircuitPlaygroundDiscountApplication.studio_person_pd_eligible?(user2)
+  end
+
   test 'application_status for unstarted application' do
     teacher = create :teacher
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -29,6 +29,30 @@ class UserTest < ActiveSupport::TestCase
     @student = create :student
   end
 
+  test 'from_identifier finds user by id' do
+    student = create :student
+    assert_equal student, User.from_identifier(student.id.to_s)
+  end
+
+  test 'from_identifier finds user by username' do
+    student = create :student
+    assert_equal student, User.from_identifier(student.username)
+  end
+
+  test 'from_identifier finds user by email' do
+    teacher = create :teacher
+    assert_equal teacher, User.from_identifier(teacher.email)
+  end
+
+  test 'from_identifier finds user by hashed_email' do
+    student = create :student, email: 'fakestudentemail@example.com'
+    assert_equal student, User.from_identifier('fakestudentemail@example.com')
+  end
+
+  test 'from_identifier returns nil when id exceeds allowed integer size' do
+    assert_nil User.from_identifier('3423423423')
+  end
+
   test 'make_teachers_21' do
     teacher = create :teacher, birthday: Time.now - 18.years
     assert_equal '21+', teacher.age


### PR DESCRIPTION
Addresses a few issues post-launch today.

- Removes the hard-coded `faketeacheremailTODO@example.com` from some of the feedback text.
- Adds a test confirming that approved facilitators will be able to receive a code from any of their studioperson-linked accounts.
- Addresses three issues seen in Honeybadger with the admin search:
  - [Return 404 instead of 500 when user is not found](https://app.honeybadger.io/projects/3240/faults/44739134)
  - [Fail gracefully if a very large id is given](https://app.honeybadger.io/projects/3240/faults/44740400)
  - [Don't cause a slow query when a user with no studio_person_id is found](https://app.honeybadger.io/projects/3240/faults/44740423)

See also recent pre-launch work:
- https://github.com/code-dot-org/code-dot-org/pull/26382
- https://github.com/code-dot-org/code-dot-org/pull/26679