### PR TITLE
correct key for leccion-9_es-mp4.mp4

### DIFF
--- a/dashboard/config/videos.csv
+++ b/dashboard/config/videos.csv
@@ -315,7 +315,7 @@ C1_happy_maps_unplugged,,,3pJTQ97vOrM,https://videos.code.org/levelbuilder/lecci
 C2_paper_airplanes,,,5oZcZIWbHdM,https://videos.code.org/levelbuilder/curso-c-leccion-4-paper-airplanes_es-mp4.mp4,es-MX
 C2_artist_intro,,,2xIF_pyLPFo,https://videos.code.org/levelbuilder/curso-c-leccion-6-artist-intro_es-mp4.mp4,es-MX
 CSF_artist_angles,,,80C7pm5BBwo,https://videos.code.org/levelbuilder/curso-d-leccion-2_es-angulos-mp4.mp4,es-MX
-CSF_scrat_loops_K1,,,q_xwH3jY0p4,https://videos.code.org/levelbuilder/leccion-9_es-mp4.mp4,es-MX
+CSF_collector_repeat_loops,,,q_xwH3jY0p4,https://videos.code.org/levelbuilder/leccion-9_es-mp4.mp4,es-MX
 C1_getting_loopy,,,1mdJgEZWVs4,https://videos.code.org/levelbuilder/curso-c-leccion-7-getting-loopy_es-mp4.mp4,es-MX
 flappy_intro,,,IAXZv7kJBW0,https://videos.code.org/levelbuilder/curso-c-leccion-12-code-your-own-flappy-game-mp4.mp4,es-MX
 CSF_Power_of_Words,,,a6_Zsj2jzLw,https://videos.code.org/levelbuilder/curso-c-leccion-14-power_of_words_2017_es-mp4.mp4,es-MX


### PR DESCRIPTION
es-MX dubbed video leccion-9_es-mp4.mp4 now correctly links to CSF_collector_repeat_loops instead of CSF_scrat_loops_K1