### PR TITLE
update page-load logic

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -5,24 +5,29 @@ SHORT_WAIT_TIMEOUT = 30.seconds
 MODULE_PROGRESS_COLOR_MAP = {not_started: 'rgb(255, 255, 255)', in_progress: 'rgb(239, 205, 28)', completed: 'rgb(14, 190, 14)'}
 
 def http_client
-  @browser.send(:bridge).http.send(:http)
+  $browser.send(:bridge).http.send(:http)
+rescue
+  nil
 end
 
-# Set HTTP read timeout greater than the wait timeout during the block.
+# Set HTTP read timeout to the specified wait timeout during the block.
 def with_read_timeout(timeout)
-  http = http_client
-  if (read_timeout = http.read_timeout) < (timeout + 5.seconds)
-    http.read_timeout = timeout + 5.seconds
+  if (http = http_client)
+    read_timeout = http.read_timeout
+    http.read_timeout = timeout
   end
   yield
 ensure
-  http.read_timeout = read_timeout
+  http.read_timeout = read_timeout if http
 end
 
 def wait_until(timeout = DEFAULT_WAIT_TIMEOUT)
   Selenium::WebDriver::Wait.new(timeout: timeout).until do
     yield
-  rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::StaleElementReferenceError
+  rescue Selenium::WebDriver::Error::UnknownError => e
+    puts "Unknown error: #{e}"
+    false
+  rescue  Selenium::WebDriver::Error::StaleElementReferenceError
     false
   end
 end
@@ -36,7 +41,10 @@ def element_stale?(element)
   false
 rescue Selenium::WebDriver::Error::JavascriptError => e
   e.message.starts_with? 'Element does not exist in cache'
-rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::StaleElementReferenceError
+rescue Selenium::WebDriver::Error::UnknownError => e
+  puts "Unknown error: #{e}"
+  true
+rescue Selenium::WebDriver::Error::StaleElementReferenceError
   true
 end
 
@@ -45,6 +53,7 @@ def page_load(wait_until_unload)
     html = @browser.find_element(tag_name: 'html')
     yield
     wait_until {element_stale?(html)}
+    navigate_to(@browser.current_url)
   else
     yield
   end
@@ -69,9 +78,7 @@ def individual_steps(steps)
   end
 end
 
-Given /^I am on "([^"]*)"$/ do |url|
-  check_window_for_js_errors('before navigation')
-  url = replace_hostname(url)
+def navigate_to(url)
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, sleep: 10, tries: 3) do
     with_read_timeout(DEFAULT_WAIT_TIMEOUT + 5.seconds) do
       @browser.navigate.to url
@@ -79,6 +86,11 @@ Given /^I am on "([^"]*)"$/ do |url|
     refute_bad_gateway_or_site_unreachable
   end
   install_js_error_recorder
+end
+
+Given /^I am on "([^"]*)"$/ do |url|
+  check_window_for_js_errors('before navigation')
+  navigate_to replace_hostname(url)
 end
 
 When /^I wait to see (?:an? )?"([.#])([^"]*)"$/ do |selector_symbol, name|

--- a/dashboard/test/ui/features/support/hooks.rb
+++ b/dashboard/test/ui/features/support/hooks.rb
@@ -2,45 +2,45 @@ Before('@as_student') do
   steps "Given I create a student named \"Test #{rand(100000)}_Student\""
 end
 
-After('@as_student') do
+After('@as_student') do |scenario|
   check_window_for_js_errors('after @as_student')
-  steps 'When I sign out'
+  steps 'When I sign out' if scenario.passed?
 end
 
 Before('@as_young_student') do
   steps "Given I create a young student named \"Test #{rand(100000)}_Student\""
 end
 
-After('@as_young_student') do
+After('@as_young_student') do |scenario|
   check_window_for_js_errors('after @as_young_student')
-  steps 'When I sign out'
+  steps 'When I sign out' if scenario.passed?
 end
 
 Before('@as_taught_student') do
   steps "Given I create a teacher-associated student named \"Taught #{rand(100000)}_Student\""
 end
 
-After('@as_taught_student') do
+After('@as_taught_student') do |scenario|
   check_window_for_js_errors('after @as_taught_student')
-  steps 'When I sign out'
+  steps 'When I sign out' if scenario.passed?
 end
 
 Before('@as_authorized_taught_student') do
   steps "Given I create an authorized teacher-associated student named \"Taught #{rand(100000)}_Student\""
 end
 
-After('@as_authorized_taught_student') do
+After('@as_authorized_taught_student') do |scenario|
   check_window_for_js_errors('after @as_authorized_taught_student')
-  steps 'When I sign out'
+  steps 'When I sign out' if scenario.passed?
 end
 
 Before('@as_teacher') do
   steps 'Given I am a teacher'
 end
 
-After('@as_teacher') do
+After('@as_teacher') do |scenario|
   check_window_for_js_errors('after @as_teacher')
-  steps 'When I sign out'
+  steps 'When I sign out' if scenario.passed?
 end
 
 # Add After hook as the last one, which results in it being run before


### PR DESCRIPTION
- reuse navigation logic for 'to load a new page' step
- reduce read timeouts around JS error recording to 10 seconds
- reduce read timeout around browser quitting to 5 seconds
- increase global read timeout to 2 minutes
- reduce page-load timeout to 2 minutes
- remove script-timeout config (only applies to execute_async_script, which we never use)
- Print debug messages to log for `Selenium::WebDriver::Error::UnknownError` errors