### PR TITLE
Remove non-actionable Honeybadger notification

### DIFF
--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -87,7 +87,7 @@ class SchoolInfo < ActiveRecord::Base
     # As of Nov. 2, 2017 there were 7 rows in school_infos with non-null school_id and conflicting
     # data between schools and school_infos. Until we better understand what is causing that we don't want
     # to flat out fail if we get conflicting inputs. Instead we overwrite the passed in fields with what
-    # is on the School and report the mismatch to HoneyBadger.
+    # is on the School.
     unless school.nil? && school_id.nil?
       original = {}
       original[:country] = country
@@ -112,21 +112,6 @@ class SchoolInfo < ActiveRecord::Base
       self.school_name = nil
       self.full_address = nil
       self.validation_type = VALIDATION_FULL
-
-      # Report if we are overriding a non-nil value that was originally passed in
-      something_overwritten = original.map {|key, value| value && value != self[key]}.reduce {|acc, b| acc || b}
-      if something_overwritten
-        Honeybadger.notify(
-          error_message: "Overwriting passed in data for new SchoolInfo",
-          error_class: "SchoolInfo.sync_from_schools",
-          context: {
-            original_input: original,
-            school_id: school.id
-          }
-        )
-        # Don't interrupt callback chain by returning false
-        return nil
-      end
     end
   end
 

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -123,24 +123,6 @@ class SchoolInfoTest < ActiveSupport::TestCase
     assert_equal school_info.validation_type, SchoolInfo::VALIDATION_FULL
   end
 
-  test 'inconsitant school data notifies' do
-    Honeybadger.expects(:notify)
-    school_info = build :school_info_with_public_school_only, country: 'Different Country'
-    assert school_info.valid?, school_info.errors.full_messages
-  end
-
-  test 'consitant school data does not notify' do
-    Honeybadger.expects(:notify).never
-    school_info = build :school_info_with_public_school_only, country: 'US'
-    assert school_info.valid?, school_info.errors.full_messages
-  end
-
-  test 'auto upgrade validation type without other overwritting does not notify' do
-    Honeybadger.expects(:notify).never
-    school_info = build :school_info_with_public_school_only, validation_type: SchoolInfo::VALIDATION_NONE
-    assert school_info.valid?, school_info.errors.full_messages
-  end
-
   test 'US public with district and school succeeds' do
     school_info = build :school_info_us_public, :with_district, :with_school
     assert school_info.valid?, school_info.errors.full_messages


### PR DESCRIPTION
[This notification](https://app.honeybadger.io/projects/3240/faults/36774862), indicating a School<>SchoolInfo mismatch was being resolved, was added in https://github.com/code-dot-org/code-dot-org/pull/18873 more than a year ago.  It fires semi-regularly but doesn't seem to indicate an actual problem, and none of us know what sort of corrective action it's supposed to drive us toward.

@drewsamnick left [this description](https://github.com/code-dot-org/code-dot-org/blob/dd7b08116100e54255ea9060f12161f9f656780a/dashboard/app/models/school_info.rb#L85-L90) on the `before_validation` hook in the original implementation:

> If a `SchoolInfo` is linked to a `School` then the `SchoolInfo` pulls its data from the `School`
> It seems like there is some code that is passing in mismatched data at times. As of Nov. 2, 2017 there were 7 rows in school_infos with non-null school_id and conflicting data between schools and school_infos. Until we better understand what is causing that we don't want to flat out fail if we get conflicting inputs. Instead we overwrite the passed in fields with what is on the School and report the mismatch to HoneyBadger.

@joshlory [asked if this is worth keeping around anymore](https://codedotorg.slack.com/archives/C55JZ1BPZ/p1553814887001300); my inclination is "no."  Curious if anyone else knows why we'd need this information in Honeybadger.