### PR TITLE
Restore populating UserSchoolInfo when teachers change schools

### DIFF
--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -47,6 +47,8 @@ class SchoolInfo < ActiveRecord::Base
 
   has_and_belongs_to_many :census_submissions, class_name: 'Census::CensusSubmission'
 
+  has_many :user_school_infos
+
   # Remap what the form has (e.g. school_zip) to what we write to (e.g. zip)
   def school_zip=(input)
     self.zip = input

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -288,7 +288,7 @@ class User < ActiveRecord::Base
   def update_school_info(new_school_info)
     if school_info.try(&:school).nil? || new_school_info.try(&:school)
       self.school_info_id = new_school_info.id
-      save!
+      save(validate: false)
     end
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -228,6 +228,9 @@ class User < ActiveRecord::Base
   accepts_nested_attributes_for :school_info, reject_if: :preprocess_school_info
   validates_presence_of :school_info, unless: :school_info_optional?
 
+  has_many :user_school_infos
+  after_save :update_and_add_users_school_infos, if: :school_info_id_changed?
+
   has_one :circuit_playground_discount_application
 
   has_many :pd_applications,
@@ -284,8 +287,26 @@ class User < ActiveRecord::Base
   # @param new_school_info a school_info object to compare to the user current school information.
   def update_school_info(new_school_info)
     if school_info.try(&:school).nil? || new_school_info.try(&:school)
-      update_column(:school_info_id, new_school_info.id)
+      self.school_info_id = new_school_info.id
+      save!
     end
+  end
+
+  def update_and_add_users_school_infos
+    last_school = user_school_infos.find_by(end_date: nil)
+    current_time = Time.now.utc
+    if last_school
+      last_school.end_date = current_time
+      last_school.save!
+    end
+    UserSchoolInfo.create(
+      user: self,
+      school_info: school_info,
+      user_id: id,
+      start_date: current_time,
+      school_info_id: school_info_id,
+      last_confirmation_date: current_time
+    )
   end
 
   # Not deployed to everyone, so we don't require this for anybody, yet

--- a/dashboard/app/models/user_school_info.rb
+++ b/dashboard/app/models/user_school_info.rb
@@ -13,6 +13,8 @@
 #
 
 class UserSchoolInfo < ApplicationRecord
-  validates_presence_of :user
-  validates_presence_of :school_info
+  validates_presence_of :user, :school_info, :start_date, :last_confirmation_date
+
+  belongs_to :user
+  belongs_to :school_info
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -92,6 +92,8 @@ class UserTest < ActiveSupport::TestCase
     teacher = create :teacher, school_info_attributes: school_attributes
     assert teacher.school_info.state == 'CA', teacher.school_info.state
     assert teacher.school_info.zip == 94107, teacher.school_info.zip
+
+    assert_equal teacher.user_school_infos.count, 1
   end
 
   test 'identical school info should not be duplicated in the database' do
@@ -110,6 +112,10 @@ class UserTest < ActiveSupport::TestCase
 
     user.update_school_info(new_school_info)
     assert_equal new_school_info, user.school_info
+
+    assert_equal user.user_school_infos.count, 2
+    assert_equal user.user_school_infos.where(school_info_id: new_school_info.id).count, 1
+    assert_equal user.user_school_infos.where(end_date: nil).count, 1
   end
 
   test 'update_school_info with custom school does nothing when the user already has a specific school' do
@@ -119,6 +125,7 @@ class UserTest < ActiveSupport::TestCase
 
     user.update_school_info(new_school_info)
     assert_equal original_school_info, user.school_info
+    assert_equal user.user_school_infos.count, 1
   end
 
   test 'update_school_info with custom school updates user info when user does not have a specific school' do
@@ -130,6 +137,9 @@ class UserTest < ActiveSupport::TestCase
     refute_equal original_school_info, user.school_info
     assert_equal new_school_info, user.school_info
     assert_not_nil user.school_info_id
+
+    assert_equal user.user_school_infos.count, 2
+    assert_equal user.user_school_infos.where(end_date: nil).count, 1
   end
 
   test 'single user experiment is enabled' do


### PR DESCRIPTION
This commit also removes validation when saving the User model, which is consistent with old behaviour.