### PR TITLE
Update Microsoft provider for Manage Linked Accounts

### DIFF
--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -12,7 +12,7 @@ import {disconnect} from './manageLinkedAccountsRedux';
 
 const OAUTH_PROVIDERS = {
   GOOGLE: 'google_oauth2',
-  MICROSOFT: 'windowslive',
+  MICROSOFT: 'microsoft_v2_auth',
   CLEVER: 'clever',
   FACEBOOK: 'facebook'
 };

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
@@ -16,7 +16,11 @@ const mockAuthenticationOptions = {
   1: {id: 1, credentialType: 'google_oauth2', email: 'google@email.com'},
   2: {id: 2, credentialType: 'facebook', email: 'facebook@email.com'},
   3: {id: 3, credentialType: 'clever', email: 'clever@email.com'},
-  4: {id: 4, credentialType: 'windowslive', email: 'windowslive@email.com'}
+  4: {
+    id: 4,
+    credentialType: 'microsoft_v2_auth',
+    email: 'microsoft@email.com'
+  }
 };
 
 export default storybook =>

--- a/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
@@ -69,12 +69,28 @@ describe('ManageLinkedAccounts', () => {
 
   it('renders teacher email for authentication options', () => {
     const authOptions = {
-      id: {
+      1: {
         id: 1,
         credentialType: 'google_oauth2',
-        email: 'teacher@email.com'
+        email: 'teacher@google.com'
+      },
+      2: {
+        id: 2,
+        credentialType: 'microsoft_v2_auth',
+        email: 'teacher@microsoft.com'
+      },
+      4: {
+        id: 4,
+        credentialType: 'clever',
+        email: 'teacher@clever.com'
+      },
+      3: {
+        id: 3,
+        credentialType: 'facebook',
+        email: 'teacher@facebook.com'
       }
     };
+
     const wrapper = mount(
       <ManageLinkedAccounts
         {...DEFAULT_PROPS}
@@ -82,17 +98,37 @@ describe('ManageLinkedAccounts', () => {
         authenticationOptions={authOptions}
       />
     );
-    const googleEmailCell = wrapper
-      .find('OauthConnection')
-      .at(0)
-      .find('td')
-      .at(1);
-    expect(googleEmailCell).to.have.text('teacher@email.com');
+
+    const oauthConnections = wrapper.find('OauthConnection');
+
+    const googleConnection = oauthConnections.at(0);
+    expect(googleConnection.find('td').at(1)).to.have.text(
+      'teacher@google.com'
+    );
+    expect(googleConnection.find('td').at(2)).to.have.text('Disconnect');
+
+    const microsoftConnection = oauthConnections.at(1);
+    expect(microsoftConnection.find('td').at(1)).to.have.text(
+      'teacher@microsoft.com'
+    );
+    expect(microsoftConnection.find('td').at(2)).to.have.text('Disconnect');
+
+    const cleverConnection = oauthConnections.at(2);
+    expect(cleverConnection.find('td').at(1)).to.have.text(
+      'teacher@clever.com'
+    );
+    expect(cleverConnection.find('td').at(2)).to.have.text('Disconnect');
+
+    const facebookConnection = oauthConnections.at(3);
+    expect(facebookConnection.find('td').at(1)).to.have.text(
+      'teacher@facebook.com'
+    );
+    expect(facebookConnection.find('td').at(2)).to.have.text('Disconnect');
   });
 
   it('renders authentication option error', () => {
     const authOptions = {
-      id: {
+      1: {
         id: 1,
         credentialType: 'google_oauth2',
         error: 'Oh no!'


### PR DESCRIPTION
Follow-up for #27187.

### What it does
Updates the "Manage Linked Accounts" table on the Account Settings page to use microsoft_v2_auth as its Microsoft provider, rather than windowslive. More specifically, when you click "connect" for Microsoft, it will route you to the `/users/auth/microsoft_v2_auth/connect` route instead of the windowslive route.

### Caveat
This change means that any AuthenticationOption of type `windowslive` will no longer display in this table. I think this is okay because we are automatically performing silent takeovers (via #27162) on windowslive accounts, and we definitely don't want users to continue connecting their accounts to windowslive.

### Example
Table still looks the same, but for reference:
![screen shot 2019-02-22 at 11 06 25 am](https://user-images.githubusercontent.com/9812299/53265043-0942ab00-3692-11e9-84cd-25d76d353b8c.png)
