### PR TITLE
Assessment UX Re-Design: Progress Bubble Tooltip

### DIFF
--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -6,7 +6,7 @@ import queryString from 'query-string';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '../FontAwesome';
-import {getIconForLevel} from './progressHelpers';
+import {getIconForLevel, isLevelAssessment} from './progressHelpers';
 import {levelType} from './progressTypes';
 import {
   DOT_SIZE,
@@ -124,6 +124,8 @@ class ProgressBubble extends React.Component {
       pairingIconEnabled
     } = this.props;
 
+    const levelIsAssessment = isLevelAssessment(level);
+
     const number = level.levelNumber;
     const url = level.url;
     const levelName = level.name || level.progression;
@@ -176,6 +178,7 @@ class ProgressBubble extends React.Component {
         tooltipId={tooltipId}
         icon={levelIcon}
         text={tooltipText}
+        includeAssessmentIcon={levelIsAssessment}
       />
     );
 

--- a/apps/src/templates/progress/StageExtrasProgressBubble.jsx
+++ b/apps/src/templates/progress/StageExtrasProgressBubble.jsx
@@ -53,6 +53,9 @@ class StageExtrasProgressBubble extends Component {
           tooltipId={tooltipId}
           icon={'flag'}
           text={i18n.stageExtras()}
+          // Currently a stage extra can not also be an assessment so this should always be false
+          // TODO (dmcavoy) : When we change the way we mark levels as assessment refactor
+          includeAssessmentIcon={false}
         />
       </a>
     );

--- a/apps/src/templates/progress/TooltipWithIcon.jsx
+++ b/apps/src/templates/progress/TooltipWithIcon.jsx
@@ -3,6 +3,7 @@ import React, {Component} from 'react';
 import ReactTooltip from 'react-tooltip';
 import FontAwesome from '../FontAwesome';
 import {DOT_SIZE} from './progressStyles';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   tooltip: {
@@ -10,6 +11,9 @@ const styles = {
   },
   tooltipIcon: {
     paddingRight: 5,
+    paddingLeft: 5
+  },
+  tooltipAssessmentIcon: {
     paddingLeft: 5
   }
 };
@@ -23,13 +27,21 @@ export default class TooltipWithIcon extends Component {
   static propTypes = {
     tooltipId: PropTypes.string.isRequired,
     icon: PropTypes.string.isRequired,
-    text: PropTypes.string.isRequired
+    text: PropTypes.string.isRequired,
+    includeAssessmentIcon: PropTypes.bool
   };
   render() {
-    const {tooltipId, icon, text} = this.props;
+    const {tooltipId, icon, text, includeAssessmentIcon} = this.props;
     return (
       <ReactTooltip id={tooltipId} role="tooltip" wrapper="span" effect="solid">
         <div style={styles.tooltip}>
+          {experiments.isEnabled(experiments.MINI_RUBRIC_2019) &&
+            includeAssessmentIcon && (
+              <FontAwesome
+                icon="check-circle"
+                style={styles.tooltipAssessmentIcon}
+              />
+            )}
           <FontAwesome icon={icon} style={styles.tooltipIcon} />
           {text}
         </div>

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -98,6 +98,13 @@ export function getIconForLevel(level) {
 }
 
 /**
+ * @returns Whether a level is an assessment level.
+ */
+export function isLevelAssessment(level) {
+  return level.kind === 'assessment';
+}
+
+/**
  * Summarizes stage progress data.
  * @param {[]} levelsWithStatus An array of objects each representing
  * students progress in a level

--- a/apps/test/unit/templates/progress/TooltipWithIconTest.jsx
+++ b/apps/test/unit/templates/progress/TooltipWithIconTest.jsx
@@ -26,6 +26,7 @@ describe('TooltipWithIcon', () => {
     ).to.equal('check-circle');
     experiments.isEnabled.restore();
   });
+
   it('does not include the check-circle icon if level is not an assessment - in experiment', () => {
     sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(<TooltipWithIcon {...DEFAULT_PROPS} />);
@@ -37,6 +38,7 @@ describe('TooltipWithIcon', () => {
     ).not.to.equal('check-circle');
     experiments.isEnabled.restore();
   });
+
   it('does not include the check-circle icon if NOT in experiment', () => {
     sinon.stub(experiments, 'isEnabled').returns(false);
     const wrapper = shallow(<TooltipWithIcon {...DEFAULT_PROPS} />);

--- a/apps/test/unit/templates/progress/TooltipWithIconTest.jsx
+++ b/apps/test/unit/templates/progress/TooltipWithIconTest.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import sinon from 'sinon';
+import experiments from '@cdo/apps/util/experiments';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import TooltipWithIcon from '@cdo/apps/templates/progress/TooltipWithIcon';
+
+const DEFAULT_PROPS = {
+  tooltipId: 'id',
+  icon: 'desktop',
+  text: 'Level Name',
+  includeAssessmentIcon: false
+};
+
+describe('TooltipWithIcon', () => {
+  it('includes the check-circle icon if level is an assessment - in experiment', () => {
+    sinon.stub(experiments, 'isEnabled').returns(true);
+    const wrapper = shallow(
+      <TooltipWithIcon {...DEFAULT_PROPS} includeAssessmentIcon={true} />
+    );
+    expect(
+      wrapper
+        .find('FontAwesome')
+        .first()
+        .props().icon
+    ).to.equal('check-circle');
+    experiments.isEnabled.restore();
+  });
+  it('does not include the check-circle icon if level is not an assessment - in experiment', () => {
+    sinon.stub(experiments, 'isEnabled').returns(true);
+    const wrapper = shallow(<TooltipWithIcon {...DEFAULT_PROPS} />);
+    expect(
+      wrapper
+        .find('FontAwesome')
+        .first()
+        .props().icon
+    ).not.to.equal('check-circle');
+    experiments.isEnabled.restore();
+  });
+  it('does not include the check-circle icon if NOT in experiment', () => {
+    sinon.stub(experiments, 'isEnabled').returns(false);
+    const wrapper = shallow(<TooltipWithIcon {...DEFAULT_PROPS} />);
+    expect(
+      wrapper
+        .find('FontAwesome')
+        .first()
+        .props().icon
+    ).not.to.equal('check-circle');
+    experiments.isEnabled.restore();
+  });
+});


### PR DESCRIPTION
When in the mini rubric experiment and you hover over a level that is marked as an assessment you will see the check-circle icon in addition to the other icon for that level in the tooltip.

# Before
<img width="462" alt="Screen Shot 2019-04-03 at 3 36 01 PM" src="https://user-images.githubusercontent.com/208083/55507727-4f424580-5626-11e9-84a2-814d81d8211e.png">

# After

## In Experiment
<img width="466" alt="Screen Shot 2019-04-03 at 3 35 05 PM" src="https://user-images.githubusercontent.com/208083/55507710-405b9300-5626-11e9-917f-7ce215f28b2e.png">

## Not in Experiment
<img width="474" alt="Screen Shot 2019-04-03 at 3 35 25 PM" src="https://user-images.githubusercontent.com/208083/55507721-4a7d9180-5626-11e9-8a1b-b1c3955c791e.png">
