### PR TITLE
Move over to new way of marking assessment in scripts

### DIFF
--- a/dashboard/config/scripts/CSF_Secret_Sample.script
+++ b/dashboard/config/scripts/CSF_Secret_Sample.script
@@ -3,11 +3,11 @@ level 'newCSFsample'
 level 'sample1'
 level 'sample2'
 level 'sample3'
-assessment 'sample3assessment'
+level 'sample3assessment', assessment: true
 level 'sample4'
 level 'sample5'
 level 'sample6'
-assessment 'sample7assessment'
+level 'sample7assessment', assessment: true
 level 'sample8'
 level 'sample9a'
 level 'sample10a'

--- a/dashboard/config/scripts/CSF_Secret_Sample_Story.script
+++ b/dashboard/config/scripts/CSF_Secret_Sample_Story.script
@@ -6,11 +6,11 @@ level 'sample1'
 level 'storyline4'
 level 'sample2'
 level 'sample3'
-assessment 'sample3assessment'
+level 'sample3assessment', assessment: true
 level 'sample4'
 level 'sample5'
 level 'sample6'
-assessment 'sample7assessment'
+level 'sample7assessment', assessment: true
 level 'sample8'
 level 'storyline5'
 level 'sample9a'

--- a/dashboard/config/scripts/Course4pre.script
+++ b/dashboard/config/scripts/Course4pre.script
@@ -22,7 +22,7 @@ level '2-3 Artist 9'
 level '2-3 Artist 7'
 level '2-3 Artist 8'
 level '2-3 Artist Free Play'
-level '2-3 Artist level 1', assessment: true
+level '2-3 Artist assessment 1', assessment: true
 level '2-3 artist match 1', assessment: true
 
 stage 'Artist: Loops'
@@ -56,7 +56,7 @@ level '2-3 Bee Conditionals 12'
 level '2-3 Bee Conditionals 13'
 level '2-3 Bee Conditionals 14'
 level '2-3 Bee Conditionals 15'
-level '2-3 Bee Conditionals level 1', assessment: true
+level '2-3 Bee Conditionals assessment 1', assessment: true
 level '2-3 bee conditionals multi 1', assessment: true
 level '2-3 bee conditionals multi 3', assessment: true
 
@@ -71,7 +71,7 @@ level '4-5 Nested Loops 7'
 level '4-5 Nested Loops 11'
 level '4-5 Nested Loops 8'
 level '4-5 Nested Loops 12'
-level '4-5 Nested Loops level 1', assessment: true
+level '4-5 Nested Loops assessment 1', assessment: true
 level '4-5 artist loops multi 1', assessment: true
 
 stage 'Farmer: While Loops'
@@ -83,7 +83,7 @@ level '4-5 While Loops 5'
 level '4-5 While Loops 6'
 level '4-5 While Loops 7'
 level '4-5 While Loops 8'
-level '4-5 While Loops level 1', assessment: true
+level '4-5 While Loops assessment 1', assessment: true
 
 stage 'Bee: Nested Loops'
 level '4-5 Bee Nested Loops 1'
@@ -96,8 +96,8 @@ level '4-5 Bee Nested Loops 7'
 level '2-3 Bee Loops 10'
 level '4-5 Bee Nested Loops 9'
 level '4-5 Bee Nested Loops Rows'
-level '2-3 Bee Loops level 1', assessment: true
-level '4-5 Bee Nested Loops level 1', assessment: true
+level '2-3 Bee Loops assessment 1', assessment: true
+level '4-5 Bee Nested Loops assessment 1', assessment: true
 level '4-5 bee loops multi 1', assessment: true
 
 stage 'Artist: Functions'
@@ -124,5 +124,5 @@ level '4-5 Bee Debugging 8'
 level '4-5 Bee Debugging 9'
 level '4-5 Bee Debugging 10'
 level '4-5 Bee Debugging 11'
-level '4-5 Bee Debugging level 1', assessment: true
+level '4-5 Bee Debugging assessment 1', assessment: true
 level '4-5 bee debug multi 1', assessment: true

--- a/dashboard/config/scripts/Course4pre.script
+++ b/dashboard/config/scripts/Course4pre.script
@@ -22,7 +22,7 @@ level '2-3 Artist 9'
 level '2-3 Artist 7'
 level '2-3 Artist 8'
 level '2-3 Artist Free Play'
-level '2-3 Artist assessment 1', assessment: true
+level '2-3 Artist Assessment 1', assessment: true
 level '2-3 artist match 1', assessment: true
 
 stage 'Artist: Loops'
@@ -56,7 +56,7 @@ level '2-3 Bee Conditionals 12'
 level '2-3 Bee Conditionals 13'
 level '2-3 Bee Conditionals 14'
 level '2-3 Bee Conditionals 15'
-level '2-3 Bee Conditionals assessment 1', assessment: true
+level '2-3 Bee Conditionals Assessment 1', assessment: true
 level '2-3 bee conditionals multi 1', assessment: true
 level '2-3 bee conditionals multi 3', assessment: true
 
@@ -71,7 +71,7 @@ level '4-5 Nested Loops 7'
 level '4-5 Nested Loops 11'
 level '4-5 Nested Loops 8'
 level '4-5 Nested Loops 12'
-level '4-5 Nested Loops assessment 1', assessment: true
+level '4-5 Nested Loops Assessment 1', assessment: true
 level '4-5 artist loops multi 1', assessment: true
 
 stage 'Farmer: While Loops'
@@ -83,7 +83,7 @@ level '4-5 While Loops 5'
 level '4-5 While Loops 6'
 level '4-5 While Loops 7'
 level '4-5 While Loops 8'
-level '4-5 While Loops assessment 1', assessment: true
+level '4-5 While Loops Assessment 1', assessment: true
 
 stage 'Bee: Nested Loops'
 level '4-5 Bee Nested Loops 1'
@@ -96,8 +96,8 @@ level '4-5 Bee Nested Loops 7'
 level '2-3 Bee Loops 10'
 level '4-5 Bee Nested Loops 9'
 level '4-5 Bee Nested Loops Rows'
-level '2-3 Bee Loops assessment 1', assessment: true
-level '4-5 Bee Nested Loops assessment 1', assessment: true
+level '2-3 Bee Loops Assessment 1', assessment: true
+level '4-5 Bee Nested Loops Assessment 1', assessment: true
 level '4-5 bee loops multi 1', assessment: true
 
 stage 'Artist: Functions'
@@ -124,5 +124,5 @@ level '4-5 Bee Debugging 8'
 level '4-5 Bee Debugging 9'
 level '4-5 Bee Debugging 10'
 level '4-5 Bee Debugging 11'
-level '4-5 Bee Debugging assessment 1', assessment: true
+level '4-5 Bee Debugging Assessment 1', assessment: true
 level '4-5 bee debug multi 1', assessment: true

--- a/dashboard/config/scripts/Course4pre.script
+++ b/dashboard/config/scripts/Course4pre.script
@@ -8,8 +8,8 @@ level '2-3 Maze 7'
 level '2-3 Maze 8'
 level '2-3 Maze 9'
 level '2-3 Maze 10'
-assessment '2-3 Maze Multi 2'
-assessment '2-3 Maze Match 2'
+level '2-3 Maze Multi 2', assessment: true
+level '2-3 Maze Match 2', assessment: true
 
 stage 'Artist: Sequence'
 level '2-3 Artist 1 new'
@@ -22,8 +22,8 @@ level '2-3 Artist 9'
 level '2-3 Artist 7'
 level '2-3 Artist 8'
 level '2-3 Artist Free Play'
-assessment '2-3 Artist Assessment 1'
-assessment '2-3 artist match 1'
+level '2-3 Artist level 1', assessment: true
+level '2-3 artist match 1', assessment: true
 
 stage 'Artist: Loops'
 level '2-3 Artist Loops New 1'
@@ -39,9 +39,9 @@ level '2-3 Artist Loops New 12'
 level '2-3 Artist Loops New 13'
 level '2-3 Artist Loops New 14'
 level '2-3 Artist Loops New 15'
-assessment '2-3 artist loops match 1'
-assessment '2-3 artist loops multi 2'
-assessment '2-3 artist loops multi 1'
+level '2-3 artist loops match 1', assessment: true
+level '2-3 artist loops multi 2', assessment: true
+level '2-3 artist loops multi 1', assessment: true
 
 stage 'Bee: Conditionals'
 level '2-3 Bee Conditionals 2'
@@ -56,9 +56,9 @@ level '2-3 Bee Conditionals 12'
 level '2-3 Bee Conditionals 13'
 level '2-3 Bee Conditionals 14'
 level '2-3 Bee Conditionals 15'
-assessment '2-3 Bee Conditionals Assessment 1'
-assessment '2-3 bee conditionals multi 1'
-assessment '2-3 bee conditionals multi 3'
+level '2-3 Bee Conditionals level 1', assessment: true
+level '2-3 bee conditionals multi 1', assessment: true
+level '2-3 bee conditionals multi 3', assessment: true
 
 stage 'Artist: Nested Loops'
 level '4-5 Nested Loops 1'
@@ -71,8 +71,8 @@ level '4-5 Nested Loops 7'
 level '4-5 Nested Loops 11'
 level '4-5 Nested Loops 8'
 level '4-5 Nested Loops 12'
-assessment '4-5 Nested Loops Assessment 1'
-assessment '4-5 artist loops multi 1'
+level '4-5 Nested Loops level 1', assessment: true
+level '4-5 artist loops multi 1', assessment: true
 
 stage 'Farmer: While Loops'
 level '4-5 While Loops 1'
@@ -83,7 +83,7 @@ level '4-5 While Loops 5'
 level '4-5 While Loops 6'
 level '4-5 While Loops 7'
 level '4-5 While Loops 8'
-assessment '4-5 While Loops Assessment 1'
+level '4-5 While Loops level 1', assessment: true
 
 stage 'Bee: Nested Loops'
 level '4-5 Bee Nested Loops 1'
@@ -96,9 +96,9 @@ level '4-5 Bee Nested Loops 7'
 level '2-3 Bee Loops 10'
 level '4-5 Bee Nested Loops 9'
 level '4-5 Bee Nested Loops Rows'
-assessment '2-3 Bee Loops Assessment 1'
-assessment '4-5 Bee Nested Loops Assessment 1'
-assessment '4-5 bee loops multi 1'
+level '2-3 Bee Loops level 1', assessment: true
+level '4-5 Bee Nested Loops level 1', assessment: true
+level '4-5 bee loops multi 1', assessment: true
 
 stage 'Artist: Functions'
 level '2-3 Artist Functions 1'
@@ -110,7 +110,7 @@ level '2-3 Artist Functions 11.5'
 level '2-3 Artist Functions 12'
 level '2-3 Artist Functions 9'
 level '2-3 Artist Functions 10'
-assessment '2-3 artist functions multi 1'
+level '2-3 artist functions multi 1', assessment: true
 
 stage 'Bee: Debugging'
 level '4-5 Bee Debugging 1'
@@ -124,5 +124,5 @@ level '4-5 Bee Debugging 8'
 level '4-5 Bee Debugging 9'
 level '4-5 Bee Debugging 10'
 level '4-5 Bee Debugging 11'
-assessment '4-5 Bee Debugging Assessment 1'
-assessment '4-5 bee debug multi 1'
+level '4-5 Bee Debugging level 1', assessment: true
+level '4-5 bee debug multi 1', assessment: true

--- a/dashboard/config/scripts/MikeTest.script
+++ b/dashboard/config/scripts/MikeTest.script
@@ -4,7 +4,7 @@ stage 'Sample Stage'
 level 'MikeTest1'
 level 'MikeTest2'
 level 'MikeTest3'
-assessment 'MikeAssessment1'
+level 'MikeAssessment1', assessment: true
 skin 'basketball'
 level 'bounce_12'
 

--- a/dashboard/config/scripts/allthesurveys.script
+++ b/dashboard/config/scripts/allthesurveys.script
@@ -1,28 +1,28 @@
 login_required true
 
 stage 'CSP pre survey 2017 staging'
-assessment 'csp-pre-survey-2017-levelgroup'
+level 'csp-pre-survey-2017-levelgroup', assessment: true
 
 stage 'CSD pre survey 2017 staging'
-assessment 'csd-pre-survey-2017-levelgroup'
+level 'csd-pre-survey-2017-levelgroup', assessment: true
 
 stage 'CSD/P pulse check survey 2017'
-assessment 'csd-pulse-check-survey-1-levelgroup', progression: 'pulse check model'
+level 'csd-pulse-check-survey-1-levelgroup', progression: 'pulse check model', assessment: true
 
 stage 'CSD mid and post survey 2017 staging'
-assessment 'csd-post-survey-2017-levelgroup'
+level 'csd-post-survey-2017-levelgroup', assessment: true
 
 stage 'CSP mid and post survey 2017 staging'
-assessment 'csp-post-survey-2017-levelgroup'
+level 'csp-post-survey-2017-levelgroup', assessment: true
 
 stage 'CSP post survey 2018 staging'
-assessment 'csp-post-survey-2018-levelgroup'
+level 'csp-post-survey-2018-levelgroup', assessment: true
 
 stage 'CSD post survey 2018 staging'
-assessment 'csd-post-survey-2017-levelgroup-2018-2nd-semester'
+level 'csd-post-survey-2017-levelgroup-2018-2nd-semester', assessment: true
 
 stage 'CSP pre survey 2018 staging'
-assessment 'csp-pre-survey-2017-levelgroup_2018'
+level 'csp-pre-survey-2017-levelgroup_2018', assessment: true
 
 stage 'CSP mid survey 2018 staging'
-assessment 'csp-post-survey-2017-levelgroup_2018'
+level 'csp-post-survey-2017-levelgroup_2018', assessment: true

--- a/dashboard/config/scripts/artist-and-bb8.script
+++ b/dashboard/config/scripts/artist-and-bb8.script
@@ -22,7 +22,7 @@ level 'courseC_starWars_loops7'
 level 'courseC_starWars_loops8'
 level 'courseC_starWars_loops9'
 level 'courseC_starWars_loops10'
-assessment 'courseC_starWars_loops10_predict2'
+level 'courseC_starWars_loops10_predict2', assessment: true
 level 'courseC_starWars_loops11'
 
 stage 'C9 Artist Loops'
@@ -83,7 +83,7 @@ stage 'F7 add Conditionals'
 level 'courseF_playlab_variables1a'
 level 'courseF_playlab_variables2b'
 level 'courseF_playlab_variables3b_josh'
-assessment 'courseF_playlab_variables4c_predictive1'
+level 'courseF_playlab_variables4c_predictive1', assessment: true
 level 'courseF_playlab_variables4b'
 level 'courseF_playlab_variables5c'
 level 'courseF_playlab_variables6c'
@@ -101,7 +101,7 @@ level 'courseD_farmer_condLoops6'
 level 'courseD_farmer_condLoops7', challenge: true
 level 'courseD_farmer_condLoops8'
 level 'courseD_farmer_condLoops9'
-assessment 'courseD_farmer_condLoops9_predict1'
+level 'courseD_farmer_condLoops9_predict1', assessment: true
 bonus 'courseD_farmer_condLoops_challenge1'
 bonus 'courseD_farmer_condLoops_challenge2'
 

--- a/dashboard/config/scripts/course-f-2018.script
+++ b/dashboard/config/scripts/course-f-2018.script
@@ -26,7 +26,7 @@ level 'courseC_maze_debugging4_2018'
 level 'courseC_maze_debugging5_2018'
 level 'courseC_maze_debugging6_2018'
 level 'courseC_maze_debugging7_2018', challenge: true
-assessment 'courseC_maze_debugging8_predict1_2018'
+level 'courseC_maze_debugging8_predict1_2018', assessment: true
 level 'courseC_maze_debugging9_2018'
 
 stage 'Programming in Artist', flex_category: 'csf_f_1'
@@ -39,7 +39,7 @@ level 'courseC_artist_prog5_2018'
 level 'courseC_artist_prog6_2018'
 level 'courseC_artist_prog7_2018', challenge: true
 level 'courseC_artist_prog8_2018'
-assessment 'courseC_artist_prog6_predict1_2018'
+level 'courseC_artist_prog6_predict1_2018', assessment: true
 bonus 'courseC_artist_prog_challenge1_2018'
 bonus 'courseC_artist_prog_challenge2a_2018'
 
@@ -72,7 +72,7 @@ level 'courseD_maze_nestedLoops6_2018'
 level 'courseD_bee_nestedLoops7_2018', challenge: true
 level 'courseD_bee_nestedLoops8_2018'
 level 'courseD_bee_nestedLoops9_2018'
-assessment 'courseD_bee_nestedLoops9_predict2_2018'
+level 'courseD_bee_nestedLoops9_predict2_2018', assessment: true
 
 stage 'Nested Loops with Frozen', flex_category: 'csf_f_1'
 level 'courseD_artist_project1_2018'
@@ -163,7 +163,7 @@ stage 'Variables in Play Lab', flex_category: 'csf_f_2'
 level 'courseF_playlab_variables1a_2018'
 level 'courseF_playlab_variables2b_2018'
 level 'courseF_playlab_variables3b_josh_2018'
-assessment 'courseF_playlab_variables4c_predictive1_2018'
+level 'courseF_playlab_variables4c_predictive1_2018', assessment: true
 level 'courseF_playlab_variables4b_2018'
 level 'courseF_playlab_variables5c_2018'
 level 'courseF_playlab_variables6c_2018'
@@ -203,7 +203,7 @@ level 'courseF_artist_for6_2018'
 level 'courseF_artist_for7_2018'
 level 'courseF_artist_for8_2018'
 level 'courseF_artist_for9_2018'
-assessment 'courseF_artist_for10_predict1_2018'
+level 'courseF_artist_for10_predict1_2018', assessment: true
 level 'courseF_artist_for10_2018'
 bonus 'courseF_artist_for_challenge1_2018'
 bonus 'courseF_artist_for_challenge2_2018'
@@ -261,7 +261,7 @@ level 'courseF_bee_fwp5_2018'
 level 'courseF_bee_fwp6_2018'
 level 'courseF_bee_fwp7_2018', challenge: true
 level 'courseF_bee_fwp8_2018'
-assessment 'courseF_bee_fwp9_predict1_2018'
+level 'courseF_bee_fwp9_predict1_2018', assessment: true
 bonus 'courseF_bee_fwp_challenge1_2018'
 bonus 'courseF_bee_fwp_challenge2_2018'
 

--- a/dashboard/config/scripts/coursea-draft.script
+++ b/dashboard/config/scripts/coursea-draft.script
@@ -70,7 +70,7 @@ level 'blockly:Jigsaw:11'
 skin 'jigsaw'
 level 'blockly:Jigsaw:12'
 skin 'jigsaw'
-assessment 'blockly:Jigsaw:13'
+level 'blockly:Jigsaw:13', assessment: true
 
 stage 'Programming: Happy Maps'
 level 'UnplugHappyMaps'

--- a/dashboard/config/scripts/courseb-draft.script
+++ b/dashboard/config/scripts/courseb-draft.script
@@ -71,7 +71,7 @@ level 'blockly:Jigsaw:11'
 skin 'jigsaw'
 level 'blockly:Jigsaw:12'
 skin 'jigsaw'
-assessment 'blockly:Jigsaw:13'
+level 'blockly:Jigsaw:13', assessment: true
 
 stage 'Your Digital Footprint'
 level 'DigitalFootprint'

--- a/dashboard/config/scripts/coursec-draft.script
+++ b/dashboard/config/scripts/coursec-draft.script
@@ -13,7 +13,7 @@ level 'courseC_maze_programming5'
 level 'courseC_maze_programming6'
 level 'courseC_maze_programming7', challenge: true
 level 'courseC_maze_programming8'
-assessment 'courseC_maze_programming8_predict1'
+level 'courseC_maze_programming8_predict1', assessment: true
 level 'courseC_maze_programming9'
 bonus 'courseC_maze_programming_challenge1', challenge: true
 bonus 'courseC_maze_programming_challenge2', challenge: true
@@ -27,7 +27,7 @@ level 'courseC_maze_debugging4'
 level 'courseC_maze_debugging5'
 level 'courseC_maze_debugging6'
 level 'courseC_maze_debugging7', challenge: true
-assessment 'courseC_maze_debugging8_predict1'
+level 'courseC_maze_debugging8_predict1', assessment: true
 level 'courseC_maze_debugging9'
 bonus 'courseC_maze_debugging_challenge1', challenge: true
 bonus 'courseC_maze_debugging_challenge2', challenge: true
@@ -47,7 +47,7 @@ level 'courseC_collector_prog7', challenge: true
 level 'courseC_collector_prog8'
 level 'courseC_collector_prog9'
 level 'grade2_collector_A'
-assessment 'grade2_collector_A_predict1'
+level 'grade2_collector_A_predict1', assessment: true
 level 'grade2_collector_10'
 bonus 'courseC_collector_prog_challenge1', challenge: true
 bonus 'courseC_collector_prog_challenge2', challenge: true
@@ -62,7 +62,7 @@ level 'courseC_artist_prog5'
 level 'courseC_artist_prog6'
 level 'courseC_artist_prog7', challenge: true
 level 'courseC_artist_prog8'
-assessment 'courseC_artist_prog6_predict1'
+level 'courseC_artist_prog6_predict1', assessment: true
 bonus 'courseC_artist_prog_challenge2', challenge: true
 
 stage 'Loops: Getting Loopy'
@@ -80,7 +80,7 @@ level 'courseC_maze_loops7'
 level 'courseC_maze_loops8', challenge: true
 level 'courseC_maze_loops9'
 level 'courseC_maze_loops10'
-assessment 'courseC_maze_loops10_predict2'
+level 'courseC_maze_loops10_predict2', assessment: true
 level 'courseC_maze_loops11'
 bonus 'courseC_maze_loops_challenge1'
 bonus 'courseC_collector_loops_challenge2'
@@ -97,7 +97,7 @@ level 'courseC_harvester_loops8', challenge: true
 level 'courseC_harvester_loops9'
 level 'courseC_harvester_loops10'
 level 'courseC_harvester_loops11'
-assessment 'courseC_harvester_loops11_predict1'
+level 'courseC_harvester_loops11_predict1', assessment: true
 bonus 'courseC_harvester_loops_challenge1'
 bonus 'courseC_harvester_loops_challenge2'
 

--- a/dashboard/config/scripts/coursed-draft.script
+++ b/dashboard/config/scripts/coursed-draft.script
@@ -67,7 +67,7 @@ level 'courseD_maze_nestedLoops6'
 level 'courseD_bee_nestedLoops7', challenge: true
 level 'courseD_bee_nestedLoops8'
 level 'courseD_bee_nestedLoops9'
-assessment 'courseD_bee_nestedLoops9_predict2'
+level 'courseD_bee_nestedLoops9_predict2', assessment: true
 
 stage 'Nested Loops in Artist'
 level 'courseD_artist_nestedLoops1'
@@ -81,7 +81,7 @@ level 'courseD_artist_nestedLoops7'
 level 'courseD_artist_nestedLoops8'
 level 'courseD_artist_nestedLoops9', challenge: true
 level 'courseD_artist_nestedLoops10'
-assessment 'courseD_artist_nestedLoops9_predict1'
+level 'courseD_artist_nestedLoops9_predict1', assessment: true
 level 'courseD_artist_nestedLoopsFP'
 
 stage 'Algorithms: Relay Programming'
@@ -98,7 +98,7 @@ level 'courseD_bee_debugging6', challenge: true
 level 'courseD_bee_debugging7'
 level 'courseD_bee_debugging8'
 level 'courseD_bee_debugging9'
-assessment 'courseD_bee_debugging9_predict1'
+level 'courseD_bee_debugging9_predict1', assessment: true
 
 stage 'While Loops in Farmer'
 level 'courseD_farmer_while1'
@@ -113,7 +113,7 @@ level 'courseD_farmer_while7'
 level 'courseD_farmer_while8', challenge: true
 level 'courseD_farmer_while9'
 level 'courseD_farmer_while10'
-assessment 'courseD_farmer_while10_predict2'
+level 'courseD_farmer_while10_predict2', assessment: true
 
 stage 'Conditionals with Cards'
 level 'Conditionals'
@@ -146,7 +146,7 @@ level 'courseD_video_ifElse'
 level 'courseD_maze_until8'
 level 'courseD_maze_until9', challenge: true
 level 'courseD_maze_until10'
-assessment 'courseD_maze_until10_predict2'
+level 'courseD_maze_until10_predict2', assessment: true
 
 stage 'Conditionals & Loops in Farmer'
 level 'courseD_farmer_condLoops1'
@@ -158,7 +158,7 @@ level 'courseD_farmer_condLoops6'
 level 'courseD_farmer_condLoops7', challenge: true
 level 'courseD_farmer_condLoops8'
 level 'courseD_farmer_condLoops9'
-assessment 'courseD_farmer_condLoops9_predict1'
+level 'courseD_farmer_condLoops9_predict1', assessment: true
 
 stage 'Digital Citizenship'
 level 'courseD_unplugged_digitalCitizenship'
@@ -185,5 +185,5 @@ level 'courseD_artist_binary5'
 level 'courseD_artist_binary6'
 level 'courseD_artist_binary7'
 level 'courseD_artist_binary8'
-assessment 'courseD_artist_binary8_predict1'
+level 'courseD_artist_binary8_predict1', assessment: true
 level 'courseD_artist_binaryFP'

--- a/dashboard/config/scripts/coursed-ramp.script
+++ b/dashboard/config/scripts/coursed-ramp.script
@@ -16,4 +16,4 @@ level 'courseD_collector_ramp10'
 level 'courseD_artist_ramp11'
 level 'courseD_artist_ramp12'
 level 'courseD_farmer_ramp13'
-assessment 'courseD_farmer_ramp14'
+level 'courseD_farmer_ramp14', assessment: true

--- a/dashboard/config/scripts/coursee-draft.script
+++ b/dashboard/config/scripts/coursee-draft.script
@@ -80,7 +80,7 @@ level 'courseE_artist_functions7'
 level 'courseE_artist_functions8', challenge: true
 level 'courseE_artist_functions9'
 level 'courseE_artist_functions10'
-assessment 'courseE_artist_functions_predict2'
+level 'courseE_artist_functions_predict2', assessment: true
 
 stage 'Functions in Bee'
 level 'courseE_bee_functions1'
@@ -95,7 +95,7 @@ level 'courseE_bee_functions7'
 level 'courseE_bee_functions8', challenge: true
 level 'courseE_bee_functions9'
 level 'courseE_bee_functions10'
-assessment 'courseE_bee_functions11_predict1'
+level 'courseE_bee_functions11_predict1', assessment: true
 
 stage 'Functions in Farmer'
 level 'courseE_farmer_functions1'
@@ -110,7 +110,7 @@ level 'courseE_farmer_functions7b'
 level 'courseE_farmer_functions8b', challenge: true
 level 'courseE_farmer_functions9b'
 level 'courseE_farmer_functions10b'
-assessment 'courseE_farmer_functions11_predict'
+level 'courseE_farmer_functions11_predict', assessment: true
 
 stage 'Determine the Concept'
 level 'courseE_bee_concept1'

--- a/dashboard/config/scripts/coursef-draft.script
+++ b/dashboard/config/scripts/coursef-draft.script
@@ -77,7 +77,7 @@ stage 'Variables in Play Lab'
 level 'courseF_playlab_variables1a'
 level 'courseF_playlab_variables2b'
 level 'courseF_playlab_variables3b_josh'
-assessment 'courseF_playlab_variables4c_predictive1'
+level 'courseF_playlab_variables4c_predictive1', assessment: true
 level 'courseF_playlab_variables4b'
 level 'courseF_playlab_variables5b'
 level 'courseF_playlab_variables6b'
@@ -111,7 +111,7 @@ level 'courseF_artist_for6'
 level 'courseF_artist_for7'
 level 'courseF_artist_for8'
 level 'courseF_artist_for9'
-assessment 'courseF_artist_for10_predict1'
+level 'courseF_artist_for10_predict1', assessment: true
 level 'courseF_artist_for10'
 
 stage 'Songwriting with Parameters'
@@ -163,7 +163,7 @@ level 'courseF_bee_fwp5'
 level 'courseF_bee_fwp6'
 level 'courseF_bee_fwp7', challenge: true
 level 'courseF_bee_fwp8'
-assessment 'courseF_bee_fwp9_predict1'
+level 'courseF_bee_fwp9_predict1', assessment: true
 
 stage 'Explore Project Ideas', flex_category: 'end_of_course_project'
 level 'courseF_video_csMatters', named: true

--- a/dashboard/config/scripts/csd-post-survey.script
+++ b/dashboard/config/scripts/csd-post-survey.script
@@ -4,4 +4,4 @@ exclude_csf_column_in_legend true
 has_verified_resources true
 
 stage 'CSD post-course survey', flex_category: 'csdSurvey'
-assessment 'csd-post-survey-2017-levelgroup-2018-2nd-semester', progression: 'CS Discoveries Post-course Survey'
+level 'csd-post-survey-2017-levelgroup-2018-2nd-semester', progression: 'CS Discoveries Post-course Survey', assessment: true

--- a/dashboard/config/scripts/csd-tests.script
+++ b/dashboard/config/scripts/csd-tests.script
@@ -11,7 +11,7 @@ level 'CSD U1 Test storage FR'
 level 'CSD U1 Test Feedback FR'
 level 'CSD U1 Test Collaborate FR'
 level 'CSD U1 Test Iteration FR'
-assessment 'CSD U1 Test'
+level 'CSD U1 Test', assessment: true
 
 stage 'Web Development'
 level 'CSD U2 Test HTML Usage'
@@ -24,7 +24,7 @@ level 'CSD U2 Test Copyright'
 level 'CSD U2 Test Bug FR'
 level 'CSD U2 Test Copyright FR'
 level 'CSD U2 Test DigCit FR'
-assessment 'CSD Web Development Post-Project Test'
+level 'CSD Web Development Post-Project Test', assessment: true
 
 stage 'Interactive Animations and Games'
 level 'CSD U3 Test clean code'
@@ -36,4 +36,4 @@ level 'CSD U3 Test comment'
 level 'CSD U3 Test debug FR'
 level 'CSD U3 Test parameter FR'
 level 'CSD U3 Test collaboration FR'
-assessment 'CSD Interactive Animations and Games Post-Project Test'
+level 'CSD Interactive Animations and Games Post-Project Test', assessment: true

--- a/dashboard/config/scripts/csd1-2017.script
+++ b/dashboard/config/scripts/csd1-2017.script
@@ -13,7 +13,7 @@ version_year '2017'
 is_stable true
 
 stage 'CS Discoveries Pre-survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csd-pre-survey-2017-levelgroup'
+level 'csd-pre-survey-2017-levelgroup', assessment: true
 
 stage 'Intro to Problem Solving', flex_category: 'csd1_1'
 level 'Unit 1 Lesson 1 Overview', named: true
@@ -42,4 +42,4 @@ level 'CSD U1 Lesson 8 Overview', named: true
 
 stage 'Project - Propose an App', flex_category: 'csd1_2'
 level 'CSD U1 Lesson 9 Overview', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U1Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U1Ch2', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd1-2018.script
+++ b/dashboard/config/scripts/csd1-2018.script
@@ -11,7 +11,7 @@ version_year '2018'
 is_stable true
 
 stage 'CS Discoveries Pre-survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csd-pre-survey-2017-levelgroup_2018'
+level 'csd-pre-survey-2017-levelgroup_2018', assessment: true
 
 stage 'Intro to Problem Solving', flex_category: 'csd1_1'
 level 'CSD U1L01 TFMD_2018', named: true
@@ -37,4 +37,4 @@ level 'CSD U1L07 TFMD_2018', named: true
 
 stage 'Project - Propose an App', flex_category: 'csd1_2'
 level 'CSD U1L09 TFMD_2018', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U1Ch2_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U1Ch2_2018', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd1-2019.script
+++ b/dashboard/config/scripts/csd1-2019.script
@@ -10,7 +10,7 @@ family_name 'csd1'
 version_year '2019'
 
 stage 'CS Discoveries Pre-survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csd-pre-survey-2017-levelgroup_2018_2019'
+level 'csd-pre-survey-2017-levelgroup_2018_2019', assessment: true
 
 stage 'Intro to Problem Solving', flex_category: 'csd1_1'
 level 'CSD U1L01 TFMD_2019', named: true
@@ -36,7 +36,7 @@ level 'CSD U1L07 TFMD_2019', named: true
 
 stage 'Project - Propose an App', flex_category: 'csd1_2'
 level 'CSD U1L09 TFMD_2019', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019', progression: 'Reflection', assessment: true
 
 stage 'Post-Project Test', lockable: true, flex_category: 'csd1_2'
-assessment 'CSD U1 Test'
+level 'CSD U1 Test', assessment: true

--- a/dashboard/config/scripts/csd2-2017.script
+++ b/dashboard/config/scripts/csd2-2017.script
@@ -88,7 +88,7 @@ level 'CSD U2 add content', progression: 'Website Project'
 level 'CSD U2 header footer', progression: 'Website Project'
 level 'CSD U2 project review', progression: 'Website Project'
 level 'CSD U2 project share', progression: 'Website Project'
-assessment 'csd-pulse-check-survey-1-levelgroup U2Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U2Ch1', progression: 'Reflection', assessment: true
 
 stage 'Styling Text with CSS', flex_category: 'csd2_2'
 level 'Unit 2 Lesson 7 Overview', named: true
@@ -139,7 +139,7 @@ level 'CSDU2 - PW - Class Style Personal Site', progression: 'Styling with Class
 stage 'Project - Personal Portfolio Website', flex_category: 'csd2_2'
 level 'Unit 2 Lesson 16 Overview', named: true
 level 'Final Personal Website', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U2Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U2Ch2', progression: 'Reflection', assessment: true
 
 stage 'CSD Post-Course Survey', lockable: true, flex_category: 'csd_survey'
-assessment 'csd-post-survey-2018-markdown-with-link-to-survey'
+level 'csd-post-survey-2018-markdown-with-link-to-survey', assessment: true

--- a/dashboard/config/scripts/csd2-2018.script
+++ b/dashboard/config/scripts/csd2-2018.script
@@ -87,7 +87,7 @@ level 'CSD U2 add content_2018', progression: 'Website Project'
 level 'CSD U2 header footer_2018', progression: 'Website Project'
 level 'CSD U2 project review_2018', progression: 'Website Project'
 level 'CSD U2 project share_2018', progression: 'Website Project'
-assessment 'csd-pulse-check-survey-1-levelgroup U2Ch1_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U2Ch1_2018', progression: 'Reflection', assessment: true
 
 stage 'Styling Text with CSS', flex_category: 'csd2_2'
 level 'CSD U2L10 TFMD_2018', named: true
@@ -138,4 +138,4 @@ level 'CSDU2 - PW - Class Style Personal Site_2018', progression: 'Styling with 
 stage 'Project - Personal Portfolio Website', flex_category: 'csd2_2'
 level 'CSD U2L14 TFMD_2018', named: true
 level 'Final Personal Website_2018', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U2Ch2_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U2Ch2_2018', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd2-2019.script
+++ b/dashboard/config/scripts/csd2-2019.script
@@ -25,7 +25,7 @@ level 'CSD U2 Inspector Warm Up_2019', named: true
 level 'Intro to Web Lab - Part 2_2019', named: true
 level 'CSD U2 HTML Tags Map_2019', named: true
 level 'CSD U2 HTML Adding Paragraphs_2019', progression: 'Using HTML Tags'
-assessment 'CSD U2 HTML Adding Paragraphs pt 2_2019', progression: 'Using HTML Tags'
+level 'CSD U2 HTML Adding Paragraphs pt 2_2019', progression: 'Using HTML Tags', assessment: true
 level 'CSD U2 HTML Debug Paragraphs_2019', progression: 'Using HTML Tags'
 
 stage 'Headings', flex_category: 'csd2_1'
@@ -33,8 +33,8 @@ level 'CSD U2L04 TFMD_2019', named: true
 level 'CSD U2 Pair Programming Video_2019', named: true
 level 'CSD U2 Heading Demo_2019', progression: 'Headings'
 level 'CSD U2 Heading Sizes_2019', progression: 'Headings'
-assessment 'CSD Header Size MC_2018_2019', progression: 'Headings'
-assessment 'CSD U2 Heading Test_2019', progression: 'Headings'
+level 'CSD Header Size MC_2018_2019', progression: 'Headings', assessment: true
+level 'CSD U2 Heading Test_2019', progression: 'Headings', assessment: true
 level 'CSD U2 Headers map_2019', named: true
 level 'CSD U2 PSP Programming_2018_2019', named: true
 level 'CSD U2 Design Project_2018_2019', progression: 'Your Personal Website'
@@ -49,8 +49,8 @@ level 'CSD U2L06 TFMD_2019', named: true
 level 'CSD U2 lists intro_2019', progression: 'Lists'
 level 'CSD U2 unordered list_2019', progression: 'Lists'
 level 'CSD U2 ordered list_2019', progression: 'Lists'
-assessment 'CSD U2 lists match_2018_2019', progression: 'Lists'
-assessment 'CSD U2 un_ordered lists', progression: 'Lists'
+level 'CSD U2 lists match_2018_2019', progression: 'Lists', assessment: true
+level 'CSD U2 un_ordered lists', progression: 'Lists', assessment: true
 level 'CSD U2 lists map_2019', named: true
 level 'CSD U2 expand project_2018_2019', progression: 'Expanding Your Website'
 level 'CSD U2 new page_2019', progression: 'Expanding Personal Website'
