### PR TITLE
Testing: Avoid unneeded dependencies in entry test bundles

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
 // Auto-generated from Gruntfile.js
 import 'babel-polyfill';
 import 'whatwg-fetch';
-import { throwOnConsoleErrorsEverywhere, throwOnConsoleWarningsEverywhere } from './util/testUtils';
+import { throwOnConsoleErrorsEverywhere, throwOnConsoleWarningsEverywhere } from './util/throwOnConsole';
 ${loadContext}
 describe('entry tests', () => {
   throwOnConsoleErrorsEverywhere();

--- a/apps/test/integration-tests.js
+++ b/apps/test/integration-tests.js
@@ -4,7 +4,7 @@ import {
   throwOnConsoleErrorsEverywhere,
   throwOnConsoleWarningsEverywhere
 } from './util/throwOnConsole';
-import {clearTimeoutsBetweenTests} from './util/testUtils';
+import {clearTimeoutsBetweenTests} from './util/clearTimeoutsBetweenTests';
 
 var integrationContext = require.context('./integration', false, /Tests?\.js$/);
 

--- a/apps/test/integration-tests.js
+++ b/apps/test/integration-tests.js
@@ -2,9 +2,9 @@ import 'babel-polyfill';
 import 'whatwg-fetch';
 import {
   throwOnConsoleErrorsEverywhere,
-  throwOnConsoleWarningsEverywhere,
-  clearTimeoutsBetweenTests
-} from './util/testUtils';
+  throwOnConsoleWarningsEverywhere
+} from './util/throwOnConsole';
+import {clearTimeoutsBetweenTests} from './util/testUtils';
 
 var integrationContext = require.context('./integration', false, /Tests?\.js$/);
 

--- a/apps/test/unit-tests.js
+++ b/apps/test/unit-tests.js
@@ -3,9 +3,9 @@ import 'babel-polyfill';
 import 'whatwg-fetch';
 import {
   throwOnConsoleErrorsEverywhere,
-  throwOnConsoleWarningsEverywhere,
-  clearTimeoutsBetweenTests
-} from './util/testUtils';
+  throwOnConsoleWarningsEverywhere
+} from './util/throwOnConsole';
+import {clearTimeoutsBetweenTests} from './util/testUtils';
 
 var __karmaWebpackManifest__ = [];
 

--- a/apps/test/unit-tests.js
+++ b/apps/test/unit-tests.js
@@ -5,7 +5,7 @@ import {
   throwOnConsoleErrorsEverywhere,
   throwOnConsoleWarningsEverywhere
 } from './util/throwOnConsole';
-import {clearTimeoutsBetweenTests} from './util/testUtils';
+import {clearTimeoutsBetweenTests} from './util/clearTimeoutsBetweenTests';
 
 var __karmaWebpackManifest__ = [];
 

--- a/apps/test/util/clearTimeoutsBetweenTests.js
+++ b/apps/test/util/clearTimeoutsBetweenTests.js
@@ -1,0 +1,86 @@
+/**
+ * @file
+ * We use this helper at the top-level of our test suite, in the entry points. For that reason
+ * it's useful to keep it in a separate file and as dependency-free as possible - please don't
+ * add other dependencies to this file unless absolutely necessary. Thank you!
+ */
+
+/**
+ * Track whenever we create a timeout/interval, and then clear all timeouts/intervals
+ * upon completion of each test.
+ */
+export function clearTimeoutsBetweenTests() {
+  let timeoutList = [];
+  let intervalList = [];
+  const leftover = [];
+
+  const setTimeoutNative = window.setTimeout;
+  const setIntervalNative = window.setInterval;
+  const clearTimeoutNative = window.clearTimeout;
+  const clearIntervalNative = window.clearInterval;
+
+  window.setTimeout = (...args) => {
+    const result = setTimeoutNative(...args);
+    timeoutList.push(result);
+    return result;
+  };
+
+  window.setInterval = (...args) => {
+    const result = setIntervalNative(...args);
+    intervalList.push(result);
+    return result;
+  };
+
+  window.clearTimeout = id => {
+    const index = timeoutList.indexOf(id);
+    if (index !== -1) {
+      timeoutList.splice(index, 1);
+    }
+    return clearTimeoutNative(id);
+  };
+
+  window.clearInterval = id => {
+    const index = intervalList.indexOf(id);
+    if (index !== -1) {
+      intervalList.splice(index, 1);
+    }
+    return clearIntervalNative(id);
+  };
+
+  afterEach(function() {
+    // Guard carefully here, because arrow functions can steal our test context
+    // and prevent us from grabbing the test name.
+    const testName = this && this.currentTest && this.currentTest.fullTitle();
+
+    timeoutList.forEach(id => {
+      if (testName) {
+        leftover.push('(timeout)  ' + testName);
+      } else {
+        // When we don't know the test name, also print a note inline to help
+        // with debugging.
+        leftover.push('(timeout)  Unknown test');
+        console.log('clearing leftover timeout');
+      }
+      clearTimeoutNative(id);
+    });
+    intervalList.forEach(id => {
+      if (testName) {
+        leftover.push('(interval) ' + testName);
+      } else {
+        // When we don't know the test name, also print a note inline to help
+        // with debugging.
+        leftover.push('(interval) Unknown test');
+        console.log('clearing leftover interval');
+      }
+      clearIntervalNative(id);
+    });
+    timeoutList = [];
+    intervalList = [];
+  });
+
+  after(() => {
+    console.log('Leftover timeouts/intervals: ' + leftover.length);
+    // Uncomment if you want to see the whole list of leftover timeouts
+    // console.log(leftover.map(s => '    ' + s).join('\n'));
+  });
+}

