### PR TITLE
Add script to compare workshop email previews

### DIFF
--- a/bin/oneoff/diff_email_previews
+++ b/bin/oneoff/diff_email_previews
@@ -93,13 +93,13 @@ end
 def print_instruction
   puts "This script compares content of all workshop email previews before and after a change to make sure the change doesn't have unexpected results."
   puts "How to run:"
-  puts "In staging branch, run './emaildiff download base'"
-  puts "In feature branch, run './emaildiff download new'"
-  puts "Compare email content in base and feature branch: './emaildiff diff base new'"
+  puts "In staging branch, run './diff_email_previews download base'"
+  puts "In feature branch, run './diff_email_previews download new'"
+  puts "Compare email content in base and feature branch: './diff_email_previews diff base new'"
 
   puts "\n\nCommand syntax:"
-  puts "To download emails to a folder in the current directory: './emaildiff download <foldername>'"
-  puts "To diff emails in 2 folders in the current directory: './emaildiff diff <foldername1> <foldername2>'"
+  puts "To download emails to a folder in the current directory: './diff_email_previews download <foldername>'"
+  puts "To diff emails in 2 folders in the current directory: './diff_email_previews diff <foldername1> <foldername2>'"
 end
 
 def main

--- a/bin/oneoff/diff_email_previews
+++ b/bin/oneoff/diff_email_previews
@@ -1,0 +1,121 @@
+#!/usr/bin/env ruby
+require 'open-uri'
+require 'fileutils'
+
+# SUMMARY:
+# Comparing content of all workshop email previews before and after a change to make sure the change doesn't have unexpected results.
+
+# List of email previews are copied from http://localhost-studio.code.org:3000/rails/mailers/pd/workshop_mailer/
+PREVIEWS = %w(
+  detail_change_notification__csf_deepdive
+  detail_change_notification__admin
+  detail_change_notification__csf_intro
+  exit_survey__csd_1
+  exit_survey__csd_teacher_con
+  exit_survey__csf_deepdive
+  exit_survey__csf_intro
+  exit_survey__csp_1
+  exit_survey__csp_summer_workshop
+  exit_survey__general
+  facilitator_detail_change_notification__csf_intro
+  facilitator_enrollment_reminder
+  organizer_cancel_receipt
+  organizer_detail_change_notification__csf
+  organizer_enrollment_receipt
+  organizer_enrollment_reminder
+  organizer_should_close_reminder
+  teacher_cancel_receipt__csf
+  teacher_cancel_receipt__general
+  teacher_enrollment_receipt__admin
+  teacher_enrollment_receipt__counselor
+  teacher_enrollment_receipt__cs_in_a_phase_3
+  teacher_enrollment_receipt__cs_in_s_phase_3_semester_1
+  teacher_enrollment_receipt__cs_in_s_phase_3_semester_2
+  teacher_enrollment_receipt__csd_summer_workshop
+  teacher_enrollment_receipt__csf_deepdive
+  teacher_enrollment_receipt__csf_intro
+  teacher_enrollment_receipt__csp_1
+  teacher_enrollment_receipt__csp_summer_workshop
+  teacher_enrollment_receipt__ecs_phase_4
+  teacher_enrollment_receipt__ecs_unit_3
+  teacher_enrollment_receipt__ecs_unit_4
+  teacher_enrollment_receipt__ecs_unit_5
+  teacher_enrollment_receipt__ecs_unit_6
+  teacher_enrollment_receipt__formatted_notes
+  teacher_enrollment_receipt__phase_2
+  teacher_enrollment_receipt_csd_1
+  teacher_enrollment_reminder__admin
+  teacher_enrollment_reminder__counselor
+  teacher_enrollment_reminder__csd_summer_workshop_10_day
+  teacher_enrollment_reminder__csd_summer_workshop_3_day
+  teacher_enrollment_reminder__csf_deepdive_10_day
+  teacher_enrollment_reminder__csf_deepdive_3_day
+  teacher_enrollment_reminder__csf_intro_10_day
+  teacher_enrollment_reminder__csf_intro_3_day
+  teacher_enrollment_reminder__csp_1_10_day
+  teacher_enrollment_reminder__csp_1_3_day
+  teacher_enrollment_reminder__csp_summer_workshop_10_day
+  teacher_enrollment_reminder__csp_summer_workshop_3_day
+  teacher_enrollment_reminder_csd_1_10_day
+  teacher_enrollment_reminder_csd_1_3_day
+  teacher_enrollment_reminder_csd_unit_6_3_day
+  teacher_follow_up__csf_intro
+  teacher_survey_reminder__csf_deepdive
+).freeze
+
+def download_workshop_emails(output_folder)
+  base = 'http://localhost-studio.code.org:3000/rails/mailers/pd/workshop_mailer/'
+  body = '?part=text%2Fhtml'
+
+  output_folder_path = './' + output_folder
+  unless File.directory?(output_folder_path)
+    FileUtils.mkdir_p(output_folder_path)
+  end
+
+  PREVIEWS.each do |preview|
+    IO.copy_stream(open(base + preview + body), "#{output_folder_path}/#{preview}_body.html")
+
+    #This file contains email header like From/To/CC and a few more things.
+    #However it has DateTime field that changes, so we exclude it from the comparison.
+    #If we really want to compare headers, we will have to update diff command to ignore DateTime regex.
+    #IO.copy_stream(open(base + preview), "#{output_folder_path}/#{preview}.html")
+  end
+end
+
+def compare_workshop_emails(folder1, folder2)
+  # diff 2 folders, ignoring blank lines (-B) and lines containing enrollment codes (which are all caps 10-char strings).
+  # GNU diffutils use basic version of regex so we have to escape meta-characters like ?, +, |, {, }, (, and ).
+  # Reference: https://stackoverflow.com/questions/2072167/diff-tools-flavor-of-regex-seems-lacking
+  `diff -u -B -I '\\(/\\|=\\)[A-Z]\\{10,\\}' base new > diffresult.txt`
+  puts "Comparision result saved to diffresult.txt"
+end
+
+def print_instruction
+  puts "This script compares content of all workshop email previews before and after a change to make sure the change doesn't have unexpected results."
+  puts "How to run:"
+  puts "In staging branch, run './emaildiff download base'"
+  puts "In feature branch, run './emaildiff download new'"
+  puts "Compare email content in base and feature branch: './emaildiff diff base new'"
+
+  puts "\n\nCommand syntax:"
+  puts "To download emails to a folder in the current directory: './emaildiff download <foldername>'"
+  puts "To diff emails in 2 folders in the current directory: './emaildiff diff <foldername1> <foldername2>'"
+end
+
+def main
+  if ARGV.count == 2 && ARGV[0].downcase == 'download'
+    puts "Downloading emails to folder #{ARGV[1]}"
+    download_workshop_emails(ARGV[1])
+  elsif ARGV.count == 3 && ARGV[0].downcase == 'diff'
+    puts "Comparing emails in folders #{ARGV[1]} and #{ARGV[2]}"
+    compare_workshop_emails(ARGV[1], ARGV[2])
+  else
+    print_instruction
+
+    ARGV.each do |a|
+      puts "Argument: #{a}"
+    end
+  end
+end
+
+main

