### PR TITLE
Allow match levels in level groups

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2032,9 +2032,17 @@ a.download-video {
   transform: translateY($offset);
 }
 
+/* overrides .unplugged for match levels in level groups */
+.level-group-content .unplugged.match {
+  width: auto;
+}
+
 .match {
   .mainblock {
     margin-left: 0;
+    .level-group-content & {
+      margin-left: 50px;
+    }
   }
   .column {
     width: 260px;
@@ -2098,6 +2106,12 @@ a.download-video {
     }
     .active.emptyslot {
       background-color: $lighter_yellow;
+    }
+  }
+  .question {
+    p {
+      font-size: 16px;
+      line-height: 24px;
     }
   }
   .answer {
@@ -2247,6 +2261,9 @@ a.download-video {
     background-color: $lightest_cyan;
     border-radius: 5px;
     margin: 10px auto;
+    .level-group-content & {
+      margin-left: 50px;
+    }
     .content {
       padding: 10px;
     }

--- a/dashboard/app/dsl/level_group_dsl.rb
+++ b/dashboard/app/dsl/level_group_dsl.rb
@@ -61,7 +61,7 @@ class LevelGroupDSL < BaseDSL
       raise "User uploads aren't supported in a LevelGroup (due to global channel) '#{name}'"
     end
     level_class = level.class.to_s.underscore
-    unless %w(multi text_match free_response evaluation_multi).include? level_class
+    unless %w(multi match text_match free_response evaluation_multi).include? level_class
       raise "LevelGroup cannot contain level type #{level_class}"
     end
 

--- a/dashboard/app/views/levels/_level_group.haml
+++ b/dashboard/app/views/levels/_level_group.haml
@@ -69,6 +69,8 @@
               = render partial: 'levels/single_text_match', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt }
             - elsif level_class == "free_response"
               = render partial: 'levels/free_response', locals: {in_level_group: true, level: level, last_attempt: sublevel_last_attempt}
+            - elsif level_class == "match"
+              = render partial: 'levels/single_match', locals: {standalone: false, level: level}
 
         - unless @script_level.nil?
           = render partial: 'levels/dialog', locals: {app: app, previous_button: page.page_number > 1, next_button: page.page_number < @total_page_count}

--- a/dashboard/app/views/levels/_match.html.haml
+++ b/dashboard/app/views/levels/_match.html.haml
@@ -1,6 +1,6 @@
 - content_for(:head) do
   %script{src: minifiable_asset_path('js/levels/_match.js')}
 
-= render partial: 'levels/single_match', locals: {level: @level}
+= render partial: 'levels/single_match', locals: {standalone: true, level: @level}
 
 = render partial: 'levels/common_audio'

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -3,7 +3,13 @@
   - data = level.properties
   - app = 'match'
 
-  = render partial: 'levels/content', locals: {app: app, data: data}
+  - question_content_blank = data['content1'].blank? && data['content2'].blank? && data['content3'].blank? && data['markdown'].blank?
+  - if question_content_blank
+    - question_content_class = nil
+  - else
+    - question_content_class = "question"
+
+  = render partial: 'levels/content', locals: {app: app, data: data, content_class: question_content_class, source_level: level, hide_header: !standalone}
 
   - if standalone && !(data['options'].try(:[], 'hide_submit'))
     .buttons

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -1,6 +1,6 @@
 .unplugged.match
 
-  - data = @level.properties
+  - data = level.properties
   - app = 'match'
 
   = render partial: 'levels/content', locals: {app: app, data: data}

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -5,7 +5,7 @@
 
   = render partial: 'levels/content', locals: {app: app, data: data}
 
-  - unless !!(data['options'].try(:[], 'hide_submit'))
+  - if standalone && !(data['options'].try(:[], 'hide_submit'))
     .buttons
       %a.btn.btn-large.btn-primary.next-stage.submitButton
         =t('submit')
@@ -54,6 +54,7 @@
           %li.answer.answerlist{style: "height: #{height}px", originalIndex: answer['index']}!= match_t(answer['text'])
 
     .clear
-  = render partial: 'levels/dialog', locals: {app: app}
+  - if standalone
+    = render partial: 'levels/dialog', locals: {app: app}
   = render partial: 'levels/match_answer', locals: {data: data, height: height}
   = render partial: 'levels/teacher_markdown', locals: {data: data}


### PR DESCRIPTION
### Background

* work item: https://codedotorg.atlassian.net/browse/LP-21
* previous PR: https://github.com/code-dot-org/code-dot-org/pull/27272
* related PR from long ago: https://github.com/code-dot-org/code-dot-org/pull/6920

per conversation with curriculum, we're ok with this just _displaying_ match levels for now, even though they cannot yet be dragged and answers cannot be submitted. This will let curriculum start building out new assessment levels while I'm away on vacation next week.

### Description

* Allow match levels in level groups
* fix styling to left-align content and show correct font size

### Screenshots

| student | teacher  |
|---------|----------|
|    ![localhost-studio code org_3000_s_csp-pre-survey_stage_2_puzzle_1_page_1 1](https://user-images.githubusercontent.com/8001765/53547101-fd684600-3ae2-11e9-9f65-4698d9d4f238.png) |     ![localhost-studio code org_3000_levels_6908_show_callouts 1](https://user-images.githubusercontent.com/8001765/53547173-2a1c5d80-3ae3-11e9-97a2-77b80f660963.png) |
