### PR TITLE
Tests: Use reconfiguredChai.js in all of test/unit/code-studio

### DIFF
--- a/apps/test/unit/code-studio/components/DownloadReplayVideoButton.js
+++ b/apps/test/unit/code-studio/components/DownloadReplayVideoButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 import {shallow} from 'enzyme';
 
-import {expect} from '../../../util/configuredChai';
+import {expect} from '../../../util/reconfiguredChai';
 
 import {UnconnectedDownloadReplayVideoButton as DownloadReplayVideoButton} from '@cdo/apps/code-studio/components/DownloadReplayVideoButton';
 

--- a/apps/test/unit/code-studio/components/ReportAbuseFormTest.js
+++ b/apps/test/unit/code-studio/components/ReportAbuseFormTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from '../../../util/reconfiguredChai';
 import {getChannelIdFromUrl} from '@cdo/apps/code-studio/components/ReportAbuseForm';
 
 describe('ReportAbuseForm', () => {

--- a/apps/test/unit/code-studio/components/ShareDialogTest.js
+++ b/apps/test/unit/code-studio/components/ShareDialogTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import {UnconnectedShareDialog as ShareDialog} from '@cdo/apps/code-studio/components/ShareDialog';

--- a/apps/test/unit/code-studio/components/SoundLibraryTest.js
+++ b/apps/test/unit/code-studio/components/SoundLibraryTest.js
@@ -1,4 +1,4 @@
-import {expect} from '../../../util/configuredChai';
+import {expect} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {mount} from 'enzyme';
 import SoundLibrary from '@cdo/apps/code-studio/components/SoundLibrary';

--- a/apps/test/unit/code-studio/components/SoundListEntryTest.js
+++ b/apps/test/unit/code-studio/components/SoundListEntryTest.js
@@ -1,4 +1,4 @@
-import {assert, expect} from '../../../util/configuredChai';
+import {assert, expect} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import SoundListEntry from '@cdo/apps/code-studio/components/SoundListEntry';

--- a/apps/test/unit/code-studio/components/SoundPickerTest.js
+++ b/apps/test/unit/code-studio/components/SoundPickerTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {mount} from 'enzyme';
 import SoundPicker from '@cdo/apps/code-studio/components/SoundPicker';

--- a/apps/test/unit/code-studio/components/pairing/PairingTest.js
+++ b/apps/test/unit/code-studio/components/pairing/PairingTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import sinon from 'sinon';
 import {mount} from 'enzyme';
-import {expect} from '../../../../util/configuredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 
 import Pairing from '@cdo/apps/code-studio/components/pairing/Pairing.jsx';
 

--- a/apps/test/unit/code-studio/components/progress/MiniViewTest.js
+++ b/apps/test/unit/code-studio/components/progress/MiniViewTest.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {assert} from '../../../../util/configuredChai';
+import {assert} from '../../../../util/reconfiguredChai';
 import {UnconnectedMiniView as MiniView} from '@cdo/apps/code-studio/components/progress/MiniView';
 import {shallow} from 'enzyme';
 

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewHeaderTest.js
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewHeaderTest.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {assert, expect} from '../../../../util/configuredChai';
+import {assert, expect} from '../../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {NotificationType} from '@cdo/apps/templates/Notification';

--- a/apps/test/unit/code-studio/components/progress/ScriptTeacherPanelTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ScriptTeacherPanelTest.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../../util/reconfiguredChai';
+import {assert, expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedScriptTeacherPanel as ScriptTeacherPanel} from '@cdo/apps/code-studio/components/progress/ScriptTeacherPanel';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import TeacherPanel from '@cdo/apps/code-studio/components/TeacherPanel';
@@ -41,14 +41,16 @@ describe('ScriptTeacherPanel', () => {
     const wrapper = shallow(
       <ScriptTeacherPanel {...MINIMUM_PROPS} viewAs={ViewType.Teacher} />
     );
-    expect(wrapper).to.containMatchingElement(
-      <TeacherPanel>
-        <h3>{commonMsg.teacherPanel()}</h3>
-        <div>
-          <ViewAsToggle />
-          <div>{commonMsg.loading()}</div>
-        </div>
-      </TeacherPanel>
+    assert(
+      wrapper.containsMatchingElement(
+        <TeacherPanel>
+          <h3>{commonMsg.teacherPanel()}</h3>
+          <div>
+            <ViewAsToggle />
+            <div>{commonMsg.loading()}</div>
+          </div>
+        </TeacherPanel>
+      )
     );
   });
 
@@ -56,30 +58,28 @@ describe('ScriptTeacherPanel', () => {
     const wrapper = shallow(
       <ScriptTeacherPanel {...MINIMUM_PROPS} sectionsAreLoaded={false} />
     );
-    expect(wrapper).to.containMatchingElement(<div>{commonMsg.loading()}</div>);
+    assert(wrapper.containsMatchingElement(<div>{commonMsg.loading()}</div>));
   });
 
   it('hides loading message when sections are loaded', () => {
     const wrapper = shallow(
       <ScriptTeacherPanel {...MINIMUM_PROPS} sectionsAreLoaded={true} />
     );
-    expect(wrapper).not.to.containMatchingElement(
-      <div>{commonMsg.loading()}</div>
-    );
+    assert(!wrapper.containsMatchingElement(<div>{commonMsg.loading()}</div>));
   });
 
   it('shows SectionSelector if scriptHasLockableStages', () => {
     const wrapper = shallow(
       <ScriptTeacherPanel {...MINIMUM_PROPS} scriptHasLockableStages={true} />
     );
-    expect(wrapper).to.containMatchingElement(<SectionSelector />);
+    assert(wrapper.containsMatchingElement(<SectionSelector />));
   });
 
   it('shows SectionSelector if scriptAllowsHiddenStages', () => {
     const wrapper = shallow(
       <ScriptTeacherPanel {...MINIMUM_PROPS} scriptAllowsHiddenStages={true} />
     );
-    expect(wrapper).to.containMatchingElement(<SectionSelector />);
+    assert(wrapper.containsMatchingElement(<SectionSelector />));
   });
 
   it('hides SectionSelector if neither scriptAllowsHiddenStages nor scriptHasLockableStages', () => {
@@ -90,7 +90,7 @@ describe('ScriptTeacherPanel', () => {
         scriptAllowsHiddenStages={false}
       />
     );
-    expect(wrapper).not.to.containMatchingElement(<SectionSelector />);
+    assert(!wrapper.containsMatchingElement(<SectionSelector />));
   });
 
   it('shows section selection instructions if viewing as a teacher, and has sections and lockable stages', () => {
@@ -102,10 +102,12 @@ describe('ScriptTeacherPanel', () => {
         hasSections={true}
       />
     );
-    expect(wrapper).to.containMatchingElement(
-      <div>
-        <div>{commonMsg.selectSectionInstructions()}</div>
-      </div>
+    assert(
+      wrapper.containsMatchingElement(
+        <div>
+          <div>{commonMsg.selectSectionInstructions()}</div>
+        </div>
+      )
     );
   });
 
@@ -119,23 +121,25 @@ describe('ScriptTeacherPanel', () => {
         unlockedStageNames={['stage1', 'stage2']}
       />
     );
-    expect(wrapper).to.containMatchingElement(
-      <div>
-        <div>{commonMsg.selectSectionInstructions()}</div>
+    assert(
+      wrapper.containsMatchingElement(
         <div>
+          <div>{commonMsg.selectSectionInstructions()}</div>
           <div>
-            <FontAwesome icon="exclamation-triangle" />
-            <div>{commonMsg.dontForget()}</div>
-          </div>
-          <div>
-            {commonMsg.lockFollowing()}
-            <ul>
-              <li>stage1</li>
-              <li>stage2</li>
-            </ul>
+            <div>
+              <FontAwesome icon="exclamation-triangle" />
+              <div>{commonMsg.dontForget()}</div>
+            </div>
+            <div>
+              {commonMsg.lockFollowing()}
+              <ul>
+                <li>stage1</li>
+                <li>stage2</li>
+              </ul>
+            </div>
           </div>
         </div>
-      </div>
+      )
     );
   });
 
@@ -152,7 +156,7 @@ describe('ScriptTeacherPanel', () => {
           getSelectedUserId={() => {}}
         />
       );
-      expect(wrapper.find('StudentTable')).to.exist;
+      expect(wrapper.find('StudentTable')).to.have.length(1);
     });
 
     it('does not display StudentTable for teacher with no students', () => {
@@ -163,7 +167,7 @@ describe('ScriptTeacherPanel', () => {
           students={[]}
         />
       );
-      expect(wrapper.find('StudentTable')).to.not.exist;
+      expect(wrapper.find('StudentTable')).to.have.length(0);
     });
 
     it('does not display StudentTable for student', () => {
@@ -174,7 +178,7 @@ describe('ScriptTeacherPanel', () => {
           students={students}
         />
       );
-      expect(wrapper.find('StudentTable')).to.not.exist;
+      expect(wrapper.find('StudentTable')).to.have.length(0);
     });
   });
 });

--- a/apps/test/unit/code-studio/components/progress/StageLockDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/StageLockDialogTest.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../../util/configuredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 import sinon from 'sinon';
 import {UnconnectedStageLockDialog as StageLockDialog} from '@cdo/apps/code-studio/components/progress/StageLockDialog';
 import {LockStatus} from '@cdo/apps/code-studio/stageLockRedux';

--- a/apps/test/unit/code-studio/components/progress/ViewAsToggleTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ViewAsToggleTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
-import {expect} from '../../../../util/configuredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedViewAsToggle as ViewAsToggle} from '@cdo/apps/code-studio/components/progress/ViewAsToggle';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 

--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import clientState from '@cdo/apps/code-studio/clientState';
 import sinon from 'sinon';
-import {expect} from '../../../util/configuredChai';
+import {expect} from '../../../util/reconfiguredChai';
 import loadAppOptions, {
   setupApp,
   setAppOptions

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {expect} from '../../../util/configuredChai';
+import {expect} from '../../../util/reconfiguredChai';
 import sinon from 'sinon';
 import {replaceOnWindow, restoreOnWindow} from '../../../util/testUtils';
 import * as utils from '@cdo/apps/utils';

--- a/apps/test/unit/code-studio/pd/application_dashboard/admin_cohort_viewTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/admin_cohort_viewTest.js
@@ -1,5 +1,5 @@
 import AdminCohortView from '@cdo/apps/code-studio/pd/application_dashboard/admin_cohort_view';
-import {assert, expect} from '../../../../util/configuredChai';
+import {assert, expect} from '../../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -7,7 +7,7 @@ import {
 import React from 'react';
 import _ from 'lodash';
 import sinon from 'sinon';
-import {expect} from '../../../../util/configuredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 
 describe('DetailViewContents', () => {
@@ -156,29 +156,38 @@ describe('DetailViewContents', () => {
         .simulate('change', {target: {value: 'accepted'}});
 
       // lock status
-      expect(detailView.find('#DetailViewHeader Button').first())
-        .text()
-        .to.equal('Lock');
+      expect(
+        detailView
+          .find('#DetailViewHeader Button')
+          .first()
+          .text()
+      ).to.equal('Lock');
       detailView
         .find('#DetailViewHeader Button')
         .first()
         .simulate('click');
-      expect(detailView.find('#DetailViewHeader select')).prop('disabled').to.be
+      expect(detailView.find('#DetailViewHeader select').prop('disabled')).to.be
         .true;
-      expect(detailView.find('#DetailViewHeader Button').first())
-        .text()
-        .to.equal('Unlock');
+      expect(
+        detailView
+          .find('#DetailViewHeader Button')
+          .first()
+          .text()
+      ).to.equal('Unlock');
 
       // unlock status
       detailView
         .find('#DetailViewHeader Button')
         .first()
         .simulate('click');
-      expect(detailView.find('#DetailViewHeader select')).prop('disabled').to.be
+      expect(detailView.find('#DetailViewHeader select').prop('disabled')).to.be
         .false;
-      expect(detailView.find('#DetailViewHeader Button').first())
-        .text()
-        .to.equal('Lock');
+      expect(
+        detailView
+          .find('#DetailViewHeader Button')
+          .first()
+          .text()
+      ).to.equal('Lock');
     });
   });
 
@@ -335,7 +344,11 @@ describe('DetailViewContents', () => {
           .filterWhere(row => row.text().includes('Scholarship Teacher?'));
 
       // Dropdown is disabled
-      expect(getLastRow().find('Select')).to.have.prop('disabled', true);
+      expect(
+        getLastRow()
+          .find('Select')
+          .prop('disabled')
+      ).to.equal(true);
 
       // Click "Edit"
       detailView
@@ -344,7 +357,11 @@ describe('DetailViewContents', () => {
         .simulate('click');
 
       // Dropdown is enabled
-      expect(getLastRow().find('Select')).to.have.prop('disabled', false);
+      expect(
+        getLastRow()
+          .find('Select')
+          .prop('disabled')
+      ).to.equal(false);
 
       // Click "Save"
       detailView
@@ -353,7 +370,11 @@ describe('DetailViewContents', () => {
         .simulate('click');
 
       // Dropdown is disabled
-      expect(getLastRow().find('Select')).to.have.prop('disabled', true);
+      expect(
+        getLastRow()
+          .find('Select')
+          .prop('disabled')
+      ).to.equal(true);
     });
   });
 

--- a/apps/test/unit/code-studio/pd/components/markdownSpanTest.js
+++ b/apps/test/unit/code-studio/pd/components/markdownSpanTest.js
@@ -9,7 +9,7 @@ describe('MarkdownSpan', () => {
       <MarkdownSpan>normal text *bold text*</MarkdownSpan>
     );
 
-    expect(markdownSpan).to.have.html(
+    expect(markdownSpan.html()).to.include(
       '<span>normal text <em>bold text</em></span>'
     );
   });
@@ -19,7 +19,7 @@ describe('MarkdownSpan', () => {
       <MarkdownSpan>This is a [link](https://code.org).</MarkdownSpan>
     );
 
-    expect(markdownSpan).to.have.html(
+    expect(markdownSpan.html()).to.include(
       '<span>This is a <a href="https://code.org" target="_blank">link</a>.</span>'
     );
   });
@@ -29,8 +29,10 @@ describe('MarkdownSpan', () => {
       <MarkdownSpan style={{fontFamily: 'Gotham 7r'}}>text</MarkdownSpan>
     );
 
-    expect(markdownSpan).to.containMatchingElement(
-      <span style={{fontFamily: 'Gotham 7r'}} />
-    );
+    expect(
+      markdownSpan.containsMatchingElement(
+        <span style={{fontFamily: 'Gotham 7r'}} />
+      )
+    ).to.be.ok;
   });
 });

--- a/apps/test/unit/code-studio/pd/form_components/ButtonListTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/ButtonListTest.js
@@ -1,6 +1,6 @@
 import ButtonList from '@cdo/apps/code-studio/pd/form_components/ButtonList';
 import React from 'react';
-import {expect} from 'chai';
+import {expect} from '../../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
 import {
@@ -31,20 +31,22 @@ describe('ButtonList', () => {
     });
 
     it('Renders radio buttons', () => {
-      expect(radioList).to.containMatchingElement(
-        <FormGroup id="favoritePet" controlId="favoritePet">
-          <ControlLabel>What is your favorite pet?</ControlLabel>
-          <FormGroup>
-            <Radio value="Cat" label="Cat" name="favoritePet">
-              Cat
-            </Radio>
-            <Radio value="Dog" label="Dog" name="favoritePet">
-              Dog
-            </Radio>
+      expect(
+        radioList.containsMatchingElement(
+          <FormGroup id="favoritePet" controlId="favoritePet">
+            <ControlLabel>What is your favorite pet?</ControlLabel>
+            <FormGroup>
+              <Radio value="Cat" label="Cat" name="favoritePet">
+                Cat
+              </Radio>
+              <Radio value="Dog" label="Dog" name="favoritePet">
+                Dog
+              </Radio>
+            </FormGroup>
+            <br />
           </FormGroup>
-          <br />
-        </FormGroup>
-      );
+        )
+      ).to.be.ok;
     });
 
     it('Calls the onChange callback with a single result when one is selected', () => {
@@ -75,20 +77,22 @@ describe('ButtonList', () => {
     });
 
     it('Renders checkboxes', () => {
-      expect(checkboxList).to.containMatchingElement(
-        <FormGroup id="favoritePet" controlId="favoritePet">
-          <ControlLabel>What is your favorite pet?</ControlLabel>
-          <FormGroup>
-            <Checkbox value="Cat" label="Cat" name="favoritePet">
-              Cat
-            </Checkbox>
-            <Checkbox value="Dog" label="Dog" name="favoritePet">
-              Dog
-            </Checkbox>
+      expect(
+        checkboxList.containsMatchingElement(
+          <FormGroup id="favoritePet" controlId="favoritePet">
+            <ControlLabel>What is your favorite pet?</ControlLabel>
+            <FormGroup>
+              <Checkbox value="Cat" label="Cat" name="favoritePet">
+                Cat
+              </Checkbox>
+              <Checkbox value="Dog" label="Dog" name="favoritePet">
+                Dog
+              </Checkbox>
+            </FormGroup>
+            <br />
           </FormGroup>
-          <br />
-        </FormGroup>
-      );
+        )
+      ).to.be.ok;
     });
 
     it('Calls the onChange callback with a list of all checked when one is checked', () => {
@@ -134,7 +138,7 @@ describe('ButtonList', () => {
 
     const helpBlock = buttonList.find(HelpBlock);
     expect(helpBlock).to.have.length(1);
-    expect(helpBlock.childAt(0)).to.have.text('You must choose!');
+    expect(helpBlock.childAt(0).text()).to.equal('You must choose!');
   });
 
   it('Adds an other option when includeOther is set', () => {
@@ -151,15 +155,17 @@ describe('ButtonList', () => {
     const checkboxes = buttonList.find(Checkbox);
     expect(checkboxes).to.have.length(3);
     const otherCheckbox = checkboxes.at(2);
-    expect(otherCheckbox).to.containMatchingElement(
-      <Checkbox>
-        <div>
-          <span>Other:</span>
-          &nbsp;
-          <input type="text" id="favoritePet_other" maxLength="200" />
-        </div>
-      </Checkbox>
-    );
+    expect(
+      otherCheckbox.containsMatchingElement(
+        <Checkbox>
+          <div>
+            <span>Other:</span>
+            &nbsp;
+            <input type="text" id="favoritePet_other" maxLength="200" />
+          </div>
+        </Checkbox>
+      )
+    ).to.be.ok;
   });
 
   describe('With input fields', () => {
@@ -191,28 +197,30 @@ describe('ButtonList', () => {
     });
 
     it('Renders correctly', () => {
-      expect(buttonList).to.containMatchingElement(
-        <FormGroup>
-          <Checkbox value="Cat" label="Cat" name="favoritePet">
-            Cat
-          </Checkbox>
-          <Checkbox
-            value="Specific dog breed"
-            label="Specific dog breed"
-            name="favoritePet"
-          >
-            <div>
-              <span>Specific dog breed</span>
-              &nbsp;
-              <input type="text" id="dog-breed-input" maxLength="200" />
-            </div>
-          </Checkbox>
-        </FormGroup>
-      );
+      expect(
+        buttonList.containsMatchingElement(
+          <FormGroup>
+            <Checkbox value="Cat" label="Cat" name="favoritePet">
+              Cat
+            </Checkbox>
+            <Checkbox
+              value="Specific dog breed"
+              label="Specific dog breed"
+              name="favoritePet"
+            >
+              <div>
+                <span>Specific dog breed</span>
+                &nbsp;
+                <input type="text" id="dog-breed-input" maxLength="200" />
+              </div>
+            </Checkbox>
+          </FormGroup>
+        )
+      ).to.be.ok;
     });
 
     it('Displays supplied input value', () => {
-      expect(dogBreedInput).to.have.prop('value', '--enter dog breed--');
+      expect(dogBreedInput.prop('value')).to.equal('--enter dog breed--');
     });
 
     it('Calls the onInputChange callback when text is entered', () => {

--- a/apps/test/unit/code-studio/pd/form_components/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/FormControllerTest.js
@@ -171,7 +171,7 @@ describe('FormController', () => {
           validateCurrentPageRequiredFields.returns(true);
           submitButton.simulate('submit');
           expect(form.state('submitting')).to.be.true;
-          expect(submitButton).to.be.disabled();
+          expect(submitButton.prop('disabled')).to.be.true;
         });
 
         it('Re-enables the submit button on error', () => {
@@ -206,7 +206,7 @@ describe('FormController', () => {
           server.respond();
 
           expect(form.state('submitting')).to.be.true;
-          expect(submitButton).to.be.disabled();
+          expect(submitButton.prop('disabled')).to.be.true;
           expect(onSuccessfulSubmit).to.be.calledOnce;
         });
       });

--- a/apps/test/unit/code-studio/pd/form_components/SingleCheckboxTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/SingleCheckboxTest.js
@@ -11,9 +11,11 @@ describe('SingleCheckbox', () => {
       <SingleCheckbox name="testCheckbox" label="This is the label" />
     );
 
-    expect(singleCheckbox).to.containMatchingElement(
-      <Checkbox>This is the label</Checkbox>
-    );
+    expect(
+      singleCheckbox.containsMatchingElement(
+        <Checkbox>This is the label</Checkbox>
+      )
+    ).to.be.ok;
   });
 
   it('displays checked value', () => {

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import i18n from '@cdo/locale';
-import {expect} from '../../../../util/configuredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 import LandingPage, {
   LastWorkshopSurveyBanner
 } from '@cdo/apps/code-studio/pd/professional_learning_landing/LandingPage';
@@ -81,12 +81,14 @@ describe('LastWorkshopSurveyBanner', () => {
   });
 
   it('makes a button that opens the survey URL in a new tab', () => {
-    expect(wrapper).to.containMatchingElement(
-      <Button
-        href={TEST_SURVEY_URL}
-        target="_blank"
-        text={i18n.plLandingStartSurvey()}
-      />
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <Button
+          href={TEST_SURVEY_URL}
+          target="_blank"
+          text={i18n.plLandingStartSurvey()}
+        />
+      )
+    ).to.be.ok;
   });
 });

--- a/apps/test/unit/code-studio/pd/regional_partner_contact/RegionalPartnerContactTest.jsx
+++ b/apps/test/unit/code-studio/pd/regional_partner_contact/RegionalPartnerContactTest.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import {expect} from '../../../../util/configuredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 import RegionalPartnerContact from '@cdo/apps/code-studio/pd/regional_partner_contact/RegionalPartnerContact';
 
 describe('RegionalPartnerContactTest', () => {
@@ -25,6 +25,18 @@ describe('RegionalPartnerContactTest', () => {
     optIn: {type: 'ButtonList', expectRequired: true}
   };
 
+  let windowDashboard;
+  before(() => {
+    windowDashboard = window.dashboard;
+    window.dashboard = {
+      CODE_ORG_URL: '//test.code.org'
+    };
+  });
+
+  after(() => {
+    window.dashboard = windowDashboard;
+  });
+
   describe('Required fields', () => {
     Object.keys(FIELD_EXPECTATIONS).forEach(fieldName => {
       const expectRequired = FIELD_EXPECTATIONS[fieldName].expectRequired;
@@ -38,7 +50,7 @@ describe('RegionalPartnerContactTest', () => {
         );
 
         const field = findField(wrapper, fieldName);
-        expect(field).to.have.prop('required', expectRequired);
+        expect(field.prop('required')).to.equal(expectRequired);
       });
     });
   });

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/attendance/session_attendance_row_test.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/attendance/session_attendance_row_test.jsx
@@ -1,4 +1,4 @@
-import {expect} from '../../../../../util/configuredChai';
+import {expect} from '../../../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import React from 'react';
 import SessionAttendanceRow from '@cdo/apps/code-studio/pd/workshop_dashboard/attendance/session_attendance_row';
@@ -31,19 +31,21 @@ const DEFAULT_PROPS = {
 describe('SessionAttendanceRow', () => {
   it('renders default (unattended) row', () => {
     const wrapper = shallow(<SessionAttendanceRow {...DEFAULT_PROPS} />);
-    expect(wrapper).to.containMatchingElement(
-      <tr className={null}>
-        <td>{FAKE_FIRST_NAME}</td>
-        <td>{FAKE_LAST_NAME}</td>
-        <td>{FAKE_EMAIL}</td>
-        <td>No</td>
-        <td>
-          <div>
-            <i className="fa fa-square-o" />
-          </div>
-        </td>
-      </tr>
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <tr className={null}>
+          <td>{FAKE_FIRST_NAME}</td>
+          <td>{FAKE_LAST_NAME}</td>
+          <td>{FAKE_EMAIL}</td>
+          <td>No</td>
+          <td>
+            <div>
+              <i className="fa fa-square-o" />
+            </div>
+          </td>
+        </tr>
+      )
+    ).to.be.ok;
   });
 
   it('renders attended row', () => {
@@ -56,19 +58,21 @@ describe('SessionAttendanceRow', () => {
         }}
       />
     );
-    expect(wrapper).to.containMatchingElement(
-      <tr className="success">
-        <td>{FAKE_FIRST_NAME}</td>
-        <td>{FAKE_LAST_NAME}</td>
-        <td>{FAKE_EMAIL}</td>
-        <td>No</td>
-        <td>
-          <div>
-            <i className="fa fa-check-square-o" />
-          </div>
-        </td>
-      </tr>
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <tr className="success">
+          <td>{FAKE_FIRST_NAME}</td>
+          <td>{FAKE_LAST_NAME}</td>
+          <td>{FAKE_EMAIL}</td>
+          <td>No</td>
+          <td>
+            <div>
+              <i className="fa fa-check-square-o" />
+            </div>
+          </td>
+        </tr>
+      )
+    ).to.be.ok;
   });
 
   it('renders extra column when account is required for attendance', () => {
@@ -78,40 +82,44 @@ describe('SessionAttendanceRow', () => {
         accountRequiredForAttendance={true}
       />
     );
-    expect(wrapper).to.containMatchingElement(
-      <tr>
-        <td>{FAKE_FIRST_NAME}</td>
-        <td>{FAKE_LAST_NAME}</td>
-        <td>{FAKE_EMAIL}</td>
-        <td>Yes</td>
-        <td>No</td>
-        <td>
-          <div>
-            <i className="fa fa-square-o" />
-          </div>
-        </td>
-      </tr>
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <tr>
+          <td>{FAKE_FIRST_NAME}</td>
+          <td>{FAKE_LAST_NAME}</td>
+          <td>{FAKE_EMAIL}</td>
+          <td>Yes</td>
+          <td>No</td>
+          <td>
+            <div>
+              <i className="fa fa-square-o" />
+            </div>
+          </td>
+        </tr>
+      )
+    ).to.be.ok;
   });
 
   it('renders extra column to show completed puzzles', () => {
     const wrapper = shallow(
       <SessionAttendanceRow {...DEFAULT_PROPS} showPuzzlesCompleted={true} />
     );
-    expect(wrapper).to.containMatchingElement(
-      <tr>
-        <td>{FAKE_FIRST_NAME}</td>
-        <td>{FAKE_LAST_NAME}</td>
-        <td>{FAKE_EMAIL}</td>
-        <td>No</td>
-        <td />
-        <td>
-          <div>
-            <i className="fa fa-square-o" />
-          </div>
-        </td>
-      </tr>
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <tr>
+          <td>{FAKE_FIRST_NAME}</td>
+          <td>{FAKE_LAST_NAME}</td>
+          <td>{FAKE_EMAIL}</td>
+          <td>No</td>
+          <td />
+          <td>
+            <div>
+              <i className="fa fa-square-o" />
+            </div>
+          </td>
+        </tr>
+      )
+    ).to.be.ok;
   });
 
   it('renders shows completed puzzle count for user only if they attended', () => {
@@ -125,19 +133,21 @@ describe('SessionAttendanceRow', () => {
         }}
       />
     );
-    expect(wrapper).to.containMatchingElement(
-      <tr className="success">
-        <td>{FAKE_FIRST_NAME}</td>
-        <td>{FAKE_LAST_NAME}</td>
-        <td>{FAKE_EMAIL}</td>
-        <td>No</td>
-        <td>{42}</td>
-        <td>
-          <div>
-            <i className="fa fa-check-square-o" />
-          </div>
-        </td>
-      </tr>
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <tr className="success">
+          <td>{FAKE_FIRST_NAME}</td>
+          <td>{FAKE_LAST_NAME}</td>
+          <td>{FAKE_EMAIL}</td>
+          <td>No</td>
+          <td>{42}</td>
+          <td>
+            <div>
+              <i className="fa fa-check-square-o" />
+            </div>
+          </td>
+        </tr>
+      )
+    ).to.be.ok;
   });
 });

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/attendance/session_attendance_test.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/attendance/session_attendance_test.jsx
@@ -1,4 +1,4 @@
-import {expect} from '../../../../../util/configuredChai';
+import {expect} from '../../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
@@ -89,23 +89,25 @@ describe('SessionAttendance', () => {
 
     // Displays a spinner at first while it waits for the server to provide
     // attendance data.
-    expect(wrapper).to.containMatchingElement(<Spinner />);
+    expect(wrapper.containsMatchingElement(<Spinner />)).to.be.ok;
     expect(server.requests).to.have.length(1);
 
     // After the server responds
     server.respond();
     // Has expected columns:
-    expect(wrapper).to.containMatchingElement(
-      <thead>
-        <tr>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>Email</th>
-          <th>Verified Teacher Account</th>
-          <th>Present</th>
-        </tr>
-      </thead>
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <thead>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Email</th>
+            <th>Verified Teacher Account</th>
+            <th>Present</th>
+          </tr>
+        </thead>
+      )
+    ).to.be.ok;
 
     // Has three rows:
     expect(wrapper.find('tbody tr')).to.have.length(3);
@@ -124,18 +126,20 @@ describe('SessionAttendance', () => {
     // After the server responds
     server.respond();
     // Has expected columns:
-    expect(wrapper).to.containMatchingElement(
-      <thead>
-        <tr>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>Email</th>
-          <th>Code Studio Account</th>
-          <th>Verified Teacher Account</th>
-          <th>Present</th>
-        </tr>
-      </thead>
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <thead>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Email</th>
+            <th>Code Studio Account</th>
+            <th>Verified Teacher Account</th>
+            <th>Present</th>
+          </tr>
+        </thead>
+      )
+    ).to.be.ok;
 
     wrapper.unmount();
   });
@@ -148,18 +152,20 @@ describe('SessionAttendance', () => {
     // After the server responds
     server.respond();
     // Has expected columns:
-    expect(wrapper).to.containMatchingElement(
-      <thead>
-        <tr>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>Email</th>
-          <th>Verified Teacher Account</th>
-          <th>Puzzles Completed</th>
-          <th>Attended</th>
-        </tr>
-      </thead>
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <thead>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Email</th>
+            <th>Verified Teacher Account</th>
+            <th>Puzzles Completed</th>
+            <th>Attended</th>
+          </tr>
+        </thead>
+      )
+    ).to.be.ok;
 
     wrapper.unmount();
   });

--- a/apps/test/unit/code-studio/plc/headerTest.jsx
+++ b/apps/test/unit/code-studio/plc/headerTest.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../util/configuredChai';
+import {expect} from '../../../util/reconfiguredChai';
 import PlcHeader from '@cdo/apps/code-studio/plc/header';
 
 const TEST_UNIT_NAME = 'Test Unit';
@@ -17,13 +17,15 @@ describe('PlcHeader', () => {
       />
     );
 
-    expect(wrapper).to.containMatchingElement(
-      <div>
-        <a href={TEST_COURSE_VIEW_PATH}>My Learning Plan</a>
-        <span className="fa fa-caret-right" />
-        <span>{TEST_UNIT_NAME}</span>
-      </div>
-    );
+    expect(
+      wrapper.containsMatchingElement(
+        <div>
+          <a href={TEST_COURSE_VIEW_PATH}>My Learning Plan</a>
+          <span className="fa fa-caret-right" />
+          <span>{TEST_UNIT_NAME}</span>
+        </div>
+      )
+    ).to.be.ok;
   });
 
   it('renders an extra layer of breadcrumb with a page name', () => {
@@ -36,16 +38,18 @@ describe('PlcHeader', () => {
       />
     );
 
-    expect(wrapper).to.containMatchingElement(
-      <div>
-        <a href={TEST_COURSE_VIEW_PATH}>My Learning Plan</a>
-        <span className="fa fa-caret-right" />
-        <span>
-          <a href={TEST_UNIT_VIEW_PATH}>{TEST_UNIT_NAME}</a>
+    expect(
+      wrapper.containsMatchingElement(
+        <div>
+          <a href={TEST_COURSE_VIEW_PATH}>My Learning Plan</a>
           <span className="fa fa-caret-right" />
-          <span>{TEST_PAGE_NAME}</span>
-        </span>
-      </div>
-    );
+          <span>
+            <a href={TEST_UNIT_VIEW_PATH}>{TEST_UNIT_NAME}</a>
+            <span className="fa fa-caret-right" />
+            <span>{TEST_PAGE_NAME}</span>
+          </span>
+        </div>
+      )
+    ).to.be.ok;
   });
 });

--- a/apps/test/util/assertions.js
+++ b/apps/test/util/assertions.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import {assert} from './configuredChai';
+import {assert} from './reconfiguredChai';
 
 /**
  * Uses jQuery to locate an element matching the given selector and check that


### PR DESCRIPTION
Uses reconfiguredChai.js instead of configuredChai.js in an entire subdirectory of tests.

Changes extracted from https://github.com/code-dot-org/code-dot-org/pull/27907 for only the `apps/test/unit/code-studio` directory and one associated utility file.  See that PR for methodology.  Just trying to break apart a potentially enormous project into ratchetable parts.