### PR TITLE
Replicate user_school_infos to Redshift [ci skip]

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -106,6 +106,7 @@ cron-user-hierarchy-pii:
 - dashboard.teacher_profiles
 - dashboard.users
 - dashboard.user_geos
+- dashboard.user_school_infos
 cron-user-levels:
 - dashboard.user_levels
 cron-level-sources-pii:


### PR DESCRIPTION
Adds new table tracking historical `user_school_info` to Redshift replication. @wjordan I can't remember the process for getting this change active, I believe there was a manual step involved?