### PR TITLE
Teacher panel section link

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
@@ -11,6 +11,7 @@ import {ViewType} from '../../viewAsRedux';
 import {hasLockableStages} from '../../progressRedux';
 import commonMsg from '@cdo/locale';
 import StudentTable, {studentShape} from './StudentTable';
+import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 
 const styles = {
   text: {
@@ -24,6 +25,12 @@ const styles = {
     marginLeft: 10,
     fontSize: 16,
     fontFamily: '"Gotham 7r", sans-serif'
+  },
+  sectionHeader: {
+    margin: 10,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
   }
 };
 
@@ -36,6 +43,10 @@ class ScriptTeacherPanel extends React.Component {
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
     hasSections: PropTypes.bool.isRequired,
     sectionsAreLoaded: PropTypes.bool.isRequired,
+    selectedSection: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired
+    }),
     scriptHasLockableStages: PropTypes.bool.isRequired,
     scriptAllowsHiddenStages: PropTypes.bool.isRequired,
     unlockedStageNames: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -59,6 +70,7 @@ class ScriptTeacherPanel extends React.Component {
       viewAs,
       hasSections,
       sectionsAreLoaded,
+      selectedSection,
       scriptHasLockableStages,
       scriptAllowsHiddenStages,
       unlockedStageNames,
@@ -71,6 +83,14 @@ class ScriptTeacherPanel extends React.Component {
         <div id="teacher-panel-nonscrollable">
           <h3>{commonMsg.teacherPanel()}</h3>
           <ViewAsToggle />
+          {selectedSection && (
+            <h4 style={styles.sectionHeader}>
+              {`${commonMsg.section()} `}
+              <a href={teacherDashboardUrl(selectedSection.id)}>
+                {selectedSection.name}
+              </a>
+            </h4>
+          )}
           {!sectionsAreLoaded && (
             <div style={styles.text}>{commonMsg.loading()}</div>
           )}
@@ -153,6 +173,7 @@ export default connect((state, ownProps) => {
     hasSections: sectionIds.length > 0,
     sectionsAreLoaded,
     scriptHasLockableStages,
+    selectedSection: state.teacherSections.sections[selectedSectionId],
     scriptAllowsHiddenStages: state.hiddenStage.hideableStagesAllowed,
     unlockedStageNames: unlockedStageIds.map(id => stageNames[id]),
     students: state.teacherSections.selectedStudents

--- a/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
@@ -14,6 +13,11 @@ import StudentTable, {studentShape} from './StudentTable';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 
 const styles = {
+  scrollable: {
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    maxHeight: '90%'
+  },
   text: {
     margin: 10
   },
@@ -53,18 +57,6 @@ class ScriptTeacherPanel extends React.Component {
     students: PropTypes.arrayOf(studentShape)
   };
 
-  calculateStudentTableMaxHeight = () => {
-    let teacherPanel = $('.teacher-panel');
-    let contentToRemove = $('#teacher-panel-nonscrollable');
-
-    if (teacherPanel.length > 0 && contentToRemove.length > 0) {
-      return (
-        // Calculate max height and include 15px buffer room.
-        teacherPanel[0].clientHeight - contentToRemove[0].clientHeight - 15
-      );
-    }
-  };
-
   render() {
     const {
       viewAs,
@@ -76,12 +68,11 @@ class ScriptTeacherPanel extends React.Component {
       unlockedStageNames,
       students
     } = this.props;
-    const studentTableMaxHeight = this.calculateStudentTableMaxHeight();
 
     return (
       <TeacherPanel>
-        <div id="teacher-panel-nonscrollable">
-          <h3>{commonMsg.teacherPanel()}</h3>
+        <h3>{commonMsg.teacherPanel()}</h3>
+        <div style={styles.scrollable}>
           <ViewAsToggle />
           {selectedSection && (
             <h4 style={styles.sectionHeader}>
@@ -127,16 +118,14 @@ class ScriptTeacherPanel extends React.Component {
                 )}
               </div>
             )}
-        </div>
-        {viewAs === ViewType.Teacher && (students || []).length > 0 && (
-          <div style={{maxHeight: studentTableMaxHeight, overflowY: 'auto'}}>
+          {viewAs === ViewType.Teacher && (students || []).length > 0 && (
             <StudentTable
               students={students}
               onSelectUser={this.props.onSelectUser}
               getSelectedUserId={this.props.getSelectedUserId}
             />
-          </div>
-        )}
+          )}
+        </div>
       </TeacherPanel>
     );
   }

--- a/apps/test/unit/code-studio/components/progress/ScriptTeacherPanelTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ScriptTeacherPanelTest.jsx
@@ -25,8 +25,8 @@ describe('ScriptTeacherPanel', () => {
     );
     expect(wrapper).to.containMatchingElement(
       <TeacherPanel>
-        <div id="teacher-panel-nonscrollable">
-          <h3>{commonMsg.teacherPanel()}</h3>
+        <h3>{commonMsg.teacherPanel()}</h3>
+        <div>
           <ViewAsToggle />
           <div>{commonMsg.loading()}</div>
         </div>
@@ -40,8 +40,8 @@ describe('ScriptTeacherPanel', () => {
     );
     expect(wrapper).to.containMatchingElement(
       <TeacherPanel>
-        <div id="teacher-panel-nonscrollable">
-          <h3>{commonMsg.teacherPanel()}</h3>
+        <h3>{commonMsg.teacherPanel()}</h3>
+        <div>
           <ViewAsToggle />
           <div>{commonMsg.loading()}</div>
         </div>


### PR DESCRIPTION
### What it does
- Adds a link to teacher dashboard for the current section on the script overview page teacher panel.
- Refactors the teacher panel to make all of the content scrollable (rather than only the `StudentTable` portion). Originally, we were calculating the height of the `StudentTable`, which proved to be brittle once I added another element to the teacher panel. Making all of the content scrollable makes the solution more robust.

### Before
![screen shot 2019-03-05 at 3 46 42 pm](https://user-images.githubusercontent.com/9812299/53845432-e51e7e00-3f5d-11e9-85df-12e04673522a.png)

### After
Section with few students (i.e., no scrolling overflow):
![screen shot 2019-03-05 at 3 13 32 pm](https://user-images.githubusercontent.com/9812299/53845313-72150780-3f5d-11e9-84ed-2d124fc4ee2e.png)

Section with more students (i.e., with scrolling overflow):
![screen shot 2019-03-05 at 3 14 08 pm](https://user-images.githubusercontent.com/9812299/53845312-72150780-3f5d-11e9-90d5-390a29b2e680.png)

