### PR TITLE
PL: post-course survey gets email address

### DIFF
--- a/dashboard/app/controllers/pd/post_course_survey_controller.rb
+++ b/dashboard/app/controllers/pd/post_course_survey_controller.rb
@@ -21,7 +21,8 @@ module Pd
       key_params = {
         environment: Rails.env,
         userId: current_user.id,
-        csp_or_csd: course
+        userEmail: current_user.email,
+        csp_or_csd: course,
       }
 
       @form_id = PostCourseSurvey.form_id


### PR DESCRIPTION
The embedded JotForm for the post-course survey at https://studio.code.org/pd/post_course_survey/csd and https://studio.code.org/pd/post_course_survey/csp is now passed the user's email address as the `userEmail` parameter.