### PR TITLE
update the legacy InstructionsDialog component to use UnsafeRenderedMarkdown rather than dangerouslySetInnerHTML

### DIFF
--- a/apps/src/lib/ui/LegacyDialogContents.js
+++ b/apps/src/lib/ui/LegacyDialogContents.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import i18n from '@cdo/locale';
 import ProtectedStatefulDiv from '@cdo/apps/templates/ProtectedStatefulDiv';
+import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 
 export const SingleLevelGroupDialog = ({id, title, body}) => (
   <ProtectedStatefulDiv id={id}>
@@ -117,16 +118,14 @@ export const StartOverDialog = () => (
   </ProtectedStatefulDiv>
 );
 
-/* eslint-disable react/no-danger */
-export const InstructionsDialog = ({title, markdownContent}) => (
+export const InstructionsDialog = ({title, markdown}) => (
   <ProtectedStatefulDiv>
     <div className="modal-content no-modal-icon markdown-instructions-container">
       <p className="dialog-title">{title}</p>
       <p />
-      <div
-        className="instructions-markdown scrollable-element"
-        dangerouslySetInnerHTML={{__html: markdownContent}}
-      />
+      <div className="instructions-markdown scrollable-element">
+        <UnsafeRenderedMarkdown markdown={markdown} />
+      </div>
       <div id="buttons">
         <button id="ok-button" style={{float: 'right'}}>
           {i18n.ok()}
@@ -137,7 +136,7 @@ export const InstructionsDialog = ({title, markdownContent}) => (
 );
 InstructionsDialog.propTypes = {
   title: PropTypes.string.isRequired,
-  markdownContent: PropTypes.string.isRequired
+  markdown: PropTypes.string.isRequired
 };
 
 export const SuccessDialog = ({title, body}) => (

--- a/apps/src/sites/studio/pages/levels/widget.js
+++ b/apps/src/sites/studio/pages/levels/widget.js
@@ -14,21 +14,16 @@ import {
   StartOverDialog,
   InstructionsDialog
 } from '@cdo/apps/lib/ui/LegacyDialogContents';
-import marked from 'marked';
 import i18n from '@cdo/locale';
 
 export function showInstructionsDialog() {
-  let content;
-  if (appOptions.level.longInstructions) {
-    content = marked(appOptions.level.longInstructions);
-  }
   showDialog(
     <InstructionsDialog
       title={i18n.puzzleTitle({
         stage_total: appOptions.level.stage_total,
         puzzle_number: appOptions.level.puzzle_number
       })}
-      markdownContent={content}
+      markdown={appOptions.level.longInstructions}
     />
   );
   $('details').details();


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1VaYlNzYdPVwSIkNxezvaVG6IlBMqEi-adxzk4Iwar-U/edit#gid=0

You can see an example of this component in use at https://studio.code.org/s/frequency_analysis/stage/1/puzzle/1