### PR TITLE
Update brokenLinkChecker.json

### DIFF
--- a/tools/scripts/brokenLinkChecker/brokenLinkChecker.json
+++ b/tools/scripts/brokenLinkChecker/brokenLinkChecker.json
@@ -94,6 +94,7 @@
     "https://www.radiantgames.is/",
     "https://www.smore.com/upzfa-ap-computer-science",
     "https://www.vistaequitypartners.com/",
-    "https://www.youtube.com/codeorg"
+    "https://www.youtube.com/codeorg",
+    "http://www.startupeducation.org"
   ]
 }


### PR DESCRIPTION
Adding http://www.startupeducation.org/ to the ignore list of the broken link checker.