### PR TITLE
Bcc plc emails

### DIFF
--- a/dashboard/app/mailers/mailer_constants.rb
+++ b/dashboard/app/mailers/mailer_constants.rb
@@ -1,0 +1,3 @@
+module MailerConstants
+  PLC_EMAIL_LOG = 'plc-emails@code.org'
+end

--- a/dashboard/app/mailers/pd/application/facilitator1920_application_mailer.rb
+++ b/dashboard/app/mailers/pd/application/facilitator1920_application_mailer.rb
@@ -1,6 +1,7 @@
 module Pd::Application
   class Facilitator1920ApplicationMailer < ActionMailer::Base
     default from: 'Code.org <facilitators@code.org>'
+    default bcc: MailerConstants::PLC_EMAIL_LOG
     helper_method :signed_by, :from
 
     def confirmation(facilitator_application)

--- a/dashboard/app/mailers/pd/application/teacher1920_application_mailer.rb
+++ b/dashboard/app/mailers/pd/application/teacher1920_application_mailer.rb
@@ -1,6 +1,7 @@
 module Pd::Application
   class Teacher1920ApplicationMailer < ActionMailer::Base
     default from: 'Code.org <noreply@code.org>'
+    default bcc: MailerConstants::PLC_EMAIL_LOG
 
     def confirmation(teacher_application)
       @application = teacher_application

--- a/dashboard/app/mailers/pd/fit_weekend_registration_mailer.rb
+++ b/dashboard/app/mailers/pd/fit_weekend_registration_mailer.rb
@@ -1,5 +1,6 @@
 class Pd::FitWeekendRegistrationMailer < ActionMailer::Base
   default from: 'Sarah Fairweather <facilitators@code.org>'
+  default bcc: MailerConstants::PLC_EMAIL_LOG
 
   def confirmation(registration)
     @registration = registration

--- a/dashboard/app/mailers/pd/regional_partner_contact_mailer.rb
+++ b/dashboard/app/mailers/pd/regional_partner_contact_mailer.rb
@@ -1,6 +1,7 @@
 class Pd::RegionalPartnerContactMailer < ActionMailer::Base
   NO_REPLY = 'Code.org <noreply@code.org>'
   default from: 'Anthonette Peña <partner@code.org>'
+  default bcc: MailerConstants::PLC_EMAIL_LOG
 
   def matched(form, rp_pm)
     @form = form

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -1,6 +1,8 @@
 class Pd::WorkshopMailer < ActionMailer::Base
   include Rails.application.routes.url_helpers
 
+  default bcc: MailerConstants::PLC_EMAIL_LOG
+
   SUPPORTED_TECH_URL = 'https://support.code.org/hc/en-us/articles/202591743-What-kind-of-operating-system-and-browser-do-I-need-to-use-Code-org-s-online-learning-system-'.freeze
 
   # Name of partial view for workshop details organized by course, then subject.

--- a/dashboard/app/mailers/peer_review_mailer.rb
+++ b/dashboard/app/mailers/peer_review_mailer.rb
@@ -1,5 +1,6 @@
 class PeerReviewMailer < ActionMailer::Base
   default from: 'Code.org <teacher@code.org>'
+  default bcc: MailerConstants::PLC_EMAIL_LOG
 
   def review_completed_receipt(peer_review)
     @peer_review = peer_review

--- a/dashboard/test/mailers/pd/regional_partner_contact_mailer_test.rb
+++ b/dashboard/test/mailers/pd/regional_partner_contact_mailer_test.rb
@@ -58,4 +58,13 @@ class RegionalPartnerContactMailerTest < ActionMailer::TestCase
     assert links_are_complete_urls?(mail)
     assert_sendable mail
   end
+
+  test 'default bcc' do
+    regional_partner_contact = create :pd_regional_partner_contact, form_data: FORM_DATA.to_json
+    form = regional_partner_contact.sanitize_and_trim_form_data_hash
+    rp_pm = create :regional_partner_program_manager
+    mail = Pd::RegionalPartnerContactMailer.matched(form, rp_pm)
+
+    assert_equal MailerConstants::PLC_EMAIL_LOG, mail.bcc.first
+  end
 end

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -183,4 +183,12 @@ class WorkshopMailerTest < ActionMailer::TestCase
       assert links_are_complete_urls?(mail)
     end
   end
+
+  test 'default bcc' do
+    enrollment = create :pd_enrollment
+
+    mail = Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment)
+
+    assert_equal MailerConstants::PLC_EMAIL_LOG, mail.bcc.first
+  end
 end


### PR DESCRIPTION
[PLC-229](https://codedotorg.atlassian.net/browse/PLC-229)

Bcc our shared account on all plc-related emails to make it faster to see what emails we have sent to a user and allow non-engineers to see the email history as well.