### PR TITLE
Use real consumer key for LTI tests

### DIFF
--- a/dashboard/test/integration/lti_provider_controller_test.rb
+++ b/dashboard/test/integration/lti_provider_controller_test.rb
@@ -4,7 +4,7 @@ class LtiProviderControllerTest < ActionDispatch::IntegrationTest
   include Mocha::API
 
   TEST_PROVIDER_KEY = "dc3872a4b605f1f36242a837172ce2c0"
-  TEST_CONSUMER_KEY = "f10ee9fc082219227976f2c1603a3d77"
+  TEST_CONSUMER_KEY = "lti_prod_kids.qwikcamps.com"
 
   setup do
     CDO.stubs(:lti_credentials).returns({TEST_CONSUMER_KEY => TEST_PROVIDER_KEY})


### PR DESCRIPTION
Once we switch all users to multi-auth, we are going to start enforcing
that authentication options match a whitelist. So we should preemptively
make sure our tests work with that system.