### PR TITLE
use snack-sdk 2.2.0-apkurl-v1 and add to toTranspileWithinNodeModules

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -217,7 +217,7 @@
   },
   "dependencies": {
     "@code-dot-org/js-interpreter": "^1.3.8",
-    "@code-dot-org/snack-sdk": "2.2.0-apkurl-v2",
+    "@code-dot-org/snack-sdk": "2.2.0-apkurl-v1",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -16,7 +16,8 @@ var toTranspileWithinNodeModules = [
   path.resolve(__dirname, 'node_modules', 'playground-io'),
   path.resolve(__dirname, 'node_modules', 'chai-as-promised'),
   path.resolve(__dirname, 'node_modules', 'enzyme-wait'),
-  path.resolve(__dirname, 'node_modules', 'json-parse-better-errors')
+  path.resolve(__dirname, 'node_modules', 'json-parse-better-errors'),
+  path.resolve(__dirname, 'node_modules', '@code-dot-org', 'snack-sdk')
 ];
 
 const scssIncludePath = path.resolve(__dirname, '..', 'shared', 'css');

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -129,9 +129,9 @@
     remark-stringify "^6.0.0"
     unified "^7.0.0"
 
-"@code-dot-org/snack-sdk@2.2.0-apkurl-v2":
-  version "2.2.0-apkurl-v2"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/snack-sdk/-/snack-sdk-2.2.0-apkurl-v2.tgz#35bf9b73f5bffa230275af446fe754001d7d3a3d"
+"@code-dot-org/snack-sdk@2.2.0-apkurl-v1":
+  version "2.2.0-apkurl-v1"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/snack-sdk/-/snack-sdk-2.2.0-apkurl-v1.tgz#51afb887f4e528f42411eb1761add0d6db4ce86e"
   dependencies:
     babel-runtime "^6.23.0"
     diff "^3.2.0"


### PR DESCRIPTION
* Last week, I briefly created a `2.2.0-apkurl-v2` version of the `snack-sdk` to work around a transpiling issue. When I had tried adding this package to `toTranspileWithinNodeModules` locally, it didn't fix my `yarn test:unit` run. But, it turns out that our tests require an `apps` build first - and that needed to be done with the new webpack config before the test error went away. So, now I've made the change and converted us back to the `2.2.0-apkurl-v1` version which is close to the mainline `snack-sdk` (it just includes the changes from https://github.com/expo/snack-sdk/pull/9)