### PR TITLE
Fix cloudformation stack when not creating database [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -79,6 +79,7 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
+<% if database -%>
           # Read-only access to current secrets.
           - Effect: Allow
             Action: 'secretsmanager:GetSecretValue'
@@ -87,6 +88,7 @@ Resources:
             Condition:
               StringEquals:
                 secretsmanager:VersionStage: AWSCURRENT
+<% end -%>
           # Read-only access to bootstrap scripts.
           - Effect: Allow
             Action: 's3:GetObject'


### PR DESCRIPTION
This condition is needed; otherwise it'll fail on template validation, since it refers to a nonexistent resource.