@@ -60,7 +60,7 @@ level 'CSD U2L07 TFMD_2019', named: true
 level 'CSD U2 Image Tag 1_2019', progression: 'Adding Images'
 level 'CSD U2 Image Tag Debug_2019', progression: 'Adding Images'
 level 'CSD U2 image debug match', progression: 'Adding Images'
-assessment 'CSD U2 Image Tag 2_2019', progression: 'Adding Images'
+level 'CSD U2 Image Tag 2_2019', progression: 'Adding Images', assessment: true
 level 'CSD U2 images map_2019', named: true
 level 'CSD U2 CC Search Map_2019', named: true
 level 'CSD U2 Image Tag Attribution_2019', progression: 'Attribution'
@@ -89,14 +89,14 @@ level 'CSD U2 header footer_2019', progression: 'Website Project'
 level 'CSD U2 project review_2019', progression: 'Website Project'
 level 'CSD U2 publish video', named: true
 level 'CSD U2 project share_2019', progression: 'Publishing Your Website', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019', progression: 'Reflection', assessment: true
 
 stage 'Styling Text with CSS', flex_category: 'csd2_2'
 level 'CSD U2L10 TFMD_2019', named: true
 level 'CSD U2 CSS explore CSS_2019', named: true
 level 'Video: Intro to CSS_2019', named: true
 level 'CSD U2 text style h1_2019', progression: 'Styling Text'
-assessment 'CSD U2 text style h3_2019', progression: 'Styling Text'
+level 'CSD U2 text style h3_2019', progression: 'Styling Text', assessment: true
 level 'CSD U2 Style Sheet Map_2019', named: true
 level 'CSD U2 text style size_2019', progression: 'Fonts and Style'
 level 'CSD U2 text style font family_2019', progression: 'Fonts and Style'
@@ -118,7 +118,7 @@ level 'CSD U2 layout style borderradius_2019', progression: 'Layout with CSS'
 level 'CSD U2 layout style float_2019', progression: 'Layout with CSS'
 level 'CSD U2 layout style width_2019', progression: 'Layout with CSS'
 level 'CSD U2 layout style margin_2019', progression: 'Layout with CSS'
-assessment 'CSD U2 add style_2019', progression: 'Layout with CSS'
+level 'CSD U2 add style_2019', progression: 'Layout with CSS', assessment: true
 level 'CSD U2 Layout Properties Map_2019', named: true
 level 'CSD U2 layout style freeplay_2019', progression: 'Styling your Website'
 
@@ -135,13 +135,13 @@ level 'CSD U2 classes sample_2019', progression: 'RGB Exploration'
 level 'CSD U2 CSS Classes Map_2019', named: true
 level 'CSD U2 classes modify_2019', progression: 'Styling with Classes'
 level 'CSD U2 classes spring_2019', progression: 'Styling with Classes'
-assessment 'CSD U2 classes summer_2019', progression: 'Styling with Classes'
+level 'CSD U2 classes summer_2019', progression: 'Styling with Classes', assessment: true
 level 'CSDU2 - PW - Class Style Personal Site_2019', progression: 'Styling with Classes'
 
 stage 'Project - Personal Portfolio Website', flex_category: 'csd2_2'
 level 'CSD U2L14 TFMD_2019', named: true
 level 'Final Personal Website_2019', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019', progression: 'Reflection', assessment: true
 
 stage 'Post-Project Test', lockable: true, flex_category: 'csd2_2'
-assessment 'CSD Web Development Post-Project Test'
+level 'CSD Web Development Post-Project Test', assessment: true

--- a/dashboard/config/scripts/csd3-1819draft.script
+++ b/dashboard/config/scripts/csd3-1819draft.script
@@ -174,7 +174,7 @@ level 'CSD U3 Interactive Card Sprites', progression: 'Project Work'
 level 'CSD U3 Interactive Card User Input', progression: 'Project Work'
 level 'CSD U3 Interactive Card Other Conditionals', progression: 'Project Work'
 level 'CSD U3 Interactive Card Final', progression: 'Project Work'
-assessment 'csd-pulse-check-survey-1-levelgroup U3Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U3Ch1', progression: 'Reflection', assessment: true
 
 stage 'Velocity', flex_category: 'csd3_2'
 level 'CSD U3 SFLP Velocity', named: true
@@ -312,7 +312,7 @@ level 'CSD U3 game sprite movement', progression: 'Project - Sprites and Interac
 level 'CSD U3 game user controls', progression: 'Project - Sprites and Interactions'
 level 'CSD U3 game interactions', progression: 'Project - Sprites and Interactions'
 level 'CSD U3 finishing touches', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U3Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U3Ch2', progression: 'Reflection', assessment: true
 
 stage 'CS Discoveries End of Semester Survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csd-post-survey-2017-levelgroup'
+level 'csd-post-survey-2017-levelgroup', assessment: true

--- a/dashboard/config/scripts/csd3-2017.script
+++ b/dashboard/config/scripts/csd3-2017.script
@@ -182,7 +182,7 @@ level 'CSD U3 Interactive Card Sprites', progression: 'Project Work'
 level 'CSD U3 Interactive Card User Input', progression: 'Project Work'
 level 'CSD U3 Interactive Card Other Conditionals', progression: 'Project Work'
 level 'CSD U3 Interactive Card Final', progression: 'Project Work'
-assessment 'csd-pulse-check-survey-1-levelgroup U3Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U3Ch1', progression: 'Reflection', assessment: true
 
 stage 'Velocity', flex_category: 'csd3_2'
 level 'CSD U3 SFLP Velocity', named: true
@@ -320,10 +320,10 @@ level 'CSD U3 game sprite movement', progression: 'Project - Sprites and Interac
 level 'CSD U3 game user controls', progression: 'Project - Sprites and Interactions'
 level 'CSD U3 game interactions', progression: 'Project - Sprites and Interactions'
 level 'CSD U3 finishing touches', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U3Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U3Ch2', progression: 'Reflection', assessment: true
 
 stage 'CS Discoveries End of Semester Survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csd-post-survey-2017-levelgroup'
+level 'csd-post-survey-2017-levelgroup', assessment: true
 
 stage 'CSD Post-Course Survey', lockable: true, flex_category: 'csd_survey'
-assessment 'csd-post-survey-2018-markdown-with-link-to-survey'
+level 'csd-post-survey-2018-markdown-with-link-to-survey', assessment: true

--- a/dashboard/config/scripts/csd3-2018.script
+++ b/dashboard/config/scripts/csd3-2018.script
@@ -189,7 +189,7 @@ level 'CSD U3 Interactive Card Sprites_2018', progression: 'Project Work'
 level 'CSD U3 Interactive Card User Input_2018', progression: 'Project Work'
 level 'CSD U3 Interactive Card Other Conditionals_2018', progression: 'Project Work'
 level 'CSD U3 Interactive Card Final_2018', progression: 'Project Work'
-assessment 'csd-pulse-check-survey-1-levelgroup U3Ch1_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U3Ch1_2018', progression: 'Reflection', assessment: true
 
 stage 'Velocity', flex_category: 'csd3_2'
 level 'CSD U3L15 TFMD_2018', named: true
@@ -327,7 +327,7 @@ level 'CSD U3 game sprite movement_2018', progression: 'Project - Sprites and In
 level 'CSD U3 game user controls_2018', progression: 'Project - Sprites and Interactions'
 level 'CSD U3 game interactions_2018', progression: 'Project - Sprites and Interactions'
 level 'CSD U3 finishing touches_2018', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U3Ch2_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U3Ch2_2018', progression: 'Reflection', assessment: true
 
 stage 'CS Discoveries End of Semester Survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csd-post-survey-2017-levelgroup_2018'
+level 'csd-post-survey-2017-levelgroup_2018', assessment: true

--- a/dashboard/config/scripts/csd3-2019.script
+++ b/dashboard/config/scripts/csd3-2019.script
@@ -32,7 +32,7 @@ level 'CSD: Drawing in Game Lab 2_2019', named: true
 level 'CSD U3 fill_2019', progression: 'Drawing'
 level 'CSD U3 sequence_2019', progression: 'Drawing'
 level 'CSD U3 ellipse_2019', progression: 'Drawing'
-assessment 'CSD U3 debug_2019', progression: 'Drawing'
+level 'CSD U3 debug_2019', progression: 'Drawing', assessment: true
 level 'CSD U3 plotting shapes map_2019', named: true
 bonus 'CSD U3 picture_2019', progression: 'Challenges'
 bonus 'CSD U3 challenge face_2019', progression: 'Challenges'
@@ -46,11 +46,11 @@ level 'CSD U3 Random Ellipse Behind_2018_2019', progression: 'More Parameters'
 level 'CSD U3 Random background_2019', progression: 'More Parameters'
 level 'CSD U3 Random background2_2019', progression: 'More Parameters'
 level 'CSD U3 Random Debug Grass_2019', progression: 'More Parameters'
-assessment 'CSD U3 Random Debug Cloud_2018_2019', progression: 'More Parameters'
+level 'CSD U3 Random Debug Cloud_2018_2019', progression: 'More Parameters', assessment: true
 level 'CSD U3 shape size map_2019', named: true
 level 'CSD U3 Random random ellipse_2018_2019', progression: 'More Parameters'
 level 'CSD U3 Random random ellipse2_2018_2019', progression: 'Using Random Numbers'
-assessment 'CSD U3 Random rainbow snake_2018_2019', progression: 'Using Random Numbers'
+level 'CSD U3 Random rainbow snake_2018_2019', progression: 'Using Random Numbers', assessment: true
 level 'CSD U3 Random Number Map Level_2019', named: true
 bonus 'CSD U3 L4 Freeplay_2019'
 
@@ -63,7 +63,7 @@ level 'CSD U3 Variables change circle size_2019', progression: 'Intro to Variabl
 level 'CSD U3 Variables Draw Poppy_2019', progression: 'Intro to Variables'
 level 'CSD U3 Variables Map_2019', named: true
 level 'CSD U3 Variables naming rules v2_2018_2019', progression: 'Intro to Variables'
-assessment 'CSD U3 Variables random with assignment_2019', progression: 'Intro to Variables'
+level 'CSD U3 Variables random with assignment_2019', progression: 'Intro to Variables', assessment: true
 level 'CSD U3 naming map_2019', named: true
 bonus 'CSD U3 Variables Draw Challenge_2019'
 bonus 'CSD U3 Variables Challenge_2019'
@@ -81,12 +81,12 @@ level 'CSD U3 Animation Tab Map_2019', named: true
 level 'CSD U3 Sprites anitab 1_2019', progression: 'Adding Images'
 level 'CSD U3 Sprites anitab 2_2019', progression: 'Adding Images'
 level 'CSD U3 Sprites anitab 3_2019', progression: 'Adding Images'
-assessment 'CSD U3 drawSprites placement match_2019', progression: 'Adding Images'
+level 'CSD U3 drawSprites placement match_2019', progression: 'Adding Images', assessment: true
 level 'CSD U3 Sprites text_2019', progression: 'Making Scenes'
 level 'CSD U3 Sprites text debug_2018_2019', progression: 'Making Scenes'
 level 'CSD U3 Scene Example_2018_2019', named: true
 level 'CSD U3 Sprites scene drawing_2019', progression: 'Making Scenes'
-assessment 'CSD U3 Sprites scene sprites_2019', progression: 'Making Scenes'
+level 'CSD U3 Sprites scene sprites_2019', progression: 'Making Scenes', assessment: true
 level 'CSD U3 Sprites scene text_2019', progression: 'Making Scenes'
 bonus 'CSD U3 Sprites scene challenge_2019'
 bonus 'CSD U3 L6 Freeplay_2019'
@@ -103,7 +103,7 @@ level 'CSD U3 Sprite Properties Map_2019', named: true
 level 'CSD U3 Draw Loop Plugged wiggle sprite x_2019', progression: 'Sprites and the Draw Loop'
 level 'CSD U3 Draw Loop Plugged wiggle sprite y_2019', progression: 'Sprites and the Draw Loop'
 level 'CSD U3 Draw Loop Plugged wiggle sprite rotation_2019', progression: 'Sprites and the Draw Loop'
-assessment 'CSD U3 Draw Loop Plugged update your scene_2019', progression: 'Animate Your Scene'
+level 'CSD U3 Draw Loop Plugged update your scene_2019', progression: 'Animate Your Scene', assessment: true
 bonus 'CSD U3 L7 Freeplay_2019'
 
 stage 'The Counter Pattern Unplugged', flex_category: 'csd3_1'
@@ -115,7 +115,7 @@ level 'CSD: Animating Sprite Movement_2019', named: true
 level 'CSD U3 - Simple Counter Predict_2019', progression: 'Movement with the Counter Pattern'
 level 'CSD U3 Sprite Movement Right_2019', progression: 'Movement with the Counter Pattern'
 level 'CSD U3 Sprite Movement Left_2019', progression: 'Movement with the Counter Pattern'
-assessment 'CSD U3 Sprite Movement Predict_2019', progression: 'Movement with the Counter Pattern'
+level 'CSD U3 Sprite Movement Predict_2019', progression: 'Movement with the Counter Pattern', assessment: true
 level 'CSD U3 Diagonal Movement_2019', progression: 'Movement with the Counter Pattern'
 level 'CSD Counter Pattern Map_2019', named: true
 level 'CSD U3 Watcher Predict_2019', progression: 'Animating Sprites'
@@ -124,7 +124,7 @@ level 'CSD U3 Movement Fish_2019', progression: 'Animating Sprites'
 level 'CSD U3 Movement Gears_2019', progression: 'Animating Sprites'
 level 'CSD U3 Watchers Map_2019', named: true
 level 'CSD U3 Movement Your Own 1_2019', progression: 'Create Your Own Animation'
-assessment 'CSD U3 Movement Your Own 2_2019', progression: 'Create Your Own Animation'
+level 'CSD U3 Movement Your Own 2_2019', progression: 'Create Your Own Animation', assessment: true
 bonus 'CSD sprite movement challenge_2019'
 bonus 'CSD U3 Movement Fish challenge_2019'
 bonus 'CSD U3 L9 Freeplay_2019'
@@ -143,7 +143,7 @@ level 'CSD U3 Conditionals Apple_2018_2019', progression: 'Boolean Comparison'
 level 'CSD Booleans Map_2019', named: true
 level 'csd U3 conditional statements video_2019', named: true
 level 'CSD U3 - conditionals - first conditional_2019', progression: 'Basic Conditionals'
-assessment 'CSD U3 Conditionals Apple 2_2018_2019', progression: 'Basic Conditionals'
+level 'CSD U3 Conditionals Apple 2_2018_2019', progression: 'Basic Conditionals', assessment: true
 level 'CSD If Statements Map_2019', named: true
 bonus 'CSD U3 - conditionals - first conditional 2_2018_2019'
 bonus 'CSD U3 L11 Freeplay_2019'
@@ -155,7 +155,7 @@ level 'CSD U3 keydown conditional_2018_2019', progression: 'Keyboard Input'
 level 'CSD U3 UP_ARROW_2018_2019', progression: 'Keyboard Input'
 level 'CSD U3 Input Fish_2019', progression: 'Keyboard Input'
 level 'CSD U3 Input Gears_2019', progression: 'Keyboard Input'
-assessment 'CSD U3 Direction Arrows_2018_2019', progression: 'Keyboard Input'
+level 'CSD U3 Direction Arrows_2018_2019', progression: 'Keyboard Input', assessment: true
 level 'CSD U3 Animation Edit Map_2019', named: true
 level 'CSD U3 Direction Animations_2018_2019', progression: 'Keyboard Input'
 bonus 'CSD U3 Keyboard Input Challenge_2018_2019'
@@ -166,7 +166,7 @@ level 'CSD U3L13 TFMD_2019', named: true
 level 'CSD U3 if else predict', named: true
 level 'CSD U3 - Conditionals Video_2019', named: true
 level 'CSD U3 If Else_2019', progression: 'Input with If-Else'
-assessment 'CSD U3 Else_2019', progression: 'Input with If-Else'
+level 'CSD U3 Else_2019', progression: 'Input with If-Else', assessment: true
 level 'CSD If Else Map_2019', named: true
 level 'CSD U3 Mouse Input Bee 1_2019', progression: 'More Input'
 level 'CSD U3 Mouse Input Bee 2_2019', progression: 'More Input'
@@ -187,7 +187,7 @@ level 'CSD U3 Interactive Card Sprites_2019', progression: 'Project Work'
 level 'CSD U3 Interactive Card User Input_2019', progression: 'Project Work'
 level 'CSD U3 Interactive Card Other Conditionals_2019', progression: 'Project Work'
 level 'CSD U3 Interactive Card Final_2019', progression: 'Project Work'
-assessment 'csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019', progression: 'Reflection', assessment: true
 
 stage 'Velocity', flex_category: 'csd3_2'
 level 'CSD U3L15 TFMD_2019', named: true
@@ -212,7 +212,7 @@ level 'CSD U3 collisions build isTouching_2019', named: true
 level 'CSD U3 collisions isTouching intro_2019', progression: 'isTouching'
 level 'CSD U3 collisions egg_2019', progression: 'isTouching'
 level 'CSD U3 collisions egg2_2019', progression: 'isTouching'
-assessment 'CSD U3 collisions horse_2019', progression: 'isTouching'
+level 'CSD U3 collisions horse_2019', progression: 'isTouching', assessment: true
 level 'CSD U3 collisions debug isTouching_2019', progression: 'isTouching'
 level 'CSD U3 collisions scoreboard_2019', progression: 'Collisions in Games'
 level 'CSD U3 collisions sidescroll2_2019', progression: 'Collisions in Games'
@@ -226,7 +226,7 @@ level 'CSD U3 abstraction accelerateX_2019', progression: 'Velocity and the Coun
 level 'CSD U3 abstraction accelerateY_2019', progression: 'Velocity and the Counter Pattern'
 level 'CSD U3 abstraction accelerateY up_2019', progression: 'Velocity and the Counter Pattern'
 level 'CSD U3 abstraction decelerateX_2019', progression: 'Velocity and the Counter Pattern'
-assessment 'CSD U3 abstraction decelerateY_2019', progression: 'Velocity and the Counter Pattern'
+level 'CSD U3 abstraction decelerateY_2019', progression: 'Velocity and the Counter Pattern', assessment: true
 level 'CSD U3 abstraction jumping_2019', progression: 'Flyer Game'
 level 'CSD U3 abstraction left right counter_2019', progression: 'Flyer Game'
 level 'CSD U3 abstraction left right counter 2_2019', progression: 'Flyer Game'
@@ -252,7 +252,7 @@ level 'CSD U3 collisions flyman add obstacles_2019', progression: 'Flyer Game'
 level 'CSD U3 collisions flyman bounceOff_2019', progression: 'Flyer Game'
 level 'CSD U3 collisions flyman displace coin_2019', progression: 'Flyer Game'
 level 'CSD U3 collisions flyman change colliders_2019', progression: 'Flyer Game'
-assessment 'CSD U3 collisions flyman make it your own_2019', progression: 'Flyer Game'
+level 'CSD U3 collisions flyman make it your own_2019', progression: 'Flyer Game', assessment: true
 level 'CSD U3 interactions map_2019', named: true
 bonus 'CSD U3 L18 Freeplay_2019'
 
@@ -268,7 +268,7 @@ level 'CSD U3 Functions Randomize Sprite_2019', progression: 'Functions'
 level 'CSD U3 Functions Create Function_2019', progression: 'Functions'
 level 'CSD U3 Functions Write Reset_2019', progression: 'Collector Game'
 level 'CSD U3 Functions Add IsTouching_2019', progression: 'Collector Game'
-assessment 'CSD U3 Functions Add Change Background_2019', progression: 'Collector Game'
+level 'CSD U3 Functions Add Change Background_2019', progression: 'Collector Game', assessment: true
 level 'CSD U3 functions review_2019', named: true
 bonus 'CSD U3 L19 Freeplay_2019'
 
@@ -311,7 +311,7 @@ level 'CSD U3 platform player3_2019', progression: 'Platform Jumper - Player'
 level 'CSD U3 platform player4_2019', progression: 'Platform Jumper - Player'
 level 'CSD U3 platform sample2_2019', named: true
 level 'CSD U3 platform sample3_2019', named: true
-assessment 'CSD U3 platform challenge_2019'
+level 'CSD U3 platform challenge_2019', assessment: true
 
 stage 'Project - Design a Game', flex_category: 'csd3_2'
 level 'CSD U3L22 TFMD_2019', named: true
@@ -326,10 +326,10 @@ level 'CSD U3 game sprite movement_2019', progression: 'Project - Sprites and In
 level 'CSD U3 game user controls_2019', progression: 'Project - Sprites and Interactions'
 level 'CSD U3 game interactions_2019', progression: 'Project - Sprites and Interactions'
 level 'CSD U3 finishing touches_2019', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019', progression: 'Reflection', assessment: true
 
 stage 'Post-Project Test', lockable: true, flex_category: 'csd3_2'
-assessment 'CSD Interactive Animations and Games Post-Project Test'
+level 'CSD Interactive Animations and Games Post-Project Test', assessment: true
 
 stage 'CS Discoveries End of Semester Survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csd-post-survey-2017-levelgroup_2018_2019'
+level 'csd-post-survey-2017-levelgroup_2018_2019', assessment: true

--- a/dashboard/config/scripts/csd4-2017.script
+++ b/dashboard/config/scripts/csd4-2017.script
@@ -31,7 +31,7 @@ level 'CSD U4L06 SFLP', named: true
 
 stage 'Project - Paper Prototype', flex_category: 'csd4_1'
 level 'CSD U4L07 SFLP', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch1', progression: 'Reflection', assessment: true
 
 stage 'Designing Apps for Good', flex_category: 'csd4_2'
 level 'CSD U4L08 SFLP', named: true
@@ -63,7 +63,7 @@ level 'U4 Model Design 5', progression: 'Finish a Screen'
 level 'U4 Model Design 6', progression: 'Finish a Screen'
 level 'U4 Model Design 7', progression: 'Finish a Screen'
 level 'Design a Screen for your App', named: true
-assessment 'CSD U4 - Design Mode Project', progression: 'App Project: Screen Design'
+level 'CSD U4 - Design Mode Project', progression: 'App Project: Screen Design', assessment: true
 
 stage 'Linking Screens', flex_category: 'csd4_2'
 level 'CSD U4L13 SFLP', named: true
@@ -90,7 +90,7 @@ level 'CSDU4 Project Bug Feature', named: true
 
 stage 'Project - App Presentation', flex_category: 'csd4_2'
 level 'CSD U4L17 SFLP', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch2', progression: 'Reflection', assessment: true
 
 stage 'CSD Post-Course Survey', lockable: true, flex_category: 'csd_survey'
-assessment 'csd-post-survey-2018-markdown-with-link-to-survey'
+level 'csd-post-survey-2018-markdown-with-link-to-survey', assessment: true

--- a/dashboard/config/scripts/csd4-2018.script
+++ b/dashboard/config/scripts/csd4-2018.script
@@ -30,7 +30,7 @@ level 'CSD U4L06 autoSFLP_2018', named: true
 
 stage 'Project - Paper Prototype', flex_category: 'csd4_1'
 level 'CSD U4L07 autoSFLP_2018', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch1_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch1_2018', progression: 'Reflection', assessment: true
 
 stage 'Designing Apps for Good', flex_category: 'csd4_2'
 level 'CSD U4L08 autoSFLP_2018', named: true
@@ -62,7 +62,7 @@ level 'U4 Model Design 5_2018', progression: 'Finish a Screen'
 level 'U4 Model Design 6_2018', progression: 'Finish a Screen'
 level 'U4 Model Design 7_2018', progression: 'Finish a Screen'
 level 'Design a Screen for your App_2018', named: true
-assessment 'CSD U4 - Design Mode Project_2018', progression: 'App Project: Screen Design'
+level 'CSD U4 - Design Mode Project_2018', progression: 'App Project: Screen Design', assessment: true
 
 stage 'Linking Screens', flex_category: 'csd4_2'
 level 'CSD U4L13 autoSFLP_2018', named: true
@@ -89,4 +89,4 @@ level 'CSDU4 Project Bug Feature_2018', named: true
 
 stage 'Project - App Presentation', flex_category: 'csd4_2'
 level 'CSD U4L16 autoSFLP_2018', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch2_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch2_2018', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd4-2019.script
+++ b/dashboard/config/scripts/csd4-2019.script
@@ -28,7 +28,7 @@ level 'CSD U4L06 autoSFLP_2019', named: true
 
 stage 'Project - Paper Prototype', flex_category: 'csd4_1'
 level 'CSD U4L07 autoSFLP_2019', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019', progression: 'Reflection', assessment: true
 
 stage 'Designing Apps for Good', flex_category: 'csd4_2'
 level 'CSD U4L08 autoSFLP_2019', named: true
@@ -60,7 +60,7 @@ level 'U4 Model Design 5_2019', progression: 'Finish a Screen'
 level 'U4 Model Design 6_2019', progression: 'Finish a Screen'
 level 'U4 Model Design 7_2019', progression: 'Finish a Screen'
 level 'Design a Screen for your App_2018_2019', named: true
-assessment 'CSD U4 - Design Mode Project_2019', progression: 'App Project: Screen Design'
+level 'CSD U4 - Design Mode Project_2019', progression: 'App Project: Screen Design', assessment: true
 
 stage 'Linking Screens', flex_category: 'csd4_2'
 level 'CSD U4L13 autoSFLP_2019', named: true
@@ -87,4 +87,4 @@ level 'CSDU4 Project Bug Feature_2019', named: true
 
 stage 'Project - App Presentation', flex_category: 'csd4_2'
 level 'CSD U4L16 autoSFLP_2019', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd4-draft.script
+++ b/dashboard/config/scripts/csd4-draft.script
@@ -22,7 +22,7 @@ level 'CSD U4L06 SFLP', named: true
 
 stage 'Project - Paper Prototype', flex_category: 'csd4_1'
 level 'CSD U4L07 SFLP', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch1', progression: 'Reflection', assessment: true
 
 stage 'Designing Apps for Good', flex_category: 'csd4_2'
 level 'CSD U4L08 SFLP', named: true
@@ -54,7 +54,7 @@ level 'U4 Model Design 5', progression: 'Finish a Screen'
 level 'U4 Model Design 6', progression: 'Finish a Screen'
 level 'U4 Model Design 7', progression: 'Finish a Screen'
 level 'Design a Screen for your App', named: true
-assessment 'CSD U4 - Design Mode Project', progression: 'App Project: Screen Design'
+level 'CSD U4 - Design Mode Project', progression: 'App Project: Screen Design', assessment: true
 
 stage 'Linking Screens', flex_category: 'csd4_2'
 level 'CSD U4L13 SFLP', named: true
@@ -81,4 +81,4 @@ level 'CSDU4 Project Bug Feature', named: true
 
 stage 'App Presentation', flex_category: 'csd4_2'
 level 'CSD U4L17 SFLP', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch2', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd4-old.script
+++ b/dashboard/config/scripts/csd4-old.script
@@ -23,7 +23,7 @@ level 'CSD U4L06 SFLP', named: true
 
 stage 'Project - Paper Prototype', flex_category: 'csd4_1'
 level 'CSD U4L07 SFLP', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch1', progression: 'Reflection', assessment: true
 
 stage 'Designing Apps for Good', flex_category: 'csd4_2'
 level 'CSD U4L08 SFLP', named: true
@@ -99,4 +99,4 @@ level 'CSDU4 Project Bug Feature', named: true
 
 stage 'App Presentation', flex_category: 'csd4_2'
 level 'CSD U4L17 SFLP', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U4Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U4Ch2', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd5-2017.script
+++ b/dashboard/config/scripts/csd5-2017.script
@@ -50,7 +50,7 @@ level 'CSD U5 student record', progression: 'Combining Representations'
 
 stage 'Project - Create a Representation', flex_category: 'csd5_1'
 level 'CSD-U5-SFLP Create a Representation', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch1', progression: 'Reflection', assessment: true
 
 stage 'Problem Solving and Data', flex_category: 'csd5_2'
 level 'CSD-U5-SFLP Problem Solving and Data', named: true
@@ -79,7 +79,7 @@ level 'CSD-U5-SFLP Automating Data Decisions', named: true
 
 stage 'Project - Solve a Data Problem', flex_category: 'csd5_2'
 level 'CSD-U5-SFLP Solve a Data Problem', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch2', progression: 'Reflection', assessment: true
 
 stage 'CSD Post-Course Survey', lockable: true, flex_category: 'csd_survey'
-assessment 'csd-post-survey-2018-markdown-with-link-to-survey'
+level 'csd-post-survey-2018-markdown-with-link-to-survey', assessment: true

--- a/dashboard/config/scripts/csd5-2018.script
+++ b/dashboard/config/scripts/csd5-2018.script
@@ -49,7 +49,7 @@ level 'CSD U5 student record_2018', progression: 'Combining Representations'
 
 stage 'Project - Create a Representation', flex_category: 'csd5_1'
 level 'CSD U5L08 autoSFLP_2018', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch1_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch1_2018', progression: 'Reflection', assessment: true
 
 stage 'Problem Solving and Data', flex_category: 'csd5_2'
 level 'CSD U5L09 autoSFLP_2018', named: true
@@ -79,4 +79,4 @@ level 'CSD U5L14 autoSFLP_2018', named: true
 stage 'Project - Solve a Data Problem', flex_category: 'csd5_2'
 level 'CSD U5L15 autoSFLP_2018', named: true
 level 'csd u5 recommender sample', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch2_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch2_2018', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd5-2019.script
+++ b/dashboard/config/scripts/csd5-2019.script
@@ -47,7 +47,7 @@ level 'CSD U5 student record_2018_2019', progression: 'Combining Representations
 
 stage 'Project - Create a Representation', flex_category: 'csd5_1'
 level 'CSD U5L08 autoSFLP_2019', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019', progression: 'Reflection', assessment: true
 
 stage 'Problem Solving and Data', flex_category: 'csd5_2'
 level 'CSD U5L09 autoSFLP_2019', named: true
@@ -77,4 +77,4 @@ level 'CSD U5L14 autoSFLP_2019', named: true
 stage 'Project - Solve a Data Problem', flex_category: 'csd5_2'
 level 'CSD U5L15 autoSFLP_2019', named: true
 level 'csd u5 recommender sample_2019', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd5-draft.script
+++ b/dashboard/config/scripts/csd5-draft.script
@@ -36,7 +36,7 @@ level 'CSD U5 student record', progression: 'Combining Representations'
 
 stage 'Project - Create a Representation', flex_category: 'csd5_1'
 level 'CSD-U5-SFLP Create a Representation', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch1', progression: 'Reflection', assessment: true
 
 stage 'Problem Solving and Data', flex_category: 'csd5_2'
 level 'CSD-U5-SFLP Problem Solving and Data', named: true
@@ -67,4 +67,4 @@ level 'CSD-U5-SFLP Automating Data Decisions', named: true
 
 stage 'Project - Solve a Data Problem', flex_category: 'csd5_2'
 level 'CSD-U5-SFLP Solve a Data Problem', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch2', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd5-old.script
+++ b/dashboard/config/scripts/csd5-old.script
@@ -32,7 +32,7 @@ level 'CSD U5 student record', progression: 'Combining Representations'
 
 stage 'Project - Create a Representation', flex_category: 'csd5_1'
 level 'CSD-U5-SFLP Create a Representation', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch1', progression: 'Reflection', assessment: true
 
 stage 'Problem Solving and Data', flex_category: 'csd5_2'
 level 'CSD-U5-SFLP Problem Solving and Data', named: true
@@ -57,4 +57,4 @@ level 'CSD U5 collection ads2', progression: 'Problem Solving'
 
 stage 'Project - Solve a Data Problem', flex_category: 'csd5_2'
 level 'CSD-U5-SFLP Solve a Data Problem', named: true
-assessment 'csd-pulse-check-survey-1-levelgroup U5Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U5Ch2', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd6-2017.script
+++ b/dashboard/config/scripts/csd6-2017.script
@@ -130,7 +130,7 @@ level 'CSD U6 game project board events', progression: 'Events'
 level 'CSD U6 game project functions define', progression: 'Functions'
 level 'CSD U6 game project functions call', progression: 'Functions'
 level 'CSD U6 game project finish', progression: 'Finishing Touches'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch1', progression: 'Reflection', assessment: true
 
 stage 'Arrays and Color LEDs__', flex_category: 'csd6_2'
 level 'CSD U6L10 TFMD', named: true
@@ -240,7 +240,7 @@ level 'CSDU6 - final project 3', progression: 'Board Input and Output'
 level 'CSDU6 - final project 5', progression: 'Board Input and Output'
 level 'CSDU6 - final project 4', progression: 'Finishing Touches'
 level 'CSDU6 - final project 6', progression: 'Finishing Touches'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch2', progression: 'Reflection', assessment: true
 
 stage 'CSD Post-Course Survey', lockable: true, flex_category: 'csd_survey'
-assessment 'csd-post-survey-2018-markdown-with-link-to-survey'
+level 'csd-post-survey-2018-markdown-with-link-to-survey', assessment: true

--- a/dashboard/config/scripts/csd6-2018.script
+++ b/dashboard/config/scripts/csd6-2018.script
@@ -133,7 +133,7 @@ level 'CSD U6 game project board events_2018', progression: 'Events'
 level 'CSD U6 game project functions define_2018', progression: 'Functions'
 level 'CSD U6 game project functions call_2018', progression: 'Functions'
 level 'CSD U6 game project finish_2018', progression: 'Finishing Touches'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch1_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch1_2018', progression: 'Reflection', assessment: true
 
 stage 'Arrays and Color LEDs', flex_category: 'csd6_2'
 level 'CSD U6L10 TFMD_2018', named: true
@@ -251,4 +251,4 @@ level 'CSDU6 - final project 3_2018', progression: 'Board Input and Output'
 level 'CSDU6 - final project 5_2018', progression: 'Board Input and Output'
 level 'CSDU6 - final project 4_2018', progression: 'Finishing Touches'
 level 'CSDU6 - final project 6_2018', progression: 'Finishing Touches'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch2_2018', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch2_2018', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd6-2019.script
+++ b/dashboard/config/scripts/csd6-2019.script
@@ -131,7 +131,7 @@ level 'CSD U6 game project board events_2019', progression: 'Events'
 level 'CSD U6 game project functions define_2019', progression: 'Functions'
 level 'CSD U6 game project functions call_2019', progression: 'Functions'
 level 'CSD U6 game project finish_2019', progression: 'Finishing Touches'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019', progression: 'Reflection', assessment: true
 
 stage 'Arrays and Color LEDs', flex_category: 'csd6_2'
 level 'CSD U6L10 TFMD_2019', named: true
@@ -250,4 +250,4 @@ level 'CSDU6 - final project 3_2019', progression: 'Board Input and Output'
 level 'CSDU6 - final project 5_2019', progression: 'Board Input and Output'
 level 'CSDU6 - final project 4_2019', progression: 'Finishing Touches'
 level 'CSDU6 - final project 6_2019', progression: 'Finishing Touches'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd6-draft.script
+++ b/dashboard/config/scripts/csd6-draft.script
@@ -125,7 +125,7 @@ level 'CSD U6 game project board events', progression: 'Events'
 level 'CSD U6 game project functions define', progression: 'Functions'
 level 'CSD U6 game project functions call', progression: 'Functions'
 level 'CSD U6 game project finish', progression: 'Finishing Touches'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch1', progression: 'Reflection', assessment: true
 
 stage 'Arrays', flex_category: 'csd6_2'
 level 'CSD U6L10 TFMD', named: true
@@ -244,4 +244,4 @@ level 'CSDU6 - final project 3', progression: 'Board Input and Output'
 level 'CSDU6 - final project 5', progression: 'Board Input and Output'
 level 'CSDU6 - final project 4', progression: 'Finishing Touches'
 level 'CSDU6 - final project 6', progression: 'Finishing Touches'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch2', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csd6-old.script
+++ b/dashboard/config/scripts/csd6-old.script
@@ -125,7 +125,7 @@ level 'CSDU6 - ch 1 project events', progression: 'Project Work'
 level 'CSDU6 - ch 1 project functions', progression: 'Project Work'
 level 'CSDU6 - ch 1 project output', progression: 'Project Work'
 level 'CSDU6 - ch 1 project finish', progression: 'Project Work'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch1', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch1', progression: 'Reflection', assessment: true
 
 stage 'Physical Input', flex_category: 'csd6_2'
 level 'CSD onBoardEvent Map', named: true
@@ -180,4 +180,4 @@ level 'CSDU6 - final project 3', progression: 'Project Work'
 level 'CSDU6 - final project 4', progression: 'Project Work'
 level 'CSDU6 - final project 5', progression: 'Project Work'
 level 'CSDU6 - final project 6', progression: 'Project Work'
-assessment 'csd-pulse-check-survey-1-levelgroup U6Ch2', progression: 'Reflection'
+level 'csd-pulse-check-survey-1-levelgroup U6Ch2', progression: 'Reflection', assessment: true

--- a/dashboard/config/scripts/csp-ca-a.script
+++ b/dashboard/config/scripts/csp-ca-a.script
@@ -1,2 +1,2 @@
 stage 'Commutative Assessment A'
