### PR TITLE
Teacher Application: Inline first name and last name fields

### DIFF
--- a/apps/src/code-studio/pd/application/teacher1920/Section1AboutYou.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section1AboutYou.jsx
@@ -7,7 +7,16 @@ import {
   SectionHeaders
 } from '@cdo/apps/generated/pd/teacher1920ApplicationConstants';
 import {isEmail, isZipCode} from '@cdo/apps/util/formatValidation';
-import {FormGroup, Modal, Button} from 'react-bootstrap';
+import {
+  FormGroup,
+  Modal,
+  Button,
+  ControlLabel,
+  FormControl,
+  HelpBlock,
+  Row,
+  Col
+} from 'react-bootstrap';
 import queryString from 'query-string';
 import {styles} from './TeacherApplicationConstants';
 import _ from 'lodash';
@@ -86,6 +95,19 @@ export default class Section1AboutYou extends LabeledFormComponent {
           <Button onClick={this.exitApplication}>Exit Application</Button>
         </Modal.Footer>
       </Modal>
+    );
+  }
+
+  nameInput(id) {
+    return (
+      <NameInput
+        id={id}
+        label={this.labelFor(id)}
+        validationState={this.getValidationState(id)}
+        errorMessage={this.props.errorMessages[id]}
+        value={this.props.data[id] || ''}
+        handleChange={this.handleChange}
+      />
     );
   }
 
@@ -202,8 +224,10 @@ export default class Section1AboutYou extends LabeledFormComponent {
 
         {this.renderInternationalModal()}
 
-        {this.inputFor('firstName')}
-        {this.inputFor('lastName')}
+        <Row>
+          <Col md={3}>{this.nameInput('firstName')}</Col>
+          <Col md={3}>{this.nameInput('lastName')}</Col>
+        </Row>
 
         {this.inputFor('accountEmail', {
           value: this.props.accountEmail,
@@ -264,3 +288,37 @@ export default class Section1AboutYou extends LabeledFormComponent {
     return formatErrors;
   }
 }
+
+const NameInput = ({
+  id,
+  validationState,
+  label,
+  value,
+  handleChange,
+  errorMessage
+}) => (
+  <FormGroup controlId={id} validationState={validationState}>
+    <ControlLabel>
+      {label}
+      {REQUIRED}
+    </ControlLabel>
+    <FormControl
+      type="text"
+      componentClass="input"
+      bsClass="form-control"
+      value={value}
+      onChange={e => handleChange({[id]: e.target.value})}
+    />
+    <HelpBlock>{errorMessage}</HelpBlock>
+  </FormGroup>
+);
+NameInput.propTypes = {
+  id: PropTypes.string,
+  label: PropTypes.node,
+  value: PropTypes.any,
+  validationState: PropTypes.any,
+  errorMessage: PropTypes.node,
+  handleChange: PropTypes.func
+};
+
+const REQUIRED = <span style={{color: 'red'}}>&nbsp;*</span>;


### PR DESCRIPTION
_Note: Change base to staging before merge!_

![screenshot from 2019-02-20 18-46-48](https://user-images.githubusercontent.com/1615761/53139922-f4560280-353f-11e9-8b24-5443d66b6a0c.png)
_First and last name fields side-by-side, with one highlighted showing validation still works._

([spec](https://docs.google.com/document/d/1iubRcgyT8M1o9VU5n-T8-IE9GsmRAsT7EN1pWtVEWfc/edit#heading=h.7rg9bwsy1ix7))

Moves the first and last name fields on the first page of the application to sit side-by-side.  

This was _waaaay_ harder than it should have been! All of the form helpers here implicitly wrap every single field in its own row and column, and obfuscate what components are actually being generated.  In the end I carefully worked out what the many layers of helpers were actually doing, and recreated the bits I actually needed using the react-bootstrap components directly.

This turns out a lot simpler! The helpers are rendering:
```jsx
<FormGroup controlId="firstName">
  <Row>
    <Col>
      <ControlLabel/>
    </Col>
  </Row>
  <Row>
    <Col>
      <FormControl/>
    <Col>
  </Row>
  <HelpBlock/>
</FormGroup>
<FormGroup controlId="lastName">
  <Row>
    <Col>
      <ControlLabel/>
    </Col>
  </Row>
  <Row>
    <Col>
      <FormControl/>
    <Col>
  </Row>
  <HelpBlock/>
</FormGroup>
```

But I'm rendering:
```jsx
<Row>
  <Col>
    <FormGroup controlId="firstName">
      <ControlLabel/>
      <FormControl/>
      <HelpBlock/>
    </FormGroup>
  </Col>
  <Col>
    <FormGroup controlId="lastName">
      <ControlLabel/>
      <FormControl/>
      <HelpBlock/>
    </FormGroup>
  </Col>
</Row>
```
...which seems more sensible (and probably more bootstrap-idiomatic) to me.

Interested in feedback here, since I am breaking with the paradigm we've used so far for this form.