### PR TITLE
Script case validation

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -37,7 +37,7 @@ export default class ScriptEditor extends React.Component {
     loginRequired: PropTypes.bool,
     hideableStages: PropTypes.bool,
     studentDetailProgressView: PropTypes.bool,
-    professionalLearningCourse: PropTypes.bool,
+    professionalLearningCourse: PropTypes.string,
     peerReviewsRequired: PropTypes.number,
     wrapupVideo: PropTypes.string,
     excludeCsfColumnInLegend: PropTypes.bool,

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1089,8 +1089,13 @@ class Script < ActiveRecord::Base
   def update_teacher_resources(types, links)
     return if types.nil? || links.nil? || types.length != links.length
     # Only take those pairs in which we have both a type and a link
-    self.teacher_resources = types.zip(links).select {|type, link| type.present? && link.present?}
-    save!
+    resources = types.zip(links).select {|type, link| type.present? && link.present?}
+    update!(
+      {
+        teacher_resources: resources,
+        skip_name_format_validation: true
+      }
+    )
   end
 
   def self.rake


### PR DESCRIPTION
Levelbuilders on /s/K5-OnlinePD were getting errors saving changes to scripts with upper case names: https://app.honeybadger.io/projects/3240/faults/45403228

The root cause was a name validation failure here: https://github.com/code-dot-org/code-dot-org/blob/cb2fd67b5812161aa7e809f33fd3a3555c4ff747/dashboard/app/models/script.rb#L1089-L1093

Name validation didn't make sense here, since we aren't modifying the name. So I disabled name validation at this location.

This fixes saving /s/K5-OnlinePD for me locally.