### PR TITLE
PL: teacher application page 1 gets popup mini-contact form

### DIFF
--- a/apps/src/code-studio/pd/application/teacher1920/Section1AboutYou.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section1AboutYou.jsx
@@ -17,6 +17,7 @@ import {
   Row,
   Col
 } from 'react-bootstrap';
+import {RegionalPartnerMiniContactPopupLink} from '@cdo/apps/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact';
 import queryString from 'query-string';
 import {styles} from './TeacherApplicationConstants';
 import _ from 'lodash';
@@ -25,7 +26,6 @@ const CSD_URL = 'https://code.org/educate/professional-learning/cs-discoveries';
 const CSP_URL = 'https://code.org/educate/professional-learning/cs-principles';
 const PD_RESOURCES_URL =
   'https://support.code.org/hc/en-us/articles/115003865532';
-const REGIONAL_PARTNER_URL = '/pd/regional_partner_contact/new';
 const CS_TEACHERS_URL = 'https://code.org/educate/community';
 const INTERNATIONAL = 'Other country';
 const US = 'United States';
@@ -125,43 +125,11 @@ export default class Section1AboutYou extends LabeledFormComponent {
           </p>
         )}
 
-        <h3>What’s in this application and how long will it take?</h3>
         <p>
-          This application should take 10 - 15 minutes to complete. Fields
-          marked with a <span style={{color: 'red'}}>*</span> are required. Here
-          are the sections you will be asked to fill out:
+          Thanks for your interest in the Professional Learning Program! This
+          application should take 10 - 15 minutes to complete. Fields marked
+          with a <span style={{color: 'red'}}>*</span> are required.
         </p>
-        <ul>
-          <li>
-            <span style={styles.bold}>Section 1: About you</span>
-            &nbsp; (Your contact info)
-          </li>
-          <li>
-            <span style={styles.bold}>
-              Section 2: Teaching and school background
-            </span>
-            &nbsp; (Principal contact info, your subject areas, and what CS
-            courses are offered in your school)
-          </li>
-          <li>
-            <span style={styles.bold}>Section 3: Choose your program</span>
-            &nbsp; (Which program you want to join and how you plan on teaching
-            the course)
-          </li>
-          <li>
-            <span style={styles.bold}>
-              Section 4: Professional Learning Program commitments
-            </span>
-            &nbsp; (Your interest and ability to participate in the whole
-            program)
-          </li>
-          <li>
-            <span style={styles.bold}>
-              Section 5: Additional demographic information and submission
-            </span>
-            &nbsp; (Optional: your gender identity and race; Confirm and submit)
-          </li>
-        </ul>
 
         {!nominated && (
           <div>
@@ -207,11 +175,14 @@ export default class Section1AboutYou extends LabeledFormComponent {
           >
             check out our course and professional learning options.
           </a>{' '}
-          For additional questions regarding the program or application, please
-          <a href={REGIONAL_PARTNER_URL} target="_blank">
-            {' '}
-            contact your Regional Partner.
-          </a>
+          For additional questions regarding the program or application, please{' '}
+          <RegionalPartnerMiniContactPopupLink
+            sourcePageId="teacher-application-first-page"
+            notes="Please tell me more about the professional learning program!"
+          >
+            <span style={styles.linkLike}>contact your Regional Partner</span>
+          </RegionalPartnerMiniContactPopupLink>
+          .
         </p>
 
         <h3>Section 1: {SectionHeaders.section1AboutYou}</h3>

--- a/apps/src/code-studio/pd/application/teacher1920/TeacherApplicationConstants.js
+++ b/apps/src/code-studio/pd/application/teacher1920/TeacherApplicationConstants.js
@@ -1,3 +1,5 @@
+import color from '@cdo/apps/util/color';
+
 const PROGRAM_CSD =
   'Computer Science Discoveries (appropriate for 6th - 10th grade)';
 const PROGRAM_CSP =
@@ -20,6 +22,11 @@ const styles = {
   },
   bold: {
     fontFamily: '"Gotham 7r", sans-serif'
+  },
+  linkLike: {
+    fontFamily: '"Gotham 7r", sans-serif',
+    cursor: 'pointer',
+    color: color.purple
   }
 };
 

--- a/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
+++ b/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
@@ -20,7 +20,12 @@ const styles = {
     borderBottom: 'none'
   },
   modalBody: {
-    padding: '0 15px 15px 15px'
+    padding: '0 15px 15px 15px',
+    fontSize: 14,
+    lineHeight: '22px'
+  },
+  intro: {
+    paddingBottom: 10
   }
 };
 
@@ -111,12 +116,12 @@ export default class RegionalPartnerMiniContact extends React.Component {
           id={`regional-partner-mini-contact-form-${this.props.sourcePageId}`}
           className="regional-partner-mini-contact-form"
         >
-          <p>
+          <div style={styles.intro}>
             Your local Code.org Regional Partner provides high quality Code.org
             professional learning to teachers, and can help guide your school or
             district on implementation, certification, funding, and more. They
             are happy to answer any questions you may have about the program!
-          </p>
+          </div>
           <FieldGroup
             id="name"
             label="Name"

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -42,10 +42,10 @@ const styles = {
     marginTop: 20
   },
   bold: {
-    fontFamily: "'Gotham 5r', sans-serif"
+    fontFamily: '"Gotham 7r", sans-serif'
   },
   linkLike: {
-    fontFamily: "'Gotham 5r', sans-serif",
+    fontFamily: '"Gotham 7r", sans-serif',
     cursor: 'pointer',
     color: color.purple
   },

--- a/dashboard/app/views/pd/application/teacher_application/new.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application/new.html.haml
@@ -1,6 +1,12 @@
 = stylesheet_link_tag 'css/pd', media: 'all'
 %script{src: minifiable_asset_path('js/pd/application/teacher_application/new.js'), data: @script_data}
 
+:css
+  /* Make the X in regional partner mini-contact form's header look correct. */
+  div.modal-content .modal-header .close {
+    height: 34px
+  }
+
 %h1
   2019-20 Professional Learning Program Teacher Application
 


### PR DESCRIPTION
Page 1 of the teacher application now has:

- a pop-up regional partner mini-contact form
- no more list of the content of each page


![screenshot 2019-03-04 22 42 18](https://user-images.githubusercontent.com/2205926/53786085-5ebb5b00-3ecf-11e9-8c29-049153ec2162.png)

![screenshot 2019-03-05 09 49 21](https://user-images.githubusercontent.com/2205926/53825788-fea6d200-3f2b-11e9-8829-2da037ecd0c9.png)
