### PR TITLE
Skip level source encryption test if key is not present

### DIFF
--- a/dashboard/test/controllers/level_sources_controller_test.rb
+++ b/dashboard/test/controllers/level_sources_controller_test.rb
@@ -26,6 +26,7 @@ class LevelSourcesControllerTest < ActionController::TestCase
   end
 
   test "should get show with encrypted level source ID" do
+    skip "CDO.properties_encryption_key is not defined" unless CDO.properties_encryption_key
     encrypted = @level_source.encrypt_level_source_id @admin.id
     get :show, params: {level_source_id_and_user_id: encrypted}
     assert_response :success


### PR DESCRIPTION
Following precedent of other tests which depend on this key, e.g.:

https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/models/level_source_test.rb#L50

This will allow us to not store PROPERTIES_ENCRYPTION_KEY in our CI service.