### PR TITLE
Change the scale of teacher engagement question to 6

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Table} from 'react-bootstrap';
 import _ from 'lodash';
+import {COURSE_CSF} from '../../workshopConstants';
 
 const questionOrder = {
   facilitator_effectiveness: [
@@ -23,12 +24,6 @@ const questionOrder = {
   ]
 };
 
-const questionDenominator = {
-  facilitator_effectiveness: 5,
-  teacher_engagement: 5,
-  overall_success: 6
-};
-
 export default class FacilitatorAveragesTable extends React.Component {
   static propTypes = {
     facilitatorAverages: PropTypes.object.isRequired,
@@ -39,9 +34,21 @@ export default class FacilitatorAveragesTable extends React.Component {
     facilitatorResponseCounts: PropTypes.object.isRequired
   };
 
+  constructor(props) {
+    super(props);
+
+    this.questionDenominator = {
+      facilitator_effectiveness: 5,
+      teacher_engagement: props.courseName === COURSE_CSF ? 5 : 6,
+      overall_success: 6
+    };
+  }
+
   renderAverage(displayNumber, category) {
     if (displayNumber) {
-      return `${displayNumber.toFixed(2)} / ${questionDenominator[category]}`;
+      return `${displayNumber.toFixed(2)} / ${
+        this.questionDenominator[category]
+      }`;
     } else {
       return '-';
     }


### PR DESCRIPTION
[PLC-39](https://codedotorg.atlassian.net/browse/PLC-39).
This change sets Teacher Engagement question scale to 6 for CSD + CSP, and 5 for CSF.

Test manually using `facilitator_averages_table.story.jsx` storybook with courseName="CS Discoveries" and "CS Fundamentals".

Backlog created from this work
[PLC-141: Create UI tests for workshop dashboard or move logic out of UI components](https://codedotorg.atlassian.net/browse/PLC-141)
> In workshop dashboard, we have tests to check if UI components are rendered, but don't have tests to check if the content they show is correct. This seems necessary because we keep some data logic inside UI components. We want to either test those logic in UI components or move it upstream from UI to backend components and test them there.