### PR TITLE
Use API Key for Google Maps JavaScript access

### DIFF
--- a/apps/src/templates/GoogleSchoolLocationSearchField.jsx
+++ b/apps/src/templates/GoogleSchoolLocationSearchField.jsx
@@ -7,7 +7,7 @@ import i18n from '@cdo/locale';
  * A search box that loads a Google Location Search control.
  *
  * Note: Google location search requires the following line to be present in the haml where this component is used:
- * %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.7"}
+ * %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=true&libraries=places,geometry&v=3.7"}
  */
 export default class GoogleSchoolLocationSearchField extends React.Component {
   static propTypes = {

--- a/apps/src/templates/SchoolNotFound.jsx
+++ b/apps/src/templates/SchoolNotFound.jsx
@@ -67,7 +67,7 @@ export default class SchoolNotFound extends Component {
     showRequiredIndicators: PropTypes.bool,
     schoolNameLabel: PropTypes.string,
     // Note: Google location search requires the following line to be present in the haml where this component is used:
-    // %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.7"}
+    // %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=true&libraries=places,geometry&v=3.7"}
     useGoogleLocationSearch: PropTypes.bool
   };
 

--- a/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
@@ -161,7 +161,7 @@
     = render "devise/shared/new_links"
 
 %script{src: minifiable_asset_path('js/signup.js')}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.7"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=true&libraries=places,geometry&v=3.7"}
 
 :javascript
 

--- a/dashboard/app/views/home/_homepage.html.haml
+++ b/dashboard/app/views/home/_homepage.html.haml
@@ -19,7 +19,7 @@
     - homepage_data[:showCensusBanner] = show_census_banner
     - homepage_data[:hiddenScripts] = current_user.get_hidden_script_ids
     - if show_census_banner
-      %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.7"}
+      %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=true&libraries=places,geometry&v=3.7"}
       - teachers_school = current_user.school_info.school
       - school_stats = SchoolStatsByYear.where(school_id: teachers_school.id).order(school_year: :desc).first
       - homepage_data[:ncesSchoolId] = teachers_school.id

--- a/dashboard/app/views/layouts/_school_info_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_school_info_interstitial.html.haml
@@ -20,7 +20,7 @@
 - script_data[:existingSchoolInfo][:country] ||= 'United States' if us_ip
 
 - content_for(:head) do
-  %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.7"}
+  %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=true&libraries=places,geometry&v=3.7"}
   %script{src: minifiable_asset_path('js/schoolInfoInterstitial.js'), data: {schoolinfointerstitial: script_data.to_json}}
   :css
     .pac-container { z-index: 2000; }

--- a/dashboard/app/views/pd/workshop_dashboard/index.html.haml
+++ b/dashboard/app/views/pd/workshop_dashboard/index.html.haml
@@ -1,7 +1,7 @@
 - content_for(:head) do
   = stylesheet_link_tag 'css/pd', media: 'all'
 
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&libraries=places"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&libraries=places"}
 %script{src: minifiable_asset_path('js/pd/workshop_dashboard/index.js'), data: @script_data}
 
 #workshop-container

--- a/pegasus/sites.v3/code.org/public/learn/local.haml
+++ b/pegasus/sites.v3/code.org/public/learn/local.haml
@@ -11,7 +11,7 @@ theme: responsive
 %script{type: "text/javascript", src: "/js/sifter.min.js"}
 %script{type: "text/javascript", src: "/js/microplugin.min.js"}
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.7"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=true&libraries=places,geometry&v=3.7"}
 %script{type: "text/javascript", src: "/js/maplace.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 %script{type: "text/javascript", src: "/js/class-search.js"}

--- a/pegasus/sites.v3/code.org/public/volunteer/local/index.haml
+++ b/pegasus/sites.v3/code.org/public/volunteer/local/index.haml
@@ -5,7 +5,7 @@ theme: responsive
 %script{type: "text/javascript", src: "/js/sifter.min.js"}
 %script{type: "text/javascript", src: "/js/microplugin.min.js"}
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.7"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=true&libraries=places,geometry&v=3.7"}
 %script{type: "text/javascript", src: "/js/maplace.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.colorbox-min.js"}

