### PR TITLE
Default stage extras to 'yes' for express courses

### DIFF
--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -668,12 +668,15 @@ export default function teacherSections(state = initialState, action) {
       }
     }
 
-    // Selecting Course 1-4 or A-F should auto-enable Stage Extras.
+    // Selecting the following courses should auto-enable Stage Extras:
+    //  Course 1-4, A-F, Express, and Pre-reader Express
     if (action.props.scriptId) {
       const script =
         state.validAssignments[assignmentId(null, action.props.scriptId)];
       stageExtraSettings.stageExtras = !!(
-        script && /course[1-4a-f]/.test(script.script_name)
+        script &&
+        (/course[1-4a-f]/.test(script.script_name) ||
+          /express/.test(script.script_name))
       );
     }
 

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -414,6 +414,7 @@ function newSectionData(id, courseId, scriptId, loginType) {
 }
 
 const defaultVersionYear = '2017';
+const defaultStageExtras = false;
 
 // Fields to copy from the assignmentInfo when creating an assignmentFamily.
 export const assignmentFamilyFields = [
@@ -653,8 +654,6 @@ export default function teacherSections(state = initialState, action) {
   }
 
   if (action.type === EDIT_SECTION_PROPERTIES) {
-    const stageExtraSettings = {};
-
     if (!state.sectionBeingEdited) {
       throw new Error(
         'Cannot edit section properties; no section is' +
@@ -668,16 +667,14 @@ export default function teacherSections(state = initialState, action) {
       }
     }
 
-    // Selecting the following courses should auto-enable Stage Extras:
-    //  Course 1-4, A-F, Express, and Pre-reader Express
+    const stageExtraSettings = {};
     if (action.props.scriptId) {
       const script =
         state.validAssignments[assignmentId(null, action.props.scriptId)];
-      stageExtraSettings.stageExtras = !!(
-        script &&
-        (/course[1-4a-f]/.test(script.script_name) ||
-          /express/.test(script.script_name))
-      );
+      if (script) {
+        stageExtraSettings.stageExtras =
+          script.stage_extras_available || defaultStageExtras;
+      }
     }
 
     return {

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -170,7 +170,8 @@ const validScripts = [
     script_name: 'course3',
     category: 'other',
     position: null,
-    category_priority: 3
+    category_priority: 3,
+    stage_extras_available: true
   },
   {
     id: 112,
@@ -217,7 +218,8 @@ const validScripts = [
     script_name: 'express-2018',
     category: 'other',
     position: null,
-    category_priority: 3
+    category_priority: 3,
+    stage_extras_available: true
   }
 ];
 
@@ -635,7 +637,7 @@ describe('teacherSectionsRedux', () => {
       ).to.throw();
     });
 
-    it('switching to non-CSF course assignment turns off stage extras', () => {
+    it('switching script assignment updates stage extras value from script', () => {
       let state = reducer(
         editingNewSectionState,
         setValidAssignments(validCourses, validScripts)

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -210,6 +210,14 @@ const validScripts = [
     assignment_family_name: 'coursea',
     version_year: '2017',
     is_stable: true
+  },
+  {
+    id: 37,
+    name: 'Express Course',
+    script_name: 'express-2018',
+    category: 'other',
+    position: null,
+    category_priority: 3
   }
 ];
 
@@ -636,6 +644,9 @@ describe('teacherSectionsRedux', () => {
       expect(state.sectionBeingEdited.stageExtras).to.equal(false);
 
       state = reducer(state, editSectionProperties({scriptId: 36}));
+      expect(state.sectionBeingEdited.stageExtras).to.equal(true);
+
+      state = reducer(state, editSectionProperties({scriptId: 37}));
       expect(state.sectionBeingEdited.stageExtras).to.equal(true);
     });
   });

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1442,6 +1442,7 @@ class Script < ActiveRecord::Base
 
     info[:category] = I18n.t("data.script.category.#{info[:category]}_category_name", default: info[:category])
     info[:supported_locales] = supported_locale_names
+    info[:stage_extras_available] = stage_extras_available
 
     info
   end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1360,12 +1360,13 @@ endvariants
   end
 
   test "assignable_info: returns assignable info for a script" do
-    script = create(:script, name: 'fake-script', hidden: true)
+    script = create(:script, name: 'fake-script', hidden: true, stage_extras_available: true)
     assignable_info = script.assignable_info
 
     assert_equal("fake-script *", assignable_info[:name])
     assert_equal("fake-script", assignable_info[:script_name])
     assert_equal("other", assignable_info[:category])
+    assert(assignable_info[:stage_extras_available])
   end
 
   test "assignable_info: correctly translates script info" do


### PR DESCRIPTION
[LP-154](https://codedotorg.atlassian.net/browse/LP-154)

Sets stage extras to "yes" by default for express courses (was previously only defaulting to "yes" for courses 1-4 and a-f).

**Note:** Since we are now using the `stage_extras_available` set on scripts in levelbuilder, any script that has this property set to true will have stage extras enabled by default.