### PR TITLE
Require scholarship status on accept

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/constants.js
+++ b/apps/src/code-studio/pd/application_dashboard/constants.js
@@ -87,3 +87,14 @@ export const ApplicationTypes = {
   teacher: 'Teacher',
   facilitator: 'Facilitator'
 };
+
+/**
+ * Application statuses for which we require a scholarship status
+ */
+export const ScholarshipStatusRequiredStatuses = [
+  'accepted_not_notified',
+  'accepted_notified_by_partner',
+  'accepted_no_cost_registration',
+  'registration_sent',
+  'paid'
+];

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -282,7 +282,7 @@ export class DetailViewContents extends React.Component {
 
   handleStatusChange = (event) => {
     const workshopAssigned = this.props.applicationData.pd_workshop_id || this.props.applicationData.fit_workshop_id;
-    if (this.props.applicationData.application_type === ApplicationTypes.teacher && !this.props.applicationData.scholarship_status && SCHOLARSHIP_STATUS_REQUIRED_STATUSES.includes(event.target.value)) {
+    if (this.props.applicationData.application_type === ApplicationTypes.teacher && !this.state.scholarship_status && SCHOLARSHIP_STATUS_REQUIRED_STATUSES.includes(event.target.value)) {
       this.setState({
         cantSaveStatusReason: `Please assign a scholarship status to this applicant before setting this
                               applicant's status to ${ApplicationStatuses[this.props.viewType][event.target.value]}.`,

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -44,6 +44,7 @@ import {
   ApplicationStatuses,
   ApplicationFinalStatuses,
   ApplicationTypes,
+  ScholarshipStatusRequiredStatuses
 } from './constants';
 import {
   FacilitatorScoringFields
@@ -115,14 +116,6 @@ const styles = {
     marginLeft: '30px'
   }
 };
-
-const SCHOLARSHIP_STATUS_REQUIRED_STATUSES = [
-  'accepted_not_notified',
-  'accepted_notified_by_partner',
-  'accepted_no_cost_registration',
-  'registration_sent',
-  'paid'
-];
 
 const NA = "N/A";
 
@@ -282,7 +275,7 @@ export class DetailViewContents extends React.Component {
 
   handleStatusChange = (event) => {
     const workshopAssigned = this.props.applicationData.pd_workshop_id || this.props.applicationData.fit_workshop_id;
-    if (this.props.applicationData.application_type === ApplicationTypes.teacher && !this.state.scholarship_status && SCHOLARSHIP_STATUS_REQUIRED_STATUSES.includes(event.target.value)) {
+    if (this.props.applicationData.application_type === ApplicationTypes.teacher && !this.state.scholarship_status && ScholarshipStatusRequiredStatuses.includes(event.target.value)) {
       this.setState({
         cantSaveStatusReason: `Please assign a scholarship status to this applicant before setting this
                               applicant's status to ${ApplicationStatuses[this.props.viewType][event.target.value]}.`,

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -120,6 +120,11 @@ const NA = "N/A";
 
 const DEFAULT_NOTES = "Strengths:\nWeaknesses:\nPotential red flags to follow-up on:\nOther notes:";
 
+const WORKSHOP_REQUIRED = `Please assign a summer workshop to this applicant before setting this
+                          applicant's status to "Accepted - No Cost Registration" or "Registration Sent".
+                          These statuses will trigger an automated email with a registration link to their
+                          assigned workshop.`;
+
 export class DetailViewContents extends React.Component {
   static propTypes = {
     canLock: PropTypes.bool,
@@ -270,7 +275,8 @@ export class DetailViewContents extends React.Component {
     const workshopAssigned = this.props.applicationData.pd_workshop_id || this.props.applicationData.fit_workshop_id;
     if (this.props.applicationData.regional_partner_emails_sent_by_system && !workshopAssigned && ['accepted_no_cost_registration', 'registration_sent'].includes(event.target.value)) {
       this.setState({
-        showCantSaveStatusDialog: true
+        showCantSaveStatusDialog: true,
+        cantSaveStatusReason: WORKSHOP_REQUIRED
       });
     } else {
       this.setState({
@@ -281,7 +287,8 @@ export class DetailViewContents extends React.Component {
 
   handleCantSaveStatusOk = (event) => {
     this.setState({
-      showCantSaveStatusDialog: false
+      showCantSaveStatusDialog: false,
+      cantSaveStatusReason: null
     });
   };
 
@@ -606,12 +613,7 @@ export class DetailViewContents extends React.Component {
           show={this.state.showCantSaveStatusDialog}
           onOk={this.handleCantSaveStatusOk}
           headerText="Cannot save applicant status"
-          bodyText={
-            `Please assign a summer workshop to this applicant before setting this
-            applicant's status to "Accepted - No Cost Registration" or "Registration Sent".
-            These statuses will trigger an automated email with a registration link to their
-            assigned workshop.`
-          }
+          bodyText={this.state.cantSaveStatusReason}
           okText="OK"
         />
       </div>

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -517,6 +517,7 @@ export class DetailViewContents extends React.Component {
     return (
       <FormGroup>
         <Select
+          clearable={false}
           value={this.state.scholarship_status}
           onChange={this.handleScholarshipStatusChange}
           options={ScholarshipDropdownOptions}

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -116,6 +116,14 @@ const styles = {
   }
 };
 
+const SCHOLARSHIP_STATUS_REQUIRED_STATUSES = [
+  'accepted_not_notified',
+  'accepted_notified_by_partner',
+  'accepted_no_cost_registration',
+  'registration_sent',
+  'paid'
+];
+
 const NA = "N/A";
 
 const DEFAULT_NOTES = "Strengths:\nWeaknesses:\nPotential red flags to follow-up on:\nOther notes:";
@@ -240,7 +248,8 @@ export class DetailViewContents extends React.Component {
       pd_workshop_id: this.props.applicationData.pd_workshop_id,
       fit_workshop_id: this.props.applicationData.fit_workshop_id,
       scholarship_status: this.props.applicationData.scholarship_status,
-      bonus_point_questions: bonusPoints
+      bonus_point_questions: bonusPoints,
+      cantSaveStatusReason: ''
     };
   }
 
@@ -273,10 +282,16 @@ export class DetailViewContents extends React.Component {
 
   handleStatusChange = (event) => {
     const workshopAssigned = this.props.applicationData.pd_workshop_id || this.props.applicationData.fit_workshop_id;
-    if (this.props.applicationData.regional_partner_emails_sent_by_system && !workshopAssigned && ['accepted_no_cost_registration', 'registration_sent'].includes(event.target.value)) {
+    if (this.props.applicationData.application_type === ApplicationTypes.teacher && !this.props.applicationData.scholarship_status && SCHOLARSHIP_STATUS_REQUIRED_STATUSES.includes(event.target.value)) {
       this.setState({
-        showCantSaveStatusDialog: true,
-        cantSaveStatusReason: WORKSHOP_REQUIRED
+        cantSaveStatusReason: `Please assign a scholarship status to this applicant before setting this
+                              applicant's status to ${ApplicationStatuses[this.props.viewType][event.target.value]}.`,
+        showCantSaveStatusDialog: true
+      });
+    } else if (this.props.applicationData.regional_partner_emails_sent_by_system && !workshopAssigned && ['accepted_no_cost_registration', 'registration_sent'].includes(event.target.value)) {
+      this.setState({
+        cantSaveStatusReason: WORKSHOP_REQUIRED,
+        showCantSaveStatusDialog: true
       });
     } else {
       this.setState({
@@ -287,8 +302,8 @@ export class DetailViewContents extends React.Component {
 
   handleCantSaveStatusOk = (event) => {
     this.setState({
-      showCantSaveStatusDialog: false,
-      cantSaveStatusReason: null
+      cantSaveStatusReason: '',
+      showCantSaveStatusDialog: false
     });
   };
 


### PR DESCRIPTION
[PLC-3](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=PLC&view=detail&selectedIssue=PLC-3)
UI tests to come in a fast-follow PR.

For teacher applications, when changing the status to any of the following, if the scholarship status has been set, show a pop up asking the reviewer to set the scholarship status.
- accepted_not_notified
- accepted_notified_by_partner
- accepted_no_cost_registration
- registration_sent
- paid

Also prevent the scholarship status from being unset. It can be changed to a different value, but once it has been set the dropdown can't be cleared.

<img width="561" alt="screen shot 2019-02-05 at 4 28 32 pm" src="https://user-images.githubusercontent.com/224089/52371803-51639b80-2a0b-11e9-95de-066e33f7bc36.png">
