### PR TITLE
student without pilot access sees student homepage on login

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -93,7 +93,7 @@ class HomeController < ApplicationController
   def should_redirect_to_script_overview?
     current_user.student? &&
     !account_takeover_in_progress? &&
-    current_user.most_recently_assigned_user_script &&
+    current_user.can_access_most_recently_assigned_script? &&
     (
       !current_user.user_script_with_most_recent_progress ||
       current_user.most_recent_progress_in_recently_assigned_script? ||

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1509,6 +1509,12 @@ class User < ActiveRecord::Base
     most_recently_assigned_user_script.script
   end
 
+  def can_access_most_recently_assigned_script?
+    return false unless script = most_recently_assigned_user_script&.script
+
+    !script.pilot? || script.has_pilot_access?(self)
+  end
+
   def user_script_with_most_recent_progress
     user_scripts.
     where("last_progress_at").

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -121,6 +121,27 @@ class HomeControllerTest < ActionController::TestCase
     assert_redirected_to script_path(script)
   end
 
+  test "student without pilot access will go to index" do
+    pilot_script = create :script, pilot_experiment: 'pilot-experiment'
+    section = create :section, script: pilot_script
+    student = create(:follower, section: section).student_user
+    sign_in student
+    get :index
+
+    assert_redirected_to '/home'
+  end
+
+  test "student with pilot access will go to pilot script" do
+    pilot_script = create :script, pilot_experiment: 'pilot-experiment'
+    pilot_teacher = create :teacher, pilot_experiment: 'pilot-experiment'
+    section = create :section, script: pilot_script, user: pilot_teacher
+    student = create(:follower, section: section).student_user
+    sign_in student
+    get :index
+
+    assert_redirected_to script_path(pilot_script)
+  end
+
   test "student with assigned course or script during account takeover will go to index" do
     student = create :student
     script = create :script


### PR DESCRIPTION
### Background

Addresses the mandatory parts of [LP-159](https://codedotorg.atlassian.net/browse/LP-159), needed to launch the hiding of pilot scripts.

### Description

If a student's most recently assigned script is a pilot script which they do not have access to, just send them to the home page instead of to that script. 