### PR TITLE
Fix UI test default browser config

### DIFF
--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -251,7 +251,7 @@ end
 def select_browser_configs(options)
   if options.local
     return [{
-      'browser' => options.browser || 'local',
+      'browser' => options.browser || 'chrome',
       'name' => 'LocalBrowser',
       'browserName' => options.browser || 'chrome',
       'version' => options.browser_version || 'latest'
@@ -342,7 +342,7 @@ end
 # Example result:
 # [
 #   [
-#     { 'browser': 'local', 'name': 'ChromeDriver', 'browserName': 'chrome', 'version': 'latest' },
+#     { 'browser': 'chrome', 'name': 'ChromeDriver', 'browserName': 'chrome', 'version': 'latest' },
 #     'features/bee.feature'
 #   ],
 #   ...


### PR DESCRIPTION
Fixes a regression in https://github.com/code-dot-org/code-dot-org/pull/27943#issuecomment-482732513. Uses the `chrome` browser by default for running local UI tests.