### PR TITLE
Regional Partner Admin: Link to regional partner search by region

### DIFF
--- a/dashboard/app/views/regional_partners/index.html.haml
+++ b/dashboard/app/views/regional_partners/index.html.haml
@@ -6,7 +6,11 @@
 #application-container
   = show_flashes.html_safe
 
-%p Enter an Organization Name to view and edit a Regional Partner
+%p
+  Enter an Organization Name to view and edit a Regional Partner.
+  Trying to find a regional partner by state/zip? Check out
+  %a{href: CDO.code_org_url('/educate/professional-learning/middle-high', CDO.default_scheme)}
+    this search tool.
 = form_tag url_for(action: 'index'), method: 'get', class: 'form-inline', enforce_utf8: false do
   = text_field_tag :search_term, params[:search_term], class: 'form-control'
   %button.btn{type: 'submit'}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1615761/52980727-6daef300-3390-11e9-88bd-5eff596c46f6.png)

See [this Slack conversation](https://codedotorg.slack.com/archives/C0T10H26N/p1550530029056000) (login required).

We've already got this tool at https://code.org/educate/professional-learning/middle-high but since Emma had to ask about it, I assume we have a discoverability problem.  This seems like a sensible place to link to it.

Tracking as [PLC-84](https://codedotorg.atlassian.net/browse/PLC-84)