### PR TITLE
Tests: Use a videos fixture instead of seeding videos.csv

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -315,5 +315,5 @@ namespace :seed do
   task incremental: [:videos, :concepts, :scripts_incremental, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :courses, :ap_school_codes, :ap_cs_offerings, :ib_school_codes, :ib_cs_offerings, :state_cs_offerings]
 
   desc "seed only dashboard data required for tests"
-  task test: [:videos, :games, :concepts, :secret_words, :secret_pictures, :school_districts, :schools]
+  task test: [:games, :concepts, :secret_words, :secret_pictures, :school_districts, :schools]
 end

--- a/dashboard/test/fixtures/video.yml
+++ b/dashboard/test/fixtures/video.yml
@@ -1,12 +1,15 @@
-video_13:
-  id: 13
-  key: hoc_wrapup
-  youtube_code: 98Wft30gUQE
-  download: http://videos.code.org/new/2f-HoC-wrap-up-final.mp4
-  locale: en-US
-video_137:
+C1_pair_programming:
+  id: 326
+  key: C1_pair_programming
+  youtube_code: vgkahOzFH2Q
+  download: http://videos.code.org/2014/C1-pair-programming.mp4
+csd_gamelab_draw_2:
   id: 137
   key: csd_gamelab_draw_2
   youtube_code: QLabeWhw_O0
   download: https://videos.code.org/levelbuilder/gamelab_addingcolors-mp4.mp4
-  locale: en-US
+hoc_wrapup:
+  id: 13
+  key: hoc_wrapup
+  youtube_code: 98Wft30gUQE
+  download: http://videos.code.org/new/2f-HoC-wrap-up-final.mp4

--- a/dashboard/test/fixtures/video.yml
+++ b/dashboard/test/fixtures/video.yml
@@ -1,0 +1,12 @@
+video_13:
+  id: 13
+  key: hoc_wrapup
+  youtube_code: 98Wft30gUQE
+  download: http://videos.code.org/new/2f-HoC-wrap-up-final.mp4
+  locale: en-US
+video_137:
+  id: 137
+  key: csd_gamelab_draw_2
+  youtube_code: QLabeWhw_O0
+  download: https://videos.code.org/levelbuilder/gamelab_addingcolors-mp4.mp4
+  locale: en-US

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -120,7 +120,6 @@ namespace :test do
         fixture_hash = Digest::MD5.hexdigest(
           Dir["#{fixture_path}/{**,*}/*.yml"].
             push(dashboard_dir('db/schema.rb')).
-            push(dashboard_dir('config/videos.csv')).
             select(&File.method(:file?)).
             sort.
             map(&Digest::MD5.method(:file)).


### PR DESCRIPTION
Use a videos fixture file instead of seeding videos from videos.csv for dashboard unit tests. Follow-up work to https://github.com/code-dot-org/code-dot-org/pull/27780, see that PR for original context.

[Will mentioned on Friday](https://codedotorg.slack.com/archives/C0T0PNTM3/p1553897806054400?thread_ts=1553891076.045700&cid=C0T0PNTM3) that we could stop depending on videos.csv entirely and add a videos fixture for tests instead.  I thought this was worth a try.

### Concerns
One concern that's been raised is that testing with videos.csv does actually catch issues.  I'm not worried about this, because the same validation step that caused problems in the unit tests Friday is also run as part of the regular `rake seed:videos` task, so these issues should be caught even if we're using fixtures for tests.

~Another: I see more than 90 different video keys referenced in our [`level.yml`](https://github.com/code-dot-org/code-dot-org/blob/fbafb0e528baf543c8078ed7bd098edea3e01c96/dashboard/test/fixtures/level.yml) fixture file.  We've only got 340 rows in videos.csv. If I end up needed to add fixtures for all of those videos to get tests passing, is it worth maintaining video fixtures separate from our videos.csv file at all?~

See also: https://api.rubyonrails.org/v3.1/classes/ActiveRecord/Fixtures.html