### PR TITLE
Rename "unmigrated_sso" factories

### DIFF
--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1098,7 +1098,7 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test 'clever_classrooms queries clever with user uid for unmigrated user' do
-    teacher = create :teacher, :unmigrated_sso, :demigrated, provider: AuthenticationOption::CLEVER
+    teacher = create :teacher, :sso_provider, :demigrated, provider: AuthenticationOption::CLEVER
     sign_in teacher
 
     expected_uri = "https://api.clever.com/v1.1/teachers/#{teacher.uid}/sections"

--- a/dashboard/test/controllers/omniauth_callbacks_controller/clever_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller/clever_test.rb
@@ -65,7 +65,7 @@ module OmniauthCallbacksControllerTests
     test "student sign-in" do
       auth_hash = mock_oauth user_type: User::TYPE_STUDENT
 
-      student = create(:student, :unmigrated_clever_sso, uid: auth_hash.uid)
+      student = create(:student, :clever_sso_provider, uid: auth_hash.uid)
 
       sign_in_through_clever
       assert_redirected_to '/'
@@ -83,7 +83,7 @@ module OmniauthCallbacksControllerTests
     test "teacher sign-in" do
       auth_hash = mock_oauth user_type: User::TYPE_TEACHER
 
-      teacher = create(:teacher, :unmigrated_clever_sso, uid: auth_hash.uid)
+      teacher = create(:teacher, :clever_sso_provider, uid: auth_hash.uid)
 
       sign_in_through_clever
       assert_redirected_to '/home'

--- a/dashboard/test/controllers/omniauth_callbacks_controller/facebook_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller/facebook_test.rb
@@ -82,7 +82,7 @@ module OmniauthCallbacksControllerTests
     test "student sign-in" do
       auth_hash = mock_oauth
 
-      student = create(:student, :unmigrated_facebook_sso, uid: auth_hash.uid)
+      student = create(:student, :facebook_sso_provider, uid: auth_hash.uid)
 
       get '/users/sign_in'
       sign_in_through_facebook
@@ -107,7 +107,7 @@ module OmniauthCallbacksControllerTests
     test "teacher sign-in" do
       auth_hash = mock_oauth
 
-      teacher = create(:teacher, :unmigrated_facebook_sso, uid: auth_hash.uid)
+      teacher = create(:teacher, :facebook_sso_provider, uid: auth_hash.uid)
 
       get '/users/sign_in'
       sign_in_through_facebook

--- a/dashboard/test/controllers/omniauth_callbacks_controller/google_oauth2_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller/google_oauth2_test.rb
@@ -234,7 +234,7 @@ module OmniauthCallbacksControllerTests
     test "student sign-in" do
       auth_hash = mock_oauth
 
-      student = create(:student, :unmigrated_google_sso, uid: auth_hash.uid)
+      student = create(:student, :google_sso_provider, uid: auth_hash.uid)
 
       get '/users/sign_in'
       sign_in_through_google
@@ -253,7 +253,7 @@ module OmniauthCallbacksControllerTests
     test "teacher sign-in" do
       auth_hash = mock_oauth
 
-      teacher = create(:teacher, :unmigrated_google_sso, uid: auth_hash.uid)
+      teacher = create(:teacher, :google_sso_provider, uid: auth_hash.uid)
 
       get '/users/sign_in'
       sign_in_through_google
@@ -270,7 +270,7 @@ module OmniauthCallbacksControllerTests
     test "sign-in from sign-up page" do
       auth_hash = mock_oauth
 
-      teacher = create(:teacher, :unmigrated_google_sso, uid: auth_hash.uid)
+      teacher = create(:teacher, :google_sso_provider, uid: auth_hash.uid)
 
       get '/users/sign_up'
       refute_creates(User) {sign_in_through_google}

--- a/dashboard/test/controllers/omniauth_callbacks_controller/powerschool_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller/powerschool_test.rb
@@ -45,7 +45,7 @@ module OmniauthCallbacksControllerTests
     test "student sign-in" do
       auth_hash = mock_oauth user_type: User::TYPE_STUDENT
 
