### PR TITLE
School Info Confirmation Dialog - add api for update and save functions

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1165,7 +1165,7 @@
   "schoolCity": "School City",
   "schoolCityTown": "City / Town",
   "schoolCountry": "School Country",
-  "schoolInfoDialogDescription": "Welcome back!  Are you still teaching at",
+  "schoolInfoDialogDescription": "Welcome back!  Are you still teaching at {schoolName}?",
   "schoolInfoDialogUpdate": "No, update my info",
   "schoolInfoInterstitialDescription": "Please enter your school information below.",
   "schoolInfoInterstitialTitle": "We want to bring Computer Science to every student - help us track our progress!",

--- a/apps/src/sites/studio/pages/schoolInfoConfirmationDialog.js
+++ b/apps/src/sites/studio/pages/schoolInfoConfirmationDialog.js
@@ -1,0 +1,27 @@
+/**
+ * @file Renders the SchoolInfoConfirmationDialog component on page load.
+ * This file is responsibile for mounting and unmounting the React component,
+ * and providing props passed down from the server to the component.
+ * @see _school_info_confirmation_dialog.html.haml.
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import SchoolInfoConfirmationDialog from '@cdo/apps/lib/ui/SchoolInfoConfirmationDialog';
+import getScriptData from '@cdo/apps/util/getScriptData';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const scriptData = getScriptData('schoolinfoconfirmationdialog');
+
+  const mountPoint = document.createElement('div');
+  document.body.appendChild(mountPoint);
+
+  function unmount() {
+    ReactDOM.unmountComponentAtNode(mountPoint);
+    document.body.removeChild(mountPoint);
+  }
+
+  ReactDOM.render(
+    <SchoolInfoConfirmationDialog scriptData={scriptData} onClose={unmount} />,
+    mountPoint
+  );
+});

--- a/apps/src/templates/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/templates/SchoolInfoConfirmationDialog.jsx
@@ -21,12 +21,26 @@ class SchoolInfoConfirmationDialog extends Component {
 
   constructor(props) {
     super(props);
-
     this.state = {
       showSchoolInterstitial: false,
       schoolName: props.schoolName,
       isOpen: true
     };
+  }
+
+  componentDidMount() {
+    const {schoolName} = this.state;
+    if (!schoolName && schoolName.length > 0) {
+      fetch('/dashboardapi/v1/users/me/school_name')
+        .then(response => response.json())
+        .then(data => {
+          console.log(data);
+          this.setState({
+            schoolName: data.school_name
+          });
+        })
+        .catch(error => this.setState({error}));
+    }
   }
 
   handleUpdateClick = () => {
@@ -35,10 +49,13 @@ class SchoolInfoConfirmationDialog extends Component {
 
   renderInitialContent() {
     const {onConfirm} = this.props;
+    const {schoolName} = this.state;
     return (
       <Body>
         <div>
-          <p>{i18n.schoolInfoDialogDescription()} Lincoln Elementary School?</p>
+          <p>
+            {i18n.schoolInfoDialogDescription()} {schoolName}
+          </p>
         </div>
         <Button
           text={i18n.schoolInfoDialogUpdate()}

--- a/apps/src/templates/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/templates/SchoolInfoConfirmationDialog.jsx
@@ -39,7 +39,6 @@ class SchoolInfoConfirmationDialog extends Component {
       fetch('/dashboardapi/v1/users/me/school_name')
         .then(response => response.json())
         .then(data => {
-          console.log(data);
           this.setState({
             schoolName: data.school_name
           });

--- a/apps/src/templates/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/templates/SchoolInfoConfirmationDialog.jsx
@@ -30,7 +30,7 @@ class SchoolInfoConfirmationDialog extends Component {
 
   componentDidMount() {
     const {schoolName} = this.state;
-    if (!schoolName && schoolName.length > 0) {
+    if (schoolName && schoolName.length > 0) {
       fetch('/dashboardapi/v1/users/me/school_name')
         .then(response => response.json())
         .then(data => {

--- a/apps/src/templates/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/templates/SchoolInfoConfirmationDialog.jsx
@@ -28,9 +28,14 @@ class SchoolInfoConfirmationDialog extends Component {
     };
   }
 
+  static defaultProps = {
+    onUpdate: () => {},
+    schoolName: ''
+  };
+
   componentDidMount() {
     const {schoolName} = this.state;
-    if (schoolName && schoolName.length > 0) {
+    if (!schoolName && schoolName.length > 0) {
       fetch('/dashboardapi/v1/users/me/school_name')
         .then(response => response.json())
         .then(data => {

--- a/apps/src/templates/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/templates/SchoolInfoConfirmationDialog.jsx
@@ -63,8 +63,20 @@ class SchoolInfoConfirmationDialog extends Component {
       .catch(error => this.setState({error}));
   };
 
-  handleUpdateClick = () => {
+  handleClickUpdate = () => {
     this.setState({showSchoolInterstitial: true});
+  };
+
+  handleClickSave = () => {
+    this.props.onUpdate();
+
+    fetch('/dashboardapi/v1/users/me/update_user_info', {
+      method: 'PUT'
+    }).then(() => {
+      fetch('/dashboardapi/v1/user_school_infos/me').then(
+        () => this.props.onClose
+      );
+    });
   };
 
   renderInitialContent() {
@@ -79,7 +91,7 @@ class SchoolInfoConfirmationDialog extends Component {
         <Button
           text={i18n.schoolInfoDialogUpdate()}
           color={Button.ButtonColor.blue}
-          onClick={this.handleUpdateClick}
+          onClick={this.handleClickUpdate}
         />
         <Button
           style={styles.button}

--- a/apps/src/templates/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/templates/SchoolInfoConfirmationDialog.jsx
@@ -14,9 +14,18 @@ export const styles = {
 class SchoolInfoConfirmationDialog extends Component {
   static propTypes = {
     schoolName: PropTypes.string,
-    onUpdate: PropTypes.func,
-    onConfirm: PropTypes.func,
-    scriptData: PropTypes.object,
+    scriptData: PropTypes.shape({
+      formUrl: PropTypes.string.isRequired,
+      authTokenName: PropTypes.string.isRequired,
+      authTokenValue: PropTypes.string.isRequired,
+      existingSchoolInfo: PropTypes.shape({
+        school_id: PropTypes.string,
+        country: PropTypes.string,
+        school_type: PropTypes.string,
+        school_name: PropTypes.string,
+        full_address: PropTypes.string
+      }).isRequired
+    }).isRequired,
     onClose: PropTypes.func,
     isOpen: PropTypes.bool
   };
@@ -32,8 +41,6 @@ class SchoolInfoConfirmationDialog extends Component {
 
   static defaultProps = {
     schoolName: '',
-    onUpdate: () => {},
-    onConfirm: () => {},
     scriptData: {},
     onClose: () => {},
     isOpen: true
@@ -51,7 +58,7 @@ class SchoolInfoConfirmationDialog extends Component {
         })
         .catch(error => this.setState({error}));
     }
-  }
+  };
 
   handleClickYes = () => {
     fetch(
@@ -68,8 +75,6 @@ class SchoolInfoConfirmationDialog extends Component {
   };
 
   handleClickSave = () => {
-    this.props.onUpdate();
-
     fetch('/dashboardapi/v1/users/me/update_user_info', {
       method: 'PUT'
     }).then(() => {
@@ -79,7 +84,7 @@ class SchoolInfoConfirmationDialog extends Component {
     });
   };
 
-  renderInitialContent() {
+  renderInitialContent = () => {
     const {schoolName} = this.state;
     return (
       <Body>
@@ -101,7 +106,7 @@ class SchoolInfoConfirmationDialog extends Component {
         />
       </Body>
     );
-  }
+  };
 
   renderSchoolInformationForm() {
     return (

--- a/apps/src/templates/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/templates/SchoolInfoConfirmationDialog.jsx
@@ -16,7 +16,9 @@ class SchoolInfoConfirmationDialog extends Component {
     schoolName: PropTypes.string,
     onUpdate: PropTypes.func,
     onConfirm: PropTypes.func,
-    isOpen: PropTypes.bool.isRequired
+    scriptData: PropTypes.object,
+    onClose: PropTypes.func,
+    isOpen: PropTypes.bool
   };
 
   constructor(props) {
@@ -29,8 +31,12 @@ class SchoolInfoConfirmationDialog extends Component {
   }
 
   static defaultProps = {
+    schoolName: '',
     onUpdate: () => {},
-    schoolName: ''
+    onConfirm: () => {},
+    scriptData: {},
+    onClose: () => {},
+    isOpen: true
   };
 
   componentDidMount() {
@@ -47,12 +53,21 @@ class SchoolInfoConfirmationDialog extends Component {
     }
   }
 
+  handleClickYes = () => {
+    fetch(
+      `/dashboardapi/v1/user_school_infos/${
+        this.props.scriptData.existingSchoolInfo.id
+      }`
+    )
+      .then(() => this.props.onClose())
+      .catch(error => this.setState({error}));
+  };
+
   handleUpdateClick = () => {
     this.setState({showSchoolInterstitial: true});
   };
 
   renderInitialContent() {
-    const {onConfirm} = this.props;
     const {schoolName} = this.state;
     return (
       <Body>
@@ -70,8 +85,7 @@ class SchoolInfoConfirmationDialog extends Component {
           style={styles.button}
           text={i18n.yes()}
           color={Button.ButtonColor.orange}
-          onClick={onConfirm}
-          href={'#'}
+          onClick={this.handleClickYes}
         />
       </Body>
     );

--- a/apps/src/templates/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/templates/SchoolInfoConfirmationDialog.jsx
@@ -19,6 +19,7 @@ class SchoolInfoConfirmationDialog extends Component {
       authTokenName: PropTypes.string.isRequired,
       authTokenValue: PropTypes.string.isRequired,
       existingSchoolInfo: PropTypes.shape({
+        id: PropTypes.number,
         school_id: PropTypes.string,
         country: PropTypes.string,
         school_type: PropTypes.string,
@@ -27,7 +28,7 @@ class SchoolInfoConfirmationDialog extends Component {
       }).isRequired
     }).isRequired,
     onClose: PropTypes.func,
-    isOpen: PropTypes.bool
+    isOpen: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -58,7 +59,7 @@ class SchoolInfoConfirmationDialog extends Component {
         })
         .catch(error => this.setState({error}));
     }
-  };
+  }
 
   handleClickYes = () => {
     fetch(
@@ -89,9 +90,7 @@ class SchoolInfoConfirmationDialog extends Component {
     return (
       <Body>
         <div>
-          <p>
-            {i18n.schoolInfoDialogDescription()} {schoolName}
-          </p>
+          <p>{i18n.schoolInfoDialogDescription({schoolName})}</p>
         </div>
         <Button
           text={i18n.schoolInfoDialogUpdate()}

--- a/dashboard/app/assets/javascripts/user_school_infos.js
+++ b/dashboard/app/assets/javascripts/user_school_infos.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/dashboard/app/assets/javascripts/user_school_infos.js
+++ b/dashboard/app/assets/javascripts/user_school_infos.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/dashboard/app/assets/stylesheets/user_school_infos.scss
+++ b/dashboard/app/assets/stylesheets/user_school_infos.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the UserSchoolInfos controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/dashboard/app/assets/stylesheets/user_school_infos.scss
+++ b/dashboard/app/assets/stylesheets/user_school_infos.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the UserSchoolInfos controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -12,6 +12,13 @@ class Api::V1::UsersController < Api::V1::JsonApiController
     @user = current_user
   end
 
+  # GET /api/v1/users/<user_id>/school_name
+  def get_school_name
+    render json: {
+      school_name: current_user&.school
+    }
+  end
+
   # GET /api/v1/users/<user_id>/contact_details
   def get_contact_details
     render json: {

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -19,6 +19,11 @@ class Api::V1::UsersController < Api::V1::JsonApiController
     }
   end
 
+  # PATCH /api/vi/users/<user_id>/update_user_info
+  def update_user_info
+    current_user&.last_seen_school_info_interstitial = DateTime.now
+  end
+
   # GET /api/v1/users/<user_id>/contact_details
   def get_contact_details
     render json: {

--- a/dashboard/app/controllers/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/user_school_infos_controller.rb
@@ -1,0 +1,2 @@
+class UserSchoolInfosController < ApplicationController
+end

--- a/dashboard/app/controllers/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/user_school_infos_controller.rb
@@ -1,2 +1,13 @@
 class UserSchoolInfosController < ApplicationController
+  def update
+    user_school_info = UserSchoolInfo.find([:id])
+    result = user_school_info.update ({
+      last_confirmation_date: DateTime.current
+    })
+    if result
+      head :no_content
+    else
+      render json: user_school_info.errors, status: :unprocessable_entity
+    end
+  end
 end

--- a/dashboard/app/controllers/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/user_school_infos_controller.rb
@@ -1,6 +1,7 @@
 class UserSchoolInfosController < ApplicationController
+  # PATCH /api/v1/users_school_infos/<id>/update_last_confirmation_date
   def update
-    user_school_info = UserSchoolInfo.find([:id])
+    user_school_info = UserSchoolInfo.find(params[:id])
     result = user_school_info.update ({
       last_confirmation_date: DateTime.now
     })
@@ -9,5 +10,16 @@ class UserSchoolInfosController < ApplicationController
     else
       render json: user_school_info.errors, status: :unprocessable_entity
     end
+  end
+
+  # PATCH /api/v1/users_school_infos/<id>/update_end_date_last_seen_school_info_interstitial
+  def update_user_school_info
+    user_school_info = UserSchoolInfo.find(params[:id])
+
+    user_school_info.update!(end_date: DateTime.now)
+
+    current_user.update!(properties: {last_seen_school_info_interstitial: DateTime.now})
+
+    head :no_content
   end
 end

--- a/dashboard/app/controllers/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/user_school_infos_controller.rb
@@ -2,7 +2,7 @@ class UserSchoolInfosController < ApplicationController
   def update
     user_school_info = UserSchoolInfo.find([:id])
     result = user_school_info.update ({
-      last_confirmation_date: DateTime.current
+      last_confirmation_date: DateTime.now
     })
     if result
       head :no_content

--- a/dashboard/app/helpers/user_school_infos_helper.rb
+++ b/dashboard/app/helpers/user_school_infos_helper.rb
@@ -1,0 +1,2 @@
+module UserSchoolInfosHelper
+end

--- a/dashboard/app/views/layouts/_school_info_confirmation_dialog.html.haml
+++ b/dashboard/app/views/layouts/_school_info_confirmation_dialog.html.haml
@@ -1,0 +1,26 @@
+-# Rendering this partial causes the school info confirmation dialog to be shown to the
+-# user.  Rendering this partial into a cached view may not work properly.
+
+- require 'country_codes'
+- require 'state_abbr'
+- require 'geocoder'
+
+- location = Geocoder.search(request.ip).try(:first)
+-# geocoder sometimes shows localhost's country as RD/Reserved
+- us_ip = location.nil? || ['US', 'RD'].include?(location.country_code.to_s.upcase)
+- current_user_school_info = current_user.school_info
+
+- script_data = {}
+- script_data[:formUrl] = registration_url('user')
+- script_data[:authTokenName] = request_forgery_protection_token.to_s
+- script_data[:authTokenValue] = form_authenticity_token
+- script_data[:existingSchoolInfo] = {}
+- if current_user_school_info
+  - script_data[:existingSchoolInfo] = current_user_school_info.slice(:id, :country, :school_type, :school_id, :school_name, :full_address)
+- script_data[:existingSchoolInfo][:country] ||= 'United States' if us_ip
+
+- content_for(:head) do
+  %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.7"}
+  %script{src: minifiable_asset_path('js/schoolInfoConfirmationDialog.js'), data: {schoolinfointerstitial: script_data.to_json}}
+  :css
+    .pac-container { z-index: 2000; }

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -587,6 +587,7 @@ Dashboard::Application.routes.draw do
       post 'users/:user_id/using_text_mode', to: 'users#post_using_text_mode'
       get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
       get 'users/:user_id/contact_details', to: 'users#get_contact_details'
+      get 'users/:user_id/school_name', to: 'users#get_school_name'
 
       post 'users/:user_id/post_ui_tip_dismissed', to: 'users#post_ui_tip_dismissed'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -613,9 +613,9 @@ Dashboard::Application.routes.draw do
       get 'peer_review_submissions/index', to: 'peer_review_submissions#index'
       get 'peer_review_submissions/report_csv', to: 'peer_review_submissions#report_csv'
 
-      patch 'user_school_infos/:id', to: 'user_school_infos#update'
+      patch 'user_school_infos/:id/update_last_confirmation_date', to: 'user_school_infos#update_last_confirmation_date'
 
-      patch 'users/:id/update_user_info', to: 'users#update_user_info'
+      patch 'user_school_infos/:id/update_end_date_last_seen_school_info_interstitial', to: 'user_school_infos#update_end_date_last_seen_school_info_interstitial'
 
       resources :teacher_feedbacks, only: [:create] do
         collection do

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -613,6 +613,8 @@ Dashboard::Application.routes.draw do
       get 'peer_review_submissions/index', to: 'peer_review_submissions#index'
       get 'peer_review_submissions/report_csv', to: 'peer_review_submissions#report_csv'
 
+      patch 'user_school_infos/:id', to: 'user_school_infos#update'
+
       resources :teacher_feedbacks, only: [:create] do
         collection do
           get 'get_feedback_from_teacher'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -615,6 +615,8 @@ Dashboard::Application.routes.draw do
 
       patch 'user_school_infos/:id', to: 'user_school_infos#update'
 
+      patch 'users/:id/update_user_info', to: 'users#update_user_info'
+
       resources :teacher_feedbacks, only: [:create] do
         collection do
           get 'get_feedback_from_teacher'

--- a/dashboard/test/controllers/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/user_school_infos_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This PR is a follow up to [PR27742](https://github.com/code-dot-org/code-dot-org/pull/27742).

When a user clicks the "Yes" button, the last school confirmation date is updated in the user_schools_info table.

When a user clicks the "No, update my info" button, the school info interstitial is rendered.

I decided to do the following updates when the user clicks on the save button:
When a user clicks the "save" button on the school info interstitial form the following is updated:
end date in the user_school_infos table for the user's last school is updated to today’s date.
last_seen_school_info_interstitial in the properties column of the user’s table is updated 
Once the user clicks “Save,” the school_info_id is updated in the users and user_school-infos table. 
 
Next steps
render confirmation dialog
 - helper methods
 - tests
