### PR TITLE
Add Secrets Manager interface [Draft]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -246,6 +246,7 @@ gem 'aws-sdk-firehose', '~> 1.6'
 gem 'aws-sdk-rds', '>= 1.38.1'
 gem 'aws-sdk-route53', '~> 1'
 gem 'aws-sdk-s3', '~> 1'
+gem 'aws-sdk-secretsmanager', '~> 1'
 gem 'aws-sdk-sqs', '~> 1'
 
 # Lint tools

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.21.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
+    aws-sdk-secretsmanager (1.20.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
+      aws-sigv4 (~> 1.0)
     aws-sdk-sqs (1.4.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
@@ -897,6 +900,7 @@ DEPENDENCIES
   aws-sdk-rds (>= 1.38.1)
   aws-sdk-route53 (~> 1)
   aws-sdk-s3 (~> 1)
+  aws-sdk-secretsmanager (~> 1)
   aws-sdk-sqs (~> 1)
   bcrypt
   better_errors

--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -121,6 +121,7 @@ cat <<JSON > $FIRST_BOOT
     "override_dashboard": "<%=studio_subdomain%>",
     "override_pegasus": "<%=subdomain%>",
 <% end -%>
+    "pd_workshop_queue_url": "https://sqs.$REGION.amazonaws.com/${AWS::AccountId}/pd_workshop-$ENVIRONMENT"
     "stack_name": "$STACK"
   },
 <% if local_mode -%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -79,16 +79,17 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-<% if database -%>
           # Read-only access to current secrets.
           - Effect: Allow
             Action: 'secretsmanager:GetSecretValue'
             Resource:
+              - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:<%=environment%>/cdo/*"
+<% if database -%>
               - !Ref DatabaseSecret
+<% end -%>
             Condition:
               StringEquals:
                 secretsmanager:VersionStage: AWSCURRENT
-<% end -%>
           # Read-only access to bootstrap scripts.
           - Effect: Allow
             Action: 's3:GetObject'

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -84,6 +84,7 @@ Resources:
             NotAction:
               - iam:*
               - organizations:*
+              - secretsmanager:*
             Resource: '*'
           - Sid: IAMReadOnlyAccess
             Effect: Allow
@@ -109,6 +110,13 @@ Resources:
             Condition:
               StringNotEquals:
                 cloudformation:RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/CloudFormationService"
+            # Read-only access to current secrets.
+          - Effect: Allow
+            Action: secretsmanager:GetSecretValue
+            Resource: '*'
+            Condition:
+              StringEquals:
+                secretsmanager:VersionStage: AWSCURRENT
   Developer:
     Type: AWS::IAM::Role
     Properties:
@@ -151,6 +159,18 @@ Resources:
                 aws:ResourceTag/environment: [adhoc, development]
               ForAnyValue:StringEquals:
                 aws:TagKeys: environment
+      # Don't allow developers to view/delete secrets in non-development environments.
+      - PolicyName: SecretsAccess
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: secretsmanager:*
+            Resource: '*'
+          - Effect: Deny
+            Action:
+            - secretsmanager:GetSecretValue
+            - secretsmanager:DeleteSecret
+            NotResource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:development/*"
       ManagedPolicyArns: [!Ref DevPermissions]
   # Used by FirehoseMicroservice Lambda function.
   # TODO move to Data stack

--- a/bin/update_secrets
+++ b/bin/update_secrets
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+require_relative '../deployment'
+
+secrets_file = CDO.dir('config/secrets.yml')
+secrets_config = Cdo::SecretsConfig.load(secrets_file)
+puts "Will create/update the following secrets:"
+puts secrets_config.to_yaml
+
+require 'highline/import'
+exit 1 unless agree("Proceed? (y/n) ")
+
+secrets_config.each {|key, value| CDO.cdo_secrets.put(key, value)}
+puts "Finished updating secrets!"
+exit 0 unless agree("Delete secrets file [#{secrets_file}]? (y/n) ")
+FileUtils.rm(secrets_file)
+puts 'Done!'

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -38,13 +38,13 @@
 #
 
 env:
-_env: <%=env == 'production' ? '' : "_#{env}"%>
-unit_test: <%=!!ENV['UNIT_TEST']%>
-ci: <%=!!ENV['CI']%>
-ci_test: <%=unit_test || ci%>
-root_dir: <%=__dir__%>
-name: <%=`hostname`.strip%>
-rack_env: :<%=env%>
+_env:       <%=env == 'production' ? '' : "_#{env}"%>
+unit_test:  <%=!!ENV['UNIT_TEST']%>
+ci:         <%=!!ENV['CI']%>
+ci_test:    <%=unit_test || ci%>
+root_dir:   <%=__dir__%>
+name:       <%=`hostname`.strip%>
+rack_env:   :<%=env%>
 rack_envs:
   - :development
   - :production
@@ -57,46 +57,46 @@ rack_envs:
 #### Third-party API credentials / configuration
 
 # OAuth provider credentials, used by Omniauth for authentication.
-dashboard_facebook_key:
-dashboard_facebook_secret:
-dashboard_google_key:
-dashboard_google_secret:
-dashboard_windowslive_key:
-dashboard_windowslive_secret:
-dashboard_microsoft_key:
-dashboard_microsoft_secret:
-dashboard_clever_key:
-dashboard_clever_secret:
-dashboard_schoolproject_key:
-dashboard_schoolproject_secret:
+dashboard_facebook_key:         !Secret
+dashboard_facebook_secret:      !Secret
+dashboard_google_key:           !Secret
+dashboard_google_secret:        !Secret
+dashboard_windowslive_key:      !Secret
+dashboard_windowslive_secret:   !Secret
+dashboard_microsoft_key:        !Secret
+dashboard_microsoft_secret:     !Secret
+dashboard_clever_key:           !Secret
+dashboard_clever_secret:        !Secret
+dashboard_schoolproject_key:    !Secret
+dashboard_schoolproject_secret: !Secret
 
 # Recaptcha
-recaptcha_site_key:
-recaptcha_secret_key:
+recaptcha_site_key: !Secret
+recaptcha_secret_key: !Secret
 
 # Logentries (aka 'slog')
-logentries_secret:
+logentries_secret: !Secret
 slog_token:
 
 # Twilio
-twilio_auth:
-twilio_auth_test:
-twilio_messaging_service:
+twilio_auth:               !Secret
+twilio_auth_test:          !Secret
+twilio_messaging_service:  !Secret
 twilio_phone_test_forward:
 twilio_phone_test_to:
-twilio_sid:
-twilio_sid_test:
+twilio_sid:                !Secret
+twilio_sid_test:           !Secret
 
 # Jotform
-jotform_api_key:
+jotform_api_key: !Secret
 jotform_forms:
 jotform_min_dates:
 
 # Learning Tools Interoperability (LTI)
-lti_credentials:
+lti_credentials: !Secret
 
 # PagerDuty
-pagerduty_token:
+pagerduty_token: !Secret
 
 # Pardot
 pardot_password:
@@ -104,31 +104,31 @@ pardot_user_key:
 pardot_username:
 
 # Honeybadger
-honeybadger_api_token:
-cronjobs_honeybadger_api_key:
-dashboard_honeybadger_api_key: '00000000'
-pegasus_honeybadger_api_key: '00000000'
+honeybadger_api_token:         !Secret
+cronjobs_honeybadger_api_key:  !Secret
+dashboard_honeybadger_api_key: !Secret
+pegasus_honeybadger_api_key:   !Secret
 
 # Zendesk
-zendesk_secret:
-zendesk_dev_token:
+zendesk_secret:    !Secret
+zendesk_dev_token: !Secret
 
 # Webpurify
-webpurify_key:
+webpurify_key: !Secret
 
 # Github
-github_access_token:
+github_access_token:   !Secret
 github_webhook_secret:
 
 # Google API credentials (various)
-google_maps_client_id:
+google_maps_client_id:    !Secret
 google_maps_api_key:
-google_maps_secret:
+google_maps_secret:       !Secret
 hoc_map_account:
 hoc_map_table_id:
-ga_account:
-ga_profile_id:
-google_safe_browsing_key: fake_api_key
+ga_account:               !Secret
+ga_profile_id:            !Secret
+google_safe_browsing_key: !Secret
 
 # Mapbox
 mapbox_upload_token:
@@ -137,7 +137,7 @@ mapbox_upload_token:
 crowdin_codeorg_api_key:
 
 # Azure Content Moderator
-azure_content_moderation_endpoint:
+azure_content_moderation_endpoint: https://eastus.api.cognitive.microsoft.com/contentmoderator
 azure_content_moderation_key:
 
 # Credentials for SauceLabs.com, used for running selenium tests against
@@ -146,23 +146,23 @@ saucelabs_username:
 saucelabs_authkey:
 
 # Credentials for applitools.com, used for running automated visual tests
-applitools_eyes_api_key:
+applitools_eyes_api_key:      !Secret
 applitools_eyes_api_key_view:
 
 # Slack API credentials
 slack_set_last_dtt_green_token:
 slack_start_build_token:
-slack_endpoint:
-slack_token:
-slack_log_room: <%=env%>
-hip_chat_logging: false
+slack_endpoint:                 !Secret
+slack_token:                    !Secret
+slack_log_room:                 <%=env%>
+hip_chat_logging:               false
 # Logging endpoint used by broken link checker.
 slack_endpoint_broken_links:
 
 # Credentials/configuration for connecting to Firebase to use data blocks or data browser
 # in Applab.
-firebase_name:
-firebase_secret:
+firebase_name: cdo-v3-<%=env%>
+firebase_secret: !Secret
 firebase_channel_id_suffix: ''
 firebase_max_channel_writes_per_15_sec: 300
 firebase_max_channel_writes_per_60_sec: 600
@@ -174,9 +174,9 @@ firebase_max_property_size: 4096
 # Configuration Options for Pusher.com integration
 # Optional for most devs, very useful if working on Internet Simulator
 use_pusher: false
-pusher_app_id: fake_app_id
-pusher_application_key: fake_application_key
-pusher_application_secret: fake_application_secret
+pusher_app_id:             !Secret
+pusher_application_key:    !Secret
+pusher_application_secret: !Secret
 
 # Configuration options for Acapela-Group.com integration
 use_acapela:
@@ -204,11 +204,10 @@ aws_secret_key:
 
 freegeoip_host:
 geocoder_redis_url:
-solr_server:
+solr_server: localhost
 
 # Asynchronous queue-processor
 pd_workshop_queue_url:
-activity_queue_url:
 process_queues:
 
 # S3 bucket and (environment-specific) path-prefix configuration
@@ -243,19 +242,19 @@ netsim_shard_expiry_seconds: 7200
 # The Fusion Table ID for the census map shown at code.org/yourschool.  If this
 # is set to the ID for the production site, be careful not to run
 # update_census_map as it will overwrite that table.
-census_map_table_id: 1AUZYRjLMI5NiQsDeDBGFsOIFpL_rLGsnxNpSyR13
+census_map_table_id: '1AUZYRjLMI5NiQsDeDBGFsOIFpL_rLGsnxNpSyR13'
 
 # DynamoDB table names for dcdo/gatekeeper
 dcdo_table_name:       dcdo_<%=env%>
 gatekeeper_table_name: gatekeeper_<%=env%>
 
 # Poste (internal transactional email processing framework)
-poste_host: 'localhost.code.org:3000'
+poste_host: <%= code_org_url.sub('//', '') %>
 poste_attachment_dir:
-poste_smtp_password:
-poste_smtp_server:
-poste_smtp_user:
-poste_secret: 'not a real secret'
+poste_smtp_password: !Secret
+poste_smtp_server:   email-smtp.us-east-1.amazonaws.com
+poste_smtp_user:     !Secret
+poste_secret:        !Secret
 
 # Chef defaults
 chef_managed: false
@@ -268,8 +267,8 @@ chef_validation_key: <%="#{ENV['HOME']}/.chef/#{chef_validation_client_name}.pem
 chef_server_url: '<%="https://api.opscode.com/organizations/#{chef_org_name}"%>'
 
 # Cloudfront keys for private content
-cloudfront_key_pair_id:
-cloudfront_private_key:
+cloudfront_key_pair_id: !Secret
+cloudfront_private_key: !Secret
 
 # Discourse configuration
 discourse_sso_secret:
@@ -283,11 +282,11 @@ app_servers: {}
 rack_mini_profiler_enabled:
 https_development:
 default_scheme: '<%=(env == 'development') || ci ? 'http:' : 'https:'%>'
-allowed_iframe_ancestors:
+allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net <%=pegasus_hostname%> <%=dashboard_hostname%>
 skip_locales:
 secret_pictures_csv:
 no_https_store:
-expo_session_secret:
+expo_session_secret: !Secret
 firebase_debug:
 pd_teacher_application_list_secret_key:
 
@@ -316,7 +315,7 @@ cache_assets_in_memory:
 
 # Encryption key required for decoding certain protected level sources.
 # Contributors should ask a Code.org engineer for this if needed.
-properties_encryption_key:
+properties_encryption_key: !Secret
 
 # NOTE: When a new language is added to this set, make sure to also update
 # the redirection rules for the cdo-curriculum S3 bucket by running the
@@ -346,9 +345,9 @@ build_pegasus: true
 # Dashboard
 override_dashboard:
 dashboard_assets_dir: <%=root_dir%>/dashboard/public/assets
-dashboard_devise_secret:
-dashboard_devise_pepper: not a pepper!
-dashboard_secret_key_base: not a secret
+dashboard_devise_secret:   !Secret
+dashboard_devise_pepper:   !Secret
+dashboard_secret_key_base: !Secret
 dashboard_host: 0.0.0.0
 dashboard_port: 3000
 dashboard_workers: 8
@@ -425,15 +424,12 @@ build_blockly_core:
 build_blockly: false
 geocoder_read_replica_1:
 geocoder_read_replica_2:
-browserstack_username:
-browserstack_authkey:
 dashboard_powerschool_key:
 dashboard_powerschool_secret:
 x-dashboard_twitter_key:
 x-dashboard_twitter_secret:
 ga_service_account_email:
 ga_api_key:
-ga_api_secret:
 hipchat_secret:
 indiegogo_api_token:
 localize_blockly: true
@@ -474,14 +470,14 @@ logs_bucket:
 redshift_host:
 redshift_password:
 
-devinternal_db_writer:
+devinternal_db_writer: !Secret
 
 db_cluster_id:
-db_admin:
+db_admin: !Secret
 reporting_db_admin:
 
-db_writer: 'mysql://root@localhost/'
-reporting_db_writer: 'mysql://root@localhost/'
+db_writer: !Secret
+reporting_db_writer: <%=db_writer%>
 
 dashboard_db_name: dashboard_<%=env%>
 pegasus_db_name: pegasus<%=_env%>

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+secrets.yml

--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -1,2 +1,4 @@
+<%= clear_secrets %>
+
 chef_local_mode: true
 stub_school_data: true

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -1,5 +1,7 @@
 # Configuration defaults for development environment.
-census_map_table_id: null
+<%= clear_secrets %>
+
+census_map_table_id:
 dashboard_enable_pegasus: true
 pegasus_skip_asset_map: true
 
@@ -17,3 +19,15 @@ daemon: true
 disable_s3_image_uploads: true
 
 chef_local_mode: true
+
+devinternal_db_writer: !Secret
+dashboard_honeybadger_api_key: '00000000'
+pegasus_honeybadger_api_key:   '00000000'
+google_safe_browsing_key: fake_api_key
+pusher_app_id:             fake_app_id
+pusher_application_key:    fake_application_key
+pusher_application_secret: fake_application_secret
+poste_secret: not a real secret
+dashboard_devise_pepper: not a pepper!
+dashboard_secret_key_base: not a secret
+db_writer: 'mysql://root@localhost/'

--- a/config/levelbuilder.yml.erb
+++ b/config/levelbuilder.yml.erb
@@ -1,1 +1,20 @@
 daemon: true
+firebase_name: cdo-v3-lb
+dashboard_devise_pepper:
+dashboard_devise_secret:
+dashboard_secret_key_base:
+use_acapela:                true
+use_pusher:                 true
+jotform_api_key:
+lti_credentials:
+devinternal_db_writer:
+db_admin:
+dashboard_microsoft_key:
+dashboard_microsoft_secret:
+
+discourse_sso_secret: !Secret
+acapela_ephemeral_app: !Secret
+acapela_ephemeral_password: !Secret
+acapela_login: !Secret
+acapela_storage_app: !Secret
+acapela_storage_password: !Secret

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -1,2 +1,80 @@
+azure_content_moderation_key: !Secret
+discourse_sso_secret: !Secret
+hoc_map_account: !Secret
+hoc_map_api_key: !Secret
+hoc_map_api_secret: !Secret
+hoc_map_service_account_email: !Secret
+hoc_map_table_id: !Secret
+level_sources_redis_url: !Secret
+mimeo_api: !Secret
+pardot_password: !Secret
+pardot_user_key: !Secret
+pardot_username: !Secret
+pd_teacher_application_list_secret_key: !Secret
+pledge_map_table_id: !Secret
+redshift_host: !Secret
+redshift_password: !Secret
+sinatra_session_secret: !Secret
+slog_token: !Secret
+reporting_db_admin: !Secret
+
+<% unless name&.include?('console') %>
+  db_admin:
+  reporting_db_admin:
+<% end %>
+
 newrelic_logging: true
 stack_name: autoscale-prod
+firebase_name: cdo-v3-prod
+db_cluster_id: production-aurora-cluster
+solr_server:                            solr.code.org
+use_pusher:                             true
+jotform_forms:
+    academic_year_1:
+      day_1:         82115203919149
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_1_2:
+      day_1:         82115203919149
+      day_2:         82115636519155
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_2:
+      day_1:         82115636519155
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_3:
+      day_1:         82115699619165
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_3_4:
+      day_1:         82115699619165
+      day_2:         82115533319149
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_4:
+      day_1:         82115533319149
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    csf:
+      facilitator: 91405279991164
+      post201:     90065524560150
+      pre201:      90066184161150
+    local:
+      day_0:       81307473693159
+      day_1:       81236323593153
+      day_2:       81368536787170
+      day_3:       81368909887175
+      day_4:       81368069687170
+      day_5:       81495142793161
+      facilitator: 81276605393158
+    local_summer:
+      day_0:       90986490369171
+      day_1:       90986506471163
+      day_2:       90986458251165
+      day_3:       90986477669179
+      day_4:       90986953273169
+      day_5:       90986517815167
+      facilitator: 91372090131144
+    post_course:
+      2018-2019: 90486182774164

--- a/config/secrets.yml.template
+++ b/config/secrets.yml.template
@@ -1,0 +1,18 @@
+# Sample secrets.yml file.
+# Top-level key is secret name, second-level key is environment name.
+# (`base` is an alias for staging, test, levelbuilder, and production.)
+# The value is the secret string.
+# (Complex objects will be converted to JSON.)
+---
+foo:
+  base: bar # staging, test, levelbuilder and production
+  production: baz
+qux:
+  development:
+    qux: quux
+  staging:
+    qux: quuz
+  test:
+    qux: quuz
+  production:
+    qux: quuz

--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -1,4 +1,54 @@
+slack_endpoint_broken_links: !Secret
+github_webhook_secret: !Secret
 netsim_enable_metrics: true
 lint: true
 pretty_js: true
 daemon: true
+use_pusher:                        true
+netsim_shard_expiry_seconds:       60
+poste_attachment_dir:              /home/ubuntu/poste_attachments
+jotform_forms:
+    academic_year_1:
+      day_1:         82115203919149
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_1_2:
+      day_1:         82115203919149
+      day_2:         82115636519155
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_2:
+      day_1:         82115636519155
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_3:
+      day_1:         82115699619165
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_3_4:
+      day_1:         82115699619165
+      day_2:         82115533319149
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    academic_year_4:
+      day_1:         82115533319149
+      facilitator:   82115940819156
+      post_workshop: 82115646319154
+    local:
+      day_0:       81307473693159
+      day_1:       81236323593153
+      day_2:       81368536787170
+      day_3:       81368909887175
+      day_4:       81368069687170
+      day_5:       81495142793161
+      facilitator: 81276605393158
+    local_summer:
+      day_0:       90986490369171
+      day_1:       90986506471163
+      day_2:       90986458251165
+      day_3:       90986477669179
+      day_4:       90986953273169
+      day_5:       90986517815167
+      facilitator: 91372090131144
+    post_course:
+      2018-2019: 90486182774164

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -1,7 +1,32 @@
+github_webhook_secret: !Secret
+slack_set_last_dtt_green_token: !Secret
+slack_start_build_token: !Secret
+azure_content_moderation_key: !Secret
+saucelabs_authkey: !Secret
+saucelabs_username: !Secret
+
+# Disable Secrets in CI-test environments.
+<% if ci_test -%>
+<%= clear_secrets %>
+
+dashboard_honeybadger_api_key: '00000000'
+pegasus_honeybadger_api_key:   '00000000'
+google_safe_browsing_key: fake_api_key
+pusher_app_id:             fake_app_id
+pusher_application_key:    fake_application_key
+pusher_application_secret: fake_application_secret
+poste_secret: not a real secret
+dashboard_devise_pepper: not a pepper!
+dashboard_secret_key_base: not a secret
+db_writer: 'mysql://root@localhost/'
+<% end -%>
+
+db_cluster_id: test-cluster
 pegasus_skip_asset_map: <%=ci_test%>
 netsim_enable_metrics: true
 stub_school_data: true
 daemon: true
+use_pusher: <%=!ci_test%>
 
 # test environment should use precompiled, minified, digested assets like production,
 # unless it's being used for unit tests. This logic should be kept in sync with

--- a/dashboard/config.ru
+++ b/dashboard/config.ru
@@ -1,5 +1,9 @@
 # This file is used by Rack-based servers to start the application.
 
+require_relative '../deployment'
+# Ensure all application secrets are loaded.
+CDO.cdo_secrets&.required! unless rack_env?(:development)
+
 require ::File.expand_path('../config/environment',  __FILE__)
 
 unless rack_env?(:development)

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -1,4 +1,5 @@
 require 'cdo/config'
+require 'cdo/secrets_config'
 
 ####################################################################################################
 ##
@@ -7,7 +8,9 @@ require 'cdo/config'
 ##########
 module Cdo
   class Impl < Config
+    prepend SecretsConfig
     include Singleton
+
     @slog = nil
 
     # Match CDO_*, plus RACK_ENV and RAILS_ENV.
@@ -33,9 +36,9 @@ module Cdo
         "#{root}/config.yml.erb"
       )
 
-      defaults = YAML.load_erb_file("#{root}/config.yml.erb", binding)
+      defaults = render("#{root}/config.yml.erb").first
       to_h.keys.each do |key|
-        raise "Unknown property not in defaults: #{key}" unless defaults.key?(key.to_s)
+        raise "Unknown property not in defaults: #{key}" unless defaults.key?(key.to_sym)
       end
       raise "'#{rack_env}' is not known environment." unless rack_envs.include?(rack_env)
       freeze
@@ -129,7 +132,7 @@ module Cdo
     end
 
     def rack_env?(env)
-      rack_env.to_sym == env.to_sym
+      rack_env&.to_sym == env.to_sym
     end
 
     # Sets the slogger to use in a test.

--- a/lib/cdo/config.rb
+++ b/lib/cdo/config.rb
@@ -25,7 +25,7 @@ module Cdo
     # Resolves dynamic config self-references by re-rendering + merging until result is unchanged.
     def load_configuration(*sources)
       config = nil
-      i = 5
+      i = 8
       table = @table
       while config != (config = render(*sources))
         raise "Can't resolve config (circular dependency?)" if (i -= 1).zero?
@@ -43,17 +43,15 @@ module Cdo
           YAML.load_file(source) || {}
         elsif File.extname(source) == '.erb'
           YAML.load_erb_file(source, binding) || {}
-        end
+        end.transform_keys(&:to_sym)
       end
     end
 
     # Merge the provided config hash into the current config.
-    # 'Reverse-merge' keeps existing values except for `nil`.
+    # 'Reverse-merge' keeps existing values.
     def merge(config)
       return if config.nil?
-      table.merge!(config.transform_keys(&:to_sym)) do |_key, old, new|
-        old.nil? ? new : old
-      end
+      table.merge!(config) {|_key, old, _new| old}
     end
 
     # API for providing a default value for a property lookup.

--- a/lib/cdo/lazy.rb
+++ b/lib/cdo/lazy.rb
@@ -1,0 +1,35 @@
+module Cdo
+  # Lazy-loads a delegated object from a block.
+  #
+  # Example:
+  #
+  # > lazy = Cdo.lazy {puts 'loaded!'; 'Lazy'}; true
+  # => true
+  # > puts lazy
+  # loaded!
+  # Lazy
+  # => nil
+  #
+  # NOTE: lazy `nil` / `false` values are 'truthy' in boolean expressions:
+  #
+  # > nil && true
+  # => nil
+  # > Cdo.lazy {nil} && true
+  # => true
+  class Lazy < SimpleDelegator
+    def initialize(&block)
+      @block = block
+    end
+
+    def __getobj__
+      __setobj__(@block.call) unless defined?(@delegate_sd_obj)
+      super
+    end
+
+    undef_method(:instance_of?, :kind_of?, :is_a?, :nil?, :class)
+  end
+
+  def self.lazy(&block)
+    Lazy.new(&block)
+  end
+end

--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -1,0 +1,157 @@
+require 'aws-sdk-secretsmanager'
+require 'concurrent'
+require 'active_support/ordered_options'
+require 'active_support/core_ext/hash/keys'
+require 'cdo/lazy'
+require 'json'
+
+module Cdo
+  # Interface for fetching secrets from AWS Secrets Manager.
+  class Secrets
+    CURRENT = "AWSCURRENT".freeze
+    NOT_FOUND = Aws::SecretsManager::Errors::ResourceNotFoundException
+    EXISTS = Aws::SecretsManager::Errors::ResourceExistsException
+
+    attr_accessor :logger
+
+    def initialize(client: nil, required: [], logger: nil)
+      @logger = logger
+
+      # Cache fetched secrets in-memory in an instance-variable hash.
+      @values = {}
+      @client = client
+
+      @pool = Concurrent::CachedThreadPool.new
+      @required = Set.new
+      required(*required)
+    end
+
+    # @return [Concurrent::Promises::Future<Aws::SecretsManager::Client>] Secrets Manager Client
+    def client
+      @client_promise ||= Concurrent::Promises.future_on(@pool) do
+        @client || Aws::SecretsManager::Client.new
+      end
+    end
+
+    # Add keys to list of required secrets, and begin pre-fetching them.
+    def required(*keys)
+      keys = keys.map(&:to_s)
+      @required += keys
+      keys.map(&method(:get))
+    end
+
+    # Ensure all required secrets are fully loaded.
+    # @return [Hash] All keys and their resolved values.
+    def required!(*keys)
+      required(*keys)
+      get_multi(*@required).value!
+    end
+
+    # Asynchronously fetch keys in parallel.
+    # @return [Concurrent::Promises::Future<Hash>] All keys and their resolved values
+    def get_multi(*keys)
+      client.then do
+        promises = keys.map {|key| get(key).then {|value| [key, value]}}
+        Concurrent::Promises.zip_futures_on(@pool, *promises).
+          then {|*values| values.to_h}
+      end.flat
+    end
+
+    # Asynchronously fetch specified key from Secrets Manager.
+    # @return [Concurrent::Promises::Future<String>] Resolved value
+    def get(key)
+      key = key.to_s
+      @values[key] ||= begin
+        client.then do |client|
+          parse_json(get_secret_value(client, key))
+        rescue => e
+          e.message << " Key: #{key}"
+          raise
+        end
+      end
+    end
+
+    # Alternate lookup: Raise exception if secret is not found.
+    def get!(key)
+      get(key).value!
+    end
+
+    # Alternate lookup: secrets['secret']
+    def [](key)
+      get(key).value
+    end
+
+    # Alternate lookup: secrets.secret
+    def method_missing(key, *args)
+      return super unless args.empty?
+      get(key).value
+    end
+
+    # Wraps a Secret value in a Lazy object so that the API call to
+    # +GetSecretValue+ won't be performed until the secret is actually used.
+    # @param fetch[Boolean] asynchronously load the object in the background
+    # @param fallback[String] Fallback string to return if secret is not found.
+    # @param raise_not_found[Boolean] Raise exception if secret is not found.
+    def lazy(key, fetch: false, fallback: nil, raise_not_found: false)
+      key = key.to_s
+      @required.add(key)
+      get(key) if fetch
+      Cdo.lazy do
+        if raise_not_found
+          get(key).value!
+        else
+          get(key).value || fallback
+        end
+      end
+    end
+
+    # Ensure cached instance-variable values don't end up in any logs.
+    def inspect
+      self.class.to_s
+    end
+
+    # Create/update a stored secret.
+    # @param key [String]
+    # @param value [String, Object]
+    def put(key, value)
+      value = value.to_json unless value.is_a?(String)
+      c = client.value!
+      c.create_secret(
+        name: key,
+        secret_string: value
+      )
+    rescue EXISTS
+      c.update_secret(
+        secret_id: key,
+        secret_string: value
+      )
+    end
+
+    private
+
+    # Call GetSecretValue for the provided key.
+    # @param client[Aws::SecretsManager::Client]
+    # @param key[String]
+    # @return [String]
+    def get_secret_value(client, key)
+      logger&.info("GetSecretValue: #{key}")
+      client.get_secret_value(
+        secret_id: key,
+        version_stage: CURRENT
+      ).secret_string
+    rescue NOT_FOUND => e
+      e.set_backtrace []
+      raise
+    end
+
+    # If +value+ is JSON, parse and wrap in ActiveSupport::OrderedOptions so
+    # property-method lookup chains are possible (e.g., secrets.secret.key).
+    # @param value[String]
+    # @return [ActiveSupport::OrderedOptions, String]
+    def parse_json(value)
+      ActiveSupport::OrderedOptions[JSON.parse(value).symbolize_keys]
+    rescue JSON::ParserError, TypeError
+      value
+    end
+  end
+end

--- a/lib/cdo/secrets_config.rb
+++ b/lib/cdo/secrets_config.rb
@@ -1,0 +1,87 @@
+require 'cdo/config'
+require 'cdo/lazy'
+
+module Cdo
+  # Prepend this module to a Cdo::Config to process lazy-loaded secrets contained in special tags.
+  module SecretsConfig
+    BASE_ENVS = [:staging, :test, :levelbuilder, :production]
+
+    # Generate a standard secret path from prefix and key.
+    def self.secret_path(prefix, key)
+      "#{prefix}/cdo/#{key}"
+    end
+
+    # Load a secrets-config hash from specified file.
+    # @param filename [String]
+    # @return [Hash<String, String|Hash>]
+    def self.load(filename)
+      results = {}
+      YAML.load_file(filename)&.each do |key, envs|
+        envs.each do |env, value|
+          if env == 'base'
+            BASE_ENVS.each do |base_env|
+              results[secret_path(base_env, key)] = value.dup
+            end
+          else
+            raise "Invalid env: #{env}" unless CDO.rack_envs.include?(env.to_sym)
+            results[secret_path(env, key)] = value
+          end
+        end
+      end
+      results
+    end
+
+    def freeze
+      lazy_load_secrets!
+      super
+    end
+
+    def render(*sources)
+      super.tap do |configs|
+        configs.each(&method(:process_secrets!))
+      end
+    end
+
+    private
+
+    # Stores a reference to a secret so it can be resolved later.
+    Secret = Struct.new(:key)
+
+    YAML.add_domain_type('', 'Secret') {Secret.new}
+
+    # Processes `Secret` references in the provided config hash.
+    def process_secrets!(config)
+      return if config.nil?
+      config.select {|_, v| v.is_a?(Secret)}.each do |key, secret|
+        secret.key ||= SecretsConfig.secret_path(env, key)
+      end
+    end
+
+    # Resolve secret references to lazy-loaded values.
+    def lazy_load_secrets!
+      self.cdo_secrets = Cdo.lazy do
+        require 'cdo/secrets'
+        Cdo::Secrets.new(logger: log)
+      end
+
+      table.select {|_k, v| v.is_a?(Secret)}.each do |key, secret|
+        table[key] = cdo_secrets.lazy(secret.key, raise_not_found: true)
+        define_singleton_method(key) do
+          # Replace lazy references to the underlying object on first access,
+          # in order to support 'falsey' (false / nil) values.
+          val = @table[key]
+          val = @table[key] = val.__getobj__ if val.respond_to?(:__getobj__)
+          val
+        end
+      end
+    end
+
+    # Returns a YAML fragment clearing all secrets by overriding their values to `nil`.
+    # Any exceptions or defaults can be re-added later in the YAML document, after secrets have been cleared.
+    def clear_secrets
+      @secrets ||= []
+      @secrets |= table.select {|_, v| v.is_a?(Secret)}.keys.map(&:to_s)
+      @secrets.product([nil]).to_h.to_yaml.gsub("---\n", '')
+    end
+  end
+end

--- a/lib/test/cdo/test_config.rb
+++ b/lib/test/cdo/test_config.rb
@@ -18,7 +18,7 @@ YAML
     config.load_configuration(file)
     assert_equal 'value', config.key
     assert_equal 'b', config.a
-    assert_equal 'new', config.nil_key
+    assert_nil config.nil_key
   end
 
   def test_erb

--- a/lib/test/cdo/test_lazy.rb
+++ b/lib/test/cdo/test_lazy.rb
@@ -1,0 +1,23 @@
+require_relative '../test_helper'
+require 'cdo/lazy'
+
+class LazyTest < Minitest::Test
+  def test_lazy
+    loaded = false
+    lazy = Cdo.lazy {loaded = true; 'Lazy'}
+    refute loaded
+    assert_equal 'Lazy', lazy
+    assert loaded
+  end
+
+  def test_nil
+    lazy = Cdo.lazy {nil}
+    assert_nil lazy
+  end
+
+  def test_class
+    lazy = Cdo.lazy {'test'}
+    assert_instance_of String, lazy
+    assert_equal String, lazy.class
+  end
+end

--- a/lib/test/cdo/test_secrets.rb
+++ b/lib/test/cdo/test_secrets.rb
@@ -1,0 +1,45 @@
+require_relative '../test_helper'
+require 'cdo/secrets'
+
+class SecretsTest < Minitest::Test
+  def test_get_secret
+    values = {
+      'shared/cdo/test' => 'test456',
+      'test' => 'test123',
+      'json' => {my_key: 'my_value'}.to_json
+    }
+    client = Aws::SecretsManager::Client.new(
+      stub_responses: {
+        get_secret_value: ->(ctx) do
+          id = ctx.params[:secret_id]
+          raise Cdo::Secrets::NOT_FOUND.new(nil, '') unless (value = values[id])
+          {secret_string: value}
+        end
+      }
+    )
+    secrets = Cdo::Secrets.new(
+      client: client
+    )
+    assert_equal 'test123', secrets['test']
+    assert_equal 'test123', secrets.get('test').value
+    assert_equal 'test123', secrets.test
+    assert_nil secrets.get('test2').value
+
+    assert_equal 'test', client.api_requests.detect {|req| req[:operation_name] == :get_secret_value}[:params][:secret_id]
+
+    # Ensure API calls to GetSecretValue are cached.
+    assert_equal 2, client.api_requests.count {|req| req[:operation_name] == :get_secret_value}
+
+    assert_equal 'test456', secrets.get('shared/cdo/test').value
+
+    # Property-method lookup chain on JSON secret value.
+    assert_equal 'my_value', secrets.json.my_key
+    assert_equal 4, client.api_requests.count {|req| req[:operation_name] == :get_secret_value}
+
+    secrets.required('missing_key')
+    e = assert_raises(Cdo::Secrets::NOT_FOUND) do
+      secrets.required!
+    end
+    assert_match /Key: missing_key/, e.message
+  end
+end

--- a/pegasus/config.ru
+++ b/pegasus/config.ru
@@ -1,3 +1,7 @@
+require_relative '../deployment'
+# Ensure all application secrets are loaded.
+CDO.cdo_secrets&.required! unless rack_env?(:development)
+
 require File.expand_path('../router', __FILE__)
 
 unless rack_env?(:development)


### PR DESCRIPTION
This PR contains a first pass at integrating Secrets Manager secrets into the CDO namespace of our application.

- Add `aws-sdk-secretsmanager` gem
- Add `secretsmanager` IAM permissions to stack
- Add `Cdo::Secrets` interface for fetching secrets

### Update (May 2019)
I substantially rewrote/refined the implementation incorporating feedback so it works differently from the original description- this is the updated summary:

The `Cdo::Secrets` instance contains an `Aws::SecretsManager::Client` connection, which provides a `#get` method that asynchronously (using [`Promises`](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Promises.html)) fetches individual secrets using the [`GetSecretValue`](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html) API. A `#lazy` method allows a secret to be lazy-loaded (asynchronously fetch in the background, then wait for fetch to complete when first used), and a `#required!` method will wait until _all_ referenced secrets are fully loaded (and will raise an error if any fail to load).

A `CDO.secrets` global variable is set to an instance of `Cdo::Secrets`.

Secrets can be sequentially loaded from a set of path-prefixes (currently, `[environment]/cdo/` followed by `shared/cdo/`) that serve as namespaces. This will allow us to place a secret either in `shared/cdo/` to share across all CDO applications, or in e.g., `production/cdo/` to share in a specific environment, to support the role+environment-based secrets loading currently being used for Chef-attribute secrets.

The recommended way to reference Secrets will be through YAML configuration. The `Cdo::Secret` class implements a new custom YAML tag `!Secret`, which indicates a Secret value that will be lazy-loaded from the provided environment, defaulting to the same key as the YAML key.

This example will fetch `secret` from configured path-prefixes (e.g., it will check `[environment]/cdo/secret` then `shared/cdo/secret`, in that order):

```yaml
secret: !Secret
```

The tag takes some optional values to specify an optional key or fallback string, e.g.:

```yaml
secret2: !Secret z # Fetch `[environment]/cdo/z` or `shared/cdo/z`.
secret3: !Secret x/y/z # Fetch fully-qualified `x/y/z`.
secret4: !Secret [missing_key, 'not a secret!'] # Fetch `missing_key`, or `'not a secret!'` if not found.
secret5: !Secret [x/y/z, 'not a secret!'] # Fetch fully-qualified `x/y/z`, or `'not a secret!'` if not found.
```

In this iteration, creating and updating secrets will be done directly from the AWS Console (or directly through the API). This is still a bit cumbersome- future iterations will consider more developer-friendly processes for managing secrets, and will also consider approaches to automated rotating of existing secrets.