### PR TITLE
PL: PD workshops page gets pop-up regional partner mini-contact form

### DIFF
--- a/apps/src/regionalPartnerMiniContact/regionalPartnerMiniContact.js
+++ b/apps/src/regionalPartnerMiniContact/regionalPartnerMiniContact.js
@@ -50,13 +50,17 @@ window.showRegionalPartnerMiniContactPopupLink = function() {
     'options-notes'
   );
   const linkText = regionalPartnerMiniContactPopupLinkElement.data('link-text');
+  const isButton = regionalPartnerMiniContactPopupLinkElement.data(
+    'link-button'
+  );
 
   ReactDOM.render(
     <RegionalPartnerMiniContactPopupLink
       notes={notes}
       sourcePageId={sourcePageId}
     >
-      {linkText}
+      {isButton && <button type="button">{linkText}</button>}
+      {!isButton && linkText}
     </RegionalPartnerMiniContactPopupLink>,
     regionalPartnerMiniContactPopupLinkElement[0]
   );

--- a/pegasus/sites.v3/code.org/public/professional-development-workshops/index.md
+++ b/pegasus/sites.v3/code.org/public/professional-development-workshops/index.md
@@ -17,7 +17,9 @@ Look at the map below to find the next upcoming CS Fundamentals workshop in your
 
 If you can’t find a workshop above, and you’re in the U.S., contact your Regional Partner. They may already have a private workshop set up near your area that you can join, or can set up a workshop if they see enough demand.
 
-<a href="<%= CDO.studio_url('/pd/regional_partner_contact/new') %>"><button>Contact my Regional Partner</button></a>
+<%= view :professional_development_workshops_regional_partner_search %>
+
+<br/>
 
 Regional Partners are organizations across the country who advocate for access to computer science education, act as a K-12 computer science hub for their region, and create a strong local community of computer science educators. Our [Regional Partners](/educate/regional-partner/partners) are happy to work with you to organize a training at your school or district.
 

--- a/pegasus/sites.v3/code.org/views/professional_development_workshops_regional_partner_search.haml
+++ b/pegasus/sites.v3/code.org/views/professional_development_workshops_regional_partner_search.haml
@@ -1,0 +1,10 @@
+#regional-partner-mini-contact-popup-link-container{"data-source-page-id" => "professional-development-workshops", "data-options" => {notes: "Please tell me more about the professional learning program!"}, "data-link-text" => "Contact my Regional Partner", "data-link-button" => "true"}
+
+- js_locale = request.locale.to_s.downcase.tr('-', '_')
+%script{src: asset_path("js/#{js_locale}/common_locale.js")}
+%script{src: minifiable_asset_path('js/regionalPartnerMiniContact.js')}
+
+:javascript
+  $(document).ready(function() {
+    window.showRegionalPartnerMiniContactPopupLink();
+  });


### PR DESCRIPTION
The professional development workshops page at https://code.org/professional-development-workshops has a button which now shows the pop-up regional partner mini-contact form, rather than taking the user to the legacy regional partner contact page.

## The button
![Screenshot 2019-04-04 23 07 53](https://user-images.githubusercontent.com/2205926/55554709-2e194c00-572f-11e9-8d8e-e40c7dc6ceaf.png)

## The pop-up mini-contact form
![Screenshot 2019-04-04 23 08 41](https://user-images.githubusercontent.com/2205926/55554710-2e194c00-572f-11e9-87d1-6a7af3d75b4f.png)
