### PR TITLE
Account Deletion: Removing accounts by email removes poste data

### DIFF
--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -354,6 +354,7 @@ class DeleteAccountsHelper
 
     migrated_users.or(unmigrated_users).each {|u| purge_user u}
 
+    remove_poste_data(email)
     remove_from_pardot_by_email(email)
     clean_pegasus_forms_for_email(email)
   end


### PR DESCRIPTION
([FND-318](https://codedotorg.atlassian.net/browse/FND-318)) Specifically, removing accounts by email will remove poste data associated with that email address _even if_ there are no accounts associated with that email address - which is an important distinction
that came up this week.

I think this got missed when we originally implemented because we were so focused on the delete-by-account path that the delete-by-email path didn't get a lot of Deep Thought:tm:.