### PR TITLE
Fix misc. teacher dashboard links in apps/

### DIFF
--- a/apps/src/code-studio/components/progress/StageLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/StageLockDialog.jsx
@@ -8,6 +8,7 @@ import {LockStatus, saveLockDialog} from '../../stageLockRedux';
 import color from '../../../util/color';
 import commonMsg from '@cdo/locale';
 import SectionSelector from './SectionSelector';
+import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 
 const styles = {
   main: {
@@ -115,12 +116,11 @@ class StageLockDialog extends React.Component {
   showAnswers = () => this.setAllLockStatus(LockStatus.ReadonlyAnswers);
 
   viewSection = () => {
-    window.open(
-      `${window.dashboard.CODE_ORG_URL}/teacher-dashboard#/sections/${
-        this.props.selectedSectionId
-      }/assessments`,
-      '_blank'
+    const assessmentsUrl = teacherDashboardUrl(
+      this.props.selectedSectionId,
+      '/assessments'
     );
+    window.open(assessmentsUrl, '_blank');
   };
 
   handleRadioChange = event => {

--- a/apps/src/templates/studioHomepages/SectionsAsStudentTable.jsx
+++ b/apps/src/templates/studioHomepages/SectionsAsStudentTable.jsx
@@ -7,7 +7,6 @@ import i18n from '@cdo/locale';
 import shapes from './shapes';
 import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 import Button from '@cdo/apps/templates/Button';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import {tableLayoutStyles} from '../tables/tableConstants';
 
 // When this table gets converted to reacttabular, it should also
@@ -126,13 +125,6 @@ class SectionsAsStudentTable extends React.Component {
         sectionCode
       );
     });
-  }
-
-  sectionHref(section) {
-    if (section.numberOfStudents === 0) {
-      return pegasus(`/teacher-dashboard#/sections/${section.id}/manage`);
-    }
-    return section.linkToProgress;
   }
 
   render() {

--- a/apps/src/templates/teacherDashboard/urlHelpers.js
+++ b/apps/src/templates/teacherDashboard/urlHelpers.js
@@ -16,7 +16,9 @@ const urlMap = {
 
 /**
  * Returns the URL in teacher dashboard given a section id and (optional) path.
- * If providing a path, it *must* be the path as it appears in the pegasus teacher dashboard.
+ * If providing a path, it *must*:
+ * 1. be prepended with a forward slash (i.e., /path), and
+ * 2. be the path as it appears in the pegasus teacher dashboard.
  */
 export const teacherDashboardUrl = (sectionId, path = '') => {
   const isDashboard = experiments.isEnabled(


### PR DESCRIPTION
**Note: Change base back to staging before merging!**

Slowly cleaning up links that reference the old teacher dashboard in `apps/`. 

Going to do a follow-up for links referencing the old teacher dashboard in `dashboard/` as well.