### PR TITLE
Strip blank level names from update_contained_levels earlier

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -117,7 +117,7 @@ class Blockly < Level
     super(level_hash.tap {|hash| hash['properties'].except!(*xml_blocks)})
   end
 
-  before_save :update_contained_levels
+  before_validation :update_contained_levels
 
   def update_contained_levels
     contained_level_names = properties["contained_level_names"]

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -806,4 +806,12 @@ EOS
     assert_equal contained_level_1_copy, level_2_copy.contained_levels.first
     assert_equal contained_level_2_copy, level_2_copy.contained_levels.last
   end
+
+  test 'contained_level_names filters blank names before validation' do
+    level = build :level
+    level.contained_level_names = ['', 'real_name']
+    assert_equal level.contained_level_names, ['', 'real_name']
+    level.valid?
+    assert_equal level.contained_level_names, ['real_name']
+  end
 end


### PR DESCRIPTION
pair: ErinP

Context: Elizabeth was trying to edit a Game Lab level and was unable to save.  The stack trace (below) pointed to failure to find a contained level, which was odd since there were no contained levels in this case.

I couldn't repro this on the console for levelbuilder until I noticed that the request being sent included a blank contained level name:
```
"contained_level_names"=>[""],
```

We should fix that, but the _first_ fix seems to be making our server more resilient against this.  My theory is that this is only now breaking because we recently enabled text-to-speech for contained levels and _that_ `before_save` hook is running before the one that cleans up the contained_level_names array.  Therefore I'm making this a before_validation step which happens earlier in the save/update workflow (https://guides.rubyonrails.org/active_record_callbacks.html)

The original error message:
```
Couldn't create level:

message: Error (): ActiveRecord::RecordNotFound in LevelsController#update

Couldn't find Level
Extracted source (around line #212):

#210 
#211       def find_by!(*args) # :nodoc:
*212         find_by(*args) or raise RecordNotFound.new("Couldn't find #{name}", name)
#213       end
#214 
#215       def initialize_generated_modules # :nodoc:

Extracted source (around line #361):

#359     # which some tests rely on (unsure about non-tests).
#360     field = level_identifier.to_i.to_s == level_identifier.to_s ? :id : :name
*361     level = Level.find_by!(field => level_identifier)
#362     # Cache the level by ID and by name, unless it wasn't found.
#363     @@level_cache[level.id] = level if level && should_cache?
#364     @@level_cache[level.name] = level if level && should_cache?

Extracted source (around line #451):

#449     return [] unless names.present?
#450     names.map do |contained_level_name|
*451       Script.cache_find_level(contained_level_name)
#452     end
#453   end
#454 


Rails.root: /home/ubuntu/levelbuilder/dashboard

Application Trace
app/models/script.rb:361:in `cache_find_level'
app/models/levels/level.rb:451:in `block in contained_levels'
app/models/levels/level.rb:450:in `map'
app/models/levels/level.rb:450:in `contained_levels'
app/models/concerns/text_to_speech.rb:164:in `tts_for_contained_level'
app/models/concerns/text_to_speech.rb:158:in `tts_long_instructions_text'
app/models/concerns/text_to_speech.rb:204:in `tts_update'
app/controllers/levels_controller.rb:121:in `update'
app/controllers/application_controller.rb:152:in `block in with_locale'
app/controllers/application_controller.rb:151:in `with_locale'
```
