### PR TITLE
Pass Assessment Boolean and Mini Rubric to Curriculum Builder

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -470,7 +470,8 @@ class Level < ActiveRecord::Base
   def summary_for_lesson_plans
     summary = summarize
 
-    %w(title questions answers short_instructions long_instructions markdown teacher_markdown pages reference).each do |key|
+    %w(title questions answers short_instructions long_instructions markdown teacher_markdown pages reference
+       rubric_key_concept rubric_exceeds rubric_meets rubric_approaches rubric_no_evidence mini_rubric).each do |key|
       value = properties[key] || try(key)
       summary[key] = value if value
     end

--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -185,6 +185,7 @@ class Stage < ActiveRecord::Base
           position: script_level.position,
           named_level: script_level.named_level?,
           bonus_level: !!script_level.bonus,
+          assessment: script_level.assessment,
           progression: script_level.progression,
           path: script_level.path,
         }


### PR DESCRIPTION
* Add assessment boolean as part of information passed to lesson plans about levels.
* Add mini rubric information as part of information passed to lesson plans about levels.
