### PR TITLE
PL: regional partner gets application priority deadline date field

### DIFF
--- a/dashboard/app/controllers/regional_partners_controller.rb
+++ b/dashboard/app/controllers/regional_partners_controller.rb
@@ -58,10 +58,16 @@ class RegionalPartnersController < ApplicationController
       %w(teacher facilitator).each do |role|
         %w(open close).each do |state|
           key = "apps_#{state}_date_#{course}_#{role}".to_sym
-          update_params[key] == Date.parse(regional_partner_params[key]) if regional_partner_params[key].presence
+
+          # Do a date validation.  An exception will result if invalid.
+          Date.parse(regional_partner_params[key]) if regional_partner_params[key].presence
         end
       end
     end
+
+    # Do a date validation.  An exception will result if invalid.
+    Date.parse(regional_partner_params[:apps_priority_deadline_date]) if regional_partner_params[:apps_priority_deadline_date].presence
+
     if @regional_partner.update(update_params)
       flash[:notice] = "Regional Partner updated successfully"
       redirect_to @regional_partner
@@ -121,6 +127,7 @@ class RegionalPartnersController < ApplicationController
       apps_close_date_csd_facilitator
       apps_close_date_csp_teacher
       apps_close_date_csp_facilitator
+      apps_priority_deadline_date
       applications_principal_approval
       applications_decision_emails
       link_to_partner_application

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -55,6 +55,7 @@ class RegionalPartner < ActiveRecord::Base
     apps_close_date_csd_facilitator
     apps_close_date_csp_teacher
     apps_close_date_csp_facilitator
+    apps_priority_deadline_date
     applications_principal_approval
     applications_decision_emails
     link_to_partner_application

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -29,6 +29,9 @@
         = f.label nil, "Apps Close Date for #{course.upcase} #{role} (YYYY-MM-DD)"
         = f.text_field "apps_close_date_#{course}_#{role}".to_sym
   .field
+    = f.label nil, "Apps Priority Deadline Date (YYYY-MM-DD)"
+    = f.text_field :apps_priority_deadline_date
+  .field
     = f.label nil, "Applications Principal Approval"
     .applications_principal_approval
       %label

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -30,6 +30,9 @@
         %strong
           = "Apps #{state} date for #{course.upcase} #{role.pluralize}"
         = @regional_partner.send("apps_#{state}_date_#{course}_#{role}".to_sym)
+%p
+  %strong Apps Priority Deadline Date
+  = @regional_partner.apps_priority_deadline_date
 - %w(csd csp).each do |course|
   %p
     %strong


### PR DESCRIPTION
As well as adding a new property to `RegionalPartner`, this change adds support for the field when showing or editing a regional partner.

This uncovered one existing issue: it appears that when editing a regional partner, the intention was for the various date properties to be parsed and written, except that there was a typo [here](https://github.com/code-dot-org/code-dot-org/blob/a494c8d50a8fdf38b16961e2bf9f8d711bd62fdf/dashboard/app/controllers/regional_partners_controller.rb#L61).  As a result, the code has been validating dates (throwing an exception if invalid) but actually just writing the non-parsed date as it was originally typed in.  As it happens, the date comparison code [here](https://github.com/code-dot-org/code-dot-org/blob/a494c8d50a8fdf38b16961e2bf9f8d711bd62fdf/dashboard/app/models/regional_partner.rb#L87-L98) works regardless of his parsing.  In the interests of maintaining data format consistency, this change removes the typo, and doesn't change the way we store the dates, but still executes a date parse so that an exception continues to be thrown for an invalid date.

## Showing a regional partner
![Screenshot 2019-04-05 11 54 37](https://user-images.githubusercontent.com/2205926/55597789-0eb80880-579b-11e9-8f20-b2b7bb809354.png)

## Editing a regional partner
![Screenshot 2019-04-05 11 55 12](https://user-images.githubusercontent.com/2205926/55597790-0f509f00-579b-11e9-894e-32471a733038.png)
