### PR TITLE
Move from assessment level type to assessment as property

### DIFF
--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -719,6 +719,45 @@ DSL
     assert_equal expected, output
   end
 
+  test 'serialize assessment' do
+    level = create :maze, name: 'maze 1', level_num: 'custom'
+    script = create :script, hidden: true
+    stage = create :stage, name: 'stage 1', script: script
+    script_level = create(
+      :script_level,
+      levels: [level],
+      assessment: true,
+      stage: stage,
+      script: script
+    )
+    script_text = ScriptDSL.serialize_to_string(script_level.script)
+    expected = <<-SCRIPT
+stage 'stage 1'
+level 'maze 1', assessment: true
+    SCRIPT
+    assert_equal expected, script_text
+  end
+
+  test 'Script DSL with assessment: true' do
+    input_dsl = <<DSL
+stage 'stage 1'
+level 'maze 1', assessment: true
+DSL
+    expected = DEFAULT_PROPS.merge(
+      {
+        stages: [
+          {
+            stage: "stage 1",
+            scriptlevels: [{stage: "stage 1", levels: [{name: "maze 1", assessment: true}]},]
+          }
+        ]
+      }
+    )
+
+    output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    assert_equal expected, output
+  end
+
   test 'remove property' do
     # mock file so we don't actually write a file, 2x for each "create_from_level_builder"
     input_dsl = "


### PR DESCRIPTION
Changes the way we mark a level as assessment in script from:

` assessment 'Example Level'`
to 
`level 'Example Level', assessment: true`