### PR TITLE
CSF monthly metrics

### DIFF
--- a/aws/redshift/queries/cs_fundamentals_completion.sql
+++ b/aws/redshift/queries/cs_fundamentals_completion.sql
@@ -75,7 +75,12 @@ from
     user_id, 
     min(completed_at) as first_completed_at
   from analysis.csf_completed_teachers
-  where user_id in (select user_id from csf_teachers_trained)
+  WHERE user_id in 
+  (
+    select user_id 
+    from csf_teachers_trained 
+    where trained_at < date_trunc('month', getdate())
+  )
   group by 1
 )
 where DATE_PART(month,first_completed_at) = CASE WHEN DATE_PART(month,getdate()) = 1 THEN 12 ELSE DATE_PART(month,getdate()) - 1 END
@@ -101,7 +106,12 @@ join followers f on f.student_user_id = students.user_id
 join sections se on se.id = f.section_id
 where DATE_PART(month,first_completed_at) = CASE WHEN DATE_PART(month,getdate()) = 1 THEN 12 ELSE DATE_PART(month,getdate()) - 1 END
   AND DATE_PART(year,first_completed_at) = CASE WHEN DATE_PART(month,getdate()) = 1 THEN DATE_PART(year,getdate()) - 1 ELSE DATE_PART(year,getdate()) END
-  AND se.user_id in (select user_id from csf_teachers_trained)
+  AND se.user_id in 
+  (
+    select user_id 
+    from csf_teachers_trained 
+    where trained_at < date_trunc('month', getdate())
+  )
 group by 1
 
 union all
@@ -124,7 +134,12 @@ join sections se on se.id = f.section_id
 join users u on u.id = students.user_id
 where DATE_PART(month,first_completed_at) = CASE WHEN DATE_PART(month,getdate()) = 1 THEN 12 ELSE DATE_PART(month,getdate()) - 1 END
   AND DATE_PART(year,first_completed_at) = CASE WHEN DATE_PART(month,getdate()) = 1 THEN DATE_PART(year,getdate()) - 1 ELSE DATE_PART(year,getdate()) END
-  AND se.user_id in (select user_id from csf_teachers_trained)
+  AND se.user_id in 
+  (
+    select user_id 
+    from csf_teachers_trained 
+    where trained_at < date_trunc('month', getdate())
+  )
 group by 1
 )
 order by sort asc;

--- a/aws/redshift/queries/cs_fundamentals_started.sql
+++ b/aws/redshift/queries/cs_fundamentals_started.sql
@@ -15,9 +15,9 @@ FROM (SELECT user_id_teacher,
             FROM dashboard_production.sections se
               JOIN dashboard_production.followers f ON f.section_id = se.id
               JOIN dashboard_production.user_scripts us ON us.user_id = f.student_user_id
-            -- CSF scripts: Old courses 1-4 (17,18,19,23), new courses A-F (236-241), 20-hour course (1), express (258) and pre-express (259)
-            WHERE se.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259) 
-            AND   us.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
+            -- CSF scripts: Old courses 1-4 (17,18,19,23), 20-hour course (1), or any version of courses a-f, express, and pre-express
+            WHERE se.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
+            AND   us.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
             AND   us.started_at IS NOT NULL
             GROUP BY 1,
                      2))
@@ -38,8 +38,8 @@ FROM (SELECT user_id,
                    us.started_at
             FROM dashboard_production.user_scripts us
               JOIN dashboard_production.users u ON u.id = us.user_id
-            -- CSF scripts: Old courses 1-4 (17,18,19,23), new courses A-F (236-241), 20-hour course (1), express (258) and pre-express (259)
-            WHERE us.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
+            -- CSF scripts: Old courses 1-4 (17,18,19,23), 20-hour course (1), or any version of courses a-f, express, and pre-express
+            WHERE us.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
             AND   u.user_type = 'student')
       GROUP BY 1)
 WHERE DATE_PART(month,date_first_activity) = CASE WHEN DATE_PART(month,getdate()) = 1 THEN 12 ELSE DATE_PART(month,getdate()) - 1 END
