### PR TITLE
Finish Dialog: Move fun-o-meter to be right-aligned

### DIFF
--- a/apps/src/templates/FinishDialog.jsx
+++ b/apps/src/templates/FinishDialog.jsx
@@ -172,7 +172,9 @@ const styles = {
   funometer: {
     marginTop: 5,
     marginLeft: 20,
+    marginRight: 20,
     display: 'flex',
+    justifyContent: 'flex-end',
     minHeight: 32
   },
   button: {


### PR DESCRIPTION
Move fun-o-meter to be right-aligned in the new finish dialog per [spec](https://docs.google.com/document/d/18yEHhWhmzUm0cUj2DFOBG2gqDCZtL5_E_SBS7GPNjQU/edit#)

| Before | After |
| --- | --- |
| ![Screenshot from 2019-03-15 13-20-45](https://user-images.githubusercontent.com/1615761/54459877-2c0e2f80-4725-11e9-86c7-1f99db2dcdaf.png) | ![Screenshot from 2019-03-15 13-18-35](https://user-images.githubusercontent.com/1615761/54459886-316b7a00-4725-11e9-86d0-ffec162355c9.png) |
| ![Screenshot from 2019-03-15 13-20-35](https://user-images.githubusercontent.com/1615761/54459879-2d3f5c80-4725-11e9-9ea6-4e4ad137d8f0.png) | ![Screenshot from 2019-03-15 13-18-48](https://user-images.githubusercontent.com/1615761/54459883-2f092000-4725-11e9-86c2-f2fe49166d0e.png) |


