### PR TITLE
Teacher Application: Fixup old applications with new "Pay fee" question changes

### DIFF
--- a/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
+++ b/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
@@ -11,8 +11,8 @@ Pd::Application::Teacher1920Application.find_each do |application|
   
   if hash[:pay_fee] == 'Yes, my school or I will be able to pay the full program fee.'
     hash[:pay_fee] = 'Yes, my school will be able to pay the full program fee.'
-  elsif hash[:pay_fee] == 'Yes, my school or I will be able to pay the full program fee.'
-    hash[:pay_fee] = 'Yes, my school will be able to pay the full program fee.'
+  elsif hash[:pay_fee] == 'No, my school or I will not be able to pay the program fee. I would like to be considered for a scholarship.'
+    hash[:pay_fee] = 'No, my school will not be able to pay the program fee. I would like to be considered for a scholarship.'
   elsif hash[:pay_fee] == 'Not applicable: there is no program fee for teachers in my region.'
     hash.delete :pay_fee
   elsif hash[:pay_fee] == 'Not applicable: there is no Regional Partner in my region.'

--- a/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
+++ b/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
@@ -7,8 +7,8 @@ errors = []
 puts "Backfilling :pay_fee question changes..."
 Pd::Application::Teacher1920Application.find_each do |application|
   print '.'
-  pay_fee = application.form_data_hash[:pay_fee]
-  
+  pay_fee = application.form_data_hash["payFee"]
+
   if pay_fee == 'Yes, my school or I will be able to pay the full program fee.'
     new_pay_fee = 'Yes, my school will be able to pay the full program fee.'
   elsif pay_fee == 'No, my school or I will not be able to pay the program fee. I would like to be considered for a scholarship.'
@@ -20,8 +20,8 @@ Pd::Application::Teacher1920Application.find_each do |application|
   else
     next
   end
-  
-  application.update_form_data_hash(pay_fee: new_pay_fee)
+
+  application.update_form_data_hash({"payFee": new_pay_fee})
   if application.save
     total_updated += 1
   else
@@ -31,4 +31,4 @@ end
 
 errors.each {|e| puts e}
 
-puts "\nSuccessfully updated scholarship info for #{total_updated} applications, with ${errors.count} errors."
+puts "\nSuccessfully updated scholarship info for #{total_updated} applications, with #{errors.count} errors."

--- a/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
+++ b/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../dashboard/config/environment'
+
+total_updated = 0
+errors = []
+puts "Backfilling :pay_fee question changes..."
+Pd::Application::Teacher1920Application.find_each do |application|
+  print '.'
+  hash = application.form_data_hash
+  
+  if hash[:pay_fee] == 'Yes, my school or I will be able to pay the full program fee.'
+    hash[:pay_fee] = 'Yes, my school will be able to pay the full program fee.'
+  elsif hash[:pay_fee] == 'Yes, my school or I will be able to pay the full program fee.'
+    hash[:pay_fee] = 'Yes, my school will be able to pay the full program fee.'
+  elsif hash[:pay_fee] == 'Not applicable: there is no program fee for teachers in my region.'
+    hash.delete :pay_fee
+  elsif hash[:pay_fee] == 'Not applicable: there is no Regional Partner in my region.'
+    hash.delete :pay_fee
+  else
+    next
+  end
+  
+  if application.update_column :form_data, hash.to_json
+    total_updated += 1
+  else
+    errors << "\nError: Application #{application.id} with value #{hash[:pay_fee].inspect} couldn't be updated"
+  end
+end
+
+errors.each {|e| puts e}
+
+puts "\nSuccessfully updated scholarship info for #{total_updated} applications, with ${errors.count} errors."

--- a/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
+++ b/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
@@ -7,24 +7,25 @@ errors = []
 puts "Backfilling :pay_fee question changes..."
 Pd::Application::Teacher1920Application.find_each do |application|
   print '.'
-  hash = application.form_data_hash
+  pay_fee = application.form_data_hash[:pay_fee]
   
