### PR TITLE
Update EmailPreference for migrated users

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -276,8 +276,6 @@ class RegistrationsController < Devise::RegistrationsController
       params[:user].delete(:current_password)
       current_user.update_without_password(set_email_params)
     end
-
-    true
   end
 
   def respond_to_account_update(successfully_updated, flash_message_kind = :updated)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -276,6 +276,8 @@ class RegistrationsController < Devise::RegistrationsController
       params[:user].delete(:current_password)
       current_user.update_without_password(set_email_params)
     end
+
+    true
   end
 
   def respond_to_account_update(successfully_updated, flash_message_kind = :updated)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -193,13 +193,13 @@ class RegistrationsController < Devise::RegistrationsController
           false
         elsif needs_password?(current_user, params)
           if current_user.valid_password?(params[:user][:current_password])
-            current_user.update_primary_contact_info(user: set_email_params)
+            current_user.update_primary_contact_info(new_email: set_email_params[:email], new_hashed_email: set_email_params[:hashed_email])
           else
             current_user.errors.add :current_password
             false
           end
         else
-          current_user.update_primary_contact_info(user: set_email_params)
+          current_user.update_primary_contact_info(new_email: set_email_params[:email], new_hashed_email: set_email_params[:hashed_email])
         end
       else
         if forbidden_change?(current_user, params)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -844,9 +844,8 @@ class User < ActiveRecord::Base
     end
   end
 
-  def update_primary_contact_info(user: {email: nil, hashed_email: nil})
-    new_email = user[:email]
-    new_hashed_email = new_email.present? ? User.hash_email(new_email) : user[:hashed_email]
+  def update_primary_contact_info(new_email: nil, new_hashed_email: nil)
+    new_hashed_email = new_email.present? ? User.hash_email(new_email) : new_hashed_email
 
     return false if new_email.nil? && new_hashed_email.nil?
     return false if teacher? && new_email.nil?
@@ -882,8 +881,8 @@ class User < ActiveRecord::Base
     success
   end
 
-  def update_primary_contact_info!(user: {email: nil, hashed_email: nil})
-    success = update_primary_contact_info(user: user)
+  def update_primary_contact_info!(new_email: nil, new_hashed_email: nil)
+    success = update_primary_contact_info(new_email: new_email, new_hashed_email: new_hashed_email)
     raise "User's primary contact info was not updated successfully" unless success
     success
   end
@@ -906,7 +905,7 @@ class User < ActiveRecord::Base
     hashed_email = params.delete(:hashed_email)
     should_update_contact_info = email.present? || hashed_email.present?
     transaction do
-      update_primary_contact_info!(user: {email: email, hashed_email: hashed_email}) if should_update_contact_info
+      update_primary_contact_info!(new_email: email, new_hashed_email: hashed_email) if should_update_contact_info
       update!(params)
     end
   rescue
@@ -936,7 +935,7 @@ class User < ActiveRecord::Base
     hashed_email = User.hash_email(email)
     self.user_type = TYPE_TEACHER
     transaction do
-      update_primary_contact_info!(user: {email: email, hashed_email: hashed_email})
+      update_primary_contact_info!(new_email: email, new_hashed_email: hashed_email)
       update!(email_preference)
     end
   rescue

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1898,13 +1898,13 @@ class UserTest < ActiveSupport::TestCase
 
   test 'update_primary_contact_info is false if email and hashed_email are nil' do
     user = create :user
-    successful_save = user.update_primary_contact_info(user: {email: nil, hashed_email: nil})
+    successful_save = user.update_primary_contact_info(new_email: nil, new_hashed_email: nil)
     refute successful_save
   end
 
   test 'update_primary_contact_info is false if email is nil for teacher' do
     teacher = create :teacher
-    successful_save = teacher.update_primary_contact_info(user: {email: nil})
+    successful_save = teacher.update_primary_contact_info(new_email: nil)
     refute successful_save
   end
 
@@ -1914,7 +1914,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, teacher.authentication_options.count
     refute_nil teacher.primary_contact_info
 
-    successful_save = teacher.update_primary_contact_info(user: {email: 'example@email.com'})
+    successful_save = teacher.update_primary_contact_info(new_email: 'example@email.com')
     teacher.reload
     assert successful_save
     assert_equal 2, teacher.authentication_options.count
@@ -1927,7 +1927,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, teacher.authentication_options.count
     refute_nil teacher.primary_contact_info
 
-    successful_save = teacher.update_primary_contact_info(user: {email: 'second@email.com'})
+    successful_save = teacher.update_primary_contact_info(new_email: 'second@email.com')
     teacher.reload
     assert successful_save
     assert_equal 1, teacher.authentication_options.count
@@ -1942,13 +1942,13 @@ class UserTest < ActiveSupport::TestCase
     refute_nil teacher.primary_contact_info
 
     # Update primary to a different email
-    teacher.update_primary_contact_info(user: {email: 'example@email.com'})
+    teacher.update_primary_contact_info(new_email: 'example@email.com')
     teacher.reload
     assert_equal 2, teacher.authentication_options.count
     assert_equal 'example@email.com', teacher.primary_contact_info.email
 
     # Change back to original oauth email
