### PR TITLE
Export 5-day workshop data to S3 via cron

### DIFF
--- a/bin/cron/workshops_to_s3
+++ b/bin/cron/workshops_to_s3
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+require_relative '../../dashboard/config/environment'
+require_relative '../../lib/cdo/only_one'
+require 'cdo/aws/s3'
+
+# Automates the export of 5-day summer workshops data
+# to an S3 bucket. Mirrors what would happen via the UI
+# if an admin clicked the "Download CSV" option
+# in the workshop dashboard.
+def main
+  workshops = Pd::Workshop.
+    where(
+      {
+        course: [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD],
+        subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
+      }
+    ).
+    scheduled_start_on_or_after(Date.new(2019, 5, 1))
+
+  workshop_hash = workshops.map {|w| Api::V1::Pd::WorkshopDownloadSerializer.new(w).attributes}
+
+  # Generate throwaway class that has functionality
+  # from Api::CsvDownload module to emulate what happens in
+  # controller/api/vi/pd/workshop_controller's filter method
+  output = Class.new.extend(Api::CsvDownload).generate_csv workshop_hash
+
+  AWS::S3.upload_to_bucket('cdo-data-sharing-internal', 'summer_workshops.csv', output, no_random: true)
+end
+
+main if only_one_running?(__FILE__)

--- a/bin/cron/workshops_to_s3
+++ b/bin/cron/workshops_to_s3
@@ -19,9 +19,6 @@ def main
 
   workshop_hash = workshops.map {|w| Api::V1::Pd::WorkshopDownloadSerializer.new(w).attributes}
 
-  # Generate throwaway class that has functionality
-  # from Api::CsvDownload module to emulate what happens in
-  # controller/api/vi/pd/workshop_controller's filter method
   output = generate_csv workshop_hash
 
   AWS::S3.upload_to_bucket('cdo-data-sharing-internal', 'summer_workshops.csv', output, no_random: true)

--- a/bin/cron/workshops_to_s3
+++ b/bin/cron/workshops_to_s3
@@ -8,14 +8,14 @@ require 'cdo/aws/s3'
 # if an admin clicked the "Download CSV" option
 # in the workshop dashboard.
 def main
-  include Api::CsvDownload
+  extend Api::CsvDownload
 
   workshops = Pd::Workshop.
     where({
             course: [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD],
             subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
           }
-         ).scheduled_start_on_or_after(Date.new(2019, 5, 1))
+        ).scheduled_start_on_or_after(Date.new(2019, 5, 1))
 
   workshop_hash = workshops.map {|w| Api::V1::Pd::WorkshopDownloadSerializer.new(w).attributes}
 

--- a/bin/cron/workshops_to_s3
+++ b/bin/cron/workshops_to_s3
@@ -8,21 +8,21 @@ require 'cdo/aws/s3'
 # if an admin clicked the "Download CSV" option
 # in the workshop dashboard.
 def main
+  include Api::CsvDownload
+
   workshops = Pd::Workshop.
-    where(
-      {
-        course: [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD],
-        subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
-      }
-    ).
-    scheduled_start_on_or_after(Date.new(2019, 5, 1))
+    where({
+            course: [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD],
+            subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
+          }
+         ).scheduled_start_on_or_after(Date.new(2019, 5, 1))
 
   workshop_hash = workshops.map {|w| Api::V1::Pd::WorkshopDownloadSerializer.new(w).attributes}
 
   # Generate throwaway class that has functionality
   # from Api::CsvDownload module to emulate what happens in
   # controller/api/vi/pd/workshop_controller's filter method
-  output = Class.new.extend(Api::CsvDownload).generate_csv workshop_hash
+  output = generate_csv workshop_hash
 
   AWS::S3.upload_to_bucket('cdo-data-sharing-internal', 'summer_workshops.csv', output, no_random: true)
 end


### PR DESCRIPTION
Automates export of PD workshops to S3 for outreach team to use in tracking upcoming summer workshops.

Check out in particular odd use of a throwaway class to gain access to the Api::CsvDownload module -- might be a better way to do this, but best way I could find to gain access to the `generate_csv` method.