### PR TITLE
Change api.openweathermap to samples.openweathermap

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -35,6 +35,7 @@ class XhrProxyController < ApplicationController
     api.foursquare.com
     api.nasa.gov
     api.open-notify.org
+    api.openweathermap.org
     api.pegelalarm.at
     api.randomuser.me
     api.rebrandly.com

--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -35,7 +35,6 @@ class XhrProxyController < ApplicationController
     api.foursquare.com
     api.nasa.gov
     api.open-notify.org
-    api.openweathermap.org
     api.pegelalarm.at
     api.randomuser.me
     api.rebrandly.com
@@ -72,6 +71,7 @@ class XhrProxyController < ApplicationController
     random.org
     rhcloud.com
     runescape.com
+    samples.openweathermap.org
     sheets.googleapis.com
     spreadsheets.google.com
     stats.minecraftservers.org


### PR DESCRIPTION
The name of this API seems to have changed. See https://samples.openweathermap.org/data/2.5/weather?lat=35&lon=139&appid=b6907d289e10d714a6e88b30761fae22