### PR TITLE
Account Deletion: Limit confirmation email size

### DIFF
--- a/dashboard/app/views/teacher_mailer/delete_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/delete_teacher_email.html.haml
@@ -4,12 +4,15 @@
   Your account has been deleted along with the accounts of all of your students that didn’t have a personal login or were not in another teacher’s section. If you think this was done in error, please contact us at support@code.org to recover your and your students’ accounts. These accounts will be permanently deleted in 28 days, after which we will no longer be able to recover them.
 %p
   - if @removed_students.present?
-    Student accounts deleted:
-    %br
-    %ol
-      - @removed_students.each do |student|
-        %li
-          #{student[:name]} (#{student[:username]})
+    - if @removed_students.count <= 1000
+      Student accounts deleted:
+      %br
+      %ol
+        - @removed_students.each do |student|
+          %li
+            #{student[:name]} (#{student[:username]})
+    - else
+      #{@removed_students.count} student accounts were deleted.
 %p
   Thanks,
 %p

--- a/dashboard/test/mailers/teacher_mailer_test.rb
+++ b/dashboard/test/mailers/teacher_mailer_test.rb
@@ -20,7 +20,23 @@ class TeacherMailerTest < ActionMailer::TestCase
     assert_equal [teacher.email], mail.to
     assert_equal ['noreply@code.org'], mail.from
     assert_match 'Your account has been deleted', mail.body.encoded
+    assert_match 'Student accounts deleted:', mail.body.encoded
     assert_match "#{removed_students.first.name} (#{removed_students.first.username})", mail.body.encoded
     assert_match "#{removed_students.last.name} (#{removed_students.last.username})", mail.body.encoded
+  end
+
+  test 'delete teacher email with more than 1000 students' do
+    teacher = create :teacher, email: 'mickey@mouse.com', name: 'Mickey Mouse'
+    removed_students = create_list :student, 2
+    # Cheat to keep this test from taking 30+ seconds to run
+    removed_students.stubs(:count).returns(1001).twice
+    mail = TeacherMailer.delete_teacher_email(teacher, removed_students)
+
+    assert_equal I18n.t('teacher_mailer.delete_teacher_subject'), mail.subject
+    assert_equal [teacher.email], mail.to
+    assert_equal ['noreply@code.org'], mail.from
+    assert_match 'Your account has been deleted', mail.body.encoded
+    assert_match '1001 student accounts were deleted.', mail.body.encoded
+    refute_match "#{removed_students.first.name} (#{removed_students.first.username})", mail.body.encoded
   end
 end


### PR DESCRIPTION
[FND-324](https://codedotorg.atlassian.net/browse/FND-324), [Slack](https://codedotorg.slack.com/archives/C55JZ1BPZ/p1553539835023100): Fixes recent occurrences of [Honeybadger 37298089](https://app.honeybadger.io/projects/45435/faults/37298089#notice-summary).  We had a teacher with over 1,700 students delete their account and the dependent student accounts, and the JSON blob containing the resulting email body overflowed the `pegasus.poste_deliveries` text(65535) column `params`, causing an error when we later tried to parse this JSON in order to send it.

Solution: Don't list every student in the email if a teacher with more than 1000 students deletes their account.

