### PR TITLE
Instructions Tab: Only Force Resize for Feedback Tab

### DIFF
--- a/apps/src/templates/instructions/TopInstructionsCSP.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSP.jsx
@@ -209,7 +209,9 @@ class TopInstructions extends Component {
    * contents of the comment tab.
    */
   forceTabResizeToMaxHeight = () => {
-    this.props.setInstructionsRenderedHeight(this.adjustMaxNeededHeight());
+    if (this.state.tabSelected === TabType.COMMENTS) {
+      this.props.setInstructionsRenderedHeight(this.adjustMaxNeededHeight());
+    }
   };
 
   /**


### PR DESCRIPTION
Only allow force resize of tab when it's the comments tab.

## Before
![Screenshot from 2019-03-18 14-02-46](https://user-images.githubusercontent.com/208083/54565230-02af0700-49a4-11e9-9132-7ba7f3bf1051.png)

## After
<img width="1416" alt="Screen Shot 2019-03-18 at 5 33 11 PM" src="https://user-images.githubusercontent.com/208083/54565211-f9be3580-49a3-11e9-81bf-8dde48f013ed.png">

