### PR TITLE
add pilot_experiment field to scripts

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -52,6 +52,7 @@ export default class ScriptEditor extends React.Component {
     hasVerifiedResources: PropTypes.bool,
     hasLessonPlan: PropTypes.bool,
     curriculumPath: PropTypes.string,
+    pilotExperiment: PropTypes.string,
     announcements: PropTypes.arrayOf(announcementShape),
     supportedLocales: PropTypes.arrayOf(PropTypes.string),
     locales: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired
@@ -226,6 +227,16 @@ export default class ScriptEditor extends React.Component {
             Check if this course has lesson plans (on Curriculum Builder or in
             PDF form) that we should provide links to.
           </p>
+        </label>
+        <label>
+          Pilot Experiment. If specified, this script will only be accessible to
+          levelbuilders, or to classrooms whose teacher has this user experiment
+          enabled.
+          <input
+            name="pilot_experiment"
+            defaultValue={this.props.pilotExperiment}
+            style={styles.input}
+          />
         </label>
         <label>
           Curriculum Path

--- a/apps/src/sites/studio/pages/levelbuilder_edit_script.js
+++ b/apps/src/sites/studio/pages/levelbuilder_edit_script.js
@@ -43,6 +43,7 @@ export default function initPage(scriptEditorData) {
         hasVerifiedResources={scriptData.has_verified_resources}
         hasLessonPlan={scriptData.has_lesson_plan}
         curriculumPath={scriptData.curriculum_path}
+        pilotExperiment={scriptData.pilot_experiment}
         announcements={announcements}
         supportedLocales={scriptData.supported_locales}
         locales={locales}

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -138,6 +138,7 @@ class ScriptsController < ApplicationController
       :has_verified_resources,
       :has_lesson_plan,
       :script_announcements,
+      :pilot_experiment,
       resourceTypes: [],
       resourceLinks: [],
       project_widget_types: [],

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -30,6 +30,7 @@ class ScriptDSL < BaseDSL
     @version_year = nil
     @is_stable = nil
     @supported_locales = []
+    @pilot_experiment = nil
   end
 
   integer :id
@@ -53,6 +54,7 @@ class ScriptDSL < BaseDSL
   string :family_name
   string :version_year
   string :curriculum_path
+  string :pilot_experiment
 
   def teacher_resources(resources)
     @teacher_resources = resources
@@ -64,6 +66,10 @@ class ScriptDSL < BaseDSL
 
   def supported_locales(locales)
     @supported_locales = locales
+  end
+
+  def pilot_experiment(experiment)
+    @pilot_experiment = experiment
   end
 
   def stage(name, properties = {})
@@ -108,7 +114,8 @@ class ScriptDSL < BaseDSL
       family_name: @family_name,
       version_year: @version_year,
       is_stable: @is_stable,
-      supported_locales: @supported_locales
+      supported_locales: @supported_locales,
+      pilot_experiment: @pilot_experiment
     }
   end
 
@@ -267,6 +274,7 @@ class ScriptDSL < BaseDSL
     s << "version_year '#{script.version_year}'" if script.version_year
     s << 'is_stable true' if script.is_stable
     s << "supported_locales #{script.supported_locales}" if script.supported_locales
+    s << "pilot_experiment '#{script.pilot_experiment}'" if script.pilot_experiment
 
     s << '' unless s.empty?
     s << serialize_stages(script)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -140,6 +140,7 @@ class Script < ActiveRecord::Base
     version_year
     is_stable
     supported_locales
+    pilot_experiment
   )
 
   def self.twenty_hour_script
@@ -1364,7 +1365,8 @@ class Script < ActiveRecord::Base
       script_announcements: script_data[:script_announcements] || false,
       version_year: script_data[:version_year],
       is_stable: script_data[:is_stable],
-      supported_locales: script_data[:supported_locales]
+      supported_locales: script_data[:supported_locales],
+      pilot_experiment: script_data[:pilot_experiment]
     }.compact
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -67,6 +67,12 @@ class Script < ActiveRecord::Base
   attr_accessor :skip_name_format_validation
   include SerializedToFileValidation
 
+  before_validation :hide_pilot_scripts
+
+  def hide_pilot_scripts
+    self.hidden = true if pilot_experiment
+  end
+
   # As we read and write to files with the script name, to prevent directory
   # traversal (for security reasons), we do not allow the name to start with a
   # tilde or dot or contain a slash.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1240,6 +1240,7 @@ class Script < ActiveRecord::Base
       versions: summarize_versions(user),
       supported_locales: supported_locales,
       section_hidden_unit_info: section_hidden_unit_info(user),
