### PR TITLE
Fix cdo-users regex match

### DIFF
--- a/cookbooks/cdo-users/recipes/default.rb
+++ b/cookbooks/cdo-users/recipes/default.rb
@@ -111,7 +111,7 @@ node['cdo-users'].each_pair do |user_name, user_data|
       # SSH requires that hostnames consist of zero or more non-whitespace
       # characters, with optional wildcards:
       # http://man.openbsd.org/OpenBSD-current/man5/ssh_config.5#PATTERNS
-      next unless name.value.match =~ /^\S*$/
+      next unless name.value =~ /^\S*$/
 
       hosts[name.value] = instance.private_dns_name
     end


### PR DESCRIPTION
Followup to #27476.

This fixes an error `wrong number of arguments (0 for 1..2)` when converging the updated cookbook- I think the syntax should be either [`.match`](https://ruby-doc.org/core-2.5.0/String.html#method-i-match) or [`=~`](https://ruby-doc.org/core-2.5.0/String.html#method-i-3D~), not `.match =~` together.