### PR TITLE
Add missing AWS permissions

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -555,6 +555,15 @@ Resources:
               - Effect: Allow
                 Action: iam:PassRole
                 Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/CloudFormationService"
+        - PolicyName: StopInactiveAdhocInstances
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                  - cloudwatch:GetMetricStatistics
+                  - ec2:DescribeInstances
+                Resource: '*'
       ManagedPolicyArns: [!Ref CDOPolicy]
       PermissionsBoundary: !ImportValue IAM-DevPermissions
   DaemonInstanceProfile:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -573,6 +573,9 @@ Resources:
                   - cloudwatch:GetMetricStatistics
                   - ec2:DescribeInstances
                 Resource: '*'
+              - Effect: Allow
+                Action: cloudformation:DescribeStackResource
+                Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/adhoc-*"
         - PolicyName: RDSBackup
           PolicyDocument:
             Statement:
@@ -593,6 +596,14 @@ Resources:
                   - rds:ModifyDBSnapshotAttribute
                   - rds:DeleteDBSnapshot
                 Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:temp-snapshot-*"
+              - Effect: Allow
+                Action:
+                  - kms:CreateGrant
+                  - kms:DescribeKey
+                Resource: '*'
+                Condition:
+                  StringEquals:
+                    kms:ViaService: !Sub "rds.${AWS::Region}.amazonaws.com"
 <% end -%>
       ManagedPolicyArns: [!Ref CDOPolicy]
       PermissionsBoundary: !ImportValue IAM-DevPermissions

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -563,6 +563,7 @@ Resources:
               - Effect: Allow
                 Action: iam:PassRole
                 Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/CloudFormationService"
+<% if rack_env?(:production) -%>
         - PolicyName: StopInactiveAdhocInstances
           PolicyDocument:
             Statement:
@@ -572,6 +573,27 @@ Resources:
                   - cloudwatch:GetMetricStatistics
                   - ec2:DescribeInstances
                 Resource: '*'
+        - PolicyName: RDSBackup
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: rds:DescribeDBInstances
+                Resource: '*'
+              - Effect: Allow
+                Action: rds:DescribeDBSnapshots
+                Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:production"
+              - Effect: Allow
+                Action: rds:CopyDBSnapshot
+                Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:rds:production-*"
+              - Effect: Allow
+                Action:
+                  - rds:CopyDBSnapshot
+                  - rds:DescribeDBSnapshots
+                  - rds:DescribeDBSnapshotAttributes
+                  - rds:ModifyDBSnapshotAttribute
+                  - rds:DeleteDBSnapshot
+                Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:temp-snapshot-*"
+<% end -%>
       ManagedPolicyArns: [!Ref CDOPolicy]
       PermissionsBoundary: !ImportValue IAM-DevPermissions
   DaemonInstanceProfile:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -127,6 +127,15 @@ Resources:
           - Effect: Allow
             Action: 'firehose:PutRecord'
             Resource: !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/analysis-events"
+          # Send messages to SQS queues for asynchronous processing.
+          - Effect: Allow
+            Action: 'sqs:SendMessage'
+            Resource:
+<% unless daemon -%>
+              - !GetAtt ActivitiesQueue.Arn
+<% end -%>
+              # TODO: Import pd_workshop resources into stack.
+              - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:pd_workshop-<%=environment%>"
           # General s3 access.
           # TODO: Further restrict permissions to grant least privilege.
           - Effect: Allow
@@ -517,7 +526,6 @@ Resources:
               # SQS queues for Asynchronous batch processing by the `process_queues` service.
               - Effect: Allow
                 Action:
-                  - 'sqs:SendMessage'
                   - 'sqs:ReceiveMessage'
                   - 'sqs:DeleteMessageBatch'
                   - 'sqs:DeleteMessage'


### PR DESCRIPTION
Adds AWS permissions to the CloudFormation application stack for 3 features:
- `sqs:SendMessage` (on frontends) for enqueuing messages for pd-workshop;

Two permission sets for cron tasks run on `production-daemon`:
- `stop_inactive_adhoc_instances`
- `push_latest_rds_backup_to_secondary_account`