### PR TITLE
PL: Regional partner search gets another priority deadline tweak

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -246,6 +246,7 @@ class RegionalPartnerSearch extends Component {
               We are unable to find this ZIP code. You can still apply directly:
             </div>
             <StartApplicationButton
+              buttonOnly={true}
               nominated={this.state.nominated}
               priorityDeadlineDate={appsPriorityDeadlineDate}
             />


### PR DESCRIPTION
There was another case in which a standalone button is better than an info box.

## before
![Screenshot 2019-04-12 12 50 14](https://user-images.githubusercontent.com/2205926/56009257-88636f80-5d22-11e9-8341-a5ed3dab079f.png)

## after
![Screenshot 2019-04-12 12 47 29](https://user-images.githubusercontent.com/2205926/56009258-88636f80-5d22-11e9-8abf-220eeeca5692.png)



