### PR TITLE
Use default keyserver for mysql install

### DIFF
--- a/cookbooks/cdo-mysql/recipes/repo.rb
+++ b/cookbooks/cdo-mysql/recipes/repo.rb
@@ -3,6 +3,5 @@ apt_repository 'mysql' do
   distribution node['lsb']['codename']
   components ['mysql-5.7']
   key '5072E1F5'
-  keyserver 'pgp.mit.edu'
   retries 3
 end

--- a/cookbooks/cdo-mysql/recipes/repo.rb
+++ b/cookbooks/cdo-mysql/recipes/repo.rb
@@ -3,5 +3,6 @@ apt_repository 'mysql' do
   distribution node['lsb']['codename']
   components ['mysql-5.7']
   key '5072E1F5'
+  keyserver 'keyserver.ubuntu.com'
   retries 3
 end


### PR DESCRIPTION
When provisioning an adhoc environment our Chef recipe fetches a key from `pgp.mit.edu` to validate the signature on MySQL package.  This server is unreliable, and occasionally causes the build process to fail.  Switch to `keyserver.ubuntu.com`