### PR TITLE
Expo exports: enable offline with assetBundlePatterns

### DIFF
--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -571,7 +571,7 @@ export default {
       sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
       files,
       name: project.getCurrentName(),
-      sdkVersion: '32.0.0',
+      sdkVersion: '31.0.0',
     });
 
     // Important that index.html comes first:

--- a/apps/src/gamelab/Exporter.js
+++ b/apps/src/gamelab/Exporter.js
@@ -293,7 +293,7 @@ export default {
       sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
       files,
       name: project.getCurrentName(),
-      sdkVersion: '32.0.0',
+      sdkVersion: '31.0.0',
     });
 
     // Important that index.html comes first:

--- a/apps/src/templates/export/expo/CustomAsset.exported_js
+++ b/apps/src/templates/export/expo/CustomAsset.exported_js
@@ -33,14 +33,25 @@ export default class CustomAsset {
           // Ignore this because it throws if the dir already exists on Android
         }
       }
-      ({ md5 } = await FileSystem.downloadAsync(this.asset.uri, localUri, {
+      if (this.asset.localUri) {
+        await FileSystem.copyAsync({
+          from: this.asset.localUri,
+          to: localUri,
+        });
+        ({ md5 } = await FileSystem.getInfoAsync(localUri, {
           cache: true,
           md5: true,
-      }));
+        }));
+      } else {
+        ({ md5 } = await FileSystem.downloadAsync(this.asset.uri, localUri, {
+            cache: true,
+            md5: true,
+        }));
+      }
       if (md5 !== this.asset.hash) {
         throw new Error(
           `Downloaded file for asset '${this.fileName} ` +
-            `Located at ${this.asset.localUri} ` +
+            `Located at ${localUri} ` +
             `failed MD5 integrity check`
         );
       }

--- a/apps/src/templates/export/expo/app.json.ejs
+++ b/apps/src/templates/export/expo/app.json.ejs
@@ -4,7 +4,7 @@
     "description": "<%- appName %> from Code.org Code Studio.",
     "slug": "<%- appName.replace(/([^a-zA-Z0-9_\-]+)/gi, '-') %>",
     "privacy": "public",
-    "sdkVersion": "32.0.0",
+    "sdkVersion": "31.0.0",
     "platforms": ["ios", "android"],
     "version": "1.0.0",
     "orientation": "portrait",
@@ -15,8 +15,12 @@
       "backgroundColor": "#ffffff"
     },
     "updates": {
+      "enabled": false,
       "fallbackToCacheTimeout": 0
     },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
     "packagerOpts": {
       "assetExts": [
         "html",

--- a/apps/src/templates/export/expo/package.exported_json
+++ b/apps/src/templates/export/expo/package.exported_json
@@ -8,9 +8,9 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^32.0.0",
+    "expo": "^31.0.4",
     "expo-cli": "^2.6.14",
     "react": "16.5.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.1.tar.gz"
   }
 }

--- a/apps/src/templates/export/gamelabIndex.html.ejs
+++ b/apps/src/templates/export/gamelabIndex.html.ejs
@@ -24,8 +24,8 @@
       }
     </style>
   </head>
-  <body class="<%- exportClass %>" style="margin:0; overflow:hidden; position:absolute; top:0; left:0; width:<%- appWidth %>px; height:<%- appHeight %>px;">
-    <div id="sketch" class="<%- exportClass %>" style="position: absolute;"></div>
+  <body class="<%- exportClass %>" style="margin:0; overflow:hidden; user-select:none; -webkit-user-select:none; -webkit-touch-callout:none; position:fixed; top:0; left:0; width:<%- appWidth %>px; height:<%- appHeight %>px;">
+    <div id="sketch" class="<%- exportClass %>" style="position:absolute;"></div>
     <div id="soft-buttons" class="soft-buttons-none">
       <button id="leftButton" disabled className="arrow">
       </button>


### PR DESCRIPTION
We'd like our exported apps (IPA for iOS, APK for Android) to work without requiring connectivity to the internet.

* `assetBundlePatterns` allows us to bundle all of our assets inside the IPA/APK - added that config to `app.json`
* Our `CustomAsset` class has been been modified slightly to copy the assets at runtime from the `bundledAssets` location to the `cacheDirectory` when the assets are bundled (when running in Expo, the assets are not bundled, so we still download them from the internet)
* Disable CDN-based updates for exported student apps (adding `"enabled": "false"` under `"updates"` in `app.json`) - for now, we will assume that app updates will be handled by submitted new IPA or APK files to the respective app stores.
* Roll back from Expo SDK 32 to Expo SDK 31 - sadly, the `assetBundlePatterns` does not work (at least, on Android) in Expo SDK 32. I will report this to the Expo team.
* Added some styles to the gamelab `index.html` template to prevent user selection within the WebView - this interfered with the fidelity of the "game experience" - to be determined if we want to do something similar for applab exports.

Verified:
* iOS and Android within `Expo` app (while connected)
* iOS IPA built, installed via TestFlight, then booted/ran the app while in airplane mode
* Android APK built, installed via side load, then booted/ran the app without internet connectivity