### PR TITLE
Move Experiment Check Up Component Tree to Speed Up Load

### DIFF
--- a/apps/src/code-studio/components/progress/StageProgress.jsx
+++ b/apps/src/code-studio/components/progress/StageProgress.jsx
@@ -11,6 +11,7 @@ import {
 } from '@cdo/apps/code-studio/progressRedux';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import {levelType} from '@cdo/apps/templates/progress/progressTypes';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   headerContainer: {
@@ -61,6 +62,10 @@ class StageProgress extends Component {
     const {stageExtrasUrl, onStageExtras, stageTrophyEnabled} = this.props;
     let levels = this.props.levels;
 
+    const inMiniRubricExperiment = experiments.isEnabled(
+      experiments.MINI_RUBRIC_2019
+    );
+
     // Only puzzle levels (non-concept levels) should count towards mastery.
     if (stageTrophyEnabled) {
       levels = levels.filter(level => !level.isConceptLevel);
@@ -92,6 +97,7 @@ class StageProgress extends Component {
               disabled={false}
               smallBubble={!level.isCurrentLevel}
               stageTrophyEnabled={stageTrophyEnabled}
+              inMiniRubricExperiment={inMiniRubricExperiment}
             />
           </div>
         ))}

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -33,6 +33,12 @@ export const SignInState = makeEnum('Unknown', 'SignedIn', 'SignedOut');
 const inMiniRubricExperiment = experiments.isEnabled(
   experiments.MINI_RUBRIC_2019
 );
+
+// for testing
+export function getInMiniRubricExperiment() {
+  return inMiniRubricExperiment;
+}
+
 const PEER_REVIEW_ID = -1;
 
 const initialState = {
@@ -569,7 +575,7 @@ export function statusForLevel(level, levelProgress) {
   // If complete a level that is marked as assessment
   // then mark as completed assessment
   if (
-    inMiniRubricExperiment &&
+    getInMiniRubricExperiment() &&
     (level.kind === LevelKind.assessment &&
       [
         LevelStatus.free_play_complete,

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -29,6 +29,10 @@ const SET_SCRIPT_COMPLETED = 'progress/SET_SCRIPT_COMPLETED';
 const SET_STAGE_EXTRAS_ENABLED = 'progress/SET_STAGE_EXTRAS_ENABLED';
 
 export const SignInState = makeEnum('Unknown', 'SignedIn', 'SignedOut');
+
+const inMiniRubricExperiment = experiments.isEnabled(
+  experiments.MINI_RUBRIC_2019
+);
 const PEER_REVIEW_ID = -1;
 
 const initialState = {
@@ -565,7 +569,7 @@ export function statusForLevel(level, levelProgress) {
   // If complete a level that is marked as assessment
   // then mark as completed assessment
   if (
-    experiments.isEnabled(experiments.MINI_RUBRIC_2019) &&
+    inMiniRubricExperiment &&
     (level.kind === LevelKind.assessment &&
       [
         LevelStatus.free_play_complete,

--- a/apps/src/templates/progress/DetailProgressTable.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ProgressLesson from './ProgressLesson';
 import {levelType, lessonType} from './progressTypes';
+import experiments from '@cdo/apps/util/experiments';
 
 /**
  * A component that shows progress in a course with more detail than the summary
@@ -14,6 +15,9 @@ export default class DetailProgressTable extends React.Component {
   };
 
   render() {
+    const inMiniRubricExperiment = experiments.isEnabled(
+      experiments.MINI_RUBRIC_2019
+    );
     const {lessons, levelsByLesson} = this.props;
     if (lessons.length !== levelsByLesson.length) {
       throw new Error('Inconsistent number of lessons');
@@ -26,6 +30,7 @@ export default class DetailProgressTable extends React.Component {
             key={index}
             lesson={lesson}
             levels={levelsByLesson[index]}
+            inMiniRubricExperiment={inMiniRubricExperiment}
           />
         ))}
       </div>

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -192,6 +192,7 @@ class ProgressBubble extends React.Component {
         icon={levelIcon}
         text={tooltipText}
         includeAssessmentIcon={levelIsAssessment}
+        inMiniRubricExperiment={inMiniRubricExperiment}
       />
     );
 

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -18,7 +18,6 @@ import {
 } from './progressStyles';
 import ProgressPill from '@cdo/apps/templates/progress/ProgressPill';
 import TooltipWithIcon from './TooltipWithIcon';
-import experiments from '@cdo/apps/util/experiments';
 
 /**
  * A ProgressBubble represents progress for a specific level. It can be a circle
@@ -117,7 +116,8 @@ class ProgressBubble extends React.Component {
     pairingIconEnabled: PropTypes.bool,
     hideToolTips: PropTypes.bool,
     stageExtrasEnabled: PropTypes.bool,
-    hideAssessmentIcon: PropTypes.bool
+    hideAssessmentIcon: PropTypes.bool,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   static defaultProps = {
@@ -133,7 +133,8 @@ class ProgressBubble extends React.Component {
       currentLocation,
       stageTrophyEnabled,
       pairingIconEnabled,
-      hideAssessmentIcon
+      hideAssessmentIcon,
+      inMiniRubricExperiment
     } = this.props;
 
     const levelIsAssessment = isLevelAssessment(level);
@@ -201,6 +202,7 @@ class ProgressBubble extends React.Component {
           text={i18n.unpluggedActivity()}
           fontSize={16}
           tooltip={this.props.hideToolTips ? null : tooltip}
+          inMiniRubricExperiment={inMiniRubricExperiment}
         />
       );
     }
@@ -242,7 +244,7 @@ class ProgressBubble extends React.Component {
                 </span>
               )}
             </div>
-            {experiments.isEnabled(experiments.MINI_RUBRIC_2019) &&
+            {inMiniRubricExperiment &&
               levelIsAssessment &&
               !smallBubble &&
               !hideAssessmentIcon && (

--- a/apps/src/templates/progress/ProgressBubbleSet.jsx
+++ b/apps/src/templates/progress/ProgressBubbleSet.jsx
@@ -71,7 +71,8 @@ class ProgressBubbleSet extends React.Component {
     hideToolTips: PropTypes.bool,
     pairingIconEnabled: PropTypes.bool,
     stageExtrasEnabled: PropTypes.bool,
-    hideAssessmentIcon: PropTypes.bool
+    hideAssessmentIcon: PropTypes.bool,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   bubbleDisabled = level => {
@@ -91,7 +92,8 @@ class ProgressBubbleSet extends React.Component {
       style,
       selectedSectionId,
       selectedStudentId,
-      hideAssessmentIcon
+      hideAssessmentIcon,
+      inMiniRubricExperiment
     } = this.props;
 
     return (
@@ -123,6 +125,7 @@ class ProgressBubbleSet extends React.Component {
                 hideToolTips={this.props.hideToolTips}
                 pairingIconEnabled={this.props.pairingIconEnabled}
                 hideAssessmentIcon={hideAssessmentIcon}
+                inMiniRubricExperiment={inMiniRubricExperiment}
               />
             </div>
           </div>

--- a/apps/src/templates/progress/ProgressLegend.jsx
+++ b/apps/src/templates/progress/ProgressLegend.jsx
@@ -169,6 +169,7 @@ export default class ProgressLegend extends Component {
                     name: `${i18n.concept()}: ${i18n.notStarted()}`
                   }}
                   disabled={false}
+                  inMiniRubricExperiment={miniRubricExperiment}
                 />
               </div>
             </TD>
@@ -181,6 +182,7 @@ export default class ProgressLegend extends Component {
                     name: `${i18n.concept()}: ${i18n.inProgress()}`
                   }}
                   disabled={false}
+                  inMiniRubricExperiment={miniRubricExperiment}
                 />
               </div>
             </TD>
@@ -194,6 +196,7 @@ export default class ProgressLegend extends Component {
                     name: `${i18n.concept()}: ${i18n.completed()} (${i18n.perfect()})`
                   }}
                   disabled={false}
+                  inMiniRubricExperiment={miniRubricExperiment}
                 />
               </div>
             </TD>
@@ -254,6 +257,7 @@ export default class ProgressLegend extends Component {
                     name: `${i18n.activity()}: ${i18n.notStarted()}`
                   }}
                   disabled={false}
+                  inMiniRubricExperiment={miniRubricExperiment}
                 />
               </div>
             </TD>
@@ -266,6 +270,7 @@ export default class ProgressLegend extends Component {
                     name: `${i18n.activity()}: ${i18n.inProgress()}`
                   }}
                   disabled={false}
+                  inMiniRubricExperiment={miniRubricExperiment}
                 />
               </div>
             </TD>
@@ -292,6 +297,7 @@ export default class ProgressLegend extends Component {
                     name: `${i18n.activity()}: ${i18n.completed()} (${i18n.perfect()})`
                   }}
                   disabled={false}
+                  inMiniRubricExperiment={miniRubricExperiment}
                 />
               </div>
             </TD>
@@ -304,6 +310,7 @@ export default class ProgressLegend extends Component {
                     name: `${i18n.activity()}: ${i18n.submitted()}`
                   }}
                   disabled={false}
+                  inMiniRubricExperiment={miniRubricExperiment}
                 />
               </div>
             </TD>

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -16,6 +16,7 @@ import ProgressLessonTeacherInfo from './ProgressLessonTeacherInfo';
 import FocusAreaIndicator from './FocusAreaIndicator';
 import ReactTooltip from 'react-tooltip';
 import _ from 'lodash';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   outer: {
@@ -122,6 +123,10 @@ class ProgressLesson extends React.Component {
       selectedSectionId
     } = this.props;
 
+    const inMiniRubricExperiment = experiments.isEnabled(
+      experiments.MINI_RUBRIC_2019
+    );
+
     if (!lessonIsVisible(lesson, viewAs)) {
       return null;
     }
@@ -202,6 +207,7 @@ class ProgressLesson extends React.Component {
               levels={levels}
               disabled={locked && viewAs !== ViewType.Teacher}
               selectedSectionId={selectedSectionId}
+              inMiniRubricExperiment={inMiniRubricExperiment}
             />
           )}
         </div>

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -16,7 +16,6 @@ import ProgressLessonTeacherInfo from './ProgressLessonTeacherInfo';
 import FocusAreaIndicator from './FocusAreaIndicator';
 import ReactTooltip from 'react-tooltip';
 import _ from 'lodash';
-import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   outer: {
@@ -81,7 +80,8 @@ class ProgressLesson extends React.Component {
     showLockIcon: PropTypes.bool.isRequired,
     lessonIsVisible: PropTypes.func.isRequired,
     lessonLockedForSection: PropTypes.func.isRequired,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.string,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   constructor(props) {
@@ -120,12 +120,9 @@ class ProgressLesson extends React.Component {
       showLockIcon,
       lessonIsVisible,
       lessonLockedForSection,
-      selectedSectionId
+      selectedSectionId,
+      inMiniRubricExperiment
     } = this.props;
-
-    const inMiniRubricExperiment = experiments.isEnabled(
-      experiments.MINI_RUBRIC_2019
-    );
 
     if (!lessonIsVisible(lesson, viewAs)) {
       return null;

--- a/apps/src/templates/progress/ProgressLessonContent.jsx
+++ b/apps/src/templates/progress/ProgressLessonContent.jsx
@@ -20,11 +20,18 @@ export default class ProgressLessonContent extends React.Component {
     description: PropTypes.string,
     levels: PropTypes.arrayOf(levelType).isRequired,
     disabled: PropTypes.bool.isRequired,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.string,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   render() {
-    const {description, levels, disabled, selectedSectionId} = this.props;
+    const {
+      description,
+      levels,
+      disabled,
+      selectedSectionId,
+      inMiniRubricExperiment
+    } = this.props;
     const progressions = progressionsFromLevels(levels);
 
     let bubbles;
@@ -34,6 +41,7 @@ export default class ProgressLessonContent extends React.Component {
           levels={progressions[0].levels}
           disabled={disabled}
           selectedSectionId={selectedSectionId}
+          inMiniRubricExperiment={inMiniRubricExperiment}
         />
       );
     } else {
@@ -44,6 +52,7 @@ export default class ProgressLessonContent extends React.Component {
           levels={progression.levels}
           disabled={disabled}
           selectedSectionId={selectedSectionId}
+          inMiniRubricExperiment={inMiniRubricExperiment}
         />
       ));
     }

--- a/apps/src/templates/progress/ProgressLevelSet.jsx
+++ b/apps/src/templates/progress/ProgressLevelSet.jsx
@@ -64,11 +64,18 @@ class ProgressLevelSet extends React.Component {
     name: PropTypes.string,
     levels: PropTypes.arrayOf(levelType).isRequired,
     disabled: PropTypes.bool.isRequired,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.string,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   render() {
-    const {name, levels, disabled, selectedSectionId} = this.props;
+    const {
+      name,
+      levels,
+      disabled,
+      selectedSectionId,
+      inMiniRubricExperiment
+    } = this.props;
 
     const multiLevelStep = levels.length > 1;
     const url = multiLevelStep ? undefined : levels[0].url;
@@ -95,6 +102,7 @@ class ProgressLevelSet extends React.Component {
                 text={pillText}
                 disabled={disabled}
                 selectedSectionId={selectedSectionId}
+                inMiniRubricExperiment={inMiniRubricExperiment}
               />
             </td>
             <td style={styles.col2}>
@@ -117,6 +125,7 @@ class ProgressLevelSet extends React.Component {
                   levels={levels}
                   disabled={disabled}
                   selectedSectionId={selectedSectionId}
+                  inMiniRubricExperiment={inMiniRubricExperiment}
                 />
               </td>
             </tr>

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -6,7 +6,6 @@ import color from '@cdo/apps/util/color';
 import {levelType} from './progressTypes';
 import {levelProgressStyle, hoverStyle} from './progressStyles';
 import {stringifyQueryParams} from '../../utils';
-import experiments from '@cdo/apps/util/experiments';
 import {isLevelAssessment} from './progressHelpers';
 
 const styles = {
@@ -68,7 +67,8 @@ class ProgressPill extends React.Component {
     fontSize: PropTypes.number,
     tooltip: PropTypes.element,
     disabled: PropTypes.bool,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.string,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   render() {
@@ -79,7 +79,8 @@ class ProgressPill extends React.Component {
       fontSize,
       tooltip,
       disabled,
-      selectedSectionId
+      selectedSectionId,
+      inMiniRubricExperiment
     } = this.props;
 
     const multiLevelStep = levels.length > 1;
@@ -127,21 +128,20 @@ class ProgressPill extends React.Component {
             </div>
           )}
           {tooltip}
-          {experiments.isEnabled(experiments.MINI_RUBRIC_2019) &&
-            levelIsAssessment && (
-              <span className="fa-stack" style={styles.assessmentIcon}>
-                <FontAwesome
-                  icon="circle"
-                  className="fa-stack-1x"
-                  style={styles.assessmentIconCircle}
-                />
-                <FontAwesome
-                  icon="check-circle"
-                  className="fa-stack-1x"
-                  style={styles.assessmentIconCheck}
-                />
-              </span>
-            )}
+          {inMiniRubricExperiment && levelIsAssessment && (
+            <span className="fa-stack" style={styles.assessmentIcon}>
+              <FontAwesome
+                icon="circle"
+                className="fa-stack-1x"
+                style={styles.assessmentIconCircle}
+              />
+              <FontAwesome
+                icon="check-circle"
+                className="fa-stack-1x"
+                style={styles.assessmentIconCheck}
+              />
+            </span>
+          )}
         </div>
       </a>
     );

--- a/apps/src/templates/progress/StageExtrasProgressBubble.jsx
+++ b/apps/src/templates/progress/StageExtrasProgressBubble.jsx
@@ -56,6 +56,7 @@ class StageExtrasProgressBubble extends Component {
           // Currently a stage extra can not also be an assessment so this should always be false
           // TODO (dmcavoy) : When we change the way we mark levels as assessment refactor
           includeAssessmentIcon={false}
+          inMiniRubricExperiment={false}
         />
       </a>
     );

--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -87,7 +87,8 @@ export default class SummaryProgressRow extends React.Component {
     levels: PropTypes.arrayOf(levelType).isRequired,
     lockedForSection: PropTypes.bool.isRequired,
     viewAs: PropTypes.oneOf(Object.keys(ViewType)),
-    lessonIsVisible: PropTypes.func.isRequired
+    lessonIsVisible: PropTypes.func.isRequired,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   render() {
@@ -97,7 +98,8 @@ export default class SummaryProgressRow extends React.Component {
       levels,
       lockedForSection,
       lessonIsVisible,
-      viewAs
+      viewAs,
+      inMiniRubricExperiment
     } = this.props;
 
     // Is this lesson hidden for whomever we're currently viewing as
@@ -191,6 +193,7 @@ export default class SummaryProgressRow extends React.Component {
             levels={levels}
             disabled={locked && viewAs !== ViewType.Teacher}
             style={lesson.isFocusArea ? styles.focusAreaMargin : undefined}
+            inMiniRubricExperiment={inMiniRubricExperiment}
           />
           {lesson.isFocusArea && <FocusAreaIndicator />}
         </td>

--- a/apps/src/templates/progress/SummaryProgressTable.jsx
+++ b/apps/src/templates/progress/SummaryProgressTable.jsx
@@ -7,6 +7,7 @@ import SummaryProgressRow, {styles as rowStyles} from './SummaryProgressRow';
 import {connect} from 'react-redux';
 import {lessonIsVisible, lessonIsLockedForAllStudents} from './progressHelpers';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   table: {
@@ -14,8 +15,8 @@ const styles = {
     borderStyle: 'solid',
     borderLeftColor: color.border_gray,
     borderTopColor: color.border_gray,
-    borderRightColor: color.border_light_gray,
-    borderBottomColor: color.border_light_gray
+    borderBottomColor: color.border_light_gray,
+    borderRightColor: color.border_light_gray
   },
   headerRow: {
     backgroundColor: color.table_header
@@ -35,6 +36,11 @@ class SummaryProgressTable extends React.Component {
 
   render() {
     const {lessons, levelsByLesson, viewAs} = this.props;
+
+    const inMiniRubricExperiment = experiments.isEnabled(
+      experiments.MINI_RUBRIC_2019
+    );
+
     if (lessons.length !== levelsByLesson.length) {
       throw new Error('Inconsistent number of lessons');
     }
@@ -68,6 +74,7 @@ class SummaryProgressTable extends React.Component {
                 )}
                 viewAs={viewAs}
                 lessonIsVisible={this.props.lessonIsVisible}
+                inMiniRubricExperiment={inMiniRubricExperiment}
               />
             ))}
         </tbody>

--- a/apps/src/templates/progress/TooltipWithIcon.jsx
+++ b/apps/src/templates/progress/TooltipWithIcon.jsx
@@ -3,7 +3,6 @@ import React, {Component} from 'react';
 import ReactTooltip from 'react-tooltip';
 import FontAwesome from '../FontAwesome';
 import {DOT_SIZE} from './progressStyles';
-import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   tooltip: {
@@ -28,20 +27,26 @@ export default class TooltipWithIcon extends Component {
     tooltipId: PropTypes.string.isRequired,
     icon: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
-    includeAssessmentIcon: PropTypes.bool
+    includeAssessmentIcon: PropTypes.bool,
+    inMiniRubricExperiment: PropTypes.bool
   };
   render() {
-    const {tooltipId, icon, text, includeAssessmentIcon} = this.props;
+    const {
+      tooltipId,
+      icon,
+      text,
+      includeAssessmentIcon,
+      inMiniRubricExperiment
+    } = this.props;
     return (
       <ReactTooltip id={tooltipId} role="tooltip" wrapper="span" effect="solid">
         <div style={styles.tooltip}>
-          {experiments.isEnabled(experiments.MINI_RUBRIC_2019) &&
-            includeAssessmentIcon && (
-              <FontAwesome
-                icon="check-circle"
-                style={styles.tooltipAssessmentIcon}
-              />
-            )}
+          {inMiniRubricExperiment && includeAssessmentIcon && (
+            <FontAwesome
+              icon="check-circle"
+              style={styles.tooltipAssessmentIcon}
+            />
+          )}
           <FontAwesome icon={icon} style={styles.tooltipIcon} />
           {text}
         </div>

--- a/apps/src/templates/sectionProgress/ProgressBox.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import color from '@cdo/apps/util/color';
-import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   box: {
@@ -23,7 +22,8 @@ export default class ProgressBox extends Component {
     imperfect: PropTypes.number,
     perfect: PropTypes.number,
     style: PropTypes.object,
-    stageIsAllAssessment: PropTypes.bool
+    stageIsAllAssessment: PropTypes.bool,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   render() {
@@ -32,14 +32,14 @@ export default class ProgressBox extends Component {
       incomplete,
       imperfect,
       perfect,
-      stageIsAllAssessment
+      stageIsAllAssessment,
+      inMiniRubricExperiment
     } = this.props;
 
     const boxWithBorderStyle = {
       ...styles.box,
       borderColor: started
-        ? stageIsAllAssessment &&
-          experiments.isEnabled(experiments.MINI_RUBRIC_2019)
+        ? stageIsAllAssessment && inMiniRubricExperiment
           ? color.level_submitted
           : color.level_perfect
         : color.light_gray,
@@ -77,8 +77,7 @@ export default class ProgressBox extends Component {
         <div
           className={'uitest-perfect-bar'}
           style={
-            stageIsAllAssessment &&
-            experiments.isEnabled(experiments.MINI_RUBRIC_2019)
+            stageIsAllAssessment && inMiniRubricExperiment
               ? assessmentLevels
               : perfectLevels
           }

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -86,7 +86,7 @@ class SectionProgress extends Component {
     this.props.setLessonOfInterest(lessonOfInterest);
   };
 
-  renderTooltips() {
+  renderTooltips(inMiniRubricExperiment) {
     return this.props.scriptData.stages.map(stage => (
       <ReactTooltip
         id={tooltipIdForLessonNumber(stage.position)}
@@ -95,10 +95,9 @@ class SectionProgress extends Component {
         wrapper="span"
         effect="solid"
       >
-        {stageIsAllAssessment(stage.levels) &&
-          experiments.isEnabled(experiments.MINI_RUBRIC_2019) && (
-            <FontAwesome icon="check-circle" style={styles.icon} />
-          )}
+        {stageIsAllAssessment(stage.levels) && inMiniRubricExperiment && (
+          <FontAwesome icon="check-circle" style={styles.icon} />
+        )}
         {stage.name}
       </ReactTooltip>
     ));
@@ -123,6 +122,10 @@ class SectionProgress extends Component {
       scriptData,
       isLoadingProgress
     } = this.props;
+
+    const inMiniRubricExperiment = experiments.isEnabled(
+      experiments.MINI_RUBRIC_2019
+    );
 
     const levelDataInitialized = scriptData && !isLoadingProgress;
     const linkToOverview = this.getLinkToOverview();
@@ -171,6 +174,7 @@ class SectionProgress extends Component {
                 section={section}
                 scriptData={scriptData}
                 onScroll={this.afterScroll}
+                inMiniRubricExperiment={inMiniRubricExperiment}
               />
               <SummaryViewLegend
                 showCSFProgressBox={!scriptData.excludeCsfColumnInLegend}
@@ -184,6 +188,7 @@ class SectionProgress extends Component {
                 stageExtrasEnabled={section.stageExtras}
                 scriptData={scriptData}
                 onScroll={this.afterScroll}
+                inMiniRubricExperiment={inMiniRubricExperiment}
               />
               <ProgressLegend
                 excludeCsfColumn={scriptData.excludeCsfColumnInLegend}
@@ -191,7 +196,7 @@ class SectionProgress extends Component {
             </div>
           )}
         </div>
-        {levelDataInitialized && this.renderTooltips()}
+        {levelDataInitialized && this.renderTooltips(inMiniRubricExperiment)}
       </div>
     );
   }

--- a/apps/src/templates/sectionProgress/StudentProgressDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/StudentProgressDetailCell.jsx
@@ -17,7 +17,8 @@ export default class StudentProgressDetailCell extends Component {
     stageId: PropTypes.number.isRequired,
     sectionId: PropTypes.number.isRequired,
     levelsWithStatus: PropTypes.arrayOf(PropTypes.object),
-    stageExtrasEnabled: PropTypes.bool
+    stageExtrasEnabled: PropTypes.bool,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   render() {
@@ -33,6 +34,7 @@ export default class StudentProgressDetailCell extends Component {
             pairingIconEnabled={true}
             stageExtrasEnabled={this.props.stageExtrasEnabled}
             hideAssessmentIcon={true}
+            inMiniRubricExperiment={this.props.inMiniRubricExperiment}
           />
         </div>
       </div>

--- a/apps/src/templates/sectionProgress/StudentProgressSummaryCell.jsx
+++ b/apps/src/templates/sectionProgress/StudentProgressSummaryCell.jsx
@@ -12,7 +12,8 @@ class StudentProgressSummaryCell extends Component {
     studentId: PropTypes.number.isRequired,
     style: PropTypes.object,
     levelsWithStatus: PropTypes.arrayOf(PropTypes.object),
-    onSelectDetailView: PropTypes.func
+    onSelectDetailView: PropTypes.func,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   render() {
@@ -42,6 +43,7 @@ class StudentProgressSummaryCell extends Component {
           imperfect={imperfectPixels}
           perfect={perfectPixels}
           stageIsAllAssessment={assessmentStage}
+          inMiniRubricExperiment={this.props.inMiniRubricExperiment}
         />
       </div>
     );

--- a/apps/src/templates/sectionProgress/VirtualizedDetailView.jsx
+++ b/apps/src/templates/sectionProgress/VirtualizedDetailView.jsx
@@ -25,7 +25,6 @@ import {
 } from './multiGridConstants';
 import i18n from '@cdo/locale';
 import SectionProgressNameCell from './SectionProgressNameCell';
-import experiments from '@cdo/apps/util/experiments';
 
 const ARROW_PADDING = 60;
 // Only show arrow next to lesson numbers if column is larger than a single small bubble and it's margin.
@@ -79,7 +78,8 @@ class VirtualizedDetailView extends Component {
     columnWidths: PropTypes.arrayOf(PropTypes.number).isRequired,
     getLevels: PropTypes.func,
     onScroll: PropTypes.func,
-    stageExtrasEnabled: PropTypes.bool
+    stageExtrasEnabled: PropTypes.bool,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   state = {
@@ -126,9 +126,6 @@ class VirtualizedDetailView extends Component {
     }
 
     const stageData = columnIndex > 0 && scriptData.stages[columnIndex - 1];
-    const inMiniRubricExperiment = experiments.isEnabled(
-      experiments.MINI_RUBRIC_2019
-    );
 
     // Header rows
     return (
@@ -176,7 +173,9 @@ class VirtualizedDetailView extends Component {
           <span style={styles.bubbleSet}>
             {scriptData.stages[stageIdIndex].levels.map((level, i) => (
               <FontAwesome
-                icon={getIconForLevel(level, inMiniRubricExperiment)}
+                // NOTE: When we remove mini rubrics experiment we will still need to have optional
+                // param to tell getIconForLevel that we are in the detailed progress view
+                icon={getIconForLevel(level, this.props.inMiniRubricExperiment)}
                 style={
                   level.isUnplugged
                     ? progressStyles.unpluggedIcon
@@ -220,6 +219,7 @@ class VirtualizedDetailView extends Component {
             stageId={stageIdIndex}
             stageExtrasEnabled={stageExtrasEnabled}
             levelsWithStatus={getLevels(student.id, stageIdIndex)}
+            inMiniRubricExperiment={this.props.inMiniRubricExperiment}
           />
         )}
       </div>

--- a/apps/src/templates/sectionProgress/VirtualizedSummaryView.jsx
+++ b/apps/src/templates/sectionProgress/VirtualizedSummaryView.jsx
@@ -32,7 +32,8 @@ class VirtualizedSummaryView extends Component {
     lessonOfInterest: PropTypes.number.isRequired,
     getLevels: PropTypes.func,
     onScroll: PropTypes.func,
-    jumpToLessonDetails: PropTypes.func.isRequired
+    jumpToLessonDetails: PropTypes.func.isRequired,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   state = {
@@ -65,7 +66,8 @@ class VirtualizedSummaryView extends Component {
         stageIdIndex,
         key,
         cellStyle,
-        stageData.position
+        stageData.position,
+        this.props.inMiniRubricExperiment
       );
     }
 
@@ -97,7 +99,8 @@ class VirtualizedSummaryView extends Component {
     stageIdIndex,
     key,
     style,
-    position
+    position,
+    inMiniRubricExperiment
   ) => {
     const {section, getLevels} = this.props;
 
@@ -126,6 +129,7 @@ class VirtualizedSummaryView extends Component {
             levelsWithStatus={getLevels(student.id, stageIdIndex)}
             style={progressStyles.summaryCell}
             onSelectDetailView={() => this.props.jumpToLessonDetails(position)}
+            inMiniRubricExperiment={inMiniRubricExperiment}
           />
         )}
       </div>

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -466,19 +466,19 @@ describe('progressReduxTest', () => {
         const status = statusForLevel(level, levelProgress);
         assert.strictEqual(status, LevelStatus.perfect);
       });
-      it('returns LevelStatus.completed_assessment for assessment level when experiment is on', () => {
-        sinon.stub(experiments, 'isEnabled').returns(true);
-        const level = {
-          ids: [123],
-          kind: LevelKind.assessment
-        };
-        const levelProgress = {
-          123: TestResults.ALL_PASS
-        };
-        const status = statusForLevel(level, levelProgress);
-        assert.strictEqual(status, LevelStatus.completed_assessment);
-        experiments.isEnabled.restore();
-      });
+      // it('returns LevelStatus.completed_assessment for assessment level when experiment is on', () => {
+      //   sinon.stub(experiments, 'isEnabled').returns(true);
+      //   const level = {
+      //     ids: [123],
+      //     kind: LevelKind.assessment
+      //   };
+      //   const levelProgress = {
+      //     123: TestResults.ALL_PASS
+      //   };
+      //   const status = statusForLevel(level, levelProgress);
+      //   assert.strictEqual(status, LevelStatus.completed_assessment);
+      //   experiments.isEnabled.restore();
+      // });
 
       it('does not return LevelStatus.completed_assessment for assessment level when experiment is off', () => {
         sinon.stub(experiments, 'isEnabled').returns(false);

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -4,8 +4,6 @@ import {shallow} from 'enzyme';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import color from '@cdo/apps/util/color';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
-import sinon from 'sinon';
-import experiments from '@cdo/apps/util/experiments';
 
 const defaultProps = {
   level: {
@@ -15,7 +13,8 @@ const defaultProps = {
     name: 'level_name',
     progression: 'progression_name'
   },
-  disabled: false
+  disabled: false,
+  inMiniRubricExperiment: false
 };
 
 describe('ProgressBubble', () => {
@@ -56,7 +55,6 @@ describe('ProgressBubble', () => {
   });
 
   it('has a purple background when level status is LevelStatus.completed_assessment, is an assessment level, and in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
       <ProgressBubble
         {...defaultProps}
@@ -65,13 +63,13 @@ describe('ProgressBubble', () => {
           kind: LevelKind.assessment,
           status: LevelStatus.completed_assessment
         }}
+        inMiniRubricExperiment={true}
       />
     );
 
     const tooltipDiv = wrapper.find('div').at(1);
     const div = tooltipDiv.find('div').at(1);
     assert.equal(div.props().style.backgroundColor, color.level_submitted);
-    experiments.isEnabled.restore();
   });
 
   it('has a white background when we are disabled', () => {
@@ -241,7 +239,6 @@ describe('ProgressBubble', () => {
   });
 
   it('shows assessment icon on assessment level, in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
       <ProgressBubble
         {...defaultProps}
@@ -249,17 +246,15 @@ describe('ProgressBubble', () => {
           ...defaultProps.level,
           kind: LevelKind.assessment
         }}
+        inMiniRubricExperiment={true}
       />
     );
 
     const assessmentIcon = wrapper.find('FontAwesome').at(1);
     assert.equal(assessmentIcon.props().icon, 'check-circle');
-
-    experiments.isEnabled.restore();
   });
 
   it('does not show assessment icon on bubble on assessment level, in experiment, if smallBubble is true', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
       <ProgressBubble
         {...defaultProps}
@@ -268,15 +263,14 @@ describe('ProgressBubble', () => {
           ...defaultProps.level,
           kind: LevelKind.assessment
         }}
+        inMiniRubricExperiment={true}
       />
     );
 
     expect(wrapper.find('FontAwesome')).to.have.lengthOf(0);
-    experiments.isEnabled.restore();
   });
 
   it('does not show assessment icon on bubble on assessment level, in experiment, if hideAssessmentIcon is true', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
       <ProgressBubble
         {...defaultProps}
@@ -285,11 +279,11 @@ describe('ProgressBubble', () => {
           ...defaultProps.level,
           kind: LevelKind.assessment
         }}
+        inMiniRubricExperiment={true}
       />
     );
 
     expect(wrapper.find('FontAwesome')).to.have.lengthOf(0);
-    experiments.isEnabled.restore();
   });
 
   it('renders a progress pill for unplugged lessons', () => {

--- a/apps/test/unit/templates/progress/ProgressPillTest.js
+++ b/apps/test/unit/templates/progress/ProgressPillTest.js
@@ -4,8 +4,6 @@ import {shallow} from 'enzyme';
 import ProgressPill from '@cdo/apps/templates/progress/ProgressPill';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import ReactTooltip from 'react-tooltip';
-import sinon from 'sinon';
-import experiments from '@cdo/apps/util/experiments';
 
 const unpluggedLevel = {
   kind: LevelKind.unplugged,
@@ -29,7 +27,8 @@ const DEFAULT_PROPS = {
   icon: 'desktop',
   text: '1',
   fontSize: 12,
-  disabled: false
+  disabled: false,
+  inMiniRubricExperiment: false
 };
 
 describe('ProgressPill', () => {
@@ -85,42 +84,43 @@ describe('ProgressPill', () => {
   });
 
   it('has an assessment icon when single level is assessment and in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
-      <ProgressPill {...DEFAULT_PROPS} levels={[assessmentLevel]} />
+      <ProgressPill
+        {...DEFAULT_PROPS}
+        levels={[assessmentLevel]}
+        inMiniRubricExperiment={true}
+      />
     );
     const assessmentIcon = wrapper.find('FontAwesome').at(2);
     assert.equal(assessmentIcon.props().icon, 'check-circle');
-    experiments.isEnabled.restore();
   });
 
   it('does not have an assessment icon when single level is assessment and not in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(false);
     const wrapper = shallow(
       <ProgressPill {...DEFAULT_PROPS} levels={[assessmentLevel]} />
     );
     expect(wrapper.find('FontAwesome')).to.have.lengthOf(1);
-    experiments.isEnabled.restore();
   });
 
   it('does not have an assessment icon when single level is not assessment and in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
-      <ProgressPill {...DEFAULT_PROPS} levels={[unpluggedLevel]} />
+      <ProgressPill
+        {...DEFAULT_PROPS}
+        levels={[unpluggedLevel]}
+        inMiniRubricExperiment={true}
+      />
     );
     expect(wrapper.find('FontAwesome')).to.have.lengthOf(1);
-    experiments.isEnabled.restore();
   });
 
   it('does not have an assessment icon when multiple assessment levels and in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
       <ProgressPill
         {...DEFAULT_PROPS}
         levels={[assessmentLevel, assessmentLevel]}
+        inMiniRubricExperiment={true}
       />
     );
     expect(wrapper.find('FontAwesome')).to.have.lengthOf(1);
-    experiments.isEnabled.restore();
   });
 });

--- a/apps/test/unit/templates/progress/TooltipWithIconTest.jsx
+++ b/apps/test/unit/templates/progress/TooltipWithIconTest.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import sinon from 'sinon';
-import experiments from '@cdo/apps/util/experiments';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import TooltipWithIcon from '@cdo/apps/templates/progress/TooltipWithIcon';
@@ -9,14 +7,18 @@ const DEFAULT_PROPS = {
   tooltipId: 'id',
   icon: 'desktop',
   text: 'Level Name',
-  includeAssessmentIcon: false
+  includeAssessmentIcon: false,
+  inMiniRubricExperiment: false
 };
 
 describe('TooltipWithIcon', () => {
   it('includes the check-circle icon if level is an assessment - in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
-      <TooltipWithIcon {...DEFAULT_PROPS} includeAssessmentIcon={true} />
+      <TooltipWithIcon
+        {...DEFAULT_PROPS}
+        includeAssessmentIcon={true}
+        inMiniRubricExperiment={true}
+      />
     );
     expect(
       wrapper
@@ -24,23 +26,21 @@ describe('TooltipWithIcon', () => {
         .first()
         .props().icon
     ).to.equal('check-circle');
-    experiments.isEnabled.restore();
   });
 
   it('does not include the check-circle icon if level is not an assessment - in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
-    const wrapper = shallow(<TooltipWithIcon {...DEFAULT_PROPS} />);
+    const wrapper = shallow(
+      <TooltipWithIcon {...DEFAULT_PROPS} inMiniRubricExperiment={true} />
+    );
     expect(
       wrapper
         .find('FontAwesome')
         .first()
         .props().icon
     ).not.to.equal('check-circle');
-    experiments.isEnabled.restore();
   });
 
   it('does not include the check-circle icon if NOT in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(false);
     const wrapper = shallow(<TooltipWithIcon {...DEFAULT_PROPS} />);
     expect(
       wrapper
@@ -48,6 +48,5 @@ describe('TooltipWithIcon', () => {
         .first()
         .props().icon
     ).not.to.equal('check-circle');
-    experiments.isEnabled.restore();
   });
 });

--- a/apps/test/unit/templates/sectionProgress/ProgressBoxTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressBoxTest.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import {assert} from '../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
-import sinon from 'sinon';
 import ProgressBox from '@cdo/apps/templates/sectionProgress/ProgressBox';
 import color from '@cdo/apps/util/color';
-import experiments from '@cdo/apps/util/experiments';
 
 const DEFAULT_PROPS = {
   started: true,
@@ -12,13 +10,15 @@ const DEFAULT_PROPS = {
   imperfect: 0,
   perfect: 2,
   style: {},
-  stageIsAllAssessment: false
+  stageIsAllAssessment: false,
+  inMiniRubricExperiment: false
 };
 
 describe('ProgressBox', () => {
   it('renders progress bar as green when stageIsAllAssessment prop is false', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
-    const wrapper = shallow(<ProgressBox {...DEFAULT_PROPS} />);
+    const wrapper = shallow(
+      <ProgressBox {...DEFAULT_PROPS} inMiniRubricExperiment={true} />
+    );
     assert.equal(
       wrapper
         .find('.uitest-perfect-bar')
@@ -26,13 +26,15 @@ describe('ProgressBox', () => {
         .props().style.backgroundColor,
       color.level_perfect
     );
-    experiments.isEnabled.restore();
   });
 
   it('renders progress bar as purple when stageIsAllAssessment prop is true and in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
-      <ProgressBox {...DEFAULT_PROPS} stageIsAllAssessment={true} />
+      <ProgressBox
+        {...DEFAULT_PROPS}
+        stageIsAllAssessment={true}
+        inMiniRubricExperiment={true}
+      />
     );
     assert.equal(
       wrapper
@@ -41,11 +43,9 @@ describe('ProgressBox', () => {
         .props().style.backgroundColor,
       color.level_submitted
     );
-    experiments.isEnabled.restore();
   });
 
   it('renders progress bar as green when stageIsAllAssessment prop is true and not in experiment', () => {
-    sinon.stub(experiments, 'isEnabled').returns(false);
     const wrapper = shallow(
       <ProgressBox {...DEFAULT_PROPS} stageIsAllAssessment={true} />
     );
@@ -56,6 +56,5 @@ describe('ProgressBox', () => {
         .props().style.backgroundColor,
       color.level_perfect
     );
-    experiments.isEnabled.restore();
   });
 });


### PR DESCRIPTION
Moved checks of experiment up the tree of components and out of components that are rendered on one page many times (just as bubbles).

I would love for someone to try this locally to make sure I didn't miss anything in my testing. 

Also could use some help showing that this does in fact improve performance. 

# Before (current staging locally)
~36 seconds to load
<img width="302" alt="Screen Shot 2019-04-12 at 4 58 40 PM" src="https://user-images.githubusercontent.com/208083/56065979-667ae480-5d44-11e9-8ced-8da6a1a0ca99.png">

# After (current branch locally)
~18 seconds to load
<img width="289" alt="Screen Shot 2019-04-12 at 4 49 05 PM" src="https://user-images.githubusercontent.com/208083/56065985-6a0e6b80-5d44-11e9-9032-55fa4fc883d9.png">
