### PR TITLE
add ACM service permissions to daemon

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -535,6 +535,12 @@ Resources:
                   - 'cloudformation:DescribeStackEvents'
                   - 'cloudformation:GetStackPolicy'
                 Resource: !Ref AWS::StackId
+              # Lookup ACM certificate for ELB and CloudFront SSL.
+              - Effect: Allow
+                Action:
+                  - 'acm:ListCertificates'
+                  - 'acm:GetCertificate'
+                Resource: '*'
               # Update Stack through `ci:deploy_stack` task.
               - Effect: Allow
                 Action: 'cloudformation:UpdateStack'


### PR DESCRIPTION
Followup to #27413. Adds permissions for `acm:ListCertificates` and `acm:GetCertificate` for ACM lookup part of the CloudFormation stack update.