### PR TITLE
cdo-users fix

### DIFF
--- a/cookbooks/cdo-users/recipes/default.rb
+++ b/cookbooks/cdo-users/recipes/default.rb
@@ -102,8 +102,9 @@ node['cdo-users'].each_pair do |user_name, user_data|
         aws_config['access_key_id'],
         aws_config['access_key_secret']
       )
-    ).describe_instances.reservations.map(&:instances).flatten.each do |instance|
-      next unless instance.private_dns_name
+    ).describe_instances(filters: [{name: 'instance-state-name', values: ['running']}]).
+      reservations.map(&:instances).flatten.each do |instance|
+      next if instance.private_dns_name.nil? || instance.private_dns_name.empty?
 
       name = instance.tags.find {|tag| tag.key == "Name"}
       next unless name && name.value


### PR DESCRIPTION
Second bug-fix followup to #27476. This PR fixes an issue where stopped EC2 instances have empty-string (`''`) `private_dns_name` values, producing an invalid generated SSH config (empty-string hostnames do not parse properly), causing a syntax error in the `ssh` command.

The PR contains two related fixes:
- Skip entries for instances containing `empty?` (in addition to `nil`) private dns name values.
- Add a `filter` parameter to only list 'running' instances.