### PR TITLE
Delete unused empty string

### DIFF
--- a/pegasus/sites.v3/code.org/views/minecraft_2018.haml
+++ b/pegasus/sites.v3/code.org/views/minecraft_2018.haml
@@ -29,8 +29,6 @@
           .mc-tutorial-details
             %h2.mc-h1-second-box
               = I18n.t(:hoc2018_mc_aquatic_title)
-              %br/
-              = hoc_s(:hoc2018_minecraft_aquatic_title2)
             %p.mc-tutorial-description= I18n.t(:hoc2018_mc_short_description_shorter)
             %a{href: CDO.studio_url('/s/aquatic/reset')}
               %button.primary= I18n.t(:minecraft_agent_button)


### PR DESCRIPTION
This PR is a follow up to [PR# 27511](https://github.com/code-dot-org/code-dot-org/pull/27511). "Hoc2018_minecraft_aquatic_title2" is not defined anywhere in the code.  

### Before:
<img width="362" alt="Screen Shot 2019-03-22 at 2 16 14 PM" src="https://user-images.githubusercontent.com/30066710/54853421-182a7680-4cad-11e9-891b-b27fe21984f3.png">



### After:
<img width="360" alt="Screen Shot 2019-03-22 at 2 26 18 PM" src="https://user-images.githubusercontent.com/30066710/54853966-8b80b800-4cae-11e9-99c5-1f20bc62f4e3.png">

The removal of the line break does not affect the layout of the card.
