### PR TITLE
Fix oauth sections

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -10,7 +10,7 @@ import manageStudents, {
   convertStudentServerData,
   toggleSharingColumn,
 } from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
-import teacherSections, {setSections, selectSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import teacherSections, {setSections, selectSection, setRosterProvider} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import sectionData, {setSection} from '@cdo/apps/redux/sectionDataRedux';
 import stats, {asyncSetCompletedLevelCount} from '@cdo/apps/templates/teacherDashboard/statsRedux';
 import textResponses, {asyncLoadTextResponses} from '@cdo/apps/templates/textResponses/textResponsesRedux';
@@ -33,6 +33,7 @@ $(document).ready(function () {
   store.dispatch(setSections(allSections));
 
   store.dispatch(selectSection(section.id));
+  store.dispatch(setRosterProvider(section.login_type));
   store.dispatch(setLoginType(section.login_type));
   store.dispatch(asyncSetCompletedLevelCount(section.id));
 

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -696,13 +696,14 @@ export default function teacherSections(state=initialState, action) {
   }
 
   if (action.type === SET_ROSTER_PROVIDER) {
-    if (!OAuthSectionTypes[action.rosterProvider]) {
-      throw new Error(`SET_ROSTER_PROVIDER called with invalid provider type '${action.rosterProvider}'`);
+    // No-op if this action is called with a non-OAuth section type,
+    // since this action is triggered on every section load.
+    if (OAuthSectionTypes[action.rosterProvider]) {
+      return {
+        ...state,
+        rosterProvider: action.rosterProvider,
+      };
     }
-    return {
-      ...state,
-      rosterProvider: action.rosterProvider,
-    };
   }
 
   //

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -252,6 +252,12 @@ describe('teacherSectionsRedux', () => {
       const nextState = reducer(initialState, action);
       assert.deepEqual(nextState.rosterProvider, 'google_classroom');
     });
+
+    it('does not set section\'s roster provider if it is not an OAuth provider', () => {
+      const action = setRosterProvider('word');
+      const nextState = reducer(initialState, action);
+      assert.deepEqual(nextState.rosterProvider, null);
+    });
   });
 
   describe('setValidGrades', () => {


### PR DESCRIPTION
Make sure `setRosterProvider` is called when the new teacher dashboard is loaded. This is required for the `SyncOmniAuthSectionControl` component (button that syncs sections in the "manage students" tab) to work for OAuth sections.

I also inverted the logic in the `SET_ROSTER_PROVIDER` action since it was causing noisy errors. Now, it will just no-op if it is passed a non-OAuth section type, rather than raising an error.