### PR TITLE
Family version redirects

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -2,7 +2,10 @@ class ScriptsController < ApplicationController
   before_action :require_levelbuilder_mode, except: :show
   before_action :authenticate_user!, except: :show
   check_authorization
-  before_action :set_script, only: [:show, :edit, :update, :destroy]
+  before_action :set_script, only: [:edit, :update, :destroy]
+  # params[:id] in :show action may be a family name rather than a script,
+  # so differentiate how we set the script for this action.
+  before_action :set_script_for_show, only: [:show]
   authorize_resource
   before_action :set_script_file, only: [:edit, :update]
 
@@ -119,6 +122,11 @@ class ScriptsController < ApplicationController
     if current_user && @script&.pilot? && !@script.has_pilot_access?(current_user)
       render :no_access
     end
+  end
+
+  def set_script_for_show
+    @script = Script.get_script_family_redirect(params[:id], user: current_user, locale: request.locale)
+    set_script unless @script
   end
 
   def script_params

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -125,8 +125,9 @@ class ScriptsController < ApplicationController
   end
 
   def set_script_for_show
-    @script = Script.get_script_family_redirect(params[:id], user: current_user, locale: request.locale)
-    set_script unless @script
+    is_family_name = ScriptConstants::FAMILY_NAMES.include?(params[:id])
+    return set_script unless is_family_name
+    @script = Script.get_script_family_redirect_for_user(params[:id], user: current_user, locale: request.locale)
   end
 
   def script_params

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -454,17 +454,16 @@ class Script < ActiveRecord::Base
   def self.get_family_from_cache(family_name)
     return Script.get_family_without_cache(family_name) unless should_cache?
 
-    cache_key = "/#{family_name}"
-    script_family_cache.fetch(cache_key) do
+    script_family_cache.fetch(family_name) do
       # Populate cache on miss.
-      script_cache[cache_key] = Script.get_family_without_cache(family_name)
+      script_cache[family_name] = Script.get_family_without_cache(family_name)
     end
   end
 
   def self.get_script_family_redirect_for_user(family_name, user: nil, locale: 'en-US')
     return nil unless family_name
 
-    family_scripts = Script.get_family_from_cache(family_name)
+    family_scripts = Script.get_family_from_cache(family_name).sort_by(&:version_year).reverse
 
     if user
       assigned_script_ids = user.section_scripts.pluck(:id)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -454,8 +454,8 @@ class Script < ActiveRecord::Base
   def self.get_family_from_cache(family_name)
     return Script.get_family_without_cache(family_name) unless should_cache?
 
-    cache_key = "/family/#{family_name}"
-    script_cache.fetch(cache_key) do
+    cache_key = "/#{family_name}"
+    script_family_cache.fetch(cache_key) do
       # Populate cache on miss.
       script_cache[cache_key] = Script.get_family_without_cache(family_name)
     end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -352,8 +352,11 @@ class Script < ActiveRecord::Base
   def self.script_family_cache
     return nil unless should_cache?
     @@script_family_cache ||= {}.tap do |cache|
-      # don't store nil as cache key?
-      cache.merge!(script_cache.values.group_by(&:family_name))
+      family_scripts = script_cache.values.group_by(&:family_name)
+      # Not all scripts have a family_name, and thus will be grouped as family_scripts[nil].
+      # We do not want to store this key-value pair in the cache.
+      family_scripts.delete(nil)
+      cache.merge!(family_scripts)
     end
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -484,7 +484,7 @@ class Script < ActiveRecord::Base
 
       is_supported = script.supported_locales&.include?(locale_str) || locale_str&.downcase&.start_with?('en')
       if is_supported
-        latest_version = script if is_supported
+        latest_version = script
         break
       end
     end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -483,18 +483,14 @@ class Script < ActiveRecord::Base
   end
 
   # Given a script family name, return a dummy Script with redirect_to field
-  # pointing toward the latest stable script assigned to the user in that family, or to a specific
-  # version_year and locale if specified.
+  # pointing toward the latest stable script in that family, or to a specific
+  # version_year if one is specified.
   # @param family_name [String] The name of the script family to search in.
-  # @param version_year [String] Optional. Version year to return.
-  # @param user [User] Optional. If provided, will attempt to retrieve latest stable script
-  # that the user is assigned to or has progress in.
-  # @param locale [String] Optional. Locale of the request.
+  # @param version_year [String] Version year to return. Optional.
   # @return [Script|nil] A dummy script object, not persisted to the database,
   #   with only the redirect_to field set.
-  def self.get_script_family_redirect(family_name, version_year: nil, user: nil, locale: 'en-US')
-    script_name = Script.latest_assigned_version(family_name, user).try(:name)
-    script_name ||= Script.latest_stable_version(family_name, version_year: version_year, locale: locale, fallback: true).try(:name)
+  def self.get_script_family_redirect(family_name, version_year: nil)
+    script_name = Script.latest_stable_version(family_name, version_year: version_year).try(:name)
     script_name ? Script.new(redirect_to: script_name) : nil
   end
 
