### PR TITLE
Teacher dashboard valid scripts fix

### DIFF
--- a/apps/src/redux/scriptSelectionRedux.js
+++ b/apps/src/redux/scriptSelectionRedux.js
@@ -5,7 +5,7 @@ import {SET_SECTION} from '@cdo/apps/redux/sectionDataRedux';
 // Tab specific reducers can import actions from this file
 // if they need to respond to a script changing.
 
-const DEFAULT_SCRIPT_NAME = 'Express Course';
+const DEFAULT_SCRIPT_NAME = 'express-2017';
 
 // Action type constants
 export const SET_SCRIPT = 'scriptSelection/SET_SCRIPT';
@@ -117,7 +117,7 @@ export default function scriptSelection(state = initialState, action) {
     let validScripts = action.validScripts;
     // Set defaultScript to Express Course to use if there are no validScripts
     const defaultScript = validScripts.find(
-      script => script.name === DEFAULT_SCRIPT_NAME
+      script => script.script_name === DEFAULT_SCRIPT_NAME
     );
 
     if (action.studentScriptIds && action.validCourses) {

--- a/apps/test/unit/redux/scriptSelectionReduxTest.js
+++ b/apps/test/unit/redux/scriptSelectionReduxTest.js
@@ -35,9 +35,9 @@ const fakeValidScripts = [
     category: 'CS Fundamentals',
     category_priority: 1,
     id: 182,
-    name: 'Express Course',
+    name: 'Corso Rapido',
     position: 6,
-    script_name: 'express'
+    script_name: 'express-2017'
   }
 ];
 
@@ -142,7 +142,7 @@ describe('scriptSelectionRedux', () => {
       assert.deepEqual(nextState.scriptId, 100);
     });
 
-    it('includes Express Course if nothing assigned and no progress', () => {
+    it('includes express-2017 if nothing assigned and no progress', () => {
       const studentScriptIds = [];
       const validCourses = [];
       const action = setValidScripts(
@@ -153,7 +153,7 @@ describe('scriptSelectionRedux', () => {
       const nextState = scriptSelection(initialState, action);
       assert.deepEqual(
         nextState.validScripts,
-        fakeValidScripts.filter(script => script.name === 'Express Course')
+        fakeValidScripts.filter(script => script.script_name === 'express-2017')
       );
     });
 


### PR DESCRIPTION
pair @nkiruka 

We received [a report](https://codedotorg.slack.com/archives/C0T0UQH0R/p1552580796025400) from one of our partners in Italy this morning that the following functionality was broken:
- Set language to Italian
- Create a new section
- Visit the teacher dashboard for that new section
- Result: Teacher dashboard would not load and displayed a blank screen

**Reason:** There were no scripts to be set in `scriptSelectionRedux`, which was unexpected because we always set a default script -- "Express Course." However, we were searching for "Express Course" by its English name, which is why it was breaking in other languages.

**Solution:** Search for the default script by `script_name === 'express-2017'` as script_name is not translated (whereas name is translated).