### PR TITLE
Make it possible to render DSL levels without translations

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -654,7 +654,7 @@ module LevelsHelper
       )
     else
       level_name = source_level ? source_level.name : @level.name
-      data_t(prefix + '.' + level_name, text)
+      data_t(prefix + '.' + level_name, text, text)
     end
   end
 

--- a/dashboard/app/helpers/locale_helper.rb
+++ b/dashboard/app/helpers/locale_helper.rb
@@ -65,9 +65,14 @@ module LocaleHelper
 
   # Looks up a localized string driven by a database value.
   # See config/locales/data.en.yml for details.
-  def data_t(dotted_path, key)
+  def data_t(dotted_path, key, default=nil)
     # Escape separator in provided key to support keys containing dot characters.
-    try_t(key, scope: ['data'] + dotted_path.split('.'), separator: I18n::Backend::Flatten::SEPARATOR_ESCAPE_CHAR, default: nil)
+    try_t(
+      key,
+      scope: ['data'] + dotted_path.split('.'),
+      separator: I18n::Backend::Flatten::SEPARATOR_ESCAPE_CHAR,
+      default: default
+    )
   end
 
   # Looks up a localized string driven by a database value.

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -715,10 +715,10 @@ class LevelsHelperTest < ActionView::TestCase
       "<style>.blocklySvg { background: none; }</style>"\
       "<script src=\"/js/blockly.js\"></script>"\
       "<script src=\"/js/en_us/blockly_locale.js\"></script>"\
-      "<script src=\"/js/common.min.js\"></script>"\
+      "<script src=\"#{minifiable_asset_path('js/common.js')}\"></script>"\
       "<script src=\"/js/en_us/maze_locale.js\"></script>"\
-      "<script src=\"/js/maze.min.js\" data-appoptions=\"{&quot;readonly&quot;:true,&quot;embedded&quot;:true,&quot;locale&quot;:&quot;en_us&quot;,&quot;baseUrl&quot;:&quot;/blockly/&quot;,&quot;blocks&quot;:&quot;\\u003cxml\\u003e\\u003c/xml\\u003e&quot;,&quot;dialog&quot;:{},&quot;nonGlobal&quot;:true}\"></script>"\
-      "<script src=\"/js/embedBlocks.min.js\"></script>"
+      "<script src=\"#{minifiable_asset_path('js/maze.js')}\" data-appoptions=\"{&quot;readonly&quot;:true,&quot;embedded&quot;:true,&quot;locale&quot;:&quot;en_us&quot;,&quot;baseUrl&quot;:&quot;/blockly/&quot;,&quot;blocks&quot;:&quot;\\u003cxml\\u003e\\u003c/xml\\u003e&quot;,&quot;dialog&quot;:{},&quot;nonGlobal&quot;:true}\"></script>"\
+      "<script src=\"#{minifiable_asset_path('js/embedBlocks.js')}\"></script>"
 
     unstub(:request)
   end


### PR DESCRIPTION
Right now, all DSL levels depend on I18n.t to render their content, and
will fall back to `nil` if they can't find the translation. We want to
be able to only sync data into the translation system if we want to
actually translate it, so we add the ability for DSL levels to fall back
to the database content if they can't find translation data.

Originally added as part of https://github.com/code-dot-org/code-dot-org/pull/27881, which also includes changes to the way the DSL i18n data is synced. Extracted into this PR for a clearer division of concerns