@@ -60,8 +60,8 @@ FROM (SELECT user_id,
                    u.gender
             FROM dashboard_production.user_scripts us
               JOIN dashboard_production_pii.users u ON u.id = us.user_id
-            -- CSF scripts: Old courses 1-4 (17,18,19,23), new courses A-F (236-241), 20-hour course (1), express (258) and pre-express (259)
-            WHERE us.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
+            -- CSF scripts: Old courses 1-4 (17,18,19,23), 20-hour course (1), or any version of courses a-f, express, and pre-express
+            WHERE us.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
             AND   gender IN ('m','f')
             AND   user_type = 'student')
       GROUP BY 1,
@@ -88,9 +88,9 @@ FROM (SELECT user_id_teacher,
             FROM dashboard_production.sections se
               JOIN dashboard_production.followers f ON f.section_id = se.id
               JOIN dashboard_production.user_scripts us ON us.user_id = f.student_user_id
-            -- CSF scripts: Old courses 1-4 (17,18,19,23), new courses A-F (236-241), 20-hour course (1), express (258) and pre-express (259)
-            WHERE se.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
-            AND   us.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
+            -- CSF scripts: Old courses 1-4 (17,18,19,23), 20-hour course (1), or any version of courses a-f, express, and pre-express
+            WHERE se.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
+            AND   us.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
             AND   us.started_at IS NOT NULL
             GROUP BY 1,
                      2))
