### PR TITLE
Finish Dialog: One-column achievements

### DIFF
--- a/apps/src/templates/FinishDialog.jsx
+++ b/apps/src/templates/FinishDialog.jsx
@@ -130,18 +130,9 @@ const styles = {
     marginLeft: 20,
     marginRight: 20
   },
-  achievementsHeading: {
-    margin: '20px auto 0',
-    color: color.light_gray,
-    fontFamily: '"Gotham 5r", sans-serif',
-    fontSize: 16
-  },
   achievements: {
     display: 'block',
-    margin: '4px auto 4px',
-    borderColor: color.lighter_gray,
-    borderWidth: '1px 0',
-    borderStyle: 'solid',
+    margin: '20px auto 4px',
     fontFamily: '"Gotham 4r", sans-serif',
     fontSize: 14,
     color: color.dark_charcoal,
@@ -162,7 +153,7 @@ const styles = {
     textAlign: 'left'
   },
   achievementRowNonShare: {
-    width: '50%',
+    width: '100%',
     float: 'left'
   },
   generatedCodeWrapper: {
@@ -539,9 +530,6 @@ export class UnconnectedFinishDialog extends Component {
                         ...(this.props.feedbackImage && {marginLeft: 180})
                       }}
                     >
-                      <div style={styles.achievementsHeading}>
-                        {msg.achievements()}
-                      </div>
                       {this.getAchievements()}
                     </div>
                   )}


### PR DESCRIPTION
Changes display of achievements in the new finish dialog, per [spec](https://docs.google.com/document/d/18yEHhWhmzUm0cUj2DFOBG2gqDCZtL5_E_SBS7GPNjQU/edit#)

1. Achievements should be listed in a single, full width column instead of two columns
2. Remove “Achievements” title
3. Remove borders around achievement area

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1615761/54461514-fd468800-4729-11e9-810c-dc8eb68c62f0.png) | ![Screenshot from 2019-03-15 13-50-08](https://user-images.githubusercontent.com/1615761/54461380-a93ba380-4729-11e9-89a6-02b060b668fa.png) |
| ![Screenshot from 2019-03-15 13-38-52](https://user-images.githubusercontent.com/1615761/54461393-ae005780-4729-11e9-8431-98a6b5656db2.png) | ![Screenshot from 2019-03-15 13-50-29](https://user-images.githubusercontent.com/1615761/54461385-ab056700-4729-11e9-8ae6-111437b856df.png) |
| ![image](https://user-images.githubusercontent.com/1615761/54461478-e6a03100-4729-11e9-81cb-43a605351ed4.png) | ![Screenshot from 2019-03-15 13-50-44](https://user-images.githubusercontent.com/1615761/54461388-ac369400-4729-11e9-9c55-53d34d240eb4.png) |

