### PR TITLE
start runing one eyes test in IE

### DIFF
--- a/dashboard/test/ui/features/initial_page_views2.feature
+++ b/dashboard/test/ui/features/initial_page_views2.feature
@@ -1,4 +1,5 @@
 @eyes
+@eyes_ie
 Feature: Looking at a few things with Applitools Eyes - Part 2
 
   Background:

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -604,7 +604,8 @@ end
 def cucumber_arguments_for_browser(browser, options)
   arguments = ' -S' # strict mode, so that we fail on undefined steps
   arguments += skip_tag('@skip')
-  arguments += tag('@eyes', eyes? && !browser['mobile'])
+  # by default, marking a test @eyes will only let it run in chrome.
+  arguments += tag('@eyes', eyes? && browser['browserName'] == 'chrome')
   arguments += tag('@eyes_mobile', eyes? && browser['mobile'])
   arguments += skip_tag('@no_mobile') if browser['mobile']
   arguments += skip_tag('@only_mobile') unless browser['mobile']

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -604,10 +604,25 @@ end
 def cucumber_arguments_for_browser(browser, options)
   arguments = ' -S' # strict mode, so that we fail on undefined steps
   arguments += skip_tag('@skip')
-  # by default, marking a test @eyes will only let it run in chrome.
-  arguments += tag('@eyes', eyes? && browser['browserName'] == 'chrome')
-  arguments += tag('@eyes_mobile', eyes? && browser['mobile'])
-  arguments += tag('@eyes_ie', eyes? && browser['browserName'] == 'Internet Explorer')
+
+  # If --eyes is specified, only run scenarios with the corresponding eyes tag.
+  # Otherwise, do not call tag(), allowing any scenarios to run which are not
+  # skipped via skip_tag(). See `cucumber --help` for more info.
+  if eyes?
+    arguments +=
+      if browser['mobile']
+        # iOS browsers will only run eyes tests tagged with @eyes_mobile.
+        tag('@eyes_mobile')
+      elsif browser['browserName'] == 'Internet Explorer'
+        # IE will only run eyes tests tagged with @eyes_ie.
+        tag('@eyes_ie')
+      else
+        # All other desktop browsers, including Chrome, will run any eyes test
+        # tagged with @eyes.
+        tag('@eyes')
+      end
+  end
+
   arguments += skip_tag('@no_mobile') if browser['mobile']
   arguments += skip_tag('@only_mobile') unless browser['mobile']
   arguments += skip_tag('@no_circle') if options.is_circle

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -607,6 +607,7 @@ def cucumber_arguments_for_browser(browser, options)
   # by default, marking a test @eyes will only let it run in chrome.
   arguments += tag('@eyes', eyes? && browser['browserName'] == 'chrome')
   arguments += tag('@eyes_mobile', eyes? && browser['mobile'])
+  arguments += tag('@eyes_ie', eyes? && browser['browserName'] == 'Internet Explorer')
   arguments += skip_tag('@no_mobile') if browser['mobile']
   arguments += skip_tag('@only_mobile') unless browser['mobile']
   arguments += skip_tag('@no_circle') if options.is_circle

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -119,7 +119,7 @@ namespace :circle do
         RakeUtils.system_stream_output "bundle exec ./runner.rb" \
             " --eyes" \
             " --feature #{container_eyes_features.join(',')}" \
-            " --config ChromeLatestWin7,iPhone" \
+            " --config ChromeLatestWin7,iPhone,IE11Win10" \
             " --pegasus localhost.code.org:3000" \
             " --dashboard localhost-studio.code.org:3000" \
             " --circle" \

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -52,7 +52,7 @@ namespace :test do
       eyes_features = `find features/ -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
       failed_browser_count = RakeUtils.system_with_chat_logging(
         'bundle', 'exec', './runner.rb',
-        '-c', 'ChromeLatestWin7,iPhone',
+        '-c', 'ChromeLatestWin7,iPhone,IE11Win10',
         '-d', CDO.site_host('studio.code.org'),
         '-p', CDO.site_host('code.org'),
         '--db', # Ensure features that require database access are run even if the server name isn't "test"


### PR DESCRIPTION
See https://codedotorg.atlassian.net/browse/XTEAM-2

### Verification

Other passing drone runs have successful 50 eyes test runs. This one has 51, including `IE11Win10_initial_page_views2_eyes`.