@@ -124,9 +124,9 @@ FROM (SELECT user_id,
             FROM dashboard_production.sections se
               JOIN dashboard_production.followers f ON f.section_id = se.id
               JOIN dashboard_production.user_scripts us ON us.user_id = f.student_user_id
-            -- CSF scripts: Old courses 1-4 (17,18,19,23), new courses A-F (236-241), 20-hour course (1), express (258) and pre-express (259)
-            WHERE se.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
-            AND   us.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
+            -- CSF scripts: Old courses 1-4 (17,18,19,23), 20-hour course (1), or any version of courses a-f, express, and pre-express
+            WHERE se.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
+            AND   us.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
             AND   se.user_id IN (SELECT DISTINCT f.student_user_id user_id
                                  FROM followers f
                                    JOIN sections se ON se.id = f.section_id
@@ -160,9 +160,9 @@ FROM (SELECT user_id,
               JOIN dashboard_production.followers f ON f.section_id = se.id
               JOIN dashboard_production.user_scripts us ON us.user_id = f.student_user_id
               JOIN dashboard_production_pii.users u ON u.id = us.user_id
-            -- CSF scripts: Old courses 1-4 (17,18,19,23), new courses A-F (236-241), 20-hour course (1), express (258) and pre-express (259)
-            WHERE se.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
-            AND   us.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
+            -- CSF scripts: Old courses 1-4 (17,18,19,23), 20-hour course (1), or any version of courses a-f, express, and pre-express
+            WHERE se.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
+            AND   us.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
             AND   u.gender IN ('m','f')
             AND   se.user_id IN (SELECT DISTINCT f.student_user_id user_id
                                  FROM followers f
@@ -197,9 +197,9 @@ FROM (SELECT us.user_id,
         JOIN dashboard_production_pii.pd_enrollments pde ON pde.user_id = se.user_id
         JOIN dashboard_production.school_infos si ON si.id = pde.school_info_id
         JOIN school_stats ss ON ss.school_id = si.school_id
-      -- CSF scripts: Old courses 1-4 (17,18,19,23), new courses A-F (236-241), 20-hour course (1), express (258) and pre-express (259)
-      WHERE se.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
-      AND   us.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
+      -- CSF scripts: Old courses 1-4 (17,18,19,23), 20-hour course (1), or any version of courses a-f, express, and pre-express
+      WHERE se.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
+      AND   us.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
       AND   u.user_type = 'student'
       AND   se.user_id IN (SELECT DISTINCT f.student_user_id user_id
                            FROM followers f
@@ -233,9 +233,9 @@ FROM (SELECT us.user_id,
         JOIN dashboard_production_pii.pd_enrollments pde ON pde.user_id = se.user_id
         JOIN dashboard_production.school_infos si ON si.id = pde.school_info_id
         JOIN school_stats ss ON ss.school_id = si.school_id
-      -- CSF scripts: Old courses 1-4 (17,18,19,23), new courses A-F (236-241), 20-hour course (1), express (258) and pre-express (259)
-      WHERE se.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
-      AND   us.script_id IN (1,17,18,19,23,236,237,238,239,240,241,258,259)
+      -- CSF scripts: Old courses 1-4 (17,18,19,23), 20-hour course (1), or any version of courses a-f, express, and pre-express
+      WHERE se.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
+      AND   us.script_id IN (select id from dashboard_production.scripts where family_name in ('coursea','courseb','coursec','coursed','coursee','coursef','express','pre-express') or id in (1,17,18,19,23))
       AND   u.user_type = 'student'
       AND   se.user_id IN (SELECT DISTINCT f.student_user_id user_id
                            FROM followers f

--- a/aws/redshift/tables/csf_plugged_stage_counts.sql
+++ b/aws/redshift/tables/csf_plugged_stage_counts.sql
@@ -17,7 +17,15 @@ insert into analysis.csf_plugged_stage_counts values
 (240,8),
 (241,10),
 (258,19),
-(259,7);
+(259,7),
+(297,7),
+(301,7),
+(307,10),
+(302,14),
+(309,8),
+(310,8),
+(341,9),
+(303,27);
 
 GRANT ALL PRIVILEGES ON analysis.csf_plugged_stage_counts TO GROUP admin;
 GRANT SELECT ON analysis.csf_plugged_stage_counts TO GROUP reader, GROUP reader_pii;

--- a/aws/redshift/tables/csf_plugged_stage_counts.sql
+++ b/aws/redshift/tables/csf_plugged_stage_counts.sql
@@ -20,12 +20,12 @@ insert into analysis.csf_plugged_stage_counts values
 (259,7),
 (297,7),
 (301,7),
-(307,10),
 (302,14),
+(303,27),
+(307,10),
 (309,8),
 (310,8),
-(341,9),
-(303,27);
+(341,9);
 
 GRANT ALL PRIVILEGES ON analysis.csf_plugged_stage_counts TO GROUP admin;
 GRANT SELECT ON analysis.csf_plugged_stage_counts TO GROUP reader, GROUP reader_pii;

--- a/aws/redshift/views/csf_completed.sql
+++ b/aws/redshift/views/csf_completed.sql
@@ -23,7 +23,7 @@ from
     join analysis.csf_stages_for_completion sfc on sfc.script_id = us.script_id and sfc.stage_number = us.stage_number
 ) us
 join analysis.csf_plugged_stage_counts sc on sc.script_id = us.script_id and us.stage_order = sc.plugged_stage_counts
-with no schema binding; 
+with no schema binding;
 
 GRANT ALL PRIVILEGES ON analysis.csf_completed TO GROUP admin;
 GRANT SELECT ON analysis.csf_completed TO GROUP reader, GROUP reader_pii;

--- a/aws/redshift/views/csf_completed.sql
+++ b/aws/redshift/views/csf_completed.sql
@@ -1,5 +1,4 @@
-drop view analysis.csf_completed;
-create view analysis.csf_completed as
+create or replace view analysis.csf_completed as 
 select 
   us.user_id, 
   us.script_id, 
@@ -21,8 +20,7 @@ from
     left join analysis.script_names sn on sn.versioned_script_id = sc.id
     join analysis.school_years sy on us.started_at between sy.started_at and sy.ended_at
     join dashboard_production.users u on u.id = us.user_id and u.user_type = 'student'
-    left join analysis.stages_ignored_for_completion sic on sic.script_id = us.script_id and sic.stage_number = us.stage_number
-  where sic.script_id is null
+    join analysis.csf_stages_for_completion sfc on sfc.script_id = us.script_id and sfc.stage_number = us.stage_number
 ) us
 join analysis.csf_plugged_stage_counts sc on sc.script_id = us.script_id and us.stage_order = sc.plugged_stage_counts
 with no schema binding; 


### PR DESCRIPTION
1. Adds scripts IDs for new courses to `csf_started` monthly queries.
2. Adds new number of plugged stages (lessons) in new courses.
3. Changes completion metric to check whether the user has started all plugged stages (lessons) in a given course (identified by its location (i.e., `stage_number`) in the course.
4. Requires PD'd teachers counting as having had completed the course to have been PD'd before they finished the course.