### PR TITLE
Refactor IAM permissions in CDO CloudFormation template

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -76,7 +76,79 @@ Parameters:
     MaxLength: 41
 <% end -%>
 Resources:
+  # Stack-specific IAM permissions applied to both daemon and frontends.
+  CDOPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: !Sub "Application permissions for ${AWS::StackName}."
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          # Read-only access to bootstrap scripts.
+          - Effect: Allow
+            Action: 's3:GetObject'
+            Resource: 'arn:aws:s3:::cdo-dist/<%=environment%>/*'
+          # Instance-bootstrap CloudFormation hook.
+          - Effect: Allow
+            Action: 'cloudformation:SignalResource'
+            Resource: !Ref AWS::StackId
+          # Forward syslog to CloudWatch Logs via cdo-cloudwatch-logger.
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutRetentionPolicy'
+              - 'logs:PutLogEvents'
+            Resource:
+              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:<%=environment%>-syslog"
+              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:<%=environment%>-syslog:log-stream:*"
+              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${AWS::StackName}"
+              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${AWS::StackName}:log-stream:*"
+          # Put custom metrics to CloudWatch.
+          - Effect: Allow
+            Action: 'cloudwatch:PutMetricData'
+            Resource: '*'
+          # Frontend-bootstrap lifecycle hooks.
+          - Effect: Allow
+            Action: 'autoscaling:CompleteLifecycleAction'
+            Resource: !Sub "arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/Frontends-${AWS::StackName}"
+          # Read/Write DCDO and Gatekeeper tables.
+          # TODO: Import resources into stack.
+          - Effect: Allow
+            Action:
+              - 'dynamodb:GetItem'
+              - 'dynamodb:PutItem'
+              - 'dynamodb:Scan'
+            Resource:
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/<%=CDO.dcdo_table_name%>"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/<%=CDO.gatekeeper_table_name%>"
+          # Write analysis events to Firehose.
+          # TODO: Import resources into stack.
+          - Effect: Allow
+            Action: 'firehose:PutRecord'
+            Resource: !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/analysis-events"
+          # General s3 access.
+          # TODO: Further restrict permissions to grant least privilege.
+          - Effect: Allow
+            Action: 's3:*'
+            Resource: '*'
 <% if frontends -%>
+  FrontendRole:
+    Type: AWS::IAM::Role
+    Properties:
+      <%=service_role 'ec2'%>
+      Policies:
+        - PolicyName: LifecycleHook
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: 'autoscaling:CompleteLifecycleAction'
+                Resource: !Sub "arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/Frontends-${AWS::StackName}"
+      ManagedPolicyArns: [!Ref CDOPolicy]
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
+  FrontendInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties: {Roles: [!Ref FrontendRole]}
   # Signal when the instance is fully provisioned and ready for AMI creation.
   AMICreate<%=ami%>:
     Type: AWS::CloudFormation::WaitCondition
@@ -91,7 +163,7 @@ Resources:
     Properties:
       ImageId: <%=IMAGE_ID%>
       InstanceType: !Ref InstanceType
-      IamInstanceProfile: !ImportValue IAM-FrontendInstanceProfile
+      IamInstanceProfile: !ImportValue IAM-FrontendInstanceProfile # Migrate to: !Ref FrontendInstanceProfile
       SecurityGroupIds: [!ImportValue VPC-FrontendSecurityGroup]
       SubnetId: !ImportValue VPC-Subnet<%=azs.first%>
       KeyName: <%=SSH_KEY_NAME%>
@@ -200,7 +272,7 @@ Resources:
     Properties:
       ImageId: !GetAtt [AMI<%=ami%>, ImageId]
       InstanceType: !Ref InstanceType
-      IamInstanceProfile: !ImportValue IAM-FrontendInstanceProfile
+      IamInstanceProfile: !ImportValue IAM-FrontendInstanceProfile # Migrate to: !Ref FrontendInstanceProfile
       SecurityGroups: [!ImportValue VPC-FrontendSecurityGroup]
       KeyName: <%=SSH_KEY_NAME%>
       BlockDeviceMappings:
