### PR TITLE
Pegasus: set noindex meta tag properly for a bunch of pages

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/facilitator-2019.md
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/facilitator-2019.md
@@ -1,9 +1,8 @@
 ---
 title: Facilitator Development Program
 theme: responsive
+noindex: true
 ---
-
-<meta name=“robots” content=“noindex”>
 
 # Facilitating with Code.org
 
@@ -17,7 +16,7 @@ theme: responsive
 
 ## Change the face of computer science education - become a Code.org facilitator.
 
-Code.org counts on engaging, committed, and knowledgeable facilitators to develop and support the next generation of computer science educators. 
+Code.org counts on engaging, committed, and knowledgeable facilitators to develop and support the next generation of computer science educators.
 
 Ready to take your leadership to the next level?
 
@@ -33,7 +32,7 @@ Our online applications take 25-30 minutes to complete, and are not optimized fo
 
 <div class="col-60", style="padding-right:20px;">
 
-Code.org's Facilitator Development Program is a highly-selective professional learning program designed to prepare and support facilitators to deliver quality workshops on Code.org's curriculum. 
+Code.org's Facilitator Development Program is a highly-selective professional learning program designed to prepare and support facilitators to deliver quality workshops on Code.org's curriculum.
 
 <br>
 <br>
@@ -69,7 +68,7 @@ We're seeking candidates who demonstrate the following qualities:
 [col-80]
 
 <h3 style="font-family: 'Gotham 5r', sans-serif">Champion for CS Education</h3>
- 
+
   * Enthusiastic supporter of K-12 CS education
 
 [/col-80]
@@ -180,7 +179,7 @@ When participants apply to the program, they must select a curriculum focus area
 
 Have questions? We have answers!
 
-Check out our <a href="https://docs.google.com/document/d/e/2PACX-1vQzx_dR5g68Zzg7atSIZ_y8_tlSXln8dqBrW0oh1dQkTb6M56cdk3N9ozxgci4vJCdm6h3uwZ4douK4/pub", target=_"blank">FAQs</a> or write to us at facilitators@code.org 
+Check out our <a href="https://docs.google.com/document/d/e/2PACX-1vQzx_dR5g68Zzg7atSIZ_y8_tlSXln8dqBrW0oh1dQkTb6M56cdk3N9ozxgci4vJCdm6h3uwZ4douK4/pub", target=_"blank">FAQs</a> or write to us at facilitators@code.org
 
 ## Apply now!
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook.haml
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook.haml
@@ -1,9 +1,8 @@
 ---
 title: Regional Partner Virtual Playbook
 theme: responsive
+noindex: true
 ---
-
-%meta{name: 'robots', content: 'noindex'}
 
 %script{src: minifiable_asset_path('js/code.org/public/educate/regional-partner/playbook.js')}
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/FAQ.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/FAQ.md
@@ -1,14 +1,14 @@
 ---
 title: FAQ
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
 # Regional Partner FAQs
 
 
-Still have questions? See below for answers to commonly asked questions or email [partner@code.org](partner@code.org). 
+Still have questions? See below for answers to commonly asked questions or email [partner@code.org](partner@code.org).
 <br/><br/>
 **General questions:**<br/>
 
@@ -24,7 +24,7 @@ Still have questions? See below for answers to commonly asked questions or email
 
 **Questions about the budget:**<br/>
 
