### PR TITLE
adjust dropdown arrow position for IE11

### DIFF
--- a/apps/style/applab/skins/modern.scss
+++ b/apps/style/applab/skins/modern.scss
@@ -61,6 +61,13 @@
   }
 }
 
+// IE 11 dropdown arrow position
+_:-ms-fullscreen, :root #divApplab.appModern, #designModeViz.appModern, .draggingParent {
+  select {
+    background-position-x: right -35px;
+  }
+}
+
 #divApplab.notRunning, #designModeViz.appModern, .draggingParent {
   img[data-canonical-image-url=''], canvas:not(#turtleCanvas), .chart {
     box-sizing: border-box;


### PR DESCRIPTION
* The new dropdown arrow in applab doesn't appear in the proper place on IE11. We already have a CSS hack in place to hide our custom dropdown completely on IE9. Now, I've added a CSS hack using the documented `_:-ms-fullscreen, :root` pattern (which ensures the CSS rule will only select IE11) that properly positions this arrow (instead of 10px from the right, it is -35px from the right since IE11 computes the right edge differently)
* I separately confirmed that we don't have any issues with Edge