### PR TITLE
Add Blockly reserved words for Dancelab

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -9,6 +9,7 @@ var dom = require('../dom');
 import DanceVisualizationColumn from './DanceVisualizationColumn';
 import Sounds from '../Sounds';
 import {TestResults} from '../constants';
+import {DancelabReservedWords} from './constants';
 import {DanceParty, ResourceLoader} from '@code-dot-org/dance-party';
 import danceMsg from './locale';
 import {
@@ -350,6 +351,7 @@ Dance.prototype.afterInject_ = function() {
         'levelFailure'
       ].join(',')
     );
+    Blockly.JavaScript.addReservedWords(DancelabReservedWords.join(','));
   }
 
   // record a replay log (and generate a video) for both project levels and any

--- a/apps/src/dance/constants.js
+++ b/apps/src/dance/constants.js
@@ -3,3 +3,28 @@ export const GAME_WIDTH = 400;
 
 /** @const {number} */
 export const GAME_HEIGHT = 400;
+
+export const DancelabReservedWords = [
+  'sprites',
+  'MOVES',
+  'QueueType',
+  'inputEvents',
+  'setupCallbacks',
+  'randomNumber',
+  'randomInt',
+  'getCueList',
+  'registerSetup',
+  'runUserSetup',
+  'runUserEvents',
+  'prioritySort',
+  'executeFuncs',
+  'whenSetup',
+  'whenSetupSong',
+  'ifDanceIs',
+  'whenKey',
+  'whenPeak',
+  'atTimestamp',
+  'everySeconds',
+  'everySecondsRange',
+  'everyVerseChorus'
+];


### PR DESCRIPTION
Add the function/variable names from Dancelab interpreted code to Blockly's reserved words list so that students can't inadvertently cause naming conflicts.