### PR TITLE
bump number of final assessment page in ui tests

### DIFF
--- a/dashboard/test/ui/features/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_dashboard_assessments2.feature
@@ -6,27 +6,27 @@ Feature: Using the assessments tab in the teacher dashboard
   Scenario: Assessments tab survey submissions
     Given I create an authorized teacher-associated student named "Sally"
     And I give user "Teacher_Sally" hidden script access
-    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/5"
+    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
     And I sign out
 
     And I create a student named "Student2"
     And I navigate to the section url
-    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/5"
+    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
     And I sign out
 
     And I create a student named "Student3"
     And I navigate to the section url
-    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/5"
+    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
     And I sign out
 
     And I create a student named "Student4"
     And I navigate to the section url
-    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/5"
+    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
     And I sign out
 
     And I create a student named "Student5"
     And I navigate to the section url
-    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/5"
+    And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
     And I sign out
 
     # Assign a script with an unlocked survey


### PR DESCRIPTION
UI tests [failed](https://codedotorg.slack.com/archives/C03CM903Y/p1550114148133800) because they assumed a certain assessment level had only 5 pages. This evening's levelbuilder scoop added a 6th. 

The fix is to point the UI test at the 6th page of the assessment. I've verified on the test machine that this fixes the failing UI test.