### PR TITLE
Hygiene: Correct erroneous comment

### DIFF
--- a/dashboard/app/controllers/pd/international_opt_in_controller.rb
+++ b/dashboard/app/controllers/pd/international_opt_in_controller.rb
@@ -1,7 +1,7 @@
 class Pd::InternationalOptInController < ApplicationController
   load_resource :international_opt_in, class: 'Pd::InternationalOptIn', id_param: :contact_id, only: [:thanks]
 
-  # GET /pd/international_workshopss/new
+  # GET /pd/international_workshop
   def new
     return render '/pd/application/teacher_application/logged_out' unless current_user
     return render '/pd/application/teacher_application/not_teacher' unless current_user.teacher?


### PR DESCRIPTION
While investigating an item that ended up requiring no work, noticed that the comment in this controller didn't actually represent the related route.