### PR TITLE
PL: some emails now get a Twitter share link

### DIFF
--- a/dashboard/app/views/pd/application/teacher1920_application_mailer/_twitter_share.html.haml
+++ b/dashboard/app/views/pd/application/teacher1920_application_mailer/_twitter_share.html.haml
@@ -1,6 +1,0 @@
-- twitter_share_link = 'https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20for%20Code.org%27s%20Professional%20Learning%20Program%20to%20teach%20computer%20science%20in%20my%20classroom.%20Join%20me%20and%20sign%20up%20here%21%20code.org%2Fapply&source=clicktotweet&related=clicktotweet'
-
-Congratulations and thanks for bringing computer science to your students! Help us
-= link_to twitter_share_link do
-  spread the word in a tweet
-to encourage more teachers to join your local CS teaching community.

--- a/dashboard/app/views/pd/application/teacher1920_application_mailer/_twitter_share.html.haml
+++ b/dashboard/app/views/pd/application/teacher1920_application_mailer/_twitter_share.html.haml
@@ -1,0 +1,6 @@
+- twitter_share_link = 'https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20for%20Code.org%27s%20Professional%20Learning%20Program%20to%20teach%20computer%20science%20in%20my%20classroom.%20Join%20me%20and%20sign%20up%20here%21%20code.org%2Fapply&source=clicktotweet&related=clicktotweet'
+
+Congratulations and thanks for bringing computer science to your students! Help us
+= link_to twitter_share_link do
+  spread the word in a tweet
+to encourage more teachers to join your local CS teaching community.

--- a/dashboard/app/views/pd/application/teacher1920_application_mailer/accepted_no_cost_registration.html.haml
+++ b/dashboard/app/views/pd/application/teacher1920_application_mailer/accepted_no_cost_registration.html.haml
@@ -60,6 +60,7 @@
 
 %p
   = render partial: 'twitter_share'
+  We look forward to receiving your registration as soon as possible, but no later than 5 days.
 
 %p
   = render partial: 'partner_signature'

--- a/dashboard/app/views/pd/application/teacher1920_application_mailer/accepted_no_cost_registration.html.haml
+++ b/dashboard/app/views/pd/application/teacher1920_application_mailer/accepted_no_cost_registration.html.haml
@@ -1,4 +1,5 @@
 - registration_url = "https://studio.code.org/pd/workshops/#{@application.workshop.id}/enroll"
+- twitter_share_link = 'https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20for%20Code.org%27s%20Professional%20Learning%20Program%20to%20teach%20computer%20science%20in%20my%20classroom.%20Join%20me%20and%20sign%20up%20here%21%20code.org%2Fapply&source=clicktotweet&related=clicktotweet'
 
 %p
   Hello
@@ -59,8 +60,10 @@
     = link_to('recruitment resources', 'https://code.org/educate/resources/recruit') + '.'
 
 %p
-  = render partial: 'twitter_share'
-  We look forward to receiving your registration as soon as possible, but no later than 5 days.
+  Congratulations and thanks for bringing computer science to your students! Help us
+  = link_to twitter_share_link do
+    spread the word in a tweet
+  to encourage more teachers to join your local CS teaching community.  We look forward to receiving your registration as soon as possible, but no later than 5 days from today.
 
 %p
   = render partial: 'partner_signature'

--- a/dashboard/app/views/pd/application/teacher1920_application_mailer/accepted_no_cost_registration.html.haml
+++ b/dashboard/app/views/pd/application/teacher1920_application_mailer/accepted_no_cost_registration.html.haml
@@ -59,7 +59,7 @@
     = link_to('recruitment resources', 'https://code.org/educate/resources/recruit') + '.'
 
 %p
-  Congratulations again! We look forward to receiving your registration within two weeks.
+  = render partial: 'twitter_share'
 
 %p
   = render partial: 'partner_signature'

