### PR TITLE
Mini Rubric: Default to feedback tab if student has received feedback for that level

### DIFF
--- a/apps/src/templates/instructions/TopInstructionsCSP.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSP.jsx
@@ -174,10 +174,7 @@ class TopInstructionsCSP extends Component {
           contentType: 'application/json;charset=UTF-8'
         }).done(data => {
           // If student has feedback make their default tab the feedback tab instead of instructions
-          if (
-            data[0] &&
-            (data[0].comment !== '' || data[0].performance !== null)
-          ) {
+          if (data[0] && (data[0].comment || data[0].performance)) {
             this.setState({feedbacks: data, tabSelected: TabType.COMMENTS});
           }
         })

--- a/apps/src/templates/instructions/TopInstructionsCSP.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSP.jsx
@@ -173,7 +173,13 @@ class TopInstructionsCSP extends Component {
           method: 'GET',
           contentType: 'application/json;charset=UTF-8'
         }).done(data => {
-          this.setState({feedbacks: data});
+          // If student has feedback make their default tab the feedback tab instead of instructions
+          if (
+            data[0] &&
+            (data[0].comment !== '' || data[0].performance !== null)
+          ) {
+            this.setState({feedbacks: data, tabSelected: TabType.COMMENTS});
+          }
         })
       );
     }


### PR DESCRIPTION
To help promote students looking at the feedback they have been given, the feedback tab will be open by default on a level if a student has been given feedback.

This will be true in and out of the experiment. Out of the experiment, we will continue to not show the rubric.

# Before
![Before-Default-Open](https://user-images.githubusercontent.com/208083/56053202-85b44a80-5d21-11e9-8d6d-19cbcbc0e1fa.gif)

# After
![After-Default-Open](https://user-images.githubusercontent.com/208083/56053200-7f25d300-5d21-11e9-9b9c-247e1d91f238.gif)
