### PR TITLE
Mount AWS config directory for local docker [ci skip]

### DIFF
--- a/docker/site-compose.yml
+++ b/docker/site-compose.yml
@@ -22,6 +22,7 @@ services:
       - ../:/home/circleci/code-dot-org:delegated
       - $HOME/.ssh:/home/circleci/.ssh:ro
       - $HOME/.ssh:$HOME/.ssh:ro
+      - $HOME/.aws:/home/circleci/.aws
       - rbenv:/home/circleci/.rbenv
       - mysqldata:/var/lib/mysql
       - yarncache:/home/circleci/.cache


### PR DESCRIPTION
This allows your AWS credentials to be shared between the local development container and your host machine. Among other things, you can run `bin/aws_access` inside the container, and then use those temporary credentials with the aws cli on your host machine.