### PR TITLE
Remove teachercon mapping

### DIFF
--- a/dashboard/app/serializers/regional_partner_serializer.rb
+++ b/dashboard/app/serializers/regional_partner_serializer.rb
@@ -32,6 +32,6 @@ class RegionalPartnerSerializer < ActiveModel::Serializer
   attributes :id, :name, :group, :workshop_type
 
   def workshop_type
-    get_matching_teachercon(object) ? WORKSHOP_TYPES[:teachercon] : WORKSHOP_TYPES[:local_summer]
+    WORKSHOP_TYPES[:local_summer]
   end
 end

--- a/dashboard/app/serializers/regional_partner_serializer.rb
+++ b/dashboard/app/serializers/regional_partner_serializer.rb
@@ -27,7 +27,6 @@
 
 class RegionalPartnerSerializer < ActiveModel::Serializer
   include Pd::SharedWorkshopConstants
-
   attributes :id, :name, :group, :workshop_type
 
   def workshop_type

--- a/dashboard/app/serializers/regional_partner_serializer.rb
+++ b/dashboard/app/serializers/regional_partner_serializer.rb
@@ -26,7 +26,6 @@
 #
 
 class RegionalPartnerSerializer < ActiveModel::Serializer
-  include Pd::Application::RegionalPartnerTeacherconMapping
   include Pd::SharedWorkshopConstants
 
   attributes :id, :name, :group, :workshop_type

--- a/dashboard/lib/pd/application/regional_partner_teachercon_mapping.rb
+++ b/dashboard/lib/pd/application/regional_partner_teachercon_mapping.rb
@@ -1,6 +1,6 @@
 module Pd::Application
   module RegionalPartnerTeacherconMapping
-    THIS_YEAR = 2018
+    THIS_YEAR = 2019
 
     # This is the 2018 mapping. We can update this for next year's applications.
     TEACHERCONS = [

--- a/dashboard/lib/pd/application/regional_partner_teachercon_mapping.rb
+++ b/dashboard/lib/pd/application/regional_partner_teachercon_mapping.rb
@@ -9,23 +9,7 @@ module Pd::Application
     ].freeze
 
     # Map regional partner name to TeacherCon
-    REGIONAL_PARTNER_TC_MAPPING = {
-      'Allegheny Intermediate Unit 3' => TC_PHOENIX,
-      'Teachers Teaching Tech (ND, SD, WY)' => TC_PHOENIX,
-      'Fresno County Superintendent of Schools' => TC_ATLANTA,
-      'Institute for School Partnership Washington University in St. Louis' => TC_ATLANTA,
-      'Mississippi State University' => TC_ATLANTA,
-      'Sacramento County Office of Education' => TC_PHOENIX,
-      'Tampa Bay STEM Network' => TC_ATLANTA,
-      'Twin Cities Public Television' => TC_ATLANTA,
-      "UNH STEM Teachers' Collaborative" => TC_PHOENIX,
-      'Union Station' => TC_PHOENIX,
-      'University of Nebraska' => TC_ATLANTA,
-      'University of Rhode Island' => TC_PHOENIX,
-      'West Virginia University' => TC_ATLANTA,
-      'WNY STEM Hub' => TC_PHOENIX,
-      'Women in Technology' => TC_ATLANTA
-    }.freeze
+    REGIONAL_PARTNER_TC_MAPPING = {}.freeze
 
     def get_matching_teachercon(regional_partner)
       return nil if regional_partner.nil?

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -1024,37 +1024,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     assert_equal atlanta.id, JSON.parse(@response.body).last['id']
   end
 
