### PR TITLE
Signup: fix typo

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -156,7 +156,7 @@ en:
     student_consent: "I confirm that I have my parent or legal guardian's permission to use the Code.org services."
     agree_us_website: "I agree to using a website based in the United States."
     my_data_to_us: "Data from my use of this site may be sent to and stored or processed in the United States."
-    student_terms: "Email addresses are not stored in a form that allows us to contact students. Students will never recieve emails from Code.org except for password recovery. See our <a href='http://code.org/privacy'>privacy policy</a> for more information."
+    student_terms: "Email addresses are not stored in a form that allows us to contact students. Students will never receive emails from Code.org except for password recovery. See our <a href='http://code.org/privacy'>privacy policy</a> for more information."
     teacher_terms: "I agree to be bound by the Code.org terms of service. For more information on privacy, see our <a href='http://code.org/privacy'>privacy policy</a>."
     additional_information: "We need some additional information to continue signing you up."
     user_type_button: "Update Account Type"


### PR DESCRIPTION
Thanks to an attentive visitor after last night's TV coverage, we found a typo that's been here for a [while](https://github.com/code-dot-org/code-dot-org/pull/9943).  

As they say, I before E except in the alphabet.

### before

![screenshot 2019-03-04 09 44 02](https://user-images.githubusercontent.com/2205926/53752276-0d758200-3e63-11e9-90d2-102a309acad6.png)

### after

![screenshot 2019-03-04 09 48 51](https://user-images.githubusercontent.com/2205926/53752279-11090900-3e63-11e9-81ff-aa71681314c8.png)
