### PR TITLE
Show pilot scripts

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -77,8 +77,6 @@ class ScriptLevelsController < ApplicationController
     authorize! :read, ScriptLevel
     @script = Script.get_from_cache(params[:script_id], version_year: DEFAULT_VERSION_YEAR)
 
-    raise ActiveRecord::RecordNotFound if @script.pilot? && !@script.has_pilot_access?(@current_user)
-
     # Redirect to the same script level within @script.redirect_to.
     # There are too many variations of the script level path to use
     # a path helper, so use a regex to compute the new path.

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -77,6 +77,8 @@ class ScriptLevelsController < ApplicationController
     authorize! :read, ScriptLevel
     @script = Script.get_from_cache(params[:script_id], version_year: DEFAULT_VERSION_YEAR)
 
+    raise ActiveRecord::RecordNotFound if @script.pilot? && !@script.has_pilot_access?(@current_user)
+
     # Redirect to the same script level within @script.redirect_to.
     # There are too many variations of the script level path to use
     # a path helper, so use a regex to compute the new path.

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -7,8 +7,6 @@ class ScriptsController < ApplicationController
   before_action :set_script_file, only: [:edit, :update]
 
   def show
-    raise ActiveRecord::RecordNotFound if @script.pilot? && !@script.has_pilot_access?(current_user)
-
     if @script.redirect_to?
       redirect_path = script_path(Script.get_from_cache(@script.redirect_to))
       redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -7,6 +7,8 @@ class ScriptsController < ApplicationController
   before_action :set_script_file, only: [:edit, :update]
 
   def show
+    return head :not_found if @script.pilot? && !@script.has_pilot_access?(current_user)
+
     if @script.redirect_to?
       redirect_path = script_path(Script.get_from_cache(@script.redirect_to))
       redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -7,7 +7,7 @@ class ScriptsController < ApplicationController
   before_action :set_script_file, only: [:edit, :update]
 
   def show
-    return head :not_found if @script.pilot? && !@script.has_pilot_access?(current_user)
+    raise ActiveRecord::RecordNotFound if @script.pilot? && !@script.has_pilot_access?(current_user)
 
     if @script.redirect_to?
       redirect_path = script_path(Script.get_from_cache(@script.redirect_to))

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -177,7 +177,12 @@ class Ability
       end
     end
     can :read, ScriptLevel do |script_level|
-      user.persisted? || !script_level.script.login_required?
+      script = script_level.script
+      if script.pilot?
+        script.has_pilot_access?(user)
+      else
+        user.persisted? || !script.login_required?
+      end
     end
 
     # Handle standalone projects as a special case.

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -169,16 +169,11 @@ class Ability
     end
 
     # Override Script and ScriptLevel.
-    if user.persisted?
-      can :read, Script
-      can :read, ScriptLevel
-    else
-      can :read, Script do |script|
-        !script.login_required?
-      end
-      can :read, ScriptLevel do |script_level|
-        !script_level.script.login_required?
-      end
+    can :read, Script do |script|
+      user.persisted? || !script.login_required?
+    end
+    can :read, ScriptLevel do |script_level|
+      user.persisted? || !script_level.script.login_required?
     end
 
     # Handle standalone projects as a special case.

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -170,7 +170,11 @@ class Ability
 
     # Override Script and ScriptLevel.
     can :read, Script do |script|
-      user.persisted? || !script.login_required?
+      if script.pilot?
+        script.has_pilot_access?(user)
+      else
+        user.persisted? || !script.login_required?
+      end
     end
     can :read, ScriptLevel do |script_level|
       user.persisted? || !script_level.script.login_required?

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -214,8 +214,8 @@ class Script < ActiveRecord::Base
   # @param [User] user
   # @return [Script[]]
   def self.valid_scripts(user)
-    user_experiments_enabled = Course.has_any_course_experiments?(user)
-    with_hidden = !user_experiments_enabled && user.hidden_script_access?
+    has_any_course_experiments = Course.has_any_course_experiments?(user)
+    with_hidden = !has_any_course_experiments && user.hidden_script_access?
     cache_key = "valid_scripts/#{with_hidden ? 'all' : 'valid'}"
     scripts = Rails.cache.fetch(cache_key) do
       Script.
@@ -223,7 +223,7 @@ class Script < ActiveRecord::Base
           select {|script| with_hidden || !script.hidden}
     end
 
-    if user_experiments_enabled
+    if has_any_course_experiments
       scripts = scripts.map do |script|
         alternate_script = script.alternate_script(user)
         alternate_script.presence || script

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1462,4 +1462,8 @@ class Script < ActiveRecord::Base
   def has_pilot_access?(user = nil)
     pilot? && !!user&.permission?(UserPermission::LEVELBUILDER)
   end
