### PR TITLE
fix pegasus app-server after_fork hook

### DIFF
--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -28,6 +28,7 @@ end
 
 on_worker_boot do |_index|
   Cdo::AppServerHooks.after_fork(host: CDO.dashboard_hostname)
+  ActiveRecord::Base.establish_connection
 end
 
 require 'gctools/oobgc'

--- a/lib/cdo/app_server_hooks.rb
+++ b/lib/cdo/app_server_hooks.rb
@@ -35,7 +35,6 @@ module Cdo
           }
         ]
       )
-      ActiveRecord::Base.establish_connection
       require 'dynamic_config/gatekeeper'
       require 'dynamic_config/dcdo'
       Gatekeeper.after_fork


### PR DESCRIPTION
Followup/fix to #27638.

`ActiveRecord::Base.establish_connection` can't be run from Pegasus config because ActiveRecord is not loaded in that environment.