### PR TITLE
Fix 5XX on RegistrationsController#destroy when teacher has no email address

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -124,9 +124,11 @@ class RegistrationsController < Devise::RegistrationsController
     end
     dependent_students = current_user.dependent_students
     destroy_users(current_user, dependent_students)
-    TeacherMailer.delete_teacher_email(current_user, dependent_students).deliver_now if current_user.teacher?
+    if current_user.teacher? && current_user.email.present?
+      TeacherMailer.delete_teacher_email(current_user, dependent_students).deliver_now
+    end
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
-    return head :no_content
+    head :no_content
   end
 
   def sign_up_params

--- a/dashboard/test/controllers/registrations_controller/destroy_test.rb
+++ b/dashboard/test/controllers/registrations_controller/destroy_test.rb
@@ -156,9 +156,7 @@ module RegistrationsControllerTests
     end
 
     test "does not send email when teacher destroyed if teacher has no email" do
-      user = create :teacher, password: 'apassword'
-      user.update_primary_contact_info(new_email: "", new_hashed_email: "")
-      user.save(validate: false)
+      user = create :teacher, :without_email, password: 'apassword'
       refute user.valid?
       sign_in user
 

--- a/dashboard/test/controllers/registrations_controller/destroy_test.rb
+++ b/dashboard/test/controllers/registrations_controller/destroy_test.rb
@@ -154,5 +154,19 @@ module RegistrationsControllerTests
       assert_equal ['noreply@code.org'], mail.from
       assert_match 'Your account has been deleted', mail.body.encoded
     end
+
+    test "does not send email when teacher destroyed if teacher has no email" do
+      user = create :teacher, password: 'apassword'
+      user.update_primary_contact_info(new_email: "", new_hashed_email: "")
+      user.save(validate: false)
+      refute user.valid?
+      sign_in user
+
+      TeacherMailer.expects(:delete_teacher_email).never
+      assert_destroys(User) do
+        delete '/users', params: {password_confirmation: 'apassword'}
+      end
+      assert_equal 0, ActionMailer::Base.deliveries.length
+    end
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -170,6 +170,16 @@ FactoryGirl.define do
           create :single_user_experiment, min_user_id: teacher.id, name: evaluator.pilot_experiment
         end
       end
+
+      # We have some teacher records in our system that do not pass validation because they have
+      # no email address.  Sometimes we want to test against this case because we still want features
+      # to work for these teachers.
+      trait :without_email do
+        after(:create) do |user|
+          user.update_primary_contact_info new_email: '', new_hashed_email: ''
+          user.save validate: false
+        end
+      end
     end
 
     factory :student do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -144,12 +144,8 @@ class UserTest < ActiveSupport::TestCase
 
   # Test updating the school_info of an older user without an email address.
   test 'update_school_info with specific school overwrites user school info for user without email' do
-    user = create :teacher, :with_school_info
+    user = create :teacher, :without_email, :with_school_info
     new_school_info = create :school_info
-
-    user.update_primary_contact_info(new_email: "", new_hashed_email: "")
-    user.save(validate: false)
-    refute user.valid?
 
     user.update_school_info(new_school_info)
     assert_equal new_school_info, user.school_info


### PR DESCRIPTION
([FND-319](https://codedotorg.atlassian.net/browse/FND-319)) See Honeybadger Error https://app.honeybadger.io/projects/3240/faults/40564494.  Teacher accounts with no email address do not pass our model validations, but we still have some of them in the system.  This handles deletion of those accounts more gracefully.