### PR TITLE
Teacher dashboard fixes

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -34,7 +34,7 @@ import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashbo
 const script = document.querySelector('script[data-dashboard]');
 const scriptData = JSON.parse(script.dataset.dashboard);
 const section = scriptData.section;
-const allSections = scriptData.allSections;
+const visibleSections = scriptData.visibleSections;
 const baseUrl = `/teacher_dashboard/sections/${section.id}`;
 
 $(document).ready(function() {
@@ -51,7 +51,7 @@ $(document).ready(function() {
   const store = getStore();
   // TODO: (madelynkasula) remove duplication in sectionData.setSection and teacherSections.setSections
   store.dispatch(setSection(section));
-  store.dispatch(setSections(allSections));
+  store.dispatch(setSections(visibleSections));
 
   store.dispatch(selectSection(section.id));
   store.dispatch(setRosterProvider(section.login_type));

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -38,9 +38,15 @@ class TeacherDashboard extends Component {
       studentCount
     } = this.props;
 
-    // If current path doesn't match one of the paths in our TeacherDashboardPath type,
-    // set pathname to point to the Progress tab instead.
-    if (!Object.values(TeacherDashboardPath).includes(location.pathname)) {
+    // Select a default tab if current path doesn't match one of the paths in our TeacherDashboardPath type.
+    const emptyOrInvalidPath = !Object.values(TeacherDashboardPath).includes(
+      location.pathname
+    );
+    if (emptyOrInvalidPath && studentCount === 0) {
+      // Default to the Manage Students tab if section has 0 students.
+      location.pathname = TeacherDashboardPath.manageStudents;
+    } else if (emptyOrInvalidPath) {
+      // Default to the Progress tab if section otherwise.
       location.pathname = TeacherDashboardPath.progress;
     }
 

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
@@ -9,7 +9,7 @@ const DEFAULT_PROPS = {
   sectionId: 1,
   sectionName: 'My Section',
   location: {},
-  studentCount: 0
+  studentCount: 5
 };
 
 describe('TeacherDashboard', () => {
@@ -40,5 +40,33 @@ describe('TeacherDashboard', () => {
       <TeacherDashboard {...DEFAULT_PROPS} location={location} />
     );
     expect(wrapper.instance().props.location.pathname).to.equal('/progress');
+  });
+
+  it('defaults to manage students tab if no tab provided in route and section has 0 students', () => {
+    const location = {pathname: '/'};
+    const wrapper = shallow(
+      <TeacherDashboard
+        {...DEFAULT_PROPS}
+        location={location}
+        studentCount={0}
+      />
+    );
+    expect(wrapper.instance().props.location.pathname).to.equal(
+      '/manage_students'
+    );
+  });
+
+  it('defaults to manage students tab if incorrect tab provided in route and section has 0 students', () => {
+    const location = {pathname: '/some_fake_path'};
+    const wrapper = shallow(
+      <TeacherDashboard
+        {...DEFAULT_PROPS}
+        location={location}
+        studentCount={0}
+      />
+    );
+    expect(wrapper.instance().props.location.pathname).to.equal(
+      '/manage_students'
+    );
   });
 });

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -6,6 +6,6 @@ class TeacherDashboardController < ApplicationController
     return head :forbidden unless section
 
     @section = section.summarize
-    @all_sections = sections.map(&:summarize)
+    @visible_sections = sections.where(hidden: false).map(&:summarize)
   end
 end

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -2,7 +2,7 @@
   teacher_dashboard_data = {}
   teacher_dashboard_data[:studioUrlPrefix] = CDO.studio_url('', CDO.default_scheme)
   teacher_dashboard_data[:pegasusUrlPrefix] = CDO.code_org_url('', CDO.default_scheme)
-  teacher_dashboard_data[:allSections] = @all_sections
+  teacher_dashboard_data[:visibleSections] = @visible_sections
   teacher_dashboard_data[:section] = @section
 
 %script{src: minifiable_asset_path('js/teacher_dashboard/show.js'), data: {dashboard: teacher_dashboard_data.to_json}}


### PR DESCRIPTION
Addresses [LP-147](https://codedotorg.atlassian.net/browse/LP-147) and [LP-146](https://codedotorg.atlassian.net/browse/LP-146).

Basically,
- Filter any hidden/archived sections in teacher_dashboard#show
- Default to "Manage Students" tab for sections with no students