### PR TITLE
Remove setDangerouslyInnerHtml from ResourceCard

### DIFF
--- a/apps/src/sites/code.org/pages/public/educate/regional-partner/RegionalPartnerPlaybook.jsx
+++ b/apps/src/sites/code.org/pages/public/educate/regional-partner/RegionalPartnerPlaybook.jsx
@@ -7,7 +7,7 @@ const CARDS = [
   {
     title: 'Administrator and Counselor PD',
     description:
-      '* How-To Guide <br> * Set Your Agenda<br> * Logistics (Venue, Catering)<br> * Supplies & Resources',
+      '&bull; How-To Guide <br> &bull; Set Your Agenda<br> &bull; Logistics (Venue, Catering)<br> &bull; Supplies & Resources',
     link: '/educate/regional-partner/playbook/administrator'
   },
 
@@ -21,40 +21,42 @@ const CARDS = [
   {
     title: 'Communications and Branding',
     description:
-      '* Weekly Update Email Archive<br> * Code.org Comms to Teachers<br> * Workshop & Email Comms.<br> * Branding Guidelines',
+      '&bull; Weekly Update Email Archive<br> &bull; Code.org Comms to Teachers<br> &bull; Workshop & Email Comms.<br> &bull; Branding Guidelines',
     link: '/educate/regional-partner/playbook/communications'
   },
 
   {
     title: 'Community Building',
     description:
-      '* Resources & Ideas<br> * Community Events for Teachers<br> * CS Fair for Students',
+      '&bull; Resources & Ideas<br> &bull; Community Events for Teachers<br> &bull; CS Fair for Students',
     link: '/educate/regional-partner/playbook/community'
   },
 
   {
     title: 'Data',
-    description: '* Resources & Ideas<br> * How to use the data dashboard',
+    description:
+      '&bull; Resources & Ideas<br> &bull; How to use the data dashboard',
     link: '/educate/regional-partner/playbook/data'
   },
 
   {
     title: 'Facilitator Support',
     description:
-      '* 1-Pager & Contract Exemplars <br> * Facilitator Recruitment Resources <br> * Facilitator Support Resources <br>  * Facilitator Payments',
+      '&bull; 1-Pager & Contract Exemplars <br> &bull; Facilitator Recruitment Resources <br> &bull; Facilitator Support Resources <br>  &bull; Facilitator Payments',
     link: '/educate/regional-partner/playbook/facilitator-support'
   },
 
   {
     title: 'Fundraising Resources',
-    description: '* Organization Sustainability <br> * Fundraising Playbook',
+    description:
+      '&bull; Organization Sustainability <br> &bull; Fundraising Playbook',
     link: '/educate/regional-partner/playbook/funding'
   },
 
   {
     title: 'Ordering Supplies',
     description:
-      '* Accessing Mimeo <br> * How to Order Supplies <br> * Printable Certificates <br> * Admin/Counselor Supplies ',
+      '&bull; Accessing Mimeo <br> &bull; How to Order Supplies <br> &bull; Printable Certificates <br> &bull; Admin/Counselor Supplies ',
     link: '/educate/regional-partner/playbook/ordering-supplies'
   },
 
@@ -75,21 +77,21 @@ const CARDS = [
   {
     title: 'Reporting and Evaluations',
     description:
-      '* Annual Report Requirements<br> * Post Workshop Feedback Form<br> * Regional Partner Annual Planning',
+      '&bull; Annual Report Requirements<br> &bull; Post Workshop Feedback Form<br> &bull; Regional Partner Annual Planning',
     link: '/educate/regional-partner/playbook/reporting-and-evaluations'
   },
 
   {
     title: 'Teacher & District Recruitment',
     description:
-      '* How to recruit teachers and districts<br/> * Teacher applications',
+      '&bull; How to recruit teachers and districts<br/> &bull; Teacher applications',
     link: '/educate/regional-partner/playbook/teacher-recruitment'
   },
 
   {
     title: 'Teachers & Curriculum',
     description:
-      '* Info for Teacher Support<br> * Links to Online Curriculum <br> * Curriculum 1-pagers <br>',
+      '&bull; Info for Teacher Support<br> &bull; Links to Online Curriculum <br> &bull; Curriculum 1-pagers <br>',
     link: '/educate/regional-partner/playbook/curriculum'
   },
 

--- a/apps/src/sites/code.org/pages/public/educate/regional-partner/RegionalPartnerPlaybook.jsx
+++ b/apps/src/sites/code.org/pages/public/educate/regional-partner/RegionalPartnerPlaybook.jsx
@@ -137,7 +137,7 @@ export default class RegionalPartnerPlaybook extends Component {
             {...card}
             buttonText="Learn More"
             allowWrap={true}
-            allowDangerouslySetInnerHtml={true}
+            allowMarkdown={true}
           />
         ))}
       </ResourceCardResponsiveContainer>

--- a/apps/src/templates/studioHomepages/ResourceCard.jsx
+++ b/apps/src/templates/studioHomepages/ResourceCard.jsx
@@ -5,6 +5,8 @@ import Button from '../Button';
 import color from '../../util/color';
 import {connect} from 'react-redux';
 
+import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
+
 // If you want to include an image, you're probably looking for a ImageResourceCard.
 
 const styles = {
@@ -83,7 +85,7 @@ class ResourceCard extends Component {
     isRtl: PropTypes.bool.isRequired,
     responsiveSize: PropTypes.string.isRequired,
     allowWrap: PropTypes.bool,
-    allowDangerouslySetInnerHtml: PropTypes.bool,
+    allowMarkdown: PropTypes.bool,
     linkId: PropTypes.string,
     linkClass: PropTypes.string
   };
@@ -96,7 +98,7 @@ class ResourceCard extends Component {
       link,
       isRtl,
       allowWrap,
-      allowDangerouslySetInnerHtml,
+      allowMarkdown,
       linkId,
       linkClass,
       responsiveSize
@@ -122,22 +124,15 @@ class ResourceCard extends Component {
       titleStyles.push(styles.titleNoWrap);
     }
 
-    let descriptionContainer;
-    if (allowDangerouslySetInnerHtml) {
-      descriptionContainer = (
-        <div
-          style={descriptionStyles}
-          dangerouslySetInnerHTML={{__html: description}} // eslint-disable-line react/no-danger
-        />
-      );
-    } else {
-      descriptionContainer = <div style={descriptionStyles}>{description}</div>;
+    let descriptionContent = description;
+    if (allowMarkdown) {
+      descriptionContent = <UnsafeRenderedMarkdown markdown={description} />;
     }
 
     return (
       <div style={cardStyles}>
         <div style={titleStyles}>{title}</div>
-        {descriptionContainer}
+        <div style={descriptionStyles}>{descriptionContent}</div>;
         <br />
         <Button
           id={linkId}


### PR DESCRIPTION
Replace with UnsafeRenderedMarkdown, and update some content that had formerly been relying on the _absense_ of markdown formatting to work fine even with it.

Includes a very subtle visual change (an improvement, I'd argue):

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/54794652-b6fb9800-4c05-11e9-866f-fd80a5eadc0e.png) | ![image](https://user-images.githubusercontent.com/244100/54794648-b236e400-4c05-11e9-9098-bb3f1873aa10.png)
