### PR TITLE
PL: more principal approval improvements

### DIFF
--- a/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Component.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval1920/PrincipalApproval1920Component.jsx
@@ -384,7 +384,7 @@ export default class PrincipalApproval1920Component extends LabeledFormComponent
         <PrivacyDialog
           show={this.state.isPrivacyDialogOpen}
           onHide={this.handleClosePrivacyDialog}
-          mode={PrivacyDialogMode.TEACHER_APPLICATION}
+          mode={PrivacyDialogMode.PRINCIPAL_APPROVAL}
         />
       </FormGroup>
     );

--- a/apps/src/code-studio/pd/application/teacher1920/Section5AdditionalDemographicInformation.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section5AdditionalDemographicInformation.jsx
@@ -61,7 +61,7 @@ export default class Section5AdditionalDemographicInformation extends LabeledFor
         <PrivacyDialog
           show={this.state.isPrivacyDialogOpen}
           onHide={this.handleClosePrivacyDialog}
-          mode={PrivacyDialogMode.PRINCIPAL_APPROVAL}
+          mode={PrivacyDialogMode.TEACHER_APPLICATION}
         />
       </FormGroup>
     );

--- a/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
@@ -252,8 +252,7 @@ module Pd
       hispanic_or_latino_percent: {principal: :principal_hispanic_or_latino_percent, stats: :hispanic_or_latino_percent},
       native_hawaiian_or_pacific_islander_percent: {principal: :principal_native_hawaiian_or_pacific_islander_percent, stats: :native_hawaiian_or_pacific_islander_percent},
       white_percent: {principal: :principal_white_percent, stats: :white_percent},
-      two_or_more_races_percent: {stats: :two_or_more_races_percent},
-      other_races_percent: {principal: :principal_other_percent}
+      other_races_percent: {principal: :principal_other_percent, stats: :two_or_more_races_percent}
     }
 
     ALL_LABELS = PAGE_LABELS.values.reduce(:merge).freeze


### PR DESCRIPTION
- Show correct privacy dialog for teacher application vs. principal approval (they were flipped)
- Combine display of two groups into one for application detail view

This is a followup to https://github.com/code-dot-org/code-dot-org/pull/27589