### PR TITLE
Bugfix: student can view script if they have progress in any script i…

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -470,10 +470,11 @@ class Script < ActiveRecord::Base
     return false if user.nil?
     return true unless user.student?
 
-    # A student can view the script version if they have progress in it or are assigned to it.
-    has_progress = user.scripts.include?(self)
+    # A student can view the script version if they have progress in it or the course it belongs to.
+    has_progress = user.scripts.include?(self) || course&.has_progress?(user)
     return true if has_progress
 
+    # A student can view the script version if they are assigned to it.
     user.assigned_script?(self)
   end
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -475,11 +475,23 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'can_view_version? is true if student has progress in script' do
-    script = create :script, name: 'my-script'
+    script = create :script, name: 'my-script', family_name: 'script-fam'
     student = create :student
     student.scripts << script
 
     assert script.can_view_version?(student)
+  end
+
+  test 'can_view_version? is true if student has progress in course script belongs to' do
+    course = create :course, family_name: 'script-fam'
+    script1 = create :script, name: 'script1', family_name: 'script-fam'
+    create :course_script, course: course, script: script1, position: 1
+    script2 = create :script, name: 'script2', family_name: 'script-fam'
+    create :course_script, course: course, script: script2, position: 2
+    student = create :student
+    student.scripts << script1
+
+    assert script2.can_view_version?(student)
   end
 
   test 'self.latest_stable_version is nil if no script versions in family are stable in locale' do


### PR DESCRIPTION
…n course version

Fixes a bug in `script.can_view_version?(user)` where a student was only considered to have progress if they had progress in this specific script. We want students who have progress in _any_ script in this course version to be considered to have progress.

Example: I'm a student who has progress in csp1-2017. If I go to csp2-2017 (or any puzzle in it), I shouldn't get redirected to CSP 2018 because I have progress in CSP 2017.