### PR TITLE
PL: teacher application minor changes

### DIFF
--- a/dashboard/app/views/pd/application/teacher_application/logged_out.haml
+++ b/dashboard/app/views/pd/application/teacher_application/logged_out.haml
@@ -5,7 +5,7 @@
   = I18n.t('pd.logged_out.heading')
 
 %p
-  != I18n.t('pd.logged_out.body', url: CDO.code_org_url('/educate/professional-learning'))
+  != I18n.t('pd.logged_out.body', url: CDO.code_org_url('/educate/professional-learning/middle-high'))
 
 %div
   = link_to "/users/sign_in?user_return_to=#{request.fullpath}" do

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md
@@ -163,7 +163,7 @@ Be sure to check out our <a href="https://docs.google.com/document/d/e/2PACX-1vS
 <%=
 link = "/educate/professional-learning/program-information"
 link += "?nominated=true" if params[:nominated]
-"<a href='#{link}'><button>Get started!</button></a>"
+"<a class='linktag' id='pl-get-started-link' href='#{link}'><button>Get started!</button></a>"
 %>
 
 <!--

--- a/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
@@ -10,7 +10,7 @@
   .bigbanner p { margin: 0px }
 
 %div
-  %a{href: link}
+  %a.linktag#pl-apply-banner{href: link}
     .bigbanner{style: "width: 100%; padding: 5px; background-color: #ebe8f1"}
       .col-50{style: "background-color: #7665a0; height: 100px;"}
         .arrowcontainer.desktop-feature{style: "float:left; width: 7%"}

--- a/pegasus/sites.v3/code.org/views/regional_partner_zip_form.haml
+++ b/pegasus/sites.v3/code.org/views/regional_partner_zip_form.haml
@@ -5,7 +5,7 @@
   %p Generous scholarships or discounts are available across the country for the Code.org Professional Learning Program.
   %p
     %b Enter your school’s zip code to learn more.
-  %form{action: "/educate/professional-learning/program-information", method: "get"}
+  %form.linktag#pl-zip-form{action: "/educate/professional-learning/program-information", method: "get"}
     %span{style: "font-size:1.2em"} Zip:
     %input{type: "text", name: "zip", style: "padding:10px"}
     - if params[:nominated]


### PR DESCRIPTION
- added some CSS tags to the middle/high page (/educate/professional-learning/middle-high) so that we can differentiate clicks on the different links to the ZIP code page (/educate/professional-learning/program-information)
- the logged-out teacher application now links to the middle/high page