### PR TITLE
Script for automating process for converting files and running generateSoundMetadata.rb

### DIFF
--- a/tools/scripts/autorun_generateSoundMetadata.rb
+++ b/tools/scripts/autorun_generateSoundMetadata.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env ruby
+
+# FOR USE WHEN WORKING WITH MULTIPLE SOUND FILES IN A FOLDER
+# FOR GENERATING METDATA FOR A SINGLE FILE THEN USE: generateSoundMetadata.rb
+
+# Use this script for converting multiple audio formats into .mp3 (required)
+# Then generateSoundMetadata.rb will be run to:
+# 1. create metadata (JSON) for each file (required)
+# 2. use file_path to get the directory name like animals or notifications
+# to add category_animals or category_notifications to the aliases (required)
+
+# This script assumes the csv will have columns of filenames and aliases.
+# The csv that was used with the script had the filename in the 2nd column and aliases in the 4th column.
+
+# command to run file: bundle exec ./autorun_generateSoundMetadata.rb [folder_path] [csv_path]
+# example for folder_path = ~/Downloads/Animals
+# example for csv_location = ./sound_metadata.csv
+# example command = bundle exec ./parse_new_sound_aliases_csv.rb ~/Downloads/Animals ./sound_metadata.csv
+require 'csv'
+require 'fileutils'
+
+class NewSoundAliasesMetadataBuilder
+  CORRUPTED_FILENAME_REGEX = /(^\_+|\_+$|_{2,}|\s|[A-Z])/
+  def initialize(csv)
+    @csv = CSV.parse(File.read(csv), headers: true)
+  end
+
+  def fix_corrupted_filename(name)
+    # some names have uppercases
+    return name.downcase.tr(" ", "_").gsub(/_{2,}/, "_").gsub(/^\_+/, '').gsub(/\_+$/, '')
+  end
+
+  def convert_wav_to_mp3(folder_path)
+    # converts .wav files to .mp3
+    puts %x(
+        for file in "#{folder_path}"/*.wav
+        do \`ffmpeg -i "$file" "${file%.wav}".mp3\`
+          done
+      )
+    Dir.mkdir "#{folder_path}/mp3_files"
+
+    Dir[folder_path + "/*.mp3"].each do |f|
+      filename = File.basename(f, File.extname(f))
+
+      if filename =~ CORRUPTED_FILENAME_REGEX
+        fixed_name = fix_corrupted_filename(filename)
+        File.rename(f, folder_path + "/" + fixed_name + File.extname(f))
+        f.gsub!(f.split('/')[-1], "#{fixed_name}.mp3")
+      end
+
+      FileUtils.mv(f.to_s, "#{folder_path}/mp3_files")
+    end
+  end
+
+  def parse_filenames_in_csv(csv)
+    filename = csv.by_col[1]
+    # changed file extension to .mp3 to run .generateSoundMetaData.rb
+    return filename.map do |name|
+      # original file extensions are .wav but they shoud be .mp3
+      # in order to run ./generateSoundMetaData.rb
+      name = fix_corrupted_filename(name[0..-5])
+      # require 'pry'; binding.pry
+      name << ".mp3"
+    end
+  end
+
+  def parse_aliases_in_csv(csv)
+    # removed spaces to simplify
+    # because csv file had aliases that had
+    # more than one space or none
+    return csv.by_col[3].map do |aliase|
+      aliase.gsub(/,\s+/, ',').tr(" ", ',').gsub(/'',/, '').delete(".").downcase.gsub(/,{2,}/, ',').split(",").uniq.join(",")
+    end
+  end
+
+  def create_json
+    filenames = parse_filenames_in_csv(@csv)
+    parsed_aliases = parse_aliases_in_csv(@csv)
+
+    sound_hash = {}
+    filenames.zip(parsed_aliases).each do |name, aliases|
+      sound_hash[name.to_s] = aliases
+    end
+
+    folder_path = ARGV[0]
+    convert_wav_to_mp3(folder_path)
+
+    sound_hash.each do |name, aliases|
+      Dir[folder_path + "/mp3_files/*"].each do |file_path|
+        regex = /^#{name}$/
+
+        if file_path.split('/')[-1].downcase =~ CORRUPTED_FILENAME_REGEX
+          raise "#{file_path.split('/')[-1].downcase} is corrupted with space/multiple underscores"
+        end
+
+        next unless file_path.split('/')[-1].downcase.match(regex)
+        raise "Aliase is corrupted with space/multiple commas/spaces/uppercase/dots: #{aliases}" if aliases =~ /(,{2,}|\s|[A-Z]|[.])/
+        aliases << ",category_#{file_path.split('/')[-3].downcase},noResale"
+        puts `./generateSoundMetadata.rb --aliases "#{aliases}" "#{file_path}"`
+      end
+    end
+  end
+end
+
+NewSoundAliasesMetadataBuilder.new(ARGV[1].to_s).create_json


### PR DESCRIPTION
- **What changed**:
  A new script: `autorun_generateSoundMetadata.rb` has been added.
 
- **Where it was added**:
   - Location: `code-dot-org/tools/scripts/autorun_generateSoundMetadata.rb`. 

- **Which parts of the site does this change affect**?  
   - This script is part of the process of updating the sound library manifest which affects the sound library dialog for App lab, Sprite Lab, and Game Lab. Once the script is run, the developer that uses that script will now have mp3 files and corresponding JSON on their local machine to upload to S3. 
   - The script is currently set up for the developer to enter the full path to the folder AND the csv file so that multiple sound files in that folder can be converted/used by generateSoundMetadata.rb. I uploaded the mp3 and JSON manually to S3 by going to AWS and clicking upload.
   - Steps: 
      - Download one folder from: [](https://www.dropbox.com/sh/xwwh3p2lgmg9mwr/AADft87sqhvWkduV_qsBxbFoa?dl=0) such as Achievements
      - Unzip Achievements folder in your ~/Downloads
      - Run `./autorun_generateSoundMetadata.rb ~/Downloads/Achievements ./sound_metadata.csv`
      - Script will create a folder called "mp3_files" which will hold all the mp3 files and corresponding JSONs
       - Go to cdo-sound-library in S3 -> click appropriate category folder (ex: category_achievements) -> upload all files under mp3_files 

- **Why are we making this change**?
   - The first PR [](https://github.com/code-dot-org/code-dot-org/pull/27199) in order to update the sound library manifest included the a script similar to this as well as the taglib-ruby gem but the drone test continued to fail. Brad mentioned that it is worth removing the gem and the script to pass the test and to only include the updated manifest. Thus, it was removed and the sound library was updated with all of the new changes applied to it.
   - However, for the next time that we update the sound library manifest, which isn't often, it will be helpful to have this script to have an automated process for updating the sound library. Thus one script that did the converting and the other script that autoran the generateSoundMetadata has been combined to this one script.
    - A test was written after the sound library was pushed with some corrupted filenames but the test logic is best placed in the script. It is because that allows the developer that is updating the manifest to catch corrupted filenames earlier than later after they push their PR and drone is testing whether or not there is a corrupted one which is time consuming.
 
- How I tested the script:
   - A lot of the original sound filenames were corrupted with spaces in between, underscores in the beginning and/or end of the filename, uppercases, multiple underscores instead of one in between words, and typos. All of the spaces, multiple underscores, underscores before and after, and uppercases were fixed and visible on my local machine after running this test. 
   - For the current filenames that are corrupted in the live site can be re-run by running this script on those files on a local machine. I am 95% confident that this script will fix corrupted filenames now.

- What's next?
  - One file was found with spaces still and it is live on the site. Ryan noted one file is fine to drop the live sound and upload the new file with the correct filename with underscores. So I will submit a PR for that soon.
   - If the script doesn't pass the drone test again, then we will have to end up adding some comments in the `generateSoundmetadata.rb` regarding instructions/precautions for the next developer that updates the sound library without a script.