### PR TITLE
Fix ARN reference to WebServerHookRole

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -306,7 +306,7 @@ Resources:
       DefaultResult: ABANDON
       HeartbeatTimeout: 1200 # seconds = 20 minutes
       NotificationTargetARN: !Ref WebServerHookTopicNew
-      RoleARN: !Ref WebServerHookRole
+      RoleARN: !GetAtt WebServerHookRole.Arn
   WebServerHookEventRule:
     Type: AWS::Events::Rule
     Properties:


### PR DESCRIPTION
Small fix/followup to #27413- the `RoleARN` parameter requires the full ARN reference, not just the role name.