### PR TITLE
Fix flaky lesson_extras_teacher_panel UI test

### DIFF
--- a/dashboard/test/ui/features/lesson_extras_teacher_panel.feature
+++ b/dashboard/test/ui/features/lesson_extras_teacher_panel.feature
@@ -1,4 +1,5 @@
 @dashboard_db_access
+@no_mobile
 Feature: Lesson extras teacher panel
 
   Scenario: View student lesson extras progress

--- a/dashboard/test/ui/features/lesson_extras_teacher_panel.feature
+++ b/dashboard/test/ui/features/lesson_extras_teacher_panel.feature
@@ -1,6 +1,4 @@
 @dashboard_db_access
-# TODO: (madelynkasula) 03/28/2019 De-flake and re-enable this test.
-@skip
 Feature: Lesson extras teacher panel
 
   Scenario: View student lesson extras progress
@@ -20,9 +18,9 @@ Feature: Lesson extras teacher panel
 
     # Lesson extras individual puzzle page
     And I click selector "button:contains(Try it):eq(0)" once I see it
+    When I wait for the page to fully load
     And I wait until element ".teacher-panel" is visible
     And check that the URL contains "section_id="
     And check that the URL contains "user_id="
     And I wait until element "h4:contains(Untitled Section)" is visible
-    And I wait until element ".students h4:contains(Student)" is visible
-    And I wait until element ".students a:contains(Sally)" is visible
+    And I wait until element ".section-student a:contains(Sally)" is visible


### PR DESCRIPTION
[LP-257](https://codedotorg.atlassian.net/browse/LP-257)

Re-enabling `lesson_extras_teacher_panel.feature` with a few fixes:
1. Don't run on mobile ([this line](https://github.com/code-dot-org/code-dot-org/blob/78b4933ed7d504f4a7bea38d0879d88e4bf4a204/dashboard/test/ui/features/lesson_extras_teacher_panel.feature#L21) failed consistently when I tested iPad config on Saucelabs)
2. [Wait for page to fully load](https://github.com/code-dot-org/code-dot-org/blob/78b4933ed7d504f4a7bea38d0879d88e4bf4a204/dashboard/test/ui/features/lesson_extras_teacher_panel.feature#L22) for individual lesson extras puzzle
3. Remove [check for header with student name](https://github.com/code-dot-org/code-dot-org/blob/78b4933ed7d504f4a7bea38d0879d88e4bf4a204/dashboard/test/ui/features/lesson_extras_teacher_panel.feature#L26) (header has been removed since this test was disabled)
4. [/s/.students/.section-student](https://github.com/code-dot-org/code-dot-org/blob/78b4933ed7d504f4a7bea38d0879d88e4bf4a204/dashboard/test/ui/features/lesson_extras_teacher_panel.feature#L27) when selecting individual student (just for clarity / additional specificity)

1 and 2 above are what should actually de-flake this test. I confirmed via running the test on Saucelabs that the test was failing pretty consistently, and have not been able to repro a failure (ran ~3x on Safari and 1x in all other browsers on Saucelabs) since making these changes.