--- a/pegasus/sites.v3/code.org/public/volunteer/remote/index.haml
+++ b/pegasus/sites.v3/code.org/public/volunteer/remote/index.haml
@@ -5,7 +5,7 @@ theme: responsive
 %script{type: "text/javascript", src: "/js/sifter.min.js"}
 %script{type: "text/javascript", src: "/js/microplugin.min.js"}
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.7"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=true&libraries=places,geometry&v=3.7"}
 %script{type: "text/javascript", src: "/js/maplace.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.colorbox-min.js"}

--- a/pegasus/sites.v3/code.org/public/yourschool.haml
+++ b/pegasus/sites.v3/code.org/public/yourschool.haml
@@ -36,7 +36,7 @@ social:
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 
 - unless census_announcement && census_announcement['hide_map'] == 'true'
-  %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry&v=3.7"}
+  %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=false&libraries=places,geometry&v=3.7"}
   %script{type: "text/javascript", src: "https://www.google.com/jsapi"}
   %script{type: "text/javascript"}
     google.load('visualization', '1');

--- a/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
@@ -5,7 +5,7 @@
 %script{type: "text/javascript", src: "/js/microplugin.min.js"}
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
 %link{rel: "stylesheet", type: "text/css", href: "/css/selectize.bootstrap3.css"}/
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry&v=3.7"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=false&libraries=places,geometry&v=3.7"}
 
 /[if lt IE 9]
   %script{src: "/js/es5-shim.min.js"}

--- a/pegasus/sites.v3/code.org/views/workshop_search.haml
+++ b/pegasus/sites.v3/code.org/views/workshop_search.haml
@@ -1,4 +1,4 @@
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&libraries=places,geometry&v=3.27"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&libraries=places,geometry&v=3.27"}
 - image_path = CDO.studio_url 'blockly/media/workshop_search/m', CDO.default_scheme
 %script{type: 'text/javascript', src: minifiable_asset_path('js/code.org/views/workshop_search.js'), data: {workshopSearch: {'imagePath': image_path}.to_json} }
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}

--- a/pegasus/sites.v3/csedweek.org/public/index.haml
+++ b/pegasus/sites.v3/csedweek.org/public/index.haml
@@ -15,7 +15,7 @@ video_player: true
 -hoc_mode = DCDO.get("hoc_mode", CDO.default_hoc_mode)
 
 %script{:src=>"/js/jquery.placeholder.js"}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry&v=3.7"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=false&libraries=places,geometry&v=3.7"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 
 #index

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -24,7 +24,7 @@ social:
 -twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text)}
 -twitter[:hashtags] = 'HourOfCode' unless hoc_s(:front_header_banner).include? '#HourOfCode'
 
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry&v=3.7"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=false&libraries=places,geometry&v=3.7"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 - js_locale = request.locale.to_s.downcase.tr('-', '_')
 %script{src: asset_path("js/#{js_locale}/common_locale.js")}

--- a/pegasus/sites.v3/hourofcode.com/public/map.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/map.haml
@@ -3,7 +3,7 @@ title: <%= hoc_s(:map_title) %>
 layout: wide_index
 ---
 
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry&v=3.7"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?key=#{CDO.google_maps_api_key}&sensor=false&libraries=places,geometry&v=3.7"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 
 = view :header


### PR DESCRIPTION
Migrates our Google Maps page script-embed tags on various pages (found via search-and-replace) from Premium Plan Client-ID based authentication (`client=`) to API key authentication (`key=`).
Uses the same API-key variable currently used for Geocoder API access (`CDO.google_maps_api_key`).

- I've Enabled the Maps Javascript API for this particular key in the `code-org-maps` project, and verified locally that an existing page containing a map loads correctly when provided with the existing project's API key.