### PR TITLE
Facilitator application auto emails

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/application/facilitator_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/facilitator_applications_controller.rb
@@ -12,7 +12,7 @@ module Api::V1::Pd::Application
     protected
 
     def on_successful_create
-      @application.queue_email :confirmation, deliver_now: true
+      @application.on_successful_create
       @application.update_status_timestamp_change_log(current_user)
     end
   end

--- a/dashboard/app/models/pd/application/facilitator1920_application.rb
+++ b/dashboard/app/models/pd/application/facilitator1920_application.rb
@@ -128,6 +128,10 @@ module Pd::Application
     def log_status
       self.status_log ||= []
       status_log.push({status: status, at: Time.zone.now})
+    end
+
+    def lock!
+      super
 
       # delete any unsent emails, and queue a new status email if appropriate
       emails.unsent.destroy_all

--- a/dashboard/app/models/pd/application/facilitator1920_application.rb
+++ b/dashboard/app/models/pd/application/facilitator1920_application.rb
@@ -76,6 +76,19 @@ module Pd::Application
       )
     end
 
+    # These statuses are considered "decisions", and will queue an email that will be sent by cronjob the next morning
+    # In these decision emails, status and email_type are the same.
+    AUTO_EMAIL_STATUSES = %w(
+      declined
+      waitlisted
+    )
+
+    has_many :emails, class_name: 'Pd::Application::Email', foreign_key: 'pd_application_id'
+
+    def on_successful_create
+      queue_email :confirmation, deliver_now: true
+    end
+
     # Queries for locked and (accepted or withdrawn) and assigned to a fit workshop
     # @param [ActiveRecord::Relation<Pd::Application::Facilitator1920Application>] applications_query
     #   (optional) defaults to all
@@ -115,6 +128,14 @@ module Pd::Application
     def log_status
       self.status_log ||= []
       status_log.push({status: status, at: Time.zone.now})
+
+      # delete any unsent emails, and queue a new status email if appropriate
+      emails.unsent.destroy_all
+      queue_email(status) if should_send_decision_email?
+    end
+
+    def should_send_decision_email?
+      AUTO_EMAIL_STATUSES.include?(status)
     end
 
     # memoize in a hash, per course


### PR DESCRIPTION
[PLS-157](https://codedotorg.atlassian.net/browse/PLC-157
)
Facilitator application sends auto-emails when an application is locked on `waitlisted` or `declined` status. Before this change, the emails were not being triggered.