### PR TITLE
Pegasus: fix process_forms on production

### DIFF
--- a/pegasus/helpers/email_preference_helpers.rb
+++ b/pegasus/helpers/email_preference_helpers.rb
@@ -2,6 +2,7 @@ require 'cdo/email_validator'
 require 'active_support/core_ext/object'
 require 'active_support/dependencies'
 require_dependency 'cdo/shared_constants/email_preference_constants'
+require_relative '../helper_modules/dashboard'
 
 class EmailPreferenceHelper
   include EmailPreferenceConstants


### PR DESCRIPTION
The removal of `pegasus/helpers/section_api_helpers.rb` in #28073 broke `process_forms` when processing a petition form, because the `Dashboard` module was no longer in scope.  This is a simple fix.