### PR TITLE
skip video player test which does not work in any latest browser versions

### DIFF
--- a/dashboard/test/ui/features/videoplayer_eyes.feature
+++ b/dashboard/test/ui/features/videoplayer_eyes.feature
@@ -32,7 +32,9 @@ Scenario: Fallback player for embedded
   And I close my eyes
 
 # Starting in Chrome 62, sites can no longer automatically run plugins.
-@no_chrome
+# Skip entirely for now, because this does not work in other browsers
+# either, and therefore does not work in any browser we currently run.
+@skip
 Scenario: Flash fallback player gets injected in Chrome (assuming Flash is available)
   Given I am on "http://studio.code.org/flappy/1?force_youtube_fallback"
   When I rotate to landscape


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/28056, which mistook `@chrome_before_62` to mean "skip only latest chrome" (still running in firefox, ie, safari) whereas what it actually meant was "run only in older chrome" (not running in firefox, ie, safari)