### PR TITLE
Long Migration: index user_levels on user_id and script_id

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -18,6 +18,7 @@
 # Indexes
 #
 #  index_user_levels_on_user_id_and_level_id_and_script_id  (user_id,level_id,script_id) UNIQUE
+#  index_user_levels_on_user_id_and_script_id               (user_id,script_id)
 #
 
 require 'cdo/activity_constants'

--- a/dashboard/db/migrate/20190409223227_add_index_to_user_levels.rb
+++ b/dashboard/db/migrate/20190409223227_add_index_to_user_levels.rb
@@ -1,0 +1,5 @@
+class AddIndexToUserLevels < ActiveRecord::Migration[5.0]
+  def change
+    add_index :user_levels, [:user_id, :script_id]
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190404195323) do
+ActiveRecord::Schema.define(version: 20190409223227) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1404,6 +1404,7 @@ ActiveRecord::Schema.define(version: 20190404195323) do
     t.boolean  "readonly_answers"
     t.datetime "unlocked_at"
     t.index ["user_id", "level_id", "script_id"], name: "index_user_levels_on_user_id_and_level_id_and_script_id", unique: true, using: :btree
+    t.index ["user_id", "script_id"], name: "index_user_levels_on_user_id_and_script_id", using: :btree
   end
 
   create_table "user_module_task_assignments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
### Background

According to @sureshc 's [Data Storage Requirements](https://docs.google.com/document/d/1iKEF-bSIjS45gOOxksavcrusxxF5JF3im4XWaMDGyy8/edit#) doc, there is a query on the `user_levels` table on `user_id` and `script_id` which is responsible for 8% of total DB load:
```
SELECT `user_levels` . *
FROM `user_levels`
WHERE `user_levels` . `user_id` = ?
AND `user_levels` . `script_id` = ?
ORDER BY `id` desc
```
The existing index on this table looks like this: https://github.com/code-dot-org/code-dot-org/blob/b092e5a2421470951005e18822eb0fc61c631d60/dashboard/app/models/user_level.rb#L19-L21

According to https://dev.mysql.com/doc/refman/5.5/en/multiple-column-indexes.html, this provides an index on the `user_id` part of the query, but not the `script_id` part:

> MySQL can use multiple-column indexes for queries that test all the columns in the index, or queries that test just the first column, the first two columns, the first three columns, and so on. If you specify the columns in the right order in the index definition, a single composite index can speed up several kinds of queries on the same table.

### Description

According to the above analysis and a couple of `EXPLAIN SELECT` calls,  this problematic query was only partially indexed. This PR defines a migration that will make this query fully indexed.

### Deployment

This migration may take a very long time to run. Therefore, this PR should be merged at a time when we can afford for the deploy to take many hours, or we should find a way to run it out-of-band from our regular deploy process.