### PR TITLE
Remove unused Honeybadger notification

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1838,18 +1838,6 @@ class User < ActiveRecord::Base
 
       if learning_module && Plc::EnrollmentModuleAssignment.exists?(user_id: user_id, plc_learning_module: learning_module)
         PeerReview.create_for_submission(user_level, level_source_id)
-
-        # See if there are created peer reviews, if not, raise to honey badger
-        unless PeerReview.where(
-          submitter_id: user_level.user_id,
-          level: user_level.level,
-          level_source_id: level_source_id
-        ).size >= 2
-          Honeybadger.notify(
-            error_class: "Failed to create peer review objects for submission",
-            error_message: "Failed to create peer reviews for user_level #{user_level.id}"
-          )
-        end
       end
     end
 

--- a/dashboard/test/models/peer_review_test.rb
+++ b/dashboard/test/models/peer_review_test.rb
@@ -481,23 +481,11 @@ class PeerReviewTest < ActiveSupport::TestCase
     original_peer_reviews = PeerReview.where(level_source_id: @level_source.id)
     PeerReview.stubs(:create!).raises(Exception, "Some error")
 
-    Honeybadger.stubs(:notify)
-
     assert_raises(Exception) do
       track_progress @level_source.id
     end
 
     assert original_peer_reviews == PeerReview.where(level_source_id: @level_source.id)
-  end
-
-  test 'notify honeybadger if new entries are not created' do
-    PeerReview.stubs(:create_for_submission)
-    Honeybadger.stubs(:notify)
-    Honeybadger.expects(:notify).once
-
-    track_progress @level_source.id
-
-    assert_nil PeerReview.find_by(level_source_id: @level_source.id)
   end
 
   private


### PR DESCRIPTION
This query and notification in User#track_level_progress_sync always runs right after PeerReview.create_for_submission, which is guaranteed to create two peer reviews if it creates any at all.  That would explain why we've never run this notification.

If we _do_ fail to create peer reviews, it will be because of an exception causing the wrapper transaction to roll back, and the transaction wrapper would re-raise the exception so it would end up in Honeybadger anyway.