### PR TITLE
Use webdrivers for managing local Selenium WebDrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,6 @@ group :development, :test do
   gem 'timecop'
 
   # For UI testing.
-  gem 'chromedriver-helper', '~> 0.0.7'
   gem 'cucumber'
   gem 'eyes_selenium', '3.14.2'
   gem 'minitest', '~> 5.5'
@@ -114,6 +113,7 @@ group :development, :test do
   gem 'selenium-webdriver', '3.8.0'
   gem 'spring'
   gem 'spring-commands-testunit'
+  gem 'webdrivers', '~> 3.0'
 
   # For pegasus PDF generation / merging testing.
   gem 'parallel_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,8 +263,6 @@ GEM
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
     ansi (1.5.0)
-    archive-zip (0.7.0)
-      io-like (~> 0.3.0)
     arel (7.1.4)
     ast (2.3.0)
     attr_required (1.0.1)
@@ -346,9 +344,6 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (0.0.9)
-      archive-zip (~> 0.7.0)
-      nokogiri (~> 1.6)
     chronic (0.10.2)
     chunky_png (1.3.6)
     climate_control (0.0.3)
@@ -496,7 +491,6 @@ GEM
     httpclient (2.8.3)
     image_size (1.5.0)
     in_threads (1.4.0)
-    io-like (0.3.0)
     jbuilder (2.5.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -566,6 +560,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
+    net_http_ssl_fix (0.0.10)
     netrc (0.11.0)
     newrelic_rpm (4.8.0.341)
     nio4r (2.3.1)
@@ -857,6 +852,11 @@ GEM
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
+    webdrivers (3.7.2)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webfinger (1.0.2)
       activesupport
       httpclient (>= 2.4)
@@ -907,7 +907,6 @@ DEPENDENCIES
   bootstrap-sass (~> 2.3.2.2)
   brakeman
   cancancan (~> 1.15.0)
-  chromedriver-helper (~> 0.0.7)
   chronic (~> 0.10.2)
   codecov
   codemirror-rails
@@ -1044,6 +1043,7 @@ DEPENDENCIES
   validates_email_format_of
   vcr
   web-console
+  webdrivers (~> 3.0)
   webmock
   xxhash
   youtube-dl.rb

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -250,7 +250,6 @@ end
 
 def select_browser_configs(options)
   if options.local
-    SeleniumBrowser.ensure_chromedriver_running
     return [{
       'browser': 'local',
       'name': 'ChromeDriver',

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -1,27 +1,17 @@
 require 'selenium/webdriver'
+require 'webdrivers'
 
 module SeleniumBrowser
   def self.local_browser(headless=true)
-    ensure_chromedriver_running
-    sleep 2
     options = Selenium::WebDriver::Chrome::Options.new
     if headless
       options.add_argument('--headless')
     end
-    browser = Selenium::WebDriver.for :chrome, url: 'http://127.0.0.1:9515', options: options
+    browser = Selenium::WebDriver.for :chrome, options: options
     if ENV['MAXIMIZE_LOCAL']
       max_width, max_height = browser.execute_script('return [window.screen.availWidth, window.screen.availHeight];')
       browser.manage.window.resize_to(max_width, max_height)
     end
     browser
-  end
-
-  def self.ensure_chromedriver_running
-    # Verify that chromedriver is actually running
-    unless `ps x`.include?('chromedriver')
-      puts "You cannot run with the --local flag unless you are running chromedriver. Automatically running
-chromedriver found at #{`which chromedriver`}"
-      system('chromedriver &')
-    end
   end
 end


### PR DESCRIPTION
This PR replaces the recently-deprecated [`chromedriver-helper`](https://github.com/flavorjones/chromedriver-helper) with the [`webdrivers`](https://github.com/titusfortner/webdrivers) gem which is the recommended replacement.

The new gem also seamlessly provides the correct driver to Selenium in the background, so we need to maintain less glue code ourselves.