### PR TITLE
Alternate approach: keep old behavior by setting `display: inline` on blocks

### DIFF
--- a/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
+++ b/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
@@ -17,12 +17,10 @@ export default class LabeledFormComponent extends FormComponent {
     }
 
     return (
-      <div style={{display: 'inline-block'}}>
-        <UnsafeRenderedMarkdown
-          openExternalLinksInNewTab
-          markdown={this.constructor.labels[name]}
-        />
-      </div>
+      <UnsafeRenderedMarkdown
+        openExternalLinksInNewTab
+        markdown={this.constructor.labels[name]}
+      />
     );
   }
 

--- a/apps/src/templates/UnsafeRenderedMarkdown.jsx
+++ b/apps/src/templates/UnsafeRenderedMarkdown.jsx
@@ -37,7 +37,18 @@ export default class UnsafeRenderedMarkdown extends React.Component {
     const parser = this.props.openExternalLinksInNewTab
       ? extendedParser
       : remarkParser;
-    const processedMarkdown = parser.sourceToHtml(this.props.markdown);
+    let processedMarkdown = parser.sourceToHtml(this.props.markdown);
+
+    if (this.props.openExternalLinksInNewTab) {
+      processedMarkdown = processedMarkdown.replace(
+        /^<p>/,
+        '<p style="display: inline;">'
+      );
+
+      /* eslint-disable react/no-danger */
+      return <span dangerouslySetInnerHTML={{__html: processedMarkdown}} />;
+      /* eslint-enable react/no-danger */
+    }
 
     /* eslint-disable react/no-danger */
     return <div dangerouslySetInnerHTML={{__html: processedMarkdown}} />;


### PR DESCRIPTION
Alternate approach for fixing the "required" asterisks from PR https://github.com/code-dot-org/code-dot-org/pull/27841

This approach feels hacky, but would preserve the existing behavior.