### PR TITLE
Fix unit overview student progress bug

### DIFF
--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -358,10 +358,15 @@ function initializeStoreWithProgress(
     store.dispatch(disablePostMilestone());
   }
 
-  // Merge in progress saved on the client.
-  store.dispatch(
-    mergeProgress(clientState.allLevelsProgress()[scriptData.name] || {})
-  );
+  // Determine if we are viewing student progress.
+  var isViewingStudentAnswer = !!clientState.queryParams('user_id');
+
+  // Merge in progress saved on the client, unless we are viewing student's work.
+  if (!isViewingStudentAnswer) {
+    store.dispatch(
+      mergeProgress(clientState.allLevelsProgress()[scriptData.name] || {})
+    );
+  }
 
   if (scriptData.hideable_stages) {
     // Note: This call is async
@@ -372,7 +377,6 @@ function initializeStoreWithProgress(
 
   // Progress from the server should be written down locally, unless we're a teacher
   // viewing a student's work.
-  var isViewingStudentAnswer = !!clientState.queryParams('user_id');
   if (!isViewingStudentAnswer) {
     let lastProgress;
     store.subscribe(() => {

--- a/dashboard/test/ui/features/script_overview.feature
+++ b/dashboard/test/ui/features/script_overview.feature
@@ -16,11 +16,16 @@ Feature: Script overview page
     Then I verify progress for stage 2 level 2 is "not_tried"
     And I sign out
 
-    # Verify progress as teacher viewing student on script overview page
+    # Verify progress as teacher viewing themself and student on script overview page
     When I sign in as "Teacher_Sally"
+    And I complete the level on "http://studio.code.org/s/allthethings/stage/29/puzzle/4?level_name=2-3 Artist 1 new"
     And I am on "http://studio.code.org/s/allthethings"
     And I wait until element ".teacher-panel" is visible
+    Then I verify progress for stage 29 level 4 is "perfect"
     When I click selector ".teacher-panel table td:contains(Sally)" once I see it
     And I wait until element "td:contains(Maze)" is visible
     Then I verify progress for stage 2 level 1 is "perfect"
     Then I verify progress for stage 2 level 2 is "not_tried"
+
+    # Make sure we only see student progress, not teacher progress.
+    Then I verify progress for stage 29 level 4 is "not_tried"


### PR DESCRIPTION
Fixes [LP-139](https://codedotorg.atlassian.net/browse/LP-139).

Some progress is stored in state on the client, and we don't want to merge that progress into the current progress state if we are a teacher viewing a student's progress.

### Before
Teacher viewing own progress:
![screen shot 2019-02-22 at 2 58 05 pm](https://user-images.githubusercontent.com/9812299/53276058-62bad200-36b2-11e9-89e9-a21ac59579f5.png)

Teacher viewing "Dev Student" progress:
![screen shot 2019-02-22 at 2 58 40 pm](https://user-images.githubusercontent.com/9812299/53276056-62223b80-36b2-11e9-8b0d-624113bfae83.png)

### After
Teacher viewing own progress:
![screen shot 2019-02-22 at 2 54 44 pm](https://user-images.githubusercontent.com/9812299/53275923-dad4c800-36b1-11e9-9a1d-be259beb66bf.png)

Teacher viewing "Dev Student" progress:
![screen shot 2019-02-22 at 2 54 12 pm](https://user-images.githubusercontent.com/9812299/53275924-dad4c800-36b1-11e9-9b96-2fbb5a4d837a.png)
