### PR TITLE
Video_key: add validation to check for colon(s) in key name

### DIFF
--- a/dashboard/app/models/video.rb
+++ b/dashboard/app/models/video.rb
@@ -24,12 +24,8 @@ class Video < ActiveRecord::Base
   scope :current_locale, -> {where(locale: I18n.locale.to_s).or(Video.english_locale).unscope(:order).order("(case when locale = 'en-US' then 0 else 1 end) desc")}
 
   validates_uniqueness_of :key, scope: [:locale]
-  validates :key, format: {with: /(.*?)_([a-zA-Z])/}
+  validates :key, format: {with: /\A([A-z0-9]+)_([a-z]+)\z/}
   validates_presence_of :download
-
-  before_validation do
-    self.key = key.underscore
-  end
 
   before_save :fetch_thumbnail
 

--- a/dashboard/app/models/video.rb
+++ b/dashboard/app/models/video.rb
@@ -24,7 +24,12 @@ class Video < ActiveRecord::Base
   scope :current_locale, -> {where(locale: I18n.locale.to_s).or(Video.english_locale).unscope(:order).order("(case when locale = 'en-US' then 0 else 1 end) desc")}
 
   validates_uniqueness_of :key, scope: [:locale]
+  validates :key, format: {with: /(.*?)_([a-zA-Z])/}
   validates_presence_of :download
+
+  before_validation do
+    self.key = key.underscore
+  end
 
   before_save :fetch_thumbnail
 

--- a/dashboard/test/models/video_test.rb
+++ b/dashboard/test/models/video_test.rb
@@ -9,7 +9,7 @@ class VideoTest < ActiveSupport::TestCase
     VideosController.any_instance.stubs(:upload_to_s3).returns('_fake_s3_url_')
   end
 
-  test "converts key to snake case" do
+  test "cannot create video key that is not snake case" do
     # does not raise exception ..
     Video.check_i18n_names
 

--- a/dashboard/test/models/video_test.rb
+++ b/dashboard/test/models/video_test.rb
@@ -9,6 +9,15 @@ class VideoTest < ActiveSupport::TestCase
     VideosController.any_instance.stubs(:upload_to_s3).returns('_fake_s3_url_')
   end
 
+  test "converts key to snake case" do
+    # does not raise exception ..
+    Video.check_i18n_names
+
+    video = Video.new(key: 'TechHub', download: 'no_download_link')
+    refute video.valid?
+    assert video.errors.include?(:key)
+  end
+
   test "check_i18n_names" do
     # does not raise exception ..
     Video.check_i18n_names


### PR DESCRIPTION
Validation was added to check the format of the video_key in the video model.  A corresponding passing test is included.

Follow-up questions
- Add method to convert invalid video key string to snake case (options: using before validation (con: testing is not straightforward); add a method (we can use a setter method, which might nullify the model validation that was added).


- Examples of the edge cases that were tested:
#### Valid
a_a
h_aaaaa
see_b
tech_cs_hello
02_mac
Mac_up
what_is_this
2_see
tech_h

#### Invalid:
tech_hub tree k_j
)_2 (