### PR TITLE
Include videos.csv in the test fixture hash

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -120,6 +120,7 @@ namespace :test do
         fixture_hash = Digest::MD5.hexdigest(
           Dir["#{fixture_path}/{**,*}/*.yml"].
             push(dashboard_dir('db/schema.rb')).
+            push(dashboard_dir('config/videos.csv')).
             select(&File.method(:file?)).
             sort.
             map(&Digest::MD5.method(:file)).


### PR DESCRIPTION
Temporary fix to unblock pipeline from an issue where our test dbs are not getting required videos.csv changes.

Will follow up today with a replacement videos fixture.

### Why we're changing this

[Around noon on Friday](https://codedotorg.slack.com/archives/C0T0PNTM3/p1553885317040800) we started seeing a consisted dashboard unit test failure:

```
RuntimeError:         RuntimeError: Missing strings for video.name.["Teaching CS Fundamentals: How the Course Works"] in config/locales/data.en.yml, please add
            app/models/video.rb:42:in `check_i18n_names'
            test/models/video_test.rb:14:in `block in <class:VideoTest>'
```

The video name quickly led us back to #27740, which changed the incorrect video key `"Teaching CS Fundamentals: How the Course Works"` to the correct `teaching_csf_how_it_works`.  However, the test failure suggests this fix didn't work.  Attempts to understand this just led us to more mysteries:

- Running [`Video.check_i18n_names`](https://github.com/code-dot-org/code-dot-org/blob/511569d40879a3f8a118611388dd7517bab7eb35/dashboard/app/models/video.rb#L38) from the rails console on test did not reproduce the issue.
- Checking the videos table in the test database showed the correct key.
- [Seeding videos is very simple](https://github.com/code-dot-org/code-dot-org/blob/511569d40879a3f8a118611388dd7517bab7eb35/dashboard/app/models/video.rb#L46-L55): We truncate the table and re-import everything.
- This check is actually run [during the `seed:videos` task](https://github.com/code-dot-org/code-dot-org/blob/511569d40879a3f8a118611388dd7517bab7eb35/dashboard/app/models/video.rb#L54), before also [happening during a unit test](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/models/video_test.rb#L14). But it only failed during the unit test!

The breakthrough was remembering that we use many test databases on the test machine in order to run dashboard unit tests in parallel. (List here.) This allowed us to confirm that while the main 'dashboard_test' database had the updated video key, the parallel-unit-test databases did not:

```
mysql> select * from videos where videos.key like '%eaching%';
+-----+------------------------------+--------------+---------------------+---------------------+-----------------------------------------------------------------------------+--------+
| id  | key                          | youtube_code | created_at          | updated_at          | download                                                                    | locale |
+-----+------------------------------+--------------+---------------------+---------------------+-----------------------------------------------------------------------------+--------+
| 293 | teaching_csf_how_it_works    | yd0TQzYbnTI  | 2019-03-29 21:36:45 | 2019-03-29 21:36:45 | https://videos.code.org/levelbuilder/02howthecourseworks_small-mp4.mp4      | en-US  |
+-----+------------------------------+--------------+---------------------+---------------------+-----------------------------------------------------------------------------+--------+

mysql> select * from dashboard_test1.videos where videos.key like '%eaching%';
+-----+------------------------------------------------+--------------+---------------------+---------------------+-----------------------------------------------------------------------------+--------+
| id  | key                                            | youtube_code | created_at          | updated_at          | download                                                                    | locale |
+-----+------------------------------------------------+--------------+---------------------+---------------------+-----------------------------------------------------------------------------+--------+
| 293 | Teaching CS Fundamentals: How the Course Works | yd0TQzYbnTI  | 2019-03-26 16:54:47 | 2019-03-26 16:54:47 | https://videos.code.org/levelbuilder/02howthecourseworks_small-mp4.mp4      | en-US  |
+-----+------------------------------------------------+--------------+---------------------+---------------------+-----------------------------------------------------------------------------+--------+
```

The next mystery was _why_ these test databases were out of sync, when clearly they'd gotten the incorrect video key not long ago.  We [do a really clever thing when we set up these test databases](https://github.com/code-dot-org/code-dot-org/blob/6fdcd0baa8f8831725d539ff8688c2e33497b268/lib/rake/test.rake#L118-L190): Instead of running the whole db setup process for every database on every build, we create them from a SQL "seed file" that we cache on S3, building a new seed file when needed.  We decide whether we need a new seed file by [comparing an MD5 digest of the DB schema and our test fixtures](https://github.com/code-dot-org/code-dot-org/blob/6fdcd0baa8f8831725d539ff8688c2e33497b268/lib/rake/test.rake#L120-L127).  And [videos.csv](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/videos.csv), which looks like a fixture and was subtly depended upon by the test, is not considered in that hash.

To unblock the pipeline I [added videos.csv as input to the seed file hash](https://github.com/code-dot-org/code-dot-org/pull/27780).