### PR TITLE
fix match images in level groups

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -662,8 +662,8 @@ module LevelsHelper
     string_or_image(level.type.underscore, text, level)
   end
 
-  def match_t(text)
-    string_or_image('match', text)
+  def match_t(text, source_level = nil)
+    string_or_image('match', text, source_level)
   end
 
   def level_title

--- a/dashboard/app/views/levels/_match_answer.html.haml
+++ b/dashboard/app/views/levels/_match_answer.html.haml
@@ -6,9 +6,9 @@
       .column
         %ul#questions
           - level.questions.each do |question|
-            %li{style: "height: #{level.height}px"}!= match_t(question['text'])
+            %li{style: "height: #{level.height}px"}!= match_t(question['text'], level)
       .column#answerdest
         %ul#answers
           - level.answers.each do |answer|
-            %li.answer.answerlist{style: "height: #{level.height}px"}!= match_t(answer['text'])
+            %li.answer.answerlist{style: "height: #{level.height}px"}!= match_t(answer['text'], level)
       .clear

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -17,7 +17,7 @@
     .column
       %ul#questions
         - level.questions.each do |question|
-          %li{style: "height: #{level.height}px"}!= match_t(question['text'])
+          %li{style: "height: #{level.height}px"}!= match_t(question['text'], level)
     .column#answerdest
       %ul#slots.draggablecolumn
         - level.answers.each do |_|
@@ -37,7 +37,7 @@
     .column
       %ul#answers.draggablecolumn
         - level.shuffled_indexed_answers.each do |answer|
-          %li.answer.answerlist{style: "height: #{level.height}px", originalIndex: answer['index']}!= match_t(answer['text'])
+          %li.answer.answerlist{style: "height: #{level.height}px", originalIndex: answer['index']}!= match_t(answer['text'], level)
 
     .clear
   - if standalone


### PR DESCRIPTION
previously, https://github.com/code-dot-org/code-dot-org/pull/27294 got match levels to display in level groups. however, when question/answer contained images, the images were broken. this PR makes these images show up properly:

| before | after |
|------|------|
| ![localhost-studio code org_3000_s_csd1-2018_lockable_1_puzzle_1_page_1 (2)](https://user-images.githubusercontent.com/8001765/55674599-89e8ef80-586b-11e9-89b5-ec455cc75a39.png) | ![localhost-studio code org_3000_s_csd1-2018_lockable_1_puzzle_1_page_1 (3)](https://user-images.githubusercontent.com/8001765/55674601-8eada380-586b-11e9-970f-bcb2e795a3ce.png) |

### testing

there is basically no testing on match levels in level groups, which is ok because we haven't started putting match levels inside level groups yet. UI tests will come once they are fully working. existing tests make sure that this doesn't break normal match levels.