### PR TITLE
Refactor Puma app-server hooks

### DIFF
--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -20,45 +20,14 @@ preload_app!
 stdout_redirect dashboard_dir('log', 'puma_stdout.log'), dashboard_dir('log', 'puma_stderr.log'), true
 directory deploy_dir('dashboard')
 
+require 'cdo/app_server_hooks'
 before_fork do
-  PEGASUS_DB.disconnect
-  DASHBOARD_DB.disconnect
   ActiveRecord::Base.connection_pool.disconnect!
-  Cdo::AppServerMetrics.instance&.spawn_reporting_task if defined?(Cdo::AppServerMetrics)
-
-  # Control automated restarts of web application server processes via Gatekeeper.
-  # NOTE: before_fork runs on the parent puma process, so complete restart of the web application services on all
-  # front end instances is required for a change of this Gatekeeper flag to take effect:
-  #   sudo service dashboard upgrade && sudo service pegasus upgrade
-  require 'dynamic_config/gatekeeper'
-  require 'dynamic_config/dcdo'
-  if Gatekeeper.allows('enableWebServiceProcessRollingRestart')
-    require 'puma_worker_killer'
-
-    restart_period = DCDO.get("web_service_process_restart_period", 12 * 3600) # default to 12 hours
-    PumaWorkerKiller.enable_rolling_restart(restart_period)
-  end
+  Cdo::AppServerHooks.before_fork
 end
 
 on_worker_boot do |_index|
-  require 'cdo/aws/metrics'
-  Cdo::Metrics.push(
-    'App Server',
-    [
-      {
-        metric_name: :WorkerBoot,
-        dimensions: [
-          {name: "Host", value: CDO.dashboard_hostname}
-        ],
-          value: 1
-      }
-    ]
-  )
-  ActiveRecord::Base.establish_connection
-  require 'dynamic_config/gatekeeper'
-  require 'dynamic_config/dcdo'
-  Gatekeeper.after_fork
-  DCDO.after_fork
+  Cdo::AppServerHooks.after_fork(host: CDO.dashboard_hostname)
 end
 
 require 'gctools/oobgc'

--- a/lib/cdo/app_server_hooks.rb
+++ b/lib/cdo/app_server_hooks.rb
@@ -1,0 +1,45 @@
+module Cdo
+  # Common app-server hook logic shared between multiple application entry-points
+  # (e.g., dashboard and pegasus).
+  module AppServerHooks
+    def self.before_fork
+      PEGASUS_DB.disconnect
+      DASHBOARD_DB.disconnect
+      Cdo::AppServerMetrics.instance&.spawn_reporting_task if defined?(Cdo::AppServerMetrics)
+
+      # Control automated restarts of web application server processes via Gatekeeper.
+      # NOTE: before_fork runs on the parent puma process, so complete restart of the web application services on all
+      # front end instances is required for a change of this Gatekeeper flag to take effect:
+      #   sudo service dashboard upgrade && sudo service pegasus upgrade
+      require 'dynamic_config/gatekeeper'
+      require 'dynamic_config/dcdo'
+      if Gatekeeper.allows('enableWebServiceProcessRollingRestart')
+        require 'puma_worker_killer'
+
+        restart_period = DCDO.get("web_service_process_restart_period", 12 * 3600) # default to 12 hours
+        PumaWorkerKiller.enable_rolling_restart(restart_period)
+      end
+    end
+
+    def self.after_fork(host:)
+      require 'cdo/aws/metrics'
+      Cdo::Metrics.push(
+        'App Server',
+        [
+          {
+            metric_name: :WorkerBoot,
+            dimensions: [
+              {name: "Host", value: host}
+            ],
+            value: 1
+          }
+        ]
+      )
+      ActiveRecord::Base.establish_connection
+      require 'dynamic_config/gatekeeper'
+      require 'dynamic_config/dcdo'
+      Gatekeeper.after_fork
+      DCDO.after_fork
+    end
+  end
+end

--- a/pegasus/config/puma.rb
+++ b/pegasus/config/puma.rb
@@ -21,43 +21,13 @@ preload_app!
 stdout_redirect pegasus_dir('log', 'puma_stdout.log'), pegasus_dir('log', 'puma_stderr.log'), true
 directory deploy_dir('pegasus')
 
+require 'cdo/app_server_hooks'
 before_fork do
-  PEGASUS_DB.disconnect
-  DASHBOARD_DB.disconnect
-  Cdo::AppServerMetrics.instance&.spawn_reporting_task if defined?(Cdo::AppServerMetrics)
-
-  # Control automated restarts of web application server processes via Gatekeeper.
-  # NOTE: before_fork runs on the parent puma process, so complete restart of the web application services on all
-  # front end instances is required for a change of this Gatekeeper flag to take effect:
-  #   sudo service dashboard upgrade && sudo service pegasus upgrade
-  require 'dynamic_config/gatekeeper'
-  require 'dynamic_config/dcdo'
-  if Gatekeeper.allows('enableWebServiceProcessRollingRestart')
-    require 'puma_worker_killer'
-
-    restart_period = DCDO.get("web_service_process_restart_period", 12 * 3600) # default to 12 hours
-    PumaWorkerKiller.enable_rolling_restart(restart_period)
-  end
+  Cdo::AppServerHooks.before_fork
 end
 
 on_worker_boot do |_index|
-  require 'cdo/aws/metrics'
-  Cdo::Metrics.push(
-    'App Server',
-    [
-      {
-        metric_name: :WorkerBoot,
-        dimensions: [
-          {name: "Host", value: CDO.pegasus_hostname}
-        ],
-        value: 1
-      }
-    ]
-  )
-  require 'dynamic_config/gatekeeper'
-  require 'dynamic_config/dcdo'
-  Gatekeeper.after_fork
-  DCDO.after_fork
+  Cdo::AppServerHooks.after_fork(host: CDO.pegasus_hostname)
 end
 
 require 'gctools/oobgc'


### PR DESCRIPTION
Small code-reuse change: move some Puma-hook code to `Cdo::AppServerHooks` methods for reuse across both pegasus and dashboard configuration.