### PR TITLE
do not navigate when teacher viewing student clicks "more" dropdown

### DIFF
--- a/apps/src/code-studio/components/progress/ViewAsToggle.jsx
+++ b/apps/src/code-studio/components/progress/ViewAsToggle.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import commonMsg from '@cdo/locale';
 import ToggleGroup from '@cdo/apps/templates/ToggleGroup';
-import {ViewType, setViewType} from '../../viewAsRedux';
+import {ViewType, changeViewType} from '../../viewAsRedux';
 import {queryParams, updateQueryParam} from '@cdo/apps/code-studio/utils';
 
 const styles = {
@@ -27,7 +27,7 @@ const styles = {
 class ViewAsToggle extends React.Component {
   static propTypes = {
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
-    setViewType: PropTypes.func.isRequired
+    changeViewType: PropTypes.func.isRequired
   };
 
   componentDidMount() {
@@ -38,12 +38,12 @@ class ViewAsToggle extends React.Component {
   }
 
   onChange = viewType => {
-    const {setViewType} = this.props;
+    const {changeViewType} = this.props;
 
     updateQueryParam('viewAs', viewType);
 
     if (viewType === ViewType.Student && queryParams('user_id')) {
-      // In this case, the setViewType thunk is going to do a reload and we dont
+      // In this case, the changeViewType thunk is going to do a reload and we dont
       // want to change our UI.
     } else {
       // Ideally all the things we would want to hide would be redux backed, and
@@ -52,7 +52,7 @@ class ViewAsToggle extends React.Component {
       $('.hide-as-student').toggle(viewType === ViewType.Teacher);
     }
 
-    setViewType(viewType);
+    changeViewType(viewType);
   };
 
   render() {
@@ -90,8 +90,8 @@ export default connect(
     viewAs: state.viewAs
   }),
   dispatch => ({
-    setViewType(viewAs) {
-      dispatch(setViewType(viewAs));
+    changeViewType(viewAs) {
+      dispatch(changeViewType(viewAs));
     }
   })
 )(UnconnectedViewAsToggle);

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -274,10 +274,6 @@ function queryUserProgress(store, scriptData, currentLevelId) {
 
       store.dispatch(showTeacherInfo());
 
-      const viewAs =
-        queryString.parse(location.search).viewAs || ViewType.Teacher;
-      store.dispatch(setViewType(viewAs));
-
       renderTeacherPanel(store, scriptData.id, scriptData.section);
     }
 

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -12,7 +12,7 @@ import DisabledBubblesModal from './DisabledBubblesModal';
 import DisabledBubblesAlert from './DisabledBubblesAlert';
 import {getStore} from './redux';
 import {authorizeLockable} from './stageLockRedux';
-import {changeViewType, ViewType} from './viewAsRedux';
+import {setViewType, ViewType} from './viewAsRedux';
 import {getHiddenStages, initializeHiddenScripts} from './hiddenStageRedux';
 import {TestResults} from '@cdo/apps/constants';
 import {
@@ -230,7 +230,7 @@ function queryUserProgress(store, scriptData, currentLevelId) {
     const query = queryString.parse(location.search);
     initialViewAs = query.viewAs || ViewType.Teacher;
   }
-  store.dispatch(changeViewType(initialViewAs));
+  store.dispatch(setViewType(initialViewAs));
 
   $.ajax('/api/user_progress/' + scriptData.name, {
     data: {
@@ -277,7 +277,7 @@ function queryUserProgress(store, scriptData, currentLevelId) {
         // We don't want to redispatch if our viewAs is the same as the initial
         // one, since the user might have manually changed the view while making
         // our async call
-        store.dispatch(changeViewType(viewAs));
+        store.dispatch(setViewType(viewAs));
       }
 
       renderTeacherPanel(store, scriptData.id, scriptData.section);

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -273,12 +273,7 @@ function queryUserProgress(store, scriptData, currentLevelId) {
 
       const viewAs =
         queryString.parse(location.search).viewAs || ViewType.Teacher;
-      if (viewAs !== initialViewAs) {
-        // We don't want to redispatch if our viewAs is the same as the initial
-        // one, since the user might have manually changed the view while making
-        // our async call
-        store.dispatch(setViewType(viewAs));
-      }
+      store.dispatch(setViewType(viewAs));
 
       renderTeacherPanel(store, scriptData.id, scriptData.section);
     }

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -150,6 +150,11 @@ progress.renderStageProgress = function(
 progress.renderCourseProgress = function(scriptData) {
   const store = getStore();
   initializeStoreWithProgress(store, scriptData, null, true);
+
+  if (scriptData.student_detail_progress_view) {
+    store.dispatch(setStudentDefaultsSummaryView(false));
+  }
+  initViewAs(store, scriptData);
   queryUserProgress(store, scriptData, null);
 
   const teacherResources = (scriptData.teacher_resources || []).map(
@@ -213,17 +218,7 @@ progress.renderMiniView = function(
   });
 };
 
-/**
- * Query the server for user_progress data for this script, and update the store
- * as appropriate
- */
-function queryUserProgress(store, scriptData, currentLevelId) {
-  const onOverviewPage = !currentLevelId;
-
-  if (scriptData.student_detail_progress_view) {
-    store.dispatch(setStudentDefaultsSummaryView(false));
-  }
-
+function initViewAs(store, scriptData) {
   // Set our initial view type from current user's user_type or our query string.
   let initialViewAs = ViewType.Student;
   if (scriptData.user_type === 'teacher') {
@@ -231,6 +226,14 @@ function queryUserProgress(store, scriptData, currentLevelId) {
     initialViewAs = query.viewAs || ViewType.Teacher;
   }
   store.dispatch(setViewType(initialViewAs));
+}
+
+/**
+ * Query the server for user_progress data for this script, and update the store
+ * as appropriate
+ */
+function queryUserProgress(store, scriptData, currentLevelId) {
+  const onOverviewPage = !currentLevelId;
 
   $.ajax('/api/user_progress/' + scriptData.name, {
     data: {

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -12,7 +12,7 @@ import DisabledBubblesModal from './DisabledBubblesModal';
 import DisabledBubblesAlert from './DisabledBubblesAlert';
 import {getStore} from './redux';
 import {authorizeLockable} from './stageLockRedux';
-import {setViewType, ViewType} from './viewAsRedux';
+import {changeViewType, ViewType} from './viewAsRedux';
 import {getHiddenStages, initializeHiddenScripts} from './hiddenStageRedux';
 import {TestResults} from '@cdo/apps/constants';
 import {
@@ -230,7 +230,7 @@ function queryUserProgress(store, scriptData, currentLevelId) {
     const query = queryString.parse(location.search);
     initialViewAs = query.viewAs || ViewType.Teacher;
   }
-  store.dispatch(setViewType(initialViewAs));
+  store.dispatch(changeViewType(initialViewAs));
 
   $.ajax('/api/user_progress/' + scriptData.name, {
     data: {
@@ -277,7 +277,7 @@ function queryUserProgress(store, scriptData, currentLevelId) {
         // We don't want to redispatch if our viewAs is the same as the initial
         // one, since the user might have manually changed the view while making
         // our async call
-        store.dispatch(setViewType(viewAs));
+        store.dispatch(changeViewType(viewAs));
       }
 
       renderTeacherPanel(store, scriptData.id, scriptData.section);

--- a/apps/src/code-studio/teacher.js
+++ b/apps/src/code-studio/teacher.js
@@ -13,7 +13,7 @@ import SectionSelector from './components/progress/SectionSelector';
 import ViewAsToggle from './components/progress/ViewAsToggle';
 import TeacherContentToggle from './components/TeacherContentToggle';
 import {setSectionLockStatus} from './stageLockRedux';
-import {ViewType, setViewType} from './viewAsRedux';
+import {ViewType, changeViewType} from './viewAsRedux';
 import {lessonIsLockedForAllStudents} from '@cdo/apps/templates/progress/progressHelpers';
 import {
   setSections,
@@ -190,7 +190,7 @@ function renderViewAsToggle(element) {
   // Start viewing as teacher
   const query = queryString.parse(location.search);
   const viewAs = query.viewAs || ViewType.Teacher;
-  store.dispatch(setViewType(viewAs));
+  store.dispatch(changeViewType(viewAs));
 
   ReactDOM.render(
     <Provider store={store}>

--- a/apps/src/code-studio/teacher.js
+++ b/apps/src/code-studio/teacher.js
@@ -13,7 +13,7 @@ import SectionSelector from './components/progress/SectionSelector';
 import ViewAsToggle from './components/progress/ViewAsToggle';
 import TeacherContentToggle from './components/TeacherContentToggle';
 import {setSectionLockStatus} from './stageLockRedux';
-import {ViewType, changeViewType} from './viewAsRedux';
+import {ViewType, setViewType} from './viewAsRedux';
 import {lessonIsLockedForAllStudents} from '@cdo/apps/templates/progress/progressHelpers';
 import {
   setSections,
@@ -190,7 +190,7 @@ function renderViewAsToggle(element) {
   // Start viewing as teacher
   const query = queryString.parse(location.search);
   const viewAs = query.viewAs || ViewType.Teacher;
-  store.dispatch(changeViewType(viewAs));
+  store.dispatch(setViewType(viewAs));
 
   ReactDOM.render(
     <Provider store={store}>

--- a/apps/src/code-studio/viewAsRedux.js
+++ b/apps/src/code-studio/viewAsRedux.js
@@ -30,7 +30,7 @@ export default function reducer(state = ViewType.Student, action) {
 // Action creators
 
 // Exported for test purposes
-export const setViewTypeNonThunk = viewType => ({
+export const setViewType = viewType => ({
   type: SET_VIEW_TYPE,
   viewType
 });
@@ -47,6 +47,6 @@ export const changeViewType = viewType => {
       return;
     }
 
-    dispatch(setViewTypeNonThunk(viewType));
+    dispatch(setViewType(viewType));
   };
 };

--- a/apps/src/code-studio/viewAsRedux.js
+++ b/apps/src/code-studio/viewAsRedux.js
@@ -11,9 +11,6 @@ export const ViewType = makeEnum('Student', 'Teacher');
 // Action types
 export const SET_VIEW_TYPE = 'viewAs/SET_VIEW_TYPE';
 
-/**
- * Stage lock reducer
- */
 export default function reducer(state = ViewType.Student, action) {
   if (action.type === SET_VIEW_TYPE) {
     const viewType = action.viewType;

--- a/apps/src/code-studio/viewAsRedux.js
+++ b/apps/src/code-studio/viewAsRedux.js
@@ -35,7 +35,7 @@ export const setViewTypeNonThunk = viewType => ({
   viewType
 });
 
-export const setViewType = viewType => {
+export const changeViewType = viewType => {
   return dispatch => {
     // If changing to viewAs student while we are a particular student, remove
     // the user_id and do a reload so that we're instead viewing as a generic

--- a/apps/src/code-studio/viewAsRedux.js
+++ b/apps/src/code-studio/viewAsRedux.js
@@ -29,7 +29,6 @@ export default function reducer(state = ViewType.Student, action) {
 
 // Action creators
 
-// Exported for test purposes
 export const setViewType = viewType => ({
   type: SET_VIEW_TYPE,
   viewType

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import CourseOverview from '@cdo/apps/templates/courseOverview/CourseOverview';
-import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
+import {changeViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {getStore} from '@cdo/apps/code-studio/redux';
 import {
   setSections,
@@ -37,7 +37,7 @@ function showCourseOverview() {
   store.dispatch(setUserSignedIn(getUserSignedInFromCookieAndDom()));
 
   if (isTeacher) {
-    store.dispatch(setViewType(ViewType.Teacher));
+    store.dispatch(changeViewType(ViewType.Teacher));
     store.dispatch(setSections(scriptData.sections));
 
     if (scriptData.is_verified_teacher) {

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import CourseOverview from '@cdo/apps/templates/courseOverview/CourseOverview';
-import {changeViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
+import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {getStore} from '@cdo/apps/code-studio/redux';
 import {
   setSections,
@@ -37,7 +37,7 @@ function showCourseOverview() {
   store.dispatch(setUserSignedIn(getUserSignedInFromCookieAndDom()));
 
   if (isTeacher) {
-    store.dispatch(changeViewType(ViewType.Teacher));
+    store.dispatch(setViewType(ViewType.Teacher));
     store.dispatch(setSections(scriptData.sections));
 
     if (scriptData.is_verified_teacher) {

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
@@ -12,7 +12,7 @@ import {
   authorizeLockable,
   setSectionLockStatus
 } from '@cdo/apps/code-studio/stageLockRedux';
-import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
+import {changeViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {setHiddenStages} from '@cdo/apps/code-studio/hiddenStageRedux';
 import teacherSections, {
   setSections
@@ -67,7 +67,7 @@ const createStore = ({preload = false, allowHidden = true} = {}) => {
   );
   store.dispatch(authorizeLockable());
   store.dispatch(showTeacherInfo());
-  store.dispatch(setViewType(ViewType.Teacher));
+  store.dispatch(changeViewType(ViewType.Teacher));
   store.dispatch(
     setHiddenStages(
       {

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
@@ -12,7 +12,7 @@ import {
   authorizeLockable,
   setSectionLockStatus
 } from '@cdo/apps/code-studio/stageLockRedux';
-import {changeViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
+import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {setHiddenStages} from '@cdo/apps/code-studio/hiddenStageRedux';
 import teacherSections, {
   setSections
@@ -67,7 +67,7 @@ const createStore = ({preload = false, allowHidden = true} = {}) => {
   );
   store.dispatch(authorizeLockable());
   store.dispatch(showTeacherInfo());
-  store.dispatch(changeViewType(ViewType.Teacher));
+  store.dispatch(setViewType(ViewType.Teacher));
   store.dispatch(
     setHiddenStages(
       {

--- a/apps/test/unit/code-studio/components/progress/ViewAsToggleTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ViewAsToggleTest.jsx
@@ -6,10 +6,10 @@ import {UnconnectedViewAsToggle as ViewAsToggle} from '@cdo/apps/code-studio/com
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 describe('ViewAsToggle', () => {
-  it('calls setViewType when ToggleGroup changes', () => {
+  it('calls changeViewType when ToggleGroup changes', () => {
     const spy = sinon.spy();
     const wrapper = shallow(
-      <ViewAsToggle viewAs={ViewType.Student} setViewType={spy} />
+      <ViewAsToggle viewAs={ViewType.Student} changeViewType={spy} />
     );
     expect(spy).not.to.have.been.called;
 

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -348,7 +348,7 @@ describe('progressReduxTest', () => {
     });
 
     describe('setViewType', () => {
-      // The setViewType exported by viewAsRedux is a thunk that handles some
+      // The changeViewType exported by viewAsRedux is a thunk that handles some
       // stuff like updating query param. We just want the core action it ultimately
       // dispatches
       const setViewType = setViewTypeNonThunk;

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 import {TestResults} from '@cdo/apps/constants';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
-import {ViewType, setViewTypeNonThunk} from '@cdo/apps/code-studio/viewAsRedux';
+import {ViewType, setViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import reducer, {
   initProgress,
   isPerfect,
@@ -347,12 +347,10 @@ describe('progressReduxTest', () => {
       assert.strictEqual(nextState.stageExtrasEnabled, true);
     });
 
+    // The changeViewType exported by viewAsRedux is a thunk that handles some
+    // stuff like updating query param. We just want to test the core action
+    // it ultimately dispatches.
     describe('setViewType', () => {
-      // The changeViewType exported by viewAsRedux is a thunk that handles some
-      // stuff like updating query param. We just want the core action it ultimately
-      // dispatches
-      const setViewType = setViewTypeNonThunk;
-
       it('toggles to detail view when setting viewAs to Teacher', () => {
         const state = {
           ...initialState,

--- a/apps/test/unit/code-studio/viewAsReduxTest.js
+++ b/apps/test/unit/code-studio/viewAsReduxTest.js
@@ -2,7 +2,7 @@ import {assert} from 'chai';
 import {stub} from 'sinon';
 import reducer, {
   ViewType,
-  setViewType
+  changeViewType
 } from '@cdo/apps/code-studio/viewAsRedux';
 import {
   stubRedux,
@@ -27,21 +27,21 @@ describe('viewAs redux', () => {
   });
 
   it('can set as teacher', () => {
-    const action = setViewType(ViewType.Teacher);
+    const action = changeViewType(ViewType.Teacher);
     store.dispatch(action);
     const nextState = store.getState();
     assert.equal(nextState.viewAs, ViewType.Teacher);
   });
 
   it('can set as student', () => {
-    const action = setViewType(ViewType.Student);
+    const action = changeViewType(ViewType.Student);
     store.dispatch(action);
     const nextState = store.getState();
     assert.equal(nextState.viewAs, ViewType.Student);
   });
 
   it('does not allow for invalid view types', () => {
-    const action = setViewType('Invalid');
+    const action = changeViewType('Invalid');
     assert.throws(() => {
       store.dispatch(action);
     });
@@ -61,7 +61,7 @@ describe('viewAs redux', () => {
     });
 
     it('changes the window location when changing to Student with user_id', () => {
-      const action = setViewType(ViewType.Student);
+      const action = changeViewType(ViewType.Student);
       store.dispatch(action);
       assert(codeStudioUtils.queryParams.calledWith('user_id'));
       assert(codeStudioUtils.updateQueryParam.calledWith('user_id', undefined));

--- a/dashboard/app/views/shared/_header_progress.html.haml
+++ b/dashboard/app/views/shared/_header_progress.html.haml
@@ -9,7 +9,9 @@
   %div.header_level_container
     -# Pass along section_id param so that when teacher moves between lesson page and course overview
     -# they maintain their section.
-    = link_to text, script_path(@script, section_id: request.query_parameters[:section_id]), class: ["header_text", ('small_font_on_tablet' if small_text)]
+    -section_id = request.query_parameters[:section_id]
+    -user_id = request.query_parameters[:user_id]
+    = link_to text, script_path(@script, section_id: section_id, user_id: user_id), class: ["header_text", ('small_font_on_tablet' if small_text)]
     .progress_container
     .header_finished_link{style: 'display: none;', class: ('small_font_on_tablet' if small_text)}
     %span.header_popup_link{style: 'display: none;'}

--- a/dashboard/test/ui/features/teacher_student_toggle.feature
+++ b/dashboard/test/ui/features/teacher_student_toggle.feature
@@ -17,7 +17,6 @@ Scenario: Toggle on Multi Level
   Then I open the progress drop down of the current page
   And I see no difference for "progress dropdown for teacher"
 
-  And I select the first section
   And I click selector ".section-student .name a" to load a new page
   And I wait to see ".header_popup_link"
   Then I open the progress drop down of the current page

--- a/dashboard/test/ui/features/teacher_student_toggle.feature
+++ b/dashboard/test/ui/features/teacher_student_toggle.feature
@@ -9,11 +9,20 @@ Scenario: Toggle on Multi Level
   Then I sign in as "Teacher_Daenerys"
   Then I am on "http://studio.code.org/s/allthethings/stage/9/puzzle/1"
   And I see no difference for "page load"
-  Then I click selector ".show-handle .fa-chevron-left"
+  Then I click selector ".show-handle .fa-chevron-left" once I see it
   Then I click selector ".uitest-viewAsStudent"
   And I see no difference for "view as student"
   Then I click selector ".uitest-viewAsTeacher"
   And I see no difference for "view as teacher"
+  Then I open the progress drop down of the current page
+  And I see no difference for "progress dropdown for teacher"
+
+  And I select the first section
+  And I click selector ".section-student .name a" to load a new page
+  And I wait to see ".header_popup_link"
+  Then I open the progress drop down of the current page
+  And I wait until element ".user-stats-block:contains(Jigsaw)" is visible
+  And I see no difference for "progress dropdown for teacher viewing as student"
   And I close my eyes
 
 Scenario: Toggle on Hidden Maze Level


### PR DESCRIPTION
### Background

https://codedotorg.atlassian.net/browse/LP-188

today, the `setViewType` action has the potential to update the url params and reload the page, which is not desired anywhere outside of `ViewAsToggle`.

`queryUserProgress` (which gets called both from `renderCourseProgress` and `renderMiniView`) incorrectly does some things which should only be done in `renderCourseProgress` (when rendering a script overview page).

### Description

* rename `setViewType` --> `changeViewType` and `setViewTypeNonThunk` --> `setViewType`
* make it so that only `ViewAsToggle` calls `changeViewType`
* move remaining calls to `setViewType` out of `queryUserProgress`
* bonus: add user_id to the lesson backlink to the left of the progress bar:

    <img width="1327" alt="Screen Shot 2019-04-04 at 3 13 37 PM" src="https://user-images.githubusercontent.com/8001765/55592095-42882500-56ec-11e9-9c64-42d86feee00c.png">

