### PR TITLE
Drone.io - Disable assets precompile + log slack messages to console

### DIFF
--- a/lib/cdo/chat_client.rb
+++ b/lib/cdo/chat_client.rb
@@ -12,7 +12,7 @@ class ChatClient
   @@logger = nil
 
   def self.log(message, options={})
-    if CircleUtils.circle?
+    if ENV['CI']
       CDO.log.info("[#{CDO.slack_log_room}] #{message}")
     else
       message(CDO.slack_log_room, message, options)

--- a/lib/cdo/chat_client.rb
+++ b/lib/cdo/chat_client.rb
@@ -12,7 +12,7 @@ class ChatClient
   @@logger = nil
 
   def self.log(message, options={})
-    if CircleUtils.circle? || ENV['CI']
+    if ENV['CI']
       CDO.log.info("[#{CDO.slack_log_room}] #{message}")
     else
       message(CDO.slack_log_room, message, options)

--- a/lib/cdo/chat_client.rb
+++ b/lib/cdo/chat_client.rb
@@ -12,7 +12,7 @@ class ChatClient
   @@logger = nil
 
   def self.log(message, options={})
-    if ENV['CI']
+    if CircleUtils.circle? || ENV['CI']
       CDO.log.info("[#{CDO.slack_log_room}] #{message}")
     else
       message(CDO.slack_log_room, message, options)

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -96,8 +96,8 @@ namespace :build do
       end
 
       # Skip asset precompile in development where `config.assets.digest = false`.
-      # Also skip on Circle CI where we will precompile assets later, right before UI tests.
-      unless rack_env?(:development) || ENV['CIRCLECI']
+      # Also skip on CI services (e.g. Circle) where we will precompile assets later, right before UI tests.
+      unless rack_env?(:development) || ENV['CI']
         ChatClient.log 'Cleaning <b>dashboard</b> assets...'
         RakeUtils.rake 'assets:clean'
         ChatClient.log 'Precompiling <b>dashboard</b> assets...'

--- a/lib/test/cdo/test_chat_client.rb
+++ b/lib/test/cdo/test_chat_client.rb
@@ -16,7 +16,7 @@ class ChatClientTest < Minitest::Test
   end
 
   def test_log_calls_slack
-    CircleUtils.expects(:circle?).returns(false)
+    ENV.expects(:[]).returns(false)
     Slack.expects(:message).with do |_text, params|
       params[:channel] == CDO.slack_log_room
     end.returns(false)


### PR DESCRIPTION
Moving drone.io test run behavior closer to Circle test runs.

Simply setting the CIRCLECI env variable in drone causes other differences - namely, phantomjs tests run in parallel, which causes them to crash (memory usage too high)? However, the CI env variable is already set in the drone test run.