### PR TITLE
Cohort calc 'accepted' total matches cohort view

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -95,6 +95,15 @@ def main
   )
 
   generate_shared_js_file(
+    generate_constants(
+      'COHORT_CALCULATOR_STATUSES',
+      source_module: Pd::SharedApplicationConstants,
+      transform_keys: true
+    ),
+    "#{REPO_DIR}/apps/src/generated/pd/sharedApplicationConstants.js"
+  )
+
+  generate_shared_js_file(
     generate_multiple_constants(
       %w(SECTION_HEADERS PAGE_LABELS VALID_SCORES LABEL_OVERRIDES NUMBERED_QUESTIONS TEXT_FIELDS INTERVIEW_QUESTIONS SCOREABLE_QUESTIONS),
       source_module: Pd::Facilitator1920ApplicationConstants,

--- a/apps/src/code-studio/pd/application_dashboard/cohort_view.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_view.jsx
@@ -8,6 +8,7 @@ import Spinner from '../components/spinner';
 import $ from 'jquery';
 import CohortViewTable from './cohort_view_table';
 import CohortCalculator from './cohort_calculator';
+import {CohortCalculatorStatuses} from '@cdo/apps/generated/pd/sharedApplicationConstants';
 import RegionalPartnerDropdown, {
   RegionalPartnerPropType
 } from '../components/regional_partner_dropdown';
@@ -102,8 +103,8 @@ class CohortView extends React.Component {
       let accepted = 0;
       let registered = 0;
       if (this.state.applications !== null) {
-        accepted = this.state.applications.filter(
-          app => app.status === 'accepted'
+        accepted = this.state.applications.filter(app =>
+          CohortCalculatorStatuses.includes(app.status)
         ).length;
         registered = this.state.applications.filter(
           app => app.registered_workshop === 'Yes'

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -7,6 +7,7 @@ module Api::V1::Pd
     # Api::CsvDownload must be included after load_and_authorize_resource so the auth callback runs first
     include Api::CsvDownload
     include Pd::Application::ApplicationConstants
+    include Pd::SharedApplicationConstants
 
     REGIONAL_PARTNERS_ALL = "all"
     REGIONAL_PARTNERS_NONE = "none"
@@ -75,16 +76,6 @@ module Api::V1::Pd
         end
       end
     end
-
-    COHORT_VIEW_STATUSES = %w(
-      accepted
-      accepted_not_notified
-      accepted_notified_by_partner
-      accepted_no_cost_registration
-      registration_sent
-      paid
-      withdrawn
-    )
 
     # GET /api/v1/pd/applications/cohort_view?role=:role&regional_partner_value=:regional_partner
     def cohort_view

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -603,7 +603,7 @@ module Api::V1::Pd
 
     test 'cohort view returns teacher applications of correct statuses' do
       expected_applications = []
-      teacher_cohort_view_statuses = Api::V1::Pd::ApplicationsController::COHORT_VIEW_STATUSES & TEACHER_APPLICATION_CLASS.statuses
+      teacher_cohort_view_statuses = Pd::SharedApplicationConstants::COHORT_VIEW_STATUSES & TEACHER_APPLICATION_CLASS.statuses
       TEACHER_APPLICATION_CLASS.statuses.each do |status|
         application = create TEACHER_APPLICATION_FACTORY, course: 'csp'
         application.update_column(:status, status)
@@ -624,7 +624,7 @@ module Api::V1::Pd
 
     test 'cohort view returns facilitator applications of correct statuses' do
       expected_applications = []
-      facilitator_cohort_view_statuses = Api::V1::Pd::ApplicationsController::COHORT_VIEW_STATUSES & FACILITATOR_APPLICATION_CLASS.statuses
+      facilitator_cohort_view_statuses = Pd::SharedApplicationConstants::COHORT_VIEW_STATUSES & FACILITATOR_APPLICATION_CLASS.statuses
       FACILITATOR_APPLICATION_CLASS.statuses.each do |status|
         application = create FACILITATOR_APPLICATION_FACTORY, course: 'csp'
         application.update_column(:status, status)

--- a/lib/cdo/shared_constants/pd/shared_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_application_constants.rb
@@ -1,0 +1,14 @@
+module Pd
+  module SharedApplicationConstants
+    COHORT_CALCULATOR_STATUSES = %w(
+      accepted
+      accepted_not_notified
+      accepted_notified_by_partner
+      accepted_no_cost_registration
+      registration_sent
+      paid
+    )
+
+    COHORT_VIEW_STATUSES = COHORT_CALCULATOR_STATUSES + ['withdrawn']
+  end
+end


### PR DESCRIPTION
[PLC-168](https://codedotorg.atlassian.net/browse/PLC-168)

Cohort calculator now considers all statuses in cohort view except 'withdrawn' as accepted, and will stay in sync with cohort view as this list is updated.

<img width="1662" alt="Screen Shot 2019-04-02 at 10 28 51 AM" src="https://user-images.githubusercontent.com/224089/55423154-32c4e100-5532-11e9-8140-1012889384c5.png">