### PR TITLE
Restore applab themes

### DIFF
--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -2,6 +2,7 @@ import ChartApi from './ChartApi';
 import EventSandboxer from './EventSandboxer';
 import sanitizeHtml from './sanitizeHtml';
 import * as utils from '../utils';
+import experiments from '../util/experiments';
 import elementLibrary from './designElements/library';
 import * as elementUtils from './designElements/elementUtils';
 import * as setPropertyDropdown from './setPropertyDropdown';
@@ -198,11 +199,16 @@ applabCommands.button = function(opts) {
   var textNode = document.createTextNode(opts.text);
   newButton.id = opts.elementId;
   newButton.style.position = 'relative';
-  newButton.style.color = color.white;
-  newButton.style.backgroundColor = color.applab_button_teal;
   newButton.style.fontSize = defaultFontSizeStyle;
   newButton.style.fontFamily = fontFamilyStyles[0];
-  elementUtils.setDefaultBorderStyles(newButton, {forceDefaults: true});
+  if (experiments.isEnabled('applabThemes')) {
+    newButton.style.borderStyle = 'solid';
+    elementLibrary.applyCurrentTheme(newButton, Applab.activeScreen());
+  } else {
+    newButton.style.color = color.white;
+    newButton.style.backgroundColor = color.applab_button_teal;
+    elementUtils.setDefaultBorderStyles(newButton, {forceDefaults: true});
+  }
 
   return Boolean(
     newButton.appendChild(textNode) &&
@@ -907,10 +913,15 @@ applabCommands.textInput = function(opts) {
   newInput.style.fontFamily = fontFamilyStyles[0];
   newInput.style.height = '30px';
   newInput.style.width = '200px';
-  elementUtils.setDefaultBorderStyles(newInput, {
-    forceDefaults: true,
-    textInput: true
-  });
+  if (experiments.isEnabled('applabThemes')) {
+    newInput.style.borderStyle = 'solid';
+    elementLibrary.applyCurrentTheme(newInput, Applab.activeScreen());
+  } else {
+    elementUtils.setDefaultBorderStyles(newInput, {
+      forceDefaults: true,
+      textInput: true
+    });
+  }
 
   return Boolean(Applab.activeScreen().appendChild(newInput));
 };
@@ -929,7 +940,12 @@ applabCommands.textLabel = function(opts) {
   newLabel.style.position = 'relative';
   newLabel.style.fontSize = defaultFontSizeStyle;
   newLabel.style.fontFamily = fontFamilyStyles[0];
-  elementUtils.setDefaultBorderStyles(newLabel, {forceDefaults: true});
+  if (experiments.isEnabled('applabThemes')) {
+    newLabel.style.borderStyle = 'solid';
+    elementLibrary.applyCurrentTheme(newLabel, Applab.activeScreen());
+  } else {
+    elementUtils.setDefaultBorderStyles(newLabel, {forceDefaults: true});
+  }
   var forElement = document.getElementById(opts.forId);
   if (forElement && Applab.activeScreen().contains(forElement)) {
     newLabel.setAttribute('for', opts.forId);
@@ -994,9 +1010,19 @@ applabCommands.dropdown = function(opts) {
   newSelect.style.position = 'relative';
   newSelect.style.fontSize = defaultFontSizeStyle;
   newSelect.style.fontFamily = fontFamilyStyles[0];
-  newSelect.style.color = color.white;
-  newSelect.style.backgroundColor = color.applab_button_teal;
-  elementUtils.setDefaultBorderStyles(newSelect, {forceDefaults: true});
+  if (experiments.isEnabled('applabThemes')) {
+    newSelect.style.borderStyle = 'solid';
+    elementLibrary.applyCurrentTheme(newSelect, Applab.activeScreen());
+  } else {
+    newSelect.style.color = color.white;
+    elementLibrary.typeSpecificPropertyChange(
+      newSelect,
+      'textColor',
+      newSelect.style.color
+    );
+    newSelect.style.backgroundColor = color.applab_button_teal;
+    elementUtils.setDefaultBorderStyles(newSelect, {forceDefaults: true});
+  }
 
   return Boolean(Applab.activeScreen().appendChild(newSelect));
 };

--- a/apps/src/applab/constants.js
+++ b/apps/src/applab/constants.js
@@ -18,6 +18,14 @@ export const CAPTURE_TICK_COUNT = 300;
 
 export const defaultFontSizeStyle = '14px';
 
+export const themeOptions = ['classic', 'dark'];
+
+export const themeDisplayNames = ['Classic', 'Dark'];
+
+if (themeOptions.length !== themeDisplayNames.length) {
+  throw new Error('themeOptions length must equal themeDisplayNames length');
+}
+
 export const fontFamilyOptions = [
   'Arial',
   'Georgia',

--- a/apps/src/applab/designElements/ColorPickerPropertyRow.jsx
+++ b/apps/src/applab/designElements/ColorPickerPropertyRow.jsx
@@ -24,6 +24,15 @@ export default class ColorPickerPropertyRow extends React.Component {
     window.removeEventListener('mousedown', this.handlePageClick);
   }
 
+  componentWillReceiveProps(nextProps) {
+    const {initialValue} = nextProps;
+    if (this.props.initialValue !== initialValue) {
+      this.setState({
+        value: initialValue
+      });
+    }
+  }
+
   handlePageClick = e => {
     if (e.target === ReactDOM.findDOMNode(this.refs.button)) {
       return;

--- a/apps/src/applab/designElements/EnumPropertyRow.jsx
+++ b/apps/src/applab/designElements/EnumPropertyRow.jsx
@@ -5,6 +5,7 @@ import * as rowStyle from './rowStyle';
 export default class EnumPropertyRow extends React.Component {
   static propTypes = {
     initialValue: PropTypes.string.isRequired,
+    displayOptions: PropTypes.arrayOf(PropTypes.string),
     options: PropTypes.arrayOf(PropTypes.string).isRequired,
     handleChange: PropTypes.func.isRequired,
     desc: PropTypes.node
@@ -20,23 +21,26 @@ export default class EnumPropertyRow extends React.Component {
   };
 
   render() {
-    let options = this.props.options.map(function(option, index) {
+    const {options, displayOptions = [], desc} = this.props;
+    const {selectedValue} = this.state;
+
+    const renderedOptions = options.map(function(option, index) {
       return (
         <option key={index} value={option}>
-          {option}
+          {displayOptions[index] || option}
         </option>
       );
     });
     return (
       <div style={rowStyle.container}>
-        <div style={rowStyle.description}>{this.props.desc}</div>
+        <div style={rowStyle.description}>{desc}</div>
         <select
           className="form-control"
           style={rowStyle.enumInput}
-          value={this.state.selectedValue}
+          value={selectedValue}
           onChange={this.handleChange}
         >
-          {options}
+          {renderedOptions}
         </select>
       </div>
     );

--- a/apps/src/applab/designElements/ThemePropertyRow.jsx
+++ b/apps/src/applab/designElements/ThemePropertyRow.jsx
@@ -1,0 +1,11 @@
+import EnumPropertyRow from './EnumPropertyRow';
+import {themeDisplayNames, themeOptions} from '../constants';
+
+export default class ThemePropertyRow extends EnumPropertyRow {
+  static defaultProps = {
+    desc: 'theme',
+    displayOptions: themeDisplayNames,
+    initialValue: themeOptions[0],
+    options: themeOptions
+  };
+}

--- a/apps/src/applab/designElements/button.jsx
+++ b/apps/src/applab/designElements/button.jsx
@@ -19,6 +19,8 @@ import {
 } from '../constants';
 import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
+import elementLibrary from './library';
+import experiments from '../../util/experiments';
 
 class ButtonProperties extends React.Component {
   static propTypes = {
@@ -203,6 +205,31 @@ class ButtonEvents extends React.Component {
 export default {
   PropertyTab: ButtonProperties,
   EventTab: ButtonEvents,
+  themeValues: {
+    backgroundColor: {
+      type: 'color',
+      classic: color.applab_button_teal,
+      dark: color.yellow
+    },
+    borderRadius: {
+      classic: 0,
+      dark: 10
+    },
+    borderWidth: {
+      classic: 0,
+      dark: 0
+    },
+    borderColor: {
+      type: 'color',
+      classic: color.black,
+      dark: color.white
+    },
+    textColor: {
+      type: 'color',
+      classic: color.white,
+      dark: color.black
+    }
+  },
   create: function() {
     const element = document.createElement('button');
     element.appendChild(document.createTextNode('Button'));
@@ -212,9 +239,14 @@ export default {
     element.style.width = '80px';
     element.style.fontFamily = fontFamilyStyles[0];
     element.style.fontSize = defaultFontSizeStyle;
-    elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
-    element.style.color = color.white;
-    element.style.backgroundColor = color.applab_button_teal;
+    if (experiments.isEnabled('applabThemes')) {
+      element.style.borderStyle = 'solid';
+      elementLibrary.applyCurrentTheme(element, designMode.activeScreen());
+    } else {
+      elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
+      element.style.color = color.white;
+      element.style.backgroundColor = color.applab_button_teal;
+    }
 
     return element;
   },

--- a/apps/src/applab/designElements/dropdown.jsx
+++ b/apps/src/applab/designElements/dropdown.jsx
@@ -15,6 +15,9 @@ import FontFamilyPropertyRow from './FontFamilyPropertyRow';
 import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import {defaultFontSizeStyle, fontFamilyStyles} from '../constants';
+import elementLibrary from './library';
+import RGBColor from 'rgbcolor';
+import experiments from '../../util/experiments';
 
 class DropdownProperties extends React.Component {
   static propTypes = {
@@ -180,9 +183,39 @@ class DropdownEvents extends React.Component {
   }
 }
 
+const svgArrowUrl = color =>
+  `url(data:image/svg+xml;charset=US-ASCII,${encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 448" enable-background="new 0 0 256 448"><style type="text/css">.arrow{fill:${color};}</style><path class="arrow" d="M255.9 168c0-4.2-1.6-7.9-4.8-11.2-3.2-3.2-6.9-4.8-11.2-4.8H16c-4.2 0-7.9 1.6-11.2 4.8S0 163.8 0 168c0 4.4 1.6 8.2 4.8 11.4l112 112c3.1 3.1 6.8 4.6 11.2 4.6 4.4 0 8.2-1.5 11.4-4.6l112-112c3-3.2 4.5-7 4.5-11.4z"/></svg>`
+  )})`;
+
 export default {
   PropertyTab: DropdownProperties,
   EventTab: DropdownEvents,
+  themeValues: {
+    backgroundColor: {
+      type: 'color',
+      classic: color.applab_button_teal,
+      dark: color.yellow
+    },
+    borderRadius: {
+      classic: 0,
+      dark: 10
+    },
+    borderWidth: {
+      classic: 0,
+      dark: 0
+    },
+    borderColor: {
+      type: 'color',
+      classic: color.black,
+      dark: color.white
+    },
+    textColor: {
+      type: 'color',
+      classic: color.white,
+      dark: color.black
+    }
+  },
 
   create: function() {
     const element = document.createElement('select');
@@ -191,9 +224,17 @@ export default {
     element.style.fontFamily = fontFamilyStyles[0];
     element.style.fontSize = defaultFontSizeStyle;
     element.style.margin = '0';
-    element.style.color = color.white;
-    element.style.backgroundColor = color.applab_button_teal;
-    elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
+    if (experiments.isEnabled('applabThemes')) {
+      element.style.borderStyle = 'solid';
+      elementLibrary.applyCurrentTheme(element, designMode.activeScreen());
+    } else {
+      element.style.color = color.white;
+      element.style.backgroundImage = svgArrowUrl(
+        new RGBColor(element.style.color).toHex()
+      );
+      element.style.backgroundColor = color.applab_button_teal;
+      elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
+    }
 
     const option1 = document.createElement('option');
     option1.innerHTML = 'Option 1';
@@ -231,6 +272,11 @@ export default {
       case 'text':
         // Overrides generic text setter and sets from the dropdown options
         element.value = value;
+        break;
+      case 'textColor':
+        element.style.backgroundImage = svgArrowUrl(
+          new RGBColor(element.style.color).toHex()
+        );
         break;
       case 'index':
         element.selectedIndex = value;

--- a/apps/src/applab/designElements/dropdown.jsx
+++ b/apps/src/applab/designElements/dropdown.jsx
@@ -252,6 +252,12 @@ export default {
     elementUtils.setDefaultBorderStyles(element);
     // Set the font family for older projects that didn't set them on create:
     elementUtils.setDefaultFontFamilyStyle(element);
+    // Set the dropdown SVG for older projects that didn't have them:
+    if (!element.style.backgroundImage) {
+      element.style.backgroundImage = svgArrowUrl(
+        new RGBColor(element.style.color).toHex()
+      );
+    }
 
     // In the future we may want to trigger this on focus events as well.
     $(element).on('mousedown', function(e) {

--- a/apps/src/applab/designElements/label.jsx
+++ b/apps/src/applab/designElements/label.jsx
@@ -14,6 +14,9 @@ import * as applabConstants from '../constants';
 import * as elementUtils from './elementUtils';
 import * as gridUtils from '../gridUtils';
 import designMode from '../designMode';
+import color from '../../util/color';
+import elementLibrary from './library';
+import experiments from '../../util/experiments';
 
 class LabelProperties extends React.Component {
   static propTypes = {
@@ -191,6 +194,26 @@ const STILL_FITS = 5;
 export default {
   PropertyTab: LabelProperties,
   EventTab: LabelEvents,
+  themeValues: {
+    borderRadius: {
+      classic: 0,
+      dark: 10
+    },
+    borderWidth: {
+      classic: 0,
+      dark: 0
+    },
+    borderColor: {
+      type: 'color',
+      classic: color.text_input_default_border_color,
+      dark: color.applab_dark_border
+    },
+    textColor: {
+      type: 'color',
+      classic: color.default_text,
+      dark: color.white
+    }
+  },
 
   create: function() {
     const element = document.createElement('label');
@@ -202,10 +225,15 @@ export default {
     element.style.overflow = 'hidden';
     element.style.wordWrap = 'break-word';
     element.textContent = 'text';
-    element.style.color = '#333333';
     element.style.backgroundColor = '';
     element.style.maxWidth = applabConstants.APP_WIDTH + 'px';
-    elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
+    if (experiments.isEnabled('applabThemes')) {
+      element.style.borderStyle = 'solid';
+      elementLibrary.applyCurrentTheme(element, designMode.activeScreen());
+    } else {
+      element.style.color = '#333333';
+      elementUtils.setDefaultBorderStyles(element, {forceDefaults: true});
+    }
 
     this.resizeToFitText(element);
     return element;

--- a/apps/src/applab/designElements/library.js
+++ b/apps/src/applab/designElements/library.js
@@ -1,7 +1,8 @@
 import $ from 'jquery';
 import * as utils from '../../utils';
 import * as elementUtils from './elementUtils';
-
+import designMode from '../designMode';
+import {themeOptions} from '../constants';
 /**
  * A map from prefix to the next numerical suffix to try to
  * use as an id in the applab app's DOM.
@@ -157,6 +158,27 @@ export default {
       return null;
     }
     throw new Error('unknown element type');
+  },
+
+  /**
+   * Gets the theme values for this element type (if specified).
+   */
+  getThemeValues: function(element) {
+    const elementType = this.getElementType(element);
+    const {themeValues} = elements[elementType] || {};
+    return themeValues;
+  },
+
+  applyCurrentTheme: function(element, parentScreen) {
+    const currentTheme = parentScreen
+      ? parentScreen.getAttribute('data-theme')
+      : themeOptions[0];
+    const themeValues = this.getThemeValues(element);
+    for (const propName in themeValues) {
+      const propTheme = themeValues[propName];
+      const defaultValue = propTheme[currentTheme];
+      designMode.updateProperty(element, propName, defaultValue);
+    }
   },
 
   /**

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -3,11 +3,16 @@ import React from 'react';
 import PropertyRow from './PropertyRow';
 import ColorPickerPropertyRow from './ColorPickerPropertyRow';
 import ImagePickerPropertyRow from './ImagePickerPropertyRow';
+import ThemePropertyRow from './ThemePropertyRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import DefaultScreenButtonPropertyRow from './DefaultScreenButtonPropertyRow';
+import designMode from '../designMode';
+import elementLibrary from './library';
 import * as applabConstants from '../constants';
 import * as elementUtils from './elementUtils';
+import color from '../../util/color';
+import experiments from '../../util/experiments';
 
 class ScreenProperties extends React.Component {
   static propTypes = {
@@ -48,6 +53,12 @@ class ScreenProperties extends React.Component {
           handleChange={this.props.handleChange.bind(this, 'id')}
           isIdRow={true}
         />
+        {experiments.isEnabled('applabThemes') && (
+          <ThemePropertyRow
+            initialValue={element.getAttribute('data-theme')}
+            handleChange={this.props.handleChange.bind(this, 'theme')}
+          />
+        )}
         <ColorPickerPropertyRow
           desc={'background color'}
           initialValue={elementUtils.rgb2hex(element.style.backgroundColor)}
@@ -142,6 +153,13 @@ class ScreenEvents extends React.Component {
 export default {
   PropertyTab: ScreenProperties,
   EventTab: ScreenEvents,
+  themeValues: {
+    backgroundColor: {
+      type: 'color',
+      classic: color.white,
+      dark: color.black
+    }
+  },
 
   create: function() {
     const element = document.createElement('div');
@@ -160,6 +178,10 @@ export default {
     // see http://philipwalton.com/articles/what-no-one-told-you-about-z-index/
     element.style.position = 'absolute';
     element.style.zIndex = 0;
+    if (experiments.isEnabled('applabThemes')) {
+      element.setAttribute('data-theme', applabConstants.themeOptions[0]);
+      elementLibrary.applyCurrentTheme(element, element);
+    }
 
     return element;
   },
@@ -171,7 +193,47 @@ export default {
     // Properly position existing screens, so that canvases appear correctly.
     element.style.position = 'absolute';
     element.style.zIndex = 0;
-
     element.setAttribute('tabIndex', '1');
+
+    if (experiments.isEnabled('applabThemes')) {
+      if (!element.getAttribute('data-theme')) {
+        element.setAttribute('data-theme', applabConstants.themeOptions[0]);
+      }
+
+      if (element.style.backgroundColor === '') {
+        element.style.backgroundColor = this.themeValues.backgroundColor[
+          applabConstants.themeOptions[0]
+        ];
+      }
+    }
+  },
+  readProperty: function(element, name) {
+    switch (name) {
+      case 'theme':
+        if (experiments.isEnabled('applabThemes')) {
+          return element.getAttribute('data-theme');
+        } else {
+          throw `unknown property name ${name}`;
+        }
+      default:
+        throw `unknown property name ${name}`;
+    }
+  },
+  onPropertyChange: function(element, name, value) {
+    if (experiments.isEnabled('applabThemes')) {
+      switch (name) {
+        case 'theme': {
+          const prevValue =
+            element.getAttribute('data-theme') ||
+            applabConstants.themeOptions[0];
+          element.setAttribute('data-theme', value);
+          designMode.changeThemeForCurrentScreen(prevValue, value);
+          return true;
+        }
+        default:
+          break;
+      }
+    }
+    return false;
   }
 };

--- a/apps/src/applab/designElements/textInput.jsx
+++ b/apps/src/applab/designElements/textInput.jsx
@@ -12,7 +12,14 @@ import FontFamilyPropertyRow from './FontFamilyPropertyRow';
 import BorderProperties from './BorderProperties';
 import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
-import {defaultFontSizeStyle, fontFamilyStyles} from '../constants';
+import {
+  defaultFontSizeStyle,
+  fontFamilyStyles,
+  themeOptions
+} from '../constants';
+import color from '../../util/color';
+import elementLibrary from './library';
+import experiments from '../../util/experiments';
 
 class TextInputProperties extends React.Component {
   static propTypes = {
@@ -201,6 +208,31 @@ class TextInputEvents extends React.Component {
 export default {
   PropertyTab: TextInputProperties,
   EventTab: TextInputEvents,
+  themeValues: {
+    backgroundColor: {
+      type: 'color',
+      classic: color.white,
+      dark: color.applab_dark_background
+    },
+    borderRadius: {
+      classic: 0,
+      dark: 10
+    },
+    borderWidth: {
+      classic: 1,
+      dark: 1
+    },
+    borderColor: {
+      type: 'color',
+      classic: color.text_input_default_border_color,
+      dark: color.applab_dark_border
+    },
+    textColor: {
+      type: 'color',
+      classic: color.black,
+      dark: color.white
+    }
+  },
 
   create: function() {
     const element = document.createElement('input');
@@ -209,12 +241,17 @@ export default {
     element.style.height = '30px';
     element.style.fontFamily = fontFamilyStyles[0];
     element.style.fontSize = defaultFontSizeStyle;
-    element.style.color = '#000000';
-    element.style.backgroundColor = '';
-    elementUtils.setDefaultBorderStyles(element, {
-      forceDefaults: true,
-      textInput: true
-    });
+    if (experiments.isEnabled('applabThemes')) {
+      element.style.borderStyle = 'solid';
+      elementLibrary.applyCurrentTheme(element, designMode.activeScreen());
+    } else {
+      element.style.color = '#000000';
+      element.style.backgroundColor = '';
+      elementUtils.setDefaultBorderStyles(element, {
+        forceDefaults: true,
+        textInput: true
+      });
+    }
 
     return element;
   },
@@ -222,8 +259,16 @@ export default {
   onDeserialize: function(element) {
     // Set border styles for older projects that didn't set them on create:
     elementUtils.setDefaultBorderStyles(element, {textInput: true});
-    // Set the font family for older projects that didn't set them on create:
+    // Set the font family for older projects that didn't set it on create:
     elementUtils.setDefaultFontFamilyStyle(element);
+    if (experiments.isEnabled('applabThemes')) {
+      // Set the background color for older projects that didn't set it on create:
+      if (element.style.backgroundColor === '') {
+        element.style.backgroundColor = this.themeValues.backgroundColor[
+          themeOptions[0]
+        ];
+      }
+    }
 
     $(element).on('mousedown', function(e) {
       if (!Applab.isRunning()) {

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -14,6 +14,9 @@ import * as elementUtils from './elementUtils';
 import EnumPropertyRow from './EnumPropertyRow';
 import designMode from '../designMode';
 import {defaultFontSizeStyle, fontFamilyStyles} from '../constants';
+import color from '../../util/color';
+import elementLibrary from './library';
+import experiments from '../../util/experiments';
 
 class TextAreaProperties extends React.Component {
   static propTypes = {
@@ -192,6 +195,31 @@ class TextAreaEvents extends React.Component {
 export default {
   PropertyTab: TextAreaProperties,
   EventTab: TextAreaEvents,
+  themeValues: {
+    backgroundColor: {
+      type: 'color',
+      classic: color.white,
+      dark: color.applab_dark_background
+    },
+    borderRadius: {
+      classic: 0,
+      dark: 10
+    },
+    borderWidth: {
+      classic: 1,
+      dark: 1
+    },
+    borderColor: {
+      type: 'color',
+      classic: color.text_input_default_border_color,
+      dark: color.applab_dark_border
+    },
+    textColor: {
+      type: 'color',
+      classic: color.black,
+      dark: color.white
+    }
+  },
 
   create: function() {
     const element = document.createElement('div');
@@ -200,12 +228,17 @@ export default {
     element.style.height = '100px';
     element.style.fontFamily = fontFamilyStyles[0];
     element.style.fontSize = defaultFontSizeStyle;
-    element.style.color = '#000000';
-    element.style.backgroundColor = '#ffffff';
-    elementUtils.setDefaultBorderStyles(element, {
-      forceDefaults: true,
-      textInput: true
-    });
+    if (experiments.isEnabled('applabThemes')) {
+      element.style.borderStyle = 'solid';
+      elementLibrary.applyCurrentTheme(element, designMode.activeScreen());
+    } else {
+      element.style.color = '#000000';
+      element.style.backgroundColor = '#ffffff';
+      elementUtils.setDefaultBorderStyles(element, {
+        forceDefaults: true,
+        textInput: true
+      });
+    }
 
     $(element).addClass('textArea');
 

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -7,6 +7,7 @@ import 'jquery-ui/ui/widgets/resizable';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
+import RGBColor from 'rgbcolor';
 import DesignWorkspace from './DesignWorkspace';
 import * as assetPrefix from '../assetManagement/assetPrefix';
 import elementLibrary from './designElements/library';
@@ -585,6 +586,55 @@ designMode.onDuplicate = function(element, event) {
   designMode.editElementProperties(duplicateElement);
 
   return duplicateElement;
+};
+
+designMode.changeThemeForCurrentScreen = function(prevThemeValue, themeValue) {
+  const currentScreen = $(
+    elementUtils.getPrefixedElementById(
+      getStore().getState().screens.currentScreenId
+    )
+  );
+
+  // Unwrap the draggable wrappers around the elements in the source screen:
+  const madeUndraggable = makeUndraggable(currentScreen.children());
+
+  const screenAndChildren = [
+    currentScreen[0],
+    ...currentScreen.children().toArray()
+  ];
+
+  // Modify each element in the screen (including the screen itself):
+  screenAndChildren.forEach(element => {
+    const themeValues = elementLibrary.getThemeValues(element);
+    let modifiedProperty = false;
+    for (const propName in themeValues) {
+      const propTheme = themeValues[propName];
+      const prevDefault = propTheme[prevThemeValue];
+      const newDefault = propTheme[themeValue];
+      const currentPropValue = designMode.readProperty(element, propName);
+      const {type} = propTheme;
+      let propIsDefault = false;
+      if (type === 'color') {
+        propIsDefault =
+          new RGBColor(currentPropValue).toHex() ===
+          new RGBColor(prevDefault).toHex();
+      } else {
+        propIsDefault = currentPropValue === prevDefault;
+      }
+      if (propIsDefault) {
+        designMode.updateProperty(element, propName, newDefault);
+        modifiedProperty = true;
+      }
+    }
+    if (modifiedProperty) {
+      designMode.renderDesignWorkspace(element);
+    }
+  });
+
+  // Restore the draggable wrappers on the elements in the source screen:
+  if (madeUndraggable) {
+    makeDraggable(currentScreen.children());
+  }
 };
 
 function duplicateScreen(element) {

--- a/apps/src/applab/sanitizeHtml.js
+++ b/apps/src/applab/sanitizeHtml.js
@@ -186,6 +186,7 @@ export default function sanitizeHtml(
     div: standardAttributes.concat([
       'contenteditable',
       'data-canonical-image-url',
+      'data-theme',
       'tabindex',
       'xmlns'
     ]),

--- a/apps/style/applab/skins/modern.scss
+++ b/apps/style/applab/skins/modern.scss
@@ -30,7 +30,9 @@
     border-radius: 0;
     padding: 0 30px 0 10px;
     color: #fff;
-    background: url("/blockly/media/applab/dropdown.png") no-repeat center right;
+    background-position: right 10px center;
+    background-repeat: no-repeat;
+    background-size: auto 50%;
 
     // IE9 cant get rid of the native dropdown, so dont show our custom image and
     // get rid of our right padding so that the arrow is properly aligned
@@ -42,7 +44,7 @@
     }
 
     &:hover {
-      background: url("/blockly/media/applab/dropdown.png") no-repeat center right, url("/blockly/media/applab/brighter.png");
+      filter: opacity(0.8)
     }
   }
 


### PR DESCRIPTION
* Due to an issue with how older projects were migrated to the new dropdown arrow style, the applab themes PR from Friday (https://github.com/code-dot-org/code-dot-org/pull/27644) was reverted on Friday night (https://github.com/code-dot-org/code-dot-org/pull/27666)
* This restores that PR with one additional commit to fix the migration issue (dropdown.jsx now has code in `onDeserialize()` that detects the missing `backgroundImage` and creates it if it is missing)
