### PR TITLE
remove @chrome_before_62 and @no_older_chrome flags

### DIFF
--- a/dashboard/test/ui/features/applab/embed.feature
+++ b/dashboard/test/ui/features/applab/embed.feature
@@ -3,7 +3,7 @@
 @dashboard_db_access
 @as_student
 @no_mobile
-@no_older_chrome
+@no_chrome
 Feature: App Lab Embed
 
   Background:

--- a/dashboard/test/ui/features/applab/embed.feature
+++ b/dashboard/test/ui/features/applab/embed.feature
@@ -3,7 +3,6 @@
 @dashboard_db_access
 @as_student
 @no_mobile
-@no_chrome
 Feature: App Lab Embed
 
   Background:

--- a/dashboard/test/ui/features/dance/age_filter.feature
+++ b/dashboard/test/ui/features/dance/age_filter.feature
@@ -1,5 +1,5 @@
 # Brad 2018-11-15 Known crash on SafariYosemite
-@no_chrome @no_safari
+@no_safari
 Feature: Dance Lab Age Filter
   Scenario: Song selector is visible and doesn't display pg13 songs for age < 13
     Given I create a young student named "Harry"

--- a/dashboard/test/ui/features/dance/age_filter.feature
+++ b/dashboard/test/ui/features/dance/age_filter.feature
@@ -1,5 +1,5 @@
 # Brad 2018-11-15 Known crash on SafariYosemite
-@no_older_chrome @no_safari
+@no_chrome @no_safari
 Feature: Dance Lab Age Filter
   Scenario: Song selector is visible and doesn't display pg13 songs for age < 13
     Given I create a young student named "Harry"

--- a/dashboard/test/ui/features/dance/dance_party.feature
+++ b/dashboard/test/ui/features/dance/dance_party.feature
@@ -1,5 +1,5 @@
 # Brad 2018-11-15 Known crash on SafariYosemite
-@no_older_chrome @no_safari
+@no_chrome @no_safari
 Feature: Dance Party
   # This test relies on CloudFront signed cookies to access /restricted/ on the
   # test machine, but uses SoundLibraryApi for access in CircleCI.

--- a/dashboard/test/ui/features/dance/dance_party.feature
+++ b/dashboard/test/ui/features/dance/dance_party.feature
@@ -1,5 +1,5 @@
 # Brad 2018-11-15 Known crash on SafariYosemite
-@no_chrome @no_safari
+@no_safari
 Feature: Dance Party
   # This test relies on CloudFront signed cookies to access /restricted/ on the
   # test machine, but uses SoundLibraryApi for access in CircleCI.

--- a/dashboard/test/ui/features/videoplayer_eyes.feature
+++ b/dashboard/test/ui/features/videoplayer_eyes.feature
@@ -32,7 +32,7 @@ Scenario: Fallback player for embedded
   And I close my eyes
 
 # Starting in Chrome 62, sites can no longer automatically run plugins.
-@chrome_before_62
+@no_chrome
 Scenario: Flash fallback player gets injected in Chrome (assuming Flash is available)
   Given I am on "http://studio.code.org/flappy/1?force_youtube_fallback"
   When I rotate to landscape

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -638,9 +638,7 @@ def cucumber_arguments_for_browser(browser, options)
   arguments += skip_tag('@only_one_browser') if browser['browserName'] != 'Internet Explorer' && !options.local && !options.is_circle
 
   arguments += skip_tag('@chrome') if browser['browserName'] != 'chrome' && !options.local
-  arguments += skip_tag('@chrome_before_62') if browser['browserName'] != 'chrome' || browser['version'].to_i == 0 || browser['version'].to_i >= 62
-  # browser version 0 implies the latest version.
-  arguments += skip_tag('@no_older_chrome') if browser['browserName'] == 'chrome' && (browser['version'].to_i != 0 && browser['version'].to_i <= 67)
+  arguments += skip_tag('@no_chrome') if browser['browserName'] == 'chrome'
   arguments += skip_tag('@no_safari') if browser['name'] == 'Safari'
   arguments += skip_tag('@no_firefox') if browser['browserName'] == 'firefox'
   arguments += skip_tag('@webpurify') unless CDO.webpurify_key


### PR DESCRIPTION
### Background

See: https://github.com/code-dot-org/code-dot-org/pull/28048#discussion_r275935275

### Description

Consolidate both flags into @no_chrome. This gives us parity with how things were operating when we ran Chrome44Win7, except that the one videoplayer feature is no longer run in Chrome 44 (but is still run in other browsers) during DTTs.
