### PR TITLE
reload stages before generating plc objects

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -102,6 +102,7 @@ class Script < ActiveRecord::Base
         unit_description: I18n.t("data.script.name.#{name}.description")
       )
 
+      stages.reload
       stages.each do |stage|
         lm = Plc::LearningModule.find_or_initialize_by(stage_id: stage.id)
         lm.update!(


### PR DESCRIPTION
fixes https://app.honeybadger.io/projects/3240/faults/45451525

**repro steps** (on levelbuilder, or on localhost with levelbuilder_mode enabled + levelbuilder permissions):
1. go to /s/K5-OnlinePD/edit
2. remove any level, e.g.: `level 'OPD-K5 Celebrate'` (similar error if you remove an entire stage)

**expected**: level saves
**actual**: error like HB error above. leave levelbuilder in a bad state, where the changes persist in the DB/UI, but not the filesystem, so they disappear after the next deploy.

The problem appears to happen because the activerecord object is stale. reloading fixes it.
