### PR TITLE
Replace incorrect translation with Hour of Code

### DIFF
--- a/dashboard/config/locales/fi-FI.yml
+++ b/dashboard/config/locales/fi-FI.yml
@@ -605,7 +605,7 @@ fi:
       title: Minecraft
     hero:
       title: Minecraft
-      body: Minecraft on palannut Koodi.fi:hin uusilla toiminnoilla! Matkaa halki
+      body: Minecraft on palannut Hour of Code:hin uusilla toiminnoilla! Matkaa halki
         Minecraftin koodin matkassa
     unplugged:
       title: Oppitunnit ilman tietokonetta

--- a/dashboard/config/locales/scripts.fi-FI.yml
+++ b/dashboard/config/locales/scripts.fi-FI.yml
@@ -1341,7 +1341,7 @@ fi:
           stages:
             Minecraft Hour of Code:
               name: Minecraft Koodaustunti
-          description: Minecraft on palannut Koodi.fi:hin uusilla toiminnoilla! Matkaa
+          description: Minecraft on palannut Hour of Code:hin uusilla toiminnoilla! Matkaa
             halki Minecraftin koodin matkassa
         course-e-2018:
           stages:
@@ -1574,7 +1574,7 @@ fi:
             Aquatic:
               name: merellinen
           title: 'Minecraft: Merellinen matka'
-          description_short: Minecraft on palannut Koodi.fi:hin uusilla toiminnoilla!
+          description_short: Minecraft on palannut Hour of Code:hin uusilla toiminnoilla!
         dance-extras:
           title: Jatka tanssimista
           description: Syvennä ensimmäisen oppitunnin osaamistasi laajennetuilla projekti-ideoilla.

--- a/pegasus/cache/i18n/fi-FI.yml
+++ b/pegasus/cache/i18n/fi-FI.yml
@@ -455,7 +455,7 @@
   minecraft_adventurer: Minecraft seikkailija
   minecraft_tutorials: Minecraft Koodaustunnin ohjeet
   minecraft_specs: Useita kieliä | Modernit selaimet | Yli 6-vuotiaille
-  minecraft_agent_description: Minecraft on palannut Koodi.fi:hin uusilla toiminnoilla!
+  minecraft_agent_description: Minecraft on palannut Hour of Code:hin uusilla toiminnoilla!
     Matkaa halki Minecraftin koodin matkassa
   minecraft_agent_button: Aloita
   minecraft_designer_description: Koodaa eläimiä ja muita Minecraft otuksia omalla
@@ -1465,7 +1465,7 @@
   applab_tile_teacher_guide: Katso opettajan opas
   aquatic_name: 'Minecraft: Merellinen matka'
   hoc_overview_partner_activities_title: Enemmän toimintoja yhteistyökumppaneilta
-  hoc_overview_partner_activities_body: Koodi.fi-sivustolla on yli 100 tietojenkäsittelyn
+  hoc_overview_partner_activities_body: Hour of Code-sivustolla on yli 100 tietojenkäsittelyn
     aktiviteettia kaikenikäisille ja kaikille osaamistasoille. Sivuston on kehittänyt
     Code.org ja sen yhteistyökumppanit.
   hoc_overview_partner_activities_link: Näytä tehtävät
@@ -1475,9 +1475,9 @@
   hoc2018_creativity_what_will_you_create: Mitä luot?
   hoc2018_mc_page_title: Minecraft Koodaustunnin ohjeet
   hoc2018_mc_details: Useita kieliä | Modernit selaimet | Yli 6-vuotiaille
-  hoc2018_mc_aquatic_description: Minecraft on palannut Koodi.fi:hin uusilla toiminnoilla!
+  hoc2018_mc_aquatic_description: Minecraft on palannut Hour of Code:hin uusilla toiminnoilla!
     Matkaa halki Minecraftin koodin matkassa
-  hoc2018_mc_hero_description: Minecraft on palannut Koodi.fi:hin uusilla toiminnoilla!
+  hoc2018_mc_hero_description: Minecraft on palannut Hour of Code:hin uusilla toiminnoilla!
     Matkaa halki Minecraftin koodin matkassa
   hoc2018_mc_designer_title: Minecraft suunnittelija
   hoc2018_mc_designer_description: Koodaa eläimiä ja muita Minecraft otuksia omalla
@@ -1499,7 +1499,7 @@
   hoc2018_mc_homepage_what_create: Mitä luot?
   hoc2018_mc_homepage_join_us: Liity joukkoomme
   hoc2018_mc_homepage_try_it: Kokeile
-  hoc2018_mc_back_journey: Minecraft on palannut Koodi.fi:hin uusilla toiminnoilla!
+  hoc2018_mc_back_journey: Minecraft on palannut Hour of Code:hin uusilla toiminnoilla!
     Matkaa halki Minecraftin koodin matkassa
   hoc2018_mc_teacher_guide: Katso opettajan opas
   hoc2018_mc_minecraft_education: Minecraft koulutus


### PR DESCRIPTION
This PR is to replace the incorrectly translated phrase "Hour of Code" in Finnish with the English string.  We identified areas on the website that have the Finnish phrase "koodi  . fi " with "Hour of Code."   The "koodi . fi " links to an inappropriate site.

Once an appropriate translation is identified, the source string will be updated.

Before 
<img width="624" alt="screen shot 2019-02-06 at 2 13 47 pm" src="https://user-images.githubusercontent.com/30066710/52377379-8aa30800-2a19-11e9-8187-82e7b32d3fd9.png">



After

<img width="492" alt="screen shot 2019-02-06 at 2 32 14 pm" src="https://user-images.githubusercontent.com/30066710/52378264-1453d500-2a1c-11e9-8bf4-5558a83a5421.png">
