### PR TITLE
Set pool correctly in block path URL

### DIFF
--- a/dashboard/app/controllers/blocks_controller.rb
+++ b/dashboard/app/controllers/blocks_controller.rb
@@ -15,6 +15,12 @@ class BlocksController < ApplicationController
     update
   end
 
+  def edit
+    if @block.pool != params[:pool]
+      redirect_to(edit_block_path(pool: @block.pool, id: @block.name))
+    end
+  end
+
   def update
     if params[:commit] == 'Save as Clone'
       @block = @block.dup
@@ -22,7 +28,7 @@ class BlocksController < ApplicationController
 
     @block.update! update_params
     redirect_to(
-      edit_block_path(id: @block.name),
+      edit_block_path(pool: @block.pool, id: @block.name),
       notice: 'Block saved',
     )
   rescue => e


### PR DESCRIPTION
- When cloning a block to a different pool, the URL has the correct pool for the cloned block
- If you navigate to /pools/<wrong pool name>/blocks/<block name>, you get redirected to /pools/<right pool name/blocks/<block name>