@@ -234,7 +306,7 @@ Resources:
       DefaultResult: ABANDON
       HeartbeatTimeout: 1200 # seconds = 20 minutes
       NotificationTargetARN: !Ref WebServerHookTopicNew
-      RoleARN: !ImportValue IAM-LifecycleHookRoleARN
+      RoleARN: !ImportValue IAM-LifecycleHookRoleARN # Migrate to: !Ref WebServerHookRole
   WebServerHookEventRule:
     Type: AWS::Events::Rule
     Properties:
@@ -262,6 +334,18 @@ Resources:
       Principal: events.amazonaws.com
       SourceArn: !GetAtt WebServerHookEventRule.Arn
   WebServerHookTopicNew: {Type: 'AWS::SNS::Topic'}
+  WebServerHookRole:
+    Type: AWS::IAM::Role
+    Properties:
+      <%=service_role 'autoscaling'%>
+      Policies:
+        - PolicyName: snsPublish
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: 'sns:Publish'
+                Resource: !Ref WebServerHookTopicNew
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
 <%  if environment == :production -%>
   HealthEventRule:
     Type: AWS::Events::Rule
@@ -422,6 +506,44 @@ Resources:
       VisibilityTimeout: 15
       QueueName: !Sub "activities_dead-${AWS::StackName}"
 <% end -%>
+  DaemonRole:
+    Type: AWS::IAM::Role
+    Properties:
+      <%=service_role 'ec2'%>
+      Policies:
+        - PolicyName: Daemon
+          PolicyDocument:
+            Statement:
+              # SQS queues for Asynchronous batch processing by the `process_queues` service.
+              - Effect: Allow
+                Action:
+                  - 'sqs:SendMessage'
+                  - 'sqs:ReceiveMessage'
+                  - 'sqs:DeleteMessageBatch'
+                  - 'sqs:DeleteMessage'
+                Resource:
+<% unless daemon -%>
+                  - !GetAtt ActivitiesQueue.Arn
+                  - !GetAtt ActivitiesDeadQueue.Arn
+<% end -%>
+                  # TODO: Import pd_workshop resources into stack.
+                  - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:pd_workshop-<%=environment%>"
+                  - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:pd_workshop_dead-<%=environment%>"
+              - Effect: Allow
+                Action:
+                  - 'cloudformation:DescribeStacks'
+                  - 'cloudformation:DescribeStackEvents'
+                  - 'cloudformation:GetStackPolicy'
+                Resource: !Ref AWS::StackId
+              # Update Stack through `ci:deploy_stack` task.
+              - Effect: Allow
+                Action: 'cloudformation:UpdateStack'
+                Resource: !Ref AWS::StackId
+      ManagedPolicyArns: [!Ref CDOPolicy]
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
+  DaemonInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties: {Roles: [!Ref DaemonRole]}
 <% if daemon -%>
   <%=daemon%>:
     Type: AWS::EC2::Instance
@@ -431,7 +553,7 @@ Resources:
     Properties:
       ImageId: <%=IMAGE_ID%>
       InstanceType: !Ref InstanceType
-      IamInstanceProfile: !ImportValue IAM-<%=environment == :adhoc ? 'Standalone' : 'Staging'%>InstanceProfile
+      IamInstanceProfile: !Ref DaemonInstanceProfile
       KeyName: <%=SSH_KEY_NAME%>
       Tags:
       - Key: Name

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -1,9 +1,112 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  IAM layer including roles and access permissions for Code.org infrastructure.
-  Note: Admin permissions are required to manage this stack.
+  IAM layer including global/shared roles and access permissions for Code.org infrastructure.
+  Note: Admin permissions are required to manage some admin-only resources in this stack.
 Resources:
