### PR TITLE
Fix rerun logic in ui-test runner

### DIFF
--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -752,9 +752,9 @@ def run_feature(browser, feature, options)
       log_browser_error prefix_string(browser.to_yaml, log_prefix)
     end
 
-    rerun_arguments = File.exist?(rerun_file) ? " @#{rerun_file}" : ''
+    rerun_feature = File.exist?(rerun_file) ? File.read(rerun_file).split.join(' ') : feature
 
-    cucumber_succeeded, eyes_succeeded, output_stdout, output_stderr, test_duration = run_tests(run_environment, feature, arguments + rerun_arguments, log_prefix)
+    cucumber_succeeded, eyes_succeeded, output_stdout, output_stderr, test_duration = run_tests(run_environment, rerun_feature, arguments, log_prefix)
     feature_succeeded = cucumber_succeeded && eyes_succeeded
     log_link = upload_log_and_get_public_link(
       html_log,


### PR DESCRIPTION
This PR changes the arguments passed to `cucumber` on rerun so that only the failed scenarios get rerun, rather than all of them in the feature, allowing for more efficient UI test runs.