### PR TITLE
Recommended section version

### DIFF
--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -137,6 +137,7 @@ function showHomepage() {
             teacherId={homepageData.teacherId}
             teacherEmail={homepageData.teacherEmail}
             schoolYear={homepageData.currentSchoolYear}
+            locale={homepageData.locale}
           />
         )}
         {!isTeacher && (

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -32,6 +32,7 @@ export default class TeacherHomepage extends Component {
     queryStringOpen: PropTypes.string,
     canViewAdvancedTools: PropTypes.bool,
     isEnglish: PropTypes.bool.isRequired,
+    locale: PropTypes.string,
     showCensusBanner: PropTypes.bool.isRequired,
     ncesSchoolId: PropTypes.string,
     censusQuestion: PropTypes.oneOf(['how_many_10_hours', 'how_many_20_hours']),
@@ -154,7 +155,12 @@ export default class TeacherHomepage extends Component {
     } = this.props;
     const {ncesSchoolId, censusQuestion, schoolYear} = this.props;
     const {teacherId, teacherName, teacherEmail} = this.props;
-    const {canViewAdvancedTools, queryStringOpen, isEnglish} = this.props;
+    const {
+      canViewAdvancedTools,
+      queryStringOpen,
+      isEnglish,
+      locale
+    } = this.props;
 
     // Show the special announcement for now.
     const showSpecialAnnouncement = true;
@@ -218,7 +224,7 @@ export default class TeacherHomepage extends Component {
             <br />
           </div>
         )}
-        <TeacherSections queryStringOpen={queryStringOpen} />
+        <TeacherSections queryStringOpen={queryStringOpen} locale={locale} />
         <RecentCourses
           courses={courses}
           topCourse={topCourse}

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -151,11 +151,13 @@ export default class TeacherHomepage extends Component {
       courses,
       topCourse,
       announcement,
-      joinedSections
-    } = this.props;
-    const {ncesSchoolId, censusQuestion, schoolYear} = this.props;
-    const {teacherId, teacherName, teacherEmail} = this.props;
-    const {
+      joinedSections,
+      ncesSchoolId,
+      censusQuestion,
+      schoolYear,
+      teacherId,
+      teacherName,
+      teacherEmail,
       canViewAdvancedTools,
       queryStringOpen,
       isEnglish,

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -9,6 +9,7 @@ import {asyncLoadSectionData} from '../teacherDashboard/teacherSectionsRedux';
 class TeacherSections extends Component {
   static propTypes = {
     queryStringOpen: PropTypes.string,
+    locale: PropTypes.string,
 
     //Redux provided
     asyncLoadSectionData: PropTypes.func.isRequired
@@ -19,11 +20,11 @@ class TeacherSections extends Component {
   }
 
   render() {
-    const {queryStringOpen} = this.props;
+    const {queryStringOpen, locale} = this.props;
     return (
       <div id="classroom-sections">
         <ContentContainer heading={i18n.sectionsTitle()}>
-          <OwnedSections queryStringOpen={queryStringOpen} />
+          <OwnedSections queryStringOpen={queryStringOpen} locale={locale} />
         </ContentContainer>
       </div>
     );

--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -21,6 +21,8 @@ import {
  */
 class AddSectionDialog extends Component {
   static propTypes = {
+    locale: PropTypes.string,
+
     // Provided by Redux
     isOpen: PropTypes.bool.isRequired,
     section: sectionShape,
@@ -37,7 +39,8 @@ class AddSectionDialog extends Component {
       beginImportRosterFlow,
       setRosterProvider,
       setLoginType,
-      handleCancel
+      handleCancel,
+      locale
     } = this.props;
     const {loginType} = section || {};
     const title = i18n.newSection();
@@ -58,7 +61,7 @@ class AddSectionDialog extends Component {
               handleCancel={handleCancel}
             />
           )}
-          {loginType && <EditSectionForm title={title} />}
+          {loginType && <EditSectionForm title={title} locale={locale} />}
         </PadAndCenter>
       </BaseDialog>
     );

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -67,7 +67,8 @@ export default class AssignmentSelector extends Component {
     chooseLaterOption: PropTypes.bool,
     dropdownStyle: PropTypes.object,
     onChange: PropTypes.func,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
+    locale: PropTypes.string
   };
 
   /**

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -96,12 +96,21 @@ export default class AssignmentSelector extends Component {
       .reverse()
       .value();
 
-    // Because the versions are sorted most recent first, we can just look for
-    // the first stable version.
-    const recommendedVersion = versions.find(v => v.isStable);
+    // We recommend the user use the latest stable version that is supported in their
+    // locale. If no versions support their locale, we recommend the latest stable version.
+    // Versions are sorted from most to least recent, so the first stable version will be the latest.
+    let recommendedVersion = versions.find(v => {
+      const localeSupported =
+        (v.locales || []).includes(this.props.locale) ||
+        this.props.locale === 'English';
+
+      return v.isStable && localeSupported;
+    });
+    recommendedVersion = recommendedVersion || versions.find(v => v.isStable);
     if (recommendedVersion) {
       recommendedVersion.isRecommended = true;
     }
+
     const selectedVersion =
       versions.find(v => v.year === selectedVersionYear) ||
       recommendedVersion ||

--- a/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
@@ -109,7 +109,7 @@ export default class AssignmentVersionSelector extends Component {
           {versions.map(version => (
             <option key={version.year} value={version.year}>
               {version.isRecommended
-                ? `${version.title} (Recommended)`
+                ? `${version.title} (${i18n.recommended()})`
                 : version.title}
             </option>
           ))}

--- a/apps/src/templates/teacherDashboard/EditSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionDialog.jsx
@@ -13,6 +13,7 @@ import {isEditingSection} from './teacherSectionsRedux';
  */
 class EditSectionDialog extends Component {
   static propTypes = {
+    locale: PropTypes.string,
     isOpen: PropTypes.bool.isRequired // From Redux
   };
 
@@ -26,7 +27,10 @@ class EditSectionDialog extends Component {
         uncloseable
       >
         <PadAndCenter>
-          <EditSectionForm title={i18n.editSectionDetails()} />
+          <EditSectionForm
+            title={i18n.editSectionDetails()}
+            locale={this.props.locale}
+          />
         </PadAndCenter>
       </BaseDialog>
     );

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -53,6 +53,7 @@ const style = {
 class EditSectionForm extends Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
+    locale: PropTypes.string,
 
     //Comes from redux
     validGrades: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -118,7 +119,8 @@ class EditSectionForm extends Component {
       editSectionProperties,
       handleClose,
       stageExtrasAvailable,
-      assignedScriptName
+      assignedScriptName,
+      locale
     } = this.props;
     if (!section) {
       return null;
@@ -144,6 +146,7 @@ class EditSectionForm extends Component {
             validAssignments={validAssignments}
             assignmentFamilies={assignmentFamilies}
             disabled={isSaveInProgress}
+            locale={locale}
           />
           {stageExtrasAvailable(section.scriptId) && (
             <LessonExtrasField
@@ -264,7 +267,8 @@ const AssignmentField = ({
   onChange,
   validAssignments,
   assignmentFamilies,
-  disabled
+  disabled,
+  locale
 }) => (
   <div>
     <FieldName>{i18n.course()}</FieldName>
@@ -277,6 +281,7 @@ const AssignmentField = ({
       chooseLaterOption={true}
       dropdownStyle={style.dropdown}
       disabled={disabled}
+      locale={locale}
     />
   </div>
 );
@@ -285,7 +290,8 @@ AssignmentField.propTypes = {
   onChange: PropTypes.func.isRequired,
   validAssignments: PropTypes.objectOf(assignmentShape).isRequired,
   assignmentFamilies: PropTypes.arrayOf(assignmentFamilyShape).isRequired,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  locale: PropTypes.string
 };
 
 const LessonExtrasField = ({value, onChange, disabled}) => (

--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -41,6 +41,7 @@ const styles = {
 class OwnedSections extends React.Component {
   static propTypes = {
     queryStringOpen: PropTypes.string,
+    locale: PropTypes.string,
 
     // redux provided
     sectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
@@ -77,7 +78,8 @@ class OwnedSections extends React.Component {
       sectionIds,
       hiddenSectionIds,
       asyncLoadComplete,
-      beginEditingSection
+      beginEditingSection,
+      locale
     } = this.props;
     const {viewHidden} = this.state;
 
@@ -128,8 +130,8 @@ class OwnedSections extends React.Component {
           </div>
         )}
         <RosterDialog />
-        <AddSectionDialog />
-        <EditSectionDialog />
+        <AddSectionDialog locale={locale} />
+        <EditSectionDialog locale={locale} />
       </div>
     );
   }

--- a/apps/test/unit/templates/teacherDashboard/AssignmentSelectorTest.js
+++ b/apps/test/unit/templates/teacherDashboard/AssignmentSelectorTest.js
@@ -5,6 +5,7 @@ import {assert, expect} from '../../../util/configuredChai';
 import AssignmentSelector from '@cdo/apps/templates/teacherDashboard/AssignmentSelector';
 
 const defaultProps = {
+  locale: 'English',
   section: {
     id: 11,
     name: 'foo',
@@ -34,7 +35,8 @@ const defaultProps = {
       assignment_family_name: 'csd',
       assignment_family_title: 'CS Discoveries',
       version_year: '2017',
-      version_title: "'17-'18"
+      version_title: "'17-'18",
+      is_stable: true
     },
     // script in course
     null_168: {
@@ -51,7 +53,8 @@ const defaultProps = {
       assignment_family_name: 'csd1',
       assignment_family_title: 'Unit 1: Problem Solving',
       version_year: '2017',
-      version_title: '2017'
+      version_title: '2017',
+      is_stable: true
     },
     // script not in course
     null_6: {
@@ -68,7 +71,27 @@ const defaultProps = {
       assignment_family_name: 'flappy',
       assignment_family_title: 'Make a Flappy game',
       version_year: '2017',
-      version_title: '2017'
+      version_title: '2017',
+      is_stable: true,
+      supported_locales: ['Spanish']
+    },
+    // script not in course
+    null_7: {
+      id: 7,
+      name: 'Make a Flappy game',
+      script_name: 'flappy-2018',
+      category: 'Hour of Code',
+      position: 4,
+      category_priority: 2,
+      courseId: null,
+      scriptId: 7,
+      assignId: 'null_7',
+      path: '//localhost-studio.code.org:3000/s/flappy',
+      assignment_family_name: 'flappy',
+      assignment_family_title: 'Make a Flappy game',
+      version_year: '2018',
+      version_title: '2018',
+      is_stable: true
     }
   },
   assignmentFamilies: [
@@ -283,6 +306,61 @@ describe('AssignmentSelector', () => {
         .text(),
       'Unit 1: Problem Solving'
     );
+  });
+
+  // Make sure we are passing the proper recommended version to our child component, <AssignmentVersionSelector/>
+  describe('version recommendation', () => {
+    it('recommends the latest stable version supported in user locale', () => {
+      // Choose the 'Make a flappy game' script, which has both 2017 and 2018 versions.
+      // Make sure we are recommended 2017 version, which supports Spanish.
+      const wrapper = shallow(
+        <AssignmentSelector
+          {...defaultProps}
+          locale="Spanish"
+          section={{
+            ...defaultProps.section,
+            courseId: null,
+            scriptId: 7
+          }}
+        />
+      );
+
+      const versionSelectorProps = wrapper
+        .find('AssignmentVersionSelector')
+        .props();
+
+      assert.equal(versionSelectorProps.versions.length, 2);
+      const recommendedVersion = versionSelectorProps.versions.find(
+        v => v.isRecommended
+      );
+      assert.equal(recommendedVersion.title, '2017');
+    });
+
+    it('recommends the latest stable version if no versions are supported in user locale', () => {
+      // Choose the 'Make a flappy game' script, which has both 2017 and 2018 versions.
+      // Make sure we are recommended 2018 version, since no versions support Slovak.
+      const wrapper = shallow(
+        <AssignmentSelector
+          {...defaultProps}
+          locale="Slovak"
+          section={{
+            ...defaultProps.section,
+            courseId: null,
+            scriptId: 6
+          }}
+        />
+      );
+
+      const versionSelectorProps = wrapper
+        .find('AssignmentVersionSelector')
+        .props();
+
+      assert.equal(versionSelectorProps.versions.length, 2);
+      const recommendedVersion = versionSelectorProps.versions.find(
+        v => v.isRecommended
+      );
+      assert.equal(recommendedVersion.title, '2018');
+    });
   });
 
   it('shows two dropdowns if section has a course selected', () => {

--- a/dashboard/app/views/home/_homepage.html.haml
+++ b/dashboard/app/views/home/_homepage.html.haml
@@ -7,7 +7,7 @@
 - homepage_data[:stageExtrasScriptIds] = Script.stage_extras_script_ids
 - homepage_data[:topCourse] = @top_course
 - homepage_data[:isEnglish] = @is_english
-- homepage_data[:locale] = request.locale
+- homepage_data[:locale] = Script.locale_english_name_map[request.locale]
 
 - if current_user
   - homepage_data[:providers] = current_user.providers

--- a/dashboard/app/views/home/_homepage.html.haml
+++ b/dashboard/app/views/home/_homepage.html.haml
@@ -7,6 +7,7 @@
 - homepage_data[:stageExtrasScriptIds] = Script.stage_extras_script_ids
 - homepage_data[:topCourse] = @top_course
 - homepage_data[:isEnglish] = @is_english
+- homepage_data[:locale] = request.locale
 
 - if current_user
   - homepage_data[:providers] = current_user.providers


### PR DESCRIPTION
[LP-28](https://codedotorg.atlassian.net/browse/LP-28)
[Spec](https://docs.google.com/document/d/1jYznJYlrfXQ-MJvmgfmZbVjjAM9-i297hoFTCqoYJ5w/edit?usp=sharing)

Satisfies the following requirements in the above spec:
- If you’re in a language that is supported by a stable version of a course, we should show that as the recommended version for that course.
- If my selected language is not supported by any of the versions, the recommended version should continue to be the latest stable version in English. For example, regardless of what language you’re in for CSP, the recommended version will currently be 2018 (as of Feb 2019). 
- Set the recommended version as the dropdown default (no additional work was done to make this happen, just calling it out here)

### Example
Let's say our locale language is Spanish. `coursea-2018` does not support Spanish, but `coursea-2017` does.

#### Before
We always displayed the latest stable version as the recommended version:
![Screen Shot 2019-04-09 at 3 19 39 PM](https://user-images.githubusercontent.com/9812299/55839543-1f3eea80-5add-11e9-8683-83f6a1f88943.png)

#### After
We default to and recommend the latest stable version in the user's locale. If no versions are supported in their locale, we recommend the latest stable version.

Default in dropdown:
![Screen Shot 2019-04-09 at 3 16 18 PM](https://user-images.githubusercontent.com/9812299/55839572-367dd800-5add-11e9-841f-e085503566b6.png)

Upon opening dropdown:
![Screen Shot 2019-04-09 at 3 16 28 PM](https://user-images.githubusercontent.com/9812299/55839570-367dd800-5add-11e9-8c5e-adc4166d0d1c.png)