### PR TITLE
Facilitator Application: Do not include :completed_pd question in rollup

### DIFF
--- a/dashboard/test/models/pd/application/facilitator1920_application_test.rb
+++ b/dashboard/test/models/pd/application/facilitator1920_application_test.rb
@@ -333,7 +333,6 @@ module Pd::Application
               currently_involved_in_cs_education: 5,
               grades_taught: 5,
               experience_teaching_this_course: 5,
-              completed_pd: 5,
               why_should_all_have_access: 5,
               skills_areas_to_improve: 5,
               inquiry_based_learning: 5,
@@ -350,15 +349,15 @@ module Pd::Application
 
       assert_equal(
         {
-          total_score: "65 / 65",
-          application_score: "40 / 40",
+          total_score: "60 / 60",
+          application_score: "35 / 35",
           interview_score: "25 / 25",
           teaching_experience_score: "10 / 10",
           leadership_score: "5 / 5",
           champion_for_cs_score: "5 / 5",
           equity_score: "15 / 15",
           growth_minded_score: "15 / 15",
-          content_knowledge_score: "10 / 10",
+          content_knowledge_score: "5 / 5",
           program_commitment_score: "5 / 5"
         }, @application.all_scores
       )

--- a/lib/cdo/shared_constants/pd/facilitator1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/facilitator1920_application_constants.rb
@@ -39,7 +39,6 @@ module Pd
       currently_involved_in_cs_education: [0, 3, 5],
       grades_taught: [0, 3, 5],
       experience_teaching_this_course: [0, 3, 5],
-      completed_pd: [0, 3, 5],
       why_should_all_have_access: [0, 3, 5],
       skills_areas_to_improve: [0, 3, 5],
       inquiry_based_learning: [0, 3, 5],
@@ -56,7 +55,6 @@ module Pd
         :currently_involved_in_cs_education,
         :grades_taught,
         :experience_teaching_this_course,
-        :completed_pd,
         :why_should_all_have_access,
         :skills_areas_to_improve,
         :inquiry_based_learning,
@@ -110,7 +108,6 @@ module Pd
         :currently_involved_in_cs_education,
         :grades_taught,
         :experience_teaching_this_course,
-        :completed_pd,
         :why_should_all_have_access,
         :skills_areas_to_improve,
         :inquiry_based_learning,
@@ -144,8 +141,7 @@ module Pd
         :skills_areas_to_improve
       ],
       content_knowledge_score: [
-        :experience_teaching_this_course,
-        :completed_pd
+        :experience_teaching_this_course
       ],
       program_commitment_score: [
         :why_interested


### PR DESCRIPTION
Do not include the :completed_pd question on the facilitator application in the review score rollups.  It's not currently score-able by partners, so it should be included in the rollups as part of the calculation for the maximum possible score in each category.

Here's the question, in a reviewer's view.  You can see that there's no scoring dropdown in the third column.
![screenshot from 2019-02-04 17-28-18](https://user-images.githubusercontent.com/1615761/52248365-ebf49b00-28a2-11e9-9edb-82d2faf58a3d.png)

Removing this question from scoring rollups affects three categories:

- Total score (was 65, now 60)
- Application score (was 40, now 35)
- Content Knowledge score (was 10, now 5)

Here's the review score rollup, after this change:
![screenshot from 2019-02-04 17-28-36](https://user-images.githubusercontent.com/1615761/52248384-ff076b00-28a2-11e9-87d9-b9e0ec2d9855.png)

Fixes [PLC-28](https://codedotorg.atlassian.net/browse/PLC-28)