### PR TITLE
Reenable running CircleCI UI tests by default

### DIFF
--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -22,11 +22,8 @@ RUN_ALL_TESTS_TAG = 'test all'.freeze
 # Only run apps tests on container 0
 RUN_APPS_TESTS_TAG = 'test apps'.freeze
 
-# DEPRECATED - Temporarily default to skip UI tests unless explicitly requested in the commit message.
-# SKIP_UI_TESTS_TAG = 'skip ui'.freeze
-
-# Run UI and Eyes tests.
-TEST_UI_TAG = 'test ui'.freeze
+# Don't run any UI or Eyes tests.
+SKIP_UI_TESTS_TAG = 'skip ui'.freeze
 
 # Don't run any unit tests.
 SKIP_UNIT_TESTS_TAG = 'skip unit'.freeze
@@ -85,10 +82,8 @@ namespace :circle do
       next
     end
 
-    # We used to default to running UI tests in every CircleCI build, but that contributes to high usage of
-    # donated SauceLabs resources.  We now default to NOT run UI Tests unless explicitly requested in the commit message.
-    unless CircleUtils.tagged?(TEST_UI_TAG)
-      ChatClient.log "Commit message: '#{CircleUtils.circle_commit_message}' does not contain [#{TEST_UI_TAG}], skipping UI tests for this run."
+    if CircleUtils.tagged?(SKIP_UI_TESTS_TAG)
+      ChatClient.log "Commit message: '#{CircleUtils.circle_commit_message}' contains [#{SKIP_UI_TESTS_TAG}], skipping UI tests for this run."
       next
     end
 
@@ -161,10 +156,8 @@ namespace :circle do
       next
     end
 
-    # We used to default to running UI tests in every CircleCI build, but that contributes to high usage of
-    # donated SauceLabs resources.  We now default to NOT run UI Tests unless explicitly requested in the commit message.
-    unless CircleUtils.tagged?(TEST_UI_TAG)
-      ChatClient.log "Commit message: '#{CircleUtils.circle_commit_message}' does not contain [#{TEST_UI_TAG}], skipping UI tests for this run."
+    if CircleUtils.tagged?(SKIP_UI_TESTS_TAG)
+      ChatClient.log "Commit message: '#{CircleUtils.circle_commit_message}' contains [#{SKIP_UI_TESTS_TAG}], skipping UI tests for this run."
       next
     end
 
@@ -175,10 +168,8 @@ namespace :circle do
 
   desc 'Rebuild dashboard assets with updated locals.yml settings before running UI tests'
   task :recompile_assets do
-    # We used to default to running UI tests in every CircleCI build, but that contributes to high usage of
-    # donated SauceLabs resources.  We now default to NOT run UI Tests unless explicitly requested in the commit message.
-    unless CircleUtils.tagged?(TEST_UI_TAG)
-      ChatClient.log "Commit message: '#{CircleUtils.circle_commit_message}' does not contain [#{TEST_UI_TAG}], skipping UI tests for this run."
+    if CircleUtils.tagged?(SKIP_UI_TESTS_TAG)
+      ChatClient.log "Commit message: '#{CircleUtils.circle_commit_message}' contains [#{SKIP_UI_TESTS_TAG}], skipping UI tests for this run."
       next
     end
 


### PR DESCRIPTION
Reverts this change: https://github.com/code-dot-org/code-dot-org/pull/26809

Discussed with @simplycloud this morning; we are at 100 max concurrent saucelabs VMs, and we want to try reenabling circle runs to see if that's enough without slowing us down. If it causes problems, we can disable again, and negotiate getting more VMs with them.