### PR TITLE
Version redirects

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -115,7 +115,7 @@ class ScriptsController < ApplicationController
   end
 
   def set_script
-    @script = Script.get_from_cache(params[:id])
+    @script = Script.get_from_cache(params[:id], user: current_user, locale: request.locale)
     if current_user && @script&.pilot? && !@script.has_pilot_access?(current_user)
       render :no_access
     end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -437,8 +437,8 @@ class Script < ActiveRecord::Base
   end
 
   # Given a script family name, return a dummy Script with redirect_to field
-  # pointing toward the latest stable script in that family, or to a specific
-  # version_year if one is specified.
+  # pointing toward the latest stable script assigned to the user in that family, or to a specific
+  # version_year and locale if specified.
   # @param family_name [String] The name of the script family to search in.
   # @param version_year [String] Optional. Version year to return.
   # @param user [User] Optional. If provided, will attempt to retrieve latest stable script

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -447,11 +447,7 @@ class Script < ActiveRecord::Base
   # @return [Script|nil] A dummy script object, not persisted to the database,
   #   with only the redirect_to field set.
   def self.get_script_family_redirect(family_name, version_year: nil, user: nil, locale: nil)
-    script_name = nil
-    if user
-      # TODO: try to get latest version assigned/progress
-    end
-
+    script_name = Script.latest_assigned_version(family_name, user).try(:name)
     script_name ||= Script.latest_stable_version(family_name, version_year: version_year, locale: locale, fallback: true).try(:name)
 
     script_name ? Script.new(redirect_to: script_name) : nil

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -446,7 +446,7 @@ class Script < ActiveRecord::Base
   # @param locale [String] Optional. Locale of the request.
   # @return [Script|nil] A dummy script object, not persisted to the database,
   #   with only the redirect_to field set.
-  def self.get_script_family_redirect(family_name, version_year: nil, user: nil, locale: nil)
+  def self.get_script_family_redirect(family_name, version_year: nil, user: nil, locale: 'en-US')
     script_name = Script.latest_assigned_version(family_name, user).try(:name)
     script_name ||= Script.latest_stable_version(family_name, version_year: version_year, locale: locale, fallback: true).try(:name)
 
@@ -512,7 +512,7 @@ class Script < ActiveRecord::Base
   # @param fallback [Boolean] If no latest stable version is found in provided locale,
   # fallback to latest stable version in default locale.
   # @return [Script|nil] Returns the latest version in a script family.
-  def self.latest_stable_version(family_name, version_year: nil, locale: 'en-us', fallback: false)
+  def self.latest_stable_version(family_name, version_year: nil, locale: 'en-US', fallback: false)
     return nil unless family_name.present?
 
     script_versions = Script.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -452,10 +452,7 @@ class Script < ActiveRecord::Base
       # TODO: try to get latest version assigned/progress
     end
 
-    script_name ||= Script.latest_stable_version(family_name, version_year: version_year, locale: locale).try(:name)
-
-    # A stable version of the script may not be available in given locale, so fallback to default locale (en-US).
-    script_name ||= Script.latest_stable_version(family_name, version_year: version_year).try(:name)
+    script_name ||= Script.latest_stable_version(family_name, version_year: version_year, locale: locale, fallback: true).try(:name)
 
     script_name ? Script.new(redirect_to: script_name) : nil
   end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -501,6 +501,13 @@ class ScriptTest < ActiveSupport::TestCase
     assert_nil Script.latest_stable_version('fake-family', locale: 'es-mx')
   end
 
+  test 'self.latest_stable_version returns latest stable in default locale if no script versions in family are stable in locale and fallback is true' do
+    create :script, name: 's-2017', family_name: 'fake-family', version_year: '2017', is_stable: true, supported_locales: []
+    script_2018 = create :script, name: 's-2018', family_name: 'fake-family', version_year: '2018', is_stable: true, supported_locales: []
+
+    assert_equal script_2018, Script.latest_stable_version('fake-family', locale: 'es-mx', fallback: true)
+  end
+
   test 'self.latest_stable_version returns latest stable version for user locale' do
     create :script, name: 's-2017', family_name: 'fake-family', version_year: '2017', is_stable: true, supported_locales: ["it-it"]
     script_2018 = create :script, name: 's-2018', family_name: 'fake-family', version_year: '2018', is_stable: true, supported_locales: ["it-it"]

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -388,6 +388,38 @@ class ScriptTest < ActiveSupport::TestCase
     end
   end
 
+  test 'get_script_family_redirect returns latest stable assigned version in family if user is provided' do
+    student = create :student
+    script1 = create :script, name: 's-1', family_name: 'courseg', version_year: '2017', is_stable: true
+    script2 = create :script, name: 's-2', family_name: 'courseg', version_year: '2018', is_stable: true
+
+    script_to_redirect_to = Script.get_script_family_redirect('courseg', user: student)&.redirect_to
+    assert_equal script2.name, script_to_redirect_to
+
+    section = create :section, script: script1
+    section.students << student
+    student.reload
+
+    script_to_redirect_to = Script.get_script_family_redirect('courseg', user: student)&.redirect_to
+    assert_equal script1.name, script_to_redirect_to
+  end
+
+  test 'get_script_family_redirect returns latest stable version in locale in family if available' do
+    create :script, name: 'english-only-script', family_name: 'courseg', version_year: '2018', is_stable: true, supported_locales: []
+    latest_in_locale = create :script, name: 'localized-script', family_name: 'courseg', version_year: '2017', is_stable: true, supported_locales: ['it-it']
+
+    script_to_redirect_to = Script.get_script_family_redirect('courseg', locale: 'it-it')&.redirect_to
+    assert_equal latest_in_locale.name, script_to_redirect_to
+  end
+
+  test 'get_script_family_redirect returns latest stable version in default locale in family if no versions support locale' do
+    latest_in_english = create :script, name: 'english-only-script', family_name: 'courseg', version_year: '2018', is_stable: true, supported_locales: []
+    create :script, name: 'localized-script', family_name: 'courseg', version_year: '2017', is_stable: true, supported_locales: ['it-it']
+
+    script_to_redirect_to = Script.get_script_family_redirect('courseg', locale: 'es-mx')&.redirect_to
+    assert_equal latest_in_english.name, script_to_redirect_to
+  end
+
   test 'redirect_to_script_url returns nil unless user can view script version' do
     Script.any_instance.stubs(:can_view_version?).returns(false)
     student = create :student


### PR DESCRIPTION
[LP-28](https://codedotorg.atlassian.net/browse/LP-28)
[Spec](https://docs.google.com/document/d/1jYznJYlrfXQ-MJvmgfmZbVjjAM9-i297hoFTCqoYJ5w/edit?usp=sharing)

**Satisfies the following requirements in spec:**
If I go to a URL that is the “base name” of the script (e.g. /s/coursea), and...
- I have no existing progress in any version of that script: I should get redirected to the recommended one for my language. For example, if I’m in Spanish, /s/coursea should redirect me to /s/coursea-2017. If I’m in English or in an unsupported language (say Hindi), I should get redirected to /s/coursea-2018. 
- If I have existing progress in a newer version or I’m assigned to ONLY a newer version of the course than is recommended for my language, I should be redirected to the newest version I have progress in. EX: I have progress in Coursea-2018 in English, but my language is Spanish (2017 would be my recommended stable version), I should still go to coursea-2018 because that’s where I’ve been assigned or have progress.
- If I have existing progress in multiple versions of the script or am assigned to multiple versions of the script where some of the progress/assignment is in a newer version than is recommended for my language, I should still go to the latest version that I have progress in, but we should warn you that you have progress in other, older versions.
