### PR TITLE
PL: regional partner search gets UI tweaks

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -23,6 +23,11 @@ const styles = {
     display: 'inline-block',
     marginLeft: 10
   },
+  hr: {
+    borderColor: color.charcoal,
+    marginTop: 50,
+    marginBottom: 50
+  },
   spinner: {
     fontSize: 32,
     marginTop: 20,
@@ -260,53 +265,57 @@ class RegionalPartnerSearch extends Component {
         )}
 
         {this.state.error === WorkshopSearchErrors.no_partner && (
-          <div style={styles.noPartner}>
-            <h3>Code.org Regional Partner for your region:</h3>
-            <p>
-              We do not have a Regional Partner in your area. However, we have a
-              number of partners in nearby states or regions who may have space
-              available in their program. If you are willing to travel, please
-              fill out the application. We'll let you know if we can find you a
-              nearby spot in the program!
-            </p>
-            <p>
-              If we find a spot, we'll let you know the workshop dates and
-              program fees (if applicable) so you can decide at that point if it
-              is something you or your school can cover.
-            </p>
-            <p>
-              <span style={styles.bold}>Arkansas Teachers: </span>
-              Code.org does not have a Regional Partner in Arkansas, and we are
-              unable to offer you a space in this program this year. There are
-              many great opportunities for{' '}
-              <span style={styles.bold}>
-                state-provided professional development{' '}
-              </span>
-              for computer science in Arkansas in{' '}
-              <a
-                href="https://docs.google.com/document/d/1OeLNx97wiLon69e8lp45M6ox0BuYLCOSZedzrtMB8_k/edit"
-                target="_blank"
-              >
-                this document
+          <div>
+            <hr style={styles.hr} />
+            <div style={styles.noPartner}>
+              <h3>Code.org Regional Partner for your region:</h3>
+              <p>
+                We do not have a Regional Partner in your area. However, we have
+                a number of partners in nearby states or regions who may have
+                space available in their program. If you are willing to travel,
+                please fill out the application. We'll let you know if we can
+                find you a nearby spot in the program!
+              </p>
+              <p>
+                If we find a spot, we'll let you know the workshop dates and
+                program fees (if applicable) so you can decide at that point if
+                it is something you or your school can cover.
+              </p>
+              <p>
+                <span style={styles.bold}>Arkansas Teachers: </span>
+                Code.org does not have a Regional Partner in Arkansas, and we
+                are unable to offer you a space in this program this year. There
+                are many great opportunities for{' '}
+                <span style={styles.bold}>
+                  state-provided professional development{' '}
+                </span>
+                for computer science in Arkansas in{' '}
+                <a
+                  href="https://docs.google.com/document/d/1OeLNx97wiLon69e8lp45M6ox0BuYLCOSZedzrtMB8_k/edit"
+                  target="_blank"
+                >
+                  this document
+                </a>
+                .
+              </p>
+              <p>
+                All of our curriculum, tools, and courses are also available for
+                your school at no cost. Or,{' '}
+                <a href="/educate/curriculum/3rd-party">
+                  contact one of these computer science providers
+                </a>{' '}
+                for other Professional Development options in your area.
+              </p>
+              <a href={applicationLink}>
+                <button style={styles.bigButton}>Start application</button>
               </a>
-              .
-            </p>
-            <p>
-              All of our curriculum, tools, and courses are also available for
-              your school at no cost. Or,{' '}
-              <a href="/educate/curriculum/3rd-party">
-                contact one of these computer science providers
-              </a>{' '}
-              for other Professional Development options in your area.
-            </p>
-            <a href={applicationLink}>
-              <button style={styles.bigButton}>Start application</button>
-            </a>
+            </div>
           </div>
         )}
 
         {partnerInfo && (
           <div>
+            <hr style={styles.hr} />
             <h3>Workshop information (hosted by {partnerInfo.name}):</h3>
             {workshopCollections[0].workshops.length === 0 &&
               workshopCollections[1].workshops.length === 0 && (
@@ -450,7 +459,7 @@ class RegionalPartnerSearch extends Component {
                   id={`id-${partnerInfo.id}`}
                   href={applicationLink}
                 >
-                  Start application
+                  <button style={styles.bigButton}>Start application</button>
                 </a>
               )}
 
@@ -462,7 +471,9 @@ class RegionalPartnerSearch extends Component {
                   href={partnerInfo.link_to_partner_application}
                   target="_blank"
                 >
-                  Apply on partner's site
+                  <button style={styles.bigButton}>
+                    Apply on partner's site
+                  </button>
                 </a>
               )}
           </div>


### PR DESCRIPTION
- a horizontal line to separate search & results
- turn second application links into orange buttons

### e.g.
![screenshot 2019-02-13 11 54 16](https://user-images.githubusercontent.com/2205926/52741123-7915af00-2f89-11e9-9e96-bedc4bc746a7.png)
