### PR TITLE
Assessment Tab: Feedback Download Remove Comma (And Fix Error Message)

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -747,6 +747,7 @@
   "lessonStatus": "Lesson Status",
   "level": "Level,",
   "levelDetails": "Level Details",
+  "levelHeader": "Level",
   "levelIncompleteError": "Keep coding! Something's not quite right yet.",
   "levelN": "LEVEL {levelNumber}",
   "levelStatus": "Level Status",

--- a/apps/src/templates/sectionAssessments/FeedbackDownload.jsx
+++ b/apps/src/templates/sectionAssessments/FeedbackDownload.jsx
@@ -17,7 +17,7 @@ const CSV_FEEDBACK_RUBRIC_HEADERS = [
   {label: i18n.studentName(), key: 'studentName'},
   {label: i18n.lessonNumber(), key: 'stageNum'},
   {label: i18n.lessonName(), key: 'stageName'},
-  {label: i18n.level(), key: 'levelNum'},
+  {label: i18n.levelHeader(), key: 'levelNum'},
   {label: i18n.keyConcept(), key: 'keyConcept'},
   {label: i18n.performanceLevel(), key: 'performance'},
   {label: i18n.performanceLevelDetails(), key: 'performanceLevelDetails'},
@@ -29,7 +29,7 @@ const CSV_FEEDBACK_NO_RUBRIC_HEADERS = [
   {label: i18n.studentName(), key: 'studentName'},
   {label: i18n.lessonNumber(), key: 'stageNum'},
   {label: i18n.lessonName(), key: 'stageName'},
-  {label: i18n.level(), key: 'levelNum'},
+  {label: i18n.levelHeader(), key: 'levelNum'},
   {label: i18n.feedback(), key: 'comment'},
   {label: i18n.dateUpdatedByTeacher(), key: 'timestamp'}
 ];

--- a/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
+++ b/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
@@ -498,11 +498,13 @@ export const getAssessmentsFreeResponseResults = state => {
     responsesArray
       .filter(result => result.type === QuestionType.FREE_RESPONSE)
       .forEach((response, index) => {
-        questionsAndResults[index].responses.push({
-          id: studentId,
-          name: studentObject.student_name,
-          response: response.student_result
-        });
+        if (questionsAndResults[index]) {
+          questionsAndResults[index].responses.push({
+            id: studentId,
+            name: studentObject.student_name,
+            response: response.student_result
+          });
+        }
       });
   });
   return questionsAndResults;


### PR DESCRIPTION
The header for the Level column in the feedback download is now 'Level' instead of 'Level,'

Also, I was getting an error 'responses couldn't be called on undefined' for the getAssessmentsFreeResponseResults method in sectionAssessmentRedux so I added a check to make sure questionsAndResults[index] exists before we try to call responses on it.