### PR TITLE
Testing: Even smaller entry bundle sizes

### DIFF
--- a/apps/test/unit/lib/kits/maker/ui/SetupChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/SetupChecklistTest.js
@@ -37,50 +37,44 @@ describe('SetupChecklist', () => {
     after(() => browserChecks.isCodeOrgBrowser.restore());
     after(() => browserChecks.isChromeOS.restore());
 
-    it('renders success', () => {
+    it('renders success', async () => {
       const wrapper = mount(
         <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
       );
       expect(wrapper.find(REDETECT_BUTTON)).to.be.disabled;
       expect(wrapper.find(WAITING_ICON)).to.have.length(4);
-      return yieldUntilDoneDetecting(wrapper).then(() => {
-        expect(wrapper.find(REDETECT_BUTTON)).not.to.be.disabled;
-        expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
-        expect(window.console.error).not.to.have.been.called;
-      });
+      await yieldUntilDoneDetecting(wrapper);
+      expect(wrapper.find(REDETECT_BUTTON)).not.to.be.disabled;
+      expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
+      expect(window.console.error).not.to.have.been.called;
     });
 
     describe('test with expected console.error', () => {
-      it('reloads the page on re-detect if plugin not installed', () => {
+      it('reloads the page on re-detect if plugin not installed', async () => {
         checker.detectChromeAppInstalled.rejects(new Error('not installed'));
         const wrapper = mount(
           <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
         );
-        return yieldUntilDoneDetecting(wrapper).then(() => {
-          expect(wrapper.find(SUCCESS_ICON)).to.have.length(0);
-          expect(wrapper.find(FAILURE_ICON)).to.have.length(1);
-          expect(wrapper.find(WAITING_ICON)).to.have.length(3);
-          wrapper.find(REDETECT_BUTTON).simulate('click');
-          expect(utils.reload).to.have.been.called;
-        });
+        await yieldUntilDoneDetecting(wrapper);
+        expect(wrapper.find(SUCCESS_ICON)).to.have.length(0);
+        expect(wrapper.find(FAILURE_ICON)).to.have.length(1);
+        expect(wrapper.find(WAITING_ICON)).to.have.length(3);
+        wrapper.find(REDETECT_BUTTON).simulate('click');
+        expect(utils.reload).to.have.been.called;
       });
     });
 
-    it('does not reload the page on re-detect if successful', () => {
+    it('does not reload the page on re-detect if successful', async () => {
       const wrapper = mount(
         <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
       );
-      return yieldUntilDoneDetecting(wrapper)
-        .then(() => {
-          expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
-          wrapper.find(REDETECT_BUTTON).simulate('click');
-          expect(wrapper.find(WAITING_ICON)).to.have.length(4);
-        })
-        .then(() => yieldUntilDoneDetecting(wrapper))
-        .then(() => {
-          expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
-          expect(utils.reload).not.to.have.been.called;
-        });
+      await yieldUntilDoneDetecting(wrapper);
+      expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
+      wrapper.find(REDETECT_BUTTON).simulate('click');
+      expect(wrapper.find(WAITING_ICON)).to.have.length(4);
+      await yieldUntilDoneDetecting(wrapper);
+      expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
+      expect(utils.reload).not.to.have.been.called;
     });
   });
 
@@ -90,64 +84,57 @@ describe('SetupChecklist', () => {
     after(() => browserChecks.isCodeOrgBrowser.restore());
     after(() => browserChecks.isChrome.restore());
 
-    it('renders success', () => {
+    it('renders success', async () => {
       const wrapper = mount(
         <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
       );
       expect(wrapper.find(REDETECT_BUTTON)).to.be.disabled;
       expect(wrapper.find(WAITING_ICON)).to.have.length(4);
-      return yieldUntilDoneDetecting(wrapper).then(() => {
-        expect(wrapper.find(REDETECT_BUTTON)).not.to.be.disabled;
-        expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
-        expect(window.console.error).not.to.have.been.called;
-      });
+      await yieldUntilDoneDetecting(wrapper);
+      expect(wrapper.find(REDETECT_BUTTON)).not.to.be.disabled;
+      expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
+      expect(window.console.error).not.to.have.been.called;
     });
 
     describe('test with expected console.error', () => {
-      it('fails if Code.org browser version is wrong', () => {
+      it('fails if Code.org browser version is wrong', async () => {
         const error = new Error('test error');
         checker.detectSupportedBrowser.rejects(error);
         const wrapper = mount(
           <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
         );
         expect(wrapper.find(WAITING_ICON)).to.have.length(4);
-        return yieldUntilDoneDetecting(wrapper).then(() => {
-          expect(wrapper.find(FAILURE_ICON)).to.have.length(1);
-          expect(wrapper.find(WAITING_ICON)).to.have.length(3);
-          expect(window.console.error).to.have.been.calledWith(error);
-        });
+        await yieldUntilDoneDetecting(wrapper);
+        expect(wrapper.find(FAILURE_ICON)).to.have.length(1);
+        expect(wrapper.find(WAITING_ICON)).to.have.length(3);
+        expect(window.console.error).to.have.been.calledWith(error);
       });
 
-      it('reloads the page on re-detect if browser check fails', () => {
+      it('reloads the page on re-detect if browser check fails', async () => {
         checker.detectSupportedBrowser.rejects(new Error('test error'));
         const wrapper = mount(
           <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
         );
-        return yieldUntilDoneDetecting(wrapper).then(() => {
-          expect(wrapper.find(SUCCESS_ICON)).to.have.length(0);
-          expect(wrapper.find(FAILURE_ICON)).to.have.length(1);
-          expect(wrapper.find(WAITING_ICON)).to.have.length(3);
-          wrapper.find(REDETECT_BUTTON).simulate('click');
-          expect(utils.reload).to.have.been.called;
-        });
+        await yieldUntilDoneDetecting(wrapper);
+        expect(wrapper.find(SUCCESS_ICON)).to.have.length(0);
+        expect(wrapper.find(FAILURE_ICON)).to.have.length(1);
+        expect(wrapper.find(WAITING_ICON)).to.have.length(3);
+        wrapper.find(REDETECT_BUTTON).simulate('click');
+        expect(utils.reload).to.have.been.called;
       });
     });
 
-    it('does not reload the page on re-detect if successful', () => {
+    it('does not reload the page on re-detect if successful', async () => {
       const wrapper = mount(
         <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
       );
-      return yieldUntilDoneDetecting(wrapper)
-        .then(() => {
-          expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
-          wrapper.find(REDETECT_BUTTON).simulate('click');
-          expect(wrapper.find(WAITING_ICON)).to.have.length(4);
-        })
-        .then(() => yieldUntilDoneDetecting(wrapper))
-        .then(() => {
-          expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
-          expect(utils.reload).not.to.have.been.called;
-        });
+      await yieldUntilDoneDetecting(wrapper);
+      expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
+      wrapper.find(REDETECT_BUTTON).simulate('click');
+      expect(wrapper.find(WAITING_ICON)).to.have.length(4);
+      await yieldUntilDoneDetecting(wrapper);
+      expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
+      expect(utils.reload).not.to.have.been.called;
     });
   });
 

--- a/apps/test/unit/lib/kits/maker/ui/SetupChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/SetupChecklistTest.js
@@ -22,10 +22,12 @@ describe('SetupChecklist', () => {
 
   beforeEach(() => {
     sinon.stub(utils, 'reload');
+    sinon.stub(window.console, 'error');
     checker = new StubSetupChecker();
   });
 
   afterEach(() => {
+    window.console.error.restore();
     utils.reload.restore();
   });
 
@@ -49,9 +51,6 @@ describe('SetupChecklist', () => {
     });
 
     describe('test with expected console.error', () => {
-      // Allow console.error calls and squelch actual logging
-      beforeEach(() => console.error.reset());
-
       it('reloads the page on re-detect if plugin not installed', () => {
         checker.detectChromeAppInstalled.rejects(new Error('not installed'));
         const wrapper = mount(
@@ -105,9 +104,6 @@ describe('SetupChecklist', () => {
     });
 
     describe('test with expected console.error', () => {
-      // Allow console.error calls and squelch actual logging
-      beforeEach(() => console.error.reset());
-
       it('fails if Code.org browser version is wrong', () => {
         const error = new Error('test error');
         checker.detectSupportedBrowser.rejects(error);

--- a/apps/test/unit/lib/kits/maker/ui/SetupChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/SetupChecklistTest.js
@@ -1,7 +1,7 @@
 /** @file Test SetupChecklist component */
 import React from 'react';
 import sinon from 'sinon';
-import {expect} from '../../../../../util/configuredChai';
+import {expect} from '../../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import * as utils from '@cdo/apps/utils';
 import * as browserChecks from '@cdo/apps/lib/kits/maker/util/browserChecks';

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -954,9 +954,11 @@ describe('teacherSectionsRedux', () => {
     beforeEach(function() {
       // Stub server responses
       server = sinon.fakeServer.create();
+      sinon.stub(console, 'error');
     });
 
     afterEach(function() {
+      console.error.restore();
       server.restore();
     });
 
@@ -989,7 +991,6 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('sets asyncLoadComplete to true after first failure response', () => {
-      console.error.reset(); // Already stubbed in tests
       const promise = store.dispatch(asyncLoadSectionData());
 
       server.respondWith('GET', '/dashboardapi/sections', failureResponse);


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/27892. Implements the throwOnConsole helpers without using `sinon` to avoid pulling sinon in as a dependency unless a test specifically requests it.

### Example

Given the command
```sh
BROWSER=Chrome yarn test:entry --entry test/unit/applab/ChartApiTest.js
```
Before: 13.2 MB
```
Version: webpack 4.29.6
Time: 4769ms
Built at: 2019-04-04 17:00:45
                                                      Asset      Size               Chunks             Chunk Names
blank_sharing_drawingwpae53b62a1609cbbb425574e45b37b837.png  39.2 KiB                       [emitted]  
                                        test/entry-tests.js  13.2 MiB  test/entry-tests.js  [emitted]  test/entry-tests.js

```
After: 10.7 MB
```
Version: webpack 4.29.6
Time: 5495ms
Built at: 2019-04-04 17:13:13
                                                      Asset      Size               Chunks             Chunk Names
blank_sharing_drawingwpae53b62a1609cbbb425574e45b37b837.png  39.2 KiB                       [emitted]  
                                        test/entry-tests.js  10.7 MiB  test/entry-tests.js  [emitted]  test/entry-tests.js

```

### Testing
Introduced an intentional `console.error` call in a test to check that this functionality is still working:
```
SUMMARY:
✔ 6 tests completed
✖ 1 test failed

FAILED TESTS:
  entry tests
    ✖ "after each" hook for "only contains supported types"
      Chrome 73.0.3683 (Linux 0.0.0)
    Error: Call to console.error from "only contains supported types": Fail intentionally!
    Error
        at getStack (webpack:///test/util/throwOnConsole.js:86:10 <- test/entry-tests.js:101766:11)
        at console.(anonymous function) (webpack:///test/util/throwOnConsole.js:47:76 <- test/entry-tests.js:101727:118)
        at Context.<anonymous> (webpack:///test/unit/applab/ChartApiTest.js:74:14 <- test/entry-tests.js:101277:15)
    Error: Error: Call to console.error from "only contains supported types": Fail intentionally!
    Error
        at getStack (webpack:///test/util/throwOnConsole.js:86:10 <- test/entry-tests.js:101766:11)
        at console.(anonymous function) (webpack:///test/util/throwOnConsole.js:47:76 <- test/entry-tests.js:101727:118)
        at Context.<anonymous> (webpack:///test/unit/applab/ChartApiTest.js:74:14 <- test/entry-tests.js:101277:15)
        at Context.<anonymous> (webpack:///test/util/throwOnConsole.js:60:16 <- test/entry-tests.js:101739:17)
```

### Next steps
Reviewing the remaining contents of the bundle, one medium-sized win is not using `chai-enzyme` at all - it causes us to include `enzyme` and `ReactDOM`, even though we're not testing anything React-related at all.  Dropping it cuts the bundle size by another ~25%, below the point where Webpack stops reporting bundle sizes by default. :grin: