### PR TITLE
Levelbuilder Edit of Reference Links - Single text area

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -298,8 +298,10 @@ class LevelsController < ApplicationController
       params[:level][param].delete_if(&:empty?) if params[:level][param].is_a? Array
     end
 
-    # Removes empty reference links which are autosaved as "" by the form
-    params[:level][:reference_links].delete_if {|link| link == ""} if params[:level][:reference_links]
+    # Reference links should be stored as an array.
+    if params[:level][:reference_links].is_a? String
+      params[:level][:reference_links] = params[:level][:reference_links].split("\r\n")
+    end
 
     permitted_params.concat(Level.permitted_params)
     params[:level].permit(permitted_params)

--- a/dashboard/app/views/levels/editors/_all.html.haml
+++ b/dashboard/app/views/levels/editors/_all.html.haml
@@ -86,7 +86,8 @@
   %p Put each link on a new line
   .row
     .span8
-      = text_area_tag 'level[reference_links]', @level.reference_links.join("\r\n"), rows: 6, class: "input-block-level"
+      - @level.reference_links = [''] unless @level.reference_links.try(:present?)
+      = text_area_tag 'level[reference_links]', @level.reference_links.join("\r\n"), rows: 6, class: "input-block-level", placeholder: 'Additional Reference Link'
 
 =render partial: 'levels/editors/callouts', locals: {f: f}
 - if @level.respond_to? :free_play

--- a/dashboard/app/views/levels/editors/_all.html.haml
+++ b/dashboard/app/views/levels/editors/_all.html.haml
@@ -83,12 +83,11 @@
   = f.label :reference_link, 'Reference Links'
   %p Add links to pages on Curriculum Builder below. They will show up in the 'Help & Tips' tab below any videos and the map reference.
   %p These should be strings representing the URL on [docs|curriculum].code.org you want to embed, i.e. '/docs/csd/maker_leds/index.html' or '/curriculum/path/to/file'.
-  %p Click the + sign if you want to add multiple links
-  - @level.reference_links = [''] unless @level.reference_links.try(:present?)
-  - @level.reference_links.each do |ref_link|
-    = text_field_tag 'level[reference_links][]', ref_link, placeholder: 'Additional Reference Link'
-  #plusAnswerReference
-    %i.fa.fa-plus-circle
+  %p Put each link on a new line
+  .row
+    .span8
+      = text_area_tag 'level[reference_links]', @level.reference_links.join("\r\n"), rows: 6, class: "input-block-level"
+
 =render partial: 'levels/editors/callouts', locals: {f: f}
 - if @level.respond_to? :free_play
   .field


### PR DESCRIPTION
When levelbuilders go in to edit a level they can now add all the reference links in one box with each separate link on a new line.

### New version
<img width="964" alt="screen shot 2019-02-20 at 10 25 04 am" src="https://user-images.githubusercontent.com/208083/53102527-db2a6300-34f9-11e9-916e-8382ef5afc37.png">


### Old Version
<img width="968" alt="screen shot 2019-02-20 at 10 26 28 am" src="https://user-images.githubusercontent.com/208083/53102593-02813000-34fa-11e9-8733-fe52c5a57c9d.png">
