### PR TITLE
Unmute URLs for Sound Preview

### DIFF
--- a/apps/src/code-studio/components/SoundListEntry.jsx
+++ b/apps/src/code-studio/components/SoundListEntry.jsx
@@ -80,7 +80,10 @@ class SoundListEntry extends React.Component {
       );
       this.props.soundsRegistry.unmuteURLs();
       this.props.soundsRegistry.playURL(this.props.soundMetadata.sourceUrl, {
-        onEnded: () => this.setState({isPlaying: false})
+        onEnded: () => {
+          this.setState({isPlaying: false});
+          this.props.soundsRegistry.muteURLs();
+        }
       });
     }
   };

--- a/apps/src/code-studio/components/SoundListEntry.jsx
+++ b/apps/src/code-studio/components/SoundListEntry.jsx
@@ -78,6 +78,7 @@ class SoundListEntry extends React.Component {
         },
         {includeUserId: true}
       );
+      this.props.soundsRegistry.unmuteURLs();
       this.props.soundsRegistry.playURL(this.props.soundMetadata.sourceUrl, {
         onEnded: () => this.setState({isPlaying: false})
       });


### PR DESCRIPTION
In Sprite Lab, sound previews aren't working because the sound player is muted ([PR 26972](https://github.com/code-dot-org/code-dot-org/pull/26972) for context).
With this change, we unmute the sound player so that sound previews play as expected.