-assessment 'CSP Cumulative Assess A'
+level 'CSP Cumulative Assess A', assessment: true

--- a/dashboard/config/scripts/csp-exam.script
+++ b/dashboard/config/scripts/csp-exam.script
@@ -4,34 +4,34 @@ student_detail_progress_view true
 has_verified_resources true
 
 stage 'Unit 1 Assessment 1 - Binary and Ascii ', lockable: true
-assessment 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_exam_prep'
+level 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_exam_prep', assessment: true
 
 stage 'Unit 1 Assessment 2 - Internet Protocols, TCP/IP, DNS, HTTP, etc', lockable: true
-assessment 'CSP Unit 1 Ch2 Cumulative Assessment MC Group_exam_prep'
+level 'CSP Unit 1 Ch2 Cumulative Assessment MC Group_exam_prep', assessment: true
 
 stage 'Unit 2 Assessment 1 - Bits, Bytes, Hexadecimal and Compression', lockable: true
-assessment 'CSP Unit 2 Ch1 Cumulative Assessment MC_exam_prep'
+level 'CSP Unit 2 Ch1 Cumulative Assessment MC_exam_prep', assessment: true
 
 stage 'Unit 2 Assessment 2 - Interpreting Data & Charts, Big Data, Global Impacts', lockable: true
-assessment 'CSP Unit 2 Ch2 Cumulative Assessment MC_exam_prep'
+level 'CSP Unit 2 Ch2 Cumulative Assessment MC_exam_prep', assessment: true
 
 stage 'Unit 3 Assessment 1 - Turtle Programming, Loops, Functions, Abstraction', lockable: true
-assessment 'CSP Unit 3 Ch1 Cumulative Assessment MC Group_exam_prep'
+level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group_exam_prep', assessment: true
 
 stage 'Unit 4 Assessment 1 - Privacy, Cybersecurity, Encryption', lockable: true
-assessment 'CSP Unit 4 Ch1 Cumulative Assessment MC_exam_prep'
+level 'CSP Unit 4 Ch1 Cumulative Assessment MC_exam_prep', assessment: true
 
 stage 'Unit 5 Assessment 1 - Events, Variables, Debugging, Arithmetic, Turtle Review', lockable: true
-assessment 'CSP Unit 5 Cumulative Assessment 1 MC_exam_prep'
+level 'CSP Unit 5 Cumulative Assessment 1 MC_exam_prep', assessment: true
 
 stage 'Unit 5 Assessment 2 - If Statements, Boolean Expressions, Strings', lockable: true
-assessment 'CSP Unit 5 Cumulative Assessment 2 MC_exam_prep'
+level 'CSP Unit 5 Cumulative Assessment 2 MC_exam_prep', assessment: true
 
 stage 'Unit 5 Assessment 3 - While Loops, Boolean Expressions, Arrays and Lists', lockable: true
-assessment 'CSP Unit 5 Cumulative Assessment 3 MC_exam_prep'
+level 'CSP Unit 5 Cumulative Assessment 3 MC_exam_prep', assessment: true
 
 stage 'Unit 5 Assessment 4 - List Algorithms, Functions with Return Values', lockable: true
-assessment 'CSP Unit 5 Cumulative Assessment 4 MC_exam_prep'
+level 'CSP Unit 5 Cumulative Assessment 4 MC_exam_prep', assessment: true
 
 stage 'Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals)', lockable: true
-assessment 'CSP Cumulative Assess A_exam_prep'
+level 'CSP Cumulative Assess A_exam_prep', assessment: true

--- a/dashboard/config/scripts/csp-mid-survey.script
+++ b/dashboard/config/scripts/csp-mid-survey.script
@@ -3,4 +3,4 @@ login_required true
 has_verified_resources true
 
 stage 'CSP Mid-year survey', flex_category: 'cspSurvey'
-assessment 'csp-post-survey-2017-levelgroup_2018', progression: 'CS Principles Mid-year Survey'
+level 'csp-post-survey-2017-levelgroup_2018', progression: 'CS Principles Mid-year Survey', assessment: true

--- a/dashboard/config/scripts/csp-post-survey.script
+++ b/dashboard/config/scripts/csp-post-survey.script
@@ -3,4 +3,4 @@ login_required true
 has_verified_resources true
 
 stage 'CSP post-course survey', flex_category: 'cspSurvey'
-assessment 'csp-post-survey-2018-levelgroup', progression: 'CS Principles Post-course Survey'
+level 'csp-post-survey-2018-levelgroup', progression: 'CS Principles Post-course Survey', assessment: true

--- a/dashboard/config/scripts/csp-pre-survey.script
+++ b/dashboard/config/scripts/csp-pre-survey.script
@@ -1,22 +1,22 @@
 hideable_stages true
 
 stage 'Anonymous student pre-survey'
-assessment 'CSP pre-assessment survey'
+level 'CSP pre-assessment survey', assessment: true
 
 stage 'Unit 1 Chapter 1 Assessment', lockable: true
 variants
-  assessment 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2'
-  assessment 'CSP Unit 1 Ch1 Cumulative Assessment MC Group', active: false
+  level 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2', assessment: true
+  level 'CSP Unit 1 Ch1 Cumulative Assessment MC Group', active: false, assessment: true
 endvariants
 
 stage 'NEW Unit 1 Chapter 1 Assessment', lockable: true
-assessment 'CSP Unit 2 Ch2 Cumulative Assessment MC'
+level 'CSP Unit 2 Ch2 Cumulative Assessment MC', assessment: true
 
 stage 'Unit 3 Chapter 1 Assessment', lockable: true
-assessment 'CSP Unit 3 Ch1 Cumulative Assessment MC Group'
+level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group', assessment: true
 
 stage 'Unit 4 Chapter 1 Assessment', lockable: true
-assessment 'CSP Unit 4 Ch1 Cumulative Assessment MC'
+level 'CSP Unit 4 Ch1 Cumulative Assessment MC', assessment: true
 
 stage 'Anonymous student survey: Taking the AP exam'
-assessment 'csp_ap_questions'
+level 'csp_ap_questions', assessment: true

--- a/dashboard/config/scripts/csp1-2017.script
+++ b/dashboard/config/scripts/csp1-2017.script
@@ -12,7 +12,7 @@ version_year '2017'
 is_stable true
 
 stage 'CS Principles Pre-survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csp-pre-survey-2017-levelgroup'
+level 'csp-pre-survey-2017-levelgroup', assessment: true
 
 stage 'Personal Innovations', flex_category: 'csp1_1'
 level 'U1L1 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -24,103 +24,103 @@ endvariants
 
 stage 'Sending Binary Messages', flex_category: 'csp1_1'
 level 'v2 U1L2 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U1L2 Multiple Choice Assessment Question', progression: 'Check Your Understanding'
-assessment 'U1L2 Free response assessment question', progression: 'Check Your Understanding'
-assessment 'U1L3 Free Response', progression: 'Check Your Understanding'
+level 'U1L2 Multiple Choice Assessment Question', progression: 'Check Your Understanding', assessment: true
+level 'U1L2 Free response assessment question', progression: 'Check Your Understanding', assessment: true
+level 'U1L3 Free Response', progression: 'Check Your Understanding', assessment: true
 
 stage 'Sending Binary Messages with the Internet Simulator', flex_category: 'csp1_1'
 level 'v2 U1L3 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Internet Simulator: Sending Binary Messages', progression: 'Internet Simulator: Sending Binary Messages', named: true
 level 'The Internet: Wires, Cables, and Wifi', progression: 'The Internet: Wires, Cables, and Wifi', named: true
-assessment 'U1L3 Free response reflection question', progression: 'Check Your Understanding'
-assessment 'U1L4 Multiple Choice', progression: 'Check Your Understanding'
-assessment 'U1L3 Multiple Choice', progression: 'Check Your Understanding'
-assessment 'U1L4 Free Response Reflection', progression: 'Check Your Understanding'
-assessment 'U1L5 Matching Assessment', progression: 'Check Your Understanding'
+level 'U1L3 Free response reflection question', progression: 'Check Your Understanding', assessment: true
+level 'U1L4 Multiple Choice', progression: 'Check Your Understanding', assessment: true
+level 'U1L3 Multiple Choice', progression: 'Check Your Understanding', assessment: true
+level 'U1L4 Free Response Reflection', progression: 'Check Your Understanding', assessment: true
+level 'U1L5 Matching Assessment', progression: 'Check Your Understanding', assessment: true
 
 stage 'Number Systems', flex_category: 'csp1_1'
 level 'v2 U1L4 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U1L6 Assessment multiple choice', progression: 'Check Your Understanding'
-assessment 'U1L6 Free Response Reflection', progression: 'Check Your Understanding'
+level 'U1L6 Assessment multiple choice', progression: 'Check Your Understanding', assessment: true
+level 'U1L6 Free Response Reflection', progression: 'Check Your Understanding', assessment: true
 
 stage 'Binary Numbers', flex_category: 'csp1_1'
 level 'v2 U1L5 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Widget: Binary Odometer', progression: 'Widget: Binary Odometer', named: true
-assessment 'U1L7 Free Response Assessment', progression: 'Check Your Understanding'
-assessment 'U1L7 Free Response Reflection', progression: 'Check Your Understanding'
+level 'U1L7 Free Response Assessment', progression: 'Check Your Understanding', assessment: true
+level 'U1L7 Free Response Reflection', progression: 'Check Your Understanding', assessment: true
 
 stage 'Sending Numbers', flex_category: 'csp1_1'
 level 'v2 U1L6 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Internet Simulator: Sending Numbers', progression: 'Internet Simulator: Sending Numbers', named: true
-assessment 'U1L8 Free Response Reflection', progression: 'Check Your Understanding'
-assessment 'U1L8 Multiple Choice', progression: 'Check Your Understanding'
+level 'U1L8 Free Response Reflection', progression: 'Check Your Understanding', assessment: true
+level 'U1L8 Multiple Choice', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encoding and Sending Formatted Text', flex_category: 'csp1_1'
 level 'v2 U1L8 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Internet Simulator: Sending Text', progression: 'Internet Simulator: Sending Text', named: true
-assessment 'U1L10 Assessment 1', progression: 'Check Your Understanding'
-assessment 'U1L10 Assessment 2', progression: 'Check Your Understanding'
-assessment 'U1L10 Assessment Free Response', progression: 'Check Your Understanding'
-assessment 'U1L11 Assessment 1', progression: 'Check Your Understanding'
-assessment 'U1L11 Assessment 2', progression: 'Check Your Understanding'
-assessment 'U1L11 Reflection Free Response', progression: 'Check Your Understanding'
-assessment 'U1L11 Collaboration Reflection', progression: 'Check Your Understanding'
+level 'U1L10 Assessment 1', progression: 'Check Your Understanding', assessment: true
+level 'U1L10 Assessment 2', progression: 'Check Your Understanding', assessment: true
+level 'U1L10 Assessment Free Response', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Assessment 1', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Assessment 2', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Reflection Free Response', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Collaboration Reflection', progression: 'Check Your Understanding', assessment: true
 
 stage 'Unit 1 Chapter 1 Assessment', lockable: true, flex_category: 'csp1_1'
-assessment 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2'
+level 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2', assessment: true
 
 stage 'The Internet', flex_category: 'csp1_2'
 level 'v2 U1 Internet is for Everyone Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'What is the Internet?', progression: 'What is the Internet?', named: true
-assessment 'U2L01 Assessment 1', progression: 'Check Your Understanding'
-assessment 'U2L01 Assessment 2', progression: 'Check Your Understanding'
-assessment 'U2L01 Assessment 3', progression: 'Check Your Understanding'
-assessment 'U2L01 Assessment 4', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-1-levelgroup-U1Ch2', progression: 'Quick Check-In'
+level 'U2L01 Assessment 1', progression: 'Check Your Understanding', assessment: true
+level 'U2L01 Assessment 2', progression: 'Check Your Understanding', assessment: true
+level 'U2L01 Assessment 3', progression: 'Check Your Understanding', assessment: true
+level 'U2L01 Assessment 4', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-1-levelgroup-U1Ch2', progression: 'Quick Check-In', assessment: true
 
 stage 'The Need for Addressing', flex_category: 'csp1_2'
 level 'v2 U1L9 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Internet Simulator: Broadcast', progression: 'Internet Simulator: Broadcast', named: true
 level 'The Internet: IP Addresses & DNS', progression: 'The Internet: IP Addresses & DNS', named: true
-assessment 'U2L02 Free Response Reflection', progression: 'Check Your Understanding'
-assessment 'U2L02 Assessment 3', progression: 'Check Your Understanding'
-assessment 'U2L02 Assessment 4', progression: 'Check Your Understanding'
-assessment 'U2L02 Assessment 5', progression: 'Check Your Understanding'
-assessment 'U2L3 Assessment 2', progression: 'Check Your Understanding'
+level 'U2L02 Free Response Reflection', progression: 'Check Your Understanding'
+level 'U2L02 Assessment 3', progression: 'Check Your Understanding', assessment: true
+level 'U2L02 Assessment 4', progression: 'Check Your Understanding', assessment: true
+level 'U2L02 Assessment 5', progression: 'Check Your Understanding', assessment: true
+level 'U2L3 Assessment 2', progression: 'Check Your Understanding', assessment: true
 
 stage 'Routers and Redundancy', flex_category: 'csp1_2'
 level 'v2 U1L10 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Internet Simulator: Routers', progression: 'Internet Simulator: Routers', named: true
-assessment 'U2L04 Assessment1', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment4', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment5', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment2', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment3', progression: 'Check Your Understanding'
+level 'U2L04 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment4', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment5', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment2', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment3', progression: 'Check Your Understanding', assessment: true
 
 stage 'Packets and Making a Reliable Internet', flex_category: 'csp1_2'
 level 'v2 U1L11 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Internet Simulator: Packets', progression: 'Internet Simulator: Packets', named: true
 level 'The Internet: Packets, Routing, and Reliability', progression: 'The Internet: Packets, Routing, and Reliability', named: true
-assessment 'U2L05 Reflection 1', progression: 'Check Your Understanding'
-assessment 'U2L05 Assessment 1', progression: 'Check Your Understanding'
-assessment 'U2L05 Assessment 2', progression: 'Check Your Understanding'
-assessment 'U2L3 Assessment', progression: 'Check Your Understanding'
+level 'U2L05 Reflection 1', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Assessment 1', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Assessment 2', progression: 'Check Your Understanding', assessment: true
+level 'U2L3 Assessment', progression: 'Check Your Understanding', assessment: true
 
 stage 'The Need for DNS', flex_category: 'csp1_2'
 level 'v2 U1L12 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Internet Simulator: DNS', progression: 'Internet Simulator: DNS', named: true
 level 'The Internet: IP Addresses & DNS', progression: 'The Internet: IP Addresses & DNS', named: true
-assessment 'U2L09 Assessment1', progression: 'Check Your Understanding'
-assessment 'U2L09 Assessment2', progression: 'Check Your Understanding'
-assessment 'U2L09 Free Response Wrap Up', progression: 'Check Your Understanding'
-assessment 'U2L10 Assessment1', progression: 'Check Your Understanding'
+level 'U2L09 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U2L09 Assessment2', progression: 'Check Your Understanding', assessment: true
+level 'U2L09 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
+level 'U2L10 Assessment1', progression: 'Check Your Understanding', assessment: true
 
 stage 'HTTP and Abstraction', flex_category: 'csp1_2'
 level 'v2 U1L13 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'The Internet: HTTP and HTML', progression: 'The Internet: HTTP and HTML', named: true
-assessment 'U2L11 Assessment 1', progression: 'Check Your Understanding'
-assessment 'U2L11 Assessment 2', progression: 'Check Your Understanding'
-assessment 'U2L11 Free Response', progression: 'Check Your Understanding'
+level 'U2L11 Assessment 1', progression: 'Check Your Understanding', assessment: true
+level 'U2L11 Assessment 2', progression: 'Check Your Understanding', assessment: true
+level 'U2L11 Free Response', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - The Internet and Society', flex_category: 'csp1_2'
 level 'v2 U1L14 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -130,7 +130,7 @@ variants
   level 'csp_affirmation_control', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
   level 'csp_affirmation_intervention', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
 endvariants
-assessment 'CSP Unit 1 Ch2 Cumulative Assessment MC Group'
+level 'CSP Unit 1 Ch2 Cumulative Assessment MC Group', assessment: true
 
 stage 'Post-Course Survey', flex_category: 'cspSurvey'
 level 'csp-post-survey-2018-markdown-with-link-to-survey', progression: 'Click here! Complete the CS Principles post-course survey'

--- a/dashboard/config/scripts/csp1-2017.script
+++ b/dashboard/config/scripts/csp1-2017.script
@@ -82,7 +82,7 @@ stage 'The Need for Addressing', flex_category: 'csp1_2'
 level 'v2 U1L9 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Internet Simulator: Broadcast', progression: 'Internet Simulator: Broadcast', named: true
 level 'The Internet: IP Addresses & DNS', progression: 'The Internet: IP Addresses & DNS', named: true
-level 'U2L02 Free Response Reflection', progression: 'Check Your Understanding'
+level 'U2L02 Free Response Reflection', progression: 'Check Your Understanding', assessment: true
 level 'U2L02 Assessment 3', progression: 'Check Your Understanding', assessment: true
 level 'U2L02 Assessment 4', progression: 'Check Your Understanding', assessment: true
 level 'U2L02 Assessment 5', progression: 'Check Your Understanding', assessment: true

--- a/dashboard/config/scripts/csp1-2018.script
+++ b/dashboard/config/scripts/csp1-2018.script
@@ -12,116 +12,116 @@ version_year '2018'
 is_stable true
 
 stage 'CS Principles Pre-survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csp-pre-survey-2017-levelgroup_2018'
+level 'csp-pre-survey-2017-levelgroup_2018', assessment: true
 
 stage 'Personal Innovations', flex_category: 'csp1_1'
 level 'CSP U1L01 SFLP', named: true
 level 'Computer Science is Changing Everything_2018', progression: 'Computer Science is Changing Everything', named: true
 variants
-  assessment 'csp_socialBelonging_control_2018', active: false, progression: 'Reflection: starting out in computer science'
-  assessment 'csp_socialBelonging_intervention_2018', progression: 'Reflection: starting out in computer science'
+  level 'csp_socialBelonging_control_2018', active: false, progression: 'Reflection: starting out in computer science', assessment: true
+  level 'csp_socialBelonging_intervention_2018', progression: 'Reflection: starting out in computer science', assessment: true
 endvariants
 
 stage 'Sending Binary Messages', flex_category: 'csp1_1'
 level 'CSP U1L02 SFLP', named: true
-assessment 'U1L2 Multiple Choice Assessment Question_2018', progression: 'Check Your Understanding'
-assessment 'U1L3 Free response reflection question_2018', progression: 'Check Your Understanding'
-assessment 'U1L2 Free response assessment question_2018', progression: 'Check Your Understanding'
-assessment 'U1L3 Free Response_2018', progression: 'Check Your Understanding'
+level 'U1L2 Multiple Choice Assessment Question_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L3 Free response reflection question_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L2 Free response assessment question_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L3 Free Response_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Sending Binary Messages with the Internet Simulator', flex_category: 'csp1_1'
 level 'CSP U1L03 SFLP', named: true
 level 'Internet Simulator: Sending Binary Messages_2018', progression: 'Internet Simulator: Sending Binary Messages', named: true
 level 'The Internet: Wires, Cables, and Wifi_2018', progression: 'The Internet: Wires, Cables, and Wifi', named: true
-assessment 'U1L4 Multiple Choice_2018', progression: 'Check Your Understanding'
-assessment 'U1L3 Multiple Choice_2018', progression: 'Check Your Understanding'
-assessment 'U1L4 Free Response Reflection_2018', progression: 'Check Your Understanding'
-assessment 'U1L5 Matching Assessment_2018', progression: 'Check Your Understanding'
+level 'U1L4 Multiple Choice_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L3 Multiple Choice_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L4 Free Response Reflection_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L5 Matching Assessment_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Number Systems', flex_category: 'csp1_1'
 level 'CSP U1L04 SFLP', named: true
-assessment 'U1L6 Assessment multiple choice_2018', progression: 'Check Your Understanding'
-assessment 'U1L6 Free Response Reflection_2018', progression: 'Check Your Understanding'
+level 'U1L6 Assessment multiple choice_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L6 Free Response Reflection_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Binary Numbers', flex_category: 'csp1_1'
 level 'CSP U1L05 SFLP', named: true
 level 'Widget: Binary Odometer_2018', progression: 'Widget: Binary Odometer', named: true
-assessment 'U1L7 Free Response Assessment_2018', progression: 'Check Your Understanding'
-assessment 'U1L7 Free Response Reflection_2018', progression: 'Check Your Understanding'
+level 'U1L7 Free Response Assessment_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L7 Free Response Reflection_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Sending Numbers', flex_category: 'csp1_1'
 level 'CSP U1L06 SFLP', named: true
 level 'Internet Simulator: Sending Numbers_2018', progression: 'Internet Simulator: Sending Numbers', named: true
-assessment 'U1L8 Free Response Reflection_2018', progression: 'Check Your Understanding'
-assessment 'U1L8 Multiple Choice_2018', progression: 'Check Your Understanding'
+level 'U1L8 Free Response Reflection_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L8 Multiple Choice_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Sending Text', flex_category: 'csp1_1'
 level 'CSP U1L07 SFLP', named: true
 level 'Internet Simulator: Sending Text_2018', progression: 'Internet Simulator: Sending Text', named: true
-assessment 'U1L10 Assessment 1_2018', progression: 'Check Your Understanding'
-assessment 'U1L10 Assessment 2_2018', progression: 'Check Your Understanding'
-assessment 'U1L11 Assessment 1_2018', progression: 'Check Your Understanding'
-assessment 'U1L11 Reflection Multiple Representations_2018', progression: 'Check Your Understanding'
-assessment 'U1L11 Abstraction Reflection_2018', progression: 'Check Your Understanding'
+level 'U1L10 Assessment 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L10 Assessment 2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Assessment 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Reflection Multiple Representations_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Abstraction Reflection_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Unit 1 Chapter 1 Assessment', lockable: true, flex_category: 'csp1_1'
-assessment 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018'
+level 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018', assessment: true
 
 stage 'The Internet', flex_category: 'csp1_2'
 level 'CSP U1L08 SFLP', named: true
 level 'What is the Internet?_2018', progression: 'What is the Internet?', named: true
-assessment 'U2L01 Assessment 1_2018', progression: 'Check Your Understanding'
-assessment 'U2L01 Assessment 2_2018', progression: 'Check Your Understanding'
-assessment 'U2L01 Assessment 3_2018', progression: 'Check Your Understanding'
-assessment 'U2L01 Assessment 4_2018', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-1-levelgroup-U1Ch2_2018', progression: 'Quick Check-In'
+level 'U2L01 Assessment 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L01 Assessment 2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L01 Assessment 3_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L01 Assessment 4_2018', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-1-levelgroup-U1Ch2_2018', progression: 'Quick Check-In', assessment: true
 
 stage 'The Need for Addressing', flex_category: 'csp1_2'
 level 'CSP U1L09 SFLP', named: true
 level 'Internet Simulator: Broadcast_2018', progression: 'Internet Simulator: Broadcast', named: true
 level 'The Internet: IP Addresses & DNS_2018', progression: 'The Internet: IP Addresses & DNS', named: true
-assessment 'U2L02 Free Response Reflection_2018', progression: 'Check Your Understanding'
-assessment 'U2L02 Assessment 3_2018', progression: 'Check Your Understanding'
-assessment 'U2L02 Assessment 4_2018', progression: 'Check Your Understanding'
-assessment 'U2L02 Assessment 5_2018', progression: 'Check Your Understanding'
-assessment 'U2L3 Assessment 2_2018', progression: 'Check Your Understanding'
+level 'U2L02 Free Response Reflection_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L02 Assessment 3_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L02 Assessment 4_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L02 Assessment 5_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L3 Assessment 2_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Routers and Redundancy', flex_category: 'csp1_2'
 level 'CSP U1L10 SFLP', named: true
 level 'Internet Simulator: Routers_2018', progression: 'Internet Simulator: Routers', named: true
-assessment 'U2L04 Assessment1_2018', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment4_2018', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment5_2018', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment2_2018', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment3_2018', progression: 'Check Your Understanding'
+level 'U2L04 Assessment1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment4_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment5_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment3_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Packets and Making a Reliable Internet', flex_category: 'csp1_2'
 level 'CSP U1L11 SFLP', named: true
 level 'Internet Simulator: Packets_2018', progression: 'Internet Simulator: Packets', named: true
 level 'The Internet: Packets, Routing, and Reliability_2018', progression: 'The Internet: Packets, Routing, and Reliability', named: true
-assessment 'U2L05 Reflection 1_2018', progression: 'Check Your Understanding'
-assessment 'U2L05 Assessment 1_2018', progression: 'Check Your Understanding'
-assessment 'U2L05 Assessment 2_2018', progression: 'Check Your Understanding'
-assessment 'U2L3 Assessment_2018', progression: 'Check Your Understanding'
+level 'U2L05 Reflection 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Assessment 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Assessment 2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L3 Assessment_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'The Need for DNS', flex_category: 'csp1_2'
 level 'CSP U1L12 SFLP', named: true
 level 'Internet Simulator: DNS_2018', progression: 'Internet Simulator: DNS', named: true
 level 'The Internet: IP Addresses & DNS_2018', progression: 'The Internet: IP Addresses & DNS', named: true
-assessment 'U2L09 Assessment1_2018', progression: 'Check Your Understanding'
-assessment 'U2L09 Assessment2_2018', progression: 'Check Your Understanding'
-assessment 'U2L09 Free Response Wrap Up_2018', progression: 'Check Your Understanding'
-assessment 'U2L10 Assessment1_2018', progression: 'Check Your Understanding'
+level 'U2L09 Assessment1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L09 Assessment2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L09 Free Response Wrap Up_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L10 Assessment1_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'HTTP and Abstraction', flex_category: 'csp1_2'
 level 'CSP U1L13 SFLP', named: true
 level 'The Internet: HTTP and HTML_2018', progression: 'The Internet: HTTP and HTML', named: true
-assessment 'U2L11 Assessment 1_2018', progression: 'Check Your Understanding'
-assessment 'U2L11 Assessment 2_2018', progression: 'Check Your Understanding'
-assessment 'U2L11 Free Response_2018', progression: 'Check Your Understanding'
+level 'U2L11 Assessment 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L11 Assessment 2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L11 Free Response_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - The Internet and Society', flex_category: 'csp1_2'
 level 'CSP U1L14 SFLP', named: true
 
 stage 'Unit 1 Chapter 2 Assessment', lockable: true, flex_category: 'csp1_2'
-assessment 'CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018'
+level 'CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018', assessment: true

--- a/dashboard/config/scripts/csp1-2019.script
+++ b/dashboard/config/scripts/csp1-2019.script
@@ -9,116 +9,116 @@ family_name 'csp1'
 version_year '2019'
 
 stage 'CS Principles Pre-survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csp-pre-survey-2017-levelgroup_2018_2019'
+level 'csp-pre-survey-2017-levelgroup_2018_2019', assessment: true
 
 stage 'Personal Innovations', flex_category: 'csp1_1'
 level 'CSP U1L01 SFLP_2019', named: true
 level 'Computer Science is Changing Everything_2019', progression: 'Computer Science is Changing Everything', named: true
 variants
-  assessment 'csp_socialBelonging_control_2019', progression: 'Reflection: starting out in computer science'
-  assessment 'csp_socialBelonging_intervention_2019', progression: 'Reflection: starting out in computer science'
+  level 'csp_socialBelonging_control_2019', progression: 'Reflection: starting out in computer science', assessment: true
+  level 'csp_socialBelonging_intervention_2019', progression: 'Reflection: starting out in computer science', assessment: true
 endvariants
 
 stage 'Sending Binary Messages', flex_category: 'csp1_1'
 level 'CSP U1L02 SFLP_2019', named: true
-assessment 'U1L2 Multiple Choice Assessment Question_2018_2019', progression: 'Check Your Understanding'
-assessment 'U1L3 Free response reflection question_2019', progression: 'Check Your Understanding'
-assessment 'U1L2 Free response assessment question_2019', progression: 'Check Your Understanding'
-assessment 'U1L3 Free Response_2019', progression: 'Check Your Understanding'
+level 'U1L2 Multiple Choice Assessment Question_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L3 Free response reflection question_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L2 Free response assessment question_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L3 Free Response_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Sending Binary Messages with the Internet Simulator', flex_category: 'csp1_1'
 level 'CSP U1L03 SFLP_2019', named: true
 level 'Internet Simulator: Sending Binary Messages_2019', progression: 'Internet Simulator: Sending Binary Messages', named: true
 level 'The Internet: Wires, Cables, and Wifi_2019', progression: 'The Internet: Wires, Cables, and Wifi', named: true
-assessment 'U1L4 Multiple Choice_2018_2019', progression: 'Check Your Understanding'
-assessment 'U1L3 Multiple Choice_2018_2019', progression: 'Check Your Understanding'
-assessment 'U1L4 Free Response Reflection_2019', progression: 'Check Your Understanding'
-assessment 'U1L5 Matching Assessment_2018_2019', progression: 'Check Your Understanding'
+level 'U1L4 Multiple Choice_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L3 Multiple Choice_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L4 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L5 Matching Assessment_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Number Systems', flex_category: 'csp1_1'
 level 'CSP U1L04 SFLP_2019', named: true
-assessment 'U1L6 Assessment multiple choice_2018_2019', progression: 'Check Your Understanding'
-assessment 'U1L6 Free Response Reflection_2019', progression: 'Check Your Understanding'
+level 'U1L6 Assessment multiple choice_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L6 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Binary Numbers', flex_category: 'csp1_1'
 level 'CSP U1L05 SFLP_2019', named: true
 level 'Widget: Binary Odometer_2019', progression: 'Widget: Binary Odometer', named: true
-assessment 'U1L7 Free Response Assessment_2019', progression: 'Check Your Understanding'
-assessment 'U1L7 Free Response Reflection_2019', progression: 'Check Your Understanding'
+level 'U1L7 Free Response Assessment_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L7 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Sending Numbers', flex_category: 'csp1_1'
 level 'CSP U1L06 SFLP_2019', named: true
 level 'Internet Simulator: Sending Numbers_2019', progression: 'Internet Simulator: Sending Numbers', named: true
-assessment 'U1L8 Free Response Reflection_2019', progression: 'Check Your Understanding'
-assessment 'U1L8 Multiple Choice_2018_2019', progression: 'Check Your Understanding'
+level 'U1L8 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L8 Multiple Choice_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Sending Text', flex_category: 'csp1_1'
 level 'CSP U1L07 SFLP_2019', named: true
 level 'Internet Simulator: Sending Text_2019', progression: 'Internet Simulator: Sending Text', named: true
-assessment 'U1L10 Assessment 1_2018_2019', progression: 'Check Your Understanding'
-assessment 'U1L10 Assessment 2_2018_2019', progression: 'Check Your Understanding'
-assessment 'U1L11 Assessment 1_2018_2019', progression: 'Check Your Understanding'
-assessment 'U1L11 Reflection Multiple Representations_2019', progression: 'Check Your Understanding'
-assessment 'U1L11 Abstraction Reflection_2019', progression: 'Check Your Understanding'
+level 'U1L10 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L10 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Reflection Multiple Representations_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L11 Abstraction Reflection_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Unit 1 Chapter 1 Assessment', lockable: true, flex_category: 'csp1_1'
-assessment 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018_2019'
+level 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018_2019', assessment: true
 
 stage 'The Internet', flex_category: 'csp1_2'
 level 'CSP U1L08 SFLP_2019', named: true
 level 'What is the Internet?_2019', progression: 'What is the Internet?', named: true
-assessment 'U2L01 Assessment 1_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L01 Assessment 2_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L01 Assessment 3_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L01 Assessment 4_2019', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-1-levelgroup-U1Ch2_2018_2019', progression: 'Quick Check-In'
+level 'U2L01 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L01 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L01 Assessment 3_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L01 Assessment 4_2019', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-1-levelgroup-U1Ch2_2018_2019', progression: 'Quick Check-In', assessment: true
 
 stage 'The Need for Addressing', flex_category: 'csp1_2'
 level 'CSP U1L09 SFLP_2019', named: true
 level 'Internet Simulator: Broadcast_2019', progression: 'Internet Simulator: Broadcast', named: true
 level 'The Internet: IP Addresses & DNS_2019', progression: 'The Internet: IP Addresses & DNS', named: true
-assessment 'U2L02 Free Response Reflection_2019', progression: 'Check Your Understanding'
-assessment 'U2L02 Assessment 3_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L02 Assessment 4_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L02 Assessment 5_2019', progression: 'Check Your Understanding'
-assessment 'U2L3 Assessment 2_2018_2019', progression: 'Check Your Understanding'
+level 'U2L02 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L02 Assessment 3_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L02 Assessment 4_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L02 Assessment 5_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L3 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Routers and Redundancy', flex_category: 'csp1_2'
 level 'CSP U1L10 SFLP_2019', named: true
 level 'Internet Simulator: Routers_2019', progression: 'Internet Simulator: Routers', named: true
-assessment 'U2L04 Assessment1_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment4_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment5_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment2_2019', progression: 'Check Your Understanding'
-assessment 'U2L04 Assessment3_2019', progression: 'Check Your Understanding'
+level 'U2L04 Assessment1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment4_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment5_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment2_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L04 Assessment3_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Packets and Making a Reliable Internet', flex_category: 'csp1_2'
 level 'CSP U1L11 SFLP_2019', named: true
 level 'Internet Simulator: Packets_2019', progression: 'Internet Simulator: Packets', named: true
 level 'The Internet: Packets, Routing, and Reliability_2019', progression: 'The Internet: Packets, Routing, and Reliability', named: true
-assessment 'U2L05 Reflection 1_2019', progression: 'Check Your Understanding'
-assessment 'U2L05 Assessment 1_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L05 Assessment 2_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L3 Assessment_2018_2019', progression: 'Check Your Understanding'
+level 'U2L05 Reflection 1_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L3 Assessment_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'The Need for DNS', flex_category: 'csp1_2'
 level 'CSP U1L12 SFLP_2019', named: true
 level 'Internet Simulator: DNS_2019', progression: 'Internet Simulator: DNS', named: true
 level 'The Internet: IP Addresses & DNS_2019', progression: 'The Internet: IP Addresses & DNS', named: true
-assessment 'U2L09 Assessment1_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L09 Assessment2_2019', progression: 'Check Your Understanding'
-assessment 'U2L09 Free Response Wrap Up_2019', progression: 'Check Your Understanding'
-assessment 'U2L10 Assessment1_2018_2019', progression: 'Check Your Understanding'
+level 'U2L09 Assessment1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L09 Assessment2_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L09 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L10 Assessment1_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'HTTP and Abstraction', flex_category: 'csp1_2'
 level 'CSP U1L13 SFLP_2019', named: true
 level 'The Internet: HTTP and HTML_2019', progression: 'The Internet: HTTP and HTML', named: true
-assessment 'U2L11 Assessment 1_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L11 Assessment 2_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L11 Free Response_2019', progression: 'Check Your Understanding'
+level 'U2L11 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L11 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L11 Free Response_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - The Internet and Society', flex_category: 'csp1_2'
 level 'CSP U1L14 SFLP_2019', named: true
 
 stage 'Unit 1 Chapter 2 Assessment', lockable: true, flex_category: 'csp1_2'
-assessment 'CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018_2019'
+level 'CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018_2019', assessment: true

--- a/dashboard/config/scripts/csp1-pilot-staging.script
+++ b/dashboard/config/scripts/csp1-pilot-staging.script
@@ -35,10 +35,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -79,10 +79,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -127,4 +127,4 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/csp10-pilot-staging.script
+++ b/dashboard/config/scripts/csp10-pilot-staging.script
@@ -33,10 +33,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -77,10 +77,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -125,4 +125,4 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/csp2-2017.script
+++ b/dashboard/config/scripts/csp2-2017.script
@@ -13,26 +13,26 @@ is_stable true
 
 stage 'Bytes and File Sizes', flex_category: 'csp2_1'
 level 'v2 U2L1 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U1L12 Reflection Free Response', progression: 'Check Your Understanding'
-assessment 'CSP_U2_Shakespeare_Question', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-2-levelgroup-U2Ch1', progression: 'Quick Check-In'
+level 'U1L12 Reflection Free Response', progression: 'Check Your Understanding', assessment: true
+level 'CSP_U2_Shakespeare_Question', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-2-levelgroup-U2Ch1', progression: 'Quick Check-In', assessment: true
 
 stage 'Text Compression', flex_category: 'csp2_1'
 level 'v2 U2L2 Student Lesson Summary', progression: 'Lesson Vocabulary & Resources'
 level 'Text Compression', progression: 'Text Compression', named: true
 level 'Widget: Text Compression', progression: 'Widget: Text Compression', named: true
