### PR TITLE
Fix fail-fast feature

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -155,13 +155,6 @@ After do |_s|
   end
 end
 
-After do |scenario|
-  if ENV['FAIL_FAST'] == 'true'
-    # Tell Cucumber to quit after this scenario is done - if it failed.
-    Cucumber.wants_to_quit = true if scenario.failed?
-  end
-end
-
 at_exit do
   browser.quit unless browser.nil?
 end

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -633,6 +633,7 @@ def cucumber_arguments_for_feature(options, test_run_string, max_reruns)
   arguments = ''
   arguments += " --format html --out #{html_output_filename(test_run_string, options)}" if options.html
   arguments += ' -f pretty' if options.html # include the default (-f pretty) formatter so it does both
+  arguments += " --fail-fast" if options.fail_fast
 
   # if autorertrying, output a rerun file so on retry we only run failed tests
   if max_reruns > 0
@@ -681,7 +682,6 @@ def run_feature(browser, feature, options)
   run_environment['TEST_LOCAL_HEADLESS'] = options.local_headless ? "true" : "false"
   run_environment['MAXIMIZE_LOCAL'] = options.maximize ? "true" : "false"
   run_environment['MOBILE'] = browser['mobile'] ? "true" : "false"
-  run_environment['FAIL_FAST'] = options.fail_fast ? "true" : nil
   run_environment['TEST_RUN_NAME'] = test_run_string
   run_environment['IS_CIRCLE'] = options.is_circle ? "true" : "false"
 


### PR DESCRIPTION
Use built-in cucumber --fail-fast command-line switch.

More context: In Jan 2016, We [implemented](https://github.com/code-dot-org/code-dot-org/commit/b9e7a9c7bc8c09daf483cc115825fb112923ad53) our own UI-test fail-fast switch in `runner.rb`, which exits a feature-run as soon as a single failing scenario is encountered. This switch used the `FAIL_FAST` environment variable to pass the value of this option along to the child-process environment. However, this conflicted with [an existing (undocumented?) environment variable](https://github.com/cucumber/cucumber-ruby/commit/d1c37fdce8b932a30c9d1ff6a0712e224ca65e01#diff-0999c8acfa1567fe8b50584ac57e17d2R263) in Cucumber since v2.0.0 as part of its 'legacy API' formatter implementation.

I believe this internal, conflicting use of this environment variable within Cucumber causes the HTML formatter to abort with a raised exception as soon as a failing scenario is encountered, without printing the actual error message/stacktrace or any of the rest of the formatted HTML output.

In 2017 I had fixed a previous issue related to this conflict (PR #13847), but this more subtle bug still remained.

In [v2.1.0](https://github.com/cucumber/cucumber-ruby/blob/master/CHANGELOG.md#210), Cucumber added its own `--fail-fast` command-line switch, so this PR removes our own switch implementation and passes the same argument to the `cucumber` process to use the newly built-in switch instead.