### PR TITLE
use upgrade_to_teacher rather than set_user_type or update

### DIFF
--- a/dashboard/app/controllers/pd/session_attendance_controller.rb
+++ b/dashboard/app/controllers/pd/session_attendance_controller.rb
@@ -50,7 +50,7 @@ class Pd::SessionAttendanceController < ApplicationController
     if current_user.student?
       if User.hash_email(enrollment.email) == current_user.hashed_email
         # Email matches user's hashed email. Upgrade to teacher and set email.
-        current_user.update!(user_type: User::TYPE_TEACHER, email: enrollment.email)
+        current_user.upgrade_to_teacher(enrollment.email)
       else
         # No email match. Redirect to upgrade page.
         redirect_to action: 'upgrade_account'
@@ -75,7 +75,7 @@ class Pd::SessionAttendanceController < ApplicationController
       return
     end
 
-    current_user.update!(user_type: User::TYPE_TEACHER, email: @email)
+    current_user.upgrade_to_teacher(@email)
     redirect_to action: :attend
   end
 

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -170,12 +170,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
     if current_user.student?
       if User.hash_email(@enrollment.email) == current_user.hashed_email
         # Email matches user's hashed email. Upgrade to teacher and set email.
-        if current_user.migrated?
-          current_user.set_user_type(User::TYPE_TEACHER, @enrollment.email)
-          current_user.save!
-        else
-          current_user.update!(user_type: User::TYPE_TEACHER, email: @enrollment.email)
-        end
+        current_user.upgrade_to_teacher(@enrollment.email)
       else
         # No email match. Redirect to upgrade page.
         redirect_to controller: 'pd/session_attendance', action: 'upgrade_account'

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -949,7 +949,7 @@ class User < ActiveRecord::Base
     update(user_type: TYPE_STUDENT)
   end
 
-  def upgrade_to_teacher(email, email_preference)
+  def upgrade_to_teacher(email, email_preference = nil)
     return true if teacher? # No-op if user is already a teacher
     return false unless email.present?
 
@@ -959,7 +959,11 @@ class User < ActiveRecord::Base
     new_attributes = email_preference.nil? ? {} : email_preference
 
     transaction do
-      update_primary_contact_info!(new_email: email, new_hashed_email: hashed_email)
+      if migrated?
+        update_primary_contact_info!(new_email: email, new_hashed_email: hashed_email)
+      else
+        new_attributes[:email] = email
+      end
       update!(new_attributes)
     end
   rescue


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/27337

Turns out there are a couple of places where we upgrade accounts to teacher; rather than having them each decide whether to use `set_user_type` or `update` based on `migrated?`, I'm just gonna update `upgrade_to_teacher` to work with either, and have them use that directly.