### PR TITLE
Add comment on aurora db EngineVersion [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -703,6 +703,7 @@ Resources:
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
       DBClusterParameterGroupName: default.aurora-mysql5.7
       Engine: aurora-mysql
+      # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with cluster.
       EngineVersion: 5.7.12
       MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:username}}"
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:password}}"
@@ -717,6 +718,7 @@ Resources:
       DBInstanceClass: db.r4.large
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
+      # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with instance.
       EngineVersion: 5.7.12
 
   DatabaseSecret:


### PR DESCRIPTION
Changing this value requires replacement, but since this is a named resource it requires deleting / recreating the DB, which requires other manual changes on the test server. Instead, we'll just upgrade manually. Added comment to indicate this.