### PR TITLE
Teacher Application: Remove subjectsLicensedToTeach question

### DIFF
--- a/apps/src/code-studio/pd/application/teacher1920/Section3TeachingBackground.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section3TeachingBackground.jsx
@@ -108,15 +108,6 @@ export default class Section3TeachingBackground extends LabeledFormComponent {
           }
         )}
         {this.checkBoxesWithAdditionalTextFieldsFor(
-          'subjectsLicensedToTeach',
-          {
-            [TextFields.otherPleaseList]: 'other'
-          },
-          {
-            columnCount: 3
-          }
-        )}
-        {this.checkBoxesWithAdditionalTextFieldsFor(
           'taughtInPast',
           {
             [TextFields.otherPleaseList]: 'other'

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -245,7 +245,6 @@ module Pd::Application
         replace_existing
 
         subjects_teaching
-        subjects_licensed_to_teach
         taught_in_past
         previous_yearlong_cdo_pd
 

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -922,7 +922,6 @@ module Api::V1::Pd
         "Will this course replace an existing computer science course in the master schedule? (Teacher's response)",
         "If yes, please describe the course it will be replacing and why:",
         "What subjects are you teaching this year (2018-19)?",
-        "Which subject area(s) are you currently licensed to teach?",
         "Have you taught computer science courses or activities in the past?",
         "Have you participated in previous yearlong Code.org Professional Learning Programs?",
         "Are you committed to participating in the entire Professional Learning Program?",

--- a/dashboard/test/models/pd/application/teacher1920_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher1920_application_test.rb
@@ -319,12 +319,12 @@ module Pd::Application
       csv_header_csd = CSV.parse(Teacher1920Application.csv_header('csd'))[0]
       assert csv_header_csd.include? "To which grades does your school plan to offer CS Discoveries in the 2019-20 school year?"
       refute csv_header_csd.include? "To which grades does your school plan to offer CS Principles in the 2019-20 school year?"
-      assert_equal 99, csv_header_csd.length
+      assert_equal 98, csv_header_csd.length
 
       csv_header_csp = CSV.parse(Teacher1920Application.csv_header('csp'))[0]
       refute csv_header_csp.include? "To which grades does your school plan to offer CS Discoveries in the 2019-20 school year?"
       assert csv_header_csp.include? "To which grades does your school plan to offer CS Principles in the 2019-20 school year?"
-      assert_equal 101, csv_header_csp.length
+      assert_equal 100, csv_header_csp.length
     end
 
     test 'school cache' do

--- a/dashboard/test/ui/features/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/pd/teacher_application.feature
@@ -24,7 +24,6 @@ Scenario: Basic teacher application submission
   # Section 3
   Then I wait until element "h3" contains text "Section 2: Teaching Background"
   And I press "input[name='subjectsTeaching']:first" using jQuery
-  And I press the first "input[name='subjectsLicensedToTeach']" element
   And I press the first "input[name='taughtInPast']" element
   And I press the first "input[name='previousYearlongCdoPd']" element
 

--- a/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
@@ -88,7 +88,6 @@ module Pd
       section_3_teaching_background:
         {subjects_teaching: BASE_PAGE_LABELS[:section_2_your_school][:subjects_teaching].gsub('17-18', '18-19')}.merge(
           BASE_PAGE_LABELS[:section_2_your_school].slice(
-            :subjects_licensed_to_teach,
             :taught_in_past,
             :cs_opportunities_at_school,
             :previous_yearlong_cdo_pd
@@ -165,7 +164,6 @@ module Pd
         cs_total_course_hours: "Total course hours",
         replace_existing: "Will this course replace an existing computer science course in the master schedule? (Teacher's response)",
         subjects_teaching: "What subjects are you teaching this year (2018-19)?",
-        subjects_licensed_to_teach: "Which subject area(s) are you currently licensed to teach?",
         taught_in_past: "Have you taught computer science courses or activities in the past?",
         previous_yearlong_cdo_pd: "Have you participated in previous yearlong Code.org Professional Learning Programs?",
         able_to_attend_multiple: "Please indicate which workshops you are able to attend.",
@@ -390,7 +388,6 @@ module Pd
         :replace_existing,
         :replace_which_course,
         :subjects_teaching,
-        :subjects_licensed_to_teach,
         :taught_in_past,
         :previous_yearlong_cdo_pd,
         :committed,


### PR DESCRIPTION
Per [Slack thread](https://codedotorg.slack.com/archives/C0T10H26N/p1550701455000200) we want to also remove this additional question about teacher licensing from the application.