-assessment 'U1L13 - Assess Text Compression reverse process', progression: 'Check Your Understanding'
-assessment 'U1L13 Assess Text Compression amount', progression: 'Check Your Understanding'
-assessment 'U1L13 Assessment 1', progression: 'Check Your Understanding'
-assessment 'U1L13 Assessment 2', progression: 'Check Your Understanding'
+level 'U1L13 - Assess Text Compression reverse process', progression: 'Check Your Understanding', assessment: true
+level 'U1L13 Assess Text Compression amount', progression: 'Check Your Understanding', assessment: true
+level 'U1L13 Assessment 1', progression: 'Check Your Understanding', assessment: true
+level 'U1L13 Assessment 2', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encoding B&W Images', flex_category: 'csp2_1'
 level 'v2 U2L3 Student Lesson Summary', progression: 'Lesson Vocabulary & Resources'
 level 'Pixelation - Lesson 14 - Make the Letter A', progression: 'Pixelation Widget: Black and White Pixelation'
 level 'Pixelation - Lesson 14 - Fix bit offset', progression: 'Pixelation Widget: Black and White Pixelation'
 level 'Widget: Black and White Pixelation', progression: 'Pixelation Widget: Black and White Pixelation', named: true
-assessment 'U1L14 Assessment 1', progression: 'Check Your Understanding'
-assessment 'U1L14 - Assessment 2', progression: 'Check Your Understanding'
+level 'U1L14 Assessment 1', progression: 'Check Your Understanding', assessment: true
+level 'U1L14 - Assessment 2', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encoding Color Images', flex_category: 'csp2_1'
 level 'v2 U2L4 Student Lesson Summary', progression: 'Lesson Vocabulary & Resources'
@@ -44,38 +44,38 @@ level 'Pixelation Flappy', progression: 'Pixelation'
 level 'Pixelation Bee', progression: 'Pixelation'
 level 'Favicon Instructions', progression: 'Favicon Instructions', named: true
 level 'Widget: Color Pixelation', progression: 'Widget: Color Pixelation', named: true
-assessment 'U2L5 Color Pixel MC Question', progression: 'Check Your Understanding'
-assessment 'U2L5 FR brighten darken image', progression: 'Check Your Understanding'
+level 'U2L5 Color Pixel MC Question', progression: 'Check Your Understanding', assessment: true
+level 'U2L5 FR brighten darken image', progression: 'Check Your Understanding', assessment: true
 
 stage 'Lossy Compression and File Formats', flex_category: 'csp2_1'
 level 'v2 U2L5 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U1L16 - Matching File Compression Types', progression: 'Check Your Understanding'
+level 'U1L16 - Matching File Compression Types', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - Encode an Experience', flex_category: 'csp2_1'
 level 'v2 U2L6 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 
 stage 'Unit 2 Chapter 1 Assessment', lockable: true, flex_category: 'csp2_1'
-assessment 'CSP Unit 2 Ch1 Cumulative Assessment MC'
+level 'CSP Unit 2 Ch1 Cumulative Assessment MC', assessment: true
 
 stage 'Intro to Data', flex_category: 'csp2_2'
 level 'v2 U2L7 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'csp-pulse-check-survey-3-levelgroup-U2Ch2', progression: 'Quick Check-In'
+level 'csp-pulse-check-survey-3-levelgroup-U2Ch2', progression: 'Quick Check-In', assessment: true
 
 stage 'Finding Trends with Visualizations', flex_category: 'csp2_2'
 level 'v2 U2L8 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U2L8 google trends MC', progression: 'Check Your Understanding'
-assessment 'U2L8 google trends hypothesis', progression: 'Check Your Understanding'
+level 'U2L8 google trends MC', progression: 'Check Your Understanding', assessment: true
+level 'U2L8 google trends hypothesis', progression: 'Check Your Understanding', assessment: true
 
 stage 'Check Your Assumptions', flex_category: 'csp2_2'
 level 'v2 U2L9 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U2L9 What is digital divide MC', progression: 'Check Your Understanding'
-assessment 'U2L9 FR digital divide issue', progression: 'Check Your Understanding'
+level 'U2L9 What is digital divide MC', progression: 'Check Your Understanding', assessment: true
+level 'U2L9 FR digital divide issue', progression: 'Check Your Understanding', assessment: true
 
 stage 'Good and Bad Data Visualizations', flex_category: 'csp2_2'
 level 'v2 U2L10 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Collection A: Good and Bad Visualizations', progression: 'Collection A: Good and Bad Visualizations', named: true
 level 'Collection B: Good and Bad Visualizations', progression: 'Collection B: Good and Bad Visualizations', named: true
-assessment 'U2L10 FR why best worst viz', progression: 'Check Your Understanding'
+level 'U2L10 FR why best worst viz', progression: 'Check Your Understanding', assessment: true
 
 stage 'Making Data Visualizations', flex_category: 'csp2_2'
 level 'v2 U2L11 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -85,26 +85,26 @@ level 'Making a Line Chart', progression: 'Making a Line Chart', named: true
 level 'Making a Bar Chart', progression: 'Making a Bar Chart', named: true
 level 'Editing Chart Appearance', progression: 'Editing Chart Appearance', named: true
 level 'U4 - Making Data Visualizations - Free Play', progression: 'Making Data Visualizations - Free Play'
-assessment 'U2L10 FR describe what you made from lesson prompt', progression: 'Check Your Understanding'
+level 'U2L10 FR describe what you made from lesson prompt', progression: 'Check Your Understanding', assessment: true
 
 stage 'Discover a Data Story', flex_category: 'csp2_2'
 level 'v2 U2L12 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U2L12 FR reflection on collaboration', progression: 'Check Your Understanding'
+level 'U2L12 FR reflection on collaboration', progression: 'Check Your Understanding', assessment: true
 
 stage 'Cleaning Data', flex_category: 'csp2_2'
 level 'v2 U2L13 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Getting to Know Your Data', progression: 'Getting to Know Your Data', named: true
 level 'Cleaning Data', progression: 'Cleaning Data', named: true
 level 'Categorizing Data', progression: 'Categorizing Data', named: true
-assessment 'U2L13 Cleaning Data MC', progression: 'Check Your Understanding'
-assessment 'U2L13 FR Reflection data analysis objective', progression: 'Check Your Understanding'
+level 'U2L13 Cleaning Data MC', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 FR Reflection data analysis objective', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating Summary Tables', flex_category: 'csp2_2'
 level 'v2 U2L14 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Making Pivot Tables Part 1 - The Basics', progression: 'Making Pivot Tables Part 1 - The Basics', named: true
 level 'Making Pivot Tables Part 2 - Manipulation and Visualization', progression: 'Making Pivot Tables Part 2 - Manipulation and Visualizations', named: true
 level 'U4L08v2 Making Pivot Tables Part 3', progression: 'Making Pivot Tables Part 3'
-assessment 'U2L14 Summary Tables MC', progression: 'Check Your Understanding'
+level 'U2L14 Summary Tables MC', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - Tell a Data Story', flex_category: 'csp2_2'
 level 'v2 U2L15 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -114,7 +114,7 @@ variants
   level 'csp_affirmation_control_2', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
   level 'csp_affirmation_intervention_2', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
 endvariants
-assessment 'CSP Unit 2 Ch2 Cumulative Assessment MC'
+level 'CSP Unit 2 Ch2 Cumulative Assessment MC', assessment: true
 
 stage 'Post-Course Survey', flex_category: 'cspSurvey'
 level 'csp-post-survey-2018-markdown-with-link-to-survey', progression: 'Click here! Complete the CS Principles post-course survey'

--- a/dashboard/config/scripts/csp2-2018.script
+++ b/dashboard/config/scripts/csp2-2018.script
@@ -13,26 +13,26 @@ is_stable true
 
 stage 'Bytes and File Sizes', flex_category: 'csp2_1_2018'
 level 'CSP U2L01 SFLP', named: true
-assessment 'U1L12 Reflection Free Response_2018', progression: 'Check Your Understanding'
-assessment 'CSP_U2_Shakespeare_Question_2018', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-2-levelgroup-U2Ch1_2018', progression: 'Quick Check-In'
+level 'U1L12 Reflection Free Response_2018', progression: 'Check Your Understanding', assessment: true
+level 'CSP_U2_Shakespeare_Question_2018', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-2-levelgroup-U2Ch1_2018', progression: 'Quick Check-In', assessment: true
 
 stage 'Text Compression', flex_category: 'csp2_1_2018'
 level 'CSP U2L02 SFLP', named: true
 level 'Text Compression_2018', progression: 'Text Compression', named: true
 level 'Widget: Text Compression_2018', progression: 'Widget: Text Compression', named: true
-assessment 'U1L13 - Assess Text Compression reverse process_2018', progression: 'Check Your Understanding'
-assessment 'U1L13 Assess Text Compression amount_2018', progression: 'Check Your Understanding'
-assessment 'U1L13 Assessment 1_2018', progression: 'Check Your Understanding'
-assessment 'U1L13 Assessment 2_2018', progression: 'Check Your Understanding'
+level 'U1L13 - Assess Text Compression reverse process_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L13 Assess Text Compression amount_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L13 Assessment 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L13 Assessment 2_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encoding B&W Images', flex_category: 'csp2_1_2018'
 level 'CSP U2L03 SFLP', named: true
 level 'Pixelation - Lesson 14 - Make the Letter A_2018', progression: 'Pixelation Widget: Black and White Pixelation'
 level 'Pixelation - Lesson 14 - Fix bit offset_2018', progression: 'Pixelation Widget: Black and White Pixelation'
 level 'Widget: Black and White Pixelation_2018', progression: 'Pixelation Widget: Black and White Pixelation', named: true
-assessment 'U1L14 Assessment 1_2018', progression: 'Check Your Understanding'
-assessment 'U1L14 - Assessment 2_2018', progression: 'Check Your Understanding'
+level 'U1L14 Assessment 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U1L14 - Assessment 2_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encoding Color Images', flex_category: 'csp2_1_2018'
 level 'CSP U2L04 SFLP', named: true
@@ -44,17 +44,17 @@ level 'Pixelation Flappy_2018', progression: 'Pixelation'
 level 'Pixelation Bee_2018', progression: 'Pixelation'
 level 'Favicon Instructions_2018', progression: 'Favicon Instructions', named: true
 level 'Widget: Color Pixelation_2018', progression: 'Widget: Color Pixelation', named: true
-assessment 'U2L5 Color Pixel MC Question_2018', progression: 'Check Your Understanding'
-assessment 'U2L5 FR brighten darken image_2018', progression: 'Check Your Understanding'
+level 'U2L5 Color Pixel MC Question_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L5 FR brighten darken image_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Lossy vs Lossless Compression', flex_category: 'csp2_1_2018'
 level 'CSP U2L05 SFLP', named: true
-assessment 'U2L05 Lossy Lossless MC 1_2018', progression: 'Check Your Understanding'
-assessment 'U2L05 Lossy Lossless MC 2_2018', progression: 'Check Your Understanding'
-assessment 'U2L05 Lossy vs. Lossless FR 1_2018', progression: 'Check Your Understanding'
+level 'U2L05 Lossy Lossless MC 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Lossy Lossless MC 2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Lossy vs. Lossless FR 1_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Rapid Research - Format Showdown', flex_category: 'csp2_1_2018'
 level 'CSP U2L06 SFLP', named: true
 
 stage 'Unit 2 Assessment', lockable: true, flex_category: 'cspAssessment'
-assessment 'CSP Unit 2 Ch1 Cumulative Assessment MC_2018'
+level 'CSP Unit 2 Ch1 Cumulative Assessment MC_2018', assessment: true

--- a/dashboard/config/scripts/csp2-2019.script
+++ b/dashboard/config/scripts/csp2-2019.script
@@ -10,26 +10,26 @@ version_year '2019'
 
 stage 'Bytes and File Sizes', flex_category: 'csp2_1_2018'
 level 'CSP U2L01 SFLP_2019', named: true
-assessment 'U1L12 Reflection Free Response_2019', progression: 'Check Your Understanding'
-assessment 'CSP_U2_Shakespeare_Question_2019', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-2-levelgroup-U2Ch1_2018_2019', progression: 'Quick Check-In'
+level 'U1L12 Reflection Free Response_2019', progression: 'Check Your Understanding', assessment: true
+level 'CSP_U2_Shakespeare_Question_2019', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-2-levelgroup-U2Ch1_2018_2019', progression: 'Quick Check-In', assessment: true
 
 stage 'Text Compression', flex_category: 'csp2_1_2018'
 level 'CSP U2L02 SFLP_2019', named: true
 level 'Text Compression_2019', progression: 'Text Compression', named: true
 level 'Widget: Text Compression_2019', progression: 'Widget: Text Compression', named: true
-assessment 'U1L13 - Assess Text Compression reverse process_2018_2019', progression: 'Check Your Understanding'
-assessment 'U1L13 Assess Text Compression amount_2019', progression: 'Check Your Understanding'
-assessment 'U1L13 Assessment 1_2019', progression: 'Check Your Understanding'
-assessment 'U1L13 Assessment 2_2019', progression: 'Check Your Understanding'
+level 'U1L13 - Assess Text Compression reverse process_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L13 Assess Text Compression amount_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L13 Assessment 1_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L13 Assessment 2_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encoding B&W Images', flex_category: 'csp2_1_2018'
 level 'CSP U2L03 SFLP_2019', named: true
 level 'Pixelation - Lesson 14 - Make the Letter A_2019', progression: 'Pixelation Widget: Black and White Pixelation'
 level 'Pixelation - Lesson 14 - Fix bit offset_2019', progression: 'Pixelation Widget: Black and White Pixelation'
 level 'Widget: Black and White Pixelation_2019', progression: 'Pixelation Widget: Black and White Pixelation'
-assessment 'U1L14 Assessment 1_2019', progression: 'Check Your Understanding'
-assessment 'U1L14 - Assessment 2_2019', progression: 'Check Your Understanding'
+level 'U1L14 Assessment 1_2019', progression: 'Check Your Understanding', assessment: true
+level 'U1L14 - Assessment 2_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encoding Color Images', flex_category: 'csp2_1_2018'
 level 'CSP U2L04 SFLP_2019', named: true
@@ -41,17 +41,17 @@ level 'Pixelation Flappy_2019', progression: 'Pixelation'
 level 'Pixelation Bee_2019', progression: 'Pixelation'
 level 'Favicon Instructions_2018_2019', progression: 'Favicon Instructions', named: true
 level 'Widget: Color Pixelation_2019', progression: 'Widget: Color Pixelation', named: true
-assessment 'U2L5 Color Pixel MC Question_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L5 FR brighten darken image_2019', progression: 'Check Your Understanding'
+level 'U2L5 Color Pixel MC Question_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L5 FR brighten darken image_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Lossy vs Lossless Compression', flex_category: 'csp2_1_2018'
 level 'CSP U2L05 SFLP_2019', named: true
-assessment 'U2L05 Lossy Lossless MC 1_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L05 Lossy Lossless MC 2_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L05 Lossy vs. Lossless FR 1_2018_2019', progression: 'Check Your Understanding'
+level 'U2L05 Lossy Lossless MC 1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Lossy Lossless MC 2_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L05 Lossy vs. Lossless FR 1_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Rapid Research - Format Showdown', flex_category: 'csp2_1_2018'
 level 'CSP U2L06 SFLP_2019', named: true
 
 stage 'Unit 2 Assessment', lockable: true, flex_category: 'cspAssessment'
-assessment 'CSP Unit 2 Ch1 Cumulative Assessment MC_2018_2019'
+level 'CSP Unit 2 Ch1 Cumulative Assessment MC_2018_2019', assessment: true

--- a/dashboard/config/scripts/csp2-pilot-staging.script
+++ b/dashboard/config/scripts/csp2-pilot-staging.script
@@ -33,10 +33,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -77,10 +77,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -125,4 +125,4 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/csp3-2017.script
+++ b/dashboard/config/scripts/csp3-2017.script
@@ -13,9 +13,9 @@ is_stable true
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1'
 level 'v2 U3L01 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U3L01 Assessment1', progression: 'Check Your Understanding'
-assessment 'U3L01 Assessment3', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-4-levelgroup-U3Ch1', progression: 'Quick Check-In'
+level 'U3L01 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U3L01 Assessment3', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-4-levelgroup-U3Ch1', progression: 'Quick Check-In', assessment: true
 
 stage 'The Need for Algorithms', flex_category: 'csp3_1'
 level 'v2 U3L02 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -29,10 +29,10 @@ level 'csp_applab_turtle', named: true
 level 'U3L2 Using Simple Commands', progression: 'Using Simple Turtle Commands'
 level 'U3L2_TurtleSquare_right', progression: 'Using Simple Turtle Commands'
 level 'U3L2_Turtle3by3Grid', progression: 'Challenge: Draw a 3x3 Grid Using Turtle Commands'
-assessment 'U3L02 Assessment', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Getting Started', progression: 'Check Your Understanding'
-assessment 'csp_U3_square_v_rect_FR', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Wrap Up', progression: 'Check Your Understanding'
+level 'U3L02 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Getting Started', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_square_v_rect_FR', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating Functions', flex_category: 'csp3_1'
 level 'v2 U3L05 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -45,19 +45,19 @@ level 'U3L03 - draw rect function', progression: 'Using Functions With Turtle Co
 level 'U3L03 - draw step', progression: 'Using Functions With Turtle Commands'
 level 'U3L03 Three Steps', progression: 'Using Functions With Turtle Commands'
 level 'U3L03 draw diamond', progression: 'Challenge: Draw a Diamond Using Functions'
-assessment 'U3L03 - multiselect - properties of functions', progression: 'Check Your Understanding'
-assessment 'U3L03 Assessment', progression: 'Check Your Understanding'
-assessment 'U3L03 Free Response Wrap Up', progression: 'Check Your Understanding'
-assessment 'csp_U3_plan_code_FR', progression: 'Check Your Understanding'
+level 'U3L03 - multiselect - properties of functions', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_plan_code_FR', progression: 'Check Your Understanding', assessment: true
 
 stage 'Functions and Top-Down Design', flex_category: 'csp3_1'
 level 'v2 U3L6 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
 level 'U3L04 - snowflake', progression: 'Using Functions with Turtle Commands'
 level 'U3L04 - 3 by 3 with functions', progression: 'Using Functions with Turtle Commands'
-assessment 'U3-AP-Practice-FR-design-process', progression: '(new)AP Practice Response - Design Process'
-assessment 'U3L04 Assessment1', progression: 'Check Your Understanding'
-assessment 'U3L04 Assessment2', progression: 'Check Your Understanding'
-assessment 'U3L04 Free Response Wrap Up', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-design-process', progression: '(new)AP Practice Response - Design Process', assessment: true
+level 'U3L04 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Assessment2', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
 
 stage 'APIs and Function Parameters', flex_category: 'csp3_1'
 level 'v2 U3L07 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -70,11 +70,11 @@ level 'U3L06 Challenge 6 squiggles', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 5 overlapping circles', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 7 smiley face', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 8 make your own', progression: 'Make Your Own Turtle Drawing'
-assessment 'U3-AP-Practice-FR-score-abstraction-response', progression: '(new)AP Practice Response - Score a student response'
-assessment 'U3L06 Assessment2', progression: 'Check Your Understanding'
-assessment 'U3L06-API-multichoice', progression: 'Check Your Understanding'
-assessment 'U3L06 Assessment', progression: 'Check Your Understanding'
-assessment 'csp3_U3_turtle_subgoal_mc_levelgroup', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-score-abstraction-response', progression: '(new)AP Practice Response - Score a student response', assessment: true
+level 'U3L06 Assessment2', progression: 'Check Your Understanding', assessment: true
+level 'U3L06-API-multichoice', progression: 'Check Your Understanding', assessment: true
+level 'U3L06 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'csp3_U3_turtle_subgoal_mc_levelgroup', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating functions with Parameters', flex_category: 'csp3_1'
 level 'v2 U3L08 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -83,7 +83,7 @@ level 'U3L08 - drawSquareWithParam', progression: 'Drawing Shapes With Parameter
 level 'U3L07 - createTriangleParam', progression: 'Drawing Shapes With Parameters'
 level 'U3L08 - squareTwoParams', progression: 'Drawing Shapes With Parameters'
 level 'U3L08 - createTwoParamTriangle', progression: 'Drawing Shapes With Parameters'
-assessment 'csp_U3_turtle_subgoal_q3_mc', progression: 'Check Your Understanding: Defining Functions'
+level 'csp_U3_turtle_subgoal_q3_mc', progression: 'Check Your Understanding: Defining Functions', assessment: true
 level 'U3 whats a comment', progression: '(new) How to add comments to code', named: true
 level 'U3L08 how to add comments', progression: '(new) How to add comments to code', named: true
 level 'U3L08 - introUnderTheSea', progression: 'Under the Sea Drawing with Parameters'
@@ -92,18 +92,18 @@ level 'U3L08 - seaGrass', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - fish', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - multiParamFish', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - randomInput', progression: 'Under the Sea Drawing with Parameters'
-assessment 'csp_U3_subgoal_q4_mc', progression: 'Check Your Understanding: Using Random Numbers'
+level 'csp_U3_subgoal_q4_mc', progression: 'Check Your Understanding: Using Random Numbers', assessment: true
 level 'U3L08 - freePlay', progression: 'Challenge: Continue Your Drawing With More Functions'
-assessment 'U3-AP-Practice-FR-manage-complexity', progression: '(new)AP Practice Response - Managing Complexity'
-assessment 'U3L08 Assessment1', progression: 'Check Your Understanding'
-assessment 'U3L08 Assessment2', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-manage-complexity', progression: '(new)AP Practice Response - Managing Complexity', assessment: true
+level 'U3L08 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U3L08 Assessment2', progression: 'Check Your Understanding', assessment: true
 
 stage 'Looping and Random Numbers', flex_category: 'csp3_1'
 level 'v2 U3L09 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
 level 'csp_applab_loops', progression: 'Using Loops'
 level 'U3L07 - introSquare', progression: 'Introduction to Loops'
 level 'U3L07 - randomSquare', progression: 'Introduction to Loops'
-assessment 'subgoals_U3_turtle_prediction_FR', progression: 'Introduction to Loops'
+level 'subgoals_U3_turtle_prediction_FR', progression: 'Introduction to Loops', assessment: true
 level 'U3L07 - randomDots1', progression: 'Introduction to Loops'
 level 'U3L07 - loopsWithRandom', progression: 'Introduction to Loops'
 level 'U3L07 - topDownDesign', progression: 'Using Loops to Add Detail to Your Drawing'
@@ -114,10 +114,10 @@ level 'U3L07 - seaGrass', progression: 'Using Loops to Add Detail to Your Drawin
 level 'U3L07 - allSeaGrass', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'U3L07 - sunBeams', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'U3L07 - Free Play Loops and Random', progression: 'Project: Under the Sea'
-assessment 'U3-AP-Practice-Choose-The-Abstraction', progression: '(new)AP Practice Response - Identify the Abstraction'
-assessment 'U3L07 - MC remove line of code loops', progression: 'Check Your Understanding'
-assessment 'U3L07 Free Response Reflection', progression: 'Check Your Understanding'
-assessment 'subgoals_u3_top_down_FR', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-Choose-The-Abstraction', progression: '(new)AP Practice Response - Identify the Abstraction', assessment: true
+level 'U3L07 - MC remove line of code loops', progression: 'Check Your Understanding', assessment: true
+level 'U3L07 Free Response Reflection', progression: 'Check Your Understanding', assessment: true
+level 'subgoals_u3_top_down_FR', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - Design a Digital Scene', flex_category: 'csp3_1'
 level 'v2 U3L10 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -130,7 +130,7 @@ variants
   level 'csp_affirmation_control_3', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
   level 'csp_affirmation_intervention_3', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
 endvariants
-assessment 'CSP Unit 3 Ch1 Cumulative Assessment MC Group'
+level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group', assessment: true
 
 stage 'Post-Course Survey', flex_category: 'cspSurvey'
 level 'csp-post-survey-2018-markdown-with-link-to-survey', progression: 'Click here! Complete the CS Principles post-course survey'

--- a/dashboard/config/scripts/csp3-2018.script
+++ b/dashboard/config/scripts/csp3-2018.script
@@ -13,9 +13,9 @@ is_stable true
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1_2018'
 level 'CSP U3L01 SFLP', named: true
-assessment 'U3L01 Assessment1_2018', progression: 'Check Your Understanding'
-assessment 'U3L01 Assessment3_2018', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-4-levelgroup-U3Ch1_2018', progression: 'Quick Check-In'
+level 'U3L01 Assessment1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L01 Assessment3_2018', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-4-levelgroup-U3Ch1_2018', progression: 'Quick Check-In', assessment: true
 
 stage 'The Need for Algorithms', flex_category: 'csp3_1_2018'
 level 'CSP U3L02 SFLP', named: true
@@ -29,10 +29,10 @@ level 'csp_applab_turtle_2018', named: true
 level 'U3L2 Using Simple Commands_2018', progression: 'Using Simple Turtle Commands'
 level 'U3L2_TurtleSquare_right_2018', progression: 'Using Simple Turtle Commands'
 level 'U3L2_Turtle3by3Grid_2018', progression: 'Challenge: Draw a 3x3 Grid Using Turtle Commands'
-assessment 'U3L02 Assessment_2018', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Getting Started_2018', progression: 'Check Your Understanding'
-assessment 'csp_U3_square_v_rect_FR_2018', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Wrap Up_2018', progression: 'Check Your Understanding'
+level 'U3L02 Assessment_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Getting Started_2018', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_square_v_rect_FR_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Wrap Up_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating Functions', flex_category: 'csp3_1_2018'
 level 'CSP U3L05 SFLP', named: true
@@ -45,19 +45,19 @@ level 'U3L03 - draw rect function_2018', progression: 'Using Functions With Turt
 level 'U3L03 - draw step_2018', progression: 'Using Functions With Turtle Commands'
 level 'U3L03 Three Steps_2018', progression: 'Using Functions With Turtle Commands'
 level 'U3L03 draw diamond_2018', progression: 'Challenge: Draw a Diamond Using Functions'
-assessment 'U3L03 - multiselect - properties of functions_2018', progression: 'Check Your Understanding'
-assessment 'U3L03 Assessment_2018', progression: 'Check Your Understanding'
-assessment 'U3L03 Free Response Wrap Up_2018', progression: 'Check Your Understanding'
-assessment 'csp_U3_plan_code_FR_2018', progression: 'Check Your Understanding'
+level 'U3L03 - multiselect - properties of functions_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Assessment_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Free Response Wrap Up_2018', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_plan_code_FR_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Functions and Top-Down Design', flex_category: 'csp3_1_2018'
 level 'CSP U3L06 SFLP', named: true
 level 'U3L04 - snowflake_2018', progression: 'Using Functions with Turtle Commands'
 level 'U3L04 - 3 by 3 with functions_2018', progression: 'Using Functions with Turtle Commands'
-assessment 'U3-AP-Practice-FR-design-process_2018', progression: 'AP Practice Response - Design Process'
-assessment 'U3L04 Assessment1_2018', progression: 'Check Your Understanding'
-assessment 'U3L04 Assessment2_2018', progression: 'Check Your Understanding'
-assessment 'U3L04 Free Response Wrap Up_2018', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-design-process_2018', progression: 'AP Practice Response - Design Process', assessment: true
+level 'U3L04 Assessment1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Assessment2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Free Response Wrap Up_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'APIs and Function Parameters', flex_category: 'csp3_1_2018'
 level 'CSP U3L07 SFLP', named: true
@@ -70,11 +70,11 @@ level 'U3L06 Challenge 6 squiggles_2018', progression: 'Introduction to Paramete
 level 'U3L06 Challenge 5 overlapping circles_2018', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 7 smiley face_2018', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 8 make your own_2018', progression: 'Make Your Own Turtle Drawing'
-assessment 'U3-AP-Practice-FR-score-abstraction-response_2018', progression: 'AP Practice Response - Score a student response'
-assessment 'U3L06 Assessment2_2018', progression: 'Check Your Understanding'
-assessment 'U3L06-API-multichoice_2018', progression: 'Check Your Understanding'
-assessment 'U3L06 Assessment_2018', progression: 'Check Your Understanding'
-assessment 'csp3_U3_turtle_subgoal_mc_levelgroup_2018', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-score-abstraction-response_2018', progression: 'AP Practice Response - Score a student response', assessment: true
+level 'U3L06 Assessment2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L06-API-multichoice_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L06 Assessment_2018', progression: 'Check Your Understanding', assessment: true
+level 'csp3_U3_turtle_subgoal_mc_levelgroup_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating functions with Parameters', flex_category: 'csp3_1_2018'
 level 'CSP U3L08 SFLP', named: true
@@ -83,7 +83,7 @@ level 'U3L08 - drawSquareWithParam_2018', progression: 'Drawing Shapes With Para
 level 'U3L07 - createTriangleParam_2018', progression: 'Drawing Shapes With Parameters'
 level 'U3L08 - squareTwoParams_2018', progression: 'Drawing Shapes With Parameters'
 level 'U3L08 - createTwoParamTriangle_2018', progression: 'Drawing Shapes With Parameters'
-assessment 'csp_U3_turtle_subgoal_q3_mc_2018', progression: 'Check Your Understanding: Defining Functions'
+level 'csp_U3_turtle_subgoal_q3_mc_2018', progression: 'Check Your Understanding: Defining Functions', assessment: true
 level 'U3 whats a comment_2018', progression: 'How to add comments to code', named: true
 level 'U3L08 how to add comments_2018', progression: 'How to add comments to code', named: true
 level 'U3L08 - introUnderTheSea_2018', progression: 'Under the Sea Drawing with Parameters'
@@ -92,18 +92,18 @@ level 'U3L08 - seaGrass_2018', progression: 'Under the Sea Drawing with Paramete
 level 'U3L08 - fish_2018', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - multiParamFish_2018', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - randomInput_2018', progression: 'Under the Sea Drawing with Parameters'
-assessment 'csp_U3_subgoal_q4_mc_2018', progression: 'Check Your Understanding: Using Random Numbers'
+level 'csp_U3_subgoal_q4_mc_2018', progression: 'Check Your Understanding: Using Random Numbers', assessment: true
 level 'U3L08 - freePlay_2018', progression: 'Challenge: Continue Your Drawing With More Functions'
-assessment 'U3-AP-Practice-FR-manage-complexity_2018', progression: 'AP Practice Response - Managing Complexity'
-assessment 'U3L08 Assessment1_2018', progression: 'Check Your Understanding'
-assessment 'U3L08 Assessment2_2018', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-manage-complexity_2018', progression: 'AP Practice Response - Managing Complexity', assessment: true
+level 'U3L08 Assessment1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L08 Assessment2_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Looping and Random Numbers', flex_category: 'csp3_1_2018'
 level 'CSP U3L09 SFLP', named: true
 level 'csp_applab_loops_2018', progression: 'Using Loops'
 level 'U3L07 - introSquare_2018', progression: 'Introduction to Loops'
 level 'U3L07 - randomSquare_2018', progression: 'Introduction to Loops'
-assessment 'subgoals_U3_turtle_prediction_FR_2018', progression: 'Introduction to Loops'
+level 'subgoals_U3_turtle_prediction_FR_2018', progression: 'Introduction to Loops', assessment: true
 level 'U3L07 - randomDots1_2018', progression: 'Introduction to Loops'
 level 'U3L07 - loopsWithRandom_2018', progression: 'Introduction to Loops'
 level 'U3L07 - topDownDesign_2018', progression: 'Using Loops to Add Detail to Your Drawing'
@@ -114,10 +114,10 @@ level 'U3L07 - seaGrass_2018', progression: 'Using Loops to Add Detail to Your D
 level 'U3L07 - allSeaGrass_2018', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'U3L07 - sunBeams_2018', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'U3L07 - Free Play Loops and Random_2018', progression: 'Project: Under the Sea'
-assessment 'U3-AP-Practice-Choose-The-Abstraction_2018', progression: 'AP Practice Response - Identify the Abstraction'
-assessment 'U3L07 - MC remove line of code loops_2018', progression: 'Check Your Understanding'
-assessment 'U3L07 Free Response Reflection_2018', progression: 'Check Your Understanding'
-assessment 'subgoals_u3_top_down_FR_2018', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-Choose-The-Abstraction_2018', progression: 'AP Practice Response - Identify the Abstraction', assessment: true
+level 'U3L07 - MC remove line of code loops_2018', progression: 'Check Your Understanding', assessment: true
+level 'U3L07 Free Response Reflection_2018', progression: 'Check Your Understanding', assessment: true
+level 'subgoals_u3_top_down_FR_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - Design a Digital Scene', flex_category: 'csp3_1_2018'
 level 'CSP U3L10 SFLP', named: true
@@ -126,7 +126,7 @@ level 'How To: Share Code with Teammates_2018', progression: 'How to Share Code 
 level 'U3L08 - digitalScene_2018', progression: 'Challenge: Design Your Digital Scene'
 
 stage 'Unit 3 Chapter 1 Assessment', lockable: true, flex_category: 'cspAssessment'
-assessment 'CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018'
+level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018', assessment: true
 
 stage 'Mid-Year Survey', flex_category: 'cspSurvey'
 level 'csp-mid-survey-2018-markdown-with-link-to-survey', progression: 'Click here! Complete the CS Principles Mid-year survey'

--- a/dashboard/config/scripts/csp3-2019.script
+++ b/dashboard/config/scripts/csp3-2019.script
@@ -10,9 +10,9 @@ version_year '2019'
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1_2018'
 level 'CSP U3L01 SFLP_2019', named: true
-assessment 'U3L01 Assessment1_2019', progression: 'Check Your Understanding'
-assessment 'U3L01 Assessment3_2019', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-4-levelgroup-U3Ch1_2018_2019', progression: 'Quick Check-In'
+level 'U3L01 Assessment1_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L01 Assessment3_2019', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-4-levelgroup-U3Ch1_2018_2019', progression: 'Quick Check-In', assessment: true
 
 stage 'The Need for Algorithms', flex_category: 'csp3_1_2018'
 level 'CSP U3L02 SFLP_2019', named: true
@@ -26,10 +26,10 @@ level 'csp_applab_turtle_2019', named: true
 level 'U3L2 Using Simple Commands_2019', progression: 'Using Simple Turtle Commands'
 level 'U3L2_TurtleSquare_right_2019', progression: 'Using Simple Turtle Commands'
 level 'U3L2_Turtle3by3Grid_2019', progression: 'Challenge: Draw a 3x3 Grid Using Turtle Commands'
-assessment 'U3L02 Assessment_2019', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Getting Started_2019', progression: 'Check Your Understanding'
-assessment 'csp_U3_square_v_rect_FR_2019', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Wrap Up_2019', progression: 'Check Your Understanding'
+level 'U3L02 Assessment_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Getting Started_2019', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_square_v_rect_FR_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating Functions', flex_category: 'csp3_1_2018'
 level 'CSP U3L05 SFLP_2019', named: true
@@ -42,19 +42,19 @@ level 'U3L03 - draw rect function_2019', progression: 'Using Functions With Turt
 level 'U3L03 - draw step_2019', progression: 'Using Functions With Turtle Commands'
 level 'U3L03 Three Steps_2019', progression: 'Using Functions With Turtle Commands'
 level 'U3L03 draw diamond_2019', progression: 'Challenge: Draw a Diamond Using Functions'
-assessment 'U3L03 - multiselect - properties of functions_2018_2019', progression: 'Check Your Understanding'
-assessment 'U3L03 Assessment_2018_2019', progression: 'Check Your Understanding'
-assessment 'U3L03 Free Response Wrap Up_2019', progression: 'Check Your Understanding'
-assessment 'csp_U3_plan_code_FR_2019', progression: 'Check Your Understanding'
+level 'U3L03 - multiselect - properties of functions_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Assessment_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_plan_code_FR_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Functions and Top-Down Design', flex_category: 'csp3_1_2018'
 level 'CSP U3L06 SFLP_2019', named: true
 level 'U3L04 - snowflake_2019', progression: 'Using Functions with Turtle Commands'
 level 'U3L04 - 3 by 3 with functions_2019', progression: 'Using Functions with Turtle Commands'
-assessment 'U3-AP-Practice-FR-design-process_2019', progression: 'AP Practice Response - Design Process'
-assessment 'U3L04 Assessment1_2019', progression: 'Check Your Understanding'
-assessment 'U3L04 Assessment2_2018_2019', progression: 'Check Your Understanding'
-assessment 'U3L04 Free Response Wrap Up_2019', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-design-process_2019', progression: 'AP Practice Response - Design Process', assessment: true
+level 'U3L04 Assessment1_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Assessment2_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'APIs and Function Parameters', flex_category: 'csp3_1_2018'
 level 'CSP U3L07 SFLP_2019', named: true
@@ -67,11 +67,11 @@ level 'U3L06 Challenge 6 squiggles_2019', progression: 'Introduction to Paramete
 level 'U3L06 Challenge 5 overlapping circles_2019', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 7 smiley face_2019', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 8 make your own_2019', progression: 'Make Your Own Turtle Drawing'
-assessment 'U3-AP-Practice-FR-score-abstraction-response_2019', progression: 'AP Practice Response - Score a student response'
-assessment 'U3L06 Assessment2_2018_2019', progression: 'Check Your Understanding'
-assessment 'U3L06-API-multichoice_2018_2019', progression: 'Check Your Understanding'
-assessment 'U3L06 Assessment_2019', progression: 'Check Your Understanding'
-assessment 'csp3_U3_turtle_subgoal_mc_levelgroup_2018_2019', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-score-abstraction-response_2019', progression: 'AP Practice Response - Score a student response', assessment: true
+level 'U3L06 Assessment2_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L06-API-multichoice_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L06 Assessment_2019', progression: 'Check Your Understanding', assessment: true
+level 'csp3_U3_turtle_subgoal_mc_levelgroup_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating functions with Parameters', flex_category: 'csp3_1_2018'
 level 'CSP U3L08 SFLP_2019', named: true
