### PR TITLE
PL: remove row from teacher application details

### DIFF
--- a/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
@@ -121,7 +121,6 @@ module Pd
         hispanic_or_latino_percent: 'Percentage of student enrollment by race: Hispanic or Latino',
         native_hawaiian_or_pacific_islander_percent: 'Percentage of student enrollment by race: Native Hawaiian or Pacific Islander',
         white_percent: 'Percentage of student enrollment by race: White',
-        two_or_more_races_percent: 'Percentage of student enrollment by race: Two or More Races',
         other_races_percent: 'Percentage of student enrollment by race: Other',
         principal_approval: "Do you approve of <Teacher Name> participating in Code.org's 2019-20 Professional Learning Program?",
         principal_plan_to_teach: 'Is <Teacher Name> planning to teach this course in the 2019-20 school year?',


### PR DESCRIPTION
This appears to only remove the row from the application details page (which is no longer needed, since we show this detail in a combined row instead), with no impact on the listing in the teacher application, the principal approval, or the downloadable CSV.

This is a followup to https://github.com/code-dot-org/code-dot-org/pull/27612