### PR TITLE
Enable Browser Extended Debugging in SauceLabs

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -13,7 +13,9 @@
     "browserName": "chrome",
     "version": "latest",
     "platform": "Windows 7",
-    "screenResolution": "1280x1024"
+    "screenResolution": "1280x1024",
+    "extendedDebugging": true,
+    "capturePerformance": false
   },
   {
     "name": "Chrome44Win7",

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -14,8 +14,7 @@
     "version": "latest",
     "platform": "Windows 7",
     "screenResolution": "1280x1024",
-    "extendedDebugging": true,
-    "capturePerformance": false
+    "extendedDebugging": true
   },
   {
     "name": "Chrome44Win7",


### PR DESCRIPTION
We disabled Extended Debugging because certain UI tests were failing (exceeding 300 second timeout) when issuing WebDriver commands to SauceLabs LatestChrome (Chrome 73) on Windows 7.

SauceLabs Support (Ticket 66141) states that the root cause of this issue was due to a problem in the release of their Sauce Performance service.  They deployed a fix for this issue early on Thu 4/4/2019 and tests on this feature branch indicate that browser extended debugging works again in Chrome 73 on Windows 7.