### PR TITLE
Finish Dialog: Change “replay” and “show code” buttons to be gray

### DIFF
--- a/apps/src/templates/FinishDialog.jsx
+++ b/apps/src/templates/FinishDialog.jsx
@@ -182,10 +182,12 @@ const styles = {
     margin: '0px 5px'
   },
   replayButton: {
-    backgroundColor: color.green
+    color: color.dark_charcoal,
+    backgroundColor: color.lightest_gray
   },
   showCodeButton: {
-    backgroundColor: color.teal
+    color: color.dark_charcoal,
+    backgroundColor: color.lightest_gray
   },
   continueButton: {
     backgroundColor: color.orange


### PR DESCRIPTION
Change the "replay" and "show code" buttons to be dark gray test on a light gray button, on the new finish dialog, per [spec](https://docs.google.com/document/d/18yEHhWhmzUm0cUj2DFOBG2gqDCZtL5_E_SBS7GPNjQU/edit#)

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1615761/54460509-f9fdcd00-4726-11e9-9d03-d3600ee8ac04.png) | ![Screenshot from 2019-03-15 13-33-00](https://user-images.githubusercontent.com/1615761/54460481-ea7e8400-4726-11e9-9ff6-72a00f46a3cd.png) |



