### PR TITLE
Add Lighthouse web-page performance audit to Test CI

### DIFF
--- a/cookbooks/Berksfile.lock
+++ b/cookbooks/Berksfile.lock
@@ -73,7 +73,7 @@ GRAPH
   cdo-analytics (0.0.0)
     apt (~> 2.6.0)
     ark (>= 0.0.0)
-  cdo-apps (0.2.334)
+  cdo-apps (0.2.335)
     apt (>= 0.0.0)
     build-essential (>= 0.0.0)
     cdo-analytics (>= 0.0.0)

--- a/cookbooks/cdo-apps/metadata.rb
+++ b/cookbooks/cdo-apps/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-apps'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.334'
+version          '0.2.335'
 
 depends 'apt'
 depends 'build-essential'

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -118,3 +118,5 @@ include_recipe 'cdo-analytics' if %w[production-daemon production-console].inclu
 
 # Daemon-specific configuration for SSH access to frontend instances.
 include_recipe 'cdo-apps::daemon_ssh' if node['cdo-apps']['daemon'] && node['cdo-apps']['frontends']
+
+include_recipe 'cdo-apps::lighthouse' if node.chef_environment == 'test'

--- a/cookbooks/cdo-apps/recipes/lighthouse.rb
+++ b/cookbooks/cdo-apps/recipes/lighthouse.rb
@@ -1,0 +1,15 @@
+# Installs Lighthouse npm package and Google Chrome dependency.
+
+# Official Google Chrome debian/ubuntu repo.
+# https://www.google.com/linuxrepositories/
+apt_repository 'google-chrome' do
+  arch         'amd64'
+  uri          'http://dl.google.com/linux/chrome/deb'
+  distribution 'stable'
+  components   %w(main)
+  key          'https://dl-ssl.google.com/linux/linux_signing_key.pub'
+  retries 3
+end
+
+apt_package 'google-chrome-stable'
+nodejs_npm 'lighthouse'

--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -17,6 +17,20 @@ module Cdo
     # Ref: http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
     BYTES_PER_REQUEST = 1024 * 40
 
+    # Convenience method to put a single metric to CloudWatch.
+    # Accepts a single '[namespace]/[metric_name]' name parameter
+    # and a standard Ruby hash.
+    def put(name, value, dimensions={})
+      namespace, metric_name = name.split('/', 2)
+      push(namespace,
+        [{
+          metric_name: metric_name,
+          dimensions: dimensions.map {|k, v| {name: k, value: v}},
+          value: value
+        }]
+      )
+    end
+
     # Asynchronously send a collection of CloudWatch metrics in batches.
     # @param namespace [String]
     # @param metrics [Array<Types::MetricDatum>]

--- a/lib/cdo/lighthouse.rb
+++ b/lib/cdo/lighthouse.rb
@@ -1,0 +1,64 @@
+require 'cdo/rake_utils'
+require 'cdo/aws/s3'
+require 'tmpdir'
+require 'cdo/chat_client'
+require 'cdo/aws/metrics'
+require 'uri'
+
+# Run `lighthouse` web-page audits.
+module Lighthouse
+  S3_LOGS_BUCKET = 'cdo-build-logs'.freeze
+  S3_LOGS_PREFIX = CDO.name.freeze
+
+  class Error < ::RuntimeError; end
+  class ConsoleError < ::RuntimeError; end
+
+  # Runs `lighthouse` against the provided URL, returning HTML and JSON output.
+  def self.test(url)
+    html, json = Dir.mktmpdir do |dir|
+      exts = %w[html json]
+      RakeUtils.system 'lighthouse',
+        "--chrome-flags='--headless'",
+        "--emulated-form-factor=desktop",
+        '--quiet',
+        *exts.map {|x| "--output=#{x}"},
+        "--output-path=#{dir}/lighthouse",
+        "'#{url}'"
+      exts.map {|x| File.read("#{dir}/lighthouse.report.#{x}")}
+    end
+
+    # Raise Lighthouse::Error on any runtime warnings/errors or console errors.
+    result = JSON.parse(json)
+    if (warnings = result['runWarnings']).any?
+      raise Error.new(warnings.join("\n"))
+    end
+    if (error = result['runtimeError'])['code'] != 'NO_ERROR'
+      raise Error.new("#{error['code']}: #{error['message']}")
+    end
+    if (errors = result.dig('audits', 'errors-in-console'))['score'] == 0
+      str = "#{errors['title']}:\n#{errors['details']['items'].to_yaml(line_width: -1)}"
+      raise ConsoleError.new(str)
+    end
+
+    [html, json]
+  end
+
+  # Run a Lighthouse test and report page speed results and metrics.
+  # Upload full reports to S3 for .
+  def self.report(url)
+    url = URI.parse(url) unless url.is_a?(URI)
+    html, json = test(url)
+
+    upload = AWS::S3::LogUploader.new(S3_LOGS_BUCKET, S3_LOGS_PREFIX)
+    key = "lighthouse/#{url.host}#{url.path}"
+    html_url = upload.upload_log("#{key}.html", html)
+    upload.upload_log("#{key}.json", json)
+
+    perf = (JSON.parse(json).dig('categories', 'performance', 'score') * 100).to_i
+    ChatClient.log "#{url} Page Speed: <a href='#{html_url}'>#{perf}</a>"
+    Cdo::Metrics.instance.put 'Website/PageSpeed', perf,
+      Environment: CDO.rack_env, URL: url.to_s
+  rescue => e
+    ChatClient.log "Page speed report failed: #{e}"
+  end
+end

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -5,6 +5,7 @@ require 'cdo/chat_client'
 require 'cdo/test_run_utils'
 require 'cdo/rake_utils'
 require 'cdo/git_utils'
