### PR TITLE
Remove unused marked setting

### DIFF
--- a/apps/src/code-studio/initializeEmbeddedMarkdownEditor.js
+++ b/apps/src/code-studio/initializeEmbeddedMarkdownEditor.js
@@ -2,12 +2,7 @@
  * @file Defines a function for initializing an embedded markdown editor using
  *       CodeMirror and marked.
  */
-var marked = require('marked');
 var initializeCodeMirror = require('./initializeCodeMirror');
-
-marked.setOptions({
-  sanitize: true
-});
 
 /**
  * Initializes a live preview markdown editor that spits its contents out into


### PR DESCRIPTION
This code had formerly been used by
https://github.com/code-dot-org/code-dot-org/pull/9799 to escape HTML
entered in the DSL markdown editor, as part of an effort to discourage
excess custom HTML in those files.

However, https://github.com/code-dot-org/code-dot-org/pull/24506
switched CodeMirror over to using a markdown renderer that doesn't rely
on Marked, at which point this options injection stopped working.
Because we are moving away from marked, and because in the long run we
are going to start restricting the tags we support at the lowest level,
this dead code is simply removed rather than replaced.