-  test 'Regional Partners can view associated Teachercon workshops' do
-    partner_name = REGIONAL_PARTNER_TC_MAPPING.keys.sample
-    partner = create(:regional_partner, name: partner_name)
-    user = create(:teacher)
-    create(:regional_partner_program_manager, regional_partner: partner, program_manager: user)
-    phoenix = create(
-      :pd_workshop,
-      course: Pd::Workshop::COURSE_CSD,
-      num_sessions: 1,
-      organizer: @organizer,
-      subject: Pd::Workshop::SUBJECT_TEACHER_CON,
-      location_address: "Phoenix"
-    )
-    atlanta = create(
-      :pd_workshop,
-      course: Pd::Workshop::COURSE_CSD,
-      num_sessions: 1,
-      organizer: @organizer,
-      subject: Pd::Workshop::SUBJECT_TEACHER_CON,
-      location_address: "Atlanta"
-    )
-    associated_workshop = get_matching_teachercon(partner) == TC_PHOENIX ? phoenix : atlanta
-
-    sign_in user
-
-    get :upcoming_teachercons
-    assert_response :success
-    assert_equal 1, JSON.parse(@response.body).length
-    assert_equal associated_workshop.id, JSON.parse(@response.body).first['id']
-  end
-
   test 'Teachercon workshops can be filtered by course' do
     csd = create(
       :pd_workshop,

--- a/dashboard/test/lib/pd/application/regional_partner_teachercon_mapping_test.rb
+++ b/dashboard/test/lib/pd/application/regional_partner_teachercon_mapping_test.rb
@@ -10,11 +10,11 @@ module Pd::Application
 
       assert_nil get_matching_teachercon(build(:regional_partner))
 
-      assert_equal TC_PHOENIX, get_matching_teachercon(
+      assert_nil get_matching_teachercon(
         build(:regional_partner, name: 'Allegheny Intermediate Unit 3')
       )
 
-      assert_equal TC_ATLANTA, get_matching_teachercon(
+      assert_nil get_matching_teachercon(
         build(:regional_partner, name: 'Mississippi State University')
       )
     end
@@ -22,19 +22,19 @@ module Pd::Application
     test 'find_teachercon_workshop' do
       Pd::Workshop.any_instance.stubs(:process_location)
 
-      tc_csd_phoenix = create :pd_workshop, course: Pd::Workshop::COURSE_CSD,
+      create :pd_workshop, course: Pd::Workshop::COURSE_CSD,
         subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Phoenix, AZ',
         num_sessions: 5, sessions_from: Time.new(2018, 7, 22, 9)
 
-      tc_csp_phoenix = create :pd_workshop, course: Pd::Workshop::COURSE_CSP,
+      create :pd_workshop, course: Pd::Workshop::COURSE_CSP,
         subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Phoenix, AZ',
         num_sessions: 5, sessions_from: Time.new(2018, 7, 22, 9)
 
-      tc_csd_atlanta = create :pd_workshop, course: Pd::Workshop::COURSE_CSD,
+      create :pd_workshop, course: Pd::Workshop::COURSE_CSD,
         subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Atlanta, GA',
         num_sessions: 5, sessions_from: Time.new(2018, 7, 22, 9)
 
-      tc_csp_atlanta = create :pd_workshop, course: Pd::Workshop::COURSE_CSP,
+      create :pd_workshop, course: Pd::Workshop::COURSE_CSP,
         subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Atlanta, GA',
         num_sessions: 5, sessions_from: Time.new(2018, 7, 22, 9)
 
@@ -47,10 +47,10 @@ module Pd::Application
         subject: Pd::Workshop::SUBJECT_TEACHER_CON, location_address: 'Some place in Phoenix, AZ',
         num_sessions: 5, sessions_from: Time.new(2017, 7, 22, 9)
 
-      assert_equal tc_csd_phoenix, find_teachercon_workshop(course: Pd::Workshop::COURSE_CSD, city: 'Phoenix')
-      assert_equal tc_csp_phoenix, find_teachercon_workshop(course: Pd::Workshop::COURSE_CSP, city: 'Phoenix')
-      assert_equal tc_csd_atlanta, find_teachercon_workshop(course: Pd::Workshop::COURSE_CSD, city: 'Atlanta')
-      assert_equal tc_csp_atlanta, find_teachercon_workshop(course: Pd::Workshop::COURSE_CSP, city: 'Atlanta')
+      assert_nil find_teachercon_workshop(course: Pd::Workshop::COURSE_CSD, city: 'Phoenix')
+      assert_nil find_teachercon_workshop(course: Pd::Workshop::COURSE_CSP, city: 'Phoenix')
+      assert_nil find_teachercon_workshop(course: Pd::Workshop::COURSE_CSD, city: 'Atlanta')
+      assert_nil find_teachercon_workshop(course: Pd::Workshop::COURSE_CSP, city: 'Atlanta')
     end
   end
 end


### PR DESCRIPTION
Partners that attended teachercon last year were still seeing their application dashboard with the experience they had last year - this is a minimal change to get them back to the typical experience (with the Registered Workshop column, for example). We need to follow up and remove all remaining teachercon-related code.