### PR TITLE
Have test server use mysql endpoint specified in db_writer value [ci skip]

### DIFF
--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -88,7 +88,7 @@ test:
   collation: utf8_unicode_ci
   username: <%= writer.user || 'root' %>
   password: <%= writer.password || '' %>
-  host: 'localhost'
+  host: <%= writer.host || 'localhost' %>
   pool: <%= ENV['CI'] ? 20 : 5 %>
   database: dashboard_test<%= ENV['TEST_ENV_NUMBER'] %>
   connect_timeout: 2


### PR DESCRIPTION
Test cloudformation stack has successfully updated and provisioned an aurora instance. After this is deployed, I'll edit the locals.yml file on the test server to set db_writer to point to the aurora instance.