### PR TITLE
Add timestamp to asset path

### DIFF
--- a/apps/src/applab/designElements/ImagePickerPropertyRow.jsx
+++ b/apps/src/applab/designElements/ImagePickerPropertyRow.jsx
@@ -71,8 +71,8 @@ export default class ImagePickerPropertyRow extends React.Component {
     });
   };
 
-  changeImage = filename => {
-    this.props.handleChange(filename);
+  changeImage = (filename, timestamp) => {
+    this.props.handleChange(filename, timestamp);
     // Because we delay the call to this function via setTimeout, we must be sure not
     // to call setState after the component is unmounted, or React will warn and
     // tests will fail.

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -191,8 +191,8 @@ designMode.fontFamilyOptionFromStyle = function(style) {
  * @param name {string}
  * @param value {string}
  */
-designMode.onPropertyChange = function(element, name, value) {
-  designMode.updateProperty(element, name, value);
+designMode.onPropertyChange = function(element, name, value, timestamp) {
+  designMode.updateProperty(element, name, value, timestamp);
   designMode.editElementProperties(element);
 };
 
@@ -203,7 +203,7 @@ designMode.onPropertyChange = function(element, name, value) {
  * @param name
  * @param value
  */
-designMode.updateProperty = function(element, name, value) {
+designMode.updateProperty = function(element, name, value, timestamp) {
   // For labels, we need to remember before we change the value if the element was "fitted" around the text or if it was
   // resized by the user. If it was previously fitted, then we will keep it fitted in the typeSpecificPropertyChange
   // method at the end. If it is not a label, then the return value from getPreChangeData will be null and will be
@@ -359,12 +359,18 @@ designMode.updateProperty = function(element, name, value) {
     case 'picture':
       originalValue = element.getAttribute('data-canonical-image-url');
       element.setAttribute('data-canonical-image-url', value);
+      var cacheBustSuffix = '';
+      if (timestamp) {
+        cacheBustSuffix = `?t=${new Date(timestamp).valueOf()}`;
+      }
 
       if (ICON_PREFIX_REGEX.test(value)) {
         element.src = assetPrefix.renderIconToString(value, element);
       } else {
         element.src =
-          value === '' ? '/blockly/media/1x1.gif' : assetPrefix.fixPath(value);
+          value === ''
+            ? '/blockly/media/1x1.gif'
+            : `${assetPrefix.fixPath(value)}${cacheBustSuffix}`;
       }
       break;
     case 'hidden':

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -210,6 +210,10 @@ designMode.updateProperty = function(element, name, value, timestamp) {
   // ignored.
   var preChangeData = elementLibrary.getPreChangeData(element, name);
   var handled = true;
+  var cacheBustSuffix = '';
+  if (timestamp) {
+    cacheBustSuffix = `?t=${new Date(timestamp).valueOf()}`;
+  }
   switch (name) {
     case 'id':
       value = value.trim();
@@ -326,7 +330,7 @@ designMode.updateProperty = function(element, name, value, timestamp) {
       }
 
       var backgroundImage = new Image();
-      backgroundImage.src = assetPrefix.fixPath(value);
+      backgroundImage.src = `${assetPrefix.fixPath(value)}${cacheBustSuffix}`;
       element.style.backgroundImage = 'url("' + backgroundImage.src + '")';
 
       // do not resize if only the asset path has changed (e.g. on remix).
@@ -348,7 +352,7 @@ designMode.updateProperty = function(element, name, value, timestamp) {
         url = assetPrefix.renderIconToString(value, element);
       } else {
         const screenImage = new Image();
-        screenImage.src = assetPrefix.fixPath(value);
+        screenImage.src = `${assetPrefix.fixPath(value)}${cacheBustSuffix}`;
         url = screenImage.src;
       }
       element.style.backgroundImage = 'url("' + url + '")';
@@ -359,10 +363,6 @@ designMode.updateProperty = function(element, name, value, timestamp) {
     case 'picture':
       originalValue = element.getAttribute('data-canonical-image-url');
       element.setAttribute('data-canonical-image-url', value);
-      var cacheBustSuffix = '';
-      if (timestamp) {
-        cacheBustSuffix = `?t=${new Date(timestamp).valueOf()}`;
-      }
 
       if (ICON_PREFIX_REGEX.test(value)) {
         element.src = assetPrefix.renderIconToString(value, element);

--- a/apps/src/code-studio/assets/show.js
+++ b/apps/src/code-studio/assets/show.js
@@ -49,9 +49,9 @@ module.exports = function showAssetManager(
       uploadsEnabled: !dashboard.project.exceedsAbuseThreshold(),
       useFilesApi: !!options.useFilesApi,
       assetChosen: showChoseImageButton
-        ? function(fileWithPath) {
+        ? function(fileWithPath, timestamp) {
             dialog.hide();
-            assetChosen(fileWithPath);
+            assetChosen(fileWithPath, timestamp);
           }
         : null,
       showUnderageWarning: !!options.showUnderageWarning,

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -242,7 +242,7 @@ export default class AssetManager extends React.Component {
         function(asset) {
           const choose =
             this.props.assetChosen &&
-            this.props.assetChosen.bind(this, asset.filename);
+            this.props.assetChosen.bind(this, asset.filename, asset.timestamp);
 
           return (
             <AssetRow

--- a/apps/test/unit/applab/designModeTest.js
+++ b/apps/test/unit/applab/designModeTest.js
@@ -101,9 +101,10 @@ describe('makeUrlProtocolRelative', () => {
 });
 
 describe('setProperty and read Property', () => {
-  let text_input, text_area, dropdown;
+  let picture, text_input, text_area, dropdown;
   // Create HTML elements to get/set
   beforeEach(() => {
+    picture = document.createElement('img');
     text_input = document.createElement('input');
     text_area = document.createElement('div');
     dropdown = document.createElement('select');
@@ -133,6 +134,10 @@ describe('setProperty and read Property', () => {
       expect(text_input.value).to.equal('Iota Kappa');
       expect(text_area.innerHTML).to.equal('Lambda Mu');
       expect(dropdown.value).to.equal('Eta Theta');
+    });
+    it('Uses the asset timestamp in the source path for pictures', () => {
+      designMode.updateProperty(picture, 'picture', 'picture.jpg', 123456);
+      expect(picture.src).to.contain('picture.jpg?t=123456');
     });
   });
 


### PR DESCRIPTION
Currently, if you delete an uploaded image and replace it with a different image with the same name, you will still see the old image due to caching. Adding the timestamp of when the asset was modified to the asset path avoids this issue. See also https://github.com/code-dot-org/code-dot-org/pull/21996

Before:
![duplicate-image-before](https://user-images.githubusercontent.com/8787187/55761727-31555600-5a15-11e9-99b8-10b648f84254.gif)

After:
![duplicate-image-after](https://user-images.githubusercontent.com/8787187/55761733-37e3cd80-5a15-11e9-9140-ec284b705617.gif)
