### PR TITLE
Revert "Convert all usages of MarkdownSpan -> UnsafeRenderedMarkdown"

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -48,7 +48,7 @@ import {FacilitatorScoringFields} from './detail_view/facilitator_scoring_fields
 import PrincipalApprovalButtons from './principal_approval_buttons';
 import DetailViewWorkshopAssignmentResponse from './detail_view_workshop_assignment_response';
 import ChangeLog from './detail_view/change_log';
-import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
+import MarkdownSpan from '../components/markdownSpan';
 
 const styles = {
   notes: {
@@ -1076,13 +1076,10 @@ export class DetailViewContents extends React.Component {
                           'schoolStatsAndPrincipalApprovalSection') && (
                         <tr key={j}>
                           <td style={styles.questionColumn}>
-                            <UnsafeRenderedMarkdown
-                              openExternalLinksInNewTab
-                              markdown={
-                                this.labelOverrides[key] ||
-                                this.pageLabels[header][key]
-                              }
-                            />
+                            <MarkdownSpan>
+                              {this.labelOverrides[key] ||
+                                this.pageLabels[header][key]}
+                            </MarkdownSpan>
                           </td>
                           <td style={styles.answerColumn}>
                             {this.renderAnswer(

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_response.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_response.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 import {Row, Col, FormControl, Panel} from 'react-bootstrap';
-import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
+import MarkdownSpan from '../components/markdownSpan';
 
 const styles = {
   lineItem: {
@@ -22,10 +22,7 @@ const Question = props => {
   const suffix =
     '?:.'.indexOf(props.text[props.text.length - 1]) >= 0 ? '' : ':';
   return (
-    <UnsafeRenderedMarkdown
-      openExternalLinksInNewTab
-      markdown={`${props.text}${suffix}`}
-    />
+    <MarkdownSpan style={props.style}>{`${props.text}${suffix}`}</MarkdownSpan>
   );
 };
 Question.propTypes = {
@@ -88,9 +85,7 @@ export default class DetailViewResponse extends React.Component {
       if (this.props.layout === 'lineItem') {
         return (
           <div>
-            <div style={styles.lineItem}>
-              <Question text={this.props.question} />
-            </div>
+            <Question text={this.props.question} style={styles.lineItem} />
             {renderedValue}
           </div>
         );

--- a/apps/src/code-studio/pd/components/markdownSpan.jsx
+++ b/apps/src/code-studio/pd/components/markdownSpan.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import marked from 'marked';
+
+// Render links to open in a different tab
+const renderer = new marked.Renderer();
+renderer.link = (href, _title, text) =>
+  `<a href="${href}" target="_blank">${text}</a>`;
+
+export default class MarkdownSpan extends React.Component {
+  static propTypes = {
+    children: PropTypes.string.isRequired,
+    style: PropTypes.object
+  };
+
+  render() {
+    const renderedText = marked.inlineLexer(this.props.children, [], {
+      renderer
+    });
+    return (
+      <span
+        dangerouslySetInnerHTML={{__html: renderedText}} // eslint-disable-line react/no-danger
+        style={this.props.style}
+      />
+    );
+  }
+}

--- a/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
+++ b/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import FormComponent from './FormComponent';
-import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
+import MarkdownSpan from '../components/markdownSpan';
 
 export default class LabeledFormComponent extends FormComponent {
   /**
@@ -16,14 +16,7 @@ export default class LabeledFormComponent extends FormComponent {
       return name;
     }
 
-    return (
-      <div style={{display: 'inline-block'}}>
-        <UnsafeRenderedMarkdown
-          openExternalLinksInNewTab
-          markdown={this.constructor.labels[name]}
-        />
-      </div>
-    );
+    return <MarkdownSpan>{this.constructor.labels[name]}</MarkdownSpan>;
   }
 
   indented(depth = 1) {

--- a/apps/test/unit/code-studio/pd/components/markdownSpanTest.js
+++ b/apps/test/unit/code-studio/pd/components/markdownSpanTest.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+import MarkdownSpan from '@cdo/apps/code-studio/pd/components/markdownSpan';
+
+describe('MarkdownSpan', () => {
+  it('Renders the supplied markdown in a span element', () => {
+    const markdownSpan = shallow(
+      <MarkdownSpan>normal text *bold text*</MarkdownSpan>
+    );
+
+    expect(markdownSpan.html()).to.include(
+      '<span>normal text <em>bold text</em></span>'
+    );
+  });
+
+  it('Renders links with target=_blank', () => {
+    const markdownSpan = shallow(
+      <MarkdownSpan>This is a [link](https://code.org).</MarkdownSpan>
+    );
+
+    expect(markdownSpan.html()).to.include(
+      '<span>This is a <a href="https://code.org" target="_blank">link</a>.</span>'
+    );
+  });
+
+  it('Applies the supplied style to the rendered span', () => {
+    const markdownSpan = shallow(
+      <MarkdownSpan style={{fontFamily: 'Gotham 7r'}}>text</MarkdownSpan>
+    );
+
+    expect(
+      markdownSpan.containsMatchingElement(
+        <span style={{fontFamily: 'Gotham 7r'}} />
+      )
+    ).to.be.ok;
+  });
+});


### PR DESCRIPTION
Reverting while we come up with a more permanent solution. @breville and PLC will own deprecating the `<MarkdownSpan>` component (or switching it to use remark.js).