### PR TITLE
try harder to deflake IE11Win10_applab_level_options

### DIFF
--- a/dashboard/test/ui/features/applab/level_options.feature
+++ b/dashboard/test/ui/features/applab/level_options.feature
@@ -27,5 +27,6 @@ Scenario: Level defaults to design mode, students see design mode and teachers s
   And I wait for the page to fully load
   And I wait to see ".show-handle"
   Then I click selector ".show-handle .fa-chevron-left"
-  Then I click selector ".section-student .name a"
+  Then I click selector ".section-student .name a" to load a new page
+  And I wait for the page to fully load
   And I wait to see Applab code mode


### PR DESCRIPTION
IE11Win10_applab_level_options continues to be flaky ([example](https://cucumber-logs.s3.amazonaws.com/test/test/IE11Win10_applab_level_options_output.html?versionId=mQ2wAaudmxPZhmtuGaiUdwN3Ks83fKem)).

My hypothesis is that this is due to waiting for code mode while navigation is still in progress. The proposed solution is to wait more patiently for the navigation to complete.