### PR TITLE
Allow pilot classrooms to use pilot scripts

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1482,7 +1482,10 @@ class Script < ActiveRecord::Base
       return SingleUserExperiment.enabled?(user: user, experiment_name: pilot_experiment)
     end
 
-    false
+    user.sections_as_student.any? do |section|
+      section.script == self &&
+        SingleUserExperiment.enabled?(user: section.user, experiment_name: pilot_experiment)
+    end
   end
 
   # returns true if the user is a levelbuilder, or a teacher with any pilot

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1485,17 +1485,15 @@ class Script < ActiveRecord::Base
     false
   end
 
+  # returns true if the user is a levelbuilder, or a teacher with any pilot
+  # script experiments enabled.
   def self.has_any_pilot_access?(user = nil)
-    return false unless user
+    return false unless user&.teacher?
     return true if user.permission?(UserPermission::LEVELBUILDER)
 
-    if user.teacher?
-      return pilot_experiments.any? do |experiment_name|
-        SingleUserExperiment.enabled?(user: user, experiment_name: experiment_name)
-      end
+    pilot_experiments.any? do |experiment_name|
+      SingleUserExperiment.enabled?(user: user, experiment_name: experiment_name)
     end
-
-    false
   end
 
   def self.pilot_experiments

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1486,6 +1486,19 @@ class Script < ActiveRecord::Base
   end
 
   def self.has_any_pilot_access?(user = nil)
-    !!user&.permission?(UserPermission::LEVELBUILDER)
+    return false unless user
+    return true if user.permission?(UserPermission::LEVELBUILDER)
+
+    if user.teacher?
+      return pilot_experiments.any? do |experiment_name|
+        SingleUserExperiment.enabled?(user: user, experiment_name: experiment_name)
+      end
+    end
+
+    false
+  end
+
+  def self.pilot_experiments
+    @@pilot_experiments ||= all_scripts.map(&:pilot_experiment).compact
   end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1475,7 +1475,14 @@ class Script < ActiveRecord::Base
   end
 
   def has_pilot_access?(user = nil)
-    pilot? && !!user&.permission?(UserPermission::LEVELBUILDER)
+    return false unless pilot? && user
+    return true if user.permission?(UserPermission::LEVELBUILDER)
+
+    if user.teacher?
+      return SingleUserExperiment.enabled?(user: user, experiment_name: pilot_experiment)
+    end
+
+    false
   end
 
   def self.has_any_pilot_access?(user = nil)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1477,12 +1477,9 @@ class Script < ActiveRecord::Base
   def has_pilot_access?(user = nil)
     return false unless pilot? && user
     return true if user.permission?(UserPermission::LEVELBUILDER)
+    return true if has_pilot_experiment?(user)
 
-    if user.teacher?
-      return has_pilot_experiment?(user)
-    end
-
-    # A student has pilot script access if
+    # A user without the experiment has pilot script access if
     # (1) they have been assigned to or have progress in the pilot script, and
     # (2) one of their teachers has the pilot experiment enabled.
     has_progress = !!UserScript.find_by(user: user, script: self)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1482,9 +1482,13 @@ class Script < ActiveRecord::Base
       return SingleUserExperiment.enabled?(user: user, experiment_name: pilot_experiment)
     end
 
-    user.sections_as_student.any? do |section|
-      section.script == self &&
-        SingleUserExperiment.enabled?(user: section.user, experiment_name: pilot_experiment)
+    # A student has pilot script access if
+    # (1) they have been assigned to or have progress in the pilot script, and
+    # (2) one of their teachers has the pilot experiment enabled.
+    has_progress = !!UserScript.find_by(user: user, script: self)
+    return false unless has_progress
+    user.teachers.any? do |teacher|
+      SingleUserExperiment.enabled?(user: teacher, experiment_name: pilot_experiment)
     end
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1479,17 +1479,19 @@ class Script < ActiveRecord::Base
     return true if user.permission?(UserPermission::LEVELBUILDER)
 
     if user.teacher?
-      return SingleUserExperiment.enabled?(user: user, experiment_name: pilot_experiment)
+      return has_pilot_experiment?(user)
     end
 
     # A student has pilot script access if
     # (1) they have been assigned to or have progress in the pilot script, and
     # (2) one of their teachers has the pilot experiment enabled.
     has_progress = !!UserScript.find_by(user: user, script: self)
