### PR TITLE
Hide assign button for unassignable scripts and courses

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverview.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverview.jsx
@@ -37,7 +37,7 @@ class ScriptOverview extends React.Component {
     showRedirectWarning: PropTypes.bool,
     versions: PropTypes.arrayOf(scriptVersionShape).isRequired,
     courseName: PropTypes.string,
-    hideAssignButton: PropTypes.bool,
+    showAssignButton: PropTypes.bool,
 
     // redux provided
     perLevelProgress: PropTypes.object.isRequired,
@@ -102,7 +102,7 @@ class ScriptOverview extends React.Component {
       hiddenStageState,
       selectedSectionId,
       courseName,
-      hideAssignButton
+      showAssignButton
     } = this.props;
 
     const displayRedirectDialog =
@@ -157,7 +157,7 @@ class ScriptOverview extends React.Component {
               viewAs={viewAs}
               isRtl={isRtl}
               resources={teacherResources}
-              hideAssignButton={hideAssignButton}
+              showAssignButton={showAssignButton}
             />
           </div>
         )}

--- a/apps/src/code-studio/components/progress/ScriptOverview.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverview.jsx
@@ -37,6 +37,7 @@ class ScriptOverview extends React.Component {
     showRedirectWarning: PropTypes.bool,
     versions: PropTypes.arrayOf(scriptVersionShape).isRequired,
     courseName: PropTypes.string,
+    hideAssignButton: PropTypes.bool,
 
     // redux provided
     perLevelProgress: PropTypes.object.isRequired,
@@ -100,7 +101,8 @@ class ScriptOverview extends React.Component {
       versions,
       hiddenStageState,
       selectedSectionId,
-      courseName
+      courseName,
+      hideAssignButton
     } = this.props;
 
     const displayRedirectDialog =
@@ -155,6 +157,7 @@ class ScriptOverview extends React.Component {
               viewAs={viewAs}
               isRtl={isRtl}
               resources={teacherResources}
+              hideAssignButton={hideAssignButton}
             />
           </div>
         )}