@@ -554,20 +550,18 @@ class Script < ActiveRecord::Base
   # @param family_name [String] The family name for a script family.
   # @param version_year [String] Version year to return. Optional.
   # @param locale [String] User or request locale. Optional.
-  # @param fallback [Boolean] If no latest stable version is found in provided locale,
-  # fallback to latest stable version in default locale. Optional.
   # @return [Script|nil] Returns the latest version in a script family.
-  def self.latest_stable_version(family_name, version_year: nil, locale: 'en-US', fallback: false)
+  def self.latest_stable_version(family_name, version_year: nil, locale: 'en-us')
     return nil unless family_name.present?
 
     script_versions = Script.
       where(family_name: family_name).
       order("properties -> '$.version_year' DESC")
 
-    # Find latest stable, supported script (ignore supported locales if locale is an English-speaking locale).
+    # Only select stable, supported scripts (ignore supported locales if locale is an English-speaking locale).
     # Match on version year if one is supplied.
     locale_str = locale&.to_s
-    supported_stable_script = script_versions.find do |script|
+    supported_stable_scripts = script_versions.select do |script|
       is_supported = script.supported_locales&.include?(locale_str) || locale_str&.start_with?('en')
       if version_year
         script.is_stable && is_supported && script.version_year == version_year
@@ -576,15 +570,7 @@ class Script < ActiveRecord::Base
       end
     end
 
-    # If there are no supported stable scripts in the given locale (and fallback is true), fallback
-    # to latest stable script in the default locale.
-    if !supported_stable_script && fallback && locale_str&.present?
-      supported_stable_script = script_versions.find do |script|
-        version_year.present? ? (script.is_stable && script.version_year == version_year) : script.is_stable
-      end
-    end
-
-    supported_stable_script
+    supported_stable_scripts&.first
   end
 
   # @param family_name [String] The family name for a script family.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -469,7 +469,7 @@ class Script < ActiveRecord::Base
 
     if user
       assigned_script_ids = user.section_scripts.pluck(:id)
-      script_name = family_scripts.where(id: assigned_script_ids)&.first&.name
+      script_name = family_scripts.select {|s| assigned_script_ids.include?(s.id)}&.first&.name
       return Script.new(redirect_to: script_name) if script_name
     end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -466,19 +466,19 @@ class Script < ActiveRecord::Base
     end
 
     locale_str = locale&.to_s
-    latest_stable_version = nil
-    latest_supported_version = nil
+    latest_version = nil
     family_scripts.each do |script|
       next unless script.is_stable
-      latest_stable_version ||= script
+      latest_version ||= script
 
       is_supported = script.supported_locales&.include?(locale_str) || locale_str&.downcase&.start_with?('en')
-      latest_supported_version = script if is_supported
-
-      break if latest_supported_version
+      if is_supported
+        latest_version = script if is_supported
+        break
+      end
     end
 
-    script_name = (latest_supported_version || latest_stable_version)&.name
+    script_name = latest_version&.name
     script_name ? Script.new(redirect_to: script_name) : nil
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -482,6 +482,8 @@ class Script < ActiveRecord::Base
       next unless script.is_stable
       latest_version ||= script
 
+      # All English-speaking locales are supported, so we check that the locale starts with 'en' rather
+      # than matching en-US specifically.
       is_supported = script.supported_locales&.include?(locale_str) || locale_str&.downcase&.start_with?('en')
       if is_supported
         latest_version = script

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -348,6 +348,13 @@ class Script < ActiveRecord::Base
     end
   end
 
+  def self.script_family_cache
+    return nil unless should_cache?
+    @@script_family_cache ||= {}.tap do |cache|
+      cache.merge!(script_cache.values.index_by(&:family_name))
+    end
+  end
+
   # Find the script level with the given id from the cache, unless the level build mode
   # is enabled in which case it is always fetched from the database. If we need to fetch
   # the script and we're not in level mode (for example because the script was created after

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -348,10 +348,12 @@ class Script < ActiveRecord::Base
     end
   end
 
+  # Returns a cached map from family_name to scripts, or nil if caching is disabled.
   def self.script_family_cache
     return nil unless should_cache?
     @@script_family_cache ||= {}.tap do |cache|
-      cache.merge!(script_cache.values.index_by(&:family_name))
+      # don't store nil as cache key?
+      cache.merge!(script_cache.values.group_by(&:family_name))
     end
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -461,7 +461,7 @@ class Script < ActiveRecord::Base
 
     script_family_cache.fetch(family_name) do
       # Populate cache on miss.
