### PR TITLE
Add teacher-dashboard-react experiment

### DIFF
--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -13,6 +13,7 @@ import {pegasus} from '../../lib/util/urlHelpers';
 import SectionActionDropdown from './SectionActionDropdown';
 import Button from '@cdo/apps/templates/Button';
 import {stringifyQueryParams} from '../../utils';
+import experiments from '@cdo/apps/util/experiments';
 
 /** @enum {number} */
 export const COLUMNS = {
@@ -57,9 +58,15 @@ const styles = {
 
 // Cell formatters for sortable OwnedSectionsTable.
 export const sectionLinkFormatter = function(name, {rowData}) {
-  const pegasusUrl = pegasus('/teacher-dashboard#/sections/' + rowData.id);
+  let sectionUrl = '';
+  if (experiments.isEnabled(experiments.TEACHER_DASHBOARD_REACT)) {
+    sectionUrl = `/teacher_dashboard/sections/${rowData.id}`;
+  } else {
+    sectionUrl = pegasus(`/teacher-dashboard#/sections/${rowData.id}`);
+  }
+
   return (
-    <a style={tableLayoutStyles.link} href={pegasusUrl}>
+    <a style={tableLayoutStyles.link} href={sectionUrl}>
       {rowData.name}
     </a>
   );
@@ -107,9 +114,15 @@ export const gradeFormatter = function(grade, {rowData}) {
 
 export const loginInfoFormatter = function(loginType, {rowData}) {
   let sectionCode = '';
-  let pegasusUrl = pegasus(
-    '/teacher-dashboard#/sections/' + rowData.id + '/print_signin_cards'
-  );
+  let loginInfoUrl = '';
+  if (experiments.isEnabled(experiments.TEACHER_DASHBOARD_REACT)) {
+    loginInfoUrl = `/teacher_dashboard/sections/${rowData.id}/login_info`;
+  } else {
+    loginInfoUrl = pegasus(
+      `/teacher-dashboard#/sections/${rowData.id}/print_signin_cards`
+    );
+  }
+
   // For managed logins, just show the provider name rather than the login code.
   if (rowData.loginType === OAuthSectionTypes.clever) {
     sectionCode = i18n.loginTypeClever();
@@ -119,25 +132,33 @@ export const loginInfoFormatter = function(loginType, {rowData}) {
     sectionCode = rowData.code;
   }
   return (
-    <a style={tableLayoutStyles.link} href={pegasusUrl}>
+    <a style={tableLayoutStyles.link} href={loginInfoUrl}>
       {sectionCode}
     </a>
   );
 };
 
 export const studentsFormatter = function(studentCount, {rowData}) {
-  const pegasusUrl = pegasus(
-    '/teacher-dashboard#/sections/' + rowData.id + '/manage'
-  );
+  let manageStudentsUrl = '';
+  if (experiments.isEnabled(experiments.TEACHER_DASHBOARD_REACT)) {
+    manageStudentsUrl = `/teacher_dashboard/sections/${
+      rowData.id
+    }/manage_students`;
+  } else {
+    manageStudentsUrl = pegasus(
+      `/teacher-dashboard#/sections/${rowData.id}/manage`
+    );
+  }
+
   const studentHtml =
     rowData.studentCount <= 0 ? (
       <Button
         text={i18n.addStudents()}
-        href={pegasusUrl}
+        href={manageStudentsUrl}
         color={Button.ButtonColor.gray}
       />
     ) : (
-      <a style={tableLayoutStyles.link} href={pegasusUrl}>
+      <a style={tableLayoutStyles.link} href={manageStudentsUrl}>
         {rowData.studentCount}
       </a>
     );

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -9,11 +9,10 @@ import orderBy from 'lodash/orderBy';
 import {getSectionRows} from './teacherSectionsRedux';
 import {sortableSectionShape, OAuthSectionTypes} from './shapes';
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
-import {pegasus} from '../../lib/util/urlHelpers';
+import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import SectionActionDropdown from './SectionActionDropdown';
 import Button from '@cdo/apps/templates/Button';
 import {stringifyQueryParams} from '../../utils';
-import experiments from '@cdo/apps/util/experiments';
 
 /** @enum {number} */
 export const COLUMNS = {
@@ -58,15 +57,8 @@ const styles = {
 
 // Cell formatters for sortable OwnedSectionsTable.
 export const sectionLinkFormatter = function(name, {rowData}) {
-  let sectionUrl = '';
-  if (experiments.isEnabled(experiments.TEACHER_DASHBOARD_REACT)) {
-    sectionUrl = `/teacher_dashboard/sections/${rowData.id}`;
-  } else {
-    sectionUrl = pegasus(`/teacher-dashboard#/sections/${rowData.id}`);
-  }
-
   return (
-    <a style={tableLayoutStyles.link} href={sectionUrl}>
+    <a style={tableLayoutStyles.link} href={teacherDashboardUrl(rowData.id)}>
       {rowData.name}
     </a>
   );
@@ -114,14 +106,6 @@ export const gradeFormatter = function(grade, {rowData}) {
 
 export const loginInfoFormatter = function(loginType, {rowData}) {
   let sectionCode = '';
-  let loginInfoUrl = '';
-  if (experiments.isEnabled(experiments.TEACHER_DASHBOARD_REACT)) {
-    loginInfoUrl = `/teacher_dashboard/sections/${rowData.id}/login_info`;
-  } else {
-    loginInfoUrl = pegasus(
-      `/teacher-dashboard#/sections/${rowData.id}/print_signin_cards`
-    );
-  }
 
   // For managed logins, just show the provider name rather than the login code.
   if (rowData.loginType === OAuthSectionTypes.clever) {
@@ -132,24 +116,17 @@ export const loginInfoFormatter = function(loginType, {rowData}) {
     sectionCode = rowData.code;
   }
   return (
-    <a style={tableLayoutStyles.link} href={loginInfoUrl}>
+    <a
+      style={tableLayoutStyles.link}
+      href={teacherDashboardUrl(rowData.id, '/print_signin_cards')}
+    >
       {sectionCode}
     </a>
   );
 };
 
 export const studentsFormatter = function(studentCount, {rowData}) {
-  let manageStudentsUrl = '';
-  if (experiments.isEnabled(experiments.TEACHER_DASHBOARD_REACT)) {
-    manageStudentsUrl = `/teacher_dashboard/sections/${
-      rowData.id
-    }/manage_students`;
-  } else {
-    manageStudentsUrl = pegasus(
-      `/teacher-dashboard#/sections/${rowData.id}/manage`
-    );
-  }
-
+  const manageStudentsUrl = teacherDashboardUrl(rowData.id, '/manage');
   const studentHtml =
     rowData.studentCount <= 0 ? (
       <Button

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -4,7 +4,7 @@ import color from '../../util/color';
 import {sortableSectionShape, OAuthSectionTypes} from './shapes.jsx';
 import PopUpMenu, {MenuBreak} from '@cdo/apps/lib/ui/PopUpMenu';
 import i18n from '@cdo/locale';
-import {pegasus} from '../../lib/util/urlHelpers';
+import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import {
   sectionCode,
   sectionName,
@@ -115,24 +115,19 @@ class SectionActionDropdown extends Component {
       <span>
         <QuickActionsCell>
           <PopUpMenu.Item
-            href={pegasus(`/teacher-dashboard#/sections/${sectionData.id}`)}
+            href={teacherDashboardUrl(sectionData.id, '/progress')}
           >
             {i18n.sectionViewProgress()}
           </PopUpMenu.Item>
-          <PopUpMenu.Item
-            href={pegasus(
-              `/teacher-dashboard#/sections/${sectionData.id}/manage`
-            )}
-          >
+          <PopUpMenu.Item href={teacherDashboardUrl(sectionData.id, '/manage')}>
             {i18n.manageStudents()}
           </PopUpMenu.Item>
           {sectionData.loginType !== OAuthSectionTypes.google_classroom &&
             sectionData.loginType !== OAuthSectionTypes.clever && (
               <PopUpMenu.Item
-                href={pegasus(
-                  `/teacher-dashboard#/sections/${
-                    sectionData.id
-                  }/print_signin_cards`
+                href={teacherDashboardUrl(
+                  sectionData.id,
+                  '/print_signin_cards'
                 )}
               >
                 {sectionData.loginType === SectionLoginType.email

--- a/apps/src/templates/teacherDashboard/urlHelpers.js
+++ b/apps/src/templates/teacherDashboard/urlHelpers.js
@@ -23,6 +23,7 @@ export const teacherDashboardUrl = (sectionId, path = '') => {
     experiments.TEACHER_DASHBOARD_REACT
   );
 
+  // Check urlMap for a corresponding dashboard URL that differs from pegasus URL.
   if (isDashboard && path !== '') {
     path = urlMap[path] || path;
   }

--- a/apps/src/templates/teacherDashboard/urlHelpers.js
+++ b/apps/src/templates/teacherDashboard/urlHelpers.js
@@ -1,0 +1,35 @@
+import experiments from '@cdo/apps/util/experiments';
+import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+
+const pegasusPrefix = '/teacher-dashboard#/sections/';
+const dashboardPrefix = '/teacher_dashboard/sections/';
+
+/**
+ * Add any paths that *do not* match between pegasus and dashboard teacher dashboards.
+ * The key should be the path (prefaced with a forward slash) in pegasus, and the value
+ * should be the corresponding path in dashboard.
+ */
+const urlMap = {
+  '/print_signin_cards': '/login_info',
+  '/manage': '/manage_students'
+};
+
+/**
+ * Returns the URL in teacher dashboard given a section id and (optional) path.
+ * If providing a path, it *must* be the path as it appears in the pegasus teacher dashboard.
+ */
+export const teacherDashboardUrl = (sectionId, path = '') => {
+  const isDashboard = experiments.isEnabled(
+    experiments.TEACHER_DASHBOARD_REACT
+  );
+
+  if (isDashboard && path !== '') {
+    path = urlMap[path];
+  }
+
+  if (isDashboard) {
+    return dashboardPrefix + sectionId + path;
+  } else {
+    return pegasus(pegasusPrefix + sectionId + path);
+  }
+};

--- a/apps/src/templates/teacherDashboard/urlHelpers.js
+++ b/apps/src/templates/teacherDashboard/urlHelpers.js
@@ -24,7 +24,7 @@ export const teacherDashboardUrl = (sectionId, path = '') => {
   );
 
   if (isDashboard && path !== '') {
-    path = urlMap[path];
+    path = urlMap[path] || path;
   }
 
   if (isDashboard) {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -29,6 +29,7 @@ experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
 experiments.TEACHER_EXP_2018 = '2018-teacher-experience';
 experiments.TEACHER_EXP_2018_LIST = [experiments.COMMENT_BOX_TAB];
 experiments.MINI_RUBRIC_2019 = '2019-mini-rubric';
+experiments.TEACHER_DASHBOARD_REACT = 'teacher-dashboard-react';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1633,6 +1633,11 @@ Then /^the href of selector "([^"]*)" contains the section id$/ do |selector|
   expect(href.split('#')[0]).to include("?section_id=#{@section_id}")
 end
 
+Then /^the href of selector "([^"]*)" contains "([^"]*)"$/ do |selector, matcher|
+  href = @browser.execute_script("return $(\"#{selector}\").attr('href');")
+  expect(href).to include(matcher)
+end
+
 Then /^I navigate to teacher dashboard for the section I saved$/ do
   expect(@section_id).to be > 0
   steps %{

--- a/dashboard/test/ui/features/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_homepage.feature
@@ -24,6 +24,20 @@ Feature: Using the teacher homepage sections feature
     Then the section table should have 1 row
     And the section table row at index 0 has secondary assignment path "/s/csp3-a"
 
+  Scenario: Loading teacher dashboard with teacher-dashboard-react experiment enabled
+    When I see the section set up box
+    And I create a new section
+    Then the section table should have 1 row
+
+    And I wait until element "a:contains(Untitled Section)" is visible
+    And the href of selector "a:contains(Untitled Section)" contains "/teacher-dashboard#/sections/"
+
+    # Enable teacher-dashboard-react experiment
+    Then I am on "http://studio.code.org/home?enableExperiments=teacher-dashboard-react"
+    And I wait until element "a:contains(Untitled Section)" is visible
+    And I wait for 10 seconds
+    And the href of selector "a:contains(Untitled Section)" contains "/teacher_dashboard/sections/"
+
   Scenario: Navigate to course and unit pages
     When I see the section set up box
     And I create a new section with course "Computer Science Principles", version "'17-'18" and unit "CSP Unit 1 - The Internet ('17-'18)"


### PR DESCRIPTION
Adding an experiment to enable the new teacher dashboard experience via `?enableExperiments=teacher-dashboard-react`. 

This also implements the necessary switches on `studio.code.org/home` to take the user to the proper pegasus/dashboard teacher dashboard depending on whether the experiment is on/off. There are a few other places where this switch will be implemented, but I will put them in a separate PR.