### PR TITLE
Mini Rubric: Re-implement shrink feedback tab changes

### DIFF
--- a/apps/src/lib/ui/checkedRadioButton.css
+++ b/apps/src/lib/ui/checkedRadioButton.css
@@ -17,18 +17,30 @@ input[type=radio].with-font ~ label:before {
     font-family: FontAwesome;
     display: inline-block;
     content: "\f1db";  /* fa-circle-thin */
-    letter-spacing: 10px;
-    font-size: 1.5em;
+    font-size: 18px;
     color: color.black;
-    width: 1.4em;   /* reduce bounce */
+    width: 15px;
+    height: 15px;
+    text-align: center;
+    vertical-align: bottom;
 }
 input[type=radio].with-font:checked ~ label:before  {
+    font-family: FontAwesome;
+    display:inline-block;
     content: "\f058";  /* fa-check-circle */
-    font-size: 1.5em;
+    font-size: 18px;
     color: #0094ca;
-    letter-spacing: 5px;
+    width: 15px;
+    height: 15px;
+    line-height: 16px;
+    background-color: white;
+    text-align: center;
+    border-radius: 60%;
 }
 
 label.hidden-label-checked-radio-button {
     margin: 0px;
+    width: 16px;
+    height: 16px;
+    line-height: 16px;
 }

