### PR TITLE
Application dashboard: Scholarship Teacher? field fix

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -491,24 +491,16 @@ export class DetailViewContents extends React.Component {
   };
 
   renderScholarshipStatusAnswer = () => {
-    if (this.state.editing && this.props.isWorkshopAdmin) {
-      return (
-        <FormGroup>
-          <Select
-            value={this.state.scholarship_status}
-            onChange={this.handleScholarshipStatusChange}
-            options={ScholarshipDropdownOptions}
-          />
-        </FormGroup>
-      );
-    }
-
-    const option = ScholarshipDropdownOptions.find((option) => {
-      return option.value === this.state.scholarship_status;
-    });
-    if (option) {
-      return option.label;
-    }
+    return (
+      <FormGroup>
+        <Select
+          value={this.state.scholarship_status}
+          onChange={this.handleScholarshipStatusChange}
+          options={ScholarshipDropdownOptions}
+          disabled={!this.state.editing}
+        />
+      </FormGroup>
+    );
   };
 
   renderEditButtons = () => {

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -226,5 +226,28 @@ describe("DetailViewContents", () => {
         expect(detailView.find('#notes_2').prop('disabled')).to.be.true;
       });
     });
+
+    describe('Scholarship Teacher? row', () => {
+      it('on teacher applications', () => {
+        const detailView = mountDetailView('Teacher');
+        const lastRow = detailView.find('tr').filterWhere(row => row.text().includes('Scholarship Teacher?'));
+        const dropdown = lastRow.find('Select');
+
+        // Dropdown is disabled
+        expect(dropdown).to.have.prop('disabled', true);
+
+        // Click "Edit"
+        detailView.find('#DetailViewHeader Button').last().simulate('click');
+
+        // Dropdown is enabled
+        expect(dropdown).to.have.prop('disabled', false);
+
+        // Click "Save"
+        detailView.find('#DetailViewHeader Button').last().simulate('click');
+
+        // Dropdown is disabled
+        expect(dropdown).to.have.prop('disabled', true);
+      });
+    });
   }
 });


### PR DESCRIPTION
Fix scholarship teacher field  …
The "Scholarship Teacher?" field is now always visible as a dropdown (but disabled when not editing) and will be editable by regional partners as well as by workshop admins.

Pair: @hacodeorg 

Test that scholarship dropdown enables and disables with edit state

![image](https://user-images.githubusercontent.com/1615761/52091316-dd3b7a80-2568-11e9-826f-40500f20034f.png)
