### PR TITLE
deflake sign-in across ui tests

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -894,7 +894,7 @@ Given(/^I sign in as "([^"]*)"$/) do |name|
     Then I click ".header_user"
     And I wait to see "#signin"
     And I fill in username and password for "#{name}"
-    And I click "#signin-button"
+    And I click "#signin-button" to load a new page
     And I wait to see ".header_user"
   }
 end


### PR DESCRIPTION
The "too many connection resets" problem may be a symptom of starting a next UI test step too soon after the previous step performs an action which loads a new page. The solution is to use test steps ending in `to load a new page`, which wait for the old page to go away before continuing onto the next step.