### PR TITLE
Adds Header above map that was missing on the splat page of /promote

### DIFF
--- a/pegasus/sites.v3/code.org/public/promote/splat.haml
+++ b/pegasus/sites.v3/code.org/public/promote/splat.haml
@@ -47,6 +47,7 @@ theme: responsive
     #petition-section.section.clear
       = view :petition
 
+    %h1.tablet-feature Choose a State
     #interactive-map.section.clear
       = view :interactive_map, use_url: true
 


### PR DESCRIPTION
Issue: Should say "Choose a State" above map with h1 header.

## Before

<img width="1005" alt="screen shot 2019-02-06 at 11 58 12 am" src="https://user-images.githubusercontent.com/208083/52358715-83263380-2a06-11e9-8892-98ab5f0365ad.png">

## After

<img width="768" alt="screen shot 2019-02-06 at 12 00 57 pm" src="https://user-images.githubusercontent.com/208083/52358957-eadc7e80-2a06-11e9-930f-981d6403e283.png">


