### PR TITLE
Scroll to Top of ProjectCardGrid when select a different project view

### DIFF
--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -70,7 +70,7 @@ class ProjectCardGrid extends Component {
     const numProjects = this.state.showAll ? NUM_PROJECTS_ON_PREVIEW : NUM_PROJECTS_IN_APP_VIEW;
 
     return (
-      <div id={'projectCardGrid'} style={styles.grid}>
+      <div id="projectCardGrid" style={styles.grid}>
         {(this.state.showAll) &&
           <div>
             <ProjectAppTypeArea

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -54,8 +54,10 @@ class ProjectCardGrid extends Component {
 
   onSelectApp = (appType) => {
     const projectGridDiv = document.getElementById('projectCardGrid');
-    const projectGridRect = projectGridDiv.getBoundingClientRect();
-    window.scrollTo(projectGridRect.left + window.pageXOffset, projectGridRect.top + window.pageYOffset);
+    if (projectGridDiv) {
+      const projectGridRect = projectGridDiv.getBoundingClientRect();
+      window.scrollTo(projectGridRect.left + window.pageXOffset, projectGridRect.top + window.pageYOffset);
+    }
     this.setState({showAll: false, showApp: appType});
   };
 

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -53,6 +53,9 @@ class ProjectCardGrid extends Component {
   }
 
   onSelectApp = (appType) => {
+    const projectGridDiv = document.getElementById('projectCardGrid');
+    const projectGridRect = projectGridDiv.getBoundingClientRect();
+    window.scrollTo(projectGridRect.left + window.pageXOffset, projectGridRect.top + window.pageYOffset);
     this.setState({showAll: false, showApp: appType});
   };
 
@@ -65,7 +68,7 @@ class ProjectCardGrid extends Component {
     const numProjects = this.state.showAll ? NUM_PROJECTS_ON_PREVIEW : NUM_PROJECTS_IN_APP_VIEW;
 
     return (
-      <div style={styles.grid}>
+      <div id={'projectCardGrid'} style={styles.grid}>
         {(this.state.showAll) &&
           <div>
             <ProjectAppTypeArea


### PR DESCRIPTION
Fix Bug - If you were scrolled down the public projects gallery and clicked to view a detailed view of an app type it would not start you from the top of that app type.

Videos of before and after can be found in the Jira Task ([LP-64](https://codedotorg.atlassian.net/browse/LP-64))


