### PR TITLE
Share setting level

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -55,7 +55,8 @@ export default class ScriptEditor extends React.Component {
     pilotExperiment: PropTypes.string,
     announcements: PropTypes.arrayOf(announcementShape),
     supportedLocales: PropTypes.arrayOf(PropTypes.string),
-    locales: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired
+    locales: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
+    projectSharing: PropTypes.bool
   };
 
   handleClearProjectWidgetSelectClick = () => {
@@ -150,6 +151,20 @@ export default class ScriptEditor extends React.Component {
           <p>
             If checked this script will show up in the dropdown on the Teacher
             Dashboard, for teachers to assign to students.
+          </p>
+        </label>
+        <label>
+          Display project sharing column in Teacher Dashboard
+          <input
+            name="project_sharing"
+            type="checkbox"
+            defaultChecked={this.props.projectSharing}
+            style={styles.checkbox}
+          />
+          <p>
+            If checked, the "Sharing" column in the "Manage Students" tab of
+            Teacher Dashboard will be displayed by default for sections assigned
+            to this script.
           </p>
         </label>
         <label>

--- a/apps/src/sites/studio/pages/levelbuilder_edit_script.js
+++ b/apps/src/sites/studio/pages/levelbuilder_edit_script.js
@@ -47,6 +47,7 @@ export default function initPage(scriptEditorData) {
         announcements={announcements}
         supportedLocales={scriptData.supported_locales}
         locales={locales}
+        projectSharing={scriptData.project_sharing}
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -137,6 +137,7 @@ class ScriptsController < ApplicationController
   def general_params
     h = params.permit(
       :visible_to_teachers,
+      :project_sharing,
       :login_required,
       :hideable_stages,
       :curriculum_path,

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -31,6 +31,7 @@ class ScriptDSL < BaseDSL
     @is_stable = nil
     @supported_locales = []
     @pilot_experiment = nil
+    @project_sharing = nil
   end
 
   integer :id
@@ -47,6 +48,7 @@ class ScriptDSL < BaseDSL
   boolean :has_verified_resources
   boolean :has_lesson_plan
   boolean :is_stable
+  boolean :project_sharing
 
   string :wrapup_video
   string :script_announcements
@@ -115,7 +117,8 @@ class ScriptDSL < BaseDSL
       version_year: @version_year,
       is_stable: @is_stable,
       supported_locales: @supported_locales,
-      pilot_experiment: @pilot_experiment
+      pilot_experiment: @pilot_experiment,
+      project_sharing: @project_sharing
     }
   end
 
@@ -275,6 +278,7 @@ class ScriptDSL < BaseDSL
     s << 'is_stable true' if script.is_stable
     s << "supported_locales #{script.supported_locales}" if script.supported_locales
     s << "pilot_experiment '#{script.pilot_experiment}'" if script.pilot_experiment
+    s << 'project_sharing true' if script.project_sharing
 
     s << '' unless s.empty?
     s << serialize_stages(script)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -147,6 +147,7 @@ class Script < ActiveRecord::Base
     is_stable
     supported_locales
     pilot_experiment
+    project_sharing
   )
 
   def self.twenty_hour_script
@@ -1330,7 +1331,8 @@ class Script < ActiveRecord::Base
       supported_locales: supported_locales,
       section_hidden_unit_info: section_hidden_unit_info(user),
       pilot_experiment: pilot_experiment,
-      show_assign_button: assignable?(user)
+      show_assign_button: assignable?(user),
+      project_sharing: project_sharing
     }
 
     summary[:stages] = stages.map {|stage| stage.summarize(include_bonus_levels)} if include_stages
@@ -1465,7 +1467,8 @@ class Script < ActiveRecord::Base
       version_year: script_data[:version_year],
       is_stable: script_data[:is_stable],
       supported_locales: script_data[:supported_locales],
-      pilot_experiment: script_data[:pilot_experiment]
+      pilot_experiment: script_data[:pilot_experiment],
+      project_sharing: !!script_data[:project_sharing]
     }.compact
   end
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -230,7 +230,8 @@ class ScriptsControllerTest < ActionController::TestCase
       visible_to_teachers: true,
       login_required: true,
       hideable_stages: true,
-      wrapup_video: 'hoc_wrapup'
+      wrapup_video: 'hoc_wrapup',
+      project_sharing: 'on'
     }
     assert_redirected_to script_path id: 'test-script-create'
 
@@ -239,6 +240,7 @@ class ScriptsControllerTest < ActionController::TestCase
     refute script.hidden
     assert script.login_required
     assert script.hideable_stages
+    assert script.project_sharing
 
     File.unstub(:write)
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -317,6 +317,30 @@ class ScriptsControllerTest < ActionController::TestCase
     refute Script.find_by_name(script.name).hidden
   end
 
+  test 'updates project_sharing' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    script = create :script
+
+    assert_nil Script.find_by_name(script.name).project_sharing
+
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: '',
+      project_sharing: "on"
+    }
+    assert Script.find_by_name(script.name).project_sharing
+
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: ''
+    }
+    refute Script.find_by_name(script.name).project_sharing
+  end
+
   no_access_msg = "You don&#39;t have access to this unit."
 
   test_user_gets_response_for :show, response: :redirect, user: nil,

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -217,6 +217,7 @@ class ScriptsControllerTest < ActionController::TestCase
       login_required true
       hideable_stages true
       wrapup_video 'hoc_wrapup'
+      project_sharing true
 
     TEXT
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -29,6 +29,7 @@ class DslTest < ActiveSupport::TestCase
     is_stable: nil,
     supported_locales: [],
     pilot_experiment: nil,
+    project_sharing: nil,
   }
 
   test 'test Script DSL' do
@@ -597,6 +598,31 @@ DSL
 
     output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
     assert_equal expected, output
+  end
+
+  test 'Script DSL with project_sharing' do
+    input_dsl = 'project_sharing true'
+    expected = DEFAULT_PROPS.merge(
+      {
+        stages: [],
+        project_sharing: true
+      }
+    )
+
+    output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    assert_equal expected, output
+  end
+
+  test 'serialize project_sharing' do
+    script = create :script, project_sharing: true
+    script_text = ScriptDSL.serialize_to_string(script)
+    expected = <<-SCRIPT
+hidden false
+project_sharing true
+
+SCRIPT
+
+    assert_equal expected, script_text
   end
 
   test 'Script DSL with new_name, family_name, version_year and is_stable' do


### PR DESCRIPTION
[LP-290](https://codedotorg.atlassian.net/browse/LP-290)

**Caveat:** This is the first contribution I have made to levelbuilder, so please let me know if there are any steps I'm missing!

Adds a `project_sharing` checkbox to levelbuilder. The end goal is to have this checkbox control the default behavior of the "Sharing" column in the "Manage Students" tab of teacher dashboard (this will be done in a follow-up PR).

**In levelbuilder:**
![Screen Shot 2019-04-19 at 10 05 26 AM](https://user-images.githubusercontent.com/9812299/56434742-c1539500-628a-11e9-9089-5da77fe6260e.png)
