### PR TITLE
PL: Regional partner search gets info about priority deadline dates

### DIFF
--- a/apps/src/templates/Notification.jsx
+++ b/apps/src/templates/Notification.jsx
@@ -158,6 +158,9 @@ class Notification extends Component {
       })
     ),
 
+    // Optionally can provide children, such as one or more buttons.
+    children: PropTypes.node,
+
     // Can be specified to override default width
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
   };
@@ -280,6 +283,7 @@ class Notification extends Component {
                     className={button.className}
                   />
                 ))}
+              {this.props.children}
             </div>
           </div>
           {dismissible && (

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -81,7 +81,8 @@ const styles = {
   },
   bigButton: {
     padding: '10px 20px 10px 20px',
-    height: 'initial'
+    height: 'initial',
+    marginTop: 22
   },
   clear: {
     clear: 'both'
@@ -500,24 +501,29 @@ const StartApplicationButton = ({
     ? "Apply on partner's site"
     : 'Start application';
 
-  const notificationText = priorityDeadlineDate
-    ? `Priority deadline for your region is ${priorityDeadlineDate}. Sign up now to reserve your space!`
-    : 'We still have spaces at your local workshop! It’s not too late to sign up.';
+  let notificationHeading, notificationText;
+  if (priorityDeadlineDate) {
+    notificationHeading = `Priority deadline for your region is ${priorityDeadlineDate}`;
+    notificationText = 'Sign up now to reserve your space!';
+  } else {
+    notificationHeading = 'We still have spaces at your local workshop!';
+    notificationText = 'It’s not too late to sign up.';
+  }
 
   return (
     <div>
       <Notification
         type="information"
-        notice=""
+        notice={notificationHeading}
         details={notificationText}
         dismissible={false}
-      />
-
-      <a className={className} id={id} target={target} href={link}>
-        <button type="button" style={styles.bigButton}>
-          {buttonText}
-        </button>
-      </a>
+      >
+        <a className={className} id={id} target={target} href={link}>
+          <button type="button" style={styles.bigButton}>
+            {buttonText}
+          </button>
+        </a>
+      </Notification>
     </div>
   );
 };

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -313,7 +313,7 @@ class RegionalPartnerSearch extends Component {
               {appState === WorkshopApplicationStates.currently_open &&
                 !partnerInfo.link_to_partner_application && (
                   <StartApplicationButton
-                    class="professional_learning_link"
+                    className="professional_learning_link"
                     id={`id-${partnerInfo.id}`}
                     nominated={this.state.nominated}
                     priorityDeadlineDate={appsPriorityDeadlineDate}
@@ -323,7 +323,7 @@ class RegionalPartnerSearch extends Component {
               {appState === WorkshopApplicationStates.currently_open &&
                 partnerInfo.link_to_partner_application && (
                   <StartApplicationButton
-                    class="professional_learning_link"
+                    className="professional_learning_link"
                     id={`id-${partnerInfo.id}`}
                     link={partnerInfo.link_to_partner_application}
                     partnerSite={true}
@@ -456,7 +456,7 @@ class RegionalPartnerSearch extends Component {
             {appState === WorkshopApplicationStates.currently_open &&
               !partnerInfo.link_to_partner_application && (
                 <StartApplicationButton
-                  class="professional_learning_link"
+                  className="professional_learning_link"
                   id={`id-${partnerInfo.id}`}
                   nominated={this.state.nominated}
                   priorityDeadlineDate={appsPriorityDeadlineDate}
@@ -466,7 +466,7 @@ class RegionalPartnerSearch extends Component {
             {appState === WorkshopApplicationStates.currently_open &&
               partnerInfo.link_to_partner_application && (
                 <StartApplicationButton
-                  class="professional_learning_link"
+                  className="professional_learning_link"
                   id={`id-${partnerInfo.id}`}
                   link={partnerInfo.link_to_partner_application}
                   partnerSite={true}

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -5,6 +5,7 @@ import {
   WorkshopSearchErrors
 } from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import {RegionalPartnerMiniContactPopupLink} from '@cdo/apps/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact';
+import Notification from '@cdo/apps/templates/Notification';
 import * as color from '../util/color';
 import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
@@ -215,11 +216,9 @@ class RegionalPartnerSearch extends Component {
     const appState = partnerInfo && partnerInfo.application_state.state;
     const appsOpenDate =
       partnerInfo && partnerInfo.application_state.earliest_open_date;
-
-    let applicationLink = studio('/pd/application/teacher');
-    if (this.state.nominated) {
-      applicationLink += '?nominated=true';
-    }
+    const appsPriorityDeadlineDate =
+      partnerInfo &&
+      partnerInfo.application_state.upcoming_priority_deadline_date;
 
     return (
       <div>
@@ -245,11 +244,10 @@ class RegionalPartnerSearch extends Component {
             <div>
               We are unable to find this ZIP code. You can still apply directly:
             </div>
-            <a href={applicationLink}>
-              <button type="button" style={styles.bigButton}>
-                Start application
-              </button>
-            </a>
+            <StartApplicationButton
+              nominated={this.state.nominated}
+              priorityDeadlineDate={appsPriorityDeadlineDate}
+            />
           </div>
         )}
 
@@ -299,11 +297,10 @@ class RegionalPartnerSearch extends Component {
                 </a>{' '}
                 for other Professional Development options in your area.
               </p>
-              <a href={applicationLink}>
-                <button type="button" style={styles.bigButton}>
-                  Start application
-                </button>
-              </a>
+              <StartApplicationButton
+                nominated={this.state.nominated}
+                priorityDeadlineDate={appsPriorityDeadlineDate}
+              />
             </div>
           </div>
         )}
@@ -315,29 +312,24 @@ class RegionalPartnerSearch extends Component {
             <div style={styles.action}>
               {appState === WorkshopApplicationStates.currently_open &&
                 !partnerInfo.link_to_partner_application && (
-                  <a
-                    className="professional_learning_link"
+                  <StartApplicationButton
+                    class="professional_learning_link"
                     id={`id-${partnerInfo.id}`}
-                    href={applicationLink}
-                  >
-                    <button type="button" style={styles.bigButton}>
-                      Start application
-                    </button>
-                  </a>
+                    nominated={this.state.nominated}
+                    priorityDeadlineDate={appsPriorityDeadlineDate}
+                  />
                 )}
 
               {appState === WorkshopApplicationStates.currently_open &&
                 partnerInfo.link_to_partner_application && (
-                  <a
-                    className="professional_learning_link"
+                  <StartApplicationButton
+                    class="professional_learning_link"
                     id={`id-${partnerInfo.id}`}
-                    href={partnerInfo.link_to_partner_application}
-                    target="_blank"
-                  >
-                    <button type="button" style={styles.bigButton}>
-                      Apply on partner's site
-                    </button>
-                  </a>
+                    link={partnerInfo.link_to_partner_application}
+                    partnerSite={true}
+                    nominated={this.state.nominated}
+                    priorityDeadlineDate={appsPriorityDeadlineDate}
+                  />
                 )}
             </div>
 
@@ -463,29 +455,24 @@ class RegionalPartnerSearch extends Component {
             {/* These two links duplicate the buttons that appear above. */}
             {appState === WorkshopApplicationStates.currently_open &&
               !partnerInfo.link_to_partner_application && (
-                <a
-                  className="professional_learning_link"
+                <StartApplicationButton
+                  class="professional_learning_link"
                   id={`id-${partnerInfo.id}`}
-                  href={applicationLink}
-                >
-                  <button type="button" style={styles.bigButton}>
-                    Start application
-                  </button>
-                </a>
+                  nominated={this.state.nominated}
+                  priorityDeadlineDate={appsPriorityDeadlineDate}
+                />
               )}
 
             {appState === WorkshopApplicationStates.currently_open &&
               partnerInfo.link_to_partner_application && (
-                <a
-                  className="professional_learning_link"
+                <StartApplicationButton
+                  class="professional_learning_link"
                   id={`id-${partnerInfo.id}`}
-                  href={partnerInfo.link_to_partner_application}
-                  target="_blank"
-                >
-                  <button type="button" style={styles.bigButton}>
-                    Apply on partner's site
-                  </button>
-                </a>
+                  link={partnerInfo.link_to_partner_application}
+                  partnerSite={true}
+                  nominated={this.state.nominated}
+                  priorityDeadlineDate={appsPriorityDeadlineDate}
+                />
               )}
           </div>
         )}
@@ -493,6 +480,56 @@ class RegionalPartnerSearch extends Component {
     );
   }
 }
+
+const StartApplicationButton = ({
+  className,
+  id,
+  link,
+  partnerSite,
+  nominated,
+  priorityDeadlineDate
+}) => {
+  if (!link) {
+    link = studio('/pd/application/teacher');
+    if (nominated) {
+      link += '?nominated=true';
+    }
+  }
+  const target = partnerSite ? '_blank' : null;
+  const buttonText = partnerSite
+    ? "Apply on partner's site"
+    : 'Start application';
+
+  const notificationText = priorityDeadlineDate
+    ? `Priority deadline for your region is ${priorityDeadlineDate}. Sign up now to reserve your space!`
+    : 'We still have spaces at your local workshop! It’s not too late to sign up.';
+
+  return (
+    <div>
+      <Notification
+        type="information"
+        notice=""
+        details={notificationText}
+        dismissible={false}
+      />
+
+      <a className={className} id={id} target={target} href={link}>
+        <button type="button" style={styles.bigButton}>
+          {buttonText}
+        </button>
+      </a>
+    </div>
+  );
+};
+
+StartApplicationButton.propTypes = {
+  className: PropTypes.string,
+  id: PropTypes.string,
+  link: PropTypes.string,
+  partnerSite: PropTypes.bool,
+  nominated: PropTypes.bool,
+  priorityDeadlineDate: PropTypes.string
+};
 
 export default connect(state => ({
   responsiveSize: state.responsive.responsiveSize

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -99,6 +99,11 @@ class RegionalPartner < ActiveRecord::Base
     end
   end
 
+  # If there is a priority deadline date and it is still upcoming, then return it.  Otherwise return nil.
+  def upcoming_priority_deadline_date
+    apps_priority_deadline_date ? Date.parse(apps_priority_deadline_date).strftime('%B %e, %Y') : nil
+  end
+
   def summer_workshops_earliest_apps_open_date
     if apps_open_date_csd_teacher || apps_open_date_csp_teacher
       Date.parse([apps_open_date_csd_teacher, apps_open_date_csp_teacher].compact.min).strftime('%B %e, %Y')

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -101,7 +101,11 @@ class RegionalPartner < ActiveRecord::Base
 
   # If there is a priority deadline date and it is still upcoming, then return it.  Otherwise return nil.
   def upcoming_priority_deadline_date
-    apps_priority_deadline_date ? Date.parse(apps_priority_deadline_date).strftime('%B %e, %Y') : nil
+    if apps_priority_deadline_date && apps_priority_deadline_date > Time.zone.now
+      Date.parse(apps_priority_deadline_date).strftime('%B %e, %Y')
+    else
+      nil
+    end
   end
 
   def summer_workshops_earliest_apps_open_date

--- a/dashboard/app/serializers/api/v1/pd/regional_partner_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/regional_partner_serializer.rb
@@ -8,7 +8,8 @@ class Api::V1::Pd::RegionalPartnerSerializer < ActiveModel::Serializer
   def application_state
     {
       state: object.summer_workshops_application_state,
-      earliest_open_date: object.summer_workshops_earliest_apps_open_date
+      earliest_open_date: object.summer_workshops_earliest_apps_open_date,
+      upcoming_priority_deadline_date: object.upcoming_priority_deadline_date
     }
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1017,10 +1017,10 @@ FactoryGirl.define do
     contact_name "Contact Name"
     contact_email "contact@code.org"
     group 1
-    apps_open_date_csp_teacher {Date.today - 1.day}
-    apps_open_date_csd_teacher {Date.today - 2.days}
-    apps_close_date_csp_teacher {Date.today + 3.days}
-    apps_close_date_csd_teacher {Date.today + 4.days}
+    apps_open_date_csp_teacher {Date.current - 1.day}
+    apps_open_date_csd_teacher {Date.current - 2.days}
+    apps_close_date_csp_teacher {Date.current + 3.days}
+    apps_close_date_csd_teacher {Date.current + 4.days}
     csd_cost 10
     csp_cost 12
     cost_scholarship_information "Additional scholarship information will be here."

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1017,15 +1017,19 @@ FactoryGirl.define do
     contact_name "Contact Name"
     contact_email "contact@code.org"
     group 1
-    apps_open_date_csp_teacher {Date.current - 1.day}
-    apps_open_date_csd_teacher {Date.current - 2.days}
-    apps_close_date_csp_teacher {Date.current + 3.days}
-    apps_close_date_csd_teacher {Date.current + 4.days}
+    apps_open_date_csp_teacher {(Date.current - 1.day).strftime("%Y-%m-%d")}
+    apps_open_date_csd_teacher {(Date.current - 2.days).strftime("%Y-%m-%d")}
+    apps_close_date_csp_teacher {(Date.current + 3.days).strftime("%Y-%m-%d")}
+    apps_close_date_csd_teacher {(Date.current + 4.days).strftime("%Y-%m-%d")}
     csd_cost 10
     csp_cost 12
     cost_scholarship_information "Additional scholarship information will be here."
     additional_program_information "Additional program information will be here."
     pd_workshops {[create(:pd_workshop, :local_summer_workshop_upcoming, location_name: "Training building", location_address: "3 Smith Street")]}
+
+    trait :with_apps_priority_deadline_date do
+      apps_priority_deadline_date {(Date.current + 5.days).strftime("%Y-%m-%d")}
+    end
   end
 
   factory :regional_partner_program_manager do

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
     trait :local_summer_workshop_upcoming do
       local_summer_workshop
       num_sessions 5
-      sessions_from {Date.today + 3.months}
+      sessions_from {Date.current + 3.months}
     end
     trait :fit do
       course Pd::Workshop::COURSE_CSP
@@ -29,7 +29,7 @@ FactoryGirl.define do
     transient do
       num_sessions 0
       num_facilitators 0
-      sessions_from {Date.today + 9.hours} # Start time of the first session, then one per day after that.
+      sessions_from {Date.current + 9.hours} # Start time of the first session, then one per day after that.
       each_session_hours 6
       num_enrollments 0
       enrolled_and_attending_users 0
@@ -97,6 +97,7 @@ FactoryGirl.define do
     mappings {[create(:pd_regional_partner_mapping, state: "AL")]}
     cost_scholarship_information "Some **important** information about scholarships."
     additional_program_information "And some _additional_ program information."
+    apps_priority_deadline_date {(Date.current + 5.days).strftime("%Y-%m-%d")}
   end
 
   factory :regional_partner_illinois, parent: :regional_partner_with_summer_workshops do
@@ -108,10 +109,10 @@ FactoryGirl.define do
 
   factory :regional_partner_kentucky, parent: :regional_partner_with_summer_workshops do
     # Applications are closed.
-    apps_open_date_csp_teacher {Date.today - 5.days}
-    apps_open_date_csd_teacher {Date.today - 6.days}
-    apps_close_date_csp_teacher {Date.today - 2.days}
-    apps_close_date_csd_teacher {Date.today - 3.days}
+    apps_open_date_csp_teacher {(Date.current - 5.days).strftime("%Y-%m-%d")}
+    apps_open_date_csd_teacher {(Date.current - 6.days).strftime("%Y-%m-%d")}
+    apps_close_date_csp_teacher {(Date.current - 2.days).strftime("%Y-%m-%d")}
+    apps_close_date_csd_teacher {(Date.current - 3.days).strftime("%Y-%m-%d")}
     mappings {[create(:pd_regional_partner_mapping, state: "KY")]}
   end
 
@@ -129,19 +130,19 @@ FactoryGirl.define do
 
   factory :regional_partner_oregon, parent: :regional_partner_with_summer_workshops do
     # Opening at a specific date in the future.
-    apps_open_date_csp_teacher {Date.today + 5.days}
-    apps_open_date_csd_teacher {Date.today + 6.days}
-    apps_close_date_csp_teacher {Date.today + 14.days}
-    apps_close_date_csd_teacher {Date.today + 15.days}
+    apps_open_date_csp_teacher {(Date.current + 5.days).strftime("%Y-%m-%d")}
+    apps_open_date_csd_teacher {(Date.current + 6.days).strftime("%Y-%m-%d")}
+    apps_close_date_csp_teacher {(Date.current + 14.days).strftime("%Y-%m-%d")}
+    apps_close_date_csd_teacher {(Date.current + 15.days).strftime("%Y-%m-%d")}
     mappings {[create(:pd_regional_partner_mapping, state: "OR")]}
   end
 
   factory :regional_partner_wyoming, parent: :regional_partner_with_summer_workshops do
     # CSD dates but no CSP dates.
     apps_open_date_csp_teacher nil
-    apps_open_date_csd_teacher {Date.today + 6.days}
+    apps_open_date_csd_teacher {(Date.current + 6.days).strftime("%Y-%m-%d")}
     apps_close_date_csp_teacher nil
-    apps_close_date_csd_teacher {Date.today + 15.days}
+    apps_close_date_csd_teacher {(Date.current + 15.days).strftime("%Y-%m-%d")}
     mappings {[create(:pd_regional_partner_mapping, state: "WY")]}
   end
 
@@ -161,7 +162,7 @@ FactoryGirl.define do
       duration_hours 6
     end
     association :workshop, factory: :pd_workshop
-    start {Date.today + 9.hours}
+    start {Date.current + 9.hours}
     self.end {start + duration_hours.hours}
 
     trait :with_assigned_code do
@@ -224,7 +225,7 @@ FactoryGirl.define do
   end
 
   factory :pd_payment_term, class: 'Pd::PaymentTerm' do
-    start_date {Date.today}
+    start_date {Date.current}
     fixed_payment 50
   end
 

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -97,7 +97,6 @@ FactoryGirl.define do
     mappings {[create(:pd_regional_partner_mapping, state: "AL")]}
     cost_scholarship_information "Some **important** information about scholarships."
     additional_program_information "And some _additional_ program information."
-    apps_priority_deadline_date {(Date.current + 5.days).strftime("%Y-%m-%d")}
   end
 
   factory :regional_partner_illinois, parent: :regional_partner_with_summer_workshops do

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -262,6 +262,8 @@ class RegionalPartnerTest < ActiveSupport::TestCase
       assert_equal WORKSHOP_APPLICATION_STATES[:currently_open], regional_partner.summer_workshops_application_state
       assert_equal "September 25, 2018", regional_partner.summer_workshops_earliest_apps_open_date
       assert_nil regional_partner.link_to_partner_application
+
+      assert_equal "October  2, 2018", regional_partner.upcoming_priority_deadline_date
     end
   end
 
@@ -276,6 +278,7 @@ class RegionalPartnerTest < ActiveSupport::TestCase
     regional_partner = create :regional_partner_kentucky
 
     assert_equal WORKSHOP_APPLICATION_STATES[:now_closed], regional_partner.summer_workshops_application_state
+    assert_nil regional_partner.upcoming_priority_deadline_date
   end
 
   test 'regional_partner_summer_workshop_missing_information' do

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -248,7 +248,7 @@ class RegionalPartnerTest < ActiveSupport::TestCase
   test 'regional_partner_summer_workshop_open' do
     regional_partner = nil
     Timecop.freeze Time.zone.local(2018, 9, 27, 21, 25) do
-      regional_partner = create :regional_partner_alabama
+      regional_partner = create :regional_partner_alabama, :with_apps_priority_deadline_date
 
       assert_equal "Contact Name", regional_partner.contact_name
       assert_equal "contact@code.org", regional_partner.contact_email


### PR DESCRIPTION
The regional partner search UI now gets an info box above each "start application" button related to a regional partner's upcoming regional priority deadline date.  If there is such a date coming up, the viewer is told about it.  If there is no such date, there is a fallback message.

Because of the number of places in this code that we can show the "start application" button, it's now been factored out into a standalone stateless/functional React component.

It was interesting to discover that the unit tests failed when the local machine had its time zone set to something other than PST, and it turns out to be a known issue discussed at travisjeffery/timecop#182.  The solution is to use `Date.current` rather than `Date.today`.

A bunch of factories were also updated to use the yyyy-mm-dd date format that it turns out we're storing, as described in #27895

## Upcoming priority deadline date
![Screenshot 2019-04-09 12 01 11](https://user-images.githubusercontent.com/2205926/55768370-007e2b00-5ac0-11e9-8b39-db4cb88fb16a.png)

## No upcoming priority deadline date
![Screenshot 2019-04-09 12 06 04](https://user-images.githubusercontent.com/2205926/55768376-03791b80-5ac0-11e9-89d5-25f054e37f28.png)

## Button still working when linking to external partner site
![Screenshot 2019-04-09 12 06 40](https://user-images.githubusercontent.com/2205926/55768385-0e33b080-5ac0-11e9-988e-6cbfa1fa61f5.png)

