### PR TITLE
Re-style change password page

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1611,6 +1611,10 @@ a.download-video {
   justify-content: space-between;
 }
 
+#change-password {
+  max-width: 600px;
+}
+
 #signin,
 #change-password {
   $field-width: 310px;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1611,7 +1611,8 @@ a.download-video {
   justify-content: space-between;
 }
 
-#signin {
+#signin,
+#change-password {
   $field-width: 310px;
   $button-width: 324px;
 

--- a/dashboard/app/views/devise/passwords/edit.html.haml
+++ b/dashboard/app/views/devise/passwords/edit.html.haml
@@ -1,14 +1,28 @@
-%h2= t('password.change_form.title')
-= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f|
-  = devise_error_messages!
-  = f.hidden_field :reset_password_token
-  %div
-    = f.label :password, t('password.change_form.new_password')
-    %br/
-    = f.password_field :password, :autofocus => true
-  %div
-    = f.label :password_confirmation, t('password.change_form.confirm_password')
-    %br/
-    = f.password_field :password_confirmation
-  %div= f.submit t('password.change_form.submit')
-= render "devise/shared/oauth_links"
+%h1= t('password.change_form.title')
+%br
+
+.flex-container
+  #change-password
+    = form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f|
+      = devise_error_messages!
+      = f.hidden_field :reset_password_token
+
+      / New password
+      .field
+        = f.label :password, t('password.change_form.new_password')
+        = f.password_field :password, autofocus: true
+
+      / New password confirmation
+      .field
+        = f.label :password_confirmation, t('password.change_form.confirm_password')
+        = f.password_field :password_confirmation
+
+      / Submit button
+      %button= t('password.change_form.submit')
+
+  %div.vertical-or
+    %hr
+    = t("or").upcase
+    %hr
+
+  = render "devise/shared/oauth_links"

--- a/dashboard/app/views/devise/passwords/edit.html.haml
+++ b/dashboard/app/views/devise/passwords/edit.html.haml
@@ -1,28 +1,20 @@
 %h1= t('password.change_form.title')
 %br
 
-.flex-container
-  #change-password
-    = form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f|
-      = devise_error_messages!
-      = f.hidden_field :reset_password_token
+#change-password
+  = form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f|
+    = devise_error_messages!
+    = f.hidden_field :reset_password_token
 
-      / New password
-      .field
-        = f.label :password, t('password.change_form.new_password')
-        = f.password_field :password, autofocus: true
+    / New password
+    .field
+      = f.label :password, t('password.change_form.new_password')
+      = f.password_field :password, autofocus: true
 
-      / New password confirmation
-      .field
-        = f.label :password_confirmation, t('password.change_form.confirm_password')
-        = f.password_field :password_confirmation
+    / New password confirmation
+    .field
+      = f.label :password_confirmation, t('password.change_form.confirm_password')
+      = f.password_field :password_confirmation
 
-      / Submit button
-      %button= t('password.change_form.submit')
-
-  %div.vertical-or
-    %hr
-    = t("or").upcase
-    %hr
-
-  = render "devise/shared/oauth_links"
+    / Submit button
+    %button= t('password.change_form.submit')


### PR DESCRIPTION
Applying styles from the sign in form to the change password form, and removing OAuth links from the form.

### Before
Introduced the new OAuth buttons in #27218 last night, but the styling was... not great:
<img width="996" alt="screen shot 2019-02-25 at 8 05 44 am" src="https://user-images.githubusercontent.com/9812299/53350615-49916b80-38d4-11e9-91a3-5a5ae9dbaa6d.png">

### After
<img width="638" alt="screen shot 2019-02-26 at 9 52 38 am" src="https://user-images.githubusercontent.com/9812299/53434847-4e295300-39ac-11e9-9e43-aff0ff3e5f5d.png">

