### PR TITLE
Update tertiary tint color to follow the pattern

### DIFF
--- a/apps/src/gamelab/blocks.js
+++ b/apps/src/gamelab/blocks.js
@@ -32,7 +32,7 @@ const limitedColours = [
   // some "tertiary" colors
   '#ff8800', // ORANGE
   '#8800ff', // PURPLE
-  '#0088ff', // LIGHT BLUE
+  '#00ff88', // LIME
 ];
 
 const customInputTypes = {


### PR DESCRIPTION
Super small fix to make the tertiary tint colors be equally spaced around the color wheel. I verified existing solutions won't be affected (they store the old hex value directly in the XML).

```xml
<block type="Dancelab_setTintInline">
  <title name="SPRITE">dancer1</title>
  <title name="VAL">#0088ff</title>
</block>
```

Before:

![image](https://user-images.githubusercontent.com/413693/51626614-c0fa6680-1ef4-11e9-8e66-9e1f23e54e13.png)

After:

![image](https://user-images.githubusercontent.com/413693/51626577-b344e100-1ef4-11e9-8f96-c0ae49f62837.png)