-    successful_save = teacher.update_primary_contact_info(user: {email: existing_email})
+    successful_save = teacher.update_primary_contact_info(new_email: existing_email)
     teacher.reload
     assert successful_save
     assert_equal 1, teacher.authentication_options.count
@@ -1961,7 +1961,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, teacher.authentication_options.count
     refute_nil teacher.primary_contact_info
 
-    successful_save = teacher.update_primary_contact_info(user: {email: 'first@email.com', hashed_email: User.hash_email('second@email.com')})
+    successful_save = teacher.update_primary_contact_info(new_email: 'first@email.com', new_hashed_email: User.hash_email('second@email.com'))
     assert successful_save
     assert_equal 1, teacher.authentication_options.count
     assert_equal User.hash_email('first@email.com'), teacher.primary_contact_info.hashed_email
@@ -1974,7 +1974,7 @@ class UserTest < ActiveSupport::TestCase
     refute_nil student.primary_contact_info
 
     hashed_new_email = User.hash_email('example@email.com')
-    successful_save = student.update_primary_contact_info(user: {hashed_email: hashed_new_email})
+    successful_save = student.update_primary_contact_info(new_hashed_email: hashed_new_email)
     student.reload
     assert successful_save
     assert_equal 2, student.authentication_options.count
@@ -1988,7 +1988,7 @@ class UserTest < ActiveSupport::TestCase
     refute_nil student.primary_contact_info
 
     hashed_new_email = User.hash_email('second@email.com')
-    successful_save = student.update_primary_contact_info(user: {hashed_email: hashed_new_email})
+    successful_save = student.update_primary_contact_info(new_hashed_email: hashed_new_email)
     student.reload
     assert successful_save
     assert_equal 1, student.authentication_options.count
@@ -2004,13 +2004,13 @@ class UserTest < ActiveSupport::TestCase
 
     # Update primary to a different email
     hashed_new_email = User.hash_email('example@email.com')
-    student.update_primary_contact_info(user: {hashed_email: hashed_new_email})
+    student.update_primary_contact_info(new_hashed_email: hashed_new_email)
     student.reload
     assert_equal 2, student.authentication_options.count
     assert_equal hashed_new_email, student.primary_contact_info.hashed_email
 
     # Change back to original oauth email
-    successful_save = student.update_primary_contact_info(user: {hashed_email: existing_hashed_email})
+    successful_save = student.update_primary_contact_info(new_hashed_email: existing_hashed_email)
     student.reload
     assert successful_save
     assert_equal 1, student.authentication_options.count
@@ -2023,7 +2023,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, student.authentication_options.count
     refute_nil student.primary_contact_info
 
-    successful_save = student.update_primary_contact_info(user: {email: 'first@email.com', hashed_email: User.hash_email('second@email.com')})
+    successful_save = student.update_primary_contact_info(new_email: 'first@email.com', new_hashed_email: User.hash_email('second@email.com'))
     assert successful_save
     assert_equal 1, student.authentication_options.count
     assert_equal User.hash_email('first@email.com'), student.primary_contact_info.hashed_email
@@ -2034,7 +2034,7 @@ class UserTest < ActiveSupport::TestCase
     create :student, email: taken_email
     update_primary_contact_info_fails_safely_for \
       create(:student_in_picture_section, :multi_auth_migrated),
-      user: {email: taken_email}
+      new_email: taken_email
   end
 
   test 'update_primary_contact_info fails safely if the new email is already taken for email user' do
@@ -2042,7 +2042,7 @@ class UserTest < ActiveSupport::TestCase
     create :student, email: taken_email
     update_primary_contact_info_fails_safely_for \
       create(:student, :with_migrated_email_authentication_option),
-      user: {email: taken_email}
+      new_email: taken_email
   end
 
   test 'update_primary_contact_info fails safely if the new email is already taken for oauth user' do
@@ -2050,7 +2050,7 @@ class UserTest < ActiveSupport::TestCase
     create :student, email: taken_email
     update_primary_contact_info_fails_safely_for \
       create(:student, :with_migrated_google_authentication_option),
-      user: {email: taken_email}
+      new_email: taken_email
   end
 
   def update_primary_contact_info_fails_safely_for(user, *params)


### PR DESCRIPTION
This was a subtle one!

Turns out, we only save new email preferences if the `email_preference_opt_in` attribute has been set on the User instance: https://github.com/code-dot-org/code-dot-org/blob/e39f8bbe0ed3d6d7b19b3d1f050c4ba8f91c01fe/dashboard/app/models/user.rb#L244

However! That attribute is not actually persisted to the User model, so if we update the user email without also setting that attribute on the instance, we will have a new email for our user, but without any associated EmailPreference.

This is exactly what was happening for migrated users; because we update just the contact info and not the user instance itself when updating email for migrated users, the changes to EmailPreference were not propagating.

The fix I have here is to tweak the signature of `update_primary_contact_info` to make it clear that it does not also update the user model, and to update the relevant controller route so that it makes sure to update the user model regardless of whether the user has been migrated or not. An alternative would be to move this logic out of the controller and onto the user model so that it can own more of the responsibility for managing its state.

I also want to add some validation to User to make sure all users that are supposed to have an EmailPreference do in fact have one, but I'd like to get y'all's thoughts on this change first. 