### PR TITLE
PL: regional partner mini contact now geocodes ZIP to find regional partner

### DIFF
--- a/dashboard/app/controllers/api/v1/regional_partners_controller.rb
+++ b/dashboard/app/controllers/api/v1/regional_partners_controller.rb
@@ -34,38 +34,9 @@ class Api::V1::RegionalPartnersController < ApplicationController
 
   # GET /api/v1/regional_partners/find
   def find
-    state = nil
     zip_code = params[:zip_code]
 
-    if RegexpUtils.us_zip_code?(zip_code)
-      # Try to find the matching partner using the ZIP code.
-      partner = RegionalPartner.find_by_region(zip_code, nil)
-
-      # Otherwise, get the state for the ZIP code and try to find the matching partner using that.
-      unless partner
-        begin
-          Geocoder.with_errors do
-            # Geocoder can raise a number of errors including SocketError, with a common base of StandardError
-            # See https://github.com/alexreisner/geocoder#error-handling
-            Retryable.retryable(on: StandardError) do
-              state = Geocoder.search({zip: zip_code})&.first&.state_code
-            end
-          end
-        rescue StandardError => e
-          # Log geocoding errors to honeybadger but don't fail
-          Honeybadger.notify(e,
-            error_message: 'Error geocoding regional partner workshop zip_code',
-            context: {
-              zip_code: zip_code
-            }
-          )
-        end
-
-        if state
-          partner = RegionalPartner.find_by_region(nil, state)
-        end
-      end
-    end
+    partner, state = RegionalPartner.find_by_zip(zip_code)
 
     result = nil
 

--- a/dashboard/app/models/pd/regional_partner_mini_contact.rb
+++ b/dashboard/app/models/pd/regional_partner_mini_contact.rb
@@ -75,8 +75,7 @@ class Pd::RegionalPartnerMiniContact < ApplicationRecord
   def update_regional_partner
     hash = sanitize_form_data_hash
     zipcode = hash[:zip]
-    state = nil
 
-    self.regional_partner = RegionalPartner.find_by_region(zipcode, state)
+    self.regional_partner, _ = RegionalPartner.find_by_zip(zipcode)
   end
 end


### PR DESCRIPTION
The regional partner mini contact form was only finding a matching regional partner when the regional partner explicitly served the submitted ZIP, and wasn't finding a partner who served an entire state.  This fixes that.

The matching is now the same as that used on https://code.org/educate/professional-learning/program-information.

A good example of why it's good to hoist functionality into the model, rather than having it out in a specialised controller.