### PR TITLE
PL: workshop enrollment for CSD/CSP requires sign-in

### DIFF
--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -30,7 +30,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
           workshop_enrollment_status: "full"
         }.to_json
       }
-    elsif @workshop.local_summer? && !current_user
+    elsif [Pd::Workshop::COURSE_CSD, Pd::Workshop::COURSE_CSP].include?(@workshop.course) && !current_user
       render :logged_out
     else
       @enrollment = ::Pd::Enrollment.new workshop: @workshop

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -30,6 +30,8 @@ class Pd::WorkshopEnrollmentController < ApplicationController
           workshop_enrollment_status: "full"
         }.to_json
       }
+    elsif @workshop.local_summer? && !current_user
+      render :logged_out
     else
       @enrollment = ::Pd::Enrollment.new workshop: @workshop
       if current_user

--- a/dashboard/app/views/pd/workshop_enrollment/logged_out.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/logged_out.haml
@@ -1,0 +1,44 @@
+- content_for(:head) do
+  = stylesheet_link_tag 'css/pd', media: 'all'
+
+:css
+  /* Make the X in regional partner mini-contact form's header look correct. */
+  div.modal-content .modal-header .close {
+    height: 34px
+  }
+
+%h1
+  Start your enrollment
+
+.teacher-application-logged-out
+  .paragraph
+    To get started, you need to be logged into a Code.org account.
+
+  .paragraph
+    If you’d like more information about the program before you start your enrollment, please check out the
+    = link_to("Professional Learning Program overview", CDO.code_org_url('/educate/professional-learning/middle-high'), target: "_blank")
+    or
+    = succeed "." do
+      #regional-partner-mini-contact-popup-link-container{"data-source-page-id" => "workshop-enrollment-logged-out", "data-options" => {notes: "Please tell me more about the professional learning program!"}, "data-link-text" => "contact your local regional partner"}
+
+  .paragraph
+    Please sign in or create an account:
+
+  #signin
+    = link_to "/users/sign_in?user_return_to=#{request.fullpath}", class: "paragraph" do
+      %button= I18n.t('nav.user.signin')
+
+    = link_to "/users/sign_up?user[user_type]=teacher&user_return_to=#{request.fullpath}" do
+      %button.blue-button= I18n.t('nav.user.signup')
+
+%br/
+%br/
+
+- js_locale = request.locale.to_s.downcase.tr('-', '_')
+%script{src: asset_path("js/#{js_locale}/common_locale.js")}
+%script{src: minifiable_asset_path('js/regionalPartnerMiniContact.js')}
+
+:javascript
+  $(document).ready(function() {
+    window.showRegionalPartnerMiniContactPopupLink();
+  });

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -44,13 +44,29 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
     assert_template :logged_out
   end
 
-  test 'non-logged-in users can enroll' do
+  test 'non-logged-in users can enroll in csf' do
     get :new, params: {workshop_id: @workshop.id}
     assert_response :success
     assert_template :new
   end
 
-  test 'logged-in users can enroll' do
+  test 'logged-in users can enroll in csd' do
+    sign_in @teacher
+    workshop = create :pd_workshop, course: Pd::Workshop::COURSE_CSD
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :new
+  end
+
+  test 'logged-in users can enroll in csp' do
+    sign_in @teacher
+    workshop = create :pd_workshop, course: Pd::Workshop::COURSE_CSP
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :new
+  end
+
+  test 'logged-in users can enroll in csf' do
     sign_in @teacher
     get :new, params: {workshop_id: @workshop.id}
     assert_template :new

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -30,6 +30,13 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
     )
   end
 
+  test 'non-logged-in users can not enroll in local summer' do
+    workshop = create :pd_workshop, :local_summer_workshop
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :logged_out
+  end
+
   test 'non-logged-in users can enroll' do
     get :new, params: {workshop_id: @workshop.id}
     assert_response :success

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -30,8 +30,15 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
     )
   end
 
-  test 'non-logged-in users can not enroll in local summer' do
-    workshop = create :pd_workshop, :local_summer_workshop
+  test 'non-logged-in users can not enroll in csd' do
+    workshop = create :pd_workshop, course: Pd::Workshop::COURSE_CSD
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :logged_out
+  end
+
+  test 'non-logged-in users can not enroll in csp' do
+    workshop = create :pd_workshop, course: Pd::Workshop::COURSE_CSP
     get :new, params: {workshop_id: workshop.id}
     assert_response :success
     assert_template :logged_out


### PR DESCRIPTION
Similar to how all teacher applications require a sign-in, workshop applications now require them for CSD and CSP workshops.  This adds a new page that's shown in place of the workshop enrollment (at https://studio.code.org/pd/workshops/[id]/enroll, and lets the user sign-in or -up before returning to the enrollment.

As a bonus, there's a popup Regional Partner mini-contact form.

![screenshot 2019-03-08 00 15 24](https://user-images.githubusercontent.com/2205926/54016514-194d9680-4138-11e9-8944-056da05baa8b.png)

![screenshot 2019-03-08 10 07 26](https://user-images.githubusercontent.com/2205926/54046717-0663b200-418a-11e9-867a-af123cf5ab81.png)
