### PR TITLE
Mini Rubric: Hidden Border on RubricField

### DIFF
--- a/apps/src/templates/instructions/RubricField.jsx
+++ b/apps/src/templates/instructions/RubricField.jsx
@@ -27,9 +27,10 @@ const styles = {
     flexDirection: 'row',
     margin: '0px 8px',
     padding: 4,
+    borderRadius: 4,
+    border: `solid 1px ${color.white}`,
     ':hover': {
-      border: `solid 1px ${color.light_cyan}`,
-      borderRadius: 4
+      border: `solid 1px ${color.light_cyan}`
     }
   },
   performanceLevelHeaderSelected: {
@@ -40,9 +41,9 @@ const styles = {
     padding: 4,
     backgroundColor: color.lightest_cyan,
     borderRadius: 4,
+    border: `solid 1px ${color.white}`,
     ':hover': {
-      border: `solid 1px ${color.light_cyan}`,
-      borderRadius: 4
+      border: `solid 1px ${color.light_cyan}`
     }
   },
   tooltip: {


### PR DESCRIPTION
Since we were adding a border when we hovered over a section of the rubric but it was not there the rest of the time we were causing things to shift slightly on each hover. By having a white border (which you can't see) when we don't have a blue border it keeps everything from shifting.

# Before
![Before-Shift-Rubric](https://user-images.githubusercontent.com/208083/56041620-29443180-5d07-11e9-9f3c-16316129d039.gif)

# After
![After-Shift-Rubric](https://user-images.githubusercontent.com/208083/56041633-2e08e580-5d07-11e9-8860-fa1bd325785e.gif)
