### PR TITLE
Add school year to AP school identifier

### DIFF
--- a/dashboard/app/models/census/ap_school_code.rb
+++ b/dashboard/app/models/census/ap_school_code.rb
@@ -2,6 +2,7 @@
 #
 # Table name: ap_school_codes
 #
+#  school_year :integer          primary key
 #  school_code :string(6)        not null, primary key
 #  school_id   :string(12)       not null
 #  created_at  :datetime         not null

--- a/dashboard/app/models/census/ap_school_code.rb
+++ b/dashboard/app/models/census/ap_school_code.rb
@@ -10,8 +10,8 @@
 #
 # Indexes
 #
-#  index_ap_school_codes_on_school_code  (school_code) UNIQUE
-#  index_ap_school_codes_on_school_id    (school_id) UNIQUE
+#  fk_rails_08d2269647                                   (school_id)
+#  index_ap_school_codes_on_school_code_and_school_year  (school_code,school_year) UNIQUE
 #
 
 class Census::ApSchoolCode < ApplicationRecord

--- a/dashboard/db/migrate/20190320200540_add_school_year_to_ap_school_codes.rb
+++ b/dashboard/db/migrate/20190320200540_add_school_year_to_ap_school_codes.rb
@@ -1,0 +1,25 @@
+class AddSchoolYearToApSchoolCodes < ActiveRecord::Migration[5.0]
+  def up
+    add_column :ap_school_codes, :school_year, :integer, first: true
+
+    # Need to remove foreign key before index can be removed
+    # Readding foreign key once index is removed
+    remove_foreign_key :ap_school_codes, :schools
+    remove_index :ap_school_codes, :school_id
+    add_foreign_key :ap_school_codes, :schools
+
+    # New index created that is a composite
+    # of school code and school year
+    remove_index :ap_school_codes, :school_code
+    add_index :ap_school_codes, [:school_code, :school_year], unique: true
+  end
+
+  def down
+    remove_index :ap_school_codes, column: [:school_code, :school_year]
+
+    remove_column :ap_school_codes, :school_year
+
+    add_index :ap_school_codes, :school_code, unique: true
+    add_index :ap_school_codes, :school_id, unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190220233612) do
+ActiveRecord::Schema.define(version: 20190321174350) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -38,12 +38,13 @@ ActiveRecord::Schema.define(version: 20190220233612) do
   end
 
   create_table "ap_school_codes", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer  "school_year"
     t.string   "school_code", limit: 6,  null: false
     t.string   "school_id",   limit: 12, null: false
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
-    t.index ["school_code"], name: "index_ap_school_codes_on_school_code", unique: true, using: :btree
-    t.index ["school_id"], name: "index_ap_school_codes_on_school_id", unique: true, using: :btree
+    t.index ["school_code", "school_year"], name: "index_ap_school_codes_on_school_code_and_school_year", unique: true, using: :btree
+    t.index ["school_id"], name: "fk_rails_08d2269647", using: :btree
   end
 
   create_table "authentication_options", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190321174350) do
+ActiveRecord::Schema.define(version: 20190320200540) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"


### PR DESCRIPTION
Adds a new school year column to the `ap_school_codes` table to allow different mappings to exist between the College Board's school identifier (`school_code`) and the NCES school identifier (`school_id`) for each school year.

Follow-up PRs will a) backfill the existing rows (which are for the 2016-17 school year), b) modify model relationships to use the new composite `[school_code, school_year]` key, and c) add the new mapping for the 2017-18 school year.