### PR TITLE
deflake teacher dashboard when clicking student name to load new page

### DIFF
--- a/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard.feature
@@ -14,7 +14,8 @@ Feature: Using the teacher dashboard
     And I wait until element "#uitest-teacher-dashboard-nav" is visible
     And check that the URL contains "/teacher_dashboard/sections/"
     And I wait until element "#uitest-course-dropdown" contains text "All the Things! *"
-    When I click selector "a:contains(Sally)" once I see it
+    And I wait until element "a:contains(Sally)" is visible
+    When I click selector "a:contains(Sally)" to load a new page
     And I wait until element "#teacher-panel-container" is visible
     And check that the URL contains "/s/allthethings"
     And check that the URL contains "viewAs=Teacher"


### PR DESCRIPTION
teacher dashboard ui tests have been failing like this lately: https://cucumber-logs.s3.amazonaws.com/test/test/Firefox45Win7_teacher_dashboard_output.html?versionId=eAxoLiS5khgaJSBakDNqULY9yhA_Kqye

The "too many connection resets" problem may be a symptom of starting a next UI test step too soon after the previous step performs an action which loads a new page. The solution is to use test steps ending in `to load a new page`, which wait for the old page to go away before continuing onto the next step.