### PR TITLE
Show NPS survey 2019

### DIFF
--- a/dashboard/app/helpers/survey_results_helper.rb
+++ b/dashboard/app/helpers/survey_results_helper.rb
@@ -1,5 +1,6 @@
 module SurveyResultsHelper
   DIVERSITY_SURVEY_ENABLED = false
+  NPS_SURVEY_ENABLED = true
 
   def show_diversity_survey?(kind)
     return false unless current_user
@@ -18,8 +19,17 @@ module SurveyResultsHelper
   end
 
   def show_nps_survey?(kind)
-    # Disable NPS survey
-    false
+    return false unless current_user
+    return false unless language == "en"
+    return false if current_user.under_13?
+    return false if existing_survey_result?(kind)
+    return false unless country_us?
+    return false unless account_existed_14_days?
+
+    return false unless SurveyResultsHelper::NPS_SURVEY_ENABLED
+
+    # There is no reason not to show the survey, so show the survey.
+    return true
   end
 
   def account_existed_14_days?

--- a/dashboard/app/models/survey_result.rb
+++ b/dashboard/app/models/survey_result.rb
@@ -57,7 +57,8 @@ class SurveyResult < ActiveRecord::Base
     DIVERSITY_2017 = 'Diversity2017'.freeze,
     DIVERSITY_2018 = 'Diversity2018'.freeze,
     NET_PROMOTER_SCORE_2015 = 'NetPromoterScore2015'.freeze,
-    NET_PROMOTER_SCORE_2017 = 'NetPromoterScore2017'.freeze
+    NET_PROMOTER_SCORE_2017 = 'NetPromoterScore2017'.freeze,
+    NET_PROMOTER_SCORE_2019 = 'NetPromoterScore2019'.freeze
   ].freeze
   validates :kind, inclusion: {in: KINDS}, allow_nil: false
 end

--- a/dashboard/app/views/home/_homepage.html.haml
+++ b/dashboard/app/views/home/_homepage.html.haml
@@ -50,7 +50,7 @@
       - unless current_user.accepted_latest_terms?
         = render template: 'api/accept_terms_reminder'
         = render partial: 'layouts/terms_interstitial'
-      - if show_nps_survey? SurveyResult::NET_PROMOTER_SCORE_2017
+      - if show_nps_survey? SurveyResult::NET_PROMOTER_SCORE_2019
         = render partial: 'home/survey_nps'
       - elsif show_diversity_survey? SurveyResult::DIVERSITY_2018
         = render partial: 'home/survey_diversity'

--- a/dashboard/app/views/home/_survey_nps.html.haml
+++ b/dashboard/app/views/home/_survey_nps.html.haml
@@ -11,11 +11,11 @@
   }
 
 
-.survey{style: "background-color: rgb(200,200,200); padding:40px; font-size:18px; border-radius: 4px"}
+.survey{style: "background-color: rgb(200,200,200); padding:25px; font-size:14px; border-radius: 4px; margin-bottom: 60px"}
   #surveythanks{style: "display: none"} Thank you for your response.
   #surveybody
-    %h1{style: "margin-top:0px; color: rgb(80,80,80)"} Quick survey
-    %p{style: "padding-top: 10px; font-size:18px"}
+    %h1{style: "margin-top:0px; color: rgb(80,80,80); font-size: 25px"} Quick survey
+    %p{style: "padding-top: 10px; font-size:14px"}
       How likely are you to recommend Code.org to a friend or colleague?
     = form_for(SurveyResult.new, html: {id: 'survey', onsubmit: "return window.submitSurvey(true)", style: "margin-bottom:0px"}) do |f|
       #dots{style: "padding-top: 10px; padding-bottom: 5px; padding-left: 50px"}
@@ -30,14 +30,14 @@
         #right{style: "float: right"}
           Extremely likely
       #textbox{style: "display:none"}
-        %p{style: "font-size:18px"}
+        %p{style: "font-size:14px"}
           Optional: Any other comments?
         %input{type: "text", style: "width:600px; height:35px", name: "survey[nps_comment]"}
-        %input{type: "hidden", name: "survey[kind]", value: SurveyResult::NET_PROMOTER_SCORE_2017}
+        %input{type: "hidden", name: "survey[kind]", value: SurveyResult::NET_PROMOTER_SCORE_2019}
       #submit
-        %button.primary#submitSurvey{type: "submit", disabled: true, style: "font-size: 18px; height: 42px; width: 120px"} Submit
+        %button.primary#submitSurvey{type: "submit", disabled: true, style: "font-size: 14px; height: 42px; width: 120px"} Submit
         &nbsp;
-        %span{onclick: "return submitSurvey(false)", style: "cursor: pointer; font-size: 18px"} No thanks
+        %span{onclick: "return submitSurvey(false)", style: "cursor: pointer; font-size: 14px"} No thanks
   %br/
 
 :javascript

--- a/dashboard/app/views/home/_survey_nps.html.haml
+++ b/dashboard/app/views/home/_survey_nps.html.haml
@@ -11,7 +11,7 @@
   }
 
 
-.survey{style: "background-color: rgb(200,200,200); padding:25px; font-size:14px; border-radius: 4px; margin-bottom: 60px"}
+.survey{style: "background-color: rgb(236,236,236); padding:25px; font-size:14px; border-radius: 4px; margin-bottom: 60px; border: 1px solid rgb(187,187,187)"}
   #surveythanks{style: "display: none"} Thank you for your response.
   #surveybody
     %h1{style: "margin-top:0px; color: rgb(80,80,80); font-size: 25px"} Quick survey
@@ -22,7 +22,7 @@
         - -1.upto(10) do |i|
           - display = i == -1 ? "none" : "inline-block"
           %input{style: "margin-right:3px; vertical-align:top; display: none", id: "radio_#{i}", type: "radio", name: "survey[nps_value]", value: i, onclick: "enableSurveySubmit()"}
