### PR TITLE
No script access msg

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -116,6 +116,9 @@ class ScriptsController < ApplicationController
 
   def set_script
     @script = Script.get_from_cache(params[:id])
+    if current_user && @script&.pilot? && !@script.has_pilot_access?(current_user)
+      render :no_access
+    end
   end
 
   def script_params

--- a/dashboard/app/views/scripts/no_access.html.haml
+++ b/dashboard/app/views/scripts/no_access.html.haml
@@ -1,0 +1,2 @@
+%div
+  = current_user.student? ? t('no_script_access_student') : t('no_script_access_teacher')

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1027,6 +1027,8 @@ en:
   locked_stage: 'The contents of this stage are not visible because this stage is currently locked. Your teacher can unlock this stage when it is time to work on it or review your answers.'
   hidden_stage: "Your teacher didn't expect you to be here. Please ask your teacher which lesson you should be on."
   hidden_script: "Your teacher didn't expect you to be here. Please ask your teacher which unit you should be on."
+  no_script_access_student: "You don't have access to this unit. Please ask your teacher which unit you should be on."
+  no_script_access_teacher: "You don't have access to this unit. If you believe you should have access to this unit, please write to support@code.org so that we can fix the situation."
   return_unit_overview: 'Go to unit overview'
   return_course_overview: 'Go to course overview'
   view_all_units: 'View all units'

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -297,26 +297,43 @@ class ScriptsControllerTest < ActionController::TestCase
     assert Script.find_by_name(script.name).hidden
   end
 
+  no_access_msg = "You don&#39;t have access to this unit."
+
   test_user_gets_response_for :show, response: :redirect, user: nil,
     params: -> {{id: @pilot_script.name}},
     name: 'signed out user cannot view pilot script'
 
-  test_user_gets_response_for :show, response: :forbidden, user: :student,
+  test_user_gets_response_for(:show, response: :success, user: :student,
     params: -> {{id: @pilot_script.name}}, name: 'student cannot view pilot script'
+  ) do
+    assert response.body.include? no_access_msg
+  end
 
-  test_user_gets_response_for :show, response: :forbidden, user: :teacher,
+  test_user_gets_response_for(:show, response: :success, user: :teacher,
     params: -> {{id: @pilot_script.name}},
     name: 'teacher without pilot access cannot view pilot script'
+  ) do
+    assert response.body.include? no_access_msg
+  end
 
-  test_user_gets_response_for :show, response: :success, user: -> {@pilot_teacher},
+  test_user_gets_response_for(:show, response: :success, user: -> {@pilot_teacher},
     params: -> {{id: @pilot_script.name, section_id: @pilot_section.id}},
     name: 'pilot teacher can view pilot script'
+  ) do
+    refute response.body.include? no_access_msg
+  end
 
-  test_user_gets_response_for :show, response: :success, user: -> {@pilot_student},
+  test_user_gets_response_for(:show, response: :success, user: -> {@pilot_student},
     params: -> {{id: @pilot_script.name}}, name: 'pilot student can view pilot script'
+  ) do
+    refute response.body.include? no_access_msg
+  end
 
-  test_user_gets_response_for :show, response: :success, user: :levelbuilder,
+  test_user_gets_response_for(:show, response: :success, user: :levelbuilder,
     params: -> {{id: @pilot_script.name}}, name: 'levelbuilder can view pilot script'
+  ) do
+    refute response.body.include? no_access_msg
+  end
 
   test 'can create with has_lesson_plan param' do
     sign_in @levelbuilder


### PR DESCRIPTION
### Background

Nice-to-have for [LP-159](https://codedotorg.atlassian.net/browse/LP-159). Today if you end up on a pilot script which you do not have access to, we show a blank screen (no header/footer).

### Description

If you end up at https://studio.code.org/s/csp4-pilot but do not have access, show the code studio header/footer with a message briefly indicating why you can't see anything there. 

### Screenshots

#### student
<img width="1035" alt="screen shot 2019-03-01 at 8 08 50 am" src="https://user-images.githubusercontent.com/8001765/53650456-7063e080-3bf9-11e9-9bbc-fad2ff8f3810.png">

#### teacher
<img width="1047" alt="screen shot 2019-03-01 at 8 09 33 am" src="https://user-images.githubusercontent.com/8001765/53650466-748ffe00-3bf9-11e9-9fc6-ff049dc1166b.png">
