### PR TITLE
Pegasus: course wide block now has optional call-to-action button

### DIFF
--- a/pegasus/sites.v3/code.org/views/course_wide_block.haml
+++ b/pegasus/sites.v3/code.org/views/course_wide_block.haml
@@ -1,5 +1,6 @@
 - lesson_plans ||= nil
 - ages ||= nil
+- cta_text ||= nil
 
 .courseblock-span6.courseblock-wide-large{style: "height: 100%; max-width: 100%; padding-bottom: 20px; margin-bottom: 10px;"}
   #courseblock-header{style: 'position: relative; height: 80px;'}
@@ -10,8 +11,9 @@
     - unless ages.nil?
       %h4= ages
     .smalltext{style: 'height: 120px; margin-bottom: 10px;'}= description
-    %a{:href=>cta_link}
-      %button{style: "margin-left: 10px; margin-top: 20px;"}!= cta_text
+    - unless cta_text.nil?
+      %a{:href=>cta_link}
+        %button{style: "margin-left: 10px; margin-top: 20px;"}!= cta_text
     - unless lesson_plans.nil?
       %a{:href=>lesson_plans, :target=>'_blank'}
         %button{style: "margin-left: 10px; margin-top: 20px;"} Lesson plans


### PR DESCRIPTION
If the `cta_text` parameter is not provided, then no button is shown.

Allowing, for example, this:
![screenshot 2019-01-31 09 40 43](https://user-images.githubusercontent.com/2205926/52073430-5c668980-253c-11e9-88b2-6fa007b0aabe.png)
