### PR TITLE
Make setup docs easier to navigate

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ Wondering where to start?  See our [contribution guidelines](CONTRIBUTING.md).
 ## What's in this repo?
 Here's a quick overview of the major landmarks:
 
+### Documentation
+
+* [SETUP](./SETUP.md): Instructions to get everything up and running.
+* [TESTING](./TESTING.md): How to be sure nothing broke.
+* [STYLEGUIDE](./STYLEGUIDE.md): Our code style conventions.
+* Our [LICENSE](./LICENSE) and [NOTICE](./NOTICE).
+* There are many more topical guides in the [docs](./docs) folder.
+* In addition, several sections of the repository have their own documentation:
+  * [apps/README](./apps/README.md)
+  * [blockly/README](https://github.com/code-dot-org/blockly/blob/master/README.md)
+
 ### [dashboard](./dashboard)
 
 The server for our [**Code Studio** learning platform](https://studio.code.org/), a [Ruby on Rails](http://rubyonrails.org/) application responsible for:
@@ -46,17 +57,6 @@ Start here if you are looking for:
 * Tools like [Artist](https://studio.code.org/projects/artist), [Play Lab](https://studio.code.org/projects/playlab) and [App Lab](https://code.org/educate/applab)
 * Other core puzzle types: Maze, Farmer, Bee, Bounce, Calc, Eval
 * Other JS code consumed by dashboard and pegasus.
-
-### Documentation
-
-* [SETUP](./SETUP.md): Instructions to get everything up and running.
-* [TESTING](./TESTING.md): How to be sure nothing broke.
-* [STYLEGUIDE](./STYLEGUIDE.md): Our code style conventions.
-* Our [LICENSE](./LICENSE) and [NOTICE](./NOTICE).
-* There are many more topical guides in the [docs](./docs) folder.
-* In addition, several sections of the repository have their own documentation:
-  * [apps/README](./apps/README.md)
-  * [blockly/README](https://github.com/code-dot-org/blockly/blob/master/README.md)
 
 ### Everything else
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -38,6 +38,8 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
 1. `rake build`
 1. (Optional, Code.org engineers only) Setup AWS - Ask a Code.org engineer how to complete this step
    1. Some functionality will not work on your local site without this, for example, some project-backed level types such as https://studio.code.org/projects/gamelab. This setup is only available to Code.org engineers for now, but it is recommended for Code.org engineers.
+   
+Next, read our [code styleguide](./STYLEGUIDE.md), our [test suites](./TESTING.md), or find more docs on [the wiki](https://github.com/code-dot-org/code-dot-org/wiki/For-Developers).
 
 ## OS-specific prerequisites
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -39,7 +39,7 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
 1. (Optional, Code.org engineers only) Setup AWS - Ask a Code.org engineer how to complete this step
    1. Some functionality will not work on your local site without this, for example, some project-backed level types such as https://studio.code.org/projects/gamelab. This setup is only available to Code.org engineers for now, but it is recommended for Code.org engineers.
    
-Next, read our [code styleguide](./STYLEGUIDE.md), our [test suites](./TESTING.md), or find more docs on [the wiki](https://github.com/code-dot-org/code-dot-org/wiki/For-Developers).
+After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites](./TESTING.md), or find more docs on [the wiki](https://github.com/code-dot-org/code-dot-org/wiki/For-Developers).
 
 ## OS-specific prerequisites
 


### PR DESCRIPTION
Moves documentation links earlier in the README, and adds some "Next steps" links at the end of the setup overview in SETUP.md.