### PR TITLE
Reenable syncing dsls.en.yml with crowdin

### DIFF
--- a/bin/i18n/codeorg_crowdin.yml
+++ b/bin/i18n/codeorg_crowdin.yml
@@ -30,10 +30,8 @@ files: [
   # e.g. ["/**/?.txt", "/**/[0-9].txt", "/**/*\?*.txt"]
   #
   # hourofcode content is handled by the hourofcode-specific sync
-  # dsls content is temporarily disabled until it can be refactored
   "ignore" : [
     "/source/hourofcode/**",
-    "/source/dashboard/dsls.yml",
   ],
 
   #


### PR DESCRIPTION
Now that (as of https://github.com/code-dot-org/code-dot-org/pull/27881 and https://github.com/code-dot-org/code-dot-org/pull/27885) we are generating a version of that file that contains only the strings we know we want to translate, and as of https://github.com/code-dot-org/code-dot-org/pull/28548 we are also generating a version that includes contained levels.