### PR TITLE
International Workshop Attendance Form: More reliable workshop date validation

### DIFF
--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -65,17 +65,8 @@ class InternationalOptInComponent extends FormComponent {
   };
 
   handleDateBlur = event => {
-    this.handleDateChange(moment(event.target.value));
+    this.handleDateChange(dateStringToMoment(event.target.value));
   };
-
-  workshopDateAsMoment() {
-    const {data} = this.props;
-    const date = data && moment(data.date, DATE_FORMAT);
-    if (date && date.isValid()) {
-      return date;
-    }
-    return null;
-  }
 
   render() {
     const labels = this.props.labels;
@@ -189,7 +180,9 @@ class InternationalOptInComponent extends FormComponent {
           <Row>
             <Col md={6}>
               <DatePicker
-                date={this.workshopDateAsMoment()}
+                date={dateStringToMoment(
+                  this.props.data && this.props.data.date
+                )}
                 onChange={this.handleDateChange}
                 onBlur={this.handleDateBlur}
                 readOnly={false}
@@ -236,6 +229,14 @@ class InternationalOptInComponent extends FormComponent {
       </FormGroup>
     );
   }
+}
+
+function dateStringToMoment(dateString) {
+  const date = dateString && moment(dateString, DATE_FORMAT);
+  if (date && date.isValid()) {
+    return date;
+  }
+  return null;
 }
 
 InternationalOptInComponent.associatedFields = [

--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -55,18 +55,30 @@ class InternationalOptInComponent extends FormComponent {
     accountEmail: PropTypes.string.isRequired
   };
 
+  /** @param {moment.Moment} date */
   handleDateChange = date => {
-    // Don't allow null. If the date is cleared, default again to today.
-    date = date || moment();
-    super.handleChange({date: date.format(DATE_FORMAT)});
+    if (date && date.isValid()) {
+      super.handleChange({date: date.format(DATE_FORMAT)});
+    } else {
+      super.handleChange({date: null});
+    }
   };
+
+  handleDateBlur = event => {
+    this.handleDateChange(moment(event.target.value));
+  };
+
+  workshopDateAsMoment() {
+    const {data} = this.props;
+    const date = data && moment(data.date, DATE_FORMAT);
+    if (date && date.isValid()) {
+      return date;
+    }
+    return null;
+  }
 
   render() {
     const labels = this.props.labels;
-    const date =
-      this.props.data && this.props.data.date
-        ? moment(this.props.data.date, DATE_FORMAT)
-        : moment();
 
     const lastSubjectsKey = this.props.options.subjects.slice(-1)[0];
     const textFieldMapSubjects = {[lastSubjectsKey]: 'other'};
@@ -177,8 +189,9 @@ class InternationalOptInComponent extends FormComponent {
           <Row>
             <Col md={6}>
               <DatePicker
-                date={date}
+                date={this.workshopDateAsMoment()}
                 onChange={this.handleDateChange}
+                onBlur={this.handleDateBlur}
                 readOnly={false}
               />
             </Col>
@@ -239,6 +252,7 @@ InternationalOptInComponent.associatedFields = [
   'subjects',
   'resources',
   'robotics',
+  'date',
   'workshopOrganizer',
   'workshopFacilitator',
   'workshopCourse',

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.jsx
@@ -93,16 +93,16 @@ const DateInputWithIcon = Radium(DateInputWithIconUnwrapped);
 
 export default class DatePicker extends React.Component {
   static propTypes = {
-    date: PropTypes.object,
+    date: ReactDatePicker.propTypes.selected,
     onChange: PropTypes.func.isRequired,
     onBlur: ReactDatePicker.propTypes.onBlur,
-    minDate: PropTypes.object,
-    maxDate: PropTypes.object,
-    selectsStart: PropTypes.bool,
-    selectsEnd: PropTypes.bool,
-    startDate: PropTypes.object,
-    endDate: PropTypes.object,
-    readOnly: PropTypes.bool,
+    minDate: ReactDatePicker.propTypes.minDate,
+    maxDate: ReactDatePicker.propTypes.maxDate,
+    selectsStart: ReactDatePicker.propTypes.selectsStart,
+    selectsEnd: ReactDatePicker.propTypes.selectsEnd,
+    startDate: ReactDatePicker.propTypes.startDate,
+    endDate: ReactDatePicker.propTypes.endDate,
+    readOnly: ReactDatePicker.propTypes.disabled,
     clearable: PropTypes.bool
   };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.jsx
@@ -95,6 +95,7 @@ export default class DatePicker extends React.Component {
   static propTypes = {
     date: PropTypes.object,
     onChange: PropTypes.func.isRequired,
+    onBlur: ReactDatePicker.propTypes.onBlur,
     minDate: PropTypes.object,
     maxDate: PropTypes.object,
     selectsStart: PropTypes.bool,
@@ -127,6 +128,7 @@ export default class DatePicker extends React.Component {
         }
         selected={this.props.date}
         onChange={this.handleChange}
+        onBlur={this.props.onBlur}
         dateFormat={DATE_FORMAT}
         minDate={this.props.minDate}
         maxDate={this.props.maxDate}

--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -31,12 +31,24 @@ class Pd::InternationalOptIn < ApplicationRecord
       :school_country,
       :ages,
       :subjects,
+      :date,
       :workshop_organizer,
       :workshop_facilitator,
       :workshop_course,
       :email_opt_in,
       :legal_opt_in
     ]
+  end
+
+  def validate_required_fields
+    super
+
+    # Check that the workshop date provided is actually a date.
+    begin
+      Date.parse(form_data_hash['date']) if form_data_hash['date'].present?
+    rescue ArgumentError
+      errors.add(:form_data, :invalid)
+    end
   end
 
   def self.options

--- a/dashboard/test/controllers/api/v1/pd/international_opt_ins_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/international_opt_ins_controller_test.rb
@@ -15,6 +15,7 @@ class Api::V1::Pd::InternationalOptInsControllerTest < ::ActionController::TestC
     subjects: ['ICT'],
     resources: ['Kodable'],
     robotics: ['LEGO Education'],
+    date: '2019-02-18',
     workshop_organizer: 'Workshop Organizer',
     workshop_facilitator: 'Workshop Facilitator',
     workshop_course: 'Workshop Course',

--- a/dashboard/test/models/pd/international_opt_in_test.rb
+++ b/dashboard/test/models/pd/international_opt_in_test.rb
@@ -15,6 +15,7 @@ class Pd::InternationalOptInTest < ActiveSupport::TestCase
     subjects: ['ICT'],
     resources: ['Kodable'],
     robotics: ['LEGO Education'],
+    date: '2019-02-18',
     workshopOrganizer: 'Workshop Organizer',
     workshopFacilitator: 'Workshop Facilitator',
     workshopCourse: 'Workshop Course',
@@ -34,5 +35,24 @@ class Pd::InternationalOptInTest < ActiveSupport::TestCase
     assert build(:pd_international_opt_in, form_data: FORM_DATA.to_json, user_id: teacher.id).valid?
 
     refute build(:pd_international_opt_in, form_data: FORM_DATA.to_json).valid?
+  end
+
+  test 'Requires workshop date' do
+    teacher = create :teacher
+
+    missing_date = build :pd_international_opt_in,
+      user_id: teacher.id,
+      form_data: FORM_DATA.merge({date: nil}).to_json
+    refute missing_date.valid?
+
+    malformed_date = build :pd_international_opt_in,
+      user_id: teacher.id,
+      form_data: FORM_DATA.merge({date: 'malformed-date'}).to_json
+    refute malformed_date.valid?
+
+    valid_date = build :pd_international_opt_in,
+      user_id: teacher.id, form_data:
+        FORM_DATA.merge({date: '2019-02-18'}).to_json
+    assert valid_date.valid?
   end
 end


### PR DESCRIPTION
Update to the [International Workshop Attendance Form](https://studio.code.org/pd/international_workshop). Right now the workshop date ('date' on the model) looks required in the client UI but the form can be submitted when the textbox is blank, and a date (today) is still sent to the server. We're also not requiring the date on the model so blank submissions are possible.

Two changes:
1. Require this field on the model (and require that it is a parse-able date)
2. Make sure the user experience on the client is consistent with the field being "Required"

Fixes [PLC-91](https://codedotorg.atlassian.net/browse/PLC-91).

I'm only halfway happy with the client changes here, but I think the behavior is better than what we had before.  The date picker reflects the underlying state we're about to submit _most_ of the time. That underlying state now gets cleared to `null` if we're not able to parse a date out of the input, which results in a validation error on submission (since the field is properly required now).

![peek 2019-02-20 11-03](https://user-images.githubusercontent.com/1615761/53117490-dec0e880-34ff-11e9-9a79-5c2f4ae38d5c.gif)

Styling after submitting blank/invalid input:
![screenshot from 2019-02-20 11-01-46](https://user-images.githubusercontent.com/1615761/53117526-f4cea900-34ff-11e9-8943-8e8a0fcb30f2.png)

There's still an odd edge case where you can delete part of the date and `moment` will try to fill in the rest with a sensible default.  If, when this happens, the underlying date is not different from the previous value, the value in the text field doesn't update to show a whole date but the hidden state (and submitted value) is still the previous value.

![peek 2019-02-20 11-13](https://user-images.githubusercontent.com/1615761/53117849-aec61500-3500-11e9-9f27-15ee2c3108ed.gif)

I'm pretty sure this is a bug in the [react-datepicker](https://reactdatepicker.com) component, and has been fixed in more recent versions.  In fact, there's a generally broken paradigm here where the text field is "half-controlled" in that you hook it up like a controlled/stateless component using `Date` values, but you're not guaranteed that the textbox will always reflect a valid date after a blur event. The latest version (2.1.0) of this component doesn't have this problem - it seems to provide a stronger guarantee that the component will always be left either blank or representing a complete, valid date when not being actively editing.  We should definitely upgrade one of these days.


