### PR TITLE
Fix get_rubric fails when no mini_rubric value

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -45,7 +45,7 @@ class LevelsController < ApplicationController
   # GET all the information for the mini rubric
   def get_rubric
     @level = Level.find_by(id: params[:level_id])
-    if @level.mini_rubric && @level.mini_rubric.to_bool
+    if @level.mini_rubric&.to_bool
       render json: {
         keyConcept: @level.rubric_key_concept,
         exceeds: @level.rubric_exceeds,

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -45,7 +45,7 @@ class LevelsController < ApplicationController
   # GET all the information for the mini rubric
   def get_rubric
     @level = Level.find_by(id: params[:level_id])
-    if @level.mini_rubric.to_bool
+    if @level.mini_rubric && @level.mini_rubric.to_bool
       render json: {
         keyConcept: @level.rubric_key_concept,
         exceeds: @level.rubric_exceeds,


### PR DESCRIPTION
Check that there is a mini rubric value before trying to turn it into a bool.

In response to this honeybadger error: https://app.honeybadger.io/projects/3240/faults/46167895#notice-summary