### PR TITLE
Set db_opt_in to No when there is no source entry

### DIFF
--- a/lib/cdo/pardot.rb
+++ b/lib/cdo/pardot.rb
@@ -271,11 +271,8 @@ class Pardot
     end
 
     # The custom Pardot db_Opt_In field has type "Dropdown" with permitted values "Yes" or "No".
-    # Explicitly check for the source opt_in field to be true or false, because nil is 'falsey'
-    # and it's a little misleading to set a value for db_Opt_In in Pardot when there's no information either
-    # way from the user in our database.
-    dest[:db_Opt_In] = 'Yes' if src[:opt_in] == true
-    dest[:db_Opt_In] = 'No' if src[:opt_in] == false
+    # Set db_Opt_in to 'No' when there is no source entry, matching the process used by Marketing team.
+    dest[:db_Opt_In] = src[:opt_in] == true ? 'Yes' : 'No'
 
     # If this contact has a dashboard user ID (which means it is a teacher
     # account), mark that in a Pardot field so we can segment on that.


### PR DESCRIPTION
[Task PLC-135](https://codedotorg.atlassian.net/browse/PLC-135)

Copy from task description
> Currently Contact Rollups does not set the Pardot db_Opt_In field when there is no entry for the email address in the EmailPreference table. The processes used by our Marketing team ensure that we don’t send emails to addresses where db_Opt_In does not have a value, but to be safe, change Contact Rollups to explicitly set db_Opt_in to “No” when there is no entry in EmailPreference for the email address.

How test:
This is a simple change so I only test from local ruby console.
```
require '../lib/cdo/pardot.rb'
s = {}; d = {}
Pardot.apply_special_fields(s, d)   // verify d[:db_Opt_In] == 'No'
s = {opt_in:true}
Pardot.apply_special_fields(s, d)   // verify d[:db_Opt_In] == 'Yes'
s = {opt_in:false}
Pardot.apply_special_fields(s, d)   // verify d[:db_Opt_In] == 'No'
```
