### PR TITLE
Workshop Surveys: Use question name if question text is unavailable

### DIFF
--- a/dashboard/lib/pd/jot_form/translation.rb
+++ b/dashboard/lib/pd/jot_form/translation.rb
@@ -114,10 +114,9 @@ module Pd
       # @param replacement_text_by_name [Hash] mapping of question name to replacement text where applicable
       def parse_jotform_question(jotform_question, replacement_text_by_name)
         type = get_type(jotform_question)
-        sanitized_question_data = jotform_question.merge(
-          'type' => type,
-          'text' => replacement_text_by_name[jotform_question['name']] || jotform_question['text']
-        )
+        text = replacement_text_by_name[jotform_question['name']] || jotform_question['text']
+        text = jotform_question['name'] if text.empty?
+        sanitized_question_data = jotform_question.merge('type' => type, 'text' => text)
 
         klass = self.class.get_question_class_for type
         klass.from_jotform_question(sanitized_question_data)

--- a/dashboard/test/lib/pd/jot_form/translation_test.rb
+++ b/dashboard/test/lib/pd/jot_form/translation_test.rb
@@ -112,6 +112,57 @@ module Pd
         assert_equal 'This is the summary for scale1', questions.first.text
       end
 
+      test 'get_questions uses question name as fallback when no text is available' do
+        JotFormRestClient.any_instance.expects(:get_questions).with(@form_id).returns(
+          {
+            content: {
+              1 => {
+                qid: 1,
+                type: 'control_scale',
+                name: 'intentionallyLeftBlank',
+                text: '',
+                order: 1
+              }
+            }
+          }.deep_stringify_keys
+        )
+
+        questions = Translation.new(@form_id).get_questions
+        assert_equal 1, questions.length
+        assert_equal 1, questions.first.id
+        assert_equal 'intentionallyLeftBlank', questions.first.name
+        assert_equal 'intentionallyLeftBlank', questions.first.text
+      end
+
+      test 'get_questions prefers -summary text to fallback when no text is available' do
+        JotFormRestClient.any_instance.expects(:get_questions).with(@form_id).returns(
+          {
+            content: {
+              1 => {
+                qid: 1,
+                type: 'control_scale',
+                name: 'intentionallyLeftBlank',
+                text: '',
+                order: 1
+              },
+              2 => {
+                qid: 2,
+                type: 'control_text',
+                name: 'intentionallyLeftBlank-summary',
+                text: 'A real description',
+                order: 2
+              }
+            }
+          }.deep_stringify_keys
+        )
+
+        questions = Translation.new(@form_id).get_questions
+        assert_equal 1, questions.length
+        assert_equal 1, questions.first.id
+        assert_equal 'intentionallyLeftBlank', questions.first.name
+        assert_equal 'A real description', questions.first.text
+      end
+
       test 'get_submission queries the client and transforms the submission data' do
         last_known_submission_id = 100
 


### PR DESCRIPTION
When syncing survey questions from JotForm, if the question text is blank and our system isn't able to generate one from another source ([`-summary` system][0]) use the question name as a fallback.

We ran into an issue recently where no question text was appearing on the survey results dashboard, which made it impossible to tell questions apart:

![image (9)](https://user-images.githubusercontent.com/1615761/54165932-0381ef00-4420-11e9-91f5-f151d3c197c8.png)

It turns out we'd intentionally left the question text blank in JotForm because this question type referred to a more complex diagram listed as a different "question" in the JotForm metadata.

![image](https://user-images.githubusercontent.com/1615761/54165969-22808100-4420-11e9-8d3b-24d2c4cbb529.png)

I'm introducing this fallback text as a stopgap measure while we investigate a better fix, because at least this way we'll be able to tell which question is which in the survey results summary!

[0]: https://github.com/code-dot-org/code-dot-org/blob/7a52786ebc0756906e6d69f4de6a2ac5af304aae/dashboard/test/lib/pd/jot_form/translation_test.rb#L80-L113