### PR TITLE
Deeper Learning: Refactor PeerReview creation

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1832,15 +1832,6 @@ class User < ActiveRecord::Base
       end
     end
 
-    # Create peer reviews after submitting a peer_reviewable solution
-    if user_level.submitted && Level.cache_find(level_id).try(:peer_reviewable?)
-      learning_module = Level.cache_find(level_id).script_levels.find_by(script_id: script_id).try(:stage).try(:plc_learning_module)
-
-      if learning_module && Plc::EnrollmentModuleAssignment.exists?(user_id: user_id, plc_learning_module: learning_module)
-        PeerReview.create_for_submission(user_level, level_source_id)
-      end
-    end
-
     if new_level_completed && script_id
       User.track_script_progress(user_id, script_id)
     end

--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -32,7 +32,7 @@ class UserLevel < ActiveRecord::Base
   belongs_to :script
   belongs_to :level_source
 
-  before_save :handle_unsubmit, if: ->(ul) {ul.submitted_changed?(from: true, to: false)}
+  before_save :before_unsubmit, if: ->(ul) {ul.submitted_changed?(from: true, to: false)}
 
   validate :readonly_requires_submitted
 
@@ -94,7 +94,7 @@ class UserLevel < ActiveRecord::Base
     driver? || navigator?
   end
 
-  def handle_unsubmit
+  def before_unsubmit
     self.best_result = ActivityConstants::UNSUBMITTED_RESULT
 
     # Destroy any existing, unassigned peer reviews

--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -99,7 +99,7 @@ class UserLevel < ActiveRecord::Base
     submitted_level = Level.cache_find(level_id)
 
     # Create peer reviews after submitting a peer_reviewable solution
-    if level.peer_reviewable?
+    if submitted_level.try(:peer_reviewable?)
       submitted_script_level = submitted_level.script_levels.find_by(script_id: script_id)
       learning_module = submitted_script_level&.stage&.plc_learning_module
       assignment_exists = learning_module && Plc::EnrollmentModuleAssignment.exists?(

--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -32,7 +32,7 @@ class UserLevel < ActiveRecord::Base
   belongs_to :script
   belongs_to :level_source
 
-  after_save :after_submit, if: ->(ul) {ul.submitted_changed? to: true}
+  after_save :after_submit, if: :submitted_or_resubmitted?
   before_save :before_unsubmit, if: ->(ul) {ul.submitted_changed? from: true, to: false}
 
   validate :readonly_requires_submitted
@@ -93,6 +93,10 @@ class UserLevel < ActiveRecord::Base
 
   def paired?
     driver? || navigator?
+  end
+
+  def submitted_or_resubmitted?
+    submitted_changed?(to: true) || (submitted? && level_source_id_changed?)
   end
 
   def after_submit

--- a/dashboard/test/models/peer_review_test.rb
+++ b/dashboard/test/models/peer_review_test.rb
@@ -75,8 +75,17 @@ class PeerReviewTest < ActiveSupport::TestCase
     # Assign one review
     PeerReview.last.update! reviewer: create(:user)
 
+    # Unsubmit the level
+    user_level = UserLevel.find_by(user: @user, level: @level, script: @script)
+    user_level.update(submitted: false)
+
+    # The unassigned review was destroyed
+    assert_equal 1, PeerReview.count - original_count
+
+    # Submit a new answer
     updated_level_source = create :level_source, data: 'UPDATED: My submitted answer'
 
+    # Two new reviews were created
     track_progress updated_level_source.id
     assert_equal 3, PeerReview.count - original_count
   end
@@ -478,9 +487,18 @@ class PeerReviewTest < ActiveSupport::TestCase
   test 'create_for_submission rolls back if there is an error' do
     track_progress @level_source.id
 
-    original_peer_reviews = PeerReview.where(level_source_id: @level_source.id)
-    PeerReview.stubs(:create!).raises(Exception, "Some error")
+    # Fake that reviews have been submitted
+    PeerReview.find_by(submitter: @user, level: @level, status: nil).update data: 'fake-peer-review', reviewer: (create :teacher)
+    PeerReview.find_by(submitter: @user, level: @level, status: 'escalated').update status: 'rejected', reviewer: @instructor, from_instructor: true
 
+    # Unsubmit the level so we can check behavior on resubmit
+    user_level = UserLevel.find_by(user: @user, level: @level, script: @script)
+    user_level.update(submitted: false)
+
+    original_peer_reviews = PeerReview.where(level_source_id: @level_source.id)
+    assert_equal 2, original_peer_reviews.count
+
+    PeerReview.stubs(:create!).raises(Exception, "Some error")
     assert_raises(Exception) do
       track_progress @level_source.id
     end


### PR DESCRIPTION
Moves `PeerReview` creation-on-submit logic from `User` to `UserLevel`.

This is a little code cleanup as prep for implementing behavior change [PLC-140](https://codedotorg.atlassian.net/browse/PLC-140). I'm considering it a refactor in terms of expected behavior in real use cases, but there are some subtle differences that required updating test cases to be more representative of real circumstances.

`PeerReview` logic is scattered around the system.  Before this change:

- We create peer reviews on relevant level submit in `User.track_level_progress_sync`.
  This is tested in `PeerReviewTest` (and _not_ in `UserTest`).
- We actually create the peer reviews down in `PeerReview.create_for_submission`
  This is tested in `PeerReviewTest`.
- We destroy peer reviews on unsubmit in a `UserLevel` before_save hook
  This is tested in `UserLevelTest` and `PeerReviewTest`.

My goal here is to make peer review creation/destruction on submit/unsubmit obviously parallel in `UserLevel`, which feels like a healthy step toward consolidating this logic.

