### PR TITLE
External links remarkjs plugin

### DIFF
--- a/apps/karma.conf.js
+++ b/apps/karma.conf.js
@@ -86,6 +86,8 @@ module.exports = function(config) {
       showDiff: true
     },
 
+    hostname: 'localhost-studio.code.org',
+
     // web server port
     port: PORT,
 

--- a/apps/src/templates/UnsafeRenderedMarkdown.jsx
+++ b/apps/src/templates/UnsafeRenderedMarkdown.jsx
@@ -8,9 +8,15 @@ import xmlAsTopLevelBlock from './plugins/xmlAsTopLevelBlock';
 import stripStyles from './plugins/stripStyles';
 import externalLinks from './plugins/externalLinks';
 
+const commonPlugins = [xmlAsTopLevelBlock, expandableImages];
+
 const remarkParser = Parser.create();
-remarkParser.parser.use([xmlAsTopLevelBlock, expandableImages, externalLinks]);
+remarkParser.parser.use(commonPlugins);
 remarkParser.compilerPlugins.push(stripStyles);
+
+const extendedParser = Parser.create();
+extendedParser.parser.use([...commonPlugins, externalLinks]);
+extendedParser.compilerPlugins.push(stripStyles);
 
 /**
  * Basic component for rendering a markdown string as HTML.
@@ -22,11 +28,15 @@ remarkParser.compilerPlugins.push(stripStyles);
  */
 export default class UnsafeRenderedMarkdown extends React.Component {
   static propTypes = {
-    markdown: PropTypes.string.isRequired
+    markdown: PropTypes.string.isRequired,
+    openExternalLinksInNewTab: PropTypes.bool
   };
 
   render() {
-    const processedMarkdown = remarkParser.sourceToHtml(this.props.markdown);
+    const parser = this.props.openExternalLinksInNewTab
+      ? extendedParser
+      : remarkParser;
+    const processedMarkdown = parser.sourceToHtml(this.props.markdown);
 
     /* eslint-disable react/no-danger */
     return <div dangerouslySetInnerHTML={{__html: processedMarkdown}} />;

--- a/apps/src/templates/UnsafeRenderedMarkdown.jsx
+++ b/apps/src/templates/UnsafeRenderedMarkdown.jsx
@@ -6,9 +6,10 @@ import Parser from '@code-dot-org/redactable-markdown';
 import expandableImages from './plugins/expandableImages';
 import xmlAsTopLevelBlock from './plugins/xmlAsTopLevelBlock';
 import stripStyles from './plugins/stripStyles';
+import externalLinks from './plugins/externalLinks';
 
 const remarkParser = Parser.create();
-remarkParser.parser.use([xmlAsTopLevelBlock, expandableImages]);
+remarkParser.parser.use([xmlAsTopLevelBlock, expandableImages, externalLinks]);
 remarkParser.compilerPlugins.push(stripStyles);
 
 /**

--- a/apps/src/templates/UnsafeRenderedMarkdown.jsx
+++ b/apps/src/templates/UnsafeRenderedMarkdown.jsx
@@ -15,7 +15,8 @@ remarkParser.parser.use(commonPlugins);
 remarkParser.compilerPlugins.push(stripStyles);
 
 const extendedParser = Parser.create();
-extendedParser.parser.use([...commonPlugins, externalLinks]);
+extendedParser.parser.use(commonPlugins);
+extendedParser.parser.use(externalLinks, {links: 'all'});
 extendedParser.compilerPlugins.push(stripStyles);
 
 /**

--- a/apps/src/templates/plugins/externalLinks.js
+++ b/apps/src/templates/plugins/externalLinks.js
@@ -1,0 +1,27 @@
+/**
+ * Open external links in a new tab.
+ */
+module.exports = function externalLinks() {
+  const Parser = this.Parser;
+  const tokenizers = Parser.prototype.inlineTokenizers;
+  const original = tokenizers.link;
+  tokenizers.link = function(eat, value, silent) {
+    const link = original.call(this, eat, value, silent);
+    if (link && link.type === 'link' && isExternalLink(link.url)) {
+      link.data = link.data || {};
+      link.data.hProperties = link.data.hProperties || {};
+
+      const props = link.data.hProperties;
+      props.target = props.target || '_blank';
+      props.rel = 'noreferrer noopener';
+    }
+
+    return link;
+  };
+  tokenizers.link.locator = original.locator;
+};
+
+function isExternalLink(url) {
+  const hostname = new URL(url, location.href).hostname;
+  return !/(^|\.)code\.org$/.test(hostname);
+}

--- a/apps/src/templates/plugins/externalLinks.js
+++ b/apps/src/templates/plugins/externalLinks.js
@@ -22,6 +22,12 @@ export default function externalLinks() {
 }
 
 export function isExternalLink(url) {
-  const hostname = new URL(url, 'https://code.org').hostname;
-  return !/(^|\.)code\.org$/.test(hostname);
+  return !/https?:\/\/([^.]+\.)*code.org(:[0-9]+)?\//.test(fullyQualified(url));
+}
+
+let a;
+function fullyQualified(path) {
+  a = a || document.createElement('a');
+  a.href = path;
+  return a.href;
 }

--- a/apps/src/templates/plugins/externalLinks.js
+++ b/apps/src/templates/plugins/externalLinks.js
@@ -1,7 +1,7 @@
 /**
  * Open external links in a new tab.
  */
-module.exports = function externalLinks() {
+export default function externalLinks() {
   const Parser = this.Parser;
   const tokenizers = Parser.prototype.inlineTokenizers;
   const original = tokenizers.link;
@@ -19,9 +19,9 @@ module.exports = function externalLinks() {
     return link;
   };
   tokenizers.link.locator = original.locator;
-};
+}
 
-function isExternalLink(url) {
-  const hostname = new URL(url, location.href).hostname;
+export function isExternalLink(url) {
+  const hostname = new URL(url, 'https://code.org').hostname;
   return !/(^|\.)code\.org$/.test(hostname);
 }

--- a/apps/src/templates/plugins/externalLinks.js
+++ b/apps/src/templates/plugins/externalLinks.js
@@ -1,13 +1,15 @@
 /**
  * Open external links in a new tab.
  */
-export default function externalLinks() {
+export default function externalLinks(options = {}) {
   const Parser = this.Parser;
   const tokenizers = Parser.prototype.inlineTokenizers;
   const original = tokenizers.link;
+  const all = options.links === 'all';
+
   tokenizers.link = function(eat, value, silent) {
     const link = original.call(this, eat, value, silent);
-    if (link && link.type === 'link' && isExternalLink(link.url)) {
+    if (link && link.type === 'link' && (all || isExternalLink(link.url))) {
       link.data = link.data || {};
       link.data.hProperties = link.data.hProperties || {};
 

--- a/apps/test/unit/templates/plugins/externalLinksTest.js
+++ b/apps/test/unit/templates/plugins/externalLinksTest.js
@@ -1,0 +1,30 @@
+import {assert} from '../../../util/configuredChai';
+import {isExternalLink} from '@cdo/apps/templates/plugins/externalLinks';
+
+describe('external links remark plugin', () => {
+  it('treats relative links as internal', () => {
+    assert.equal(isExternalLink('/educate'), false);
+    assert.equal(isExternalLink('../../educate'), false);
+    assert.equal(isExternalLink('/hoc/1'), false);
+    assert.equal(isExternalLink('puzzle/1'), false);
+    assert.equal(isExternalLink('test'), false);
+  });
+
+  it('treats *.code.org links as internal', () => {
+    assert.equal(isExternalLink('//code.org/educate'), false);
+    assert.equal(isExternalLink('http://code.org/educate'), false);
+    assert.equal(isExternalLink('https://code.org/educate'), false);
+    assert.equal(isExternalLink('https://studio.code.org/'), false);
+    assert.equal(isExternalLink('//localhost-studio.code.org:3000/s/1'), false);
+  });
+
+  it('treats other domain links as internal', () => {
+    assert.equal(isExternalLink('//example.com'), true);
+    assert.equal(isExternalLink('http://scratch.org'), true);
+    assert.equal(isExternalLink('https://www.google.com/'), true);
+    assert.equal(isExternalLink('//example.com/abc/1/2/3'), true);
+    assert.equal(isExternalLink('https://not-code.org'), true);
+    assert.equal(isExternalLink('https://not-code.org:3000/hoc/1'), true);
+    assert.equal(isExternalLink('https://www.not-code.org'), true);
+  });
+});

--- a/apps/test/unit/templates/plugins/externalLinksTest.js
+++ b/apps/test/unit/templates/plugins/externalLinksTest.js
@@ -18,7 +18,7 @@ describe('external links remark plugin', () => {
     assert.equal(isExternalLink('//localhost-studio.code.org:3000/s/1'), false);
   });
 
-  it('treats other domain links as internal', () => {
+  it('treats other domain links as external', () => {
     assert.equal(isExternalLink('//example.com'), true);
     assert.equal(isExternalLink('http://scratch.org'), true);
     assert.equal(isExternalLink('https://www.google.com/'), true);


### PR DESCRIPTION
Extracted from PR https://github.com/code-dot-org/code-dot-org/pull/27841.

Match the old `MarkdownSpan.jsx` behavior of opening external links in a new tab.

https://github.com/code-dot-org/code-dot-org/blob/27425fc9425ef08ec0da783e2cc9694af3e69396/apps/src/code-studio/pd/components/markdownSpan.jsx#L5-L8