### PR TITLE
Bind-mount ssh config directory for local docker development [ci skip]

### DIFF
--- a/docker/site-compose.yml
+++ b/docker/site-compose.yml
@@ -20,6 +20,8 @@ services:
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/circleci/code-dot-org:delegated
+      - $HOME/.ssh:/home/circleci/.ssh:ro
+      - $HOME/.ssh:$HOME/.ssh:ro
       - rbenv:/home/circleci/.rbenv
       - mysqldata:/var/lib/mysql
       - yarncache:/home/circleci/.cache


### PR DESCRIPTION
This allows `ssh gateway` to work from inside the container. This is needed at the very least for some functionality of the DOTD script.