### PR TITLE
Enable slow query log for aurora cluster [ci skip]

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -154,6 +154,8 @@ AuroraCluster:
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE
 
+  # Enable slow query log.
+  slow_query_log: 1
 
 # System variables for the Aurora DB writer.
 AuroraWriter:


### PR DESCRIPTION
I've already applied the change with `RAILS_ENV=production bundle exec rake stack:data:start`; opening PR just for an audit trail.