### PR TITLE
Updating FiT registration form

### DIFF
--- a/apps/src/code-studio/pd/fit_weekend_registration/Joining.jsx
+++ b/apps/src/code-studio/pd/fit_weekend_registration/Joining.jsx
@@ -12,7 +12,7 @@ export default class Joining extends LabeledFormComponent {
     lastName: "Last name",
     email: "Email",
     phone: "Phone number",
-    ableToAttend: "Are you able to attend your assigned FiT Weekend?"
+    ableToAttend: "Are you able to attend your assigned FiT Workshop?"
   };
 
   static associatedFields = Object.keys(Joining.labels);
@@ -52,7 +52,7 @@ export default class Joining extends LabeledFormComponent {
 
         <FormGroup>
           <ControlLabel>
-            Your assigned Facilitator-in-Training (FiT) Weekend is:
+            Your assigned Facilitator-in-Training (FiT) Workshop is:
             <br />
             <strong>
               FiT {this.props.city}, {this.props.date}
@@ -61,7 +61,7 @@ export default class Joining extends LabeledFormComponent {
           {this.radioButtonsFor("ableToAttend")}
           {this.props.data.ableToAttend === "No" &&
             <p>
-              If you're unable to attend your assigned FiT Weekend, please
+              If you're unable to attend your assigned FiT Workshop, please
               contact <a href="mailto:facilitators@code.org">facilitators@code.org</a> as
               soon as possible so we can assist you.
             </p>

--- a/apps/src/code-studio/pd/fit_weekend_registration/Releases.jsx
+++ b/apps/src/code-studio/pd/fit_weekend_registration/Releases.jsx
@@ -26,11 +26,11 @@ export default class Releases extends LabeledFormComponent {
         <h4>Section 3: Releases</h4>
         <FormGroup>
           <ControlLabel>
-            Please read this <a target="_blank" href="https://docs.google.com/document/d/1APmVaRhMaRf76Vo7qjkuVy5cjFJyBN4td9DGf1Y6T-s/edit?ts=5beb5ac2">photo release.</a>
+            Please read this <a target="_blank" href="https://docs.google.com/document/d/1zke9hlGbI1XbSzwQ1rNZofXuXaOboJuTFPW2Z_XOA1w/edit">photo release.</a>
           </ControlLabel>
           {this.singleCheckboxFor("photoRelease")}
           <ControlLabel>
-            Please read this <a target="_blank" href="https://docs.google.com/document/d/15N5N1m-BPCU7obQDf7FLLhEt3IComFGB1u3N6kEQR6k/edit?ts=5bfdaf7b">liability waiver.</a>
+            Please read this <a target="_blank" href="https://docs.google.com/document/d/15N5N1m-BPCU7obQDf7FLLhEt3IComFGB1u3N6kEQR6k/edit">liability waiver.</a>
           </ControlLabel>
           {this.singleCheckboxFor("liabilityWaiver")}
         </FormGroup>

--- a/apps/src/code-studio/pd/fit_weekend_registration/Releases.jsx
+++ b/apps/src/code-studio/pd/fit_weekend_registration/Releases.jsx
@@ -26,11 +26,11 @@ export default class Releases extends LabeledFormComponent {
         <h4>Section 3: Releases</h4>
         <FormGroup>
           <ControlLabel>
-            Please read this <a target="_blank" href="https://docs.google.com/document/d/12NVUcqccNRbVukoGMCserwSpg4vfG0vNlEqTxr6oit0/edit">photo release.</a>
+            Please read this <a target="_blank" href="https://docs.google.com/document/d/1APmVaRhMaRf76Vo7qjkuVy5cjFJyBN4td9DGf1Y6T-s/edit?ts=5beb5ac2">photo release.</a>
           </ControlLabel>
           {this.singleCheckboxFor("photoRelease")}
           <ControlLabel>
-            Please read this <a target="_blank" href="https://docs.google.com/document/d/15N5N1m-BPCU7obQDf7FLLhEt3IComFGB1u3N6kEQR6k/edit">liability waiver.</a>
+            Please read this <a target="_blank" href="https://docs.google.com/document/d/15N5N1m-BPCU7obQDf7FLLhEt3IComFGB1u3N6kEQR6k/edit?ts=5bfdaf7b">liability waiver.</a>
           </ControlLabel>
           {this.singleCheckboxFor("liabilityWaiver")}
         </FormGroup>
@@ -61,7 +61,7 @@ export default class Releases extends LabeledFormComponent {
           <p>
             We're excited you're planning to join us this summer! You will receive
             more information about travel approximately six weeks before the FiT
-            Weekend. In the meantime, please <strong>do not</strong> book your flight,
+            Workshop. In the meantime, please <strong>do not</strong> book your flight,
             and make sure to contact <a href="mailto:facilitators@code.org">facilitators@code.org</a> with any questions. We look
             forward to meeting you this summer!
           </p>

--- a/apps/src/code-studio/pd/fit_weekend_registration/TravelPlans.jsx
+++ b/apps/src/code-studio/pd/fit_weekend_registration/TravelPlans.jsx
@@ -22,10 +22,10 @@ export default class TravelPlans extends LabeledFormComponent {
     addressCity: "City",
     addressState: "State",
     addressZip: "Zip",
-    howTraveling: "Code.org provides a round trip flight for every FiT Weekend attendee. If you choose to fly, we will provide you with detailed flight booking instructions approximately six weeks prior to the event. If you choose not to fly, and live at least 25 miles from the event location, Code.org will provide you with a $150 gift card to help cover the cost of driving, trains, or public transit. Code.org is not able to provide reimbursement for the cost of driving, trains, or public transit if you live less than 25 miles from the event location. How will you travel to the FiT Weekend?",
-    needHotel: "Code.org provides a hotel room for every FiT Weekend attendee. Attendees will not be required to share a room. Would you like a hotel room at the FiT Weekend?",
+    howTraveling: "Code.org provides a round trip flight for every FiT Workshop attendee. If you choose to fly, we will provide you with detailed flight booking instructions approximately six weeks prior to the event. If you choose not to fly, and live at least 25 miles from the event location, Code.org will provide you with a $150 gift card to help cover the cost of driving, trains, or public transit. Code.org is not able to provide reimbursement for the cost of driving, trains, or public transit if you live less than 25 miles from the event location. How will you travel to the FiT Workshop?",
+    needHotel: "Code.org provides a hotel room for every FiT Workshop attendee. Attendees will not be required to share a room. Would you like a hotel room at the FiT Workshop?",
     needAda: "Do you require an ADA accessible hotel room?",
-    explainAda: "Please explain your specific accommodation needs."
+    needDisabilitySupport: "Do you have a disability and/or require accommodation in order to fully participate in our event? If so, please select yes, and you will be contacted by someone from our staff to discuss your specific needs."
   };
 
   static associatedFields = Object.keys(TravelPlans.labels).concat([
@@ -63,16 +63,12 @@ export default class TravelPlans extends LabeledFormComponent {
       );
     }
 
-    if (data.dietaryNeeds && data.dietaryNeeds.includes('Food Allergy')) {
+    if (data.dietaryNeeds && (data.dietaryNeeds.includes('Food Allergy') || data.dietaryNeeds.includes('Other'))) {
       requiredFields.push('dietaryNeedsDetails');
     }
 
     if (data.needHotel === 'Yes') {
       requiredFields.push("needAda");
-
-      if (data.needAda === 'Yes') {
-        requiredFields.push("explainAda");
-      }
     }
 
     return requiredFields;
@@ -98,7 +94,7 @@ export default class TravelPlans extends LabeledFormComponent {
           {this.checkBoxesFor("dietaryNeeds")}
           {
             this.props.data.dietaryNeeds &&
-            this.props.data.dietaryNeeds.includes('Food Allergy') &&
+            (this.props.data.dietaryNeeds.includes('Food Allergy') || this.props.data.dietaryNeeds.includes('Other')) &&
             this.largeInputFor("dietaryNeedsDetails")
           }
         </FormGroup>
@@ -126,7 +122,7 @@ export default class TravelPlans extends LabeledFormComponent {
 
         <FormGroup>
           {this.radioButtonsWithAdditionalTextFieldsFor("howTraveling", {
-            'I will carpool with another FiT Weekend attendee (Please note who)': 'carpooling_with_attendee'
+            'I will carpool with another FiT Workshop attendee (Please note who)': 'carpooling_with_attendee'
           })}
           {this.radioButtonsFor("needHotel")}
           {
@@ -135,9 +131,9 @@ export default class TravelPlans extends LabeledFormComponent {
           }
           {
             this.props.data.needHotel === 'Yes' &&
-            this.props.data.needAda === 'Yes' &&
-            this.largeInputFor("explainAda")
+            this.props.data.needAda === 'Yes'
           }
+          {this.radioButtonsFor("needDisabilitySupport")}
         </FormGroup>
       </FormGroup>
     );
@@ -154,11 +150,8 @@ export default class TravelPlans extends LabeledFormComponent {
     if (data.needHotel !== 'Yes') {
       changes.needAda = undefined;
     }
-    if (changes.needAda !== 'Yes') {
-      changes.explainAda = undefined;
-    }
 
-    if (data.dietaryNeeds && !data.dietaryNeeds.includes('Food Allergy')) {
+    if (data.dietaryNeeds && !data.dietaryNeeds.includes('Food Allergy') && !data.dietaryNeeds.includes('Other')) {
       changes.dietaryNeedsDetails = undefined;
     }
 

--- a/apps/src/code-studio/pd/fit_weekend_registration/TravelPlans.jsx
+++ b/apps/src/code-studio/pd/fit_weekend_registration/TravelPlans.jsx
@@ -129,10 +129,6 @@ export default class TravelPlans extends LabeledFormComponent {
             this.props.data.needHotel === 'Yes' &&
             this.radioButtonsFor("needAda")
           }
-          {
-            this.props.data.needHotel === 'Yes' &&
-            this.props.data.needAda === 'Yes'
-          }
           {this.radioButtonsFor("needDisabilitySupport")}
         </FormGroup>
       </FormGroup>

--- a/apps/src/code-studio/pd/fit_weekend_registration/TravelPlans.jsx
+++ b/apps/src/code-studio/pd/fit_weekend_registration/TravelPlans.jsx
@@ -17,7 +17,7 @@ export default class TravelPlans extends LabeledFormComponent {
     contactRelationship: "Relationship to you:",
     contactPhone: "Phone number:",
     dietaryNeeds: "Do you have any dietary needs or food allergies?",
-    dietaryNeedsDetails: "Please provide details about your food allergy.",
+    dietaryNeedsDetails: "Please provide details about your dietary needs.",
     addressStreet: "Street",
     addressCity: "City",
     addressState: "State",

--- a/dashboard/app/models/pd/fit_weekend_registration_base.rb
+++ b/dashboard/app/models/pd/fit_weekend_registration_base.rb
@@ -56,18 +56,20 @@ class Pd::FitWeekendRegistrationBase < ActiveRecord::Base
         'Halal',
         'Gluten Free',
         'Food Allergy',
+        'Other'
       ],
       liveFarAway: YES_OR_NO,
       addressState: get_all_states_with_dc.to_h.values,
       howTraveling: [
         'I will drive by myself',
-        'I will carpool with another FiT Weekend attendee (Please note who)',
+        'I will carpool with another FiT Workshop attendee (Please note who)',
         'Flying',
         'Amtrak or regional train service',
         'Public transit (e.g., city bus or light rail)',
       ],
       needHotel: YES_OR_NO,
       needAda: YES_OR_NO,
+      needDisabilitySupport: YES_OR_NO,
       photoRelease: [YES],
       liabilityWaiver: [YES],
     }.freeze
@@ -88,6 +90,7 @@ class Pd::FitWeekendRegistrationBase < ActiveRecord::Base
       :live_far_away,
       :how_traveling,
       :need_hotel,
+      :need_disability_support,
       :photo_release,
       :liability_waiver,
       :agree_share_contact,
@@ -116,7 +119,7 @@ class Pd::FitWeekendRegistrationBase < ActiveRecord::Base
       ]
     end
 
-    if hash[:dietary_needs].try(:include?, 'Food Allergy')
+    if hash[:dietary_needs].try(:include?, 'Food Allergy') || hash[:dietary_needs].try(:include?, 'Other')
       requireds.concat [
         :dietary_needs_details
       ]

--- a/dashboard/app/views/pd/fit_weekend_registration/new.html.haml
+++ b/dashboard/app/views/pd/fit_weekend_registration/new.html.haml
@@ -2,7 +2,7 @@
 %script{src: minifiable_asset_path('js/pd/fit_weekend_registration/new.js'), data: @script_data}
 
 %h1
-  2019-20 FiT Weekend Registration
+  2019-20 FiT Workshop Registration
 
 #application-container
   -# populated by React

--- a/dashboard/app/views/pd/fit_weekend_registration/submitted.html.haml
+++ b/dashboard/app/views/pd/fit_weekend_registration/submitted.html.haml
@@ -4,11 +4,11 @@
 
 - if @registration.accepted?
   %h1
-    Thank you for completing the FiT Weekend registration form
+    Thank you for completing the FiT Workshop registration form
   %p
-    Thank you for submitting your FiT Weekend registration form. We’re excited you’re
+    Thank you for submitting your FiT Workshop registration form. We’re excited you’re
     planning to join us this summer! You will receive more information about travel
-    approximately six weeks before the FiT Weekend. In the meantime, please
+    approximately six weeks before the FiT Workshop. In the meantime, please
     %strong
       do not
     book your flight, and make sure to contact
@@ -16,9 +16,9 @@
     with any questions. We look forward to meeting you this summer!
 - else
   %h1
-    Thank you for completing the FiT Weekend registration form
+    Thank you for completing the FiT Workshop registration form
   %p
-    Thank you for submitting your FiT Weekend registration form. We noticed you responded
-    that you’re not able to attend your assigned FiT weekend. Please contact us at
+    Thank you for submitting your FiT Workshop registration form. We noticed you responded
+    that you’re not able to attend your assigned FiT Workshop. Please contact us at
     = link_to(email, "mailto:#{email}")
     so that we can assist you.

--- a/dashboard/app/views/pd/fit_weekend_registration/unauthorized.html.haml
+++ b/dashboard/app/views/pd/fit_weekend_registration/unauthorized.html.haml
@@ -2,6 +2,6 @@
   = stylesheet_link_tag 'css/pd', media: 'all'
 
 %p
-  If you are a facilitator who has been accepted to a FiT Weekend, please sign in with the
+  If you are a facilitator who has been accepted to a FiT Workshop, please sign in with the
   same Code.org account you used to submit your facilitator application. Please
   email <a href="mailto:facilitators@code.org">facilitators@code.org</a> for support.

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -1478,6 +1478,7 @@ FactoryGirl.define do
       liability_waiver "Yes"
       live_far_away "Yes"
       need_hotel "No"
+      need_disability_support "No"
       photo_release "Yes"
     end
 

--- a/dashboard/test/models/pd/fit_weekend_registration_base_test.rb
+++ b/dashboard/test/models/pd/fit_weekend_registration_base_test.rb
@@ -24,6 +24,7 @@ class Pd::FitWeekendRegistrationBaseTest < ActiveSupport::TestCase
       "Form data liveFarAway",
       "Form data howTraveling",
       "Form data needHotel",
+      "Form data needDisabilitySupport",
       "Form data photoRelease",
       "Form data liabilityWaiver",
       "Form data agreeShareContact",


### PR DESCRIPTION
List of changes:

- Added option to answer “Other” for dietary needs. Required details if user choose "Other".
![screen shot 2019-01-23 at 1 24 24 pm](https://user-images.githubusercontent.com/46507039/51638350-fada6580-1f12-11e9-868b-742bdaa17e94.png)

- Removed the free-response ADA question. Added Yes/No question for disability support. Also added it to PD factory test.
![screen shot 2019-01-23 at 1 26 43 pm](https://user-images.githubusercontent.com/46507039/51638234-b64eca00-1f12-11e9-9b46-2a721087a018.png)

- Changed "FiT Weekend" string -> "Fit Workshop".
![screen shot 2019-01-23 at 1 21 22 pm](https://user-images.githubusercontent.com/46507039/51637996-109b5b00-1f12-11e9-85e6-a9fe28b7eac5.png)

- Updated links to photo release and liability waver.