### PR TITLE
Speed up initialization of the i18n sync script

### DIFF
--- a/bin/i18n/upload_i18n_translation_percentages_to_gdrive.rb
+++ b/bin/i18n/upload_i18n_translation_percentages_to_gdrive.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative('../../dashboard/config/environment')
+require_relative('../../dashboard/config/deployment')
 require 'cdo/languages'
 require 'cdo/google_drive'
 require 'csv'


### PR DESCRIPTION
I had been foolishly requiring `environment.rb` to grant access to dashboard `ScriptConstants` in one of the scripts used by the i18n sync. We don't need access to the full environment, just those constants, so we can include `deployment.rb` instead and dramatically speed up the time it takes the script to start up:

**Before**

```
[~/cdo (speed-up-i18n-sync)]$ time bundle exec bin/i18n/sync-codeorg-all.rb --help

real    0m24.036s
user    0m20.876s
sys     0m1.911s
```

**After**
```
[~/cdo (speed-up-i18n-sync)]$ time bundle exec bin/i18n/sync-codeorg-all.rb --help

real    0m2.810s
user    0m2.294s
sys     0m0.511s
```