### PR TITLE
Remove 'enzyme-wait' package, because it's not compatible with Enzyme 3

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -92,7 +92,6 @@
     "ejs": "^2.6.1",
     "ejs-compiled-loader": "2.1.1",
     "enzyme": "~2.8.0",
-    "enzyme-wait": "^1.0.9",
     "es6-promise": "3.0.2",
     "eslint": "^3.19.0",
     "eslint-config-prettier": "^3.6.0",

--- a/apps/test/unit/code-studio/pd/application_dashboard/workshop_assignment_loaderTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/workshop_assignment_loaderTest.js
@@ -3,7 +3,8 @@ import React from 'react';
 import {expect} from 'chai';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
-import {createWaitForElement} from 'enzyme-wait';
+
+const defer = () => new Promise(resolve => setTimeout(resolve, 0));
 
 describe('WorkshopAssignmentLoader', () => {
   // We aren't testing any of the responses of the workshop selector control, so just
@@ -61,7 +62,7 @@ describe('WorkshopAssignmentLoader', () => {
       );
     });
 
-    it('Renders WorkshopAssignmentSelect with combined workshop list', () => {
+    it('Renders WorkshopAssignmentSelect with combined workshop list', async () => {
       respondWithLocal({
         workshops: [
           {id: 1, date_and_location_name: 'Dec 10 - 15, 2018, Seattle WA'},
@@ -73,21 +74,17 @@ describe('WorkshopAssignmentLoader', () => {
       ]);
       sandbox.server.respond();
 
-      const waitForSelect = createWaitForElement('WorkshopAssignmentSelect');
-      return waitForSelect(workshopAssignmentLoader).then(
-        workshopAssignmentLoader => {
-          expect(workshopAssignmentLoader.find('Spinner')).to.have.length(0);
-          const select = workshopAssignmentLoader.find(
-            'WorkshopAssignmentSelect'
-          );
-          expect(select).to.have.length(1);
-          expect(select.prop('workshops')).to.eql([
-            {value: 1, label: 'Dec 10 - 15, 2018, Seattle WA'},
-            {value: 2, label: 'Dec 15 - 20, 2018, Buffalo NY'},
-            {value: 11, label: 'July 22 - 27, 2018, Phoenix AZ'}
-          ]);
-        }
-      );
+      await defer();
+      workshopAssignmentLoader.update();
+
+      expect(workshopAssignmentLoader.find('Spinner')).to.have.length(0);
+      const select = workshopAssignmentLoader.find('WorkshopAssignmentSelect');
+      expect(select).to.have.length(1);
+      expect(select.prop('workshops')).to.eql([
+        {value: 1, label: 'Dec 10 - 15, 2018, Seattle WA'},
+        {value: 2, label: 'Dec 15 - 20, 2018, Buffalo NY'},
+        {value: 11, label: 'July 22 - 27, 2018, Phoenix AZ'}
+      ]);
     });
   });
 
@@ -103,7 +100,7 @@ describe('WorkshopAssignmentLoader', () => {
       );
     });
 
-    it('Renders WorkshopAssignmentSelect with combined workshop list', () => {
+    it('Renders WorkshopAssignmentSelect with combined workshop list', async () => {
       respondWithLocal({
         workshops: [
           {id: 1, date_and_location_name: 'Dec 10 - 15, 2018, Seattle WA'},
@@ -112,32 +109,34 @@ describe('WorkshopAssignmentLoader', () => {
       });
       sandbox.server.respond();
 
-      const waitForSelect = createWaitForElement('WorkshopAssignmentSelect');
-      return waitForSelect(workshopAssignmentLoader).then(
-        workshopAssignmentLoader => {
-          expect(workshopAssignmentLoader.find('Spinner')).to.have.length(0);
-          const select = workshopAssignmentLoader.find(
-            'WorkshopAssignmentSelect'
-          );
-          expect(select).to.have.length(1);
-          expect(select.prop('workshops')).to.eql([
-            {value: 1, label: 'Dec 10 - 15, 2018, Seattle WA'},
-            {value: 2, label: 'Dec 15 - 20, 2018, Buffalo NY'}
-          ]);
-        }
-      );
+      await defer();
+      workshopAssignmentLoader.update();
+
+      expect(workshopAssignmentLoader.find('Spinner')).to.have.length(0);
+      const select = workshopAssignmentLoader.find('WorkshopAssignmentSelect');
+      expect(select).to.have.length(1);
+      expect(select.prop('workshops')).to.eql([
+        {value: 1, label: 'Dec 10 - 15, 2018, Seattle WA'},
+        {value: 2, label: 'Dec 15 - 20, 2018, Buffalo NY'}
+      ]);
     });
   });
 
-  it('Displays error message when query fails', () => {
+  it('Displays error message when query fails', async () => {
     workshopAssignmentLoader = mountWorkshopAssignmentLoader('summer');
 
     // bad request
     sandbox.server.respondWith([400, {}, '']);
     sandbox.server.respond();
 
-    const waitForError = createWaitForElement('div.workshop-load-error');
-    return waitForError(workshopAssignmentLoader);
+    await defer();
+    workshopAssignmentLoader.update();
+
+    expect(
+      workshopAssignmentLoader.find('div.workshop-load-error').text()
+    ).to.equal(
+      'Oops. Something went wrong and we are unable to load workshops.'
+    );
   });
 
   it('Aborts pending ajax requests on unmount', () => {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -733,7 +733,7 @@ assertion-error@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.0.tgz#c7f85438fdd466bc7ca16ab90c81513797a5d23b"
 
-assertion-error@^1.0.1, assertion-error@^1.0.2:
+assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
@@ -4296,12 +4296,6 @@ entities@1.0:
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-
-enzyme-wait@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/enzyme-wait/-/enzyme-wait-1.0.9.tgz#f7a08bf49c7047358fa03e1f411a565c3a15101a"
-  dependencies:
-    assertion-error "^1.0.2"
 
 enzyme@~2.8.0:
   version "2.8.2"


### PR DESCRIPTION
We don't actually need to wait for an element to become visible, only defer once to allow the event queue to process.

See: https://github.com/etiennedi/enzyme-wait/issues/8.