### PR TITLE
PL: priority deadline announcement tweaks

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -299,6 +299,7 @@ class RegionalPartnerSearch extends Component {
                 for other Professional Development options in your area.
               </p>
               <StartApplicationButton
+                buttonOnly={true}
                 nominated={this.state.nominated}
                 priorityDeadlineDate={appsPriorityDeadlineDate}
               />
@@ -483,6 +484,7 @@ class RegionalPartnerSearch extends Component {
 }
 
 const StartApplicationButton = ({
+  buttonOnly,
   className,
   id,
   link,
@@ -510,25 +512,34 @@ const StartApplicationButton = ({
     notificationText = 'It’s not too late to sign up.';
   }
 
-  return (
-    <div>
-      <Notification
-        type="information"
-        notice={notificationHeading}
-        details={notificationText}
-        dismissible={false}
-      >
-        <a className={className} id={id} target={target} href={link}>
-          <button type="button" style={styles.bigButton}>
-            {buttonText}
-          </button>
-        </a>
-      </Notification>
-    </div>
+  const button = (
+    <a className={className} id={id} target={target} href={link}>
+      <button type="button" style={styles.bigButton}>
+        {buttonText}
+      </button>
+    </a>
   );
+
+  if (buttonOnly) {
+    return button;
+  } else {
+    return (
+      <div>
+        <Notification
+          type="information"
+          notice={notificationHeading}
+          details={notificationText}
+          dismissible={false}
+        >
+          {button}
+        </Notification>
+      </div>
+    );
+  }
 };
 
 StartApplicationButton.propTypes = {
+  buttonOnly: PropTypes.bool,
   className: PropTypes.string,
   id: PropTypes.string,
   link: PropTypes.string,

--- a/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
@@ -8,17 +8,17 @@
           .banner
             %img{src: "/images/homepage/professional-learning-2018-banner-purple.png"}
             .text
-              2019 Professional Learning deadlines are fast
+              Professional Learning deadlines fast approaching!
               %br/
-              approaching! Join now to reserve your spot
+              Sign up now to reserve your seat.
         .right.col-20
           %button
             Join us
       .phone.phone-feature
         .text
-          2019 Professional Learning deadlines are fast
+          Professional Learning deadlines fast approaching!
           %br/
-          approaching! Join now to reserve your spot
+          Sign up now to reserve your seat.
         %button
           Join us
 

--- a/shared/css/homepage_below_hero_plane_banner.scss
+++ b/shared/css/homepage_below_hero_plane_banner.scss
@@ -53,7 +53,7 @@ $light_background_colour: #a69bc1;
           line-height: 1.5;
           position: absolute;
           top: 0px;
-          left: 60px;
+          left: 37px;
           animation: fadein 5s;
         }
       }


### PR DESCRIPTION
## deadline announcement on homepage gets updated text

![Screenshot 2019-04-10 08 40 12](https://user-images.githubusercontent.com/2205926/55840995-d59fdf80-5b70-11e9-995c-6e694e2f8fa0.png)
![Screenshot 2019-04-10 08 40 28](https://user-images.githubusercontent.com/2205926/55840996-d59fdf80-5b70-11e9-83c6-86ba45ef64ca.png)

Followup to https://github.com/code-dot-org/code-dot-org/pull/27947

## regional partner search gets standalone button when no partner found

### before
![Screenshot 2019-04-10 08 49 57](https://user-images.githubusercontent.com/2205926/55841013-e51f2880-5b70-11e9-8220-389429c0d1d1.png)

### after
![Screenshot 2019-04-10 09 08 01](https://user-images.githubusercontent.com/2205926/55841016-e94b4600-5b70-11e9-8d39-32d9496fc8dd.png)

Followup to https://github.com/code-dot-org/code-dot-org/pull/27924