### PR TITLE
Minor fixes for CSF emails

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
@@ -35,7 +35,7 @@
   and your feedback helps us build the experience that teachers have in the future!
 
 %p
-  %a{href:"https://studio.code.org/home",
+  %a{href: @survey_url,
     style: 'width: 240px; height: 36px; border: 0; color: white; background-color: #FDC62C; font: bolder 18px Arial; display: block; text-align: center; line-height: 36px; text-decoration: none; border-radius: 5px;'}
     Take the 5 minute survey
 

--- a/dashboard/app/views/pd/workshop_mailer/workshop_details/_csf.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/workshop_details/_csf.html.haml
@@ -1,6 +1,6 @@
 %ol
-  %li
-    - if @workshop.subject == Pd::Workshop::SUBJECT_CSF_101
+  - if @workshop.subject == Pd::Workshop::SUBJECT_CSF_101
+    %li
       Sign up for a
       = link_to 'teacher account', 'http://learn.code.org/users/sign_up?user%5Buser_type%5D=teacher'
       at Code.org if you don’t already have one.


### PR DESCRIPTION
- Fix line item in CSF 201 confirmation email. 
- Fix survey link in orange box so it matches other survey link in exit email. This applies to CSD/CSP emails also (confirmed with Jordyn)