### PR TITLE
Lesson Extras Icon Consistent

### DIFF
--- a/apps/src/templates/progress/StageExtrasProgressBubble.jsx
+++ b/apps/src/templates/progress/StageExtrasProgressBubble.jsx
@@ -51,7 +51,7 @@ class StageExtrasProgressBubble extends Component {
         <div style={{...styles.main, ...styles.hoverOverlay}} />
         <TooltipWithIcon
           tooltipId={tooltipId}
-          icon={'flag'}
+          icon={'flag-checkered'}
           text={i18n.stageExtras()}
           // Currently a stage extra can not also be an assessment so this should always be false
           // TODO (dmcavoy) : When we change the way we mark levels as assessment refactor


### PR DESCRIPTION
(NOTE: Accidently based this off another branch which is about to be merged so going to base this off that for now and switch it staging once merged)

The icon that was showing in the tooltip for bubbles for lesson extras was not consistent with the other areas of the site. 

# Before
<img width="381" alt="Screen Shot 2019-04-11 at 4 31 14 PM" src="https://user-images.githubusercontent.com/208083/55991081-61039880-5c77-11e9-9438-dc8caf9b45ff.png">

# After
<img width="340" alt="Screen Shot 2019-04-11 at 4 30 40 PM" src="https://user-images.githubusercontent.com/208083/55991080-61039880-5c77-11e9-90c1-ca2b6d4c1273.png">

