### PR TITLE
Show discount code in monospace font to disambiguate characters

### DIFF
--- a/apps/src/lib/kits/maker/ui/DiscountCodeInstructions.jsx
+++ b/apps/src/lib/kits/maker/ui/DiscountCodeInstructions.jsx
@@ -22,6 +22,9 @@ const styles = {
   },
   expired: {
     color: color.dark_red
+  },
+  codeText: {
+    fontFamily: 'monospace'
   }
 };
 
@@ -48,7 +51,8 @@ export default class DiscountCodeInstructions extends Component {
           <h1 style={styles.title}>Subsidized Circuit Playground Kits</h1>
           <h2>
             <div>
-              Discount code for subsidized kit: {this.props.discountCode}
+              Discount code for subsidized kit:{' '}
+              <span style={styles.codeText}>{this.props.discountCode}</span>
             </div>
             <div style={styles.expired}>(Expired {expirationString})</div>
           </h2>
@@ -96,8 +100,9 @@ export default class DiscountCodeInstructions extends Component {
         </div>
         <div style={styles.step}>
           <div>
-            3) Put in your discount code ({this.props.discountCode}) and hit
-            "Apply".
+            3) Put in your discount code (
+            <span style={styles.codeText}>{this.props.discountCode}</span>) and
+            hit "Apply".
           </div>
           <a href="https://images.code.org/maker/enterDiscountCode_19.png">
             <img

--- a/apps/src/lib/kits/maker/ui/DiscountCodeInstructions.jsx
+++ b/apps/src/lib/kits/maker/ui/DiscountCodeInstructions.jsx
@@ -67,7 +67,10 @@ export default class DiscountCodeInstructions extends Component {
       <div>
         <h1 style={styles.title}>Subsidized Circuit Playground Kits</h1>
         <h2>
-          <div>Discount code for subsidized kit: {this.props.discountCode}</div>
+          <div>
+            Discount code for subsidized kit:{' '}
+            <span style={styles.codeText}>{this.props.discountCode}</span>
+          </div>
           <div>(Expires {expirationString})</div>
         </h2>
         <div>

--- a/apps/src/lib/kits/maker/ui/DiscountCodeInstructions.story.jsx
+++ b/apps/src/lib/kits/maker/ui/DiscountCodeInstructions.story.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import DiscountCodeInstructions from './DiscountCodeInstructions';
 
+const testDiscountCode = 'disambiguates-0O1Il5S';
+
 export default storybook => {
   return storybook
     .storiesOf('MakerToolkit/Discounts/Discount Code Instructions', module)
@@ -11,7 +13,7 @@ export default storybook => {
           'Discount Code Instructions when qualified for a full discount',
         story: () => (
           <DiscountCodeInstructions
-            discountCode="123abc"
+            discountCode={testDiscountCode}
             expiration="2034-12-31T00:00:00.000Z"
           />
         )
@@ -21,7 +23,7 @@ export default storybook => {
         description: 'Discount Code Instructions when code is expired',
         story: () => (
           <DiscountCodeInstructions
-            discountCode="123abc"
+            discountCode={testDiscountCode}
             expiration="2017-12-31T00:00:00.000Z"
           />
         )


### PR DESCRIPTION
What it says on the box.

Before:

![screenshot from 2019-02-15 13-00-27](https://user-images.githubusercontent.com/1615761/52892527-ee2ee300-3147-11e9-9c69-77e91cdca430.png)

After:

![screenshot from 2019-02-15 17-32-57](https://user-images.githubusercontent.com/1615761/52892531-f0913d00-3147-11e9-8298-602cede9a513.png)
