### PR TITLE
Show block previews in levelbuilder

### DIFF
--- a/apps/src/sites/studio/pages/levelbuilder.js
+++ b/apps/src/sites/studio/pages/levelbuilder.js
@@ -6,6 +6,7 @@ import codemirror from 'codemirror';
 import marked from 'marked';
 import renderer from '@cdo/apps/util/StylelessRenderer';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
+import {convertXmlToBlockly} from '@cdo/apps/templates/instructions/utils';
 
 window.levelbuilder = window.levelbuilder || {};
 _.extend(window.levelbuilder, {
@@ -36,3 +37,4 @@ window.CodeMirror = codemirror;
 // TODO: Remove when global `marked` is no longer required.
 window.marked = marked;
 window.renderer = renderer;
+window.convertXmlToBlockly = convertXmlToBlockly;

--- a/apps/src/sites/studio/pages/levelbuilder.js
+++ b/apps/src/sites/studio/pages/levelbuilder.js
@@ -37,4 +37,6 @@ window.CodeMirror = codemirror;
 // TODO: Remove when global `marked` is no longer required.
 window.marked = marked;
 window.renderer = renderer;
+
+// TODO: Extract .js from _authored_hints.haml and _instructions.haml, then remove this
 window.convertXmlToBlockly = convertXmlToBlockly;

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -77,6 +77,7 @@
             'markdown',
             {
               callback: function(editor, change) {
+                convertXmlToBlockly(space.find('.markdown_preview').get(0));
                 space.find('.hint_markdown').val(editor.getValue());
                 space.find('.hint_markdown').trigger('change');
               },

--- a/dashboard/app/views/levels/editors/_instructions.haml
+++ b/dashboard/app/views/levels/editors/_instructions.haml
@@ -55,6 +55,8 @@
 :javascript
   var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', {
     callback: function (editor, change) {
+      convertXmlToBlockly(document.getElementById('level_long_instructions_preview'));
+
       localStorage.setItem('markdown_' + '#{@level.id || html_escape(params[:type])}', editor.getValue());
     },
     attachments: true


### PR DESCRIPTION
It's not perfect; specifically, it only works on _update_ rather than on _initialization_, because it's not clear to me how to hook into the "preview area fully rendered" event. Still, it's a lot better than nothing!

### Instructions

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/53058338-7f16fe80-3467-11e9-804c-d1784084ff0d.png) | ![image](https://user-images.githubusercontent.com/244100/53058202-16c81d00-3467-11e9-8693-84ce1753c375.png)

### Authored Hints

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/53058372-9b1aa000-3467-11e9-9626-13cad7b3cef2.png) | ![image](https://user-images.githubusercontent.com/244100/53058387-ab327f80-3467-11e9-957a-56ac39a6ef84.png)