-      script_cache[family_name] = Script.get_family_without_cache(family_name)
+      script_family_cache[family_name] = Script.get_family_without_cache(family_name)
     end
   end
 

--- a/dashboard/config/initializers/script_preload.rb
+++ b/dashboard/config/initializers/script_preload.rb
@@ -11,6 +11,7 @@ if File.basename($0) != 'rake' &&
   Script.script_cache
   Script.script_level_cache
   Script.level_cache
+  Script.script_family_cache
   Course.course_cache_to_cache
   Course.course_cache
 end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -17,6 +17,9 @@ class ScriptTest < ActiveSupport::TestCase
     @script_in_course = create(:script, hidden: true)
     create(:course_script, position: 1, course: @course, script: @script_in_course)
 
+    @script_2017 = create :script, name: 'script-2017', family_name: 'family-cache-test', version_year: '2017'
+    @script_2018 = create :script, name: 'script-2018', family_name: 'family-cache-test', version_year: '2018'
+
     # ensure that we have freshly generated caches with this course/script
     Course.clear_cache
     Script.clear_cache
@@ -312,16 +315,13 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'get_family_from_cache uses script_family_cache' do
-    script_2017 = create :script, name: 'script-2017', family_name: 'family-cache-test', version_year: '2017'
-    script_2018 = create :script, name: 'script-2018', family_name: 'family-cache-test', version_year: '2018'
     family_scripts = Script.where(family_name: 'family-cache-test')
-
-    assert_equal [script_2017.name, script_2018.name], family_scripts.map(&:name)
+    assert_equal [@script_2017.name, @script_2018.name], family_scripts.map(&:name)
 
     populate_cache_and_disconnect_db
 
     cached_family_scripts = Script.get_family_from_cache('family-cache-test')
-    assert_equal [script_2017.name, script_2018.name], cached_family_scripts.map(&:name).uniq
+    assert_equal [@script_2017.name, @script_2018.name], cached_family_scripts.map(&:name).uniq
   end
 
   test 'cache_find_script_level uses cache' do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -27,6 +27,7 @@ class ScriptTest < ActiveSupport::TestCase
     # Only need to populate cache once per test-suite run
     @@script_cached ||= Script.script_cache_to_cache
     Script.script_cache
+    Script.script_family_cache
 
     # Also populate course_cache, as it's used by course_link
     Course.stubs(:should_cache?).returns true
@@ -308,6 +309,19 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal flappy, Script.get_from_cache(flappy_id)
     assert_equal frozen, Script.get_from_cache('frozen')
     assert_equal frozen, Script.get_from_cache(frozen_id)
+  end
+
+  test 'get_family_from_cache uses script_family_cache' do
+    script_2017 = create :script, name: 'script-2017', family_name: 'family-cache-test', version_year: '2017'
+    script_2018 = create :script, name: 'script-2018', family_name: 'family-cache-test', version_year: '2018'
+    family_scripts = Script.where(family_name: 'family-cache-test')
+
+    assert_equal [script_2017.name, script_2018.name], family_scripts.map(&:name)
+
+    populate_cache_and_disconnect_db
+
+    cached_family_scripts = Script.get_family_from_cache('family-cache-test')
+    assert_equal [script_2017.name, script_2018.name], cached_family_scripts.map(&:name).uniq
   end
 
   test 'cache_find_script_level uses cache' do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -388,38 +388,6 @@ class ScriptTest < ActiveSupport::TestCase
     end
   end
 
-  test 'get_script_family_redirect returns latest stable assigned version in family if user is provided' do
-    student = create :student
-    script1 = create :script, name: 's-1', family_name: 'courseg', version_year: '2017', is_stable: true
-    script2 = create :script, name: 's-2', family_name: 'courseg', version_year: '2018', is_stable: true
-
-    script_to_redirect_to = Script.get_script_family_redirect('courseg', user: student)&.redirect_to
-    assert_equal script2.name, script_to_redirect_to
-
-    section = create :section, script: script1
-    section.students << student
-    student.reload
-
-    script_to_redirect_to = Script.get_script_family_redirect('courseg', user: student)&.redirect_to
-    assert_equal script1.name, script_to_redirect_to
-  end
-
-  test 'get_script_family_redirect returns latest stable version in locale in family if available' do
-    create :script, name: 'english-only-script', family_name: 'courseg', version_year: '2018', is_stable: true, supported_locales: []
-    latest_in_locale = create :script, name: 'localized-script', family_name: 'courseg', version_year: '2017', is_stable: true, supported_locales: ['it-it']
-
-    script_to_redirect_to = Script.get_script_family_redirect('courseg', locale: 'it-it')&.redirect_to
-    assert_equal latest_in_locale.name, script_to_redirect_to
-  end
-
-  test 'get_script_family_redirect returns latest stable version in default locale in family if no versions support locale' do
-    latest_in_english = create :script, name: 'english-only-script', family_name: 'courseg', version_year: '2018', is_stable: true, supported_locales: []
-    create :script, name: 'localized-script', family_name: 'courseg', version_year: '2017', is_stable: true, supported_locales: ['it-it']
-
-    script_to_redirect_to = Script.get_script_family_redirect('courseg', locale: 'es-mx')&.redirect_to
-    assert_equal latest_in_english.name, script_to_redirect_to
-  end
-
   test 'redirect_to_script_url returns nil unless user can view script version' do
     Script.any_instance.stubs(:can_view_version?).returns(false)
     student = create :student
