### PR TITLE
Only check for video downloads for Dance projects

### DIFF
--- a/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
+++ b/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
@@ -151,6 +151,10 @@ class DownloadReplayVideoButton extends React.Component {
   }
 
   checkVideoUntilSuccess = (delay = 1000) => {
+    if (!this.hasReplayVideo()) {
+      return;
+    }
+
     if (this.state.videoExists) {
       return;
     }


### PR DESCRIPTION
[Jira](https://codedotorg.atlassian.net/browse/LP-62)

The DownloadReplayVideoButton component, which is reponsible for
creating and downloading the replay videos in Dance Projects, is
included even for non-Dance projects but is smart enough not to render
itself unless it identifies that it is actually needed (ie, if the
current project is a Dance project).

Unfortunately, we _also_ start a thread that checks to see whether or
not the video already exists, and that thread was happening regardless
of whether or not the component renders. Adding a simple sanity check to
the controlling method is sufficient to prevent those unnecessary
network requests.