### PR TITLE
ESLint: Enable react/button-has-type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,16 +40,27 @@ module.exports = {
     "no-unused-vars": ["error", { args: "none" }],
     "no-with": "error",
     "object-curly-spacing": "off",
+    "react/button-has-type": "off", // TODO: turn this on
     "react/display-name": "off",
     "react/jsx-closing-bracket-location": "error", // autofixable
     "react/jsx-curly-spacing": "error", // autofixable
     "react/jsx-first-prop-new-line": ["error", "multiline"],
     "react/jsx-indent-props": ["error", 2], // autofixable
+    "react/jsx-key": "off",
+    "react/jsx-no-target-blank": "off", // TODO: turn this on
+    "react/jsx-wrap-multilines": "error", // autofixable
+    "react/no-find-dom-node": "off",
     "react/no-render-return-value": "off", // TODO: turn this on
+    "react/no-string-refs": "off",
+    "react/no-unescaped-entities": "off",
     "react/self-closing-comp": "error",
-    "react/wrap-multilines": "error", // autofixable
     semi: "off", // enforced by babel/semi
     "space-before-blocks": "error",
     strict: "error"
+  },
+  settings: {
+    react: {
+      version: "detect"
+    }
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,10 +47,10 @@ module.exports = {
     "react/jsx-first-prop-new-line": ["error", "multiline"],
     "react/jsx-indent-props": ["error", 2], // autofixable
     "react/jsx-key": "off",
-    "react/jsx-no-target-blank": "off", // TODO: turn this on
+    "react/jsx-no-target-blank": "off",
     "react/jsx-wrap-multilines": "error", // autofixable
     "react/no-find-dom-node": "off",
-    "react/no-render-return-value": "off", // TODO: turn this on
+    "react/no-render-return-value": "off",
     "react/no-string-refs": "off",
     "react/no-unescaped-entities": "off",
     "react/self-closing-comp": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
     "no-unused-vars": ["error", { args: "none" }],
     "no-with": "error",
     "object-curly-spacing": "off",
-    "react/button-has-type": "off", // TODO: turn this on
+    "react/button-has-type": "error",
     "react/display-name": "off",
     "react/jsx-closing-bracket-location": "error", // autofixable
     "react/jsx-curly-spacing": "error", // autofixable

--- a/apps/package.json
+++ b/apps/package.json
@@ -98,7 +98,7 @@
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-mocha": "^4.9.0",
     "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-react": "^5.2.2",
+    "eslint-plugin-react": "7",
     "fake-fetch": "^2.0.0",
     "fast-memoize": "2.0.2",
     "file-loader": "^3.0.1",

--- a/apps/package.json
+++ b/apps/package.json
@@ -98,7 +98,7 @@
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-mocha": "^4.9.0",
     "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-react": "7",
+    "eslint-plugin-react": "^7.11.0",
     "fake-fetch": "^2.0.0",
     "fast-memoize": "2.0.2",
     "file-loader": "^3.0.1",

--- a/apps/src/applab/PlaySpaceHeader.jsx
+++ b/apps/src/applab/PlaySpaceHeader.jsx
@@ -38,14 +38,26 @@ class PlaySpaceHeader extends React.Component {
           selected={this.props.interfaceMode}
           onChange={this.props.onInterfaceModeChange}
         >
-          <button id="codeModeButton" value={ApplabInterfaceMode.CODE}>
+          <button
+            type="button"
+            id="codeModeButton"
+            value={ApplabInterfaceMode.CODE}
+          >
             {msg.codeMode()}
           </button>
-          <button id="designModeButton" value={ApplabInterfaceMode.DESIGN}>
+          <button
+            type="button"
+            id="designModeButton"
+            value={ApplabInterfaceMode.DESIGN}
+          >
             {msg.designMode()}
           </button>
           {this.props.hasDataMode && (
-            <button id="dataModeButton" value={ApplabInterfaceMode.DATA}>
+            <button
+              type="button"
+              id="dataModeButton"
+              value={ApplabInterfaceMode.DATA}
+            >
               {msg.dataMode()}
             </button>
           )}

--- a/apps/src/applab/designElements/ColorPickerPropertyRow.jsx
+++ b/apps/src/applab/designElements/ColorPickerPropertyRow.jsx
@@ -90,6 +90,7 @@ export default class ColorPickerPropertyRow extends React.Component {
           />
           <button
             ref="button"
+            type="button"
             className={this.state.value === '' ? 'rainbow-gradient' : undefined}
             style={buttonStyle}
             onClick={this.toggleColorPicker}

--- a/apps/src/applab/designElements/CopyElementToScreenButton.jsx
+++ b/apps/src/applab/designElements/CopyElementToScreenButton.jsx
@@ -100,6 +100,7 @@ class CopyElementToScreenButton extends React.Component {
     return (
       <div style={styles.main} ref={element => (this.element = element)}>
         <button
+          type="button"
           style={[commonStyles.button, styles.copyElementToScreenButton]}
           onClick={this.handleDropdownClick}
         >

--- a/apps/src/applab/designElements/DefaultScreenButtonPropertyRow.jsx
+++ b/apps/src/applab/designElements/DefaultScreenButtonPropertyRow.jsx
@@ -31,7 +31,11 @@ export default class DefaultScreenButtonPropertyRow extends React.Component {
 
     return (
       <div style={{marginLeft: 15}}>
-        <button style={defaultButtonStyle} onClick={this.handleMakeDefault}>
+        <button
+          type="button"
+          style={defaultButtonStyle}
+          onClick={this.handleMakeDefault}
+        >
           Make Default
         </button>
       </div>

--- a/apps/src/applab/designElements/DeleteElementButton.jsx
+++ b/apps/src/applab/designElements/DeleteElementButton.jsx
@@ -49,12 +49,17 @@ class DeleteElementButton extends React.Component {
         <div style={[styles.right, styles.confirming]}>
           Delete?
           <button
+            type="button"
             style={[commonStyles.button, styles.red]}
             onClick={this.finishDelete}
           >
             Yes
           </button>
-          <button style={commonStyles.button} onClick={this.abortDelete}>
+          <button
+            type="button"
+            style={commonStyles.button}
+            onClick={this.abortDelete}
+          >
             No
           </button>
         </div>
@@ -63,6 +68,7 @@ class DeleteElementButton extends React.Component {
     return (
       <div>
         <button
+          type="button"
           style={[commonStyles.button, styles.red, styles.right]}
           onClick={this.handleDeleteInternal}
         >

--- a/apps/src/applab/designElements/DuplicateElementButton.jsx
+++ b/apps/src/applab/designElements/DuplicateElementButton.jsx
@@ -25,6 +25,7 @@ class DuplicateElementButton extends React.Component {
     return (
       <div style={styles.main}>
         <button
+          type="button"
           style={[commonStyles.button, styles.duplicateButton]}
           onClick={this.handleDuplicate}
         >

--- a/apps/src/applab/designElements/ZOrderRow.jsx
+++ b/apps/src/applab/designElements/ZOrderRow.jsx
@@ -42,6 +42,7 @@ export default class ZOrderRow extends React.Component {
         <div style={rowStyle.description}>depth</div>
         <div>
           <button
+            type="button"
             style={isBackMost ? squareButtonDisabled : squareButton}
             onClick={this.props.onDepthChange.bind(this, element, 'toBack')}
             disabled={isBackMost}
@@ -50,6 +51,7 @@ export default class ZOrderRow extends React.Component {
             <FontAwesome icon="angle-double-left" />
           </button>
           <button
+            type="button"
             style={isBackMost ? squareButtonDisabled : squareButton}
             onClick={this.props.onDepthChange.bind(this, element, 'backward')}
             disabled={isBackMost}
@@ -58,6 +60,7 @@ export default class ZOrderRow extends React.Component {
             <FontAwesome icon="angle-left" />
           </button>
           <button
+            type="button"
             style={isFrontMost ? squareButtonDisabled : squareButton}
             onClick={this.props.onDepthChange.bind(this, element, 'forward')}
             disabled={isFrontMost}
@@ -66,6 +69,7 @@ export default class ZOrderRow extends React.Component {
             <FontAwesome icon="angle-right" />
           </button>
           <button
+            type="button"
             style={isFrontMost ? squareButtonDisabled : squareButton}
             onClick={this.props.onDepthChange.bind(this, element, 'toFront')}
             disabled={isFrontMost}

--- a/apps/src/bounce/BounceVisualizationColumn.jsx
+++ b/apps/src/bounce/BounceVisualizationColumn.jsx
@@ -22,7 +22,7 @@ var BounceVisualizationColumn = function() {
 
         <ProtectedStatefulDiv id="share-cell-wrapper">
           <div id="share-cell" className="share-cell-none">
-            <button id="finishButton" className="share">
+            <button type="button" id="finishButton" className="share">
               <img src="/blockly/media/1x1.gif" />
               {msg.finish()}
             </button>

--- a/apps/src/code-studio/DisabledBubblesModal.jsx
+++ b/apps/src/code-studio/DisabledBubblesModal.jsx
@@ -43,7 +43,9 @@ export default class DisabledBubblesModal extends React.Component {
             </a>
           </div>
           <div style={styles.button}>
-            <button onClick={this.handleClose}>{i18n.dialogOK()}</button>
+            <button type="button" onClick={this.handleClose}>
+              {i18n.dialogOK()}
+            </button>
           </div>
         </div>
       </BaseDialog>

--- a/apps/src/code-studio/LinkCleverAccountModal.jsx
+++ b/apps/src/code-studio/LinkCleverAccountModal.jsx
@@ -129,6 +129,7 @@ export default class LinkCleverAccountModal extends React.Component {
         <div style={styles.footer}>
           {!this.props.forceConnect && (
             <button
+              type="button"
               onClick={this.cancel}
               style={{...styles.buttonPrimary, ...styles.buttonSecondary}}
             >
@@ -136,6 +137,7 @@ export default class LinkCleverAccountModal extends React.Component {
             </button>
           )}
           <button
+            type="button"
             onClick={this.ok}
             style={Object.assign({}, styles.buttonPrimary)}
           >

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -274,7 +274,11 @@ class AdvancedShareOptions extends React.Component {
           Export your project as a zipped file, which will contain the
           HTML/CSS/JS files, as well as any assets, for your project.
         </p>
-        <button onClick={this.downloadExport} style={{marginLeft: 0}}>
+        <button
+          type="button"
+          onClick={this.downloadExport}
+          style={{marginLeft: 0}}
+        >
           {spinner}
           Export
         </button>
@@ -331,11 +335,16 @@ class AdvancedShareOptions extends React.Component {
         </p>
         <div style={style.expoContainer}>
           <div style={[style.expoExportRow, style.expoExportButtonRow]}>
-            <button onClick={this.publishExpoExport} style={style.expoButton}>
+            <button
+              type="button"
+              onClick={this.publishExpoExport}
+              style={style.expoButton}
+            >
               {publishSpinner}
               Test in Expo App
             </button>
             <button
+              type="button"
               onClick={this.downloadExpoExport}
               style={[style.expoButton, style.expoButtonLast]}
             >
@@ -371,6 +380,7 @@ class AdvancedShareOptions extends React.Component {
                     style={style.expoInput}
                   />
                   <button
+                    type="button"
                     onClick={this.generateExpoApk}
                     style={[style.expoButton, style.expoButtonApk]}
                   >
@@ -378,6 +388,7 @@ class AdvancedShareOptions extends React.Component {
                     Create Android App
                   </button>
                   <button
+                    type="button"
                     onClick={this.visitExpoSite}
                     style={[style.expoButton, style.expoButtonApk]}
                   >

--- a/apps/src/code-studio/components/AssetRow.jsx
+++ b/apps/src/code-studio/components/AssetRow.jsx
@@ -173,7 +173,11 @@ export default class AssetRow extends React.Component {
     let actions, flex;
     // `flex` is the "Choose" button in file-choose mode, or the filesize.
     if (this.props.onChoose) {
-      flex = <button onClick={this.chooseAsset}>{i18n.choose()}</button>;
+      flex = (
+        <button type="button" onClick={this.chooseAsset}>
+          {i18n.choose()}
+        </button>
+      );
     } else {
       const size = (this.props.size / 1000).toFixed(2);
       flex = size + ' kb';
@@ -184,7 +188,11 @@ export default class AssetRow extends React.Component {
         actions = (
           <td width="250" style={{textAlign: 'right'}}>
             {flex}
-            <button className="btn-danger" onClick={this.confirmDelete}>
+            <button
+              type="button"
+              className="btn-danger"
+              onClick={this.confirmDelete}
+            >
               <i className="fa fa-trash-o" />
             </button>
           </td>
@@ -209,10 +217,16 @@ export default class AssetRow extends React.Component {
                 }
               />
             )}
-            <button className="btn-danger" onClick={this.handleDelete}>
+            <button
+              type="button"
+              className="btn-danger"
+              onClick={this.handleDelete}
+            >
               Delete File
             </button>
-            <button onClick={this.cancelDelete}>Cancel</button>
+            <button type="button" onClick={this.cancelDelete}>
+              Cancel
+            </button>
             <div style={styles.deleteWarning}>
               {i18n.confirmDeleteExplanation()}
             </div>

--- a/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
+++ b/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
@@ -210,6 +210,7 @@ class DownloadReplayVideoButton extends React.Component {
 
     return (
       <button
+        type="button"
         className="download-replay-video-button"
         style={style}
         disabled={!this.buttonEnabled()}

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -175,7 +175,11 @@ export default class ReportAbuseForm extends React.Component {
               })}
             />
           </div>
-          <button onClick={this.handleSubmit} id="uitest-submit-report-abuse">
+          <button
+            type="button"
+            onClick={this.handleSubmit}
+            id="uitest-submit-report-abuse"
+          >
             {i18n.t('submit')}
           </button>
         </form>

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -176,7 +176,7 @@ export default class ReportAbuseForm extends React.Component {
             />
           </div>
           <button
-            type="button"
+            type="submit"
             onClick={this.handleSubmit}
             id="uitest-submit-report-abuse"
           >

--- a/apps/src/code-studio/components/SendToPhone.jsx
+++ b/apps/src/code-studio/components/SendToPhone.jsx
@@ -124,6 +124,7 @@ export default class SendToPhone extends React.Component {
           }
         />
         <button
+          type="button"
           disabled={this.state.sendState === SendState.invalidVal}
           onClick={this.handleSubmit}
         >

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -318,6 +318,7 @@ class ShareAllowedDialog extends React.Component {
               </div>
               <div style={{clear: 'both', height: 40}}>
                 <button
+                  type="button"
                   id="continue-button"
                   style={{position: 'absolute', right: 0, bottom: 0, margin: 0}}
                   onClick={this.close}
@@ -386,6 +387,7 @@ class ShareAllowedDialog extends React.Component {
                   </a>
                   {canPublish && !isPublished && (
                     <button
+                      type="button"
                       id="share-dialog-publish-button"
                       style={
                         hasThumbnail ? styles.button : styles.buttonDisabled

--- a/apps/src/code-studio/components/SoundLibrary.jsx
+++ b/apps/src/code-studio/components/SoundLibrary.jsx
@@ -193,6 +193,7 @@ export default class SoundLibrary extends React.Component {
               soundsRegistry={this.sounds}
             />
             <button
+              type="button"
               className={'primary'}
               onClick={this.onClickChoose}
               style={styles.button}

--- a/apps/src/code-studio/components/pairing/Pairing.jsx
+++ b/apps/src/code-studio/components/pairing/Pairing.jsx
@@ -153,10 +153,10 @@ export default class Pairing extends React.Component {
           </div>
         ))}
         <div className="clear" />
-        <button className="stop" onClick={this.handleStop}>
+        <button type="button" className="stop" onClick={this.handleStop}>
           {i18n.pairProgrammingStop()}
         </button>
-        <button className="ok" onClick={this.props.handleClose}>
+        <button type="button" className="ok" onClick={this.props.handleClose}>
           OK
         </button>
       </div>

--- a/apps/src/code-studio/components/pairing/StudentSelector.jsx
+++ b/apps/src/code-studio/components/pairing/StudentSelector.jsx
@@ -64,7 +64,11 @@ export default class StudentSelector extends React.Component {
         {studentDivs}
         <div className="clear" />
         {this.state.selectedStudentIds.length !== 0 && (
-          <button onClick={this.handleSubmit} className="addPartners">
+          <button
+            type="button"
+            onClick={this.handleSubmit}
+            className="addPartners"
+          >
             {i18n.addPartners()}
           </button>
         )}

--- a/apps/src/code-studio/components/playzone.jsx
+++ b/apps/src/code-studio/components/playzone.jsx
@@ -42,6 +42,7 @@ export default class PlayZone extends React.Component {
         <CreateSomething />
         <div className="farSide">
           <button
+            type="button"
             id="ok-button"
             onClick={this.props.onContinue}
             style={styles.continueButton}

--- a/apps/src/code-studio/components/progress/StageLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/StageLockDialog.jsx
@@ -172,6 +172,7 @@ class StageLockDialog extends React.Component {
                 <td>1. {commonMsg.allowEditingInstructions()}</td>
                 <td>
                   <button
+                    type="button"
                     style={progressStyles.orangeButton}
                     onClick={this.allowEditing}
                   >
@@ -183,6 +184,7 @@ class StageLockDialog extends React.Component {
                 <td>2. {commonMsg.lockStageInstructions()}</td>
                 <td>
                   <button
+                    type="button"
                     style={progressStyles.orangeButton}
                     onClick={this.lockStage}
                   >
@@ -194,6 +196,7 @@ class StageLockDialog extends React.Component {
                 <td>3. {commonMsg.showAnswersInstructions()}</td>
                 <td>
                   <button
+                    type="button"
                     style={progressStyles.orangeButton}
                     onClick={this.showAnswers}
                   >
@@ -205,6 +208,7 @@ class StageLockDialog extends React.Component {
                 <td>4. {commonMsg.relockStageInstructions()}</td>
                 <td>
                   <button
+                    type="button"
                     style={progressStyles.orangeButton}
                     onClick={this.lockStage}
                   >
@@ -216,6 +220,7 @@ class StageLockDialog extends React.Component {
                 <td>5. {commonMsg.reviewResponses()}</td>
                 <td>
                   <button
+                    type="button"
                     style={progressStyles.whiteButton}
                     onClick={this.viewSection}
                   >
@@ -300,12 +305,14 @@ class StageLockDialog extends React.Component {
         </div>
         <div style={styles.buttonContainer}>
           <button
+            type="button"
             style={progressStyles.baseButton}
             onClick={this.props.handleClose}
           >
             {commonMsg.dialogCancel()}
           </button>
           <button
+            type="button"
             style={[progressStyles.blueButton, hiddenUnlessSelectedSection]}
             onClick={this.handleSave}
             disabled={this.props.saving}

--- a/apps/src/code-studio/components/progress/ViewAsToggle.jsx
+++ b/apps/src/code-studio/components/progress/ViewAsToggle.jsx
@@ -64,10 +64,18 @@ class ViewAsToggle extends React.Component {
         <div style={styles.viewAs}>{commonMsg.viewPageAs()}</div>
         <div style={styles.toggleGroup}>
           <ToggleGroup selected={viewAs} onChange={this.onChange}>
-            <button className="uitest-viewAsStudent" value={ViewType.Student}>
+            <button
+              type="button"
+              className="uitest-viewAsStudent"
+              value={ViewType.Student}
+            >
               {commonMsg.student()}
             </button>
-            <button className="uitest-viewAsTeacher" value={ViewType.Teacher}>
+            <button
+              type="button"
+              className="uitest-viewAsTeacher"
+              value={ViewType.Teacher}
+            >
               {commonMsg.teacher()}
             </button>
           </ToggleGroup>

--- a/apps/src/code-studio/components/stageExtras/BonusLevels.jsx
+++ b/apps/src/code-studio/components/stageExtras/BonusLevels.jsx
@@ -70,9 +70,13 @@ class BonusLevelButton extends React.Component {
 
   render() {
     return this.props.perfected ? (
-      <button className="btn btn-large">{i18n.review()}</button>
+      <button type="button" className="btn btn-large">
+        {i18n.review()}
+      </button>
     ) : (
-      <button className="btn btn-large btn-primary">{i18n.tryIt()}</button>
+      <button type="button" className="btn btn-large btn-primary">
+        {i18n.tryIt()}
+      </button>
     );
   }
 }

--- a/apps/src/code-studio/components/stageExtras/StageExtras.jsx
+++ b/apps/src/code-studio/components/stageExtras/StageExtras.jsx
@@ -46,6 +46,7 @@ export default class StageExtras extends React.Component {
         <h2 style={styles.h2}>{msg.continue()}</h2>
         <a href={nextLevelPath}>
           <button
+            type="button"
             className="btn btn-large btn-primary"
             style={{marginBottom: 20}}
           >

--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_enrollment.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_enrollment.jsx
@@ -165,7 +165,9 @@ export default class WorkshopEnrollment extends React.Component {
             </p>
 
             <a href={this.state.signUpUrl}>
-              <button className="primary">Create account now</button>
+              <button type="button" className="primary">
+                Create account now
+              </button>
             </a>
           </div>
         )}

--- a/apps/src/craft/agent/CraftVisualizationColumn.jsx
+++ b/apps/src/craft/agent/CraftVisualizationColumn.jsx
@@ -20,7 +20,11 @@ var CraftVisualizationColumn = function(props) {
 
         {props.showFinishButton && (
           <div id="right-button-cell">
-            <button id="finishButton" className="share mc-share-button">
+            <button
+              type="button"
+              id="finishButton"
+              className="share mc-share-button"
+            >
               <div>{msg.finish()}</div>
             </button>
           </div>

--- a/apps/src/craft/designer/CraftVisualizationColumn.jsx
+++ b/apps/src/craft/designer/CraftVisualizationColumn.jsx
@@ -35,7 +35,11 @@ export default class CraftVisualizationColumn extends React.Component {
 
           {this.props.showFinishButton && (
             <div id="right-button-cell">
-              <button id="rightButton" className="share mc-share-button">
+              <button
+                type="button"
+                id="rightButton"
+                className="share mc-share-button"
+              >
                 <div>{msg.finish()}</div>
               </button>
             </div>

--- a/apps/src/craft/simple/CraftVisualizationColumn.jsx
+++ b/apps/src/craft/simple/CraftVisualizationColumn.jsx
@@ -17,7 +17,11 @@ var CraftVisualizationColumn = function(props) {
       <GameButtons>
         {props.showFinishButton && (
           <div id="right-button-cell">
-            <button id="rightButton" className="share mc-share-button">
+            <button
+              type="button"
+              id="rightButton"
+              className="share mc-share-button"
+            >
               <div>{msg.finish()}</div>
             </button>
           </div>

--- a/apps/src/eval/EvalVisualizationColumn.jsx
+++ b/apps/src/eval/EvalVisualizationColumn.jsx
@@ -18,7 +18,11 @@ var EvalVisualizationColumn = function() {
         </svg>
       </ProtectedVisualizationDiv>
       <GameButtons>
-        <button id="continueButton" className="launch hide float-right">
+        <button
+          type="button"
+          id="continueButton"
+          className="launch hide float-right"
+        >
           <img src="/blockly/media/1x1.gif" />
           {msg.continue()}
         </button>

--- a/apps/src/flappy/FlappyVisualizationColumn.jsx
+++ b/apps/src/flappy/FlappyVisualizationColumn.jsx
@@ -15,7 +15,7 @@ const FlappyVisualizationColumn = ({showFinishButton}) => {
       <GameButtons>
         {showFinishButton && (
           <div id="right-button-cell">
-            <button id="rightButton" className="share">
+            <button type="button" id="rightButton" className="share">
               <img src="/blockly/media/1x1.gif" />
               {msg.finish()}
             </button>

--- a/apps/src/gamelab/GameLabVisualizationHeader.jsx
+++ b/apps/src/gamelab/GameLabVisualizationHeader.jsx
@@ -38,11 +38,15 @@ class GameLabVisualizationHeader extends React.Component {
     return (
       <div style={styles.main} id="playSpaceHeader">
         <ToggleGroup selected={interfaceMode} onChange={onInterfaceModeChange}>
-          <button value={GameLabInterfaceMode.CODE} id="codeMode">
+          <button type="button" value={GameLabInterfaceMode.CODE} id="codeMode">
             {msg.codeMode()}
           </button>
           {allowAnimationMode && (
-            <button value={GameLabInterfaceMode.ANIMATION} id="animationMode">
+            <button
+              type="button"
+              value={GameLabInterfaceMode.ANIMATION}
+              id="animationMode"
+            >
               {this.props.spriteLab ? msg.costumeMode() : msg.animationMode()}
             </button>
           )}

--- a/apps/src/lib/kits/maker/ui/OverlayButton.jsx
+++ b/apps/src/lib/kits/maker/ui/OverlayButton.jsx
@@ -53,6 +53,7 @@ class OverlayButton extends Component {
 
     return (
       <button
+        type="button"
         className={this.props.className}
         style={composedStyle}
         onClick={this.props.onClick}

--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -77,16 +77,16 @@ class Downloads extends React.Component {
     return (
       <div>
         <ToggleGroup selected={platform} onChange={this.onPlatformChange}>
-          <button value={WINDOWS}>
+          <button type="button" value={WINDOWS}>
             <FontAwesome icon="windows" /> Windows
           </button>
-          <button value={MAC}>
+          <button type="button" value={MAC}>
             <FontAwesome icon="apple" /> Mac
           </button>
-          <button value={LINUX}>
+          <button type="button" value={LINUX}>
             <FontAwesome icon="linux" /> Linux
           </button>
-          <button value={CHROMEBOOK}>
+          <button type="button" value={CHROMEBOOK}>
             <FontAwesome icon="chrome" /> Chromebook
           </button>
         </ToggleGroup>

--- a/apps/src/lib/script-editor/StageDescriptions.jsx
+++ b/apps/src/lib/script-editor/StageDescriptions.jsx
@@ -139,7 +139,7 @@ export default class StageDescriptions extends React.Component {
         <h4>Stage Descriptions</h4>
         <div style={styles.main}>
           {this.state.collapsed && (
-            <button className="btn" onClick={this.expand}>
+            <button type="button" className="btn" onClick={this.expand}>
               Click to Expand
             </button>
           )}
@@ -206,6 +206,7 @@ export default class StageDescriptions extends React.Component {
                 />
               )}
               <button
+                type="button"
                 className="btn"
                 disabled={!!this.state.buttonText}
                 onClick={this.importDescriptions}

--- a/apps/src/lib/tools/jsdebugger/DebugButtons.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugButtons.jsx
@@ -48,6 +48,7 @@ export default connect(
               ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
             }
             <button
+              type="button"
               id="pauseButton"
               className="debugger_button"
               onClick={this.props.togglePause}
@@ -61,6 +62,7 @@ export default connect(
               ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
             }
             <button
+              type="button"
               id="continueButton"
               className="debugger_button"
               onClick={this.props.togglePause}
@@ -76,6 +78,7 @@ export default connect(
               ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
             }
             <button
+              type="button"
               id="stepOverButton"
               className="debugger_button"
               onClick={this.props.stepOver}
@@ -89,6 +92,7 @@ export default connect(
             </button>
 
             <button
+              type="button"
               id="stepOutButton"
               className="debugger_button"
               onClick={this.props.stepOut}
@@ -104,6 +108,7 @@ export default connect(
               ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
             }
             <button
+              type="button"
               id="stepInButton"
               className="debugger_button"
               onClick={this.props.stepIn}

--- a/apps/src/lib/ui/LegacyDialogContents.js
+++ b/apps/src/lib/ui/LegacyDialogContents.js
@@ -14,10 +14,10 @@ export const SingleLevelGroupDialog = ({id, title, body}) => (
     <div className="modal-content no-modal-icon">
       <p className="dialog-title">{title}</p>
       <p className="dialog-body">{body}</p>
-      <button id="cancel-button" style={{float: 'left'}}>
+      <button type="button" id="cancel-button" style={{float: 'left'}}>
         {i18n.cancel()}
       </button>
-      <button id="ok-button" style={{float: 'right'}}>
+      <button type="button" id="ok-button" style={{float: 'right'}}>
         {i18n.okay()}
       </button>
     </div>
@@ -46,7 +46,9 @@ export const MatchAngiGifDialog = () => (
         <img src="/script_assets/images/matching_ani.gif" />
       </div>
       <div className="farSide">
-        <button id="ok-button">{i18n.ok()}</button>
+        <button type="button" id="ok-button">
+          {i18n.ok()}
+        </button>
       </div>
     </div>
   </ProtectedStatefulDiv>
@@ -58,7 +60,9 @@ export const TooFewDialog = () => (
       <p className="dialog-title">{i18n.tooFewTitle()}</p>
       <p>{i18n.tooFewBody()}</p>
       <div className="farSide">
-        <button id="ok-button">{i18n.ok()}</button>
+        <button type="button" id="ok-button">
+          {i18n.ok()}
+        </button>
       </div>
     </div>
   </ProtectedStatefulDiv>
@@ -70,7 +74,9 @@ export const ContractMatchErrorDialog = ({text}) => (
       <p className="dialog-title">{i18n.incorrectAnswer()}</p>
       <p>{text}</p>
       <div className="farSide">
-        <button id="ok-button">{i18n.ok()}</button>
+        <button type="button" id="ok-button">
+          {i18n.ok()}
+        </button>
       </div>
     </div>
   </ProtectedStatefulDiv>
@@ -85,7 +91,9 @@ export const MatchErrorDialog = () => (
       <p className="dialog-title">{i18n.incorrectSolution()}</p>
       <p>{i18n.incorrectSolutionBody()}</p>
       <div className="farSide">
-        <button id="ok-button">{i18n.ok()}</button>
+        <button type="button" id="ok-button">
+          {i18n.ok()}
+        </button>
       </div>
     </div>
   </ProtectedStatefulDiv>
@@ -97,7 +105,9 @@ export const ErrorDialog = () => (
       <p className="dialog-title">{i18n.incorrectAnswer()}</p>
       <p>{i18n.incorrectAnswerBody()}</p>
       <div className="farSide">
-        <button id="ok-button">{i18n.ok()}</button>
+        <button type="button" id="ok-button">
+          {i18n.ok()}
+        </button>
       </div>
     </div>
   </ProtectedStatefulDiv>
@@ -109,8 +119,15 @@ export const StartOverDialog = () => (
       <p className="dialog-title">{i18n.startOverTitle()}</p>
       <p>{i18n.startOverBody()}</p>
       <div id="buttons">
-        <button id="cancel-button">{i18n.cancel()}</button>
-        <button id="ok-button" className="btn-danger" style={{float: 'right'}}>
+        <button type="button" id="cancel-button">
+          {i18n.cancel()}
+        </button>
+        <button
+          type="button"
+          id="ok-button"
+          className="btn-danger"
+          style={{float: 'right'}}
+        >
           {i18n.startOver()}
         </button>
       </div>
@@ -127,7 +144,7 @@ export const InstructionsDialog = ({title, markdown}) => (
         <UnsafeRenderedMarkdown markdown={markdown} />
       </div>
       <div id="buttons">
-        <button id="ok-button" style={{float: 'right'}}>
+        <button type="button" id="ok-button" style={{float: 'right'}}>
           {i18n.ok()}
         </button>
       </div>
@@ -145,7 +162,9 @@ export const SuccessDialog = ({title, body}) => (
       <p className="dialog-title">{title}</p>
       <p>{body}</p>
       <div className="farSide">
-        <button id="ok-button">{i18n.ok()}</button>
+        <button type="button" id="ok-button">
+          {i18n.ok()}
+        </button>
       </div>
     </div>
   </ProtectedStatefulDiv>

--- a/apps/src/lib/ui/PopUpMenu.jsx
+++ b/apps/src/lib/ui/PopUpMenu.jsx
@@ -71,10 +71,11 @@ export default class PopUpMenu extends Component {
           targetPoint={this.props.targetPoint}
           offset={this.props.offset}
           className={this.props.className}
-          children={this.props.children}
           showTail={this.props.showTail}
           style={this.props.style}
-        />
+        >
+          {this.props.children}
+        </MenuBubble>
       </Portal>
     );
   }

--- a/apps/src/lib/ui/WireframeButtons.jsx
+++ b/apps/src/lib/ui/WireframeButtons.jsx
@@ -111,6 +111,7 @@ SendToPhoneButton.propTypes = {
   onClick: PropTypes.func.isRequired
 };
 
+/* eslint-disable react/prop-types */
 const SendToPhoneControls = ({appType, channelId, isLegacyShare}) => (
   <div className="WireframeButtons_active">
     <SendToPhone
@@ -126,6 +127,7 @@ SendToPhoneControls.propTypes = _.pick(WireframeButtons.propTypes, [
   'channelId',
   'isLegacyShare'
 ]);
+/* eslint-enable react/prop-types */
 
 const styles = {
   main: {

--- a/apps/src/lib/ui/WireframeButtons.jsx
+++ b/apps/src/lib/ui/WireframeButtons.jsx
@@ -111,6 +111,7 @@ SendToPhoneButton.propTypes = {
   onClick: PropTypes.func.isRequired
 };
 
+// ESLint doesn't seem to understand our inherited-proptypes pattern here
 /* eslint-disable react/prop-types */
 const SendToPhoneControls = ({appType, channelId, isLegacyShare}) => (
   <div className="WireframeButtons_active">

--- a/apps/src/lib/ui/accounts/BootstrapButton.jsx
+++ b/apps/src/lib/ui/accounts/BootstrapButton.jsx
@@ -41,6 +41,7 @@ export default class BootstrapButton extends React.Component {
 
     return (
       <button
+        type="button"
         className={this.buttonClasses()}
         style={{...styles.button, ...style}}
         onClick={onClick}

--- a/apps/src/maze/SpellingControls.jsx
+++ b/apps/src/maze/SpellingControls.jsx
@@ -11,7 +11,12 @@ var SpellingControls = function(props) {
           <tr>
             <td className="spellingTextCell">{msg.word()}:</td>
             <td className="spellingButtonCell">
-              <button id="searchWord" className="spellingButton" disabled>
+              <button
+                type="button"
+                id="searchWord"
+                className="spellingButton"
+                disabled
+              >
                 <img src="/blockly/media/1x1.gif" />
                 {props.searchWord}
               </button>
@@ -20,7 +25,12 @@ var SpellingControls = function(props) {
           <tr>
             <td className="spellingTextCell">{msg.youSpelled()}:</td>
             <td className="spellingButtonCell">
-              <button id="currentWord" className="spellingButton" disabled>
+              <button
+                type="button"
+                id="currentWord"
+                className="spellingButton"
+                disabled
+              >
                 <img src="/blockly/media/1x1.gif" />
                 <span id="currentWordContents" />
               </button>

--- a/apps/src/maze/StepButton.jsx
+++ b/apps/src/maze/StepButton.jsx
@@ -8,7 +8,7 @@ var StepButton = function(props) {
     classes += ' hide';
   }
   return (
-    <button id="stepButton" className={classes}>
+    <button type="button" id="stepButton" className={classes}>
       <img src="/blockly/media/1x1.gif" />
       {msg.step()}
     </button>

--- a/apps/src/publicKeyCryptography/PublicKeyCryptographyWidget.jsx
+++ b/apps/src/publicKeyCryptography/PublicKeyCryptographyWidget.jsx
@@ -208,16 +208,16 @@ const CharacterSelect = props => (
   <span>
     <strong style={characterSelectTextStyle}>Pick a character:</strong>
     <ToggleGroup selected={props.selectedCharacter} onChange={props.onChange}>
-      <button value={ALICE_VIEW}>
+      <button type="button" value={ALICE_VIEW}>
         <FontAwesome icon="user" /> Alice
       </button>
-      <button value={EVE_VIEW}>
+      <button type="button" value={EVE_VIEW}>
         <FontAwesome icon="user-secret" /> Eve
       </button>
-      <button value={BOB_VIEW}>
+      <button type="button" value={BOB_VIEW}>
         <FontAwesome icon="user" /> Bob
       </button>
-      <button value={ALL_VIEW}>
+      <button type="button" value={ALL_VIEW}>
         <FontAwesome icon="users" /> All
       </button>
     </ToggleGroup>

--- a/apps/src/publicKeyCryptography/StartOverButton.jsx
+++ b/apps/src/publicKeyCryptography/StartOverButton.jsx
@@ -23,7 +23,11 @@ export default class StartOverButton extends React.Component {
   render() {
     return (
       <span>
-        <button className="btn btn-info pull-right" onClick={this.confirm}>
+        <button
+          type="button"
+          className="btn btn-info pull-right"
+          onClick={this.confirm}
+        >
           {i18n.clearPuzzle()}
         </button>
         <Dialog

--- a/apps/src/publicKeyCryptography/cryptographyFields.jsx
+++ b/apps/src/publicKeyCryptography/cryptographyFields.jsx
@@ -89,6 +89,7 @@ export function GoButton(props) {
   const {className, ...rest} = props;
   return (
     <button
+      type="button"
       className={classNames('primary', className)}
       style={style.GoButton}
       {...rest}

--- a/apps/src/regionalPartnerMiniContact/regionalPartnerMiniContact.js
+++ b/apps/src/regionalPartnerMiniContact/regionalPartnerMiniContact.js
@@ -55,8 +55,9 @@ window.showRegionalPartnerMiniContactPopupLink = function() {
     <RegionalPartnerMiniContactPopupLink
       notes={notes}
       sourcePageId={sourcePageId}
-      children={linkText}
-    />,
+    >
+      {linkText}
+    </RegionalPartnerMiniContactPopupLink>,
     regionalPartnerMiniContactPopupLinkElement[0]
   );
 };

--- a/apps/src/scratch/ScratchVisualizationColumn.jsx
+++ b/apps/src/scratch/ScratchVisualizationColumn.jsx
@@ -16,13 +16,13 @@ export default function ScratchVisualizationColumn() {
       <ProtectedVisualizationDiv isResponsive={true}>
         <canvas id="scratch-stage" style={styles.scratchStage} />
       </ProtectedVisualizationDiv>
-      <button id="green-flag">
+      <button type="button" id="green-flag">
         <img
           src={assetUrl('media/scratch-blocks/icons/event_whenflagclicked.svg')}
           width={30}
         />
       </button>
-      <button id="stop-all">
+      <button type="button" id="stop-all">
         <img
           src={assetUrl('media/scratch-blocks/icons/control_stop.svg')}
           width={30}

--- a/apps/src/sites/studio/pages/levels/contract_match.jsx
+++ b/apps/src/sites/studio/pages/levels/contract_match.jsx
@@ -222,6 +222,7 @@ $(window).load(function() {
             }
           />
           <button
+            type="button"
             className="btn domain-x-button"
             onClick={(...args) =>
               this.props.onDomainRemove(object.key, ...args)
@@ -235,6 +236,7 @@ $(window).load(function() {
         <div className="domainsList">
           {typeChoiceNodes}
           <button
+            type="button"
             className="btn domain-add-button"
             onClick={this.props.onDomainAdd}
           >

--- a/apps/src/storage/dataBrowser/AddTableListRow.jsx
+++ b/apps/src/storage/dataBrowser/AddTableListRow.jsx
@@ -47,7 +47,11 @@ class AddTableListRow extends React.Component {
           />
         </td>
         <td style={dataStyles.cell}>
-          <button style={dataStyles.blueButton} onClick={this.handleAdd}>
+          <button
+            type="button"
+            style={dataStyles.blueButton}
+            onClick={this.handleAdd}
+          >
             Add
           </button>
         </td>

--- a/apps/src/storage/dataBrowser/ConfirmDeleteButton.jsx
+++ b/apps/src/storage/dataBrowser/ConfirmDeleteButton.jsx
@@ -42,6 +42,7 @@ class ConfirmDeleteButton extends React.Component {
           {...otherProps}
         />
         <button
+          type="button"
           id={this.props.buttonId}
           onClick={() => this.setState({open: true})}
           style={dataStyles.redButton}

--- a/apps/src/storage/dataBrowser/EditKeyRow.jsx
+++ b/apps/src/storage/dataBrowser/EditKeyRow.jsx
@@ -97,7 +97,11 @@ class EditKeyRow extends React.Component {
                 text="Save"
               />
             ) : (
-              <button style={dataStyles.editButton} onClick={this.handleEdit}>
+              <button
+                type="button"
+                style={dataStyles.editButton}
+                onClick={this.handleEdit}
+              >
                 Edit
               </button>
             ))}

--- a/apps/src/storage/dataBrowser/EditTableRow.jsx
+++ b/apps/src/storage/dataBrowser/EditTableRow.jsx
@@ -120,7 +120,11 @@ class EditTableRow extends React.Component {
                 text="Save"
               />
             ) : (
-              <button style={dataStyles.editButton} onClick={this.handleEdit}>
+              <button
+                type="button"
+                style={dataStyles.editButton}
+                onClick={this.handleEdit}
+              >
                 Edit
               </button>
             ))}

--- a/apps/src/storage/dataBrowser/TableControls.jsx
+++ b/apps/src/storage/dataBrowser/TableControls.jsx
@@ -77,7 +77,11 @@ class TableControls extends React.Component {
             containerStyle={{marginLeft: 10}}
           />
 
-          <button onClick={this.props.exportCsv} style={styles.exportButton}>
+          <button
+            type="button"
+            onClick={this.props.exportCsv}
+            style={styles.exportButton}
+          >
             Export to csv
           </button>
         </div>

--- a/apps/src/studio/StudioVisualizationColumn.jsx
+++ b/apps/src/studio/StudioVisualizationColumn.jsx
@@ -25,7 +25,7 @@ var StudioVisualizationColumn = function(props) {
 
         {props.finishButton && (
           <div id="share-cell" className="share-cell-none">
-            <button id="finishButton" className="share">
+            <button type="button" id="finishButton" className="share">
               <img src="/blockly/media/1x1.gif" />
               {msg.finish()}
             </button>

--- a/apps/src/templates/ArrowButtons.jsx
+++ b/apps/src/templates/ArrowButtons.jsx
@@ -7,25 +7,25 @@ var ProtectedStatefulDiv = require('./ProtectedStatefulDiv');
 var ArrowButtons = function(props) {
   return (
     <ProtectedStatefulDiv id="soft-buttons" className="soft-buttons-none">
-      <button id="leftButton" disabled className="arrow">
+      <button type="button" id="leftButton" disabled className="arrow">
         <img src="/blockly/media/1x1.gif" className="left-btn icon21" />
       </button>
       {
         ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
       }
-      <button id="rightButton" disabled className="arrow">
+      <button type="button" id="rightButton" disabled className="arrow">
         <img src="/blockly/media/1x1.gif" className="right-btn icon21" />
       </button>
       {
         ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
       }
-      <button id="upButton" disabled className="arrow">
+      <button type="button" id="upButton" disabled className="arrow">
         <img src="/blockly/media/1x1.gif" className="up-btn icon21" />
       </button>
       {
         ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
       }
-      <button id="downButton" disabled className="arrow">
+      <button type="button" id="downButton" disabled className="arrow">
         <img src="/blockly/media/1x1.gif" className="down-btn icon21" />
       </button>
     </ProtectedStatefulDiv>

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -154,6 +154,7 @@ class Certificate extends Component {
                 ref={input => (this.nameInput = input)}
               />
               <button
+                type="button"
                 style={styles.submit}
                 onClick={this.personalizeCertificate.bind(this, certificate)}
               >

--- a/apps/src/templates/CompletionButton.jsx
+++ b/apps/src/templates/CompletionButton.jsx
@@ -60,6 +60,7 @@ class CompletionButton extends Component {
       <ProtectedStatefulDiv style={styles.main}>
         <div id="share-cell" className={divClass}>
           <button
+            type="button"
             id={id}
             className="share"
             style={[this.props.playspacePhoneFrame && styles.phoneFrameButton]}

--- a/apps/src/templates/FinishDialog.jsx
+++ b/apps/src/templates/FinishDialog.jsx
@@ -423,6 +423,7 @@ export class UnconnectedFinishDialog extends Component {
   getButtons() {
     const showCode = !this.state.showingCode ? (
       <button
+        type="button"
         key="showcode"
         style={{...styles.button, ...styles.showCodeButton}}
         onClick={() =>
@@ -436,6 +437,7 @@ export class UnconnectedFinishDialog extends Component {
       </button>
     ) : (
       <button
+        type="button"
         key="hidecode"
         style={{...styles.button, ...styles.showCodeButton}}
         onClick={() =>
@@ -451,6 +453,7 @@ export class UnconnectedFinishDialog extends Component {
 
     return [
       <button
+        type="button"
         key="replay"
         style={{...styles.button, ...styles.replayButton}}
         onClick={this.props.onReplay}
@@ -459,6 +462,7 @@ export class UnconnectedFinishDialog extends Component {
       </button>,
       showCode,
       <button
+        type="button"
         key="continue"
         style={{...styles.button, ...styles.continueButton}}
         onClick={this.props.onContinue}
@@ -525,6 +529,7 @@ export class UnconnectedFinishDialog extends Component {
                         }}
                       />
                       <button
+                        type="button"
                         style={styles.shareButton}
                         onClick={() => shareProject(this.props.getShareUrl())}
                       >

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -20,7 +20,7 @@ const styles = {
 };
 
 export const FinishButton = () => (
-  <button id="finishButton" className="share">
+  <button type="button" id="finishButton" className="share">
     <img src="/blockly/media/1x1.gif" />
     {msg.finish()}
   </button>
@@ -29,6 +29,7 @@ export const FinishButton = () => (
 export const RunButton = Radium(props => (
   <span id="runButtonWrapper">
     <button
+      type="button"
       id="runButton"
       className={classNames([
         'launch',
@@ -51,6 +52,7 @@ RunButton.displayName = 'RunButton';
 
 export const ResetButton = Radium(props => (
   <button
+    type="button"
     id="resetButton"
     // See apps/style/common.scss for these class definitions
     className={classNames([

--- a/apps/src/templates/GameButtons.story.jsx
+++ b/apps/src/templates/GameButtons.story.jsx
@@ -94,7 +94,7 @@ export default function(storybook) {
       description: 'Additional children can be provided',
       story: () => (
         <UnconnectedGameButtons>
-          <button>another button</button>
+          <button type="button">another button</button>
         </UnconnectedGameButtons>
       )
     },
@@ -103,7 +103,7 @@ export default function(storybook) {
       description: 'The default version with no props',
       story: () => (
         <UnconnectedGameButtons showSkipButton nextLevelUrl="#">
-          <button>another button</button>
+          <button type="button">another button</button>
         </UnconnectedGameButtons>
       )
     }

--- a/apps/src/templates/LegacyButton.jsx
+++ b/apps/src/templates/LegacyButton.jsx
@@ -132,7 +132,7 @@ const BaseButton = Radium(function BaseButton({
   const config = BUTTON_TYPES[type];
   let styleArray = [style.base, config.style, sizeStyle];
   return (
-    <button {...props} style={[styleArray, props.style]}>
+    <button type="button" {...props} style={[styleArray, props.style]}>
       {children}
     </button>
   );

--- a/apps/src/templates/PendingButton.jsx
+++ b/apps/src/templates/PendingButton.jsx
@@ -22,6 +22,7 @@ class PendingButton extends React.Component {
       : this.props.style;
     return (
       <button
+        type="button"
         id={this.props.id}
         style={style}
         className={this.props.className}

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -246,7 +246,9 @@ class RegionalPartnerSearch extends Component {
               We are unable to find this ZIP code. You can still apply directly:
             </div>
             <a href={applicationLink}>
-              <button style={styles.bigButton}>Start application</button>
+              <button type="button" style={styles.bigButton}>
+                Start application
+              </button>
             </a>
           </div>
         )}
@@ -298,7 +300,9 @@ class RegionalPartnerSearch extends Component {
                 for other Professional Development options in your area.
               </p>
               <a href={applicationLink}>
-                <button style={styles.bigButton}>Start application</button>
+                <button type="button" style={styles.bigButton}>
+                  Start application
+                </button>
               </a>
             </div>
           </div>
@@ -316,7 +320,9 @@ class RegionalPartnerSearch extends Component {
                     id={`id-${partnerInfo.id}`}
                     href={applicationLink}
                   >
-                    <button style={styles.bigButton}>Start application</button>
+                    <button type="button" style={styles.bigButton}>
+                      Start application
+                    </button>
                   </a>
                 )}
 
@@ -328,7 +334,7 @@ class RegionalPartnerSearch extends Component {
                     href={partnerInfo.link_to_partner_application}
                     target="_blank"
                   >
-                    <button style={styles.bigButton}>
+                    <button type="button" style={styles.bigButton}>
                       Apply on partner's site
                     </button>
                   </a>
@@ -396,7 +402,7 @@ class RegionalPartnerSearch extends Component {
                   notes={'Please notify me when I can apply!'}
                   sourcePageId="regional-partner-search-notify"
                 >
-                  <button style={styles.bigButton}>
+                  <button type="button" style={styles.bigButton}>
                     Notify me when I can apply
                   </button>
                 </RegionalPartnerMiniContactPopupLink>
@@ -462,7 +468,9 @@ class RegionalPartnerSearch extends Component {
                   id={`id-${partnerInfo.id}`}
                   href={applicationLink}
                 >
-                  <button style={styles.bigButton}>Start application</button>
+                  <button type="button" style={styles.bigButton}>
+                    Start application
+                  </button>
                 </a>
               )}
 
@@ -474,7 +482,7 @@ class RegionalPartnerSearch extends Component {
                   href={partnerInfo.link_to_partner_application}
                   target="_blank"
                 >
-                  <button style={styles.bigButton}>
+                  <button type="button" style={styles.bigButton}>
                     Apply on partner's site
                   </button>
                 </a>

--- a/apps/src/templates/ShareWarnings.jsx
+++ b/apps/src/templates/ShareWarnings.jsx
@@ -96,7 +96,7 @@ class ShareWarnings extends Component {
           >
             {commonMsg.shareWarningsMoreInfo()}
           </a>
-          <button style={styles.ok} onClick={this.handleOk}>
+          <button type="button" style={styles.ok} onClick={this.handleOk}>
             {commonMsg.dialogOK()}
           </button>
         </div>

--- a/apps/src/templates/SkipButton.jsx
+++ b/apps/src/templates/SkipButton.jsx
@@ -11,7 +11,7 @@ export default class SkipButton extends React.Component {
 
   render() {
     return (
-      <button id="skipButton" className={LAUNCH_CLASS}>
+      <button type="button" id="skipButton" className={LAUNCH_CLASS}>
         {msg.skipPuzzle()}
       </button>
     );

--- a/apps/src/templates/SocialShare.jsx
+++ b/apps/src/templates/SocialShare.jsx
@@ -54,6 +54,7 @@ export default class SocialShare extends Component {
             onClick={dashboard.popupWindow}
           >
             <button
+              type="button"
               style={{background: color.facebook_blue, ...styles.shareButton}}
             >
               <i className="fa fa-facebook" />
@@ -67,6 +68,7 @@ export default class SocialShare extends Component {
             onClick={dashboard.popupWindow}
           >
             <button
+              type="button"
               style={{background: color.twitter_blue, ...styles.shareButton}}
             >
               <i className="fa fa-twitter" />
@@ -74,7 +76,10 @@ export default class SocialShare extends Component {
           </a>
         )}
         <a href={this.props.print}>
-          <button style={{background: color.charcoal, ...styles.shareButton}}>
+          <button
+            type="button"
+            style={{background: color.charcoal, ...styles.shareButton}}
+          >
             <i className="fa fa-print" />
             {' ' + i18n.print()}
           </button>

--- a/apps/src/templates/ToggleButton.jsx
+++ b/apps/src/templates/ToggleButton.jsx
@@ -21,6 +21,7 @@ class ToggleButton extends Component {
   render() {
     return (
       <button
+        type="button"
         id={this.props.id}
         style={this.getStyle()}
         className={'no-outline ' + (this.props.className || '')}

--- a/apps/src/templates/VersionHistory.jsx
+++ b/apps/src/templates/VersionHistory.jsx
@@ -143,13 +143,18 @@ export default class VersionHistory extends React.Component {
         <div>
           <p>Are you sure you want to clear all progress for this level&#63;</p>
           <button
+            type="button"
             id="confirm-button"
             style={{float: 'right'}}
             onClick={this.onClearPuzzle}
           >
             Start Over
           </button>
-          <button id="again-button" onClick={this.onCancelClearPuzzle}>
+          <button
+            type="button"
+            id="again-button"
+            onClick={this.onCancelClearPuzzle}
+          >
             Cancel
           </button>
         </div>
@@ -183,6 +188,7 @@ export default class VersionHistory extends React.Component {
                   </td>
                   <td width="250" style={{textAlign: 'right'}}>
                     <button
+                      type="button"
                       className="btn-danger"
                       onClick={this.onConfirmClearPuzzle}
                       style={{float: 'right'}}

--- a/apps/src/templates/VersionRow.jsx
+++ b/apps/src/templates/VersionRow.jsx
@@ -31,6 +31,7 @@ export default class VersionRow extends React.Component {
     if (this.props.isLatest) {
       button = (
         <button
+          type="button"
           className="btn-default"
           disabled="disabled"
           style={{cursor: 'default'}}
@@ -50,11 +51,16 @@ export default class VersionRow extends React.Component {
           }
           target="_blank"
         >
-          <button className="version-preview">
+          <button type="button" className="version-preview">
             <i className="fa fa-eye" />
           </button>
         </a>,
-        <button key={1} className="btn-info" onClick={this.props.onChoose}>
+        <button
+          type="button"
+          key={1}
+          className="btn-info"
+          onClick={this.props.onChoose}
+        >
           {msg.restoreThisVersion()}
         </button>
       ];

--- a/apps/src/templates/WidgetContinueButton.jsx
+++ b/apps/src/templates/WidgetContinueButton.jsx
@@ -21,6 +21,7 @@ export default class ContinueButton extends React.Component {
     const {submitting} = this.state;
     return (
       <button
+        type="button"
         className="btn btn-primary pull-right"
         disabled={submitting}
         onClick={submitting ? null : this.onClick}

--- a/apps/src/templates/alert.jsx
+++ b/apps/src/templates/alert.jsx
@@ -80,7 +80,11 @@ export default class Alert extends React.Component {
       setTimeout(this.props.onClose, this.props.closeDelayMillis);
     } else {
       closeButton = (
-        <button style={styles.closeButton} onClick={this.props.onClose}>
+        <button
+          type="button"
+          style={styles.closeButton}
+          onClick={this.props.onClose}
+        >
           <span>&times;</span>
         </button>
       );

--- a/apps/src/templates/census2017/CensusTeacherBanner.jsx
+++ b/apps/src/templates/census2017/CensusTeacherBanner.jsx
@@ -292,12 +292,12 @@ export default class CensusTeacherBanner extends Component {
         </div>
         <div style={styles.share}>
           <a href={facebookShareUrl} target="_blank">
-            <button style={styles.shareButton}>
+            <button type="button" style={styles.shareButton}>
               <i className="fa fa-facebook" /> Share on Facebook
             </button>
           </a>
           <a href={twitterShareUrl} target="_blank">
-            <button style={styles.shareButton}>
+            <button type="button" style={styles.shareButton}>
               <i className="fa fa-twitter" /> Share on Twitter
             </button>
           </a>

--- a/apps/src/templates/instructions/CollapserButton.jsx
+++ b/apps/src/templates/instructions/CollapserButton.jsx
@@ -28,6 +28,7 @@ const CollapserButton = props => (
   // the toggle; for minecraft, we have a custom asset.
 
   <button
+    type="button"
     style={[styles.collapseButton, props.style]}
     id="toggleButton"
     onClick={props.onClick}

--- a/apps/src/templates/instructions/HintPrompt.jsx
+++ b/apps/src/templates/instructions/HintPrompt.jsx
@@ -27,12 +27,14 @@ const HintPrompt = ({onConfirm, onDismiss, borderColor}) => {
     <ChatBubble borderColor={borderColor} ttsMessage={message}>
       <p>{message}</p>
       <button
+        type="button"
         onClick={onConfirm}
         style={[buttonStyles.common, buttonStyles.yes]}
       >
         {msg.yes()}
       </button>
       <button
+        type="button"
         onClick={onDismiss}
         style={[buttonStyles.common, buttonStyles.no]}
       >

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -147,6 +147,7 @@ class ScrollButtons extends React.Component {
 
     const upButton = this.props.isMinecraft ? (
       <button
+        type="button"
         className="arrow"
         ref={c => {
           this.scrollUp = c;
@@ -170,6 +171,7 @@ class ScrollButtons extends React.Component {
 
     const downButton = this.props.isMinecraft ? (
       <button
+        type="button"
         className="arrow"
         ref={c => {
           this.scrollDown = c;

--- a/apps/src/templates/progress/ProgressDetailToggle.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.jsx
@@ -83,6 +83,7 @@ class ProgressDetailToggle extends React.Component {
         onChange={this.onChange}
       >
         <button
+          type="button"
           value="summary"
           style={whiteBorder ? styles.whiteBorder : undefined}
         >
@@ -92,6 +93,7 @@ class ProgressDetailToggle extends React.Component {
           />
         </button>
         <button
+          type="button"
           value="detail"
           style={whiteBorder ? styles.whiteBorder : undefined}
         >

--- a/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
@@ -75,10 +75,15 @@ class SectionProgressToggle extends React.Component {
         activeColor={color.teal}
         onChange={this.onChange}
       >
-        <button value={ViewType.SUMMARY} style={styles.toggleButton}>
+        <button
+          type="button"
+          value={ViewType.SUMMARY}
+          style={styles.toggleButton}
+        >
           <FontAwesome icon="search-minus" />
         </button>
         <button
+          type="button"
           id={'uitest-toggle-detail-view'}
           value={ViewType.DETAIL}
           style={styles.toggleButton}

--- a/apps/src/templates/teacherDashboard/RosterDialog.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.jsx
@@ -232,12 +232,14 @@ class RosterDialog extends React.Component {
         </div>
         <div style={styles.footer}>
           <button
+            type="button"
             onClick={this.cancel}
             style={{...styles.buttonPrimary, ...styles.buttonSecondary}}
           >
             {locale.dialogCancel()}
           </button>
           <button
+            type="button"
             onClick={this.importClassroom}
             style={Object.assign(
               {},

--- a/apps/src/turtle/ArtistVisualizationColumn.jsx
+++ b/apps/src/turtle/ArtistVisualizationColumn.jsx
@@ -55,7 +55,7 @@ var ArtistVisualizationColumn = function(props) {
             width="15"
           />{' '}
           {props.showFinishButton && (
-            <button id="finishButton" className="share">
+            <button type="button" id="finishButton" className="share">
               <img src="/blockly/media/1x1.gif" />
               {msg.finish()}
             </button>

--- a/apps/src/tutorialExplorer/backButton.jsx
+++ b/apps/src/tutorialExplorer/backButton.jsx
@@ -13,7 +13,7 @@ const styles = {
 
 const BackButton = props => (
   <a href="/learn">
-    <button style={styles.backButton}>
+    <button type="button" style={styles.backButton}>
       <i className="fa fa-arrow-left" aria-hidden={true} />
       &nbsp;
       {i18n.backButtonBack()}

--- a/apps/src/tutorialExplorer/filterHeader.jsx
+++ b/apps/src/tutorialExplorer/filterHeader.jsx
@@ -150,6 +150,7 @@ export default class FilterHeader extends React.Component {
                   {this.shouldShowOpenFiltersButton() && (
                     <span>
                       <button
+                        type="button"
                         onClick={this.props.showModalFilters}
                         style={styles.button}
                         className="noFocusButton"
@@ -162,6 +163,7 @@ export default class FilterHeader extends React.Component {
                   {this.shouldShowCloseFiltersButton() && (
                     <span>
                       <button
+                        type="button"
                         onClick={this.props.hideModalFilters}
                         style={styles.button}
                         className="noFocusButton"

--- a/apps/src/tutorialExplorer/toggleAllTutorialsButton.jsx
+++ b/apps/src/tutorialExplorer/toggleAllTutorialsButton.jsx
@@ -27,7 +27,7 @@ export default class ToggleAllTutorialsButton extends React.Component {
     return (
       <div style={styles.toggleAllTutorialsBlock}>
         {!this.props.showingAllTutorials && (
-          <button onClick={this.props.showAllTutorials}>
+          <button type="button" onClick={this.props.showAllTutorials}>
             {i18n.showAllTutorialsButton()}
             &nbsp;
             <i className="fa fa-caret-down" aria-hidden={true} />
@@ -35,7 +35,7 @@ export default class ToggleAllTutorialsButton extends React.Component {
         )}
 
         {this.props.showingAllTutorials && (
-          <button onClick={this.props.hideAllTutorials}>
+          <button type="button" onClick={this.props.hideAllTutorials}>
             {i18n.hideAllTutorialsButton()}
             &nbsp;
             <i className="fa fa-caret-up" aria-hidden={true} />

--- a/apps/src/tutorialExplorer/tutorialDetail.jsx
+++ b/apps/src/tutorialExplorer/tutorialDetail.jsx
@@ -289,7 +289,7 @@ export default class TutorialDetail extends React.Component {
                       target="_blank"
                       onClick={this.startTutorialClicked}
                     >
-                      <button style={{marginTop: 20}}>
+                      <button type="button" style={{marginTop: 20}}>
                         {i18n.startButton()}
                       </button>
                     </a>

--- a/apps/src/util/ExampleDialogButton.jsx
+++ b/apps/src/util/ExampleDialogButton.jsx
@@ -33,7 +33,9 @@ export default class ExampleDialogButton extends React.Component {
           isOpen: this.state.open,
           ...closeCallbacks
         })}
-        <button onClick={this.open}>Open the example dialog</button>
+        <button type="button" onClick={this.open}>
+          Open the example dialog
+        </button>
       </div>
     );
   }

--- a/apps/test/unit/code-studio/DisabledBubblesModalTest.jsx
+++ b/apps/test/unit/code-studio/DisabledBubblesModalTest.jsx
@@ -24,7 +24,7 @@ describe('DisabledBubblesModal', () => {
               </a>
             </div>
             <div>
-              <button onClick={wrapper.instance().handleClose}>
+              <button type="button" onClick={wrapper.instance().handleClose}>
                 {i18n.dialogOK()}
               </button>
             </div>

--- a/apps/test/unit/code-studio/levels/dialogHelperTest.js
+++ b/apps/test/unit/code-studio/levels/dialogHelperTest.js
@@ -43,8 +43,12 @@ describe('dialogHelper', () => {
         <div className="modal-content no-modal-icon">
           <p className="dialog-title">Title</p>
           <p className="dialog-body">Body</p>
-          <button id="cancel-button">Cancel</button>
-          <button id="ok-button">Okay</button>
+          <button type="button" id="cancel-button">
+            Cancel
+          </button>
+          <button type="button" id="ok-button">
+            Okay
+          </button>
         </div>
       </div>
     );

--- a/apps/test/unit/shareWarningsDialogTest.js
+++ b/apps/test/unit/shareWarningsDialogTest.js
@@ -112,7 +112,7 @@ describe('ShareWarningsDialog', () => {
     );
     expect(dialog.state('modalIsOpen')).to.be.true;
     expect(dialog).to.containMatchingElement(
-      <button>{commonMsg.dialogOK()}</button>
+      <button type="button">{commonMsg.dialogOK()}</button>
     );
     expect(closeSpy).not.to.have.been.called;
     dialog.find('button').simulate('click');
@@ -133,7 +133,7 @@ describe('ShareWarningsDialog', () => {
     );
     expect(dialog.state('modalIsOpen')).to.be.true;
     expect(dialog).to.containMatchingElement(
-      <button>{commonMsg.dialogOK()}</button>
+      <button type="button">{commonMsg.dialogOK()}</button>
     );
     expect(closeSpy).not.to.have.been.called;
     dialog.find('button').simulate('click');
@@ -154,7 +154,7 @@ describe('ShareWarningsDialog', () => {
     );
     expect(dialog.state('modalIsOpen')).to.be.true;
     expect(dialog).to.containMatchingElement(
-      <button>{commonMsg.dialogOK()}</button>
+      <button type="button">{commonMsg.dialogOK()}</button>
     );
     expect(closeSpy).not.to.have.been.called;
     const ageDropdown = dialog.find('AgeDropdown');
@@ -181,7 +181,7 @@ describe('ShareWarningsDialog', () => {
     );
     expect(dialog.state('modalIsOpen')).to.be.true;
     expect(dialog).to.containMatchingElement(
-      <button>{commonMsg.dialogOK()}</button>
+      <button type="button">{commonMsg.dialogOK()}</button>
     );
     expect(closeSpy).not.to.have.been.called;
     expect(tooYoungSpy).not.to.have.been.called;

--- a/apps/test/unit/templates/ToggleGroupTest.js
+++ b/apps/test/unit/templates/ToggleGroupTest.js
@@ -12,9 +12,15 @@ describe('ToggleGroup', function() {
     onChange = sinon.spy();
     const group = (
       <ToggleGroup selected="one" onChange={onChange}>
-        <button value="one">One</button>
-        <button value="two">Two</button>
-        <button value="three">Three</button>
+        <button type="button" value="one">
+          One
+        </button>
+        <button type="button" value="two">
+          Two
+        </button>
+        <button type="button" value="three">
+          Three
+        </button>
       </ToggleGroup>
     );
 

--- a/apps/test/unit/templates/VersionHistoryTest.jsx
+++ b/apps/test/unit/templates/VersionHistoryTest.jsx
@@ -188,8 +188,12 @@ describe('VersionHistory', () => {
       expect(wrapper).to.containMatchingElement(
         <div>
           <p>Are you sure you want to clear all progress for this level&#63;</p>
-          <button id="confirm-button">Start Over</button>
-          <button id="again-button">Cancel</button>
+          <button type="button" id="confirm-button">
+            Start Over
+          </button>
+          <button type="button" id="again-button">
+            Cancel
+          </button>
         </div>
       );
     });
@@ -205,8 +209,12 @@ describe('VersionHistory', () => {
       expect(wrapper).to.containMatchingElement(
         <div>
           <p>Are you sure you want to clear all progress for this level&#63;</p>
-          <button id="confirm-button">Start Over</button>
-          <button id="again-button">Cancel</button>
+          <button type="button" id="confirm-button">
+            Start Over
+          </button>
+          <button type="button" id="again-button">
+            Cancel
+          </button>
         </div>
       );
 

--- a/apps/test/unit/templates/VersionRowTest.jsx
+++ b/apps/test/unit/templates/VersionRowTest.jsx
@@ -15,20 +15,22 @@ describe('VersionRow', () => {
     const wrapper = shallow(<VersionRow {...MINIMUM_PROPS} isLatest={false} />);
     expect(wrapper).to.containMatchingElement(
       <a target="_blank">
-        <button className="version-preview">
+        <button type="button" className="version-preview">
           <i className="fa fa-eye" />
         </button>
       </a>
     );
     expect(wrapper).to.containMatchingElement(
-      <button className="btn-info">{msg.restoreThisVersion()}</button>
+      <button type="button" className="btn-info">
+        {msg.restoreThisVersion()}
+      </button>
     );
   });
 
   it('renders a disabled button for the current version', () => {
     const wrapper = shallow(<VersionRow {...MINIMUM_PROPS} isLatest={true} />);
     expect(wrapper).to.containMatchingElement(
-      <button className="btn-default" disabled="disabled">
+      <button type="button" className="btn-default" disabled="disabled">
         {msg.currentVersion()}
       </button>
     );

--- a/apps/test/unit/tutorialExplorer/backButtonTest.jsx
+++ b/apps/test/unit/tutorialExplorer/backButtonTest.jsx
@@ -9,7 +9,7 @@ describe('BackButton', () => {
     const wrapper = shallow(<BackButton />);
     expect(wrapper).to.containMatchingElement(
       <a href="/learn">
-        <button>
+        <button type="button">
           <i className="fa fa-arrow-left" />
           &nbsp;
           {i18n.backButtonBack()}

--- a/apps/test/unit/tutorialExplorer/filterHeaderTest.jsx
+++ b/apps/test/unit/tutorialExplorer/filterHeaderTest.jsx
@@ -31,7 +31,7 @@ describe('FilterHeader', () => {
       <span>{i18n.filterHeaderTutorialCountPlural({tutorial_count: 5})}</span>
     );
     expect(wrapper).to.containMatchingElement(
-      <button onClick={FAKE_SHOW_MODAL_FILTERS}>
+      <button type="button" onClick={FAKE_SHOW_MODAL_FILTERS}>
         {i18n.filterHeaderShowFilters()}
       </button>
     );
@@ -49,7 +49,7 @@ describe('FilterHeader', () => {
       <span>{i18n.filterHeaderTutorialCountPlural({tutorial_count: 5})}</span>
     );
     expect(wrapper).to.containMatchingElement(
-      <button onClick={FAKE_HIDE_MODAL_FILTERS}>
+      <button type="button" onClick={FAKE_HIDE_MODAL_FILTERS}>
         {i18n.filterHeaderHideFilters()}
       </button>
     );

--- a/apps/test/unit/tutorialExplorer/toggleAllTutorialsButtonTest.jsx
+++ b/apps/test/unit/tutorialExplorer/toggleAllTutorialsButtonTest.jsx
@@ -18,7 +18,7 @@ describe('ToggleAllTutorialsButton', () => {
     );
     expect(wrapper).to.containMatchingElement(
       <div>
-        <button onClick={FAKE_HIDE_ALL}>
+        <button type="button" onClick={FAKE_HIDE_ALL}>
           {i18n.hideAllTutorialsButton()}
           &nbsp;
           <i className="fa fa-caret-up" />
@@ -36,7 +36,7 @@ describe('ToggleAllTutorialsButton', () => {
     );
     expect(wrapper).to.containMatchingElement(
       <div>
-        <button onClick={FAKE_SHOW_ALL}>
+        <button type="button" onClick={FAKE_SHOW_ALL}>
           {i18n.showAllTutorialsButton()}
           &nbsp;
           <i className="fa fa-caret-down" />

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -4844,7 +4844,7 @@ eslint-plugin-prettier@^3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react@7:
+eslint-plugin-react@^7.11.0:
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"
   dependencies:

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -516,7 +516,7 @@ acorn-dynamic-import@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
 
-acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
+acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
   dependencies:
@@ -4341,19 +4341,18 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-doctrine@^1.2.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
-  dependencies:
-    esutils "^2.0.2"
-    isarray "^1.0.0"
-
 doctrine@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
 
 dom-confetti@~0.0.7:
   version "0.0.8"
@@ -4656,6 +4655,17 @@ es-abstract@^1.10.0, es-abstract@^1.4.3, es-abstract@^1.5.1, es-abstract@^1.7.0,
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
+es-abstract@^1.11.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
 es-abstract@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.6.1.tgz#bb8a2064120abcf928a086ea3d9043114285ec99"
@@ -4672,6 +4682,14 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es5-ext@^0.10.7, es5-ext@^0.10.8, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
   version "0.10.12"
@@ -4826,12 +4844,17 @@ eslint-plugin-prettier@^3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-5.2.2.tgz#7db068e1f5487f6871e4deef36a381c303eac161"
+eslint-plugin-react@7:
+  version "7.12.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"
   dependencies:
-    doctrine "^1.2.2"
-    jsx-ast-utils "^1.2.1"
+    array-includes "^3.0.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.0.1"
+    object.fromentries "^2.0.0"
+    prop-types "^15.6.2"
+    resolve "^1.9.0"
 
 eslint-scope@^4.0.0:
   version "4.0.3"
@@ -6331,6 +6354,10 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -6367,6 +6394,12 @@ has@^1.0.1:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^2.0.0:
   version "2.0.2"
@@ -6987,6 +7020,10 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
+is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -7211,6 +7248,12 @@ is-svg@^2.0.0:
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -7451,12 +7494,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-jsx-ast-utils@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.3.tgz#ccfdbe0320ba03f7a1fc4e67ceaf7e2cc0169721"
+jsx-ast-utils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
-    acorn-jsx "^3.0.1"
-    object-assign "^4.1.0"
+    array-includes "^3.0.3"
 
 jszip@3.0.0:
   version "3.0.0"
@@ -9047,6 +9089,10 @@ object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
+object-keys@^1.0.12:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+
 object-keys@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
@@ -9072,6 +9118,15 @@ object.entries@^1.0.3, object.entries@^1.0.4:
     define-properties "^1.1.2"
     es-abstract "^1.6.1"
     function-bind "^1.1.0"
+    has "^1.0.1"
+
+object.fromentries@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.0.tgz#49a543d92151f8277b3ac9600f1e930b189d30ab"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.11.0"
+    function-bind "^1.1.1"
     has "^1.0.1"
 
 object.getownpropertydescriptors@^2.0.3:
@@ -9456,6 +9511,10 @@ path-key@^1.0.0:
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -11322,6 +11381,12 @@ resolve-url@^0.2.1:
 resolve@1.1.x, resolve@^1.1.6:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.9.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
+  dependencies:
+    path-parse "^1.0.6"
 
 resolve@~0.3.1:
   version "0.3.1"


### PR DESCRIPTION
Follow-up work to https://github.com/code-dot-org/code-dot-org/pull/27812, in which I learned that [the `button` element has a default `type` of `"submit."`](https://stackoverflow.com/questions/3314989/can-i-make-a-button-not-submit-a-form) :sob: which can lead to unexpected behavior.

The workaround is to always set a button type e.g. `<button type="button"/>` which feels silly but ensures we get expected behavior.  It turns out [there's a lint rule for that](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/button-has-type.md)!

This feature was introduced in `eslint-plugin-react` 7.5.0 but we're on 5.2.2, so I had to upgrade the plugin - which was relatively painless, and just required disabling a few of the new default rules.