### PR TITLE
Throw on invalid `grunt karma` arguments

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -17,6 +17,9 @@ module.exports = function (grunt) {
 
   process.env.mocha_entry = grunt.option('entry') || '';
   if (process.env.mocha_entry) {
+    if (path.resolve(process.env.mocha_entry).indexOf('/apps/test/integration') > -1) {
+      throw new Error('Cannot use karma:entry to run integration tests');
+    }
     const isDirectory = fs.lstatSync(path.resolve(process.env.mocha_entry)).isDirectory();
     const loadContext = isDirectory ?
       `let testsContext = require.context(${JSON.stringify(path.resolve(process.env.mocha_entry))}, true, /\\.jsx?$/);` :


### PR DESCRIPTION
Running `grunt karma:entry --entry ./test/integration/levelTests.js` doesn't work, throw immediately.

Apparently this [hasn't worked for a while](https://codedotorg.slack.com/archives/C0T0PNR0D/p1549058164048200), and the failure message just looks like a test is failing with an error.

Before:

```
FAILED TESTS:
  entry tests
    Level tests
      ./applab/ec_design.js
        ✖ button image with absolute url
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        TypeError: undefined is not a constructor (evaluating 'codegen.clearDropletAceHighlighting(this.editor, true)') (webpack:///src/StudioApp.js:1446:4 <- test/entry-tests.js:40037)

      ✖ "after each" hook for "button image with absolute url"
        PhantomJS 2.1.1 (Mac OS X 0.0.0)
      originalAddEventListener is not a native function
      detach@webpack:///test/integration/util/wrappedEventListener.js:38:6 <- test/entry-tests.js:364646:75
      webpack:///test/integration/levelTests.js:170:4 <- test/entry-tests.js:329731:32
```

After:

```
Loading "Gruntfile.js" tasks...ERROR
>> Error: Cannot use karma:entry to run integration tests
Warning: Task "karma:entry" not found. Use --force to continue.

Aborted due to warnings.
```