+
+  def self.has_any_pilot_access?(user = nil)
+    !!user&.permission?(UserPermission::LEVELBUILDER)
+  end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -225,6 +225,10 @@ class Script < ActiveRecord::Base
       end
     end
 
+    if !with_hidden && has_any_pilot_access?(user)
+      scripts = scripts.concat(all_scripts.select {|s| s.has_pilot_access?(user)})
+    end
+
     scripts
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1454,4 +1454,12 @@ class Script < ActiveRecord::Base
       sl.levels.first.is_a?(LevelGroup) && sl.long_assessment? && !sl.anonymous?
     end
   end
+
+  def pilot?
+    !!pilot_experiment
+  end
+
+  def has_pilot_access?(user = nil)
+    pilot? && !!user&.permission?(UserPermission::LEVELBUILDER)
+  end
 end

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -44,9 +44,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     @script = @custom_script
     @script_level = @custom_s1_l1
 
-    @pilot_script_level = create :script_level
-    @pilot_script_level.script.pilot_experiment = 'pilot-experiment'
-    @pilot_script_level.script.save!
+    pilot_script = create(:script, pilot_experiment: 'pilot-experiment')
+    @pilot_script_level = create :script_level, script: pilot_script
   end
 
   setup do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -92,7 +92,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   def get_show_script_level_page(script_level)
