### PR TITLE
Replace dangeroulsySetInnerHtml in Abuse error with UnsafeRenderedMarkdown

### DIFF
--- a/apps/src/code-studio/components/AbuseError.jsx
+++ b/apps/src/code-studio/components/AbuseError.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-danger */
 import PropTypes from 'prop-types';
 import React from 'react';
+import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 
 /**
  * A component containing some text/links for projects that have had abuse
@@ -24,14 +25,10 @@ export default class AbuseError extends React.Component {
     // our i18n strings
     return (
       <div className={this.props.className} style={this.props.style}>
-        <p
-          style={this.props.textStyle}
-          dangerouslySetInnerHTML={{__html: this.props.i18n.tos}}
-        />
-        <p
-          style={this.props.textStyle}
-          dangerouslySetInnerHTML={{__html: this.props.i18n.contact_us}}
-        />
+        <div style={this.props.textStyle}>
+          <UnsafeRenderedMarkdown markdown={this.props.i18n.tos} />
+          <UnsafeRenderedMarkdown markdown={this.props.i18n.contact_us} />
+        </div>
       </div>
     );
   }

--- a/apps/src/code-studio/components/AbuseError.jsx
+++ b/apps/src/code-studio/components/AbuseError.jsx
@@ -25,8 +25,10 @@ export default class AbuseError extends React.Component {
     // our i18n strings
     return (
       <div className={this.props.className} style={this.props.style}>
-        <div style={this.props.textStyle}>
+        <div>
           <UnsafeRenderedMarkdown markdown={this.props.i18n.tos} />
+        </div>
+        <div>
           <UnsafeRenderedMarkdown markdown={this.props.i18n.contact_us} />
         </div>
       </div>


### PR DESCRIPTION
Abuse error message is shown when users attempt to open a project that is marked as abusive.

### Before 
<img width="656" alt="Screen Shot 2019-04-04 at 9 31 31 PM" src="https://user-images.githubusercontent.com/30066710/55744955-09e99380-59eb-11e9-9268-0294256b1cd9.png">

### After
<img width="706" alt="Screen Shot 2019-04-05 at 3 20 19 PM" src="https://user-images.githubusercontent.com/30066710/55744976-14a42880-59eb-11e9-822d-8d0f7b185a13.png">
