### PR TITLE
Cleanup: Simplify GoogleChart.js

### DIFF
--- a/apps/src/applab/ChartApi.js
+++ b/apps/src/applab/ChartApi.js
@@ -5,7 +5,7 @@
  * @see {GoogleChart}
  */
 /* global Promise */
-import * as utils from '../utils';
+import {quote} from '../utils';
 
 import GoogleChart from './GoogleChart';
 
@@ -87,7 +87,7 @@ ChartApi.supportsType = function(chartType) {
  */
 ChartApi.getChartTypeDropdown = function() {
   return ChartApi.getChartTypeNames()
-    .map(utils.quote)
+    .map(quote)
     .sort();
 };
 
@@ -185,9 +185,9 @@ ChartApi.prototype.warnIfColumnsNotFound = function(
     if (columnsInTable.indexOf(columnName) === -1) {
       this.warn(
         'Column ' +
-          utils.quote(columnName) +
+          quote(columnName) +
           ' not found in table ' +
-          utils.quote(tableName) +
+          quote(tableName) +
           '.'
       );
     }
@@ -216,7 +216,7 @@ ChartApi.prototype.guessColumnsIfNecessary = function(
     if (columnsInTable.length === 0) {
       throw new Error(
         'No columns found in table ' +
-          utils.quote(tableName) +
+          quote(tableName) +
           '. Charts require at least 2 columns.'
       );
     } else if (columnsInTable.length < 2) {
@@ -224,9 +224,9 @@ ChartApi.prototype.guessColumnsIfNecessary = function(
         'Only found ' +
           columnsInTable.length +
           ' columns in table ' +
-          utils.quote(tableName) +
+          quote(tableName) +
           ': ' +
-          columnsInTable.map(utils.quote).join(', ') +
+          columnsInTable.map(quote).join(', ') +
           '. Charts require at least 2 columns.'
       );
     } else {
@@ -234,11 +234,11 @@ ChartApi.prototype.guessColumnsIfNecessary = function(
       requestedColumns = columnsInTable.slice(0, 2);
       this.warn(
         'Using columns ' +
-          requestedColumns.map(utils.quote).join(' and ') +
+          requestedColumns.map(quote).join(' and ') +
           '.  Possible columns for table ' +
-          utils.quote(tableName) +
+          quote(tableName) +
           ' are ' +
-          columnsInTable.map(utils.quote).join(', ') +
+          columnsInTable.map(quote).join(', ') +
           '.'
       );
     }

--- a/apps/src/applab/ChartApi.js
+++ b/apps/src/applab/ChartApi.js
@@ -70,7 +70,7 @@ ChartApi.TypeNameToType = {
  * @returns {string[]}
  */
 ChartApi.getChartTypeNames = function() {
-  return Object.getOwnPropertyNames(ChartApi.TypeNameToType);
+  return Object.keys(ChartApi.TypeNameToType);
 };
 
 /**

--- a/apps/src/applab/GoogleChart.js
+++ b/apps/src/applab/GoogleChart.js
@@ -20,134 +20,138 @@ require('../utils'); // Provides Function.prototype.inherits
  * @param {Element} targetDiv
  * @constructor
  */
-export default function GoogleChart(targetDiv) {
-  // Define this late so we can overwrite it in tests.
-  if (!GoogleChart.lib) {
-    GoogleChart.lib = google;
-  }
+export default class GoogleChart {
+  constructor(targetDiv) {
+    // Define this late so we can overwrite it in tests.
+    if (!GoogleChart.lib) {
+      GoogleChart.lib = google;
+    }
 
-  /** @private {Element} */
-  this.targetDiv_ = targetDiv;
+    /** @private {Element} */
+    this.targetDiv_ = targetDiv;
+
+    /**
+     * List of all warnings logged while performing operations with this chart
+     * instance.
+     * @type {Error[]}
+     */
+    this.warnings = [];
+  }
 
   /**
-   * List of all warnings logged while performing operations with this chart
-   * instance.
-   * @type {Error[]}
+   * Loads the required libraries for this particular chart type.
+   * Safe to call multiple times - Google's loader caches dependencies.
+   * @returns {Promise} that resolves when dependencies have been loaded.
    */
-  this.warnings = [];
+  loadDependencies() {
+    return new Promise((resolve, reject) => {
+      try {
+        GoogleChart.lib.load('visualization', '1', {
+          packages: this.getDependencies(),
+          callback: resolve
+        });
+      } catch (e) {
+        // We catch and return a different error so that we don't surface Google
+        // API errors to students.
+        reject(
+          new Error('Unable to load Charts API.  Please try again later.')
+        );
+      }
+    });
+  }
+
+  /**
+   * Renders the chart into the target container using the specified options.
+   *
+   *  @param {Object[]} rawData - data to display in chart, formatted as an array
+   *        of objects where each object represents a row, and the object keys
+   *        are column names.
+   * @param {string[]} columnList - Ordered list of column names to use as source
+   *        data for the chart.  Column names must match keys in rawData.
+   * @param {Object} options - Plain options object that gets passed through to
+   *        the Charts API.
+   * @returns {Promise} that resolves when the chart has been rendered to the
+   *          target container.
+   */
+  async drawChart(rawData, columnList, options) {
+    await this.loadDependencies();
+
+    this.verifyData_(rawData, columnList);
+    const dataTable = GoogleChart.dataTableFromRowsAndColumns(
+      rawData,
+      columnList
+    );
+    this.render_(dataTable, options);
+  }
+
+  /**
+   * Array of packages the chart needs to load to render.
+   * @returns {string[]}
+   */
+  getDependencies() {
+    return ['corechart'];
+  }
+
+  /**
+   * Pushes the provided warning message into a collection of warnings for this
+   * chart, which can be parsed and displayed later.
+   * @param {string} warningMessage
+   */
+  warn(warningMessage) {
+    this.warnings.push(new Error(warningMessage));
+  }
+
+  /**
+   * Makes sure data looks okay, throws errors and logs warnings as appropriate.
+   * @param {string[]} columns
+   * @param {Object[]} data
+   * @private
+   */
+  verifyData_(data, columns) {
+    // Warn when no rows are present
+    if (data.length === 0) {
+      this.warn('No data.');
+    }
+
+    // Error when not enough columns are provided
+    if (columns.length < 2) {
+      throw new Error('Not enough columns for chart; expected at least 2.');
+    }
+
+    // Warn on empty columns?
+    columns.forEach(colName => {
+      const exists = data.some(row => row[colName] !== undefined);
+      if (!exists) {
+        this.warn('No data found for column "' + colName + '".');
+      }
+    });
+  }
+
+  /**
+   * @param {Object[]} rows - Rows as POJOs with keys.
+   * @param {string[]} columns - Column names which must correspond to keys
+   *        in the row objects.
+   * @return {google.visualization.DataTable}
+   */
+  static dataTableFromRowsAndColumns(rows, columns) {
+    const dataArray = rows.map(row => columns.map(key => row[key]));
+    return GoogleChart.lib.visualization.arrayToDataTable(
+      [columns].concat(dataArray)
+    );
+  }
+
+  /**
+   * Internal 'abstract' method that subclasses should use to implement the actual
+   * rendering step.
+   *
+   * @param {google.visualzation.DataTable} dataTable
+   * @param {Object} options
+   * @private
+   */
+  render_(dataTable, options) {
+    throw new Error('Rendering unimplemented for chart type.');
+  }
 }
-
-/**
- * Loads the required libraries for this particular chart type.
- * Safe to call multiple times - Google's loader caches dependencies.
- * @returns {Promise} that resolves when dependencies have been loaded.
- */
-GoogleChart.prototype.loadDependencies = function() {
-  return new Promise((resolve, reject) => {
-    try {
-      GoogleChart.lib.load('visualization', '1', {
-        packages: this.getDependencies(),
-        callback: resolve
-      });
-    } catch (e) {
-      // We catch and return a different error so that we don't surface Google
-      // API errors to students.
-      reject(new Error('Unable to load Charts API.  Please try again later.'));
-    }
-  });
-};
-
-/**
- * Renders the chart into the target container using the specified options.
- *
- *  @param {Object[]} rawData - data to display in chart, formatted as an array
- *        of objects where each object represents a row, and the object keys
- *        are column names.
- * @param {string[]} columnList - Ordered list of column names to use as source
- *        data for the chart.  Column names must match keys in rawData.
- * @param {Object} options - Plain options object that gets passed through to
- *        the Charts API.
- * @returns {Promise} that resolves when the chart has been rendered to the
- *          target container.
- */
-GoogleChart.prototype.drawChart = async function(rawData, columnList, options) {
-  await this.loadDependencies();
-
-  this.verifyData_(rawData, columnList);
-  const dataTable = GoogleChart.dataTableFromRowsAndColumns(
-    rawData,
-    columnList
-  );
-  this.render_(dataTable, options);
-};
-
-/**
- * Array of packages the chart needs to load to render.
- * @returns {string[]}
- */
-GoogleChart.prototype.getDependencies = function() {
-  return ['corechart'];
-};
-
-/**
- * Pushes the provided warning message into a collection of warnings for this
- * chart, which can be parsed and displayed later.
- * @param {string} warningMessage
- */
-GoogleChart.prototype.warn = function(warningMessage) {
-  this.warnings.push(new Error(warningMessage));
-};
-
-/**
- * Makes sure data looks okay, throws errors and logs warnings as appropriate.
- * @param {string[]} columns
- * @param {Object[]} data
- * @private
- */
-GoogleChart.prototype.verifyData_ = function(data, columns) {
-  // Warn when no rows are present
-  if (data.length === 0) {
-    this.warn('No data.');
-  }
-
-  // Error when not enough columns are provided
-  if (columns.length < 2) {
-    throw new Error('Not enough columns for chart; expected at least 2.');
-  }
-
-  // Warn on empty columns?
-  columns.forEach(colName => {
-    const exists = data.some(row => row[colName] !== undefined);
-    if (!exists) {
-      this.warn('No data found for column "' + colName + '".');
-    }
-  });
-};
-
-/**
- * @param {Object[]} rows - Rows as POJOs with keys.
- * @param {string[]} columns - Column names which must correspond to keys
- *        in the row objects.
- * @return {google.visualization.DataTable}
- */
-GoogleChart.dataTableFromRowsAndColumns = function(rows, columns) {
-  const dataArray = rows.map(row => columns.map(key => row[key]));
-  return GoogleChart.lib.visualization.arrayToDataTable(
-    [columns].concat(dataArray)
-  );
-};
-
-/**
- * Internal 'abstract' method that subclasses should use to implement the actual
- * rendering step.
- *
- * @param {google.visualzation.DataTable} dataTable
- * @param {Object} options
- * @private
- */
-GoogleChart.prototype.render_ = function(dataTable, options) {
-  throw new Error('Rendering unimplemented for chart type.');
-};
 
 /**
  * Google Charts API Pie Chart
@@ -158,31 +162,30 @@ GoogleChart.prototype.render_ = function(dataTable, options) {
  * @constructor
  * @extends GoogleChart
  */
-var PieChart = function(targetDiv) {
-  GoogleChart.call(this, targetDiv);
-};
-PieChart.inherits(GoogleChart);
-GoogleChart.PieChart = PieChart;
-
-PieChart.prototype.render_ = function(dataTable, options) {
-  const apiChart = new GoogleChart.lib.visualization.PieChart(this.targetDiv_);
-  apiChart.draw(dataTable, options);
-};
-
-/**
- *
- * @param {string[]} columns
- * @param {Object[]} data
- * @private
- * @override
- */
-PieChart.prototype.verifyData_ = function(data, columns) {
-  PieChart.superPrototype.verifyData_.call(this, data, columns);
-
-  if (columns.length > 2) {
-    this.warn('Too many columns for pie chart; only using the first 2.');
+class PieChart extends GoogleChart {
+  render_(dataTable, options) {
+    const apiChart = new GoogleChart.lib.visualization.PieChart(
+      this.targetDiv_
+    );
+    apiChart.draw(dataTable, options);
   }
-};
+
+  /**
+   *
+   * @param {string[]} columns
+   * @param {Object[]} data
+   * @private
+   * @override
+   */
+  verifyData_(data, columns) {
+    super.verifyData_(data, columns);
+
+    if (columns.length > 2) {
+      this.warn('Too many columns for pie chart; only using the first 2.');
+    }
+  }
+}
+GoogleChart.PieChart = PieChart;
 
 /**
  * Google Charts API Bar Chart
@@ -193,23 +196,22 @@ PieChart.prototype.verifyData_ = function(data, columns) {
  * @constructor
  * @extends GoogleChart
  */
-var BarChart = function(targetDiv) {
-  GoogleChart.call(this, targetDiv);
-};
-BarChart.inherits(GoogleChart);
+class BarChart extends GoogleChart {
+  /**
+   * @param {google.visualization.DataTable} dataTable
+   * @param {Object} options
+   * @returns {Promise}
+   * @private
+   * @override
+   */
+  render_(dataTable, options) {
+    const apiChart = new GoogleChart.lib.visualization.BarChart(
+      this.targetDiv_
+    );
+    apiChart.draw(dataTable, options);
+  }
+}
 GoogleChart.BarChart = BarChart;
-
-/**
- * @param {google.visualization.DataTable} dataTable
- * @param {Object} options
- * @returns {Promise}
- * @private
- * @override
- */
-BarChart.prototype.render_ = function(dataTable, options) {
-  const apiChart = new GoogleChart.lib.visualization.BarChart(this.targetDiv_);
-  apiChart.draw(dataTable, options);
-};
 
 /**
  * Google Charts API Material Design Bar Chart
@@ -221,34 +223,31 @@ BarChart.prototype.render_ = function(dataTable, options) {
  * @constructor
  * @extends GoogleChart
  */
-var MaterialBarChart = function(targetDiv) {
-  GoogleChart.call(this, targetDiv);
-};
-MaterialBarChart.inherits(GoogleChart);
+class MaterialBarChart extends GoogleChart {
+  /**
+   * @param {google.visualization.DataTable} dataTable
+   * @param {Object} options
+   * @returns {Promise}
+   * @private
+   * @override
+   */
+  render_(dataTable, options) {
+    const apiChart = new GoogleChart.lib.charts.Bar(this.targetDiv_);
+    // Material charts have a built-in options converter for now.
+    const convertedOptions = GoogleChart.lib.charts.Bar.convertOptions(options);
+    apiChart.draw(dataTable, convertedOptions);
+  }
+
+  /**
+   * Array of packages the chart needs to load to render.
+   * @returns {string[]}
+   * @override
+   */
+  getDependencies() {
+    return ['bar'];
+  }
+}
 GoogleChart.MaterialBarChart = MaterialBarChart;
-
-/**
- * @param {google.visualization.DataTable} dataTable
- * @param {Object} options
- * @returns {Promise}
- * @private
- * @override
- */
-MaterialBarChart.prototype.render_ = function(dataTable, options) {
-  const apiChart = new GoogleChart.lib.charts.Bar(this.targetDiv_);
-  // Material charts have a built-in options converter for now.
-  const convertedOptions = GoogleChart.lib.charts.Bar.convertOptions(options);
-  apiChart.draw(dataTable, convertedOptions);
-};
-
-/**
- * Array of packages the chart needs to load to render.
- * @returns {string[]}
- * @override
- */
-MaterialBarChart.prototype.getDependencies = function() {
-  return ['bar'];
-};
 
 /**
  * Google Charts API Line Chart
@@ -259,23 +258,22 @@ MaterialBarChart.prototype.getDependencies = function() {
  * @constructor
  * @extends GoogleChart
  */
-var LineChart = function(targetDiv) {
-  GoogleChart.call(this, targetDiv);
-};
-LineChart.inherits(GoogleChart);
+class LineChart extends GoogleChart {
+  /**
+   * @param {google.visualization.DataTable} dataTable
+   * @param {Object} options
+   * @returns {Promise}
+   * @private
+   * @override
+   */
+  render_(dataTable, options) {
+    const apiChart = new GoogleChart.lib.visualization.LineChart(
+      this.targetDiv_
+    );
+    apiChart.draw(dataTable, options);
+  }
+}
 GoogleChart.LineChart = LineChart;
-
-/**
- * @param {google.visualization.DataTable} dataTable
- * @param {Object} options
- * @returns {Promise}
- * @private
- * @override
- */
-LineChart.prototype.render_ = function(dataTable, options) {
-  const apiChart = new GoogleChart.lib.visualization.LineChart(this.targetDiv_);
-  apiChart.draw(dataTable, options);
-};
 
 /**
  * Google Charts API Material Design Line Chart
@@ -287,34 +285,33 @@ LineChart.prototype.render_ = function(dataTable, options) {
  * @constructor
  * @extends GoogleChart
  */
-var MaterialLineChart = function(targetDiv) {
-  GoogleChart.call(this, targetDiv);
-};
-MaterialLineChart.inherits(GoogleChart);
+class MaterialLineChart extends GoogleChart {
+  /**
+   * @param {google.visualization.DataTable} dataTable
+   * @param {Object} options
+   * @returns {Promise}
+   * @private
+   * @override
+   */
+  render_(dataTable, options) {
+    const apiChart = new GoogleChart.lib.charts.Line(this.targetDiv_);
+    // Material charts have a built-in options converter for now.
+    const convertedOptions = GoogleChart.lib.charts.Line.convertOptions(
+      options
+    );
+    apiChart.draw(dataTable, convertedOptions);
+  }
+
+  /**
+   * Array of packages the chart needs to load to render.
+   * @returns {string[]}
+   * @override
+   */
+  getDependencies() {
+    return ['line'];
+  }
+}
 GoogleChart.MaterialLineChart = MaterialLineChart;
-
-/**
- * @param {google.visualization.DataTable} dataTable
- * @param {Object} options
- * @returns {Promise}
- * @private
- * @override
- */
-MaterialLineChart.prototype.render_ = function(dataTable, options) {
-  const apiChart = new GoogleChart.lib.charts.Line(this.targetDiv_);
-  // Material charts have a built-in options converter for now.
-  const convertedOptions = GoogleChart.lib.charts.Line.convertOptions(options);
-  apiChart.draw(dataTable, convertedOptions);
-};
-
-/**
- * Array of packages the chart needs to load to render.
- * @returns {string[]}
- * @override
- */
-MaterialLineChart.prototype.getDependencies = function() {
-  return ['line'];
-};
 
 /**
  * Google Charts API Scatter Chart
@@ -325,25 +322,22 @@ MaterialLineChart.prototype.getDependencies = function() {
  * @constructor
  * @extends GoogleChart
  */
-var ScatterChart = function(targetDiv) {
-  GoogleChart.call(this, targetDiv);
-};
-ScatterChart.inherits(GoogleChart);
+class ScatterChart extends GoogleChart {
+  /**
+   * @param {google.visualization.DataTable} dataTable
+   * @param {Object} options
+   * @returns {Promise}
+   * @private
+   * @override
+   */
+  render_(dataTable, options) {
+    const apiChart = new GoogleChart.lib.visualization.ScatterChart(
+      this.targetDiv_
+    );
+    apiChart.draw(dataTable, options);
+  }
+}
 GoogleChart.ScatterChart = ScatterChart;
-
-/**
- * @param {google.visualization.DataTable} dataTable
- * @param {Object} options
- * @returns {Promise}
- * @private
- * @override
- */
-ScatterChart.prototype.render_ = function(dataTable, options) {
-  const apiChart = new GoogleChart.lib.visualization.ScatterChart(
-    this.targetDiv_
-  );
-  apiChart.draw(dataTable, options);
-};
 
 /**
  * Google Charts API Material Design Scatter Chart
@@ -355,33 +349,30 @@ ScatterChart.prototype.render_ = function(dataTable, options) {
  * @constructor
  * @extends GoogleChart
  */
-var MaterialScatterChart = function(targetDiv) {
-  GoogleChart.call(this, targetDiv);
-};
-MaterialScatterChart.inherits(GoogleChart);
+class MaterialScatterChart extends GoogleChart {
+  /**
+   * @param {google.visualization.DataTable} dataTable
+   * @param {Object} options
+   * @returns {Promise}
+   * @private
+   * @override
+   */
+  render_(dataTable, options) {
+    const apiChart = new GoogleChart.lib.charts.Scatter(this.targetDiv_);
+    // Material charts have a built-in options converter for now.
+    const convertedOptions = GoogleChart.lib.charts.Scatter.convertOptions(
+      options
+    );
+    apiChart.draw(dataTable, convertedOptions);
+  }
+
+  /**
+   * Array of packages the chart needs to load to render.
+   * @returns {string[]}
+   * @override
+   */
+  getDependencies() {
+    return ['scatter'];
+  }
+}
 GoogleChart.MaterialScatterChart = MaterialScatterChart;
-
-/**
- * @param {google.visualization.DataTable} dataTable
- * @param {Object} options
- * @returns {Promise}
- * @private
- * @override
- */
-MaterialScatterChart.prototype.render_ = function(dataTable, options) {
-  const apiChart = new GoogleChart.lib.charts.Scatter(this.targetDiv_);
-  // Material charts have a built-in options converter for now.
-  const convertedOptions = GoogleChart.lib.charts.Scatter.convertOptions(
-    options
-  );
-  apiChart.draw(dataTable, convertedOptions);
-};
-
-/**
- * Array of packages the chart needs to load to render.
- * @returns {string[]}
- * @override
- */
-MaterialScatterChart.prototype.getDependencies = function() {
-  return ['scatter'];
-};

--- a/apps/src/applab/GoogleChart.js
+++ b/apps/src/applab/GoogleChart.js
@@ -29,9 +29,6 @@ export default function GoogleChart(targetDiv) {
   /** @private {Element} */
   this.targetDiv_ = targetDiv;
 
-  /** @private {google.visualization.DataTable} */
-  this.dataTable_ = null;
-
   /**
    * List of all warnings logged while performing operations with this chart
    * instance.
@@ -46,22 +43,18 @@ export default function GoogleChart(targetDiv) {
  * @returns {Promise} that resolves when dependencies have been loaded.
  */
 GoogleChart.prototype.loadDependencies = function() {
-  return new Promise(
-    function(resolve, reject) {
-      try {
-        GoogleChart.lib.load('visualization', '1', {
-          packages: this.getDependencies(),
-          callback: resolve
-        });
-      } catch (e) {
-        // We catch and return a different error so that we don't surface Google
-        // API errors to students.
-        reject(
-          new Error('Unable to load Charts API.  Please try again later.')
-        );
-      }
-    }.bind(this)
-  );
+  return new Promise((resolve, reject) => {
+    try {
+      GoogleChart.lib.load('visualization', '1', {
+        packages: this.getDependencies(),
+        callback: resolve
+      });
+    } catch (e) {
+      // We catch and return a different error so that we don't surface Google
+      // API errors to students.
+      reject(new Error('Unable to load Charts API.  Please try again later.'));
+    }
+  });
 };
 
 /**
@@ -77,17 +70,15 @@ GoogleChart.prototype.loadDependencies = function() {
  * @returns {Promise} that resolves when the chart has been rendered to the
  *          target container.
  */
-GoogleChart.prototype.drawChart = function(rawData, columnList, options) {
-  return this.loadDependencies().then(
-    function() {
-      this.verifyData_(rawData, columnList);
-      var dataTable = GoogleChart.dataTableFromRowsAndColumns(
-        rawData,
-        columnList
-      );
-      return this.render_(dataTable, options);
-    }.bind(this)
+GoogleChart.prototype.drawChart = async function(rawData, columnList, options) {
+  await this.loadDependencies();
+
+  this.verifyData_(rawData, columnList);
+  const dataTable = GoogleChart.dataTableFromRowsAndColumns(
+    rawData,
+    columnList
   );
+  this.render_(dataTable, options);
 };
 
 /**
@@ -125,16 +116,12 @@ GoogleChart.prototype.verifyData_ = function(data, columns) {
   }
 
   // Warn on empty columns?
-  columns.forEach(
-    function(colName) {
-      var exists = data.some(function(row) {
-        return row[colName] !== undefined;
-      });
-      if (!exists) {
-        this.warn('No data found for column "' + colName + '".');
-      }
-    }.bind(this)
-  );
+  columns.forEach(colName => {
+    const exists = data.some(row => row[colName] !== undefined);
+    if (!exists) {
+      this.warn('No data found for column "' + colName + '".');
+    }
+  });
 };
 
 /**
@@ -144,11 +131,7 @@ GoogleChart.prototype.verifyData_ = function(data, columns) {
  * @return {google.visualization.DataTable}
  */
 GoogleChart.dataTableFromRowsAndColumns = function(rows, columns) {
-  var dataArray = rows.map(function(row) {
-    return columns.map(function(key) {
-      return row[key];
-    });
-  });
+  const dataArray = rows.map(row => columns.map(key => row[key]));
   return GoogleChart.lib.visualization.arrayToDataTable(
     [columns].concat(dataArray)
   );
@@ -160,11 +143,10 @@ GoogleChart.dataTableFromRowsAndColumns = function(rows, columns) {
  *
  * @param {google.visualzation.DataTable} dataTable
  * @param {Object} options
- * @returns {Promise}
  * @private
  */
 GoogleChart.prototype.render_ = function(dataTable, options) {
-  return Promise.reject(new Error('Rendering unimplemented for chart type.'));
+  throw new Error('Rendering unimplemented for chart type.');
 };
 
 /**
@@ -183,9 +165,8 @@ PieChart.inherits(GoogleChart);
 GoogleChart.PieChart = PieChart;
 
 PieChart.prototype.render_ = function(dataTable, options) {
-  var apiChart = new GoogleChart.lib.visualization.PieChart(this.targetDiv_);
+  const apiChart = new GoogleChart.lib.visualization.PieChart(this.targetDiv_);
   apiChart.draw(dataTable, options);
-  return Promise.resolve();
 };
 
 /**
@@ -226,9 +207,8 @@ GoogleChart.BarChart = BarChart;
  * @override
  */
 BarChart.prototype.render_ = function(dataTable, options) {
-  var apiChart = new GoogleChart.lib.visualization.BarChart(this.targetDiv_);
+  const apiChart = new GoogleChart.lib.visualization.BarChart(this.targetDiv_);
   apiChart.draw(dataTable, options);
-  return Promise.resolve();
 };
 
 /**
@@ -255,11 +235,10 @@ GoogleChart.MaterialBarChart = MaterialBarChart;
  * @override
  */
 MaterialBarChart.prototype.render_ = function(dataTable, options) {
-  var apiChart = new GoogleChart.lib.charts.Bar(this.targetDiv_);
+  const apiChart = new GoogleChart.lib.charts.Bar(this.targetDiv_);
   // Material charts have a built-in options converter for now.
-  var convertedOptions = GoogleChart.lib.charts.Bar.convertOptions(options);
+  const convertedOptions = GoogleChart.lib.charts.Bar.convertOptions(options);
   apiChart.draw(dataTable, convertedOptions);
-  return Promise.resolve();
 };
 
 /**
@@ -294,9 +273,8 @@ GoogleChart.LineChart = LineChart;
  * @override
  */
 LineChart.prototype.render_ = function(dataTable, options) {
-  var apiChart = new GoogleChart.lib.visualization.LineChart(this.targetDiv_);
+  const apiChart = new GoogleChart.lib.visualization.LineChart(this.targetDiv_);
   apiChart.draw(dataTable, options);
-  return Promise.resolve();
 };
 
 /**
@@ -323,11 +301,10 @@ GoogleChart.MaterialLineChart = MaterialLineChart;
  * @override
  */
 MaterialLineChart.prototype.render_ = function(dataTable, options) {
-  var apiChart = new GoogleChart.lib.charts.Line(this.targetDiv_);
+  const apiChart = new GoogleChart.lib.charts.Line(this.targetDiv_);
   // Material charts have a built-in options converter for now.
-  var convertedOptions = GoogleChart.lib.charts.Line.convertOptions(options);
+  const convertedOptions = GoogleChart.lib.charts.Line.convertOptions(options);
   apiChart.draw(dataTable, convertedOptions);
-  return Promise.resolve();
 };
 
 /**
@@ -362,11 +339,10 @@ GoogleChart.ScatterChart = ScatterChart;
  * @override
  */
 ScatterChart.prototype.render_ = function(dataTable, options) {
-  var apiChart = new GoogleChart.lib.visualization.ScatterChart(
+  const apiChart = new GoogleChart.lib.visualization.ScatterChart(
     this.targetDiv_
   );
   apiChart.draw(dataTable, options);
-  return Promise.resolve();
 };
 
 /**
@@ -393,11 +369,12 @@ GoogleChart.MaterialScatterChart = MaterialScatterChart;
  * @override
  */
 MaterialScatterChart.prototype.render_ = function(dataTable, options) {
-  var apiChart = new GoogleChart.lib.charts.Scatter(this.targetDiv_);
+  const apiChart = new GoogleChart.lib.charts.Scatter(this.targetDiv_);
   // Material charts have a built-in options converter for now.
-  var convertedOptions = GoogleChart.lib.charts.Scatter.convertOptions(options);
+  const convertedOptions = GoogleChart.lib.charts.Scatter.convertOptions(
+    options
+  );
   apiChart.draw(dataTable, convertedOptions);
-  return Promise.resolve();
 };
 
 /**


### PR DESCRIPTION
Update `GoogleChart.js` and `ChartApi.js` to a more modern JavaScript idiom.

- Use ES6 classes
- Prefer `const/let` to `var`
- Use arrow functions to avoid verbose binding
- Use `async/await` to significantly simplify implementations of certain methods.

While checking for whether we had any metrics around chart API usage, noticed some code in this file that could be simplified with async/await, and found myself doing a full cleanup pass.  Oops!

### Testing
ChartApi.js already has a test file, which passes without changes after this change, and also uses `GoogleChart.js` without stubbing (much) of it.  Good coverage already.  The following coverage report is from running `BROWSER=Chrome COVERAGE=1 yarn test:entry --entry test/unit/applab/ChartApiTest.js`:

![image](https://user-images.githubusercontent.com/1615761/55595526-23dc5b00-56f9-11e9-9aba-7dea16ee0b1d.png)
