### PR TITLE
Alternate rtl hamburger

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -331,12 +331,6 @@ img.video_thumbnail {
     }
   }
 
-  #sign_in_or_user {
-    html[dir=rtl] & {
-      padding-right: 20px;
-    }
-  }
-
   .user_menu, .create_menu {
     margin-top: 6px;
     height: 38px;

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -63,6 +63,15 @@
     span {
       @extend %extend_burger;
       transition: all 500ms ease-in-out;
+      html[dir=rtl] & {
+        margin-right: -25px;
+        &::before {
+          margin-right: 0;
+        }
+        &::after {
+          margin-right: 0;
+        }
+      }
       &::before {
         @extend %extend_burger;
         transition: all 500ms ease-in-out;


### PR DESCRIPTION
Improves the RTL hamburger experience by moving the lines under the click target, and then getting rid of the padding which is no longer necessary.

![screen shot 2019-02-15 at 2 11 15 pm](https://user-images.githubusercontent.com/11651276/52888165-81a7ea00-312f-11e9-90eb-014df0f2ef87.png)
![screen shot 2019-02-15 at 2 11 44 pm](https://user-images.githubusercontent.com/11651276/52888167-87053480-312f-11e9-8aa4-5f464f4bcdbf.png)
