### PR TITLE
Create aurora db for test stack, and adhoc stacks when ENV['DATABASE'] is set [ci skip]

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -69,6 +69,15 @@ CERT=$(aws s3 cp $CURRENT/cert.pem - | replace_newline)
 CHAIN=$(aws s3 cp $CURRENT/chain.pem - | replace_newline)
 KEY=$(aws s3 cp $CURRENT/key.pem - | replace_newline)
 <% end -%>
+
+<% if TEMPLATE == 'cloud_formation_stack.yml.erb' && @database -%>
+apt-get install -y  jq
+DB_SECRET_NAME=${DatabaseSecret}
+DB_SECRET=$(aws --region $REGION secretsmanager get-secret-value --secret-id $DB_SECRET_NAME --version-stage AWSCURRENT | jq -r ".SecretString")
+DB_USERNAME=$(echo $DB_SECRET | jq -r ".username")
+DB_PASSWORD=$(echo $DB_SECRET | jq -r ".password")
+<% end -%>
+
 # Customize Chef configuration.
 FIRST_BOOT=/etc/chef/first-boot.json
 mkdir -p $(dirname $FIRST_BOOT)
@@ -102,7 +111,7 @@ cat <<JSON > $FIRST_BOOT
     "redis_read_ports": "${GeocoderGroup.ReadEndPoint.Ports}",
 <% end -%>
 <% if TEMPLATE == 'cloud_formation_stack.yml.erb' && @database -%>
-    "db_writer": "mysql://${DatabaseUsername}:${DatabasePassword}@${Database.Endpoint.Address}:${Database.Endpoint.Port}/",
+    "db_writer": "mysql://$DB_USERNAME:$DB_PASSWORD@${AuroraCluster.Endpoint.Address}:${AuroraCluster.Endpoint.Port}/",
 <% end -%>
 <% unless cdn_enabled -%>
     "cdn_enabled": false,

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -24,7 +24,7 @@ commit = ENV['COMMIT'] || `git ls-remote origin #{branch}`.split.first
 ami = commit[0..4]
 
 frontends = @frontends = rack_env?(:production) || ENV['FRONTENDS']
-database = @database = ENV['DATABASE']
+database = @database = rack_env?(:test) || ENV['DATABASE']
 load_balancer = @load_balancer = !rack_env?(:adhoc) || ENV['FRONTENDS']
 
 unless dry_run
@@ -69,11 +69,6 @@ Parameters:
     Type: String
     Default: master
     MaxLength: 16
-  DatabasePassword:
-    Type: String
-    NoEcho: true
-    MinLength: 8
-    MaxLength: 41
 <% end -%>
 Resources:
   # Stack-specific IAM permissions applied to both daemon and frontends.
@@ -84,6 +79,14 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
+          # Read-only access to current secrets.
+          - Effect: Allow
+            Action: 'secretsmanager:GetSecretValue'
+            Resource:
+              - !Ref DatabaseSecret
+            Condition:
+              StringEquals:
+                secretsmanager:VersionStage: AWSCURRENT
           # Read-only access to bootstrap scripts.
           - Effect: Allow
             Action: 's3:GetObject'
@@ -692,35 +695,39 @@ Resources:
       Threshold: 87
       TreatMissingData: missing
 <% if database -%>
-  Database:
+  AuroraCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
+      DBClusterParameterGroupName: default.aurora-mysql5.7
+      Engine: aurora-mysql
+      EngineVersion: 5.7.12
+      MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:username}}"
+      MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:password}}"
+      VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
+      DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
+
+  AuroraMaster:
     Type: AWS::RDS::DBInstance
     Properties:
-      DBInstanceIdentifier: !Ref AWS::StackName
-      DBInstanceClass: db.t2.micro
-      AllocatedStorage: 64
-      StorageType: gp2
-      Engine: mysql
-      EngineVersion: 5.7.23
-      DBParameterGroupName: !Ref DatabaseParameters
-      VPCSecurityGroups: [!ImportValue VPC-DBSecurityGroup]
+      DBInstanceIdentifier: !Sub "${AWS::StackName}-master"
+      DBClusterIdentifier: !Ref AuroraCluster
+      DBInstanceClass: db.r4.large
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
-      MasterUsername: !Ref DatabaseUsername
-      MasterUserPassword: !Ref DatabasePassword
-  DatabaseParameters:
-    Type: AWS::RDS::DBParameterGroup
+      Engine: aurora-mysql
+      EngineVersion: 5.7.12
+      PubliclyAccessible: true
+
+  DatabaseSecret:
+    Type: AWS::SecretsManager::Secret
     Properties:
-      Description: !Sub "Parameters for ${AWS::StackName}."
-      Family: mysql5.7
-      Parameters:
-        innodb_autoinc_lock_mode: 2
-        innodb_flush_log_at_trx_commit: 0
-        innodb_flush_method: O_DIRECT
-        sync_binlog: 0
-        tx_isolation: READ-COMMITTED
-        skip_name_resolve: 1
-        performance_schema: 1
-        innodb_buffer_pool_dump_at_shutdown: 1
-        innodb_buffer_pool_load_at_startup: 1
+      Description: !Sub "Secrets for accessing database from ${AWS::StackName} CloudFormation stack"
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{"username": "${DatabaseUsername}"}'
+        GenerateStringKey: password
+        PasswordLength: 10
+        ExcludePunctuation: True
+      Name: !Sub "CfnStack/${AWS::StackName}/database-secret"
 <% end -%>
 Outputs:
   DashboardURL:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -716,7 +716,6 @@ Resources:
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
       EngineVersion: 5.7.12
-      PubliclyAccessible: true
 
   DatabaseSecret:
     Type: AWS::SecretsManager::Secret

--- a/pegasus/migrations/130_add_forms_country_code_index.rb
+++ b/pegasus/migrations/130_add_forms_country_code_index.rb
@@ -2,12 +2,11 @@
 Sequel.migration do
   up do
     # Generated column feature required for this migration.
-    unless database_type == :mysql &&
-      supports_generated_columns? &&
-      server_version >= 50713
+    # JSON ->> operator also required: https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#operator_json-inline-path
+    unless database_type == :mysql && supports_generated_columns?
       raise "MySQL JSON functions and generated column features required.
 You are currently using #{database_type} version #{server_version}.
-Upgrade your MySQL server to >= 5.7.13 and retry the migration."
+Upgrade your MySQL server to a version which supports these features and retry the migration."
     end
 
     alter_table(:forms) do


### PR DESCRIPTION
Can create an adhoc that can connect to the provisioned database:

```
RAILS_ENV=adhoc DATABASE=1 STACK_NAME=adhoc-aurora-cf bundle exec rake adhoc:start
```

Not sure if this is enough to deploy to test though; opening PR to get feedback.