--- a/apps/src/templates/instructions/CommentArea.jsx
+++ b/apps/src/templates/instructions/CommentArea.jsx
@@ -6,21 +6,25 @@ import i18n from '@cdo/locale';
 const styles = {
   textInput: {
     marginTop: 0,
-    marginBottom: 16,
-    display: 'block',
-    width: '90%'
-  },
-  textInputStudent: {
-    margin: 10,
+    marginBottom: 8,
     display: 'block',
     width: '90%',
-    backgroundColor: color.lightest_cyan
+    fontSize: 12
+  },
+  textInputStudent: {
+    marginTop: 0,
+    marginBottom: 8,
+    display: 'block',
+    width: '90%',
+    backgroundColor: color.lightest_cyan,
+    fontSize: 12
   },
   h1: {
     color: color.charcoal,
-    marginTop: 8,
-    marginBottom: 12,
-    fontSize: 24,
+    marginTop: 0,
+    marginBottom: 8,
+    fontSize: 18,
+    lineHeight: '18px',
     fontFamily: '"Gotham 5r", sans-serif',
     fontWeight: 'normal'
   }

--- a/apps/src/templates/instructions/RubricField.jsx
+++ b/apps/src/templates/instructions/RubricField.jsx
@@ -12,10 +12,11 @@ const styles = {
     width: '100%'
   },
   detailsArea: {
-    width: '100%'
+    width: '100%',
+    paddingTop: 2
   },
   rubricHeader: {
-    fontSize: 13,
+    fontSize: 12,
     marginLeft: 10,
     color: color.black,
     fontFamily: '"Gotham 5r", sans-serif'
@@ -24,28 +25,37 @@ const styles = {
     display: 'flex',
     justifyContent: 'flex-start',
     flexDirection: 'row',
-    padding: '4px 10px',
+
+    margin: '0px 8px',
+    padding: 4,
     ':hover': {
       border: `solid 1px ${color.light_cyan}`,
-      borderRadius: 10
+      borderRadius: 4
     }
   },
   performanceLevelHeaderSelected: {
     display: 'flex',
     justifyContent: 'flex-start',
     flexDirection: 'row',
+    margin: '0px 8px',
+    padding: 4,
     backgroundColor: color.lightest_cyan,
-    borderRadius: 10,
-    padding: '4px 10px',
+    borderRadius: 4,
     ':hover': {
       border: `solid 1px ${color.light_cyan}`,
-      borderRadius: 10
+      borderRadius: 4
     }
   },
   tooltip: {
     maxWidth: 200,
     lineHeight: '20px',
     whiteSpace: 'normal'
+  },
+  rubricDetails: {
+    paddingLeft: 23,
+    paddingTop: 5,
+    fontSize: 12,
+    margin: 0
   }
 };
 
@@ -93,7 +103,7 @@ class RubricField extends Component {
             <summary style={styles.rubricHeader}>
               {rubricLevelHeaders[this.props.rubricLevel]}
             </summary>
-            <p>{this.props.rubricValue}</p>
+            <p style={styles.rubricDetails}>{this.props.rubricValue}</p>
           </details>
         </div>
         <ReactTooltip

--- a/apps/src/templates/instructions/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/TeacherFeedback.jsx
@@ -13,20 +13,23 @@ import {CommentArea} from './CommentArea';
 
 const styles = {
   button: {
-    margin: 10,
     fontWeight: 'bold'
   },
   errorIcon: {
     color: 'red',
     margin: 10
   },
-  time: {
-    height: 24,
-    paddingTop: 6,
+  timeTeacher: {
+    paddingTop: 8,
+    paddingLeft: 8,
     fontStyle: 'italic',
     fontSize: 12,
-    color: color.cyan,
-    backgroundColor: color.lightest_cyan
+    color: color.cyan
+  },
+  timeStudent: {
+    fontStyle: 'italic',
+    fontSize: 12,
+    color: color.cyan
   },
   footer: {
     display: 'flex',
@@ -35,8 +38,9 @@ const styles = {
   h1: {
     color: color.charcoal,
     marginTop: 8,
-    marginBottom: 12,
-    fontSize: 24,
+    marginBottom: 8,
+    fontSize: 18,
+    lineHeight: '18px',
     fontFamily: '"Gotham 5r", sans-serif',
     fontWeight: 'normal'
   },
@@ -44,21 +48,25 @@ const styles = {
     display: 'flex',
     justifyContent: 'flex-start',
     flexDirection: 'row',
-    margin: '0px 16px 20px 16px'
+    margin: '0px 16px 16px 16px'
   },
   keyConceptArea: {
     marginRight: 28,
     flexBasis: '40%'
   },
   keyConcepts: {
-    fontSize: 13,
-    color: color.charcoal
+    fontSize: 12,
+    color: color.charcoal,
+    margin: 0
   },
   rubricArea: {
     flexBasis: '60%'
   },
   commentAndFooter: {
-    margin: '0px 16px 16px 16px'
+    margin: '0px 16px 8px 16px'
+  },
+  form: {
+    margin: 0
   }
 };
 
@@ -237,6 +245,11 @@ class TeacherFeedback extends Component {
 
     const rubricLevels = ['exceeds', 'meets', 'approaches', 'noEvidence'];
 
+    const timeStyle =
+      this.props.viewAs === ViewType.Student
+        ? styles.timeStudent
+        : styles.timeTeacher;
+
     return (
       <div>
         {this.state.errorState === ErrorType.Load && (
@@ -244,15 +257,6 @@ class TeacherFeedback extends Component {
             <i className="fa fa-warning" style={styles.errorIcon} />
             {i18n.feedbackLoadError()}
           </span>
-        )}
-        {this.state.latestFeedback.length > 0 && (
-          <div style={styles.time} id="ui-test-feedback-time">
-            {i18n.lastUpdated({
-              time: moment
-                .min(moment(), moment(latestFeedback.created_at))
-                .fromNow()
-            })}
-          </div>
         )}
         {this.props.rubric && !dontShowStudentRubric && (
           <div style={styles.performanceArea}>
@@ -262,7 +266,7 @@ class TeacherFeedback extends Component {
             </div>
             <div style={styles.rubricArea}>
               <h1 style={styles.h1}> {i18n.rubricHeader()} </h1>
-              <form>
+              <form style={styles.form}>
                 {rubricLevels.map(level => (
                   <RubricField
                     key={level}
@@ -306,6 +310,15 @@ class TeacherFeedback extends Component {
                       {i18n.feedbackSaveError()}
                     </span>
                   )}
+                </div>
+              )}
+              {this.state.latestFeedback.length > 0 && (
+                <div style={timeStyle} id="ui-test-feedback-time">
+                  {i18n.lastUpdated({
+                    time: moment
+                      .min(moment(), moment(latestFeedback.created_at))
+                      .fromNow()
+                  })}
                 </div>
               )}
             </div>


### PR DESCRIPTION
Re-implements PR #27487 which was reverted by PR #27530.

Change sizing of elements in feedback tab in order to shrink vertical space. Also some style changes to layout of rubric fields.

# Before
<img width="1413" alt="Screen Shot 2019-03-13 at 10 38 58 AM" src="https://user-images.githubusercontent.com/208083/54287672-7e601c80-457c-11e9-834c-850347aab8b3.png">

# After

## Teacher

### In Experiment
<img width="797" alt="Screen Shot 2019-03-15 at 3 02 29 PM" src="https://user-images.githubusercontent.com/208083/54456323-3c79d680-4734-11e9-8d27-ae74a1417aad.png">
<img width="800" alt="Screen Shot 2019-03-15 at 3 02 52 PM" src="https://user-images.githubusercontent.com/208083/54456324-3c79d680-4734-11e9-98fb-cea8ce7e9d54.png">

### Without Experiment
<img width="800" alt="Screen Shot 2019-03-15 at 3 01 53 PM" src="https://user-images.githubusercontent.com/208083/54456309-371c8c00-4734-11e9-8bde-7e883c23b057.png">


## Student

### In Experiment
<img width="1043" alt="Screen Shot 2019-03-15 at 2 58 15 PM" src="https://user-images.githubusercontent.com/208083/54456279-25d37f80-4734-11e9-9f65-d1e52e3a52b0.png">

### Without Experiment
<img width="1051" alt="Screen Shot 2019-03-15 at 2 57 53 PM" src="https://user-images.githubusercontent.com/208083/54456278-25d37f80-4734-11e9-8477-914d48ed44d0.png">
