### PR TITLE
Level: add validation to check for colon(s) in level name

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -38,6 +38,7 @@ class Level < ActiveRecord::Base
 
   validates_length_of :name, within: 1..70
   validates_uniqueness_of :name, case_sensitive: false, conditions: -> {where.not(user_id: nil)}
+  validates :name, format: {with: /\A(?~:)\z/}
 
   after_save :write_custom_level_file
   after_destroy :delete_custom_level_file

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -11,6 +11,7 @@ class LevelTest < ActiveSupport::TestCase
     @maze_data = {game_id: 25, name: "__bob4", level_num: "custom", skin: "birds", short_instructions: "sdfdfs", type: 'Maze'}
     @custom_maze_data = @maze_data.merge(user_id: 1)
     @gamelab_data = {game_id: 48, name: 'some gamelab level', level_num: 'custom', type: 'Gamelab'}
+    @custom_gamelab_data = {game_id: 30, name: 'game:puzzle', level_num: 'custom', type: 'Gamelab'}
     @custom_level = Level.create(@custom_maze_data.dup)
     @level = Level.create(@maze_data.dup)
 
@@ -69,6 +70,14 @@ class LevelTest < ActiveSupport::TestCase
 
     assert_raises ArgumentError do
       Karel.parse_maze(json, 7)
+    end
+  end
+
+  test "cannot create a level with a name that contains a colon" do
+    assert_does_not_create(Level) do
+      level2 = Level.create(@custom_gamelab_data)
+      assert_not level2.valid?
+      assert level2.errors.include?(:name)
     end
   end
 


### PR DESCRIPTION
Currently, content editors can assign a levelbuilder_key a name that includes a colon. This naming prevents show notes from being displayed for a particular video/level.

Validation is added to the Level model to check if the name of a level contains a colon.  I verified that the new validation added did not break previous tests.