### PR TITLE
Don't navigate after adding a script announcement

### DIFF
--- a/apps/src/lib/script-editor/ScriptAnnouncementsEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptAnnouncementsEditor.jsx
@@ -77,7 +77,7 @@ const Announce = ({announcement, inputStyle, index, onChange, onRemove}) => (
         </select>
       </div>
     </label>
-    <button className="btn" onClick={() => onRemove(index)}>
+    <button className="btn" type="button" onClick={() => onRemove(index)}>
       Remove
     </button>
   </div>
@@ -158,7 +158,7 @@ export default class ScriptAnnouncementsEditor extends Component {
             onRemove={this.remove}
           />
         ))}
-        <button className="btn" onClick={this.add}>
+        <button className="btn" type="button" onClick={this.add}>
           Additional Announcement
         </button>
         {announcements.length > 0 && (


### PR DESCRIPTION
[LP-49](https://codedotorg.atlassian.net/browse/LP-49): The script edit page was saving and navigating away immediately after adding a new, empty announcement.  Now it does not.

Root cause: [The `button` element has a default `type` of `"submit."`](https://stackoverflow.com/questions/3314989/can-i-make-a-button-not-submit-a-form) :sob:

Solution: `<button type="button"/>` will prevent the button from submitting the nearest form.

Follow-up: I'll be adding an eslint rule [requiring that all button tags (at least in React code) have an explicit type.](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/button-has-type.md)