### PR TITLE
Progress tab styles

### DIFF
--- a/apps/src/templates/sectionProgress/ProgressBox.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.jsx
@@ -21,6 +21,7 @@ export default class ProgressBox extends Component {
     incomplete: PropTypes.number,
     imperfect: PropTypes.number,
     perfect: PropTypes.number,
+    style: PropTypes.object,
   };
 
   render() {
@@ -28,7 +29,8 @@ export default class ProgressBox extends Component {
 
     const boxWithBorderStyle = {
       ...styles.box,
-      borderColor: started ? color.level_perfect : color.light_gray
+      borderColor: started ? color.level_perfect : color.light_gray,
+      ...this.props.style,
     };
 
     const perfectLevels = {

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -45,15 +45,9 @@ const styles = {
   lessonSelectorContainer: {
     float: 'right',
   },
-  viewCourseLink: {
-    float: 'right',
-    marginTop: 10,
-  },
   viewCourseLinkBox: {
     width: '100%',
-    height: 10,
-    lineHeight: '10px',
-    clear: 'both'
+    textAlign: 'right',
   },
 };
 
@@ -130,17 +124,15 @@ class SectionProgress extends Component {
 
     return (
       <div>
-        <div style={styles.viewCourseLinkBox}>
-          <div style={styles.viewCourseLink}>
-            {linkToOverview &&
-              <SmallChevronLink
-                link={linkToOverview}
-                linkText={i18n.viewCourse()}
-                isRtl={false}
-              />
-            }
+        {linkToOverview &&
+          <div style={styles.viewCourseLinkBox}>
+            <SmallChevronLink
+              link={linkToOverview}
+              linkText={i18n.viewCourse()}
+              isRtl={false}
+            />
           </div>
-        </div>
+        }
         <div style={styles.selectorContainer}>
           <div style={styles.scriptSelectorContainer}>
             <div style={{...h3Style, ...styles.heading}}>

--- a/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
+++ b/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
@@ -5,53 +5,25 @@ import color from "@cdo/apps/util/color";
 import i18n from '@cdo/locale';
 
 const styles = {
-  legendBox: {
-    borderWidth: 1,
-    float: 'left',
-    display: 'inline-block',
-    marginTop: 20,
-    boxSizing: 'content-box',
-  },
-  progressBox: {
-    float: 'left',
-    width: 130,
-    borderColor: color.lightest_gray,
-    borderWidth: 2,
-    borderBottomStyle: 'solid',
-    borderRightStyle: 'solid',
-  },
-  leftBorder: {
-    borderColor: color.lightest_gray,
-    borderWidth: 2,
-    borderLeftStyle: 'solid',
-  },
-  heading: {
-    fontSize: 18,
+  header: {
     fontWeight: 'bold',
     color: color.charcoal,
-    float: 'left',
-    paddingTop: 10,
-    paddingBottom: 10,
-    textAlign: 'center',
   },
-  label: {
-    fontSize: 14,
-    fontWeight: 900,
-    color: color.charcoal,
-  },
-  parenthetical: {
-    fontSize: 10,
-    color: color.charcoal,
-  },
-  labelBox: {
-    padding: 10,
-    height: 60,
-    width: '100%',
+  th: {
     backgroundColor: color.lightest_gray,
-    textAlign: 'center'
+    color: color.charcoal,
+    border: `1px solid ${color.lightest_gray}`,
+    fontFamily: '"Gotham 4r", sans-serif',
+    fontSize: 14,
+    textAlign: 'center',
+    padding: 15,
   },
-  boxContainer: {
-    padding: '15px 50px',
+  td: {
+    border: `1px solid ${color.lightest_gray}`,
+    padding: 15,
+  },
+  boxStyle: {
+    margin: '0 auto',
   }
 };
 
@@ -61,78 +33,77 @@ export default class SummaryViewLegend extends Component {
   };
 
   render() {
-    const { showCSFProgressBox } = this.props;
-    const headingStyle = {
-      ...styles.heading,
-      width: showCSFProgressBox ? '48%' : '100%'
-    };
+    const {showCSFProgressBox} = this.props;
 
     return (
-      <div style={styles.legendBox}>
-        <div>
-          <div style={headingStyle}>{i18n.lessonStatus()}</div>
-          {showCSFProgressBox &&
-            <div style={headingStyle}>{i18n.completionStatus()}</div>
-          }
-        </div>
-        <div style={styles.progressBox}>
-          <div style={styles.labelBox}>
-            <div>{i18n.notStarted()}</div>
-          </div>
-          <div style={{...styles.boxContainer, ...styles.leftBorder}}>
-            <ProgressBox
-              started={false}
-              incomplete={20}
-              imperfect={0}
-              perfect={0}
-            />
-          </div>
-        </div>
-        <div style={styles.progressBox}>
-          <div style={styles.labelBox}>
-            <div>{i18n.inProgress()}</div>
-          </div>
-          <div style={styles.boxContainer}>
-            <ProgressBox
-              started={true}
-              incomplete={20}
-              imperfect={0}
-              perfect={0}
-            />
-          </div>
-        </div>
-        <div style={styles.progressBox}>
-          <div style={styles.labelBox}>
-            <div>{i18n.completed()}</div>
-            {showCSFProgressBox &&
-              <div style={styles.parenthetical}>({i18n.perfect()})</div>
-            }
-          </div>
-          <div style={styles.boxContainer}>
-            <ProgressBox
-              started={true}
-              incomplete={0}
-              imperfect={0}
-              perfect={20}
-            />
-          </div>
-        </div>
-        {showCSFProgressBox &&
-          <div style={styles.progressBox}>
-            <div style={styles.labelBox}>
-              <div>{i18n.completed()}</div>
-              <div style={styles.parenthetical}>({i18n.tooManyBlocks()})</div>
-            </div>
-            <div style={styles.boxContainer}>
-              <ProgressBox
-                started={true}
-                incomplete={0}
-                imperfect={20}
-                perfect={0}
-              />
-            </div>
-          </div>
-        }
+      <div style={{marginTop: 30}}>
+        <h4 style={styles.header}>{i18n.lessonStatus()}</h4>
+        <table>
+          <thead>
+            <tr>
+              <th style={styles.th}>{i18n.notStarted()}</th>
+              <th style={styles.th}>{i18n.inProgress()}</th>
+              <th style={styles.th}>
+                {i18n.completed()}
+                {showCSFProgressBox &&
+                  <span>
+                    <br/>
+                    {`(${i18n.perfect()})`}
+                  </span>
+                }
+              </th>
+              {showCSFProgressBox &&
+                <th style={styles.th}>
+                  {i18n.completed()}
+                  <br/>
+                  {`(${i18n.tooManyBlocks()})`}
+                </th>
+              }
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style={styles.td}>
+                <ProgressBox
+                  style={styles.boxStyle}
+                  started={false}
+                  incomplete={20}
+                  imperfect={0}
+                  perfect={0}
+                />
+              </td>
+              <td style={styles.td}>
+                <ProgressBox
+                  style={styles.boxStyle}
+                  started={true}
+                  incomplete={20}
+                  imperfect={0}
+                  perfect={0}
+                />
+              </td>
+              <td style={styles.td}>
+                <ProgressBox
+                  style={styles.boxStyle}
+                  started={true}
+                  incomplete={0}
+                  imperfect={0}
+                  perfect={20}
+                />
+              </td>
+              {showCSFProgressBox &&
+                <td style={styles.td}>
+                  <ProgressBox
+                    style={styles.boxStyle}
+                    started={true}
+                    incomplete={0}
+                    imperfect={20}
+                    perfect={0}
+                  />
+                </td>
+              }
+            </tr>
+          </tbody>
+        </table>
       </div>
     );
   }

--- a/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
+++ b/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
@@ -8,6 +8,7 @@ const styles = {
   header: {
     fontWeight: 'bold',
     color: color.charcoal,
+    textAlign: 'center',
   },
   th: {
     backgroundColor: color.lightest_gray,
@@ -34,12 +35,22 @@ export default class SummaryViewLegend extends Component {
 
   render() {
     const {showCSFProgressBox} = this.props;
+    const headerColSpan = showCSFProgressBox ? 2 : 3;
 
     return (
-      <div style={{marginTop: 30}}>
-        <h4 style={styles.header}>{i18n.lessonStatus()}</h4>
+      <div style={{marginTop: 60}}>
         <table>
           <thead>
+            <tr>
+              <td colSpan={headerColSpan}>
+                <h3 style={styles.header}>{i18n.lessonStatus()}</h3>
+              </td>
+              {showCSFProgressBox &&
+                <td colSpan={2}>
+                  <h3 style={styles.header}>{i18n.completionStatus()}</h3>
+                </td>
+              }
+            </tr>
             <tr>
               <th style={styles.th}>{i18n.notStarted()}</th>
               <th style={styles.th}>{i18n.inProgress()}</th>

--- a/apps/src/templates/sectionProgress/multiGridConstants.js
+++ b/apps/src/templates/sectionProgress/multiGridConstants.js
@@ -11,6 +11,8 @@ export const PILL_BUBBLE_WIDTH = 180;
 export const progressStyles = {
   lessonHeading: {
     fontFamily: '"Gotham 5r", sans-serif',
+    fontSize: 14,
+    color: color.charcoal,
     paddingTop: 10,
     paddingLeft: 8
   },
@@ -24,7 +26,8 @@ export const progressStyles = {
     ':hover': {
       cursor: 'pointer'
     },
-    textAlign: 'center'
+    textAlign: 'center',
+    height: '100%',
   },
   lessonOfInterest: {
     backgroundColor: color.teal,
@@ -84,8 +87,7 @@ export const progressStyles = {
     overflow: 'hidden'
   },
   cell: {
-    borderRight: '1px solid',
-    borderColor: color.border_gray,
+    borderRight: `1px solid ${color.border_gray}`,
   }
 };
 

--- a/apps/src/templates/sectionProgress/multiGridConstants.js
+++ b/apps/src/templates/sectionProgress/multiGridConstants.js
@@ -84,7 +84,8 @@ export const progressStyles = {
     margin: 10,
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    overflow: 'hidden'
+    overflow: 'hidden',
+    fontSize: 14,
   },
   cell: {
     borderRight: `1px solid ${color.border_gray}`,


### PR DESCRIPTION
Style tweaks to the "Progress" tab in the new teacher dashboard:

### Before
<img width="991" alt="screen shot 2019-02-06 at 5 02 55 pm" src="https://user-images.githubusercontent.com/9812299/52384145-11afaa80-2a31-11e9-830f-5e9346f87f7c.png">

### After
<img width="996" alt="screen shot 2019-02-06 at 4 58 52 pm" src="https://user-images.githubusercontent.com/9812299/52384020-9221db80-2a30-11e9-9ac6-224b3790e777.png">
