### PR TITLE
change position of the user and create menu text and caret icon for rtl

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -343,6 +343,10 @@ img.video_thumbnail {
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
+
+      html[dir=rtl] & {
+        float: right;
+      }
     }
 
     .pairing_icon {


### PR DESCRIPTION
The menu arrows and text in user and create menus are not positioned correctly.

Fix:  Right aligned the text in user and create menus by setting float to right.

### Before:
<img width="667" alt="screen shot 2019-03-01 at 12 49 33 pm" src="https://user-images.githubusercontent.com/30066710/53674157-d58ef480-3c40-11e9-9cf6-864afd49e167.png">

### After:
<img width="672" alt="screen shot 2019-03-01 at 4 32 25 pm" src="https://user-images.githubusercontent.com/30066710/53674156-d58ef480-3c40-11e9-9c28-d17754e003dd.png">



