### PR TITLE
Scroll elements into view before typing into element input

### DIFF
--- a/dashboard/test/ui/features/pd/regional_partner_mini_contact.feature
+++ b/dashboard/test/ui/features/pd/regional_partner_mini_contact.feature
@@ -18,6 +18,7 @@ Scenario: Teacher submits inline mini-contact form after adding zip
   And I wait until element "#regional-partner-mini-contact-error-zip" is visible
 
   # Submit again with the ZIP.
+  Given I scroll the "#zip" element into view
   And I press keys "90210" for element "#zip"
   And I press "#submit" using jQuery
   And I wait until element "#regional-partner-mini-contact-thanks-middle-high" is visible
@@ -30,6 +31,7 @@ Scenario: Teacher submits inline mini-contact form after adding zip and email
   And I wait until element "#regional-partner-mini-contact-form-middle-high" is visible
 
   # Let's clear out the email to make sure that it's required.
+  Given I scroll the "#email" element into view
   And I press backspace to clear element "#email"
   And I press "#submit" using jQuery
 
@@ -38,6 +40,7 @@ Scenario: Teacher submits inline mini-contact form after adding zip and email
   And element "#regional-partner-mini-contact-error-email" is visible
 
   # Submit again with a ZIP and an email.
+  Given I scroll the "#zip" element into view
   And I press keys "90210" for element "#zip"
   And I press keys "test-email@code.org" for element "#email"
   And I press "#submit" using jQuery
@@ -58,6 +61,7 @@ Scenario: Signed-out user submits pop-up mini-contact form after adding zip and 
   And element "#regional-partner-mini-contact-error-email" is visible
 
   # Submit again with a ZIP and an email.
+  Given I scroll the "#zip" element into view
   And I press keys "90210" for element "#zip"
   And I press keys "test-email@code.org" for element "#email"
   And I press "#submit" using jQuery


### PR DESCRIPTION
On #27868, an unrelated PR, I'm seeing a consistent failure (locally and on drone) in `pd/regional_partner_mini_contact.feature`: [S3 logs](https://cucumber-logs.s3.amazonaws.com/circle/625/ChromeLatestWin7_pd_regional_partner_mini_contact_output.html?versionId=GT3V0nth7qmv.z2pmLEpTIJsQVMu7jfV)

The failure is happening at steps where we are typing into text input elements, and it fails because the element is not "interactable". 

Adding a step to scroll to the input element before typing into it fixes the problem on my end, although I'm still confused as to why this issue is only happening on my PR.