### PR TITLE
Improve CSV download for Fit cohort view

### DIFF
--- a/apps/test/unit/code-studio/pd/application_dashboard/admin_cohort_viewTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/admin_cohort_viewTest.js
@@ -1,0 +1,134 @@
+import AdminCohortView from '@cdo/apps/code-studio/pd/application_dashboard/admin_cohort_view';
+import {assert, expect} from '../../../../util/configuredChai';
+import React from 'react';
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+
+describe('AdminCohortView component', () => {
+  // FiT cohort data is combination of application and registration data
+  const DEFAULT_FIT_COHORT_DATA = [
+    {
+      accepted_fit: 'Yes',
+      applicant_name: 'applicant',
+      assigned_fit: 'fit',
+      assigned_workshop: 'workshop',
+      course_name: 'CS Discoveries',
+      date_accepted: '2019-03-22',
+      district_name: 'district',
+      email: 'teacher@school.edu',
+      form_data: {
+        ableToAttend: 'Yes',
+        addressCity: 'city',
+        addressState: 'state',
+        addressStreet: 'street',
+        addressZip: '12345',
+        agreeShareContact: true,
+        city: null,
+        contactFirstName: 'first',
+        contactLastName: 'last',
+        contactPhone: '1234567890',
+        contactRelationship: 'me',
+        date: 'June 1-1, 2019',
+        dietaryNeeds: ['None'],
+        email: 'teacher@school.edu',
+        howTraveling: 'I will drive by myself',
+        howTraveling_carpooling_with_attendee: 'the passenger',
+        lastName: 'last',
+        liabilityWaiver: true,
+        liveFarAway: 'Yes',
+        needAda: 'Yes',
+        needDisabilitySupport: 'Yes',
+        needHotel: 'Yes',
+        phone: '1234567890',
+        photoRelease: true,
+        preferredFirstName: 'first'
+      },
+      id: 1,
+      locked: true,
+      notes: '3/21: Approved by Code.org.',
+      notes_2: 'Questions has for us:\n',
+      notes_3:
+        'Strengths: \nWeaknesses: \nPotential red flags to follow- up on: \nOther notes:',
+      notes_4: null,
+      notes_5: null,
+      regional_partner_name: 'partner',
+      registered_fit: true,
+      registered_fit_submission_time: 'Mar 22 2019 12:02am UTC',
+      registered_workshop: false,
+      role: 'Lead Facilitator',
+      school_name: 'school',
+      status: 'accepted',
+      type: 'Pd::Application::Facilitator1920Application'
+    }
+  ];
+
+  const minProps = {route: {cohortType: 'FiT'}};
+
+  before(() => {
+    // Prevent AdminCohortView load() function to send ajax request to server
+    // by stubbing it and faking the server-returned data.
+    sinon.stub(AdminCohortView.prototype, 'load');
+  });
+
+  after(() => {
+    AdminCohortView.prototype.load.restore();
+  });
+
+  it('can be rendered', () => {
+    const wrapper = shallow(<AdminCohortView {...minProps} />);
+    expect(wrapper).not.to.be.null;
+  });
+
+  it('can sanitize strings', () => {
+    const testCases = [
+      {input: undefined, expected: ''},
+      {input: '', expected: ''},
+      {input: '\ta ', expected: 'a'},
+      {input: 'a  b\t\tc \t d', expected: 'a b c d'},
+      {input: '\na\nb\rc\n\rd\r\ne\n\nf\r\r', expected: '. a. b. c. d. e. f.'}
+    ];
+
+    testCases.forEach(testCase => {
+      expect(AdminCohortView.sanitizeString(testCase.input)).to.equal(
+        testCase.expected
+      );
+    });
+  });
+
+  it('can compile data to export to CSV', () => {
+    let downloadCsvSpy = sinon.spy();
+    const wrapper = shallow(
+      <AdminCohortView {...minProps} downloadCsv={downloadCsvSpy} />
+    );
+
+    // Fake component state instead of loading real data from server
+    wrapper.setState({
+      cohort: DEFAULT_FIT_COHORT_DATA,
+      filteredCohort: DEFAULT_FIT_COHORT_DATA,
+      loading: false
+    });
+
+    // Test part of handleDownloadCsv function to the point where it calls downloadCsv function.
+    wrapper.instance().handleDownloadCsv();
+
+    expect(downloadCsvSpy).to.have.been.calledOnce;
+
+    let spyCallArgs = downloadCsvSpy.lastCall.args[0];
+    assert.strictEqual(
+      spyCallArgs.filename,
+      `${minProps.route.cohortType.toLowerCase()}_cohort.csv`,
+      'CSV file name is not as expected'
+    );
+
+    let missingKeyCnt = 0;
+    Object.keys(DEFAULT_FIT_COHORT_DATA[0].form_data).forEach(key => {
+      if (
+        !spyCallArgs.headers.hasOwnProperty(key) ||
+        !spyCallArgs.data[0].hasOwnProperty(key)
+      ) {
+        missingKeyCnt += 1;
+      }
+    });
+    assert.equal(missingKeyCnt, 0, 'Form data keys are missing');
+  });
+});

