### PR TITLE
Convert public_key_cryptography.html to haml and use minified import

### DIFF
--- a/dashboard/public/public_key_cryptography/public_key_cryptography.css
+++ b/dashboard/public/public_key_cryptography/public_key_cryptography.css
@@ -1,1 +1,0 @@
-../blockly/css/publicKeyCryptography.css

--- a/dashboard/public/public_key_cryptography/public_key_cryptography.html
+++ b/dashboard/public/public_key_cryptography/public_key_cryptography.html
@@ -1,3 +1,0 @@
-<link rel="stylesheet" href="/public_key_cryptography/public_key_cryptography.css">
-<script src="/public_key_cryptography/public_key_cryptography.js"></script>
-<div id="public-key-cryptography-mount"></div>

--- a/dashboard/public/public_key_cryptography/public_key_cryptography.html.haml
+++ b/dashboard/public/public_key_cryptography/public_key_cryptography.html.haml
@@ -1,0 +1,4 @@
+= stylesheet_link_tag asset_path('css/publicKeyCryptography.css')
+%script{src: minifiable_asset_path('js/publicKeyCryptography.js')}
+
+#public-key-cryptography-mount

--- a/dashboard/public/public_key_cryptography/public_key_cryptography.js
+++ b/dashboard/public/public_key_cryptography/public_key_cryptography.js
@@ -1,1 +1,0 @@
-../blockly/js/publicKeyCryptography.js


### PR DESCRIPTION
We noticed this page is pointing to the unminified version of `publicKeyCryptography.js` which is 6.8mb (!).

Rails still seems to find the .html.haml file, even without updating the PublicKeyCryptography "href" properties. It also has no problem rendering haml in the /public folder.