### PR TITLE
Add signature to drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,4 @@
+---
 kind: pipeline
 name: unit
 
@@ -98,3 +99,8 @@ trigger:
 #   event:
 #     include:
 #     - pull_request
+---
+kind: signature
+hmac: 9f72be71d82bcfea9865aad1a6c4ed47fe6b29d8f1be25cc00b895005a846e94
+
+...


### PR DESCRIPTION
https://docs.drone.io/user-guide/signature/

Drone.io doesn't have Circle's built-in feature for disabling runs for PRs from forks: https://discourse.drone.io/t/global-flag-for-disabling-pull-request-builds-coming-from-forked-repos/1105

My tentative plan is to enable protected mode, and write a check in the .drone.yml file that stops the build if it's from a fork.