### PR TITLE
Set font dropdown initial value to element's current font

### DIFF
--- a/apps/src/applab/designElements/button.jsx
+++ b/apps/src/applab/designElements/button.jsx
@@ -101,7 +101,7 @@ class ButtonProperties extends React.Component {
         />
         <FontFamilyPropertyRow
           initialValue={designMode.fontFamilyOptionFromStyle(
-            element.style.fontSize
+            element.style.fontFamily
           )}
           handleChange={this.props.handleChange.bind(this, 'fontFamily')}
         />

--- a/apps/src/applab/designElements/dropdown.jsx
+++ b/apps/src/applab/designElements/dropdown.jsx
@@ -81,7 +81,7 @@ class DropdownProperties extends React.Component {
         />
         <FontFamilyPropertyRow
           initialValue={designMode.fontFamilyOptionFromStyle(
-            element.style.fontSize
+            element.style.fontFamily
           )}
           handleChange={this.props.handleChange.bind(this, 'fontFamily')}
         />

--- a/apps/src/applab/designElements/label.jsx
+++ b/apps/src/applab/designElements/label.jsx
@@ -82,7 +82,7 @@ class LabelProperties extends React.Component {
         />
         <FontFamilyPropertyRow
           initialValue={designMode.fontFamilyOptionFromStyle(
-            element.style.fontSize
+            element.style.fontFamily
           )}
           handleChange={this.props.handleChange.bind(this, 'fontFamily')}
         />

--- a/apps/src/applab/designElements/textInput.jsx
+++ b/apps/src/applab/designElements/textInput.jsx
@@ -73,7 +73,7 @@ class TextInputProperties extends React.Component {
         />
         <FontFamilyPropertyRow
           initialValue={designMode.fontFamilyOptionFromStyle(
-            element.style.fontSize
+            element.style.fontFamily
           )}
           handleChange={this.props.handleChange.bind(this, 'fontFamily')}
         />

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -83,7 +83,7 @@ class TextAreaProperties extends React.Component {
         />
         <FontFamilyPropertyRow
           initialValue={designMode.fontFamilyOptionFromStyle(
-            element.style.fontSize
+            element.style.fontFamily
           )}
           handleChange={this.props.handleChange.bind(this, 'fontFamily')}
         />


### PR DESCRIPTION
It was previously trying to use the element's size, not font family, to set the initial value, so it was always falling back to the default font (Arial)