-    return false unless has_progress
-    user.teachers.any? do |teacher|
-      SingleUserExperiment.enabled?(user: teacher, experiment_name: pilot_experiment)
-    end
+    has_progress && user.teachers.any? {|t| has_pilot_experiment?(t)}
+  end
+
+  # Whether this particular user has the pilot experiment enabled.
+  def has_pilot_experiment?(user)
+    SingleUserExperiment.enabled?(user: user, experiment_name: pilot_experiment)
   end
 
   # returns true if the user is a levelbuilder, or a teacher with any pilot

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1488,6 +1488,7 @@ class Script < ActiveRecord::Base
 
   # Whether this particular user has the pilot experiment enabled.
   def has_pilot_experiment?(user)
+    return false unless pilot_experiment
     SingleUserExperiment.enabled?(user: user, experiment_name: pilot_experiment)
   end
 
@@ -1496,13 +1497,6 @@ class Script < ActiveRecord::Base
   def self.has_any_pilot_access?(user = nil)
     return false unless user&.teacher?
     return true if user.permission?(UserPermission::LEVELBUILDER)
-
-    pilot_experiments.any? do |experiment_name|
-      SingleUserExperiment.enabled?(user: user, experiment_name: experiment_name)
-    end
-  end
-
-  def self.pilot_experiments
-    @@pilot_experiments ||= all_scripts.map(&:pilot_experiment).compact
+    all_scripts.any? {|script| script.has_pilot_experiment?(user)}
   end
 end

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -46,6 +46,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     pilot_script = create(:script, pilot_experiment: 'pilot-experiment')
     @pilot_script_level = create :script_level, script: pilot_script
+    @pilot_teacher = create :teacher, pilot_experiment: 'pilot-experiment'
   end
 
   setup do
@@ -1728,9 +1729,17 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     params: -> {script_level_params(@pilot_script_level)},
     name: 'signed out user cannot view pilot script level'
 
+  test_user_gets_response_for :show, response: :forbidden, user: :student,
+    params: -> {script_level_params(@pilot_script_level)},
+    name: 'student cannot view pilot script level'
+
   test_user_gets_response_for :show, response: :forbidden, user: :teacher,
     params: -> {script_level_params(@pilot_script_level)},
     name: 'teacher without pilot access cannot view pilot script level'
+
+  test_user_gets_response_for :show, response: :success, user: -> {@pilot_teacher},
+    params: -> {script_level_params(@pilot_script_level)},
+    name: 'pilot teacher can view pilot script level'
 
   test_user_gets_response_for :show, response: :success, user: :levelbuilder,
     params: -> {script_level_params(@pilot_script_level)},

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -47,6 +47,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     pilot_script = create(:script, pilot_experiment: 'pilot-experiment')
     @pilot_script_level = create :script_level, script: pilot_script
     @pilot_teacher = create :teacher, pilot_experiment: 'pilot-experiment'
+    pilot_section = create :section, user: @pilot_teacher, script: pilot_script
+    @pilot_student = create(:follower, section: pilot_section).student_user
   end
 
   setup do
@@ -1740,6 +1742,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test_user_gets_response_for :show, response: :success, user: -> {@pilot_teacher},
     params: -> {script_level_params(@pilot_script_level)},
     name: 'pilot teacher can view pilot script level'
+
+  test_user_gets_response_for :show, response: :success, user: -> {@pilot_student},
+    params: -> {script_level_params(@pilot_script_level)},
+    name: 'pilot student can view pilot script level'
 
   test_user_gets_response_for :show, response: :success, user: :levelbuilder,
     params: -> {script_level_params(@pilot_script_level)},

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -9,6 +9,8 @@ class ScriptsControllerTest < ActionController::TestCase
     @levelbuilder = create(:levelbuilder)
     @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
     @pilot_script = create :script, pilot_experiment: 'my-experiment'
+    @pilot_section = create :section, user: @pilot_teacher, script: @pilot_script
+    @pilot_student = create(:follower, section: @pilot_section).student_user
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
   end
