### PR TITLE
only increase read/open timeouts in slow browsers

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -50,7 +50,10 @@ def saucelabs_browser(test_run_name)
       http_client = Selenium::WebDriver::Remote::Http::Persistent.new
 
       # Longer overall timeout, because iOS takes more time. This must be set before initializing Selenium::WebDriver.
-      http_client.timeout = 5.minutes
+      if slow_browser?
+        http_client.read_timeout = 5.minutes
+        http_client.open_timeout = 5.minutes
+      end
 
       browser = Selenium::WebDriver.for(:remote,
         url: url,


### PR DESCRIPTION
Improve stability/fail faster in other browser tests.

Also, split [now-deprecated](https://github.com/SeleniumHQ/selenium/commit/1e60e34c54e48c27b55d0040d340f1ed4dfabf20) `#timeout=` into `#read_timeout` and `#open_timeout`.

Fixes [`XTEAM-140`](https://codedotorg.atlassian.net/browse/XTEAM-140).