### PR TITLE
Commit hook: don't scoop pegasus avatar filenames with any uppercase

### DIFF
--- a/tools/hooks/restrict_staging_changes.rb
+++ b/tools/hooks/restrict_staging_changes.rb
@@ -12,6 +12,7 @@ def prohibited?(filename)
   return true if ['.mp4', '.mov'].include? File.extname(filename)
   return true if File.extname(filename) != File.extname(filename).downcase
   return true if filename.include?(' ')
+  return true if filename.include?('/code.org/public/images/avatars/') && File.basename(filename).downcase != File.basename(filename)
   false
 end
 


### PR DESCRIPTION
The "avatar" filenames need to be all lowercase because of the way we generate the filename from a friendly name here: https://github.com/code-dot-org/code-dot-org/blob/staging/pegasus/helpers.rb#L6