--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -59,7 +59,7 @@ export default class ScriptOverviewTopRow extends React.Component {
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
     isRtl: PropTypes.bool.isRequired,
     resources: PropTypes.arrayOf(resourceShape).isRequired,
-    hideAssignButton: PropTypes.bool
+    showAssignButton: PropTypes.bool
   };
 
   render() {
@@ -74,7 +74,7 @@ export default class ScriptOverviewTopRow extends React.Component {
       viewAs,
       isRtl,
       resources,
-      hideAssignButton
+      showAssignButton
     } = this.props;
 
     return (
@@ -97,7 +97,7 @@ export default class ScriptOverviewTopRow extends React.Component {
         )}
         {!professionalLearningCourse &&
           viewAs === ViewType.Teacher &&
-          !hideAssignButton && (
+          showAssignButton && (
             <AssignToSection
               sectionsInfo={sectionsInfo}
               courseId={currentCourseId}

--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -38,8 +38,7 @@ const styles = {
     top: 0
   },
   dropdown: {
-    display: 'inline-block',
-    marginLeft: 10
+    display: 'inline-block'
   }
 };
 
@@ -59,7 +58,8 @@ export default class ScriptOverviewTopRow extends React.Component {
     scriptTitle: PropTypes.string.isRequired,
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
     isRtl: PropTypes.bool.isRequired,
-    resources: PropTypes.arrayOf(resourceShape).isRequired
+    resources: PropTypes.arrayOf(resourceShape).isRequired,
+    hideAssignButton: PropTypes.bool
   };
 
   render() {
@@ -73,7 +73,8 @@ export default class ScriptOverviewTopRow extends React.Component {
       scriptTitle,
       viewAs,
       isRtl,
-      resources
+      resources,
+      hideAssignButton
     } = this.props;
 
     return (
@@ -94,14 +95,16 @@ export default class ScriptOverviewTopRow extends React.Component {
             />
           </div>
         )}
-        {!professionalLearningCourse && viewAs === ViewType.Teacher && (
-          <AssignToSection
-            sectionsInfo={sectionsInfo}
-            courseId={currentCourseId}
-            scriptId={scriptId}
-            assignmentName={scriptTitle}
-          />
-        )}
+        {!professionalLearningCourse &&
+          viewAs === ViewType.Teacher &&
+          !hideAssignButton && (
+            <AssignToSection
+              sectionsInfo={sectionsInfo}
+              courseId={currentCourseId}
+              scriptId={scriptId}
+              assignmentName={scriptTitle}
+            />
+          )}
         {!professionalLearningCourse &&
           viewAs === ViewType.Teacher &&
           resources.length > 0 && (

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -179,6 +179,7 @@ progress.renderCourseProgress = function(scriptData) {
         redirectScriptUrl={scriptData.redirect_script_url}
         versions={scriptData.versions}
         courseName={scriptData.course_name}
+        hideAssignButton={scriptData.hidden}
       />
     </Provider>,
     mountPoint

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -179,7 +179,7 @@ progress.renderCourseProgress = function(scriptData) {
         redirectScriptUrl={scriptData.redirect_script_url}
         versions={scriptData.versions}
         courseName={scriptData.course_name}
-        hideAssignButton={scriptData.hidden}
+        showAssignButton={scriptData.show_assign_button}
       />
     </Provider>,
     mountPoint

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -79,6 +79,7 @@ function showCourseOverview() {
         }
         showRedirectWarning={scriptData.show_redirect_warning}
         redirectToCourseUrl={scriptData.redirect_to_course_url}
+        showAssignButton={courseSummary.show_assign_button}
       />
     </Provider>,
     document.getElementById('course_overview')

--- a/apps/src/sites/studio/pages/scriptOverview.js
+++ b/apps/src/sites/studio/pages/scriptOverview.js
@@ -17,7 +17,6 @@ function initPage() {
   const config = JSON.parse(script.dataset.scriptoverview);
 
   const {scriptData, plcBreadcrumb} = config;
-
   const store = getStore();
 
   if (plcBreadcrumb) {

--- a/apps/src/sites/studio/pages/scriptOverview.js
+++ b/apps/src/sites/studio/pages/scriptOverview.js
@@ -17,6 +17,7 @@ function initPage() {
   const config = JSON.parse(script.dataset.scriptoverview);
 
   const {scriptData, plcBreadcrumb} = config;
+
   const store = getStore();
 
   if (plcBreadcrumb) {

--- a/apps/src/templates/courseOverview/AssignToSection.js
+++ b/apps/src/templates/courseOverview/AssignToSection.js
@@ -37,8 +37,7 @@ class AssignToSection extends Component {
       })
     ).isRequired,
     hiddenStageState: PropTypes.object,
-    updateHiddenScript: PropTypes.func.isRequired,
-    hidden: PropTypes.bool
+    updateHiddenScript: PropTypes.func.isRequired
   };
 
   state = {
@@ -94,8 +93,7 @@ class AssignToSection extends Component {
       scriptId,
       assignmentName,
       sectionsInfo,
-      hiddenStageState,
-      hidden
+      hiddenStageState
     } = this.props;
     const {sectionIndexToAssign, errorString} = this.state;
     const section = sectionsInfo[sectionIndexToAssign];
@@ -107,34 +105,32 @@ class AssignToSection extends Component {
 
     return (
       <div style={styles.main}>
-        {!hidden && (
-          <div style={{marginRight: 10}}>
-            <DropdownButton
-              text={
-                courseId && scriptId ? i18n.assignUnit() : i18n.assignCourse()
-              }
-              color={Button.ButtonColor.orange}
-            >
-              {[]
-                .concat(
-                  <a key={-1} href={`/home?${queryParams}`}>
-                    {i18n.newSectionEllipsis()}
+        <div style={{marginRight: 10}}>
+          <DropdownButton
+            text={
+              courseId && scriptId ? i18n.assignUnit() : i18n.assignCourse()
+            }
+            color={Button.ButtonColor.orange}
+          >
+            {[]
+              .concat(
+                <a key={-1} href={`/home?${queryParams}`}>
+                  {i18n.newSectionEllipsis()}
+                </a>
+              )
+              .concat(
+                sectionsInfo.map((section, index) => (
+                  <a
+                    key={index}
+                    data-section-index={index}
+                    onClick={this.onClickCourse}
+                  >
+                    {section.name}
                   </a>
-                )
-                .concat(
-                  sectionsInfo.map((section, index) => (
-                    <a
-                      key={index}
-                      data-section-index={index}
-                      onClick={this.onClickCourse}
-                    >
-                      {section.name}
-                    </a>
-                  ))
-                )}
-            </DropdownButton>
-          </div>
-        )}
+                ))
+              )}
+          </DropdownButton>
+        </div>
         {sectionIndexToAssign !== null && (
           <ConfirmAssignment
             sectionName={section.name}

--- a/apps/src/templates/courseOverview/AssignToSection.js
+++ b/apps/src/templates/courseOverview/AssignToSection.js
@@ -37,7 +37,8 @@ class AssignToSection extends Component {
       })
     ).isRequired,
     hiddenStageState: PropTypes.object,
-    updateHiddenScript: PropTypes.func.isRequired
+    updateHiddenScript: PropTypes.func.isRequired,
+    hidden: PropTypes.bool
   };
 
   state = {
@@ -93,7 +94,8 @@ class AssignToSection extends Component {
       scriptId,
       assignmentName,
       sectionsInfo,
-      hiddenStageState
+      hiddenStageState,
+      hidden
     } = this.props;
     const {sectionIndexToAssign, errorString} = this.state;
     const section = sectionsInfo[sectionIndexToAssign];
@@ -105,28 +107,34 @@ class AssignToSection extends Component {
 
     return (
       <div style={styles.main}>
-        <DropdownButton
-          text={courseId && scriptId ? i18n.assignUnit() : i18n.assignCourse()}
-          color={Button.ButtonColor.orange}
-        >
-          {[]
-            .concat(
-              <a key={-1} href={`/home?${queryParams}`}>
-                {i18n.newSectionEllipsis()}
-              </a>
-            )
-            .concat(
-              sectionsInfo.map((section, index) => (
-                <a
-                  key={index}
-                  data-section-index={index}
-                  onClick={this.onClickCourse}
-                >
-                  {section.name}
-                </a>
-              ))
-            )}
-        </DropdownButton>
+        {!hidden && (
+          <div style={{marginRight: 10}}>
+            <DropdownButton
+              text={
+                courseId && scriptId ? i18n.assignUnit() : i18n.assignCourse()
+              }
+              color={Button.ButtonColor.orange}
+            >
+              {[]
+                .concat(
+                  <a key={-1} href={`/home?${queryParams}`}>
+                    {i18n.newSectionEllipsis()}
+                  </a>
+                )
+                .concat(
+                  sectionsInfo.map((section, index) => (
+                    <a
+                      key={index}
+                      data-section-index={index}
+                      onClick={this.onClickCourse}
+                    >
+                      {section.name}
+                    </a>
+                  ))
+                )}
+            </DropdownButton>
+          </div>
+        )}
         {sectionIndexToAssign !== null && (
           <ConfirmAssignment
             sectionName={section.name}

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -80,7 +80,8 @@ export default class CourseOverview extends Component {
     ).isRequired,
     showVersionWarning: PropTypes.bool,
     showRedirectWarning: PropTypes.bool,
-    redirectToCourseUrl: PropTypes.string
+    redirectToCourseUrl: PropTypes.string,
+    showAssignButton: PropTypes.bool
   };
 
   constructor(props) {
@@ -144,7 +145,8 @@ export default class CourseOverview extends Component {
       versions,
       showVersionWarning,
       showRedirectWarning,
-      redirectToCourseUrl
+      redirectToCourseUrl,
+      showAssignButton
     } = this.props;
 
     // We currently set .container.main to have a width of 940 at a pretty high
@@ -233,6 +235,7 @@ export default class CourseOverview extends Component {
               id={id}
               title={title}
               resources={teacherResources}
+              showAssignButton={showAssignButton}
             />
           </div>
         )}

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -21,18 +21,22 @@ export default class CourseOverviewTopRow extends Component {
     ).isRequired,
     id: PropTypes.number.isRequired,
     title: PropTypes.string.isRequired,
-    resources: PropTypes.arrayOf(resourceShape).isRequired
+    resources: PropTypes.arrayOf(resourceShape).isRequired,
+    showAssignButton: PropTypes.bool
   };
 
   render() {
-    const {sectionsInfo, id, title, resources} = this.props;
+    const {sectionsInfo, id, title, resources, showAssignButton} = this.props;
+
     return (
       <div style={styles.main}>
-        <AssignToSection
-          sectionsInfo={sectionsInfo}
-          courseId={id}
-          assignmentName={title}
-        />
+        {showAssignButton && (
+          <AssignToSection
+            sectionsInfo={sectionsInfo}
+            courseId={id}
+            assignmentName={title}
+          />
+        )}
         {resources.map(({type, link}) => (
           <Button
             key={type}

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -36,7 +36,7 @@ export default class CourseOverviewTopRow extends Component {
         {resources.map(({type, link}) => (
           <Button
             key={type}
-            style={{marginLeft: 10}}
+            style={{marginRight: 10}}
             text={stringForType[type]}
             href={link}
             target="blank"

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
@@ -24,7 +24,8 @@ const defaultProps = {
   isRtl: false,
   resources: [],
   scriptHasLockableStages: false,
-  scriptAllowsHiddenStages: false
+  scriptAllowsHiddenStages: false,
+  showAssignButton: true
 };
 
 describe('ScriptOverviewTopRow', () => {

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
@@ -21,7 +21,8 @@ const defaultProps = {
       type: ResourceType.teacherForum,
       link: 'https://forum.code.org/'
     }
-  ]
+  ],
+  showAssignButton: true
 };
 
 describe('CourseOverviewTopRow', () => {

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -242,6 +242,16 @@ class Course < ApplicationRecord
     valid_courses.any? {|course| course[:id] == course_id.to_i}
   end
 
+  # @param user [User]
+  # @param course_id [String] id of the course we're checking
+  # @returns [Boolean] Whether the user can assign this course.
+  # Users should only be able to assign one of their valid courses.
+  def assignable?(user, course_id)
+    if user
+      Course.valid_course_id?(course_id)
+    end
+  end
+
   def summarize(user = nil)
     {
       name: name,
@@ -257,7 +267,8 @@ class Course < ApplicationRecord
       end,
       teacher_resources: teacher_resources,
       has_verified_resources: has_verified_resources?,
-      versions: summarize_versions(user)
+      versions: summarize_versions(user),
+      show_assign_button: assignable?(user, id)
     }
   end
 

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -246,7 +246,7 @@ class Course < ApplicationRecord
   # @returns [Boolean] Whether the user can assign this course.
   # Users should only be able to assign one of their valid courses.
   def assignable?(user)
-    if user
+    if user&.teacher?
       Course.valid_course_id?(id)
     end
   end

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -243,12 +243,11 @@ class Course < ApplicationRecord
   end
 
   # @param user [User]
-  # @param course_id [String] id of the course we're checking
   # @returns [Boolean] Whether the user can assign this course.
   # Users should only be able to assign one of their valid courses.
-  def assignable?(user, course_id)
+  def assignable?(user)
     if user
-      Course.valid_course_id?(course_id)
+      Course.valid_course_id?(id)
     end
   end
 
@@ -268,7 +267,7 @@ class Course < ApplicationRecord
       teacher_resources: teacher_resources,
       has_verified_resources: has_verified_resources?,
       versions: summarize_versions(user),
-      show_assign_button: assignable?(user, id)
+      show_assign_button: assignable?(user)
     }
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -252,7 +252,7 @@ class Script < ActiveRecord::Base
   # @returns [Boolean] Whether the user can assign this script.
   # Users should only be able to assign one of their valid scripts.
   def assignable?(user)
-    if user
+    if user&.teacher?
       Script.valid_script_id?(user, id)
     end
   end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -248,11 +248,14 @@ class Script < ActiveRecord::Base
     end
   end
 
-  # Teachers should only be allowed to assign scripts from their valid
-  # script list. We use this information to hide/show the "Assign unit"
-  # button on the script overview page.
+  # @param user [User]
+  # @param script_id [String] id of the script we're checking
+  # @returns [Boolean] Whether the user can assign this script.
+  # Users should only be able to assign one of their valid scripts.
   def assignable?(user, script_id)
-    Script.valid_script_id?(user, script_id)
+    if user
+      Script.valid_script_id?(user, script_id)
+    end
   end
 
   # @param [User] user

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -249,12 +249,11 @@ class Script < ActiveRecord::Base
   end
 
   # @param user [User]
-  # @param script_id [String] id of the script we're checking
   # @returns [Boolean] Whether the user can assign this script.
   # Users should only be able to assign one of their valid scripts.
-  def assignable?(user, script_id)
+  def assignable?(user)
     if user
-      Script.valid_script_id?(user, script_id)
+      Script.valid_script_id?(user, id)
     end
   end
 
@@ -1272,7 +1271,7 @@ class Script < ActiveRecord::Base
       supported_locales: supported_locales,
       section_hidden_unit_info: section_hidden_unit_info(user),
       pilot_experiment: pilot_experiment,
-      show_assign_button: assignable?(user, id)
+      show_assign_button: assignable?(user)
     }
 
     summary[:stages] = stages.map {|stage| stage.summarize(include_bonus_levels)} if include_stages

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -248,6 +248,13 @@ class Script < ActiveRecord::Base
     end
   end
 
+  # Teachers should only be allowed to assign scripts from their valid
+  # script list. We use this information to hide/show the "Assign unit"
+  # button on the script overview page.
+  def assignable?(user, script_id)
+    Script.valid_script_id?(user, script_id)
+  end
+
   # @param [User] user
   # @param script_id [String] id of the script we're checking the validity of
   # @return [Boolean] Whether this is a valid script ID
@@ -1262,6 +1269,7 @@ class Script < ActiveRecord::Base
       supported_locales: supported_locales,
       section_hidden_unit_info: section_hidden_unit_info(user),
       pilot_experiment: pilot_experiment,
+      show_assign_button: assignable?(user, id)
     }
 
     summary[:stages] = stages.map {|stage| stage.summarize(include_bonus_levels)} if include_stages

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -55,7 +55,7 @@ class CoursesControllerTest < ActionController::TestCase
     end
   end
 
-  test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @course_regular.name}}, queries: 7
+  test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @course_regular.name}}, queries: 8
 
   test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @course_regular.name}}, queries: 2
 

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -144,7 +144,7 @@ class CourseTest < ActiveSupport::TestCase
     assert_equal [:name, :id, :title, :assignment_family_title,
                   :description_short, :description_student,
                   :description_teacher, :scripts, :teacher_resources,
-                  :has_verified_resources, :versions], summary.keys
+                  :has_verified_resources, :versions, :show_assign_button], summary.keys
     assert_equal 'my-course', summary[:name]
     assert_equal 'my-course-title', summary[:title]
     assert_equal 'short description', summary[:description_short]

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -787,6 +787,27 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 'foo-2017', versions[2][:name]
   end
 
+  test 'summarize includes show assign button' do
+    script = create(:script, name: 'script')
+
+    # No user, show_assign_button set to nil
+    assert_nil script.summarize[:show_assign_button]
+
+    # Teacher should be able to assign a visible script.
+    assert_equal false, script.summarize[:hidden]
+    assert_equal true, script.summarize(true, create(:teacher))[:show_assign_button]
+
+    # Teacher should not be able to assign a hidden script.
+    hidden_script = create(:script, name: 'unassignable-hidden', hidden: true)
+    assert_equal true, hidden_script.summarize[:hidden]
+    assert_equal false, hidden_script.summarize(true, create(:teacher))[:show_assign_button]
+
+    # Student should not be able to assign a script,
+    # regardless of visibility.
+    assert_equal false, script.summarize[:hidden]
+    assert_nil script.summarize(true, create(:student))[:show_assign_button]
+  end
+
   test 'summarize includes bonus levels for stages if include_bonus_levels and include_stages are true' do
     script = create :script
     stage = create :stage, script: script


### PR DESCRIPTION
Bug fix:  [LP 186](https://codedotorg.atlassian.net/browse/LP-186)

This PR hides the "Assign Unit" button on script overview pages for scripts that a given teacher can not assign. Teachers can't assign scripts that are not in their set of valid scripts, so it's confusing that the button appears currently. Similarly, the "Assign Course" button is now hidden if the course is not assignable. 

If the script is not in the teacher's set of valid scripts - script is not assignable: 
<img width="1125" alt="hide assign unit button" src="https://user-images.githubusercontent.com/12300669/56160292-b1cb0800-5f7b-11e9-9f0d-4617adaefd9a.png">

If the script is in the teacher's set of valid scripts - script is assignable: 
<img width="872" alt="show assign unit button" src="https://user-images.githubusercontent.com/12300669/56160268-9fe96500-5f7b-11e9-94e2-3ae474518df3.png">

I also include a couple little style tweaks to keep the buttons aligned correctly on course overview pages, as I applied styling such that the remaining buttons would be flush with the edge of the page if the "Assign Unit" button is removed. 
<img width="519" alt="Screen Shot 2019-04-11 at 4 50 33 PM" src="https://user-images.githubusercontent.com/12300669/56003278-b5f4de00-5c7a-11e9-8e70-7965bbd8e14a.png">
