### PR TITLE
PL: principal approval improvements

### DIFF
--- a/apps/src/code-studio/pd/application/PrivacyDialog.jsx
+++ b/apps/src/code-studio/pd/application/PrivacyDialog.jsx
@@ -6,12 +6,16 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Modal, Button} from 'react-bootstrap';
 import color from '@cdo/apps/util/color';
+import {PrivacyDialogMode} from '../constants';
 
 export default class PrivacyDialog extends React.Component {
   static propTypes = {
     show: PropTypes.bool,
     onHide: PropTypes.func.isRequired,
-    teacherApproval: PropTypes.bool
+    mode: PropTypes.oneOf([
+      PrivacyDialogMode.TEACHER_APPLICATION,
+      PrivacyDialogMode.PRINCIPAL_APPROVAL
+    ]).isRequired
   };
 
   render() {
@@ -27,36 +31,67 @@ export default class PrivacyDialog extends React.Component {
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <p style={STYLE.bodyText}>
-            Code.org works closely with local Regional Partners to organize and
-            deliver the Professional Learning Program. By submitting this
-            application, you are agreeing to allow Code.org to share information
-            on how you use Code.org and the Professional Learning resources with
-            your Regional Partner and school district. In order to organize the
-            workshops and support you, our partners need to know who is
-            attending and what content is relevant for them. So, we will share
-            your contact information, which courses/units you are using in your
-            classrooms and aggregate data about your classes. This includes the
-            number of students in your classes, the demographic breakdown of
-            your classroom, and the name of your school and district. We will
-            not share any information about individual students with our
-            Regional Partners - all information will be de-identified and
-            aggregated. Our Regional Partners are contractually obliged to treat
-            this information with the same level of confidentiality as Code.org.
-            To see the full Code.org privacy policy, visit{' '}
-            <a href="https://code.org/privacy" target="_blank">
-              code.org/privacy
-            </a>
-            .
-          </p>
-          {this.props.teacherApproval && (
+          {this.props.mode === PrivacyDialogMode.TEACHER_APPLICATION && (
+            <div>
+              <p style={STYLE.bodyText}>
+                Code.org works closely with local Regional Partners to organize
+                and deliver the Professional Learning Program. By submitting
+                this application, you are agreeing to allow Code.org to share
+                information on how you use Code.org and the Professional
+                Learning resources with your Regional Partner and school
+                district. In order to organize the workshops and support you,
+                our partners need to know who is attending and what content is
+                relevant for them. So, we will share your contact information,
+                which courses/units you are using in your classrooms and
+                aggregate data about your classes. This includes the number of
+                students in your classes, the demographic breakdown of your
+                classroom, and the name of your school and district. We will not
+                share any information about individual students with our
+                Regional Partners - all information will be de-identified and
+                aggregated. Our Regional Partners are contractually obliged to
+                treat this information with the same level of confidentiality as
+                Code.org. To see the full Code.org privacy policy, visit{' '}
+                <a href="https://code.org/privacy" target="_blank">
+                  code.org/privacy
+                </a>
+                .
+              </p>
+
+              <p style={STYLE.bodyText}>
+                Teachers may be required to get principal approval for their
+                application to the Professional Learning Program. As part of
+                this process principals may opt in to let the College Board
+                share de-identified and aggregated Computer Science AP scores
+                with Code.org to help us improve the program and curriculum. AP
+                test scores will not be shared with Regional Partners.
+              </p>
+            </div>
+          )}
+
+          {this.props.mode === PrivacyDialogMode.PRINCIPAL_APPROVAL && (
             <p style={STYLE.bodyText}>
-              Teachers may be required to get principal approval for their
-              application to the Professional Learning Program. As part of this
-              process principals may opt in to let the College Board share
-              de-identified and aggregated Computer Science AP scores with
-              Code.org to help us improve the program and curriculum. AP test
-              scores will not be shared with Regional Partners.
+              Code.org works closely with local Regional Partners to organize
+              and deliver the Professional Learning Program. By submitting their
+              application to the professional learning program, teachers have
+              agreed to allow Code.org to share information on how they use
+              Code.org and the Professional Learning resources with their
+              Regional Partner and school district. In order to organize the
+              workshops and support teachers, our partners need to know who is
+              attending and what content is relevant for them. So, we will share
+              teachers’ contact information, which courses/units they are using
+              in their classrooms and aggregate data about their classes. This
+              includes the number of students in their classes, the demographic
+              breakdown of their classroom, and the name of their school and
+              district. We will not share any information about individual
+              students with our Regional Partners - all information will be
+              de-identified and aggregated. Our Regional Partners are
+              contractually obliged to treat this information with the same
+              level of confidentiality as Code.org. To see Code.org’s complete
+              Privacy Policy, visit{' '}
+              <a href="http://code.org/privacy" target="_blank">
+                http://code.org/privacy
+              </a>
+              .
             </p>
           )}
         </Modal.Body>

--- a/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Application.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Application.jsx
@@ -24,7 +24,8 @@ export default class PrincipalApproval1920Application extends FormController {
       hispanic_or_latino_percent: PropTypes.string,
       asian_percent: PropTypes.string,
       native_hawaiian_or_pacific_islander_percent: PropTypes.string,
-      american_indian_alaskan_native_percent: PropTypes.string
+      american_indian_alaskan_native_percent: PropTypes.string,
+      two_or_more_races_percent: PropTypes.string
     }).isRequired
   };
   /**
@@ -55,7 +56,8 @@ export default class PrincipalApproval1920Application extends FormController {
           .native_hawaiian_or_pacific_islander_percent,
       americanIndian:
         props.teacherApplicationSchoolStats
-          .american_indian_alaskan_native_percent
+          .american_indian_alaskan_native_percent,
+      other: props.teacherApplicationSchoolStats.two_or_more_races_percent
     });
   }
   /**

--- a/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Component.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Component.jsx
@@ -6,6 +6,7 @@ import {
 } from '@cdo/apps/generated/pd/principalApproval1920ApplicationConstants';
 import LabeledFormComponent from '../../form_components/LabeledFormComponent';
 import PrivacyDialog from '../PrivacyDialog';
+import {PrivacyDialogMode} from '../../constants';
 import SchoolAutocompleteDropdown from '@cdo/apps/templates/SchoolAutocompleteDropdown';
 import {isInt, isPercent} from '@cdo/apps/util/formatValidation';
 import {styles} from '../teacher1920/TeacherApplicationConstants';
@@ -383,7 +384,7 @@ export default class PrincipalApproval1920Component extends LabeledFormComponent
         <PrivacyDialog
           show={this.state.isPrivacyDialogOpen}
           onHide={this.handleClosePrivacyDialog}
-          teacherApproval={false}
+          mode={PrivacyDialogMode.TEACHER_APPLICATION}
         />
       </FormGroup>
     );

--- a/apps/src/code-studio/pd/application/teacher1920/Section5AdditionalDemographicInformation.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section5AdditionalDemographicInformation.jsx
@@ -7,6 +7,7 @@ import {
 } from '@cdo/apps/generated/pd/teacher1920ApplicationConstants';
 import {FormGroup} from 'react-bootstrap';
 import PrivacyDialog from '../PrivacyDialog';
+import {PrivacyDialogMode} from '../../constants';
 
 export default class Section5AdditionalDemographicInformation extends LabeledFormComponent {
   static labels = PageLabels.section5AdditionalDemographicInformation;
@@ -60,7 +61,7 @@ export default class Section5AdditionalDemographicInformation extends LabeledFor
         <PrivacyDialog
           show={this.state.isPrivacyDialogOpen}
           onHide={this.handleClosePrivacyDialog}
-          teacherApproval={true}
+          mode={PrivacyDialogMode.PRINCIPAL_APPROVAL}
         />
       </FormGroup>
     );

--- a/apps/src/code-studio/pd/constants.js
+++ b/apps/src/code-studio/pd/constants.js
@@ -2,6 +2,8 @@
  * @fileoverview Constants used in pd components.
  */
 
+import * as utils from '../../utils';
+
 /** Default max height for the React-Select menu popup, as defined in the imported react-select.css,
  * is 200px for the container, and 198 for the actual menu (to accommodate 2px for the border).
  * React-Select has props for overriding these default css styles. Increase the max height here:
@@ -14,3 +16,8 @@ exports.SelectStyleProps = {
     maxHeight: 398
   }
 };
+
+export const PrivacyDialogMode = utils.makeEnum(
+  'TEACHER_APPLICATION',
+  'PRINCIPAL_APPROVAL'
+);

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -703,7 +703,9 @@ module Pd::Application
           principal_other_percent: format("%0.02f%%", principal_response[:other]),
           principal_wont_replace_existing_course: replace_course_string,
           principal_send_ap_scores: principal_response[:send_ap_scores],
-          principal_pay_fee: principal_response[:pay_fee]
+          principal_pay_fee: principal_response[:pay_fee],
+          principal_contact_invoicing: principal_response[:contact_invoicing],
+          principal_contact_invoicing_detail: principal_response[:contact_invoicing_detail]
         }
       )
       save!

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -983,6 +983,8 @@ module Api::V1::Pd
         "If there is a fee for the program, will your teacher or your school be able to pay for the fee?",
         "How did you hear about this program? (Principal's response)",
         "Principal authorizes college board to send AP Scores",
+        "Contact name for invoicing",
+        "Contact email or phone number for invoicing",
         "Title I status code (NCES data)",
         "Total student enrollment (NCES data)",
         "Percentage of students who are eligible to receive free or reduced lunch (NCES data)",

--- a/dashboard/test/models/pd/application/teacher1920_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher1920_application_test.rb
@@ -319,12 +319,12 @@ module Pd::Application
       csv_header_csd = CSV.parse(Teacher1920Application.csv_header('csd'))[0]
       assert csv_header_csd.include? "To which grades does your school plan to offer CS Discoveries in the 2019-20 school year?"
       refute csv_header_csd.include? "To which grades does your school plan to offer CS Principles in the 2019-20 school year?"
-      assert_equal 98, csv_header_csd.length
+      assert_equal 100, csv_header_csd.length
 
       csv_header_csp = CSV.parse(Teacher1920Application.csv_header('csp'))[0]
       refute csv_header_csp.include? "To which grades does your school plan to offer CS Discoveries in the 2019-20 school year?"
       assert csv_header_csp.include? "To which grades does your school plan to offer CS Principles in the 2019-20 school year?"
-      assert_equal 100, csv_header_csp.length
+      assert_equal 102, csv_header_csp.length
     end
 
     test 'school cache' do

--- a/lib/cdo/shared_constants/pd/principal_approval1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/principal_approval1920_application_constants.rb
@@ -22,7 +22,7 @@ module Pd
       understand_fee: 'By checking this box, you indicate that you understand there may be a fee for the professional learning program your teacher attends.',
       pay_fee: 'If there is a fee for the program, will your teacher or your school be able to pay for the fee?',
       contact_invoicing: "Contact name for invoicing (if applicable)",
-      contact_invoicing_detail: "Contact e-mail or phone number for invoicing (if applicable)",
+      contact_invoicing_detail: "Contact email or phone number for invoicing (if applicable)",
       confirm_principal: 'By submitting this application, I confirm that I am the principal of this school and agree to share my contact info, school info, and this application with my local Code.org Regional Partner.',
 
       school: 'School',

--- a/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
@@ -435,6 +435,8 @@ module Pd
         :pay_fee,
         :how_heard,
         :share_ap_scores,
+        :contact_invoicing,
+        :contact_invoicing_detail
       ],
       nces: [
         :title_i_status,

--- a/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
@@ -128,6 +128,8 @@ module Pd
         principal_schedule_confirmed: 'Are you committed to including Computer Science <Program> on the master schedule in 2019-20 if <Teacher Name> is accepted into the program?',
         principal_implementation: "To participate in Code.org's Computer Science <Program> Professional Learning Program, we require that this course be offered in one of the following ways. Please select which option will be implemented at your school.",
         principal_diversity_recruitment: 'Do you commit to recruiting and enrolling a diverse group of students in this course, representative of the overall demographics of your school?',
+        contact_invoicing: "Contact name for invoicing",
+        contact_invoicing_detail: "Contact email or phone number for invoicing",
       }
     }.freeze
 
@@ -235,6 +237,9 @@ module Pd
       pay_fee: {teacher: :pay_fee, principal: :principal_pay_fee},
 
       how_heard: {teacher: :how_heard, principal: :principal_how_heard},
+
+      contact_invoicing: {principal: :principal_contact_invoicing},
+      contact_invoicing_detail: {principal: :principal_contact_invoicing_detail},
 
       title_i_status: {stats: :title_i_status},
       school_type: {teacher: :school_type, stats: :school_type},


### PR DESCRIPTION
This acts as a followup to https://github.com/code-dot-org/code-dot-org/pull/27510 and makes some improvements to the principal approval changes.

- Principal approval gets updated privacy dialog content.
- Principal approval gets pre-populated "other" category.
- Application details show invoicing information from principal.
  - If the principal approval has added invoicing contact name and/or detail, then those are written into the teacher application upon principal approval, and are then shown in the application detail view at a path like /pd/application_dashboard/csd_Teachers/:application_id.
- Application downloadable CSV gets contact invoice details.
  - The contact invoice name & detail fields from the principal approval are now included in the downloadable CSV for teacher applications.  (Such as that available from /pd/application_dashboard/csd_Teachers.)
- Principal approval form's "e-mail" becomes "email".

#### Application details:
![Screenshot 2019-03-19 10 51 43](https://user-images.githubusercontent.com/2205926/54640383-e1eebc00-4a4c-11e9-8785-6e5ceff1a2cf.png)

#### Privacy for principal approval:
![Screenshot 2019-03-18 10 54 42](https://user-images.githubusercontent.com/2205926/54640433-fa5ed680-4a4c-11e9-9ac4-b77962e1be94.png)

#### Privacy for teacher application:
![Screenshot 2019-03-18 10 54 54](https://user-images.githubusercontent.com/2205926/54640434-fa5ed680-4a4c-11e9-9397-7695025e7b76.png)
