### PR TITLE
Pegasus: Fix headshots grid overlapping issue

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/brstrap.css
+++ b/pegasus/sites.v3/code.org/public/css/brstrap.css
@@ -121,7 +121,6 @@
   .mobile-pad-left64 { padding-left: 64px; }
 
   .mobile-pad-edge { padding: 20px; }
-  .avatar_container { max-height: 550px; }
   .avatar_container p { padding-right: 0px; }
   .avatar_container img { margin-left: 25px; }
 


### PR DESCRIPTION
Fix a problem where a long entry in a headshots grid (where the text is very long) would overlap its successor.  The `max-height` didn't seem necessary.  Tested on desktop & mobile width on a variety of pages that use this grid.

### before fix:

![Screenshot 2019-03-26 16 17 44](https://user-images.githubusercontent.com/2205926/55039853-2a751f00-4fe3-11e9-8dac-d30968c4fb1c.png)

