### PR TITLE
 use correct sublevel name when cloning a level group

### DIFF
--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -120,8 +120,8 @@ ruby
 
     if new_properties['texts']
       new_properties['texts'].map! do |text|
-        Level.find_by_name(text['level_name']).clone_with_suffix(new_suffix)
-        text['level_name'] << new_suffix
+        new_level = Level.find_by_name(text['level_name']).clone_with_suffix(new_suffix)
+        text['level_name'] = new_level.name
         text
       end
     end
@@ -129,8 +129,8 @@ ruby
     if new_properties['pages']
       new_properties['pages'].map! do |page|
         page['levels'].map! do |level_name|
-          Level.find_by_name(level_name).clone_with_suffix(new_suffix)
-          level_name << new_suffix
+          new_level = Level.find_by_name(level_name).clone_with_suffix(new_suffix)
+          new_level.name
         end
         page
       end

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -228,7 +228,7 @@ MARKDOWN
   test 'clone level group with suffix' do
     # DSL for the level_group.
     level_group_input_dsl = "
-  name 'long assessment'
+  name 'level_group_test long assessment'
   title 'Long Assessment'
   submittable 'true'
 
@@ -245,7 +245,7 @@ MARKDOWN
   level 'level7'
   "
 
-    level_group_copy_dsl = "name 'long assessment_copy'
+    level_group_copy_dsl = "name 'level_group_test long assessment_copy'
 title 'Long Assessment'
 submittable 'true'
 
@@ -298,7 +298,7 @@ level 'level7_copy'"
 
   test 'clone previously cloned level group' do
     level_group_input_dsl = "
-  name 'assessment'
+  name 'level_group_test assessment'
   title 'Assessment'
 
   page
@@ -306,14 +306,14 @@ level 'level7_copy'"
   level 'level1'
   "
 
-    level_group_copy1_dsl = "name 'assessment copy1'
+    level_group_copy1_dsl = "name 'level_group_test assessment copy1'
 title 'Assessment'
 
 page
 text 'external1 copy1'
 level 'level1 copy1'"
 
-    level_group_copy2_dsl = "name 'assessment copy2'
+    level_group_copy2_dsl = "name 'level_group_test assessment copy2'
 title 'Assessment'
 
 page
@@ -337,7 +337,7 @@ level 'level1 copy2'"
     # Copy the level group and all its sub levels.
     level_group_copy1 = level_group.clone_with_suffix(' copy1')
     assert_equal level_group_copy1_dsl, level_group_copy1.dsl_text
-    assert_equal 'assessment copy1', level_group_copy1.name
+    assert_equal 'level_group_test assessment copy1', level_group_copy1.name
     assert_equal 'level1 copy1', level_group_copy1.pages.first.levels.first.name
     assert_equal 'external1 copy1', level_group_copy1.properties['texts'].first['level_name']
     refute_nil Level.find_by_name('external1 copy1')
@@ -346,7 +346,7 @@ level 'level1 copy2'"
     # rather than being concatenated, due to name_suffix field.
     level_group_copy2 = level_group.clone_with_suffix(' copy2')
     assert_equal level_group_copy2_dsl, level_group_copy2.dsl_text
-    assert_equal 'assessment copy2', level_group_copy2.name
+    assert_equal 'level_group_test assessment copy2', level_group_copy2.name
     assert_equal 'level1 copy2', level_group_copy2.pages.first.levels.first.name
     assert_equal 'external1 copy2', level_group_copy2.properties['texts'].first['level_name']
     refute_nil Level.find_by_name('external1 copy2')

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -296,6 +296,62 @@ level 'level7_copy'"
     File.delete(level_group_copy.filename)
   end
 
+  test 'clone previously cloned level group' do
+    level_group_input_dsl = "
+  name 'assessment'
+  title 'Assessment'
+
+  page
+  text 'external1'
+  level 'level1'
+  "
+
+    level_group_copy1_dsl = "name 'assessment copy1'
+title 'Assessment'
+
+page
+text 'external1 copy1'
+level 'level1 copy1'"
+
+    level_group_copy2_dsl = "name 'assessment copy2'
+title 'Assessment'
+
+page
+text 'external1 copy2'
+level 'level1 copy2'"
+
+    # Create the multi level
+    multi_dsl = get_multi_dsl(1)
+    Multi.create_from_level_builder({}, {dsl_text: multi_dsl})
+    Multi.any_instance.stubs(:dsl_text).returns(multi_dsl)
+
+    # Create the external level.
+    external_dsl = get_external_dsl(1)
+    External.create_from_level_builder({}, {dsl_text: external_dsl})
+    External.any_instance.stubs(:dsl_text).returns(external_dsl)
+
+    # Create the level_group.
+    level_group = LevelGroup.create_from_level_builder({}, {name: 'my_level_group', dsl_text: level_group_input_dsl})
+    level_group.stubs(:dsl_text).returns(level_group_input_dsl)
+
+    # Copy the level group and all its sub levels.
+    level_group_copy1 = level_group.clone_with_suffix(' copy1')
+    assert_equal level_group_copy1_dsl, level_group_copy1.dsl_text
+    assert_equal 'assessment copy1', level_group_copy1.name
+    assert_equal 'level1 copy1', level_group_copy1.pages.first.levels.first.name
+    assert_equal 'external1 copy1', level_group_copy1.properties['texts'].first['level_name']
+    refute_nil Level.find_by_name('external1 copy1')
+
+    # Copy the level group again. copy2 suffix replaces copy1 suffix throughout,
+    # rather than being concatenated, due to name_suffix field.
+    level_group_copy2 = level_group.clone_with_suffix(' copy2')
+    assert_equal level_group_copy2_dsl, level_group_copy2.dsl_text
+    assert_equal 'assessment copy2', level_group_copy2.name
+    assert_equal 'level1 copy2', level_group_copy2.pages.first.levels.first.name
+    assert_equal 'external1 copy2', level_group_copy2.properties['texts'].first['level_name']
+    refute_nil Level.find_by_name('external1 copy2')
+  end
+
   test 'get_summarized_survey_results returns a hash of results' do
     # Seed the RNG deterministically so we get the same "random" shuffling of results.
     srand 1

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -350,6 +350,10 @@ level 'level1 copy2'"
     assert_equal 'level1 copy2', level_group_copy2.pages.first.levels.first.name
     assert_equal 'external1 copy2', level_group_copy2.properties['texts'].first['level_name']
     refute_nil Level.find_by_name('external1 copy2')
+
+    # clean up
+    File.delete(level_group_copy1.filename)
+    File.delete(level_group_copy2.filename)
   end
 
   test 'get_summarized_survey_results returns a hash of results' do


### PR DESCRIPTION
### Background

`Script.find_by_name('csp1-2018').clone_with_suffix('2019')` initially failed because the level group's sublevels were having their `_2018` suffix removed during the rename, but the level group was looking for files with the concatenated `_2018_2019` suffix. 

### Description

This PR makes the LevelGroup use the actual new filename as the source of truth for what filename to point to, eliminating any ambiguity. This should also be future-proof against sublevel filenames getting truncated, although I haven't tested for that explicitly.