--- a/dashboard/app/serializers/api/v1/pd/fit_cohort_view_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/fit_cohort_view_serializer.rb
@@ -50,7 +50,7 @@ class Api::V1::Pd::FitCohortViewSerializer < ActiveModel::Serializer
 
   def registered_fit_submission_time
     # Return friendly time format: "Mar 21 2019 10:33am UTC"
-    object.try(FIT_WEEKEND_REGISTRATION_SYMBOL).try(:created_at).strftime('%b %d %Y %l:%M%P %Z')
+    object.try(FIT_WEEKEND_REGISTRATION_SYMBOL).try(:created_at).try(:strftime, '%b %d %Y %l:%M%P %Z')
   end
 
   def fit_assigned_at_registration

--- a/dashboard/app/serializers/api/v1/pd/fit_cohort_view_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/fit_cohort_view_serializer.rb
@@ -14,6 +14,7 @@ class Api::V1::Pd::FitCohortViewSerializer < ActiveModel::Serializer
     :assigned_fit,
     :registered_fit,
     :accepted_fit,
+    :registered_fit_submission_time,
     :role,
     :status,
     :locked,
@@ -47,12 +48,16 @@ class Api::V1::Pd::FitCohortViewSerializer < ActiveModel::Serializer
     object.try(:registered_fit_workshop?)
   end
 
+  def registered_fit_submission_time
+    object.try(FIT_WEEKEND_REGISTRATION_SYMBOL).try(:created_at)
+  end
+
   def fit_assigned_at_registration
-    object.try(FIT_WEEKEND_REGISTRATION_FACTORY).try(:fit_city)
+    object.try(FIT_WEEKEND_REGISTRATION_SYMBOL).try(:fit_city)
   end
 
   def accepted_fit
-    object.try(FIT_WEEKEND_REGISTRATION_FACTORY).try(:accepted_seat_simplified)
+    object.try(FIT_WEEKEND_REGISTRATION_SYMBOL).try(:accepted_seat_simplified)
   end
 
   def role

--- a/dashboard/app/serializers/api/v1/pd/fit_cohort_view_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/fit_cohort_view_serializer.rb
@@ -49,7 +49,8 @@ class Api::V1::Pd::FitCohortViewSerializer < ActiveModel::Serializer
   end
 
   def registered_fit_submission_time
-    object.try(FIT_WEEKEND_REGISTRATION_SYMBOL).try(:created_at)
+    # Return friendly time format: "Mar 21 2019 10:33am UTC"
+    object.try(FIT_WEEKEND_REGISTRATION_SYMBOL).try(:created_at).strftime('%b %d %Y %l:%M%P %Z')
   end
 
   def fit_assigned_at_registration


### PR DESCRIPTION
[PLC-161](https://codedotorg.atlassian.net/browse/PLC-161) 
- Add more fields to Fit cohort CSV file.
- Sanitize strings so CSV file can be viewed correctly in spreadsheet tools.
- Injecting `downloadCsv` into `AdminCohortView` so the function can be tested properly.
- Add 3 tests for `AdminCohortView` component
  1. It can be rendered 
  2. It can sanitize string 
  3. It can compile data to export to CSV file.


**How tested**
* Unit test
  - In `apps` folder, run `yarn test:entry --entry test/unit/code-studio/pd/application_dashboard/admin_cohort_viewTest.js`
  - In `dashboard` folder, run `bundle exec rails test test/controllers/api/v1/pd/applications_controller_test.rb`

* Manual test
  - In local dev environment, created FiT 1920 application and a summer Workshop. 
  - Registered the application for Fit Weekend workshop
  - In Application dashboard (log in as a workshop admin) -> Fit cohort view -> Download CSV. Got a CSV file like this:
  <img width="965" alt="Screen Shot 2019-03-20 at 1 28 15 PM" src="https://user-images.githubusercontent.com/46507039/54717081-97d10d80-4b14-11e9-9810-030416b1077e.png">
  <img width="1113" alt="Screen Shot 2019-03-20 at 1 28 29 PM" src="https://user-images.githubusercontent.com/46507039/54717083-97d10d80-4b14-11e9-9caa-84eb50a53728.png">
  <img width="1071" alt="Screen Shot 2019-03-20 at 1 28 44 PM" src="https://user-images.githubusercontent.com/46507039/54717084-97d10d80-4b14-11e9-8307-29ea3f457b16.png">
  <img width="622" alt="Screen Shot 2019-03-20 at 1 29 02 PM" src="https://user-images.githubusercontent.com/46507039/54717085-9869a400-4b14-11e9-863a-c52ebe5b614d.png">