### PR TITLE
Bug fix: Minecraft Course aquatic Stage 1 Puzzle 5 - Dutch

### DIFF
--- a/dashboard/config/locales/blocks.nl-NL.yml
+++ b/dashboard/config/locales/blocks.nl-NL.yml
@@ -983,7 +983,7 @@ nl:
             '"squid"': inktvis
             '"tropicalFish"': tropische vis
       craft_turn:
-        text: draai [DIR][0]
+        text: draai {DIR}
         options:
           DIR:
             right: rechtsom ↻

--- a/dashboard/config/locales/long_instructions.nl-NL.yml
+++ b/dashboard/config/locales/long_instructions.nl-NL.yml
@@ -560,8 +560,8 @@ nl:
         te vangen.
       HOC 2018 Level_4: Laten we de kabeljauw aan de ** dolfijn ** ![] (https://images.code.org/8c240fd4df4da2795ba7ca942b77a057-image-1538947890991.png)
         voeren. Gebruik een herhalingsblok om de oceaan sneller te doorkruisen.
-      HOC 2018 Level_5: Er is ergens een ** nautilusschelp** ![] (https://images.code.org/2eb084fa0c718dee6ca4b6379381f735-image-1538698936660.png)
-        verborgen! Verken het scheepswrak om de **kist** ![] (https://images.code.org/16cdd5779b38909d4bf47b29535c92b0-image-1538698950602.png)
+      HOC 2018 Level_5: Er is ergens een **nautilusschelp** ![](https://images.code.org/2eb084fa0c718dee6ca4b6379381f735-image-1538698936660.png)
+        verborgen! Verken het scheepswrak om de **kist** ![](https://images.code.org/16cdd5779b38909d4bf47b29535c92b0-image-1538698950602.png)
         te vinden.
       HOC 2018 Level_6: Dat ziet er ijskoud uit! Vang een **zalm** ![] (https://images.code.org/c66eadf25b3cdfe20bbfdc91e2c28c94-image-1538699000102.png)
         op weg naar de onderwaterruïnes.


### PR DESCRIPTION
The turn right/left block and long instructions for Minecraft-aquatic puzzle 5 is not displaying correctly in Dutch. The minecraft character (Alex) always turns left even when the right direction is selected.  See [Zendesk](https://codeorg.zendesk.com/agent/tickets/227794)

In addition, the shell and treasure box are not showing in the long instructions.

#### Solution
- Fixed markdown syntax in long instructions 
- Fix restoration of string (string was still in the redacted format)
        text: draai [DIR][0] (before)
        text: draai {DIR}  (fix)

#### Screen shots:
Before fix:
- Turn right/left block:
<img width="401" alt="screen shot 2019-02-07 at 10 44 31 pm" src="https://user-images.githubusercontent.com/30066710/52579116-6b6df700-2dda-11e9-9cbb-1e76b848d6c8.png">

- Long instruction: images are not displayed
<img width="927" alt="screen shot 2019-02-11 at 8 32 08 am" src="https://user-images.githubusercontent.com/30066710/52579224-96584b00-2dda-11e9-8bb7-27eae5828a2e.png">

- gif:
![mc_aquatic_puz5_bug_before](https://user-images.githubusercontent.com/30066710/52579220-95bfb480-2dda-11e9-997b-a710caa6381a.gif)

After fix:
- gif:  turn right selected
![mc_aquatic_puz5_bug](https://user-images.githubusercontent.com/30066710/52579225-96584b00-2dda-11e9-9c61-cd659f7aa68d.gif)

- gif: turn left selected

![mc_aquatic_puz5_bug_fix_left](https://user-images.githubusercontent.com/30066710/52579213-948e8780-2dda-11e9-9814-971fc12ef2eb.gif)