### PR TITLE
It's now `@client.api.account.messages` or `@client.messages` for short

### DIFF
--- a/bin/cron/delete_twilio_data
+++ b/bin/cron/delete_twilio_data
@@ -18,38 +18,33 @@ def main
   # every five minutes. We further backtrack a minute for rounding error.
   date_to_delete = Time.now - (60 + 5 + 1) * 60
 
-  messages_to_delete = @client.messages.list(
+  @client.messages.list(
     date_sent: date_to_delete.strftime('%F'),
     page_size: 1000
-  )
-  until messages_to_delete.empty?
-    messages_to_delete.each do |message|
-      # As it is an error to delete a message being processed, we pass them
-      # by, allowing them to be deleted after being processed, as part of
-      # another execution of this script.
-      # Per customer ticket #712102, it is also an error to delete a message
-      # in state sent, despite not seeing public documentation of this.
-      if %w(accepted queued sending sent SENT receiving).include? message.status
-        next
-      end
-
-      # Note that any media associated with a message is deleted independently
-      # of the message itself. As there is a maximum limit of ten media per
-      # message, we do not need to worry about iterating through pages.
-      if message.num_media != '0'
-        media_to_delete = message.media.list
-        media_to_delete.each(&:delete)
-      end
-
-      message.delete
-    rescue Twilio::REST::RestError => e
-      # Sanitize the exception message so that we don't expose secrets.
-      e.message.gsub! CDO.twilio_sid, 'CDO.twilio_sid'
-      Honeybadger.notify(e)
+  ).each do |message|
+    # As it is an error to delete a message being processed, we pass them
+    # by, allowing them to be deleted after being processed, as part of
+    # another execution of this script.
+    # Per customer ticket #712102, it is also an error to delete a message
+    # in state sent, despite not seeing public documentation of this.
+    if %w(accepted queued sending sent SENT receiving).include? message.status
       next
     end
 
-    messages_to_delete = messages_to_delete.next_page
+    # Note that any media associated with a message is deleted independently
+    # of the message itself. As there is a maximum limit of ten media per
+    # message, we do not need to worry about iterating through pages.
+    if message.num_media != '0'
+      media_to_delete = message.media.list
+      media_to_delete.each(&:delete)
+    end
+
+    message.delete
+  rescue Twilio::REST::RestError => e
+    # Sanitize the exception message so that we don't expose secrets.
+    e.message.gsub! CDO.twilio_sid, 'CDO.twilio_sid'
+    Honeybadger.notify(e)
+    next
   end
 end
 

--- a/bin/cron/delete_twilio_data
+++ b/bin/cron/delete_twilio_data
@@ -18,7 +18,7 @@ def main
   # every five minutes. We further backtrack a minute for rounding error.
   date_to_delete = Time.now - (60 + 5 + 1) * 60
 
-  messages_to_delete = @client.account.messages.list(
+  messages_to_delete = @client.messages.list(
     date_sent: date_to_delete.strftime('%F'),
     page_size: 1000
   )


### PR DESCRIPTION
Fix for https://app.honeybadger.io/projects/45435/faults/46684302#notice-summary.

Follow up to PR https://github.com/code-dot-org/code-dot-org/pull/27392.