### PR TITLE
O365 silent takeover

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -395,6 +395,14 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
             oauth_refresh_token: auth_hash.credentials&.refresh_token
           }.to_json
         )
+
+        # If the user is now logging in through microsoft_v2_auth and has an existing
+        # windowslive AuthenticationOption, we want to delete windowslive since that is
+        # deprecated in favor of microsoft_v2_auth.
+        windowslive_auth_option = lookup_user.authentication_options.find {|auth_option| auth_option.credential_type == AuthenticationOption::WINDOWS_LIVE}
+        if windowslive_auth_option.present? && provider == AuthenticationOption::MICROSOFT
+          windowslive_auth_option.destroy!
+        end
       else
         lookup_user.update!(
           email: lookup_email,

--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -54,7 +54,8 @@ class AuthenticationOption < ApplicationRecord
   SILENT_TAKEOVER_CREDENTIAL_TYPES = [
     FACEBOOK,
     GOOGLE,
-    WINDOWS_LIVE
+    WINDOWS_LIVE,
+    MICROSOFT
   ]
 
   def oauth?

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1012,6 +1012,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal 1, user.authentication_options.count
     microsoft_auth_option = user.authentication_options.first
     refute_nil microsoft_auth_option
+    assert_equal 'microsoft_v2_auth', microsoft_auth_option.credential_type
     assert_equal uid, microsoft_auth_option.authentication_id
     assert_equal signed_in_user_id, user.id
   end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -782,6 +782,33 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal user.id, signed_in_user_id
   end
 
+  test 'login: microsoft_v2_auth silently takes over unmigrated student with matching email' do
+    email = 'test@foo.xyz'
+    uid = '654321'
+    user = create(:student, email: email)
+    auth = OmniAuth::AuthHash.new(
+      provider: 'microsoft_v2_auth',
+      uid: uid,
+      info: {},
+      extra: {
+        raw_info: {
+          userPrincipalName: email,
+          displayName: 'My Name'
+        }
+      },
+    )
+
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+    assert_does_not_create(User) do
+      get :microsoft_v2_auth
+    end
+    user.reload
+    assert_equal 'microsoft_v2_auth', user.provider
+    assert_equal uid, user.uid
+    assert_equal signed_in_user_id, user.id
+  end
+
   test 'login: google_oauth2 silently takes over unmigrated Google Classroom student with matching email' do
     email = 'test@foo.xyz'
     uid = '654321'
@@ -816,6 +843,33 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal 'google_oauth2', user.provider
     assert_equal user.uid, uid
     assert_equal user.id, signed_in_user_id
+  end
+
+  test 'login: microsoft_v2_auth silently takes over unmigrated teacher with matching email' do
+    email = 'test@foo.xyz'
+    uid = '654321'
+    user = create(:teacher, email: email)
+    auth = OmniAuth::AuthHash.new(
+      provider: 'microsoft_v2_auth',
+      uid: uid,
+      info: {},
+      extra: {
+        raw_info: {
+          userPrincipalName: email,
+          displayName: 'My Name'
+        }
+      },
+    )
+
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+    assert_does_not_create(User) do
+      get :microsoft_v2_auth
+    end
+    user.reload
+    assert_equal 'microsoft_v2_auth', user.provider
+    assert_equal uid, user.uid
+    assert_equal signed_in_user_id, user.id
   end
 
   test 'login: google_oauth2 silently adds authentication_option to migrated student with matching email' do
@@ -871,6 +925,66 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     found_google = user.authentication_options.any? {|auth_option| auth_option.credential_type == AuthenticationOption::GOOGLE}
     assert found_google
     assert_equal user.id, signed_in_user_id
+  end
+
+  test 'login: microsoft_v2_auth silently adds authentication_option to migrated teacher with matching email' do
+    email = 'test@foo.xyz'
+    uid = '654321'
+    user = create(:teacher, :with_migrated_email_authentication_option, email: email)
+    auth = OmniAuth::AuthHash.new(
+      provider: 'microsoft_v2_auth',
+      uid: uid,
+      info: {},
+      extra: {
+        raw_info: {
+          userPrincipalName: email,
+          displayName: 'My Name'
+        }
+      },
+    )
+
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+    assert_does_not_create(User) do
+      get :microsoft_v2_auth
+    end
+    user.reload
+    assert_equal 'migrated', user.provider
+    assert_equal 2, user.authentication_options.count
+    microsoft_auth_option = user.authentication_options.find {|auth_option| auth_option.credential_type == AuthenticationOption::MICROSOFT}
+    refute_nil microsoft_auth_option
+    assert_equal uid, microsoft_auth_option.authentication_id
+    assert_equal signed_in_user_id, user.id
+  end
+
+  test 'login: microsoft_v2_auth silently adds authentication_option to migrated student with matching email' do
+    email = 'test@foo.xyz'
+    uid = '654321'
+    user = create(:student, :with_migrated_email_authentication_option, email: email)
+    auth = OmniAuth::AuthHash.new(
+      provider: 'microsoft_v2_auth',
+      uid: uid,
+      info: {},
+      extra: {
+        raw_info: {
+          userPrincipalName: email,
+          displayName: 'My Name'
+        }
+      },
+    )
+
+    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.params'] = {}
+    assert_does_not_create(User) do
+      get :microsoft_v2_auth
+    end
+    user.reload
+    assert_equal 'migrated', user.provider
+    assert_equal 2, user.authentication_options.count
+    microsoft_auth_option = user.authentication_options.find {|auth_option| auth_option.credential_type == AuthenticationOption::MICROSOFT}
+    refute_nil microsoft_auth_option
+    assert_equal uid, microsoft_auth_option.authentication_id
+    assert_equal signed_in_user_id, user.id
   end
 
   test 'login: google_oauth2 updates unmigrated Google Classroom student email if silent takeover not available' do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -447,6 +447,24 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_migrated_windowslive_authentication_option do
+      after(:create) do |user|
+        ao = create(:authentication_option,
+          user: user,
+          email: user.email,
+          hashed_email: user.hashed_email,
+          credential_type: AuthenticationOption::WINDOWS_LIVE,
+          authentication_id: user.hashed_email
+        )
+        user.update!(
+          primary_contact_info: ao,
+          provider: User::PROVIDER_MIGRATED,
+          email: '',
+          hashed_email: nil
+        )
+      end
+    end
+
     trait :multi_auth_migrated do
       after(:create) do |user|
         user.update_attributes(


### PR DESCRIPTION
Implements silent takeover for our new Microsoft logins 🎉 

### What is silent takeover?
Let's say...
- You have a Code.org account with your email address (no SSO/OAuth account(s) set up)
- You try to log in to Code.org with Google SSO and that same email address
- If you are a migrated user, we will add that new Google AuthenticationOption to your account
- If you are a non-migrated user, we will update your account to now be Google SSO

### What this does
1. Allows for users logging in through `microsoft_v2_auth` (our new Microsoft SSO service) to enjoy the benefits of silent takeover
2. If that user is migrated and has a `windowslive` AuthenticationOption (our old Microsoft SSO service), we will delete it. (Doesn't apply to non-migrated users because they only ever have 1 way to log in, and that new way will be `microsoft_v2_auth` anyways.)

### What this means for `windowslive` users
Once we swap the "continue with Microsoft" login button to point to `microsoft_v2_auth`, the next time `windowslive` users log in via Microsoft SSO, they will silently be updated to the new Microsoft SSO service.