### PR TITLE
always clear single-auth fields after migrating user to multi-auth

### DIFF
--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -88,6 +88,7 @@ module UserMultiAuthHelper
         end
     end
     self.provider = 'migrated'
+    clear_single_auth_fields
     save
   end
 

--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -88,12 +88,6 @@ module UserMultiAuthHelper
         end
     end
     self.provider = 'migrated'
-    clear_single_auth_fields
-    save
-  end
-
-  def clear_single_auth_fields
-    raise "Single auth fields may not be cleared on an unmigrated user" unless migrated?
     self.uid = nil
     self.oauth_token = nil
     self.oauth_token_expiration = nil

--- a/dashboard/test/lib/user_multi_auth_helper_test.rb
+++ b/dashboard/test/lib/user_multi_auth_helper_test.rb
@@ -349,12 +349,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
       }
   end
 
-  test 'clear_single_auth_fields throws on unmigrated user' do
-    user = create :student
-    assert_raises {user.clear_single_auth_fields}
-  end
-
-  test 'clear_single_auth_fields clears single-auth fields' do
+  test 'migration clears single-auth fields' do
     user = create :teacher, :unmigrated_google_sso
 
     assert_user user,
@@ -584,11 +579,9 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
 
     refute user.migrated?
     migration_result = user.migrate_to_multi_auth
-    clear_result = user.clear_single_auth_fields
     demigration_result = user.demigrate_from_multi_auth
     user.reload
     assert migration_result
-    assert clear_result
     assert demigration_result
     refute user.migrated?
 

--- a/dashboard/test/lib/user_multi_auth_helper_test.rb
+++ b/dashboard/test/lib/user_multi_auth_helper_test.rb
@@ -356,7 +356,6 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
 
   test 'clear_single_auth_fields clears single-auth fields' do
     user = create :teacher, :unmigrated_google_sso
-    user.migrate_to_multi_auth
 
     assert_user user,
       uid: :not_nil,
@@ -366,7 +365,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
     refute_empty user.read_attribute(:email)
     refute_nil user.read_attribute(:hashed_email)
 
-    assert user.clear_single_auth_fields
+    assert user.migrate_to_multi_auth
     user.reload
 
     assert_user user,

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4058,13 +4058,15 @@ class UserTest < ActiveSupport::TestCase
 
   test 'find_by_credential locates migrated SSO user' do
     user = create :student, :unmigrated_clever_sso
+    original_uid = user.uid
+
     user.migrate_to_multi_auth
 
     User.expects(:find_by).never
     assert_equal user,
       User.find_by_credential(
         type: AuthenticationOption::CLEVER,
-        id: user.uid
+        id: original_uid
       )
   end
 


### PR DESCRIPTION
for consistency, particularly WRT round-trip tests