### PR TITLE
Fix script overview teacher view when viewing in new session

### DIFF
--- a/apps/src/code-studio/clientState.js
+++ b/apps/src/code-studio/clientState.js
@@ -291,19 +291,6 @@ clientState.cacheUserIsTeacher = function(isTeacher) {
 };
 
 /**
- * Get the cached state of whether the user is a teacher.
- */
-clientState.getUserIsTeacher = function() {
-  let isTeacher = false;
-  try {
-    isTeacher = JSON.parse(sessionStorage.getItem('isTeacher'));
-  } catch (e) {
-    isTeacher = false;
-  }
-  return isTeacher;
-};
-
-/**
  * Private helper for videos and callouts - looks in local storage to see if the element has been seen
  * @param visualElementType
  * @param visualElementId

--- a/apps/src/code-studio/clientState.js
+++ b/apps/src/code-studio/clientState.js
@@ -282,15 +282,6 @@ function recordVisualElementSeen(visualElementType, visualElementId) {
 }
 
 /**
- * Cache whether the user is a teacher, so that we can appropriately update the
- * UI on future pageloads without waiting on API
- * @param {boolean} isTeacher
- */
-clientState.cacheUserIsTeacher = function(isTeacher) {
-  trySetSessionStorage('isTeacher', isTeacher);
-};
-
-/**
  * Private helper for videos and callouts - looks in local storage to see if the element has been seen
  * @param visualElementType
  * @param visualElementId

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -224,12 +224,12 @@ function queryUserProgress(store, scriptData, currentLevelId) {
     store.dispatch(setStudentDefaultsSummaryView(false));
   }
 
-  // Set our initial view type
+  // Set our initial view type from our query string.
   const query = queryString.parse(location.search);
-  let initialViewAs = ViewType.Student;
-  if (clientState.getUserIsTeacher() && query.viewAs !== ViewType.Student) {
-    // query param viewAs takes precedence over whether or not user is a teacher
-    initialViewAs = ViewType.Teacher;
+  let initialViewAs = query.viewAs;
+  if (scriptData.user_type === 'student') {
+    // Make sure student users are only ever viewing as "Student".
+    initialViewAs = ViewType.Student;
   }
   store.dispatch(setViewType(initialViewAs));
 

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -224,12 +224,11 @@ function queryUserProgress(store, scriptData, currentLevelId) {
     store.dispatch(setStudentDefaultsSummaryView(false));
   }
 
-  // Set our initial view type from our query string.
-  const query = queryString.parse(location.search);
-  let initialViewAs = query.viewAs;
-  if (scriptData.user_type === 'student') {
-    // Make sure student users are only ever viewing as "Student".
-    initialViewAs = ViewType.Student;
+  // Set our initial view type from current user's user_type or our query string.
+  let initialViewAs = ViewType.Student;
+  if (scriptData.user_type === 'teacher') {
+    const query = queryString.parse(location.search);
+    initialViewAs = query.viewAs || ViewType.Teacher;
   }
   store.dispatch(setViewType(initialViewAs));
 

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -282,7 +282,6 @@ function queryUserProgress(store, scriptData, currentLevelId) {
       }
 
       renderTeacherPanel(store, scriptData.id, scriptData.section);
-      clientState.cacheUserIsTeacher(true);
     }
 
     if (data.focusAreaStageIds) {

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -1,6 +1,6 @@
 -# This variable will get any data we need to pass along to scriptOverview.js
 - script_data = @script.summarize(true, current_user)
-- additional_script_data = {course_name: @script.course&.name, show_redirect_warning: @show_redirect_warning, redirect_script_url: @redirect_script_url, section: @section}
+- additional_script_data = {course_name: @script.course&.name, show_redirect_warning: @show_redirect_warning, redirect_script_url: @redirect_script_url, section: @section, user_type: current_user.user_type}
 - scriptOverviewData = {scriptData: script_data.merge(additional_script_data)}
 - if @script.professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
   -  scriptOverviewData[:plcBreadcrumb] = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.get_url_name)}

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -1,6 +1,6 @@
 -# This variable will get any data we need to pass along to scriptOverview.js
 - script_data = @script.summarize(true, current_user)
-- additional_script_data = {course_name: @script.course&.name, show_redirect_warning: @show_redirect_warning, redirect_script_url: @redirect_script_url, section: @section, user_type: current_user.user_type}
+- additional_script_data = {course_name: @script.course&.name, show_redirect_warning: @show_redirect_warning, redirect_script_url: @redirect_script_url, section: @section, user_type: current_user&.user_type}
 - scriptOverviewData = {scriptData: script_data.merge(additional_script_data)}
 - if @script.professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
   -  scriptOverviewData[:plcBreadcrumb] = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.get_url_name)}


### PR DESCRIPTION
### Description
When I view a student's progress (via the script overview page -- `/s/:script_name?section_id=section_id&user_id=student_id&viewAs=Teacher`), sometimes the `user_id` query parameter is removed while the page is loading.

### Root Cause
On the script overview page, we were relying on `isTeacher` being set to `true` in the session and this value was only ever set [here](https://github.com/code-dot-org/code-dot-org/blob/bd22bcfcd8b0d21597460df530cf67561d3b8e5f/apps/src/code-studio/progress.js#L285). This meant:
- If a teacher _had_ visited the script overview page in the current session, the script overview page displayed properly and showed the student's progress.
- If a teacher _had not_ visited the script overview page in the current session, `viewAs` was set to "Student" in redux ([here](https://github.com/code-dot-org/code-dot-org/blob/bd22bcfcd8b0d21597460df530cf67561d3b8e5f/apps/src/code-studio/progress.js#L228-L234)), and [setViewType](https://github.com/code-dot-org/code-dot-org/blob/bd22bcfcd8b0d21597460df530cf67561d3b8e5f/apps/src/code-studio/viewAsRedux.js#L38-L52) removed `user_id` from our query params.

### Solution
Don't rely on `isTeacher` being set in the browser session. Instead, pass the user_type from the server. We were only using the `isTeacher` session logic in this one place, so that meant I could totally remove [cacheUserIsTeacher](https://github.com/code-dot-org/code-dot-org/search?q=cacheUserIsTeacher&unscoped_q=cacheUserIsTeacher) and [getUserIsTeacher](https://github.com/code-dot-org/code-dot-org/search?q=getUserIsTeacher&unscoped_q=getUserIsTeacher).