### PR TITLE
Mini Rubric: Remove Default Summary Tag Styling on Rubric

### DIFF
--- a/apps/src/templates/instructions/RubricField.jsx
+++ b/apps/src/templates/instructions/RubricField.jsx
@@ -19,7 +19,10 @@ const styles = {
     fontSize: 12,
     marginLeft: 10,
     color: color.black,
-    fontFamily: '"Gotham 5r", sans-serif'
+    fontFamily: '"Gotham 5r", sans-serif',
+    // Don't show default summary tag outline and background on hover or focus
+    outline: 'none',
+    background: 'none'
   },
   performanceLevelHeader: {
     display: 'flex',


### PR DESCRIPTION
Remove default background and border on hovering and focusing on the summary tag element in the rubric.

# Before
![Before-Remove-Border](https://user-images.githubusercontent.com/208083/56145950-54cb5400-5f73-11e9-993c-f2021da76586.gif)

# After
![After-Remove-Border](https://user-images.githubusercontent.com/208083/56145959-5b59cb80-5f73-11e9-8f99-ec41b1515756.gif)
