### PR TITLE
update FiT Cohort view

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -139,7 +139,7 @@ module Api::V1::Pd
     # GET /api/v1/pd/applications/fit_cohort
     def fit_cohort
       serialized_fit_cohort = Pd::Application::Facilitator1819Application.fit_cohort(@applications).map do |application|
-        TcFitCohortViewSerializer.new(application, scope: {view: 'fit'}).attributes
+        FitCohortViewSerializer.new(application, scope: {view: 'fit'}).attributes
       end
 
       render json: serialized_fit_cohort

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -138,7 +138,7 @@ module Api::V1::Pd
 
     # GET /api/v1/pd/applications/fit_cohort
     def fit_cohort
-      serialized_fit_cohort = Pd::Application::Facilitator1819Application.fit_cohort(@applications).map do |application|
+      serialized_fit_cohort = FACILITATOR_APPLICATION_CLASS.fit_cohort(@applications).map do |application|
         FitCohortViewSerializer.new(application, scope: {view: 'fit'}).attributes
       end
 

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -1017,6 +1017,35 @@ module Api::V1::Pd
       assert_equal expected_headers.length, response_csv.second.length
     end
 
+    test 'fit_cohort' do
+      fit_workshop = create :pd_workshop, :fit
+
+      # create some applications to be included in fit_cohort
+      create FACILITATOR_APPLICATION_FACTORY, :locked, fit_workshop_id: fit_workshop.id, status: :accepted
+      create FACILITATOR_APPLICATION_FACTORY, :locked, fit_workshop_id: fit_workshop.id, status: :waitlisted
+
+      #create some applications that won't be included in fit_cohort
+      # not locked
+      create FACILITATOR_APPLICATION_FACTORY, fit_workshop_id: fit_workshop.id, status: :accepted
+
+      # not accepted or waitlisted
+      create FACILITATOR_APPLICATION_FACTORY, fit_workshop_id: fit_workshop.id
+
+      # no workshop
+      create FACILITATOR_APPLICATION_FACTORY
+
+      sign_in @workshop_admin
+
+      get :fit_cohort
+      assert_response :success
+
+      result = JSON.parse response.body
+      actual_applications = result.map {|a| a["id"]}
+      expected_applications = FACILITATOR_APPLICATION_CLASS.fit_cohort.map(&:id)
+
+      assert_equal expected_applications, actual_applications
+    end
+
     test 'search finds applications by email for workshop admins' do
       sign_in @workshop_admin
       get :search, params: {email: @csd_teacher_application.user.email}

--- a/dashboard/test/models/pd/application/facilitator1920_application_test.rb
+++ b/dashboard/test/models/pd/application/facilitator1920_application_test.rb
@@ -267,7 +267,6 @@ module Pd::Application
     end
 
     test 'fit_cohort' do
-      skip "update when 1920 fit registration is implemented"
       included = [
         create(:pd_facilitator1920_application, :locked, fit_workshop_id: @fit_workshop.id, status: :accepted),
         create(:pd_facilitator1920_application, :locked, fit_workshop_id: @fit_workshop.id, status: :waitlisted)


### PR DESCRIPTION
Update FiT Cohort view to show this year's FiT cohort and add/re-enable tests.

Remove outdated reference to a serializer that had been renamed, which was causing an HB error.