### PR TITLE
HOTFIX Temporarily switch Google Maps API Key

### DIFF
--- a/lib/cdo/geocoder.rb
+++ b/lib/cdo/geocoder.rb
@@ -60,15 +60,16 @@ def geocoder_config
     units: :km,
   }.tap do |config|
     config[:cache] = Redis.connect(url: CDO.geocoder_redis_url) if CDO.geocoder_redis_url
-    if CDO.google_maps_client_id && CDO.google_maps_secret
-      config[:lookup] = :google_premier
-      config[:api_key] = [CDO.google_maps_secret, CDO.google_maps_client_id, 'pegasus']
-    # Temporarily allow fallback to a Google Maps Project that uses a new Billing Account while we resolve issues
+    # Temporarily use a Google Maps Project that uses a new Billing Account while we resolve issues
     # with our existing Billing Account.
-    elsif CDO.google_maps_api_key
+    if CDO.google_maps_api_key
       config[:lookup] = :google
       config[:use_https] = true
       config[:api_key] = CDO.google_maps_api_key
+    # Normal execution path - use our Google Premium Maps Project
+    elsif CDO.google_maps_client_id && CDO.google_maps_secret
+      config[:lookup] = :google_premier
+      config[:api_key] = [CDO.google_maps_secret, CDO.google_maps_client_id, 'pegasus']
     end
     config[:freegeoip] = {host: CDO.freegeoip_host} if CDO.freegeoip_host
   end

--- a/lib/cdo/geocoder.rb
+++ b/lib/cdo/geocoder.rb
@@ -63,6 +63,12 @@ def geocoder_config
     if CDO.google_maps_client_id && CDO.google_maps_secret
       config[:lookup] = :google_premier
       config[:api_key] = [CDO.google_maps_secret, CDO.google_maps_client_id, 'pegasus']
+    # Temporarily allow fallback to a Google Maps Project that uses a new Billing Account while we resolve issues
+    # with our existing Billing Account.
+    elsif CDO.google_maps_api_key
+      config[:lookup] = :google
+      config[:use_https] = true
+      config[:api_key] = CDO.google_maps_api_key
     end
     config[:freegeoip] = {host: CDO.freegeoip_host} if CDO.freegeoip_host
   end


### PR DESCRIPTION
Our existing Google Maps Project has not been successfully migrated to our account in the new Google Cloud billing system and all API requests are failing.

We've provisioned a temporary new Google Cloud Project with a new API key.  Temporarily change geocoder to use the new key.