--- a/apps/test/util/testUtils.js
+++ b/apps/test/util/testUtils.js
@@ -10,6 +10,7 @@ export {
   allowConsoleErrors,
   allowConsoleWarnings
 } from './throwOnConsole';
+export {clearTimeoutsBetweenTests} from './clearTimeoutsBetweenTests';
 
 export function setExternalGlobals(beforeFunc = before, afterFunc = after) {
   // Temporary: Provide React on window while we still have a direct dependency
@@ -287,86 +288,6 @@ export function sandboxDocumentBody() {
   let originalDocumentBody;
   beforeEach(() => (originalDocumentBody = document.body.innerHTML));
   afterEach(() => (document.body.innerHTML = originalDocumentBody));
-}
-
-/**
- * Track whenever we create a timeout/interval, and then clear all timeouts/intervals
- * upon completion of each test.
- */
-export function clearTimeoutsBetweenTests() {
-  let timeoutList = [];
-  let intervalList = [];
-  const leftover = [];
-
-  const setTimeoutNative = window.setTimeout;
-  const setIntervalNative = window.setInterval;
-  const clearTimeoutNative = window.clearTimeout;
-  const clearIntervalNative = window.clearInterval;
-
-  window.setTimeout = (...args) => {
-    const result = setTimeoutNative(...args);
-    timeoutList.push(result);
-    return result;
-  };
-
-  window.setInterval = (...args) => {
-    const result = setIntervalNative(...args);
-    intervalList.push(result);
-    return result;
-  };
-
-  window.clearTimeout = id => {
-    const index = timeoutList.indexOf(id);
-    if (index !== -1) {
-      timeoutList.splice(index, 1);
-    }
-    return clearTimeoutNative(id);
-  };
-
-  window.clearInterval = id => {
-    const index = intervalList.indexOf(id);
-    if (index !== -1) {
-      intervalList.splice(index, 1);
-    }
-    return clearIntervalNative(id);
-  };
-
-  afterEach(function() {
-    // Guard carefully here, because arrow functions can steal our test context
-    // and prevent us from grabbing the test name.
-    const testName = this && this.currentTest && this.currentTest.fullTitle();
-
-    timeoutList.forEach(id => {
-      if (testName) {
-        leftover.push('(timeout)  ' + testName);
-      } else {
-        // When we don't know the test name, also print a note inline to help
-        // with debugging.
-        leftover.push('(timeout)  Unknown test');
-        console.log('clearing leftover timeout');
-      }
-      clearTimeoutNative(id);
-    });
-    intervalList.forEach(id => {
-      if (testName) {
-        leftover.push('(interval) ' + testName);
-      } else {
-        // When we don't know the test name, also print a note inline to help
-        // with debugging.
-        leftover.push('(interval) Unknown test');
-        console.log('clearing leftover interval');
-      }
-      clearIntervalNative(id);
-    });
-    timeoutList = [];
-    intervalList = [];
-  });
-
-  after(() => {
-    console.log('Leftover timeouts/intervals: ' + leftover.length);
-    // Uncomment if you want to see the whole list of leftover timeouts
-    // console.log(leftover.map(s => '    ' + s).join('\n'));
-  });
 }
 
 /**

--- a/apps/test/util/throwOnConsole.js
+++ b/apps/test/util/throwOnConsole.js
@@ -1,0 +1,97 @@
+/**
+ * @file
+ * We include these helpers at the top-level of our test suite, in the entry points, so that
+ * we can detect unexpected uses of console.warn and console.error in all of our tests.
+ * For that reason it's useful to keep these in a separate file and as dependency-free as
+ * possible - please don't add other dependencies to this file unless absolutely necessary.
+ * Thank you!
+ */
+
+import sinon from 'sinon';
+
+/**
+ * We want to be able to have test throw by default on console error/warning, but
+ * also be able to allow these calls in specific tests. This method creates two
+ * functions associated with the given console method (i.e. console.warn and
+ * console.error). The first method - throwEverywhere - causes us to throw any
+ * time the console method in question is called in this test scope. The second
+ * method - allow - overrides that behavior, allowing calls to the console method.
+ */
+function throwOnConsoleEverywhere(methodName) {
+  let throwing = true;
+  let firstInstance = null;
+
+  return {
+    // Method that will stub console[methodName] during each test and throw after
+    // the test completes if it was called.
+    throwEverywhere() {
+      beforeEach(function() {
+        // Stash test title so that we can include it in any errors
+        let testTitle;
+        if (this.currentTest) {
+          testTitle = this.currentTest.title;
+        }
+
+        sinon.stub(console, methodName).callsFake(msg => {
+          const prefix = throwing ? '' : '[ignoring]';
+          console[methodName].wrappedMethod(prefix, msg);
+
+          // Store error so we can throw in after. This will ensure we hit a failure
+          // even if message was originally thrown in async code
+          if (throwing && !firstInstance) {
+            // It seems that format(msg) might be causing calls to console.error itself
+            // Unstub so that those dont go through our stubbed console.error
+            console[methodName].restore();
+
+            firstInstance = new Error(
+              `Call to console.${methodName} from "${testTitle}": ${msg}\n${getStack()}`
+            );
+          }
+        });
+      });
+
+      // After the test, throw an error if we called the console method.
+      afterEach(function() {
+        if (console[methodName].restore) {
+          console[methodName].restore();
+        }
+        if (firstInstance) {
+          throw new Error(firstInstance);
+        }
+        firstInstance = null;
+      });
+    },
+
+    // Method to be called in tests that want console[methodName] to be called without
+    // failure
+    allow() {
+      beforeEach(() => (throwing = false));
+      afterEach(() => (throwing = true));
+    }
+  };
+}
+
+/**
+ * Gets a stack trace for the current location. Phantomjs doesn't add the stack
+ * property unless the exception is thrown, thus we need to throw/catch a generic error.
+ */
+function getStack() {
+  let stack;
+  try {
+    throw new Error();
+  } catch (e) {
+    stack = e.stack;
+  }
+  return stack;
+}
+
+// Create/export methods for both console.error and console.warn
+const consoleErrorFunctions = throwOnConsoleEverywhere('error');
+export const throwOnConsoleErrorsEverywhere =
+  consoleErrorFunctions.throwEverywhere;
+export const allowConsoleErrors = consoleErrorFunctions.allow;
+
+const consoleWarningFunctions = throwOnConsoleEverywhere('warn');
+export const throwOnConsoleWarningsEverywhere =
+  consoleWarningFunctions.throwEverywhere;
+export const allowConsoleWarnings = consoleWarningFunctions.allow;


### PR DESCRIPTION
Pulls utilities used in our test entry points into their own files with minimum dependencies.  In particular, this allows our entry-tests option to build a smaller test bundle in many cases, which means faster builds and less memory overhead.

For example, given the command
```sh
BROWSER=Chrome yarn test:entry --entry test/unit/applab/ChartApiTest.js
```
Before: 21.5 MB
```
Version: webpack 4.29.6
Time: 7405ms
Built at: 2019-04-04 17:03:19
                                                      Asset       Size               Chunks             Chunk Names
blank_sharing_drawingwpae53b62a1609cbbb425574e45b37b837.png   39.2 KiB                       [emitted]  
                       f5e1081deedd64646a3ba3481d41e0e5.svg  714 bytes                       [emitted]  
                                        test/entry-tests.js   21.5 MiB  test/entry-tests.js  [emitted]  test/entry-tests.js

```
After: 13.2 MB
```
Version: webpack 4.29.6
Time: 4769ms
Built at: 2019-04-04 17:00:45
                                                      Asset      Size               Chunks             Chunk Names
blank_sharing_drawingwpae53b62a1609cbbb425574e45b37b837.png  39.2 KiB                       [emitted]  
                                        test/entry-tests.js  13.2 MiB  test/entry-tests.js  [emitted]  test/entry-tests.js

```

I believe the savings are because we're no longer requiring all of the things `testUtils.js` implicitly requires, including React, jQuery, project.js, the asset manager, and an i18n file.

### Testing

I've run entry tests for several test files.  Otherwise, counting on drone to tell me this is okay for all cases.  Next steps: [Rewriting the throwOnConsole.js helpers without sinon!](https://github.com/code-dot-org/code-dot-org/pull/27893)