-- [Where can I find a breakdown of what Code.org provides?](#pay)	
+- [Where can I find a breakdown of what Code.org provides?](#pay)
 
 <br/>
 
@@ -57,7 +57,7 @@ ________________
 <br/>
 ### **Does my organization need to provide facilitators for CS Principles and CS Discoveries?**
 
-Your organization does not need to have its own facilitators. Code.org Regional Partners contracts with facilitators and alumni from Code.org's [facilitator development program](https://code.org/facilitator). 
+Your organization does not need to have its own facilitators. Code.org Regional Partners contracts with facilitators and alumni from Code.org's [facilitator development program](https://code.org/facilitator).
 <br/>
 
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/administrator.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/administrator.md
@@ -1,8 +1,8 @@
 ---
 title: administrator and counselor PD
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
 # Administrator and Counselor Workshops

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/advocacy.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/advocacy.md
@@ -1,13 +1,13 @@
 ---
 title: Advocacy
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
 # Advocacy
 
-Regional partners who are interested in advocacy can use the following resources to advocate for K-12 computer science policy in your state. 
+Regional partners who are interested in advocacy can use the following resources to advocate for K-12 computer science policy in your state.
 
 ## General Resources
 
@@ -17,7 +17,7 @@ Regional partners who are interested in advocacy can use the following resources
 - [Making CS Fundamental](https://code.org/files/Making_CS_Fundamental.pdf): Description of 9 policy ideas to expand computer science in a state
 - [Advocacy Slide Deck](https://code.org/files/computer_science_advocacy.pptx): Generic presentation to convince someone that computer science is important to teach in grades K-12. Also see this [master slide deck](https://docs.google.com/presentation/d/1SUGh9QdyXoXPepD1vC5YXRnicxp-th_yWX8dNM_vywc/edit?usp=sharing) with sample slides that you can remix into your own presentation
 - [Letter to elected official](https://code.org/files/policy_maker_letter.pdf): Sample text to explain the importance of computer science to governors, members of state legislature, or school board members
-- Interested in setting up a **Coding in the Capitol** or similar event? These resources help with event considerations, marketing, tracking, and so much more. Start with this [overview document](https://docs.google.com/document/d/1h1Owwx4J0E-o08YzY_OfoyXFpDoHJPi73dCCBqNapsk/edit#heading=h.i5l0dimqr6zg), which points to all the [resources and examples](https://drive.google.com/drive/u/0/folders/1p7xXx75cRHj2G5AWJ7_FCklh1OaR6pR1) for your coding event.  
+- Interested in setting up a **Coding in the Capitol** or similar event? These resources help with event considerations, marketing, tracking, and so much more. Start with this [overview document](https://docs.google.com/document/d/1h1Owwx4J0E-o08YzY_OfoyXFpDoHJPi73dCCBqNapsk/edit#heading=h.i5l0dimqr6zg), which points to all the [resources and examples](https://drive.google.com/drive/u/0/folders/1p7xXx75cRHj2G5AWJ7_FCklh1OaR6pR1) for your coding event.
 
 ## State-by-State Data
 - [2018 State of Computer Science Education](https://code.org/files/2018_state_of_cs.pdf): Annual report on computer science education policy and implementation across the U.S.
@@ -27,7 +27,7 @@ Regional partners who are interested in advocacy can use the following resources
 - <a href="https://public.tableau.com/profile/liz.gauthier#!/vizhome/9Policies-Public/PublicTracker"target=_blank>9 Policies Tracker:</a> Track the number of policies adopted per state.
 
 ## Policy Development Resources
-- [State Planning Toolkit](https://docs.google.com/document/d/13N843-BjK9JHXNWKFzJlxhpw7f6Y2pJF6tpV2aHM1HU/edit?usp=sharing): A guide for state teams creating strategic plans for implementing K-12 computer science 
+- [State Planning Toolkit](https://docs.google.com/document/d/13N843-BjK9JHXNWKFzJlxhpw7f6Y2pJF6tpV2aHM1HU/edit?usp=sharing): A guide for state teams creating strategic plans for implementing K-12 computer science
 - [Teacher Pathways Recommendations](http://code.org/files/TeacherPathwayRecommendations.pdf): Whitepaper providing recommendations around teacher certification and preservice teacher preparation
 - [Championing K-12 Computer Science Education](http://media.wix.com/ugd/be22fe_c41ff338edaa4b6594764859b8657c51.pdf): In-depth explanations of the top three policy ideas, plus other ideas for policymakers to advance computer science in a state
 - [Model Legislation](https://docs.google.com/document/d/1TL70O0pxsiv-ilC6puSagG4JzLTrDc5UMKfzyBwUgNI/edit?usp=sharing): Sample language that can be used for legislation related to three computer science education policies
@@ -36,9 +36,9 @@ Regional partners who are interested in advocacy can use the following resources
 - [Rethinking Perkins](https://code.org/files/CS_and_ESSA.pdf): Guidance to states for leveraging Perkins funding to support and expand CS education
 
 ## Other Links
-Visit the websites below to find out more. 
+Visit the websites below to find out more.
 
-- [Governors’ Partnership for K-12 Computer Science](http://governorsforcs.org) 
+- [Governors’ Partnership for K-12 Computer Science](http://governorsforcs.org)
 - [K-12 Computer Science Framework](http://k12cs.org)
 - [More Advocacy Materials](https://code.org/promote/morestats): Resources and statistics from Code.org to assist in creation of advocacy materials, including Code.org talking points, blog posts, and outside resources
 - [More Policy Resources](https://advocacy.code.org/policy-resources): Resources and whitepapers for advacing computer science education policy in your state

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/communications.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/communications.md
@@ -1,8 +1,8 @@
 ---
 title: Communications
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 
 # Communications Playbook
 
@@ -25,15 +25,15 @@ ________________
 
 Hour of Code is an exciting time and leads towards increased interest in CS Fundamentals professional learning. Use <a href="https://docs.google.com/presentation/d/16RpRhMBbmEDboAKKcNMOcoG71bqQkZq__qrTA6Z-bLQ/edit?usp=sharing" target=_blank>this marketing kit</a> to attract new schools post-Hour of Code with highly customizable marketing collateral. From email templates, social media messages, one-page flyers, and stock images - this kit has all you need!
 
-#### Hour of Code Toolkits are now available! 
+#### Hour of Code Toolkits are now available!
 
-View the <a href="https://drive.google.com/file/d/1U_xHspO5Js5CNEI0WQlgZPEAaJMRnRvX/view?usp=sharing" target=_blank>Hour of Code Toolkit</a> for information on how to organize an Hour of Code event or the <a href="https://drive.google.com/drive/folders/1pvpRd-B4Ug41vnJkK5-P67rpdATaM8AH" target=_blank>Creativity Campaign Toolkit</a> to begin planning a campaign in your region. 
+View the <a href="https://drive.google.com/file/d/1U_xHspO5Js5CNEI0WQlgZPEAaJMRnRvX/view?usp=sharing" target=_blank>Hour of Code Toolkit</a> for information on how to organize an Hour of Code event or the <a href="https://drive.google.com/drive/folders/1pvpRd-B4Ug41vnJkK5-P67rpdATaM8AH" target=_blank>Creativity Campaign Toolkit</a> to begin planning a campaign in your region.
 
 ________________
 <a id="archive"></a>
 
 ## Regional Partner Weekly Update Emails
-Each week we send out an email with important action items, new collateral, CS Education news, etc. 
+Each week we send out an email with important action items, new collateral, CS Education news, etc.
 
 - [Group 1 weekly emails](https://docs.google.com/document/d/1suhDTctEfeGnXY4shwWqBmb8dIXZ603RkVfqPuVPbnU/edit?usp=sharing)
 - [Group 2 weekly emails](https://docs.google.com/document/d/1Z1gXtCTU5Veih9gAxLw4VsAHeSC4HA_A70O1VWH_ZZI/edit?usp=sharing)

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/community.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/community.md
@@ -1,8 +1,8 @@
 ---
 title: Community Building
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
 # Community Building
@@ -39,7 +39,7 @@ Teachers should feel supported as members of a teacher community. Use community 
 Incorporate the diverse and varied computer science community in your events! Anyone who is interested in supporting computer science in the classroom should feel like they can attend.
 
 **When to hold them?**<br/>
-Hold at least 4 community events for teachers through the year.  Please ensure at least 3 of these events are spread out during the academic year.  We recommend 2 events during the "fall term" before December 31 and 2 events between January 1 and the end of the school year. 
+Hold at least 4 community events for teachers through the year.  Please ensure at least 3 of these events are spread out during the academic year.  We recommend 2 events during the "fall term" before December 31 and 2 events between January 1 and the end of the school year.
 
 **What's expected?**<br/>
 All events should include teachers from your professional learning programs across CS Fundamentals, Discoveries, and Principles.  We also encourage you to open up these events to CS teachers outside your cohorts. Consider partnering with other organizations to host these events.

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/curriculum.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/curriculum.md
@@ -1,8 +1,8 @@
 ---
 title: Teachers & Curriculum
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 
 # Teachers & Curriculum
 
@@ -79,9 +79,9 @@ ________________
 
 ## **Technology in Classroom**
 
-As part of the application and selection process, it's important to ensure that schools, districts, and teachers selected to participate in our programs can meet Code.org’s technology requirements before they are selected to participate in the program. 
+As part of the application and selection process, it's important to ensure that schools, districts, and teachers selected to participate in our programs can meet Code.org’s technology requirements before they are selected to participate in the program.
 
-Whitelisting is the act of placing a domain or email on an ‘acceptable list’ for an organization's (school district or company) firewall. Some school districts will block all websites and emails that are not specifically entered into their whitelist. Generally, to whitelist a domain or email you will need to reach out to the organization’s IT department.    
+Whitelisting is the act of placing a domain or email on an ‘acceptable list’ for an organization's (school district or company) firewall. Some school districts will block all websites and emails that are not specifically entered into their whitelist. Generally, to whitelist a domain or email you will need to reach out to the organization’s IT department.
 
 Please review these general guidelines for whitelisting:<br/>
 [Teacher Participation Guidelines](/educate/it) <br/>

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/data.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/data.md
@@ -1,16 +1,16 @@
 ---
 title: Using Data
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 
 # Using Data
 
-More resources to come. 
+More resources to come.
 
 ## Quick Links
 - [Access Your Data Dashboard](#tableau)
-- [2018 Summer Data Clean-up](#summer) 
+- [2018 Summer Data Clean-up](#summer)
 - [Data Dashboard How-To Guide](#guide)
 - [Access Report](#access)
 
@@ -20,19 +20,19 @@ More resources to come.
 
 
 ### Sign In
-Visit <a href="http://online.tableau.com/" target=_blank>http://online.tableau.com/</a> to sign into the Code.org Data Dashboard. 
+Visit <a href="http://online.tableau.com/" target=_blank>http://online.tableau.com/</a> to sign into the Code.org Data Dashboard.
 
 ### Don't have an account?
 <details>
   <summary>Set up your account</summary>
-  <p> 
+  <p>
 
-1. Each Regional Partner organization is provided with one partner account. 
-	* If multiple people in your organization need to access the data, we encourage you to set up your account with a password that can be shared within your organization. 
-2. Email your Regional Manager if you have not been set up with an account. 
-	* Once your account has been set up, you will receive an email from Tableau with instructions on how to access your Tableau account, including setting up your password. 
+1. Each Regional Partner organization is provided with one partner account.
+	* If multiple people in your organization need to access the data, we encourage you to set up your account with a password that can be shared within your organization.
+2. Email your Regional Manager if you have not been set up with an account.
+	* Once your account has been set up, you will receive an email from Tableau with instructions on how to access your Tableau account, including setting up your password.
 	* The email will say “You’ve been invited to Tableau Online”
-	* There will be an orange button prompting you to sign up for the first time and set up your password. 
+	* There will be an orange button prompting you to sign up for the first time and set up your password.
 </p>
 </details>
 
@@ -43,7 +43,7 @@ Check out **<a href="https://docs.google.com/document/d/14KgWKsfRuzC740lDZLlgjTp
 <a name="summer"></a>
 ## 2018 Summer Data Clean-up
 
-Teacher data from your 2018-19 CS Principles and CS Discoveries local summer workshop or TeacherCon cohorts is now available in Tableau. We need your help to identify errors to be fixed so this data will be more useful to you long term. This is a one-time clean-up process that will give you a more accurate view into important metrics like implementation rate, URM student numbers, and overall program health. Changes that you’ve requested will be implemented by the Code.org data team and visible in your Tableau data dashboard by the end of November. 
+Teacher data from your 2018-19 CS Principles and CS Discoveries local summer workshop or TeacherCon cohorts is now available in Tableau. We need your help to identify errors to be fixed so this data will be more useful to you long term. This is a one-time clean-up process that will give you a more accurate view into important metrics like implementation rate, URM student numbers, and overall program health. Changes that you’ve requested will be implemented by the Code.org data team and visible in your Tableau data dashboard by the end of November.
 
 Please navigate to the <a href="https://us-east-1.online.tableau.com/#/site/codeorg/views/Regionalpartnerdatasharing/TeacherRoster
 " target=_blank>Teacher Roster tab</a> of your data dashboard and filter to this school year.
@@ -52,16 +52,16 @@ Note that there is a filter for each course, CS Discoveries and CS Principles, s
 
 <details>
   <summary>Teachers who are actually implementing, but are listed as having 0 students</summary>
-  <p> 
-  
+  <p>
+
 * This might occur if a teacher is teaching with a Code.org account that is different from the one they used to register for your workshop or TeacherCon. If you are able to give us the email address of the account the teacher is using to teach, we can fix their data in Tableau.
 </p>
 </details>
 
 <details>
   <summary>Teachers to remove</summary>
-  <p> 
-  
+  <p>
+
 * There may be some people that are included in the attendance for your workshop according to the dashboard, but shouldn't be listed as part of your cohort (e.g., novice and apprentice facilitators). Please identify these people so we can remove them.
 * It is possible that the same teacher might appear multiple times on your list. Please identify these people so we can remove one of the two entries.
 * You should not remove teachers that are no longer teaching the course or participating in PD for any reason. This information is important to retain for implementation rates.
@@ -70,16 +70,16 @@ Note that there is a filter for each course, CS Discoveries and CS Principles, s
 
 <details>
   <summary>Teachers to add</summary>
-  <p> 
+  <p>
 
-* If for any reason a teacher is missing from your roster, please provide their email address. The address you provide should be associated with the Code.org account they use to teach. 
+* If for any reason a teacher is missing from your roster, please provide their email address. The address you provide should be associated with the Code.org account they use to teach.
 </p>
 </details>
 
 
-**Data change requests will be accepted until November 9**. Indicate the changes that you’re requesting in **<a href="https://docs.google.com/forms/d/e/1FAIpQLSfyI2FIPoncROIZ3GDf0Uxt2W5OLqBvIjYUP8rONFc5qTp12w/viewform?usp=sf_link" target=_blank>this survey</a>**. 
+**Data change requests will be accepted until November 9**. Indicate the changes that you’re requesting in **<a href="https://docs.google.com/forms/d/e/1FAIpQLSfyI2FIPoncROIZ3GDf0Uxt2W5OLqBvIjYUP8rONFc5qTp12w/viewform?usp=sf_link" target=_blank>this survey</a>**.
 
-Please also note that this process is for CS Discoveries and CS Principles programs only. We have not yet defined a process for CS Fundamentals teacher data. 
+Please also note that this process is for CS Discoveries and CS Principles programs only. We have not yet defined a process for CS Fundamentals teacher data.
 
 <a name="access"></a>
 ## K-12 Computer Science Access Report
@@ -89,8 +89,8 @@ The data we gather can be an incredible resource to you, but only if it is robus
 
 <details>
   <summary>How can you help?</summary>
-  <p> 
-  
+  <p>
+
 * Include a call in your newsletters for students, teachers, parents, and districts to fill out the survey at <a href="http://code.org/yourschool" target=_blank>http://code.org/yourschool</a>. You can find sample language to use in your newsletter [here](https://docs.google.com/document/d/1O9julhujYWIkg-JAm92B-6havhPLSTI0avnXFXlthsk/edit?usp=sharing)
 * Connect to local organizations in your region who can spread the word on your behalf.
 * Connect us to organizations that may already have this information in your region (accessreport@code.org).

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/directory.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/directory.md
@@ -1,8 +1,8 @@
 ---
 title: Regional Partner Directory
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name=“robots” content=“noindex”>
 
 # Regional Partner Network
 
@@ -28,9 +28,9 @@ As the Regional Partner program continues to mature and expand, Code.org will lo
 
 **Purpose**
 
-The advisory committee is a valuable resource for Code.org to understand our partners’ needs and to tailor our models accordingly. Regional Partners are carrying on the teacher recruitment, professional learning, and district management work that Code.org began, and as such, they are now the power users of Code.org tools and processes and are best suited to offer valuable feedback and input.  While there are numerous avenues for all partners to provide feedback, make suggestions, and share ideas such as regional managers, ongoing feedback surveys, and at Partner Summits, the advisory committee provides a formal structure for ongoing communication with a representative group of Regional Partners. Code.org benefits from hearing feedback, advice and receiving guidance on the direction of the program. 
+The advisory committee is a valuable resource for Code.org to understand our partners’ needs and to tailor our models accordingly. Regional Partners are carrying on the teacher recruitment, professional learning, and district management work that Code.org began, and as such, they are now the power users of Code.org tools and processes and are best suited to offer valuable feedback and input.  While there are numerous avenues for all partners to provide feedback, make suggestions, and share ideas such as regional managers, ongoing feedback surveys, and at Partner Summits, the advisory committee provides a formal structure for ongoing communication with a representative group of Regional Partners. Code.org benefits from hearing feedback, advice and receiving guidance on the direction of the program.
 
-The advisory committee is also a forum to connect peers across the Regional Partner network to share resources and successes, discuss ideas, and connect and learn from each other.  Committee members serve a 2- or 3-year term and represent a broad range of partners from all Groups, institutional types, and geographic locations.  New committee members are nominated by Code.org staff in collaboration with the current advisory committee.  If you are interested in serving on the committee in the future, have questions, or would like to learn more, please email the Chair(s) to express your interest. 
+The advisory committee is also a forum to connect peers across the Regional Partner network to share resources and successes, discuss ideas, and connect and learn from each other.  Committee members serve a 2- or 3-year term and represent a broad range of partners from all Groups, institutional types, and geographic locations.  New committee members are nominated by Code.org staff in collaboration with the current advisory committee.  If you are interested in serving on the committee in the future, have questions, or would like to learn more, please email the Chair(s) to express your interest.
 
 <a id="members"></a>
 
@@ -39,7 +39,7 @@ The advisory committee is also a forum to connect peers across the Regional Part
 <%= view :about_headshots, people:DB[:cdo_team].where(kind_s:'rpadvisory') %>
 
 <a id="resources"></a>
-## Shared Resources 
+## Shared Resources
 
 Access the Regional Partner Network Google Drive [here](https://drive.google.com/drive/folders/1yKAijpPre8wFRStRhIpl_1BuKcxQa9HW?usp=sharing).
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/facilitator-support.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/facilitator-support.md
@@ -1,8 +1,8 @@
 ---
 title: Facilitators
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 
 <a id="top"></a>
 
@@ -30,11 +30,11 @@ ________________
 ________________
 
 <a id="interviews"></a>
-### Interviewing Facilitators 
+### Interviewing Facilitators
 
 Keep these three important things on your radar as you prepare for upcoming facilitator interviews. Watch this [very quick recording](https://code.zoom.us/recording/play/_kbC3EU3s8sHFBPeessecWvewQcZLofgK0dFZXzOFL2BU8SYM-gorH_WBj6vuXQ-?startTime=1548267193000) for more details, and read below for the highlights.
 
-1.  **Interview Scheduling:** 
+1.  **Interview Scheduling:**
 All Group 1 - 3 Regional Partners are responsible for scheduling interviews with their candidates during the interview period of Feb. 11 - March 1. Interviews should be booked for 30 minutes, and should include a video chat (e.g., Google hangout, Zoom, etc.) if they’re not hosted in-person. However, we recommend you block an hour on your calendar for prepare and review. Remember that many candidates are teachers who have limited availability during the school day, so please be prepared to host interviews in the late-afternoon or early evening.
 2.  **Interview Support:** All Group 1 - 3 Regional Partners are responsible for hosting interviews on their own, without the support of a Code.org-contracted co-interviewer. This means that Regional Partners will need to plan ahead to make sure they are able to conduct the interview while taking notes in the application dashboard.
 3.  **Interview Questions and Process:** We will cover the interview process and required interview questions in detail during the February Regional Partner Summit.
@@ -60,10 +60,10 @@ ________________
 ### Example contract
 [This is an example](/files/example-facilitation-agreement.pdf) of an agreement that facilitators sign when facilitating for Code.org. You should develop your own agreement for use with facilitators that meets your organization's particular needs, and which ensures that the terms of the Regional Partner agreement you have signed with Code.org, particularly Section 3 (Indemnification), Section 6.1 (Description of Duties) and Section 7 (Confidential Information), are met.
 
-We have created these example Scope of Work documents that you can use as a planning resource when establishing a relationship with a K-5 or 6-12 facilitators. These document lives in our shared Google Drive folder. 
+We have created these example Scope of Work documents that you can use as a planning resource when establishing a relationship with a K-5 or 6-12 facilitators. These document lives in our shared Google Drive folder.
 
 - <a href="https://docs.google.com/document/d/1sdGbB5BSBTjjjjC6abIjAO4XzznXVvgwQe95CRL_c6E/edit?usp=sharing" target=_blank>K-5 example Scope of Work</a>
--  <a href="https://docs.google.com/document/d/1JM9UmPcwLUv_lCDAdFtX3jBst4B34ll-zQukaGl34Kc/edit" target=_blank>6-12 example Scope of Work</a> 
+-  <a href="https://docs.google.com/document/d/1JM9UmPcwLUv_lCDAdFtX3jBst4B34ll-zQukaGl34Kc/edit" target=_blank>6-12 example Scope of Work</a>
 
 
 *DISCLAIMER: By providing these resources and example documents, Code.org is not offering you legal advice. You should consult a lawyer if you need advice about contracts, the language therein, or any other legal matter. These resources are meant to serve as general guides for you to customize and make adjustments that are right for your organization, while still staying within the bounds of the program guidelines Code.org has outlined.*

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/funding.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/funding.md
@@ -1,8 +1,8 @@
 ---
 title: Fundraising Resources
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
 # Topics
@@ -35,9 +35,9 @@ It's important to start thinking about how you will sustain these programs witho
 <a id="gettingstarted"></a>
 ### What can you do if you're just getting started?
 
-- Create your prospect list of potential funders (who is likely to fund your Program Manager, etc.) 
-- Project how much you need and how much you can raise from this list in 3-4 months 
-- Start outreach to potential funders to pitch them through emails, calls or in person meetings 
+- Create your prospect list of potential funders (who is likely to fund your Program Manager, etc.)
+- Project how much you need and how much you can raise from this list in 3-4 months
+- Start outreach to potential funders to pitch them through emails, calls or in person meetings
 - Use a special event as your “closer” event
 
 [**Back to the top**](#top)
@@ -46,16 +46,16 @@ ________________
 <a id="start"></a>
 <br/>
 <br/>
-# Fundraising Playbook 
+# Fundraising Playbook
 
 When looking for donor support, it is important for your organization to understand the different types of donors. Each donor type may have different partnership expectations and giving trends that can either help or detract from your organization’s mission.
 
 **Types of Support:**
- 
-- **Individuals:** “major donors” - high net worth/family foundations, “small” donors (typically online) 
-- **Corporate:** grant from corporation’s foundation or sponsorship (donation in exchange for benefits such as logos and other marketing / visibility) 
-- **Large National Foundations:** ex. Gates Foundation, Rockefeller, etc. 
-- **In-Kind:** donated products and services (ex. office space, software, catering, advertising) 
+
+- **Individuals:** “major donors” - high net worth/family foundations, “small” donors (typically online)
+- **Corporate:** grant from corporation’s foundation or sponsorship (donation in exchange for benefits such as logos and other marketing / visibility)
+- **Large National Foundations:** ex. Gates Foundation, Rockefeller, etc.
+- **In-Kind:** donated products and services (ex. office space, software, catering, advertising)
 
 Note: This list of revenue streams is not exhaustive, but outlines the types of revenue streams Code.org pursues. You could also explore: crowdfunding, employee matching/giving, planned giving, events/galas, etc). Your organization should decide what fundraising methods work best to achieve your mission.
 
@@ -82,11 +82,11 @@ ________________
 
 ### Fundraising Strategy Best Practices:
 
-- **Diversify your revenue streams:** ex. Code.org if funded by approximately 40% corporations, 40% foundations/high net worth individuals, 20% online donations 
-  * Having a mix of types of support creates more stable funding and reduces risk year over year 
-- **Program/mission focus:** Code.org best practice is lead with the ask with potential funders who have mutual goals, believe in your mission, and do not ask for you to stray away from your mission. Code.org does not pursue customized programs with funders, where the funder donates to create a specific program with the nonprofit. This enables us to stay focused on achieving our mission at scale, maintain lean fundraising operations/staff, and ultimately create more impact. 
-- **General operating support vs. restricted funding:** Code.org best practice is to try to maintain as much general operating support to allow your organization to stay flexible to meet the needs of your program goals, and maintain low overhead and staff to manage grants and donors 
-- **Multi-Year Grants:** if possible, try to secure multi year grants to advance your mission. This will help you raise funds more efficiently and be able to better project your future income and cash flow. 
+- **Diversify your revenue streams:** ex. Code.org if funded by approximately 40% corporations, 40% foundations/high net worth individuals, 20% online donations
+  * Having a mix of types of support creates more stable funding and reduces risk year over year
+- **Program/mission focus:** Code.org best practice is lead with the ask with potential funders who have mutual goals, believe in your mission, and do not ask for you to stray away from your mission. Code.org does not pursue customized programs with funders, where the funder donates to create a specific program with the nonprofit. This enables us to stay focused on achieving our mission at scale, maintain lean fundraising operations/staff, and ultimately create more impact.
+- **General operating support vs. restricted funding:** Code.org best practice is to try to maintain as much general operating support to allow your organization to stay flexible to meet the needs of your program goals, and maintain low overhead and staff to manage grants and donors
+- **Multi-Year Grants:** if possible, try to secure multi year grants to advance your mission. This will help you raise funds more efficiently and be able to better project your future income and cash flow.
 
 
 |Best Practices| |
@@ -102,7 +102,7 @@ ________________
 <a id="research"></a>
 <br/>
 # Research
-The relationship between an organization and their donors should be based on clear communication and a partnership based in a common goal and mission. Throughout the research process to identify prospective donors, your organization will look at many different aspects of the prospective donor to assess if the donor is a good match for your organization. 
+The relationship between an organization and their donors should be based on clear communication and a partnership based in a common goal and mission. Throughout the research process to identify prospective donors, your organization will look at many different aspects of the prospective donor to assess if the donor is a good match for your organization.
 
 ## Prospective Research sheet:
 
@@ -126,30 +126,30 @@ Overall, match level is based on the research areas aligning with your own organ
 
 ## Other Research Resources:
 - Here is a list of potential funders.
-- General Fundraising Websites: 
+- General Fundraising Websites:
   * [Foundation Center](http://foundationcenter.org/findfunders/fundingsources/fdo.html)
   * [The Chronicle of Philanthropy](https://philanthropy.com/)
   * [GrantSpace](http://grantspace.org)
   * [Charity Navigator](http://www.charitynavigator.org/)
-  
+
 [**Back to the top**](#top)
 <br/>
 ________________
 <a id="outreach"></a>
 <br/>
-# Outreach 
+# Outreach
 Outreach is the securing of initial calls and meetings with potential funders. Once you have your research completed and you have determined your “pipeline” i.e. target list of potential donors to reach out to, its time to make the ask.
 
 ## Basic Solicitation Cycle:
-- Begin with thoughtful research to determine if potential donor is a good fit for your mission (see research template) 
+- Begin with thoughtful research to determine if potential donor is a good fit for your mission (see research template)
 - Outreach to potential donor via email (an introduction from a mutual contact or Board Member is always helpful)
 - Meet or schedule a call to determine interest and inclination of potential donor
-  * Involve donor prospect substantively to determine partnership value and fit - ask questions on what goals they have, what are their pain points? 
-  * Demonstrate your organization’s accomplishments and share your community of supporters who help provide credibility 
-  * Show you address their goals and why your partnership is a good fit 
-  * Ask if you can follow up with another call, meeting, or proposal 
-- Develop a proposal (include $ ask) 
-- Follow-up, answer any questions, negotiate and secure the donation 
+  * Involve donor prospect substantively to determine partnership value and fit - ask questions on what goals they have, what are their pain points?
+  * Demonstrate your organization’s accomplishments and share your community of supporters who help provide credibility
+  * Show you address their goals and why your partnership is a good fit
+  * Ask if you can follow up with another call, meeting, or proposal
+- Develop a proposal (include $ ask)
+- Follow-up, answer any questions, negotiate and secure the donation
 - Thank and steward the donor throughout the year. Include an opportunity to engage directly with your programs or employee engagement. Email communications on your accomplishments and program updates and engaging key executives to learn more about your mission.
 - Create Impact Reports/communications to demonstrate the value of the donor’s support
 - Reach out and set up a call or meeting 6-9 months into your grant cycle to start having renewal discussions
@@ -216,16 +216,16 @@ ________________
 
 ## Do's:
 
-- Have a clear vision, strategy and outcomes 
+- Have a clear vision, strategy and outcomes
 - Focus on building authentic, mutually beneficial relationships
-- Find funders who truly believe in your organization’s mission, vision and program 
+- Find funders who truly believe in your organization’s mission, vision and program
 - Leverage your position as a leader and expertise for your cause
-- Understand the pain points and goals of your potential funder and position yourself as a solution to help them achieve those goals 
+- Understand the pain points and goals of your potential funder and position yourself as a solution to help them achieve those goals
 - Share a list of your other donors and funders to demonstrate credibility
-- Be transparent with your finances and how you spend your money / where the money goes 
-- Recognize, thank and communicate with your donors often 
-- Be proactive with your follow up and stewardship 
-- Demonstrate the impact of your work through data, evaluation, case studies, impact stories 
+- Be transparent with your finances and how you spend your money / where the money goes
+- Recognize, thank and communicate with your donors often
+- Be proactive with your follow up and stewardship
+- Demonstrate the impact of your work through data, evaluation, case studies, impact stories
 
 ## Don'ts:
 
@@ -244,9 +244,9 @@ ________________
 <br/>
 # Supports for Pursuing Federal and State Grants
 
-This resource has been created to provide regional partners who may be interested in pursuing federal or state grant funding with some basic guidance and suggestions on doing so. In many cases the language can also be applied to the pursuit of corporate, foundation, or individual funding. 
+This resource has been created to provide regional partners who may be interested in pursuing federal or state grant funding with some basic guidance and suggestions on doing so. In many cases the language can also be applied to the pursuit of corporate, foundation, or individual funding.
 
-The document has been organized to reflect the major sections typically associated with federal grant applications and will include a basic explanation of what the particular section is about, indicators of effectiveness, a few tips to keep in mind, and generic templates from which to build your specific proposal off of. Templates are meant to be examples and not prescriptive. In the end your proposal should uniquely reflect the strengths and resources of your organization and the efforts you will engage in both as a Regional Partner of Code.org and as a leader of computer science education in your region. It is up to you to determine how much you want to highlight your collaboration with Code.org or take a more general approach focusing on your organization’s efforts. 
+The document has been organized to reflect the major sections typically associated with federal grant applications and will include a basic explanation of what the particular section is about, indicators of effectiveness, a few tips to keep in mind, and generic templates from which to build your specific proposal off of. Templates are meant to be examples and not prescriptive. In the end your proposal should uniquely reflect the strengths and resources of your organization and the efforts you will engage in both as a Regional Partner of Code.org and as a leader of computer science education in your region. It is up to you to determine how much you want to highlight your collaboration with Code.org or take a more general approach focusing on your organization’s efforts.
 
 Click [here](https://docs.google.com/document/d/1-F21aQTOmWuYt4l1wm8Ae2SrsGydBDoXiM7ifzCqsi0/edit#) to access the resource.
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/legacy.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/legacy.md
@@ -1,15 +1,14 @@
-<meta name="robots" content="noindex">
-
 ---
 title: Legacy Programs
 nav: regional_partner_playbook_nav
+noindex: true
 ---
 
 <a id="top"></a>
 
 # Legacy Programs
 
-See below for documents and more information about Code.org's legacy programs.  Code.org has discontinued professional learning for these programs, but are leaving the information available for those partners who have decided to continue them. 
+See below for documents and more information about Code.org's legacy programs.  Code.org has discontinued professional learning for these programs, but are leaving the information available for those partners who have decided to continue them.
 
 ## Quick Links
 
@@ -24,7 +23,7 @@ Click on the program name below to find out more about our **legacy programs**. 
 
 <a id="algebra"></a>
 ________________
-## **Computer Science in Algebra** 
+## **Computer Science in Algebra**
 
 [CS In Algebra homepage](https://code.org/curriculum/algebra)<br/>
 [CS in Algebra Course A Curriculum (PDF)](https://curriculum.code.org/algebra/courseA.pdf)<br/>
@@ -105,7 +104,7 @@ Always accommodate vegetarian needs, roughly ⅓ of the order. In communications
 ________________
 <a id="science"></a>
 
-## **Computer Science in Science** 
+## **Computer Science in Science**
 
 [CS in Science homepage](https://code.org/curriculum/science)
 
@@ -180,7 +179,7 @@ Always accommodate vegetarian needs, roughly ⅓ of the order. In communications
 ________________
 <a id="ecs"></a>
 
-## **Exploring Computer Science** 
+## **Exploring Computer Science**
 [ECS Curriculum homepage](http://www.exploringcs.org/for-teachers-districts/curriculum)
 
 <details>
@@ -208,7 +207,7 @@ These guidelines explain the type of space your facilitators need to run a succe
 | |Requirements and Suggestions|
 |:-----|:-----------|
 |**Location**|**Ask yourself these questions when searching for the the ideal location for your workshop.**<br/> - Central location: Is the location central to the spread of teachers attending? <br/>- Catering: Are there several options to order from within 20 miles? Is there an internal or preferred caterer for the venue?<br/> - Parking: Does parking cost anything? Will teachers need parking passes? Is the lot close to an entrance? *Tip: teachers are more likely to show up to the workshop when parking is free.* <br/> - Access: Will there be someone from the venue there to open the building, help with getting supplies to your room(s), and be available to help with technology as needed during the workshop?|
-|**Rooms and <br/>Set Up**|Reservation time: <br/>Rooms need to be reserved from 7:30 am to 4:30 pm (M-Th) and 7:30 am to 2:30 pm (F).<Br/><br/> General itinerary:<br/> 7:30 am - 8:30 am - facilitators arrive and set up room<br/>8:30 am - 9:00 am - teachers arrive, register & eat breakfast</br> 9:00 am - 12:00 pm - workshop time<br/> 12:00 pm - 1:00 pm - break for lunch<br/>1:00 pm - 3:30 pm - workshop time<br/>3:30 pm - 4:30 pm - facilitators clean up for the night<br/>Note: ECS workshops end at 1:30 pm on Fridays.<br/><br/>Rooms Needed:<br/>- One room for entire group<br/>- Breakout room to set up catering and for eating. Hallway space also works. We want to avoid interrupting the session by setting up food in the room.<br/>- Wall space for hanging poster sized paper with Blue painter's tape<br/><br/>Seating<br/>- Pods of 4 people for the size of the group. We recommend 8 pods.|  
+|**Rooms and <br/>Set Up**|Reservation time: <br/>Rooms need to be reserved from 7:30 am to 4:30 pm (M-Th) and 7:30 am to 2:30 pm (F).<Br/><br/> General itinerary:<br/> 7:30 am - 8:30 am - facilitators arrive and set up room<br/>8:30 am - 9:00 am - teachers arrive, register & eat breakfast</br> 9:00 am - 12:00 pm - workshop time<br/> 12:00 pm - 1:00 pm - break for lunch<br/>1:00 pm - 3:30 pm - workshop time<br/>3:30 pm - 4:30 pm - facilitators clean up for the night<br/>Note: ECS workshops end at 1:30 pm on Fridays.<br/><br/>Rooms Needed:<br/>- One room for entire group<br/>- Breakout room to set up catering and for eating. Hallway space also works. We want to avoid interrupting the session by setting up food in the room.<br/>- Wall space for hanging poster sized paper with Blue painter's tape<br/><br/>Seating<br/>- Pods of 4 people for the size of the group. We recommend 8 pods.|
 |**Technology <br/>Requirements**| - Projector and screen<br/> - Power outlets and extension cords<br/> - Wifi that can support access by all participants (4 MB/s minimum, 8 MB/s is ideal.)<br/> |
 |**Logistical and Facilitator One Pager Information**|- Physical Address of Workshop<br/>- Address to ship supplies (If needed)<br/> - Map of the Campus and/or building to help teachers find the room. Driving instructions should be provded to teachers. This can be done via Google Maps or Bing Maps.<br/> - Wifi strength, name and password. All participants will need to be on the network at the same time with no lag.<br/> - Arrangments for Access: You should make arrangements with your venue contact to give you access to the building and help you locate supplies.<br/>
 </p>

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/ordering-supplies.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/ordering-supplies.md
@@ -1,11 +1,11 @@
 ---
 title: Ordering Supplies
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
-# Ordering Supplies 
+# Ordering Supplies
 
 ## Quick Links
 
@@ -41,7 +41,7 @@ Forget your login information or don't have an account? Email partner@code.org.
 <a id="adafruit"></a>
 ## Adafruit Circuit Playground
 
-The [Adafruit Circuit Playground](https://www.adafruit.com/product/3399) is the core tool used in [CS Discoveries Unit 6, Physical Computing](https://studio.code.org/s/csd6). Find more information about The Circuit Playground on the Code.org website [here](https://code.org/circuitplayground) and find details about the different subsidies available below. 
+The [Adafruit Circuit Playground](https://www.adafruit.com/product/3399) is the core tool used in [CS Discoveries Unit 6, Physical Computing](https://studio.code.org/s/csd6). Find more information about The Circuit Playground on the Code.org website [here](https://code.org/circuitplayground) and find details about the different subsidies available below.
 
 
 **Discounts for Partners and Educators**
@@ -92,7 +92,7 @@ You may order 1 swag bag per attendee and 1 of each of the documents shown in th
 Guidelines to keep in mind:
 
 - Orders need to be placed no later than 21 calendar days before the workshop to ensure timely arrival. No rush shipping will be accommodated.
-- Please provide a link to the workshops that you are ordering for in the 'Workshop Link' field on the payment page. Orders without a link will be declined.  
+- Please provide a link to the workshops that you are ordering for in the 'Workshop Link' field on the payment page. Orders without a link will be declined.
 - Orders with printed material of $100 or more qualifies for free shipping of the full order. Please ensure that if you need swag bags, you are ordering them with printed materials.
 - All orders will go through an approval process.
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/payments.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/payments.md
@@ -1,8 +1,8 @@
 ---
 title: Payment Information
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
 # Payment Information
@@ -21,17 +21,17 @@ ________________
 
 ## Announcements
 
-**March 8 -** 
+**March 8 -**
 
 Instructions for requesting reimbursement towards the [Teacher Recruitment Fund](https://code.org/educate/regional-partner/playbook/teacher-recruitment#recruitment) is now available. Jump to the [Teacher Recruitment Fund](#recruitment) section below.
 
 
 
-**March 1 -** 
+**March 1 -**
 
-All invoices should be submitted by completing the form and attaching the required documentation at [bit.ly/codeinvoices](http://bit.ly/codeinvoices). 
+All invoices should be submitted by completing the form and attaching the required documentation at [bit.ly/codeinvoices](http://bit.ly/codeinvoices).
 
-Please note that invoices submitted to invoices@code.org on or after March 1 will be redirected to the new submission form. Invoices submitted more than 30 days after the event or workshop date will not be paid per our existing policy. 
+Please note that invoices submitted to invoices@code.org on or after March 1 will be redirected to the new submission form. Invoices submitted more than 30 days after the event or workshop date will not be paid per our existing policy.
 
 Before visiting [bit.ly/codeinvoices](http://bit.ly/codeinvoices) to submit for your reimbursement, be prepared with the following information and documents based on the reimbursement type:
 
@@ -49,20 +49,20 @@ Code.org pays Regional Partners for program expenses related to hosting workshop
 - All CS Fundamentals, CS Discoveries, CS Principles, and Admin/Counselor workshop payments are now made via ACH direct deposit (unless otherwise agreed with a partner).
 - Payments for CS Fairs, Community Events, workshop supplies payments, and other reimbursements will still be paid via check. Submit your invoice to invoices@code.org with receipts and attendance list (if required) to initiate the payment process.
 
-**When you'll be paid**  
+**When you'll be paid**
 
-- The Code.org payment cycle runs twice per month to capture workshops that took place between the *1st-15th* and *16th-last day* of each month. 
-- At the close of a payment cycle, Code.org prepares a payment report. 
-- You will receive an email from **workshoppayments@code.org** with summary payment details for each workshop that you ran during that period, with an opportunity to amend any incorrect information within 3 business days. 
+- The Code.org payment cycle runs twice per month to capture workshops that took place between the *1st-15th* and *16th-last day* of each month.
+- At the close of a payment cycle, Code.org prepares a payment report.
+- You will receive an email from **workshoppayments@code.org** with summary payment details for each workshop that you ran during that period, with an opportunity to amend any incorrect information within 3 business days.
 - After the review period, Code.org initates remittance via ACH direct deposit and you will receive an email confirming the amount that has been deposited.
-- If you hosted both K-5 and 6-12 workshops during a given payment cycle, you will receive two deposits in the amount due per batch of workshops. 
+- If you hosted both K-5 and 6-12 workshops during a given payment cycle, you will receive two deposits in the amount due per batch of workshops.
 
 **Paying Facilitators**
 
 - When you arrange for a facilitator to lead an upcoming workshop, please be upfront with them about the process and timeline for payments so they know:
-	- how much they will be paid, 
-	- any steps they need to take to request payment (e.g., signing an invoice, submitting a timesheet, etc.), and 
-	- how many weeks after the workshop they can expect to receive payment. 
+	- how much they will be paid,
+	- any steps they need to take to request payment (e.g., signing an invoice, submitting a timesheet, etc.), and
+	- how many weeks after the workshop they can expect to receive payment.
 
 
 [**Back to the top**](#top)
@@ -77,7 +77,7 @@ ________________
   - Note: CS Discoveries and CS Principles are paid $500 per workshop day, which is different from CS Fundamentals. Each CS Discoveries and CS Principles academic year workshop contains different content, so this payment includes the additional preparation required to deliver these workshops.
 - Each Regional Partner is responsible for contracting with and paying any facilitators who run local workshops. (Note: this includes any out of region facilitators).
 - Code.org will directly pay facilitators for Facilitator Development activities and events.
-- If facilitators help with recruiting or other aspects of running the workshop, you should consider increasing their per workshop rate. Please reference Exhibit B in your CS Fundamentals MOU to see how the workshop payments received can support an increased rate.   
+- If facilitators help with recruiting or other aspects of running the workshop, you should consider increasing their per workshop rate. Please reference Exhibit B in your CS Fundamentals MOU to see how the workshop payments received can support an increased rate.
 - Some facilitators will have a different payment structure because they work for a district.
 Facilitators can host workshops that are not associated with their Regional Partner, but these will no longer be paid for by Code.org. Two common cases for this will be:
   - Working with another Regional Partner to help meet demand in their region
@@ -164,7 +164,7 @@ ________________
 ## Community Events
 Code.org reimburses up to $500 per event that serves a minimum of 10 teacher attendees. To receive reimbursement for venue or catering costs associated with a community event, submit an official invoice, receipts, and an attendance list at [bit.ly/codeinvoices](http://bit.ly/codeinvoices) within 30 days of the event. Requests for reimbursement received after the 30 day cutoff will not be processed.<br/>
 
-Need an example of an official invoice? Visit [this site](http://www.wikihow.com/Sample/Services-Rendered-Invoice).  
+Need an example of an official invoice? Visit [this site](http://www.wikihow.com/Sample/Services-Rendered-Invoice).
 See more info in the [Community Building tile](http://code.org/educate/regional-partner/playbook/community).
 
 [**Back to the top**](#top)
@@ -185,7 +185,7 @@ ________________
 
 ## Teacher Recruitment Fund
 
-To receive reimbursement for expenses incurred towards your Recruitment Fund, complete the form and attach recripts for [allowable expenses](https://staging.code.org/educate/regional-partner/playbook/teacher-recruitment#recruitment) at [bit.ly/codeinvoices](http://bit.ly/codeinvoices). 
+To receive reimbursement for expenses incurred towards your Recruitment Fund, complete the form and attach recripts for [allowable expenses](https://staging.code.org/educate/regional-partner/playbook/teacher-recruitment#recruitment) at [bit.ly/codeinvoices](http://bit.ly/codeinvoices).
 
 Required information for reimbursement will include date, amount, invoice, receipts, a brief explanation of how the expenses supported recruitment in your region, and your best estimate of the number of teachers reached.
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/reporting-and-evaluations.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/reporting-and-evaluations.md
@@ -1,8 +1,8 @@
 ---
 title: Reporting and Evaluation
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
 # Reporting and Evaluations
@@ -30,7 +30,7 @@ ________________
 <a id="roadmap"></a>
 <br/>
 ## **Regional Partner Annual Planning**
-The annual plan is one of the tools you will use to self-evaluate and improve in the main categories for success as a Regional Partner. 
+The annual plan is one of the tools you will use to self-evaluate and improve in the main categories for success as a Regional Partner.
 
 Find the annual plan template for your group:
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/summit.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/summit.md
@@ -2,10 +2,8 @@
 title: Summit
 theme: responsive
 style_min: true
-
+noindex: true
 ---
-<meta name=“robots” content=“noindex”>
-
 
 # Who's Who at the Regional Partner Summit
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/teacher-recruitment.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/teacher-recruitment.md
@@ -1,8 +1,8 @@
 ---
 title: Teacher and District Recruitment
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
 # Teacher and District Recruitment
@@ -33,25 +33,25 @@ ________________
 Review the <a href="https://docs.google.com/document/d/1Bx-o1kRCKZxM_prrQqxQH7mXp9jXY0vT_eufgNpkKYM/edit?usp=sharing", target=_"blank">2019-20 Teacher Application Process Document</a> for everything you need to know about the Code.org teacher application process including finalizing your Local Summer Workshop dates, the list of teacher application questions and how they map to the rubrics, using the Code.org teacher applications system, and FAQs.
 
 ### What are the important dates I need to know about?
-- **Two weeks** before your application open date your set-up forms are due. <a href="https://drive.google.com/file/d/1_wJkryXiRLnH2tTaKMURR7x_LDmXq6zU/view", target=_"blank">Save this table</a> for a quick way to reference these important dates. 
+- **Two weeks** before your application open date your set-up forms are due. <a href="https://drive.google.com/file/d/1_wJkryXiRLnH2tTaKMURR7x_LDmXq6zU/view", target=_"blank">Save this table</a> for a quick way to reference these important dates.
 - **Two months** prior to your Local Summer Workshops is the deadline for accepting a minimum cohort of teachers. This is to allow adequate time to go through the process of cancelling a workshop, if absolutely necessary, and reaccommodating teachers into another workshop outside your region.
-- **Four weeks** prior to your Local Summer Workshop is the deadline for accepting teachers as this is also the deadline for ordering workshop supplies.  
+- **Four weeks** prior to your Local Summer Workshop is the deadline for accepting teachers as this is also the deadline for ordering workshop supplies.
 
 ### Application Links
 - <a href="https://code.org/educate/professional-learning/program-information", target=_"blank">Landing page</a> for school ZIP code lookup
 - <a href="https://studio.code.org/pd/application/teacher", target=_"blank">2019-20 Professional Learning Program Teacher Application</a>
 
 ### Where can I find some resources to help with recruitment?
-- Visit the [Curriculum Tile](https://code.org/educate/regional-partner/playbook/curriculum) for one-pagers on each program as well as a overview of the professional learning program that you can share with administrators and potential applications.  
+- Visit the [Curriculum Tile](https://code.org/educate/regional-partner/playbook/curriculum) for one-pagers on each program as well as a overview of the professional learning program that you can share with administrators and potential applications.
 - Teachers and administrators can visit https://code.org/educate/professional-learning/middle-high to start learning about CS Discoveries, CS Principles and the program requirements.
 - Encourage teachers to check out our <a href="https://code.org/files/course-pl-options.pdf", target=_"blank">course and Professional Learning Program options</a> to determine the best fit for their teaching situation.
 
 <a id="recruitment"></a>
 
 ### Teacher Recruitment Fund
-In order to support teacher recruitment efforts and increase the number of submitted teacher applications, Code.org will reimburse each Regional Partner a maximum of $1,000 towards the costs of teacher recruitment that you incur between March 8 and 8-weeks prior to your Local Summer Workshop. 
+In order to support teacher recruitment efforts and increase the number of submitted teacher applications, Code.org will reimburse each Regional Partner a maximum of $1,000 towards the costs of teacher recruitment that you incur between March 8 and 8-weeks prior to your Local Summer Workshop.
 
-This additional funding may be used for: 
+This additional funding may be used for:
 
 - Registration fees for a booth at education leadership/educator conferences
 - Travel for on-the-ground recruitment, including mileage, hotels, flights, and meals
@@ -106,7 +106,7 @@ The K–12 Computer Science Framework is a high-level guide for states, district
 
 <a href="https://www.ncwit.org/sites/default/files/resources/microsoft_digitalskills_cs_toolkit_092018.pdf", target=_"blank">Microsoft Digital Skills Toolkit</a><br/>
 A toolkit for middle and high schools to increase
-diversity in computer science education. 
+diversity in computer science education.
 
 
 ### Agreeing to Terms

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/timeline.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/timeline.md
@@ -1,8 +1,8 @@
 ---
 title: Timeline
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <style>
 table {width: 100%;}
 </style>

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/training-materials.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/training-materials.md
@@ -1,8 +1,8 @@
 ---
 title: training materials
 nav: regional_partner_playbook_nav
+noindex: true
 ---
-<meta name="robots" content="noindex">
 <a id="top"></a>
 
 # Training Materials
@@ -74,7 +74,7 @@ January 2018
     <summary>**2017 Virtual Trainings**</summary>
     <p>
 
-December 2017  
+December 2017
 
   - Dec 12 TEALS & the CS Principles Classroom ([Video](https://code.zoom.us/recording/play/7YH4DmJAL5OutCqgRsE5-YORNg0RUP5Uu-c_KtcX0P-LS-ohu9wUfXJS-K_URZz6))
 
@@ -108,7 +108,7 @@ March 2017:
   - Guest Speaker Series: NCWIT [Video](http://videos.code.org/plp/NCWIT_March17.mp4), [Slides](https://docs.google.com/presentation/d/1nxC--kbLdFF41laOZqKFmKjMZmfsFUMAwf2VZkF59q4/edit)
   - CS Principles Webinar for Teachers [Video](http://videos.code.org/plp/3-28-2017_CSPrinciples_Webinar.mp4)
 
-January 2017:                                            
+January 2017:
 
   - How to Review Teacher Applications [Video](https://videos.code.org/teacher/Teacher+Application+Review+Process.mp4), [Slides](https://docs.google.com/presentation/d/11bDnl_ekOspmJ4cVhShvoRQ3k0GVq0DeSWpRPx56CJg/edit?usp=sharing)
   - CSP Teacher Application Process for Local Workshops [Video](http://videos.code.org/cs-principles/CSP-teacher-application-process-for-local-workshops.mp4), [Slides](https://docs.google.com/presentation/d/1SHF7pfrJmFt53Cp6GRpvw6VIo93x4euT-InYWYfe8Q4/edit?usp=sharing)

--- a/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
@@ -1,6 +1,8 @@
 - @header['social'].each_pair do |property, content|
   %meta{property:property, content:content}
 
+- if header['noindex']
+  %meta{name: "robots", content: "noindex"}
 
 %title= page_title_with_tagline
 


### PR DESCRIPTION
Properly set the `"noindex"` meta tag for a bunch of pages that we'd apparently attempted to hide from indexing previously:

https://code.org/educate/professional-learning/facilitator-2019
https://code.org/educate/regional-partner/playbook
https://code.org/educate/regional-partner/playbook/FAQ
https://code.org/educate/regional-partner/playbook/administrator
https://code.org/educate/regional-partner/playbook/advocacy
https://code.org/educate/regional-partner/playbook/communications
https://code.org/educate/regional-partner/playbook/community
https://code.org/educate/regional-partner/playbook/curriculum
https://code.org/educate/regional-partner/playbook/data
https://code.org/educate/regional-partner/playbook/directory
https://code.org/educate/regional-partner/playbook/facilitator-support
https://code.org/educate/regional-partner/playbook/funding
https://code.org/educate/regional-partner/playbook/legacy
https://code.org/educate/regional-partner/playbook/ordering-supplies
https://code.org/educate/regional-partner/playbook/payments
https://code.org/educate/regional-partner/playbook/reporting-and-evaluations
https://code.org/educate/regional-partner/playbook/summit
https://code.org/educate/regional-partner/playbook/teacher-recruitment
https://code.org/educate/regional-partner/playbook/timeline
https://code.org/educate/regional-partner/playbook/training-materials

This is a belated followup to https://github.com/code-dot-org/code-dot-org/pull/20662