### PR TITLE
Applab set property dropdown fixes

### DIFF
--- a/apps/src/applab/setPropertyDropdown.js
+++ b/apps/src/applab/setPropertyDropdown.js
@@ -76,7 +76,7 @@ var PROP_INFO = {
     friendlyName: 'font-size',
     internalName: 'fontSize',
     type: 'number',
-    defaultValue: '100'
+    defaultValue: '14'
   },
   textAlign: {
     friendlyName: 'text-align',
@@ -524,6 +524,8 @@ function getPropertyValueDropdown(param2) {
       return ['"fill"', '"cover"', '"contain"', '"none"'];
     case 'hidden':
     case 'checked':
+    case 'font-size':
+      return ['8', '10', '12', '14', '18', '24', '36', '72'];
     case 'readonly':
       return ['true', 'false'];
     case 'text':


### PR DESCRIPTION
* The `font-size` property wasn't particularly well handled in the `setProperty()` code - it provided a default of '100' and a dropdown with '0', '25', '50', '75', '100', '150', and '200'. Fixed to provide a default of '14' and a dropdown with '8', '10', '12', '14', '18', '24', '36', and '72'.
* The autocomplete handler for a parameter dropdown with a click handler didn't use our special `insertMatch` code that knows how to replace the text you're in the middle of typing. The end result could be quite messy. Fixed to always use our special `insertMatch` code.

Before:
![dropdown-before](https://user-images.githubusercontent.com/5429146/53046258-837df000-3444-11e9-9990-cc15087036b2.gif)

After:
![dropdown-after](https://user-images.githubusercontent.com/5429146/53046161-49ace980-3444-11e9-884e-0a0828144f07.gif)