+  # Admin Service Role for managing all resources in CloudFormation stacks.
+  # Only admins can update stacks using this service role.
+  CloudFormationAdmin:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: CloudFormationAdmin
+      <%=service_role 'cloudformation'%>
+      Path: /admin/
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/AdministratorAccess']
+  # Shared CloudFormation Service Role used by all stacks.
+  CloudFormationService:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: CloudFormationService
+      <%=service_role 'cloudformation'%>
+      Path: /admin/
+      Policies:
+        # Grant permissions for managing specific non-admin AWS::IAM resources.
+        - PolicyName: RolePermissionsBoundary
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  # AWS::IAM::ManagedPolicy
+                  - iam:CreatePolicy
+                  - iam:CreatePolicyVersion
+                  - iam:DeletePolicy
+                  - iam:DeletePolicyVersion
+                NotResource: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/*"
+              - Effect: Allow
+                Action:
+                  # AWS::IAM::InstanceProfile
+                  - iam:CreateInstanceProfile
+                  - iam:AddRoleToInstanceProfile
+                  - iam:RemoveRoleFromInstanceProfile
+                  - iam:DeleteInstanceProfile
+                NotResource: !Sub "arn:aws:iam::${AWS::AccountId}:instance-profile/admin/*"
+              - Effect: Allow
+                Action:
+                  - iam:DeleteRole
+                  - iam:UpdateAssumeRolePolicy
+                NotResource: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/*"
+              - Effect: Allow
+                Action:
+                  # AWS::IAM::Role
+                  - iam:CreateRole
+                  - iam:PutRolePermissionsBoundary
+                  # Managed policies attached to a Role
+                  - iam:AttachRolePolicy
+                  - iam:DetachRolePolicy
+                  # Inline policies embedded in a Role
+                  - iam:PutRolePolicy
+                  - iam:DeleteRolePolicy
+                NotResource: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/*"
+                # Require DevPermissions boundary on all Roles, e.g.:
+                # PermissionsBoundary: !ImportValue IAM-DevPermissions
+                Condition:
+                  StringEquals:
+                    iam:PermissionsBoundary: !Ref DevPermissions
+      ManagedPolicyArns: [!Ref DevPermissions]
+  # Shared 'Developer' permissions.
+  # Used as default permissions for all developer Roles,
+  # and as a required permissions boundary for CloudFormation-managed resources.
+  DevPermissions:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: DevPermissions
+      Path: /admin/
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            NotAction:
+              - iam:*
+              - organizations:*
+            Resource: '*'
+          - Sid: IAMReadOnlyAccess
+            Effect: Allow
+            Action:
+              - iam:GenerateCredentialReport
+              - iam:GenerateServiceLastAccessedDetails
+              - iam:Get*
+              - iam:List*
+              - iam:SimulateCustomPolicy
+              - iam:SimulatePrincipalPolicy
+            Resource: '*'
+          - Effect: Allow
+            Action: iam:PassRole
+            Resource: '*'
+          # Require CloudFormation Service Role on all stack operations.
+          - Effect: Deny
+            Action:
+              - cloudformation:CreateStack
+              - cloudformation:UpdateStack
+              - cloudformation:DeleteStack
+              - cloudformation:CreateChangeSet
+            Resource: '*'
+            Condition:
+              StringNotEquals:
+                cloudformation:RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/CloudFormationService"
+
+  # Deprecated: use FrontendRole in application stack
   FrontendRole:
     Type: AWS::IAM::Role
     Properties:
@@ -42,6 +145,7 @@ Resources:
             - 'dynamodb:*'
             - 'sqs:*'
             Resource: '*'
+  # Deprecated: use FrontendRole in application stack
   StandaloneFrontendRole:
     Type: AWS::IAM::Role
     Properties:
@@ -83,6 +187,7 @@ Resources:
             Resource:
             - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/adhoc_tables"
             - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/adhoc_properties"
+  # Deprecated: use DaemonRole in application stack
   StandaloneRole:
     Type: AWS::IAM::Role
     Properties:
@@ -130,6 +235,7 @@ Resources:
             - "arn:aws:s3:::cdo-dist/adhoc/*"
             - "arn:aws:s3:::cdo-build-logs/*"
             - "arn:aws:s3:::<%=TEMP_BUCKET%>/*"
+  # Deprecated: use DaemonRole in application stack
   DaemonRole:
     Type: AWS::IAM::Role
     Properties:
@@ -151,31 +257,37 @@ Resources:
             Action:
             - 'iam:GetServerCertificate'
             Resource: '*'
+  # Deprecated: use FrontendInstanceProfile in application stack
   FrontendInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: '/'
       Roles: [!Ref FrontendRole]
+  # Deprecated: use DaemonInstanceProfile in application stack
   StandaloneInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
       Roles: [!Ref StandaloneRole]
+  # Deprecated: use FrontendInstanceProfile in application stack
   StandaloneFrontendInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: '/'
       Roles: [!Ref StandaloneFrontendRole]
+  # Deprecated: use DaemonInstanceProfile in application stack
   ProductionInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: '/'
       Roles: [!Ref DaemonRole]
+  # Deprecated: use DaemonInstanceProfile in application stack
   StagingInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: '/'
       Roles: [!Ref DaemonRole]
+  # Deprecated: use WebServerHookRole in application stack
   LifecycleHookRole:
     Type: AWS::IAM::Role
     Properties:
@@ -193,6 +305,8 @@ Resources:
           - Effect: Allow
             Action: ['sns:Publish']
             Resource: '*'
+  # Used by FirehoseMicroservice Lambda function.
+  # TODO move to Data stack
   FirehoseLambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -216,6 +330,7 @@ Resources:
             - !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/analysis-events"
       ManagedPolicyArns:
       - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  # Deprecated: use CloudFormationService for all stack updates
   CloudFormationRole:
     Type: AWS::IAM::Role
     Properties:
@@ -235,7 +350,8 @@ Resources:
             - 'iam:PassRole'
             Resource: '*'
       ManagedPolicyArns:
-      - "arn:aws:iam::aws:policy/PowerUserAccess"
+        - "arn:aws:iam::aws:policy/PowerUserAccess"
+  # TODO: Move to Data stack
   GlueRole:
     Type: AWS::IAM::Role
     Properties:
@@ -259,6 +375,7 @@ Resources:
       - 'arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole'
   # Percona Monitoring and Management RDS access role.
   # See: https://www.percona.com/doc/percona-monitoring-and-management/amazon-rds.html#creating-a-policy
+  # TODO: Move to Data stack
   PMMRole:
     Type: AWS::IAM::Role
     Properties:
@@ -288,6 +405,7 @@ Resources:
                   - 'logs:FilterLogEvents'
                 Resource:
                   - "arn:aws:logs:*:*:log-group:RDSOSMetrics:*"
+  # TODO: Move to Data stack
   PMMInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -309,6 +427,10 @@ Resources:
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
 Outputs:
+  DevPermissions:
+    Description: Developer Permissions
+    Value: !Ref DevPermissions
+    Export: {Name: !Sub "${AWS::StackName}-DevPermissions"}
   FrontendInstanceProfile:
     Description: Frontend Instance Profile
     Value: !Ref FrontendInstanceProfile


### PR DESCRIPTION
This PR refactors various existing admin-managed IAM-permissions resources ([`AWS::IAM::Role`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html) and [`AWS::IAM::InstanceProfile`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html)) to stack-specific IAM resources, constrained to more fine-grained resources specific to the stack where they are located.

Previously, `AWS::IAM` resources could not exist in application stacks because permissions to `iam:*` APIs were restricted to the `root` account and 'admin' role (to prevent privilege-escalation from non-admin logins). This PR creates a [CloudFormation Service Role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html) granting CloudFormation just enough `iam` permissions to manage a few key IAM resources (`AWS::IAM::Role`, `AWS::IAM::ManagedPolicy`, `AWS::IAM::InstanceProfile`) within stacks. Additionally, a `Condition` requires all `AWS::IAM::Role`s to include a [`PermissionsBoundary`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-permissionsboundary), which prevents privilege-escalation through creating/assuming `Role` resources. (See [blog post](https://aws.amazon.com/blogs/security/delegate-permission-management-to-developers-using-iam-permissions-boundaries/) for more details on how the permissions-boundary feature works.)

This will provide better security (more restricted IAM permissions on `frontend` and `daemon` EC2 instance profiles), and simplifies permissions management moving forward (since we can create `AWS::IAM` resources alongside the service resources in application-stack templates).

Allowing for these fine-grained permissions within each application stack is also a prerequisite to integrating Secrets Manager service into our application.