### PR TITLE
PL: regional partner mini-contact UI test fix for Safari

### DIFF
--- a/dashboard/test/ui/features/pd/regional_partner_mini_contact.feature
+++ b/dashboard/test/ui/features/pd/regional_partner_mini_contact.feature
@@ -46,7 +46,8 @@ Scenario: Teacher submits inline mini-contact form after adding zip and email
 Scenario: Signed-out user submits pop-up mini-contact form after adding zip and email
   # First pop up the mini-contact form for signed-out user, and submit it.
   And I am on "http://studio.code.org/pd/application/teacher"
-  And I click "#regional-partner-mini-contact-popup-link-container"
+  And I wait until element "#regional-partner-mini-contact-popup-link-container span span" is visible
+  And I press "#regional-partner-mini-contact-popup-link-container span" using jQuery
   And I wait until element "#regional-partner-mini-contact-form-teacher-application-logged-out" is visible
   And I press "#submit" using jQuery
 


### PR DESCRIPTION
After a bunch of trial-and-error, this makes the click to pop-up the mini-contact form work on Safari (on Yosemite, iPhone, and iPad).

- A visibility test worked not on the parent div but on the child spans.
- A click worked not on the parent div but on the child span.

Followup to https://github.com/code-dot-org/code-dot-org/pull/27789.