### PR TITLE
fix regression: don't run eyes tests during ui test runs

### DIFF
--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -621,6 +621,11 @@ def cucumber_arguments_for_browser(browser, options)
         # tagged with @eyes.
         tag('@eyes')
       end
+  else
+    # Make sure eyes tests don't run when --eyes is not specified.
+    arguments += skip_tag('@eyes_mobile')
+    arguments += skip_tag('@eyes_ie')
+    arguments += skip_tag('@eyes')
   end
 
   arguments += skip_tag('@no_mobile') if browser['mobile']


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/27850 introduced a regression whereby we start running eyes tests even when `--eyes` is not specified. This PR fixes that, and has been verified on the test machine:
<img width="659" alt="Screen Shot 2019-04-03 at 9 55 09 AM" src="https://user-images.githubusercontent.com/8001765/55498246-007db700-55f8-11e9-92a7-33b5975a2750.png">

