### PR TITLE
Resizing Instructions Tab Content

### DIFF
--- a/apps/src/templates/instructions/TopInstructionsCSP.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSP.jsx
@@ -243,6 +243,7 @@ class TopInstructions extends Component {
       RESIZER_HEIGHT;
 
     this.props.setInstructionsMaxHeightNeeded(maxNeededHeight);
+    this.props.setInstructionsRenderedHeight(maxNeededHeight);
     return maxNeededHeight;
   };
 
@@ -271,15 +272,18 @@ class TopInstructions extends Component {
   };
 
   handleHelpTabClick = () => {
-    this.setState({tabSelected: TabType.RESOURCES});
+    this.setState({tabSelected: TabType.RESOURCES}, this.adjustMaxNeededHeight);
   };
 
   handleInstructionTabClick = () => {
-    this.setState({tabSelected: TabType.INSTRUCTIONS});
+    this.setState(
+      {tabSelected: TabType.INSTRUCTIONS},
+      this.adjustMaxNeededHeight
+    );
   };
 
   handleCommentTabClick = () => {
-    this.setState({tabSelected: TabType.COMMENTS});
+    this.setState({tabSelected: TabType.COMMENTS}, this.adjustMaxNeededHeight);
   };
 
   render() {

--- a/apps/src/templates/instructions/TopInstructionsCSP.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSP.jsx
@@ -243,7 +243,10 @@ class TopInstructions extends Component {
       RESIZER_HEIGHT;
 
     this.props.setInstructionsMaxHeightNeeded(maxNeededHeight);
-    this.props.setInstructionsRenderedHeight(maxNeededHeight);
+    // Force instruction area to resize to show full feedback area
+    if (this.state.tabSelected === TabType.COMMENTS) {
+      this.props.setInstructionsRenderedHeight(maxNeededHeight);
+    }
     return maxNeededHeight;
   };
 


### PR DESCRIPTION
Instructions area now resizes to show the full feedback tab contents when selected. All other tabs stay with the same behavior they had before. Once the instructions area resizes for the feedback tab though it keeps that size until manually resized by the user.

## Full Size Feedback Area
<img width="1175" alt="Screen Shot 2019-03-12 at 11 21 01 AM" src="https://user-images.githubusercontent.com/208083/54213455-cdde1400-44ba-11e9-98bc-abb79f941d2e.png">

## Demo of resizing
![Resize-Instructions-Feedback 2](https://user-images.githubusercontent.com/208083/54213444-c9b1f680-44ba-11e9-8389-d3bb505977bc.gif)

