### PR TITLE
Scholarship dropdown fix

### DIFF
--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormGroup} from 'react-bootstrap';
 import Select from 'react-select';
-import {ScholarshipDropdownOptions} from '@cdo/apps/generated/pd/teacher1920ApplicationConstants';
+import {ScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
 
 export class ScholarshipDropdown extends React.Component {
   static propTypes = {


### PR DESCRIPTION
My [changes](https://github.com/code-dot-org/code-dot-org/pull/27094/files) yesterday moved where the dropdown options are defined, but was still looking for them in their original file. 

It looks like I made a mistake resolving merge conflicts in my branch, because the correct change was made in this [commit](https://github.com/code-dot-org/code-dot-org/pull/27094/commits/0dbc2f7f933329a3c7bf297ac7cdf86e6183e5a1) but then was undone.

Fixed dropdown:
<img width="439" alt="screen shot 2019-02-22 at 9 08 48 am" src="https://user-images.githubusercontent.com/224089/53258473-8ca7d080-3681-11e9-9b09-f6eff71a0c3f.png">
