### PR TITLE
Deeper Learning: Display relative review time

### DIFF
--- a/apps/src/code-studio/peer_reviews/PeerReviewLinkSection.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewLinkSection.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import moment from 'moment';
 
 class PeerReviewLinkSection extends React.Component {
   static propTypes = {
@@ -26,12 +27,12 @@ class PeerReviewLinkSection extends React.Component {
       <ul className="fa-ul">
         {this.props.reviews.map((submission, i) => {
           return (
-            <li key={i}>
+            <li key={i} style={{whiteSpace: 'nowrap'}}>
               <FontAwesome
                 icon={`${this.getIconForStatus(submission[1])} fa-li`}
               />
               <a key={i} href={`/peer_reviews/${submission[0]}`}>
-                Submission
+                {moment(submission[2]).fromNow()}
               </a>
             </li>
           );

--- a/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
+++ b/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
@@ -14,12 +14,18 @@ describe('PeerReviewSubmissions', () => {
     {
       submitter: 'User 1',
       course_name: 'Course 1',
-      review_ids: [[1, 'accepted'], [2, 'accepted']]
+      review_ids: [
+        [1, 'accepted', '2019-03-05T01:11:50Z'],
+        [2, 'accepted', '2019-03-05T01:11:50Z']
+      ]
     },
     {
       submitter: 'User 2',
       course_name: 'Course 2',
-      review_ids: [[3, 'accepted'], [4, 'accepted']]
+      review_ids: [
+        [3, 'accepted', '2019-03-05T01:11:50Z'],
+        [4, 'accepted', '2019-03-05T01:11:50Z']
+      ]
     }
   ];
 

--- a/dashboard/app/models/peer_review.rb
+++ b/dashboard/app/models/peer_review.rb
@@ -250,7 +250,7 @@ class PeerReview < ActiveRecord::Base
       level_name: user_level.level.name,
       submission_date: reviews.any? && reviews.first.created_at.strftime("%-m/%-d/%Y"),
       escalated_review_id: status == 'escalated' ? escalated_review.id : nil,
-      review_ids: reviews.pluck(:id, :status),
+      review_ids: reviews.pluck(:id, :status, :updated_at),
       status: status
     }
   end

--- a/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
@@ -53,7 +53,10 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     assert_response :success
     response = JSON.parse(@response.body)
     assert_equal [
-      [[submissions.first.id, nil], [submissions.second.id, 'escalated']]
+      [
+        [submissions.first.id, nil, submissions.first.updated_at],
+        [submissions.second.id, 'escalated', submissions.second.updated_at]
+      ]
     ], response.map {|submission| submission['review_ids']}
   end
 
@@ -62,9 +65,18 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     assert_response :success
     response = JSON.parse(@response.body)
     assert_equal [
-      [[@level_1_reviews.first.id, nil], [@level_1_reviews.second.id, 'escalated']],
-      [[@level_2_reviews.first.id, nil], [@level_2_reviews.second.id, 'accepted']],
-      [[@level_3_reviews.first.id, nil], [@level_3_reviews.second.id, 'escalated']],
+      [
+        [@level_1_reviews.first.id, nil, @level_1_reviews.first.updated_at],
+        [@level_1_reviews.second.id, 'escalated', @level_1_reviews.second.updated_at]
+      ],
+      [
+        [@level_2_reviews.first.id, nil, @level_2_reviews.first.updated_at],
+        [@level_2_reviews.second.id, 'accepted', @level_2_reviews.second.updated_at]
+      ],
+      [
+        [@level_3_reviews.first.id, nil, @level_3_reviews.first.updated_at],
+        [@level_3_reviews.second.id, 'escalated', @level_3_reviews.second.updated_at]
+      ],
     ], response.map {|submission| submission['review_ids']}
   end
 

--- a/dashboard/test/models/peer_review_test.rb
+++ b/dashboard/test/models/peer_review_test.rb
@@ -389,9 +389,11 @@ class PeerReviewTest < ActiveSupport::TestCase
       unit_name: @learning_module.name,
     }
 
+    level_1_pr_1 = PeerReview.find_by(level: level_1, status: nil)
+    level_1_pr_2 = PeerReview.find_by(level: level_1, status: 'escalated')
     expected_level_1_ids = [
-      [PeerReview.find_by(level: level_1, status: nil).id, nil],
-      [PeerReview.find_by(level: level_1, status: 'escalated').id, 'escalated']
+      [level_1_pr_1.id, nil, level_1_pr_1.updated_at],
+      [level_1_pr_2.id, 'escalated', level_1_pr_2.updated_at]
     ]
 
     assert_equal base_expected.merge(
@@ -403,9 +405,11 @@ class PeerReviewTest < ActiveSupport::TestCase
       }
     ), PeerReview.get_submission_summary_for_user_level(ul1, @script).except(:submission_date)
 
+    level_2_pr_1 = PeerReview.find_by(level: level_2, status: nil)
+    level_2_pr_2 = PeerReview.find_by(level: level_2, status: 'accepted')
     expected_level_2_ids = [
-      [PeerReview.find_by(level: level_2, status: nil).id, nil],
-      [PeerReview.find_by(level: level_2, status: 'accepted').id, 'accepted']
+      [level_2_pr_1.id, nil, level_2_pr_1.updated_at],
+      [level_2_pr_2.id, 'accepted', level_2_pr_2.updated_at]
     ]
     assert_equal base_expected.merge(
       {
@@ -416,9 +420,11 @@ class PeerReviewTest < ActiveSupport::TestCase
       }
     ), PeerReview.get_submission_summary_for_user_level(ul2, @script).except(:submission_date)
 
+    level_3_pr_1 = PeerReview.find_by(level: level_3, status: nil)
+    level_3_pr_2 = PeerReview.find_by(level: level_3, status: 'rejected')
     expected_level_3_ids = [
-      [PeerReview.find_by(level: level_3, status: nil).id, nil],
-      [PeerReview.find_by(level: level_3, status: 'rejected').id, 'rejected']
+      [level_3_pr_1.id, nil, level_3_pr_1.updated_at],
+      [level_3_pr_2.id, 'rejected', level_3_pr_2.updated_at]
     ]
     assert_equal base_expected.merge(
       {


### PR DESCRIPTION
Replaces the redundant "Submission" text used for links to submission reviews in the deeper learning dashboard with text representing the updated_at time of the reviews, differentiating them and making chronological order visible.

| Before: | After: |
| --- | --- |
| ![Pasted_image_at_2019-03-06__10_50_AM](https://user-images.githubusercontent.com/1615761/54064437-249cd280-41c9-11e9-9587-e8bb3f37c48f.png) | ![image](https://user-images.githubusercontent.com/1615761/54064431-1a7ad400-41c9-11e9-93f1-452b82e8ba9b.png) |

I'm passing the `PeerReview.updated_at` value when loading submissions. It's sent to the client in [ISO 8601 format](https://www.iso.org/iso-8601-date-and-time-format.html).  On the client I'm using [Moment.js](https://momentjs.com)' `fromNow()` to generate an appropriate relative time.