### PR TITLE
replace dangerouslySetInnerHtml in GeneratedCode with UnsafeRenderedMarkdown

### DIFF
--- a/apps/src/templates/feedback/GeneratedCode.jsx
+++ b/apps/src/templates/feedback/GeneratedCode.jsx
@@ -1,6 +1,7 @@
-/* eslint-disable react/no-danger */
 import PropTypes from 'prop-types';
 import React from 'react';
+
+import UnsafeRenderedMarkdown from '../UnsafeRenderedMarkdown';
 
 export default class GeneratedCode extends React.Component {
   static propTypes = {
@@ -12,17 +13,14 @@ export default class GeneratedCode extends React.Component {
   render() {
     return (
       <div className="generated-code-container" style={this.props.style}>
-        <p
-          className="generatedCodeMessage"
-          dangerouslySetInnerHTML={{__html: this.props.message}}
-        />
+        <div className="generatedCodeMessage">
+          <UnsafeRenderedMarkdown markdown={this.props.message} />
+        </div>
 
         {/* code container should be LTR even in RTL mode */}
-        <pre
-          className="generatedCode"
-          dir="ltr"
-          dangerouslySetInnerHTML={{__html: this.props.code}}
-        />
+        <pre className="generatedCode" dir="ltr">
+          {this.props.code}
+        </pre>
       </div>
     );
   }

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1167,17 +1167,19 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
 .generated-code-container {
   margin-top: 10px;
   .generatedCodeMessage {
-    font-size: 14px;
-    line-height: inherit;
-    color: $charcoal;
-    margin-bottom: 10px;
+    p {
+      font-size: 14px;
+      line-height: inherit;
+      color: $charcoal;
+      margin-bottom: 10px;
 
-    a {
-      font-family: $gotham-extra-bold;
-      font-weight: normal;
-      color: $purple;
-      &:hover {
-        text-decoration: underline;
+      a {
+        font-family: $gotham-extra-bold;
+        font-weight: normal;
+        color: $purple;
+        &:hover {
+          text-decoration: underline;
+        }
       }
     }
   }

--- a/apps/style/craft/style.scss
+++ b/apps/style/craft/style.scss
@@ -1081,7 +1081,7 @@ $height-to-width: 434 / 477;
   }
 
   // "Show Code" explanation
-  .generated-code-container .generatedCodeMessage {
+  .generated-code-container .generatedCodeMessage p {
     color: $lightest_gray;
 
     a {

--- a/apps/test/unit/templates/feedback/GeneratedCodeTest.jsx
+++ b/apps/test/unit/templates/feedback/GeneratedCodeTest.jsx
@@ -11,15 +11,12 @@ describe('GeneratedCode', () => {
     );
     expect(wrapper).to.containMatchingElement(
       <div className="generated-code-container">
-        <p
-          className="generatedCodeMessage"
-          dangerouslySetInnerHTML={{__html: 'Test message'}}
-        />
-        <pre
-          className="generatedCode"
-          dir="ltr"
-          dangerouslySetInnerHTML={{__html: 'Test code'}}
-        />
+        <div className="generatedCodeMessage">
+          <p>Test message</p>
+        </div>
+        <pre className="generatedCode" dir="ltr">
+          Test code
+        </pre>
       </div>
     );
   });

--- a/apps/test/unit/templates/feedback/GeneratedCodeTest.jsx
+++ b/apps/test/unit/templates/feedback/GeneratedCodeTest.jsx
@@ -1,23 +1,21 @@
-/* eslint-disable react/no-danger */
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/configuredChai';
 import GeneratedCode from '@cdo/apps/templates/feedback/GeneratedCode';
+import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 
 describe('GeneratedCode', () => {
-  it('renders successfully', () => {
-    const wrapper = shallow(
-      <GeneratedCode message="Test message" code="Test code" />
-    );
+  const wrapper = shallow(
+    <GeneratedCode message="Test message" code="Test code" />
+  );
+
+  it('renders code explicitly in ltr', () => {
+    expect(wrapper).to.containMatchingElement(<pre dir="ltr">Test code</pre>);
+  });
+
+  it('renders message with markdown support', () => {
     expect(wrapper).to.containMatchingElement(
-      <div className="generated-code-container">
-        <div className="generatedCodeMessage">
-          <p>Test message</p>
-        </div>
-        <pre className="generatedCode" dir="ltr">
-          Test code
-        </pre>
-      </div>
+      <UnsafeRenderedMarkdown markdown="Test message" />
     );
   });
 });


### PR DESCRIPTION
Part of our [overall dSIH deprecation effort](https://docs.google.com/spreadsheets/d/1VaYlNzYdPVwSIkNxezvaVG6IlBMqEi-adxzk4Iwar-U/edit#gid=1842789459)

Also requires a styling change, since we're changing the `.generatedCodeMessage` element from a paragraph to a div.