### PR TITLE
Add parameter groups for aurora to data stack [ci skip]

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -130,6 +130,24 @@ Resources:
       Description: !Sub "Reporting Read Replica DB Parameters for ${AWS::StackName}."
       Family: mysql5.7
       Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['Replica'].compact.to_json %>
+  AuroraClusterDBParameters:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Properties:
+      Description: !Sub "Aurora DB Cluster Parameters for ${AWS::StackName}."
+      Family: aurora-mysql5.7
+      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['AuroraCluster'].compact.to_json %>
+  AuroraWriterDBParameters:
+    Type: AWS::RDS::DBParameterGroup
+    Properties:
+      Description: !Sub "Aurora Writer Parameters for ${AWS::StackName}."
+      Family: aurora-mysql5.7
+      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['AuroraWriter'].compact.to_json %>
+  AuroraReportingReplicaDBParameters:
+    Type: AWS::RDS::DBParameterGroup
+    Properties:
+      Description: !Sub "Aurora Reporting Replica Parameters for ${AWS::StackName}."
+      Family: aurora-mysql5.7
+      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['AuroraReportingReplica'].compact.to_json %>
 <%
   # Add CloudWatch Logs Metric Filters for RDS Enhanced Monitoring metrics.
   # Ref: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#w2ab1c20c23c17b7b5

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -137,3 +137,30 @@ Replica:
   slave_parallel_workers: 1
   # Ensure transactions are externalized in the same order as they appear in the replica's relay log.
   slave_preserve_commit_order: 1
+
+# System variables for the Aurora DB cluster.
+AuroraCluster:
+  # When using row-based logging, the master writes events to the binary log that indicate how individual table rows are changed.
+  # Replication of the master to the slave works by copying the events representing the changes to the table rows to the slave.
+  # ROW required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  binlog_format: ROW
+  # When enabled, this variable causes the master to write a checksum for each event in the binary log.
+  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
+  # NONE required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  binlog_checksum: NONE
+
+  # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
+  gtid-mode: ON_PERMISSIVE
+
+
+# System variables for the Aurora DB writer.
+AuroraWriter:
+  # Enable Performance Schema.
+  performance_schema: 1
+
+# System variables for the Aurora DB writer.
+AuroraReportingReplica:
+  # No max execution time on reporting DB.
+  max_execution_time: null


### PR DESCRIPTION
validate output:

```
circleci@183349f5f1c6:~/code-dot-org$ RAILS_ENV=production bundle exec rake stack:data:validate
Data layer including RedShift cluster configuration and synchronization with RDS instance.
Listing changes to existing stack `DATA-production`:
Add AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] 
Add AuroraReportingReplicaDBParameters [AWS::RDS::DBParameterGroup] 
Add AuroraWriterDBParameters [AWS::RDS::DBParameterGroup]
```