### PR TITLE
Support UI tests in local headless firefox

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -91,8 +91,8 @@ end
 def get_browser(test_run_name)
   if ENV['TEST_LOCAL'] == 'true'
     headless = ENV['TEST_LOCAL_HEADLESS'] == 'true'
-    # This drives a local installation of ChromeDriver running on port 9515, instead of Saucelabs.
-    SeleniumBrowser.local_browser(headless)
+    # Run a local headless browser instead of Saucelabs.
+    SeleniumBrowser.local_browser(headless, ENV['BROWSER_CONFIG'])
   else
     saucelabs_browser test_run_name
   end

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -251,10 +251,10 @@ end
 def select_browser_configs(options)
   if options.local
     return [{
-      'browser': 'local',
-      'name': 'ChromeDriver',
-      'browserName': 'chrome',
-      'version': 'latest'
+      'browser' => options.browser || 'local',
+      'name' => 'LocalBrowser',
+      'browserName' => options.browser || 'chrome',
+      'version' => options.browser_version || 'latest'
     }]
   end
 
@@ -655,7 +655,7 @@ def cucumber_arguments_for_feature(options, test_run_string, max_reruns)
   arguments += ' -f pretty' if options.html # include the default (-f pretty) formatter so it does both
   arguments += " --fail-fast" if options.fail_fast
 
-  # if autorertrying, output a rerun file so on retry we only run failed tests
+  # if auto-retrying, output a rerun file so on retry we only run failed tests
   if max_reruns > 0
     arguments += " --format rerun --out #{rerun_filename test_run_string}"
   end
@@ -690,7 +690,7 @@ def run_feature(browser, feature, options)
   puts "#{log_prefix}Starting UI tests for #{test_run_string}"
 
   run_environment = {}
-  run_environment['BROWSER_CONFIG'] = browser_name
+  run_environment['BROWSER_CONFIG'] = options.local ? browser['browser'] : browser_name
 
   run_environment['BS_ROTATABLE'] = browser['rotatable'] ? "true" : "false"
   run_environment['PEGASUS_TEST_DOMAIN'] = options.pegasus_domain if options.pegasus_domain

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -2,12 +2,17 @@ require 'selenium/webdriver'
 require 'webdrivers'
 
 module SeleniumBrowser
-  def self.local_browser(headless=true)
-    options = Selenium::WebDriver::Chrome::Options.new
-    if headless
-      options.add_argument('--headless')
+  def self.local_browser(headless=true, browser=:chrome)
+    browser = browser.to_sym
+    options = {}
+    if browser == :chrome
+      options[:options] = Selenium::WebDriver::Chrome::Options.new
+      options[:options].add_argument('--headless') if headless
+    elsif browser == :firefox
+      options[:options] = Selenium::WebDriver::Firefox::Options.new
+      options[:options].headless! if headless
     end
-    browser = Selenium::WebDriver.for :chrome, options: options
+    browser = Selenium::WebDriver.for browser, options
     if ENV['MAXIMIZE_LOCAL']
       max_width, max_height = browser.execute_script('return [window.screen.availWidth, window.screen.availHeight];')
       browser.manage.window.resize_to(max_width, max_height)


### PR DESCRIPTION
Followup to #27848, this allows you to run UI tests in local headless firefox using `--local --browser firefox`  command-line options.

It might also work with local Safari using `--local --browser safari` - I'd love it if someone on OSX could test/confirm whether this works as-is as well!