### PR TITLE
Accounts: Account takeover edge cases

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -65,8 +65,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
 
     # Credential is already held by another user with activity
+    #   Or a student is trying to take over a teacher account
     # Display an error explaining that the credential is already in use.
-    if existing_credential_holder&.has_activity?
+    if existing_credential_holder&.has_activity? || (current_user.student? && existing_credential_holder&.teacher?)
       flash.alert = I18n.t('auth.already_in_use', provider: I18n.t("auth.#{provider}"))
       return redirect_to edit_user_registration_path
     end

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -42,6 +42,13 @@ module UsersHelper
         end
       end
 
+      # If both users are teachers, transfer ownership of sections
+      if source_user.teacher? && destination_user.teacher?
+        Section.where(user: source_user).each do |owned_section|
+          owned_section.update! user: destination_user
+        end
+      end
+
       source_user.destroy!
     end
 

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -13,7 +13,8 @@ module UsersHelper
   ACCT_TAKEOVER_OAUTH_TOKEN = 'clever_takeover_token'
   ACCT_TAKEOVER_FORCE_TAKEOVER = 'force_clever_takeover'
 
-  # Move followed sections from source_user to destination_user and destroy source_user.
+  # Move section membership and (for teachers) section ownership from source_user to
+  # destination_user and destroy source_user.
   # Returns a boolean - true if all steps were successful, false otherwise.
   def move_sections_and_destroy_source_user(source_user:, destination_user:, takeover_type:, provider:)
     # No-op if source_user is nil

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -36,10 +36,8 @@ module UsersHelper
 
     ActiveRecord::Base.transaction do
       # Move over sections that source_user follows
-      if destination_user.student?
-        Follower.where(student_user_id: source_user.id).each do |followed|
-          followed.update!(student_user_id: destination_user.id)
-        end
+      Follower.where(student_user_id: source_user.id).each do |followed|
+        followed.update!(student_user_id: destination_user.id)
       end
 
       # If both users are teachers, transfer ownership of sections

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1372,6 +1372,30 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     refute_includes section.students, other_user
   end
 
+  test "connect_provider: Teacher takeover of student transfers section enrollment" do
+    # Given I am a teacher
+    user = create :teacher
+
+    # And there exists a student
+    #   having credential X
+    #   and has no activity
+    other_user = create :student
+    credential = create :google_authentication_option, user: other_user
+    refute other_user.has_activity?
+    section = create :section
+    section.students << other_user
+
+    # When I add credential X
+    link_credential user,
+      type: credential.credential_type,
+      id: credential.authentication_id
+
+    # Then I should be enrolled in section Y instead of the other user
+    section.reload
+    assert_includes section.students, user
+    refute_includes section.students, other_user
+  end
+
   test "connect_provider: Successful takeover transfers ownership of sections" do
     # Given I am a teacher
     user = create :teacher

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1372,6 +1372,31 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     refute_includes section.students, other_user
   end
 
+  test "connect_provider: Successful takeover transfers ownership of sections" do
+    # Given I am a teacher
+    user = create :teacher
+
+    # And there exists another teacher
+    #   having credential X
+    #   and who owns section Y
+    #   and has no activity
+    other_user = create :teacher
+    credential = create :google_authentication_option, user: other_user
+    section = create :section, teacher: other_user
+    refute other_user.has_activity?
+
+    # When I add credential X
+    link_credential user,
+      type: credential.credential_type,
+      id: credential.authentication_id
+
+    # Then I should own section Y instead of the other user
+    section.reload
+    refute section.deleted?
+    assert_equal user, section.teacher
+    refute_equal other_user, section.teacher
+  end
+
   test "connect_provider: Refuses to link credential if there is an account with matching credential that has activity" do
     user = create :user
 


### PR DESCRIPTION
([FND-320](https://codedotorg.atlassian.net/browse/FND-320)) Implements three new account takeover edge cases:

**Teacher taking over another teacher account that has no progress but _does_ own sections**
```
Given I am a teacher
And there exists another teacher
  having credential X
  and having no activity
  and owning section Y
When I link credential X
Then the other teacher is destroyed
And I own section Y instead of the other teacher
```

**Teacher taking over a student account that has no progress but is enrolled in sections**
```
Given I am a teacher
And there exists a student
  having credential X
  and having no activity
  and enrolled in section Y
When I link credential X
Then the student is destroyed
And I am enrolled in section Y instead of the student
```

**Student taking over a teacher account that has no progress**
```
Given I am a student
And there exists a teacher
  having credential X
  and having no activity
When I link credential X
Then linking credential X fails with a message about it already being in use by another account.
```

I've captured these cases as tests and updated our implementation to match.