### PR TITLE
Maintain circuit playground connection on reset

### DIFF
--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -204,6 +204,13 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
     });
   }
 
+  reset() {
+    const {led, buzzer, colorLeds} = this.prewiredComponents_;
+    led.off();
+    colorLeds.forEach(led => led.off());
+    buzzer.off();
+  }
+
   /**
    * Play a song and animate some LEDs to demonstrate successful connection
    * to the board.

--- a/apps/src/lib/kits/maker/toolkit.js
+++ b/apps/src/lib/kits/maker/toolkit.js
@@ -63,12 +63,9 @@ export function connect({interpreter, onDisconnect}) {
   }
 
   if (currentBoard) {
-    return Promise.reject(
-      new Error(
-        'Attempted to connect Maker Toolkit when ' +
-          'an existing board is already connected.'
-      )
-    );
+    commands.injectBoardController(currentBoard);
+    currentBoard.installOnInterpreter(interpreter);
+    return Promise.resolve();
   }
 
   const store = getStore();
@@ -153,18 +150,7 @@ function shouldRunWithFakeBoard() {
  * and puts maker UI back in a default state.
  */
 export function reset() {
-  if (!redux.isEnabled(getStore().getState())) {
-    return;
-  }
-
-  const setDisconnected = () => {
-    currentBoard = null;
-    getStore().dispatch(redux.disconnect());
-  };
-
   if (currentBoard) {
-    currentBoard.destroy().then(setDisconnected);
-  } else {
-    setDisconnected();
+    currentBoard.reset();
   }
 }


### PR DESCRIPTION
This fixes a live-site issue where Circuit playgrounds are not working correctly with Chromebooks. 
We currently do not have an exact root cause of the issue, but clicking the reset button on Chromebooks causes severe connectivity issues that can only be solved by resetting the circuit playground board.
Instead of connecting/disconnecting to the circuit playground board on each run/reset click, this will maintain the connection. Clicking the reset button will just turn off the led lights and the buzzer, but not actually turn off the connection to the board.