### PR TITLE
set min width on project name wrapper to avoid jitter during ui tests

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -925,6 +925,9 @@ $default-modal-width: 640px;
   .header_text, .header_button {
     float: left;
   }
+  .project_name_wrapper {
+    min-width: 160px;
+  }
   .project_name_wrapper .header_text {
     float: left;
     clear: left;


### PR DESCRIPTION
our eyes tests show erroneous diffs due to timing issues, because the amount of time that has passed since the page loaded and saved is different on each run, and the text that indicates how much time has passed changes length.

![image (1)](https://user-images.githubusercontent.com/8001765/56067167-088fd200-5d2f-11e9-83bf-869d23c10bc0.png)

the solution is to assign just enough min-width to be longer than the longest english message "Saved less than a minute ago".

### before

<img width="620" alt="Screen Shot 2019-04-12 at 1 54 02 PM" src="https://user-images.githubusercontent.com/8001765/56066123-b305f600-5d2b-11e9-84e1-4eb5807f8682.png">

<img width="624" alt="Screen Shot 2019-04-12 at 1 59 48 PM" src="https://user-images.githubusercontent.com/8001765/56066130-b7caaa00-5d2b-11e9-982f-f665829d3cdf.png">

### after

<img width="624" alt="Screen Shot 2019-04-12 at 1 53 51 PM" src="https://user-images.githubusercontent.com/8001765/56066136-bc8f5e00-5d2b-11e9-9070-5c4d3028c856.png">

<img width="622" alt="Screen Shot 2019-04-12 at 2 02 39 PM" src="https://user-images.githubusercontent.com/8001765/56066140-c022e500-5d2b-11e9-8869-61e379deed12.png">
