### PR TITLE
Add AWS permissions for ci:flush_cache task to Daemon role

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -529,6 +529,14 @@ Resources:
                   # TODO: Import pd_workshop resources into stack.
                   - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:pd_workshop-<%=environment%>"
                   - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:pd_workshop_dead-<%=environment%>"
+              # APIs used by ci:flush_cache task.
+              - Effect: Allow
+                Action:
+                  - 'ec2:DescribeInstances'
+                  - 'cloudfront:ListDistributions'
+                  - 'cloudfront:CreateInvalidation'
+                  - 'cloudfront:GetInvalidation'
+                Resource: '*'
               # Lookup ACM certificate for ELB and CloudFront SSL.
               - Effect: Allow
                 Action:


### PR DESCRIPTION
Followup to #27448, adds extra AWS service permissions to the `daemon` role needed by the `ci:flush_cache` task.