### PR TITLE
sanitize empty values from i18n data

### DIFF
--- a/bin/i18n/sync-codeorg-out.rb
+++ b/bin/i18n/sync-codeorg-out.rb
@@ -60,11 +60,15 @@ end
 
 # Recursively run through the data received from crowdin, sanitizing it for
 # consumption by our system.
-# Currently just restores carraige returns (since crowdin escapes them), but
-# could be expanded to do more.
+#
+# Sanitization rules applied:
+#   - restore carraige returns (crowdin escapes them)
+#   - eliminate empty strings from hashes (empty strings are how crowdin
+#     returns untranslated strings for certain serialization formats)
 def sanitize!(data)
   if data.is_a? Hash
     data.values.each {|datum| sanitize!(datum)}
+    data.delete_if {|_key, value| value.nil? || value.try(:empty?)}
   elsif data.is_a? Array
     data.each {|datum| sanitize!(datum)}
   elsif data.is_a? String


### PR DESCRIPTION
Just some minor cleanup, in anticipation of converting over all our .yml data to .json

For some reason, when the "skip untranslated strings" option is enabled, crowdin will provide keys with empty strings for all the source strings when the file type is JSON (see https://github.com/code-dot-org/code-dot-org/blob/5b664c73345657384bf7d36637bf1246e2d0fee6/apps/i18n/bounce/te_in.json). When the file is YAML, crowdin will just skip the key entirely.

We prefer not to have a bunch of empty strings polluting our files for no reason, so I'm adding a sanitization rule to remove em. We should expect this to be applied with Monday's sync, so look out for some big negative diffs!