### PR TITLE
Finish Dialog: Remove % number below the trophy visualization

### DIFF
--- a/apps/src/templates/progress/StageTrophyProgressBubble.jsx
+++ b/apps/src/templates/progress/StageTrophyProgressBubble.jsx
@@ -16,7 +16,6 @@ export default class StageTrophyProgressBubble extends Component {
 
   render() {
     const ratio = this.props.percentPerfect;
-    const percentage = Math.round(ratio * 100);
 
     const theta = Math.PI * 2 * ratio;
     const x = Math.cos(theta) * 18;
@@ -58,17 +57,6 @@ export default class StageTrophyProgressBubble extends Component {
               fill={ratio === 1 ? color.yellow : color.lighter_gray}
             />
           </g>
-        </g>
-        <g transform="translate(25, 70)">
-          <text
-            textAnchor="middle"
-            alignmentBaseline="hanging"
-            fill={shapeColor}
-            fontSize="14"
-            fontFamily='"Gotham 5r", sans-serif'
-          >
-            {percentage}%
-          </text>
         </g>
       </svg>
     );


### PR DESCRIPTION
Removing stage percentile complete from below the trophy in the new finish dialog, per [spec](https://docs.google.com/document/d/18yEHhWhmzUm0cUj2DFOBG2gqDCZtL5_E_SBS7GPNjQU/edit#).

| Before | After |
| --- | --- |
| ![Screenshot from 2019-03-15 13-11-21](https://user-images.githubusercontent.com/1615761/54459409-d84f1680-4723-11e9-8498-4691e0a44e72.png) | ![Screenshot from 2019-03-15 13-10-29](https://user-images.githubusercontent.com/1615761/54459385-c5d4dd00-4723-11e9-9247-262c16f55f09.png) |
