### PR TITLE
Clean up channel options

### DIFF
--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -29,7 +29,6 @@
  * @property {string} channel
  * @property {boolean} readonlyWorkspace
  * @property {boolean} isExternalProjectLevel
- * @property {boolean} isChannelBacked
  * @property {boolean} isLegacyShare
  * @property {boolean} legacyShareStyle
  * @property {PostMileStoneMode} postMilestoneMode

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1343,7 +1343,7 @@ var projects = (module.exports = {
         isEditing = true;
         deferred.resolve();
       }
-    } else if (appOptions.isChannelBacked) {
+    } else if (appOptions.channel) {
       isEditing = true;
       channels.fetch(appOptions.channel, (err, data) => {
         if (err) {

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -95,7 +95,7 @@ module LevelsHelper
       )
     end
 
-    channel_token.try :channel
+    channel_token.channel if channel_token
   end
 
   def select_and_track_autoplay_video
@@ -153,9 +153,10 @@ module LevelsHelper
     return @app_options unless @app_options.nil?
 
     if @level.channel_backed?
-      view_options(channel: get_channel_for(@level, @user))
-      view_options(is_channel_backed: true)
-      view_options(server_project_level_id: @level.project_template_level.try(:id))
+      view_options(
+        channel: get_channel_for(@level, @user),
+        server_project_level_id: @level.project_template_level.try(:id),
+      )
       # readonly if viewing another user's channel
       readonly_view_options if @user
     end

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -95,7 +95,7 @@ module LevelsHelper
       )
     end
 
-    channel_token.channel if channel_token
+    channel_token&.channel
   end
 
   def select_and_track_autoplay_video

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -154,6 +154,8 @@ module LevelsHelper
 
     if @level.channel_backed?
       view_options(channel: get_channel_for(@level, @user))
+      view_options(is_channel_backed: true)
+      view_options(server_project_level_id: @level.project_template_level.try(:id))
       # readonly if viewing another user's channel
       readonly_view_options if @user
     end
@@ -187,11 +189,6 @@ module LevelsHelper
     # External project levels are any levels of type 'external' which use
     # the projects code to save and load the user's progress on that level.
     view_options(is_external_project_level: true) if @level.is_a? Pixelation
-
-    if @level.channel_backed?
-      view_options(is_channel_backed: true)
-      view_options(server_project_level_id: @level.project_template_level.try(:id))
-    end
 
     post_milestone = @script ? Gatekeeper.allows('postMilestone', where: {script_name: @script.name}, default: true) : true
     post_failed_run_milestone = @script ? Gatekeeper.allows('postFailedRunMilestone', where: {script_name: @script.name}, default: true) : true

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -12,7 +12,6 @@ module ViewOptionsHelper
     :channel,
     :readonly_workspace,
     :is_external_project_level,
-    :is_channel_backed,
     :is_legacy_share,
     :legacy_share_style,
     :is_challenge_level,


### PR DESCRIPTION
The only usage of `isChannelBacked` is in project.js when deciding whether a project is editable. I _think_ once we get to this decision point, the presence of `appOptions.channel` is enough to tell that a project is channel-backed.

A bit more discussion here: https://codedotorg.slack.com/archives/C0T0PNR0D/p1550689911000600