### PR TITLE
Map Chart

### DIFF
--- a/apps/src/applab/ChartApi.js
+++ b/apps/src/applab/ChartApi.js
@@ -54,7 +54,8 @@ ChartApi.ChartType = {
   BAR: 'bar',
   PIE: 'pie',
   LINE: 'line',
-  SCATTER: 'scatter'
+  SCATTER: 'scatter',
+  MAP: 'map'
 };
 
 /** @type {Object.<string, GoogleChart>} */
@@ -62,7 +63,8 @@ ChartApi.TypeNameToType = {
   bar: GoogleChart.MaterialBarChart,
   pie: GoogleChart.PieChart,
   line: GoogleChart.MaterialLineChart,
-  scatter: GoogleChart.MaterialScatterChart
+  scatter: GoogleChart.MaterialScatterChart,
+  map: GoogleChart.MapChart
 };
 
 /**

--- a/apps/src/applab/GoogleChart.js
+++ b/apps/src/applab/GoogleChart.js
@@ -396,6 +396,13 @@ class MapChart extends GoogleChart {
    */
   render_(dataTable, options) {
     const apiChart = new GoogleChart.lib.visualization.Map(this.targetDiv_);
+    GoogleChart.lib.visualization.events.addListener(
+      apiChart,
+      'error',
+      function() {
+        console.error(...arguments);
+      }
+    );
     apiChart.draw(dataTable, options);
   }
 

--- a/apps/src/applab/GoogleChart.js
+++ b/apps/src/applab/GoogleChart.js
@@ -376,3 +376,36 @@ class MaterialScatterChart extends GoogleChart {
   }
 }
 GoogleChart.MaterialScatterChart = MaterialScatterChart;
+
+/**
+ * Google Charts API Map Chart
+ *
+ * @see https://developers.google.com/chart/interactive/docs/gallery/map
+ *
+ * @param {Element} targetDiv
+ * @constructor
+ * @extends GoogleChart
+ */
+class MapChart extends GoogleChart {
+  /**
+   * @param {google.visualization.DataTable} dataTable
+   * @param {Object} options
+   * @returns {Promise}
+   * @private
+   * @override
+   */
+  render_(dataTable, options) {
+    const apiChart = new GoogleChart.lib.visualization.Map(this.targetDiv_);
+    apiChart.draw(dataTable, options);
+  }
+
+  /**
+   * Array of packages the chart needs to load to render.
+   * @returns {string[]}
+   * @override
+   */
+  getDependencies() {
+    return ['map'];
+  }
+}
+GoogleChart.MapChart = MapChart;

--- a/apps/test/unit/applab/ChartApiTest.js
+++ b/apps/test/unit/applab/ChartApiTest.js
@@ -127,10 +127,18 @@ describe('ChartApi', function() {
     assert.isTrue(ChartApi.supportsType('scatter'));
   });
 
+  it('supports type MAP', function() {
+    assert.isTrue(ChartApi.supportsType(ChartApi.ChartType.MAP));
+    assert.isTrue(ChartApi.supportsType('MAP'));
+    assert.isTrue(ChartApi.supportsType('Map'));
+    assert.isTrue(ChartApi.supportsType('map'));
+  });
+
   it('quotes and alphabetizes types for dropdown', function() {
     assert.deepEqual(ChartApi.getChartTypeDropdown(), [
       '"bar"',
       '"line"',
+      '"map"',
       '"pie"',
       '"scatter"'
     ]);
@@ -420,6 +428,18 @@ describe('ChartApi', function() {
 
     it('scatter charts do not warn about three columns', function(testDone) {
       testMethod('fakeDiv', ChartType.SCATTER, 'fakeTable', [
+        'column1',
+        'column2',
+        'column3'
+      ]).then(
+        ensureDone(testDone, function() {
+          assertNotWarns(chartApi, /Too many columns/);
+        })
+      );
+    });
+
+    it('map charts do not warn about three columns', function(testDone) {
+      testMethod('fakeDiv', ChartType.MAP, 'fakeTable', [
         'column1',
         'column2',
         'column3'


### PR DESCRIPTION
Quick attempt to add Map chart type - needs to be validated and tested, this was a 10-minute spike.

### Needs an API key

![image (10)](https://user-images.githubusercontent.com/1615761/56448803-5e342380-62c7-11e9-9b8a-6c5c52367581.png)
![image (11)](https://user-images.githubusercontent.com/1615761/56448804-5ffde700-62c7-11e9-8309-d4ae1acaad69.png)


Next steps here would be to add a Maps API key, ([get one here](https://developers.google.com/maps/documentation/javascript/get-api-key)) and do some local testing of this, and work out what this looks like on an organizational scale from a cost and secrets perspective.