### PR TITLE
add new colors referenced by applab dark theme

### DIFF
--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -119,4 +119,6 @@ $droplet_green: #68d995;
 $droplet_white: $white;
 
 // Colors needed for applab styles.
+$applab_dark_border: #b4b4b4;
+$applab_dark_background: #50575d;
 $text_input_default_border_color: rgb(153, 153, 153);


### PR DESCRIPTION
* These colors are referenced by the applab "dark" theme, under the `applabThemes` experiment. They were missed in the previous PR, probably because the `apps/src/util/color.js` file was modified locally, but they need to be in `shared/css/color.scss`