### PR TITLE
Consolidate duplicated logic

### DIFF
--- a/apps/src/lib/kits/maker/ui/DiscountAdminOverride.jsx
+++ b/apps/src/lib/kits/maker/ui/DiscountAdminOverride.jsx
@@ -3,6 +3,7 @@ import React, {Component} from 'react';
 import i18n from "@cdo/locale";
 import Button from "@cdo/apps/templates/Button";
 import ValidationStep, {Status} from '@cdo/apps/lib/ui/ValidationStep';
+import {isUnit6IntentionEligible} from '../util/discountLogic';
 import Unit6ValidationStep from './Unit6ValidationStep';
 
 const styles = {
@@ -75,8 +76,7 @@ export default class DiscountAdminOverride extends Component {
       submitting: false,
       statusPD: application.is_pd_eligible ? Status.SUCCEEDED : Status.FAILED,
       statusStudentCount: application.is_progress_eligible ? Status.SUCCEEDED : Status.FAILED,
-      statusYear: (application.unit_6_intention === 'yes1718' ||
-        application.unit_6_intention === 'yes1819') ? Status.SUCCEEDED : Status.FAILED,
+      statusYear: isUnit6IntentionEligible(application.unit_6_intention) ? Status.SUCCEEDED : Status.FAILED,
       unit6Intention: application.unit_6_intention,
       userSchool: application.user_school,
       applicationSchool: application.application_school,

--- a/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
@@ -5,6 +5,7 @@ import DiscountCodeSchoolChoice from "./DiscountCodeSchoolChoice";
 import Button from "@cdo/apps/templates/Button";
 import ValidationStep, {Status} from '@cdo/apps/lib/ui/ValidationStep';
 import UnsafeRenderedMarkdown from '../../../../templates/UnsafeRenderedMarkdown';
+import {isUnit6IntentionEligible} from '../util/discountLogic';
 import Unit6ValidationStep from "./Unit6ValidationStep";
 import EligibilityConfirmDialog from "./EligibilityConfirmDialog";
 import DiscountCodeInstructions from './DiscountCodeInstructions';
@@ -50,8 +51,7 @@ export default class EligibilityChecklist extends React.Component {
       this.state = {
         ...this.state,
         yearChoice: props.unit6Intention,
-        statusYear: ['yes1718', 'yes1819', 'yes1920'].includes(props.unit6Intention) ?
-          Status.SUCCEEDED : Status.FAILED,
+        statusYear: isUnit6IntentionEligible(props.unit6Intention) ? Status.SUCCEEDED : Status.FAILED,
       };
     }
 

--- a/apps/src/lib/kits/maker/ui/EligibilityChecklist.story.jsx
+++ b/apps/src/lib/kits/maker/ui/EligibilityChecklist.story.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import EligibilityChecklist from './EligibilityChecklist';
 import {Status} from '@cdo/apps/lib/ui/ValidationStep';
+import {Unit6Intention} from "../util/discountLogic";
 
 const defaultProps = {
   statusPD: Status.SUCCEEDED,
@@ -83,7 +84,7 @@ export default storybook => {
               schoolName="Code.org Junior Academy"
               hasConfirmedSchool={true}
               getsFullDiscount={true}
-              unit6Intention="no"
+              unit6Intention={Unit6Intention.NO}
             />
           </div>
         )
@@ -99,7 +100,7 @@ export default storybook => {
               schoolName="Code.org Junior Academy"
               hasConfirmedSchool={true}
               getsFullDiscount={true}
-              unit6Intention="yes1819"
+              unit6Intention={Unit6Intention.YES_18_19}
             />
           </div>
         )

--- a/apps/src/lib/kits/maker/ui/Unit6ValidationStep.jsx
+++ b/apps/src/lib/kits/maker/ui/Unit6ValidationStep.jsx
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 import i18n from "@cdo/locale";
 import Button from "@cdo/apps/templates/Button";
 import ValidationStep, {Status} from '@cdo/apps/lib/ui/ValidationStep';
+import {Unit6Intention} from "../util/discountLogic";
 
 const styles = {
   unit6Form: {
@@ -86,11 +87,11 @@ export default class Unit6ValidationStep extends Component {
                 {i18n.eligibilityReqYearConfirmInstructions()}
               </strong>
               {[
-                ['no', i18n.eligibilityYearNo()],
-                ['yes1819', i18n.eligibilityYearYes1819()],
-                ['yes1920', i18n.eligibilityYearYes1920()],
-                ['yesAfter', i18n.eligibilityYearAfter()],
-                ['unsure', i18n.eligibilityYearUnknown()],
+                [Unit6Intention.NO, i18n.eligibilityYearNo()],
+                [Unit6Intention.YES_18_19, i18n.eligibilityYearYes1819()],
+                [Unit6Intention.YES_19_20, i18n.eligibilityYearYes1920()],
+                [Unit6Intention.YES_AFTER, i18n.eligibilityYearAfter()],
+                [Unit6Intention.UNSURE, i18n.eligibilityYearUnknown()],
               ].map(([value, description]) =>
                 <label key={value}>
                   <input

--- a/apps/src/lib/kits/maker/util/discountLogic.js
+++ b/apps/src/lib/kits/maker/util/discountLogic.js
@@ -1,0 +1,23 @@
+/**
+ * @file Consolidates business logic for discount code eligibility into pure functions.
+ */
+
+/**
+ * @enum {string} Possible answers to the Unit 6 question.
+ */
+export const Unit6Intention = {
+  NO: 'no',
+  YES_18_19: 'yes1819',
+  YES_19_20: 'yes1920',
+  YES_AFTER: 'yesAfter',
+  UNSURE: 'unsure',
+};
+
+/**
+ * @param {string} unit6Intention
+ * @returns {boolean} True if the given answer to the unit 6 question contributes to the
+ *   teacher's eligibility for a discount code.
+ */
+export function isUnit6IntentionEligible(unit6Intention) {
+  return [Unit6Intention.YES_18_19, Unit6Intention.YES_19_20].includes(unit6Intention);
+}

--- a/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
@@ -3,6 +3,7 @@ import {shallow} from 'enzyme';
 import {assert} from '../../../../../util/configuredChai';
 import EligibilityChecklist from '@cdo/apps/lib/kits/maker/ui/EligibilityChecklist';
 import {Status} from '@cdo/apps/lib/ui/ValidationStep';
+import {Unit6Intention} from "@cdo/apps/lib/kits/maker/util/discountLogic";
 
 
 describe('EligibilityChecklist', () => {
@@ -64,7 +65,7 @@ describe('EligibilityChecklist', () => {
     const wrapper = shallow(
       <EligibilityChecklist
         {...defaultProps}
-        unit6Intention="yes1819"
+        unit6Intention={Unit6Intention.YES_18_19}
         schoolId="12345"
         schoolName="Code.org Junior Academy"
         hasConfirmedSchool={true}
@@ -78,7 +79,7 @@ describe('EligibilityChecklist', () => {
     const wrapper = shallow(
       <EligibilityChecklist
         {...defaultProps}
-        unit6Intention="yes1819"
+        unit6Intention={Unit6Intention.YES_18_19}
         schoolId="12345"
         schoolName="Code.org Junior Academy"
         hasConfirmedSchool={true}
@@ -95,7 +96,7 @@ describe('EligibilityChecklist', () => {
     const wrapper = shallow(
       <EligibilityChecklist
         {...defaultProps}
-        unit6Intention="yes1819"
+        unit6Intention={Unit6Intention.YES_18_19}
         schoolId="12345"
         schoolName="Code.org Junior Academy"
         hasConfirmedSchool={true}
@@ -111,7 +112,7 @@ describe('EligibilityChecklist', () => {
     const wrapper = shallow(
       <EligibilityChecklist
         {...defaultProps}
-        unit6Intention="yes1819"
+        unit6Intention={Unit6Intention.YES_18_19}
         initialDiscountCode="MYCODE"
         initialExpiration="2018-12-31T00:00:00.000Z"
         getsFullDiscount={false}
@@ -124,7 +125,7 @@ describe('EligibilityChecklist', () => {
     const wrapper = shallow(
       <EligibilityChecklist
         {...defaultProps}
-        unit6Intention="yes1819"
+        unit6Intention={Unit6Intention.YES_18_19}
         adminSetStatus={true}
         getsFullDiscount={true}
       />
@@ -136,7 +137,7 @@ describe('EligibilityChecklist', () => {
     const wrapper = shallow(
       <EligibilityChecklist
         {...defaultProps}
-        unit6Intention="no"
+        unit6Intention={Unit6Intention.NO}
         adminSetStatus={true}
         getsFullDiscount={true}
       />
@@ -148,7 +149,7 @@ describe('EligibilityChecklist', () => {
     const wrapper = shallow(
       <EligibilityChecklist
         {...defaultProps}
-        unit6Intention="no"
+        unit6Intention={Unit6Intention.NO}
         adminSetStatus={true}
         getsFullDiscount={true}
       />

--- a/apps/test/unit/lib/kits/maker/ui/Unit6ValidationStepTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/Unit6ValidationStepTest.js
@@ -3,6 +3,7 @@ import {shallow} from 'enzyme';
 import {assert} from '../../../../../util/configuredChai';
 import Unit6ValidationStep from '@cdo/apps/lib/kits/maker/ui/Unit6ValidationStep';
 import {Status} from '@cdo/apps/lib/ui/ValidationStep';
+import {Unit6Intention} from "@cdo/apps/lib/kits/maker/util/discountLogic";
 
 describe('Unit6ValidationStep', () => {
   const defaultProps = {
@@ -48,7 +49,7 @@ describe('Unit6ValidationStep', () => {
       <Unit6ValidationStep
         {...defaultProps}
         stepStatus={Status.FAILED}
-        initialChoice="no"
+        initialChoice={Unit6Intention.NO}
       />
     );
     assert.equal(wrapper.find('input [value="no"]').props().checked, true);
@@ -60,10 +61,10 @@ describe('Unit6ValidationStep', () => {
       <Unit6ValidationStep
         {...defaultProps}
         stepStatus={Status.SUCCEEDED}
-        initialChoice="yes1819"
+        initialChoice={Unit6Intention.YES_18_19}
       />
     );
-    assert.equal(wrapper.find('input [value="yes1819"]').props().checked, true);
+    assert.equal(wrapper.find(`input [value="${Unit6Intention.YES_18_19}"]`).props().checked, true);
     assert.equal(wrapper.find('Button').length, 0);
   });
 });

--- a/apps/test/unit/lib/kits/maker/util/discountLogicTest.js
+++ b/apps/test/unit/lib/kits/maker/util/discountLogicTest.js
@@ -1,0 +1,28 @@
+import {expect} from '../../../../../util/configuredChai';
+import {isUnit6IntentionEligible, Unit6Intention} from "@cdo/apps/lib/kits/maker/util/discountLogic";
+
+describe('discountLogic.js', () => {
+  describe('isUnit6IntentionEligible', () => {
+    // For winter/spring 2019, discount codes are eligible for teachers that plan to teach
+    // CSD6 during the 18-19 or 19-20 school years.
+    it('yes if teaching CSD6 during 18-19', () => {
+      expect(isUnit6IntentionEligible(Unit6Intention.YES_18_19)).to.be.true;
+    });
+
+    it('yes if teaching CSD6 during 19-20', () => {
+      expect(isUnit6IntentionEligible(Unit6Intention.YES_19_20)).to.be.true;
+    });
+
+    it('no if not teaching CSD6', () => {
+      expect(isUnit6IntentionEligible(Unit6Intention.NO)).to.be.false;
+    });
+
+    it('no if teaching CSD6 later than 19-20', () => {
+      expect(isUnit6IntentionEligible(Unit6Intention.YES_AFTER)).to.be.false;
+    });
+
+    it('no if unsure', () => {
+      expect(isUnit6IntentionEligible(Unit6Intention.UNSURE)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
The display logic for which unit 6 teaching timeframe is eligible for a discount code was duplicated: Present in both the form we show to teachers, and the admin view.  When I updated the form for this year I forgot to update the admin view logic, which led to some confusion today where it looked like an ineligible teacher had received a code.

Here I've both updated the admin logic to be correct for this year, and consolidated the duplicated logic into one place so this won't happen again.

Recent work in this area:
- ['19-20 discount codes update](https://github.com/code-dot-org/code-dot-org/pull/26382)
- [Pre-launch bugfixes after the initial PR above](https://github.com/code-dot-org/code-dot-org/pull/26679)
- [Some post-launch fixes](https://github.com/code-dot-org/code-dot-org/pull/26700)
- [Special case for expired discount codes](https://github.com/code-dot-org/code-dot-org/pull/26783)