### PR TITLE
BugFix 164: In levelbuilder, setting app lab debugger speed to 0 for a level doesn't work correctly.

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -222,7 +222,7 @@ StudioApp.prototype.configure = function(options) {
     options.minVisualizationWidth || MIN_VISUALIZATION_WIDTH;
 
   // Set default speed
-  if (options.level && typeof options.level.sliderSpeed === 'number') {
+  if (options.level) {
     getStore().dispatch(setStepSpeed(options.level.sliderSpeed));
   }
 };

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -222,7 +222,7 @@ StudioApp.prototype.configure = function(options) {
     options.minVisualizationWidth || MIN_VISUALIZATION_WIDTH;
 
   // Set default speed
-  if (options.level && options.level.sliderSpeed) {
+  if (options.level && typeof options.level.sliderSpeed === 'number') {
     getStore().dispatch(setStepSpeed(options.level.sliderSpeed));
   }
 };

--- a/apps/src/redux/runState.js
+++ b/apps/src/redux/runState.js
@@ -45,9 +45,11 @@ export default function reducer(state, action) {
   }
 
   if (action.type === SET_STEP_SPEED) {
-    return _.assign({}, state, {
-      stepSpeed: action.stepSpeed
-    });
+    if (typeof action.stepSpeed === 'number') {
+      return _.assign({}, state, {
+        stepSpeed: action.stepSpeed
+      });
+    }
   }
 
   if (action.type === SET_AWAITING_CONTAINED_RESPONSE) {

--- a/apps/test/unit/runStateTest.js
+++ b/apps/test/unit/runStateTest.js
@@ -32,7 +32,7 @@ describe('runState', () => {
 
     it('can be set to a decimal', function() {
       var state = reducer(null, runState.setStepSpeed(0.5));
-      assert.strictEqual(state.stepSpeed, .5);
+      assert.strictEqual(state.stepSpeed, 0.5);
     });
   });
 

--- a/apps/test/unit/runStateTest.js
+++ b/apps/test/unit/runStateTest.js
@@ -7,6 +7,35 @@ var runState = require('@cdo/apps/redux/runState');
 describe('runState', () => {
   testUtils.setExternalGlobals();
 
+  describe('stepSpeed', function() {
+    var reducer = runState.default;
+
+    it('is initially 1', function() {
+      var state = reducer(null, {});
+      assert.strictEqual(state.stepSpeed, 1);
+    });
+
+    it('remains 1 when set to null', function() {
+      var state = reducer(null, runState.setStepSpeed(null));
+      assert.strictEqual(state.stepSpeed, 1);
+    });
+
+    it('remains 1 when set to undefined', function() {
+      var state = reducer(null, runState.setStepSpeed(undefined));
+      assert.strictEqual(state.stepSpeed, 1);
+    });
+
+    it('can be set to 0.0', function() {
+      var state = reducer(null, runState.setStepSpeed(0.0));
+      assert.strictEqual(state.stepSpeed, 0);
+    });
+
+    it('can be set to a decimal', function() {
+      var state = reducer(null, runState.setStepSpeed(0.5));
+      assert.strictEqual(state.stepSpeed, .5);
+    });
+  });
+
   describe('isRunning reducer', function() {
     var reducer = runState.default;
 


### PR DESCRIPTION
StudioApp was attempting to check whether sliderSpeed had been set, but this check would return false if the value of sliderSpeed was set to 0. This change updates the condition so it checks whether sliderSpeed is a number rather than if it exists (if it doesn't exist, typeof sliderSpeed === 'number' will return false). This change also moves the check to the more testable runState.js and adds unit tests for the various possible values of sliderSpeed.
Ticket: https://codedotorg.atlassian.net/browse/STAR-164 