### PR TITLE
Fix student link

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudentsNameCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsNameCell.jsx
@@ -51,9 +51,16 @@ class ManageStudentNameCell extends Component {
       <div>
         {!this.props.isEditing && (
           <div>
-            <a style={tableLayoutStyles.link} href={studentUrl} target="_blank">
-              {name}
-            </a>
+            {studentUrl && (
+              <a
+                style={tableLayoutStyles.link}
+                href={studentUrl}
+                target="_blank"
+              >
+                {name}
+              </a>
+            )}
+            {!studentUrl && <span>{name}</span>}
             {username && (
               <div style={styles.details}>
                 {i18n.usernameLabel() + username}

--- a/apps/src/templates/sectionProgress/SectionProgressNameCell.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressNameCell.jsx
@@ -21,9 +21,12 @@ class SectionProgressNameCell extends Component {
 
     return (
       <div style={progressStyles.nameCell}>
-        <a href={studentUrl} style={progressStyles.link}>
-          {name}
-        </a>
+        {studentUrl && (
+          <a href={studentUrl} style={progressStyles.link}>
+            {name}
+          </a>
+        )}
+        {!studentUrl && <span>{name}</span>}
       </div>
     );
   }

--- a/apps/src/templates/teacherDashboard/StatsTable.jsx
+++ b/apps/src/templates/teacherDashboard/StatsTable.jsx
@@ -56,7 +56,7 @@ class StatsTable extends Component {
         </a>
       );
     } else {
-      return <span>{name}</span>;
+      return <span className="uitest-name-cell">{name}</span>;
     }
   };
 

--- a/apps/src/templates/teacherDashboard/StatsTable.jsx
+++ b/apps/src/templates/teacherDashboard/StatsTable.jsx
@@ -44,16 +44,20 @@ class StatsTable extends Component {
     const {section, scriptName} = this.props;
     const studentUrl = scriptUrlForStudent(section.id, scriptName, rowData.id);
 
-    return (
-      <a
-        className="uitest-name-cell"
-        style={tableLayoutStyles.link}
-        href={studentUrl}
-        target="_blank"
-      >
-        {name}
-      </a>
-    );
+    if (studentUrl) {
+      return (
+        <a
+          className="uitest-name-cell"
+          style={tableLayoutStyles.link}
+          href={studentUrl}
+          target="_blank"
+        >
+          {name}
+        </a>
+      );
+    } else {
+      return <span>{name}</span>;
+    }
   };
 
   getSortingColumns = () => {

--- a/apps/src/templates/teacherDashboard/urlHelpers.js
+++ b/apps/src/templates/teacherDashboard/urlHelpers.js
@@ -13,5 +13,9 @@ export const teacherDashboardUrl = (sectionId, path = '') => {
 };
 
 export const scriptUrlForStudent = (sectionId, scriptName, studentId) => {
+  if (!scriptName) {
+    return null;
+  }
+
   return `/s/${scriptName}?section_id=${sectionId}&user_id=${studentId}&viewAs=Teacher`;
 };

--- a/apps/src/templates/textResponses/TextResponsesTable.jsx
+++ b/apps/src/templates/textResponses/TextResponsesTable.jsx
@@ -37,16 +37,20 @@ class TextResponsesTable extends Component {
       rowData.studentId
     );
 
-    return (
-      <a
-        className="uitest-name-cell"
-        style={tableLayoutStyles.link}
-        href={studentUrl}
-        target="_blank"
-      >
-        {name}
-      </a>
-    );
+    if (studentUrl) {
+      return (
+        <a
+          className="uitest-name-cell"
+          style={tableLayoutStyles.link}
+          href={studentUrl}
+          target="_blank"
+        >
+          {name}
+        </a>
+      );
+    } else {
+      return <span>{name}</span>;
+    }
   };
 
   responseFormatter = (_, {rowData}) => {

--- a/apps/src/templates/textResponses/TextResponsesTable.jsx
+++ b/apps/src/templates/textResponses/TextResponsesTable.jsx
@@ -49,7 +49,7 @@ class TextResponsesTable extends Component {
         </a>
       );
     } else {
-      return <span>{name}</span>;
+      return <span className="uitest-name-cell">{name}</span>;
     }
   };
 


### PR DESCRIPTION
Fixes [LP-307](https://codedotorg.atlassian.net/browse/LP-307).

If we do not have a `scriptName` when displaying a student's name in teacher dashboard, display the name as a `<span>` element rather than a broken link.

### Example
On the progress tab, when we do not have a script in scope, we now display the students name without a hyperlink:
<img width="988" alt="Screen Shot 2019-04-22 at 5 27 33 PM" src="https://user-images.githubusercontent.com/9812299/56621824-df026080-65e2-11e9-9cbd-8e3ae954bcb2.png">
