### PR TITLE
Video key: validation checks if video key name contains a colon

### DIFF
--- a/dashboard/app/models/video.rb
+++ b/dashboard/app/models/video.rb
@@ -24,6 +24,7 @@ class Video < ActiveRecord::Base
   scope :current_locale, -> {where(locale: I18n.locale.to_s).or(Video.english_locale).unscope(:order).order("(case when locale = 'en-US' then 0 else 1 end) desc")}
 
   validates_uniqueness_of :key, scope: [:locale]
+  validates :key, format: {with: /\A(?~:)\z/}
   validates_presence_of :download
 
   before_save :fetch_thumbnail

--- a/dashboard/app/models/video.rb
+++ b/dashboard/app/models/video.rb
@@ -24,7 +24,7 @@ class Video < ActiveRecord::Base
   scope :current_locale, -> {where(locale: I18n.locale.to_s).or(Video.english_locale).unscope(:order).order("(case when locale = 'en-US' then 0 else 1 end) desc")}
 
   validates_uniqueness_of :key, scope: [:locale]
-  validates :key, format: {with: /\A(?~:)\z/}
+  validates :key, format: {with: /\A[a-zA-Z0-9\-_]+\z/}
   validates_presence_of :download
 
   before_save :fetch_thumbnail

--- a/dashboard/test/models/video_test.rb
+++ b/dashboard/test/models/video_test.rb
@@ -9,6 +9,15 @@ class VideoTest < ActiveSupport::TestCase
     VideosController.any_instance.stubs(:upload_to_s3).returns('_fake_s3_url_')
   end
 
+  test "cannot create a video key with a name that contains a colon(s)" do
+    # does not raise exception ..
+    Video.check_i18n_names
+
+    video = Video.new(key: 'Tech:Hub sea:tac', download: 'no_download_link')
+    refute video.valid?
+    assert video.errors.include?(:key)
+  end
+
   test "check_i18n_names" do
     # does not raise exception ..
     Video.check_i18n_names

--- a/dashboard/test/models/video_test.rb
+++ b/dashboard/test/models/video_test.rb
@@ -10,9 +10,6 @@ class VideoTest < ActiveSupport::TestCase
   end
 
   test "cannot create a video key with a name that contains a colon(s)" do
-    # does not raise exception ..
-    Video.check_i18n_names
-
     video = Video.new(key: 'Tech:Hub sea:tac', download: 'no_download_link')
     refute video.valid?
     assert video.errors.include?(:key)


### PR DESCRIPTION
This is follow up work to [PR #27740](https://github.com/code-dot-org/code-dot-org/pull/27740), to ensure that a video key name does not contain a colon.