### PR TITLE
simplify creation of project_info entries for the 'create' button

### DIFF
--- a/lib/cdo/create_header.rb
+++ b/lib/cdo/create_header.rb
@@ -2,61 +2,42 @@
 # dropdown in the header.
 
 class CreateHeader
+  PROJECT_INFO_OVERRIDES = {
+    minecraft: {
+      url: CDO.studio_url('projects/minecraft_designer/new'),
+    },
+    applab: {
+      image: "logo_applab_square.png"
+    },
+    gamelab: {
+      image: "logo_gamelab_square.png"
+    }
+  }.freeze
+
+  # project info data can be inferred from the key, except when otherwise
+  # specified
+  def self.get_project_info(key)
+    info = {
+      id: "create_dropdown_#{key}",
+      image: "logo_#{key}.png",
+      title: key,
+      url: CDO.studio_url("projects/#{key}/new"),
+    }
+
+    info.merge(PROJECT_INFO_OVERRIDES[key.to_sym] || {})
+  end
+
   def self.get_create_dropdown_contents(options)
-    everyone_entries = [
-      {
-        id: "create_dropdown_spritelab",
-        title: "spritelab",
-        url: CDO.studio_url('projects/spritelab/new'),
-        image: "logo_spritelab.png"
-      },
-      {
-        id: "create_dropdown_artist",
-        title: "artist",
-        url: CDO.studio_url('projects/artist/new'),
-        image: "logo_artist.png"
-      },
-    ]
+    everyone_entries = %w(spritelab artist)
 
-    minecraft = [
-      {
-        id: "create_dropdown_minecraft",
-        title: "minecraft",
-        url: CDO.studio_url('projects/minecraft_designer/new'),
-        image: "logo_minecraft.png"
-      },
-    ]
-
-    applab_gamelab = [
-      {
-        id: "create_dropdown_applab",
-        title: "applab",
-        url: CDO.studio_url('projects/applab/new'),
-        image: "logo_applab_square.png"
-      },
-      {
-        id: "create_dropdown_gamelab",
-        title: "gamelab",
-        url: CDO.studio_url('projects/gamelab/new'),
-        image: "logo_gamelab_square.png"
-      },
-    ]
-
-    dance_party = [
-      {
-        id: "create_dropdown_dance",
-        title: "dance",
-        url: CDO.studio_url('projects/dance/new'),
-        image: "logo_dance.png"
-      }
-    ]
+    applab_gamelab = %w(applab gamelab)
 
     entries = options[:limit_project_types] == "true" ?
-      everyone_entries + minecraft :
+      everyone_entries + ["minecraft"] :
       everyone_entries + applab_gamelab
 
-    entries += dance_party
+    entries << "dance"
 
-    entries
+    entries.map(&method(:get_project_info))
   end
 end


### PR DESCRIPTION
**Context:** I'm working on teaching the creation button [how to dynamically include the currently-being-viewed project type](https://docs.google.com/document/d/1V0ApTIbg7qWIIq9pDcJ2kdP1rcuxLKi2lmKXkYdIdVA/edit#), and so I'd like to reduce the necessary complexity for adding new project types to that header.

This approach makes creation of new entries happen dynamically and automatically, with the option for overrides as necessary.