### PR TITLE
Remove npm version-specific installation from setup

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -12,7 +12,6 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
      ```
      ruby --version  # --> ruby 2.5.0
      node --version  # --> v8.15.0
-     npm --version   # --> 3.10.8
      yarn --version  # --> 1.6.0
      ```
 1. If using HTTPS: `git clone https://github.com/code-dot-org/code-dot-org.git`, if using SSH: `git@github.com:code-dot-org/code-dot-org.git`
@@ -85,7 +84,7 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
         ```
 
     1. Pick up those changes: `source ~/.bash_profile`
-1. Install Node, npm, and yarn
+1. Install Node and yarn
     1. `nvm install 8.15.0 && nvm alias default 8.15.0` this command should make this version the default version and print something like: `Creating default alias: default -> 8.15.0 (-> v8.15.0)`
     1. `curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0`
     1. (You can reinstall with your updated version after you clone the repository if necessary) Reinstall node_modules `cd apps; yarn; cd ..`
@@ -115,7 +114,7 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
 ### Ubuntu 16.04 ([Download iso][ubuntu-iso-url]) Note: Virtual Machine Users should check the Windows Note below before starting
 
 1. `sudo apt-get update`
-1. `sudo apt-get install -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-9-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk enscript libsqlite3-dev phantomjs build-essential redis-server rbenv npm`
+1. `sudo apt-get install -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-9-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk enscript libsqlite3-dev phantomjs build-essential redis-server rbenv`
     * **Hit enter and select default options for any configuration popups, leaving mysql passwords blank**
 1. *(If working from an EC2 instance)* `sudo apt-get install -y libreadline-dev libffi-dev`
 1. Install Node and Nodejs

--- a/apps/package.json
+++ b/apps/package.json
@@ -5,7 +5,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "engines": {
     "node": ">=8.15",
-    "npm": "^3.10.8"
+    "npm": ">=3.10.8"
   },
   "scripts": {
     "lint": "eslint --ext .js,.jsx src test",

--- a/cookbooks/Berksfile
+++ b/cookbooks/Berksfile
@@ -5,11 +5,12 @@ source "https://supermarket.chef.io"
 
 #metadata
 
-cookbook 'apt', '~> 2.6.0'
+cookbook 'apt', '~> 2.6.0' # 6.0.0 requires Chef >= 12.9
 cookbook 'ark', '< 4.0.0' # 4.0.0 requires Chef >= 13.4
 cookbook 'build-essential', '~> 2.1.3'
 cookbook 'chef-client', '~> 4.2.0'
 cookbook 'ntp', '~> 1.8.6'
+cookbook 'seven_zip', '< 3.0.0' # 3.0.0 requires Chef >= 13
 
 # Not yet published to Supermarket: https://github.com/PaytmLabs/chef-ixgbevf/issues/1
 cookbook 'ixgbevf', github: 'wjordan/chef-ixgbevf', branch: 'cdo'

--- a/cookbooks/cdo-nodejs/.kitchen.yml
+++ b/cookbooks/cdo-nodejs/.kitchen.yml
@@ -9,7 +9,7 @@ driver:
 provisioner:
   name: chef_zero
   data_path: test/shared
-  require_chef_omnibus: 12.6.0
+  require_chef_omnibus: 12.7.2
 
 platforms:
   - name: ubuntu-14.04
@@ -27,10 +27,8 @@ suites:
         attributes:
           cdo-nodejs:
             version: '0.12'
-            npm_version: '2'
       - run_list:
         - recipe[cdo-nodejs]
         attributes:
           cdo-nodejs:
             version: '6.x'
-            npm_version: '3'

--- a/cookbooks/cdo-nodejs/Berksfile
+++ b/cookbooks/cdo-nodejs/Berksfile
@@ -1,3 +1,4 @@
 source 'https://supermarket.chef.io'
 
 metadata
+instance_eval File.read('../local_cookbooks.rb'), __FILE__

--- a/cookbooks/cdo-nodejs/README.md
+++ b/cookbooks/cdo-nodejs/README.md
@@ -6,4 +6,4 @@ Installs NodeJS.
 
 - `node['cdo-nodejs']['version']` - the version of Node.js to install, automatically selecting the latest patch release.
   Valid values are from [NodeSource distribution](https://github.com/nodesource/distributions) IDs, currently: `"0.10"`, `"0.12"`, or `"4.x"`.
-- `node['cdo-nodejs']['npm_version']` - [semver](https://docs.npmjs.com/getting-started/semantic-versioning) string of npm version to install, e.g., `"2"` or `"latest"`
+- `node['cdo-nodejs']['yarn_version']` - Yarn [APT package version](https://www.ubuntuupdates.org/ppa/yarn) to install, e.g., `'1.6.0-1'` 

--- a/cookbooks/cdo-nodejs/attributes/default.rb
+++ b/cookbooks/cdo-nodejs/attributes/default.rb
@@ -1,3 +1,2 @@
 default['cdo-nodejs']['version'] = '8.x'
-default['cdo-nodejs']['npm_version'] = '3'
 default['cdo-nodejs']['yarn_version'] = '1.6.0-1'

--- a/cookbooks/cdo-nodejs/recipes/default.rb
+++ b/cookbooks/cdo-nodejs/recipes/default.rb
@@ -11,12 +11,6 @@ package 'nodejs' do
   action :upgrade
 end
 
-nodejs_npm 'npm' do
-  version node['cdo-nodejs']['npm_version']
-end
-
-nodejs_npm 'grunt-cli'
-
 apt_repository "yarn" do
   uri "https://dl.yarnpkg.com/debian/"
   distribution 'stable'

--- a/cookbooks/cdo-nodejs/test/integration/default/serverspec/node_spec.rb
+++ b/cookbooks/cdo-nodejs/test/integration/default/serverspec/node_spec.rb
@@ -2,4 +2,6 @@ require_relative '../../../kitchen/data/helper_spec'
 
 file_exist '/usr/bin/node'
 cmd 'node -v', 'v8.'
-cmd 'npm -v', '3.'
+
+cmd 'which yarn', '/usr/bin/yarn'
+cmd 'yarn --version', '1.6.0'

--- a/cookbooks/cdo-nodejs/test/integration/upgrade_step_2/serverspec/node_spec.rb
+++ b/cookbooks/cdo-nodejs/test/integration/upgrade_step_2/serverspec/node_spec.rb
@@ -2,7 +2,6 @@ require_relative '../../../kitchen/data/helper_spec'
 
 file_exist '/usr/bin/node'
 cmd 'node -v', 'v8.'
-cmd 'npm -v', '3.'
 
 cmd 'which yarn', '/usr/bin/yarn'
 cmd 'yarn --version', '1.6.0'

--- a/cookbooks/local_cookbooks.rb
+++ b/cookbooks/local_cookbooks.rb
@@ -6,3 +6,7 @@ Ridley::Chef::Cookbook::Metadata.from_file('metadata.rb').dependencies.keys.each
   next unless File.directory? path
   cookbook cookbook, path: path
 end
+
+# Pin specific dependency versions:
+cookbook 'seven_zip', '< 3.0.0' # 3.0.0 requires Chef 13
+cookbook 'apt', '< 6.0.0' # 6.0.0 requires Chef >= 12.9


### PR DESCRIPTION
No longer pin any specific version of `npm` in our installation process.

Recent versions of Node come bundled with recent `npm` versions, and we use (a pinned version of) `yarn` for managing node modules anyway, so this PR removes an unnecessary `npm`-downgrade step that itself triggers bugs/issues.

Specific bug/issue prompting this PR: The `nodejs_npm 'npm'` resource (for pinning a specific npm version) executes `npm install -g npm@3` as `root` (required, because `npm` global modules are installed to `root`-owned `/usr/lib/node_modules`). In recent versions of `npm` (>= 4.4.0; our current pinned `node` version 8.15.1 is bundled with `npm` v6.4.1), a bug causes `$HOME/.config/configstore/update-notifier-npm.json` to be created with `root` permissions when this command is run. This causes permission errors the next time a user-process tries to create files/folders within `$HOME/.config`.

Part of the PR diff includes some changes to Chef / Test Kitchen / Berkshelf config, which needed a bit of a refresh to run the (manual) integration tests used for verifying the cookbook changes within a Docker container.