### PR TITLE
CodeMirror preview option

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -39,15 +39,20 @@ const INVALID_COLOR = '#d00';
  * @param {!string|!Element} target - element or id of element to replace.
  * @param {!string} mode - editor syntax mode
  * @param {function} [callback] - onChange callback for editor
- * @param {booblen} [attachments] - whether to enable attachment uploading in
+ * @param {boolean} [attachments] - whether to enable attachment uploading in
  *        this editor.
+ * @param {???} [onUpdateLinting]
+ * @param {!string!Element} [preview] - element or id of element to populate
+ *        with a preview. If none specified, will look for an element by
+ *        appending "_preview" to the id of the target element.
  */
 function initializeCodeMirror(
   target,
   mode,
   callback,
   attachments,
-  onUpdateLinting
+  onUpdateLinting,
+  preview
 ) {
   let updatePreview;
 
@@ -68,15 +73,16 @@ function initializeCodeMirror(
     // In markdown mode, look for a preview element (found by just appending
     // _preview to the target id), if it exists extend our callback to update
     // the preview element with the markdown contents
-    const previewElement = $(`#${node.id}_preview`);
-    if (previewElement.length > 0) {
+    preview = preview || `#${node.id}_preview`;
+    const previewElement = preview.nodeType ? preview : $(preview).get(0);
+    if (previewElement) {
       const originalCallback = callback;
       updatePreview = editor => {
         ReactDOM.render(
           React.createElement(UnsafeRenderedMarkdown, {
             markdown: editor.getValue()
           }),
-          previewElement[0]
+          previewElement
         );
       };
 

--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -42,7 +42,7 @@ const INVALID_COLOR = '#d00';
  * @param {function} [options.callback] - onChange callback for editor
  * @param {boolean} [options.attachments] - whether to enable attachment
  *        uploading in this editor.
- * @param {???} [options.onUpdateLinting]
+ * @param {function} [options.onUpdateLinting]
  * @param {!string!Element} [options.preview] - element or id of element to
  *        populate with a preview. If none specified, will look for an element
  *        by appending "_preview" to the id of the target element.

--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -38,22 +38,17 @@ const INVALID_COLOR = '#d00';
  * CodeMirror editor.
  * @param {!string|!Element} target - element or id of element to replace.
  * @param {!string} mode - editor syntax mode
- * @param {function} [callback] - onChange callback for editor
- * @param {boolean} [attachments] - whether to enable attachment uploading in
- *        this editor.
- * @param {???} [onUpdateLinting]
- * @param {!string!Element} [preview] - element or id of element to populate
- *        with a preview. If none specified, will look for an element by
- *        appending "_preview" to the id of the target element.
+ * @param {Object} options - misc optional arguments
+ * @param {function} [options.callback] - onChange callback for editor
+ * @param {boolean} [options.attachments] - whether to enable attachment
+ *        uploading in this editor.
+ * @param {???} [options.onUpdateLinting]
+ * @param {!string!Element} [options.preview] - element or id of element to
+ *        populate with a preview. If none specified, will look for an element
+ *        by appending "_preview" to the id of the target element.
  */
-function initializeCodeMirror(
-  target,
-  mode,
-  callback,
-  attachments,
-  onUpdateLinting,
-  preview
-) {
+function initializeCodeMirror(target, mode, options) {
+  let {callback, attachments, onUpdateLinting, preview} = options;
   let updatePreview;
 
   // Code mirror parses html using xml mode

--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -43,7 +43,7 @@ const INVALID_COLOR = '#d00';
  * @param {boolean} [options.attachments] - whether to enable attachment
  *        uploading in this editor.
  * @param {function} [options.onUpdateLinting]
- * @param {!string!Element} [options.preview] - element or id of element to
+ * @param {(string|Element)} [options.preview] - element or id of element to
  *        populate with a preview. If none specified, will look for an element
  *        by appending "_preview" to the id of the target element.
  */

--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -47,7 +47,7 @@ const INVALID_COLOR = '#d00';
  *        populate with a preview. If none specified, will look for an element
  *        by appending "_preview" to the id of the target element.
  */
-function initializeCodeMirror(target, mode, options) {
+function initializeCodeMirror(target, mode, options = {}) {
   let {callback, attachments, onUpdateLinting, preview} = options;
   let updatePreview;
 

--- a/apps/src/code-studio/initializeEmbeddedMarkdownEditor.js
+++ b/apps/src/code-studio/initializeEmbeddedMarkdownEditor.js
@@ -34,10 +34,8 @@ module.exports = function(embeddedElement, markdownTextArea, markdownProperty) {
   var dslElement = embeddedElement;
   var dslText = dslElement.val();
 
-  var mdEditor = initializeCodeMirror(
-    markdownTextArea,
-    'markdown',
-    function(editor, change) {
+  var mdEditor = initializeCodeMirror(markdownTextArea, 'markdown', {
+    callback: function(editor, change) {
       var editorText = editor.getValue();
       var dslText = dslElement.val();
       var replacedText;
@@ -57,8 +55,8 @@ module.exports = function(embeddedElement, markdownTextArea, markdownProperty) {
       }
       dslElement.val(replacedText);
     },
-    true
-  );
+    attachments: true
+  });
 
   // Match against markdown heredoc syntax and capture contents in [2].
   var match = regex.exec(dslText);

--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -31,19 +31,16 @@ $(document).ready(() => {
 
   let submitButton = document.querySelector('#block_submit');
   const fixupJson = initializeCodeMirrorForJson('block_config', {onChange});
-  helperEditor = initializeCodeMirror(
-    'block_helper_code',
-    'javascript',
-    fixupJson,
-    null,
-    (_, errors) => {
+  helperEditor = initializeCodeMirror('block_helper_code', 'javascript', {
+    callback: fixupJson,
+    onUpdateLinting: (_, errors) => {
       if (errors.length) {
         submitButton.setAttribute('disabled', 'disabled');
       } else {
         submitButton.removeAttribute('disabled');
       }
     }
-  );
+  });
   poolField.addEventListener('change', fixupJson);
 
   $('.alert.alert-success')

--- a/apps/src/sites/studio/pages/levelbuilder_gamelab.js
+++ b/apps/src/sites/studio/pages/levelbuilder_gamelab.js
@@ -38,8 +38,10 @@ $(document).ready(function() {
   validateAnimationJSON(
     document.getElementById('level_start_animations').value
   );
-  initializeCodeMirror('level_start_animations', 'json', codeMirror => {
-    validateAnimationJSON(codeMirror.getValue());
+  initializeCodeMirror('level_start_animations', 'json', {
+    callback: codeMirror => {
+      validateAnimationJSON(codeMirror.getValue());
+    }
   });
 
   // Leniently validate and fix up custom block JSON using jsonic

--- a/apps/src/sites/studio/pages/libraries/edit.js
+++ b/apps/src/sites/studio/pages/libraries/edit.js
@@ -1,16 +1,12 @@
 import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
 
 const submitButton = document.querySelector('#library_submit');
-initializeCodeMirror(
-  'library_content',
-  'javascript',
-  null,
-  null,
-  (_, errors) => {
+initializeCodeMirror('library_content', 'javascript', {
+  onUpdateLinting: (_, errors) => {
     if (errors.length) {
       submitButton.setAttribute('disabled', 'disabled');
     } else {
       submitButton.removeAttribute('disabled');
     }
   }
-);
+});

--- a/dashboard/app/views/levels/editors/_artist.html.haml
+++ b/dashboard/app/views/levels/editors/_artist.html.haml
@@ -49,4 +49,4 @@
     %p Paste or drag images into this field to upload them, similar to adding images to Long Instructions.
   = f.text_area :images, placeholder: 'Images', rows: 4, value: @level.properties['images']
   :javascript
-    levelbuilder.initializeCodeMirror('level_images', 'javascript', null, true);
+    levelbuilder.initializeCodeMirror('level_images', 'javascript', {attachments: true});

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -75,13 +75,14 @@
           levelbuilder.initializeCodeMirror(
             space.find('.hint_markdown').get(0),
             'markdown',
-            function(editor, change) {
-              space.find('.hint_markdown').val(editor.getValue());
-              space.find('.hint_markdown').trigger('change');
-            },
-            true,
-            undefined,
-            space.find('.markdown_preview').get(0)
+            {
+              callback: function(editor, change) {
+                space.find('.hint_markdown').val(editor.getValue());
+                space.find('.hint_markdown').trigger('change');
+              },
+              attachments: true,
+              preview: space.find('.markdown_preview').get(0)
+            }
           );
         },
         model: {

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -72,14 +72,17 @@
         form_container: "#all_authored_hints_editor",
         wrapper: ".json_editor",
         onNewSpace: function (space) {
-          levelbuilder.initializeCodeMirror(space.find(".hint_markdown").get(0), 'markdown', function(editor, change) {
-            space.find('.markdown_preview')
-              .html(limitedMarked(editor.getValue()))
-              .children('details').details();
-
-            space.find(".hint_markdown").val(editor.getValue());
-            space.find(".hint_markdown").trigger('change');
-          }, true);
+          levelbuilder.initializeCodeMirror(
+            space.find('.hint_markdown').get(0),
+            'markdown',
+            function(editor, change) {
+              space.find('.hint_markdown').val(editor.getValue());
+              space.find('.hint_markdown').trigger('change');
+            },
+            true,
+            undefined,
+            space.find('.markdown_preview').get(0)
+          );
         },
         model: {
           hint_class: "",

--- a/dashboard/app/views/levels/editors/_instructions.haml
+++ b/dashboard/app/views/levels/editors/_instructions.haml
@@ -53,9 +53,12 @@
     = render partial: 'levels/editors/tts', locals: {f: f}
 
 :javascript
-  var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', function (editor, change) {
-    localStorage.setItem('markdown_' + '#{@level.id || html_escape(params[:type])}', editor.getValue());
-  }, true);
+  var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', {
+    callback: function (editor, change) {
+      localStorage.setItem('markdown_' + '#{@level.id || html_escape(params[:type])}', editor.getValue());
+    },
+    attachments: true
+  });
 
   var locallyStoredMarkdown = localStorage.getItem('markdown_' + '#{@level.id || html_escape(params[:type])}');
   if (locallyStoredMarkdown) {


### PR DESCRIPTION
[Jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&projectKey=FND&view=detail&selectedIssue=FND-158)

Update initializeCodeMirror to:
1. take an options object rather than an ordered set of optional arguments
2. accept a "preview" option to control the preview area (still defaults to trying to infer the preview area from the id of the target if option is unspecified)

Also update the authored hints editor to _use_ said preview option, rather than implementing a preview area manually.