### PR TITLE
PL: use alternate email for teacher application emails if needed

### DIFF
--- a/dashboard/app/controllers/pd/application/teacher_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/teacher_application_controller.rb
@@ -14,6 +14,7 @@ module Pd::Application
 
       return render :logged_out unless current_user
       return render :not_teacher unless current_user.teacher?
+      return render :no_teacher_email unless current_user.email.present?
 
       @application = TEACHER_APPLICATION_CLASS.find_by(user: current_user)
       return render :submitted if @application

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -5,6 +5,10 @@ class Pd::WorkshopEnrollmentController < ApplicationController
   load_resource :workshop, class: 'Pd::Workshop', through: :session, singleton: true,
     only: [:join_session, :confirm_join_session]
 
+  def csd_or_csp_workshop
+    [Pd::Workshop::COURSE_CSD, Pd::Workshop::COURSE_CSP].include?(@workshop.course)
+  end
+
   # GET /pd/workshops/1/enroll
   def new
     view_options(no_footer: true, answerdash: true)
@@ -30,9 +34,9 @@ class Pd::WorkshopEnrollmentController < ApplicationController
           workshop_enrollment_status: "full"
         }.to_json
       }
-    elsif [Pd::Workshop::COURSE_CSD, Pd::Workshop::COURSE_CSP].include?(@workshop.course) && !current_user
+    elsif csd_or_csp_workshop && !current_user
       render :logged_out
-    elsif current_user.teacher? && !current_user.email.present?
+    elsif csd_or_csp_workshop && current_user && current_user.teacher? && !current_user.email.present?
       render '/pd/application/teacher_application/no_teacher_email'
     else
       @enrollment = ::Pd::Enrollment.new workshop: @workshop

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -32,6 +32,8 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       }
     elsif [Pd::Workshop::COURSE_CSD, Pd::Workshop::COURSE_CSP].include?(@workshop.course) && !current_user
       render :logged_out
+    elsif current_user.teacher? && !current_user.email.present?
+      render '/pd/application/teacher_application/no_teacher_email'
     else
       @enrollment = ::Pd::Enrollment.new workshop: @workshop
       if current_user

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -158,7 +158,8 @@ module Pd::Application
     end
 
     def formatted_teacher_email
-      "\"#{teacher_full_name}\" <#{user.email}>"
+      teacher_email = user.email.presence || sanitize_form_data_hash[:alternate_email]
+      "\"#{teacher_full_name}\" <#{teacher_email}>"
     end
 
     def formatted_principal_email


### PR DESCRIPTION
In rare cases, we apparently have teacher accounts without an email address.  As an initial mitigation, the 19/20 teacher application mailer now uses the provided fallback email address.

Additionally, visits to the teacher application and to the 6-12 workshop enrollment (which already requires a signed-in account) now direct the user to set an email address on their account before allowing them to proceed.

![Screenshot 2019-03-18 16 31 43](https://user-images.githubusercontent.com/2205926/54571681-0ee59500-49a1-11e9-8cb7-81f0408f67b5.png)

