### PR TITLE
shorter name to prevent error in automatic username generation

### DIFF
--- a/dashboard/test/ui/features/hamburger.feature
+++ b/dashboard/test/ui/features/hamburger.feature
@@ -115,7 +115,7 @@ Scenario: Signed out user viewing hamburger dropdown in Spanish on desktop
   And I wait for 2 seconds
 
 Scenario: Student viewing hamburger dropdown in Spanish on desktop
-  Given I create a student named "Estrella Estudiante"
+  Given I create a student named "Eva Estudiante"
   Then I wait until I am on "http://studio.code.org/home"
   Given I am on "http://studio.code.org/home/lang/es"
   Then I wait until I am on "http://studio.code.org/home"
@@ -155,7 +155,7 @@ Scenario: Teacher viewing hamburger dropdown in Spanish on desktop
   And I wait for 2 seconds
 
 Scenario: Student viewing hamburger dropdown in Spanish on desktop on level
-  Given I create a student named "Estrella Estudiante"
+  Given I create a student named "Eva Estudiante"
   Given I am on "http://studio.code.org/s/allthethings/stage/1/puzzle/1/lang/es"
   Then I wait until I am on "http://studio.code.org/s/allthethings/stage/1/puzzle/1"
   Then I wait to see "#hamburger-icon"


### PR DESCRIPTION
Quick fix- these tests were failing because in the step to create a student, it falls through to [this range-scan query in `generate_username`](https://github.com/code-dot-org/code-dot-org/blame/staging/lib/cdo/user_helpers.rb#L37) which fails because the resulting username is too long. Shortening the username will unblock us for now.

Long-term we should either have a shorter recommended username length for testing, because the test db has so many accounts with the same prefix, or clean up accounts created during past test runs.