### PR TITLE
Remove aalab pool from Sprite Lab Project

### DIFF
--- a/dashboard/config/scripts/levels/New Sprite Lab Project.level
+++ b/dashboard/config/scripts/levels/New Sprite Lab Project.level
@@ -54,8 +54,7 @@
     "include_shared_functions": "true",
     "block_pool": "gamelab",
     "block_pools": [
-      "GamelabJr",
-      "aalab"
+      "GamelabJr"
     ],
     "contained_level_names": null,
     "preload_asset_list": null,


### PR DESCRIPTION
This should've been removed when the aalab library was removed, but we missed it.