@@ -80,7 +80,7 @@ level 'U3L08 - drawSquareWithParam_2019', progression: 'Drawing Shapes With Para
 level 'U3L07 - createTriangleParam_2019', progression: 'Drawing Shapes With Parameters'
 level 'U3L08 - squareTwoParams_2019', progression: 'Drawing Shapes With Parameters'
 level 'U3L08 - createTwoParamTriangle_2019', progression: 'Drawing Shapes With Parameters'
-assessment 'csp_U3_turtle_subgoal_q3_mc_2018_2019', progression: 'Check Your Understanding: Defining Functions'
+level 'csp_U3_turtle_subgoal_q3_mc_2018_2019', progression: 'Check Your Understanding: Defining Functions', assessment: true
 level 'U3 whats a comment_2018_2019', progression: 'How to add comments to code'
 level 'U3L08 how to add comments_2019', progression: 'How to add comments to code'
 level 'U3L08 - introUnderTheSea_2019', progression: 'Under the Sea Drawing with Parameters'
@@ -89,18 +89,18 @@ level 'U3L08 - seaGrass_2019', progression: 'Under the Sea Drawing with Paramete
 level 'U3L08 - fish_2019', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - multiParamFish_2019', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - randomInput_2019', progression: 'Under the Sea Drawing with Parameters'
-assessment 'csp_U3_subgoal_q4_mc_2018_2019', progression: 'Check Your Understanding: Using Random Numbers'
+level 'csp_U3_subgoal_q4_mc_2018_2019', progression: 'Check Your Understanding: Using Random Numbers', assessment: true
 level 'U3L08 - freePlay_2019', progression: 'Challenge: Continue Your Drawing With More Functions'
-assessment 'U3-AP-Practice-FR-manage-complexity_2019', progression: 'AP Practice Response - Managing Complexity'
-assessment 'U3L08 Assessment1_2018_2019', progression: 'Check Your Understanding'
-assessment 'U3L08 Assessment2_2019', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-manage-complexity_2019', progression: 'AP Practice Response - Managing Complexity', assessment: true
+level 'U3L08 Assessment1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L08 Assessment2_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Looping and Random Numbers', flex_category: 'csp3_1_2018'
 level 'CSP U3L09 SFLP_2019', named: true
 level 'csp_applab_loops_2019', progression: 'Using Loops'
 level 'U3L07 - introSquare_2019', progression: 'Introduction to Loops'
 level 'U3L07 - randomSquare_2019', progression: 'Introduction to Loops'
-assessment 'subgoals_U3_turtle_prediction_FR_2019', progression: 'Introduction to Loops'
+level 'subgoals_U3_turtle_prediction_FR_2019', progression: 'Introduction to Loops', assessment: true
 level 'U3L07 - randomDots1_2019', progression: 'Introduction to Loops'
 level 'U3L07 - loopsWithRandom_2019', progression: 'Introduction to Loops'
 level 'U3L07 - topDownDesign_2019', progression: 'Using Loops to Add Detail to Your Drawing'
@@ -111,19 +111,19 @@ level 'U3L07 - seaGrass_2019', progression: 'Using Loops to Add Detail to Your D
 level 'U3L07 - allSeaGrass_2019', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'U3L07 - sunBeams_2019', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'U3L07 - Free Play Loops and Random_2019', progression: 'Project: Under the Sea'
-assessment 'U3-AP-Practice-Choose-The-Abstraction_2019', progression: 'AP Practice Response - Identify the Abstraction'
-assessment 'U3L07 - MC remove line of code loops_2018_2019', progression: 'Check Your Understanding'
-assessment 'U3L07 Free Response Reflection_2019', progression: 'Check Your Understanding'
-assessment 'subgoals_u3_top_down_FR_2019', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-Choose-The-Abstraction_2019', progression: 'AP Practice Response - Identify the Abstraction', assessment: true
+level 'U3L07 - MC remove line of code loops_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U3L07 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
+level 'subgoals_u3_top_down_FR_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - Design a Digital Scene', flex_category: 'csp3_1_2018'
 level 'CSP U3L10 SFLP_2019', named: true
 level 'U3L08 - individualCode_2019', progression: 'Design Your Components'
 level 'How To: Share Code with Teammates_2018_2019', progression: 'How to Share Code with Teammates'
-assessment 'U3L08 - digitalScene_2019', progression: 'Challenge: Design Your Digital Scene'
+level 'U3L08 - digitalScene_2019', progression: 'Challenge: Design Your Digital Scene', assessment: true
 
 stage 'Unit 3 Chapter 1 Assessment', lockable: true, flex_category: 'cspAssessment'
-assessment 'CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018_2019'
+level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018_2019', assessment: true
 
 stage 'Mid-Year Survey', flex_category: 'cspSurvey'
 level 'csp-mid-survey-2018-markdown-with-link-to-survey_2019', progression: 'Click here! Complete the CS Principles Mid-year survey'

