### PR TITLE
Restore applab border styles

### DIFF
--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -193,6 +193,7 @@ applabCommands.button = function(opts) {
   newButton.style.position = 'relative';
   newButton.style.color = color.white;
   newButton.style.backgroundColor = color.applab_button_teal;
+  elementUtils.setDefaultBorderStyles(newButton, {forceDefaults: true});
 
   return Boolean(
     newButton.appendChild(textNode) &&
@@ -215,6 +216,7 @@ applabCommands.image = function(opts) {
   newImage.setAttribute('data-canonical-image-url', opts.src);
   newImage.id = opts.elementId;
   newImage.style.position = 'relative';
+  elementUtils.setDefaultBorderStyles(newImage, {forceDefaults: true});
 
   Applab.updateProperty(newImage, 'objectFit', 'contain');
 
@@ -894,6 +896,10 @@ applabCommands.textInput = function(opts) {
   newInput.style.position = 'relative';
   newInput.style.height = '30px';
   newInput.style.width = '200px';
+  elementUtils.setDefaultBorderStyles(newInput, {
+    forceDefaults: true,
+    textInput: true
+  });
 
   return Boolean(Applab.activeScreen().appendChild(newInput));
 };
@@ -910,6 +916,7 @@ applabCommands.textLabel = function(opts) {
   var textNode = document.createTextNode(opts.text);
   newLabel.id = opts.elementId;
   newLabel.style.position = 'relative';
+  elementUtils.setDefaultBorderStyles(newLabel, {forceDefaults: true});
   var forElement = document.getElementById(opts.forId);
   if (forElement && Applab.activeScreen().contains(forElement)) {
     newLabel.setAttribute('for', opts.forId);
@@ -974,6 +981,7 @@ applabCommands.dropdown = function(opts) {
   newSelect.style.position = 'relative';
   newSelect.style.color = color.white;
   newSelect.style.backgroundColor = color.applab_button_teal;
+  elementUtils.setDefaultBorderStyles(newSelect, {forceDefaults: true});
 
   return Boolean(Applab.activeScreen().appendChild(newSelect));
 };

--- a/apps/src/applab/designElements/BorderProperties.jsx
+++ b/apps/src/applab/designElements/BorderProperties.jsx
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react';
 import PropertyRow from './PropertyRow';
 import ColorPickerPropertyRow from './ColorPickerPropertyRow';
 import * as elementUtils from './elementUtils';
+import * as rowStyle from './rowStyle';
 
 export default class BorderProperties extends React.Component {
   static propTypes = {
@@ -20,7 +21,7 @@ export default class BorderProperties extends React.Component {
     } = this.props;
 
     return (
-      <div>
+      <div style={rowStyle.wrapperContainer}>
         <PropertyRow
           desc={'border width (px)'}
           isNumber

--- a/apps/src/applab/designElements/BorderProperties.jsx
+++ b/apps/src/applab/designElements/BorderProperties.jsx
@@ -1,0 +1,44 @@
+import React, {PropTypes} from 'react';
+import PropertyRow from './PropertyRow';
+import ColorPickerPropertyRow from './ColorPickerPropertyRow';
+import * as elementUtils from './elementUtils';
+
+export default class BorderProperties extends React.Component {
+  static propTypes = {
+    element: PropTypes.instanceOf(HTMLElement).isRequired,
+    handleBorderWidthChange: PropTypes.func.isRequired,
+    handleBorderColorChange: PropTypes.func.isRequired,
+    handleBorderRadiusChange: PropTypes.func.isRequired
+  };
+
+  render() {
+    const {
+      element,
+      handleBorderWidthChange,
+      handleBorderColorChange,
+      handleBorderRadiusChange
+    } = this.props;
+
+    return (
+      <div>
+        <PropertyRow
+          desc={'border width (px)'}
+          isNumber
+          initialValue={parseInt(element.style.borderWidth, 10)}
+          handleChange={handleBorderWidthChange}
+        />
+        <ColorPickerPropertyRow
+          desc={'border color'}
+          initialValue={elementUtils.rgb2hex(element.style.borderColor)}
+          handleChange={handleBorderColorChange}
+        />
+        <PropertyRow
+          desc={'border radius (px)'}
+          isNumber
+          initialValue={parseInt(element.style.borderRadius, 10)}
+          handleChange={handleBorderRadiusChange}
+        />
+      </div>
+    );
+  }
+}

--- a/apps/src/applab/designElements/ImagePickerPropertyRow.jsx
+++ b/apps/src/applab/designElements/ImagePickerPropertyRow.jsx
@@ -87,6 +87,7 @@ export default class ImagePickerPropertyRow extends React.Component {
         <div style={rowStyle.description}>{this.props.desc}</div>
         <div>
           <input
+            className="imagePickerInput"
             value={this.state.value}
             onChange={this.handleChangeInternal}
             style={rowStyle.input}

--- a/apps/src/applab/designElements/button.jsx
+++ b/apps/src/applab/designElements/button.jsx
@@ -9,6 +9,7 @@ import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import EnumPropertyRow from './EnumPropertyRow';
+import BorderProperties from './BorderProperties';
 import color from '../../util/color';
 import {ICON_PREFIX_REGEX} from '../constants';
 import * as elementUtils from './elementUtils';
@@ -51,7 +52,7 @@ class ButtonProperties extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <PropertyRow
           desc={'text'}
@@ -60,25 +61,25 @@ class ButtonProperties extends React.Component {
         />
         <PropertyRow
           desc={'width (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.width, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-width')}
         />
         <PropertyRow
           desc={'height (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.height, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-height')}
         />
         <PropertyRow
           desc={'x position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.left, 10)}
           handleChange={this.props.handleChange.bind(this, 'left')}
         />
         <PropertyRow
           desc={'y position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.top, 10)}
           handleChange={this.props.handleChange.bind(this, 'top')}
         />
@@ -94,7 +95,7 @@ class ButtonProperties extends React.Component {
         />
         <PropertyRow
           desc={'font size (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.fontSize, 10)}
           handleChange={this.props.handleChange.bind(this, 'fontSize')}
         />
@@ -111,6 +112,21 @@ class ButtonProperties extends React.Component {
           elementId={elementUtils.getId(element)}
         />
         {iconColorPicker}
+        <BorderProperties
+          element={element}
+          handleBorderWidthChange={this.props.handleChange.bind(
+            this,
+            'borderWidth'
+          )}
+          handleBorderColorChange={this.props.handleChange.bind(
+            this,
+            'borderColor'
+          )}
+          handleBorderRadiusChange={this.props.handleChange.bind(
+            this,
+            'borderRadius'
+          )}
+        />
         <BooleanPropertyRow
           desc={'hidden'}
           initialValue={$(element).hasClass('design-mode-hidden')}
@@ -183,6 +199,7 @@ export default {
     element.style.height = '30px';
     element.style.width = '80px';
     element.style.fontSize = '14px';
+    elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
     element.style.color = color.white;
     element.style.backgroundColor = color.applab_button_teal;
 
@@ -193,5 +210,7 @@ export default {
     if (url) {
       updateProperty(element, 'image', url);
     }
+    // Set border styles for older projects that didn't set them on create:
+    elementUtils.setDefaultBorderStyles(element);
   }
 };

--- a/apps/src/applab/designElements/dropdown.jsx
+++ b/apps/src/applab/designElements/dropdown.jsx
@@ -10,6 +10,7 @@ import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import color from '../../util/color';
 import EnumPropertyRow from './EnumPropertyRow';
+import BorderProperties from './BorderProperties';
 import * as elementUtils from './elementUtils';
 
 class DropdownProperties extends React.Component {
@@ -28,7 +29,7 @@ class DropdownProperties extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <OptionsSelectRow
           desc={'options'}
@@ -37,31 +38,31 @@ class DropdownProperties extends React.Component {
         />
         <PropertyRow
           desc={'index'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.selectedIndex, 10)}
           handleChange={this.props.handleChange.bind(this, 'index')}
         />
         <PropertyRow
           desc={'width (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.width, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-width')}
         />
         <PropertyRow
           desc={'height (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.height, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-height')}
         />
         <PropertyRow
           desc={'x position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.left, 10)}
           handleChange={this.props.handleChange.bind(this, 'left')}
         />
         <PropertyRow
           desc={'y position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.top, 10)}
           handleChange={this.props.handleChange.bind(this, 'top')}
         />
@@ -77,7 +78,7 @@ class DropdownProperties extends React.Component {
         />
         <PropertyRow
           desc={'font size (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.fontSize, 10)}
           handleChange={this.props.handleChange.bind(this, 'fontSize')}
         />
@@ -86,6 +87,21 @@ class DropdownProperties extends React.Component {
           initialValue={element.style.textAlign || 'center'}
           options={['left', 'right', 'center', 'justify']}
           handleChange={this.props.handleChange.bind(this, 'textAlign')}
+        />
+        <BorderProperties
+          element={element}
+          handleBorderWidthChange={this.props.handleChange.bind(
+            this,
+            'borderWidth'
+          )}
+          handleBorderColorChange={this.props.handleChange.bind(
+            this,
+            'borderColor'
+          )}
+          handleBorderRadiusChange={this.props.handleChange.bind(
+            this,
+            'borderRadius'
+          )}
         />
         <BooleanPropertyRow
           desc={'hidden'}
@@ -142,7 +158,7 @@ class DropdownEvents extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <EventHeaderRow />
         <EventRow
@@ -167,6 +183,7 @@ export default {
     element.style.margin = '0';
     element.style.color = color.white;
     element.style.backgroundColor = color.applab_button_teal;
+    elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
 
     const option1 = document.createElement('option');
     option1.innerHTML = 'Option 1';
@@ -180,6 +197,9 @@ export default {
   },
 
   onDeserialize: function(element) {
+    // Set border styles for older projects that didn't set them on create:
+    elementUtils.setDefaultBorderStyles(element);
+
     // In the future we may want to trigger this on focus events as well.
     $(element).on('mousedown', function(e) {
       if (!Applab.isRunning()) {

--- a/apps/src/applab/designElements/elementUtils.js
+++ b/apps/src/applab/designElements/elementUtils.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import * as constants from '../constants';
 import * as utils from '../../utils';
+import color from '../../util/color';
 
 // Taken from http://stackoverflow.com/a/3627747/2506748
 export function rgb2hex(rgb) {
@@ -188,4 +189,30 @@ export function getScreens() {
 
 export function getDefaultScreenId() {
   return getId(getScreens()[0]);
+}
+
+/**
+ * Sets the default border styles on a new element.
+ * @param {DOMElement} element The element to modify.
+ * @param {Object.<string, boolean>} options Optional map of options
+ *     indicating how the styles should be applied.
+ * @param {string} options.textInput treat the element as a text
+ *     input or text area, which has a gray default border. Default: false
+ * @param {string} options.forceDefaults: always set default
+ *     styles, even if current styles already exist. Default: false
+ */
+export function setDefaultBorderStyles(element, options = {}) {
+  const {textInput, forceDefaults} = options;
+  element.style.borderStyle = 'solid';
+  if (forceDefaults || element.style.borderWidth === '') {
+    element.style.borderWidth = textInput ? '1px' : '0px';
+  }
+  if (forceDefaults || element.style.borderColor === '') {
+    element.style.borderColor = textInput
+      ? color.text_input_default_border_color
+      : color.black;
+  }
+  if (forceDefaults || element.style.borderRadius === '') {
+    element.style.borderRadius = '0px';
+  }
 }

--- a/apps/src/applab/designElements/image.jsx
+++ b/apps/src/applab/designElements/image.jsx
@@ -10,6 +10,7 @@ import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import {ICON_PREFIX_REGEX} from '../constants';
 import EnumPropertyRow from './EnumPropertyRow';
+import BorderProperties from './BorderProperties';
 import * as elementUtils from './elementUtils';
 import {applabObjectFitImages} from '../applabObjectFitImages';
 
@@ -51,29 +52,29 @@ class ImageProperties extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <PropertyRow
           desc={'width (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.width, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-width')}
         />
         <PropertyRow
           desc={'height (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.height, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-height')}
         />
         <PropertyRow
           desc={'x position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.left, 10)}
           handleChange={this.props.handleChange.bind(this, 'left')}
         />
         <PropertyRow
           desc={'y position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.top, 10)}
           handleChange={this.props.handleChange.bind(this, 'top')}
         />
@@ -89,6 +90,21 @@ class ImageProperties extends React.Component {
           initialValue={element.style.objectFit || 'fill'}
           options={['fill', 'cover', 'contain', 'none']}
           handleChange={this.props.handleChange.bind(this, 'objectFit')}
+        />
+        <BorderProperties
+          element={element}
+          handleBorderWidthChange={this.props.handleChange.bind(
+            this,
+            'borderWidth'
+          )}
+          handleBorderColorChange={this.props.handleChange.bind(
+            this,
+            'borderColor'
+          )}
+          handleBorderRadiusChange={this.props.handleChange.bind(
+            this,
+            'borderRadius'
+          )}
         />
         <BooleanPropertyRow
           desc={'hidden'}
@@ -140,7 +156,7 @@ class ImageEvents extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <EventHeaderRow />
         <EventRow
@@ -180,6 +196,7 @@ export default {
     const element = document.createElement('img');
     element.style.height = '100px';
     element.style.width = '100px';
+    elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
     element.setAttribute('src', '/blockly/media/1x1.gif');
     element.setAttribute('data-canonical-image-url', '');
 
@@ -191,6 +208,9 @@ export default {
     return element;
   },
   onDeserialize: function(element, updateProperty) {
+    // Set border styles for older projects that didn't set them on create:
+    elementUtils.setDefaultBorderStyles(element);
+
     const url = element.getAttribute('data-canonical-image-url') || '';
     if (url) {
       updateProperty(element, 'picture', url);

--- a/apps/src/applab/designElements/label.jsx
+++ b/apps/src/applab/designElements/label.jsx
@@ -8,6 +8,7 @@ import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import EnumPropertyRow from './EnumPropertyRow';
+import BorderProperties from './BorderProperties';
 import * as applabConstants from '../constants';
 import * as elementUtils from './elementUtils';
 import * as gridUtils from '../gridUtils';
@@ -28,7 +29,7 @@ class LabelProperties extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <PropertyRow
           desc={'text'}
@@ -37,7 +38,7 @@ class LabelProperties extends React.Component {
         />
         <PropertyRow
           desc={'width (px)'}
-          isNumber={true}
+          isNumber
           lockState={
             $(element).data('lock-width') || PropertyRow.LockState.UNLOCKED
           }
@@ -47,7 +48,7 @@ class LabelProperties extends React.Component {
         />
         <PropertyRow
           desc={'height (px)'}
-          isNumber={true}
+          isNumber
           lockState={
             $(element).data('lock-height') || PropertyRow.LockState.UNLOCKED
           }
@@ -57,13 +58,13 @@ class LabelProperties extends React.Component {
         />
         <PropertyRow
           desc={'x position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.left, 10)}
           handleChange={this.props.handleChange.bind(this, 'left')}
         />
         <PropertyRow
           desc={'y position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.top, 10)}
           handleChange={this.props.handleChange.bind(this, 'top')}
         />
@@ -79,7 +80,7 @@ class LabelProperties extends React.Component {
         />
         <PropertyRow
           desc={'font size (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.fontSize, 10)}
           handleChange={this.props.handleChange.bind(this, 'fontSize')}
         />
@@ -88,6 +89,21 @@ class LabelProperties extends React.Component {
           initialValue={element.style.textAlign || 'left'}
           options={['left', 'right', 'center', 'justify']}
           handleChange={this.props.handleChange.bind(this, 'textAlign')}
+        />
+        <BorderProperties
+          element={element}
+          handleBorderWidthChange={this.props.handleChange.bind(
+            this,
+            'borderWidth'
+          )}
+          handleBorderColorChange={this.props.handleChange.bind(
+            this,
+            'borderColor'
+          )}
+          handleBorderRadiusChange={this.props.handleChange.bind(
+            this,
+            'borderRadius'
+          )}
         />
         <BooleanPropertyRow
           desc={'hidden'}
@@ -144,7 +160,7 @@ class LabelEvents extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <EventHeaderRow />
         <EventRow
@@ -180,9 +196,15 @@ export default {
     element.style.color = '#333333';
     element.style.backgroundColor = '';
     element.style.maxWidth = applabConstants.APP_WIDTH + 'px';
+    elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
 
     this.resizeToFitText(element);
     return element;
+  },
+
+  onDeserialize: function(element) {
+    // Set border styles for older projects that didn't set them on create:
+    elementUtils.setDefaultBorderStyles(element);
   },
 
   getCurrentSize: function(element) {

--- a/apps/src/applab/designElements/rowStyle.js
+++ b/apps/src/applab/designElements/rowStyle.js
@@ -21,6 +21,10 @@ export var container = {
   marginBottom: 8
 };
 
+export var wrapperContainer = {
+  marginTop: -8
+};
+
 export var maxWidth = {
   maxWidth: 245
 };

--- a/apps/src/applab/designElements/textInput.jsx
+++ b/apps/src/applab/designElements/textInput.jsx
@@ -8,6 +8,7 @@ import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import EnumPropertyRow from './EnumPropertyRow';
+import BorderProperties from './BorderProperties';
 import * as elementUtils from './elementUtils';
 
 class TextInputProperties extends React.Component {
@@ -26,7 +27,7 @@ class TextInputProperties extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <PropertyRow
           desc={'placeholder'}
@@ -35,25 +36,25 @@ class TextInputProperties extends React.Component {
         />
         <PropertyRow
           desc={'width (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.width, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-width')}
         />
         <PropertyRow
           desc={'height (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.height, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-height')}
         />
         <PropertyRow
           desc={'x position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.left, 10)}
           handleChange={this.props.handleChange.bind(this, 'left')}
         />
         <PropertyRow
           desc={'y position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.top, 10)}
           handleChange={this.props.handleChange.bind(this, 'top')}
         />
@@ -69,7 +70,7 @@ class TextInputProperties extends React.Component {
         />
         <PropertyRow
           desc={'font size (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.fontSize, 10)}
           handleChange={this.props.handleChange.bind(this, 'fontSize')}
         />
@@ -78,6 +79,21 @@ class TextInputProperties extends React.Component {
           initialValue={element.style.textAlign || 'left'}
           options={['left', 'right', 'center', 'justify']}
           handleChange={this.props.handleChange.bind(this, 'textAlign')}
+        />
+        <BorderProperties
+          element={element}
+          handleBorderWidthChange={this.props.handleChange.bind(
+            this,
+            'borderWidth'
+          )}
+          handleBorderColorChange={this.props.handleChange.bind(
+            this,
+            'borderColor'
+          )}
+          handleBorderRadiusChange={this.props.handleChange.bind(
+            this,
+            'borderRadius'
+          )}
         />
         <BooleanPropertyRow
           desc={'hidden'}
@@ -155,7 +171,7 @@ class TextInputEvents extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <EventHeaderRow />
         <EventRow
@@ -184,11 +200,18 @@ export default {
     element.style.height = '30px';
     element.style.color = '#000000';
     element.style.backgroundColor = '';
+    elementUtils.setDefaultBorderStyles(element, {
+      forceDefaults: true,
+      textInput: true
+    });
 
     return element;
   },
 
   onDeserialize: function(element) {
+    // Set border styles for older projects that didn't set them on create:
+    elementUtils.setDefaultBorderStyles(element, {textInput: true});
+
     $(element).on('mousedown', function(e) {
       if (!Applab.isRunning()) {
         // Disable clicking into text input unless running

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -7,6 +7,7 @@ import ColorPickerPropertyRow from './ColorPickerPropertyRow';
 import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
+import BorderProperties from './BorderProperties';
 import * as utils from '../../utils';
 import * as elementUtils from './elementUtils';
 import EnumPropertyRow from './EnumPropertyRow';
@@ -34,36 +35,36 @@ class TextAreaProperties extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <PropertyRow
           desc={'text'}
-          isMultiLine={true}
+          isMultiLine
           initialValue={escapedText}
           handleChange={this.props.handleChange.bind(this, 'text')}
         />
         <PropertyRow
           desc={'width (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.width, 10)}
           foo={parseInt(element.style.width, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-width')}
         />
         <PropertyRow
           desc={'height (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.height, 10)}
           handleChange={this.props.handleChange.bind(this, 'style-height')}
         />
         <PropertyRow
           desc={'x position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.left, 10)}
           handleChange={this.props.handleChange.bind(this, 'left')}
         />
         <PropertyRow
           desc={'y position (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.top, 10)}
           handleChange={this.props.handleChange.bind(this, 'top')}
         />
@@ -79,7 +80,7 @@ class TextAreaProperties extends React.Component {
         />
         <PropertyRow
           desc={'font size (px)'}
-          isNumber={true}
+          isNumber
           initialValue={parseInt(element.style.fontSize, 10)}
           handleChange={this.props.handleChange.bind(this, 'fontSize')}
         />
@@ -88,6 +89,21 @@ class TextAreaProperties extends React.Component {
           initialValue={element.style.textAlign || 'left'}
           options={['left', 'right', 'center', 'justify']}
           handleChange={this.props.handleChange.bind(this, 'textAlign')}
+        />
+        <BorderProperties
+          element={element}
+          handleBorderWidthChange={this.props.handleChange.bind(
+            this,
+            'borderWidth'
+          )}
+          handleBorderColorChange={this.props.handleChange.bind(
+            this,
+            'borderColor'
+          )}
+          handleBorderRadiusChange={this.props.handleChange.bind(
+            this,
+            'borderRadius'
+          )}
         />
         <BooleanPropertyRow
           desc={'read only'}
@@ -151,7 +167,7 @@ class TextAreaEvents extends React.Component {
           desc={'id'}
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
-          isIdRow={true}
+          isIdRow
         />
         <EventHeaderRow />
         <EventRow
@@ -176,6 +192,10 @@ export default {
     element.style.fontSize = '14px';
     element.style.color = '#000000';
     element.style.backgroundColor = '#ffffff';
+    elementUtils.setDefaultBorderStyles(element, {
+      forceDefaults: true,
+      textInput: true
+    });
 
     $(element).addClass('textArea');
 
@@ -185,6 +205,9 @@ export default {
   },
 
   onDeserialize: function(element) {
+    // Set border styles for older projects that didn't set them on create:
+    elementUtils.setDefaultBorderStyles(element, {textInput: true});
+
     $(element).addClass('textArea');
 
     $(element).on('mousedown', function(e) {

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -257,6 +257,15 @@ designMode.updateProperty = function(element, name, value) {
     case 'backgroundColor':
       element.style.backgroundColor = value;
       break;
+    case 'borderWidth':
+      element.style.borderWidth = appendPx(value);
+      break;
+    case 'borderColor':
+      element.style.borderColor = value;
+      break;
+    case 'borderRadius':
+      element.style.borderRadius = appendPx(value);
+      break;
     case 'fontSize':
       element.style.fontSize = appendPx(value);
       break;
@@ -487,6 +496,12 @@ designMode.readProperty = function(element, name) {
       return element.style.color;
     case 'backgroundColor':
       return element.style.backgroundColor;
+    case 'borderWidth':
+      return parseFloat(element.style.borderWidth);
+    case 'borderColor':
+      return element.style.borderColor;
+    case 'borderRadius':
+      return parseFloat(element.style.borderRadius);
     case 'fontSize':
       return parseFloat(element.style.fontSize);
     case 'textAlign':

--- a/apps/src/applab/setPropertyDropdown.js
+++ b/apps/src/applab/setPropertyDropdown.js
@@ -72,6 +72,24 @@ var PROP_INFO = {
     type: 'string',
     defaultValue: '"red"'
   },
+  borderWidth: {
+    friendlyName: 'border-width',
+    internalName: 'borderWidth',
+    type: 'number',
+    defaultValue: '0'
+  },
+  borderColor: {
+    friendlyName: 'border-color',
+    internalName: 'borderColor',
+    type: 'string',
+    defaultValue: '"black"'
+  },
+  borderRadius: {
+    friendlyName: 'border-radius',
+    internalName: 'borderRadius',
+    type: 'number',
+    defaultValue: '0'
+  },
   fontSize: {
     friendlyName: 'font-size',
     internalName: 'fontSize',
@@ -238,7 +256,10 @@ PROPERTIES[ElementType.BUTTON] = {
     'textAlign',
     'image',
     'iconColor',
-    'hidden'
+    'hidden',
+    'borderWidth',
+    'borderColor',
+    'borderRadius'
   ]
 };
 PROPERTIES[ElementType.TEXT_INPUT] = {
@@ -254,7 +275,10 @@ PROPERTIES[ElementType.TEXT_INPUT] = {
     'fontSize',
     'textAlign',
     'hidden',
-    'value'
+    'value',
+    'borderWidth',
+    'borderColor',
+    'borderRadius'
   ]
 };
 PROPERTIES[ElementType.LABEL] = {
@@ -268,7 +292,10 @@ PROPERTIES[ElementType.LABEL] = {
     'backgroundColor',
     'fontSize',
     'textAlign',
-    'hidden'
+    'hidden',
+    'borderWidth',
+    'borderColor',
+    'borderRadius'
   ]
 };
 PROPERTIES[ElementType.DROPDOWN] = {
@@ -285,7 +312,10 @@ PROPERTIES[ElementType.DROPDOWN] = {
     'fontSize',
     'textAlign',
     'hidden',
-    'value'
+    'value',
+    'borderWidth',
+    'borderColor',
+    'borderRadius'
   ]
 };
 PROPERTIES[ElementType.RADIO_BUTTON] = {
@@ -314,7 +344,10 @@ PROPERTIES[ElementType.IMAGE] = {
     'picture', // Since this is an alias, it is not shown in the dropdown but is allowed as a value
     'iconColor',
     'hidden',
-    'fit'
+    'fit',
+    'borderWidth',
+    'borderColor',
+    'borderRadius'
   ]
 };
 PROPERTIES[ElementType.CANVAS] = {
@@ -336,7 +369,10 @@ PROPERTIES[ElementType.TEXT_AREA] = {
     'textAlign',
     'readonly',
     'hidden',
-    'value'
+    'value',
+    'borderWidth',
+    'borderColor',
+    'borderRadius'
   ]
 };
 PROPERTIES[ElementType.CHART] = {
@@ -507,6 +543,7 @@ function getPropertyValueDropdown(param2) {
       return getAssetDropdown('image');
     case 'text-color':
     case 'background-color':
+    case 'border-color':
     case 'icon-color':
       return [
         '"white"',
@@ -518,6 +555,9 @@ function getPropertyValueDropdown(param2) {
         'rgb(255,0,0,0.5)',
         '"#FF0000"'
       ];
+    case 'border-radius':
+    case 'border-width':
+      return ['0', '1', '2', '5', '10'];
     case 'text-align':
       return ['"left"', '"right"', '"center"', '"justify"'];
     case 'fit':

--- a/apps/style/applab/skins/modern.scss
+++ b/apps/style/applab/skins/modern.scss
@@ -61,7 +61,6 @@
 
 #divApplab.notRunning, #designModeViz.appModern, .draggingParent {
   img[data-canonical-image-url=''], canvas:not(#turtleCanvas), .chart {
-    border: 5px solid #fff;
     box-sizing: border-box;
     -moz-box-sizing: border-box;
     outline: 1px solid #bdc3c7;

--- a/apps/test/integration/levelSolutions/applab/ec_design.js
+++ b/apps/test/integration/levelSolutions/applab/ec_design.js
@@ -148,7 +148,7 @@ module.exports = {
 
         var assetUrl = '/blockly/media/skins/studio/small_static_avatar.png';
         var encodedAssetUrl = assetUrl;
-        var imageInput = $('#propertyRowContainer input').last()[0];
+        var imageInput = $('.imagePickerInput')[0];
 
         var buttonElement = $('#design_button1')[0];
 
@@ -184,7 +184,7 @@ module.exports = {
           'https://studio.code.org/blockly/media/skins/studio/small_static_avatar.png';
         var encodedAssetUrl =
           '/media?u=https%3A%2F%2Fstudio.code.org%2Fblockly%2Fmedia%2Fskins%2Fstudio%2Fsmall_static_avatar.png';
-        var imageInput = $('#propertyRowContainer input').last()[0];
+        var imageInput = $('.imagePickerInput')[0];
 
         var buttonElement = $('#design_button1')[0];
 
@@ -223,7 +223,7 @@ module.exports = {
         var assetUrl = 'flappy (1).png';
         var encodedAssetUrl =
           '/base/test/integration/assets/applab-channel-id/flappy%20(1).png';
-        var imageInput = $('#propertyRowContainer input').last()[0];
+        var imageInput = $('.imagePickerInput')[0];
 
         var buttonElement = $('#design_button1')[0];
         var originalButtonWidth = buttonElement.style.width;
@@ -800,8 +800,9 @@ module.exports = {
         assertPropertyRowExists(4, 'y position (px)', assert);
         assertPropertyRowExists(5, 'image Choose...', assert);
         assertPropertyRowExists(6, 'fit imagefillcovercontainnone', assert);
-        assertPropertyRowExists(7, 'hidden', assert);
-        assertPropertyRowExists(8, 'depth', assert);
+        // Ignore BorderProperties
+        assertPropertyRowExists(8, 'hidden', assert);
+        assertPropertyRowExists(9, 'depth', assert);
 
         // Make sure it's draggable
         var manipulator = newImage.parent();
@@ -1182,7 +1183,7 @@ module.exports = {
 
         assertPropertyRowExists(5, 'image Choose...', assert);
 
-        var input = $('#propertyRowContainer input').eq(5)[0];
+        var input = $('.imagePickerInput')[0];
         var designImage = $('#design_image1')[0];
         assert.equal(designImage.style.width, '110px');
         assert.equal(designImage.style.height, '105px');

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -117,3 +117,6 @@ $droplet_pink: #f57ac6;
 $droplet_purple: #bb77c7;
 $droplet_green: #68d995;
 $droplet_white: $white;
+
+// Colors needed for applab styles.
+$text_input_default_border_color: rgb(153, 153, 153);


### PR DESCRIPTION
* Restored reverted applab border styles (reverting this revert: https://github.com/code-dot-org/code-dot-org/pull/27061)
* Confirmed with @poorvasingal that we no longer want to show the 5px border on images in design mode. At her request, removed that border from charts and canvases in design mode as well.
* Adjusted a margin at the top of the `BorderProperties` component to ensure equal spacing.

Before:
<img width="416" alt="screen shot 2019-02-15 at 9 53 50 am" src="https://user-images.githubusercontent.com/5429146/52876345-d20d5080-310b-11e9-8d86-c206f7d43545.png">
After:
<img width="418" alt="screen shot 2019-02-15 at 9 55 46 am" src="https://user-images.githubusercontent.com/5429146/52876349-d6d20480-310b-11e9-92bb-05f9129b7e7b.png">
