### PR TITLE
Question Level Type Icon Update

### DIFF
--- a/apps/src/templates/progress/ProgressLegend.jsx
+++ b/apps/src/templates/progress/ProgressLegend.jsx
@@ -192,7 +192,7 @@ export default class ProgressLegend extends Component {
             </TD>
             <TD style={styles.rightBorder}>
               <div style={styles.iconAndText}>
-                <FontAwesome icon="check-square-o" style={styles.icon} />
+                <FontAwesome icon="list-ul" style={styles.icon} />
                 {i18n.question()}
               </div>
             </TD>

--- a/dashboard/app/models/levels/contract_match.rb
+++ b/dashboard/app/models/levels/contract_match.rb
@@ -39,6 +39,6 @@ ruby
   end
 
   def icon
-    'fa-check-square-o'
+    'fa fa-list-ul'
   end
 end

--- a/dashboard/app/models/levels/free_response.rb
+++ b/dashboard/app/models/levels/free_response.rb
@@ -51,6 +51,6 @@ class FreeResponse < Level
   end
 
   def icon
-    'fa-check-square-o'
+    'fa fa-list-ul'
   end
 end

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -42,7 +42,7 @@ ruby
   end
 
   def icon
-    'fa-check-square-o'
+    'fa fa-list-ul'
   end
 
   # Returns a flattened array of all the Levels in this LevelGroup, in order.

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -41,6 +41,6 @@ ruby
   end
 
   def icon
-    'fa-check-square-o'
+    'fa fa-list-ul'
   end
 end

--- a/dashboard/app/models/levels/text_match.rb
+++ b/dashboard/app/models/levels/text_match.rb
@@ -39,6 +39,6 @@ ruby
   end
 
   def icon
-    'fa-check-square-o'
+    'fa fa-list-ul'
   end
 end


### PR DESCRIPTION
Updates the icon for the following level types:
* match (all types)
* free response
* multi
* level groups

Used to be this icon:
<img width="286" alt="screen shot 2019-03-01 at 11 54 18 am" src="https://user-images.githubusercontent.com/208083/53653212-d2800e00-3c18-11e9-98c0-78ea7e9a9387.png">

Now this icon:
<img width="339" alt="screen shot 2019-03-01 at 11 54 30 am" src="https://user-images.githubusercontent.com/208083/53653213-d2800e00-3c18-11e9-8b8a-9dfb762369a3.png">

### Updates Progress Legend:

<img width="1093" alt="screen shot 2019-03-01 at 11 55 27 am" src="https://user-images.githubusercontent.com/208083/53653293-022f1600-3c19-11e9-9417-d9f2665c7910.png">

### Updates Bubble Icons:

<img width="520" alt="screen shot 2019-03-01 at 11 55 41 am" src="https://user-images.githubusercontent.com/208083/53653292-022f1600-3c19-11e9-832e-1dd7e288443c.png">
<img width="364" alt="screen shot 2019-03-01 at 11 55 22 am" src="https://user-images.githubusercontent.com/208083/53653294-022f1600-3c19-11e9-9be1-d1e2b9f95af6.png">

As part of the [Mini Rubrics Work](https://docs.google.com/document/d/1QSnZRxrx38QX-ZbcBaT0y1cT6fwvAm1llCqeELVHGW8/edit#)