### PR TITLE
do not re-lock locked applications

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -181,9 +181,8 @@ module Api::V1::Pd
 
             if locked_param != @application.locked?
               lock_changed = true
+              locked_param ? @application.lock! : @application.unlock!
             end
-
-            locked_param ? @application.lock! : @application.unlock!
           end
         end
 

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -469,6 +469,18 @@ module Api::V1::Pd
       assert_equal expected_log, @csp_facilitator_application.sanitize_status_timestamp_change_log
     end
 
+    test 'do not re-lock locked applications on update' do
+      sign_in @workshop_admin
+      @csp_facilitator_application.update(status: 'declined', locked_at: Time.zone.now)
+      @csp_facilitator_application.reload
+      assert @csp_facilitator_application.locked?
+
+      Pd::Application::Facilitator1920Application.any_instance.expects(:lock!).never
+
+      # edit locked application
+      post :update, params: {id: @csp_facilitator_application.id, application: {locked: true}}
+    end
+
     test 'workshop admins can lock and unlock applications' do
       sign_in @workshop_admin
       put :update, params: {id: @csf_facilitator_application_no_partner, application: {status: 'accepted', locked: 'true'}}

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -481,6 +481,18 @@ module Api::V1::Pd
       post :update, params: {id: @csp_facilitator_application.id, application: {locked: true}}
     end
 
+    test 'do not re-unlock unlocked applications on update' do
+      sign_in @workshop_admin
+      @csp_facilitator_application.update(status: 'declined')
+      @csp_facilitator_application.reload
+      refute @csp_facilitator_application.locked?
+
+      Pd::Application::Facilitator1920Application.any_instance.expects(:unlock!).never
+
+      # edit locked application
+      post :update, params: {id: @csp_facilitator_application.id, application: {locked: false}}
+    end
+
     test 'workshop admins can lock and unlock applications' do
       sign_in @workshop_admin
       put :update, params: {id: @csf_facilitator_application_no_partner, application: {status: 'accepted', locked: 'true'}}

--- a/dashboard/test/models/pd/application/facilitator1920_application_test.rb
+++ b/dashboard/test/models/pd/application/facilitator1920_application_test.rb
@@ -348,6 +348,25 @@ module Pd::Application
       end
     end
 
+    test 'should_send_decision_email?' do
+      application = build :pd_facilitator1920_application, status: :pending
+
+      # no auto-email status: no email
+      refute application.should_send_decision_email?
+
+      # auto-email status with no partner: yes email
+      application.status = :declined
+      assert application.should_send_decision_email?
+    end
+
+    test 'queue_email queues up email' do
+      application = build :pd_facilitator1920_application, status: 'declined'
+
+      assert_creates Email do
+        application.queue_email :declined
+      end
+    end
+
     test 'meets_criteria says yes if everything is set to YES, no if anything is NO, and INCOMPLETE if anything is unset' do
       %w(csf csd csp).each do |course|
         application = create :pd_facilitator1920_application, course: course


### PR DESCRIPTION
[PLC-166](https://codedotorg.atlassian.net/browse/PLC-166)

We had a bug that new decision emails were triggered whenever a locked and waitlisted/declined application was edited. It turns out we were re-locking locked applications with every edit, which had no side effects until we began sending these emails when the applications were locked. This fix prevents re-locking applications and thus prevents triggering the duplicate emails.

I snuck in some related tests as well.