### PR TITLE
PL: make regional partner mini-contact UI tests work for iOS Safari

### DIFF
--- a/dashboard/test/ui/features/pd/regional_partner_mini_contact.feature
+++ b/dashboard/test/ui/features/pd/regional_partner_mini_contact.feature
@@ -12,15 +12,16 @@ Scenario: Teacher submits inline mini-contact form after adding zip
   # By using a teacher account, the email field will be prepopulated.
   And I am on "http://code.org/educate/professional-learning/middle-high"
   And I wait until element "#regional-partner-mini-contact-form-middle-high" is visible
-  And I click "#submit"
+  And I press "#submit" using jQuery
 
   # Wait until we see an error for no ZIP.
   And I wait until element "#regional-partner-mini-contact-error-zip" is visible
 
   # Submit again with the ZIP.
   And I press keys "90210" for element "#zip"
-  And I click "#submit"
+  And I press "#submit" using jQuery
   And I wait until element "#regional-partner-mini-contact-thanks-middle-high" is visible
+  And I sign out
 
 
 Scenario: Teacher submits inline mini-contact form after adding zip and email
@@ -30,7 +31,7 @@ Scenario: Teacher submits inline mini-contact form after adding zip and email
 
   # Let's clear out the email to make sure that it's required.
   And I press backspace to clear element "#email"
-  And I click "#submit"
+  And I press "#submit" using jQuery
 
   # Wait until we see errors for no ZIP and no email.
   And I wait until element "#regional-partner-mini-contact-error-zip" is visible
@@ -39,8 +40,9 @@ Scenario: Teacher submits inline mini-contact form after adding zip and email
   # Submit again with a ZIP and an email.
   And I press keys "90210" for element "#zip"
   And I press keys "test-email@code.org" for element "#email"
-  And I click "#submit"
+  And I press "#submit" using jQuery
   And I wait until element "#regional-partner-mini-contact-thanks-middle-high" is visible
+  And I sign out
 
 
 Scenario: Signed-out user submits pop-up mini-contact form after adding zip and email
@@ -58,5 +60,5 @@ Scenario: Signed-out user submits pop-up mini-contact form after adding zip and 
   # Submit again with a ZIP and an email.
   And I press keys "90210" for element "#zip"
   And I press keys "test-email@code.org" for element "#email"
-  And I click "#submit"
+  And I press "#submit" using jQuery
   And I wait until element "#regional-partner-mini-contact-thanks-teacher-application-logged-out" is visible


### PR DESCRIPTION
Two more tricks to make these UI tests work for iOS Safari:

- Sign out the teacher between scenarios.  Unlike all other browsers, iOS Safari tests were not signing the teacher out before the final scenario.
- Use jQuery to press the submit button in the final scenario.  The landscape iPhone meant that the button was not visible, and a "click" wasn't able to work.  (For consistency, changed them all, but it was really only the final one that was having trouble.)

This is a followup to https://github.com/code-dot-org/code-dot-org/pull/27849
