### PR TITLE
Fix teacher_application.feature

### DIFF
--- a/dashboard/test/ui/features/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/pd/teacher_application.feature
@@ -129,7 +129,7 @@ Scenario: Basic teacher application submission
 
   Then I press the first "input[name='committedToDiversity']" element
   Then I press the first "#understandFee" element
-  Then I press the first "input[name='payFee']" element
+  Then I press the first "input[name='payFee']" element if I see it
   Then I press the first "input[name='howHeard']" element
   Then I press the first "#confirmPrincipal" element
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -286,6 +286,10 @@ When /^I press the child number (.*) of class "([^"]*)"( to load a new page)?$/ 
   end
 end
 
+When /^I press the first "([^"]*)" element if I see it?$/ do |selector|
+  @browser.find_element(:css, selector)&.click
+end
+
 When /^I press the first "([^"]*)" element( to load a new page)?$/ do |selector, load|
   wait_short_until do
     @element = @browser.find_element(:css, selector)


### PR DESCRIPTION
This feature is passing on the test machine but failing on drone.

I believe this is because of a change in https://github.com/code-dot-org/code-dot-org/pull/27203 that made the `:pay_fee` field present and required _only if_ you were matched to a regional partner while filling out the application - which can happen or not, depending on the regional partner information present in your environment.  It's possible this information is present on test but not on drone.

A deeper fix might be to make sure we seed an appropriate regional partner fixture for this test on drone, but this workaround seems like it'll get us up and running faster.