### PR TITLE
Circuit Playground Express Pin Mapping

### DIFF
--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -229,34 +229,17 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
   }
 
   pinMode(pin, modeConstant) {
-    switch (pin) {
-      case "A0":
-        pin = 12;
-        break;
-      case "A1":
-        pin = 6;
-        break;
-      case "A2":
-        pin = 9;
-        break;
-      case "A3":
-        pin = 10;
-        break;
-      case "A4":
-        pin = 3;
-        break;
-      case "A5":
-        pin = 2;
-        break;
-      case "A6":
-        pin = 0;
-        break;
-      case "A7":
-        pin = 1;
-        break;
-      default:
-        break;
-    }
+    const pinMapping = {
+      "A0": 12,
+      "A1": 6,
+      "A2": 9,
+      "A3": 10,
+      "A4": 3,
+      "A5": 2,
+      "A6": 0,
+      "A7": 1
+    };
+    pin = pinMapping.hasOwnProperty(pin) ? pinMapping[pin] : pin;
     this.fiveBoard_.pinMode(pin, modeConstant);
   }
 

--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -257,12 +257,14 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
   }
 
   createLed(pin) {
+    pin = this.mappedPin(pin);
     const newLed = new Led({board: this.fiveBoard_, pin});
     this.dynamicComponents_.push(newLed);
     return newLed;
   }
 
   createButton(pin) {
+    pin = this.mappedPin(pin);
     const newButton = new Button({board: this.fiveBoard_, pin});
     this.dynamicComponents_.push(newButton);
     return newButton;

--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -29,6 +29,10 @@ process.hrtime = require('browser-process-hrtime');
 /** @const {number} serial port transfer rate */
 const SERIAL_BAUD = 57600;
 
+/** Maps the Circuit Playground Express pins to Circuit Playground Classic*/
+const pinMapping = {"A0": 12, "A1": 6, "A2": 9, "A3": 10, "A4": 3, "A5": 2, "A6": 0, "A7": 1};
+
+
 /**
  * Controller interface for an Adafruit Circuit Playground board using
  * Circuit Playground Firmata firmware.
@@ -228,35 +232,28 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
         .then(() => forEachLedInSequence(led => led.off(), 80));
   }
 
+  mappedPin(pin) {
+    return pinMapping.hasOwnProperty(pin) ? pinMapping[pin] : pin;
+  }
+
   pinMode(pin, modeConstant) {
-    const pinMapping = {
-      "A0": 12,
-      "A1": 6,
-      "A2": 9,
-      "A3": 10,
-      "A4": 3,
-      "A5": 2,
-      "A6": 0,
-      "A7": 1
-    };
-    pin = pinMapping.hasOwnProperty(pin) ? pinMapping[pin] : pin;
-    this.fiveBoard_.pinMode(pin, modeConstant);
+    this.fiveBoard_.pinMode(this.mappedPin(pin), modeConstant);
   }
 
   digitalWrite(pin, value) {
-    this.fiveBoard_.digitalWrite(pin, value);
+    this.fiveBoard_.digitalWrite(this.mappedPin(pin), value);
   }
 
   digitalRead(pin, callback) {
-    this.fiveBoard_.digitalRead(pin, callback);
+    this.fiveBoard_.digitalRead(this.mappedPin(pin), callback);
   }
 
   analogWrite(pin, value) {
-    this.fiveBoard_.analogWrite(pin, value);
+    this.fiveBoard_.analogWrite(this.mappedPin(pin), value);
   }
 
   analogRead(pin, callback) {
-    this.fiveBoard_.analogRead(pin, callback);
+    this.fiveBoard_.analogRead(this.mappedPin(pin), callback);
   }
 
   createLed(pin) {

--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -229,6 +229,34 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
   }
 
   pinMode(pin, modeConstant) {
+    switch (pin) {
+      case "A0":
+        pin = 12;
+        break;
+      case "A1":
+        pin = 6;
+        break;
+      case "A2":
+        pin = 9;
+        break;
+      case "A3":
+        pin = 10;
+        break;
+      case "A4":
+        pin = 3;
+        break;
+      case "A5":
+        pin = 2;
+        break;
+      case "A6":
+        pin = 0;
+        break;
+      case "A7":
+        pin = 1;
+        break;
+      default:
+        break;
+    }
     this.fiveBoard_.pinMode(pin, modeConstant);
   }
 

--- a/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
@@ -269,6 +269,20 @@ describe('CircuitPlaygroundBoard', () => {
   describe(`pinMode(pin, modeConstant)`, () => {
     it('forwards the call to firmata', () => {
       return board.connect().then(() => {
+        const xPins = ["A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7"];
+        const classicPins = [12, 6, 9, 10, 3, 2, 0, 1];
+        const arg2 = 1023;
+
+        for (let i = 0; i < xPins.length; i++) {
+          board.pinMode(xPins[i], arg2);
+          expect(playground.pinMode).to.have.been.calledWith(classicPins[i], arg2);
+        }
+
+      });
+    });
+
+    it('forwards the call to firmata with the modified CPX value', () => {
+      return board.connect().then(() => {
         const pin = 11;
         const arg2 = 1023;
         board.pinMode(pin, arg2);

--- a/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
@@ -277,7 +277,6 @@ describe('CircuitPlaygroundBoard', () => {
         board.pinMode(pin, arg2);
         expect(playground.pinMode).to.have.been.calledWith(pin, arg2);
       });
-
     });
 
     it('forwards the call to firmata with the modified CPX value', () => {

--- a/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
@@ -13,6 +13,9 @@ import experiments from '@cdo/apps/util/experiments';
 // Polyfill node process.hrtime for the browser, which gets used by johnny-five
 process.hrtime = require('browser-process-hrtime');
 
+const xPins = ["A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7"];
+const classicPins = [12, 6, 9, 10, 3, 2, 0, 1];
+
 describe('CircuitPlaygroundBoard', () => {
   let board, playground;
 
@@ -279,14 +282,10 @@ describe('CircuitPlaygroundBoard', () => {
 
     it('forwards the call to firmata with the modified CPX value', () => {
       return board.connect().then(() => {
-        const xPins = ["A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7"];
-        const classicPins = [12, 6, 9, 10, 3, 2, 0, 1];
+        const pin = xPins[0];
         const arg2 = 1023;
-
-        for (let i = 0; i < xPins.length; i++) {
-          board.pinMode(xPins[i], arg2);
-          expect(playground.pinMode).to.have.been.calledWith(classicPins[i], arg2);
-        }
+        board.pinMode(pin, arg2);
+        expect(playground.pinMode).to.have.been.calledWith(classicPins[0], arg2);
       });
     });
   });
@@ -300,6 +299,15 @@ describe('CircuitPlaygroundBoard', () => {
         expect(playground.digitalWrite).to.have.been.calledWith(pin, arg2);
       });
     });
+
+    it('forwards the call to firmata with the modified CPX value', () => {
+      return board.connect().then(() => {
+          const pin = xPins[1];
+          const arg2 = 1023;
+          board.digitalWrite(pin, arg2);
+          expect(playground.digitalWrite).to.have.been.calledWith(classicPins[1], arg2);
+        });
+    });
   });
 
   describe(`digitalRead(pin, callback)`, () => {
@@ -309,6 +317,15 @@ describe('CircuitPlaygroundBoard', () => {
         const arg2 = () => {};
         board.digitalRead(pin, arg2);
         expect(playground.digitalRead).to.have.been.calledWith(pin, arg2);
+      });
+    });
+
+    it('forwards the call to firmata with the modified CPX value', () => {
+      return board.connect().then(() => {
+        const pin = xPins[2];
+        const arg2 = () => {};
+        board.digitalRead(pin, arg2);
+        expect(playground.digitalRead).to.have.been.calledWith(classicPins[2], arg2);
       });
     });
   });
@@ -322,6 +339,15 @@ describe('CircuitPlaygroundBoard', () => {
         expect(playground.analogWrite).to.have.been.calledWith(pin, arg2);
       });
     });
+
+    it('forwards the call to firmata with the modified CPX value', () => {
+      return board.connect().then(() => {
+        const pin = xPins[3];
+        const arg2 = 1023;
+        board.analogWrite(pin, arg2);
+        expect(playground.analogWrite).to.have.been.calledWith(classicPins[3], arg2);
+      });
+    });
   });
 
   describe(`analogRead(pin, callback)`, () => {
@@ -331,6 +357,15 @@ describe('CircuitPlaygroundBoard', () => {
         const arg2 = () => {};
         board.analogRead(pin, arg2);
         expect(playground.analogRead).to.have.been.calledWith(pin, arg2);
+      });
+    });
+
+    it('forwards the call to firmata with the modified CPX value', () => {
+      return board.connect().then(() => {
+        const pin = xPins[4];
+        const arg2 = () => {};
+        board.analogRead(pin, arg2);
+        expect(playground.analogRead).to.have.been.calledWith(classicPins[4], arg2);
       });
     });
   });
@@ -392,6 +427,14 @@ describe('CircuitPlaygroundBoard', () => {
             expect(newButton.pullup).to.be.false;
           });
       });
+    });
+  });
+
+  describe(`mappedPin(pin)`, () => {
+    it(`returns the Classic pin value of the provided Express pin value`, () =>{
+      for (let i = 0; i < xPins.length; i++) {
+        expect(board.mappedPin(xPins[i])).to.equal(classicPins[i]);
+      }
     });
   });
 });

--- a/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
@@ -269,6 +269,16 @@ describe('CircuitPlaygroundBoard', () => {
   describe(`pinMode(pin, modeConstant)`, () => {
     it('forwards the call to firmata', () => {
       return board.connect().then(() => {
+        const pin = 11;
+        const arg2 = 1023;
+        board.pinMode(pin, arg2);
+        expect(playground.pinMode).to.have.been.calledWith(pin, arg2);
+      });
+
+    });
+
+    it('forwards the call to firmata with the modified CPX value', () => {
+      return board.connect().then(() => {
         const xPins = ["A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7"];
         const classicPins = [12, 6, 9, 10, 3, 2, 0, 1];
         const arg2 = 1023;
@@ -277,16 +287,6 @@ describe('CircuitPlaygroundBoard', () => {
           board.pinMode(xPins[i], arg2);
           expect(playground.pinMode).to.have.been.calledWith(classicPins[i], arg2);
         }
-
-      });
-    });
-
-    it('forwards the call to firmata with the modified CPX value', () => {
-      return board.connect().then(() => {
-        const pin = 11;
-        const arg2 = 1023;
-        board.pinMode(pin, arg2);
-        expect(playground.pinMode).to.have.been.calledWith(pin, arg2);
       });
     });
   });

--- a/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
@@ -398,6 +398,14 @@ describe('CircuitPlaygroundBoard', () => {
         expect(newLed).to.be.an.instanceOf(Led);
       });
     });
+
+    it('uses the express pin value to make an LED controller with the classic pin value', () => {
+      return board.connect().then(() => {
+        const pin = xPins[5];
+        const newLed = board.createLed(pin);
+        expect(newLed.pin).to.equal(classicPins[5]);
+      });
+    });
   });
 
   describe(`createButton(pin)`, () => {
@@ -406,6 +414,14 @@ describe('CircuitPlaygroundBoard', () => {
         const pin = 13;
         const newButton = board.createButton(pin);
         expect(newButton).to.be.an.instanceOf(five.Button);
+      });
+    });
+
+    it('uses the express pin value to make a button controller with the classic pin value', () => {
+      return board.connect().then(() => {
+        const pin = xPins[6];
+        const newLed = board.createButton(pin);
+        expect(newLed.pin).to.equal(classicPins[6]);
       });
     });
 


### PR DESCRIPTION
I *think* I updated all the relevant methods.

This PR adds a mapping between the Circuit Playground Express to the Circuit Playground Classic pin values. Part of a larger effort to adapt our system to work for CPExpress.

Includes test.