### PR TITLE
don't use dangerouslySetInnerHtml for InlineFeedback messages

### DIFF
--- a/apps/src/templates/instructions/InlineFeedback.jsx
+++ b/apps/src/templates/instructions/InlineFeedback.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
@@ -26,10 +25,7 @@ class InlineFeedback extends Component {
     // styling.
     return (
       <ChatBubble borderColor={borderColor} ttsMessage={message}>
-        <p
-          className="uitest-topInstructions-inline-feedback"
-          dangerouslySetInnerHTML={{__html: message}}
-        />
+        <p className="uitest-topInstructions-inline-feedback">{message}</p>
         {extra && <p style={styles.message}>{extra}</p>}
       </ChatBubble>
     );


### PR DESCRIPTION
I _think_ these are always just plain text (with one caveat). See my reasoning:

This component is exclusively used by TopInstructionsCSF:

https://github.com/code-dot-org/code-dot-org/blob/34ba0ff28e68f3cda17cd6fed64f05b72ea8cd6a/apps/src/templates/instructions/TopInstructionsCSF.jsx#L775-L780

where `this.props.feedback` is provided by redux:

https://github.com/code-dot-org/code-dot-org/blob/34ba0ff28e68f3cda17cd6fed64f05b72ea8cd6a/apps/src/templates/instructions/TopInstructionsCSF.jsx#L862

which is in turn set by StudioApp:

https://github.com/code-dot-org/code-dot-org/blob/34ba0ff28e68f3cda17cd6fed64f05b72ea8cd6a/apps/src/StudioApp.js#L1606-L1608

(I _think_ this is the only place where `feedback` gets set in redux, but I'm not certain)

which is in turn set by FeedbackUtils.getFeedbackMessage:

https://github.com/code-dot-org/code-dot-org/blob/34ba0ff28e68f3cda17cd6fed64f05b72ea8cd6a/apps/src/feedback.js#L693-L708

which draws feedback messages from several sources. I've spot-checked some of these and confirmed that they're all plain text without HTML, and I plan to check the rest of them before merging if y'all think this seems like the right approach.

However! Remember that caveat I mentioned? One source we use for this text are the levelbuilder-provided "failure message overrides" you can apply to each level. We don't use this very much (there are a total of 44 levels that use this field at all, and I don't think all of those are actually in use), and we've never claimed to support markdown for this field, but a couple levels are trying (and failing) to use markdown syntax here anyway. We _could_ update this to support markdown ,which would support html like the current component component does rather than updating it as this PR is doing to support just plain text.

Thoughts?