--- a/dashboard/config/scripts/csp3-pilot-staging.script
+++ b/dashboard/config/scripts/csp3-pilot-staging.script
@@ -33,10 +33,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -77,10 +77,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -125,4 +125,4 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/csp3-research-mxghyt.script
+++ b/dashboard/config/scripts/csp3-research-mxghyt.script
@@ -8,9 +8,9 @@ script_announcements [{"notice"=>"Check out the CSP mid-course survey", "details
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1'
 level 'v2 U3L01 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U3L01 Assessment1', progression: 'Check Your Understanding'
-assessment 'U3L01 Assessment3', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-4-levelgroup-U3Ch1', progression: 'Quick Check-In'
+level 'U3L01 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U3L01 Assessment3', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-4-levelgroup-U3Ch1', progression: 'Quick Check-In', assessment: true
 
 stage 'The Need for Algorithms', flex_category: 'csp3_1'
 level 'v2 U3L02 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -27,10 +27,10 @@ level 'SG U3L2 Using Simple Commands', progression: 'Introducing Simple Commands
 level 'SG U3L2_TurtleSquare_right', progression: 'Introducing Simple Commands and Subgoals'
 level 'SG Add Subgoals practice', progression: 'Introducing Simple Commands and Subgoals'
 level 'SG U3L2_Turtle3by3Grid', progression: 'Challenge: Draw a 3x3 Grid Using Turtle Commands'
-assessment 'U3L02 Assessment', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Getting Started', progression: 'Check Your Understanding'
-assessment 'csp_U3_square_v_rect_FR', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Wrap Up', progression: 'Check Your Understanding'
+level 'U3L02 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Getting Started', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_square_v_rect_FR', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating Functions', flex_category: 'csp3_1'
 level 'SG v2 U3L05 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -43,19 +43,19 @@ level 'SG U3L03 - draw rect function', progression: 'Using Functions With Turtle
 level 'SG U3L03 - draw step', progression: 'Using Functions With Turtle Commands'
 level 'SG U3L03 Three Steps', progression: 'Using Functions With Turtle Commands'
 level 'SG U3L03 draw diamond', progression: 'Challenge: Draw a Diamond Using Functions'
-assessment 'U3L03 - multiselect - properties of functions', progression: 'Check Your Understanding'
-assessment 'U3L03 Assessment', progression: 'Check Your Understanding'
-assessment 'U3L03 Free Response Wrap Up', progression: 'Check Your Understanding'
-assessment 'csp_U3_plan_code_FR', progression: 'Check Your Understanding'
+level 'U3L03 - multiselect - properties of functions', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_plan_code_FR', progression: 'Check Your Understanding', assessment: true
 
 stage 'Functions and Top-Down Design', flex_category: 'csp3_1'
 level 'SG v2 U3L6 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
 level 'SG U3L04 - snowflake', progression: 'Using Functions with Turtle Commands'
 level 'SG U3L04 - 3 by 3 with functions', progression: 'Using Functions with Turtle Commands'
-assessment 'U3-AP-Practice-FR-design-process', progression: '(new)AP Practice Response - Design Process'
-assessment 'U3L04 Assessment1', progression: 'Check Your Understanding'
-assessment 'U3L04 Assessment2', progression: 'Check Your Understanding'
-assessment 'U3L04 Free Response Wrap Up', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-design-process', progression: '(new)AP Practice Response - Design Process', assessment: true
+level 'U3L04 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Assessment2', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
 
 stage 'APIs and Function Parameters', flex_category: 'csp3_1'
 level 'SG v2 U3L07 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -69,11 +69,11 @@ level 'SG U3L06 Challenge 6 squiggles', progression: 'Introduction to Parameters
 level 'SG U3L06 Challenge 5 overlapping circles', progression: 'Introduction to Parameters'
 level 'SG U3L06 Challenge 7 smiley face', progression: 'Introduction to Parameters'
 level 'SG U3L06 Challenge 8 make your own', progression: 'Make Your Own Turtle Drawing'
-assessment 'U3-AP-Practice-FR-score-abstraction-response', progression: '(new)AP Practice Response - Score a student response'
-assessment 'U3L06 Assessment2', progression: 'Check Your Understanding'
-assessment 'U3L06-API-multichoice', progression: 'Check Your Understanding'
-assessment 'U3L06 Assessment', progression: 'Check Your Understanding'
-assessment 'csp3_U3_turtle_subgoal_mc_levelgroup', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-score-abstraction-response', progression: '(new)AP Practice Response - Score a student response', assessment: true
+level 'U3L06 Assessment2', progression: 'Check Your Understanding', assessment: true
+level 'U3L06-API-multichoice', progression: 'Check Your Understanding', assessment: true
+level 'U3L06 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'csp3_U3_turtle_subgoal_mc_levelgroup', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating functions with Parameters', flex_category: 'csp3_1'
 level 'SG v2 U3L08 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -82,7 +82,7 @@ level 'SG U3L08 - drawSquareWithParam', progression: 'Drawing Shapes With Parame
 level 'SG U3L07 - createTriangleParam', progression: 'Drawing Shapes With Parameters'
 level 'SG U3L08 - squareTwoParams', progression: 'Drawing Shapes With Parameters'
 level 'SG U3L08 - createTwoParamTriangle', progression: 'Drawing Shapes With Parameters'
-assessment 'SG csp_U3_turtle_subgoal_q3_mc', progression: 'Check Your Understanding: Defining Functions'
+level 'SG csp_U3_turtle_subgoal_q3_mc', progression: 'Check Your Understanding: Defining Functions', assessment: true
 level 'SG U3 whats a comment', progression: '(new) How to add comments to code', named: true
 level 'SG U3L08 how to add comments', progression: '(new) How to add comments to code', named: true
 level 'SG U3L08 - introUnderTheSea', progression: 'Under the Sea Drawing with Parameters'
@@ -91,18 +91,18 @@ level 'SG U3L08 - seaGrass', progression: 'Under the Sea Drawing with Parameters
 level 'SG U3L08 - fish', progression: 'Under the Sea Drawing with Parameters'
 level 'SG U3L08 - multiParamFish', progression: 'Under the Sea Drawing with Parameters'
 level 'SG U3L08 - randomInput', progression: 'Under the Sea Drawing with Parameters'
-assessment 'csp_U3_subgoal_q4_mc', progression: 'Check Your Understanding: Using Random Numbers'
+level 'csp_U3_subgoal_q4_mc', progression: 'Check Your Understanding: Using Random Numbers', assessment: true
 level 'SG U3L08 - freePlay', progression: 'Challenge: Continue Your Drawing With More Functions'
-assessment 'U3-AP-Practice-FR-manage-complexity', progression: '(new)AP Practice Response - Managing Complexity'
-assessment 'U3L08 Assessment1', progression: 'Check Your Understanding'
-assessment 'U3L08 Assessment2', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-manage-complexity', progression: '(new)AP Practice Response - Managing Complexity', assessment: true
+level 'U3L08 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U3L08 Assessment2', progression: 'Check Your Understanding', assessment: true
 
 stage 'Looping and Random Numbers', flex_category: 'csp3_1'
 level 'SG v2 U3L09 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
 level 'SG csp_applab_loops', progression: 'Using Loops'
 level 'SG U3L07 - introSquare', progression: 'Introduction to Loops'
 level 'SG U3L07 - randomSquare', progression: 'Introduction to Loops'
-assessment 'SG subgoals_U3_turtle_prediction_FR', progression: 'Introduction to Loops'
+level 'SG subgoals_U3_turtle_prediction_FR', progression: 'Introduction to Loops', assessment: true
 level 'SG U3L07 - randomDots1', progression: 'Introduction to Loops'
 level 'SG U3L07 - loopsWithRandom', progression: 'Introduction to Loops'
 level 'SG U3L07 - topDownDesign', progression: 'Using Loops to Add Detail to Your Drawing'
@@ -113,10 +113,10 @@ level 'SG U3L07 - seaGrass', progression: 'Using Loops to Add Detail to Your Dra
 level 'SG U3L07 - allSeaGrass', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'SG U3L07 - sunBeams', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'SG U3L07 - Free Play Loops and Random', progression: 'Project: Under the Sea'
-assessment 'U3-AP-Practice-Choose-The-Abstraction', progression: '(new)AP Practice Response - Identify the Abstraction'
-assessment 'U3L07 - MC remove line of code loops', progression: 'Check Your Understanding'
-assessment 'U3L07 Free Response Reflection', progression: 'Check Your Understanding'
-assessment 'subgoals_u3_top_down_FR', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-Choose-The-Abstraction', progression: '(new)AP Practice Response - Identify the Abstraction', assessment: true
+level 'U3L07 - MC remove line of code loops', progression: 'Check Your Understanding', assessment: true
+level 'U3L07 Free Response Reflection', progression: 'Check Your Understanding', assessment: true
+level 'subgoals_u3_top_down_FR', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - Design a Digital Scene', flex_category: 'csp3_1'
 level 'SG v2 U3L10 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -129,7 +129,7 @@ variants
   level 'csp_affirmation_control_3', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
   level 'csp_affirmation_intervention_3', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
 endvariants
-assessment 'CSP Unit 3 Ch1 Cumulative Assessment MC Group'
+level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group', assessment: true
 
 stage 'Please complete the CSP Mid-course survey', lockable: true, flex_category: 'cspSurvey'
-assessment 'csp-post-survey-2017-levelgroup'
+level 'csp-post-survey-2017-levelgroup', assessment: true

--- a/dashboard/config/scripts/csp3-staging.script
+++ b/dashboard/config/scripts/csp3-staging.script
@@ -5,9 +5,9 @@ has_verified_resources true
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1'
 level 'v2 U3L01 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U3L01 Assessment1', progression: 'Check Your Understanding'
-assessment 'U3L01 Assessment3', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-4-levelgroup-U3Ch1', progression: 'Quick Check-In'
+level 'U3L01 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U3L01 Assessment3', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-4-levelgroup-U3Ch1', progression: 'Quick Check-In', assessment: true
 
 stage 'The Need for Algorithms', flex_category: 'csp3_1'
 level 'v2 U3L02 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -21,10 +21,10 @@ level 'csp_applab_turtle', progression: 'Turtle Programming'
 level 'U3L2 Using Simple Commands', progression: 'Using Simple Turtle Commands'
 level 'U3L2_TurtleSquare_right', progression: 'Using Simple Turtle Commands'
 level 'U3L2_Turtle3by3Grid', progression: 'Challenge: Draw a 3x3 Grid Using Turtle Commands'
-assessment 'U3L02 Assessment', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Getting Started', progression: 'Check Your Understanding'
-assessment 'csp_U3_square_v_rect_FR', progression: 'Check Your Understanding'
-assessment 'U3L02 Free Response Wrap Up', progression: 'Check Your Understanding'
+level 'U3L02 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Getting Started', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_square_v_rect_FR', progression: 'Check Your Understanding', assessment: true
+level 'U3L02 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating Functions', flex_category: 'csp3_1'
 level 'v2 U3L05 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -37,19 +37,19 @@ level 'U3L03 - draw rect function', progression: 'Using Functions With Turtle Co
 level 'U3L03 - draw step', progression: 'Using Functions With Turtle Commands'
 level 'U3L03 Three Steps', progression: 'Using Functions With Turtle Commands'
 level 'U3L03 draw diamond', progression: 'Challenge: Draw a Diamond Using Functions'
-assessment 'U3L03 - multiselect - properties of functions', progression: 'Check Your Understanding'
-assessment 'U3L03 Assessment', progression: 'Check Your Understanding'
-assessment 'U3L03 Free Response Wrap Up', progression: 'Check Your Understanding'
-assessment 'csp_U3_plan_code_FR', progression: 'Check Your Understanding'
+level 'U3L03 - multiselect - properties of functions', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'U3L03 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
+level 'csp_U3_plan_code_FR', progression: 'Check Your Understanding', assessment: true
 
 stage 'Functions and Top-Down Design', flex_category: 'csp3_1'
 level 'v2 U3L6 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
 level 'U3L04 - snowflake', progression: 'Using Functions with Turtle Commands'
 level 'U3L04 - 3 by 3 with functions', progression: 'Using Functions with Turtle Commands'
-assessment 'U3-AP-Practice-FR-design-process', progression: '(new)AP Practice Response - Design Process'
-assessment 'U3L04 Assessment1', progression: 'Check Your Understanding'
-assessment 'U3L04 Assessment2', progression: 'Check Your Understanding'
-assessment 'U3L04 Free Response Wrap Up', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-design-process', progression: '(new)AP Practice Response - Design Process', assessment: true
+level 'U3L04 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Assessment2', progression: 'Check Your Understanding', assessment: true
+level 'U3L04 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
 
 stage 'APIs and Function Parameters', flex_category: 'csp3_1'
 level 'v2 U3L07 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -62,11 +62,11 @@ level 'U3L06 Challenge 6 squiggles', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 5 overlapping circles', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 7 smiley face', progression: 'Introduction to Parameters'
 level 'U3L06 Challenge 8 make your own', progression: 'Make Your Own Turtle Drawing'
-assessment 'U3-AP-Practice-FR-score-abstraction-response', progression: '(new)AP Practice Response - Score a student response'
-assessment 'U3L06 Assessment2', progression: 'Check Your Understanding'
-assessment 'U3L06-API-multichoice', progression: 'Check Your Understanding'
-assessment 'U3L06 Assessment', progression: 'Check Your Understanding'
-assessment 'csp3_U3_turtle_subgoal_mc_levelgroup', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-score-abstraction-response', progression: '(new)AP Practice Response - Score a student response', assessment: true
+level 'U3L06 Assessment2', progression: 'Check Your Understanding', assessment: true
+level 'U3L06-API-multichoice', progression: 'Check Your Understanding', assessment: true
+level 'U3L06 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'csp3_U3_turtle_subgoal_mc_levelgroup', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating functions with Parameters', flex_category: 'csp3_1'
 level 'v2 U3L08 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -75,7 +75,7 @@ level 'U3L08 - drawSquareWithParam', progression: 'Drawing Shapes With Parameter
 level 'U3L07 - createTriangleParam', progression: 'Drawing Shapes With Parameters'
 level 'U3L08 - squareTwoParams', progression: 'Drawing Shapes With Parameters'
 level 'U3L08 - createTwoParamTriangle', progression: 'Drawing Shapes With Parameters'
-assessment 'csp_U3_turtle_subgoal_q3_mc', progression: 'Check Your Understanding: Defining Functions'
+level 'csp_U3_turtle_subgoal_q3_mc', progression: 'Check Your Understanding: Defining Functions', assessment: true
 level 'U3 whats a comment', progression: '(new) How to add comments to code', named: true
 level 'U3L08 how to add comments', progression: '(new) How to add comments to code', named: true
 level 'U3L08 - introUnderTheSea with comments', progression: '(modification only) Intro to under the sea (instruction, and template change only)', named: true
@@ -84,18 +84,18 @@ level 'U3L08 - seaGrass', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - fish', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - multiParamFish', progression: 'Under the Sea Drawing with Parameters'
 level 'U3L08 - randomInput', progression: 'Under the Sea Drawing with Parameters'
-assessment 'csp_U3_subgoal_q4_mc', progression: 'Check Your Understanding: Using Random Numbers'
+level 'csp_U3_subgoal_q4_mc', progression: 'Check Your Understanding: Using Random Numbers', assessment: true
 level 'U3L08 - freePlay', progression: 'Challenge: Continue Your Drawing With More Functions'
-assessment 'U3-AP-Practice-FR-manage-complexity', progression: '(new)AP Practice Response - Managing Complexity'
-assessment 'U3L08 Assessment1', progression: 'Check Your Understanding'
-assessment 'U3L08 Assessment2', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-FR-manage-complexity', progression: '(new)AP Practice Response - Managing Complexity', assessment: true
+level 'U3L08 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U3L08 Assessment2', progression: 'Check Your Understanding', assessment: true
 
 stage 'Looping and Random Numbers', flex_category: 'csp3_1'
 level 'v2 U3L09 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources', named: true
 level 'csp_applab_loops', progression: 'Using Loops'
 level 'U3L07 - introSquare', progression: 'Introduction to Loops'
 level 'U3L07 - randomSquare', progression: 'Introduction to Loops'
-assessment 'subgoals_U3_turtle_prediction_FR', progression: 'Introduction to Loops'
+level 'subgoals_U3_turtle_prediction_FR', progression: 'Introduction to Loops', assessment: true
 level 'U3L07 - randomDots1', progression: 'Introduction to Loops'
 level 'U3L07 - loopsWithRandom', progression: 'Introduction to Loops'
 level 'U3L07 - topDownDesign', progression: 'Using Loops to Add Detail to Your Drawing'
@@ -106,10 +106,10 @@ level 'U3L07 - seaGrass', progression: 'Using Loops to Add Detail to Your Drawin
 level 'U3L07 - allSeaGrass', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'U3L07 - sunBeams', progression: 'Using Loops to Add Detail to Your Drawing'
 level 'U3L07 - Free Play Loops and Random', progression: 'Project: Under the Sea'
-assessment 'U3-AP-Practice-Choose-The-Abstraction', progression: '(new)AP Practice Response - Identify the Abstraction'
-assessment 'U3L07 - MC remove line of code loops', progression: 'Check Your Understanding'
-assessment 'U3L07 Free Response Reflection', progression: 'Check Your Understanding'
-assessment 'subgoals_u3_top_down_FR', progression: 'Check Your Understanding'
+level 'U3-AP-Practice-Choose-The-Abstraction', progression: '(new)AP Practice Response - Identify the Abstraction', assessment: true
+level 'U3L07 - MC remove line of code loops', progression: 'Check Your Understanding', assessment: true
+level 'U3L07 Free Response Reflection', progression: 'Check Your Understanding', assessment: true
+level 'subgoals_u3_top_down_FR', progression: 'Check Your Understanding', assessment: true
 
 stage 'Practice PT - Design a Digital Scene', flex_category: 'csp3_1'
 level 'v2 U3L10 Student Lesson Introduction - stage mods only', progression: '(Modified) Lesson Vocabulary & Resources', named: true
@@ -122,4 +122,4 @@ variants
   level 'csp_affirmation_control_3', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
   level 'csp_affirmation_intervention_3', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
 endvariants
-assessment 'CSP Unit 3 Ch1 Cumulative Assessment MC Group'
+level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group', assessment: true

--- a/dashboard/config/scripts/csp4-2017.script
+++ b/dashboard/config/scripts/csp4-2017.script
@@ -13,27 +13,27 @@ is_stable true
 
 stage 'What is Big Data?', flex_category: 'csp4_1'
 level 'Unit 4 Lesson 1 Introduction', progression: 'Lesson Vocabulary & Resources'
-assessment 'U4L1 - MC moores law', progression: 'Check Your Understanding'
-assessment 'U4L1 - MC big data def', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-5-levelgroup-U4Ch1', progression: 'Quick Check-In'
+level 'U4L1 - MC moores law', progression: 'Check Your Understanding', assessment: true
+level 'U4L1 - MC big data def', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-5-levelgroup-U4Ch1', progression: 'Quick Check-In', assessment: true
 
 stage 'Rapid Research - Data Innovations', flex_category: 'csp4_1'
 level 'Unit 4 Lesson 2 Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Video - Data and Medicine', progression: 'Data and Medicine'
 level 'Video - CS is Changing Everything', progression: 'CS is Changing Everything'
-assessment 'U4L2 - FR Practice AP response about data', progression: 'Check Your Understanding'
+level 'U4L2 - FR Practice AP response about data', progression: 'Check Your Understanding', assessment: true
 
 stage 'Identifying People with Data', flex_category: 'csp4_1'
 level 'Unit 4 Lesson 3 Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'U4-AP-Practice-Choose-The-Data-Concern', named: true
-assessment 'U4L3 - FR Identifying people', progression: 'Check Your Understanding'
+level 'U4L3 - FR Identifying people', progression: 'Check Your Understanding', assessment: true
 
 stage 'The Cost of Free', flex_category: 'csp4_1'
 level 'Unit 4 Lesson 4 Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Video - The Future of Big Data', progression: 'The Future of Big Data', named: true
 level 'U4-AP-Practice-Justify-the-Score', named: true
-assessment 'U4L4 - MC cost of free', progression: 'Check Your Understanding'
-assessment 'U4L4 - FR cost of free', progression: 'Check Your Understanding'
+level 'U4L4 - MC cost of free', progression: 'Check Your Understanding', assessment: true
+level 'U4L4 - FR cost of free', progression: 'Check Your Understanding', assessment: true
 
 stage 'Simple Encryption', flex_category: 'csp4_1'
 level 'Unit 4 Lesson 5 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -42,23 +42,23 @@ level 'Terminology Recap', progression: 'Terminology Recap', named: true
 level 'New Challenge Introduction', progression: 'New Challenge Introduction', named: true
 level 'Crack Random Substitution', progression: 'Crack Random Substitution', named: true
 level 'Technique: Frequency Analysis', progression: 'Technique: Frequency Analysis', named: true
-assessment 'U2L13 Free Response Getting Started', progression: 'Check Your Understanding'
-assessment 'U2L13 Assessment1', progression: 'Check Your Understanding'
-assessment 'U2L13 Assessment3', progression: 'Check Your Understanding'
-assessment 'U2L13 Assessment4', progression: 'Check Your Understanding'
-assessment 'U2L13 Free Response Wrap Up', progression: 'Check Your Understanding'
-assessment 'U2L14 Free Response Wrap Up', progression: 'Check Your Understanding'
+level 'U2L13 Free Response Getting Started', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Assessment1', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Assessment3', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Assessment4', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encryption with Keys and Passwords', flex_category: 'csp4_1'
 level 'Unit 4 Lesson 6 Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'The Vigenere Cipher Widget', progression: 'The Vigenere Cipher Widget', named: true
 level 'How Secure Is Your Password?', progression: 'How Secure Is Your Password?', named: true
 level 'Video - Encryption and Public Keys', progression: 'Encryption and Public Keys', named: true
-assessment 'U2L14 Free Response Getting Started', progression: 'Check Your Understanding'
-assessment 'U2L14 Assessment', progression: 'Check Your Understanding'
-assessment 'U2L14 Free Response Wrap Up', progression: 'Check Your Understanding'
-assessment 'U2L14 Assessment2', progression: 'Check Your Understanding'
-assessment 'U2L15 Assessment1', progression: 'Check Your Understanding'
+level 'U2L14 Free Response Getting Started', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Assessment', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Assessment2', progression: 'Check Your Understanding', assessment: true
+level 'U2L15 Assessment1', progression: 'Check Your Understanding', assessment: true
 
 stage 'Public Key Crypto', flex_category: 'csp4_1'
 level 'Unit 4 Lesson 7 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -68,12 +68,12 @@ level 'Modulo Clock Instructions', progression: 'Modulo Clock Instructions', nam
 level 'The Modulo Clock', progression: 'The Modulo Clock', named: true
 level 'Public Key Crypto Widget Instructions', progression: 'Public Key Crypto Widget Instructions', named: true
 level 'Public Key Cryptography Widget', progression: 'Public Key Cryptography Widget', named: true
-assessment 'U2L18 Free Response Assessment 1', progression: 'Check Your Understanding'
-assessment 'U2L18 Match terms to cups and beans analogy', progression: 'Check Your Understanding'
-assessment 'U2L19 Free Response Getting Started', progression: 'Check Your Understanding'
-assessment 'U2L19 mutlichoice 20 mod 15', progression: 'Check Your Understanding'
-assessment 'U2L19 multichoice 13 MOD 17', progression: 'Check Your Understanding'
-assessment 'U2L19 Free Response Wrap Up', progression: 'Check Your Understanding'
+level 'U2L18 Free Response Assessment 1', progression: 'Check Your Understanding', assessment: true
+level 'U2L18 Match terms to cups and beans analogy', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 Free Response Getting Started', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 mutlichoice 20 mod 15', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 multichoice 13 MOD 17', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 Free Response Wrap Up', progression: 'Check Your Understanding', assessment: true
 
 stage 'Rapid Research - Cybercrime', flex_category: 'csp4_1'
 level 'Unit 4 Lesson 8 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -87,7 +87,7 @@ variants
   level 'csp_affirmation_control_4', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
   level 'csp_affirmation_intervention_4', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
 endvariants
-assessment 'CSP Unit 4 Ch1 Cumulative Assessment MC'
+level 'CSP Unit 4 Ch1 Cumulative Assessment MC', assessment: true
 
 stage 'Post-Course Survey', flex_category: 'cspSurvey'
 level 'csp-post-survey-2018-markdown-with-link-to-survey', progression: 'Click here! Complete the CS Principles post-course survey'

--- a/dashboard/config/scripts/csp4-2018.script
+++ b/dashboard/config/scripts/csp4-2018.script
@@ -13,39 +13,39 @@ is_stable true
 
 stage 'What is Big Data?', flex_category: 'csp4_1_2018'
 level 'CSP U4L01 SFLP', named: true
-assessment 'U4L1 - MC moores law_2018', progression: 'Check Your Understanding'
-assessment 'U4L1 - MC big data def_2018', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-5-levelgroup-U4Ch1_2018', progression: 'Quick Check-In'
+level 'U4L1 - MC moores law_2018', progression: 'Check Your Understanding', assessment: true
+level 'U4L1 - MC big data def_2018', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-5-levelgroup-U4Ch1_2018', progression: 'Quick Check-In', assessment: true
 
 stage 'Finding Trends with Visualizations', flex_category: 'csp4_1_2018'
 level 'CSP U2L08 SFLP', named: true
-assessment 'U2L8 google trends MC_2018', progression: 'Check Your Understanding'
-assessment 'U2L8 google trends hypothesis_2018', progression: 'Check Your Understanding'
-assessment 'CSP Unit 4 google trends MC_2018', progression: 'Check Your Understanding'
-assessment 'CSP Unit 4 trends as predictors_2018', progression: 'Check Your Understanding'
+level 'U2L8 google trends MC_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L8 google trends hypothesis_2018', progression: 'Check Your Understanding', assessment: true
+level 'CSP Unit 4 google trends MC_2018', progression: 'Check Your Understanding', assessment: true
+level 'CSP Unit 4 trends as predictors_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Check Your Assumptions', flex_category: 'csp4_1_2018'
 level 'CSP U2L09 SFLP', named: true
-assessment 'U2L9 What is digital divide MC_2018', progression: 'Check Your Understanding'
-assessment 'U2L9 FR digital divide issue_2018', progression: 'Check Your Understanding'
-assessment 'CSP Unit 4 MC data bias_2018', progression: 'Check Your Understanding'
+level 'U2L9 What is digital divide MC_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L9 FR digital divide issue_2018', progression: 'Check Your Understanding', assessment: true
+level 'CSP Unit 4 MC data bias_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Rapid Research - Data Innovations', flex_category: 'csp4_1_2018'
 level 'CSP U4L02 SFLP', named: true
 level 'Video - Data and Medicine_2018', progression: 'Data and Medicine'
 level 'Video - CS is Changing Everything_2018', progression: 'CS is Changing Everything'
-assessment 'U4L2 - FR Practice AP response about data_2018', progression: 'Check Your Understanding'
+level 'U4L2 - FR Practice AP response about data_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Identifying People with Data', flex_category: 'csp4_1_2018'
 level 'CSP U4L03 SFLP', named: true
 level 'U4-AP-Practice-Choose-The-Data-Concern_2018'
-assessment 'U4L3 - FR Identifying people_2018', progression: 'Check Your Understanding'
+level 'U4L3 - FR Identifying people_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'The Cost of Free', flex_category: 'csp4_1_2018'
 level 'CSP U4L04 SFLP', named: true
 level 'U4-AP-Practice-Justify-the-Score_2018', named: true
-assessment 'U4L4 - MC cost of free_2018', progression: 'Check Your Understanding'
-assessment 'U4L4 - FR cost of free_2018', progression: 'Check Your Understanding'
+level 'U4L4 - MC cost of free_2018', progression: 'Check Your Understanding', assessment: true
+level 'U4L4 - FR cost of free_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Simple Encryption', flex_category: 'csp4_1_2018'
 level 'CSP U4L05 SFLP', named: true
@@ -54,23 +54,23 @@ level 'Terminology Recap_2018', progression: 'Terminology Recap', named: true
 level 'New Challenge Introduction_2018', progression: 'New Challenge Introduction', named: true
 level 'Crack Random Substitution_2018', progression: 'Crack Random Substitution', named: true
 level 'Technique: Frequency Analysis_2018', progression: 'Technique: Frequency Analysis', named: true
-assessment 'U2L13 Free Response Getting Started_2018', progression: 'Check Your Understanding'
-assessment 'U2L13 Assessment1_2018', progression: 'Check Your Understanding'
-assessment 'U2L13 Assessment3_2018', progression: 'Check Your Understanding'
-assessment 'U2L13 Assessment4_2018', progression: 'Check Your Understanding'
-assessment 'U2L13 Free Response Wrap Up_2018', progression: 'Check Your Understanding'
-assessment 'U2L14 Free Response Wrap Up_2018', progression: 'Check Your Understanding'
+level 'U2L13 Free Response Getting Started_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Assessment1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Assessment3_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Assessment4_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Free Response Wrap Up_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Free Response Wrap Up_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encryption with Keys and Passwords', flex_category: 'csp4_1_2018'
 level 'CSP U4L06 SFLP', named: true
 level 'The Vigenere Cipher Widget_2018', progression: 'The Vigenere Cipher Widget', named: true
 level 'How Secure Is Your Password?_2018', progression: 'How Secure Is Your Password?', named: true
 level 'Video - Encryption and Public Keys_2018', progression: 'Encryption and Public Keys', named: true
-assessment 'U2L14 Free Response Getting Started_2018', progression: 'Check Your Understanding'
-assessment 'U2L14 Assessment_2018', progression: 'Check Your Understanding'
-assessment 'U2L14 Free Response Wrap Up_2018', progression: 'Check Your Understanding'
-assessment 'U2L14 Assessment2_2018', progression: 'Check Your Understanding'
-assessment 'U2L15 Assessment1_2018', progression: 'Check Your Understanding'
+level 'U2L14 Free Response Getting Started_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Assessment_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Free Response Wrap Up_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Assessment2_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L15 Assessment1_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Public Key Crypto', flex_category: 'csp4_1_2018'
 level 'CSP U4L07 SFLP', named: true
@@ -80,19 +80,19 @@ level 'Modulo Clock Instructions_2018', progression: 'Modulo Clock Instructions'
 level 'The Modulo Clock_2018', progression: 'The Modulo Clock', named: true
 level 'Public Key Crypto Widget Instructions_2018', progression: 'Public Key Crypto Widget Instructions', named: true
 level 'Public Key Cryptography Widget_2018', progression: 'Public Key Cryptography Widget', named: true
-assessment 'U2L18 Free Response Assessment 1_2018', progression: 'Check Your Understanding'
-assessment 'U2L18 Match terms to cups and beans analogy_2018', progression: 'Check Your Understanding'
-assessment 'U2L19 Free Response Getting Started_2018', progression: 'Check Your Understanding'
-assessment 'U2L19 mutlichoice 20 mod 15_2018', progression: 'Check Your Understanding'
-assessment 'U2L19 multichoice 13 MOD 17_2018', progression: 'Check Your Understanding'
-assessment 'U2L19 Free Response Wrap Up_2018', progression: 'Check Your Understanding'
+level 'U2L18 Free Response Assessment 1_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L18 Match terms to cups and beans analogy_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 Free Response Getting Started_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 mutlichoice 20 mod 15_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 multichoice 13 MOD 17_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 Free Response Wrap Up_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Rapid Research - Cybercrime', flex_category: 'csp4_1_2018'
 level 'CSP U4L08 SFLP', named: true
 level 'Video - Cybersecurity and Crime_2018', progression: 'Cybersecurity and Crime', named: true
 
 stage 'Unit 4 Assessment', lockable: true, flex_category: 'cspAssessment'
-assessment 'CSP Unit 4 Ch1 Cumulative Assessment MC_2018'
+level 'CSP Unit 4 Ch1 Cumulative Assessment MC_2018', assessment: true
 
 stage 'Mid-Year Survey', flex_category: 'cspSurvey'
 level 'csp-mid-survey-2018-markdown-with-link-to-survey', progression: 'Click here! Complete the CS Principles Mid-year survey'

--- a/dashboard/config/scripts/csp4-2019.script
+++ b/dashboard/config/scripts/csp4-2019.script
@@ -10,39 +10,39 @@ version_year '2019'
 
 stage 'What is Big Data?', flex_category: 'csp4_1_2018'
 level 'CSP U4L01 SFLP_2019', named: true
-assessment 'U4L1 - MC moores law_2018_2019', progression: 'Check Your Understanding'
-assessment 'U4L1 - MC big data def_2018_2019', progression: 'Check Your Understanding'
-assessment 'csp-pulse-check-survey-5-levelgroup-U4Ch1_2018_2019', progression: 'Quick Check-In'
+level 'U4L1 - MC moores law_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U4L1 - MC big data def_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'csp-pulse-check-survey-5-levelgroup-U4Ch1_2018_2019', progression: 'Quick Check-In', assessment: true
 
 stage 'Finding Trends with Visualizations', flex_category: 'csp4_1_2018'
 level 'CSP U2L08 SFLP_2019', named: true
-assessment 'U2L8 google trends MC_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L8 google trends hypothesis_2019', progression: 'Check Your Understanding'
-assessment 'CSP Unit 4 google trends MC_2018_2019', progression: 'Check Your Understanding'
-assessment 'CSP Unit 4 trends as predictors_2018_2019', progression: 'Check Your Understanding'
+level 'U2L8 google trends MC_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L8 google trends hypothesis_2019', progression: 'Check Your Understanding', assessment: true
+level 'CSP Unit 4 google trends MC_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'CSP Unit 4 trends as predictors_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Check Your Assumptions', flex_category: 'csp4_1_2018'
 level 'CSP U2L09 SFLP_2019', named: true
-assessment 'U2L9 What is digital divide MC_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L9 FR digital divide issue_2019', progression: 'Check Your Understanding'
-assessment 'CSP Unit 4 MC data bias_2018_2019', progression: 'Check Your Understanding'
+level 'U2L9 What is digital divide MC_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L9 FR digital divide issue_2019', progression: 'Check Your Understanding', assessment: true
+level 'CSP Unit 4 MC data bias_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Rapid Research - Data Innovations', flex_category: 'csp4_1_2018'
 level 'CSP U4L02 SFLP_2019', named: true
 level 'Video - Data and Medicine_2019', progression: 'Data and Medicine'
 level 'Video - CS is Changing Everything_2019', progression: 'CS is Changing Everything'
-assessment 'U4L2 - FR Practice AP response about data_2019', progression: 'Check Your Understanding'
+level 'U4L2 - FR Practice AP response about data_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Identifying People with Data', flex_category: 'csp4_1_2018'
 level 'CSP U4L03 SFLP_2019', named: true
 level 'U4-AP-Practice-Choose-The-Data-Concern_2019', named: true
-assessment 'U4L3 - FR Identifying people_2019', progression: 'Check Your Understanding'
+level 'U4L3 - FR Identifying people_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'The Cost of Free', flex_category: 'csp4_1_2018'
 level 'CSP U4L04 SFLP_2019', named: true
 level 'U4-AP-Practice-Justify-the-Score_2019', named: true
-assessment 'U4L4 - MC cost of free_2018_2019', progression: 'Check Your Understanding'
-assessment 'U4L4 - FR cost of free_2019', progression: 'Check Your Understanding'
+level 'U4L4 - MC cost of free_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U4L4 - FR cost of free_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Simple Encryption', flex_category: 'csp4_1_2018'
 level 'CSP U4L05 SFLP_2019', named: true
@@ -51,24 +51,24 @@ level 'Terminology Recap_2018_2019', progression: 'Terminology Recap', named: tr
 level 'New Challenge Introduction_2018_2019', progression: 'New Challenge Introduction', named: true
 level 'Crack Random Substitution_2019', progression: 'Crack Random Substitution', named: true
 level 'Technique: Frequency Analysis_2018_2019', progression: 'Technique: Frequency Analysis', named: true
-assessment 'U2L13 Free Response Getting Started_2019', progression: 'Check Your Understanding'
-assessment 'U2L13 Assessment1_2019', progression: 'Check Your Understanding'
-assessment 'U2L13 Assessment3_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L13 Assessment4_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L13 Free Response Wrap Up_2019', progression: 'Check Your Understanding'
-assessment 'U2L14 Free Response Wrap Up_2019', progression: 'Check Your Understanding'
+level 'U2L13 Free Response Getting Started_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Assessment1_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Assessment3_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Assessment4_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Encryption with Keys and Passwords', flex_category: 'csp4_1_2018'
 level 'CSP U4L06 SFLP_2019', named: true
 level 'The Vigenere Cipher Widget_2019', progression: 'The Vigenere Cipher Widget', named: true
 level 'How Secure Is Your Password?_2018_2019', progression: 'How Secure Is Your Password?', named: true
 level 'Video - Encryption and Public Keys_2019', progression: 'Encryption and Public Keys', named: true
-assessment 'U2L14 Free Response Getting Started_2019', progression: 'Check Your Understanding'
-assessment 'U2L14 Assessment_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L14 Free Response Wrap Up_2019', progression: 'Check Your Understanding'
-assessment 'U2L14 Assessment2_2019', progression: 'Check Your Understanding'
-assessment 'U2L15 Assessment1_2018_2019', progression: 'Check Your Understanding'
-assessment 'CB_Question_12_2018_2019', progression: 'Check Your Understanding'
+level 'U2L14 Free Response Getting Started_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Assessment_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L14 Assessment2_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L15 Assessment1_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'CB_Question_12_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Public Key Crypto', flex_category: 'csp4_1_2018'
 level 'CSP U4L07 SFLP_2019', named: true
@@ -78,22 +78,22 @@ level 'Modulo Clock Instructions_2018_2019', progression: 'Modulo Clock Instruct
 level 'The Modulo Clock_2019', progression: 'The Modulo Clock', named: true
 level 'Public Key Crypto Widget Instructions_2018_2019', progression: 'Public Key Crypto Widget Instructions', named: true
 level 'Public Key Cryptography Widget_2019', progression: 'Public Key Cryptography Widget', named: true
-assessment 'U2L18 Free Response Assessment 1_2019', progression: 'Check Your Understanding'
-assessment 'U2L18 Match terms to cups and beans analogy_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L19 Free Response Getting Started_2019', progression: 'Check Your Understanding'
-assessment 'U2L19 mutlichoice 20 mod 15_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L19 multichoice 13 MOD 17_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L19 Free Response Wrap Up_2019', progression: 'Check Your Understanding'
+level 'U2L18 Free Response Assessment 1_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L18 Match terms to cups and beans analogy_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 Free Response Getting Started_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 mutlichoice 20 mod 15_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 multichoice 13 MOD 17_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L19 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Rapid Research - Cybercrime', flex_category: 'csp4_1_2018'
 level 'CSP U4L08 SFLP_2019', named: true
 level 'Video - Cybersecurity and Crime_2019', progression: 'Cybersecurity and Crime', named: true
 
 stage 'Unit 4 Assessment', lockable: true, flex_category: 'cspAssessment'
-assessment 'CSP Unit 4 Ch1 Cumulative Assessment MC_2018_2019'
+level 'CSP Unit 4 Ch1 Cumulative Assessment MC_2018_2019', assessment: true
 
 stage 'Optional: Data Questions', lockable: true, flex_category: 'optional'
-assessment 'CSP 18-19 Unit 4 Data Questions'
+level 'CSP 18-19 Unit 4 Data Questions', assessment: true
 
 stage 'Mid-Year Survey', flex_category: 'cspSurvey'
-assessment 'csp-mid-survey-2018-markdown-with-link-to-survey_2019', progression: 'Click here! Complete the CS Principles Mid-year survey'
+level 'csp-mid-survey-2018-markdown-with-link-to-survey_2019', progression: 'Click here! Complete the CS Principles Mid-year survey', assessment: true

--- a/dashboard/config/scripts/csp4-pilot-staging.script
+++ b/dashboard/config/scripts/csp4-pilot-staging.script
@@ -2,7 +2,7 @@ stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'
 level 'U4 L01 Poetry App', progression: 'Sample Apps'
 level 'U4 L01 Thermostat App', progression: 'Sample Apps'
-assessment 'U1 L02 CYU MC', progression: 'Check Your Understanding'
+level 'U1 L02 CYU MC', progression: 'Check Your Understanding', assessment: true
 
 stage 'Variables Investigate', flex_category: 'csp_variables'
 level 'U4 L02 Thermostat App v1', progression: 'Thermostat App v1'
@@ -11,7 +11,7 @@ level 'U4 L02 Thermostat App v2', progression: 'Thermostat App v2'
 level 'U4 L02 Thermostat App v3', progression: 'Thermostat App v3'
 level 'U4 L02 Thermostat App v3 pt2', progression: 'Thermostat App v3'
 level 'U4 L02 Thermostat App v3 pt3', progression: 'Thermostat App v3'
-assessment 'U4 L02 CYU Exit Ticket', progression: 'Check Your Understanding'
+level 'U4 L02 CYU Exit Ticket', progression: 'Check Your Understanding', assessment: true
 
 stage 'Variables Practice', flex_category: 'csp_variables'
 level 'U4 L03 Variables numbers practice 1', progression: 'Assigning Numbers and Strings'
@@ -30,17 +30,17 @@ level 'U4 L04 Variables Make Project Sample', progression: 'Photo Liker App'
 level 'U4 L04 Variables Make Project 1', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 2', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
-assessment 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
+level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App', assessment: true
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
-assessment 'U4 L05 CYU Exit Ticket', progression: 'Check Your Understanding'
+level 'U4 L05 CYU Exit Ticket', progression: 'Check Your Understanding', assessment: true
 
 stage 'Conditionals Investigate', flex_category: 'csp_conditionals'
 level 'U4L06 Introduction to Conditionals: if Statements', progression: 'If-Statements', named: true
@@ -54,7 +54,7 @@ level 'U4L06 Introduction to Conditionals: Compound Boolean Expressions', progre
 level 'U4 L06 Thermostat App v6', progression: 'Logical Operators: AND OR'
 level 'U4 L06 Thermostat App v6 Code', progression: 'Logical Operators: AND OR'
 level 'Checking Multiple Conditions with If-elseif', progression: 'Patterns: If-else-if'
-assessment 'U4 L06 CYU Exit Ticket', progression: 'Check Your Understanding'
+level 'U4 L06 CYU Exit Ticket', progression: 'Check Your Understanding', assessment: true
 
 stage 'Conditionals Practice', flex_category: 'csp_conditionals'
 level 'U4 L07 Conditionals Practice 1', progression: 'Boolean expressions'
@@ -74,13 +74,13 @@ level 'U4 L08 Conditionals Make Project Flowchart', progression: 'Make the Museu
 level 'U4L08 Museum Ticket Generator 1', progression: 'Make the Museum Ticket Generator App'
 level 'U4L08 Museum Ticket Generator 2', progression: 'Make the Museum Ticket Generator App'
 level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Generator App'
-assessment 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
+level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App', assessment: true
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -108,7 +108,7 @@ level 'U4 L11 Functions Make 4', progression: 'Make the Quote Maker App'
 level 'U4 L11 Functions Make 4.5', progression: 'Make the Quote Maker App'
 level 'U4 L11 Functions Make 4.75', progression: 'Make the Quote Maker App'
 level 'U4 L11 Functions Make 5', progression: 'Make the Quote Maker App'
-assessment 'U4 L11 Functions Make 6', progression: 'Make the Quote Maker App'
+level 'U4 L11 Functions Make 6', progression: 'Make the Quote Maker App', assessment: true
 
 stage 'Practice PT Part 1', flex_category: 'csp_project'
 level 'U4 L12 Practice PT 1', progression: 'Sample Apps'
@@ -122,7 +122,7 @@ level 'U4 L13 Practice PT 4', progression: 'Add onEvents'
 
 stage 'Practice PT Part 3', flex_category: 'csp_project'
 level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
-assessment 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
+level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App', assessment: true
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/csp4-pilot.script
+++ b/dashboard/config/scripts/csp4-pilot.script
@@ -38,10 +38,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -124,10 +124,10 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true

--- a/dashboard/config/scripts/csp5-2017.script
+++ b/dashboard/config/scripts/csp5-2017.script
@@ -34,7 +34,7 @@ level 'CSPU5_U3L16 - setPosition to move button', progression: 'How setPosition 
 level 'CSPU5_AddLabelToChaserGame', progression: 'Using Labels'
 level 'How Images Work', progression: 'How Images Work'
 level 'Finalize Your Chaser Game v.1', progression: 'Chaser Game v.1'
-assessment 'csp-pulse-check-survey-6-levelgroup-U5Ch1', progression: 'Quick Check-In'
+level 'csp-pulse-check-survey-6-levelgroup-U5Ch1', progression: 'Quick Check-In', assessment: true
 
 stage 'Multi-screen Apps', flex_category: 'csp5_1'
 level 'Unit 5 Lesson 2 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -58,7 +58,7 @@ level 'Unit 5 Lesson 3 Introduction', progression: 'Lesson Vocabulary & Resource
 level 'Event Driven Programming Recap', progression: 'Event Driven Programming Recap'
 level 'Tips For Working on Your Own', progression: 'Tips For Working on Your Own'
 level 'Project - Your Own Multi Screen App', progression: 'Project - Your Own Multi-Screen App'
-assessment 'U5 AP Practice Create Process', progression: '(new) AP Practice Response - Describe Your Process'
+level 'U5 AP Practice Create Process', progression: '(new) AP Practice Response - Describe Your Process', assessment: true
 
 stage 'Controlling Memory with Variables', flex_category: 'csp5_1'
 level 'Unit 5 Lesson 4 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -87,7 +87,7 @@ level 'CSPU5_U3L14 - moving memory challenge4', progression: 'The Mental Model f
 level 'CSPU5_U3L14 - moving memory challenge5', progression: 'The Mental Model for Variables'
 level 'CSPU5_U3L14 - moving memory challenge6', progression: 'The Mental Model for Variables'
 level 'CSPU5_U3L19 - variable reassignment challenge pt2', progression: 'The Mental Model for Variables'
-assessment 'CSPU5_U3L14 - MC variable reassignment', progression: 'Check Your Understanding'
+level 'CSPU5_U3L14 - MC variable reassignment', progression: 'Check Your Understanding', assessment: true
 
 stage 'Building an App: Clicker Game', flex_category: 'csp5_1'
 level 'Unit 5 Lesson 5 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -111,14 +111,14 @@ level 'CSPU5_U3L15 - Debugging Simple If-statements =v==', progression: 'Simple 
 level 'CSPU5_U3L15 - Debug forget to update var on reset in UpDown app', progression: 'Simple Decisions with if-statements'
 level 'CSPU5_U3L15 - Debug if never triggers in UpDown app', progression: 'Simple Decisions with if-statements'
 level 'CSPU5_U3L15 full clicker app', progression: 'Project: Clicker App'
-assessment 'U5 AP Create Practice onEvent Doesnt Count', progression: '(new) AP Practice Response - Choosing an Abstraction'
+level 'U5 AP Create Practice onEvent Doesnt Count', progression: '(new) AP Practice Response - Choosing an Abstraction', assessment: true
 
 stage 'Unit 5 Assessment 1', lockable: true, flex_category: 'csp5_1'
 variants
   level 'csp_affirmation_control_5', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
   level 'csp_affirmation_intervention_5', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
 endvariants
-assessment 'CSP Unit 5 Cumulative Assessment 1 MC'
+level 'CSP Unit 5 Cumulative Assessment 1 MC', assessment: true
 
 stage 'User Input and Strings', flex_category: 'csp5_1'
 level 'Unit 5 Lesson 6 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -179,7 +179,7 @@ level 'How Compound Boolean Expressions Work', progression: 'How Compound Boolea
 level 'CSPU5_U3 - Conditionals - Combine AND OR Simple', progression: 'How Compound Boolean Expressions Work'
 level 'U5 compound boolean museum example', progression: 'How Compound Boolean Expressions Work'
 level 'CSPU5_U3 - Conditionals - Combine AND OR and NOT', progression: 'How Compound Boolean Expressions Work'
-assessment 'U5-AP-Algorithm-Does-It-Count', progression: '(new) AP Practice Response - Score the Response'
+level 'U5-AP-Algorithm-Does-It-Count', progression: '(new) AP Practice Response - Score the Response', assessment: true
 
 stage 'Building an App: Color Sleuth', flex_category: 'csp5_1'
 level 'Unit 5 Lesson 10 Introduction', progression: 'Lesson Vocabulary & Resources', named: true
@@ -206,16 +206,16 @@ level 'U5 ColorSleuth scoring pt3 update UI for scoring', progression: 'Updating
 level 'Color Sleuth - How does it end?', progression: 'Color Sleuth - How Does It End?', named: true
 level 'Project: Finish Color Sleuth', progression: 'Project: Color Sleuth', named: true
 level 'Color Sleuth - Epilogue', progression: 'Color Sleuth - Epilogue', named: true
-assessment 'U5 AP Practice Create Abstraction Color Sleuth', progression: '(new) AP Practice Responses - Algorithms and Abstraction'
-assessment 'CSP U5 AP Practice Choose the Algorithm', progression: '(new) AP Practice Responses - Algorithms and Abstraction'
-assessment 'U5 AP Practice Create Algorithm Color Sleuth', progression: '(new) AP Practice Responses - Algorithms and Abstraction'
+level 'U5 AP Practice Create Abstraction Color Sleuth', progression: '(new) AP Practice Responses - Algorithms and Abstraction', assessment: true
+level 'CSP U5 AP Practice Choose the Algorithm', progression: '(new) AP Practice Responses - Algorithms and Abstraction', assessment: true
+level 'U5 AP Practice Create Algorithm Color Sleuth', progression: '(new) AP Practice Responses - Algorithms and Abstraction', assessment: true
 
 stage 'Unit 5 Assessment 2', lockable: true, flex_category: 'csp5_1'
 variants
   level 'csp_affirmation_control_5', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
   level 'csp_affirmation_intervention_5', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
 endvariants
-assessment 'CSP Unit 5 Cumulative Assessment 2 MC'
+level 'CSP Unit 5 Cumulative Assessment 2 MC', assessment: true
 
 stage 'While Loops', flex_category: 'csp5_2'
 level 'Unit 5 Lesson 11 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -239,7 +239,7 @@ level 'CSPU5_U3 - Loops - plus and minus = operator', progression: 'Loops Contin
 level 'CSPU5_U3 - Loops - minus = operator', progression: 'Loops Continued'
 level 'CSPU5_U3 - Loops - 14', progression: 'Loops Continued'
 level 'CSPU5_U3 - Loops - 15', progression: 'Loops Continued'
-assessment 'csp-pulse-check-survey-7-levelgroup-U5Ch2', progression: 'Quick Check-In'
+level 'csp-pulse-check-survey-7-levelgroup-U5Ch2', progression: 'Quick Check-In', assessment: true
 
 stage 'Loops and Simulations', flex_category: 'csp5_2'
 level 'Unit 5 Lesson 12 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -302,7 +302,7 @@ level 'Project - Final Image Scroller', progression: 'Project: Image Scroller'
 level 'CSPU5_U3- Keys - Code Refactoring Exit Ticket', progression: 'My Favorite Things Reflection Question'
 
 stage 'Unit 5 Assessment 3', lockable: true, flex_category: 'csp5_2'
-assessment 'CSP Unit 5 Cumulative Assessment 3 MC'
+level 'CSP Unit 5 Cumulative Assessment 3 MC', assessment: true
 
 stage 'Processing Arrays', flex_category: 'csp5_2'
 level 'Unit 5 Lesson 15 Introduction', progression: 'Lesson Vocabulary & Resources'
@@ -354,14 +354,14 @@ level 'CSPU5_U3 - Canvas - sketch', progression: 'Using Stored Information'
 level 'CSPU5_U3 - Canvas - freePlay', progression: 'Project: Canvas Painter', named: true
 
 stage 'Unit 5 Assessment 4', lockable: true, flex_category: 'csp5_2'
-assessment 'CSP Unit 5 Cumulative Assessment 4 MC'
+level 'CSP Unit 5 Cumulative Assessment 4 MC', assessment: true
 
 stage 'Practice PT: Create', flex_category: 'csp5_2'
 level 'Unit 5 Lesson 18 Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Practice Create Performance Task', progression: 'Practice Performance Task: Create'
 
 stage 'Unit 5 Assessment 5 - AP Pseudocode Practice Questions', lockable: true, flex_category: 'csp5_2'
-assessment 'CSP Cumulative Assess A'
+level 'CSP Cumulative Assess A', assessment: true
 
 stage 'Post-Course Survey', flex_category: 'cspSurvey'
 level 'csp-post-survey-2018-markdown-with-link-to-survey', progression: 'Click here! Complete the CS Principles post-course survey'

--- a/dashboard/config/scripts/csp5-2018.script
+++ b/dashboard/config/scripts/csp5-2018.script
@@ -34,7 +34,7 @@ level 'CSPU5_U3L16 - setPosition to move button_2018', progression: 'How setPosi
 level 'CSPU5_AddLabelToChaserGame_2018', progression: 'Using Labels'
 level 'How Images Work_2018', progression: 'How Images Work'
 level 'Finalize Your Chaser Game v.1_2018', progression: 'Chaser Game v.1'
-assessment 'csp-pulse-check-survey-6-levelgroup-U5Ch1_2018', progression: 'Quick Check-In'
+level 'csp-pulse-check-survey-6-levelgroup-U5Ch1_2018', progression: 'Quick Check-In', assessment: true
 
 stage 'Multi-screen Apps', flex_category: 'csp5_1'
 level 'CSP U5L02 SFLP', named: true
@@ -58,7 +58,7 @@ level 'CSP U5L03 SFLP', named: true
 level 'Event Driven Programming Recap_2018', progression: 'Event Driven Programming Recap'
 level 'Tips For Working on Your Own_2018', progression: 'Tips For Working on Your Own'
 level 'Project - Your Own Multi Screen App_2018', progression: 'Project - Your Own Multi-Screen App'
-assessment 'U5 AP Practice Create Process_2018', progression: 'AP Practice Response - Describe Your Process'
+level 'U5 AP Practice Create Process_2018', progression: 'AP Practice Response - Describe Your Process', assessment: true
 
 stage 'Controlling Memory with Variables', flex_category: 'csp5_1'
 level 'CSP U5L04 SFLP', named: true
@@ -87,7 +87,7 @@ level 'CSPU5_U3L14 - moving memory challenge4_2018', progression: 'The Mental Mo
 level 'CSPU5_U3L14 - moving memory challenge5_2018', progression: 'The Mental Model for Variables'
 level 'CSPU5_U3L14 - moving memory challenge6_2018', progression: 'The Mental Model for Variables'
 level 'CSPU5_U3L19 - variable reassignment challenge pt2_2018', progression: 'The Mental Model for Variables'
-assessment 'CSPU5_U3L14 - MC variable reassignment_2018', progression: 'Check Your Understanding'
+level 'CSPU5_U3L14 - MC variable reassignment_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Building an App: Clicker Game', flex_category: 'csp5_1'
 level 'CSP U5L05 SFLP', named: true
@@ -111,10 +111,10 @@ level 'CSPU5_U3L15 - Debugging Simple If-statements =v==_2018', progression: 'Si
 level 'CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2018', progression: 'Simple Decisions with if-statements'
 level 'CSPU5_U3L15 - Debug if never triggers in UpDown app_2018', progression: 'Simple Decisions with if-statements'
 level 'CSPU5_U3L15 full clicker app_2018', progression: 'Project: Clicker App'
-assessment 'U5 AP Create Practice onEvent Doesnt Count_2018', progression: 'AP Practice Response - Choosing an Abstraction'
+level 'U5 AP Create Practice onEvent Doesnt Count_2018', progression: 'AP Practice Response - Choosing an Abstraction', assessment: true
 
 stage 'Unit 5 Assessment 1', lockable: true, flex_category: 'csp5_1'
-assessment 'CSP Unit 5 Cumulative Assessment 1 MC_2018'
+level 'CSP Unit 5 Cumulative Assessment 1 MC_2018', assessment: true
 
 stage 'User Input and Strings', flex_category: 'csp5_1'
 level 'CSP U5L06 SFLP', named: true
@@ -175,7 +175,7 @@ level 'How Compound Boolean Expressions Work_2018', progression: 'How Compound B
 level 'CSPU5_U3 - Conditionals - Combine AND OR Simple_2018', progression: 'How Compound Boolean Expressions Work'
 level 'U5 compound boolean museum example_2018', progression: 'How Compound Boolean Expressions Work'
 level 'CSPU5_U3 - Conditionals - Combine AND OR and NOT_2018', progression: 'How Compound Boolean Expressions Work'
-assessment 'U5-AP-Algorithm-Does-It-Count_2018', progression: 'AP Practice Response - Score the Response'
+level 'U5-AP-Algorithm-Does-It-Count_2018', progression: 'AP Practice Response - Score the Response', assessment: true
 
 stage 'Building an App: Color Sleuth', flex_category: 'csp5_1'
 level 'CSP U5L10 SFLP', named: true
@@ -202,12 +202,12 @@ level 'U5 ColorSleuth scoring pt3 update UI for scoring_2018', progression: 'Upd
 level 'Color Sleuth - How does it end?_2018', progression: 'Color Sleuth - How Does It End?', named: true
 level 'Project: Finish Color Sleuth_2018', progression: 'Project: Color Sleuth', named: true
 level 'Color Sleuth - Epilogue_2018', progression: 'Color Sleuth - Epilogue', named: true
-assessment 'U5 AP Practice Create Abstraction Color Sleuth_2018', progression: 'AP Practice Responses - Algorithms and Abstraction'
-assessment 'CSP U5 AP Practice Choose the Algorithm_2018', progression: 'AP Practice Responses - Algorithms and Abstraction'
-assessment 'U5 AP Practice Create Algorithm Color Sleuth_2018', progression: 'AP Practice Responses - Algorithms and Abstraction'
+level 'U5 AP Practice Create Abstraction Color Sleuth_2018', progression: 'AP Practice Responses - Algorithms and Abstraction', assessment: true
+level 'CSP U5 AP Practice Choose the Algorithm_2018', progression: 'AP Practice Responses - Algorithms and Abstraction', assessment: true
+level 'U5 AP Practice Create Algorithm Color Sleuth_2018', progression: 'AP Practice Responses - Algorithms and Abstraction', assessment: true
 
 stage 'Unit 5 Assessment 2', lockable: true, flex_category: 'csp5_1'
-assessment 'CSP Unit 5 Cumulative Assessment 2 MC_2018'
+level 'CSP Unit 5 Cumulative Assessment 2 MC_2018', assessment: true
 
 stage 'While Loops', flex_category: 'csp5_2'
 level 'CSP U5L11 SFLP', named: true
@@ -231,7 +231,7 @@ level 'CSPU5_U3 - Loops - plus and minus = operator_2018', progression: 'Loops C
 level 'CSPU5_U3 - Loops - minus = operator_2018', progression: 'Loops Continued'
 level 'CSPU5_U3 - Loops - 14_2018', progression: 'Loops Continued'
 level 'CSPU5_U3 - Loops - 15_2018', progression: 'Loops Continued'
-assessment 'csp-pulse-check-survey-7-levelgroup-U5Ch2_2018', progression: 'Quick Check-In'
+level 'csp-pulse-check-survey-7-levelgroup-U5Ch2_2018', progression: 'Quick Check-In', assessment: true
 
 stage 'Loops and Simulations', flex_category: 'csp5_2'
 level 'CSP U5L12 SFLP', named: true
@@ -294,7 +294,7 @@ level 'Project - Final Image Scroller_2018', progression: 'Project: Image Scroll
 level 'CSPU5_U3- Keys - Code Refactoring Exit Ticket_2018', progression: 'My Favorite Things Reflection Question'
 
 stage 'Unit 5 Assessment 3', lockable: true, flex_category: 'csp5_2'
-assessment 'CSP Unit 5 Cumulative Assessment 3 MC_2018'
+level 'CSP Unit 5 Cumulative Assessment 3 MC_2018', assessment: true
 
 stage 'Processing Arrays', flex_category: 'csp5_2'
 level 'CSP U5L15 SFLP', named: true
@@ -346,10 +346,10 @@ level 'CSPU5_U3 - Canvas - sketch_2018', progression: 'Using Stored Information'
 level 'CSPU5_U3 - Canvas - freePlay_2018', progression: 'Project: Canvas Painter', named: true
 
 stage 'Unit 5 Assessment 4', lockable: true, flex_category: 'csp5_2'
-assessment 'CSP Unit 5 Cumulative Assessment 4 MC_2018'
+level 'CSP Unit 5 Cumulative Assessment 4 MC_2018', assessment: true
 
 stage 'Unit 5 Assessment 5 - AP Pseudocode Practice Questions', lockable: true, flex_category: 'csp5_2'
-assessment 'CSP Cumulative Assess A_2018'
+level 'CSP Cumulative Assess A_2018', assessment: true
 
 stage 'Mid-Year Survey', flex_category: 'cspSurvey'
 level 'csp-mid-survey-2018-markdown-with-link-to-survey', progression: 'Click here! Complete the CS Principles Mid-year survey'

--- a/dashboard/config/scripts/csp5-2019.script
+++ b/dashboard/config/scripts/csp5-2019.script
@@ -31,7 +31,7 @@ level 'CSPU5_U3L16 - setPosition to move button_2019', progression: 'How setPosi
 level 'CSPU5_AddLabelToChaserGame_2019', progression: 'Using Labels'
 level 'How Images Work_2018_2019', progression: 'How Images Work'
 level 'Finalize Your Chaser Game v.1_2019', progression: 'Chaser Game v.1'
-assessment 'csp-pulse-check-survey-6-levelgroup-U5Ch1_2018_2019', progression: 'Quick Check-In'
+level 'csp-pulse-check-survey-6-levelgroup-U5Ch1_2018_2019', progression: 'Quick Check-In', assessment: true
 
 stage 'Multi-screen Apps', flex_category: 'csp5_1'
 level 'CSP U5L02 SFLP_2019', named: true
@@ -48,14 +48,14 @@ level 'CSPU5 Use setScreen for first time_2019', progression: 'Making Multiple S
 level 'Making a Multi Screen Chaser Game v.2_2018_2019', progression: 'Making a Multi-Screen Chaser Game v.2'
 level 'CSPU5 Add welcome screen to chaser game_2019', progression: 'Making a Multi-Screen Chaser Game v.2'
 level 'CSPU5 Add full screen image to bg of chaser game_2019', progression: 'Making a Multi-Screen Chaser Game v.2'
-assessment 'CSPU5 Add game over screen_2019', progression: 'Project: Multi-Screen Chaser Game'
+level 'CSPU5 Add game over screen_2019', progression: 'Project: Multi-Screen Chaser Game', assessment: true
 
 stage 'Building an App: Multi-Screen App', flex_category: 'csp5_1'
 level 'CSP U5L03 SFLP_2019', named: true
 level 'Event Driven Programming Recap_2018_2019', progression: 'Event Driven Programming Recap'
 level 'Tips For Working on Your Own_2018_2019', progression: 'Tips For Working on Your Own'
-assessment 'Project - Your Own Multi Screen App_2019', progression: 'Project - Your Own Multi-Screen App'
-assessment 'U5 AP Practice Create Process_2019', progression: 'AP Practice Response - Describe Your Process'
+level 'Project - Your Own Multi Screen App_2019', progression: 'Project - Your Own Multi-Screen App', assessment: true
+level 'U5 AP Practice Create Process_2019', progression: 'AP Practice Response - Describe Your Process', assessment: true
 
 stage 'Controlling Memory with Variables', flex_category: 'csp5_1'
 level 'CSP U5L04 SFLP_2019', named: true
@@ -84,7 +84,7 @@ level 'CSPU5_U3L14 - moving memory challenge4_2019', progression: 'The Mental Mo
 level 'CSPU5_U3L14 - moving memory challenge5_2019', progression: 'The Mental Model for Variables'
 level 'CSPU5_U3L14 - moving memory challenge6_2019', progression: 'The Mental Model for Variables'
 level 'CSPU5_U3L19 - variable reassignment challenge pt2_2019', progression: 'The Mental Model for Variables'
-assessment 'CSPU5_U3L14 - MC variable reassignment_2018_2019', progression: 'Check Your Understanding'
+level 'CSPU5_U3L14 - MC variable reassignment_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Building an App: Clicker Game', flex_category: 'csp5_1'
 level 'CSP U5L05 SFLP_2019', named: true
@@ -107,11 +107,11 @@ level 'CSPU5_U3L15 - Add reset button to UpDown app_2019', progression: 'Simple 
 level 'CSPU5_U3L15 - Debugging Simple If-statements =v==_2019', progression: 'Simple Decisions with if-statements'
 level 'CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2019', progression: 'Simple Decisions with if-statements'
 level 'CSPU5_U3L15 - Debug if never triggers in UpDown app_2019', progression: 'Simple Decisions with if-statements'
-assessment 'CSPU5_U3L15 full clicker app_2019', progression: 'Project: Clicker App'
-assessment 'U5 AP Create Practice onEvent Doesnt Count_2019', progression: 'AP Practice Response - Choosing an Abstraction'
+level 'CSPU5_U3L15 full clicker app_2019', progression: 'Project: Clicker App', assessment: true
+level 'U5 AP Create Practice onEvent Doesnt Count_2019', progression: 'AP Practice Response - Choosing an Abstraction', assessment: true
 
 stage 'Unit 5 Assessment 1', lockable: true, flex_category: 'csp5_1'
-assessment 'CSP Unit 5 Cumulative Assessment 1 MC_2018_2019'
+level 'CSP Unit 5 Cumulative Assessment 1 MC_2018_2019', assessment: true
 
 stage 'User Input and Strings', flex_category: 'csp5_1'
 level 'CSP U5L06 SFLP_2019', named: true
@@ -172,7 +172,7 @@ level 'How Compound Boolean Expressions Work_2018_2019', progression: 'How Compo
 level 'CSPU5_U3 - Conditionals - Combine AND OR Simple_2019', progression: 'How Compound Boolean Expressions Work'
 level 'U5 compound boolean museum example_2019', progression: 'How Compound Boolean Expressions Work'
 level 'CSPU5_U3 - Conditionals - Combine AND OR and NOT_2019', progression: 'How Compound Boolean Expressions Work'
-assessment 'U5-AP-Algorithm-Does-It-Count_2019', progression: 'AP Practice Response - Score the Response'
+level 'U5-AP-Algorithm-Does-It-Count_2019', progression: 'AP Practice Response - Score the Response', assessment: true
 
 stage 'Building an App: Color Sleuth', flex_category: 'csp5_1'
 level 'CSP U5L10 SFLP_2019', named: true
@@ -197,14 +197,14 @@ level 'Color Sleuth - Keeping score_2018_2019', progression: 'Updating the Score
 level 'U5 ColorSleuth scoring pt1 vars function stub console_2019', progression: 'Updating the Score'
 level 'U5 ColorSleuth scoring pt3 update UI for scoring_2019', progression: 'Updating the Score'
 level 'Color Sleuth - How does it end?_2018_2019', progression: 'Color Sleuth - How Does It End?'
-assessment 'Project: Finish Color Sleuth_2019', progression: 'Project: Color Sleuth'
+level 'Project: Finish Color Sleuth_2019', progression: 'Project: Color Sleuth', assessment: true
 level 'Color Sleuth - Epilogue_2018_2019', progression: 'Color Sleuth - Epilogue'
-assessment 'U5 AP Practice Create Abstraction Color Sleuth_2019', progression: 'AP Practice Responses - Algorithms and Abstraction'
-assessment 'CSP U5 AP Practice Choose the Algorithm_2019', progression: 'AP Practice Responses - Algorithms and Abstraction'
-assessment 'U5 AP Practice Create Algorithm Color Sleuth_2019', progression: 'AP Practice Responses - Algorithms and Abstraction'
+level 'U5 AP Practice Create Abstraction Color Sleuth_2019', progression: 'AP Practice Responses - Algorithms and Abstraction', assessment: true
+level 'CSP U5 AP Practice Choose the Algorithm_2019', progression: 'AP Practice Responses - Algorithms and Abstraction', assessment: true
+level 'U5 AP Practice Create Algorithm Color Sleuth_2019', progression: 'AP Practice Responses - Algorithms and Abstraction', assessment: true
 
 stage 'Unit 5 Assessment 2', lockable: true, flex_category: 'csp5_1'
-assessment 'CSP Unit 5 Cumulative Assessment 2 MC_2018_2019'
+level 'CSP Unit 5 Cumulative Assessment 2 MC_2018_2019', assessment: true
 
 stage 'While Loops', flex_category: 'csp5_2'
 level 'CSP U5L11 SFLP_2019', named: true
@@ -228,7 +228,7 @@ level 'CSPU5_U3 - Loops - plus and minus = operator_2019', progression: 'Loops C
 level 'CSPU5_U3 - Loops - minus = operator_2019', progression: 'Loops Continued'
 level 'CSPU5_U3 - Loops - 14_2019', progression: 'Loops Continued'
 level 'CSPU5_U3 - Loops - 15_2019', progression: 'Loops Continued'
-assessment 'csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019', progression: 'Quick Check-In'
+level 'csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019', progression: 'Quick Check-In', assessment: true
 
 stage 'Loops and Simulations', flex_category: 'csp5_2'
 level 'CSP U5L12 SFLP_2019', named: true
@@ -287,11 +287,11 @@ level 'CSPU5_U3 - Keys - Multiple Keys_2019', progression: 'Key Event'
 level 'CSPU5_U3 - Keys - Buttons and Keys_2019', progression: 'Key Event'
 level 'CSPU5_U3 - Keys - Functions_2019', progression: 'Functions in Your App'
 level 'CSPU5_U3 - Keys - Add Image URLs_2019', progression: 'Adding Images Using URLs'
-assessment 'Project - Final Image Scroller_2019', progression: 'Project: Image Scroller'
+level 'Project - Final Image Scroller_2019', progression: 'Project: Image Scroller', assessment: true
 level 'CSPU5_U3- Keys - Code Refactoring Exit Ticket_2019', progression: 'My Favorite Things Reflection Question'
 
 stage 'Unit 5 Assessment 3', lockable: true, flex_category: 'csp5_2'
-assessment 'CSP Unit 5 Cumulative Assessment 3 MC_2018_2019'
+level 'CSP Unit 5 Cumulative Assessment 3 MC_2018_2019', assessment: true
 
 stage 'Processing Arrays', flex_category: 'csp5_2'
 level 'CSP U5L15 SFLP_2019', named: true
@@ -340,13 +340,13 @@ level 'CSPU5_U3 - Canvas - movementFunction fix Orig_2019', progression: 'Adding
 level 'CSPU5_U3 - Canvas - One Dot sprayPaint_2019', progression: 'Adding More Features to Your App'
 level 'CSPU5_U3 - Canvas - sprayPaint_2019', progression: 'Adding More Features to Your App'
 level 'CSPU5_U3 - Canvas - sketch_2019', progression: 'Using Stored Information'
-assessment 'CSPU5_U3 - Canvas - freePlay_2019', progression: 'Project: Canvas Painter'
+level 'CSPU5_U3 - Canvas - freePlay_2019', progression: 'Project: Canvas Painter', assessment: true
 
 stage 'Unit 5 Assessment 4', lockable: true, flex_category: 'csp5_2'
-assessment 'CSP Unit 5 Cumulative Assessment 4 MC_2018_2019'
+level 'CSP Unit 5 Cumulative Assessment 4 MC_2018_2019', assessment: true
 
 stage 'Unit 5 Assessment 5 - AP Pseudocode Practice Questions', lockable: true, flex_category: 'csp5_2'
-assessment 'CSP Cumulative Assess A_2018_2019'
+level 'CSP Cumulative Assess A_2018_2019', assessment: true
 
 stage 'Mid-Year Survey', flex_category: 'cspSurvey'
 level 'csp-mid-survey-2018-markdown-with-link-to-survey_2019', progression: 'Click here! Complete the CS Principles Mid-year survey'

--- a/dashboard/config/scripts/csp5-pilot-staging.script
+++ b/dashboard/config/scripts/csp5-pilot-staging.script
@@ -1,7 +1,7 @@
 stage 'Lists Explore', flex_category: 'csp_lists'
 level 'U5 L01 Introduction to Lists', progression: 'Introduction to Lists'
 level 'Introduction to Lists - Part 2_2018', progression: 'Introduction to Lists'
-assessment 'csp-20-21-u5-assess-lists', progression: 'Check Your Understanding'
+level 'csp-20-21-u5-assess-lists', progression: 'Check Your Understanding', assessment: true
 
 stage 'Lists Investigate', flex_category: 'csp_lists'
 level 'Introduction to Lists - Part 3_2018', progression: 'Lists: Assigning and Updating'
@@ -9,11 +9,11 @@ level 'Introduction to Lists - Part 4_2018', progression: 'Lists: Length'
 
 stage 'Loops Explore', flex_category: 'csp_loops'
 level 'csp_applab_loops_2018', progression: 'Introduction to Loops'
-assessment 'U3L07 Free Response Reflection_2018', progression: 'Check Your Understanding'
+level 'U3L07 Free Response Reflection_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Traversals Explore', flex_category: 'csp_traversals'
 level 'Processing Lists with Loops_2018', progression: 'Introduction to Traversal'
-assessment 'U5 L09 Traversals Exit Ticket', progression: 'Check Your Understanding'
+level 'U5 L09 Traversals Exit Ticket', progression: 'Check Your Understanding', assessment: true
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'
@@ -50,10 +50,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -94,10 +94,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -142,4 +142,4 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/csp6-pilot-staging.script
+++ b/dashboard/config/scripts/csp6-pilot-staging.script
@@ -33,10 +33,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -77,10 +77,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -125,4 +125,4 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/csp7-pilot-staging.script
+++ b/dashboard/config/scripts/csp7-pilot-staging.script
@@ -3,7 +3,7 @@ level 'U7 L01 More with Functions', progression: 'More with Functions'
 
 stage 'Libraries', flex_category: 'csp_libraries'
 level 'U7 L01 More with Functions', progression: 'Intro to Libraries'
-assessment 'U7 L05 Exit Ticket', progression: 'Check Your Understanding'
+level 'U7 L05 Exit Ticket', progression: 'Check Your Understanding', assessment: true
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'
@@ -40,10 +40,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -84,10 +84,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -132,4 +132,4 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/csp8-pilot-staging.script
+++ b/dashboard/config/scripts/csp8-pilot-staging.script
@@ -33,10 +33,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -77,10 +77,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -125,4 +125,4 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/csp9-pilot-staging.script
+++ b/dashboard/config/scripts/csp9-pilot-staging.script
@@ -33,10 +33,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -77,10 +77,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -125,4 +125,4 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true

--- a/dashboard/config/scripts/cspassessment.script
+++ b/dashboard/config/scripts/cspassessment.script
@@ -2,7 +2,7 @@ login_required true
 
 stage 'NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment'
 level 'CSP_Final_instructions'
-assessment 'CSP Culminating Assessment'
+level 'CSP Culminating Assessment', assessment: true
 
 stage 'RQB Questions test'
-assessment 'RQB test levelgroup'
+level 'RQB test levelgroup', assessment: true

--- a/dashboard/config/scripts/cspexam1-mWU7ilDYM9.script
+++ b/dashboard/config/scripts/cspexam1-mWU7ilDYM9.script
@@ -2,4 +2,4 @@ login_required true
 
 stage 'CS Principles Culminating Assessment Part 1'
 level 'CSP_Final_instructions'
-assessment 'Part 1 - CSP Culminating Assessment'
+level 'Part 1 - CSP Culminating Assessment', assessment: true

--- a/dashboard/config/scripts/cspexam2-AKwgAh1ac5.script
+++ b/dashboard/config/scripts/cspexam2-AKwgAh1ac5.script
@@ -2,4 +2,4 @@ login_required true
 
 stage 'CS Principles Culminating Assessment Part 2'
 level 'CSP_Final_instructions'
-assessment 'Part 2 - CSP Culminating Assessment'
+level 'Part 2 - CSP Culminating Assessment', assessment: true

--- a/dashboard/config/scripts/cspoptional.script
+++ b/dashboard/config/scripts/cspoptional.script
@@ -4,49 +4,49 @@ has_lesson_plan true
 stage 'Unit 1 - Sending Bits in the Real World'
 level 'Sending Bits Real World Student Lesson Introduction'
 level 'U1L5 How the Internet Works - Video'
-assessment 'U1L5 Matching Assessment'
+level 'U1L5 Matching Assessment', assessment: true
 
 stage 'Unit 1 - Encoding Numbers in the Real World'
 level 'Encoding Numbers Real World Student Lesson Introduction'
-assessment 'U1L9 Free Response Assessment'
+level 'U1L9 Free Response Assessment', assessment: true
 
 stage 'Unit 1 - Algorithms Detour - Minimum Spanning Tree'
 level 'Algo MST Student Lesson Introduction'
-assessment 'U2L06 - Matching: Label the Diagram'
-assessment 'U2L06- MC: what is an MST?'
-assessment 'U2L06 - MC: Which is an MST?'
+level 'U2L06 - Matching: Label the Diagram', assessment: true
+level 'U2L06- MC: what is an MST?', assessment: true
+level 'U2L06 - MC: Which is an MST?', assessment: true
 
 stage 'Unit 1 - Algorithms Detour - Shortest Path'
 level 'Algo Shortest Path Student Lesson Introduction'
-assessment 'U1L07 Assessment 1'
-assessment 'U2L07 Assessment2'
-assessment 'U2L07 Assessment3'
-assessment 'U2L07 Assessment4'
-assessment 'U2L07 Assessment5'
+level 'U1L07 Assessment 1', assessment: true
+level 'U2L07 Assessment2', assessment: true
+level 'U2L07 Assessment3', assessment: true
+level 'U2L07 Assessment4', assessment: true
+level 'U2L07 Assessment5', assessment: true
 
 stage 'Unit 1 - How Routers Learn'
 level 'Algo How Routers Learn Student Lesson Introduction'
-assessment 'U2L08 Free Response 3'
-assessment 'U2L08 Free Response 1'
-assessment 'U2L08 Free Response 2'
-assessment 'U2L08 Assessment 0'
-assessment 'U2L08 Assessment 1'
+level 'U2L08 Free Response 3', assessment: true
+level 'U2L08 Free Response 1', assessment: true
+level 'U2L08 Free Response 2', assessment: true
+level 'U2L08 Assessment 0', assessment: true
+level 'U2L08 Assessment 1', assessment: true
 
 stage 'Unit 4 - Hard Problems - The Traveling Salesperson Problem'
 level 'U2L17 Student Lesson Introduction'
-assessment 'U2L17 Assessment 1'
-assessment 'U2L17 Assessment 2'
-assessment 'U2L16 Free Response Assessment 3'
-assessment 'U2L17 Free Response Wrap Up'
+level 'U2L17 Assessment 1', assessment: true
+level 'U2L17 Assessment 2', assessment: true
+level 'U2L16 Free Response Assessment 3', assessment: true
+level 'U2L17 Free Response Wrap Up', assessment: true
 
 stage 'Unit 4 - One-Way Functions - The WiFi Hotspot Problem'
 level 'U2L18 Student Lesson Introduction'
-assessment 'U2L17 Free Response Getting Started'
-assessment 'U2L17 Free Responses Assessment 1'
-assessment 'U2L17 - Vocabulary matching'
-assessment 'U2L18 Free Response Getting Started'
-assessment 'U2L18 Assessment'
-assessment 'U2L18 Free Response Wrap Up'
+level 'U2L17 Free Response Getting Started', assessment: true
+level 'U2L17 Free Responses Assessment 1', assessment: true
+level 'U2L17 - Vocabulary matching', assessment: true
+level 'U2L18 Free Response Getting Started', assessment: true
+level 'U2L18 Assessment', assessment: true
+level 'U2L18 Free Response Wrap Up', assessment: true
 
 stage 'Algorithms Detour - Minimum Spanning Tree'
 stage 'Algorithms Detour - Shortest Path'

--- a/dashboard/config/scripts/cspplayground.script
+++ b/dashboard/config/scripts/cspplayground.script
@@ -33,10 +33,10 @@ level 'U4 L04 Variables Make Project 3', progression: 'Make the Photo Liker App'
 level 'U4 L04 Variables Make Project 4', progression: 'Make the Photo Liker App'
 
 stage 'Student Survey (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Student Survey', progression: 'Student Survey (Variables)'
+level 'Pilot Student Survey', progression: 'Student Survey (Variables)', assessment: true
 
 stage 'Teacher Surveys (Variables)', lockable: true, flex_category: 'csp_variables'
-assessment 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)'
+level 'Pilot Teacher Surveys CSP2021', progression: 'Teacher Surveys (Variables)', assessment: true
 
 stage 'Conditionals Explore', flex_category: 'csp_conditionals'
 level 'U4 L06 Introduction to Conditionals: Boolean Expressions', named: true
@@ -77,10 +77,10 @@ level 'U4L08 Museum Ticket Generator 4', progression: 'Make the Museum Ticket Ge
 level 'U4L08 Museum Ticket Generator 5', progression: 'Make the Museum Ticket Generator App'
 
 stage 'Student Survey (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)'
+level 'Pilot Student Survey Conditionals', progression: 'Student Survey (Conditionals)', assessment: true
 
 stage 'Teacher Surveys (Conditionals)', lockable: true, flex_category: 'csp_conditionals'
-assessment 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)'
+level 'Pilot Teacher Surveys Conditionals CSP2021', progression: 'Teacher Surveys (Conditionals)', assessment: true
 
 stage 'Functions Explore / Investigate', flex_category: 'csp_functions'
 level 'U4 L09 Functions Song', progression: 'Explore Functions'
