### PR TITLE
allow blank properties_encryption_key in test env

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -217,7 +217,7 @@ class Level < ActiveRecord::Base
       end
     rescue Encryption::KeyMissingError
       # developers and adhoc environments must be able to seed levels without properties_encryption_key
-      raise unless rack_env?(:development) || rack_env?(:adhoc)
+      raise unless [:development, :test, :adhoc].include? rack_env
       puts "WARNING: level '#{name}' not seeded properly due to missing CDO.properties_encryption_key"
     end
     hash


### PR DESCRIPTION
developers and contributors need to be able to run `RAILS_ENV=test rake seed:all`. this lets them do it without defining `CDO.properties_encryption_key`.