### PR TITLE
PL: regional partner search no longer has special message

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -238,21 +238,6 @@ class RegionalPartnerSearch extends Component {
           </form>
         )}
 
-        {/* Special message for NYC DOE teachers. */}
-        {partnerInfo && partnerInfo.name === 'Mouse' && (
-          <div>
-            <h3 style={styles.bold}>NYC Department of Education teachers:</h3>
-            We will share a more specific option for NYC DOE teachers in
-            February. The details are still being finalized. If you're a NYC DOE
-            teacher, please complete{' '}
-            <a href="https://goo.gl/forms/MEz3KmikwgPvIk332" target="_blank">
-              this very short form
-            </a>{' '}
-            and we'll alert you when details are available.
-            <h3 style={styles.bold}>For all other teachers:</h3>
-          </div>
-        )}
-
         {(this.state.error === WorkshopSearchErrors.no_state ||
           this.state.error === WorkshopSearchErrors.unknown) && (
           <div>


### PR DESCRIPTION
The special message for provider "Mouse" (added in https://github.com/code-dot-org/code-dot-org/pull/26639) is no longer needed.