### PR TITLE
Overwrite user school information when appropriate from PLC

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -54,6 +54,9 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
       enrollment = ::Pd::Enrollment.new workshop: @workshop
       enrollment.school_info_attributes = school_info_params
       if enrollment.update enrollment_params
+        if user
+          user.update_school_info(enrollment.school_info)
+        end
         Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
         Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
 

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -106,9 +106,6 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       @enrollment.school_info_attributes = school_info_params
 
       if @enrollment.update enrollment_params
-        if user
-          user.update_school_info(@enrollment.school_info)
-        end
         Pd::WorkshopMailer.teacher_enrollment_receipt(@enrollment).deliver_now
         Pd::WorkshopMailer.organizer_enrollment_receipt(@enrollment).deliver_now
         redirect_to action: :thanks, code: @enrollment.code, controller: 'pd/workshop_enrollment'

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -106,6 +106,9 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       @enrollment.school_info_attributes = school_info_params
 
       if @enrollment.update enrollment_params
+        if user
+          user.update_school_info(@enrollment.school_info)
+        end
         Pd::WorkshopMailer.teacher_enrollment_receipt(@enrollment).deliver_now
         Pd::WorkshopMailer.organizer_enrollment_receipt(@enrollment).deliver_now
         redirect_to action: :thanks, code: @enrollment.code, controller: 'pd/workshop_enrollment'

--- a/dashboard/app/models/pd/application/teacher_application_base.rb
+++ b/dashboard/app/models/pd/application/teacher_application_base.rb
@@ -67,7 +67,7 @@ module Pd::Application
     def update_user_school_info!
       if school_id || user.school_info.try(&:school).nil?
         school_info = get_duplicate_school_info(school_info_attr) || SchoolInfo.create!(school_info_attr)
-        user.update_column(:school_info_id, school_info.id)
+        user.update_school_info(school_info)
       end
     end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -296,6 +296,18 @@ class User < ActiveRecord::Base
     student? || deduplicate_school_info(school_info_attr, self)
   end
 
+  # takes a new school info objected collected somewhere (e.g., PD enrollment) and compares to
+  # a user's current school information.
+  # overwrites if:
+  # new school info object has a NCES school ID associated with it
+  # old school info object doesn't have a NCES school ID associated with it
+  # @param new_school_info a school_info object to compare to the user current school information.
+  def update_school_info(new_school_info)
+    if school_info.try(&:school).nil? || new_school_info.try(&:school)
+      update_column(:school_info_id, new_school_info.id)
+    end
+  end
+
   # Not deployed to everyone, so we don't require this for anybody, yet
   def school_info_optional?
     true # update if/when A/B test is done and accepted

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -296,7 +296,7 @@ class User < ActiveRecord::Base
     student? || deduplicate_school_info(school_info_attr, self)
   end
 
-  # takes a new school info objected collected somewhere (e.g., PD enrollment) and compares to
+  # takes a new school info object collected somewhere (e.g., PD enrollment) and compares to
   # a user's current school information.
   # overwrites if:
   # new school info object has a NCES school ID associated with it

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -131,16 +131,6 @@ class UserTest < ActiveSupport::TestCase
     assert_not_nil user.school_info_id
   end
 
-  test 'update_school_info info does not update information for another user' do
-    user_to_update = create :teacher, school_info: create(:school_info)
-    user_not_to_update = create :teacher, school_info: create(:school_info_us_other)
-    new_school_info = create :school_info
-
-    user_to_update.update_school_info(new_school_info)
-    refute_equal user_not_to_update.school_info, new_school_info
-    assert_not_nil user_not_to_update.school_info_id
-  end
-
   test 'single user experiment is enabled' do
     experiment = create(:single_user_experiment, min_user_id: @user.id)
     assert_equal [experiment[:name]], @user.get_active_experiment_names

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -104,6 +104,43 @@ class UserTest < ActiveSupport::TestCase
     assert_equal teachers[0].school_info, teachers[1].school_info
   end
 
+  test 'update_school_info with specific school overwrites user school info' do
+    user = create :teacher, school_info: create(:school_info)
+    new_school_info = create :school_info
+
+    user.update_school_info(new_school_info)
+    assert_equal new_school_info, user.school_info
+  end
+
+  test 'update_school_info with custom school does nothing when the user already a specific school' do
+    original_school_info = create :school_info
+    user = create :teacher, school_info: original_school_info
+    new_school_info = create :school_info_us_other
+
+    user.update_school_info(new_school_info)
+    assert_equal original_school_info, user.school_info
+  end
+
+  test 'update_school_info with custom school updates user info when user does not have a specific school' do
+    original_school_info = create :school_info_us_other
+    user = create :teacher, school_info: original_school_info
+    new_school_info = create :school_info_us_other
+
+    user.update_school_info(new_school_info)
+    refute_equal original_school_info, user.school_info
+    assert_not_nil user.school_info_id
+  end
+
+  test 'update_school_info info does not update information for another user' do
+    user_to_update = create :teacher, school_info: create(:school_info)
+    user_not_to_update = create :teacher, school_info: create(:school_info_us_other)
+    new_school_info = create :school_info
+
+    user_to_update.update_school_info(new_school_info)
+    refute_equal user_not_to_update.school_info, new_school_info
+    assert_not_nil user_not_to_update.school_info_id
+  end
+
   test 'single user experiment is enabled' do
     experiment = create(:single_user_experiment, min_user_id: @user.id)
     assert_equal [experiment[:name]], @user.get_active_experiment_names

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -105,14 +105,14 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'update_school_info with specific school overwrites user school info' do
-    user = create :teacher, school_info: create(:school_info)
+    user = create :teacher, :with_school_info
     new_school_info = create :school_info
 
     user.update_school_info(new_school_info)
     assert_equal new_school_info, user.school_info
   end
 
-  test 'update_school_info with custom school does nothing when the user already a specific school' do
+  test 'update_school_info with custom school does nothing when the user already has a specific school' do
     original_school_info = create :school_info
     user = create :teacher, school_info: original_school_info
     new_school_info = create :school_info_us_other
@@ -128,6 +128,7 @@ class UserTest < ActiveSupport::TestCase
 
     user.update_school_info(new_school_info)
     refute_equal original_school_info, user.school_info
+    assert_equal new_school_info, user.school_info
     assert_not_nil user.school_info_id
   end
 


### PR DESCRIPTION
Enrollments and applications in received for our PD workshops ask teachers for information about the school at which they teach. This PR:

1. Makes school information received in a workshop enrollment overwrite a user's school information
2. Changes existing logic that takes school information received in applications to CSP/CSD PD to use a new method added to the User model.

This is code that was largely approved in this PR, but became stale after being left unmerged for a while and was easiest just to replicate the changes in a new branch:

https://github.com/code-dot-org/code-dot-org/pull/23883

[note for any future inspection: early commits here changed dashboard/app/controllers/pd/workshop_enrollment_controller.rb, but we realized that the enrollment page actually now uses the very similar dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb]