### PR TITLE
validate project_template_level_name

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -387,7 +387,7 @@ class Level < ActiveRecord::Base
 
   def validate_project_template_level
     if try(:project_template_level_name) && !project_template_level
-      errors.add(:project_template_level_name, :not_found)
+      errors.add(:project_template_level_name, "not found: '#{project_template_level_name}'")
     end
   end
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -38,6 +38,7 @@ class Level < ActiveRecord::Base
 
   validates_length_of :name, within: 1..70
   validates_uniqueness_of :name, case_sensitive: false, conditions: -> {where.not(user_id: nil)}
+  validate :validate_project_template_level
 
   after_save :write_custom_level_file
   after_destroy :delete_custom_level_file
@@ -382,6 +383,12 @@ class Level < ActiveRecord::Base
   def project_template_level
     return nil if try(:project_template_level_name).nil?
     Level.find_by_key(project_template_level_name)
+  end
+
+  def validate_project_template_level
+    if try(:project_template_level_name) && !project_template_level
+      errors.add(:project_template_level_name, :not_found)
+    end
   end
 
   def strip_name


### PR DESCRIPTION
### Background

The goal of this change is to eliminate a class of problems where `project_template_level_name` for a given level is invalid and goes unnoticed, causing puzzle progressions which are supposed to share the same code to silently not share code. I'm addressing this now as an added safeguard against errors when copying scripts.

### Description

This PR causes an error to be raised when an invalid `project_template_level_name` is specified in the following situations:

1. on levelbuilder save
<img width="400" alt="screen shot 2019-02-13 at 12 36 31 pm" src="https://user-images.githubusercontent.com/8001765/52743331-a153dc80-2f8e-11e9-8e55-b1f2302732c1.png">

2. during `rake seed:scripts`

3. during `Script.clone_with_suffix` (or `Level.clone_with_suffix`)

### Verification

I've manually verified that an exception is raised in each of the above scenarios. I've also verified that `rake seed:all` passes locally, since circle will only seed a subset of our scripts.