### PR TITLE
Backfill AP school codes school year column

### DIFF
--- a/dashboard/db/migrate/20190321174350_backfill_school_year_in_ap_school_codes.rb
+++ b/dashboard/db/migrate/20190321174350_backfill_school_year_in_ap_school_codes.rb
@@ -1,5 +1,5 @@
 class BackfillSchoolYearInApSchoolCodes < ActiveRecord::Migration[5.0]
   def change
-    Census::ApSchoolCode.where(school_year: nil).update_all('school_year = 2016')
+    Census::ApSchoolCode.where(school_year: nil).update_all(school_year: 2016)
   end
 end

--- a/dashboard/db/migrate/20190321174350_backfill_school_year_in_ap_school_codes.rb
+++ b/dashboard/db/migrate/20190321174350_backfill_school_year_in_ap_school_codes.rb
@@ -1,0 +1,5 @@
+class BackfillSchoolYearInApSchoolCodes < ActiveRecord::Migration[5.0]
+  def change
+    Census::ApSchoolCode.where(school_year: nil).update_all('school_year = 2016')
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190320200540) do
+ActiveRecord::Schema.define(version: 20190321174350) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/27634 -- backfills the new `school_year` column with the year for the data that currently exists in that table (2016).

All rows in production are null currently, so this will update the entire table -- I added the `where(school_year: nil)` filter in case this gets run at some point in the future when there is existing data with a populated `school_year`.

I have the production version of the `school_codes` table in my local database, so I tested this migration there.

Subsequent PR will a) update model associations and b) add data for 2017.