### PR TITLE
Update setup docs / docker setup docs with enabling apps build [ci skip]

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -36,9 +36,6 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
     </details>
 
 1. `rake install`
-1. [Enable JavaScript builds](#enabling-javascript-builds)
-    1. Note: You can skip this step if not editing javascript frequently. However, if you skip this step, you will need AWS access (described below, Code.org engineers only), 
-    as the build process will attempt to download pre-built javascript packages from S3.
 1. `rake build`
 1. (Optional, Code.org engineers only) Setup AWS - Ask a Code.org engineer how to complete this step
    1. Some functionality will not work on your local site without this, for example, some project-backed level types such as https://studio.code.org/projects/gamelab. This setup is only available to Code.org engineers for now, but it is recommended for Code.org engineers.
@@ -183,7 +180,9 @@ Many Windows developers have found that setting up an Ubuntu virtual machine is 
      * navigate to http://localhost-studio.code.org:3000/ on your local machine
 
 ## Enabling JavaScript builds
-The default dashboard install uses a static build of JS, but if you want to make modifications to these you'll want to enable local builds of the JavaScript packages. You'll need to do this once:
+**Note:** the installation process now enables this by default. OS X users should still follow the first step of installing the Java 8 JDK.
+
+If you want to make JavaScript changes and have them take effect locally, you'll want to enable local builds of the JavaScript packages. You'll need to do this once:
 
 1. (OS X) Install the [Java 8 JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 1. Edit locals.yml and enable the following options:

--- a/SETUP.md
+++ b/SETUP.md
@@ -110,6 +110,7 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
               check to make sure XCode is downloaded and up to date manually.
 
     </details>
+1. Install the [Java 8 JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 
 ### Ubuntu 16.04 ([Download iso][ubuntu-iso-url]) Note: Virtual Machine Users should check the Windows Note below before starting
 
@@ -180,11 +181,10 @@ Many Windows developers have found that setting up an Ubuntu virtual machine is 
      * navigate to http://localhost-studio.code.org:3000/ on your local machine
 
 ## Enabling JavaScript builds
-**Note:** the installation process now enables this by default. OS X users should still follow the first step of installing the Java 8 JDK.
+**Note:** the installation process now enables this by default, which is recommended. You can manually edit these values later if you want to disable local JS builds.
 
 If you want to make JavaScript changes and have them take effect locally, you'll want to enable local builds of the JavaScript packages. You'll need to do this once:
 
-1. (OS X) Install the [Java 8 JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 1. Edit locals.yml and enable the following options:
 
    ```

--- a/SETUP.md
+++ b/SETUP.md
@@ -37,7 +37,8 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
 
 1. `rake install`
 1. [Enable JavaScript builds](#enabling-javascript-builds)
-    1. Note: You can skip this step if not editing javascript frequently.
+    1. Note: You can skip this step if not editing javascript frequently. However, if you skip this step, you will need AWS access (described below, Code.org engineers only), 
+    as the build process will attempt to download pre-built javascript packages from S3.
 1. `rake build`
 1. (Optional, Code.org engineers only) Setup AWS - Ask a Code.org engineer how to complete this step
    1. Some functionality will not work on your local site without this, for example, some project-backed level types such as https://studio.code.org/projects/gamelab. This setup is only available to Code.org engineers for now, but it is recommended for Code.org engineers.

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,20 +26,13 @@ Run all docker-compose commands from this directory.
     export FIXUID=$(id -u)
     export FIXGID=$(id -g)
     ```
-2. If you haven't already, add the following to your locals.yml file:
-
-   ```
-   build_apps: true
-   use_my_apps: true
-   ```
-
-3. Run the following command. This recreates most of the SETUP.md instructions, and will probably take a long time:
+2. Run the following command. This recreates most of the SETUP.md instructions, and will probably take a long time:
 
     ```
     docker-compose -f setup-compose.yml up
     ```
 
-4. Setup the rest of your locals.yml file as normal.
+3. Setup the rest of your locals.yml file as normal.
 
 ## Usage
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,7 +39,7 @@ Run all docker-compose commands from this directory.
     docker-compose -f setup-compose.yml up
     ```
 
-4. Setup the rest your locals.yml file as normal.
+4. Setup the rest of your locals.yml file as normal.
 
 ## Usage
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,13 +26,20 @@ Run all docker-compose commands from this directory.
     export FIXUID=$(id -u)
     export FIXGID=$(id -g)
     ```
-2. This recreates most of the SETUP.md instructions, and will probably take a long time:
+2. If you haven't already, add the following to your locals.yml file:
+
+   ```
+   build_apps: true
+   use_my_apps: true
+   ```
+
+3. Run the following command. This recreates most of the SETUP.md instructions, and will probably take a long time:
 
     ```
     docker-compose -f setup-compose.yml up
     ```
 
-3. Setup your locals.yml file as normal.
+4. Setup the rest your locals.yml file as normal.
 
 ## Usage
 

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -15,12 +15,12 @@ dashboard_enable_pegasus: true
 
 
 # Whether rake:build should rebuild the apps package
-#build_apps: true
+build_apps: true
 
 
 # Whether dashboard should use your local build of the apps package.
 # If false, dashboard will try to use a prepackaged version from S3.
-#use_my_apps: true
+use_my_apps: true
 
 # Allows your local server to render non-English locales, defaults to false.
 # If false, choosing a locale other than English will have no effect.


### PR DESCRIPTION
I think this explains why it seemed like sometimes AWS credentials were required for setup and sometimes they weren't. I updated the "Enable JS builds" step with an explanation. I could also see just leaving off the note altogether and treating it as a required step, for simplicity. Thoughts?