### PR TITLE
Tweaks to migration script

### DIFF
--- a/bin/oneoff/migrate_users_to_multi_auth.rb
+++ b/bin/oneoff/migrate_users_to_multi_auth.rb
@@ -13,14 +13,12 @@ def migrate_batches(limit=nil)
   puts "Migrating #{limit || 'all'} slice(s)"
   unmigrated_users.find_in_batches(batch_size: SLICE_SIZE) do |slice|
     puts "\tSLICE_COUNT: #{slice_count + 1} of ~#{unmigrated_users_count / SLICE_SIZE}..."
-    ActiveRecord::Base.transaction do
-      successes = 0
-      slice.each do |user|
-        user.migrate_to_multi_auth
-        successes += 1 if user.valid? && user.provider == User::PROVIDER_MIGRATED
-      end
-      puts "\t\tsuccessful migrations: #{successes} / #{SLICE_SIZE}"
+    successes = 0
+    slice.each do |user|
+      user.migrate_to_multi_auth
+      successes += 1 if user.valid? && user.provider == User::PROVIDER_MIGRATED
     end
+    puts "\t\tsuccessful migrations: #{successes} / #{SLICE_SIZE}"
     slice_count += 1
 
     if limit && slice_count >= limit

--- a/bin/oneoff/migrate_users_to_multi_auth.rb
+++ b/bin/oneoff/migrate_users_to_multi_auth.rb
@@ -11,7 +11,7 @@ def migrate_batches(limit=nil)
 
   slice_count = 0
   puts "Migrating #{limit || 'all'} slice(s)"
-  unmigrated_users.each_slice(SLICE_SIZE) do |slice|
+  unmigrated_users.find_in_batches(batch_size: SLICE_SIZE) do |slice|
     puts "\tSLICE_COUNT: #{slice_count + 1} of ~#{unmigrated_users_count / SLICE_SIZE}..."
     ActiveRecord::Base.transaction do
       successes = 0


### PR DESCRIPTION
- use find_in_batches rather than each_slice, since the former is an offical ActiveRecord method and the latter is a generic Enumerator one
- don't bother to use transactions in this script, since the migration is already internally transaction-safe