### PR TITLE
Enable redaction for instructions and hints

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -91,9 +91,8 @@ def redact(source, dest, *plugins)
   data = YAML.load_file(source)
   args = ['bin/i18n/node_modules/.bin/redact',
           '-c bin/i18n/plugins/nonCommonmarkLinebreak.js']
-  unless plugins.empty?
-    args.push('-p ' + plugins)
-  end
+  args.push('-p ' + plugins) unless plugins.empty?
+
   stdout, _status = Open3.capture2(
     args.join(" "),
     stdin_data: JSON.generate(data)
@@ -122,9 +121,8 @@ def restore(source, redacted, dest, *plugins)
 
   args = ['bin/i18n/node_modules/.bin/restore',
           '-c bin/i18n/plugins/nonCommonmarkLinebreak.js']
-  unless plugins.empty?
-    args.push('-p ' + plugins)
-  end
+  args.push('-p ' + plugins) unless plugins.empty?
+
   args.push("-s #{source_json.path}")
   args.push("-r #{redacted_json.path}")
   stdout, _status = Open3.capture2(

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -80,7 +80,7 @@ def run_bash_script(location)
 end
 
 def plugins_to_arg(plugins)
-  plugins.map {|name| "bin/i18n/plugins/#{name}.js"}.join(',')
+  plugins.map {|name| "bin/i18n/plugins/#{name}.js" if name}.join(',')
 end
 
 def redact(source, dest, *plugins)
@@ -89,12 +89,13 @@ def redact(source, dest, *plugins)
 
   plugins = plugins_to_arg(plugins)
   data = YAML.load_file(source)
+  args = ['bin/i18n/node_modules/.bin/redact',
+          '-c bin/i18n/plugins/nonCommonmarkLinebreak.js']
+  unless plugins.empty?
+    args.push('-p ' + plugins)
+  end
   stdout, _status = Open3.capture2(
-    [
-      'bin/i18n/node_modules/.bin/redact',
-      '-c bin/i18n/plugins/nonCommonmarkLinebreak.js',
-      '-p ' + plugins,
-    ].join(" "),
+    args.join(" "),
     stdin_data: JSON.generate(data)
   )
   data = JSON.parse(stdout)
@@ -119,14 +120,15 @@ def restore(source, redacted, dest, *plugins)
   source_json.flush
   redacted_json.flush
 
+  args = ['bin/i18n/node_modules/.bin/restore',
+          '-c bin/i18n/plugins/nonCommonmarkLinebreak.js']
+  unless plugins.empty?
+    args.push('-p ' + plugins)
+  end
+  args.push("-s #{source_json.path}")
+  args.push("-r #{redacted_json.path}")
   stdout, _status = Open3.capture2(
-    [
-      'bin/i18n/node_modules/.bin/restore',
-      '-c bin/i18n/plugins/nonCommonmarkLinebreak.js',
-      '-p ' + plugins,
-      "-s #{source_json.path}",
-      "-r #{redacted_json.path}",
-    ].join(" ")
+    args.join(" ")
   )
   redacted_key = redacted_data.keys.first
   restored_data = {}

--- a/bin/i18n/sync-codeorg-in.rb
+++ b/bin/i18n/sync-codeorg-in.rb
@@ -17,8 +17,7 @@ def sync_in
   localize_level_content
   localize_block_content
   run_bash_script "bin/i18n-codeorg/in.sh"
-  # disable redaction of level content until the switch to remark is complete
-  #redact_level_content
+  redact_level_content
   redact_block_content
 end
 


### PR DESCRIPTION
The script failed if you don't pass a plugin into redaction, which is why there's some refactoring.