### PR TITLE
Ui browsers update

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -2,7 +2,7 @@
 
 [
   {
-    "name": "ChromeLatestWin7",
+    "name": "Chrome",
     "browserName": "chrome",
     "version": "latest",
     "platform": "Windows 7",

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -2,25 +2,12 @@
 
 [
   {
-    "name": "Chrome72Win7",
-    "browserName": "chrome",
-    "version": "72",
-    "platform": "Windows 7",
-    "screenResolution": "1280x1024"
-  },
-  {
     "name": "ChromeLatestWin7",
     "browserName": "chrome",
     "version": "latest",
     "platform": "Windows 7",
     "screenResolution": "1280x1024",
     "extendedDebugging": true
-  },
-  {
-    "name": "Chrome44Win7",
-    "browserName": "chrome",
-    "version": "44.0",
-    "platform": "Windows 7"
   },
   {
     "name": "SafariYosemite",

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -30,10 +30,9 @@
   {
     "name": "iPhone",
     "platformName": "iOS",
-    "platformVersion": "9.3",
+    "platformVersion": "11.3",
     "browserName": "safari",
     "deviceName": "iPhone Simulator",
-    "appiumVersion": "1.6.5",
     "mobile": true,
     "deviceOrientation": "landscape",
     "rotatable": true
@@ -41,10 +40,9 @@
   {
     "name": "iPad",
     "platformName": "iOS",
-    "platformVersion": "9.3",
+    "platformVersion": "11.3",
     "browserName": "safari",
     "deviceName": "iPad Simulator",
-    "appiumVersion": "1.6.5",
     "mobile": true,
     "deviceOrientation": "landscape",
     "rotatable": true

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -10,10 +10,10 @@
     "extendedDebugging": true
   },
   {
-    "name": "SafariYosemite",
+    "name": "Safari",
     "browserName": "Safari",
-    "platform": "OS X 10.10",
-    "version": "8.0"
+    "platform": "OS X 10.11",
+    "version": "10.0"
   },
   {
     "name": "IE11Win10",

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -16,7 +16,7 @@
     "version": "10.0"
   },
   {
-    "name": "IE11Win10",
+    "name": "IE11",
     "browserName": "Internet Explorer",
     "version": "11.0",
     "platform": "Windows 10"

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -22,16 +22,10 @@
     "platform": "Windows 10"
   },
   {
-    "name": "FirefoxLatest-2Yosemite",
-    "browserName": "firefox",
-    "version": "latest-2",
-    "platform": "OS X 10.10"
-  },
-  {
-    "name": "Firefox45Win7",
+    "name": "Firefox",
     "browserName": "firefox",
     "version": "45.0",
-    "platform": "Windows 7"
+    "platform": "Windows 10"
   },
   {
     "name": "iPhone",

--- a/dashboard/test/ui/features/applab/scenarios.feature
+++ b/dashboard/test/ui/features/applab/scenarios.feature
@@ -91,7 +91,7 @@ Feature: App Lab Scenarios
     And I blur selector "#text_area1"
     Then element "#debug-output" has text "text_area1: abc"
 
-  @no_safari_yosemite
+  @no_safari
   @no_mobile
   Scenario: Upload Image Asset
     When I press "designModeButton"

--- a/dashboard/test/ui/features/dance/age_filter.feature
+++ b/dashboard/test/ui/features/dance/age_filter.feature
@@ -1,5 +1,5 @@
 # Brad 2018-11-15 Known crash on SafariYosemite
-@no_older_chrome @no_safari_yosemite
+@no_older_chrome @no_safari
 Feature: Dance Lab Age Filter
   Scenario: Song selector is visible and doesn't display pg13 songs for age < 13
     Given I create a young student named "Harry"

--- a/dashboard/test/ui/features/dance/dance_party.feature
+++ b/dashboard/test/ui/features/dance/dance_party.feature
@@ -1,10 +1,10 @@
 # Brad 2018-11-15 Known crash on SafariYosemite
-@no_older_chrome @no_safari_yosemite
+@no_older_chrome @no_safari
 Feature: Dance Party
   # This test relies on CloudFront signed cookies to access /restricted/ on the
   # test machine, but uses SoundLibraryApi for access in CircleCI.
   @no_firefox
-  @no_safari_yosemite
+  @no_safari
   Scenario: Restricted audio content is protected
     When I am on "http://studio.code.org/restricted/placeholder.txt"
     Then page text does not contain "placeholder for testing"

--- a/dashboard/test/ui/features/dance/save_for_share.feature
+++ b/dashboard/test/ui/features/dance/save_for_share.feature
@@ -1,7 +1,7 @@
 # Testing that various paths out of a project-backed level to a sharing link trigger
 # a save at the appropriate time so the student's latest changes are saved.
 
-@no_mobile @no_ie @no_safari_yosemite
+@no_mobile @no_ie @no_safari
 Feature: Saving project before sharing
   Background:
     # Block numbers are based on default code of free-play level

--- a/dashboard/test/ui/features/droplet.feature
+++ b/dashboard/test/ui/features/droplet.feature
@@ -27,7 +27,7 @@ Feature: Droplet levels work as expected
     And the Droplet ACE text is "radioButton()"
     And there is a Tooltipster tooltip with text "unique identifier"
 
-  @no_safari_yosemite @no_mobile
+  @no_safari @no_mobile
   Scenario: Open editcode level and verify parameter autocomplete replaces quoted text
     When I rotate to landscape
     And I ensure droplet is in text mode

--- a/dashboard/test/ui/features/droplet.feature
+++ b/dashboard/test/ui/features/droplet.feature
@@ -27,7 +27,7 @@ Feature: Droplet levels work as expected
     And the Droplet ACE text is "radioButton()"
     And there is a Tooltipster tooltip with text "unique identifier"
 
-  @no_safari_yosemite
+  @no_safari_yosemite @no_mobile
   Scenario: Open editcode level and verify parameter autocomplete replaces quoted text
     When I rotate to landscape
     And I ensure droplet is in text mode

--- a/dashboard/test/ui/features/manage_assets.feature
+++ b/dashboard/test/ui/features/manage_assets.feature
@@ -9,7 +9,7 @@ Feature: Manage Assets
     Then I click selector "#record-asset" once I see it
     And I wait until element ".modal-content" contains text "Your computer is not set-up to record audio."
 
-  @no_safari_yosemite
+  @no_safari
   #ToDo: epeach - solve safari specific failure
   Scenario: The manage assets dialog displays the audio preview, and toggles between play and pause button.
     Given I am a student
@@ -24,7 +24,7 @@ Feature: Manage Assets
     And element ".fa-play-circle" is visible
 
   # Brad (2018-11-14) Skip on IE due to blocked pop-ups
-  @no_safari_yosemite @no_ie
+  @no_safari @no_ie
   Scenario: The manage assets dialog displays an image thumbnail and opens in a new tab when clicked
     Given I am a student
     And I start a new Game Lab project

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -641,7 +641,7 @@ def cucumber_arguments_for_browser(browser, options)
   arguments += skip_tag('@chrome_before_62') if browser['browserName'] != 'chrome' || browser['version'].to_i == 0 || browser['version'].to_i >= 62
   # browser version 0 implies the latest version.
   arguments += skip_tag('@no_older_chrome') if browser['browserName'] == 'chrome' && (browser['version'].to_i != 0 && browser['version'].to_i <= 67)
-  arguments += skip_tag('@no_safari_yosemite') if browser['browserName'] == 'Safari' && browser['platform'] == 'OS X 10.10'
+  arguments += skip_tag('@no_safari') if browser['browserName'] == 'Safari'
   arguments += skip_tag('@no_firefox') if browser['browserName'] == 'firefox'
   arguments += skip_tag('@webpurify') unless CDO.webpurify_key
   arguments += skip_tag('@pegasus_db_access') unless options.pegasus_db_access

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -641,7 +641,7 @@ def cucumber_arguments_for_browser(browser, options)
   arguments += skip_tag('@chrome_before_62') if browser['browserName'] != 'chrome' || browser['version'].to_i == 0 || browser['version'].to_i >= 62
   # browser version 0 implies the latest version.
   arguments += skip_tag('@no_older_chrome') if browser['browserName'] == 'chrome' && (browser['version'].to_i != 0 && browser['version'].to_i <= 67)
-  arguments += skip_tag('@no_safari') if browser['browserName'] == 'Safari'
+  arguments += skip_tag('@no_safari') if browser['name'] == 'Safari'
   arguments += skip_tag('@no_firefox') if browser['browserName'] == 'firefox'
   arguments += skip_tag('@webpurify') unless CDO.webpurify_key
   arguments += skip_tag('@pegasus_db_access') unless options.pegasus_db_access

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -28,20 +28,17 @@ SKIP_UI_TESTS_TAG = 'skip ui'.freeze
 # Don't run any unit tests.
 SKIP_UNIT_TESTS_TAG = 'skip unit'.freeze
 
-# Run UI tests against ChromeLatestWin7
+# Run UI tests against Chrome
 SKIP_CHROME_TAG = 'skip chrome'.freeze
 
-# Run UI tests against Chrome44Win7
-TEST_CHROME_44_TAG = 'test chrome 44'.freeze
-
-# Run UI tests against Firefox45Win7
+# Run UI tests against Firefox
 TEST_FIREFOX_TAG = 'test firefox'.freeze
 
 # Run UI tests against IE11Win10
 TEST_IE_TAG = 'test ie'.freeze
 TEST_IE_VERBOSE_TAG = 'test internet explorer'.freeze
 
-# Run UI tests against SafariYosemite
+# Run UI tests against Safari
 TEST_SAFARI_TAG = 'test safari'.freeze
 
 # Run UI tests against iPad, iPhone or both
@@ -119,7 +116,7 @@ namespace :circle do
         RakeUtils.system_stream_output "bundle exec ./runner.rb" \
             " --eyes" \
             " --feature #{container_eyes_features.join(',')}" \
-            " --config ChromeLatestWin7,iPhone,IE11Win10" \
+            " --config Chrome,iPhone,IE11Win10" \
             " --pegasus localhost.code.org:3000" \
             " --dashboard localhost-studio.code.org:3000" \
             " --circle" \
@@ -183,11 +180,10 @@ end
 # @return [Array<String>] names of browser configurations for this test run
 def browsers_to_run
   browsers = []
-  browsers << 'ChromeLatestWin7' unless CircleUtils.tagged?(SKIP_CHROME_TAG)
-  browsers << 'Chrome44Win7' if CircleUtils.tagged?(TEST_CHROME_44_TAG)
-  browsers << 'Firefox45Win7' if CircleUtils.tagged?(TEST_FIREFOX_TAG)
+  browsers << 'Chrome' unless CircleUtils.tagged?(SKIP_CHROME_TAG)
+  browsers << 'Firefox' if CircleUtils.tagged?(TEST_FIREFOX_TAG)
   browsers << 'IE11Win10' if CircleUtils.tagged?(TEST_IE_TAG) || CircleUtils.tagged?(TEST_IE_VERBOSE_TAG)
-  browsers << 'SafariYosemite' if CircleUtils.tagged?(TEST_SAFARI_TAG)
+  browsers << 'Safari' if CircleUtils.tagged?(TEST_SAFARI_TAG)
   browsers << 'iPad' if CircleUtils.tagged?(TEST_IPAD_TAG) || CircleUtils.tagged?(TEST_IOS_TAG)
   browsers << 'iPhone' if CircleUtils.tagged?(TEST_IPHONE_TAG) || CircleUtils.tagged?(TEST_IOS_TAG)
   browsers

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -34,7 +34,7 @@ SKIP_CHROME_TAG = 'skip chrome'.freeze
 # Run UI tests against Firefox
 TEST_FIREFOX_TAG = 'test firefox'.freeze
 
-# Run UI tests against IE11Win10
+# Run UI tests against IE11
 TEST_IE_TAG = 'test ie'.freeze
 TEST_IE_VERBOSE_TAG = 'test internet explorer'.freeze
 
@@ -116,7 +116,7 @@ namespace :circle do
         RakeUtils.system_stream_output "bundle exec ./runner.rb" \
             " --eyes" \
             " --feature #{container_eyes_features.join(',')}" \
-            " --config Chrome,iPhone,IE11Win10" \
+            " --config Chrome,iPhone,IE11" \
             " --pegasus localhost.code.org:3000" \
             " --dashboard localhost-studio.code.org:3000" \
             " --circle" \
@@ -182,7 +182,7 @@ def browsers_to_run
   browsers = []
   browsers << 'Chrome' unless CircleUtils.tagged?(SKIP_CHROME_TAG)
   browsers << 'Firefox' if CircleUtils.tagged?(TEST_FIREFOX_TAG)
-  browsers << 'IE11Win10' if CircleUtils.tagged?(TEST_IE_TAG) || CircleUtils.tagged?(TEST_IE_VERBOSE_TAG)
+  browsers << 'IE11' if CircleUtils.tagged?(TEST_IE_TAG) || CircleUtils.tagged?(TEST_IE_VERBOSE_TAG)
   browsers << 'Safari' if CircleUtils.tagged?(TEST_SAFARI_TAG)
   browsers << 'iPad' if CircleUtils.tagged?(TEST_IPAD_TAG) || CircleUtils.tagged?(TEST_IOS_TAG)
   browsers << 'iPhone' if CircleUtils.tagged?(TEST_IPHONE_TAG) || CircleUtils.tagged?(TEST_IOS_TAG)

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -53,7 +53,7 @@ namespace :test do
       eyes_features = `find features/ -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
       failed_browser_count = RakeUtils.system_with_chat_logging(
         'bundle', 'exec', './runner.rb',
-        '-c', 'Chrome,iPhone,IE11Win10',
+        '-c', 'Chrome,iPhone,IE11',
         '-d', CDO.site_host('studio.code.org'),
         '-p', CDO.site_host('code.org'),
         '--db', # Ensure features that require database access are run even if the server name isn't "test"

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -53,7 +53,7 @@ namespace :test do
       eyes_features = `find features/ -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
       failed_browser_count = RakeUtils.system_with_chat_logging(
         'bundle', 'exec', './runner.rb',
-        '-c', 'ChromeLatestWin7,iPhone,IE11Win10',
+        '-c', 'Chrome,iPhone,IE11Win10',
         '-d', CDO.site_host('studio.code.org'),
         '-p', CDO.site_host('code.org'),
         '--db', # Ensure features that require database access are run even if the server name isn't "test"


### PR DESCRIPTION
Updates browsers in our UI-test matrix, and normalizes some browser-config names.

- remove redundant Chrome and Firefox versions to reduce overall saucelab usage, since we are concurrency-constrainee.
- upgrade iOS and Safari versions slightly