### PR TITLE
Organizer Survey Results: Temporary message about missing survey data

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results_header.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results_header.jsx
@@ -530,6 +530,7 @@ export default class SurveyResultsHeader extends React.Component {
     return (
       <div>
         <div> View Survey Results </div>
+
         <Row>
           <Col sm={2}>
             <select
@@ -552,6 +553,20 @@ export default class SurveyResultsHeader extends React.Component {
           </Col>
         </Row>
         <br />
+        {/* Temporary warning about missing data until we fix this view to include new results! */}
+        {['CS Discoveries', 'CS Principles'].includes(
+          this.state.selectedCourse
+        ) && (
+          <div style={{padding: '0em 4em 1em'}}>
+            <strong>
+              Averages displayed below only include results from June 2018 or
+              earlier.
+            </strong>{' '}
+            More recent results are available when viewing surveys for an
+            individual workshop. This page will be updated to include recent
+            survey results soon. Thank you for your patience!
+          </div>
+        )}
         {this.renderSurveyPanel()}
         {this.renderFreeResponseAnswers()}
         {this.renderDownloadCsvButton()}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1615761/52979515-d5fad600-338a-11e9-9214-152f158e5560.png)

Fixes [PLC-82](https://codedotorg.atlassian.net/browse/PLC-82).

We've had to deprioritize new data sources for this dashboard ([PLC-49](https://codedotorg.atlassian.net/browse/PLC-49), [spec](https://docs.google.com/document/d/1iCHurHdCDUoo5N6k2lLML-tU_Qy2YLz5CFRGcYSb7mE/edit#)). Because we are deferring this cleanup about a week, we're dropping a small warning message at the top of the dashboard to explain the issue and let partners know we're aware of it.