### PR TITLE
update mysql command credentials in test:dashboard_ci

### DIFF
--- a/lib/cdo/mysql_console_helper.rb
+++ b/lib/cdo/mysql_console_helper.rb
@@ -1,17 +1,18 @@
 module MysqlConsoleHelper
+  def self.options(db)
+    opts = %W(
+      --user=#{db.user}
+      --host=#{db.host}
+    )
+    database = db.path[1..-1]
+    opts << "--database=#{database}" if database
+    opts << "--port=#{db.port}" if db.port
+    opts << "--password=#{db.password}" if db.password
+    opts.join(' ')
+  end
+
   def self.run(connection_uri, args)
     db = URI.parse connection_uri
-
-    command = [
-      'mysql',
-      "--user=#{db.user}",
-      "--host=#{db.host}",
-      "--database=#{db.path[1..-1]}",
-    ]
-    command << "--port=#{db.port}" if db.port
-    command << "--execute=\"#{args}\"" unless args.empty?
-    command << "--password=#{db.password}" unless db.password.nil?
-
     warning =
       "*****************************************************************\n"\
       "*** You are connecting to the master production database.     ***\n"\
@@ -20,6 +21,8 @@ module MysqlConsoleHelper
       "*****************************************************************"
     puts warning if db.host.start_with?('production')
 
-    system(command.join(' '))
+    mysql_command = "mysql #{options(db)}"
+    mysql_command += " --execute=\"#{args}\"" unless args.empty?
+    system(mysql_command)
   end
 end

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -8,6 +8,7 @@ require 'cdo/git_utils'
 require 'cdo/lighthouse'
 require 'parallel'
 require 'aws-sdk-s3'
+require 'cdo/mysql_console_helper'
 
 namespace :test do
   desc 'Runs apps tests.'
@@ -145,7 +146,10 @@ namespace :test do
 
         seed_file = Tempfile.new(['db_seed', '.sql'])
         auto_inc = 's/ AUTO_INCREMENT=[0-9]*\b//'
-        writer = URI.parse(CDO.dashboard_db_writer || 'mysql://root@localhost')
+        writer = URI.parse(CDO.dashboard_db_writer || 'mysql://root@localhost/dashboard_test')
+        database = writer.path[1..-1]
+        writer.path = ''
+        opts = MysqlConsoleHelper.options(writer)
 
         if seed_data
           File.write(seed_file, seed_data)
@@ -155,7 +159,7 @@ namespace :test do
           RakeUtils.rake_stream_output 'db:create db:test:prepare'
           ENV.delete 'TEST_ENV_NUMBER'
           # Store new DB contents
-          `mysqldump -u#{writer.user} dashboard_test1 --skip-comments | sed '#{auto_inc}' > #{seed_file.path}`
+          `mysqldump #{opts} #{database}1 --skip-comments | sed '#{auto_inc}' > #{seed_file.path}`
           gzip_data = Zlib::GzipWriter.wrap(StringIO.new) {|gz| IO.copy_stream(seed_file.path, gz); gz.finish}.tap(&:rewind)
 
           s3_client.put_object(
@@ -167,7 +171,7 @@ namespace :test do
           CDO.log.info "Uploaded seed data to #{s3_key}"
         end
 
-        cloned_data = `mysqldump -u#{writer.user} dashboard_test2 --skip-comments | sed '#{auto_inc}'`
+        cloned_data = `mysqldump #{opts} #{database}2 --skip-comments | sed '#{auto_inc}'`
         if seed_data.equal?(cloned_data)
           CDO.log.info 'Test data not modified'
         else
@@ -180,12 +184,12 @@ namespace :test do
           require 'parallel_tests'
           procs = ParallelTests.determine_number_of_processes(nil)
           CDO.log.info "Test data modified, cloning across #{procs} databases..."
-          databases = procs.times.map {|i| "dashboard_test#{i + 1}"}
+          databases = procs.times.map {|i| "#{database}#{i + 1}"}
           databases.each do |db|
             recreate_db = "DROP DATABASE IF EXISTS #{db}; CREATE DATABASE IF NOT EXISTS #{db};"
-            RakeUtils.system_stream_output "echo '#{recreate_db}' | mysql -u#{writer.user}"
+            RakeUtils.system_stream_output "echo '#{recreate_db}' | mysql #{opts}"
           end
-          pipes = databases.map {|db| ">(mysql -u#{writer.user} #{db})"}.join(' ')
+          pipes = databases.map {|db| ">(mysql #{opts} #{db})"}.join(' ')
           RakeUtils.system_stream_output "/bin/bash -c 'tee <#{seed_file.path} #{pipes} >/dev/null'"
         end
 


### PR DESCRIPTION
Followup to #13569.

This PR updates the `test:dashboard_ci` Rake task to explicitly specify database-connection credentials used by calls to `mysqldump` and `mysql`, instead of assuming default (or empty) login credentials would be used.

This is needed now that `test` is no longer using localhost/default credentials for its database connection.