### PR TITLE
Refresh static models in dev/staging environments

### DIFF
--- a/pegasus/test/test_static_models.rb
+++ b/pegasus/test/test_static_models.rb
@@ -1,0 +1,24 @@
+require_relative './test_helper'
+require_relative '../../lib/cdo/pegasus'
+require 'timecop'
+
+class StaticModelsTest < Minitest::Test
+  include CaptureQueries
+
+  def test_static_models
+    CDO.cache.clear
+    StaticModels.stubs(:expires_in).returns(2.minutes)
+    Timecop.freeze
+
+    query = -> {PEGASUS_DB[:cdo_donors].all}
+    query.call
+
+    Timecop.travel 1.minute
+    assert_empty(capture_queries(PEGASUS_DB, &query))
+
+    Timecop.travel 2.minutes
+    refute_empty(capture_queries(PEGASUS_DB, &query))
+
+    Timecop.return
+  end
+end


### PR DESCRIPTION
Allows CSV-driven static model caches to allow configurable expiration, allowing updates to the models without requiring an application restart.
Default is configured to expire caches in 10 seconds in `development` and `staging` environments.

Followup to #24613.