@@ -125,7 +125,7 @@ level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App'
 
 stage 'Unit 4 Assessment', lockable: true
-assessment 'CSP 20-21 Unit 4 Assessment'
+level 'CSP 20-21 Unit 4 Assessment', assessment: true
 
 stage 'Lists Explore'
 level 'U5 L01 Introduction to Lists', progression: 'Introduction to Lists'

--- a/dashboard/config/scripts/csppostap-2018.script
+++ b/dashboard/config/scripts/csppostap-2018.script
@@ -13,13 +13,13 @@ is_stable true
 
 stage 'Intro to Data', flex_category: 'csp_postap_1'
 level 'CSP U2L07 SFLP', named: true
-assessment 'csp-pulse-check-survey-3-levelgroup-U2Ch2_2018', progression: 'Quick Check-In'
+level 'csp-pulse-check-survey-3-levelgroup-U2Ch2_2018', progression: 'Quick Check-In', assessment: true
 
 stage 'Good and Bad Data Visualizations', flex_category: 'csp_postap_1'
 level 'CSP U2L10 SFLP', named: true
 level 'Collection A: Good and Bad Visualizations_2018', progression: 'Collection A: Good and Bad Visualizations', named: true
 level 'Collection B: Good and Bad Visualizations_2018', progression: 'Collection B: Good and Bad Visualizations', named: true
-assessment 'U2L10 FR why best worst viz_2018', progression: 'Check Your Understanding'
+level 'U2L10 FR why best worst viz_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Making Data Visualizations', flex_category: 'csp_postap_1'
 level 'CSP U2L11 SFLP', named: true
@@ -29,26 +29,26 @@ level 'Making a Line Chart_2018', progression: 'Making a Line Chart', named: tru
 level 'Making a Bar Chart_2018', progression: 'Making a Bar Chart', named: true
 level 'Editing Chart Appearance_2018', progression: 'Editing Chart Appearance', named: true
 level 'U4 - Making Data Visualizations - Free Play_2018', progression: 'Making Data Visualizations - Free Play'
-assessment 'U2L10 FR describe what you made from lesson prompt_2018', progression: 'Check Your Understanding'
+level 'U2L10 FR describe what you made from lesson prompt_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Discover a Data Story', flex_category: 'csp_postap_1'
 level 'CSP U2L12 SFLP', named: true
-assessment 'U2L12 FR reflection on collaboration_2018', progression: 'Check Your Understanding'
+level 'U2L12 FR reflection on collaboration_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Cleaning Data', flex_category: 'csp_postap_1'
 level 'CSP U2L13 SFLP', named: true
 level 'Getting to Know Your Data_2018', progression: 'Getting to Know Your Data', named: true
 level 'Cleaning Data_2018', progression: 'Cleaning Data', named: true
 level 'Categorizing Data_2018', progression: 'Categorizing Data', named: true
-assessment 'U2L13 Cleaning Data MC_2018', progression: 'Check Your Understanding'
-assessment 'U2L13 FR Reflection data analysis objective_2018', progression: 'Check Your Understanding'
+level 'U2L13 Cleaning Data MC_2018', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 FR Reflection data analysis objective_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating Summary Tables', flex_category: 'csp_postap_1'
 level 'CSP U2L14 SFLP', named: true
 level 'Making Pivot Tables Part 1 - The Basics_2018', progression: 'Making Pivot Tables Part 1 - The Basics', named: true
 level 'Making Pivot Tables Part 2 - Manipulation and Visualization_2018', progression: 'Making Pivot Tables Part 2 - Manipulation and Visualizations', named: true
 level 'U4L08v2 Making Pivot Tables Part 3_2018', progression: 'Making Pivot Tables Part 3'
-assessment 'U2L14 Summary Tables MC_2018', progression: 'Check Your Understanding'
+level 'U2L14 Summary Tables MC_2018', progression: 'Check Your Understanding', assessment: true
 
 stage 'Project - Tell a Data Story', flex_category: 'csp_postap_1'
 level 'CSP U2L15 SFLP', named: true
@@ -58,7 +58,7 @@ variants
   level 'csp_affirmation_control_2_2018', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
   level 'csp_affirmation_intervention_2_2018', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
 endvariants
-assessment 'CSP Unit 2 Ch2 Cumulative Assessment MC_2018'
+level 'CSP Unit 2 Ch2 Cumulative Assessment MC_2018', assessment: true
 
 stage 'Creating Javascript Objects', flex_category: 'csp_postap_2'
 level 'U4L02 Student Lesson Introduction_2018'

--- a/dashboard/config/scripts/csppostap-2019.script
+++ b/dashboard/config/scripts/csppostap-2019.script
@@ -10,13 +10,13 @@ version_year '2019'
 
 stage 'Intro to Data', flex_category: 'csp_postap_1'
 level 'CSP U2L07 SFLP_2019', named: true
-assessment 'csp-pulse-check-survey-3-levelgroup-U2Ch2_2018_2019', progression: 'Quick Check-In'
+level 'csp-pulse-check-survey-3-levelgroup-U2Ch2_2018_2019', progression: 'Quick Check-In', assessment: true
 
 stage 'Good and Bad Data Visualizations', flex_category: 'csp_postap_1'
 level 'CSP U2L10 SFLP_2019', named: true
 level 'Collection A: Good and Bad Visualizations_2018_2019', progression: 'Collection A: Good and Bad Visualizations', named: true
 level 'Collection B: Good and Bad Visualizations_2018_2019', progression: 'Collection B: Good and Bad Visualizations', named: true
-assessment 'U2L10 FR why best worst viz_2019', progression: 'Check Your Understanding'
+level 'U2L10 FR why best worst viz_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Making Data Visualizations', flex_category: 'csp_postap_1'
 level 'CSP U2L11 SFLP_2019', named: true
@@ -26,26 +26,26 @@ level 'Making a Line Chart_2018_2019', progression: 'Making a Line Chart', named
 level 'Making a Bar Chart_2018_2019', progression: 'Making a Bar Chart', named: true
 level 'Editing Chart Appearance_2018_2019', progression: 'Editing Chart Appearance', named: true
 level 'U4 - Making Data Visualizations - Free Play_2018_2019', progression: 'Making Data Visualizations - Free Play'
-assessment 'U2L10 FR describe what you made from lesson prompt_2019', progression: 'Check Your Understanding'
+level 'U2L10 FR describe what you made from lesson prompt_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Discover a Data Story', flex_category: 'csp_postap_1'
 level 'CSP U2L12 SFLP_2019', named: true
-assessment 'U2L12 FR reflection on collaboration_2019', progression: 'Check Your Understanding'
+level 'U2L12 FR reflection on collaboration_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Cleaning Data', flex_category: 'csp_postap_1'
 level 'CSP U2L13 SFLP_2019', named: true
 level 'Getting to Know Your Data_2018_2019', progression: 'Getting to Know Your Data', named: true
 level 'Cleaning Data_2018_2019', progression: 'Cleaning Data', named: true
 level 'Categorizing Data_2018_2019', progression: 'Categorizing Data', named: true
-assessment 'U2L13 Cleaning Data MC_2018_2019', progression: 'Check Your Understanding'
-assessment 'U2L13 FR Reflection data analysis objective_2019', progression: 'Check Your Understanding'
+level 'U2L13 Cleaning Data MC_2018_2019', progression: 'Check Your Understanding', assessment: true
+level 'U2L13 FR Reflection data analysis objective_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Creating Summary Tables', flex_category: 'csp_postap_1'
 level 'CSP U2L14 SFLP_2019', named: true
 level 'Making Pivot Tables Part 1 - The Basics_2018_2019', progression: 'Making Pivot Tables Part 1 - The Basics', named: true
 level 'Making Pivot Tables Part 2 - Manipulation and Visualization_2018_2019', progression: 'Making Pivot Tables Part 2 - Manipulation and Visualizations', named: true
 level 'U4L08v2 Making Pivot Tables Part 3_2018_2019', progression: 'Making Pivot Tables Part 3'
-assessment 'U2L14 Summary Tables MC_2018_2019', progression: 'Check Your Understanding'
+level 'U2L14 Summary Tables MC_2018_2019', progression: 'Check Your Understanding', assessment: true
 
 stage 'Project - Tell a Data Story', flex_category: 'csp_postap_1'
 level 'CSP U2L15 SFLP_2019', named: true
@@ -140,4 +140,4 @@ level 'U6 - Sample Apps - Flashcards_2019'
 
 stage 'Final Project', flex_category: 'csp_postap_2'
 level 'U6 - Final Project - Student Introduction_2018_2019'
-assessment 'U6 - Final Project - Project Level_2019'
+level 'U6 - Final Project - Project Level_2019', assessment: true

--- a/dashboard/config/scripts/cspunit1.script
+++ b/dashboard/config/scripts/cspunit1.script
@@ -8,83 +8,83 @@ level 'U1L1 - FR computer science word association'
 
 stage 'Sending Binary Messages'
 level 'U1L2 Student Lesson Introduction'
-assessment 'U1L2 Multiple Choice Assessment Question'
-assessment 'U1L2 Free response assessment question'
-assessment 'U1L2 Free response reflection question'
+level 'U1L2 Multiple Choice Assessment Question', assessment: true
+level 'U1L2 Free response assessment question', assessment: true
+level 'U1L2 Free response reflection question', assessment: true
 
 stage 'Sending Complex Messages'
 level 'U1L3 Student Lesson Introduction'
-assessment 'U1L3 Free response reflection question'
-assessment 'U1L3 Multiple Choice'
-assessment 'U1L3 Free Response'
+level 'U1L3 Free response reflection question', assessment: true
+level 'U1L3 Multiple Choice', assessment: true
+level 'U1L3 Free Response', assessment: true
 
 stage 'Sending Binary Messages with the Internet Simulator'
 level 'U1L4 Student Lesson Introduction'
 level 'U1L4 NetSim SendAB'
-assessment 'U1L4 Multiple Choice'
-assessment 'U1L4 Free Response Reflection'
+level 'U1L4 Multiple Choice', assessment: true
+level 'U1L4 Free Response Reflection', assessment: true
 
 stage 'Sending Bits in the Real World'
 level 'U1L5 Student Lesson Introduction'
 level 'U1L5 How the Internet Works - Video'
-assessment 'U1L5 Matching Assessment'
+level 'U1L5 Matching Assessment', assessment: true
 
 stage 'Number Systems'
 level 'U1L6 Student Lesson Introduction'
-assessment 'U1L6 Assessment multiple choice'
-assessment 'U1L6 Free Response Reflection'
+level 'U1L6 Assessment multiple choice', assessment: true
+level 'U1L6 Free Response Reflection', assessment: true
 
 stage 'Binary Numbers'
 level 'U1L7 Student Lesson Introduction'
 level 'Odometer'
-assessment 'U1L7 Free Response Assessment'
-assessment 'U1L7 Free Response Reflection'
+level 'U1L7 Free Response Assessment', assessment: true
+level 'U1L7 Free Response Reflection', assessment: true
 
 stage 'Sending Numbers'
 level 'U1L8 Student Lesson Introduction'
 level 'U1L8 NetSim numbers with decimal'
-assessment 'U1L8 Free Response Reflection'
-assessment 'U1L8 Free Response2'
-assessment 'U1L8 Multiple Choice'
+level 'U1L8 Free Response Reflection', assessment: true
+level 'U1L8 Free Response2', assessment: true
+level 'U1L8 Multiple Choice', assessment: true
 
 stage 'Encoding Numbers in the Real World'
 level 'U1L9 Student Lesson Introduction'
-assessment 'U1L9 Free Response Assessment'
+level 'U1L9 Free Response Assessment', assessment: true
 
 stage 'Encoding and Sending Text'
 level 'U1L10 Student Lesson Introduction'
 level 'U1L10 NetSim numbers with decimal'
-assessment 'U1L10 Assessment 1'
-assessment 'U1L10 Assessment 2'
-assessment 'U1L10 Assessment Free Response'
+level 'U1L10 Assessment 1', assessment: true
+level 'U1L10 Assessment 2', assessment: true
+level 'U1L10 Assessment Free Response', assessment: true
 
 stage 'Sending Formatted Text'
 level 'U1L11 Student Lesson Introduction'
 level 'U1L11 NetSim numbers with Ascii'
-assessment 'U1L11 Assessment 1'
-assessment 'U1L11 Assessment 2'
-assessment 'U1L11 Reflection Free Response'
-assessment 'U1L11 Collaboration Reflection'
+level 'U1L11 Assessment 1', assessment: true
+level 'U1L11 Assessment 2', assessment: true
+level 'U1L11 Reflection Free Response', assessment: true
+level 'U1L11 Collaboration Reflection', assessment: true
 
 stage 'Bytes and File Sizes'
 level 'U1L12 Student Lesson Introduction'
-assessment 'U1L12 Reflection Free Response'
+level 'U1L12 Reflection Free Response', assessment: true
 
 stage 'Text Compression'
 level 'U1L13 Student Lesson Summary'
 level 'U1L13 Text Compression'
-assessment 'U1L13 - Assess Text Compression reverse process'
-assessment 'U1L13 Assess Text Compression amount'
-assessment 'U1L13 Assessment 1'
-assessment 'U1L13 Assessment 2'
+level 'U1L13 - Assess Text Compression reverse process', assessment: true
+level 'U1L13 Assess Text Compression amount', assessment: true
+level 'U1L13 Assessment 1', assessment: true
+level 'U1L13 Assessment 2', assessment: true
 
 stage 'Encoding B&W Images'
 level 'U1L14 Student Lesson Summary'
 level 'Pixelation - Lesson 14 - Make the Letter A'
 level 'Pixelation - Lesson 14 - Fix bit offset'
 level 'Pixelation - Lesson 14 - Make your own B and W Image'
-assessment 'U1L14 Assessment 1'
-assessment 'U1L14 - Assessment 2'
+level 'U1L14 Assessment 1', assessment: true
+level 'U1L14 - Assessment 2', assessment: true
 
 stage 'Encoding Color Images'
 level 'U1L15 Student Lesson Summary'
@@ -99,7 +99,7 @@ level 'a bit about pixels'
 
 stage 'Lossy Compression and File Formats'
 level 'U1L16 Student Lesson Introduction'
-assessment 'U1L16 - Matching File Compression Types'
+level 'U1L16 - Matching File Compression Types', assessment: true
 
 stage 'Encode a Complex Thing'
 level 'U1L17 Student Lesson Introduction'

--- a/dashboard/config/scripts/cspunit2.script
+++ b/dashboard/config/scripts/cspunit2.script
@@ -3,88 +3,88 @@ has_lesson_plan true
 
 stage 'The Internet'
 level 'U2L1 Student Lesson Introduction'
-assessment 'U2L01 Assessment 1'
-assessment 'U2L01 Assessment 2'
-assessment 'U2L01 Assessment 3'
-assessment 'U2L01 Assessment 4'
+level 'U2L01 Assessment 1', assessment: true
+level 'U2L01 Assessment 2', assessment: true
+level 'U2L01 Assessment 3', assessment: true
+level 'U2L01 Assessment 4', assessment: true
 
 stage 'The Need for Addressing'
 level 'U2L2 Student Lesson Introduction'
 level 'U2L2 NetSim Hub Mode'
-assessment 'U2L02 Free Response Reflection'
-assessment 'U2L02 Assessment 3'
-assessment 'U2L02 Assessment 4'
-assessment 'U2L02 Assessment 5'
+level 'U2L02 Free Response Reflection', assessment: true
+level 'U2L02 Assessment 3', assessment: true
+level 'U2L02 Assessment 4', assessment: true
+level 'U2L02 Assessment 5', assessment: true
 
 stage 'Invent an Addressing Protocol'
 level 'U2L3 Student Lesson Introduction'
 level 'U2L3: IP DNS Video'
-assessment 'U2L3 Assessment'
+level 'U2L3 Assessment', assessment: true
 level 'U2L3 NetSim Hub Mode'
-assessment 'U2L3 Assessment 2'
-assessment 'U2L3 Assessment 3'
-assessment 'U2L3 Assessment 4'
+level 'U2L3 Assessment 2', assessment: true
+level 'U2L3 Assessment 3', assessment: true
+level 'U2L3 Assessment 4', assessment: true
 
 stage 'Routers and Redundancy'
 level 'U2L4 Student Lesson Introduction'
 level 'U2L04 - NetSim Routers with Addresses'
-assessment 'U2L04 Assessment1'
-assessment 'U2L04 Assessment4'
-assessment 'U2L04 Assessment5'
-assessment 'U2L04 Assessment2'
-assessment 'U2L04 Assessment3'
+level 'U2L04 Assessment1', assessment: true
+level 'U2L04 Assessment4', assessment: true
+level 'U2L04 Assessment5', assessment: true
+level 'U2L04 Assessment2', assessment: true
+level 'U2L04 Assessment3', assessment: true
 
 stage 'Packets and Making a Reliable Internet'
 level 'U2L5 Student Lesson Introduction'
 level 'U2L05 - NetSim - Packets and Building TCP'
 level 'U2L5 Packets and Reliability - Video'
-assessment 'U2L05 Assessment 1'
-assessment 'U2L05 Assessment 2'
-assessment 'U2L05 Reflection 1'
+level 'U2L05 Assessment 1', assessment: true
+level 'U2L05 Assessment 2', assessment: true
+level 'U2L05 Reflection 1', assessment: true
 
 stage 'Algorithms Detour - Minimum Spanning Tree'
 level 'U2L6 Student Lesson Introduction'
-assessment 'U2L06 - Matching: Label the Diagram'
-assessment 'U2L06- MC: what is an MST?'
-assessment 'U2L06 - MC: Which is an MST?'
+level 'U2L06 - Matching: Label the Diagram', assessment: true
+level 'U2L06- MC: what is an MST?', assessment: true
+level 'U2L06 - MC: Which is an MST?', assessment: true
 
 stage 'Algorithms Detour - Shortest Path'
 level 'U2L7 Student Lesson Introduction'
-assessment 'U1L07 Assessment 1'
-assessment 'U2L07 Assessment2'
-assessment 'U2L07 Assessment3'
-assessment 'U2L07 Assessment4'
-assessment 'U2L07 Assessment5'
+level 'U1L07 Assessment 1', assessment: true
+level 'U2L07 Assessment2', assessment: true
+level 'U2L07 Assessment3', assessment: true
+level 'U2L07 Assessment4', assessment: true
+level 'U2L07 Assessment5', assessment: true
 
 stage 'Algorithms Detour - How Routers Learn'
 level 'U2L8 Student Lesson Introduction'
-assessment 'U2L08 Free Response 3'
-assessment 'U2L08 Free Response 1'
-assessment 'U2L08 Free Response 2'
-assessment 'U2L08 Assessment 0'
-assessment 'U2L08 Assessment 1'
+level 'U2L08 Free Response 3', assessment: true
+level 'U2L08 Free Response 1', assessment: true
+level 'U2L08 Free Response 2', assessment: true
+level 'U2L08 Assessment 0', assessment: true
+level 'U2L08 Assessment 1', assessment: true
 
 stage 'The Need for DNS'
 level 'U2L9 Student Lesson Introduction'
 level 'U2L10 NetSim Automatic DNS'
-assessment 'U2L09 Assessment1'
-assessment 'U2L09 Assessment2'
-assessment 'U2L09 Free Response Wrap Up'
+level 'U2L09 Assessment1', assessment: true
+level 'U2L09 Assessment2', assessment: true
+level 'U2L09 Free Response Wrap Up', assessment: true
 
 stage 'DNS in the Real World'
 level 'U2L10 Student Lesson Introduction'
-assessment 'U2L10 Free Response Getting Started'
-assessment 'U2L10 Assessment1'
-assessment 'U2L10 Assessment2'
-assessment 'U2L10 Assessment3'
-assessment 'U2L10 Free Response Wrap Up'
+level 'U2L10 Free Response Getting Started', assessment: true
+level 'U2L10 Assessment1', assessment: true
+level 'U2L10 Assessment2', assessment: true
+level 'U2L10 Assessment3', assessment: true
+level 'U2L10 Free Response Wrap Up', assessment: true
 
 stage 'HTTP and Abstraction'
 level 'U2L11 Student Lesson Introduction'
 level 'U2 HTTP and HTML - Video'
-assessment 'U2L11 Assessment 1'
-assessment 'U2L11 Assessment 2'
-assessment 'U2L11 Free Response'
+level 'U2L11 Assessment 1', assessment: true
+level 'U2L11 Assessment 2', assessment: true
+level 'U2L11 Free Response', assessment: true
 
 stage 'Practice PT - The Internet and Society'
 level 'U2L12 Student Lesson Introduction'
@@ -92,60 +92,60 @@ level 'U2L12 Student Lesson Introduction'
 stage 'Tell Me a Secret - Encrypting Text'
 level 'U2L13 Student Lesson Introduction'
 level 'U2 frequency caesar'
-assessment 'U2L13 Free Response Getting Started'
-assessment 'U2L13 Assessment1'
-assessment 'U2L13 Assessment3'
-assessment 'U2L13 Assessment4'
-assessment 'U2L13 Free Response Wrap Up'
+level 'U2L13 Free Response Getting Started', assessment: true
+level 'U2L13 Assessment1', assessment: true
+level 'U2L13 Assessment3', assessment: true
+level 'U2L13 Assessment4', assessment: true
+level 'U2L13 Free Response Wrap Up', assessment: true
 
 stage 'Cracking the Code'
 level 'U2L14 Student Lesson Introduction'
 level 'U2 frequency random sub'
 level 'U2 vigenere cipher'
-assessment 'U2L14 Free Response Getting Started'
-assessment 'U2L14 Assessment'
-assessment 'U2L14 Free Response Wrap Up'
-assessment 'U2L14 Assessment2'
-assessment 'U2L14 Assessment3'
-assessment 'U2L14 Assessment4'
+level 'U2L14 Free Response Getting Started', assessment: true
+level 'U2L14 Assessment', assessment: true
+level 'U2L14 Free Response Wrap Up', assessment: true
+level 'U2L14 Assessment2', assessment: true
+level 'U2L14 Assessment3', assessment: true
+level 'U2L14 Assessment4', assessment: true
 
 stage 'Encryption Algorithms'
 level 'U2L15 Student Lesson Introduction'
-assessment 'U2L15 Assessment1'
-assessment 'U2L15 Assessment2'
-assessment 'U2L15 Assessment3'
-assessment 'U2L15 Assessment4'
+level 'U2L15 Assessment1', assessment: true
+level 'U2L15 Assessment2', assessment: true
+level 'U2L15 Assessment3', assessment: true
+level 'U2L15 Assessment4', assessment: true
 
 stage 'Algorithms Detour - Hard Problems TSP'
 level 'U2L17 Student Lesson Introduction'
-assessment 'U2L17 Assessment 1'
-assessment 'U2L17 Assessment 2'
-assessment 'U2L16 Free Response Assessment 3'
-assessment 'U2L17 Free Response Wrap Up'
+level 'U2L17 Assessment 1', assessment: true
+level 'U2L17 Assessment 2', assessment: true
+level 'U2L16 Free Response Assessment 3', assessment: true
+level 'U2L17 Free Response Wrap Up', assessment: true
 
 stage 'One Way Functions - Ice Cream Vans'
 level 'U2L18 Student Lesson Introduction'
-assessment 'U2L17 Free Response Getting Started'
-assessment 'U2L17 Free Responses Assessment 1'
-assessment 'U2L17 - Vocabulary matching'
-assessment 'U2L18 Free Response Getting Started'
-assessment 'U2L18 Assessment'
-assessment 'U2L18 Free Response Wrap Up'
+level 'U2L17 Free Response Getting Started', assessment: true
+level 'U2L17 Free Responses Assessment 1', assessment: true
+level 'U2L17 - Vocabulary matching', assessment: true
+level 'U2L18 Free Response Getting Started', assessment: true
+level 'U2L18 Assessment', assessment: true
+level 'U2L18 Free Response Wrap Up', assessment: true
 
 stage 'Alice and Bob and Asymmetric Keys'
 level 'U2L16 Student Lesson Introduction'
 level 'U2 Encryption and Public Keys - Video'
-assessment 'U2L18 Free Response Assessment 1'
-assessment 'U2L18 Match terms to cups and beans analogy'
-assessment 'U2L18 Free Response Assessment 3'
+level 'U2L18 Free Response Assessment 1', assessment: true
+level 'U2L18 Match terms to cups and beans analogy', assessment: true
+level 'U2L18 Free Response Assessment 3', assessment: true
 
 stage 'Public Key Crypto'
 level 'U2L19 Student Lesson Introduction'
-assessment 'U2L19 Free Response Getting Started'
-assessment 'U2L19 mutlichoice 20 mod 15'
-assessment 'U2L19 multichoice 13 MOD 17'
-assessment 'U2L19 Assessment'
-assessment 'U2L19 Free Response Wrap Up'
+level 'U2L19 Free Response Getting Started', assessment: true
+level 'U2L19 mutlichoice 20 mod 15', assessment: true
+level 'U2L19 multichoice 13 MOD 17', assessment: true
+level 'U2L19 Assessment', assessment: true
+level 'U2L19 Free Response Wrap Up', assessment: true
 
 stage 'Practice PT - Cybersecurity Innovations'
 level 'U2L20 Student Lesson Introduction'

