### PR TITLE
Do not withdraw facilitator application if they can't attend fit weekend

### DIFF
--- a/dashboard/app/models/pd/fit_weekend_registration_base.rb
+++ b/dashboard/app/models/pd/fit_weekend_registration_base.rb
@@ -25,11 +25,6 @@ class Pd::FitWeekendRegistrationBase < ActiveRecord::Base
   after_initialize :set_registration_year
   before_validation :set_registration_year
 
-  after_create :update_application_status
-  def update_application_status
-    pd_application.update!(status: 'withdrawn') unless accepted?
-  end
-
   after_create :send_fit_weekend_confirmation_email
   def send_fit_weekend_confirmation_email
     Pd::FitWeekendRegistrationMailer.confirmation(self).deliver_now

--- a/dashboard/test/models/pd/fit_weekend_registration_base_test.rb
+++ b/dashboard/test/models/pd/fit_weekend_registration_base_test.rb
@@ -42,15 +42,13 @@ class Pd::FitWeekendRegistrationBaseTest < ActiveSupport::TestCase
     refute registration.sanitize_form_data_hash.key?(:dietary_needs)
   end
 
-  test 'declining the registration updates the application status' do
-    {
-      accepted: 'accepted',
-      declined: 'withdrawn'
-    }.each do |registration_status, expected_application_status|
+  test 'declining the registration does not affect the application status' do
+    [:accepted, :declined].each do |registration_status|
       application = create(:pd_facilitator1920_application, :locked)
+      assert_equal 'accepted', application.status
 
       create(:pd_fit_weekend1920_registration, pd_application: application, status: registration_status)
-      assert_equal expected_application_status, application.reload.status
+      assert_equal 'accepted', application.reload.status
     end
   end
 end


### PR DESCRIPTION
[PLC-162](https://codedotorg.atlassian.net/browse/PLC-162)

Previously, we automatically withdrew the facilitator application if they could not attend their assigned FiT weekend. Now, we don't update their facilitator application status, and they will work with the team to either attend the other weekend or be manually updated to 'withdrawn'.