### PR TITLE
PL: make regional partner mini-contact slightly more general

### DIFF
--- a/apps/src/code-studio/pd/application/teacher1920/Section1AboutYou.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section1AboutYou.jsx
@@ -178,7 +178,7 @@ export default class Section1AboutYou extends LabeledFormComponent {
           For additional questions regarding the program or application, please{' '}
           <RegionalPartnerMiniContactPopupLink
             sourcePageId="teacher-application-first-page"
-            notes="Please tell me more about the professional learning program!"
+            notes="Please tell me more about the professional learning program for grades 6-12!"
           >
             <span style={styles.linkLike}>contact your Regional Partner</span>
           </RegionalPartnerMiniContactPopupLink>

--- a/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
+++ b/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
@@ -60,7 +60,8 @@ export class RegionalPartnerMiniContact extends React.Component {
       name: this.state.name,
       email: this.state.email,
       zip: this.state.zip,
-      notes: this.state.notes
+      notes: this.state.notes,
+      source: this.props.sourcePageId
     };
 
     this.setState({submitting: true});

--- a/dashboard/app/mailers/pd/regional_partner_contact_mailer.rb
+++ b/dashboard/app/mailers/pd/regional_partner_contact_mailer.rb
@@ -9,7 +9,7 @@ class Pd::RegionalPartnerContactMailer < ActionMailer::Base
     @name = pm.name
 
     subject = if form[:mini]
-                "Submitted question about 6-12 PL program from Code.org site"
+                "Question about Code.org program"
               else
                 "A teacher and/or administrator would like to connect with you"
               end

--- a/dashboard/app/models/pd/regional_partner_mini_contact.rb
+++ b/dashboard/app/models/pd/regional_partner_mini_contact.rb
@@ -37,7 +37,7 @@ class Pd::RegionalPartnerMiniContact < ApplicationRecord
 
     if regional_partner_id
       partner = RegionalPartner.find(regional_partner_id)
-      regional_partner_program_managers = RegionalPartnerProgramManager.where(regional_partner_id: partner)
+      regional_partner_program_managers = RegionalPartnerProgramManager.where(regional_partner: partner)
 
       if regional_partner_program_managers.empty?
         matched_but_no_pms = true

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md
@@ -35,13 +35,13 @@ theme: responsive
 
 ## Why should I apply?
 
-The majority of our workshop attendees rank it the **best professional development ever.** Over 90% of attendees would recommend our program to another teacher. 
+The majority of our workshop attendees rank it the **best professional development ever.** Over 90% of attendees would recommend our program to another teacher.
 
 **No experience needed!** Whether you are new to teaching computer science (CS) or have experience teaching other CS courses, the Code.org Professional Learning Program offers year round support. We’ve designed this program to promote growth by providing space for you to become comfortable with curricular materials, CS content, and pedagogy.
 
 **Over a third of schools** use Code.org's curriculum, including the largest school districts in the U.S., such as LAUSD, Broward, and Dallas ISD. And, over a quarter of our teachers come from rural schools.
 
-**Proven results** - peer reviewed research shows that school participation in the Code.org program causes an estimated 5x increase in students that take and pass the AP Computer Science Principles exam. 
+**Proven results** - peer reviewed research shows that school participation in the Code.org program causes an estimated 5x increase in students that take and pass the AP Computer Science Principles exam.
 
 ## Find the right course for your classroom
 
@@ -158,7 +158,7 @@ Check out these 3 key benefits of ISTE membership:
 
 The Code.org Professional Learning Program is open to educators who are interested in teaching Code.org courses - no prior computer science experience required! In order to participate in this program, we ask that applicants:
 
-* Commit to participating in the full, year-long professional learning program 
+* Commit to participating in the full, year-long professional learning program
 * Plan to teach the course in the 2019-20 school year
 * For CS Discoveries, teach students between 6th and 10th grade
 * For CS Principles, teach students between 9th and 12th grade
@@ -166,7 +166,7 @@ The Code.org Professional Learning Program is open to educators who are interest
 
 ## Have questions?
 
-<%= view :professional_learning_regional_partner_mini_contact, source_page_id: "middle-high", notes: "Please tell me more about the professional learning program!" %>
+<%= view :professional_learning_regional_partner_mini_contact, source_page_id: "middle-high", notes: "Please tell me more about the professional learning program for grades 6-12!" %>
 
 <br/>
 


### PR DESCRIPTION
The subject of the email sent to the regional partner goes from `"Submitted question about 6-12 PL program from Code.org site"` to `"Question about Code.org program"` so that it's useful for K-5 contacts as well.

For /educate/professional-learning/middle-high and page 1 of the teacher application, the mini-contact default text goes from `"Please tell me more about the professional learning program!"` to `"Please tell me more about the professional learning program for grades 6-12!"`.

We're not using it for anything yet, but we now report back the "source page ID" when submitting the information.  This might prove useful later on.