### PR TITLE
Do not check if 2019-mini-rubric experiment is enabled in every getIc…

### DIFF
--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -2,7 +2,6 @@ import {fullyLockedStageMapping} from '@cdo/apps/code-studio/stageLockRedux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {isStageHiddenForSection} from '@cdo/apps/code-studio/hiddenStageRedux';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
-import experiments from '@cdo/apps/util/experiments';
 
 /**
  * This is conceptually similar to being a selector, except that it operates on
@@ -75,12 +74,8 @@ export function stageLocked(levels) {
  * @returns A friendly name for the icon name (that can be passed to FontAwesome)
  *   for the given level.
  */
-export function getIconForLevel(level, inDetailedProgressView = false) {
-  if (
-    experiments.isEnabled(experiments.MINI_RUBRIC_2019) &&
-    inDetailedProgressView &&
-    isLevelAssessment(level)
-  ) {
+export function getIconForLevel(level, miniRubricExperiment = false) {
+  if (miniRubricExperiment && isLevelAssessment(level)) {
     return 'check-circle';
   }
   if (level.icon) {

--- a/apps/src/templates/sectionProgress/VirtualizedDetailView.jsx
+++ b/apps/src/templates/sectionProgress/VirtualizedDetailView.jsx
@@ -25,6 +25,7 @@ import {
 } from './multiGridConstants';
 import i18n from '@cdo/locale';
 import SectionProgressNameCell from './SectionProgressNameCell';
+import experiments from '@cdo/apps/util/experiments';
 
 const ARROW_PADDING = 60;
 // Only show arrow next to lesson numbers if column is larger than a single small bubble and it's margin.
@@ -125,6 +126,9 @@ class VirtualizedDetailView extends Component {
     }
 
     const stageData = columnIndex > 0 && scriptData.stages[columnIndex - 1];
+    const inMiniRubricExperiment = experiments.isEnabled(
+      experiments.MINI_RUBRIC_2019
+    );
 
     // Header rows
     return (
@@ -172,7 +176,7 @@ class VirtualizedDetailView extends Component {
           <span style={styles.bubbleSet}>
             {scriptData.stages[stageIdIndex].levels.map((level, i) => (
               <FontAwesome
-                icon={getIconForLevel(level, true)}
+                icon={getIconForLevel(level, inMiniRubricExperiment)}
                 style={
                   level.isUnplugged
                     ? progressStyles.unpluggedIcon


### PR DESCRIPTION
…onForLevel call

Fixes a performance issue introduced in yesterday's deploy via #27949 where every time `getIconForLevel` was called, we were checking if the 2019-mini-rubric experiment was enabled.