### PR TITLE
Bug Fix: Bubbles Showing Over Top of Other Header Elments

### DIFF
--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -44,12 +44,7 @@ const styles = {
       'background-color .2s ease-out, border-color .2s ease-out, color .2s ease-out',
     marginTop: 3,
     marginBottom: 3,
-    position: 'relative',
-    // ReactTooltip sets a zIndex of 999. However, because in some cases for us
-    // the ReactTooltip is inside of a rotated div, it ends up in a different
-    // stacking context, and the zIndex doesn't work. Instead we set it here on
-    // the top component
-    zIndex: 999
+    position: 'relative'
   },
   largeDiamond: {
     width: DIAMOND_DOT_SIZE,


### PR DESCRIPTION
We ran into this eyes failure today where bubbles were showing above other buttons in the header.

![Screenshot 2019-04-10 at 10 56 43 AM (1)](https://user-images.githubusercontent.com/208083/55911470-c17ad300-5bae-11e9-8d11-f77068efce13.png)

This was introduced by adding `position: relative` to the bubbles for assessment work #27925 . It was that combined with the z-index which was causing the bubbles to show up in front of buttons. The z-index was added as a workaround for an issue with the tooltip. See #19538 . 

In testing, I was able to remove the z-index and not see the issue which promoted the change in #19538. 

<img width="596" alt="Screen Shot 2019-04-10 at 4 32 38 PM" src="https://user-images.githubusercontent.com/208083/55911698-233b3d00-5baf-11e9-97be-22993d315d74.png">

Since that z-index is over a year old there is a chance other work has fixed this issue and we did not know. 

Removing the z-index fixes the button overlap issue.

<img width="816" alt="Screen Shot 2019-04-10 at 4 41 41 PM" src="https://user-images.githubusercontent.com/208083/55911895-95138680-5baf-11e9-91f2-31c6ae550294.png">
