### PR TITLE
Adding test for updating user_school_info for user without email

### DIFF
--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -142,12 +142,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal user.user_school_infos.where(end_date: nil).count, 1
   end
 
+  # Test updating the school_info of an older user without an email address.
   test 'update_school_info with specific school overwrites user school info for user without email' do
     user = create :teacher, :with_school_info
     new_school_info = create :school_info
 
     user.email = ""
     user.save(validate: false)
+    refute user.valid?
 
     user.update_school_info(new_school_info)
     assert_equal new_school_info, user.school_info

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -142,6 +142,21 @@ class UserTest < ActiveSupport::TestCase
     assert_equal user.user_school_infos.where(end_date: nil).count, 1
   end
 
+  test 'update_school_info with specific school overwrites user school info for user without email' do
+    user = create :teacher, :with_school_info
+    new_school_info = create :school_info
+
+    user.email = ""
+    user.save(validate: false)
+
+    user.update_school_info(new_school_info)
+    assert_equal new_school_info, user.school_info
+
+    assert_equal user.user_school_infos.count, 2
+    assert_equal user.user_school_infos.where(school_info_id: new_school_info.id).count, 1
+    assert_equal user.user_school_infos.where(end_date: nil).count, 1
+  end
+
   test 'single user experiment is enabled' do
     experiment = create(:single_user_experiment, min_user_id: @user.id)
     assert_equal [experiment[:name]], @user.get_active_experiment_names


### PR DESCRIPTION
Follow up to PR #27035, #27318 (rollback), and #27322 (restore from rollback). The first PR caused an error when a teacher doesn't have an email address -- which is not currently allowed but was at one point.