### PR TITLE
Move remaining teacher dashboard tabs to dashboard

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/index.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/index.js
@@ -13,6 +13,8 @@ import manageStudents, {
 import teacherSections, {setSections, selectSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import sectionData, {setSection} from '@cdo/apps/redux/sectionDataRedux';
 import stats, {asyncSetCompletedLevelCount} from '@cdo/apps/templates/teacherDashboard/statsRedux';
+import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
+import scriptSelection, {loadValidScripts} from '@cdo/apps/redux/scriptSelectionRedux';
 import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashboard';
 
 const script = document.querySelector('script[data-dashboard]');
@@ -21,7 +23,7 @@ const section = scriptData.section;
 const baseUrl = `/teacher_dashboard/sections/${section.id}`;
 
 $(document).ready(function () {
-  registerReducers({teacherSections, sectionData, manageStudents, stats});
+  registerReducers({teacherSections, sectionData, manageStudents, sectionProgress, scriptSelection, stats});
   const store = getStore();
   // TODO: (madelynkasula) remove duplication in sectionData.setSection and teacherSections.setSections
   store.dispatch(setSection(section));
@@ -45,6 +47,14 @@ $(document).ready(function () {
    }).done(studentData => {
     const convertedStudentData = convertStudentServerData(studentData, section.login_type, section.id);
     store.dispatch(setStudents(convertedStudentData));
+  });
+
+  $.ajax({
+    method: 'GET',
+    url: '/dashboardapi/sections/valid_scripts',
+    dataType: 'json'
+  }).done(validScripts => {
+    store.dispatch(loadValidScripts(section, validScripts));
   });
 
   ReactDOM.render(

--- a/apps/src/sites/studio/pages/teacher_dashboard/index.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/index.js
@@ -56,21 +56,26 @@ $(document).ready(function () {
     url: '/dashboardapi/sections/valid_scripts',
     dataType: 'json'
   }).done(validScripts => {
-    store.dispatch(loadValidScripts(section, validScripts));
-    const scriptId = store.getState().scriptSelection.scriptId;
-    store.dispatch(asyncLoadTextResponses(section.id, scriptId));
-    store.dispatch(asyncLoadAssessments(section.id, scriptId));
+    store.dispatch(loadValidScripts(section, validScripts)).then(() => {
+      const scriptId = store.getState().scriptSelection.scriptId;
+      store.dispatch(asyncLoadTextResponses(section.id, scriptId));
+      store.dispatch(asyncLoadAssessments(section.id, scriptId));
+
+      renderTeacherDashboard();
+    });
   });
 
-  ReactDOM.render(
-    <Provider store={store}>
-      <Router basename={baseUrl}>
-        <Route
-          path="/"
-          component={props => <TeacherDashboard {...props} studioUrlPrefix=""/>}
-        />
-      </Router>
-    </Provider>,
-    document.getElementById('teacher-dashboard')
-  );
+  const renderTeacherDashboard = () => {
+    ReactDOM.render(
+      <Provider store={store}>
+        <Router basename={baseUrl}>
+          <Route
+            path="/"
+            component={props => <TeacherDashboard {...props} studioUrlPrefix=""/>}
+          />
+        </Router>
+      </Provider>,
+      document.getElementById('teacher-dashboard')
+    );
+  };
 });

--- a/apps/src/sites/studio/pages/teacher_dashboard/index.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/index.js
@@ -52,7 +52,7 @@ $(document).ready(function () {
       <Router basename={baseUrl}>
         <Route
           path="/"
-          component={props => <TeacherDashboard {...props} sectionId={section.id} section={section} studioUrlPrefix=""/>}
+          component={props => <TeacherDashboard {...props} studioUrlPrefix=""/>}
         />
       </Router>
     </Provider>,

--- a/apps/src/sites/studio/pages/teacher_dashboard/index.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/index.js
@@ -13,6 +13,7 @@ import manageStudents, {
 import teacherSections, {setSections, selectSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import sectionData, {setSection} from '@cdo/apps/redux/sectionDataRedux';
 import stats, {asyncSetCompletedLevelCount} from '@cdo/apps/templates/teacherDashboard/statsRedux';
+import textResponses, {asyncLoadTextResponses} from '@cdo/apps/templates/textResponses/textResponsesRedux';
 import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import scriptSelection, {loadValidScripts} from '@cdo/apps/redux/scriptSelectionRedux';
 import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashboard';
@@ -23,7 +24,7 @@ const section = scriptData.section;
 const baseUrl = `/teacher_dashboard/sections/${section.id}`;
 
 $(document).ready(function () {
-  registerReducers({teacherSections, sectionData, manageStudents, sectionProgress, scriptSelection, stats});
+  registerReducers({teacherSections, sectionData, manageStudents, sectionProgress, scriptSelection, stats, textResponses});
   const store = getStore();
   // TODO: (madelynkasula) remove duplication in sectionData.setSection and teacherSections.setSections
   store.dispatch(setSection(section));
@@ -55,6 +56,8 @@ $(document).ready(function () {
     dataType: 'json'
   }).done(validScripts => {
     store.dispatch(loadValidScripts(section, validScripts));
+    const scriptId = store.getState().scriptSelection.scriptId;
+    store.dispatch(asyncLoadTextResponses(section.id, scriptId));
   });
 
   ReactDOM.render(

--- a/apps/src/sites/studio/pages/teacher_dashboard/index.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/index.js
@@ -14,6 +14,7 @@ import teacherSections, {setSections, selectSection} from '@cdo/apps/templates/t
 import sectionData, {setSection} from '@cdo/apps/redux/sectionDataRedux';
 import stats, {asyncSetCompletedLevelCount} from '@cdo/apps/templates/teacherDashboard/statsRedux';
 import textResponses, {asyncLoadTextResponses} from '@cdo/apps/templates/textResponses/textResponsesRedux';
+import sectionAssessments, {asyncLoadAssessments} from '@cdo/apps/templates/sectionAssessments/sectionAssessmentsRedux';
 import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import scriptSelection, {loadValidScripts} from '@cdo/apps/redux/scriptSelectionRedux';
 import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashboard';
@@ -24,7 +25,7 @@ const section = scriptData.section;
 const baseUrl = `/teacher_dashboard/sections/${section.id}`;
 
 $(document).ready(function () {
-  registerReducers({teacherSections, sectionData, manageStudents, sectionProgress, scriptSelection, stats, textResponses});
+  registerReducers({teacherSections, sectionData, manageStudents, sectionProgress, scriptSelection, stats, textResponses, sectionAssessments});
   const store = getStore();
   // TODO: (madelynkasula) remove duplication in sectionData.setSection and teacherSections.setSections
   store.dispatch(setSection(section));
@@ -58,6 +59,7 @@ $(document).ready(function () {
     store.dispatch(loadValidScripts(section, validScripts));
     const scriptId = store.getState().scriptSelection.scriptId;
     store.dispatch(asyncLoadTextResponses(section.id, scriptId));
+    store.dispatch(asyncLoadAssessments(section.id, scriptId));
   });
 
   ReactDOM.render(

--- a/apps/src/templates/projects/SectionProjectsListWithData.jsx
+++ b/apps/src/templates/projects/SectionProjectsListWithData.jsx
@@ -1,11 +1,14 @@
 import React, {Component, PropTypes} from 'react';
+import {connect} from 'react-redux';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 import SectionProjectsList from './SectionProjectsList';
 
 class SectionProjectsListWithData extends Component {
   static propTypes = {
+    studioUrlPrefix: PropTypes.string,
+
+    // Props provided by redux.
     sectionId: PropTypes.number,
-    studioUrlPrefix: PropTypes.string
   };
 
   state = {
@@ -48,4 +51,8 @@ class SectionProjectsListWithData extends Component {
   }
 }
 
-export default SectionProjectsListWithData;
+export const UnconnectedSectionProjectsListWithData = SectionProjectsListWithData;
+
+export default connect(state => ({
+  sectionId: state.sectionData.section.id,
+}))(SectionProjectsListWithData);

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -4,16 +4,14 @@ import TeacherDashboardNavigation from './TeacherDashboardNavigation';
 import StatsTableWithData from './StatsTableWithData';
 import SectionProjectsListWithData from '@cdo/apps/templates/projects/SectionProjectsListWithData';
 import ManageStudentsTable from '@cdo/apps/templates/manageStudents/ManageStudentsTable';
-import {summarizedSectionShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 
 export default class TeacherDashboard extends Component {
   static propTypes = {
-    section: summarizedSectionShape.isRequired,
     studioUrlPrefix: PropTypes.string
   };
 
   render() {
-    const {section, studioUrlPrefix} = this.props;
+    const {studioUrlPrefix} = this.props;
 
     return (
       <div>
@@ -29,13 +27,12 @@ export default class TeacherDashboard extends Component {
           />
           <Route
             path="/manage_students"
-            component={props => <ManageStudentsTable  {...props} studioUrlPrefix={studioUrlPrefix}/>
+            component={props => <ManageStudentsTable {...props} studioUrlPrefix={studioUrlPrefix}/>
             }
           />
-          {/* TODO: (madelynkasula) refactor SectionProjectsListWithData to use section from redux */}
           <Route
             path="/projects"
-            component={props => <SectionProjectsListWithData {...props} sectionId={section.id} studioUrlPrefix={studioUrlPrefix}/>}
+            component={props => <SectionProjectsListWithData {...props} studioUrlPrefix={studioUrlPrefix}/>}
           />
           <Route
             path="/text_responses"

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -3,9 +3,10 @@ import {Route, Switch} from 'react-router-dom';
 import TeacherDashboardNavigation from './TeacherDashboardNavigation';
 import StatsTableWithData from './StatsTableWithData';
 import SectionProgress from '@cdo/apps/templates/sectionProgress/SectionProgress';
+import ManageStudentsTable from '@cdo/apps/templates/manageStudents/ManageStudentsTable';
 import SectionProjectsListWithData from '@cdo/apps/templates/projects/SectionProjectsListWithData';
 import TextResponses from '@cdo/apps/templates/textResponses/TextResponses';
-import ManageStudentsTable from '@cdo/apps/templates/manageStudents/ManageStudentsTable';
+import SectionAssessments from '@cdo/apps/templates/sectionAssessments/SectionAssessments';
 
 export default class TeacherDashboard extends Component {
   static propTypes = {
@@ -29,12 +30,12 @@ export default class TeacherDashboard extends Component {
           />
           <Route
             path="/manage_students"
-            component={props => <ManageStudentsTable {...props} studioUrlPrefix={studioUrlPrefix}/>
+            component={props => <ManageStudentsTable studioUrlPrefix={studioUrlPrefix}/>
             }
           />
           <Route
             path="/projects"
-            component={props => <SectionProjectsListWithData {...props} studioUrlPrefix={studioUrlPrefix}/>}
+            component={props => <SectionProjectsListWithData studioUrlPrefix={studioUrlPrefix}/>}
           />
           <Route
             path="/text_responses"
@@ -42,9 +43,10 @@ export default class TeacherDashboard extends Component {
           />
           <Route
             path="/assessments"
-            component={props => <div>Assessments/Surveys content goes here!</div>}
+            component={props => <SectionAssessments/>}
           />
-          <Route component={props => <div>Progress content goes here - default for now.</div>} />
+          {/* Render <SectionProgress/> by default */}
+          <Route component={props => <SectionProgress/>} />
         </Switch>
       </div>
     );

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -2,6 +2,7 @@ import React, {PropTypes, Component} from 'react';
 import {Route, Switch} from 'react-router-dom';
 import TeacherDashboardNavigation from './TeacherDashboardNavigation';
 import StatsTableWithData from './StatsTableWithData';
+import SectionProgress from '@cdo/apps/templates/sectionProgress/SectionProgress';
 import SectionProjectsListWithData from '@cdo/apps/templates/projects/SectionProjectsListWithData';
 import ManageStudentsTable from '@cdo/apps/templates/manageStudents/ManageStudentsTable';
 
@@ -23,7 +24,7 @@ export default class TeacherDashboard extends Component {
           />
           <Route
             path="/progress"
-            component={props => <div>Progress content goes here!</div>}
+            component={props => <SectionProgress/>}
           />
           <Route
             path="/manage_students"

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -4,6 +4,7 @@ import TeacherDashboardNavigation from './TeacherDashboardNavigation';
 import StatsTableWithData from './StatsTableWithData';
 import SectionProgress from '@cdo/apps/templates/sectionProgress/SectionProgress';
 import SectionProjectsListWithData from '@cdo/apps/templates/projects/SectionProjectsListWithData';
+import TextResponses from '@cdo/apps/templates/textResponses/TextResponses';
 import ManageStudentsTable from '@cdo/apps/templates/manageStudents/ManageStudentsTable';
 
 export default class TeacherDashboard extends Component {
@@ -37,7 +38,7 @@ export default class TeacherDashboard extends Component {
           />
           <Route
             path="/text_responses"
-            component={props => <div>Text responses content goes here!</div>}
+            component={props => <TextResponses/>}
           />
           <Route
             path="/assessments"

--- a/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
@@ -32,9 +32,7 @@ const teacherDashboardLinks = [
 export default class TeacherDashboardNavigation extends Component {
   render() {
     return (
-      <NavigationBar
-        links = {teacherDashboardLinks}
-      />
+      <NavigationBar links={teacherDashboardLinks}/>
     );
   }
 }

--- a/apps/src/templates/textResponses/textResponsesRedux.js
+++ b/apps/src/templates/textResponses/textResponsesRedux.js
@@ -28,7 +28,7 @@ export const setTextResponses = (scriptId, responseData) => ({ type: SET_TEXT_RE
 export const startLoadingResponses = () => ({ type: START_LOADING_TEXT_RESPONSES });
 export const finishLoadingResponses = () => ({ type: FINISH_LOADING_TEXT_RESPONSES });
 
-export const asyncLoadTextResponses = (sectionId, scriptId, onComplete) => {
+export const asyncLoadTextResponses = (sectionId, scriptId, onComplete = () => {}) => {
   return (dispatch, getState) => {
     const state = getState().textResponses;
 


### PR DESCRIPTION
Moves the remaining teacher dashboard tabs to be served from dashboard instead of pegasus. 

### Follow-up Work
There is a bit of follow-up work that I'm not addressing here, mainly in the following areas:
- Fixing URLs in teacher dashboard (previously, we were using `studioUrlPrefix` to determine various routes, but now that teacher dashboard is in dashboard, we will need `pegasusUrlPrefix` instead, as some links should route the user to pegasus)
- Lots of styling fixes
- Add the section selector dropdown (to swap between sections in teacher dashboard)
- Fixes to make sure OAuth sections can still be synced properly

### Post-follow-up-work Work
Once all of those items are done, we can make the final swap from pegasus-teacher-dashboard to dashboard-teacher-dashboard:
- Fix UI tests to make sure we are accessing dashboard-teacher-dashboard and everything still works as expected (feature parity)
- Route teachers to dashboard-teacher-dashboard
- Delete pegasus-teacher-dashboard 🎉 