### PR TITLE
Refactor: Instructions Area Resize Only for Feedback Tab

### DIFF
--- a/apps/src/templates/instructions/TopInstructionsCSP.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSP.jsx
@@ -165,7 +165,7 @@ class TopInstructions extends Component {
         method: 'GET',
         contentType: 'application/json;charset=UTF-8'
       }).done(data => {
-        this.setState({feedbacks: data}, this.forceTabResizeToMaxHeight);
+        this.setState({feedbacks: data}, this.forceCommentTabResizeToMaxHeight);
       });
     }
     //While this is behind an experiment flag we will only pull the rubric
@@ -177,7 +177,7 @@ class TopInstructions extends Component {
         method: 'GET',
         contentType: 'application/json;charset=UTF-8'
       }).done(data => {
-        this.setState({rubric: data}, this.forceTabResizeToMaxHeight);
+        this.setState({rubric: data}, this.forceCommentTabResizeToMaxHeight);
       });
     }
   }
@@ -203,15 +203,23 @@ class TopInstructions extends Component {
   }
 
   /**
-   * Function to force the height of the instructions area to be the
+   * Function to force the height of the instructions area when the comment tab is chosen to be the
    * full size of the content for that area. This is used when the comment
    * tab loads in order to make the instructions area show the whole
    * contents of the comment tab.
    */
-  forceTabResizeToMaxHeight = () => {
+  forceCommentTabResizeToMaxHeight = () => {
     if (this.state.tabSelected === TabType.COMMENTS) {
-      this.props.setInstructionsRenderedHeight(this.adjustMaxNeededHeight());
+      this.forceTabResizeToMaxHeight();
     }
+  };
+
+  /**
+   * Function to force the height of the instructions area to be the
+   * full size of the content for that area.
+   */
+  forceTabResizeToMaxHeight = () => {
+    this.props.setInstructionsRenderedHeight(this.adjustMaxNeededHeight());
   };
 
   /**


### PR DESCRIPTION
Refactor the restriction that the force resize only happens on load for the feedback tab. This is a refactor of the way we did #27571 based on feedback from Maddie that we should just not call the method if we aren't in the comments tab.