### PR TITLE
fix param names passed to checkbox partial in bounce level editor

### DIFF
--- a/dashboard/app/views/levels/editors/_bounce.html.haml
+++ b/dashboard/app/views/levels/editors/_bounce.html.haml
@@ -3,7 +3,7 @@
   = f.number_field :ball_direction, step: :any
 
 .field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, symbol: 'fail_on_ball_exit', description: "Fail on Ball Exit"}
+  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: 'fail_on_ball_exit', description: "Fail on Ball Exit"}
 
 .field
   = f.label :soft_buttons, 'Software Buttons'
@@ -38,7 +38,7 @@
   = f.text_area :failure_condition, rows: 4
 
 .field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, symbol: 'use_flag_goal', description: "Use Flag Goal"}
+  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: 'use_flag_goal', description: "Use Flag Goal"}
 
 .field
   = f.label :theme, 'Theme'


### PR DESCRIPTION
While investigating a different issue, I noticed that the level editor page for "New Basketball Project" failed to load. This change appears to fix it.