### PR TITLE
Make authored hints id a required field in a level

### DIFF
--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -10,7 +10,7 @@
         %input.tts_url{type: 'hidden', value: 'general'}
         .row
           .span10
-            %input.hint_id{type: 'text', placeholder: 'hint_id'}
+            %input.hint_id{type: 'text', placeholder: 'hint_id', required: true}
             %select.hint_class
               %option{value: 'content'} Content Hint
               %option{value: 'pointer'} Pointer Hint

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -74,12 +74,12 @@
           levelbuilder.initializeCodeMirror(
             space.find('.hint_markdown').get(0),
             'markdown',
-            space.find('.hint_id').get(0).setAttribute("required", ""),
             {
               callback: function(editor, change) {
                 convertXmlToBlockly(space.find('.markdown_preview').get(0));
                 space.find('.hint_markdown').val(editor.getValue());
                 space.find('.hint_markdown').trigger('change');
+                space.find('.hint_id').get(0).setAttribute("required", "");
               },
               attachments: true,
               preview: space.find('.markdown_preview').get(0)

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -10,7 +10,7 @@
         %input.tts_url{type: 'hidden', value: 'general'}
         .row
           .span10
-            %input.hint_id{type: 'text', placeholder: 'hint_id', id: 'hint_id_input', required: true}
+            %input.hint_id{type: 'text', placeholder: 'hint_id'}
             %select.hint_class
               %option{value: 'content'} Content Hint
               %option{value: 'pointer'} Pointer Hint
@@ -19,7 +19,7 @@
             = select_tag :hint_video, options_for_select(video_key_choices), {include_blank: true, class: 'hint_video'}
         .row
           .span5
-            %textarea.hint_markdown{id: 'hint_markdown_input'}
+            %textarea.hint_markdown
           .span5
             .markdown_preview
         .row
@@ -42,19 +42,6 @@
 - content_for :body_scripts do
   :javascript
     $(document).ready(function () {
-      // Hint id is only required when there is an authored hint.
-      // If authored hint does not exist, a level can be created or
-      // edited and saved.
-      var hintMarkdown = document.getElementById('hint_markdown_input');
-      var hintId = document.getElementById('hint_id_input');
-      hintMarkdown.addEventListener('change', function() {
-        if (hintMarkdown.value.length > 0) {
-          hintId.addAttribute("required");
-        } else {
-          hindId.removeAttribute("required");
-        }
-      })
-
       // A markdown parser that supports a subset of rules; specifically,
       // those rules that we feel comfortable entrusting to translators
       var limitedMarked = (function () {

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -71,7 +71,7 @@
         form_container: "#all_authored_hints_editor",
         wrapper: ".json_editor",
         onNewSpace: function (space) {
-          space.find('.hint_id').get(0).setAttribute("required", ""),
+          space.find('.hint_id').get(0).setAttribute("required", "");
           levelbuilder.initializeCodeMirror(
             space.find('.hint_markdown').get(0),
             'markdown',

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -10,7 +10,7 @@
         %input.tts_url{type: 'hidden', value: 'general'}
         .row
           .span10
-            %input.hint_id{type: 'text', placeholder: 'hint_id', required: true}
+            %input.hint_id{type: 'text', placeholder: 'hint_id', id: 'hint_id_input', required: true}
             %select.hint_class
               %option{value: 'content'} Content Hint
               %option{value: 'pointer'} Pointer Hint
@@ -19,7 +19,7 @@
             = select_tag :hint_video, options_for_select(video_key_choices), {include_blank: true, class: 'hint_video'}
         .row
           .span5
-            %textarea.hint_markdown
+            %textarea.hint_markdown{id: 'hint_markdown_input'}
           .span5
             .markdown_preview
         .row
@@ -42,6 +42,16 @@
 - content_for :body_scripts do
   :javascript
     $(document).ready(function () {
+      var hintMarkdown = document.getElementById('hint_markdown_input');
+      var hintId = document.getElementById('hint_id_input');
+      hintMarkdown.addEventListener('change', function() {
+        if (hintMarkdown.value.length > 0) {
+          hintId.addAttribute("required");
+        } else {
+          hindId.removeAttribute("required");
+        }
+        console.log(e.target.value);
+      })
 
       // A markdown parser that supports a subset of rules; specifically,
       // those rules that we feel comfortable entrusting to translators

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -42,6 +42,9 @@
 - content_for :body_scripts do
   :javascript
     $(document).ready(function () {
+      // Hint id is only required when there is an authored hint.
+      // If authored hint does not exist, a level can be created or
+      // edited and saved.
       var hintMarkdown = document.getElementById('hint_markdown_input');
       var hintId = document.getElementById('hint_id_input');
       hintMarkdown.addEventListener('change', function() {
@@ -50,7 +53,6 @@
         } else {
           hindId.removeAttribute("required");
         }
-        console.log(e.target.value);
       })
 
       // A markdown parser that supports a subset of rules; specifically,

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -71,6 +71,7 @@
         form_container: "#all_authored_hints_editor",
         wrapper: ".json_editor",
         onNewSpace: function (space) {
+          space.find('.hint_id').get(0).setAttribute("required", ""),
           levelbuilder.initializeCodeMirror(
             space.find('.hint_markdown').get(0),
             'markdown',
@@ -79,7 +80,6 @@
                 convertXmlToBlockly(space.find('.markdown_preview').get(0));
                 space.find('.hint_markdown').val(editor.getValue());
                 space.find('.hint_markdown').trigger('change');
-                space.find('.hint_id').get(0).setAttribute("required", "");
               },
               attachments: true,
               preview: space.find('.markdown_preview').get(0)

--- a/dashboard/app/views/levels/editors/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/_authored_hints.haml
@@ -87,6 +87,7 @@
           levelbuilder.initializeCodeMirror(
             space.find('.hint_markdown').get(0),
             'markdown',
+            space.find('.hint_id').get(0).setAttribute("required", ""),
             {
               callback: function(editor, change) {
                 convertXmlToBlockly(space.find('.markdown_preview').get(0));


### PR DESCRIPTION
This PR is to resolve i18n user issues reported by our partner in Italy.  

### i18n issues
The [hint string](https://levelbuilder-studio.code.org/s/coursed-2018/stage/17/puzzle/7)  "The second hint, "The 'safe zone' is an area the ninja can't go into, making it safe for the pirate." is not found in Crowdin
  

The [hint string](https://levelbuilder-studio.code.org/s/coursea-2018/stage/10/puzzle/2)   The second hint string, "If you're still having trouble, try saying the steps out loud." is not found in Crowdin. 
[ ] Follow up question:  Why is the authored_hints string for puzzle 2 not in authored__hints.yml


### Root cause
Upon investigation/discussion with Elijah, the value of the authored_hint for puzzle 7 is an empty hash.  When puzzle 2 and puzzle 7 were created an authored_hints "hint_id" was not assigned, which is required when a "sync-in" is run.  Since, there were no authored hint strings for these levels pulled in during a normal sync in process, the strings were not in Crowdin. 
 
### Solution
- Add hint_id to the level on level builder for each puzzle
- Make hint_id a required field 
- Perform manual test to ensure the required field does not break saving of levels without authored hints

### Before
<img width="830" alt="screen shot 2018-12-04 at 2 10 46 pm" src="https://user-images.githubusercontent.com/30066710/49476369-a5b18b80-f7ce-11e8-9c2b-02480005c5d7.png">


### After (Editor cannot save level without an authored hints id)
<img width="828" alt="screen shot 2018-12-04 at 2 10 14 pm" src="https://user-images.githubusercontent.com/30066710/49476357-9d595080-f7ce-11e8-8b13-f784737ef9b9.png">

### Preventative measures
[ ] Search for all authored hints without ids in level content.
[ ] Add hint_ids 

### Search
```
Level.select {|l| l.properties["authored_hints"].present? && JSON.parse(l.properties["authored_hints"]).any? {|authored_hint| authored_hint["hint_markdown"].present? && authored_hint["hint_id"].blank? } }.count
```
### Results:
- 1917 levels have authored_hints with hint_ids
- 6 levels have authored_hints without hint_ids (Found in Maze, Karel)
   - of the 6 levels, 3 authored hints had content, while the other 3 where empty
- Add hint_ids to the levels identified

### Follow-up - completed
- Run a sync-in post HOC that will include the authored_hint id for the updated puzzles
