### PR TITLE
increase app server metrics reporting-task test sleep

### DIFF
--- a/lib/test/cdo/test_app_server_metrics.rb
+++ b/lib/test/cdo/test_app_server_metrics.rb
@@ -55,7 +55,7 @@ class AppServerMetricsTest < Minitest::Test
     )
     listener.spawn_reporting_task
     Cdo::Metrics.expects(:push).at_least(1)
-    sleep 0.3
+    sleep 1
   ensure
     listener && listener.shutdown
   end


### PR DESCRIPTION
Attempt to reduce flakiness from timing issues in test.