### PR TITLE
Add simple Contact Rollups integration test

### DIFF
--- a/dashboard/test/integration/contact_rollups_test.rb
+++ b/dashboard/test/integration/contact_rollups_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+require 'cdo/contact_rollups'
+
+class ContactRollupsTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+  def test_build_contact_rollups
+    ContactRollups.build_contact_rollups
+  end
+end


### PR DESCRIPTION
Contact Rollups does not have any tests because of the complexity of writing factories that exercise each of the queries.  Run the `build_contact_rollups` Class method to verify that basic functionality is working.