### PR TITLE
Update to blockly 3.4.5

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -43,7 +43,7 @@
     "@cdo/apps": "file:src",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.4.4",
+    "@code-dot-org/blockly": "3.4.5",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "0.0.42",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -124,9 +124,9 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.4.4.tgz#697e6362d51a45d5f973857e6724bb693df5d6f1"
+"@code-dot-org/blockly@3.4.5":
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.4.5.tgz#4da705a1f01f8b5c21ec5d4e4eff25c24ed0ad38"
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
Updates to includes changes that allow static and dynamic blocks in the behavior category flyout and to enable draggable blocks to be duplicated.