### PR TITLE
Fix NoMethodError

### DIFF
--- a/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
+++ b/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
@@ -489,7 +489,7 @@ module Pd::WorkshopSurveyResultsHelper
       QUESTIONS_FOR_FACILITATOR_AVERAGES.each do |category, questions|
         facilitator_averages[facilitator][category.to_s.downcase.to_sym] = {}
         [:this_workshop, :all_my_workshops].each do |column|
-          average = (facilitator_averages[facilitator].slice(*(questions.map {|question| question[:primary_id]})).values.map {|x| x[column]}.reduce(:+) || 0) / questions.size.to_f
+          average = (facilitator_averages[facilitator].slice(*(questions.map {|question| question[:primary_id]})).values.map {|x| x[column]}.inject(0) {|sum, n| sum + (n || 0)} || 0) / questions.size.to_f
           facilitator_averages[facilitator][category.to_s.downcase.to_sym][column] = average.round(2)
         end
       end


### PR DESCRIPTION
We were calling `.reduce(:+)` on an array of nil values, which caused the user to see a 500 error and endless spinner.

Fixed code rendering data that was previously erroring out:
<img width="1631" alt="screen shot 2019-02-11 at 12 43 09 pm" src="https://user-images.githubusercontent.com/224089/52592526-78e7a900-2dfb-11e9-9fcf-3e1b1a1414a5.png">
