### PR TITLE
Strip version suffix from level name when copying levels

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -561,13 +561,22 @@ class Level < ActiveRecord::Base
     false
   end
 
+  # Returns the level name, removing any name suffix first (if present).
+  def base_name
+    suffix = get_name_suffix
+    return name unless suffix
+    strip_suffix_regex = /^(.*)#{Regexp.escape(suffix)}$/
+    name[strip_suffix_regex, 1] || name
+  end
+
   private
 
-  # Returns the level name, removing the name_suffix first (if present).
-  def base_name
-    return name unless name_suffix
-    strip_suffix_regex = /^(.*)#{Regexp.escape(name_suffix)}$/
-    name[strip_suffix_regex, 1] || name
+  # return the name_suffix property (if present), or a version year suffix on
+  # the name field in the form of e.g. '_2018' (if present), or nil otherwise.
+  def get_name_suffix
+    return name_suffix if name_suffix
+    m = /^(.*)(_[0-9]{4})$/.match(name)
+    m ? m[2] : nil
   end
 
   def write_to_file?

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -706,6 +706,17 @@ EOS
     refute level.uses_droplet?
   end
 
+  test 'base name' do
+    level = create :level, name: 'level_1'
+    assert_equal 'level_1', level.base_name
+
+    level.name_suffix = '_1'
+    assert_equal 'level', level.base_name
+
+    level = create :level, name: 'level_1000'
+    assert_equal 'level', level.base_name
+  end
+
   test 'can clone' do
     old_level = create :level, name: 'old level', start_blocks: '<xml>foo</xml>'
     new_level = old_level.clone_with_name('new level')

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -749,6 +749,12 @@ EOS
     assert_equal '_3', level_3.name_suffix
   end
 
+  test 'clone with suffix recognized and removes version year suffix' do
+    old_level = create :level, name: 'level_1999'
+    new_level = old_level.clone_with_suffix('_2000')
+    assert_equal 'level_2000', new_level.name
+  end
+
   test 'clone with suffix properly escapes suffixes' do
     level_1 = create :level, name: 'your_level_1'
 


### PR DESCRIPTION
If we wanted to avoid having level names like foo_2018_2019_2020.level, this is how we would do it. but there's no real harm in having long level names, so I'm not going to move forward with merging this right now.