### PR TITLE
Make runner.rb use headless chrome by default in local mode

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -87,8 +87,9 @@ end
 
 def get_browser(test_run_name)
   if ENV['TEST_LOCAL'] == 'true'
+    headless = ENV['TEST_LOCAL_HEADLESS'] == 'true'
     # This drives a local installation of ChromeDriver running on port 9515, instead of Saucelabs.
-    SeleniumBrowser.local_browser
+    SeleniumBrowser.local_browser(headless)
   else
     saucelabs_browser test_run_name
   end

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -101,6 +101,7 @@ def parse_options
     options.csedweek_domain = 'test.csedweek.org'
     options.advocacy_domain = 'test-advocacy.code.org'
     options.local = nil
+    options.local_headless = true
     options.html = nil
     options.maximize = nil
     options.auto_retry = false
@@ -139,6 +140,9 @@ def parse_options
         options.hourofcode_domain = 'localhost.hourofcode.com:3000'
         options.csedweek_domain = 'localhost.csedweek.org:3000'
         options.advocacy_domain = 'localhost-advocacy.code.org:3000'
+      end
+      opts.on("--headed", "Open visible chrome browser windows. Runs in headless mode without this flag. Only relevant when -l is specified.") do
+        options.local_headless = false
       end
       opts.on("-p", "--pegasus Domain", String, "Specify an override domain for code.org, e.g. localhost.code.org:3000") do |p|
         if p == 'localhost:3000'
@@ -673,6 +677,7 @@ def run_feature(browser, feature, options)
   run_environment['CSEDWEEK_TEST_DOMAIN'] = options.csedweek_domain if options.csedweek_domain
   run_environment['ADVOCACY_TEST_DOMAIN'] = options.advocacy_domain if options.advocacy_domain
   run_environment['TEST_LOCAL'] = options.local ? "true" : "false"
+  run_environment['TEST_LOCAL_HEADLESS'] = options.local_headless ? "true" : "false"
   run_environment['MAXIMIZE_LOCAL'] = options.maximize ? "true" : "false"
   run_environment['MOBILE'] = browser['mobile'] ? "true" : "false"
   run_environment['FAIL_FAST'] = options.fail_fast ? "true" : nil

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -1,10 +1,14 @@
 require 'selenium/webdriver'
 
 module SeleniumBrowser
-  def self.local_browser
+  def self.local_browser(headless=true)
     ensure_chromedriver_running
     sleep 2
-    browser = Selenium::WebDriver.for :chrome, url: 'http://127.0.0.1:9515'
+    options = Selenium::WebDriver::Chrome::Options.new
+    if headless
+      options.add_argument('--headless')
+    end
+    browser = Selenium::WebDriver.for :chrome, url: 'http://127.0.0.1:9515', options: options
     if ENV['MAXIMIZE_LOCAL']
       max_width, max_height = browser.execute_script('return [window.screen.availWidth, window.screen.availHeight];')
       browser.manage.window.resize_to(max_width, max_height)


### PR DESCRIPTION
This is needed (as far as I can tell) to have our tests run using local chrome on CircleCI.

Tested locally with these commands:

Did not open browser window:
`./runner.rb -l --dashboard studio.code.org --pegasus code.org -f features/projects/artist_project.feature`

Opened new browser window:
`./runner.rb -l --headed --dashboard studio.code.org --pegasus code.org -f features/projects/artist_project.feature`