-          %label{style: "display: #{display}; font-size: 14px; width: 32px; height: 32px; margin-right: 24px; background-color: white; border-radius: 32px; text-align: center; line-height: 32px", for: "radio_#{i}"}
+          %label{style: "display: #{display}; font-size: 14px; width: 32px; height: 32px; margin-right: 24px; background-color: white; border-radius: 32px; text-align: center; line-height: 32px; border: 1px solid rgb(187,187,187)", for: "radio_#{i}"}
             = i
       #scale{style: "font-size: 12px; width: 710px; padding-left: 20px; overflow: hidden; padding-bottom: 20px"}
         #left{style: "float: left"}

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -354,7 +354,9 @@ class HomeControllerTest < ActionController::TestCase
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers see dashboard links' do
     sign_in create(:workshop_organizer, :with_terms_of_service)
-    assert_queries 12 do
+    query_count = 12
+    query_count += 1 if SurveyResultsHelper::NPS_SURVEY_ENABLED
+    assert_queries query_count do
       get :home
     end
     assert_select 'h1', count: 1, text: 'Workshop Dashboard'
@@ -362,7 +364,9 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'program managers see dashboard links' do
     sign_in create(:program_manager, :with_terms_of_service)
-    assert_queries 14 do
+    query_count = 14
+    query_count += 1 if SurveyResultsHelper::NPS_SURVEY_ENABLED
+    assert_queries query_count do
       get :home
     end
     assert_select 'h1', count: 1, text: 'Workshop Dashboard'
@@ -370,7 +374,9 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'workshop admins see dashboard links' do
     sign_in create(:workshop_admin, :with_terms_of_service)
-    assert_queries 10 do
+    query_count = 10
+    query_count += 1 if SurveyResultsHelper::NPS_SURVEY_ENABLED
+    assert_queries query_count do
       get :home
     end
     assert_select 'h1', count: 1, text: 'Workshop Dashboard'
@@ -379,7 +385,9 @@ class HomeControllerTest < ActionController::TestCase
   test 'facilitators see dashboard links' do
     facilitator = create(:facilitator, :with_terms_of_service)
     sign_in facilitator
-    assert_queries 11 do
+    query_count = 11
+    query_count += 1 if SurveyResultsHelper::NPS_SURVEY_ENABLED
+    assert_queries query_count do
       get :home
     end
     assert_select 'h1', count: 1, text: 'Workshop Dashboard'
@@ -387,7 +395,9 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'teachers cannot see dashboard links' do
     sign_in create(:terms_of_service_teacher)
-    assert_queries 10 do
+    query_count = 10
+    query_count += 1 if SurveyResultsHelper::NPS_SURVEY_ENABLED
+    assert_queries query_count do
       get :home
     end
     assert_select 'h1', count: 0, text: 'Workshop Dashboard'
@@ -395,7 +405,9 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'workshop admins see application dashboard links' do
     sign_in create(:workshop_admin, :with_terms_of_service)
-    assert_queries 10 do
+    query_count = 10
+    query_count += 1 if SurveyResultsHelper::NPS_SURVEY_ENABLED
+    assert_queries query_count do
       get :home
     end
     assert_select 'h1', count: 1, text: 'Application Dashboard'
@@ -405,7 +417,9 @@ class HomeControllerTest < ActionController::TestCase
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers who are regional partner program managers see application dashboard links' do
     sign_in create(:workshop_organizer, :as_regional_partner_program_manager, :with_terms_of_service)
-    assert_queries 14 do
+    query_count = 14
+    query_count += 1 if SurveyResultsHelper::NPS_SURVEY_ENABLED
+    assert_queries query_count do
       get :home
     end
     assert_select 'h1', count: 1, text: 'Application Dashboard'
@@ -414,7 +428,9 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'program managers see application dashboard links' do
     sign_in create(:program_manager, :with_terms_of_service)
-    assert_queries 14 do
+    query_count = 14
+    query_count += 1 if SurveyResultsHelper::NPS_SURVEY_ENABLED
+    assert_queries query_count do
       get :home
     end
     assert_select 'h1', count: 1, text: 'Application Dashboard'
@@ -424,7 +440,9 @@ class HomeControllerTest < ActionController::TestCase
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers who are not regional partner program managers do not see application dashboard links' do
     sign_in create(:workshop_organizer, :with_terms_of_service)
-    assert_queries 12 do
+    query_count = 12
+    query_count += 1 if SurveyResultsHelper::NPS_SURVEY_ENABLED
+    assert_queries query_count do
       get :home
     end
     assert_select 'h1', count: 0, text: 'Application Dashboard'


### PR DESCRIPTION
Revive the NPS survey for 2019.  

To see the survey, the user might be signed in, language "en", over 13, not already submitted, geocoded to the US, and with an account 14 days or older.  This is designed to be the same criteria we used for the survey in 2017, as seen [here](https://github.com/code-dot-org/code-dot-org/pull/13002/files#diff-23eaf9fa8d1cff41043703632396fbafR11) at the time we turned it off.

### Initial view, in context
![Screenshot 2019-03-25 22 02 43](https://user-images.githubusercontent.com/2205926/54972665-d2d6a500-4f49-11e9-94c6-81096c76ba1d.png)

### Expanded comment view after selecting a number
![Screenshot 2019-03-25 22 02 51](https://user-images.githubusercontent.com/2205926/54972667-d79b5900-4f49-11e9-91d3-d865f3347d46.png)

### After submitting
![Screenshot 2019-03-25 22 03 01](https://user-images.githubusercontent.com/2205926/54972670-dec26700-4f49-11e9-8b35-cb8458a5cee9.png)