@@ -307,7 +309,11 @@ class ScriptsControllerTest < ActionController::TestCase
     name: 'teacher without pilot access cannot view pilot script'
 
   test_user_gets_response_for :show, response: :success, user: -> {@pilot_teacher},
-    params: -> {{id: @pilot_script.name}}, name: 'pilot teacher can view pilot script'
+    params: -> {{id: @pilot_script.name, section_id: @pilot_section.id}},
+    name: 'pilot teacher can view pilot script'
+
+  test_user_gets_response_for :show, response: :success, user: -> {@pilot_student},
+    params: -> {{id: @pilot_script.name}}, name: 'pilot student can view pilot script'
 
   test_user_gets_response_for :show, response: :success, user: :levelbuilder,
     params: -> {{id: @pilot_script.name}}, name: 'levelbuilder can view pilot script'

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -7,6 +7,7 @@ class ScriptsControllerTest < ActionController::TestCase
     @admin = create(:admin)
     @not_admin = create(:user)
     @levelbuilder = create(:levelbuilder)
+    @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
     @pilot_script = create :script, pilot_experiment: 'my-experiment'
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
@@ -298,9 +299,15 @@ class ScriptsControllerTest < ActionController::TestCase
     params: -> {{id: @pilot_script.name}},
     name: 'signed out user cannot view pilot script'
 
+  test_user_gets_response_for :show, response: :forbidden, user: :student,
+    params: -> {{id: @pilot_script.name}}, name: 'student cannot view pilot script'
+
   test_user_gets_response_for :show, response: :forbidden, user: :teacher,
     params: -> {{id: @pilot_script.name}},
     name: 'teacher without pilot access cannot view pilot script'
+
+  test_user_gets_response_for :show, response: :success, user: -> {@pilot_teacher},
+    params: -> {{id: @pilot_script.name}}, name: 'pilot teacher can view pilot script'
 
   test_user_gets_response_for :show, response: :success, user: :levelbuilder,
     params: -> {{id: @pilot_script.name}}, name: 'levelbuilder can view pilot script'

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -178,6 +178,12 @@ FactoryGirl.define do
           )
         end
       end
+      transient {pilot_experiment nil}
+      after(:create) do |teacher, evaluator|
+        if evaluator.pilot_experiment
+          create :single_user_experiment, min_user_id: teacher.id, name: evaluator.pilot_experiment
+        end
+      end
     end
 
     factory :student do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1437,15 +1437,20 @@ endvariants
   end
 
   test "self.valid_scripts: omits pilot scripts" do
+    student = create :student
     teacher = create :teacher
     levelbuilder = create :levelbuilder
-
+    pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
     pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
     assert pilot_script.hidden
     assert Script.any?(&:pilot?)
 
+    refute Script.valid_scripts(student).any?(&:pilot?)
+
     teacher_scripts = Script.valid_scripts(teacher)
     refute teacher_scripts.any?(&:pilot?)
+
+    assert Script.valid_scripts(pilot_teacher).any?(&:pilot?)
 
     levelbuilder_scripts = Script.valid_scripts(levelbuilder)
     assert levelbuilder_scripts.any?(&:pilot?)

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1550,12 +1550,14 @@ endvariants
   end
 
   test 'has pilot access' do
+    script = create :script
+    pilot_script = create :script, pilot_experiment: 'my-experiment'
+
     student = create :student
     teacher = create :teacher
     pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
     levelbuilder = create :levelbuilder
 
-    script = create :script
     refute script.pilot?
     refute script.has_pilot_access?
     refute script.has_pilot_access?(student)
@@ -1563,13 +1565,12 @@ endvariants
     refute script.has_pilot_access?(pilot_teacher)
     refute script.has_pilot_access?(levelbuilder)
 
-    script.pilot_experiment = 'my-experiment'
-    assert script.pilot?
-    refute script.has_pilot_access?
-    refute script.has_pilot_access?(student)
-    refute script.has_pilot_access?(teacher)
-    assert script.has_pilot_access?(pilot_teacher)
-    assert script.has_pilot_access?(levelbuilder)
+    assert pilot_script.pilot?
+    refute pilot_script.has_pilot_access?
+    refute pilot_script.has_pilot_access?(student)
+    refute pilot_script.has_pilot_access?(teacher)
+    assert pilot_script.has_pilot_access?(pilot_teacher)
+    assert pilot_script.has_pilot_access?(levelbuilder)
   end
 
   test 'has any pilot access' do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1550,20 +1550,26 @@ endvariants
   end
 
   test 'has pilot access' do
