### PR TITLE
Disable 'mismatching links and images check'

### DIFF
--- a/bin/i18n/sync-codeorg-out.rb
+++ b/bin/i18n/sync-codeorg-out.rb
@@ -21,7 +21,6 @@ def sync_out
   distribute_translations
   copy_untranslated_apps
   rebuild_blockly_js_files
-  check_for_mismatching_links_or_images
   puts "updating TTS I18n (should usually take 2-3 minutes, may take up to 15 if there are a whole lot of translation updates)"
   run_standalone_script "dashboard/scripts/update_tts_i18n.rb"
 end
@@ -196,84 +195,6 @@ def get_links_and_images(value)
     end
     return values.flatten
   end
-end
-
-def check_for_mismatching_links_or_images
-  categories_to_check = %w(
-    short_instructions
-    long_instructions
-    failure_message_overrides
-    authored_hints
-    callouts
-  )
-
-  outputfile = Tempfile.new('sync-codeorg-out')
-
-  Languages.get_locale.each do |prop|
-    locale = prop[:locale_s]
-
-    # don't check english, as it is our base language
-    next if locale == 'en-US'
-
-    # also don't check Italian; they have a lot of custom translation
-    # work which we whitelist
-    next if locale == 'it-IT'
-
-    print "validating #{locale} ..."
-
-    mismatch_found = false
-
-    categories_to_check.each do |category|
-      locale_file = "dashboard/config/locales/#{category}.#{locale}.yml"
-      source_file = "dashboard/config/locales/#{category}.en.yml"
-
-      # this absurd little dance is necessary because of the format of
-      # each of these yaml files; they each have a hash with a single
-      # key representing the two-character version of the locale whose
-      # value is a hash with the single key 'data' whose value is a hash
-      # with a single key representing the category name whose value is
-      # (finally) the data we actually want.
-      source_data = YAML.load(File.open(source_file)).values.first.values.first.values.first
-      locale_data = YAML.load(File.open(locale_file)).values.first.values.first.values.first
-
-      if source_data.keys != locale_data.keys
-        outputfile.write "mismatching keys in #{locale_file}"
-        mismatch_found = true
-      end
-
-      mismatching_keys = locale_data.keys.select do |key|
-        get_links_and_images(source_data[key]) != get_links_and_images(locale_data[key])
-      end
-
-      next if mismatching_keys.empty?
-      mismatch_found = true
-      outputfile.write("mismatching values in #{locale_file}\n")
-      outputfile.write("and therefore also in i18n/locales/#{locale}/dashboard/#{category}.yml:\n")
-      mismatching_keys.each do |key|
-        outputfile.write("\t#{key}\n")
-        outputfile.write("\t\ten:\n")
-        get_links_and_images(source_data[key]).each do |x|
-          outputfile.write("\t\t\t#{x}\n")
-        end
-        outputfile.write("\t\t#{locale}:\n")
-        get_links_and_images(locale_data[key]).each do |x|
-          outputfile.write("\t\t\t#{x}\n")
-        end
-      end
-      outputfile.write("\n")
-    end
-
-    if mismatch_found
-      # if we find at least one mismatch, remove the finalizer from the
-      # tempfile that would otherwise delete it when this script exits
-      ObjectSpace.undefine_finalizer(outputfile)
-      puts " MISMATCH FOUND! output in #{outputfile.path}"
-    else
-      puts " all good"
-    end
-  end
-
-  outputfile.close
 end
 
 sync_out if __FILE__ == $0


### PR DESCRIPTION
This is a check that we've been running as part of the i18n sync
process, but without any real purpose. The idea is that it should be
able to check for occasions when translators added links or images in
their translations that we didn't have in the source text, but what
actually happens is that it just creates a ton of noise whenever a
levelbuilder adds or changes a link or image, because the translations
then need to get updated to match.

The amount of noise has made it completely impractical to check the
output for any _actual_ mismatching data, so I'm just removing it. We
hope to find a better solution to this problem by leveraging redaction.