### PR TITLE
Update FiT Workshop registration form and confirmation email

### DIFF
--- a/apps/src/code-studio/pd/fit_weekend_registration/TravelPlans.jsx
+++ b/apps/src/code-studio/pd/fit_weekend_registration/TravelPlans.jsx
@@ -20,7 +20,7 @@ export default class TravelPlans extends LabeledFormComponent {
     addressState: 'State',
     addressZip: 'Zip',
     howTraveling:
-      'Code.org provides a round trip flight for every FiT Workshop attendee. If you choose to fly, we will provide you with detailed flight booking instructions approximately six weeks prior to the event. If you choose not to fly, and live at least 25 miles from the event location, Code.org will provide you with a $150 gift card to help cover the cost of driving, trains, or public transit. Code.org is not able to provide reimbursement for the cost of driving, trains, or public transit if you live less than 25 miles from the event location. How will you travel to the FiT Workshop?',
+      'Code.org provides a round trip flight for every FiT Workshop attendee. If you choose to fly, we will provide you with detailed flight booking instructions approximately six weeks prior to the event. If you choose not to fly, and live at least 25 miles from the event location, Code.org will provide you with $150 mileage support to help cover the cost of driving, trains, or public transit. Code.org is not able to provide reimbursement for the cost of driving, trains, or public transit if you live less than 25 miles from the event location. How will you travel to the FiT Workshop?',
     needHotel:
       'Code.org provides a hotel room for every FiT Workshop attendee. Attendees will not be required to share a room. Would you like a hotel room at the FiT Workshop?',
     needAda: 'Do you require an ADA accessible hotel room?',

--- a/dashboard/app/views/pd/fit_weekend_registration_mailer/confirmation.html.haml
+++ b/dashboard/app/views/pd/fit_weekend_registration_mailer/confirmation.html.haml
@@ -3,8 +3,7 @@
   = @registration.pd_application.first_name + ','
 
 %p
-  Thank you for submitting your FiT Workshop registration form for Code.org’s Professional
-  Learning Program.
+  Thank you for submitting your FiT Workshop registration form!
 
 - if @registration.accepted?
   We look forward to meeting you this summer! You will receive more information about
@@ -19,8 +18,7 @@
 
 %p
   Thank you,
-  %br
-  Sarah
+
 %p
   Sarah Fairweather
   %br

--- a/dashboard/app/views/pd/fit_weekend_registration_mailer/confirmation.html.haml
+++ b/dashboard/app/views/pd/fit_weekend_registration_mailer/confirmation.html.haml
@@ -3,16 +3,16 @@
   = @registration.pd_application.first_name + ','
 
 %p
-  Thank you for submitting your FiT Weekend registration form for Code.org’s Professional
+  Thank you for submitting your FiT Workshop registration form for Code.org’s Professional
   Learning Program.
 
 - if @registration.accepted?
   We look forward to meeting you this summer! You will receive more information about
-  travel approximately six weeks before the event. In the meantime, please contact
+  travel approximately six weeks before the workshop. In the meantime, please contact
   = link_to("facilitators@code.org", "mailto:facilitators@code.org")
   with any questions.
 - else
-  We noticed you responded that you’re not able to attend your assigned FiT weekend.
+  We noticed you responded that you’re not able to attend your assigned FiT Workshop.
   Please contact us at
   = link_to("facilitators@code.org", "mailto:facilitators@code.org")
   so that we can assist you.
@@ -24,6 +24,6 @@
 %p
   Sarah Fairweather
   %br
-  Education Team Program Manager
+  Education Program Manager
   %br
   Code.org

--- a/dashboard/test/mailers/previews/pd_fit_weekend_registration_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_fit_weekend_registration_mailer_preview.rb
@@ -12,7 +12,7 @@ class Pd::FitWeekendRegistrationMailerPreview < ActionMailer::Preview
   private
 
   def build_registration(status)
-    user = build :teacher, email: 'facilitator@code.org'
+    user = build :teacher, email: 'facilitator_name@code.org'
     application = build :pd_facilitator1920_application, user: user
 
     workshop = application.find_fit_workshop(course: Pd::Workshop::COURSE_CSD, city: 'Phoenix', year: 2019) ||


### PR DESCRIPTION
Task [PLC-112](https://codedotorg.atlassian.net/browse/PLC-112).
These are just minor text changes. 

* Change _FiT Weekend_ -> _FiT Workshop_
* Change _a $150 gift card_ -> _$150 mileage support_
* Few minor things in FiT workshop confirmation email.
* Change facilitator email in email preview from _facilitator@code.org_ ->  _facilitator_name@code.org_ to avoid confusion with facilitator**s**@code.org (which is the address used to send confirmation email).