### PR TITLE
Use relative_position to get stage number [ci skip]

### DIFF
--- a/aws/redshift/views/course_structure.sql
+++ b/aws/redshift/views/course_structure.sql
@@ -12,10 +12,13 @@ select
   sc.name script_name, 
   st.id stage_id, 
   st.name stage_name, 
-  st.absolute_position stage_number, 
+  case when lockable = 1 then st.absolute_position else st.relative_position end stage_number, 
   lsl.level_id, 
   le.name level_name, 
-  sl.position as level_number
+  sl.position as level_number,
+  case when json_extract_path_text(sl.properties, 'challenge') = 'true' then 1 else 0 end as challenge,
+  case when sl.assessment = 1 then 1 else 0 end as assessment,
+  case when json_extract_path_text(le.properties, 'mini_rubric') = 'true' then 1 else 0 end as mini_rubric
 from dashboard_production.levels_script_levels lsl
   join dashboard_production.script_levels sl on sl.id = lsl.script_level_id
   join dashboard_production.stages st on st.id = sl.stage_id


### PR DESCRIPTION
Learned that the `relative_position` attribute shows where a lesson appears in scripts that have "lockable" lessons (e.g., assessments and surveys) before them in the script. An example of this is CSP Unit 5, Lesson 11 (While Loops), where the `absolute_position` is 13, but the `relative_position` is 11.

Also added columns that say whether a level is a challenge puzzle, assessment level, or has a mini rubric.