### PR TITLE
Fix URLs to work for old/new teacher dashboard

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudentsLoginInfo.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsLoginInfo.jsx
@@ -21,6 +21,18 @@ class ManageStudentsLoginInfo extends Component {
     studioUrlPrefix: PropTypes.string,
   };
 
+  // TODO: (madelynkasula) Delete this method once the old pegasus-served teacher dashboard
+  // has been fully removed.
+  printLoginCardsUrl = () => {
+    const {studioUrlPrefix, sectionId} = this.props;
+
+    if (studioUrlPrefix === window.location.origin) {
+      return `/teacher_dashboard/sections/${sectionId}/print_login_cards`;
+    } else {
+      return `/teacher-dashboard#/sections/${sectionId}/print_signin_cards`;
+    }
+  };
+
   render() {
     const {loginType, sectionId, sectionCode, studioUrlPrefix} = this.props;
     return (
@@ -44,7 +56,7 @@ class ManageStudentsLoginInfo extends Component {
               </a>
             </p>
             <p>
-              <a target="_blank" href={`/teacher-dashboard#/sections/${sectionId}/print_signin_cards`}>
+              <a target="_blank" href={this.printLoginCardsUrl()}>
                 {i18n.printLoginCardExplanation()}
               </a>
             </p>

--- a/apps/src/templates/manageStudents/ManageStudentsLoginInfo.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsLoginInfo.jsx
@@ -17,7 +17,7 @@ class ManageStudentsLoginInfo extends Component {
     sectionCode: PropTypes.string,
     loginType: PropTypes.string,
     // The prefix for the code studio url in the current environment,
-    // e.g. '//studio.code.org' or '//localhost-studio.code.org:3000'.
+    // e.g. 'https://studio.code.org' or 'http://localhost-studio.code.org:3000'.
     studioUrlPrefix: PropTypes.string,
   };
 
@@ -33,14 +33,14 @@ class ManageStudentsLoginInfo extends Component {
             </p>
             <p>
               {i18n.joinSectionExplanation()}
-              <a target="_blank" href={`${window.location.origin}/join`}>
-                {`${window.location.origin}/join`}
+              <a target="_blank" href={`${studioUrlPrefix}/join`}>
+                {`${studioUrlPrefix}/join`}
               </a>
             </p>
             <p>
               {i18n.sectionSignInInfo()}
-              <a target="_blank" href={`http:${studioUrlPrefix}/sections/${sectionCode}`}>
-                {`http:${studioUrlPrefix}/sections/${sectionCode}`}
+              <a target="_blank" href={`${studioUrlPrefix}/sections/${sectionCode}`}>
+                {`${studioUrlPrefix}/sections/${sectionCode}`}
               </a>
             </p>
             <p>
@@ -55,7 +55,7 @@ class ManageStudentsLoginInfo extends Component {
             <p>
               {i18n.joinSectionAsk()}
               <a target="_blank" href={`http:${studioUrlPrefix}/join/${sectionCode}`}>
-                {`http:${studioUrlPrefix}/join/${sectionCode}`}
+                {`${studioUrlPrefix}/join/${sectionCode}`}
               </a>
             </p>
           </div>

--- a/pegasus/sites.v3/code.org/public/teacher-dashboard/index.haml
+++ b/pegasus/sites.v3/code.org/public/teacher-dashboard/index.haml
@@ -51,7 +51,7 @@ title: <%= I18n.t('dashboard_landing_title').inspect %>
 - i18n[:error_string_other_section] = I18n.t('dashboard_error_other_section').gsub(/"/,"\\\\\"")
 
 - data = {}
-- data[:studiourlprefix] = CDO.studio_url
+- data[:studiourlprefix] = CDO.studio_url('', CDO.default_scheme)
 - data[:i18n] = i18n
 - data[:valid_login_types] = DashboardSection::valid_login_types
 - data[:valid_grades] = DashboardSection::valid_grades


### PR DESCRIPTION
Add the protocol to `studioUrlPrefix` in pegasus-served teacher dashboard to reuse work done in #26903.

Note: There is one URL that is still broken between pegasus/dashboard teacher dashboards, which I will fix in another PR. (`/teacher-dashboard#/sections/${sectionId}/student/${id}` -- this route will no longer exist in the new dashboard, and will instead point to the course or script overview page, viewing as that student)