### PR TITLE
Feedback CSV Download: Only look for feedback on level types where you can give feedback

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -618,7 +618,7 @@
   "feedback": "Feedback",
   "feedbackCommentAreaHeader": "Teacher Feedback",
   "feedbackDownloadFileName": "Feedback for {sectionName} in {scriptName} on {date}.csv",
-  "feedbackDownloadOverview": "This CSV file contains all feedback you’ve completed for your section {sectionName} in levels within **{scriptName}**. You can leave feedback your students by going to a level in this unit, viewing a students work, and clicking the \"Feedback\" tab.",
+  "feedbackDownloadOverview": "This CSV file contains all feedback you’ve completed for your section {sectionName} in levels within **{scriptName}**. You can leave feedback for your students by going to a level in this unit, viewing a student's work, and clicking the \"Feedback\" tab.",
   "feedbackDownloadRecommendation": "We recommend checking student progress and giving feedback on levels marked as assessment opportunities.",
   "feedbackFrom": "Feedback from {teacher}",
   "feedbackLoadError": "There's been an error establishing a connection to our servers. Please refresh the page and try again.",

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -468,6 +468,11 @@ class Level < ActiveRecord::Base
     false
   end
 
+  # Currently only Web Lab, Game Lab and App Lab levels can have teacher feedback
+  def can_have_feedback?
+    ["Applab", "Gamelab", "Weblab"].include?(type)
+  end
+
   # Returns an array of all the contained levels
   # (based on the contained_level_names property)
   def contained_levels

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1471,25 +1471,38 @@ class Script < ActiveRecord::Base
 
   def get_feedback_for_section(section)
     feedback = {}
+
+    level_ids = script_levels.map {|script_level| script_level.level.id}
+    student_ids = section.students.map(&:id)
+    all_feedback = TeacherFeedback.get_all_feedback_for_section(student_ids, level_ids, section.user_id)
+
+    feedback_hash = {}
+    all_feedback.each do |feedback_element|
+      feedback_hash[feedback_element.student_id] ||= {}
+      feedback_hash[feedback_element.student_id][feedback.level_id] = feedback
+    end
+
     script_levels.each do |script_level|
-      # Filter down to only the levels a teacher can give feedback on
       next unless ["Applab", "Gamelab", "Weblab"].include?(script_level.level.type)
       section.students.each do |student|
-        temp_feedback = TeacherFeedback.get_student_level_feedback(student.id, script_level.level.id, section.user_id)
+        current_level = script_level.level
+        next unless feedback_hash[student.id]
+        temp_feedback = feedback_hash[student.id][current_level.id]
         next unless temp_feedback
         feedback[temp_feedback.id] = {
           studentName: student.name,
           stageNum: script_level.stage.relative_position.to_s,
           stageName: script_level.stage.localized_title,
           levelNum: script_level.position.to_s,
-          keyConcept: (script_level.level.rubric_key_concept || ''),
-          performanceLevelDetails: (script_level.level.properties["rubric_#{temp_feedback.performance}"] || ''),
+          keyConcept: (current_level.rubric_key_concept || ''),
+          performanceLevelDetails: (current_level.properties["rubric_#{temp_feedback.performance}"] || ''),
           performance: temp_feedback.performance,
           comment: temp_feedback.comment,
           timestamp: temp_feedback.updated_at.localtime.strftime("%D at %r")
         }
       end
     end
+
     return feedback
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1472,6 +1472,8 @@ class Script < ActiveRecord::Base
   def get_feedback_for_section(section)
     feedback = {}
     script_levels.each do |script_level|
+      # Filter down to only the levels a teacher can give feedback on
+      next unless ["Applab", "Gamelab", "Weblab"].include?(script_level.level.type)
       section.students.each do |student|
         temp_feedback = TeacherFeedback.get_student_level_feedback(student.id, script_level.level.id, section.user_id)
         next unless temp_feedback

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1472,7 +1472,7 @@ class Script < ActiveRecord::Base
   def get_feedback_for_section(section)
     feedback = {}
 
-    level_ids = script_levels.map {|script_level| script_level.oldest_active_level.id}
+    level_ids = script_levels.map(&:oldest_active_level).select(&:can_have_feedback?).map(&:id)
     student_ids = section.students.map(&:id)
     all_feedback = TeacherFeedback.get_all_feedback_for_section(student_ids, level_ids, section.user_id)
 
@@ -1483,6 +1483,7 @@ class Script < ActiveRecord::Base
     end
 
     script_levels.each do |script_level|
+      next unless script_level.oldest_active_level.can_have_feedback?
       section.students.each do |student|
         current_level = script_level.oldest_active_level
         next unless feedback_hash[student.id]

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1472,20 +1472,19 @@ class Script < ActiveRecord::Base
   def get_feedback_for_section(section)
     feedback = {}
 
-    level_ids = script_levels.map {|script_level| script_level.level.id}
+    level_ids = script_levels.map {|script_level| script_level.oldest_active_level.id}
     student_ids = section.students.map(&:id)
     all_feedback = TeacherFeedback.get_all_feedback_for_section(student_ids, level_ids, section.user_id)
 
     feedback_hash = {}
     all_feedback.each do |feedback_element|
       feedback_hash[feedback_element.student_id] ||= {}
-      feedback_hash[feedback_element.student_id][feedback.level_id] = feedback
+      feedback_hash[feedback_element.student_id][feedback_element.level_id] = feedback_element
     end
 
     script_levels.each do |script_level|
-      next unless ["Applab", "Gamelab", "Weblab"].include?(script_level.level.type)
       section.students.each do |student|
-        current_level = script_level.level
+        current_level = script_level.oldest_active_level
         next unless feedback_hash[student.id]
         temp_feedback = feedback_hash[student.id][current_level.id]
         next unless temp_feedback

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -34,6 +34,16 @@ class TeacherFeedback < ApplicationRecord
     ).latest
   end
 
+  def self.get_all_feedback_for_section(student_ids, level_ids, teacher_id)
+    find(
+      where(
+        student_id: student_ids,
+        level_id: level_ids,
+        teacher_id: teacher_id
+      ).group([:student_id, :level_id]).pluck('MAX(teacher_feedbacks.id)')
+    )
+  end
+
   def self.latest_per_teacher
     #Only select feedback from teachers who lead sections in which the student is still enrolled
     find(


### PR DESCRIPTION
Updated `get_feedback_for_section` by creating a new database query in teacher_feedback which gets all the latest feedback for each student for each level in a script with one query instead of many separate ones. 

Fixed a couple of typos Brendan pointed out on the page also.