### PR TITLE
Replace dangerouslySetInnerHTML with UnsafeRenderedMarkdown in the facilitator bio

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/facilitator_bio.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/facilitator_bio.jsx
@@ -2,8 +2,8 @@
  * Facilitator bio as used on the workshop enrollment form
  */
 import React from 'react';
-import marked from 'marked';
 import {FacilitatorPropType} from './enrollmentConstants';
+import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 
 export default class FacilitatorBio extends React.Component {
   static propTypes = {
@@ -19,9 +19,9 @@ export default class FacilitatorBio extends React.Component {
   bio = () => {
     if (this.props.facilitator.bio) {
       return (
-        <div
-          dangerouslySetInnerHTML={{__html: marked(this.props.facilitator.bio)}} // eslint-disable-line react/no-danger
-        />
+        <div>
+          <UnsafeRenderedMarkdown markdown={this.props.facilitator.bio} />
+        </div>
       );
     } else {
       return (


### PR DESCRIPTION
Tested locally using one of the facilitator bios in pegasus. I don't believe any of the bios have HTML in them (based on a simple grep of the directory) but I have obviously not tested every facilitator bio. 