### PR TITLE
Enzyme3 upgrade: fixed 1 unit6 validation test

### DIFF
--- a/apps/test/unit/lib/kits/maker/ui/Unit6ValidationStepTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/Unit6ValidationStepTest.js
@@ -41,7 +41,7 @@ describe('Unit6ValidationStep', () => {
         initialChoice={Unit6Intention.NO}
       />
     );
-    assert.equal(wrapper.find('input [value="no"]').props().checked, true);
+    assert.equal(wrapper.find('[value="no"]').props().checked, true);
     assert.equal(wrapper.find('Button').length, 0);
   });
 
@@ -54,8 +54,7 @@ describe('Unit6ValidationStep', () => {
       />
     );
     assert.equal(
-      wrapper.find(`input [value="${Unit6Intention.YES_18_19}"]`).props()
-        .checked,
+      wrapper.find(`[value="${Unit6Intention.YES_18_19}"]`).props().checked,
       true
     );
     assert.equal(wrapper.find('Button').length, 0);


### PR DESCRIPTION
- **What changed**:
   - 2 tests from `apps/test/unit/lib/kits/maker/ui/Unit6ValidationStepTest.js` changed. 5 ids were added to `apps/src/lib/kits/maker/ui/Unit6ValidationStep.jsx`.
- **Where it changed**:
   - Ids were added as an element to each of the array in `apps/src/lib/kits/maker/ui/Unit6ValidationStep.jsx` in order to target each input component in the `apps/test/unit/lib/kits/maker/ui/Unit6ValidationStepTest.js`. 
   - In order to comply with the existing rules, the ids were prepended with `ui-test-id`.
   - The 2 tests use the newly created ids.
- **Why are we making this change**?
   - This change is due to the enzyme upgrade from version 2 to version 3. The test failed in v3. 
- **How I tested the change**:
   - Tested by making sure the test passes for both tests.
- **What's next**?
   - None at this time.