### PR TITLE
Fix print logins

### DIFF
--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -227,7 +227,6 @@ class WordOrPictureLogins extends React.Component {
     printWindow.document.write('<body onafterprint="self.close()">');
     printWindow.document.write(printArea);
     printWindow.document.write('</body></html>');
-    printWindow.print();
   };
 
   render() {

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -188,7 +188,8 @@ const styles = {
     margin: 8,
     float: 'left',
     fontFamily: '"Gotham 4r", sans-serif',
-    color: 'dimgray'
+    color: 'dimgray',
+    pageBreakInside: 'avoid'
   },
   text: {
     fontSize: 14


### PR DESCRIPTION
Fixes [LP-148](https://codedotorg.atlassian.net/browse/LP-148) (logged after the fact for tracking purposes).

Found 2 small bugs while testing `/login_info` for picture sections:
1. Automatically calling `printWindow.print()` when the print window opens causes the students' secret pictures to not load. _Solution: Don't automatically call `.print()`. This means the teacher will have to print themselves, which I assume they know how to do, but there may be a better solution for this._
2. If things don't line up properly, login cards can get cut-off (meaning, a page would print 2.5 cards, where the third card would be cut-off). _Solution: Add `pageBreakInside: 'avoid'` for login cards._
![screen shot 2019-02-22 at 4 40 03 pm](https://user-images.githubusercontent.com/9812299/53278889-0e6b1e80-36c1-11e9-9635-a108a2a4a559.png)
