### PR TITLE
ensure no attachment before taking eyes shapshot on free response level

### DIFF
--- a/apps/src/code-studio/components/Attachments.jsx
+++ b/apps/src/code-studio/components/Attachments.jsx
@@ -73,6 +73,7 @@ export default class Attachments extends React.Component {
             key={asset.filename}
             style={styles.attachment}
             href={url}
+            className="uitest-attachment"
             target="_blank"
           >
             {asset.filename}

--- a/dashboard/test/ui/features/initial_page_views2.feature
+++ b/dashboard/test/ui/features/initial_page_views2.feature
@@ -13,6 +13,8 @@ Feature: Looking at a few things with Applitools Eyes - Part 2
     And I am on "<url>"
     When I rotate to landscape
     And I close the instructions overlay if it exists
+    # hack to deflake "free response" scenario below
+    And element ".uitest-attachment" is not visible
     Then I see no difference for "initial load"
     And I close my eyes
     And I sign out


### PR DESCRIPTION
### Background

The following ui test example has been flaky because a bogus attachment sometimes shows up: https://github.com/code-dot-org/code-dot-org/blob/a224329e9f4f9e59a77a09cc66c010c319a59884/dashboard/test/ui/features/initial_page_views2.feature#L28

![image (2)](https://user-images.githubusercontent.com/8001765/56252385-647a9380-606c-11e9-92bd-f54144ea5685.png)

### Description

the root cause is probably improper cleanup of content in the /v3/assets API between test runs. rather than trying to fix that, this PR attempts to trigger a selenium error (rather than an eyes diff) when bogus attachments appear. this allows our test infrastructure to rerun the failing scenario, which we don't do for failures which are just eyes differences: https://github.com/code-dot-org/code-dot-org/blob/db82fea41d58b46d68916d98a41ff595b935127a/dashboard/test/ui/runner.rb#L738
