### PR TITLE
Teacher Application: Warn when navigating away without completing application

### DIFF
--- a/apps/src/code-studio/pd/application/teacher1920/Teacher1920Application.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Teacher1920Application.jsx
@@ -21,6 +21,17 @@ export default class Teacher1920Application extends FormController {
 
   static sessionStorageKey = 'Teacher1920Application';
 
+  componentDidMount() {
+    window.addEventListener('beforeunload', event => {
+      if (!this.state.submitting) {
+        event.preventDefault();
+        const customWarning = `Are you sure? Your application may not be saved.`;
+        event.returnValue = customWarning;
+        return customWarning;
+      }
+    });
+  }
+
   /**
    * @override
    */

--- a/apps/src/code-studio/pd/application/teacher1920/Teacher1920Application.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Teacher1920Application.jsx
@@ -25,9 +25,7 @@ export default class Teacher1920Application extends FormController {
     window.addEventListener('beforeunload', event => {
       if (!this.state.submitting) {
         event.preventDefault();
-        const customWarning = `Are you sure? Your application may not be saved.`;
-        event.returnValue = customWarning;
-        return customWarning;
+        event.returnValue = 'Are you sure? Your application may not be saved.';
       }
     });
   }


### PR DESCRIPTION
([PLC-95](https://codedotorg.atlassian.net/browse/PLC-95), [spec](https://docs.google.com/document/d/1iubRcgyT8M1o9VU5n-T8-IE9GsmRAsT7EN1pWtVEWfc/edit#heading=h.siybo18ubi9s))

Detects an attempt to navigate away from the application without submitting it, and displays a browser warning.

Note that in most modern browsers we have no way do to a custom dialog or to customize the text in this dialog (see [onbeforeunload - MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload)).  I provide a custom string for older browsers, but for example in Chrome dialogs will look like this when you try to navigate away:

![screenshot from 2019-02-20 17-07-15](https://user-images.githubusercontent.com/1615761/53136072-6e7f8a80-3532-11e9-98b1-21daf9b66b0f.png)

Or like this when you try to reload the page:

![screenshot from 2019-02-20 17-07-25](https://user-images.githubusercontent.com/1615761/53136080-75a69880-3532-11e9-89ac-9b1960769f23.png)

You won't get any such warning when submitting the form.