### PR TITLE
Announcements: PL 2019 nomination trophy -> normal

### DIFF
--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -219,29 +219,6 @@ export class SpecialAnnouncementActionBlock extends Component {
   };
 
   render() {
-    const imageExtra = (
-      <div>
-        <img
-          className="sparkle sparkle1"
-          src={pegasus(
-            '/images/homepage/professional-learning-2019-trophy-sparkle.svg'
-          )}
-        />
-        <img
-          className="sparkle sparkle2"
-          src={pegasus(
-            '/images/homepage/professional-learning-2019-trophy-sparkle.svg'
-          )}
-        />
-        <img
-          className="sparkle sparkle3"
-          src={pegasus(
-            '/images/homepage/professional-learning-2019-trophy-sparkle.svg'
-          )}
-        />
-      </div>
-    );
-
     return !!this.props.hasIncompleteApplication ? (
       <TwoColumnActionBlock
         id="teacher-application-continue-announcement"
@@ -268,18 +245,17 @@ export class SpecialAnnouncementActionBlock extends Component {
       <TwoColumnActionBlock
         id="teacher-nomination-announcement"
         imageUrl={pegasus(
-          '/shared/images/fill-540x289/teacher-announcement/professional-learning-2019-trophy.jpg'
+          '/shared/images/fill-540x289/teacher-announcement/professional-learning-2019-3.jpg'
         )}
-        imageExtra={imageExtra}
-        teacherStyle={true}
-        subHeading={i18n.specialAnnouncementHeadingJoinProfessionalLearning2019Trophy()}
-        subHeadingSmallFont={false}
-        description={i18n.specialAnnouncementDescriptionJoinProfessionalLearning2019Trophy()}
+        subHeading={i18n.specialAnnouncementHeadingJoinProfessionalLearning2019()}
+        subHeadingSmallFont={true}
+        description={i18n.specialAnnouncementDescriptionJoinProfessionalLearning2019()}
+        imageExtra={false}
+        teacherStyle={false}
         buttons={[
           {
-            id: 'teacher-nomination-button',
-            url: pegasus('/nominate'),
-            text: i18n.nominateATeacher()
+            url: pegasus('/educate/professional-learning'),
+            text: i18n.joinUs()
           }
         ]}
       />

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -243,7 +243,7 @@ export class SpecialAnnouncementActionBlock extends Component {
       />
     ) : (
       <TwoColumnActionBlock
-        id="teacher-nomination-announcement"
+        id="teacher-application-announcement"
         imageUrl={pegasus(
           '/shared/images/fill-540x289/teacher-announcement/professional-learning-2019-3.jpg'
         )}
@@ -254,6 +254,7 @@ export class SpecialAnnouncementActionBlock extends Component {
         teacherStyle={false}
         buttons={[
           {
+            id: 'teacher-application-join-button',
             url: pegasus('/educate/professional-learning'),
             text: i18n.joinUs()
           }

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -25,7 +25,7 @@ style_min: true
   - if request.language == "en"
     = view :curriculum_banner
     = view :homepage_below_hero_announcement
-    = view :homepage_below_hero_trophy_banner
+    = view :homepage_below_hero_plane_banner
     = view :stats_homepage
   - else
     = view :homepage_below_hero_announcement


### PR DESCRIPTION
Go from the temporary nomination anouncement (trophy with sparkles) back to the normal profesional leaning 2019 announcement, on code.org/, code.org/yourschool, and teacher /home.

### teacher /home & /yourschool
![Screenshot 2019-03-25 07 59 59](https://user-images.githubusercontent.com/2205926/54931209-cdd80e00-4ed5-11e9-815f-b8dd2fb67360.png)

### code.org/
![Screenshot 2019-03-25 08 08 17](https://user-images.githubusercontent.com/2205926/54931210-cdd80e00-4ed5-11e9-91ef-3087522f2b39.png)
