### PR TITLE
getParamFromCodeAtIndex fixes

### DIFF
--- a/apps/test/unit/dropletUtilsTest.js
+++ b/apps/test/unit/dropletUtilsTest.js
@@ -386,6 +386,19 @@ describe('dropletUtils', () => {
       assert.equal(getParamFromCodeAtIndex(1, 'myProperty', code), 'element2');
     });
 
+    it('works with single quotes on the 1st param and a parenthetical expression for the 2nd param', () => {
+      const code = "myProperty('element1', (a + b),";
+      assert.equal(getParamFromCodeAtIndex(1, 'myProperty', code), '(a + b)');
+    });
+
+    it('works with single quotes for 2 params and embedded commas', () => {
+      const code = "myProperty('element1', 'value,with,commas',";
+      assert.equal(
+        getParamFromCodeAtIndex(1, 'myProperty', code),
+        'value,with,commas'
+      );
+    });
+
     it('works with double quotes', () => {
       const code = 'myProperty("element1", ';
       assert.equal(getParamFromCodeAtIndex(0, 'myProperty', code), 'element1');
@@ -396,9 +409,32 @@ describe('dropletUtils', () => {
       assert.equal(getParamFromCodeAtIndex(1, 'myProperty', code), 'element2');
     });
 
-    it('should return null with mixed quotes', () => {
+    it('works with double quotes on the 1st param and a parenthetical expression for the 2nd param', () => {
+      const code = 'myProperty("element1", (a + b),';
+      assert.equal(getParamFromCodeAtIndex(1, 'myProperty', code), '(a + b)');
+    });
+
+    it('works with double quotes for 2 params and embedded commas', () => {
+      const code = 'myProperty("element1", "value,with,commas",';
+      assert.equal(
+        getParamFromCodeAtIndex(1, 'myProperty', code),
+        'value,with,commas'
+      );
+    });
+
+    it('works with single quotes on the 1st param and double quotes on the 2nd param', () => {
+      const code = 'myProperty(\'element1\', "element2",';
+      assert.equal(getParamFromCodeAtIndex(1, 'myProperty', code), 'element2');
+    });
+
+    it('works with double quotes on the 1st param and single quotes on the 2nd param', () => {
+      const code = 'myProperty("element1", \'element2\',';
+      assert.equal(getParamFromCodeAtIndex(1, 'myProperty', code), 'element2');
+    });
+
+    it('should return single parameter with mixed quotes and embedded comma', () => {
       const code = 'myProperty("element1\', ';
-      assert.equal(getParamFromCodeAtIndex(0, 'myProperty', code), null);
+      assert.equal(getParamFromCodeAtIndex(0, 'myProperty', code), 'element1,');
     });
 
     it('works with no trailing space', () => {
@@ -415,6 +451,16 @@ describe('dropletUtils', () => {
     it('works with non-quoted strings (variable names)', () => {
       const code = 'myProperty(object1, ';
       assert.equal(getParamFromCodeAtIndex(0, 'myProperty', code), 'object1');
+    });
+
+    it('works with non-quoted strings (variable names) and double quotes on the 2nd param', () => {
+      const code = 'myProperty(object1, "element2",';
+      assert.equal(getParamFromCodeAtIndex(1, 'myProperty', code), 'element2');
+    });
+
+    it('works with non-quoted strings (variable names) and single quotes on the 2nd param', () => {
+      const code = "myProperty(object1, 'element2',";
+      assert.equal(getParamFromCodeAtIndex(1, 'myProperty', code), 'element2');
     });
   });
 


### PR DESCRIPTION
* Text mode autocomplete was a bit broken because we couldn't identify the 2nd parameter of a function call in the somewhat common cases where the 1st parameter is a non-quoted variable name OR a quoted string that used a different type of quotes.
* The result is that the "intelligent" dropdown for the 3rd parameter of `setProperty` didn't work properly in these cases, suggesting choices that weren't the right set for the property name specified in the 2nd parameter (see examples below)
* Modified the regex we used to extract params and the logic we used to separate the parameters
* Added new test cases to cover these cases - as well as the other previously untested cases of embedded commas within quoted string parameters and parentheses within parameters.

Before:
![second-param-dropdown-before](https://user-images.githubusercontent.com/5429146/53367740-cb48bf80-38fb-11e9-9676-862376777ce6.gif)


After:
![second-param-dropdown-after](https://user-images.githubusercontent.com/5429146/53367749-cf74dd00-38fb-11e9-8545-f8a683ed7924.gif)

