### PR TITLE
Use school zip code for regional partner lookup link

### DIFF
--- a/apps/src/code-studio/pd/application/teacher1920/Section3TeachingBackground.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section3TeachingBackground.jsx
@@ -36,8 +36,20 @@ export default class Section3TeachingBackground extends LabeledFormComponent {
     'currentRole'
   ];
 
-  handleSchoolChange = selectedSchool =>
-    this.handleChange({school: selectedSchool && selectedSchool.value});
+  handleSchoolChange = selectedSchool => {
+    console.log(
+      `selectedSchool.school.zip = ${selectedSchool && selectedSchool.value}`
+    );
+    console.log(
+      `selectedSchool = ${selectedSchool && JSON.stringify(selectedSchool)}`
+    );
+
+    this.handleChange({
+      school: selectedSchool && selectedSchool.value,
+      schoolZipCode:
+        selectedSchool && selectedSchool.school && selectedSchool.school.zip
+    });
+  };
 
   render() {
     return (

--- a/apps/src/code-studio/pd/application/teacher1920/Section3TeachingBackground.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section3TeachingBackground.jsx
@@ -37,13 +37,6 @@ export default class Section3TeachingBackground extends LabeledFormComponent {
   ];
 
   handleSchoolChange = selectedSchool => {
-    console.log(
-      `selectedSchool.school.zip = ${selectedSchool && selectedSchool.value}`
-    );
-    console.log(
-      `selectedSchool = ${selectedSchool && JSON.stringify(selectedSchool)}`
-    );
-
     this.handleChange({
       school: selectedSchool && selectedSchool.value,
       schoolZipCode:

--- a/apps/src/code-studio/pd/application/teacher1920/Section4ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section4ProfessionalLearningProgramRequirements.jsx
@@ -284,8 +284,8 @@ export default class Section4SummerWorkshop extends LabeledFormComponent {
                 <a
                   href={
                     'https://code.org/educate/professional-learning/program-information' +
-                    (!!this.props.data.zipCode
-                      ? '?zip=' + this.props.data.zipCode
+                    (!!this.props.data.schoolZipCode
+                      ? '?zip=' + this.props.data.schoolZipCode
                       : '')
                   }
                   target="_blank"


### PR DESCRIPTION
Use user's school zip code instead of home zip code to look up corresponding regional partner.
This is a continuation of [PR 27239](https://github.com/code-dot-org/code-dot-org/pull/27239). 