### PR TITLE
Drone.io - clone PR branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,9 +3,18 @@ kind: pipeline
 name: unit
 
 clone:
-  depth: 50
+  disable: true
 
 steps:
+- name: clone
+  image: docker:git
+  commands:
+  - git clone --branch $DRONE_SOURCE_BRANCH  --depth 50 $DRONE_GIT_HTTP_URL
+  - git checkout $DRONE_COMMIT
+  - git status
+  - git log
+  - exit 1
+
 - name: verify-pr
   image: wintercdo/code-dot-org:0.7
   pull: always
@@ -141,6 +150,6 @@ trigger:
 #     - pull_request
 ---
 kind: signature
-hmac: 85bf71e91bbb85284b075768b4df3288bf99fce202b02e28835cfea417026b7e
+hmac: 2ecc4abd74c846f2c677fe19459a76411bc8f463bacd37dc4f9d7cbf179164c3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,11 +9,8 @@ steps:
 - name: clone
   image: docker:git
   commands:
-  - git clone --branch $DRONE_SOURCE_BRANCH  --depth 50 $DRONE_GIT_HTTP_URL
-  - git checkout $DRONE_COMMIT
-  - git status
-  - git log
-  - exit 1
+  - git clone --branch $DRONE_SOURCE_BRANCH  --depth 50 $DRONE_GIT_HTTP_URL .
+  - git reset --hard $DRONE_COMMIT
 
 - name: verify-pr
   image: wintercdo/code-dot-org:0.7
@@ -88,7 +85,6 @@ trigger:
   event:
     include:
     - pull_request
-    - push
 
 # ---
 # kind: pipeline
@@ -151,6 +147,6 @@ trigger:
 #     - pull_request
 ---
 kind: signature
-hmac: 2ecc4abd74c846f2c677fe19459a76411bc8f463bacd37dc4f9d7cbf179164c3
+hmac: 4ef30caa9dc7941b06d4ed3e8427def6b650ee9b3ceb3b161e2ffe83e603cae4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -88,6 +88,7 @@ trigger:
   event:
     include:
     - pull_request
+    - push
 
 # ---
 # kind: pipeline


### PR DESCRIPTION
Clone the PR branch, instead of doing the default behavior (checkout staging branch, then merge the commit from the PR).

There's logic in circle.rake which uses the current branch to determine the base branch to find changed test files, which doesn't work unless we're on the PR branch, not staging.