--- a/bin/oneoff/diff_email_previews
+++ b/bin/oneoff/diff_email_previews
@@ -86,7 +86,7 @@ def compare_workshop_emails(folder1, folder2)
   # diff 2 folders, ignoring blank lines (-B) and lines containing enrollment codes (which are all caps 10-char strings).
   # GNU diffutils use basic version of regex so we have to escape meta-characters like ?, +, |, {, }, (, and ).
   # Reference: https://stackoverflow.com/questions/2072167/diff-tools-flavor-of-regex-seems-lacking
-  `diff -u -B -I '\\(/\\|=\\)[A-Z]\\{10,\\}' base new > diffresult.txt`
+  `diff -u -B -I '\\(/\\|=\\)[A-Z]\\{10,\\}' #{folder1} #{folder2} > diffresult.txt`
   puts "Comparision result saved to diffresult.txt"
 end
 


### PR DESCRIPTION
This script compares content of all workshop email previews before and after a change to make sure the change doesn't have unexpected results.

**How to run:**
In staging branch, run `./diff_email_previews download base`
In feature branch, run `./diff_email_previews download new`
Compare email content in base and feature branch: `./diff_email_previews diff base new`

**Command syntax:**
To download emails to a folder in the current directory: `./diff_email_previews download <foldername>`
To diff emails in 2 folders in the current directory: `./diff_email_previews diff <foldername1> <foldername2>`
Running the script without argument will show the instruction `./diff_email_previews`

**Example result**
```
diff -u -B -I '\(/\|=\)[A-Z]\{10,\}' base/detail_change_notification__csf_deepdive_body.html new/detail_change_notification__csf_deepdive_body.html
--- base/detail_change_notification__csf_deepdive_body.html	2019-03-28 16:12:14.000000000 -0700
+++ new/detail_change_notification__csf_deepdive_body.html	2019-03-28 16:14:45.000000000 -0700
@@ -91,7 +91,6 @@
 A physical copy of the 2019-2020 CS Fundamentals Curriculum Guide. If you
 do not have one available, one will be provided for you at the workshop.
 </li>
-<li>Code.org Curriculum Guide.</li>
 </ul>
```