### PR TITLE
Levelbuilder Reference Link: Remove Blank Entry

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -330,7 +330,7 @@ class LevelsController < ApplicationController
     # Reference links should be stored as an array.
     if params[:level][:reference_links].is_a? String
       params[:level][:reference_links] = params[:level][:reference_links].split("\r\n")
-      params[:level][:reference_links].delete_if {|link| link == ""} if params[:level][:reference_links]
+      params[:level][:reference_links].delete_if {|link| link == ""}
     end
 
     permitted_params.concat(Level.permitted_params)

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -330,6 +330,7 @@ class LevelsController < ApplicationController
     # Reference links should be stored as an array.
     if params[:level][:reference_links].is_a? String
       params[:level][:reference_links] = params[:level][:reference_links].split("\r\n")
+      params[:level][:reference_links].delete_if {|link| link == ""} if params[:level][:reference_links]
     end
 
     permitted_params.concat(Level.permitted_params)


### PR DESCRIPTION
Remove empty link entry in reference links if levelbuilder leaves a blank line between the links provided. 