### PR TITLE
Mini Rubric & Assessment Re-design: Add notification on homepage if you are in experiment

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -5,6 +5,9 @@ import i18n from '@cdo/locale';
 import ContentContainer from '../ContentContainer';
 import OwnedSections from '../teacherDashboard/OwnedSections';
 import {asyncLoadSectionData} from '../teacherDashboard/teacherSectionsRedux';
+import experiments from '@cdo/apps/util/experiments';
+import Notification from '../Notification';
+import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 
 class TeacherSections extends Component {
   static propTypes = {
@@ -21,8 +24,32 @@ class TeacherSections extends Component {
 
   render() {
     const {queryStringOpen, locale} = this.props;
+
+    /*
+     * TODO (dmcavoy): Remove for May 31st launch
+     * Temporary notification for the experiment facilitators will be using to
+     * see the mini rubric and assessment re-design from May 1 to May 31st
+     */
+    const inMiniRubricExperiment = experiments.isEnabled(
+      experiments.MINI_RUBRIC_2019
+    );
     return (
       <div id="classroom-sections">
+        {inMiniRubricExperiment && (
+          <Notification
+            type={'bullhorn'}
+            notice={'Experiment Enabled'}
+            details={
+              <UnsafeRenderedMarkdown
+                markdown={
+                  'The Mini Rubric and Assessment Re-design experiment is enabled for your account. To disable this experiment go [here](https://studio.code.org/home?disableExperiments=2019-mini-rubric).'
+                }
+              />
+            }
+            dismissible={true}
+            newWindow={false}
+          />
+        )}
         <ContentContainer heading={i18n.sectionsTitle()}>
           <OwnedSections queryStringOpen={queryStringOpen} locale={locale} />
         </ContentContainer>

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -42,7 +42,7 @@ class TeacherSections extends Component {
             details={
               <UnsafeRenderedMarkdown
                 markdown={
-                  'The Mini Rubric and Assessment Re-design experiment is enabled for your account. To disable this experiment go [here](https://studio.code.org/home?disableExperiments=2019-mini-rubric).'
+                  'The Mini Rubric and Assessment Re-design experiment is enabled for your account. To disable this experiment go [here](/home?disableExperiments=2019-mini-rubric).'
                 }
               />
             }


### PR DESCRIPTION
This will both:
1- Allow someone to enable the experiment from the homepage
2- Show a notification if you are in the mini rubric experiment.

This is temporary to help facilitators from May 1 to May 31st before we pull this feature out from behind the experiment.

# Before
<img width="906" alt="Screen Shot 2019-04-15 at 2 55 44 PM" src="https://user-images.githubusercontent.com/208083/56157856-90bfe280-5f8e-11e9-9afe-881b7840359f.png">

# After

## In Experiment
<img width="903" alt="Screen Shot 2019-04-15 at 2 55 29 PM" src="https://user-images.githubusercontent.com/208083/56157863-93bad300-5f8e-11e9-96e4-d5151d91ce24.png">

## Out of Experiment

<img width="906" alt="Screen Shot 2019-04-15 at 2 55 44 PM" src="https://user-images.githubusercontent.com/208083/56157856-90bfe280-5f8e-11e9-9afe-881b7840359f.png">
