### PR TITLE
Generate Expo Android APK with a custom app.json

### DIFF
--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -361,6 +361,9 @@ export default {
       zipAssetPrefix
     });
 
+    const iconPath = '/appassets/icon.png';
+    const splashImagePath = '/appassets/splash.png';
+
     if (expoMode) {
       appAssets.push({
         url: exportExpoWarningPng,
@@ -369,12 +372,12 @@ export default {
       });
       appAssets.push({
         url: exportExpoIconPng,
-        zipPath: appName + '/appassets/icon.png',
+        zipPath: appName + iconPath,
         dataType: 'binary'
       });
       appAssets.push({
         url: exportExpoSplashPng,
-        zipPath: appName + '/appassets/splash.png',
+        zipPath: appName + splashImagePath,
         dataType: 'binary'
       });
     }
@@ -385,7 +388,9 @@ export default {
     if (expoMode) {
       const appJson = exportExpoAppJsonEjs({
         appName: appName,
-        projectId: project.getCurrentId()
+        projectId: project.getCurrentId(),
+        iconPath: '.' + iconPath,
+        splashImagePath: '.' + splashImagePath
       });
       const {shareWarningInfo = {}} = getAppOptions();
       const {hasDataAPIs} = shareWarningInfo;
@@ -598,18 +603,26 @@ export default {
     return exportExpoPackagedFilesEjs({entries});
   },
 
-  async generateExpoApk(snackId, config) {
+  async generateExpoApk(options, config) {
+    const {appName, expoSnackId, iconUri, splashImageUri} = options;
     const session = new SnackSession({
       sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
       name: `project-${project.getCurrentId()}`,
       sdkVersion: '31.0.0',
-      snackId,
+      snackId: expoSnackId,
       user: {
         sessionSecret: config.expoSession || EXPO_SESSION_SECRET
       }
     });
 
-    const appJson = session.generateAppJson();
+    const appJson = JSON.parse(
+      exportExpoAppJsonEjs({
+        appName,
+        projectId: project.getCurrentId(),
+        iconPath: iconUri,
+        splashImagePath: splashImageUri
+      })
+    );
 
     const artifactUrl = await session.getApkUrlAsync(appJson);
 
@@ -702,6 +715,18 @@ export default {
       filename: 'warning.png',
       assetLocation: 'appassets/'
     });
+    appAssets.push({
+      url: exportExpoIconPng,
+      dataType: 'binary',
+      filename: 'icon.png',
+      assetLocation: 'appassets/'
+    });
+    appAssets.push({
+      url: exportExpoSplashPng,
+      dataType: 'binary',
+      filename: 'splash.png',
+      assetLocation: 'appassets/'
+    });
 
     const assetDownloads = appAssets.map(asset =>
       download(asset.url, asset.dataType || 'text')
@@ -734,7 +759,9 @@ export default {
 
     return {
       expoUri,
-      expoSnackId
+      expoSnackId,
+      iconUri: files['appassets/icon.png'].contents,
+      splashImageUri: files['appassets/splash.png'].contents
     };
   }
 };

--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -624,6 +624,16 @@ export default {
       })
     );
 
+    // TODO: remove the onlineOnlyExpo patching once getApkUrlAsync()
+    // properly supports our full app.json
+    const {
+      updates, // eslint-disable-line no-unused-vars
+      assetBundlePatterns, // eslint-disable-line no-unused-vars
+      packagerOpts, // eslint-disable-line no-unused-vars
+      ...onlineOnlyExpo
+    } = appJson.expo;
+    appJson.expo = onlineOnlyExpo;
+
     const artifactUrl = await session.getApkUrlAsync(appJson);
 
     return artifactUrl;
@@ -673,7 +683,7 @@ export default {
     const session = new SnackSession({
       sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
       files,
-      name: project.getCurrentName(),
+      name: `project-${project.getCurrentId()}`,
       sdkVersion: '31.0.0',
       user: {
         sessionSecret: config.expoSession || EXPO_SESSION_SECRET

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -808,7 +808,7 @@ Applab.reactMountPoint_ = null;
  */
 Applab.render = function() {
   var nextProps = Object.assign({}, Applab.reactInitialProps_, {
-    isEditingProject: window.dashboard && window.dashboard.project.isEditing(),
+    isEditingProject: project.isEditing(),
     screenIds: designMode.getAllScreenIds(),
     onScreenCreate: designMode.createScreen,
     handleVersionHistory: Applab.handleVersionHistory
@@ -827,8 +827,7 @@ Applab.exportApp = function(expoOpts) {
   studioApp().resetButtonClick();
 
   // TODO: find another way to get this info that doesn't rely on globals.
-  const appName =
-    (window.dashboard && window.dashboard.project.getCurrentName()) || 'my-app';
+  const appName = project.getCurrentName() || 'my-app';
 
   const {mode, expoSnackId, iconUri, splashImageUri} = expoOpts || {};
   if (mode === 'expoGenerateApk') {

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -826,14 +826,25 @@ Applab.exportApp = function(expoOpts) {
   var html = document.getElementById('divApplab').outerHTML;
   studioApp().resetButtonClick();
 
-  const {mode, expoSnackId} = expoOpts || {};
+  // TODO: find another way to get this info that doesn't rely on globals.
+  const appName =
+    (window.dashboard && window.dashboard.project.getCurrentName()) || 'my-app';
+
+  const {mode, expoSnackId, iconUri, splashImageUri} = expoOpts || {};
   if (mode === 'expoGenerateApk') {
-    return Exporter.generateExpoApk(expoSnackId, studioApp().config);
+    return Exporter.generateExpoApk(
+      {
+        appName,
+        expoSnackId,
+        iconUri,
+        splashImageUri
+      },
+      studioApp().config
+    );
   }
 
   return Exporter.exportApp(
-    // TODO: find another way to get this info that doesn't rely on globals.
-    (window.dashboard && window.dashboard.project.getCurrentName()) || 'my-app',
+    appName,
     studioApp().editor.getValue(),
     html,
     expoOpts,

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -159,14 +159,21 @@ class AdvancedShareOptions extends React.Component {
   publishExpoExport = async () => {
     this.setState({exportingExpo: 'publish'});
     try {
-      const {expoUri, expoSnackId} = await this.props.exportApp({
+      const {
+        expoUri,
+        expoSnackId,
+        iconUri,
+        splashImageUri
+      } = await this.props.exportApp({
         mode: 'expoPublish'
       });
       this.setState({
         exportingExpo: null,
         exportExpoError: null,
         expoUri,
-        expoSnackId
+        expoSnackId,
+        iconUri,
+        splashImageUri
       });
     } catch (e) {
       this.setState({
@@ -180,12 +187,14 @@ class AdvancedShareOptions extends React.Component {
   };
 
   generateExpoApk = async () => {
-    const {expoSnackId} = this.state;
+    const {expoSnackId, iconUri, splashImageUri} = this.state;
     this.setState({generatingExpoApk: true});
     try {
       const expoApkUri = await this.props.exportApp({
         mode: 'expoGenerateApk',
-        expoSnackId
+        expoSnackId,
+        iconUri,
+        splashImageUri
       });
       this.setState({
         generatingExpoApk: false,

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -210,6 +210,11 @@ class AdvancedShareOptions extends React.Component {
     }
   };
 
+  visitExpoSite = () => {
+    const {expoSnackId} = this.state;
+    window.open(`https://snack.expo.io/${expoSnackId}`, '_blank');
+  };
+
   renderEmbedTab() {
     let url = `${this.props.shareUrl}/embed`;
     if (this.state.embedWithoutCode) {
@@ -371,6 +376,12 @@ class AdvancedShareOptions extends React.Component {
                   >
                     {generateApkSpinner}
                     Create Android App
+                  </button>
+                  <button
+                    onClick={this.visitExpoSite}
+                    style={[style.expoButton, style.expoButtonApk]}
+                  >
+                    Visit Expo Site
                   </button>
                   <p style={style.p}>{apkStatusString}</p>
                   {!!expoApkUri && (

--- a/apps/src/gamelab/Exporter.js
+++ b/apps/src/gamelab/Exporter.js
@@ -316,6 +316,16 @@ export default {
       })
     );
 
+    // TODO: remove the onlineOnlyExpo patching once getApkUrlAsync()
+    // properly supports our full app.json
+    const {
+      updates, // eslint-disable-line no-unused-vars
+      assetBundlePatterns, // eslint-disable-line no-unused-vars
+      packagerOpts, // eslint-disable-line no-unused-vars
+      ...onlineOnlyExpo
+    } = appJson.expo;
+    appJson.expo = onlineOnlyExpo;
+
     const artifactUrl = await session.getApkUrlAsync(appJson);
 
     return artifactUrl;

--- a/apps/src/gamelab/Exporter.js
+++ b/apps/src/gamelab/Exporter.js
@@ -64,6 +64,9 @@ export default {
       animationListJSON
     });
 
+    const iconPath = '/appassets/icon.png';
+    const splashImagePath = '/appassets/splash.png';
+
     if (expoMode) {
       appAssets.push({
         url: exportExpoWarningPng,
@@ -72,12 +75,12 @@ export default {
       });
       appAssets.push({
         url: exportExpoIconPng,
-        zipPath: appName + '/appassets/icon.png',
+        zipPath: appName + iconPath,
         dataType: 'binary'
       });
       appAssets.push({
         url: exportExpoSplashPng,
-        zipPath: appName + '/appassets/splash.png',
+        zipPath: appName + splashImagePath,
         dataType: 'binary'
       });
     }
@@ -88,7 +91,9 @@ export default {
     if (expoMode) {
       const appJson = exportExpoAppJsonEjs({
         appName,
-        projectId: project.getCurrentId()
+        projectId: project.getCurrentId(),
+        iconPath: '.' + iconPath,
+        splashImagePath: '.' + splashImagePath
       });
       const appJs = exportExpoAppEjs({
         appHeight,
@@ -290,18 +295,26 @@ export default {
     return exportExpoPackagedFilesEjs({entries});
   },
 
-  async generateExpoApk(snackId, config) {
+  async generateExpoApk(options, config) {
+    const {appName, expoSnackId, iconUri, splashImageUri} = options;
     const session = new SnackSession({
       sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
       name: `project-${project.getCurrentId()}`,
       sdkVersion: '31.0.0',
-      snackId,
+      snackId: expoSnackId,
       user: {
         sessionSecret: config.expoSession || EXPO_SESSION_SECRET
       }
     });
 
-    const appJson = session.generateAppJson();
+    const appJson = JSON.parse(
+      exportExpoAppJsonEjs({
+        appName,
+        projectId: project.getCurrentId(),
+        iconPath: iconUri,
+        splashImagePath: splashImageUri
+      })
+    );
 
     const artifactUrl = await session.getApkUrlAsync(appJson);
 
@@ -388,6 +401,18 @@ export default {
       filename: 'warning.png',
       assetLocation: 'appassets/'
     });
+    appAssets.push({
+      url: exportExpoIconPng,
+      dataType: 'binary',
+      filename: 'icon.png',
+      assetLocation: 'appassets/'
+    });
+    appAssets.push({
+      url: exportExpoSplashPng,
+      dataType: 'binary',
+      filename: 'splash.png',
+      assetLocation: 'appassets/'
+    });
 
     const assetDownloads = appAssets.map(asset => {
       if (asset.blob) {
@@ -424,7 +449,9 @@ export default {
 
     return {
       expoUri,
-      expoSnackId
+      expoSnackId,
+      iconUri: files['appassets/icon.png'].contents,
+      splashImageUri: files['appassets/splash.png'].contents
     };
   },
 

--- a/apps/src/gamelab/GameLab.js
+++ b/apps/src/gamelab/GameLab.js
@@ -420,12 +420,24 @@ GameLab.prototype.init = function(config) {
  * @param {Object} expoOpts
  */
 GameLab.prototype.exportApp = async function(expoOpts) {
-  const {mode, expoSnackId} = expoOpts || {};
+  // TODO: find another way to get this info that doesn't rely on globals.
+  const appName =
+    (window.dashboard && window.dashboard.project.getCurrentName()) || 'my-app';
+  const {mode, expoSnackId, iconUri, splashImageUri} = expoOpts || {};
   if (mode === 'expoGenerateApk') {
-    return Exporter.generateExpoApk(expoSnackId, this.studioApp_.config);
+    return Exporter.generateExpoApk(
+      {
+        appName,
+        expoSnackId,
+        iconUri,
+        splashImageUri
+      },
+      this.studioApp_.config
+    );
   }
   await this.whenAnimationsAreReady();
   return this.exportAppWithAnimations(
+    appName,
     getStore().getState().animationList,
     expoOpts
   );
@@ -433,17 +445,21 @@ GameLab.prototype.exportApp = async function(expoOpts) {
 
 /**
  * Export the project for web or use within Expo.
+ * @param {string} appName
  * @param {Object} animationList - object of {AnimationKey} to {AnimationProps}
  * @param {Object} expoOpts
  */
-GameLab.prototype.exportAppWithAnimations = function(animationList, expoOpts) {
+GameLab.prototype.exportAppWithAnimations = function(
+  appName,
+  animationList,
+  expoOpts
+) {
   const {pauseAnimationsByDefault} = this.level;
   const allAnimationsSingleFrame = allAnimationsSingleFrameSelector(
     getStore().getState()
   );
   return Exporter.exportApp(
-    // TODO: find another way to get this info that doesn't rely on globals.
-    (window.dashboard && window.dashboard.project.getCurrentName()) || 'my-app',
+    appName,
     this.studioApp_.editor.getValue(),
     {
       animationList,

--- a/apps/src/templates/export/expo/App.js.ejs
+++ b/apps/src/templates/export/expo/App.js.ejs
@@ -102,6 +102,7 @@ export default class App extends React.Component {
       <View onLayout={this.onLayout} style={styles.container}>
         {height && indexUri && <View style={this.webViewContainerStyle()}>
           <WebView
+            allowUniversalAccessFromFileURLs
             originWhitelist={['*']}
             allowFileAccess
             source={{uri: indexUri}}

--- a/apps/src/templates/export/expo/app.json.ejs
+++ b/apps/src/templates/export/expo/app.json.ejs
@@ -2,7 +2,7 @@
   "expo": {
     "name": "<%- appName %>",
     "description": "<%- appName %> from Code.org Code Studio.",
-    "slug": "project-<%- projectId.toLowerCase().replace(/([^a-zA-Z0-9_\-]+)/gi, '-') %>",
+    "slug": "project-<%- projectId.toLowerCase().replace(/[^\w-]+/g, '-') %>",
     "privacy": "public",
     "sdkVersion": "31.0.0",
     "platforms": ["ios", "android"],
@@ -37,11 +37,11 @@
       ]
     },
     "ios": {
-      "bundleIdentifier": "org.code.studio.app.<%- projectId.replace(/([^a-zA-Z0-9\-]+)/gi, '-') %>",
+      "bundleIdentifier": "org.code.studio.app.<%- projectId.toLowerCase().replace(/([^a-zA-Z0-9\-]+)/g, '-') %>",
       "buildNumber": "1"
     },
     "android": {
-      "package": "org.code.studio.app_<%- projectId.replace(/([^a-zA-Z0-9\_]+)/gi, '_') %>",
+      "package": "org.code.studio.app_<%- projectId.toLowerCase().replace(/([^a-zA-Z0-9\_]+)/g, '_') %>",
       "permissions": [],
       "versionCode": 1
     }

--- a/apps/src/templates/export/expo/app.json.ejs
+++ b/apps/src/templates/export/expo/app.json.ejs
@@ -2,15 +2,15 @@
   "expo": {
     "name": "<%- appName %>",
     "description": "<%- appName %> from Code.org Code Studio.",
-    "slug": "<%- appName.replace(/([^a-zA-Z0-9_\-]+)/gi, '-') %>",
+    "slug": "project-<%- projectId.toLowerCase().replace(/([^a-zA-Z0-9_\-]+)/gi, '-') %>",
     "privacy": "public",
     "sdkVersion": "31.0.0",
     "platforms": ["ios", "android"],
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./appassets/icon.png",
+    "icon": "<%- iconPath %>",
     "splash": {
-      "image": "./appassets/splash.png",
+      "image": "<%- splashImagePath %>",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },


### PR DESCRIPTION
* We've used a custom `app.json` file for our Expo exports with via a ZIP file (see https://docs.expo.io/versions/latest/workflow/configuration/) - however, we didn't do this for the "Test in Expo App" path since that path didn't previously lead to a complete, finished app
* Now that we've connected up the "Create Android App" pathway, which call's the Snack SDK's `generateApk()` function, we'd like to pass through our custom `app.json` file (with project name, icon, splash screen, and other unique info) instead of using a generic `app.json` file generated by the Snack SDK
* This PR does that, however it also contains some code to work around some keys that aren't properly supported by Expo using the `generateApk()` path. (We are stripping out `updates`, `assetBundlePatterns`, and `packagerOpts` until we can confirm with testing that those keys are supported properly)
* Added a new `Visit Expo Site` button so we can identify UX issues with the forthcoming iOS IPA generation, which will require navigating to the Expo site in a new tab. This button simply opens the recently generated project in the Expo UI in a new tab. NOTE: All of this is under an experiment flag, so the temporary UI is part of the iterative process of arriving at a proper UI.
* Minor Expo export bug fixes:
  * The `app.json` slug now is based on the code.org project id (it also requires lowercasing in order to match what happens on the expo backend)
  * The snack creation for applab now properly uses `project-${project.getCurrentId()}` for the name to ensure uniqueness in the `code.org` namespace
  * The react native app we create uses the `allowUniversalAccessFromFileURLs` property on `WebView` in order to make Android apps work properly

<img width="692" alt="Screen Shot 2019-03-25 at 9 20 17 AM" src="https://user-images.githubusercontent.com/5429146/54936266-5f984900-4edf-11e9-9dba-eb771d89c907.png">
