### PR TITLE
PL: teacher application reports GA pageviews

### DIFF
--- a/apps/src/code-studio/pd/application/teacher1920/Teacher1920Application.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Teacher1920Application.jsx
@@ -6,6 +6,7 @@ import Section3TeachingBackground from './Section3TeachingBackground';
 import Section4ProfessionalLearningProgramRequirements from './Section4ProfessionalLearningProgramRequirements';
 import Section5AdditionalDemographicInformation from './Section5AdditionalDemographicInformation';
 import Section6Submission from './Section6Submission';
+/* global ga */
 
 export default class Teacher1920Application extends FormController {
   static propTypes = {
@@ -47,5 +48,14 @@ export default class Teacher1920Application extends FormController {
   onSuccessfulSubmit() {
     // Let the server display a confirmation page as appropriate
     window.location.reload(true);
+  }
+
+  /**
+   * @override
+   */
+  onSuccessfulSetPage(newPage) {
+    // Report a unique page view to GA.
+    ga('set', 'page', '/pd/application/teacher/' + newPage);
+    ga('send', 'pageview');
   }
 }

--- a/apps/src/code-studio/pd/application/teacher1920/Teacher1920Application.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Teacher1920Application.jsx
@@ -53,9 +53,9 @@ export default class Teacher1920Application extends FormController {
   /**
    * @override
    */
-  onSuccessfulSetPage(newPage) {
+  onSetPage(newPage) {
     // Report a unique page view to GA.
-    ga('set', 'page', '/pd/application/teacher/' + newPage);
+    ga('set', 'page', '/pd/application/teacher/' + newPage + 1);
     ga('send', 'pageview');
   }
 }

--- a/apps/src/code-studio/pd/form_components/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components/FormController.jsx
@@ -48,15 +48,19 @@ export default class FormController extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.nextPage = this.nextPage.bind(this);
     this.prevPage = this.prevPage.bind(this);
-
-    this.onSuccessfulSetPage(0);
   }
 
   componentWillMount() {
+    let newPage;
     if (this.constructor.sessionStorageKey && sessionStorage[this.constructor.sessionStorageKey]) {
       const reloadedState = JSON.parse(sessionStorage[this.constructor.sessionStorageKey]);
       this.setState(reloadedState);
+      newPage = reloadedState.currentPage;
+    } else {
+      newPage = this.state.currentPage;
     }
+
+    this.onSetPage(newPage);
   }
 
   /**
@@ -170,9 +174,9 @@ export default class FormController extends React.Component {
   }
 
   /**
-   * Called when we succesfully set a new page.
+   * Called when we set a new page.
    */
-  onSuccessfulSetPage(newPage) {
+  onSetPage(newPage) {
     // Intentional noop; overridden by child classes
   }
 
@@ -409,7 +413,7 @@ export default class FormController extends React.Component {
 
       this.saveToSessionStorage({currentPage: newPage});
 
-      this.onSuccessfulSetPage(newPage);
+      this.onSetPage(newPage);
     }
   }
 

--- a/apps/src/code-studio/pd/form_components/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components/FormController.jsx
@@ -48,6 +48,8 @@ export default class FormController extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.nextPage = this.nextPage.bind(this);
     this.prevPage = this.prevPage.bind(this);
+
+    this.onSuccessfulSetPage(0);
   }
 
   componentWillMount() {
@@ -164,6 +166,13 @@ export default class FormController extends React.Component {
    * Called when we get a successful response from the API submission
    */
   onSuccessfulSubmit() {
+    // Intentional noop; overridden by child classes
+  }
+
+  /**
+   * Called when we succesfully set a new page.
+   */
+  onSuccessfulSetPage(newPage) {
     // Intentional noop; overridden by child classes
   }
 
@@ -399,6 +408,8 @@ export default class FormController extends React.Component {
       });
 
       this.saveToSessionStorage({currentPage: newPage});
+
+      this.onSuccessfulSetPage(newPage);
     }
   }
 

--- a/dashboard/app/views/pd/application/teacher_application/submitted.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application/submitted.html.haml
@@ -12,3 +12,10 @@
     = link_to 'https://code.org/educate', 'https://code.org/educate'
     for additional resources and opportunities to connect with other computer science educators.
     Thank you for supporting computer science for all!
+
+:javascript
+  $(document).ready(function() {
+    // Report a unique page view to GA.
+    ga('set', 'page', '/pd/application/teacher/submitted');
+    ga('send', 'pageview');
+  });


### PR DESCRIPTION
Each page will report a page view at https://studio.code.org/pd/application/teacher/1 through https://studio.code.org/pd/application/teacher/6.

The submitted page will report a page view at https://studio.code.org/pd/application/teacher/submitted.

This is designed to be easily extensible so that other PD forms can do similar.