### PR TITLE
JotForm Monitoring: RenderJotFormView event

### DIFF
--- a/dashboard/app/controllers/pd/post_course_survey_controller.rb
+++ b/dashboard/app/controllers/pd/post_course_survey_controller.rb
@@ -28,6 +28,16 @@ module Pd
       @form_params = key_params.merge(
         submitRedirect: url_for(action: 'submit', params: {key: key_params})
       )
+
+      if CDO.newrelic_logging
+        NewRelic::Agent.record_custom_event(
+          "RenderJotFormView",
+          {
+            route: "GET /pd/post_course_survey/#{params[:course_initials]}",
+            form_id: @form_id
+          }
+        )
+      end
     end
 
     # POST /pd/post_course_survey/submit

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -69,6 +69,19 @@ module Pd
         regionalPartnerName: workshop.regional_partner&.name,
         submitRedirect: url_for(action: 'submit_general', params: {key: key_params})
       )
+
+      if CDO.newrelic_logging
+        NewRelic::Agent.record_custom_event(
+          "RenderJotFormView",
+          {
+            route: "GET /pd/workshop_survey/day/#{day}",
+            form_id: @form_id,
+            workshop_course: workshop.course,
+            workshop_subject: workshop.subject,
+            regional_partner_name: workshop.regional_partner&.name,
+          }
+        )
+      end
     end
 
     # POST /pd/workshop_survey/submit

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -152,6 +152,19 @@ module Pd
         numFacilitators: facilitators.size,
         submitRedirect: url_for(action: 'submit_facilitator', params: {key: key_params})
       )
+
+      if CDO.newrelic_logging
+        NewRelic::Agent.record_custom_event(
+          "RenderJotFormView",
+          {
+            route: "GET /pd/workshop_survey/facilitators/#{session.id}/#{facilitator_index}",
+            form_id: @form_id,
+            workshop_course: workshop.course,
+            workshop_subject: workshop.subject,
+            regional_partner_name: workshop.regional_partner&.name,
+          }
+        )
+      end
     end
 
     # POST /pd/workshop_survey/facilitators/submit

--- a/dashboard/test/controllers/pd/post_course_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/post_course_survey_controller_test.rb
@@ -1,0 +1,36 @@
+require_relative '../../../../shared/test/spy_newrelic_agent'
+require 'test_helper'
+module Pd
+  class PostCourseSurveyControllerTest < ActionDispatch::IntegrationTest
+    include WorkshopConstants
+
+    self.use_transactional_test_case = true
+
+    FAKE_FORM_ID = 123459
+
+    setup do
+      CDO.stubs(:jotform_forms).returns(
+        {
+          post_course: {
+            '2018-2019' => FAKE_FORM_ID
+          },
+        }.deep_stringify_keys
+      )
+    end
+
+    test 'post course survey reports render to New Relic' do
+      NewRelic::Agent.expects(:record_custom_event).with(
+        'RenderJotFormView',
+        {
+          route: "GET /pd/post_course_survey/csp",
+          form_id: PostCourseSurvey.form_id,
+        }
+      )
+      CDO.stubs(:newrelic_logging).returns(true)
+
+      sign_in create :teacher
+      get "/pd/post_course_survey/csp"
+      assert_response :success
+    end
+  end
+end

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -398,6 +398,27 @@ module Pd
       assert_response :success
     end
 
+    test 'facilitator specific survey reports render to New Relic' do
+      NewRelic::Agent.expects(:record_custom_event).with(
+        'RenderJotFormView',
+        {
+          route: "GET /pd/workshop_survey/facilitators/#{@summer_workshop.sessions[0].id}/0",
+          form_id: FAKE_FACILITATOR_FORM_ID,
+          workshop_course: COURSE_CSP,
+          workshop_subject: SUBJECT_TEACHER_CON,
+          regional_partner_name: @regional_partner.name
+        }
+      )
+
+      CDO.stubs(:newrelic_logging).returns(true)
+
+      Session.any_instance.expects(:open_for_attendance?).returns(true)
+      create :pd_attendance, session: @summer_workshop.sessions[0], teacher: @enrolled_summer_teacher, enrollment: @summer_enrollment
+      sign_in @enrolled_summer_teacher
+      get "/pd/workshop_survey/facilitators/#{@summer_workshop.sessions[0].id}/0"
+      assert_response :success
+    end
+
     test 'facilitator specific submit redirect creates placeholder and redirects to next facilitator form' do
       sign_in @enrolled_summer_teacher
 

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -1,3 +1,4 @@
+require_relative '../../../../shared/test/spy_newrelic_agent'
 require 'test_helper'
 
 module Pd
@@ -114,6 +115,24 @@ module Pd
         }
       )
 
+      sign_in @enrolled_summer_teacher
+      get '/pd/workshop_survey/day/0'
+      assert_response :success
+    end
+
+    test 'pre-workshop survey reports render to New Relic' do
+      NewRelic::Agent.expects(:record_custom_event).with(
+        'RenderJotFormView',
+        {
+          route: 'GET /pd/workshop_survey/day/0',
+          form_id: FAKE_DAILY_FORM_IDS[0],
+          workshop_course: COURSE_CSP,
+          workshop_subject: SUBJECT_TEACHER_CON,
+          regional_partner_name: @regional_partner.name
+        }
+      )
+
+      CDO.stubs(:newrelic_logging).returns(true)
       sign_in @enrolled_summer_teacher
       get '/pd/workshop_survey/day/0'
       assert_response :success


### PR DESCRIPTION
([PLC-10](https://codedotorg.atlassian.net/browse/PLC-10)) We've had a number of reports of errors or blank pages when clicking on survey links.  This PR is the first of several to instrument some monitoring around loading JotForm surveys, in an effort to understand and prevent these errors.

In particular, we're adding a custom New Relic event, `RenderJotFormView`, fired by the server right before rendering any view that embeds JotForm.  I strongly suspect this won't be sufficient to detect any issues (in all cases, the view itself seems to appear just fine) but it'll be a useful baseline for JotForm loads we expect to succeed, and we'll be able to cross-reference it within New Relic later.

**Next steps:** I'm planning to inject a bit of JavaScript into these views that watches for the JotForm script to embed its iframe into the DOM, hopefully also follows the loading process within that iframe, and  reports success rates and timing back to New Relic from the client.

Other steps I'm considering:
- I wonder if there's any way to wrap and report JavaScript errors happening within the iframe, or maybe to segment New Relic JS error reports to these routes.  Likewise any ability to monitor network traffic from the client to particular domains.
- Adding some kind of loading spinner or other content to the otherwise blank pages to prompt users to retry, or report to us more consistently when something goes wrong.
- I think some of the problem cases may involve the fairly complex redirect-on-submit logic we use to direct teachers between forms, wondering if I can instrument for that case specifically, perhaps with a session history.
- We pass a lot of queryparams to JotForm and I wonder if we sometimes pass something badly formed that causes problems on their end (there's already a weird edge case around the plus sign).  Checking that we're properly urlencoding everything would be good.  I'm not dumping all of the queryparams into New Relic yet since they include PII, but that's a possible future investigation.