### PR TITLE
omit empty teacher name from admin search query

### DIFF
--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -24,10 +24,14 @@ class AdminSearchController < ApplicationController
       users = users.where(hashed_email: hashed_email)
     end
     if params[:teacherNameFilter].present? || params[:teacherEmailFilter].present?
-      teachers = User.
-        where("name LIKE ?", "%#{params[:teacherNameFilter]}%").
-        where("email LIKE ?", "%#{params[:teacherEmailFilter]}%").
-        all
+      teachers = User
+      if params[:teacherNameFilter].present?
+        teachers = teachers.where("name LIKE ?", "%#{params[:teacherNameFilter]}%")
+      end
+      if params[:teacherEmailFilter].present?
+        teachers = teachers.where("email LIKE ?", "%#{params[:teacherEmailFilter]}%")
+      end
+      teachers = teachers.all
       if teachers.count > 1
         flash[:alert] = 'Multiple teachers matched the name and email search criteria.'
       end


### PR DESCRIPTION
addresses https://app.honeybadger.io/projects/3240/faults/44751141 . I suspect the slowness there was due to the inclusion of `where name like '%%'` in the query. This PR tries harder to omit empty strings from the query. I've verified locally that teacher name and teacher email are each omitted from the query when empty.