-    get :show, params: {
+    get :show, params: script_level_params(script_level)
+  end
+
+  def script_level_params(script_level)
+    {
       script_id: script_level.script,
       stage_position: script_level.stage.absolute_position,
       id: script_level.position

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1716,4 +1716,27 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
     assert_nil assigns(:view_options)[:is_challenge_level]
   end
+
+  test "pilot script levels only visible with pilot access" do
+    teacher = create(:teacher)
+    levelbuilder = create(:levelbuilder)
+
+    @script_level.script.pilot_experiment = 'my-experiment'
+    @script_level.script.save!
+
+    assert_raises ActiveRecord::RecordNotFound do
+      get_show_script_level_page(@script_level)
+    end
+
+    sign_in teacher
+    assert_raises ActiveRecord::RecordNotFound do
+      get_show_script_level_page(@script_level)
+    end
+    sign_out teacher
+
+    sign_in levelbuilder
+    get_show_script_level_page(@script_level)
+    assert_response :success
+    sign_out levelbuilder
+  end
 end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -7,6 +7,7 @@ class ScriptsControllerTest < ActionController::TestCase
     @admin = create(:admin)
     @not_admin = create(:user)
     @levelbuilder = create(:levelbuilder)
+    @pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
   end
@@ -293,21 +294,23 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_equal true, Script.find_by_name(script.name).hidden
   end
 
-  test 'cannot view pilot script without pilot access' do
-    create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
-
+  test 'signed out user cannot view pilot script' do
     assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {id: 'pilot-script'}
+      get :show, params: {id: @pilot_script.name}
     end
+  end
 
+  test 'teacher without pilot access cannot view pilot script' do
     sign_in @not_admin
     assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {id: 'pilot-script'}
+      get :show, params: {id: @pilot_script.name}
     end
     sign_out @not_admin
+  end
 
+  test 'levelbuilder can view pilot script' do
     sign_in @levelbuilder
-    get :show, params: {id: 'pilot-script'}
+    get :show, params: {id: @pilot_script.name}
     assert_response :success
     sign_out @levelbuilder
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -296,12 +296,14 @@ class ScriptsControllerTest < ActionController::TestCase
   test 'cannot view pilot script without pilot access' do
     create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
 
-    get :show, params: {id: 'pilot-script'}
-    assert_response :not_found
+    assert_raises ActiveRecord::RecordNotFound do
+      get :show, params: {id: 'pilot-script'}
+    end
 
     sign_in @not_admin
-    get :show, params: {id: 'pilot-script'}
-    assert_response :not_found
+    assert_raises ActiveRecord::RecordNotFound do
+      get :show, params: {id: 'pilot-script'}
+    end
     sign_out @not_admin
 
     sign_in @levelbuilder

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -295,24 +295,21 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'signed out user cannot view pilot script' do
-    assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {id: @pilot_script.name}
-    end
+    get :show, params: {id: @pilot_script.name}
+    assert_response :redirect
+    assert_redirected_to '/users/sign_in'
   end
 
   test 'teacher without pilot access cannot view pilot script' do
     sign_in @not_admin
-    assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {id: @pilot_script.name}
-    end
-    sign_out @not_admin
+    get :show, params: {id: @pilot_script.name}
+    assert_response :forbidden
   end
 
   test 'levelbuilder can view pilot script' do
     sign_in @levelbuilder
     get :show, params: {id: @pilot_script.name}
     assert_response :success
-    sign_out @levelbuilder
   end
 
   test 'can create with has_lesson_plan param' do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -294,23 +294,16 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_equal true, Script.find_by_name(script.name).hidden
   end
 
-  test 'signed out user cannot view pilot script' do
-    get :show, params: {id: @pilot_script.name}
-    assert_response :redirect
-    assert_redirected_to '/users/sign_in'
-  end
+  test_user_gets_response_for :show, response: :redirect, user: nil,
+    params: -> {{id: @pilot_script.name}},
+    name: 'signed out user cannot view pilot script'
 
-  test 'teacher without pilot access cannot view pilot script' do
-    sign_in @not_admin
-    get :show, params: {id: @pilot_script.name}
-    assert_response :forbidden
-  end
+  test_user_gets_response_for :show, response: :forbidden, user: :teacher,
+    params: -> {{id: @pilot_script.name}},
+    name: 'teacher without pilot access cannot view pilot script'
 
-  test 'levelbuilder can view pilot script' do
-    sign_in @levelbuilder
-    get :show, params: {id: @pilot_script.name}
-    assert_response :success
-  end
+  test_user_gets_response_for :show, response: :success, user: :levelbuilder,
+    params: -> {{id: @pilot_script.name}}, name: 'levelbuilder can view pilot script'
 
   test 'can create with has_lesson_plan param' do
     sign_in @levelbuilder

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -293,6 +293,23 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_equal true, Script.find_by_name(script.name).hidden
   end
 
+  test 'cannot view pilot script without pilot access' do
+    create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
+
+    get :show, params: {id: 'pilot-script'}
+    assert_response :not_found
+
+    sign_in @not_admin
+    get :show, params: {id: 'pilot-script'}
+    assert_response :not_found
+    sign_out @not_admin
+
+    sign_in @levelbuilder
+    get :show, params: {id: 'pilot-script'}
+    assert_response :success
+    sign_out @levelbuilder
+  end
+
   test 'can create with has_lesson_plan param' do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -7,7 +7,7 @@ class ScriptsControllerTest < ActionController::TestCase
     @admin = create(:admin)
     @not_admin = create(:user)
     @levelbuilder = create(:levelbuilder)
-    @pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
+    @pilot_script = create :script, pilot_experiment: 'my-experiment'
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
   end
@@ -291,7 +291,7 @@ class ScriptsControllerTest < ActionController::TestCase
     }
     assert_equal 'pilot-experiment', Script.find_by_name(script.name).pilot_experiment
     # pilot scripts are always marked hidden
-    assert_equal true, Script.find_by_name(script.name).hidden
+    assert Script.find_by_name(script.name).hidden
   end
 
   test_user_gets_response_for :show, response: :redirect, user: nil,

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1436,6 +1436,17 @@ endvariants
     assert_equal [script], scripts
   end
 
+  test "self.valid_scripts: omits pilot scripts" do
+    teacher = create :teacher
+
+    pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
+    assert_equal true, pilot_script.hidden
+    assert_equal true, has_pilot_script?(Script.all)
+
+    teacher_scripts = Script.valid_scripts(teacher)
+    assert_equal false, has_pilot_script?(teacher_scripts)
+  end
+
   test "get_assessment_script_levels returns an empty list if no level groups" do
     script = create(:script, name: 'test-no-levels')
     level_group_script_level = script.get_assessment_script_levels
@@ -1566,5 +1577,9 @@ endvariants
 
   def has_hidden_script?(scripts)
     scripts.any?(&:hidden)
+  end
+
+  def has_pilot_script?(scripts)
+    scripts.any?(&:pilot?)
   end
 end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1442,7 +1442,7 @@ endvariants
 
     pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
     assert pilot_script.hidden
-    assert Script.all.any?(&:pilot?)
+    assert Script.any?(&:pilot?)
 
     teacher_scripts = Script.valid_scripts(teacher)
     refute teacher_scripts.any?(&:pilot?)

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1552,6 +1552,16 @@ endvariants
     assert_equal true, script.has_pilot_access?(levelbuilder)
   end
 
+  test 'has any pilot access' do
+    teacher = create :teacher
+    levelbuilder = create :levelbuilder
+
+    # for now, only levelbuilders have any pilot access.
+    assert_equal false, Script.has_any_pilot_access?
+    assert_equal false, Script.has_any_pilot_access?(teacher)
+    assert_equal true, Script.has_any_pilot_access?(levelbuilder)
+  end
+
   private
 
   def has_hidden_script?(scripts)

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1438,6 +1438,7 @@ endvariants
 
   test "self.valid_scripts: omits pilot scripts" do
     teacher = create :teacher
+    levelbuilder = create :levelbuilder
 
     pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
     assert_equal true, pilot_script.hidden
@@ -1445,6 +1446,9 @@ endvariants
 
     teacher_scripts = Script.valid_scripts(teacher)
     assert_equal false, has_pilot_script?(teacher_scripts)
+
+    levelbuilder_scripts = Script.valid_scripts(levelbuilder)
+    assert_equal true, has_pilot_script?(levelbuilder_scripts)
   end
 
   test "get_assessment_script_levels returns an empty list if no level groups" do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1534,6 +1534,24 @@ endvariants
     assert_equal true, script.hidden
   end
 
+  test 'has pilot access' do
+    teacher = create :teacher
+    levelbuilder = create :levelbuilder
+
+    script = create :script
+    assert_equal false, script.pilot?
+    assert_equal false, script.has_pilot_access?
+    assert_equal false, script.has_pilot_access?(teacher)
+    assert_equal false, script.has_pilot_access?(levelbuilder)
+
+    # for now, only levelbuilders have pilot script access.
+    script.pilot_experiment = 'my-experiment'
+    assert_equal true, script.pilot?
+    assert_equal false, script.has_pilot_access?
+    assert_equal false, script.has_pilot_access?(teacher)
+    assert_equal true, script.has_pilot_access?(levelbuilder)
+  end
+
   private
 
   def has_hidden_script?(scripts)

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1441,14 +1441,14 @@ endvariants
     levelbuilder = create :levelbuilder
 
     pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
-    assert_equal true, pilot_script.hidden
-    assert_equal true, has_pilot_script?(Script.all)
+    assert pilot_script.hidden
+    assert Script.all.any?(&:pilot?)
 
     teacher_scripts = Script.valid_scripts(teacher)
-    assert_equal false, has_pilot_script?(teacher_scripts)
+    refute teacher_scripts.any?(&:pilot?)
 
     levelbuilder_scripts = Script.valid_scripts(levelbuilder)
-    assert_equal true, has_pilot_script?(levelbuilder_scripts)
+    assert levelbuilder_scripts.any?(&:pilot?)
   end
 
   test "get_assessment_script_levels returns an empty list if no level groups" do
@@ -1546,7 +1546,7 @@ endvariants
 
     assert_equal 'pilot-script', script.name
     assert_equal 'pilot-experiment', script.pilot_experiment
-    assert_equal true, script.hidden
+    assert script.hidden
   end
 
   test 'has pilot access' do
@@ -1554,17 +1554,17 @@ endvariants
     levelbuilder = create :levelbuilder
 
     script = create :script
-    assert_equal false, script.pilot?
-    assert_equal false, script.has_pilot_access?
-    assert_equal false, script.has_pilot_access?(teacher)
-    assert_equal false, script.has_pilot_access?(levelbuilder)
+    refute script.pilot?
+    refute script.has_pilot_access?
+    refute script.has_pilot_access?(teacher)
+    refute script.has_pilot_access?(levelbuilder)
 
     # for now, only levelbuilders have pilot script access.
     script.pilot_experiment = 'my-experiment'
-    assert_equal true, script.pilot?
-    assert_equal false, script.has_pilot_access?
-    assert_equal false, script.has_pilot_access?(teacher)
-    assert_equal true, script.has_pilot_access?(levelbuilder)
+    assert script.pilot?
+    refute script.has_pilot_access?
+    refute script.has_pilot_access?(teacher)
+    assert script.has_pilot_access?(levelbuilder)
   end
 
   test 'has any pilot access' do
@@ -1572,18 +1572,14 @@ endvariants
     levelbuilder = create :levelbuilder
 
     # for now, only levelbuilders have any pilot access.
-    assert_equal false, Script.has_any_pilot_access?
-    assert_equal false, Script.has_any_pilot_access?(teacher)
-    assert_equal true, Script.has_any_pilot_access?(levelbuilder)
+    refute Script.has_any_pilot_access?
+    refute Script.has_any_pilot_access?(teacher)
+    assert Script.has_any_pilot_access?(levelbuilder)
   end
 
   private
 
   def has_hidden_script?(scripts)
     scripts.any?(&:hidden)
-  end
-
-  def has_pilot_script?(scripts)
-    scripts.any?(&:pilot?)
   end
 end


### PR DESCRIPTION
### Background

https://codedotorg.atlassian.net/browse/LP-128

Today, pilot scripts (which are always `hidden`) are not visible in the dropdowns on teacher homepage or teacher dashboard, unless you have "hidden script access", which only code.org employees have. However, pilot scripts are currently visible when navigating directly to them or to the script levels they contain.

### Description

* show pilot scripts in teacher dropdowns for levelbuilders
* hide pilot scripts and script levels for everyone except levelbuilders