### PR TITLE
Update craft to 0.2.1

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -42,7 +42,7 @@
     "@code-dot-org/artist": "0.2.1",
     "@code-dot-org/blockly": "3.4.2",
     "@code-dot-org/bramble": "0.1.26",
-    "@code-dot-org/craft": "0.2.0",
+    "@code-dot-org/craft": "0.2.1",
     "@code-dot-org/dance-party": "0.0.42",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -60,9 +60,9 @@
     semver "^4.1.0"
     xmldoc "^0.1.2"
 
-"@code-dot-org/craft@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/craft/-/craft-0.2.0.tgz#3354090ecb81c60386b33931c7c64c4c9948e8b3"
+"@code-dot-org/craft@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/craft/-/craft-0.2.1.tgz#007cfc859a14c3fbe686cae49d2114a3e03a223f"
 
 "@code-dot-org/dance-party@0.0.42":
   version "0.0.42"


### PR DESCRIPTION
Picks up [Allow WASD keys and Spacebar to be used in project names]( https://github.com/code-dot-org/craft/pull/551 )