### PR TITLE
Homepage: PL 2019 airplane banner gets new content & link

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
@@ -2,23 +2,23 @@
   = inline_css 'homepage_below_hero_plane_banner.css'
 
   .homepage-professional-learning-banner
-    %a.linktag#pl-2019{href: "/educate/professional-learning"}
+    %a.linktag#pl-2019{href: "/educate/professional-learning/middle-high"}
       .nonphone.col-80.tablet-feature
         .left.col-80.animateSlideInFromLeft
           .banner
             %img{src: "/images/homepage/professional-learning-2018-banner.png"}
             .text
-              Sign up for Professional Learning for
+              Sign up for Professional Learning. Middle
               %br/
-              Elementary, Middle, or High School
+              and High School applications now open.
         .right.col-20
           %button
             Join us
       .phone.phone-feature
         .text
-          Sign up for Professional Learning for
+          Sign up for Professional Learning. Middle
           %br/
-          Elementary, Middle, or High School
+          and High School applications now open.
         %button
           Join us
 


### PR DESCRIPTION
In advance of doing some more A/B testing for the banner, this gets one of our desired variants into code.  This adjusts the text of the plane banner and also links directly to the 6-12 (middle/high school) [page](https://code.org/educate/professional-learning/middle-high).

![screenshot 2019-01-29 10 03 32](https://user-images.githubusercontent.com/2205926/51933860-20ee8280-23b7-11e9-855f-91c199e83361.png)