+    student = create :student
     teacher = create :teacher
+    pilot_teacher = create :teacher
+    create :single_user_experiment, min_user_id: pilot_teacher.id, name: 'my-experiment'
     levelbuilder = create :levelbuilder
 
     script = create :script
     refute script.pilot?
     refute script.has_pilot_access?
+    refute script.has_pilot_access?(student)
     refute script.has_pilot_access?(teacher)
+    refute script.has_pilot_access?(pilot_teacher)
     refute script.has_pilot_access?(levelbuilder)
 
-    # for now, only levelbuilders have pilot script access.
     script.pilot_experiment = 'my-experiment'
     assert script.pilot?
     refute script.has_pilot_access?
+    refute script.has_pilot_access?(student)
     refute script.has_pilot_access?(teacher)
+    assert script.has_pilot_access?(pilot_teacher)
     assert script.has_pilot_access?(levelbuilder)
   end
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1574,12 +1574,17 @@ endvariants
   end
 
   test 'has any pilot access' do
+    student = create :student
     teacher = create :teacher
+    pilot_teacher = create :teacher
+    create :single_user_experiment, min_user_id: pilot_teacher.id, name: 'my-experiment'
+    create :script, pilot_experiment: 'my-experiment'
     levelbuilder = create :levelbuilder
 
-    # for now, only levelbuilders have any pilot access.
     refute Script.has_any_pilot_access?
+    refute Script.has_any_pilot_access?(student)
     refute Script.has_any_pilot_access?(teacher)
+    assert Script.has_any_pilot_access?(pilot_teacher)
     assert Script.has_any_pilot_access?(levelbuilder)
   end
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1555,7 +1555,17 @@ endvariants
 
     student = create :student
     teacher = create :teacher
+
     pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
+
+    # student in a pilot teacher's section which is not assigned to any script
+    section = create :section, user: pilot_teacher
+    unassigned_student = create(:follower, section: section).student_user
+
+    # student in a pilot teacher's section which is assigned to a pilot script
+    pilot_section = create :section, user: pilot_teacher, script: pilot_script
+    pilot_student = create(:follower, section: pilot_section).student_user
+
     levelbuilder = create :levelbuilder
 
     refute script.pilot?
@@ -1563,6 +1573,8 @@ endvariants
     refute script.has_pilot_access?(student)
     refute script.has_pilot_access?(teacher)
     refute script.has_pilot_access?(pilot_teacher)
+    refute script.has_pilot_access?(unassigned_student)
+    refute script.has_pilot_access?(pilot_student)
     refute script.has_pilot_access?(levelbuilder)
 
     assert pilot_script.pilot?
@@ -1570,6 +1582,8 @@ endvariants
     refute pilot_script.has_pilot_access?(student)
     refute pilot_script.has_pilot_access?(teacher)
     assert pilot_script.has_pilot_access?(pilot_teacher)
+    refute pilot_script.has_pilot_access?(unassigned_student)
+    assert pilot_script.has_pilot_access?(pilot_student)
     assert pilot_script.has_pilot_access?(levelbuilder)
   end
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1441,19 +1441,14 @@ endvariants
     teacher = create :teacher
     levelbuilder = create :levelbuilder
     pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
-    pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment'
+    pilot_script = create :script, pilot_experiment: 'my-experiment'
     assert pilot_script.hidden
     assert Script.any?(&:pilot?)
 
     refute Script.valid_scripts(student).any?(&:pilot?)
-
-    teacher_scripts = Script.valid_scripts(teacher)
-    refute teacher_scripts.any?(&:pilot?)
-
+    refute Script.valid_scripts(teacher).any?(&:pilot?)
     assert Script.valid_scripts(pilot_teacher).any?(&:pilot?)
