### PR TITLE
Top Instructions CSP: Eyes Test

### DIFF
--- a/dashboard/test/ui/features/instructions/csp_top_instructions_eyes.feature
+++ b/dashboard/test/ui/features/instructions/csp_top_instructions_eyes.feature
@@ -8,12 +8,20 @@ Scenario: CSD and CSP Top Instructions
   And I wait for the page to fully load
   Then I see no difference for "teacher in applab level with rubric"
   Then I click selector ".uitest-feedback"
+  And I wait for the page to fully load
   Then I see no difference for "teacher in applab level viewing rubric"
   Then I click selector ".uitest-instructionsTab"
+  And I wait for the page to fully load
   Then I see no difference for "teacher in applab level with rubric after viewing rubric"
 
   And I am on "http://studio.code.org/s/allthethings/stage/38/puzzle/2?enableExperiments=2019-mini-rubric"
-  And I wait to see ".uitest-feedback"
+  And I wait until element ".user_menu" is visible
+  And I wait until element "iframe" is visible
+  And I switch to the first iframe
+  And I wait to see "#bramble"
+  And I switch to the first iframe
+  And I wait to see "#editor-holder"
+  And I switch to the default content
   Then I see no difference for "teacher in weblab level with rubric"
   Then I click selector ".uitest-feedback"
   Then I see no difference for "teacher in weblab level viewing rubric"

--- a/dashboard/test/ui/features/instructions/csp_top_instructions_eyes.feature
+++ b/dashboard/test/ui/features/instructions/csp_top_instructions_eyes.feature
@@ -8,10 +8,8 @@ Scenario: CSD and CSP Top Instructions
   And I wait for the page to fully load
   Then I see no difference for "teacher in applab level with rubric"
   Then I click selector ".uitest-feedback"
-  And I wait for the page to fully load
   Then I see no difference for "teacher in applab level viewing rubric"
   Then I click selector ".uitest-instructionsTab"
-  And I wait for the page to fully load
   Then I see no difference for "teacher in applab level with rubric after viewing rubric"
 
   And I am on "http://studio.code.org/s/allthethings/stage/38/puzzle/2?enableExperiments=2019-mini-rubric"
@@ -19,6 +17,7 @@ Scenario: CSD and CSP Top Instructions
   And I wait until element "iframe" is visible
   And I switch to the first iframe
   And I wait to see "#bramble"
+  And I wait until element "iframe" is visible
   And I switch to the first iframe
   And I wait to see "#editor-holder"
   And I switch to the default content

--- a/dashboard/test/ui/features/weblab.feature
+++ b/dashboard/test/ui/features/weblab.feature
@@ -9,3 +9,6 @@ Scenario: Web Lab iframe contents loads
   And I wait until element "iframe" is visible
   And I switch to the first iframe
   Then I wait to see "#bramble"
+  And I wait until element "iframe" is visible
+  And I switch to the first iframe
+  Then I wait to see "#editor-holder"


### PR DESCRIPTION
We were not waiting for the code area of a web lab level to fully load before taking the eyes capture which was causing the test to be flaky. This will fix that problem by waiting for the editor area in web lab to fully load before capturing the screen.

Also update the weblab.feature test to drill one level deeper in the iframes to really make sure web lab loads.