-      student = create(:student, :unmigrated_powerschool_sso, uid: auth_hash.uid)
+      student = create(:student, :powerschool_sso_provider, uid: auth_hash.uid)
 
       sign_in_through_powerschool
       assert_redirected_to '/'
@@ -61,7 +61,7 @@ module OmniauthCallbacksControllerTests
     test "teacher sign-in" do
       auth_hash = mock_oauth user_type: 'staff'
 
-      teacher = create(:teacher, :unmigrated_powerschool_sso, uid: auth_hash.uid)
+      teacher = create(:teacher, :powerschool_sso_provider, uid: auth_hash.uid)
 
       sign_in_through_powerschool
       assert_redirected_to '/home'

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -468,7 +468,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
   test 'clever: signs in user if user is found by credentials' do
     # Given I have a Clever-Code.org account
-    user = create :student, :unmigrated_clever_sso
+    user = create :student, :clever_sso_provider
 
     # When I hit the clever oauth callback
     auth = generate_auth_user_hash \
@@ -487,7 +487,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
   test 'clever: updates tokens when unmigrated user is found by credentials' do
     # Given I have a Clever-Code.org account
-    user = create :teacher, :unmigrated_clever_sso, :demigrated
+    user = create :teacher, :clever_sso_provider, :demigrated
 
     # When I hit the clever oauth callback
     auth = generate_auth_user_hash \
@@ -615,7 +615,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
   test 'google_oauth2: signs in user if user is found by credentials' do
     # Given I have a Google-Code.org account
-    user = create :student, :unmigrated_google_sso
+    user = create :student, :google_sso_provider
 
     # When I hit the google oauth callback
     auth = generate_auth_user_hash \
@@ -634,7 +634,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
   test 'google_oauth2: updates tokens when unmigrated user is found by credentials' do
     # Given I have a Google-Code.org account
-    user = create :teacher, :unmigrated_google_sso, :demigrated
+    user = create :teacher, :google_sso_provider, :demigrated
 
     # When I hit the google oauth callback
     auth = generate_auth_user_hash \
@@ -663,7 +663,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   test 'google_oauth2: updates tokens when migrated user is found by credentials' do
     # Given I have a Google-Code.org account
     user = create(:teacher,
-      :unmigrated_google_sso,
+      :google_sso_provider,
       uid: 'fake-uid'
     )
     assert user.migrated?
@@ -1001,7 +1001,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   test 'login: microsoft_v2_auth deletes an existing windowslive authentication_option for migrated user' do
     email = 'test@foo.xyz'
     uid = '654321'