-  if hash[:pay_fee] == 'Yes, my school or I will be able to pay the full program fee.'
-    hash[:pay_fee] = 'Yes, my school will be able to pay the full program fee.'
-  elsif hash[:pay_fee] == 'No, my school or I will not be able to pay the program fee. I would like to be considered for a scholarship.'
-    hash[:pay_fee] = 'No, my school will not be able to pay the program fee. I would like to be considered for a scholarship.'
-  elsif hash[:pay_fee] == 'Not applicable: there is no program fee for teachers in my region.'
-    hash.delete :pay_fee
-  elsif hash[:pay_fee] == 'Not applicable: there is no Regional Partner in my region.'
-    hash.delete :pay_fee
+  if pay_fee == 'Yes, my school or I will be able to pay the full program fee.'
+    new_pay_fee = 'Yes, my school will be able to pay the full program fee.'
+  elsif pay_fee == 'No, my school or I will not be able to pay the program fee. I would like to be considered for a scholarship.'
+    new_pay_fee = 'No, my school will not be able to pay the program fee. I would like to be considered for a scholarship.'
+  elsif pay_fee == 'Not applicable: there is no program fee for teachers in my region.'
+    new_pay_fee = nil
+  elsif pay_fee == 'Not applicable: there is no Regional Partner in my region.'
+    new_pay_fee = nil
   else
     next
   end
   
-  if application.update_column :form_data, hash.to_json
+  application.update_form_data_hash(pay_fee: new_pay_fee)
+  if application.save
     total_updated += 1
   else
-    errors << "\nError: Application #{application.id} with value #{hash[:pay_fee].inspect} couldn't be updated"
+    errors << "\nError: Application #{application.id} with value #{pay_fee.inspect} couldn't be updated"
   end
 end
 

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -269,10 +269,6 @@ module Pd::Application
           end
         end
 
-        if hash[:regional_partner_id].present?
-          required << :pay_fee
-        end
-
         if hash[:pay_fee] == TEXT_FIELDS[:no_pay_fee_1920]
           required << :scholarship_reasons
         end

--- a/dashboard/test/models/pd/application/teacher1920_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher1920_application_test.rb
@@ -479,23 +479,15 @@ module Pd::Application
       assert_equal %w(completingOnBehalfOfName travelToAnotherWorkshop scholarshipReasons), application.errors.messages[:form_data]
     end
 
-    test 'requires pay_fee if regional_partner_id is present' do
+    # We changed the possible answers to this question after opening the application,
+    # including removing some possible answers.  Since we can't reasonably backfill those,
+    # we are clearing them and making this field not required on the server (it's still
+    # required on the client for new applications).
+    test 'does not require pay_fee' do
       application_hash = build :pd_teacher1920_application_hash,
         regional_partner_id: create(:regional_partner).id,
         pay_fee: nil
       application = build :pd_teacher1920_application, form_data_hash: application_hash
-      refute_nil application.sanitize_form_data_hash[:regional_partner_id]
-      assert_nil application.sanitize_form_data_hash[:pay_fee]
-      refute application.valid?
-      assert_equal %w(payFee), application.errors.messages[:form_data]
-    end
-
-    test 'does not require pay_fee if regional_partner_id is not present' do
-      application_hash = build :pd_teacher1920_application_hash,
-        regional_partner_id: nil,
-        pay_fee: nil
-      application = build :pd_teacher1920_application, form_data_hash: application_hash
-      assert_nil application.sanitize_form_data_hash[:regional_partner_id]
       assert_nil application.sanitize_form_data_hash[:pay_fee]
       assert application.valid?
       assert_equal %w(), application.errors.messages[:form_data]


### PR DESCRIPTION
In https://github.com/code-dot-org/code-dot-org/pull/27203 I changed the possible answers to a teacher application question.  I failed to consider that these changes would make _existing_ application records invalid, and did not know that we depend on the ability to update these records later, after the principal approves them.  We learned about the issue through [this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/46241523#notice-summary).

The possible answers to that question changed like this:

| Before | After |
| --- | --- |
| Yes, my school or I will be able to pay the full program fee. | Yes, my school will be able to pay the full program fee. |
| No, my school or I will not be able to pay the program fee. I would like to be considered for a scholarship. | No, my school will not be able to pay the program fee. I would like to be considered for a scholarship. |
| Not applicable: there is no program fee for teachers in my region. | _Removed_ |
| Not applicable: there is no Regional Partner in my region. | _Removed_ |
| I don't know. | I don't know. |

Our fix for this issue has two parts:

1. Backfill script
   We are running a script to update previous teacher applications so that their answers match the new set of available answers.
   - For the first two answers, where we simply removed the "or I" from the answer, we are updating the answer text (and assuming the basic meaning of the answer is the same).
  - For the removed answers, we are simply clearing the field rather than try to coerce to one of the first two answers and risk answering incorrectly on behalf of a teacher.

2. Question no longer required on the server
   Because the above backfill leaves some applications with no answer to a conditionally-required question, we are removing the required-ness of this question on the server to bring all applications back into a valid state.  The question is still required on the client for new applications.

This PR includes a script for (1) and the code changes for (2).  We'll ship them together and then manually run the script on production.