### PR TITLE
Enable ~The Daily Zendesk~ for #developers, #plc-engineering

### DIFF
--- a/bin/cron/zendesk_slack_report
+++ b/bin/cron/zendesk_slack_report
@@ -29,10 +29,10 @@ STATUSES_TO_REPORT = %w(new open)
 # Slack room -> Zendesk group mappings to report on
 MONITORING_GROUPS = {
   # 'slack-room-name' => ['Zendesk group name', 'Zendesk group name', ...]
+  'developers' => ['Developers'],
   'learning-platform' => ['Learning Platform'],
+  'plc-engineering' => ['PLC Tools'],
   'star-labs-cabal' => ['*Labs'],
-  # 'developers' => ['Developers'],
-  # 'plc-engineering' => ['PLC Tools'],
   # 'privacy' => ['Privacy'],
   # 'user-accounts' => ['Accounts'],
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1615761/54703415-fcc93b00-4af5-11e9-8d81-38e40c6272e8.png)

Enables **The Daily Zendesk** notification for:

- `#developers` (from the "Developers" group)
- `#plc-engineering` (from the "PLC Tools" group)

We discussed keeping this out of `#developers` which we usually try to keep free of automated notifications, but settled on trying it out since this will only notify once per day and it's easy to move to another room if we find it's too noisy.