### PR TITLE
Append include_bonus_levels value to cache key for stage_summary cach…

### DIFF
--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -119,7 +119,7 @@ class Stage < ActiveRecord::Base
   end
 
   def summarize(include_bonus_levels = false)
-    stage_summary = Rails.cache.fetch("#{cache_key}/stage_summary/#{I18n.locale}") do
+    stage_summary = Rails.cache.fetch("#{cache_key}/stage_summary/#{I18n.locale}/#{include_bonus_levels}") do
       cached_levels = include_bonus_levels ? cached_script_levels : cached_script_levels.reject(&:bonus)
 
       stage_data = {


### PR DESCRIPTION
…e fetch

Slack discussion [here](https://codedotorg.slack.com/archives/C0T10HG6N/p1553717290041800).

When I added the `include_bonus_levels` param to `stage#summarize`, I didn't add its value to the cache key Rails uses for `stage_summary`, so we were seeing inconsistent results across requests to the same endpoint.

Thank you to Will for figuring this out and to Brad for debugging with me! 🎉 