### PR TITLE
Add script for migrating only sponsored users to multi auth

### DIFF
--- a/bin/oneoff/migrate_sponsored_users_to_multi_auth.rb
+++ b/bin/oneoff/migrate_sponsored_users_to_multi_auth.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require_relative '../../dashboard/config/environment'
+
+# The only effect that user.migrate_to_multi_auth has on sponsored users is to
+# update the "provider" field to "migrated", so for simplicity we do all those
+# directly with SQL
+User.
+  where(provider: User::PROVIDER_SPONSORED).
+  in_batches(of: 100_000).
+  update_all(provider: User::PROVIDER_MIGRATED)


### PR DESCRIPTION
Since they represent the largest chunk of unmigrated users, and are also
simple to migrate with a direct ActiveRecord/SQL query rather than going
through all the complex logic necessary for some other kinds of user.