### PR TITLE
Make match levels draggable within level groups

### DIFF
--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -10,7 +10,7 @@ jQuery.fn.swap = function(b) {
   return this;
 };
 
-export function initMatch() {
+export function initMatch(enableSounds = false) {
   $('.mainblock #answers li').draggable({revert: 'invalid', stack: '.answer'});
 
   // set up the central list of empty slots.
@@ -19,7 +19,9 @@ export function initMatch() {
     hoverClass: 'hover',
     accept: '.answerlist,.answerslot',
     drop: function(event, ui) {
-      CDOSounds.play('click');
+      if (enableSounds) {
+        CDOSounds.play('click');
+      }
       // once an answer is in the central list of slots, it will just swap with whatever it's dragged onto
       if (ui.draggable.hasClass('answerslot')) {
         // swap this empty slot and the answer dragged onto it
@@ -53,7 +55,9 @@ export function initMatch() {
           accept: '.answerslot',
           activeClass: 'active',
           drop: function(event, ui) {
-            CDOSounds.play('whoosh');
+            if (enableSounds) {
+              CDOSounds.play('whoosh');
+            }
 
             // remove offset coordinates from the dragged item
             ui.draggable.css({top: '0px', left: '0px'});

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -10,6 +10,12 @@ jQuery.fn.swap = function(b) {
   return this;
 };
 
+// Initialize drag and drop for all match elements (answers and slots) within
+// the container. Answers are made draggable and slots are made droppable. The
+// container limits this as follows:
+//   * only elements within the container are marked draggable / droppable
+//   * answers are only droppable on slots within the same container
+//   * answers cannot be dragged outside of the container.
 export function initMatch(container, enableSounds = false) {
   $(container)
     .find('.mainblock #answers li')

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -1,0 +1,79 @@
+/* global jQuery, CDOSounds */
+jQuery.fn.swap = function(b) {
+  // method from: http://blog.pengoworks.com/index.cfm/2008/9/24/A-quick-and-dirty-swap-method-for-jQuery
+  b = jQuery(b)[0];
+  var a = this[0];
+  var t = a.parentNode.insertBefore(document.createTextNode(''), a);
+  b.parentNode.insertBefore(a, b);
+  t.parentNode.insertBefore(b, t);
+  t.parentNode.removeChild(t);
+  return this;
+};
+
+export function initMatch() {
+  $('.mainblock #answers li').draggable({revert: 'invalid', stack: '.answer'});
+
+  // set up the central list of empty slots.
+  $('.mainblock #slots li').droppable({
+    activeClass: 'active',
+    hoverClass: 'hover',
+    accept: '.answerlist,.answerslot',
+    drop: function(event, ui) {
+      CDOSounds.play('click');
+      // once an answer is in the central list of slots, it will just swap with whatever it's dragged onto
+      if (ui.draggable.hasClass('answerslot')) {
+        // swap this empty slot and the answer dragged onto it
+        ui.draggable.swap(event.target);
+
+        // remove offset coordinates from this item
+        ui.draggable.css({top: 'auto', left: 'auto'});
+      } else {
+        // when an answer is in the rightmost list of answers, it can be dragged in to replace an empty slot
+        // in the central list of slots.
+
+        var movingItem = ui.draggable.detach();
+
+        // replace target with this new item
+        $(event.target).replaceWith(movingItem);
+
+        // the new item is now droppable
+        movingItem.droppable();
+
+        // remove offset coordinates from the dragged item
+        movingItem.css({top: 'auto', left: 'auto'});
+
+        // this class is no longer in the answer list
+        movingItem.removeClass('answerlist');
+
+        // this class can now be both dragged and a drop target for fellow answers in slots
+        movingItem.addClass('answerslot');
+
+        // this new item can now be dropped onto by other answers in the central list
+        movingItem.droppable({
+          accept: '.answerslot',
+          activeClass: 'active',
+          drop: function(event, ui) {
+            CDOSounds.play('whoosh');
+
+            // remove offset coordinates from the dragged item
+            ui.draggable.css({top: '0px', left: '0px'});
+
+            // determine y difference between old location and new location of item that will be swapped out
+            var origY = $(event.target).offset().top;
+            var destY = $(ui.draggable).offset().top;
+            var diffY = destY - origY;
+
+            // swap this answer with the answer dropped onto it
+            ui.draggable.swap(event.target);
+
+            // move the target object back to its old location for a moment
+            $(event.target).css({top: -diffY + 'px'});
+
+            // and animate back to its new location
+            $(event.target).animate({top: '0px'});
+          }
+        });
+      }
+    }
+  });
+}

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -10,74 +10,80 @@ jQuery.fn.swap = function(b) {
   return this;
 };
 
-export function initMatch(enableSounds = false) {
-  $('.mainblock #answers li').draggable({revert: 'invalid', stack: '.answer'});
+export function initMatch(container, enableSounds = false) {
+  $(container)
+    .find('.mainblock #answers li')
+    .draggable({revert: 'invalid', stack: '.answer', containment: container});
 
   // set up the central list of empty slots.
-  $('.mainblock #slots li').droppable({
-    activeClass: 'active',
-    hoverClass: 'hover',
-    accept: '.answerlist,.answerslot',
-    drop: function(event, ui) {
-      if (enableSounds) {
-        CDOSounds.play('click');
-      }
-      // once an answer is in the central list of slots, it will just swap with whatever it's dragged onto
-      if (ui.draggable.hasClass('answerslot')) {
-        // swap this empty slot and the answer dragged onto it
-        ui.draggable.swap(event.target);
+  $(container)
+    .find('.mainblock #slots li')
+    .droppable({
+      activeClass: 'active',
+      hoverClass: 'hover',
+      accept: element =>
+        $(element).is('.answerlist,.answerslot') &&
+        $(container).find(element[0]).length,
+      drop: function(event, ui) {
+        if (enableSounds) {
+          CDOSounds.play('click');
+        }
+        // once an answer is in the central list of slots, it will just swap with whatever it's dragged onto
+        if (ui.draggable.hasClass('answerslot')) {
+          // swap this empty slot and the answer dragged onto it
+          ui.draggable.swap(event.target);
 
-        // remove offset coordinates from this item
-        ui.draggable.css({top: 'auto', left: 'auto'});
-      } else {
-        // when an answer is in the rightmost list of answers, it can be dragged in to replace an empty slot
-        // in the central list of slots.
+          // remove offset coordinates from this item
+          ui.draggable.css({top: 'auto', left: 'auto'});
+        } else {
+          // when an answer is in the rightmost list of answers, it can be dragged in to replace an empty slot
+          // in the central list of slots.
 
-        var movingItem = ui.draggable.detach();
+          var movingItem = ui.draggable.detach();
 
-        // replace target with this new item
-        $(event.target).replaceWith(movingItem);
+          // replace target with this new item
+          $(event.target).replaceWith(movingItem);
 
-        // the new item is now droppable
-        movingItem.droppable();
+          // the new item is now droppable
+          movingItem.droppable();
 
-        // remove offset coordinates from the dragged item
-        movingItem.css({top: 'auto', left: 'auto'});
+          // remove offset coordinates from the dragged item
+          movingItem.css({top: 'auto', left: 'auto'});
 
-        // this class is no longer in the answer list
-        movingItem.removeClass('answerlist');
+          // this class is no longer in the answer list
+          movingItem.removeClass('answerlist');
 
-        // this class can now be both dragged and a drop target for fellow answers in slots
-        movingItem.addClass('answerslot');
+          // this class can now be both dragged and a drop target for fellow answers in slots
+          movingItem.addClass('answerslot');
 
-        // this new item can now be dropped onto by other answers in the central list
-        movingItem.droppable({
-          accept: '.answerslot',
-          activeClass: 'active',
-          drop: function(event, ui) {
-            if (enableSounds) {
-              CDOSounds.play('whoosh');
+          // this new item can now be dropped onto by other answers in the central list
+          movingItem.droppable({
+            accept: '.answerslot',
+            activeClass: 'active',
+            drop: function(event, ui) {
+              if (enableSounds) {
+                CDOSounds.play('whoosh');
+              }
+
+              // remove offset coordinates from the dragged item
+              ui.draggable.css({top: '0px', left: '0px'});
+
+              // determine y difference between old location and new location of item that will be swapped out
+              var origY = $(event.target).offset().top;
+              var destY = $(ui.draggable).offset().top;
+              var diffY = destY - origY;
+
+              // swap this answer with the answer dropped onto it
+              ui.draggable.swap(event.target);
+
+              // move the target object back to its old location for a moment
+              $(event.target).css({top: -diffY + 'px'});
+
+              // and animate back to its new location
+              $(event.target).animate({top: '0px'});
             }
-
-            // remove offset coordinates from the dragged item
-            ui.draggable.css({top: '0px', left: '0px'});
-
-            // determine y difference between old location and new location of item that will be swapped out
-            var origY = $(event.target).offset().top;
-            var destY = $(ui.draggable).offset().top;
-            var diffY = destY - origY;
-
-            // swap this answer with the answer dropped onto it
-            ui.draggable.swap(event.target);
-
-            // move the target object back to its old location for a moment
-            $(event.target).css({top: -diffY + 'px'});
-
-            // and animate back to its new location
-            $(event.target).animate({top: '0px'});
-          }
-        });
+          });
+        }
       }
-    }
-  });
+    });
 }

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -7,6 +7,7 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 import * as codeStudioLevels from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {SingleLevelGroupDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
 import i18n from '@cdo/locale';
+import {initMatch} from '@cdo/apps/code-studio/levels/match';
 
 window.Multi = require('@cdo/apps/code-studio/levels/multi.js');
 window.TextMatch = require('@cdo/apps/code-studio/levels/textMatch.js');
@@ -25,6 +26,8 @@ $(document).ready(() => {
       initData.last_attempt
     );
   }
+
+  initMatch();
 });
 
 function initLevelGroup(levelCount, currentPage, lastAttempt) {

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -27,7 +27,7 @@ $(document).ready(() => {
     );
   }
 
-  initMatch();
+  $('.level-group-content').each((i, element) => initMatch(element));
 });
 
 function initLevelGroup(levelCount, currentPage, lastAttempt) {

--- a/apps/src/sites/studio/pages/levels/_match.js
+++ b/apps/src/sites/studio/pages/levels/_match.js
@@ -1,4 +1,4 @@
-/*global jQuery, CDOSounds, appOptions */
+/* global appOptions */
 import React from 'react';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {showDialog} from '@cdo/apps/code-studio/levels/dialogHelper';
@@ -7,16 +7,7 @@ import {
   MatchErrorDialog
 } from '@cdo/apps/lib/ui/LegacyDialogContents';
 
-jQuery.fn.swap = function(b) {
-  // method from: http://blog.pengoworks.com/index.cfm/2008/9/24/A-quick-and-dirty-swap-method-for-jQuery
-  b = jQuery(b)[0];
-  var a = this[0];
-  var t = a.parentNode.insertBefore(document.createTextNode(''), a);
-  b.parentNode.insertBefore(a, b);
-  t.parentNode.insertBefore(b, t);
-  t.parentNode.removeChild(t);
-  return this;
-};
+import {initMatch} from '@cdo/apps/code-studio/levels/match';
 
 $(function() {
   // This setting (pre_title) is used by only 3 levels in our application.
@@ -25,71 +16,7 @@ $(function() {
     window.setTimeout(() => showDialog(<MatchAngiGifDialog />), 1000);
   }
 
-  $('.mainblock #answers li').draggable({revert: 'invalid', stack: '.answer'});
-
-  // set up the central list of empty slots.
-  $('.mainblock #slots li').droppable({
-    activeClass: 'active',
-    hoverClass: 'hover',
-    accept: '.answerlist,.answerslot',
-    drop: function(event, ui) {
-      CDOSounds.play('click');
-      // once an answer is in the central list of slots, it will just swap with whatever it's dragged onto
-      if (ui.draggable.hasClass('answerslot')) {
-        // swap this empty slot and the answer dragged onto it
-        ui.draggable.swap(event.target);
-
-        // remove offset coordinates from this item
-        ui.draggable.css({top: 'auto', left: 'auto'});
-      } else {
-        // when an answer is in the rightmost list of answers, it can be dragged in to replace an empty slot
-        // in the central list of slots.
-
-        var movingItem = ui.draggable.detach();
-
-        // replace target with this new item
-        $(event.target).replaceWith(movingItem);
-
-        // the new item is now droppable
-        movingItem.droppable();
-
-        // remove offset coordinates from the dragged item
-        movingItem.css({top: 'auto', left: 'auto'});
-
-        // this class is no longer in the answer list
-        movingItem.removeClass('answerlist');
-
-        // this class can now be both dragged and a drop target for fellow answers in slots
-        movingItem.addClass('answerslot');
-
-        // this new item can now be dropped onto by other answers in the central list
-        movingItem.droppable({
-          accept: '.answerslot',
-          activeClass: 'active',
-          drop: function(event, ui) {
-            CDOSounds.play('whoosh');
-
-            // remove offset coordinates from the dragged item
-            ui.draggable.css({top: '0px', left: '0px'});
-
-            // determine y difference between old location and new location of item that will be swapped out
-            var origY = $(event.target).offset().top;
-            var destY = $(ui.draggable).offset().top;
-            var diffY = destY - origY;
-
-            // swap this answer with the answer dropped onto it
-            ui.draggable.swap(event.target);
-
-            // move the target object back to its old location for a moment
-            $(event.target).css({top: -diffY + 'px'});
-
-            // and animate back to its new location
-            $(event.target).animate({top: '0px'});
-          }
-        });
-      }
-    }
-  });
+  initMatch();
 });
 
 registerGetResult(() => {

--- a/apps/src/sites/studio/pages/levels/_match.js
+++ b/apps/src/sites/studio/pages/levels/_match.js
@@ -16,7 +16,7 @@ $(function() {
     window.setTimeout(() => showDialog(<MatchAngiGifDialog />), 1000);
   }
 
-  initMatch();
+  initMatch(true);
 });
 
 registerGetResult(() => {

--- a/apps/src/sites/studio/pages/levels/_match.js
+++ b/apps/src/sites/studio/pages/levels/_match.js
@@ -16,7 +16,8 @@ $(function() {
     window.setTimeout(() => showDialog(<MatchAngiGifDialog />), 1000);
   }
 
-  initMatch(true);
+  const container = $('#level-body').first();
+  initMatch(container, true);
 });
 
 registerGetResult(() => {


### PR DESCRIPTION
### Background

* work item: https://codedotorg.atlassian.net/browse/LP-166 (updated)
* previous PR: https://github.com/code-dot-org/code-dot-org/pull/27294

### Description

Enables match levels within level groups as follows:
* extracts drag/drop code and applies it to match levels in level groups
* disables sounds when in level group
* configures drag/drop to isolate multiple match levels from each other within a single level group page

### Testing

existing test coverage verifies that I did not break exising match levels. tests will be added for match levels in level groups once they are working end-to-end, which includes saving / loading student choices like we do for multi levels.

### screencast

![match-after](https://user-images.githubusercontent.com/8001765/55761015-c30f9400-5a12-11e9-8a9b-0b2907dce846.gif)

