### PR TITLE
Mini Rubric: Sizing of key concept vs rubric area

### DIFF
--- a/apps/src/templates/instructions/RubricField.jsx
+++ b/apps/src/templates/instructions/RubricField.jsx
@@ -8,6 +8,9 @@ import _ from 'lodash';
 import i18n from '@cdo/locale';
 
 const styles = {
+  rubricLevelHeaders: {
+    width: '100%'
+  },
   detailsArea: {
     width: '100%'
   },
@@ -70,7 +73,7 @@ class RubricField extends Component {
 
     const tooltipId = _.uniqueId();
     return (
-      <div>
+      <div style={styles.rubricLevelHeaders}>
         <div
           style={performanceHeaderStyle}
           data-tip

--- a/apps/src/templates/instructions/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/TeacherFeedback.jsx
@@ -47,14 +47,15 @@ const styles = {
     margin: '0px 16px 20px 16px'
   },
   keyConceptArea: {
-    marginRight: 28
+    marginRight: 28,
+    flexBasis: '40%'
   },
   keyConcepts: {
     fontSize: 13,
     color: color.charcoal
   },
   rubricArea: {
-    flexBasis: '70%'
+    flexBasis: '60%'
   },
   commentAndFooter: {
     margin: '0px 16px 16px 16px'

--- a/apps/src/templates/instructions/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/TeacherFeedback.jsx
@@ -47,7 +47,6 @@ const styles = {
     margin: '0px 16px 20px 16px'
   },
   keyConceptArea: {
-    flexGrow: 1,
     marginRight: 28
   },
   keyConcepts: {
@@ -55,7 +54,7 @@ const styles = {
     color: color.charcoal
   },
   rubricArea: {
-    flexGrow: 2
+    flexBasis: '70%'
   },
   commentAndFooter: {
     margin: '0px 16px 16px 16px'


### PR DESCRIPTION
Fixes the sizing of the key concepts vs the rubric area in the feedback tab of the instructions area.

## Before
Some places looked okay but especially in a web lab level something about the sizing was off.
<img width="1412" alt="Screen Shot 2019-03-12 at 10 39 54 AM" src="https://user-images.githubusercontent.com/208083/54208979-5062d580-44b3-11e9-954a-ad373b603256.png">


## After

### App Lab
<img width="733" alt="Screen Shot 2019-03-12 at 10 35 46 AM" src="https://user-images.githubusercontent.com/208083/54208732-d92d4180-44b2-11e9-9332-dd8f4adf96fe.png">


### Web Lab
<img width="1406" alt="Screen Shot 2019-03-12 at 10 44 25 AM" src="https://user-images.githubusercontent.com/208083/54209264-d97a0c80-44b3-11e9-97bf-1a0cde08ba46.png">
<img width="807" alt="Screen Shot 2019-03-12 at 10 36 44 AM" src="https://user-images.githubusercontent.com/208083/54208729-d92d4180-44b2-11e9-9630-ad3e6c3f3ddf.png">
<img width="774" alt="Screen Shot 2019-03-12 at 10 36 27 AM" src="https://user-images.githubusercontent.com/208083/54208730-d92d4180-44b2-11e9-9d2a-f304a04c8a5d.png">

### Game Lab
<img width="777" alt="Screen Shot 2019-03-12 at 10 36 19 AM" src="https://user-images.githubusercontent.com/208083/54208731-d92d4180-44b2-11e9-80f2-731273ecbd26.png">
<img width="800" alt="Screen Shot 2019-03-12 at 10 36 51 AM" src="https://user-images.githubusercontent.com/208083/54208728-d894ab00-44b2-11e9-8188-25a6adb4b08a.png">




