### PR TITLE
Never Show 0 for Lines of Code, Project Count, or Petition Signatures 

### DIFF
--- a/lib/cdo/properties.rb
+++ b/lib/cdo/properties.rb
@@ -63,7 +63,7 @@ def fetch_metrics
     'petition_signatures' => 1_774_817,
     'lines_of_code' => 21_238_497_830,
     'project_count' => 35_000_000
-  }.merge((Properties.get(:metrics) || {}).delete_if {|_, v| v.nil?})
+  }.merge((Properties.get(:metrics) || {}).delete_if {|_, v| v.nil? || v == 0})
 end
 
 def fetch_project_count


### PR DESCRIPTION
Prevents us from ever displaying 0.