### PR TITLE
Update Pardot authentication mechanism

### DIFF
--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -15,7 +15,7 @@ def main
   # Build new daily table of contact rollups
   ContactRollups.build_contact_rollups
 
-  # Validate that daily contact rollups meets sanity exoectations
+  # Validate that daily contact rollups meets sanity expectations
   results = ContactRollupsValidation.validate_contact_rollups
   unless results[:pass]
     message = "Contact rollups process failed. "\

--- a/lib/cdo/contact_rollups_validation.rb
+++ b/lib/cdo/contact_rollups_validation.rb
@@ -232,7 +232,7 @@ class ContactRollupsValidation
       query:  "SELECT COUNT(*) FROM contact_rollups_daily
               WHERE ages_taught IS NOT NULL",
       min: 190_000,
-      max: 400_000
+      max: 600_000
     },
     {
       name: "Check that all contacts with ages taught are "\

--- a/lib/cdo/pardot.rb
+++ b/lib/cdo/pardot.rb
@@ -451,9 +451,15 @@ class Pardot
   # @return [Nokogiri::XML] XML response from Pardot
   def self.post_request_with_auth(url)
     request_pardot_api_key if $pardot_api_key.nil?
-    # add the API key and user key parameters to the URL
-    auth_url = append_auth_params_to_url(url)
-    post_request(auth_url, {})
+
+    # add the API key and user key parameters to body of the POST request
+    post_request(
+      url,
+      {
+        api_key: $pardot_api_key,
+        user_key: CDO.pardot_user_key
+      }
+    )
   end
 
   # Make an API request. This method may raise exceptions.
@@ -485,14 +491,6 @@ class Pardot
     raise "Pardot response did not include status" if status.nil?
 
     doc
-  end
-
-  # Append standard Pardot auth parameters (per-session API key and fixed user
-  # key) to a Pardot API request
-  # @param url [String] URL to post to
-  # @return [String] URL with auth parameters appended
-  def self.append_auth_params_to_url(url)
-    "#{url}&api_key=#{$pardot_api_key}&user_key=#{CDO.pardot_user_key}"
   end
 
   # Parse a Pardot XML response and raise an exception on the first error


### PR DESCRIPTION
[Task PLC-131](https://codedotorg.atlassian.net/browse/PLC-131)
- Send Pardot authentication key in POST body instead of in query string. 
- Update validation test limit.

How test:
- In ruby console with Pardot settings copied from production, run `Pardot.request_pardot_api_key` to get authentication key.
- Create a query to find 1 prospect that is updated in the last 7 days 
`url = "https://pi.pardot.com/api/prospect/version/4/do/query?updated_after=last_7_days&limit=1"
- Send the query to Pardot `res = Pardot.post_with_auth_retry(url)`, which has authentication key inside its POST request.
- Expect: Pardot returns 1 prospect -> Passed!
