### PR TITLE
Get application payment info from principal instead of teacher [ci skip]

### DIFF
--- a/bin/cron/teacher_applications_to_s3
+++ b/bin/cron/teacher_applications_to_s3
@@ -14,7 +14,7 @@ def main
       app.status,
       app.scholarship_status,
       app.school_type,
-      app.sanitize_form_data_hash[:pay_fee],
+      app.sanitize_form_data_hash[:principal_pay_fee],
       app.email
     ])
   end


### PR DESCRIPTION
Exports information to application tracker from principal instead of teacher on whether they can pay to attend PD, which we think is more likely to be accurate.