### PR TITLE
skip seeding encrypted levels on adhocs when no key present

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -216,8 +216,8 @@ class Level < ActiveRecord::Base
         hash['notes'] = Encryption.decrypt_object(encrypted_notes)
       end
     rescue Encryption::KeyMissingError
-      # developers must be able to seed levels without properties_encryption_key
-      raise unless rack_env?(:development)
+      # developers and adhocs must be able to seed levels without properties_encryption_key
+      raise unless [:development, :adhoc].include? rack_env
       puts "WARNING: level '#{name}' not seeded properly due to missing CDO.properties_encryption_key"
     end
     hash


### PR DESCRIPTION
Follow on to https://github.com/code-dot-org/code-dot-org/pull/27546 . This is needed for `rake adhoc:start` to work.