### PR TITLE
save code on Match levels within level groups

### DIFF
--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -45,21 +45,22 @@ export default class Match {
     const response = [];
 
     for (let index = 0; index < elements.length; index++) {
+      const xmark = $(`#xmark_${this.levelId}_${index}`);
       const originalIndex = elements[index].getAttribute('originalIndex');
       response.push(originalIndex);
       if (originalIndex === null) {
         // nothing dragged in this slot yet
         wrongAnswer = true;
 
-        $('#xmark_' + index).hide();
+        xmark.hide();
       } else if (originalIndex !== String(index)) {
         // wrong answer
         wrongAnswer = true;
 
-        $('#xmark_' + index).show();
+        xmark.show();
       } else {
         // correct answer
-        $('#xmark_' + index).hide();
+        xmark.hide();
       }
     }
     return {

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -1,4 +1,9 @@
 /* global jQuery, CDOSounds */
+
+import React from 'react';
+import {MatchErrorDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
+import {registerGetResult} from './codeStudioLevels';
+
 jQuery.fn.swap = function(b) {
   // method from: http://blog.pengoworks.com/index.cfm/2008/9/24/A-quick-and-dirty-swap-method-for-jQuery
   b = jQuery(b)[0];
@@ -20,10 +25,46 @@ export default class Match {
 
     // Whether this is the only puzzle on a page, or part of a group of them.
     this.standalone = standalone;
+
+    $(document).ready(() => this.ready());
+  }
+
+  ready() {
+    if (this.standalone) {
+      registerGetResult(this.getResult.bind(this));
+    }
   }
 
   getResult() {
-    throw 'getResult not implemented';
+    let wrongAnswer = false;
+
+    const elements = $('#slots li');
+
+    const response = [];
+
+    for (let index = 0; index < elements.length; index++) {
+      const originalIndex = elements[index].getAttribute('originalIndex');
+      response.push(originalIndex);
+      if (originalIndex === null) {
+        // nothing dragged in this slot yet
+        wrongAnswer = true;
+
+        $('#xmark_' + index).hide();
+      } else if (originalIndex !== String(index)) {
+        // wrong answer
+        wrongAnswer = true;
+
+        $('#xmark_' + index).show();
+      } else {
+        // correct answer
+        $('#xmark_' + index).hide();
+      }
+    }
+    return {
+      response: response,
+      result: !wrongAnswer,
+      errorDialog: wrongAnswer ? <MatchErrorDialog /> : null
+    };
   }
   getAppName() {
     return 'match';

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -152,8 +152,10 @@ export default class Match {
 
   makeItemDroppable(item) {
     const enableSounds = this.standalone;
+    const container = document.getElementById(this.id);
     item.droppable({
-      accept: '.answerslot',
+      accept: element =>
+        $(element).is('.answerslot') && $(container).find(element[0]).length,
       activeClass: 'active',
       drop: function(event, ui) {
         if (enableSounds) {

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -34,8 +34,7 @@ export default class Match {
       registerGetResult(this.getResult.bind(this));
     }
 
-    const container = document.getElementById(this.id);
-    initMatch(container, this.standalone);
+    this.initMatch();
   }
 
   getResult() {
@@ -78,88 +77,91 @@ export default class Match {
   getCurrentAnswerFeedback() {
     throw 'getCurrentAnswerFeedback not implemented';
   }
-}
 
-// Initialize drag and drop for all match elements (answers and slots) within
-// the container. Answers are made draggable and slots are made droppable. The
-// container limits this as follows:
-//   * only elements within the container are marked draggable / droppable
-//   * answers are only droppable on slots within the same container
-//   * answers cannot be dragged outside of the container.
-function initMatch(container, enableSounds = false) {
-  $(container)
-    .find('.mainblock #answers li')
-    .draggable({revert: 'invalid', stack: '.answer', containment: container});
+  // Initialize drag and drop for all match elements (answers and slots) within
+  // the container. Answers are made draggable and slots are made droppable. The
+  // container limits this as follows:
+  //   * only elements within the container are marked draggable / droppable
+  //   * answers are only droppable on slots within the same container
+  //   * answers cannot be dragged outside of the container.
+  initMatch() {
+    const container = document.getElementById(this.id);
+    const enableSounds = this.standalone;
 
-  // set up the central list of empty slots.
-  $(container)
-    .find('.mainblock #slots li')
-    .droppable({
-      activeClass: 'active',
-      hoverClass: 'hover',
-      accept: element =>
-        $(element).is('.answerlist,.answerslot') &&
-        $(container).find(element[0]).length,
-      drop: function(event, ui) {
-        if (enableSounds) {
-          CDOSounds.play('click');
-        }
-        // once an answer is in the central list of slots, it will just swap with whatever it's dragged onto
-        if (ui.draggable.hasClass('answerslot')) {
-          // swap this empty slot and the answer dragged onto it
-          ui.draggable.swap(event.target);
+    $(container)
+      .find('.mainblock #answers li')
+      .draggable({revert: 'invalid', stack: '.answer', containment: container});
 
-          // remove offset coordinates from this item
-          ui.draggable.css({top: 'auto', left: 'auto'});
-        } else {
-          // when an answer is in the rightmost list of answers, it can be dragged in to replace an empty slot
-          // in the central list of slots.
+    // set up the central list of empty slots.
+    $(container)
+      .find('.mainblock #slots li')
+      .droppable({
+        activeClass: 'active',
+        hoverClass: 'hover',
+        accept: element =>
+          $(element).is('.answerlist,.answerslot') &&
+          $(container).find(element[0]).length,
+        drop: function(event, ui) {
+          if (enableSounds) {
+            CDOSounds.play('click');
+          }
+          // once an answer is in the central list of slots, it will just swap with whatever it's dragged onto
+          if (ui.draggable.hasClass('answerslot')) {
+            // swap this empty slot and the answer dragged onto it
+            ui.draggable.swap(event.target);
 
-          var movingItem = ui.draggable.detach();
+            // remove offset coordinates from this item
+            ui.draggable.css({top: 'auto', left: 'auto'});
+          } else {
+            // when an answer is in the rightmost list of answers, it can be dragged in to replace an empty slot
+            // in the central list of slots.
 
-          // replace target with this new item
-          $(event.target).replaceWith(movingItem);
+            var movingItem = ui.draggable.detach();
 
-          // the new item is now droppable
-          movingItem.droppable();
+            // replace target with this new item
+            $(event.target).replaceWith(movingItem);
 
-          // remove offset coordinates from the dragged item
-          movingItem.css({top: 'auto', left: 'auto'});
+            // the new item is now droppable
+            movingItem.droppable();
 
-          // this class is no longer in the answer list
-          movingItem.removeClass('answerlist');
+            // remove offset coordinates from the dragged item
+            movingItem.css({top: 'auto', left: 'auto'});
 
-          // this class can now be both dragged and a drop target for fellow answers in slots
-          movingItem.addClass('answerslot');
+            // this class is no longer in the answer list
+            movingItem.removeClass('answerlist');
 
-          // this new item can now be dropped onto by other answers in the central list
-          movingItem.droppable({
-            accept: '.answerslot',
-            activeClass: 'active',
-            drop: function(event, ui) {
-              if (enableSounds) {
-                CDOSounds.play('whoosh');
+            // this class can now be both dragged and a drop target for fellow answers in slots
+            movingItem.addClass('answerslot');
+
+            // this new item can now be dropped onto by other answers in the central list
+            movingItem.droppable({
+              accept: '.answerslot',
+              activeClass: 'active',
+              drop: function(event, ui) {
+                if (enableSounds) {
+                  CDOSounds.play('whoosh');
+                }
+
+                // remove offset coordinates from the dragged item
+                ui.draggable.css({top: '0px', left: '0px'});
+
+                // determine y difference between old location and new location of item that will be swapped out
+                var origY = $(event.target).offset().top;
+                var destY = $(ui.draggable).offset().top;
+                var diffY = destY - origY;
+
+                // swap this answer with the answer dropped onto it
+                ui.draggable.swap(event.target);
+
+                // move the target object back to its old location for a moment
+                $(event.target).css({top: -diffY + 'px'});
+
+                // and animate back to its new location
+                $(event.target).animate({top: '0px'});
               }
-
-              // remove offset coordinates from the dragged item
-              ui.draggable.css({top: '0px', left: '0px'});
-
-              // determine y difference between old location and new location of item that will be swapped out
-              var origY = $(event.target).offset().top;
-              var destY = $(ui.draggable).offset().top;
-              var diffY = destY - origY;
-
-              // swap this answer with the answer dropped onto it
-              ui.draggable.swap(event.target);
-
-              // move the target object back to its old location for a moment
-              $(event.target).css({top: -diffY + 'px'});
-
-              // and animate back to its new location
-              $(event.target).animate({top: '0px'});
-            }
-          });
+            });
+          }
         }
-      }
-    });
+      });
+  }
 }

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import {MatchErrorDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
-import {registerGetResult} from './codeStudioLevels';
+import {registerGetResult, onAnswerChanged} from './codeStudioLevels';
 
 jQuery.fn.swap = function(b) {
   // method from: http://blog.pengoworks.com/index.cfm/2008/9/24/A-quick-and-dirty-swap-method-for-jQuery
@@ -137,6 +137,8 @@ export default class Match {
 
             // this new item can now be dropped onto by other answers in the central list
             this.makeItemDroppable(movingItem);
+
+            onAnswerChanged(this.levelId, true);
           }
         }
       });

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -40,7 +40,8 @@ export default class Match {
   getResult() {
     let wrongAnswer = false;
 
-    const elements = $('.match_slots li');
+    const container = document.getElementById(this.id);
+    const elements = $(container).find('.match_slots li');
 
     const response = [];
 

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -58,7 +58,9 @@ export default class Match {
         // wrong answer
         wrongAnswer = true;
 
-        xmark.show();
+        if (this.standalone) {
+          xmark.show();
+        }
       } else {
         // correct answer
         xmark.hide();

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -10,6 +10,32 @@ jQuery.fn.swap = function(b) {
   return this;
 };
 
+export default class Match {
+  constructor(levelId, id, standalone) {
+    // The dashboard levelId.
+    this.levelId = levelId;
+
+    // The DOM id.
+    this.id = id;
+
+    // Whether this is the only puzzle on a page, or part of a group of them.
+    this.standalone = standalone;
+  }
+
+  getResult() {
+    throw 'getResult not implemented';
+  }
+  getAppName() {
+    return 'match';
+  }
+  lockAnswers() {
+    throw 'lockAnswers not implemented';
+  }
+  getCurrentAnswerFeedback() {
+    throw 'getCurrentAnswerFeedback not implemented';
+  }
+}
+
 // Initialize drag and drop for all match elements (answers and slots) within
 // the container. Answers are made draggable and slots are made droppable. The
 // container limits this as follows:

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -33,6 +33,9 @@ export default class Match {
     if (this.standalone) {
       registerGetResult(this.getResult.bind(this));
     }
+
+    const container = document.getElementById(this.id);
+    initMatch(container, this.standalone);
   }
 
   getResult() {
@@ -83,7 +86,7 @@ export default class Match {
 //   * only elements within the container are marked draggable / droppable
 //   * answers are only droppable on slots within the same container
 //   * answers cannot be dragged outside of the container.
-export function initMatch(container, enableSounds = false) {
+function initMatch(container, enableSounds = false) {
   $(container)
     .find('.mainblock #answers li')
     .draggable({revert: 'invalid', stack: '.answer', containment: container});

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -138,7 +138,11 @@ export default class Match {
             // this new item can now be dropped onto by other answers in the central list
             this.makeItemDroppable(movingItem);
 
-            onAnswerChanged(this.levelId, true);
+            // Once all answers have been dropped into a slot, let anyone
+            // listening know that an answer has been selected.
+            if ($(container).find('.match_answers .answer').length === 0) {
+              onAnswerChanged(this.levelId, true);
+            }
           }
         }
       });

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -40,7 +40,7 @@ export default class Match {
   getResult() {
     let wrongAnswer = false;
 
-    const elements = $('#slots li');
+    const elements = $('.match_slots li');
 
     const response = [];
 
@@ -90,12 +90,12 @@ export default class Match {
     const enableSounds = this.standalone;
 
     $(container)
-      .find('.mainblock #answers li')
+      .find('.mainblock .match_answers li')
       .draggable({revert: 'invalid', stack: '.answer', containment: container});
 
     // set up the central list of empty slots.
     $(container)
-      .find('.mainblock #slots li')
+      .find('.mainblock .match_slots li')
       .droppable({
         activeClass: 'active',
         hoverClass: 'hover',

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -103,7 +103,7 @@ export default class Match {
         accept: element =>
           $(element).is('.answerlist,.answerslot') &&
           $(container).find(element[0]).length,
-        drop: function(event, ui) {
+        drop: (event, ui) => {
           if (enableSounds) {
             CDOSounds.play('click');
           }
@@ -136,34 +136,39 @@ export default class Match {
             movingItem.addClass('answerslot');
 
             // this new item can now be dropped onto by other answers in the central list
-            movingItem.droppable({
-              accept: '.answerslot',
-              activeClass: 'active',
-              drop: function(event, ui) {
-                if (enableSounds) {
-                  CDOSounds.play('whoosh');
-                }
-
-                // remove offset coordinates from the dragged item
-                ui.draggable.css({top: '0px', left: '0px'});
-
-                // determine y difference between old location and new location of item that will be swapped out
-                var origY = $(event.target).offset().top;
-                var destY = $(ui.draggable).offset().top;
-                var diffY = destY - origY;
-
-                // swap this answer with the answer dropped onto it
-                ui.draggable.swap(event.target);
-
-                // move the target object back to its old location for a moment
-                $(event.target).css({top: -diffY + 'px'});
-
-                // and animate back to its new location
-                $(event.target).animate({top: '0px'});
-              }
-            });
+            this.makeItemDroppable(movingItem);
           }
         }
       });
+  }
+
+  makeItemDroppable(item) {
+    const enableSounds = this.standalone;
+    item.droppable({
+      accept: '.answerslot',
+      activeClass: 'active',
+      drop: function(event, ui) {
+        if (enableSounds) {
+          CDOSounds.play('whoosh');
+        }
+
+        // remove offset coordinates from the dragged item
+        ui.draggable.css({top: '0px', left: '0px'});
+
+        // determine y difference between old location and new location of item that will be swapped out
+        var origY = $(event.target).offset().top;
+        var destY = $(ui.draggable).offset().top;
+        var diffY = destY - origY;
+
+        // swap this answer with the answer dropped onto it
+        ui.draggable.swap(event.target);
+
+        // move the target object back to its old location for a moment
+        $(event.target).css({top: -diffY + 'px'});
+
+        // and animate back to its new location
+        $(event.target).animate({top: '0px'});
+      }
+    });
   }
 }

--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -96,7 +96,11 @@ export default class Match {
       .find('.mainblock .match_answers li')
       .draggable({revert: 'invalid', stack: '.answer', containment: container});
 
-    // set up the central list of empty slots.
+    this.makeInitialAnswersDroppable(container, enableSounds);
+  }
+
+  // set up the central list of empty slots.
+  makeInitialAnswersDroppable(container, enableSounds) {
     $(container)
       .find('.mainblock .match_slots li')
       .droppable({

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -7,8 +7,8 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 import * as codeStudioLevels from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {SingleLevelGroupDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
 import i18n from '@cdo/locale';
-import {initMatch} from '@cdo/apps/code-studio/levels/match';
-
+import Match, {initMatch} from '@cdo/apps/code-studio/levels/match';
+window.Match = Match;
 window.Multi = require('@cdo/apps/code-studio/levels/multi.js');
 window.TextMatch = require('@cdo/apps/code-studio/levels/textMatch.js');
 var saveAnswers = require('@cdo/apps/code-studio/levels/saveAnswers.js')

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -7,7 +7,7 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 import * as codeStudioLevels from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {SingleLevelGroupDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
 import i18n from '@cdo/locale';
-import Match, {initMatch} from '@cdo/apps/code-studio/levels/match';
+import Match from '@cdo/apps/code-studio/levels/match';
 window.Match = Match;
 window.Multi = require('@cdo/apps/code-studio/levels/multi.js');
 window.TextMatch = require('@cdo/apps/code-studio/levels/textMatch.js');
@@ -26,8 +26,6 @@ $(document).ready(() => {
       initData.last_attempt
     );
   }
-
-  $('.level-group-content').each((i, element) => initMatch(element));
 });
 
 function initLevelGroup(levelCount, currentPage, lastAttempt) {

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -64,9 +64,10 @@ function initLevelGroup(levelCount, currentPage, lastAttempt) {
       }
       const subLevel = codeStudioLevels.getLevel(subLevelId);
       var subLevelResult = subLevel.getResult(true);
-      var response = encodeURIComponent(
-        replaceEmoji(subLevelResult.response.toString())
-      );
+      var response = subLevelResult.response;
+      if (subLevel.getAppName() !== 'match') {
+        response = encodeURIComponent(replaceEmoji(response.toString()));
+      }
       var result = subLevelResult.result;
       var testResult = subLevelResult.testResult
         ? subLevelResult.testResult

--- a/apps/src/sites/studio/pages/levels/_match.js
+++ b/apps/src/sites/studio/pages/levels/_match.js
@@ -1,11 +1,7 @@
 /* global appOptions */
 import React from 'react';
-import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {showDialog} from '@cdo/apps/code-studio/levels/dialogHelper';
-import {
-  MatchAngiGifDialog,
-  MatchErrorDialog
-} from '@cdo/apps/lib/ui/LegacyDialogContents';
+import {MatchAngiGifDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
 
 import Match, {initMatch} from '@cdo/apps/code-studio/levels/match';
 window.Match = Match;
@@ -19,36 +15,4 @@ $(function() {
 
   const container = $('#level-body').first();
   initMatch(container, true);
-});
-
-registerGetResult(() => {
-  let wrongAnswer = false;
-
-  const elements = $('#slots li');
-
-  const response = [];
-
-  for (let index = 0; index < elements.length; index++) {
-    const originalIndex = elements[index].getAttribute('originalIndex');
-    response.push(originalIndex);
-    if (originalIndex === null) {
-      // nothing dragged in this slot yet
-      wrongAnswer = true;
-
-      $('#xmark_' + index).hide();
-    } else if (originalIndex !== String(index)) {
-      // wrong answer
-      wrongAnswer = true;
-
-      $('#xmark_' + index).show();
-    } else {
-      // correct answer
-      $('#xmark_' + index).hide();
-    }
-  }
-  return {
-    response: response,
-    result: !wrongAnswer,
-    errorDialog: wrongAnswer ? <MatchErrorDialog /> : null
-  };
 });

--- a/apps/src/sites/studio/pages/levels/_match.js
+++ b/apps/src/sites/studio/pages/levels/_match.js
@@ -7,7 +7,8 @@ import {
   MatchErrorDialog
 } from '@cdo/apps/lib/ui/LegacyDialogContents';
 
-import {initMatch} from '@cdo/apps/code-studio/levels/match';
+import Match, {initMatch} from '@cdo/apps/code-studio/levels/match';
+window.Match = Match;
 
 $(function() {
   // This setting (pre_title) is used by only 3 levels in our application.

--- a/apps/src/sites/studio/pages/levels/_match.js
+++ b/apps/src/sites/studio/pages/levels/_match.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {showDialog} from '@cdo/apps/code-studio/levels/dialogHelper';
 import {MatchAngiGifDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
 
-import Match, {initMatch} from '@cdo/apps/code-studio/levels/match';
+import Match from '@cdo/apps/code-studio/levels/match';
 window.Match = Match;
 
 $(function() {
@@ -12,7 +12,4 @@ $(function() {
     // Note: This dialog depends on the presence of some haml, found in _dialog.html.haml
     window.setTimeout(() => showDialog(<MatchAngiGifDialog />), 1000);
   }
-
-  const container = $('#level-body').first();
-  initMatch(container, true);
 });

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2072,7 +2072,7 @@ a.download-video {
     border-color: transparent;
     border-width: 6px;
   }
-  #questions {
+  .match_questions {
     list-style-type: none;
     margin-left: 0;
     li {
@@ -2083,7 +2083,7 @@ a.download-video {
   li {
     text-align: center;
   }
-  #slots {
+  .match_slots {
     list-style-type: none;
     margin-left: 0;
     .emptyslot {
@@ -2119,7 +2119,7 @@ a.download-video {
     border-color: $light_green;
     cursor: move;
   }
-  #answerdest {
+  .match_answerdest {
     width: 240px;
   }
   .answerlist {
@@ -2129,7 +2129,7 @@ a.download-video {
       @include yTranslation(-50%);
     }
   }
-  #answers {
+  .match_answers {
     list-style-type: none;
     margin-left: 0;
   }
@@ -2140,11 +2140,11 @@ a.download-video {
       @include yTranslation(-50%);
     }
   }
-  #correctmarkscolumn {
+  .match_correctmarkscolumn {
     width: 20px;
     padding-right: 20px;
   }
-  #correctmarks {
+  .match_correctmarks {
     margin-left: 0;
   }
   .correctmark {

--- a/dashboard/app/views/levels/_match_answer.html.haml
+++ b/dashboard/app/views/levels/_match_answer.html.haml
@@ -4,11 +4,11 @@
     %h3= t('teacher.answer')
     .content
       .column
-        %ul#questions
+        %ul.match_questions
           - level.questions.each do |question|
             %li{style: "height: #{level.height}px"}!= match_t(question['text'], level)
-      .column#answerdest
-        %ul#answers
+      .column.match_answerdest
+        %ul.match_answers
           - level.answers.each do |answer|
             %li.answer.answerlist{style: "height: #{level.height}px"}!= match_t(answer['text'], level)
       .clear

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -31,7 +31,7 @@
       %ul#correctmarks
         - level.questions.each_with_index do |question, index|
           %li.correctmark{style: "height: #{level.height}px"}
-            .xmark{style: 'display: none;', id: "xmark_#{index}"}
+            .xmark{style: 'display: none;', id: "xmark_#{level.id}_#{index}"}
               %strong X
 
     .column

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -15,11 +15,11 @@
 
   .mainblock
     .column
-      %ul#questions
+      %ul.match_questions
         - level.questions.each do |question|
           %li{style: "height: #{level.height}px"}!= match_t(question['text'], level)
-    .column#answerdest
-      %ul#slots.draggablecolumn
+    .column.match_answerdest
+      %ul.match_slots.draggablecolumn
         - level.answers.each do |_|
           %li.emptyslot{style: "height: #{level.height}px"}
             .giantmark
@@ -27,15 +27,15 @@
               .text{style: "font-size: #{giantmark_height}px; line-height: #{giantmark_height}px"}
                 ?
 
-    .column#correctmarkscolumn
-      %ul#correctmarks
+    .column.match_correctmarkscolumn
+      %ul.match_correctmarks
         - level.questions.each_with_index do |question, index|
           %li.correctmark{style: "height: #{level.height}px"}
             .xmark{style: 'display: none;', id: "xmark_#{level.id}_#{index}"}
               %strong X
 
     .column
-      %ul#answers.draggablecolumn
+      %ul.match_answers.draggablecolumn
         - level.shuffled_indexed_answers.each do |answer|
           %li.answer.answerlist{style: "height: #{level.height}px", originalIndex: answer['index']}!= match_t(answer['text'], level)
 

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -1,4 +1,4 @@
-.unplugged.match
+.unplugged.match{id: "level_#{level.id}"}
   = render partial: 'levels/content', locals: {app: 'match', data: level.properties, content_class: level.question_content_class, source_level: level, hide_header: !standalone}
 
   - if standalone && !(level.properties['options'].try(:[], 'hide_submit'))
@@ -44,3 +44,10 @@
     = render partial: 'levels/dialog', locals: {app: 'match'}
   = render partial: 'levels/match_answer', locals: {level: level}
   = render partial: 'levels/teacher_markdown', locals: {data: level.properties}
+
+  :javascript
+    window.dashboard.codeStudioLevels.registerLevel(#{level.id}, new Match(
+      #{level.id},
+      "level_#{level.id}",
+      #{standalone},
+    ));

--- a/dashboard/config/scripts/test_longassessment_multigroup_new.level_group
+++ b/dashboard/config/scripts/test_longassessment_multigroup_new.level_group
@@ -4,3 +4,5 @@ page
 level 'K-1 Happy Maps Multi 1'
 level 'Multi Horizontal Scroll Test'
 level 'Choose 2 Test'
+level 'CSD U3 drawSprites placement match'
+level 'CSD U3 - conditionals - Matching_2018'

--- a/dashboard/test/ui/features/level_group.feature
+++ b/dashboard/test/ui/features/level_group.feature
@@ -30,3 +30,11 @@ Scenario: Submit three answers.
   And element ".level-group-content:nth(1) #checked_1" is visible
   And element ".level-group-content:nth(2) #checked_2" is visible
   And element ".level-group-content:nth(2) #checked_0" is visible
+
+Scenario: Match levels within level group
+  Given match level 0 question contains text "Match the code to the image that it will produce."
+  And match level 0 contains 4 unplaced answers
+  And match level 0 contains 4 empty slots
+  And match level 1 question contains text "Match the boolean expression to the English description."
+  And match level 1 contains 5 unplaced answers
+  And match level 1 contains 5 empty slots

--- a/dashboard/test/ui/features/level_group.feature
+++ b/dashboard/test/ui/features/level_group.feature
@@ -38,3 +38,12 @@ Scenario: Match levels within level group
   And match level 1 question contains text "Match the boolean expression to the English description."
   And match level 1 contains 5 unplaced answers
   And match level 1 contains 5 empty slots
+
+  When I drag match level 0 unplaced answer 0 to empty slot 0
+  And I drag match level 1 unplaced answer 0 to empty slot 0
+
+  Then match level 0 contains 3 unplaced answers
+  And match level 0 contains 3 empty slots
+  And match level 1 contains 4 unplaced answers
+  And match level 1 contains 4 empty slots
+  And element ".xmark" is not visible

--- a/dashboard/test/ui/features/step_definitions/match_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/match_steps.rb
@@ -15,3 +15,11 @@ And /^match level (\d+) contains (\d+) empty slots$/ do |index, expected_count|
   actual_count = @browser.execute_script("return $(#{selector.dump}).length;")
   expect(actual_count).to eq(expected_count.to_i)
 end
+
+And /^I drag match level (\d+) unplaced answer (\d+) to empty slot (\d+)$/ do |level, answer, slot|
+  level_selector = ".level-group-content .match:nth(#{level})"
+  answer_selector = "#{level_selector} .match_answers .answer:nth(#{answer})"
+  slot_selector = "#{level_selector} .match_slots .emptyslot:nth(#{slot})"
+  code = generate_selector_drag_code(answer_selector, slot_selector, 0, 0)
+  @browser.execute_script code
+end

--- a/dashboard/test/ui/features/step_definitions/match_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/match_steps.rb
@@ -1,0 +1,17 @@
+And /^match level (\d+) question contains text "([^"]*)"$/ do |index, expected_text|
+  selector = ".level-group-content .match:nth(#{index}) .question"
+  actual_text = @browser.execute_script("return $(#{selector.dump}).text();")
+  expect(actual_text).to include(expected_text)
+end
+
+And /^match level (\d+) contains (\d+) unplaced answers$/ do |index, expected_count|
+  selector = ".level-group-content .match:nth(#{index}) .match_answers .answer"
+  actual_count = @browser.execute_script("return $(#{selector.dump}).length;")
+  expect(actual_count).to eq(expected_count.to_i)
+end
+
+And /^match level (\d+) contains (\d+) empty slots$/ do |index, expected_count|
+  selector = ".level-group-content .match:nth(#{index}) .match_slots .emptyslot"
+  actual_count = @browser.execute_script("return $(#{selector.dump}).length;")
+  expect(actual_count).to eq(expected_count.to_i)
+end


### PR DESCRIPTION
### Background

* partially implements https://codedotorg.atlassian.net/browse/LP-166
* builds on https://github.com/code-dot-org/code-dot-org/pull/27296
* the Match class is modeled after the [Multi](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/levels/multi.js) class

Today, standalone match levels make milestone posts to save student code, but that data is never surfaced again in the product. non-standalone match levels (e.g. those within level groups) do not save student code.

### Description

start saving code on match levels within level groups. specifically:

* create Match class implementing this interface: https://github.com/code-dot-org/code-dot-org/blob/1cad5ac667f9ed1a3aa31063e6d06bd21a78e2bd/apps/src/code-studio/levels/codeStudioLevels.js#L78-L83
* extract existing "getResult" method into Match class
* convert many element ids to classnames, to allow multiple match levels on the same page
* start making milestone posts on match levels within level groups once all answer slots have been filled

### Testing
* Including a basic ui test for match levels in level groups in this PR
* per today's testing discussion, I'll add integration / unit tests soon to cover more pathways, avoiding duplication of UI test pathways
* end-to-end test for code saving / loading will come after code loading is implemented. For now, I've just manually verified that milestone posts are happening and that UserLevel entries are being created.