### PR TITLE
Reenable spritelab test on Drone

### DIFF
--- a/dashboard/test/ui/features/spritelab/spritelab.feature
+++ b/dashboard/test/ui/features/spritelab/spritelab.feature
@@ -1,4 +1,3 @@
-@no_circle
 Feature: Sprite Lab
 
 Background:


### PR DESCRIPTION
I believe this is passing again. I still don't know the root cause, as I wasn't able to reproduce it yesterday even running the drone container locally.