### PR TITLE
hourofcode.com: Fix Twitter embed

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
@@ -4,7 +4,7 @@
       %br/
       %h2
         Hour of Code Highlights
-      %a.twitter-grid{href: "https://twitter.com/codeorg/timelines/925449654308704256?limit=4?ref_src=twsrc%5Etfw?limit=4"}
+      %a.twitter-grid{data: {tweet: {limit: "1"}, chrome: "noheader nofooter"}, href: "https://twitter.com/codeorg/timelines/925449654308704256"}
         Hour of Code Highlights
       %script{async: "", charset: "utf-8", src: "//platform.twitter.com/widgets.js"}
     .col-md-3.highlights-column


### PR DESCRIPTION
The Twitter embed API seems to have changed, and no longer offers an option for a 2x2 grid.  This simple fix just shows one item, sans header and footer.

This fixes a problem on production in which there was a very long, very large Twitter feed in the embed.

# Before the problem
![screenshot 2019-02-12 12 51 27](https://user-images.githubusercontent.com/2205926/52667297-4b673200-2ec5-11e9-82ad-df898a8f6d37.png)

# During the problem
![hourofcode very long 2](https://user-images.githubusercontent.com/2205926/52667468-c7617a00-2ec5-11e9-9a21-f439214f6aa8.png)

# After the fix
![hourofcode fixed](https://user-images.githubusercontent.com/2205926/52667586-0ee80600-2ec6-11e9-898c-50bd0dc48583.png)

