### PR TITLE
update mismatching link/image checker to consider the renamed instructions rather than the old naming scheme

### DIFF
--- a/bin/i18n/sync-codeorg-out.rb
+++ b/bin/i18n/sync-codeorg-out.rb
@@ -200,8 +200,8 @@ end
 
 def check_for_mismatching_links_or_images
   categories_to_check = %w(
-    instructions
-    markdown_instructions
+    short_instructions
+    long_instructions
     failure_message_overrides
     authored_hints
     callouts


### PR DESCRIPTION
We don't actively use this checker anymore, but it should still be looking at the right files until we replace it with something better