### PR TITLE
Assessment UX Re-design: Teacher Panel Completed Assessment Bubbles

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -260,6 +260,10 @@ class ScriptLevel < ActiveRecord::Base
     build_script_level_path(self)
   end
 
+  def assessment?
+    assessment
+  end
+
   def summarize(include_prev_next=true)
     kind =
       if level.unplugged?

--- a/dashboard/app/views/levels/_teacher.html.haml
+++ b/dashboard/app/views/levels/_teacher.html.haml
@@ -16,6 +16,8 @@
             .level
               - status = activity_css_class(@user_level)
               - passed = [SharedConstants::LEVEL_STATUS.passed, SharedConstants::LEVEL_STATUS.perfect].include?(status)
+              - if @script_level&.assessment? && passed
+                - status = SharedConstants::LEVEL_STATUS.completed_assessment
               - if @script_level&.bonus
                 - flag_image = passed ? 'flag_active.png' : 'flag_inactive.png'
                 = image_tag flag_image, style: 'width: 60px;'
@@ -116,6 +118,8 @@
                     - user_level = student.last_attempt_for_any(@script_level.levels)
                   - status = activity_css_class(user_level)
                   - passed = [SharedConstants::LEVEL_STATUS.passed, SharedConstants::LEVEL_STATUS.perfect].include?(status)
+                  - if @script_level&.assessment? && passed
+                    - status = SharedConstants::LEVEL_STATUS.completed_assessment
                   - if @script_level.bonus
                     - flag_image = passed ? 'flag_active.png' : 'flag_inactive.png'
                     %td= image_tag flag_image

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -80,6 +80,7 @@ $table_dark_row: #f4f4f4;
 
 // Progress colors.
 $level_submitted: $purple;
+$level_completed_assessment: $purple;
 $level_perfect: rgb(14, 190, 14);
 $level_passed: rgb(159, 212, 159);
 $level_attempted: $realyellow;

--- a/shared/css/user-progress.scss
+++ b/shared/css/user-progress.scss
@@ -37,7 +37,8 @@ a.level_link.not_tried:hover,
 a.level_link.attempted:hover,
 a.level_link.perfect:hover,
 a.level_link.passed:hover,
-a.level_link.submitted:hover
+a.level_link.submitted:hover,
+a.level_link.completed_assessment:hover
  {
     background-color: $level_current;
     color: white;
@@ -62,6 +63,11 @@ a.level_link.submitted:hover
 
 .level_link.submitted, .level_link.submitted:link, .level_link.submitted:visited {
   background-color: $level_submitted;
+  color: white !important;
+}
+
+.level_link.completed_assessment, .level_link.completed_assessment:link, .level_link.completed_assessment:visited {
+  background-color: $level_completed_assessment;
   color: white !important;
 }
 


### PR DESCRIPTION
If a student has completed an assessment level we mark the bubble in the teacher panel purple.

# Before
<img width="714" alt="Screen Shot 2019-04-12 at 10 59 32 AM" src="https://user-images.githubusercontent.com/208083/56046805-16832a00-5d12-11e9-92a4-2f6992285df2.png">

# After
<img width="715" alt="Screen Shot 2019-04-12 at 10 53 53 AM" src="https://user-images.githubusercontent.com/208083/56046646-b55b5680-5d11-11e9-8138-4220e110c868.png">

<img width="703" alt="Screen Shot 2019-04-12 at 11 56 52 AM" src="https://user-images.githubusercontent.com/208083/56050573-3f0f2200-5d1a-11e9-80da-96ebcea92237.png">

