### PR TITLE
Add rb-readline to Gemfile to fix `pry` in :development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem 'rack-mini-profiler'
 group :development do
   gem 'annotate'
   gem 'pry'
+  gem 'rb-readline'
   gem 'ruby-progressbar', require: false
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -704,6 +704,7 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rb-readline (0.5.5)
     rdoc (4.2.2)
       json (~> 1.4)
     recaptcha (4.6.3)
@@ -1007,6 +1008,7 @@ DEPENDENCIES
   rails (~> 5.0.1)
   rails-controller-testing
   rambling-trie
+  rb-readline
   recaptcha
   redcarpet (~> 3.3.4)
   redis (~> 3.3.3)


### PR DESCRIPTION
I started getting this error this morning, with no apparent changes to my local environment:

![image](https://user-images.githubusercontent.com/413693/53434325-369d9a80-39ab-11e9-9d5c-c77c930902ac.png)

Adding `rb-readline` to our Gemfile seems to fix, but I'd like to better-understand what changed s.t. this is now required.