### PR TITLE
Surveys: Monitor embedded JotForm load success rates

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -627,6 +627,7 @@ describe('entry tests', () => {
   var otherEntries = {
     essential: './src/sites/studio/pages/essential.js',
     plc: './src/sites/studio/pages/plc.js',
+    jotformLoader: './src/sites/studio/pages/jotformLoader.js',
 
     // Build embedVideo.js in its own step (skipping factor-bundle) so that
     // we don't have to include the large code-studio-common file in the

--- a/apps/script/checkEntryPoints.js
+++ b/apps/script/checkEntryPoints.js
@@ -59,6 +59,7 @@ const SILENCED = [
   'gamelab',
   'gamelab-api',
   'jigsaw',
+  'jotformLoader',
   'levelbuilder',
   'levelbuilder_applab',
   'levelbuilder_craft',

--- a/apps/src/logToCloud.js
+++ b/apps/src/logToCloud.js
@@ -13,7 +13,9 @@ const PageAction = makeEnum(
   'DancePartyOnInit',
   'BrambleError',
   'BrambleFilesystemResetSuccess',
-  'BrambleFilesystemResetFailed'
+  'BrambleFilesystemResetFailed',
+  'JotFormFrameLoaded',
+  'JotFormLoadFailed'
 );
 
 const MAX_FIELD_LENGTH = 4095;

--- a/apps/src/sites/studio/pages/jotformLoader.js
+++ b/apps/src/sites/studio/pages/jotformLoader.js
@@ -1,0 +1,87 @@
+/**
+ * @file Entry point for a bundle to embed on pages where we are also letting JotForm embed
+ * an inline form using an iframe.  This bundle monitors the JotForm script and attempts
+ * to measure reachability of the JotForm domain, load success, load time, and reports metrics
+ * back to our system so we have a sense of how often this fails.
+ * We also attempt to improve the user experience when the form is unavailable.
+ */
+import logToCloud from '../../../logToCloud';
+
+function main(context) {
+  Promise.all([
+    checkJotFormFrameLoaded(context),
+    // Domains used by Jotform:
+    // cdn.jotfor.ms       https://cdn.jotfor.ms/images/calendar.png  817B
+    checkReachability('https://cdn.jotfor.ms/images/calendar.png'),
+    // www.jotform.com     https://www.jotform.com/favicon.ico        887B
+    checkReachability('https://www.jotform.com/favicon.ico')
+    // Not using these yet, they're likely to fall under the same policy as www.jotform.com
+    // events.jotform.com
+    // files.jotform.com
+    // form.jotform.com
+  ]).then(([jotFormFrameLoadedMs, cdnjotformsMs, wwwjotformcomMs]) => {
+    if (jotFormFrameLoadedMs === false) {
+      // Load failed if we specifcially got 'false'
+      logToCloud.addPageAction(logToCloud.PageAction.JotFormLoadFailed, {
+        route: `GET ${context.location.pathname}`,
+        reachedCdnjotforms: false !== cdnjotformsMs,
+        reachedWwwjotformcom: false !== wwwjotformcomMs,
+        cdnjotformsMs,
+        wwwjotformcomMs
+      });
+    } else {
+      logToCloud.addPageAction(logToCloud.PageAction.JotFormFrameLoaded, {
+        route: `GET ${context.location.pathname}`,
+        jotFormFrameLoadedMs,
+        cdnjotformsMs,
+        wwwjotformcomMs
+      });
+    }
+  });
+}
+
+/**
+ * Report page time when JotForm's embedded form successfully loads, or resolve(false) if it
+ * fails to load within five seconds.
+ * @param {Window} context
+ * @returns {Promise<number|false>} Always resolves, page time (ms) if load succeeded, `false` if not.
+ */
+function checkJotFormFrameLoaded(context) {
+  return new Promise(resolve => {
+    context.JotFormFrameLoaded = function() {
+      const time = performance.now();
+      if (timeoutKey) {
+        clearTimeout(timeoutKey);
+      }
+      console.log(`JotFormFrameLoaded fired at ${time}ms`);
+      resolve(time);
+    };
+
+    const timeoutKey = setTimeout(function() {
+      console.log(`JotForm failed to load in 5s`);
+      resolve(false);
+    }, 5000);
+  });
+}
+
+/**
+ * Check reachability of another domain from this client.
+ * @param {string} url - an image URL on another domain.
+ * @returns {Promise<number|false>} Always resolves, load time (ms) if reachable, `false` if not.
+ */
+function checkReachability(url) {
+  return new Promise(resolve => {
+    const img = new Image();
+    img.onabort = () => resolve(false);
+    img.onerror = () => resolve(false);
+    img.onload = () => {
+      const duration = performance.now() - startTime;
+      console.log(`Loaded ${url} in ${duration}ms`);
+      resolve(duration);
+    };
+    const startTime = performance.now();
+    img.src = `${url}?__cacheBust=${Math.random()}`;
+  });
+}
+
+main(window);

--- a/dashboard/app/views/pd/post_course_survey/new.haml
+++ b/dashboard/app/views/pd/post_course_survey/new.haml
@@ -1,1 +1,2 @@
+%script{src: minifiable_asset_path('js/jotformLoader.js')}
 = embed_jotform @form_id, @form_params

--- a/dashboard/app/views/pd/workshop_daily_survey/new_facilitator.html.haml
+++ b/dashboard/app/views/pd/workshop_daily_survey/new_facilitator.html.haml
@@ -1,1 +1,2 @@
+%script{src: minifiable_asset_path('js/jotformLoader.js')}
 = embed_jotform @form_id, @form_params

--- a/dashboard/app/views/pd/workshop_daily_survey/new_general.haml
+++ b/dashboard/app/views/pd/workshop_daily_survey/new_general.haml
@@ -1,1 +1,2 @@
+%script{src: minifiable_asset_path('js/jotformLoader.js')}
 = embed_jotform @form_id, @form_params


### PR DESCRIPTION
[PLC-10](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=PLC&modal=detail&selectedIssue=PLC-10): Adds a small JavaScript snippet to views where we embed JotForm which monitors whether the form loads successfully within five seconds and reports to New Relic.

Specifically:

- Expects a `JotFormFrameLoaded` callback from the JotForm embed script to be called within five seconds of this initial script running.  If called, reports a `JotFormFrameLoaded` event to New Relic with [`performance.now()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) page time in milliseconds.  If not called, reports `JotFormLoadFailed` instead.
  
  This depends on this feature in the JotForm loader script, which I can't find referenced anywhere in the official docs but which clearly looks designed to interface with a host application. (The `JotFormFrameLoaded` function is not defined anywhere within the loader script itself.)
  
  ![image](https://user-images.githubusercontent.com/1615761/55198686-3f34ec80-5174-11e9-9e55-472a26a1ec9b.png)

- Independently checks reachability of a couple of JotForm domains, `www.jotform.com` and `cdn.jotfor.ms` which I noticed monitoring network activity on these pages.  Results from these checks are reported with the New Relic event regardless of success or failure, as they may be useful for spotting patterns in load failures.

  I've documented some additional domains we might check but haven't included them because (a) they're all `*.jotform.com` domains and likely to be reachable if `www.jotform.com` is reachable, and (b) I haven't found small image files to use for a reachablilty check on these domains yet.

**Tested** on my local server by loading `http://localhost-studio.code.org:3000/pd/post_course_survey/csp` with and without having blocked various domains from devtools.  I have not fully verified the New Relic reporting behavior yet.

### Prior work
- https://github.com/code-dot-org/code-dot-org/pull/27664