### PR TITLE
Cohort view statuses

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/cohort_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_view_table.jsx
@@ -9,7 +9,7 @@ import _, {orderBy} from 'lodash';
 import moment from 'moment';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
 import {WorkshopTypes} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
-import {StatusColors} from './constants';
+import {StatusColors, ApplicationStatuses} from './constants';
 import {
   UNMATCHED_PARTNER_VALUE,
   ALL_PARTNERS_VALUE,
@@ -146,9 +146,9 @@ export class CohortViewTable extends React.Component {
           transforms: [sortable]
         },
         cell: {
-          format: status => {
-            return _.upperFirst(status);
-          },
+          format: status =>
+            ApplicationStatuses[this.props.viewType][status] ||
+            _.upperFirst(status),
           transforms: [
             status => ({
               style: {...styles.statusCellCommon, ...styles.statusCell[status]}

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -81,6 +81,7 @@ module Api::V1::Pd
       accepted_not_notified
       accepted_notified_by_partner
       accepted_no_cost_registration
+      registration_sent
       paid
       withdrawn
     )

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -593,8 +593,8 @@ module Api::V1::Pd
       assert_response :success
 
       assert_equal(
-        expected_applications.map {|application| application[:id]}.sort,
-        JSON.parse(@response.body).map {|application| application['id']}.sort
+        expected_applications.map {|application| application[:status]}.sort,
+        JSON.parse(@response.body).map {|application| application['status']}.sort
       )
     end
 
@@ -614,8 +614,8 @@ module Api::V1::Pd
       assert_response :success
 
       assert_equal(
-        expected_applications.map {|application| application[:id]}.sort,
-        JSON.parse(@response.body).map {|application| application['id']}.sort
+        expected_applications.map {|application| application[:status]}.sort,
+        JSON.parse(@response.body).map {|application| application['status']}.sort
       )
     end
 


### PR DESCRIPTION
[PLC-147](https://codedotorg.atlassian.net/browse/PLC-147)

- Applications with status "Registration sent" now appear in cohort view
- Remove underscores in statuses as displayed on cohort view (Registration_sent --> Registration sent)

before:
<img width="259" alt="Screen Shot 2019-03-11 at 5 45 42 PM" src="https://user-images.githubusercontent.com/224089/54167169-a426dd80-4425-11e9-9957-ac1261cfb404.png">


after:
<img width="166" alt="Screen Shot 2019-03-11 at 5 43 37 PM" src="https://user-images.githubusercontent.com/224089/54167157-98d3b200-4425-11e9-8b24-fad45859245c.png">
