### PR TITLE
Update EC2 instance-profile roles to use fine-grained permissions

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -163,7 +163,7 @@ Resources:
     Properties:
       ImageId: <%=IMAGE_ID%>
       InstanceType: !Ref InstanceType
-      IamInstanceProfile: !ImportValue IAM-FrontendInstanceProfile # Migrate to: !Ref FrontendInstanceProfile
+      IamInstanceProfile: !Ref FrontendInstanceProfile
       SecurityGroupIds: [!ImportValue VPC-FrontendSecurityGroup]
       SubnetId: !ImportValue VPC-Subnet<%=azs.first%>
       KeyName: <%=SSH_KEY_NAME%>
@@ -272,7 +272,7 @@ Resources:
     Properties:
       ImageId: !GetAtt [AMI<%=ami%>, ImageId]
       InstanceType: !Ref InstanceType
-      IamInstanceProfile: !ImportValue IAM-FrontendInstanceProfile # Migrate to: !Ref FrontendInstanceProfile
+      IamInstanceProfile: !Ref FrontendInstanceProfile
       SecurityGroups: [!ImportValue VPC-FrontendSecurityGroup]
       KeyName: <%=SSH_KEY_NAME%>
       BlockDeviceMappings:
@@ -306,7 +306,7 @@ Resources:
       DefaultResult: ABANDON
       HeartbeatTimeout: 1200 # seconds = 20 minutes
       NotificationTargetARN: !Ref WebServerHookTopicNew
-      RoleARN: !ImportValue IAM-LifecycleHookRoleARN # Migrate to: !Ref WebServerHookRole
+      RoleARN: !Ref WebServerHookRole
   WebServerHookEventRule:
     Type: AWS::Events::Rule
     Properties:


### PR DESCRIPTION
Follow-up to #27413, updating stack references to use the newly-created IAM roles so they will be used throughout our infrastructure.