+      pilot_experiment: pilot_experiment,
     }
 
     summary[:stages] = stages.map(&:summarize) if include_stages

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -11515,3 +11515,11 @@ en:
               name: Final Project
               description_student: ''
               description_teacher: ''
+        csp1-pilot:
+          stages:
+            new stage:
+              name: new stage
+          title: CSP Unit 1 Pilot
+          description_audience: ''
+          description_short: ''
+          description: ''

--- a/dashboard/config/scripts/csp1-pilot.script
+++ b/dashboard/config/scripts/csp1-pilot.script
@@ -1,0 +1,5 @@
+login_required true
+pilot_experiment 'csp-piloters'
+
+stage 'new stage'
+level 'csp_socialBelonging_control_2018'

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -274,6 +274,22 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_equal [['curriculum', '/link/to/curriculum'], ['vocabulary', '/link/to/vocab']], Script.find_by_name(script.name).teacher_resources
   end
 
+  test 'updates pilot_experiment' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    script = create :script
+    File.stubs(:write).with {|filename, _| filename == "config/scripts/#{script.name}.script" || filename.end_with?('scripts.en.yml')}
+
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: '',
+      pilot_experiment: 'pilot-experiment',
+    }
+    assert_equal 'pilot-experiment', Script.find_by_name(script.name).pilot_experiment
+  end
+
   test 'can create with has_lesson_plan param' do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -286,8 +286,11 @@ class ScriptsControllerTest < ActionController::TestCase
       script: {name: script.name},
       script_text: '',
       pilot_experiment: 'pilot-experiment',
+      hidden: false,
     }
     assert_equal 'pilot-experiment', Script.find_by_name(script.name).pilot_experiment
+    # pilot scripts are always marked hidden
+    assert_equal true, Script.find_by_name(script.name).hidden
   end
 
   test 'can create with has_lesson_plan param' do

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -28,6 +28,7 @@ class DslTest < ActiveSupport::TestCase
     version_year: nil,
     is_stable: nil,
     supported_locales: [],
+    pilot_experiment: nil,
   }
 
   test 'test Script DSL' do
@@ -631,7 +632,6 @@ DSL
   end
 
   test 'serialize new_name, family_name, version_year and is_stable' do
-    puts 'test_serialize_new_name_and_family_name'
     script = create :script,
       {
         new_name: 'new name',

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -441,6 +441,17 @@ DSL
     assert_equal [{"notice": "NoticeHere", "details": "DetailsHere", "link": "/foo/bar", "type": "information"}], output[:script_announcements]
   end
 
+  test 'can set pilot_experiment' do
+    input_dsl = <<DSL
+pilot_experiment 'science-experiment'
+
+stage 'Stage1'
+level 'Level 1'
+DSL
+    output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    assert_equal 'science-experiment', output[:pilot_experiment]
+  end
+
   test 'Script DSL with level progressions' do
     input_dsl = <<DSL
 stage 'Stage1'

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1515,6 +1515,25 @@ endvariants
     )
   end
 
+  test 'pilot scripts are always hidden during seed' do
+    l = create :level
+    dsl = <<-SCRIPT
+      hidden false
+      pilot_experiment 'pilot-experiment'
+
+      stage 'Stage1'
+      level '#{l.name}'
+    SCRIPT
+
+    File.stubs(:read).returns(dsl)
+    scripts, _ = Script.setup(['pilot-script.script'])
+    script = scripts.first
+
+    assert_equal 'pilot-script', script.name
+    assert_equal 'pilot-experiment', script.pilot_experiment
+    assert_equal true, script.hidden
+  end
+
   private
 
   def has_hidden_script?(scripts)


### PR DESCRIPTION
### Background

* Jira item [LP-125](https://codedotorg.atlassian.net/browse/LP-125)
* [design doc](https://docs.google.com/document/d/1jJzM6u6oUP4jSMISGgp_aaoq82hDRPzg5HPMXZEE-MA/edit#)

### Description

1. add `pilot_experiment` to the .script file format as well as to the script editor form on levelbuilder. The text added to the levelbuilder UI describes what this field will do in the future, even though that hasn't been implemented yet.
2. whenever a script is given a pilot_experiment, also mark it as hidden (see https://github.com/code-dot-org/code-dot-org/pull/27124/commits/277646e3e07e126e661fdfb06a5f51fb75065ef8). This is to make it so there are only 3 states (pilot, hidden, or visible) rather than 4, as described in Brad's comments in the [design doc](https://docs.google.com/document/d/1jJzM6u6oUP4jSMISGgp_aaoq82hDRPzg5HPMXZEE-MA/edit#).
