### PR TITLE
Pegasus: reenable Optimizely

### DIFF
--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -19,7 +19,7 @@
     = render file: Rails.root.join('..', 'shared', 'haml', 'answerdash.haml') if view_options[:answerdash]
     = javascript_include_tag 'application'
     = javascript_include_tag "js/#{js_locale}/common_locale"
-    = javascript_include_tag '//cdn.optimizely.com/js/12977480133.js' # if Rails.env.production?
+    = javascript_include_tag '//cdn.optimizely.com/js/12977480133.js' if Rails.env.production?
     %script{src: minifiable_asset_path('js/code-studio-common.js')}
     = csrf_meta_tags
     = yield :head

--- a/dashboard/test/ui/features/step_definitions/flappy_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/flappy_steps.rb
@@ -22,5 +22,5 @@ end
 
 Then /^I see the first Flappy YouTube video with the correct parameters$/ do
   correct_video_url = 'https://www.youtube-nocookie.com/embed/VQ4lo6Huylc/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=VQ4lo6Huylc&wmode=transparent'
-  expect(@browser.execute_script("return $('iframe').attr('src')")).to eq(correct_video_url)
+  expect(@browser.execute_script("return $('#video').attr('src')")).to eq(correct_video_url)
 end

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -11,7 +11,6 @@ critical_font: true
 jquery: defer
 style_min: true
 ---
-%script{src: "https://cdn.optimizely.com/js/12977480133.js"}
 =inline_css 'homepage.css'
 
 - cookie_key = '_user_type' + (rack_env == :production ? '' : "_#{rack_env.to_s}")

--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -16,7 +16,6 @@ social:
   "og:image:height": '630'
 style_min: false
 ---
-%script{src: "https://cdn.optimizely.com/js/12977480133.js"}
 :css
   .noFocusButton:focus {
     outline: 0;

--- a/pegasus/sites.v3/code.org/public/yourschool.haml
+++ b/pegasus/sites.v3/code.org/public/yourschool.haml
@@ -11,7 +11,7 @@ social:
 - require 'country_codes'
 - require 'state_abbr'
 - require 'census_helper'
-%script{src: "https://cdn.optimizely.com/js/12977480133.js"}
+
 - census_announcement = DCDO.get('census_announcement', nil)
 - census_announcement ||= {}
 - census_announcement['user_name'] = request.params["name"] if request.params["name"]

--- a/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
@@ -7,8 +7,7 @@
 %link{rel:'shortcut icon', href:'/images/favicon.ico'}
 %link{rel:'apple-touch-icon', href:'/images/apple-touch-icon-precomposed.png'}
 
--# Temporarily disable Optimizely bundle for page-load improvements.
-  %script{src:'//cdn.optimizely.com/js/12977480133.js'}
+%script{src:'//cdn.optimizely.com/js/12977480133.js'}
 
 =view :fonts
 -if @header['style_min'] && request.site == 'code.org'


### PR DESCRIPTION
This reincludes the Optimizely snippet across most of code.org, while removing it from some pages that no longer need it included explicitly.

Including it across the whole site should improve its ability to do bounce rate measurement.

Also improving one dashboard UI test to cope with Optimizely adding a new `iframe`.