### PR TITLE
Mini Rubric: Expand the selected performance level for student by default

### DIFF
--- a/apps/src/templates/instructions/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/TeacherFeedback.jsx
@@ -242,6 +242,12 @@ export class TeacherFeedback extends Component {
         ? styles.timeStudent
         : styles.timeTeacher;
 
+    // If a student has rubric feedback we want to expand that field
+    const expandPerformanceLevelForStudent =
+      this.props.viewAs === ViewType.Student &&
+      showFeedbackInputAreas &&
+      this.state.performance !== null;
+
     return (
       <div style={tabVisible}>
         {this.state.errorState === ErrorType.Load && (
@@ -263,7 +269,11 @@ export class TeacherFeedback extends Component {
                   <RubricField
                     key={level}
                     showFeedbackInputAreas={showFeedbackInputAreas}
-                    expandByDefault={this.props.displayKeyConcept}
+                    expandByDefault={
+                      this.props.displayKeyConcept ||
+                      (expandPerformanceLevelForStudent &&
+                        this.state.performance === level)
+                    }
                     rubricLevel={level}
                     rubricValue={this.props.rubric[level]}
                     disabledMode={this.props.disabledMode}

--- a/apps/test/unit/templates/instructions/TeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/TeacherFeedbackTest.jsx
@@ -423,17 +423,25 @@ describe('TeacherFeedback', () => {
 
       // Rubric
       expect(wrapper.find('RubricField')).to.have.lengthOf(4);
-      const confirmExceedsRatioButton = wrapper.find('RubricField').at(1);
-      expect(confirmExceedsRatioButton.props().disabledMode).to.equal(true);
-      expect(confirmExceedsRatioButton.props().showFeedbackInputAreas).to.equal(
+      const confirmExceedsRatioButton = wrapper.find('RubricField').at(0);
+      const confirmMeetsRatioButton = wrapper.find('RubricField').at(1);
+      expect(confirmMeetsRatioButton.props().disabledMode).to.equal(true);
+      expect(confirmMeetsRatioButton.props().showFeedbackInputAreas).to.equal(
         true
       );
+
+      // The rubric value that was given as feedback should be expanded
       expect(confirmExceedsRatioButton.props().expandByDefault).to.equal(false);
-      expect(confirmExceedsRatioButton.props().rubricLevel).to.equal('meets');
-      expect(confirmExceedsRatioButton.props().rubricValue).to.equal(
+      expect(confirmMeetsRatioButton.props().expandByDefault).to.equal(true);
+
+      expect(confirmMeetsRatioButton.props().rubricLevel).to.equal('meets');
+      expect(confirmMeetsRatioButton.props().rubricValue).to.equal(
         'met expectations'
       );
-      expect(confirmExceedsRatioButton.props().currentlyChecked).to.equal(true);
+      expect(confirmMeetsRatioButton.props().currentlyChecked).to.equal(true);
+      expect(confirmExceedsRatioButton.props().currentlyChecked).to.equal(
+        false
+      );
 
       // Comment
       const confirmCommentArea = wrapper.find('CommentArea').first();
@@ -474,17 +482,25 @@ describe('TeacherFeedback', () => {
 
       // Rubric
       expect(wrapper.find('RubricField')).to.have.lengthOf(4);
-      const confirmExceedsRatioButton = wrapper.find('RubricField').at(1);
-      expect(confirmExceedsRatioButton.props().disabledMode).to.equal(true);
-      expect(confirmExceedsRatioButton.props().showFeedbackInputAreas).to.equal(
+      const confirmExceedsRatioButton = wrapper.find('RubricField').at(0);
+      const confirmMeetsRatioButton = wrapper.find('RubricField').at(1);
+      expect(confirmMeetsRatioButton.props().disabledMode).to.equal(true);
+      expect(confirmMeetsRatioButton.props().showFeedbackInputAreas).to.equal(
         true
       );
+
+      // The rubric value that was given as feedback should be expanded
       expect(confirmExceedsRatioButton.props().expandByDefault).to.equal(false);
-      expect(confirmExceedsRatioButton.props().rubricLevel).to.equal('meets');
-      expect(confirmExceedsRatioButton.props().rubricValue).to.equal(
+      expect(confirmMeetsRatioButton.props().expandByDefault).to.equal(true);
+
+      expect(confirmMeetsRatioButton.props().rubricLevel).to.equal('meets');
+      expect(confirmMeetsRatioButton.props().rubricValue).to.equal(
         'met expectations'
       );
-      expect(confirmExceedsRatioButton.props().currentlyChecked).to.equal(true);
+      expect(confirmMeetsRatioButton.props().currentlyChecked).to.equal(true);
+      expect(confirmExceedsRatioButton.props().currentlyChecked).to.equal(
+        false
+      );
 
       // Comment
       expect(wrapper.find('CommentArea')).to.have.lengthOf(0);


### PR DESCRIPTION
Expand the performance level the teacher gave to a student (if they gave them rubric feedback) by default when the student is looking at feedback.

# Before
<img width="645" alt="Screen Shot 2019-04-12 at 11 48 48 AM" src="https://user-images.githubusercontent.com/208083/56050094-f5720780-5d18-11e9-8050-c3389c859880.png">


# After
<img width="634" alt="Screen Shot 2019-04-12 at 11 35 07 AM" src="https://user-images.githubusercontent.com/208083/56050038-d5424880-5d18-11e9-8d95-5e2253d7a7d8.png">