--- a/dashboard/config/scripts/cspunit3.script
+++ b/dashboard/config/scripts/cspunit3.script
@@ -3,17 +3,17 @@ has_lesson_plan true
 
 stage 'The Need For Programming Languages'
 level 'U3L01 Student Lesson Introduction'
-assessment 'U3L01 Assessment1'
-assessment 'U3L01 Assessment3'
+level 'U3L01 Assessment1', assessment: true
+level 'U3L01 Assessment3', assessment: true
 
 stage 'Using Simple Commands'
 level 'U3L02 Student Lesson Introduction'
 level 'U3L2 Using Simple Commands'
 level 'U3L2_TurtleSquare_right'
 level 'U3L2_Turtle3by3Grid'
-assessment 'U3L02 Assessment'
-assessment 'U3L02 Free Response Getting Started'
-assessment 'U3L02 Free Response Wrap Up'
+level 'U3L02 Assessment', assessment: true
+level 'U3L02 Free Response Getting Started', assessment: true
+level 'U3L02 Free Response Wrap Up', assessment: true
 
 stage 'Creating Functions'
 level 'U3L03 Student Lesson Introduction'
@@ -24,17 +24,17 @@ level 'U3L03 - draw rect function'
 level 'U3L03 - draw step'
 level 'U3L03 Three Steps'
 level 'U3L03 draw diamond'
-assessment 'U3L03 - multiselect - properties of functions'
-assessment 'U3L03 Assessment'
-assessment 'U3L03 Free Response Wrap Up'
+level 'U3L03 - multiselect - properties of functions', assessment: true
+level 'U3L03 Assessment', assessment: true
+level 'U3L03 Free Response Wrap Up', assessment: true
 
 stage 'Functions and Top-Down Design'
 level 'u3L04 Student Lesson Introduction'
 level 'U3L04 - snowflake'
 level 'U3L04 - 3 by 3 with functions'
-assessment 'U3L04 Assessment1'
-assessment 'U3L04 Assessment2'
-assessment 'U3L04 Free Response Wrap Up'
+level 'U3L04 Assessment1', assessment: true
+level 'U3L04 Assessment2', assessment: true
+level 'U3L04 Free Response Wrap Up', assessment: true
 
 stage 'APIs and Function Parameters'
 level 'U3L06 Student Lesson Introduction'
@@ -47,9 +47,9 @@ level 'U3L06 Challenge 6 squiggles'
 level 'U3L06 Challenge 5 overlapping circles'
 level 'U3L06 Challenge 7 smiley face'
 level 'U3L06 Challenge 8 make your own'
-assessment 'U3L06 Assessment2'
-assessment 'U3L06-API-multichoice'
-assessment 'U3L06 Assessment'
+level 'U3L06 Assessment2', assessment: true
+level 'U3L06-API-multichoice', assessment: true
+level 'U3L06 Assessment', assessment: true
 
 stage 'Creating functions with Parameters'
 level 'U3L08 Student Lesson Introduction'
@@ -64,8 +64,8 @@ level 'U3L08 - fish'
 level 'U3L08 - multiParamFish'
 level 'U3L08 - randomInput'
 level 'U3L08 - freePlay'
-assessment 'U3L08 Assessment1'
-assessment 'U3L08 Assessment2'
+level 'U3L08 Assessment1', assessment: true
+level 'U3L08 Assessment2', assessment: true
 
 stage 'Looping and Random Numbers'
 level 'U3L07 Student Lesson Introduction'
@@ -81,8 +81,8 @@ level 'U3L07 - seaGrass'
 level 'U3L07 - allSeaGrass'
 level 'U3L07 - sunBeams'
 level 'U3L07 - Free Play Loops and Random'
-assessment 'U3L07 - MC remove line of code loops'
-assessment 'U3L07 Free Response Reflection'
+level 'U3L07 - MC remove line of code loops', assessment: true
+level 'U3L07 Free Response Reflection', assessment: true
 
 stage 'Practice PT - Design a Digital Scene'
 level 'U3L09 Student Lesson Introduction'
@@ -103,10 +103,10 @@ level 'U3L13 - Debugging 1'
 level 'U3L13 - Debugging 2'
 level 'U3L13 - Debugging 3'
 level 'U3L13 - Turtle Driver Project'
-assessment 'U3L13 debugging Multi'
-assessment 'U3L13 Free Response Reflection'
-assessment 'U3L14 - MC order of button and onEvent'
-assessment 'U3L14 - MC Duplicate Ids'
+level 'U3L13 debugging Multi', assessment: true
+level 'U3L13 Free Response Reflection', assessment: true
+level 'U3L14 - MC order of button and onEvent', assessment: true
+level 'U3L14 - MC Duplicate Ids', assessment: true
 
 stage 'Beyond Buttons Toward Apps'
 level 'U3L16 Student Lesson Introduction'
@@ -114,7 +114,7 @@ level 'U3L16 - singleSetPosition'
 level 'U3L16 - introSetPosition'
 level 'U3L16 - setPosition to move button'
 level 'U3L16 - newEventTypes'
-assessment 'U3L14 - Matching Events to Description'
+level 'U3L14 - Matching Events to Description', assessment: true
 level 'U3L16 - text labels'
 level 'U3L16 - use images'
 level 'U3L16 - chooseImages'
@@ -161,7 +161,7 @@ level 'U3L14 - moving memory challenge4'
 level 'U3L14 - moving memory challenge5'
 level 'U3L14 - moving memory challenge6'
 level 'U3L19 - variable reassignment challenge pt2'
-assessment 'U3L14 - MC variable reassignment'
+level 'U3L14 - MC variable reassignment', assessment: true
 
 stage 'Using Variables in Apps'
 level 'U3L15 Student Lesson Intro - new'
@@ -201,22 +201,22 @@ level 'U3L16 Mad Lib setText'
 level 'U3L16 Mad Lib getText'
 level 'U3L16 Mad Lib toUpper'
 level 'U3L16 Mad Lib Clear Input'
-assessment 'U3L25 Free Response 3'
+level 'U3L25 Free Response 3', assessment: true
 
 stage 'Introduction to Digital Assistants'
 level 'U3L23 Student Lesson Introduction'
-assessment 'U3L23 Free Response Getting Started'
+level 'U3L23 Free Response Getting Started', assessment: true
 level 'U3 Digital Assistant Target'
 level 'U3L16 - challenge say hi app'
 level 'U3 Digital Assistant Design'
 level 'U3 Digital Assistant Set Text'
-assessment 'U3L23 Free Response Wrap Up'
+level 'U3L23 Free Response Wrap Up', assessment: true
 
 stage 'Understanding Program Flow and Logic'
 level 'U3L20 Student Lesson Introduction'
 level 'U3 - Conditionals - Boolean Expressions and Operators'
 level 'U3L18 comparison operators'
-assessment 'U3L18 Matching'
+level 'U3L18 Matching', assessment: true
 level 'U3 - Conditionals - Translating Flowcharts - If Statement'
 level 'U3 - High Low - If'
 level 'U3 - High Low - Dropdown'
@@ -319,8 +319,8 @@ level 'U3 - Arrays - favThings Prev'
 level 'U3 - Arrays - favThings addItem'
 level 'U3 - Arrays - favThings bounds'
 level 'U3 - Arrays - favThings keepPlaying'
-assessment 'U3 - Arrays - Wrap Up 1'
-assessment 'U3 - Arrays - Wrap Up 2'
+level 'U3 - Arrays - Wrap Up 1', assessment: true
+level 'U3 - Arrays - Wrap Up 2', assessment: true
 
 stage 'Image Scroller with Key Events'
 level 'U3L31 Student Lesson Introduction'
@@ -333,7 +333,7 @@ level 'U3 - Keys - Buttons and Keys'
 level 'U3 - Keys - Functions'
 level 'U3 - Keys - Add Image URLs'
 level 'U3 - Keys - Final Image Scroller'
-assessment 'U3- Keys - Code Refactoring Exit Ticket'
+level 'U3- Keys - Code Refactoring Exit Ticket', assessment: true
 
 stage 'Processing Arrays'
 level 'U3L32 Student Lesson Introduction'

--- a/dashboard/config/scripts/cspunit3temp.script
+++ b/dashboard/config/scripts/cspunit3temp.script
@@ -22,7 +22,7 @@ level 'U3 - Loops - plus and minus = operator'
 level 'U3 - Loops - minus = operator'
 level 'U3 - Loops - 14'
 level 'U3 - Loops - 15'
-assessment 'U3L28 Free Response Wrap Up'
+level 'U3L28 Free Response Wrap Up', assessment: true
 
 stage 'Loops and Simulations'
 level 'U3L29 Student Lesson Introduction'
@@ -78,7 +78,7 @@ level 'U3 - Keys - Buttons and Keys'
 level 'U3 - Keys - Functions'
 level 'U3 - Keys - Add Image URLs'
 level 'U3 - Keys - Final Image Scroller'
-assessment 'U3- Keys - Code Refactoring Exit Ticket'
+level 'U3- Keys - Code Refactoring Exit Ticket', assessment: true
 
 stage 'Processing Arrays'
 level 'U3L32 Student Lesson Introduction'
@@ -125,7 +125,7 @@ level 'U3 - Canvas - movementFunction'
 level 'U3 - Canvas - movementFunction fix Orig'
 level 'U3 - Canvas - sprayPaint'
 level 'U3 - Canvas - sketch'
-assessment 'U3L33 Free Response Getting Started'
+level 'U3L33 Free Response Getting Started', assessment: true
 
 stage 'Practice PT: Create'
 level 'U3L34 Student Lesson Introduction'

--- a/dashboard/config/scripts/cspunit4draft.script
+++ b/dashboard/config/scripts/cspunit4draft.script
@@ -48,9 +48,9 @@ level 'U4L12 - Student Introduction'
 #1old
 stage 'Why Make Apps?'
 level 'U4L01 Student Lesson Introduction'
-assessment 'U4L01 Free Response'
-assessment 'U4L01 Choose 2'
-assessment 'U4L01 Multiple Choice'
+level 'U4L01 Free Response', assessment: true
+level 'U4L01 Choose 2', assessment: true
+level 'U4L01 Multiple Choice', assessment: true
 
 #2
 stage 'Creating Javascript Objects'
@@ -70,9 +70,9 @@ level 'U4 - Objects - pullValues'
 level 'U4 - Objects - createContactObject'
 level 'U4 - Objects - resetIndexAndShow'
 level 'U4 - Objects - showSampleImage'
-assessment 'U4L02 Free Response'
-assessment 'U4L02 Choose 2'
-assessment 'U4L02 Multiple Choice'
+level 'U4L02 Free Response', assessment: true
+level 'U4L02 Choose 2', assessment: true
+level 'U4L02 Multiple Choice', assessment: true
 
 #3
 stage 'Permanent Data Storage'
@@ -114,16 +114,16 @@ level 'U4 - ReadRecords - Contacts App 5 make delete work'
 #5
 stage 'Search Terms'
 level 'U4L05 Student Lesson Introduction'
-assessment 'U4L05 Free Response'
-assessment 'U4L05 Choose 2'
-assessment 'U4L05 Multiple Choice'
+level 'U4L05 Free Response', assessment: true
+level 'U4L05 Choose 2', assessment: true
+level 'U4L05 Multiple Choice', assessment: true
 
 #6
 stage 'Unique IDs, Delete and Update Records'
 level 'U4L06 Student Lesson Introduction'
-assessment 'U4L06 Free Response'
-assessment 'U4L06 Choose 2'
-assessment 'U4L06 Multiple Choice'
+level 'U4L06 Free Response', assessment: true
+level 'U4L06 Choose 2', assessment: true
+level 'U4L06 Multiple Choice', assessment: true
 
 #7
 stage 'Import, Export, and Visualize Data'
@@ -138,92 +138,92 @@ level 'U4 - Charts - Line Chart 1'
 level 'U4 - Charts - Line Chart 2'
 level 'U4 - Charts - drawChartFromRecords Options 1'
 level 'U4 - Charts - drawChartFromRecords Options 2'
-assessment 'U4L07 Free Response'
-assessment 'U4L07 Choose 2'
-assessment 'U4L07 Multiple Choice'
+level 'U4L07 Free Response', assessment: true
+level 'U4L07 Choose 2', assessment: true
+level 'U4L07 Multiple Choice', assessment: true
 
 #8
 stage 'Interpreting Data Visualizations'
 level 'U4L08 Student Lesson Introduction'
-assessment 'U4L08 Free Response'
-assessment 'U4L08 Choose 2'
-assessment 'U4L08 Multiple Choice'
+level 'U4L08 Free Response', assessment: true
+level 'U4L08 Choose 2', assessment: true
+level 'U4L08 Multiple Choice', assessment: true
 
 #9
 stage 'How is Data Collected?'
 level 'U4L09 Student Lesson Introduction'
-assessment 'U4L09 Free Response'
-assessment 'U4L09 Choose 2'
-assessment 'U4L09 Multiple Choice'
+level 'U4L09 Free Response', assessment: true
+level 'U4L09 Choose 2', assessment: true
+level 'U4L09 Multiple Choice', assessment: true
 
 #10
 stage 'Using Data in the Real World' 
 level 'U4L10 Student Lesson Introduction'
-assessment 'U4L10 Free Response'
-assessment 'U4L10 Choose 2'
-assessment 'U4L10 Multiple Choice'
+level 'U4L10 Free Response', assessment: true
+level 'U4L10 Choose 2', assessment: true
+level 'U4L10 Multiple Choice', assessment: true
 
 # 11
 stage 'Web Requests and APIs'
 level 'U4L11 Student Lesson Introduction'
-assessment 'U4L11 Free Response'
-assessment 'U4L11 Choose 2'
-assessment 'U4L11 Multiple Choice'
+level 'U4L11 Free Response', assessment: true
+level 'U4L11 Choose 2', assessment: true
+level 'U4L11 Multiple Choice', assessment: true
 
 # 12
 stage 'Data, Security, and Privacy'
 level 'U4L12 Student Lesson Introduction'
-assessment 'U4L12 Free Response'
-assessment 'U4L12 Choose 2'
-assessment 'U4L12 Multiple Choice'
+level 'U4L12 Free Response', assessment: true
+level 'U4L12 Choose 2', assessment: true
+level 'U4L12 Multiple Choice', assessment: true
 
 #13
 stage 'Privacy vs Utility'
 level 'U4L13 Student Lesson Introduction'
-assessment 'U4L13 Free Response'
-assessment 'U4L13 Choose 2'
-assessment 'U4L13 Multiple Choice'
+level 'U4L13 Free Response', assessment: true
+level 'U4L13 Choose 2', assessment: true
+level 'U4L13 Multiple Choice', assessment: true
 
 #14
 stage 'Privacy in a Digital World'
 level 'U4L14 Student Lesson Introduction'
-assessment 'U4L14 Free Response'
-assessment 'U4L14 Choose 2'
-assessment 'U4L14 Multiple Choice'
+level 'U4L14 Free Response', assessment: true
+level 'U4L14 Choose 2', assessment: true
+level 'U4L14 Multiple Choice', assessment: true
 
 #15
 stage 'Compiling Data'
 level 'U4L15 Student Lesson Introduction'
-assessment 'U4L15 Free Response'
-assessment 'U4L15 Choose 2'
-assessment 'U4L15 Multiple Choice'
+level 'U4L15 Free Response', assessment: true
+level 'U4L15 Choose 2', assessment: true
+level 'U4L15 Multiple Choice', assessment: true
 
 #16
 stage 'Cleaning Data'
-assessment 'U4L16 Free Response'
-assessment 'U4L16 Choose 2'
-assessment 'U4L16 Multiple Choice'
+level 'U4L16 Free Response', assessment: true
+level 'U4L16 Choose 2', assessment: true
+level 'U4L16 Multiple Choice', assessment: true
 
 #17
 stage 'Designing Data Collection'
 level 'U4L17 Student Lesson Introduction'
-assessment 'U4L17 Free Response'
-assessment 'U4L17 Choose 2'
-assessment 'U4L17 Multiple Choice'
+level 'U4L17 Free Response', assessment: true
+level 'U4L17 Choose 2', assessment: true
+level 'U4L17 Multiple Choice', assessment: true
 
 #18
 stage 'Designing for Your User'
 level 'U4L18 Student Lesson Introduction'
-assessment 'U4L18 Free Response'
-assessment 'U4L18 Choose 2'
-assessment 'U4L18 Multiple Choice'
+level 'U4L18 Free Response', assessment: true
+level 'U4L18 Choose 2', assessment: true
+level 'U4L18 Multiple Choice', assessment: true
 
 #19
 stage 'Practice Create PT: Data App'
 level 'U4L19 Student Lesson Introduction'
-assessment 'U4L19 Free Response'
-assessment 'U4L19 Choose 2'
-assessment 'U4L19 Multiple Choice'
+level 'U4L19 Free Response', assessment: true
+level 'U4L19 Choose 2', assessment: true
+level 'U4L19 Multiple Choice', assessment: true
 
 stage 'What Data Can Tell Us'
 level 'CSP Data Unit -Counting Records - Hard Way'
@@ -238,6 +238,6 @@ level 'U3L17 - setKeyValue'
 level 'U3L17 - twoSetKeyValue'
 level 'U3L17 - introCallbacks'
 level 'U3L17 - getKeyValue'
-assessment 'U3L22 Free Response Getting Started'
-assessment 'U3L22 Assessment'
-assessment 'U3L22 Reflection'
+level 'U3L22 Free Response Getting Started', assessment: true
+level 'U3L22 Assessment', assessment: true
+level 'U3L22 Reflection', assessment: true

--- a/dashboard/config/scripts/e-f-ramp.script
+++ b/dashboard/config/scripts/e-f-ramp.script
@@ -27,7 +27,7 @@ level 'courseC_maze_debugging4'
 level 'courseC_maze_debugging5'
 level 'courseC_maze_debugging6'
 level 'courseC_maze_debugging7', challenge: true
-assessment 'courseC_maze_debugging8_predict1'
+level 'courseC_maze_debugging8_predict1', assessment: true
 level 'courseC_maze_debugging9'
 
 stage 'Programming in Artist', flex_category: 'csf_e_1'
@@ -40,7 +40,7 @@ level 'courseC_artist_prog5'
 level 'courseC_artist_prog6'
 level 'courseC_artist_prog7', challenge: true
 level 'courseC_artist_prog8'
-assessment 'courseC_artist_prog6_predict1'
+level 'courseC_artist_prog6_predict1', assessment: true
 bonus 'courseC_artist_prog_challenge1'
 bonus 'courseC_artist_prog_challenge2'
 
@@ -73,7 +73,7 @@ level 'courseD_maze_nestedLoops6'
 level 'courseD_bee_nestedLoops7', challenge: true
 level 'courseD_bee_nestedLoops8'
 level 'courseD_bee_nestedLoops9'
-assessment 'courseD_bee_nestedLoops9_predict2'
+level 'courseD_bee_nestedLoops9_predict2', assessment: true
 
 stage 'Nested Loops with Frozen', flex_category: 'csf_e_1'
 level 'courseD_artist_project1'
@@ -161,7 +161,7 @@ level 'courseE_bee_functions7'
 level 'courseE_bee_functions8', challenge: true
 level 'courseE_bee_functions9'
 level 'courseE_bee_functions10'
-assessment 'courseE_bee_functions11_predict1'
+level 'courseE_bee_functions11_predict1', assessment: true
 bonus 'courseE_bee_functions_challenge1'
 bonus 'courseE_bee_functions_challenge2'
 
@@ -178,7 +178,7 @@ level 'courseE_artist_functions7'
 level 'courseE_artist_functions8', challenge: true
 level 'courseE_artist_functions9'
 level 'courseE_artist_functions10'
-assessment 'courseE_artist_functions_predict2'
+level 'courseE_artist_functions_predict2', assessment: true
 bonus 'courseE_artist_functions_challenge1'
 bonus 'courseE_artist_functions_challenge2'
 
@@ -196,7 +196,7 @@ level 'courseE_farmer_functions7b'
 level 'courseE_farmer_functions8b', challenge: true
 level 'courseE_farmer_functions9b'
 level 'courseE_farmer_functions10b'
-assessment 'courseE_farmer_functions11_predict'
+level 'courseE_farmer_functions11_predict', assessment: true
 
 stage 'Determine the Concept', flex_category: 'csf_e_2'
 level 'courseE_bee_concept1'

--- a/dashboard/config/scripts/flappy-impact-study.script
+++ b/dashboard/config/scripts/flappy-impact-study.script
@@ -2,7 +2,7 @@ hidden false
 login_required true
 
 stage 'Pre Hour of Code Survey'
-assessment 'HOC pre-survey 2016 levelgroup'
+level 'HOC pre-survey 2016 levelgroup', assessment: true
 
 stage 'Flappy Code'
 skin 'flappy'
@@ -37,4 +37,4 @@ level_concept_difficulty '{"sequencing":1,"events":1}'
 level 'flappy_11'
 
 stage 'Post Hour of Code Survey'
-assessment 'HOC post-survey 2016 levelgroup'
+level 'HOC post-survey 2016 levelgroup', assessment: true

--- a/dashboard/config/scripts/hoc-impact-study.script
+++ b/dashboard/config/scripts/hoc-impact-study.script
@@ -2,7 +2,7 @@ hidden false
 login_required true
 
 stage 'Pre Hour of Code Survey'
-assessment 'HOC pre-survey 2016 levelgroup'
+level 'HOC pre-survey 2016 levelgroup', assessment: true
 
 stage 'Hour of Code 2013'
 skin 'birds'
@@ -90,4 +90,4 @@ level_concept_difficulty '{"sequencing":5,"repeat_until_while":4,"conditionals":
 level 'blockly:Maze:2_19'
 
 stage 'Post Hour of Code Survey'
-assessment 'HOC post-survey 2016 levelgroup'
+level 'HOC post-survey 2016 levelgroup', assessment: true

--- a/dashboard/config/scripts/k5concepts.script
+++ b/dashboard/config/scripts/k5concepts.script
@@ -1,24 +1,24 @@
 stage 'Events'
 level 'BigEvent'
-assessment '2-3 Big Event Match 1'
+level '2-3 Big Event Match 1', assessment: true
 
 stage 'Loops'
 level 'GettingLoopy'
-assessment '2-3 Getting Loopy Multi 1'
+level '2-3 Getting Loopy Multi 1', assessment: true
 
 stage 'Nested Loops'
 level 'comingSoon'
 
 stage 'Conditionals'
 level 'Conditionals'
-assessment '2-3 Conditionals Multi 1'
+level '2-3 Conditionals Multi 1', assessment: true
 
 stage 'While Loops'
 level 'comingSoon'
 
 stage 'Functions'
 level 'SongwritingParameters'
-assessment '4-5 Songwriting Multi 1'
+level '4-5 Songwriting Multi 1', assessment: true
 
 stage 'Variables'
 level 'EnvelopeVariables'
@@ -40,7 +40,7 @@ level 'grade5_artist_functionparameters11'
 
 stage 'Binary'
 level 'BinaryBracelets'
-assessment '2-3 Binary Match 1'
+level '2-3 Binary Match 1', assessment: true
 level 'BinaryImages'
 level 'grade5_pixelation'
 level 'grade5_artist_binary5'

--- a/dashboard/config/scripts/new-d.script
+++ b/dashboard/config/scripts/new-d.script
@@ -101,7 +101,7 @@ level 'courseD_maze_nestedLoops6'
 level 'courseD_bee_nestedLoops7', challenge: true
 level 'courseD_bee_nestedLoops8'
 level 'courseD_bee_nestedLoops9'
-assessment 'courseD_bee_nestedLoops9_predict2'
+level 'courseD_bee_nestedLoops9_predict2', assessment: true
 bonus 'courseD_harvester_nested_loops_challenge1'
 bonus 'courseD_collector_nested_loops_challenge2'
 
@@ -117,7 +117,7 @@ level 'courseD_artist_nestedLoops7'
 level 'courseD_artist_nestedLoops8'
 level 'courseD_artist_nestedLoops9', challenge: true
 level 'courseD_artist_nestedLoops10'
-assessment 'courseD_artist_nestedLoops9_predict1'
+level 'courseD_artist_nestedLoops9_predict1', assessment: true
 level 'courseD_artist_nestedLoopsFP'
 bonus 'courseD_artist_nestedLoops_challenge1'
 bonus 'courseD_artist_nestedLoops_challenge2'
@@ -135,7 +135,7 @@ level 'courseD_farmer_while7'
 level 'courseD_farmer_while8', challenge: true
 level 'courseD_farmer_while9'
 level 'courseD_farmer_while10'
-assessment 'courseD_farmer_while10_predict2'
+level 'courseD_farmer_while10_predict2', assessment: true
 bonus 'courseD_farmer_while_challenge1'
 bonus 'courseD_farmer_while_challenge2'
 
@@ -172,7 +172,7 @@ level 'courseD_video_ifElse'
 level 'courseD_maze_until8'
 level 'courseD_maze_until9', challenge: true
 level 'courseD_maze_until10'
-assessment 'courseD_maze_until10_predict2'
+level 'courseD_maze_until10_predict2', assessment: true
 bonus 'courseD_maze_until_challenge1'
 bonus 'courseD_farmer_until_challenge2'
 
@@ -186,7 +186,7 @@ level 'courseD_farmer_condLoops6'
 level 'courseD_farmer_condLoops7', challenge: true
 level 'courseD_farmer_condLoops8'
 level 'courseD_farmer_condLoops9'
-assessment 'courseD_farmer_condLoops9_predict1'
+level 'courseD_farmer_condLoops9_predict1', assessment: true
 bonus 'courseD_farmer_condLoops_challenge1'
 bonus 'courseD_farmer_condLoops_challenge2'
 
@@ -217,7 +217,7 @@ level 'courseD_artist_binary5'
 level 'courseD_artist_binary6'
 level 'courseD_artist_binary7'
 level 'courseD_artist_binary8'
-assessment 'courseD_artist_binary8_predict1'
+level 'courseD_artist_binary8_predict1', assessment: true
 level 'courseD_artist_binaryFP'
 bonus 'courseD_artist_binary_challenge1'
 bonus 'courseD_artist_binary_challenge2'

--- a/dashboard/config/scripts/new-e.script
+++ b/dashboard/config/scripts/new-e.script
@@ -25,7 +25,7 @@ level 'courseC_maze_debugging4'
 level 'courseC_maze_debugging5'
 level 'courseC_maze_debugging6'
 level 'courseC_maze_debugging7', challenge: true
-assessment 'courseC_maze_debugging8_predict1'
+level 'courseC_maze_debugging8_predict1', assessment: true
 level 'courseC_maze_debugging9'
 
 stage 'Programming in Artist', flex_category: 'csf_e_1'
@@ -38,7 +38,7 @@ level 'courseC_artist_prog5'
 level 'courseC_artist_prog6'
 level 'courseC_artist_prog7', challenge: true
 level 'courseC_artist_prog8'
-assessment 'courseC_artist_prog6_predict1'
+level 'courseC_artist_prog6_predict1', assessment: true
 bonus 'courseC_artist_prog_challenge1'
 bonus 'courseC_artist_prog_challenge2'
 
@@ -71,7 +71,7 @@ level 'courseD_maze_nestedLoops6'
 level 'courseD_bee_nestedLoops7', challenge: true
 level 'courseD_bee_nestedLoops8'
 level 'courseD_bee_nestedLoops9'
-assessment 'courseD_bee_nestedLoops9_predict2'
+level 'courseD_bee_nestedLoops9_predict2', assessment: true
 
 stage 'Nested Loops with Frozen', flex_category: 'csf_e_1'
 level 'courseD_artist_project1'
@@ -159,7 +159,7 @@ level 'courseE_bee_functions7'
 level 'courseE_bee_functions8', challenge: true
 level 'courseE_bee_functions9'
 level 'courseE_bee_functions10'
-assessment 'courseE_bee_functions11_predict1'
+level 'courseE_bee_functions11_predict1', assessment: true
 bonus 'courseE_bee_functions_challenge1'
 bonus 'courseE_bee_functions_challenge2'
 
@@ -176,7 +176,7 @@ level 'courseE_artist_functions7'
 level 'courseE_artist_functions8', challenge: true
 level 'courseE_artist_functions9'
 level 'courseE_artist_functions10'
-assessment 'courseE_artist_functions_predict2'
+level 'courseE_artist_functions_predict2', assessment: true
 bonus 'courseE_artist_functions_challenge1'
 bonus 'courseE_artist_functions_challenge2'
 
@@ -194,7 +194,7 @@ level 'courseE_farmer_functions7b'
 level 'courseE_farmer_functions8b', challenge: true
 level 'courseE_farmer_functions9b'
 level 'courseE_farmer_functions10b'
-assessment 'courseE_farmer_functions11_predict'
+level 'courseE_farmer_functions11_predict', assessment: true
 
 stage 'Determine the Concept', flex_category: 'csf_e_2'
 level 'courseE_bee_concept1'

--- a/dashboard/config/scripts/new-f.script
+++ b/dashboard/config/scripts/new-f.script
@@ -25,7 +25,7 @@ level 'courseC_maze_debugging4'
 level 'courseC_maze_debugging5'
 level 'courseC_maze_debugging6'
 level 'courseC_maze_debugging7', challenge: true
-assessment 'courseC_maze_debugging8_predict1'
+level 'courseC_maze_debugging8_predict1', assessment: true
 level 'courseC_maze_debugging9'
 
 stage 'Programming in Artist', flex_category: 'csf_f_1'
@@ -38,7 +38,7 @@ level 'courseC_artist_prog5'
 level 'courseC_artist_prog6'
 level 'courseC_artist_prog7', challenge: true
 level 'courseC_artist_prog8'
-assessment 'courseC_artist_prog6_predict1'
+level 'courseC_artist_prog6_predict1', assessment: true
 bonus 'courseC_artist_prog_challenge1'
 bonus 'courseC_artist_prog_challenge2'
 
@@ -71,7 +71,7 @@ level 'courseD_maze_nestedLoops6'
 level 'courseD_bee_nestedLoops7', challenge: true
 level 'courseD_bee_nestedLoops8'
 level 'courseD_bee_nestedLoops9'
-assessment 'courseD_bee_nestedLoops9_predict2'
+level 'courseD_bee_nestedLoops9_predict2', assessment: true
 
 stage 'Nested Loops with Frozen', flex_category: 'csf_f_1'
 level 'courseD_artist_project1'
@@ -198,7 +198,7 @@ stage 'Variables in Play Lab', flex_category: 'csf_f_2'
 level 'courseF_playlab_variables1a'
 level 'courseF_playlab_variables2b'
 level 'courseF_playlab_variables3b_josh'
-assessment 'courseF_playlab_variables4c_predictive1'
+level 'courseF_playlab_variables4c_predictive1', assessment: true
 level 'courseF_playlab_variables4b'
 level 'courseF_playlab_variables5c'
 level 'courseF_playlab_variables6c'
@@ -238,7 +238,7 @@ level 'courseF_artist_for6'
 level 'courseF_artist_for7'
 level 'courseF_artist_for8'
 level 'courseF_artist_for9'
-assessment 'courseF_artist_for10_predict1'
+level 'courseF_artist_for10_predict1', assessment: true
 level 'courseF_artist_for10'
 bonus 'courseF_artist_for_challenge1'
 bonus 'courseF_artist_for_challenge2'
@@ -299,7 +299,7 @@ level 'courseF_bee_fwp5'
 level 'courseF_bee_fwp6'
 level 'courseF_bee_fwp7', challenge: true
 level 'courseF_bee_fwp8'
-assessment 'courseF_bee_fwp9_predict1'
+level 'courseF_bee_fwp9_predict1', assessment: true
 bonus 'courseF_bee_fwp_challenge1'
 bonus 'courseF_bee_fwp_challenge2'
 

--- a/dashboard/config/scripts/sconyers.script
+++ b/dashboard/config/scripts/sconyers.script
@@ -13,7 +13,7 @@ level 'U4 Model Design 5_2018', progression: 'Finish a Screen'
 level 'U4 Model Design 6_2018', progression: 'Finish a Screen'
 level 'U4 Model Design 7_2018', progression: 'Finish a Screen'
 level 'Design a Screen for your App_2018', named: true
-assessment 'CSD U4 - Design Mode Project_2018', progression: 'App Project: Screen Design'
+level 'CSD U4 - Design Mode Project_2018', progression: 'App Project: Screen Design', assessment: true
 
 stage 'Linking Screens'
 level 'CSD U4L13 autoSFLP_2018', named: true

--- a/dashboard/config/scripts/subgoals-assessment-staging.script
+++ b/dashboard/config/scripts/subgoals-assessment-staging.script
@@ -1,31 +1,31 @@
 login_required true
 
 stage 'all assessment items as standalone assessment levels'
-assessment 'csp_U3_square_v_rect_FR'
-assessment 'csp_U3_plan_code_FR'
-assessment 'csp_U3_turtle_subgoal_q1_mc'
-assessment 'csp_U3_turtle_subgoal_q2_mc'
-assessment 'csp_U3_turtle_subgoal_q3_mc'
-assessment 'csp_U3_subgoal_q4_mc'
-assessment 'subgoals_U3_turtle_prediction_FR'
-assessment 'subgoals_u3_top_down_FR'
+level 'csp_U3_square_v_rect_FR', assessment: true
+level 'csp_U3_plan_code_FR', assessment: true
+level 'csp_U3_turtle_subgoal_q1_mc', assessment: true
+level 'csp_U3_turtle_subgoal_q2_mc', assessment: true
+level 'csp_U3_turtle_subgoal_q3_mc', assessment: true
+level 'csp_U3_subgoal_q4_mc', assessment: true
+level 'subgoals_U3_turtle_prediction_FR', assessment: true
+level 'subgoals_u3_top_down_FR', assessment: true
 
 stage 'submittable if last assessment item'
 level 'U3L03 Three Steps', progression: 'Some app lab progression'
 level 'U3L03 draw diamond', progression: 'Some app lab progression'
-assessment 'csp_U3_turtle_subgoal_q1_mc', progression: 'Check for understanding'
-assessment 'csp3_U3_turtle_subgoal_mc_levelgroup', progression: 'Check for understanding'
+level 'csp_U3_turtle_subgoal_q1_mc', progression: 'Check for understanding', assessment: true
+level 'csp3_U3_turtle_subgoal_mc_levelgroup', progression: 'Check for understanding', assessment: true
 
 stage 'dummy'
-assessment 'subgoals_assessement_levelgroup_test2', progression: 'Check for understanding (diff between 3 and 4)'
+level 'subgoals_assessement_levelgroup_test2', progression: 'Check for understanding (diff between 3 and 4)', assessment: true
 
 stage 'assessment sandwiched between app lab levels'
 level 'U3L03 Draw a T using turnAround', progression: 'Some app lab progression'
-assessment 'csp_U3_square_v_rect_FR', progression: 'Some app lab progression'
+level 'csp_U3_square_v_rect_FR', progression: 'Some app lab progression', assessment: true
 level 'U3L03 define turnRight and draw a rectangle', progression: 'Some app lab progression'
 
 stage 'all assessment items clustered in levelgroup as a single "test"'
-assessment 'subgoal_assessments_levelgroup_test'
+level 'subgoal_assessments_levelgroup_test', assessment: true
 
 stage 'CSP 3 updates staging ground'
 level 'SG CSP Abstraction in Programming 2', progression: 'Lesson 5.6 - (new) Abstraction in Programming'

--- a/dashboard/config/scripts/time4csdemo.script
+++ b/dashboard/config/scripts/time4csdemo.script
@@ -32,7 +32,7 @@ level 'courseC_maze_debugging4_2018'
 level 'courseC_maze_debugging5_2018'
 level 'courseC_maze_debugging6_2018'
 level 'courseC_maze_debugging7_2018', challenge: true
-assessment 'courseC_maze_debugging8_predict1_2018'
+level 'courseC_maze_debugging8_predict1_2018', assessment: true
 level 'courseC_maze_debugging9_2018'
 level 'courseF_markdown_debugging_end'
 
@@ -46,7 +46,7 @@ level 'courseC_artist_prog5_2018'
 level 'courseC_artist_prog6_2018'
 level 'courseC_artist_prog7_2018', challenge: true
 level 'courseC_artist_prog8_2018'
-assessment 'courseC_artist_prog6_predict1_2018'
+level 'courseC_artist_prog6_predict1_2018', assessment: true
 bonus 'courseC_artist_prog_challenge1_2018'
 bonus 'courseC_artist_prog_challenge2a_2018'
 
@@ -82,7 +82,7 @@ level 'courseD_maze_nestedLoops6_2018'
 level 'courseD_bee_nestedLoops7_2018', challenge: true
 level 'courseD_bee_nestedLoops8_2018'
 level 'courseD_bee_nestedLoops9_2018'
-assessment 'courseD_bee_nestedLoops9_predict2_2018'
+level 'courseD_bee_nestedLoops9_predict2_2018', assessment: true
 level 'courseF_markdown_nestedloops_end'
 
 stage 'Nested Loops with Frozen', flex_category: 'ramp_up'


### PR DESCRIPTION
Moves all levels in scripts that were marked as `assessment 'Example Level'` to `level 'Example Level', assessment: true`

Checked that `rake seed:scripts` was successful locally.