### PR TITLE
Fix Cdo::YAML.load_file

### DIFF
--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -2,7 +2,7 @@ require 'yaml'
 
 module Cdo
   # Extend YAML with customizations.
-  module YAML
+  module YAMLExtension
     def parse_yaml_header(content, locals={})
       match = content.match(/\A\s*^(?<yaml>---\s*\n.*?\n?)^(---\s*$\n?)/m)
       return [{}, content] unless match
@@ -17,5 +17,5 @@ module Cdo
     end
   end
 
-  ::YAML.singleton_class.prepend YAML
+  ::YAML.singleton_class.prepend YAMLExtension
 end

--- a/pegasus/test/test_yaml.rb
+++ b/pegasus/test/test_yaml.rb
@@ -31,4 +31,17 @@ some long variable name: also works
     assert_equal({'a' => 'b', 'b' => 1, 'c' => true, 'some long variable name' => 'also works'}, head)
     assert_equal("# This is some markdown content\n", body)
   end
+
+  # Ensure YAML.* method works when called from CDO namespace.
+  module ::Cdo
+    module TestCdoYaml
+      def self.test
+        YAML.load_file('')
+      end
+    end
+  end
+
+  def test_cdo_yaml_load_file
+    assert_nil ::Cdo::TestCdoYaml.test
+  end
 end


### PR DESCRIPTION
Fixes bug introduced by #27640.

Rename `Cdo::YAML` to `Cdo::YAMLExtension` to avoid namespace collision
with `::YAML` class when calling `YAML.load_file` within `Cdo` namespace.
Add test to prevent regression