+require 'cdo/lighthouse'
 require 'parallel'
 require 'aws-sdk-s3'
 
@@ -74,10 +75,15 @@ namespace :test do
     end
   end
 
+  desc 'Run Lighthouse audits against key pages (currently Code Studio homepage).'
+  task :lighthouse do
+    Lighthouse.report CDO.studio_url('', CDO.default_scheme)
+  end
+
   # Run the eyes tests and ui test suites in parallel. If one of these suites
   # raises, allow the other suite to complete, then make sure this task raises.
   task :ui_all do
-    Parallel.each([:eyes_ui, :regular_ui], in_threads: 2) do |target|
+    Parallel.each([:eyes_ui, :regular_ui, :lighthouse], in_threads: 3) do |target|
       Rake::Task["test:#{target}"].invoke
     end
   end

--- a/lib/test/cdo/test_lighthouse.rb
+++ b/lib/test/cdo/test_lighthouse.rb
@@ -1,0 +1,55 @@
+require_relative '../test_helper'
+require 'cdo/lighthouse'
+require 'webrick'
+
+class LighthouseTest < Minitest::Test
+  PORT = 8000
+
+  def ensure_lighthouse
+    skip 'Lighthouse not installed' unless system('which lighthouse >/dev/null 2>&1')
+  end
+
+  # Run a temporary WEBrick server around provided block.
+  def with_server(proc)
+    null = WEBrick::Log.new(File::Constants::NULL)
+    server = WEBrick::HTTPServer.new Port: PORT, Logger: null, AccessLog: null
+    server.mount_proc('/', proc)
+    thread = Thread.new do
+      server.start
+    ensure server.shutdown
+    end
+    yield
+  ensure
+    thread.kill
+  end
+
+  def test_lighthouse
+    ensure_lighthouse
+    _, json = with_server(->(_, resp) {resp.body = 'Hello World!'}) do
+      Lighthouse.test("http://localhost:#{PORT}/")
+    end
+    result = JSON.parse(json)
+    assert_equal 1, result.dig('categories', 'performance', 'score')
+  end
+
+  def test_lighthouse_errors
+    ensure_lighthouse
+    mount = ->(req, resp) do
+      if req.path == '/'
+        resp.content_type = 'text/html'
+        resp.body = '<html><body><img src="/error1"/><img src="/error2"/></body></html>'
+      else
+        resp.status = 404
+        resp.body = 'Not Found'
+      end
+    end
+    with_server(mount) do
+      assert_raises(Lighthouse::ConsoleError) do
+        Lighthouse.test("http://localhost:#{PORT}/")
+      end
+      assert_raises(Lighthouse::Error) do
+        Lighthouse.test("http://localhost:#{PORT}/error")
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Lighthouse](https://developers.google.com/web/tools/lighthouse/) is an [open-source](https://github.com/GoogleChrome/lighthouse) tool actively maintained by Google that loads web pages in a (Chrome) browser and reports a huge number of performance, accessibility and other metrics and audits.

This PR adds Lighthouse to our CI process in the `test` environment, starting off by testing against a single page (Code Studio home page) and reporting a single metric (overall [performance score](https://developers.google.com/web/tools/lighthouse/v3/scoring)) to Slack chat and CloudWatch metrics, with a link to the full HTML report for detailed audit results. If successful, I plan to tweak and expand this experiment to a greater number of pages we'd like to track and improve.

The full HTML reports look like this:

![image](https://user-images.githubusercontent.com/56541/52095534-1e875680-2578-11e9-9862-ddb6d5f12885.png)

The general idea of this feature is to constantly and visibly track page-load performance of important pages in an effort to continuously improve the experience (and prevent performance/experience regressions).