### PR TITLE
Export app details

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "apps/test/interpreter/test262"]
-	path = apps/test/interpreter/test262
-	url = https://github.com/tc39/test262.git
-	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "apps/test/interpreter/test262"]
+	path = apps/test/interpreter/test262
+	url = https://github.com/tc39/test262.git
+	shallow = true

--- a/bin/cron/teacher_applications_to_s3
+++ b/bin/cron/teacher_applications_to_s3
@@ -14,12 +14,13 @@ def main
       app.status,
       app.scholarship_status,
       app.school_type,
-      app.sanitize_form_data_hash[:pay_fee]
+      app.sanitize_form_data_hash[:pay_fee],
+      app.email
     ])
   end
 
   output = CSV.generate(col_sep: "\t") do |csv|
-    csv << %w(course regional_partner status scholarship_status school_type pay_fee)
+    csv << %w(course regional_partner status scholarship_status school_type pay_fee email)
     applications.each {|row| csv << row}
   end
 


### PR DESCRIPTION
Our professional learning team is currently manually downloading all teacher applications weekly to send to the marketing team so that they can exclude sending recruitment emails to teachers who have already applied. 

This adds teacher email addresses to the application email cron that is already being used elsewhere on the PL team to track teacher applications, so it can be used for this additional purpose (exclusions for recruitment emails) as well.