-
-    levelbuilder_scripts = Script.valid_scripts(levelbuilder)
-    assert levelbuilder_scripts.any?(&:pilot?)
+    assert Script.valid_scripts(levelbuilder).any?(&:pilot?)
   end
 
   test "get_assessment_script_levels returns an empty list if no level groups" do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1552,8 +1552,7 @@ endvariants
   test 'has pilot access' do
     student = create :student
     teacher = create :teacher
-    pilot_teacher = create :teacher
-    create :single_user_experiment, min_user_id: pilot_teacher.id, name: 'my-experiment'
+    pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
     levelbuilder = create :levelbuilder
 
     script = create :script
@@ -1576,8 +1575,7 @@ endvariants
   test 'has any pilot access' do
     student = create :student
     teacher = create :teacher
-    pilot_teacher = create :teacher
-    create :single_user_experiment, min_user_id: pilot_teacher.id, name: 'my-experiment'
+    pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
     create :script, pilot_experiment: 'my-experiment'
     levelbuilder = create :levelbuilder
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1566,6 +1566,10 @@ endvariants
     pilot_section = create :section, user: pilot_teacher, script: pilot_script
     pilot_student = create(:follower, section: pilot_section).student_user
 
+    # teacher in a pilot teacher's section
+    teacher_in_section = create :teacher
+    create(:follower, section: pilot_section, student_user: teacher_in_section)
+
     # student in a section which was previously assigned to a pilot script
     other_pilot_section = create :section, user: pilot_teacher, script: pilot_script
     previous_student = create(:follower, section: other_pilot_section).student_user
@@ -1581,6 +1585,7 @@ endvariants
     refute script.has_pilot_access?(pilot_teacher)
     refute script.has_pilot_access?(unassigned_student)
     refute script.has_pilot_access?(pilot_student)
+    refute script.has_pilot_access?(teacher_in_section)
     refute script.has_pilot_access?(previous_student)
     refute script.has_pilot_access?(levelbuilder)
 
@@ -1591,6 +1596,7 @@ endvariants
     assert pilot_script.has_pilot_access?(pilot_teacher)
     refute pilot_script.has_pilot_access?(unassigned_student)
     assert pilot_script.has_pilot_access?(pilot_student)
+    assert pilot_script.has_pilot_access?(teacher_in_section)
     assert pilot_script.has_pilot_access?(previous_student)
     assert pilot_script.has_pilot_access?(levelbuilder)
   end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1566,6 +1566,12 @@ endvariants
     pilot_section = create :section, user: pilot_teacher, script: pilot_script
     pilot_student = create(:follower, section: pilot_section).student_user
 
+    # student in a section which was previously assigned to a pilot script
+    other_pilot_section = create :section, user: pilot_teacher, script: pilot_script
+    previous_student = create(:follower, section: other_pilot_section).student_user
+    other_pilot_section.script = nil
+    other_pilot_section.save!
+
     levelbuilder = create :levelbuilder
 
     refute script.pilot?
@@ -1575,6 +1581,7 @@ endvariants
     refute script.has_pilot_access?(pilot_teacher)
     refute script.has_pilot_access?(unassigned_student)
     refute script.has_pilot_access?(pilot_student)
+    refute script.has_pilot_access?(previous_student)
     refute script.has_pilot_access?(levelbuilder)
 
     assert pilot_script.pilot?
@@ -1584,6 +1591,7 @@ endvariants
     assert pilot_script.has_pilot_access?(pilot_teacher)
     refute pilot_script.has_pilot_access?(unassigned_student)
     assert pilot_script.has_pilot_access?(pilot_student)
+    assert pilot_script.has_pilot_access?(previous_student)
     assert pilot_script.has_pilot_access?(levelbuilder)
   end
 


### PR DESCRIPTION
### Background

https://codedotorg.atlassian.net/browse/LP-129

### Description

Teachers with the pilot experiment enabled can now access pilot scripts and see them in the dropdowns.

Students in sections can access pilot scripts in either of the following cases:

* (A) they belong to a section which is assigned to the pilot script, and whose teacher has the pilot experiment, or
* (B) they were previously assigned to the pilot script, and one of their teachers has the pilot experiment enabled

The result is that a pilot script can only be seen by a teacher with the pilot experiment enabled, or by a student they assign the pilot script to.