### PR TITLE
Free response assessments table is now sortable by student name

### DIFF
--- a/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.jsx
@@ -87,7 +87,8 @@ class FreeResponsesAssessmentsTable extends Component {
               ...tableLayoutStyles.headerCell,
               ...styles.studentNameColumnHeader
             }
-          }
+          },
+          transforms: [sortable]
         },
         cell: {
           props: {


### PR DESCRIPTION
BEFORE: not sortable
![not-sort-free-response](https://user-images.githubusercontent.com/12300669/55980342-1c610880-5c49-11e9-865d-34cff18884ce.jpg)


AFTER: sortable by student name 
![sort-free-response](https://user-images.githubusercontent.com/12300669/55980350-22ef8000-5c49-11e9-9846-0481ac629ed6.gif)

Addresses: https://codedotorg.atlassian.net/browse/LP-208