### PR TITLE
Update drone.yml signature for new drone stack

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -194,6 +194,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: fecce68aa5a56fb8f6e6295c9f9d399eb39b2689f8d1a486182da1b5b77164f6
+hmac: 6b7e7814aa5e4affe72e051161413e62d24dc552d6a2c85aabed23d134fd8cc3
 
 ...


### PR DESCRIPTION
I'm in the process of switching us from my initial, manually-created drone stack to the one provisioned through cloudformation (see: https://github.com/code-dot-org/code-dot-org/pull/27440).

Because it's a new stack, the drone signature also needs to be updated. (I updated the relevant environment variables and ran: `drone sign code-dot-org/code-dot-org --save`)