### PR TITLE
PL: embedded plane banner is updated for 2019

### DIFF
--- a/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
@@ -1,12 +1,17 @@
 - buttons = capture_haml do
+  -# Two buttons, legacy
+    %div
+      %a.pl-2018-link#banner-csd{href: "/educate/professional-learning/cs-discoveries"}
+        %button
+          Professional Learning for Grades 6-10
+    %div
+      %a.pl-2018-link#banner-csp{href: "/educate/professional-learning/cs-principles"}
+        %button
+          Professional Learning for Grades 9-12
   %div
-    %a.pl-2018-link#banner-csd{href: "/educate/professional-learning/cs-discoveries"}
-      %button
-        Professional Learning for Grades 6-10
-  %div
-    %a.pl-2018-link#banner-csp{href: "/educate/professional-learning/cs-principles"}
-      %button
-        Professional Learning for Grades 9-12
+    %a.pl-2018-link{href: "/educate/professional-learning/program-information"}
+      %button{style: "margin-top: 33px"}
+        Apply Now
 
 .bigbanner{style: "width: 100%; padding: 5px; background-color: #ebe8f1"}
   .col-50{style: "background-color: #7665a0; height: 100px;"}
@@ -14,7 +19,7 @@
       .arrow{style: "width: 0; height: 0; border-style: solid; border-width: 50px 0 50px 25px; border-color: transparent transparent transparent #ebe8f1"}
     .textcontainer{style: "float:left; width: 93%"}
       .text{style: "color: white;  font-size: 18px; padding: 20px; text-align: center; line-height: 1.5"}
-        SPOTS OPEN - 2018 Professional Learning for Middle and High School teachers
+        SPOTS OPEN - 2019 Professional Learning for Middle and High School teachers
   .col-50{style: "background-color: #ebe8f1; color: white; height: 100px; font-size: 18px; text-align: center"}
     .desktop-feature{style: "float:left; width: 30%"}
       .arrowcontainer{style: "float:left"}


### PR DESCRIPTION
The year is updated in the text, and there is now a single Apply Now button which goes to /educate/professional-learning/program-information.

![screenshot 2019-01-31 00 30 47](https://user-images.githubusercontent.com/2205926/52041659-ec321680-24ef-11e9-9b3d-cc120b067367.png)
![screenshot 2019-01-31 00 30 59](https://user-images.githubusercontent.com/2205926/52041660-ec321680-24ef-11e9-9149-357236725b3c.png)
