### PR TITLE
Prompt user for consent upon logging in through google

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -24,12 +24,14 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   # GET /users/auth/google_oauth2/callback
   def google_oauth2
+    user = find_user_by_credential
+    user&.update_oauth_credential_tokens auth_hash
+
     # Redirect to open roster dialog on home page if user just authorized access
     # to Google Classroom courses and rosters
     return redirect_to '/home?open=rosterDialog' if just_authorized_google_classroom?
     return connect_provider if should_connect_provider?
 
-    user = find_user_by_credential
     if user
       sign_in_google_oauth2 user
     else
@@ -160,7 +162,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def sign_in_google_oauth2(user)
     SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, session
     prepare_locale_cookie user
-    user.update_oauth_credential_tokens auth_hash
 
     if allows_google_classroom_takeover user
       user = silent_takeover user, auth_hash
@@ -226,6 +227,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def find_user_by_credential
+    return nil unless auth_hash
+
     User.find_by_credential \
       type: auth_hash.provider,
       id: auth_hash.uid

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -283,6 +283,7 @@ Devise.setup do |config|
 
   config.omniauth :google_oauth2, CDO.dashboard_google_key, CDO.dashboard_google_secret, {
     include_granted_scopes: true,
+    prompt: 'consent',
     setup: lambda do |env|
       # If requesting additional scopes, always re-confirm with the user so we get a new refresh token.
       if env['omniauth.strategy'].authorize_params['scope'] != 'email profile'


### PR DESCRIPTION
This should fix 2 related Honeybadger errors ([1](https://app.honeybadger.io/projects/3240/faults/34448392#notice-summary), [2](https://app.honeybadger.io/projects/3240/faults/34460333#notice-summary)). I determined that these errors were stemming from the fact that some users do not have a `refresh_token` from Google.

### Problem
We have a lot of Google users who, for whatever reason, are missing a `refresh_token` from Google. This means that once their current `token` expires, the next request to Google fails because there is no `refresh_token` available to grab a new, valid `token`. To get around this, the user has to log out and back in, which updates their `token`, but does not add a `refresh_token` to their account.

### Solution
When a user logs in through Google, explicitly prompt the user for their consent. This will give us a `refresh_token` that we can add to the user's account. 

It isn't _great_ that we will be updating the user's `refresh_token` every time they log in through Google, but I think it's okay for a few reasons:
1. Users stay logged in to Code.org for a long time, so they aren't logging in very often, and
2. Google allows each user-client combination to have 50 valid refresh_tokens, then will begin automatically invalidating old ones: 
> There is currently a limit of 50 refresh tokens per user account per client. If the limit is reached, creating a new refresh token automatically invalidates the oldest refresh token without warning. This limit does not apply to service accounts. ([source](https://developers.google.com/identity/protocols/OAuth2#expiration))

We only care about 1 `refresh_token`, so old tokens being invalidated should not be an issue.

Now, when a user logs in through Google, they will see the consent screen(s) every time:
1. All users:
![Screen Shot 2019-03-25 at 9 54 34 AM](https://user-images.githubusercontent.com/9812299/54951496-0b9e5c00-4f01-11e9-835c-32d668ae3cf0.png)

2. Users who have granted Google Classroom access:
![Screen Shot 2019-03-25 at 9 54 46 AM](https://user-images.githubusercontent.com/9812299/54951497-0b9e5c00-4f01-11e9-9f99-0a52ae7a454f.png)

This is a minimally invasive inconvenience that will hopefully fix the errors we're seeing (and greatly reduce the number of Zendesk tickets around this issue!)