### PR TITLE
Adjust cron job schedules for the start of daylight savings

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -66,17 +66,17 @@
 
     if node.chef_environment == 'test' && node.name == 'test' # 'real' test only
       # This should be run shortly after the commit_content job run on levelbuilder.
-      cronjob at:'20 23 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
+      cronjob at:'20 22 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
       cronjob at:'*/2 * * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_test')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'snapshot')
     end
 
     if node.chef_environment == 'levelbuilder'
-      cronjob at:'0 20 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
-      cronjob at:'18 23 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      cronjob at:'0 19 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      cronjob at:'18 22 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       # This should be run shortly after the commit_content job, running on both levelbuilder and
       # staging.
-      cronjob at:'5 20 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
+      cronjob at:'5 19 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
     end
 
     if node.chef_environment == 'production' # production daemon


### PR DESCRIPTION
Content editors and the Developer of the Day expect several content pipeline activities to take place on the following schedule regardless of whether it is currently daylight savings or standard time.  Ubuntu cron jobs on our managed servers currently all run in UTC.  Manually adjust the UTC times of the cron jobs that support these activities so that they occur at expected times.  Note that the Staging Content Scoop was not adjusted when Standard Time resumed in the Fall of 2018.  It was running, incorrectly at 11AM PT and is now running, correctly at Noon PT since Daylight Savings resumed 3/10/2019, so it is not being adjusted in this Pull Request.

- Noon PT: Staging Content Scoop
- Noon  PT: LevelBuilder Content Push
- 12:05 PM PT: Merge LevelBuilder to Staging
- 3:18 PM PT: LevelBuilder Content Push
- 3:20 PM PT: Merge Test to LevelBuilder
