### PR TITLE
Wait until elements are visible before checking current URL

### DIFF
--- a/dashboard/test/ui/features/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_dashboard.feature
@@ -11,16 +11,20 @@ Feature: Using the teacher dashboard
 
     When I sign in as "Teacher_Sally"
     When I click selector "a:contains(Untitled Section)" once I see it
+    And I wait until element "#learn-tabs" is visible
     And check that the URL contains "/teacher-dashboard#/sections/"
     When I click selector "a:contains(Sally)" once I see it
+    And I wait until element "#course-dropdown" is visible
     And check that the URL contains "/teacher-dashboard#/sections/"
     And check that the URL contains "/student/"
 
     Then I am on "http://studio.code.org/home?enableExperiments=teacher-dashboard-react"
     When I click selector "a:contains(Untitled Section)" once I see it
+    And I wait until element "#uitest-teacher-dashboard-nav" is visible
     And check that the URL contains "/teacher_dashboard/sections/"
     And I wait until element "#uitest-course-dropdown" contains text "All the Things! *"
     When I click selector "a:contains(Sally)" once I see it
+    And I wait until element "#teacher-panel-container" is visible
     And check that the URL contains "/s/allthethings"
     And check that the URL contains "viewAs=Teacher"
 


### PR DESCRIPTION
Once this test got to the test environment, it began failing consistently on IE11Win10 and SafariYosemite at the `And check that the URL contains ...` steps. After I verified that it was a race condition in the test rather than actual broken functionality, I added `wait` steps to the test to fix it. I confirmed via Saucelabs Connect that this fixes the test in both configurations.