### PR TITLE
Fix oauth sections in new teacher dashboard

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudents.jsx
+++ b/apps/src/templates/manageStudents/ManageStudents.jsx
@@ -1,0 +1,30 @@
+import React, {PropTypes} from 'react';
+import {connect} from 'react-redux';
+import ManageStudentsTable from './ManageStudentsTable';
+import SyncOmniAuthSectionControl from '@cdo/apps/lib/ui/SyncOmniAuthSectionControl';
+
+class ManageStudents extends React.Component {
+  static propTypes = {
+    studioUrlPrefix: PropTypes.string,
+
+    // Provided by redux
+    sectionId: PropTypes.number,
+  };
+
+  render() {
+    const {sectionId, studioUrlPrefix} = this.props;
+
+    return (
+      <div>
+        <SyncOmniAuthSectionControl sectionId={sectionId}/>
+        <ManageStudentsTable studioUrlPrefix={studioUrlPrefix}/>
+      </div>
+    );
+  }
+}
+
+export const UnconnectedManageStudents = ManageStudents;
+
+export default connect(state => ({
+  sectionId: state.sectionData.section.id,
+}))(ManageStudents);

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -4,7 +4,7 @@ import SelectSectionDropdown from './SelectSectionDropdown';
 import TeacherDashboardNavigation from './TeacherDashboardNavigation';
 import StatsTableWithData from './StatsTableWithData';
 import SectionProgress from '@cdo/apps/templates/sectionProgress/SectionProgress';
-import ManageStudentsTable from '@cdo/apps/templates/manageStudents/ManageStudentsTable';
+import ManageStudents from '@cdo/apps/templates/manageStudents/ManageStudents';
 import SectionProjectsListWithData from '@cdo/apps/templates/projects/SectionProjectsListWithData';
 import TextResponses from '@cdo/apps/templates/textResponses/TextResponses';
 import SectionAssessments from '@cdo/apps/templates/sectionAssessments/SectionAssessments';
@@ -32,7 +32,7 @@ export default class TeacherDashboard extends Component {
           />
           <Route
             path="/manage_students"
-            component={props => <ManageStudentsTable studioUrlPrefix={studioUrlPrefix}/>
+            component={props => <ManageStudents studioUrlPrefix={studioUrlPrefix}/>
             }
           />
           <Route


### PR DESCRIPTION
**Change base back to `staging` before merging!**

The old teacher dashboard renders `< SyncOmniAuthSectionControl/>` and `<ManageStudentsTable/>` separately, so this PR creates a component (`<ManageStudents/>`) that renders them together in the new teacher dashboard.

There may be additional fixes to get OAuth sections to sync in the new teacher dashboard, but this is the first step toward feature parity.