### PR TITLE
extract moveAnswerToSlot to move answers during match load

### DIFF
--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -147,35 +147,40 @@ export default class Match {
           } else {
             // when an answer is in the rightmost list of answers, it can be dragged in to replace an empty slot
             // in the central list of slots.
-
-            var movingItem = ui.draggable.detach();
-
-            // replace target with this new item
-            $(event.target).replaceWith(movingItem);
-
-            // the new item is now droppable
-            movingItem.droppable();
-
-            // remove offset coordinates from the dragged item
-            movingItem.css({top: 'auto', left: 'auto'});
-
-            // this class is no longer in the answer list
-            movingItem.removeClass('answerlist');
-
-            // this class can now be both dragged and a drop target for fellow answers in slots
-            movingItem.addClass('answerslot');
-
-            // this new item can now be dropped onto by other answers in the central list
-            this.makeItemDroppable(movingItem);
-
-            // Once all answers have been dropped into a slot, let anyone
-            // listening know that an answer has been selected.
-            if ($(container).find('.match_answers .answer').length === 0) {
-              onAnswerChanged(this.levelId, true);
-            }
+            var answer = ui.draggable.detach();
+            var slot = $(event.target);
+            this.moveAnswerToSlot(slot, answer);
           }
         }
       });
+  }
+
+  moveAnswerToSlot(slot, answer) {
+    const container = document.getElementById(this.id);
+
+    // replace target with this new item
+    slot.replaceWith(answer);
+
+    // the new item is now droppable
+    answer.droppable();
+
+    // remove offset coordinates from the dragged item
+    answer.css({top: 'auto', left: 'auto'});
+
+    // this class is no longer in the answer list
+    answer.removeClass('answerlist');
+
+    // this class can now be both dragged and a drop target for fellow answers in slots
+    answer.addClass('answerslot');
+
+    // this new item can now be dropped onto by other answers in the central list
+    this.makeItemDroppable(answer);
+
+    // Once all answers have been dropped into a slot, let anyone
+    // listening know that an answer has been selected.
+    if ($(container).find('.match_answers .answer').length === 0) {
+      onAnswerChanged(this.levelId, true);
+    }
   }
 
   makeItemDroppable(item) {
@@ -222,20 +227,14 @@ export default class Match {
       .toArray();
 
     for (let i = 0; i < this.lastAttempt.length; i++) {
-      const slot = slots[i];
+      const slot = $(slots[i]);
       const originalIndex = parseInt(this.lastAttempt[i], 10);
       if (!isNaN(originalIndex)) {
         const answer = $(container).find(
           `.answer[originalIndex=${originalIndex}]`
         );
-        this.dragAnswerToSlot(answer, slot);
+        this.moveAnswerToSlot(slot, answer);
       }
     }
-  }
-
-  dragAnswerToSlot(answer, slot) {
-    var dx = $(slot).offset().left - $(answer).offset().left;
-    var dy = $(slot).offset().top - $(answer).offset().top;
-    $(answer).simulate('drag', {dx, dy});
   }
 }


### PR DESCRIPTION
### Background

Elizabeth reported a problem where her match answers were not always properly displayed. The problem looked like this:

![flaky-matchload](https://user-images.githubusercontent.com/8001765/56519842-e0a32a00-64f7-11e9-8daf-a579f7bc92af.gif)

Upon inspection, the server was sending the correct `lastAttempt` to the client, but the code that simulated dragging the answers into position wasn't working reliably for match levels which were not scrolled into view on initial load.

tracked by: https://codedotorg.atlassian.net/browse/LP-358

### Description

When restoring the user's past work from `lastAttempt`, the fix is to cut out the drag events at the UI layer, and call directly into the code that moves the elements over to the new column via direct DOM manipulation.

### Testing

Existing functionality is covered by existing ui tests in match.feature and level_group.feature. No new tests are added for the off-screen case, so I've verified that case manually, and am relying on the assumption that without using drag events the browser won't really care if the elements are visible on the screen or not when it manipulates them.

### Future work

You can see there is a problem where the text is not properly contained inside the match element. that work is tracked separately in [LP-357](https://codedotorg.atlassian.net/browse/LP-357).