### PR TITLE
add a reference from old workshops table to new pd_workshops

### DIFF
--- a/dashboard/app/models/workshop.rb
+++ b/dashboard/app/models/workshop.rb
@@ -2,19 +2,21 @@
 #
 # Table name: workshops
 #
-#  id           :integer          not null, primary key
-#  name         :string(255)
-#  program_type :string(255)      not null
-#  location     :string(1000)
-#  instructions :string(1000)
-#  created_at   :datetime
-#  updated_at   :datetime
-#  phase        :integer
+#  id             :integer          not null, primary key
+#  name           :string(255)
+#  program_type   :string(255)      not null
+#  location       :string(1000)
+#  instructions   :string(1000)
+#  created_at     :datetime
+#  updated_at     :datetime
+#  phase          :integer
+#  pd_workshop_id :integer
 #
 # Indexes
 #
-#  index_workshops_on_name          (name)
-#  index_workshops_on_program_type  (program_type)
+#  index_workshops_on_name            (name)
+#  index_workshops_on_pd_workshop_id  (pd_workshop_id)
+#  index_workshops_on_program_type    (program_type)
 #
 
 require 'cdo/workshop_constants'

--- a/dashboard/app/serializers/workshop_serializer.rb
+++ b/dashboard/app/serializers/workshop_serializer.rb
@@ -2,19 +2,21 @@
 #
 # Table name: workshops
 #
-#  id           :integer          not null, primary key
-#  name         :string(255)
-#  program_type :string(255)      not null
-#  location     :string(1000)
-#  instructions :string(1000)
-#  created_at   :datetime
-#  updated_at   :datetime
-#  phase        :integer
+#  id             :integer          not null, primary key
+#  name           :string(255)
+#  program_type   :string(255)      not null
+#  location       :string(1000)
+#  instructions   :string(1000)
+#  created_at     :datetime
+#  updated_at     :datetime
+#  phase          :integer
+#  pd_workshop_id :integer
 #
 # Indexes
 #
-#  index_workshops_on_name          (name)
-#  index_workshops_on_program_type  (program_type)
+#  index_workshops_on_name            (name)
+#  index_workshops_on_pd_workshop_id  (pd_workshop_id)
+#  index_workshops_on_program_type    (program_type)
 #
 
 class WorkshopSerializer < ActiveModel::Serializer

--- a/dashboard/db/migrate/20190124225754_add_converted_pd_workshop_to_workshop.rb
+++ b/dashboard/db/migrate/20190124225754_add_converted_pd_workshop_to_workshop.rb
@@ -1,0 +1,5 @@
+class AddConvertedPdWorkshopToWorkshop < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :workshops, :pd_workshop, foreign_key: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190111004745) do
+ActiveRecord::Schema.define(version: 20190124225754) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1632,13 +1632,15 @@ ActiveRecord::Schema.define(version: 20190111004745) do
 
   create_table "workshops", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name"
-    t.string   "program_type",              null: false
-    t.string   "location",     limit: 1000
-    t.string   "instructions", limit: 1000
+    t.string   "program_type",                null: false
+    t.string   "location",       limit: 1000
+    t.string   "instructions",   limit: 1000
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "phase"
+    t.integer  "pd_workshop_id"
     t.index ["name"], name: "index_workshops_on_name", using: :btree
+    t.index ["pd_workshop_id"], name: "index_workshops_on_pd_workshop_id", using: :btree
     t.index ["program_type"], name: "index_workshops_on_program_type", using: :btree
   end
 
@@ -1684,4 +1686,5 @@ ActiveRecord::Schema.define(version: 20190111004745) do
   add_foreign_key "survey_results", "users"
   add_foreign_key "user_geos", "users"
   add_foreign_key "user_proficiencies", "users"
+  add_foreign_key "workshops", "pd_workshops"
 end


### PR DESCRIPTION
[Jira Card](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=11&projectKey=DEVPROD&modal=detail&selectedIssue=DEVPROD-32&quickFilter=22)

This PR represents the first step in deprecating the old `workshops` table in favor of the new `pd_workshops` table. We add a column to the old table which can point to the new table, so when we transfer the data from old to new we can keep track of which Workshop objects have been successfully converted to Pd::Workshops.

Steps:
1. Add column to track conversion
2. Convert data
3. Validate conversion
4. Delete old data
5. Delete old tables