### PR TITLE
Display blocks after show code

### DIFF
--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -226,7 +226,8 @@ class CodeWorkspace extends React.Component {
   }
 }
 
-module.exports = connect(state => ({
+export const UnconnectedCodeWorkspace = Radium(CodeWorkspace);
+export default connect(state => ({
   editCode: state.pageConstants.isDroplet,
   isRtl: state.isRtl,
   readonlyWorkspace: state.pageConstants.isReadOnlyWorkspace,

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -142,7 +142,7 @@ class CodeWorkspace extends React.Component {
 
   onToggleShowCode = usingBlocks => {
     this.blockCounterEl.style.display =
-      usingBlocks && studioApp.enableShowBlockCount ? 'inline-block' : 'none';
+      usingBlocks && studioApp().enableShowBlockCount ? 'inline-block' : 'none';
   };
 
   render() {

--- a/apps/test/unit/templates/CodeWorkspaceTest.js
+++ b/apps/test/unit/templates/CodeWorkspaceTest.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from '../../util/configuredChai';
+import {UnconnectedCodeWorkspace as CodeWorkspace} from '../../../src/templates/CodeWorkspace';
+import {singleton as studioAppSingleton} from '@cdo/apps/StudioApp';
+import sinon from 'sinon';
+import ShowCodeToggle from '@cdo/apps/templates/ShowCodeToggle';
+
+describe('CodeWorkspace', () => {
+  const MINIMUM_PROPS = {
+    editCode: true,
+    isRtl: false,
+    readonlyWorkspace: false,
+    isRunning: false,
+    showDebugger: false,
+    pinWorkspaceToBottom: false,
+    showProjectTemplateWorkspaceIcon: false,
+    isMinecraft: false,
+    runModeIndicators: false,
+    showMakerToggle: false
+  };
+
+  const studioApp = studioAppSingleton();
+  sinon.stub(studioApp, 'showGeneratedCode');
+  let workspace = mount(<CodeWorkspace {...MINIMUM_PROPS} />);
+
+  it('onToggleShowCode displays blocks for levels with enableShowBlockCount=true', () => {
+    studioApp.enableShowBlockCount = true;
+
+    workspace.find(ShowCodeToggle).simulate('click');
+    let counter = workspace.find('#blockCounter');
+    expect(counter).to.have.style('display', 'inline-block');
+  });
+
+  it('onToggleShowCode does not display blocks for levels with enableShowBlockCount=false', () => {
+    studioApp.enableShowBlockCount = false;
+
+    workspace.find(ShowCodeToggle).simulate('click');
+    let counter = workspace.find('#blockCounter');
+    expect(counter).to.have.style('display', 'none');
+  });
+});


### PR DESCRIPTION
Zendesk: https://codeorg.zendesk.com/agent/tickets/227807

If the blocks count was displayed when the page initialized, toggling the 'Show Code' would cause them to no longer display.

Fixed bug and added test to cover expected behavior.