### PR TITLE
Levelbuilder Reference Links: Code Simplification 

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -330,7 +330,7 @@ class LevelsController < ApplicationController
     # Reference links should be stored as an array.
     if params[:level][:reference_links].is_a? String
       params[:level][:reference_links] = params[:level][:reference_links].split("\r\n")
-      params[:level][:reference_links].delete_if {|link| link == ""}
+      params[:level][:reference_links].delete_if(&:blank?)
     end
 
     permitted_params.concat(Level.permitted_params)


### PR DESCRIPTION
Use `.delete_if(&:blank?)` instead of longer code to delete blank array items. Based on feedback from this merged PR: https://github.com/code-dot-org/code-dot-org/pull/27221