### PR TITLE
Updating all titles on new promote page to use Title Case

### DIFF
--- a/pegasus/sites.v3/code.org/public/promote/index.haml
+++ b/pegasus/sites.v3/code.org/public/promote/index.haml
@@ -30,7 +30,7 @@ theme: responsive
     #stats-section-mobile.section.clear.mobile-feature
       = view :stats_mobile
 
-    %h1 Code.org’s impact in schools
+    %h1 Code.org’s Impact in Schools
     #impact-section.section.clear.desktop-feature
       = view :stats_impact_carousel
 
@@ -45,19 +45,19 @@ theme: responsive
     #interactive-map.section.clear
       = view :interactive_map, use_url: true
 
-    %h1 Advocate for computer science locally
+    %h1 Advocate for Computer Science Locally
     #advocate-locally.section.clear
       = view :stats_advocate_locally
 
   %div{:id=>'universal_content'}
 
-    %h1 Tell the world!
+    %h1 Tell the World!
     #youtube-section.section.clear
-      %h2 Share the Code.org video
+      %h2 Share the Code.org Video
       = view :youtube_videos
 
     #quotes-section.section.clear
-      %h2 Leaders and trendsetters agree more students should learn computer science
+      %h2 Leaders and Trendsetters Agree More Students Should Learn Computer Science
       = view :top_quotes
 
 = view 'popup_window.js'

--- a/pegasus/sites.v3/code.org/public/promote/splat.haml
+++ b/pegasus/sites.v3/code.org/public/promote/splat.haml
@@ -36,7 +36,7 @@ theme: responsive
     #stats-section-mobile.section.clear.mobile-feature
       = view :stats_mobile
 
-    %h1 Code.org’s impact in schools
+    %h1 Code.org’s Impact in Schools
     #impact-section.section.clear.desktop-feature
       = view :stats_impact_carousel
 
@@ -51,19 +51,19 @@ theme: responsive
     #interactive-map.section.clear
       = view :interactive_map, use_url: true
 
-    %h1 Advocate for computer science locally
+    %h1 Advocate for Computer Science Locally
     #advocate-locally.section.clear
       = view :stats_advocate_locally
 
   %div{:id=>'universal_content'}
 
-    %h1 Tell the world!
+    %h1 Tell the World!
     #youtube-section.section.clear
-      %h2 Share the Code.org video
+      %h2 Share the Code.org Video
       = view :youtube_videos
 
     #quotes-section.section.clear
-      %h2 Leaders and trendsetters agree more students should learn computer science
+      %h2 Leaders and Trendsetters Agree More Students Should Learn Computer Science
       = view :top_quotes
 
 = view 'popup_window.js'


### PR DESCRIPTION
H1 and H2 headings on promote page now use title case.

## Before

<img width="789" alt="screen shot 2019-02-06 at 2 09 43 pm" src="https://user-images.githubusercontent.com/208083/52366993-02246780-2a19-11e9-9edc-42f08d04923e.png">
<img width="771" alt="screen shot 2019-02-06 at 2 09 48 pm" src="https://user-images.githubusercontent.com/208083/52366994-02246780-2a19-11e9-920d-7c7cb92af009.png">
<img width="546" alt="screen shot 2019-02-06 at 2 09 53 pm" src="https://user-images.githubusercontent.com/208083/52366995-02246780-2a19-11e9-885b-24b3bb60a0ac.png">
<img width="681" alt="screen shot 2019-02-06 at 2 09 57 pm" src="https://user-images.githubusercontent.com/208083/52366996-02246780-2a19-11e9-95dd-d5fa71038c40.png">

## After

<img width="689" alt="screen shot 2019-02-06 at 2 09 11 pm" src="https://user-images.githubusercontent.com/208083/52366971-fafd5980-2a18-11e9-8904-fc82cf5425db.png">
<img width="626" alt="screen shot 2019-02-06 at 2 09 29 pm" src="https://user-images.githubusercontent.com/208083/52366972-fb95f000-2a18-11e9-98b1-139f48e78380.png">
<img width="458" alt="screen shot 2019-02-06 at 2 09 24 pm" src="https://user-images.githubusercontent.com/208083/52366973-fb95f000-2a18-11e9-956c-0e23d96b0d6d.png">
<img width="680" alt="screen shot 2019-02-06 at 2 09 17 pm" src="https://user-images.githubusercontent.com/208083/52366974-fb95f000-2a18-11e9-8673-03bc9abf99cb.png">


