### PR TITLE
Deeper Learning: Don't reopen accepted submissions

### DIFF
--- a/dashboard/app/models/peer_review.rb
+++ b/dashboard/app/models/peer_review.rb
@@ -128,6 +128,13 @@ class PeerReview < ActiveRecord::Base
   end
 
   def self.create_for_submission(user_level, level_source_id)
+    return if PeerReview.where(
+      submitter: user_level.user,
+      level: user_level.level,
+      from_instructor: true,
+      status: :accepted
+    ).exists?
+
     transaction do
       # Remove old unassigned reviews for this submitter+script+level combination
       where(


### PR DESCRIPTION
[PLC-140](https://codedotorg.atlassian.net/browse/PLC-140). Resubmitting for a previously-accepted (user, level) combination should not create new `PeerReview` objects, particularly not a new "escalated" review which implies that further action is required from the instructor.

This is follow-on work from https://github.com/code-dot-org/code-dot-org/pull/27406 where I believe we've addressed the issue with lost reviews and odd backfill behaviors.  While working on that we found another odd behavior with a different root cause.

![Pasted_image_at_2019-03-06__10_50_AM](https://user-images.githubusercontent.com/1615761/54062366-62462f00-41ba-11e9-805e-b063fcdc2af8.png)

This image is read as a timeline, with the oldest review at the top and the newest at the bottom.
- The top two reviews were created when this work was originally submitted.  They were initially in open `O` and escalated/pending `?` state, respectively.
- At some point the instructor reviewed and accepted this work, changing the `?` to a `✓`.
- The work was un-submitted, changed, and re-submitted with a different `LevelSource`.
- Upon second submit, the third and fourth reviews were created, one open `O` and one pending/escalated `?`.

This led our team to believe that the review had moved from accepted state back to pending, but it wasn't clear why.  Once work is accepted it should stay that way.

This change updates the `PeerReview` logic to skip creating new reviews if the submission is already accepted.
