### PR TITLE
Help & Tips links can be opened in new tab/window

### DIFF
--- a/apps/src/templates/instructions/ResourceLink.jsx
+++ b/apps/src/templates/instructions/ResourceLink.jsx
@@ -50,7 +50,13 @@ class ResourceLink extends React.Component {
     dialogSelected: false
   };
 
-  selectResource = () => {
+  selectResource = (e) => {
+    if (e.shiftKey || e.metaKey || e.altKey) {
+      // Don't open modal, just open link in new tab/window
+      return;
+    }
+    // Don't open link, just open modal.
+    e.preventDefault();
     var dialog = new LegacyDialog({
       body: $('<iframe>')
         .addClass('instructions-container')

--- a/apps/src/templates/instructions/ResourceLink.jsx
+++ b/apps/src/templates/instructions/ResourceLink.jsx
@@ -89,7 +89,7 @@ class ResourceLink extends React.Component {
               title={text}
             />
           </span>
-          <a style={styles.textLink}>
+          <a href={this.props.reference} style={styles.textLink}>
             {text}
           </a>
         </div>


### PR DESCRIPTION
Shift+click opens the link in a new window
Command+click opens the link in a new tab
Regular click still opens the modal view 