### PR TITLE
allow developers to seed levels without CDO.properties_encryption_key

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -218,6 +218,7 @@ class Level < ActiveRecord::Base
     rescue Encryption::KeyMissingError
       # developers must be able to seed levels without properties_encryption_key
       raise unless rack_env?(:development)
+      puts "WARNING: level '#{name}' not seeded properly due to missing CDO.properties_encryption_key"
     end
     hash
   end


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/27521. Recover when decrypting .level files for developers without CDO.properties_encryption_key. This partially mirrors how we handle errors when decrypting DSLDefined levels: https://github.com/code-dot-org/code-dot-org/blob/feb33e03cf50a2ba89d8f60fc7ef0e933094c97d/dashboard/app/models/levels/dsl_defined.rb#L116-L121