### PR TITLE
 enable non-english TTS for long instructions 

### DIFF
--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -154,8 +154,14 @@ module TextToSpeech
   end
 
   def tts_long_instructions_text
-    # Instructions in contained levels are used as TTS instead of the instructions of the containing level
-    tts_long_instructions_override || TextToSpeech.sanitize(tts_for_contained_level || long_instructions || "")
+    if I18n.locale == I18n.default_locale
+      # Instructions in contained levels are used as TTS instead of the
+      # instructions of the containing level
+      return tts_long_instructions_override ||
+        TextToSpeech.sanitize(tts_for_contained_level || long_instructions || "")
+    else
+      TextToSpeech.sanitize(try(:localized_long_instructions) || "")
+    end
   end
 
   def tts_for_contained_level

--- a/dashboard/test/models/concerns/text_to_speech_test.rb
+++ b/dashboard/test/models/concerns/text_to_speech_test.rb
@@ -102,4 +102,59 @@ class TextToSpeechTest < ActiveSupport::TestCase
     assert_equal "This is contained\nThis is also contained\n", outer_level_with_multiple_contained_levels.tts_long_instructions_text
     assert_equal "Contained\nQuestion text\nanswer 1\nanswer 2\nanswer 3\n", outer_level_with_contained_multi_level.tts_long_instructions_text
   end
+
+  test 'tts works for non-english short instructions' do
+    translatable_level = create :level, name: 'TTS test Short Instructions',
+      type: 'Blockly', short_instructions: "regular instructions in English"
+
+    test_locale = :"te-ST"
+    I18n.locale = test_locale
+    custom_i18n = {
+      "data" => {
+        "short_instructions" => {
+          translatable_level.name => "regular instructions in another language"
+        }
+      }
+    }
+
+    I18n.backend.store_translations test_locale, custom_i18n
+    assert_equal "regular instructions in another language\n", translatable_level.tts_short_instructions_text
+  end
+
+  test 'tts works for non-english long instructions' do
+    translatable_level = create :level, name: 'TTS test Long Instructions',
+      type: 'Blockly', long_instructions: "long instructions in English"
+
+    test_locale = :"te-ST"
+    I18n.locale = test_locale
+    custom_i18n = {
+      "data" => {
+        "long_instructions" => {
+          translatable_level.name => "long instructions in another language"
+        }
+      }
+    }
+
+    I18n.backend.store_translations test_locale, custom_i18n
+    assert_equal "long instructions in another language\n", translatable_level.tts_long_instructions_text
+  end
+
+  test 'tts ignores overrides for non-english' do
+    translatable_level = create :level, name: 'TTS test Short Instructions',
+      type: 'Blockly', short_instructions: "regular instructions in English",
+      tts_short_instructions_override: "instructions override"
+
+    test_locale = :"te-ST"
+    I18n.locale = test_locale
+    custom_i18n = {
+      "data" => {
+        "short_instructions" => {
+          translatable_level.name => "regular instructions in another language"
+        }
+      }
+    }
+
+    I18n.backend.store_translations test_locale, custom_i18n
+    assert_equal "regular instructions in another language\n", translatable_level.tts_short_instructions_text
+  end
 end


### PR DESCRIPTION
Looks like this might have _never_ worked for long instructions, only ever for short. Which is a little worrying.