### PR TITLE
fix `stop_inactive_adhoc_instances`

### DIFF
--- a/bin/cron/stop_inactive_adhoc_instances
+++ b/bin/cron/stop_inactive_adhoc_instances
@@ -49,7 +49,7 @@ def main
 
   # find all stacks with 'adhoc' name prefix or environment tag
   adhoc_stacks = cloudformation_resource.stacks.select do |stack|
-    stack.name.starts_with?('adhoc-') ||
+    stack.name.start_with?('adhoc-') ||
     stack.tags.detect {|tag| tag.key == 'environment'}&.value == 'adhoc'
   end
 


### PR DESCRIPTION
Tiny typo fix / followup to #27533.
`starts_with` is an alias added by ActiveSupport, `start_with` is the original method.