--- a/dashboard/app/views/pd/application/teacher1920_application_mailer/confirmation.html.haml
+++ b/dashboard/app/views/pd/application/teacher1920_application_mailer/confirmation.html.haml
@@ -25,6 +25,10 @@
   Or, visit
   = link_to 'https://code.org/educate', 'https://code.org/educate'
   for additional resources and opportunities to connect with other computer science educators.
+
+%p
+  = render partial: 'twitter_share'
+
   Thank you for supporting computer science for all!
 
   - if @application.regional_partner

--- a/dashboard/app/views/pd/application/teacher1920_application_mailer/confirmation.html.haml
+++ b/dashboard/app/views/pd/application/teacher1920_application_mailer/confirmation.html.haml
@@ -1,4 +1,5 @@
 - partner_name = @application.regional_partner&.name || 'Code.org'
+- twitter_share_link = 'https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20for%20Code.org%27s%20Professional%20Learning%20Program%20to%20teach%20computer%20science%20in%20my%20classroom.%20Join%20me%20and%20sign%20up%20here%21%20code.org%2Fapply&source=clicktotweet&related=clicktotweet'
 
 %p
   Hello
@@ -27,8 +28,10 @@
   for additional resources and opportunities to connect with other computer science educators.
 
 %p
-  = render partial: 'twitter_share'
-
+  Finally, help us
+  = link_to twitter_share_link do
+    spread the word in a tweet
+  to encourage more teachers to join your local CS teaching community.
   Thank you for supporting computer science for all!
 
   - if @application.regional_partner

--- a/dashboard/app/views/pd/application/teacher1920_application_mailer/registration_sent.html.haml
+++ b/dashboard/app/views/pd/application/teacher1920_application_mailer/registration_sent.html.haml
@@ -1,4 +1,5 @@
 - registration_url = "https://studio.code.org/pd/workshops/#{@application.workshop.id}/enroll"
+- twitter_share_link = 'https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20for%20Code.org%27s%20Professional%20Learning%20Program%20to%20teach%20computer%20science%20in%20my%20classroom.%20Join%20me%20and%20sign%20up%20here%21%20code.org%2Fapply&source=clicktotweet&related=clicktotweet'
 
 %p
   Hello
@@ -46,7 +47,10 @@
     = link_to('recruitment resources', 'https://code.org/educate/resources/recruit') + '.'
 
 %p
-  = render partial: 'twitter_share'
+  Congratulations and thanks for bringing computer science to your students! Help us
+  = link_to twitter_share_link do
+    spread the word in a tweet
+  to encourage more teachers to join your local CS teaching community.  We look forward to receiving your registration as soon as possible, but no later than 5 days from today.
 
 = render partial: 'partner_signature'
 

--- a/dashboard/app/views/pd/application/teacher1920_application_mailer/registration_sent.html.haml
+++ b/dashboard/app/views/pd/application/teacher1920_application_mailer/registration_sent.html.haml
@@ -46,7 +46,7 @@
     = link_to('recruitment resources', 'https://code.org/educate/resources/recruit') + '.'
 
 %p
-  Congratulations again! We look forward to receiving your registration within two weeks.
+  = render partial: 'twitter_share'
 
 = render partial: 'partner_signature'
 


### PR DESCRIPTION
A [link](https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20for%20Code.org%27s%20Professional%20Learning%20Program%20to%20teach%20computer%20science%20in%20my%20classroom.%20Join%20me%20and%20sign%20up%20here%21%20code.org%2Fapply&source=clicktotweet&related=clicktotweet) to generate a tweet is added to these three emails.

## Confirmation of teacher application
![Screenshot 2019-04-16 09 19 55](https://user-images.githubusercontent.com/2205926/56171502-e6e16400-6028-11e9-8bd3-0d8261f37ecb.png)

## Accepted - no cost registration
![Screenshot 2019-04-16 09 19 48](https://user-images.githubusercontent.com/2205926/56171513-f52f8000-6028-11e9-8396-5373f8d3804b.png)

## Registration sent
![Screenshot 2019-04-16 09 20 10](https://user-images.githubusercontent.com/2205926/56171573-26a84b80-6029-11e9-86fe-7292a2ef8427.png)


