### PR TITLE
Upgrade test server db to latest aurora engine version [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -703,7 +703,7 @@ Resources:
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
       DBClusterParameterGroupName: default.aurora-mysql5.7
       Engine: aurora-mysql
-      EngineVersion: 5.7.mysql_aurora.2.04.1
+      EngineVersion: 5.7.mysql_aurora.2.04.1.2
       MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:username}}"
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:password}}"
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
@@ -717,7 +717,7 @@ Resources:
       DBInstanceClass: db.r4.large
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
-      EngineVersion: 5.7.mysql_aurora.2.04.1
+      EngineVersion: 5.7.mysql_aurora.2.04.1.2
 
   DatabaseSecret:
     Type: AWS::SecretsManager::Secret

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -703,7 +703,7 @@ Resources:
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
       DBClusterParameterGroupName: default.aurora-mysql5.7
       Engine: aurora-mysql
-      EngineVersion: 5.7.12
+      EngineVersion: 5.7.mysql_aurora.2.04.1
       MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:username}}"
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:password}}"
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
@@ -717,7 +717,7 @@ Resources:
       DBInstanceClass: db.r4.large
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
-      EngineVersion: 5.7.12
+      EngineVersion: 5.7.mysql_aurora.2.04.1
 
   DatabaseSecret:
     Type: AWS::SecretsManager::Secret


### PR DESCRIPTION
You can view valid engine versions with:
```
aws --profile cdo rds describe-db-engine-versions
```

2.04.1.2 doesn't appear to be documented yet: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.20Updates.html

but I was able to manually upgrade the current aurora production replica to 2.04.1.2 through the console.