-    user = create(:user, :unmigrated_windowslive_sso, email: email)
+    user = create(:user, :windowslive_sso_provider, email: email)
     auth = OmniAuth::AuthHash.new(
       provider: 'microsoft_v2_auth',
       uid: uid,
@@ -1197,7 +1197,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test 'connect_provider: returns bad_request if user not migrated' do
-    user = create :user, :unmigrated_facebook_sso
+    user = create :user, :facebook_sso_provider
     Timecop.freeze do
       setup_should_connect_provider(user)
       get :google_oauth2

--- a/dashboard/test/controllers/registrations_controller/new_account_tracking_test.rb
+++ b/dashboard/test/controllers/registrations_controller/new_account_tracking_test.rb
@@ -137,7 +137,7 @@ module RegistrationsControllerTests
       OmniAuth.config.mock_auth[:google_oauth2] = generate_auth_user_hash(
         provider: 'google_oauth2'
       )
-      create :teacher, :unmigrated_google_sso, uid: DEFAULT_UID, email: EMAIL
+      create :teacher, :google_sso_provider, uid: DEFAULT_UID, email: EMAIL
       events = %w(load-sign-up-page)
       FirehoseClient.instance.expects(:put_record).once.with do |data|
         data[:study] == STUDY &&

--- a/dashboard/test/controllers/registrations_controller/update_test.rb
+++ b/dashboard/test/controllers/registrations_controller/update_test.rb
@@ -143,7 +143,7 @@ module RegistrationsControllerTests
       # so it's possible to add a recovery option to their account.  Once they are
       # on multi-auth they can just add an email or another SSO, so this is no
       # longer needed.
-      student = create :student, :unmigrated_clever_sso
+      student = create :student, :clever_sso_provider
       assert_nil student.parent_email
       assert_nil student.encrypted_password
 

--- a/dashboard/test/controllers/registrations_controller/users_to_destroy_test.rb
+++ b/dashboard/test/controllers/registrations_controller/users_to_destroy_test.rb
@@ -92,7 +92,7 @@ module RegistrationsControllerTests
     end
 
     test "returns students in rostered sections without passwords that have no other teachers" do
-      student = create :student, :unmigrated_google_sso, encrypted_password: nil
+      student = create :student, :google_sso_provider, encrypted_password: nil
       section = create :section, login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM
       section.students << student
       sign_in section.teacher

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -245,7 +245,7 @@ FactoryGirl.define do
       end
 
       trait :migrated_imported_from_google_classroom do
-        unmigrated_google_sso
+        google_sso_provider
         without_email
         after(:create) do |user|
           section = create :section, login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM
@@ -260,20 +260,20 @@ FactoryGirl.define do
       end
     end
 
-    trait :unmigrated_sso do
+    trait :sso_provider do
       encrypted_password nil
       provider %w(facebook windowslive clever).sample
       sequence(:uid) {|n| n}
     end
 
-    trait :unmigrated_sso_with_token do
-      unmigrated_sso
+    trait :sso_provider_with_token do
+      sso_provider
       oauth_token 'fake-oauth-token'
       oauth_token_expiration 'fake-oauth-token-expiration'
     end
 
-    trait :unmigrated_untrusted_email_sso do
-      unmigrated_sso_with_token
+    trait :untrusted_email_sso_provider do
+      sso_provider_with_token
       after(:create) do |user|
         if user.student?
           user.hashed_email = nil
@@ -282,44 +282,44 @@ FactoryGirl.define do
       end
     end
 
-    trait :unmigrated_clever_sso do
-      unmigrated_untrusted_email_sso
+    trait :clever_sso_provider do
+      untrusted_email_sso_provider
       provider 'clever'
     end
 
-    trait :unmigrated_facebook_sso do
-      unmigrated_sso_with_token
+    trait :facebook_sso_provider do
+      sso_provider_with_token
       provider 'facebook'
     end
 
-    trait :unmigrated_google_sso do
-      unmigrated_sso_with_token
+    trait :google_sso_provider do
+      sso_provider_with_token
       provider 'google_oauth2'
       oauth_refresh_token 'fake-oauth-refresh-token'
     end
 
-    trait :unmigrated_powerschool_sso do
-      unmigrated_untrusted_email_sso
+    trait :powerschool_sso_provider do
+      untrusted_email_sso_provider
       provider 'powerschool'
     end
 
-    trait :unmigrated_the_school_project_sso do
-      unmigrated_sso
+    trait :the_school_project_sso_provider do
+      sso_provider
       provider 'the_school_project'
     end
 
-    trait :unmigrated_twitter_sso do
-      unmigrated_sso
+    trait :twitter_sso_provider do
+      sso_provider
       provider 'twitter'
     end
 
-    trait :unmigrated_qwiklabs_sso do
-      unmigrated_sso
+    trait :qwiklabs_sso_provider do
+      sso_provider
       provider 'lti_lti_prod_kids.qwikcamps.com'
     end
 
-    trait :unmigrated_windowslive_sso do
-      unmigrated_sso_with_token
+    trait :windowslive_sso_provider do
+      sso_provider_with_token
       provider 'windowslive'
     end
 

--- a/dashboard/test/lib/user_multi_auth_helper_test.rb
+++ b/dashboard/test/lib/user_multi_auth_helper_test.rb
@@ -36,7 +36,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   # The following two tests check the oauth_tokens_for_provider logic for demigrated teachers, and
   # can be deleted after we migrate all users to multiauth
   test 'oauth_tokens_for_provider returns correct token for demigrated Google teacher' do
-    user = create :teacher, :unmigrated_google_sso, :demigrated
+    user = create :teacher, :google_sso_provider, :demigrated
     google_token = user.oauth_tokens_for_provider(AuthenticationOption::GOOGLE)[:oauth_token]
     google_expiration = user.oauth_tokens_for_provider(AuthenticationOption::GOOGLE)[:oauth_token_expiration]
     google_refresh_token = user.oauth_tokens_for_provider(AuthenticationOption::GOOGLE)[:oauth_refresh_token]
@@ -150,27 +150,27 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   #
 
   test 'create migrated Google OAuth student' do
-    assert_created_google_user create(:student, :unmigrated_google_sso)
+    assert_created_google_user create(:student, :google_sso_provider)
   end
 
   test 'create migrated Google OAuth teacher' do
-    assert_created_google_user create(:teacher, :unmigrated_google_sso)
+    assert_created_google_user create(:teacher, :google_sso_provider)
   end
 
   test 'create migrated Windows Live OAuth student' do
-    assert_created_sso_user_with_oauth_token create(:student, :unmigrated_windowslive_sso)
+    assert_created_sso_user_with_oauth_token create(:student, :windowslive_sso_provider)
   end
 
   test 'create migrated Windows Live OAuth teacher' do
-    assert_created_sso_user_with_oauth_token create(:teacher, :unmigrated_windowslive_sso)
+    assert_created_sso_user_with_oauth_token create(:teacher, :windowslive_sso_provider)
   end
 
   test 'create migrated Facebook OAuth student' do
-    assert_created_sso_user_with_oauth_token create(:student, :unmigrated_facebook_sso)
+    assert_created_sso_user_with_oauth_token create(:student, :facebook_sso_provider)
   end
 
   test 'create migrated Facebook OAuth teacher' do
-    assert_created_sso_user_with_oauth_token create(:teacher, :unmigrated_facebook_sso)
+    assert_created_sso_user_with_oauth_token create(:teacher, :facebook_sso_provider)
   end
 
   def assert_created_google_user(user)
@@ -190,19 +190,19 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   #
 
   test 'create migrated Clever OAuth student' do
-    assert_created_sso_user_with_oauth_token create(:student, :unmigrated_clever_sso)
+    assert_created_sso_user_with_oauth_token create(:student, :clever_sso_provider)
   end
 
   test 'create migrated Clever OAuth teacher' do
-    assert_created_sso_user_with_oauth_token create(:teacher, :unmigrated_clever_sso)
+    assert_created_sso_user_with_oauth_token create(:teacher, :clever_sso_provider)
   end
 
   test 'create migrated Powerschool OAuth student' do
-    assert_created_sso_user_with_oauth_token create(:student, :unmigrated_powerschool_sso)
+    assert_created_sso_user_with_oauth_token create(:student, :powerschool_sso_provider)
   end
 
   test 'create migrated Powerschool OAuth teacher' do
-    assert_created_sso_user_with_oauth_token create(:teacher, :unmigrated_powerschool_sso)
+    assert_created_sso_user_with_oauth_token create(:teacher, :powerschool_sso_provider)
   end
 
   def assert_created_sso_user_with_oauth_token(user)
@@ -222,22 +222,22 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   # supporting them.
 
   test 'create migrated The School Project student' do
-    assert_created_sso_user create(:student, :unmigrated_the_school_project_sso)
+    assert_created_sso_user create(:student, :the_school_project_sso_provider)
   end
 
   test 'create migrated The School Project teacher' do
-    assert_created_sso_user create(:teacher, :unmigrated_the_school_project_sso)
+    assert_created_sso_user create(:teacher, :the_school_project_sso_provider)
   end
 
   # Our Twitter SSO support is very old - we have a few thousand such accounts
   # but less than 10 are still active.
 
   test 'create migrated Twitter student' do
-    assert_created_sso_user create(:student, :unmigrated_twitter_sso)
+    assert_created_sso_user create(:student, :twitter_sso_provider)
   end
 
   test 'create migrated Twitter teacher' do
-    assert_created_sso_user create(:teacher, :unmigrated_twitter_sso)
+    assert_created_sso_user create(:teacher, :twitter_sso_provider)
   end
 
   #
@@ -249,11 +249,11 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   # That doesn't mean we couldn't end up with a teacher account though.
 
   test 'create migrated Qwiklabs LTI student' do
-    assert_created_lti_user create(:student, :unmigrated_qwiklabs_sso)
+    assert_created_lti_user create(:student, :qwiklabs_sso_provider)
   end
 
   test 'create migrated Qwiklabs LTI teacher' do
-    assert_created_lti_user create(:teacher, :unmigrated_qwiklabs_sso)
+    assert_created_lti_user create(:teacher, :qwiklabs_sso_provider)
   end
 
   def assert_created_lti_user(user)
@@ -288,7 +288,7 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   end
 
   test 'migration clears single-auth fields' do
-    user = create :teacher, :unmigrated_google_sso
+    user = create :teacher, :google_sso_provider
 
     assert_user user,
       uid: nil,
@@ -375,11 +375,11 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   end
 
   test 'de- and re-migrate Google OAuth student' do
-    round_trip_google_user create(:student, :unmigrated_google_sso)
+    round_trip_google_user create(:student, :google_sso_provider)
   end
 
   test 'de- and re-migrate Google OAuth teacher' do
-    round_trip_google_user create(:teacher, :unmigrated_google_sso)
+    round_trip_google_user create(:teacher, :google_sso_provider)
   end
 
   def round_trip_google_user(for_user)
@@ -395,35 +395,35 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   end
 
   test 'de- and re-migrate Windows Live OAuth student' do
-    round_trip_sso_with_token create(:student, :unmigrated_windowslive_sso)
+    round_trip_sso_with_token create(:student, :windowslive_sso_provider)
   end
 
   test 'de- and re-migrate Windows Live OAuth teacher' do
-    round_trip_sso_with_token create(:teacher, :unmigrated_windowslive_sso)
+    round_trip_sso_with_token create(:teacher, :windowslive_sso_provider)
   end
 
   test 'de- and re-migrate Facebook OAuth student' do
-    round_trip_sso_with_token create(:student, :unmigrated_facebook_sso)
+    round_trip_sso_with_token create(:student, :facebook_sso_provider)
   end
 
   test 'de- and re-migrate Facebook OAuth teacher' do
-    round_trip_sso_with_token create(:teacher, :unmigrated_facebook_sso)
+    round_trip_sso_with_token create(:teacher, :facebook_sso_provider)
   end
 
   test 'de- and re-migrate Clever OAuth student' do
-    round_trip_sso_with_token create(:student, :unmigrated_clever_sso)
+    round_trip_sso_with_token create(:student, :clever_sso_provider)
   end
 
   test 'de- and re-migrate Clever OAuth teacher' do
-    round_trip_sso_with_token create(:teacher, :unmigrated_clever_sso)
+    round_trip_sso_with_token create(:teacher, :clever_sso_provider)
   end
 
   test 'de- and re-migrate Powerschool OAuth student' do
-    round_trip_sso_with_token create(:student, :unmigrated_powerschool_sso)
+    round_trip_sso_with_token create(:student, :powerschool_sso_provider)
   end
 
   test 'de- and re-migrate Powerschool OAuth teacher' do
-    round_trip_sso_with_token create(:teacher, :unmigrated_powerschool_sso)
+    round_trip_sso_with_token create(:teacher, :powerschool_sso_provider)
   end
 
   def round_trip_sso_with_token(for_user)
@@ -444,27 +444,27 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   end
 
   test 'de- and re-migrate The School Project student' do
-    round_trip_sso create(:student, :unmigrated_the_school_project_sso)
+    round_trip_sso create(:student, :the_school_project_sso_provider)
   end
 
   test 'de- and re-migrate The School Project teacher' do
-    round_trip_sso create(:teacher, :unmigrated_the_school_project_sso)
+    round_trip_sso create(:teacher, :the_school_project_sso_provider)
   end
 
   test 'de- and re-migrate Twitter student' do
-    round_trip_sso create(:student, :unmigrated_twitter_sso)
+    round_trip_sso create(:student, :twitter_sso_provider)
   end
 
   test 'de- and re-migrate Twitter teacher' do
-    round_trip_sso create(:teacher, :unmigrated_twitter_sso)
+    round_trip_sso create(:teacher, :twitter_sso_provider)
   end
 
   test 'de- and re-migrate Qwiklabs LTI student' do
-    round_trip_sso create(:student, :unmigrated_qwiklabs_sso)
+    round_trip_sso create(:student, :qwiklabs_sso_provider)
   end
 
   test 'de- and re-migrate Qwiklabs LTI teacher' do
-    round_trip_sso create(:teacher, :unmigrated_qwiklabs_sso)
+    round_trip_sso create(:teacher, :qwiklabs_sso_provider)
   end
 
   def round_trip_sso(for_user)

--- a/dashboard/test/models/concerns/partial_registration_test.rb
+++ b/dashboard/test/models/concerns/partial_registration_test.rb
@@ -68,7 +68,7 @@ class PartialRegistrationTest < ActiveSupport::TestCase
     # This avoids "cookie overflow" errors.
 
     session = fake_empty_session
-    user = build :student, :unmigrated_google_sso
+    user = build :student, :google_sso_provider
 
     PartialRegistration.persist_attributes session, user
 
@@ -85,7 +85,7 @@ class PartialRegistrationTest < ActiveSupport::TestCase
 
   test 'round-trip preserves important attributes' do
     session = fake_empty_session
-    user = build :user, :unmigrated_google_sso
+    user = build :user, :google_sso_provider
 
     PartialRegistration.persist_attributes session, user
 
@@ -102,7 +102,7 @@ class PartialRegistrationTest < ActiveSupport::TestCase
   end
 
   test 'cancel ends signup tracking and deletes user attributes from the session' do
-    user = build :user, :unmigrated_google_sso
+    user = build :user, :google_sso_provider
     session = fake_session user.attributes
 
     SignUpTracking.expects(:log_cancel_finish_sign_up)

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1041,7 +1041,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'changing oauth user from student to teacher with same email is allowed' do
-    user = create :student, :unmigrated_google_sso, email: 'email@new.xx'
+    user = create :student, :google_sso_provider, email: 'email@new.xx'
     assert user.primary_contact_info.credential_type == 'google_oauth2'
 
     assert user.set_user_type(User::TYPE_TEACHER, 'email@new.xx')
@@ -1051,7 +1051,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'changing oauth user from student to teacher with different email is allowed' do
-    user = create :student, :unmigrated_google_sso
+    user = create :student, :google_sso_provider
     assert user.primary_contact_info.credential_type == 'google_oauth2'
 
     assert user.set_user_type(User::TYPE_TEACHER, 'email@new.xx')
@@ -1570,7 +1570,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'can change own user type as an oauth student' do
-    student = create :student, :unmigrated_google_sso
+    student = create :student, :google_sso_provider
     assert student.can_change_own_user_type?
   end
 
@@ -3905,7 +3905,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'find_by_credential returns nil when no matching user is found' do
-    user = create :student, :unmigrated_clever_sso
+    user = create :student, :clever_sso_provider
 
     assert_nil User.find_by_credential(
       type: AuthenticationOption::CLEVER,
@@ -3915,7 +3915,7 @@ class UserTest < ActiveSupport::TestCase
 
   test 'find_by_credential locates migrated SSO user' do
     original_uid = 'test-uid'
-    user = create :student, :unmigrated_clever_sso, uid: original_uid
+    user = create :student, :clever_sso_provider, uid: original_uid
 
     User.expects(:find_by).never
     assert_equal user,
@@ -3956,7 +3956,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'depended_upon_for_login? if teacher has a roster-managed student with no other teachers' do
-    student = create :student, :unmigrated_google_sso
+    student = create :student, :google_sso_provider
     section = create :section, login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM
     section.students << student
     another_section = create :section, user: section.teacher, login_type: Section::LOGIN_TYPE_EMAIL
@@ -4004,7 +4004,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'dependent_students for teacher: returns students in rostered sections without passwords that have no other teachers' do
-    student = create :student, :unmigrated_google_sso, encrypted_password: nil
+    student = create :student, :google_sso_provider, encrypted_password: nil
     section = create :section, login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM
     section.students << student
 


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/27232

Now that users are created already-migrated, all the "unmigrated_sso" factories are misleadingly named. This PR renames them to look more like "sso_provider".

Next up: the "with_migrated_authentication_option" factories