### PR TITLE
PL: Regional Partner mini-contact gets a public standalone page

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/contact-regional-partner.md
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/contact-regional-partner.md
@@ -1,0 +1,8 @@
+---
+title: Contact your local Regional Partner
+theme: responsive
+---
+
+# Contact your local Regional Partner
+
+<%= view :professional_learning_regional_partner_mini_contact, source_page_id: "contact-regional-partner", notes: "Please tell me more about the professional learning program!" %>

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/regional-partner-mini-contact-test.md
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/regional-partner-mini-contact-test.md
@@ -1,8 +1,0 @@
----
-title: Professional Learning Regional Partner Mini Contact Test
-theme: responsive
----
-
-# Professional Learning Regional Partner Mini Contact Test
-
-<%= view :professional_learning_regional_partner_mini_contact %>


### PR DESCRIPTION
The URL is https://code.org/educate/professional-learning/contact-regional-partner

![screenshot 2019-03-04 16 11 41](https://user-images.githubusercontent.com/2205926/53771808-e76ad480-3e98-11e9-8671-588807a41956.png)
