### PR TITLE
Assessment UX Re-design: Progress Summary View Legend

### DIFF
--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -178,6 +178,7 @@ class SectionProgress extends Component {
               />
               <SummaryViewLegend
                 showCSFProgressBox={!scriptData.excludeCsfColumnInLegend}
+                inMiniRubricExperiment={inMiniRubricExperiment}
               />
             </div>
           )}

--- a/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
+++ b/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
@@ -78,7 +78,7 @@ export default class SummaryViewLegend extends Component {
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr style={styles.tr}>
               <td style={styles.td}>
                 <ProgressBox
                   style={styles.boxStyle}
@@ -109,15 +109,17 @@ export default class SummaryViewLegend extends Component {
                     perfect={20}
                     stageIsAllAssessment={false}
                   />
-                  <ProgressBox
-                    style={styles.boxStyle}
-                    started={true}
-                    incomplete={0}
-                    imperfect={0}
-                    perfect={20}
-                    stageIsAllAssessment={true}
-                    inMiniRubricExperiment={inMiniRubricExperiment}
-                  />
+                  {inMiniRubricExperiment && (
+                    <ProgressBox
+                      style={styles.boxStyle}
+                      started={true}
+                      incomplete={0}
+                      imperfect={0}
+                      perfect={20}
+                      stageIsAllAssessment={true}
+                      inMiniRubricExperiment={inMiniRubricExperiment}
+                    />
+                  )}
                 </div>
               </td>
               {showCSFProgressBox && (

--- a/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
+++ b/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
@@ -25,16 +25,21 @@ const styles = {
   },
   boxStyle: {
     margin: '0 auto'
+  },
+  completedBoxes: {
+    display: 'flex',
+    flexDirection: 'row'
   }
 };
 
 export default class SummaryViewLegend extends Component {
   static propTypes = {
-    showCSFProgressBox: PropTypes.bool
+    showCSFProgressBox: PropTypes.bool,
+    inMiniRubricExperiment: PropTypes.bool
   };
 
   render() {
-    const {showCSFProgressBox} = this.props;
+    const {showCSFProgressBox, inMiniRubricExperiment} = this.props;
     const headerColSpan = showCSFProgressBox ? 2 : 3;
 
     return (
@@ -81,6 +86,7 @@ export default class SummaryViewLegend extends Component {
                   incomplete={20}
                   imperfect={0}
                   perfect={0}
+                  stageIsAllAssessment={false}
                 />
               </td>
               <td style={styles.td}>
@@ -90,16 +96,29 @@ export default class SummaryViewLegend extends Component {
                   incomplete={20}
                   imperfect={0}
                   perfect={0}
+                  stageIsAllAssessment={false}
                 />
               </td>
               <td style={styles.td}>
-                <ProgressBox
-                  style={styles.boxStyle}
-                  started={true}
-                  incomplete={0}
-                  imperfect={0}
-                  perfect={20}
-                />
+                <div style={styles.completedBoxes}>
+                  <ProgressBox
+                    style={styles.boxStyle}
+                    started={true}
+                    incomplete={0}
+                    imperfect={0}
+                    perfect={20}
+                    stageIsAllAssessment={false}
+                  />
+                  <ProgressBox
+                    style={styles.boxStyle}
+                    started={true}
+                    incomplete={0}
+                    imperfect={0}
+                    perfect={20}
+                    stageIsAllAssessment={true}
+                    inMiniRubricExperiment={inMiniRubricExperiment}
+                  />
+                </div>
               </td>
               {showCSFProgressBox && (
                 <td style={styles.td}>
@@ -109,6 +128,7 @@ export default class SummaryViewLegend extends Component {
                     incomplete={0}
                     imperfect={20}
                     perfect={0}
+                    stageIsAllAssessment={false}
                   />
                 </td>
               )}

--- a/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
+++ b/apps/src/templates/sectionProgress/SummaryViewLegend.jsx
@@ -78,7 +78,7 @@ export default class SummaryViewLegend extends Component {
             </tr>
           </thead>
           <tbody>
-            <tr style={styles.tr}>
+            <tr>
               <td style={styles.td}>
                 <ProgressBox
                   style={styles.boxStyle}


### PR DESCRIPTION
We added purple boxes for when a lesson is entirely assessment and completed to the summary progress view. This adds that information to the legend at the bottom of the summary progress view.

# Before
<img width="100" alt="Screen Shot 2019-04-15 at 11 02 15 AM" src="https://user-images.githubusercontent.com/208083/56143364-68c08700-5f6e-11e9-9651-3f19b601a07a.png">

# After

## In Experiment
<img width="102" alt="Screen Shot 2019-04-15 at 11 00 46 AM" src="https://user-images.githubusercontent.com/208083/56143383-71b15880-5f6e-11e9-978e-a54227a39e3e.png">

## Out of Experiment
<img width="100" alt="Screen Shot 2019-04-15 at 11 02 15 AM" src="https://user-images.githubusercontent.com/208083/56143364-68c08700-5f6e-11e9-9651-3f19b601a07a.png">
