### PR TITLE
Add explanation of Delete Assets

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -206,6 +206,7 @@
   "completedWithoutRecommendedBlock": "Congratulations! You completed Puzzle {puzzleNumber}. (But you could use a different block for stronger code.)",
   "completionStatus": "Completion Status",
   "concept": "Concept",
+  "confirmDeleteExplanation": "Deleting this file will remove it everywhere in your project",
   "confirming": "Confirming...",
   "confirmSchool": "Confirm School",
   "congratsCertificateHeading": "You Earned a Certificate of Completion",

--- a/apps/src/code-studio/components/AssetRow.jsx
+++ b/apps/src/code-studio/components/AssetRow.jsx
@@ -3,6 +3,15 @@ import {assets as assetsApi, files as filesApi} from '@cdo/apps/clientApi';
 import AssetThumbnail from './AssetThumbnail';
 import i18n from '@cdo/locale';
 import firehoseClient from "@cdo/apps/lib/util/firehose";
+import color from "@cdo/apps/util/color";
+
+const styles = {
+  deleteWarning: {
+    paddingLeft: '34px',
+    textAlign: 'left',
+    color: color.red
+  }
+};
 
 /**
  * A single row in the AssetManager, describing one asset.
@@ -114,6 +123,9 @@ export default class AssetRow extends React.Component {
               Delete File
             </button>
             <button onClick={this.cancelDelete}>Cancel</button>
+            <div style={styles.deleteWarning}>
+              {i18n.confirmDeleteExplanation()}
+            </div>
             {this.state.actionText}
           </td>
         );


### PR DESCRIPTION
This PR makes it clearer to students that deleting an asset from the "Manage Assets" or "Choose Assets" dialog will delete the image from their project.

![screenshot from 2019-01-25 16-58-13](https://user-images.githubusercontent.com/2959170/51855799-f8955400-22e2-11e9-8527-6bd4af235248.png)

cc @ryansloan 