@@ -531,13 +499,6 @@ class ScriptTest < ActiveSupport::TestCase
     create :script, name: 's-2018', family_name: 'fake-family', version_year: '2018', is_stable: true, supported_locales: ["it-it"]
 
     assert_nil Script.latest_stable_version('fake-family', locale: 'es-mx')
-  end
-
-  test 'self.latest_stable_version returns latest stable in default locale if no script versions in family are stable in locale and fallback is true' do
-    create :script, name: 's-2017', family_name: 'fake-family', version_year: '2017', is_stable: true, supported_locales: []
-    script_2018 = create :script, name: 's-2018', family_name: 'fake-family', version_year: '2018', is_stable: true, supported_locales: []
-
-    assert_equal script_2018, Script.latest_stable_version('fake-family', locale: 'es-mx', fallback: true)
   end
 
   test 'self.latest_stable_version returns latest stable version for user locale' do

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -165,9 +165,35 @@ module ScriptConstants
 
   DEFAULT_VERSION_YEAR = '2017'
 
-  # TODO: add all family names
+  # A whitelist of all family names for scripts.
   FAMILY_NAMES = [
-    COURSEA = 'coursea'.freeze
+    # CSF
+    COURSEA = 'coursea'.freeze,
+    COURSEB = 'courseb'.freeze,
+    COURSEC = 'coursec'.freeze,
+    COURSED = 'coursed'.freeze,
+    COURSEE = 'coursee'.freeze,
+    COURSEF = 'coursef'.freeze,
+    EXPRESS = 'express'.freeze,
+    PREEXPRESS = 'pre-express'.freeze,
+
+    # CSP
+    CSP1 = 'csp1'.freeze,
+    CSP2 = 'csp2'.freeze,
+    CSP3 = 'csp3'.freeze,
+    CSP4 = 'csp4'.freeze,
+    CSP5 = 'csp5'.freeze,
+    CSP_POSTAP = 'csppostap'.freeze,
+    CSP_CREATE = 'csp-create'.freeze,
+    CSP_EXPLORE = 'csp-explore'.freeze,
+
+    # CSD
+    CSD1 = "csd1".freeze,
+    CSD2 = "csd2".freeze,
+    CSD3 = "csd3".freeze,
+    CSD4 = "csd4".freeze,
+    CSD5 = "csd5".freeze,
+    CSD6 = "csd6".freeze
   ].freeze
 
   def self.script_in_category?(category, script)

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -165,6 +165,11 @@ module ScriptConstants
 
   DEFAULT_VERSION_YEAR = '2017'
 
+  # TODO: add all family names
+  FAMILY_NAMES = [
+    COURSEA = 'coursea'.freeze
+  ].freeze
+
   def self.script_in_category?(category, script)
     return CATEGORIES[category].include? script
   end


### PR DESCRIPTION
Previously implemented in #27977, which I closed in order to implement a different approach.

[LP-28](https://codedotorg.atlassian.net/browse/LP-28)
[Spec](https://docs.google.com/document/d/1jYznJYlrfXQ-MJvmgfmZbVjjAM9-i297hoFTCqoYJ5w/edit?usp=sharing)

**Satisfies the following requirements in spec:**
If I go to a URL that is the “base name” of the script (e.g. /s/coursea), and...
- I have no existing progress in any version of that script: I should get redirected to the recommended one for my language. For example, if I’m in Spanish, /s/coursea should redirect me to /s/coursea-2017. If I’m in English or in an unsupported language (say Hindi), I should get redirected to /s/coursea-2018. 
- If I have existing progress in a newer version or I’m assigned to ONLY a newer version of the course than is recommended for my language, I should be redirected to the newest version I have progress in. EX: I have progress in Coursea-2018 in English, but my language is Spanish (2017 would be my recommended stable version), I should still go to coursea-2018 because that’s where I’ve been assigned or have progress.
- If I have existing progress in multiple versions of the script or am assigned to multiple versions of the script where some of the progress/assignment is in a newer version than is recommended for my language, I should still go to the latest version that I have progress in, but we should warn you that you have progress in other, older versions.