### PR TITLE
add script to backfill data

### DIFF
--- a/bin/oneoff/backfill_data/user_school_infos_backfill
+++ b/bin/oneoff/backfill_data/user_school_infos_backfill
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../dashboard/config/environment'
+
+num_users_updated = 0
+batch_size = 10000
+
+User.where.not(school_info: nil).find_in_batches(batch_size: batch_size) do |batch|
+  ActiveRecord::Base.transaction do
+    batch.each do |user|
+    puts "Processing #{num_users_updated}...."
+      UserSchoolInfo.create!(
+        user_id: user.id,
+        school_info_id: user.school_info_id,
+        start_date: user.created_at,
+        end_date: nil,
+        last_confirmation_date: user.created_at
+      )
+      num_users_updated += 1
+    end
+  end
+end
+
+# Output how many total users were updated.
+puts "\nFinished updating #{num_users_updated} users school information."
+
+

--- a/bin/oneoff/backfill_data/user_school_infos_backfill
+++ b/bin/oneoff/backfill_data/user_school_infos_backfill
@@ -7,7 +7,7 @@ batch_size = 10000
 
 puts "Processing..."
 
-User.where(user_type: "teacher", school_info: !nil).find_in_batches(batch_size: batch_size) do |batch|
+User.where.not(school_info: nil).where(user_type: "teacher").find_in_batches(batch_size: batch_size) do |batch|
   ActiveRecord::Base.transaction do
     batch.each do |user|
       UserSchoolInfo.create!(

--- a/bin/oneoff/backfill_data/user_school_infos_backfill
+++ b/bin/oneoff/backfill_data/user_school_infos_backfill
@@ -5,10 +5,11 @@ require_relative '../../../dashboard/config/environment'
 num_users_updated = 0
 batch_size = 10000
 
-User.where.not(school_info: nil).find_in_batches(batch_size: batch_size) do |batch|
+puts "Processing..."
+
+User.where(user_type: "teacher", school_info: !nil).find_in_batches(batch_size: batch_size) do |batch|
   ActiveRecord::Base.transaction do
     batch.each do |user|
-    puts "Processing #{num_users_updated}...."
       UserSchoolInfo.create!(
         user_id: user.id,
         school_info_id: user.school_info_id,
@@ -23,5 +24,3 @@ end
 
 # Output how many total users were updated.
 puts "\nFinished updating #{num_users_updated} users school information."
-
-


### PR DESCRIPTION
This PR migrates data from the users table onto the user_school_infos table.  The user_school_infos table will store the full history of schools the teacher has provided to preserve historical data.

After this PR reaches all environments, I will check to see if any new teacher accounts were created that were not captured in this migration.  

LOCAL TESTING:
- [x] Confirm that the new table is only populated with users that are teachers and have school info
- [X] Confirm rollback when there is an error
