### PR TITLE
Fix StageLockDialog unit test

### DIFF
--- a/apps/test/unit/code-studio/components/progress/StageLockDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/StageLockDialogTest.jsx
@@ -120,9 +120,7 @@ describe('StageLockDialog', () => {
 
       wrapper.instance().viewSection();
       expect(window.open).to.have.been.calledOnce.and.calledWith(
-        `${
-          window.dashboard.CODE_ORG_URL
-        }/teacher-dashboard#/sections/fakeSectionId/assessments`
+        '/teacher-dashboard#/sections/fakeSectionId/assessments'
       );
     });
   });


### PR DESCRIPTION
I broke a unit test for the `StageLockDialog` component in #27258, which looks like it didn't get caught because drone.io never ran on that branch and I didn't pay close enough attention when I merged 😢 thankfully, it was a very small PR, but I'll be more careful in the future!