### PR TITLE
Fix renamed file: old_links -> oauth_links

### DIFF
--- a/dashboard/app/views/devise/passwords/edit.html.haml
+++ b/dashboard/app/views/devise/passwords/edit.html.haml
@@ -11,4 +11,4 @@
     %br/
     = f.password_field :password_confirmation
   %div= f.submit t('password.change_form.submit')
-= render "devise/shared/old_links"
+= render "devise/shared/oauth_links"


### PR DESCRIPTION
I deleted `_old_links.haml` in #27187 (in favor of using `_oauth_links.haml` in #27197) and missed a spot where `_old_links.haml` was still being used