### PR TITLE
Teacher dashboard UI tests

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -588,7 +588,11 @@ class ManageStudentsTable extends Component {
             />
           )}
         </div>
-        <Table.Provider columns={columns} style={tableLayoutStyles.table}>
+        <Table.Provider
+          columns={columns}
+          style={tableLayoutStyles.table}
+          id="uitest-manage-students-table"
+        >
           <Table.Header />
           <Table.Body rows={sortedRows} rowKey="id" />
         </Table.Provider>

--- a/apps/src/templates/projects/ProjectsList.jsx
+++ b/apps/src/templates/projects/ProjectsList.jsx
@@ -220,6 +220,7 @@ class ProjectsList extends React.Component {
 
     return (
       <Table.Provider
+        id="uitest-projects-table"
         className="pure-table pure-table-striped"
         columns={columns}
         style={tableLayoutStyles.table}

--- a/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsTable.jsx
+++ b/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsTable.jsx
@@ -217,7 +217,11 @@ class SubmissionStatusAssessmentsTable extends Component {
     })(this.props.studentOverviewData);
 
     return (
-      <Table.Provider columns={columns} style={tableLayoutStyles.table}>
+      <Table.Provider
+        columns={columns}
+        style={tableLayoutStyles.table}
+        id="uitest-submission-status-table"
+      >
         <Table.Header />
         <Table.Body rows={sortedRows} rowKey="id" />
       </Table.Provider>

--- a/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
+++ b/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
@@ -303,7 +303,7 @@ export const getCurrentQuestion = state => {
 
       return {
         question: question.question_text,
-        ...answers
+        answers: answers
       };
     } else {
       return emptyQuestion;

--- a/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
+++ b/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
@@ -295,13 +295,15 @@ export const getCurrentQuestion = state => {
       ? assessmentQuestions[state.sectionAssessments.questionIndex]
       : null;
     if (question) {
+      const answers =
+        question.type === QuestionType.MULTI &&
+        (question.answers || []).map((answer, index) => {
+          return {...answer, letter: ANSWER_LETTERS[index]};
+        });
+
       return {
         question: question.question_text,
-        answers:
-          question.type === QuestionType.MULTI &&
-          question.answers.map((answer, index) => {
-            return {...answer, letter: ANSWER_LETTERS[index]};
-          })
+        ...answers
       };
     } else {
       return emptyQuestion;

--- a/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
@@ -128,7 +128,12 @@ export default class TeacherDashboardNavigation extends Component {
       : styles.chevron;
 
     return (
-      <div ref="navbar" style={containerStyles} onScroll={this.handleScroll}>
+      <div
+        ref="navbar"
+        id="uitest-teacher-dashboard-nav"
+        style={containerStyles}
+        onScroll={this.handleScroll}
+      >
         {listPosition !== ListPosition.start && shouldScroll && (
           <FontAwesome
             icon="chevron-left"

--- a/apps/test/unit/templates/sectionAssessments/sectionAssessmentsReduxTest.js
+++ b/apps/test/unit/templates/sectionAssessments/sectionAssessmentsReduxTest.js
@@ -1182,10 +1182,11 @@ describe('sectionAssessmentsRedux', () => {
         };
 
         const question = getCurrentQuestion(stateWithSurvey);
-        assert.deepEqual(question.question, 'What is a variable?');
-        assert.deepEqual(question.answers, [
-          {text: 'a', correct: false, letter: 'A'}
-        ]);
+        assert.deepEqual('What is a variable?', question.question);
+        assert.deepEqual(
+          [{text: 'a', correct: false, letter: 'A'}],
+          question.answers
+        );
       });
 
       it('returns the question text for an assessment', () => {
@@ -1222,6 +1223,35 @@ describe('sectionAssessmentsRedux', () => {
         assert.deepEqual(question.answers, [
           {text: 'a', correct: true, letter: 'A'}
         ]);
+      });
+
+      it('returns an empty answers array if answers is undefined', () => {
+        const stateWithAssessment = {
+          ...rootState,
+          sectionAssessments: {
+            ...rootState.sectionAssessments,
+            questionIndex: 0,
+            assessmentId: 123,
+            assessmentQuestionsByScript: {
+              3: {
+                123: {
+                  name: 'name',
+                  questions: [
+                    {
+                      question_text: 'What is a variable?',
+                      type: 'Multi',
+                      answers: undefined
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        };
+
+        const question = getCurrentQuestion(stateWithAssessment);
+        assert.deepEqual(question.question, 'What is a variable?');
+        assert.deepEqual(question.answers, []);
       });
     });
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1633,6 +1633,13 @@ Then /^the href of selector "([^"]*)" contains the section id$/ do |selector|
   expect(href.split('#')[0]).to include("?section_id=#{@section_id}")
 end
 
+Then /^I navigate to teacher dashboard for the section I saved$/ do
+  expect(@section_id).to be > 0
+  steps %{
+    Then I am on "http://studio.code.org/teacher_dashboard/sections/#{@section_id}"
+  }
+end
+
 Then /^I hide unit "([^"]+)"$/ do |unit_name|
   selector = ".uitest-CourseScript:contains(#{unit_name}) .fa-eye-slash"
   @browser.execute_script("$(#{selector.inspect}).click();")
@@ -1649,7 +1656,7 @@ end
 
 # @return [Number] the section id for the corresponding row in the sections table
 def get_section_id_from_table(row_index)
-  # e.g. https://code.org/teacher-dashboard#/sections/54
+  # e.g. https://studio-code.org/teacher_dashboard/sections/54
   href = @browser.execute_script(
     "return $('.uitest-owned-sections tbody tr:eq(#{row_index}) td:eq(1) a').attr('href')"
   )

--- a/dashboard/test/ui/features/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_dashboard.feature
@@ -3,7 +3,7 @@
 @pegasus_db_access
 Feature: Using the teacher dashboard
 
-  Scenario: Loading student progress
+  Scenario: Viewing a student
     Given I create an authorized teacher-associated student named "Sally"
     And I give user "Teacher_Sally" hidden script access
     And I complete the level on "http://studio.code.org/s/allthethings/stage/2/puzzle/1"
@@ -14,32 +14,42 @@ Feature: Using the teacher dashboard
     # Progress tab
     When I sign in as "Teacher_Sally"
     And I am on "http://studio.code.org/home"
-    And I click selector "a:contains('Untitled Section')" once I see it
+    And I save the section id from row 0 of the section table
+    And I wait until element "a:contains('Untitled Section')" is visible
+    Then I navigate to teacher dashboard for the section I saved
     And I wait until element "#uitest-course-dropdown" contains text "All the Things! *"
 
     # Stats tab
-    And I click selector "#learn-tabs a:contains('Stats')" once I see it
+    And I click selector "#uitest-teacher-dashboard-nav a:contains(Stats)" once I see it
     And I wait until element "#uitest-stats-table" is visible
+    And element "#uitest-stats-table tr:eq(1)" contains text "Sally"
 
     # Manage students tab
-    When I click selector "#learn-tabs a:contains('Manage Students')" once I see it
-    And I wait until element "#uitest-manage-tab" is visible
+    When I click selector "#uitest-teacher-dashboard-nav a:contains(Manage Students)" once I see it
+    And I wait until element "#uitest-manage-students-table" is visible
+    And element "#uitest-manage-students-table tr:eq(1)" contains text "Sally"
     And I wait until element "#uitest-privacy-link" is visible
     And element "#uitest-privacy-link" contains text "privacy document"
 
     # Text responses tab
-    When I click selector "#learn-tabs a:contains('Text Responses')" once I see it
-    And I wait until element "#uitest-course-dropdown" is visible
+    When I click selector "#uitest-teacher-dashboard-nav a:contains(Text Responses)" once I see it
+    And I wait until element "#uitest-course-dropdown" contains text "All the Things! *"
+    And I wait until element "#text-responses-table" is visible
     And element "#text-responses-table tr:contains(Sally)" contains text "hello world"
 
-    # Assessments and surveys tab
-    When I click selector "#learn-tabs a:contains('Assessments/Surveys')" once I see it
-    And I wait until element "#uitest-course-dropdown" is visible
+    # Assessments/Surveys tab: anonymous survey
+    When I click selector "#uitest-teacher-dashboard-nav a:contains(Assessments/Surveys)" once I see it
+    And I wait until element "#uitest-course-dropdown" contains text "All the Things! *"
     And I wait until element "div:contains(no submissions for this assessment)" is visible
     And I wait until element "div:contains(this survey is anonymous)" is not visible
     And I select the "Lesson 30: Anonymous student survey" option in dropdown "assessment-selector"
     And I wait until element "div:contains(this survey is anonymous)" is visible
     And I wait until element "div:contains(no submissions for this assessment)" is not visible
+
+    # Assessments/Surveys tab: assessment
+    And I select the "Lesson 33: Single page assessment" option in dropdown "assessment-selector"
+    And I wait until element "#uitest-submission-status-table" is visible
+    And element "#uitest-submission-status-table tr:eq(1)" contains text "Sally"
 
   Scenario: Loading section projects
     Given I create a teacher-associated student named "Sally"
@@ -60,7 +70,7 @@ Feature: Using the teacher dashboard
 
     When I sign in as "Teacher_Sally"
     And I click selector "a:contains('Untitled Section')" once I see it
-    And I click selector "#learn-tabs a:contains('Projects')" once I see it
+    And I click selector "#uitest-teacher-dashboard-nav a:contains('Projects')" once I see it
     And I wait until element "#projects-list" is visible
     And I click selector "a:contains('thumb wars')" once I see it
     And I go to the newly opened tab
@@ -180,7 +190,7 @@ Feature: Using the teacher dashboard
     When I sign in as "Teacher_Sally"
     Then I am on "http://studio.code.org/home"
     And I click selector "a:contains('Untitled Section')" once I see it
-    And I click selector "#learn-tabs a:contains('Projects')" once I see it
+    And I click selector "#uitest-teacher-dashboard-nav a:contains('Projects')" once I see it
     And I wait until element "#projects-list" is visible
     And I wait until the image within element "tr:eq(1)" has loaded
     And I wait until the image within element "tr:eq(2)" has loaded

--- a/dashboard/test/ui/features/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_dashboard.feature
@@ -193,9 +193,11 @@ Feature: Using the teacher dashboard
 
     When I sign in as "Teacher_Sally"
     Then I am on "http://studio.code.org/home"
-    And I click selector "a:contains('Untitled Section')" once I see it
-    And I click selector "#uitest-teacher-dashboard-nav a:contains('Projects')" once I see it
-    And I wait until element "#projects-list" is visible
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved
+    And I click selector "#uitest-teacher-dashboard-nav a:contains(Projects)" once I see it
+    And I wait until element "#uitest-projects-table" is visible
     And I wait until the image within element "tr:eq(1)" has loaded
     And I wait until the image within element "tr:eq(2)" has loaded
     And I wait until the image within element "tr:eq(3)" has loaded

--- a/dashboard/test/ui/features/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_dashboard.feature
@@ -89,7 +89,9 @@ Feature: Using the teacher dashboard
     # Progress tab
     When I sign in as "Teacher_Sally"
     And I am on "http://studio.code.org/home"
-    And I click selector "a:contains('Untitled Section')" once I see it
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved
     And I wait until element "#uitest-course-dropdown" contains text "All the Things! *"
     And I press the first ".uitest-summary-cell" element
     And I see ".uitest-detail-cell"

--- a/dashboard/test/ui/features/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_dashboard.feature
@@ -14,8 +14,8 @@ Feature: Using the teacher dashboard
     # Progress tab
     When I sign in as "Teacher_Sally"
     And I am on "http://studio.code.org/home"
-    And I save the section id from row 0 of the section table
     And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
     Then I navigate to teacher dashboard for the section I saved
     And I wait until element "#uitest-course-dropdown" contains text "All the Things! *"
 
@@ -69,9 +69,11 @@ Feature: Using the teacher dashboard
     And I sign out
 
     When I sign in as "Teacher_Sally"
-    And I click selector "a:contains('Untitled Section')" once I see it
-    And I click selector "#uitest-teacher-dashboard-nav a:contains('Projects')" once I see it
-    And I wait until element "#projects-list" is visible
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved
+    And I click selector "#uitest-teacher-dashboard-nav a:contains(Projects)" once I see it
+    And I wait until element "#uitest-projects-table" is visible
     And I click selector "a:contains('thumb wars')" once I see it
     And I go to the newly opened tab
     And I wait until element ".project_name.header_text:contains('thumb wars')" is visible

--- a/dashboard/test/ui/features/teacher_dashboard_assessments1.feature
+++ b/dashboard/test/ui/features/teacher_dashboard_assessments1.feature
@@ -18,15 +18,18 @@ Feature: Using the assessments tab in the teacher dashboard
     And I wait until element "#assignment-version-year" is visible
     And I press "assignment-version-year"
     And I click selector ".assignment-version-title:contains('17-'18)" once I see it
+    And I wait until element "#uitest-secondary-assignment" is visible
     And I select the "CSP Student Post-Course Survey ('17-'18)" option in dropdown "uitest-secondary-assignment"
     And I press the first ".uitest-saveButton" element
     And I wait until element ".modal-backdrop" is gone
 
     # Progress tab
-    When I click selector "a:contains('Untitled Section')" once I see it
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved
     And I wait until element "#uitest-course-dropdown" is visible
 
     # Assessments tab
-    When I click selector "#learn-tabs a:contains('Assessments/Surveys')" once I see it
+    And I click selector "#uitest-teacher-dashboard-nav a:contains(Assessments/Surveys)" once I see it
     And I wait until element "#uitest-course-dropdown" is visible
     Then I wait until element "div:contains(this survey is anonymous)" is visible

--- a/dashboard/test/ui/features/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_dashboard_assessments2.feature
@@ -44,10 +44,12 @@ Feature: Using the assessments tab in the teacher dashboard
     And I wait until element ".modal-backdrop" is gone
 
     # Progress tab
-    When I click selector "a:contains('Untitled Section')" once I see it
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved
     And I wait until element "#uitest-course-dropdown" contains text "CSP Student Post-Course Survey ('17-'18)"
 
     # Assessments tab
-    When I click selector "#learn-tabs a:contains('Assessments/Surveys')" once I see it
+    And I click selector "#uitest-teacher-dashboard-nav a:contains(Assessments/Surveys)" once I see it
     And I wait until element "#uitest-course-dropdown" is visible
     Then I wait until element "h2:contains(Multiple choice questions overview)" is visible


### PR DESCRIPTION
Updates UI tests to cover the new teacher dashboard. (Minus [`teacher_homepage.feature`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/features/teacher_homepage.feature), which I will update once /home actually directs teachers to the new teacher dashboard.)

I'm pretty sure I converted all the necessary tests to point to the new dashboard, but definitely call it out if you know of anything I missed.