### PR TITLE
Csf 19 stage names

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -9836,15 +9836,15 @@ en:
               description_student: 'Envelopes and variables have something in common: both can hold valuable things. Here you will learn what variables are and the awesome things they can do.'
               description_teacher: Variables are used as placeholders for values such as numbers or words. Variables allow for a lot of freedom in programming. Instead of having to type out a phrase many times or remember an obscure number, computer scientists can use variables to reference them. This lesson helps to explain what variables are and how we can use them in many different ways. The idea of variables isn't an easy concept to grasp, so we recommend allowing plenty of time for discussion at the end of the lesson.
             Variables as Constant in Artist:
-              name: Variables as Constant in Artist
+              name: Variables with Artist
               description_student: ''
               description_teacher: ''
             Variables that Change in Bee:
-              name: Variables that Change in Bee
+              name: Changing Variables with Bee
               description_student: ''
               description_teacher: ''
             Variables that Change in Artist:
-              name: Variables that Change in Artist
+              name: Changing Variables with Artist
               description_student: ''
               description_teacher: ''
             For Loop Fun:
@@ -9852,15 +9852,15 @@ en:
               description_student: You're going to have loads of fun learning about `for` loops!
               description_teacher: 'We know that loops allow us to do things over and over again, but now we’re going to learn how to use loops that have extra structures built right in. These new structures will allow students to create code that is more powerful and dynamic. '
             For Loops in Bee:
-              name: For Loops in Bee
+              name: For Loops with Bee
               description_student: Buzz buzz. In these puzzles you will be guiding a bee to nectar and honey using `for` loops!
               description_teacher: Featuring Bee, this lesson focuses on for loops and using an incrementing variable to solve more complicated puzzles. Students will begin by reviewing loops from previous lessons, then walked through using for loops to more effectively solve complicated problems.
             For Loops in Artist:
-              name: For Loops in Artist
+              name: For Loops with Artist
               description_student: Get ready to make your next masterpiece. Here you will be using `for` loops to make some jaw-dropping pictures.
               description_teacher: In this lesson, students continue to practice for loops, this time with Artist. Students will complete puzzles combining the ideas of variables, loops, and for loops to create complex designs. At the end, they will have a chance to create their own art in a freeplay level.
             Learning Sprites with Sprite Lab:
-              name: Learning Sprites with Sprite Lab
+              name: Swimming Fish with Sprite Lab
               description_student: ''
               description_teacher: ''
             Alien Dance Party with Sprite Lab:
@@ -9891,26 +9891,24 @@ en:
               name: Present Your Project
               description_student: Time to show your work! Here you will be presenting your awesome project to your peers.
               description_teacher: Over the course of five lessons, students will be building up to building a project of their own design using either Play Lab or Artist as their programming environment. Finally, students will be able to present their finished work to their peers or share with their loved ones with a special link. The lesson guide overviewing all five stages of the process can be found in the beginning of the project process, [here](https://curriculum.code.org/csf/coursef/15/).
-            new stage:
-              name: new stage
             The Artist:
               name: The Artist
             Nested Loops in the Maze:
-              name: Nested Loops in the Maze
+              name: Nested Loops in Maze
             Sequencing in the Maze:
               name: Sequencing in the Maze
             Programming and Loops with the Artist:
               name: Programming and Loops with the Artist
             Events with Sprite Lab:
-              name: Events with Sprite Lab
+              name: Alien Dance Party with Sprite Lab
             Loops with the Artist:
-              name: Loops with the Artist
+              name: Drawing with Loops
             Sprite Lab Behaviors:
               name: Sprite Lab Behaviors
             Editing Behaviors:
-              name: Editing Behaviors
+              name: Behaviors in Sprite Lab
             Virtual Pet:
-              name: Virtual Pet
+              name: Virtual Pet with Sprite Lab
             Data from Sprite Lab:
               name: Data from Sprite Lab
             End of Course Project:
@@ -9918,7 +9916,7 @@ en:
             Copyright and Creativity:
               name: Copyright and Creativity
             Internet:
-              name: Internet
+              name: The Internet
             Crowdsourcing:
               name: Crowdsourcing
             Digital Sharing:

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -10566,24 +10566,12 @@ en:
           description_short: An introduction to computer science for pre-readers.
           description_audience: 'Ages: 4-7'
           stages:
-            'Debugging: Unspotted Bugs':
-              name: 'Debugging: Unspotted Bugs'
-              description_student: ''
-              description_teacher: 'This lesson will guide students through the steps of debugging.  Students will learn the mantra: "What happened?  What was supposed to happen? What does that tell you?"'
-            'Persistence & Frustration: Stevie and the Big Project':
-              name: 'Persistence & Frustration: Stevie and the Big Project'
-              description_student: ''
-              description_teacher: ''
-            'Real-life Algorithms: Plant a Seed':
-              name: 'Real-life Algorithms: Plant a Seed'
-              description_student: ''
-              description_teacher: "In this lesson, students will relate the concept of algorithms back to everyday, real-life activities by planting an actual seed. The goal here is to start building the skills to translate real-world situations to online scenarios and vice versa.\r\n"
             Sequencing in Maze:
               name: Sequencing in Maze
               description_student: ''
               description_teacher: ''
             'Programming: Happy Maps':
-              name: 'Programming: Happy Maps'
+              name: Happy Maps
               description_student: ''
               description_teacher: The bridge from algorithms to programming can be a short one if students understand the difference between planning out a sequence and encoding that sequence into the appropriate language.  This activity will help students gain experience reading and writing in shorthand code.
             Programming in Maze:
@@ -10599,15 +10587,11 @@ en:
               description_student: ''
               description_teacher: In collaboration with [r common-sense-media], this lesson helps students learn that many websites ask for information that is private and discusses how to responsibly handle such requests. Students also find out that they can go to exciting places online, but they need to follow certain rules to remain safe.
             'Loops: Happy Loops':
-              name: 'Loops: Happy Loops'
+              name: Happy Loops
               description_student: ''
               description_teacher: Loops are a very helpful and powerful tool in programming. To understand how helpful loops can be, students will need to be driven to want an easier way to solve mundane problems.
-            Loops in Harvester:
-              name: Loops in Harvester
-              description_student: ''
-              description_teacher: ''
             Loops in Collector:
-              name: Loops in Collector
+              name: Loops with Laurel
               description_student: ''
               description_teacher: Building on the concept of repeating instructions from "Happy Loops," this stage will have students using loops to collect treasure more efficiently on Code.org.
             Loops in Artist:
@@ -10615,11 +10599,11 @@ en:
               description_student: ''
               description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous plugged lesson, loops were used to traverse a maze and collect treasure. Here, loops are creating patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             'Events: The Big Event':
-              name: 'Events: The Big Event'
+              name: 'The Big Event Jr.'
               description_student: ''
               description_teacher: Events are a great way to add variety to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. That is what events are for.
             Events in Play Lab:
-              name: Events in Play Lab
+              name: On the Move with Events
               description_student: ''
               description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and to apply all of the coding skills they've learned to create an animated game. It's time to get creative and make a story in the Play Lab!
             Ocean Scene with Loops:
@@ -10627,9 +10611,9 @@ en:
             Learn to Drag and Drop:
               name: Learn to Drag and Drop
             Loops in Ice Age:
-              name: Loops in Ice Age
+              name: Loops with Scrat
             Programming in Ice Age:
-              name: Programming in Ice Age
+              name: Programming with Scrat
             Programming with Rey and BB-8:
               name: Programming with Rey and BB-8
             Sequencing with Scrat:

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -10068,7 +10068,7 @@ en:
               description_student: ''
               description_teacher: ''
             Conditionals:
-              name: Conditionals
+              name: Conditionals with the Farmer
               description_student: You will get to tell the computer what to do under certain conditions in this fun and challenging series.
               description_teacher: This lesson introduces students to `while` loops and `if / else` statements. _While loops_ are loops that continue to repeat commands as long as a condition is true. While loops are used when the programmer doesn't know the exact number of times the commands need to be repeated, but the programmer does know what condition needs to be true in order for the loop to continue looping. `If / Else` statements offer flexibility in programming by running entire sections of code only if something is true, otherwise it runs something else.
             Private and Personal Information:
@@ -10083,7 +10083,7 @@ en:
               description_student: Feel the force as you build your own Star Wars game in this lesson.
               description_teacher: In this lesson, students will practice using events to build a game that they can share online. Featuring R2-D2 and other Star Wars characters, students will be guided through events, then given space to create their own game.
             'Functions: Songwriting':
-              name: 'Functions: Songwriting'
+              name: Songwriting
               description_student: Even rockstars need programming skills. This lesson will teach you about functions using lyrics from songs.
               description_teacher: One of the most magnificent structures in the computer science world is the function. Functions (sometimes called procedures) are mini programs that you can use over and over inside of your bigger program. This lesson will help students intuitively understand why combining chunks of code into functions can be such a helpful practice.
             Functions in Minecraft:
@@ -10091,7 +10091,7 @@ en:
               description_student: ''
               description_teacher: ''
             Functions in Harvester:
-              name: Functions in Harvester
+              name: Functions with Harvester
               description_student: ''
               description_teacher: ''
             Copyright and Creativity:
@@ -10099,7 +10099,7 @@ en:
               description_student: ''
               description_teacher: ''
             Functions in Artist:
-              name: Functions in Artist
+              name: Functions with Artist
               description_student: Make complex drawings more easily with functions!
               description_teacher: Students will be introduced to using functions on Code.org. Magnificent images will be created and modified with functions in Artist. For more complicated patterns, students will learn about nesting functions by calling one function from inside another.
             Determine the Concept:
@@ -10107,7 +10107,7 @@ en:
               description_student: "We aren't giving away any secrets! \nThis lesson could use any of the skills you've learned so far."
               description_teacher: This lesson brings together concepts from the previous lessons and gives students a chance to think critically about how they would solve each problem, but without telling them which concept to apply. Students will review basic algorithms, debugging, `repeat` loops, conditionals, `while` loops, and functions.
             Learning Sprites with Sprite Lab:
-              name: Learning Sprites with Sprite Lab
+              name: Swimming Fish with Sprite Lab
               description_student: ''
               description_teacher: ''
             Alien Dance Party with Sprite Lab:
@@ -10143,25 +10143,25 @@ en:
               description_student: This lesson will teach you about crowdsourcing, the process of building a project with a team.
               description_teacher: In computer science, we face some big, daunting problems. Challenges such as finding large prime numbers or sequencing DNA are almost impossible to do as an individual. Adding the power of others makes these tasks manageable. This lesson will show your students how helpful teamwork can be in the industry of computer science.
             Nested Loops in Bee:
-              name: Nested Loops in Bee
+              name: Nested Loops in Maze
             Nested Loops in Artist:
-              name: Nested Loops in Artist
+              name: Fancy Shapes using Nested Loops
             Nested Loops in Frozen:
-              name: Nested Loops in Frozen
+              name: Nested Loops with Frozen
             Sequencing in the Maze:
               name: Sequencing in the Maze
             Programming and Loops with the Artist:
-              name: Programming and Loops with the Artist
+              name: Drawing with Loops
             End of Course Project:
               name: End of Course Project
             Conditionals in Minecraft:
               name: Conditionals in Minecraft
             About Me:
-              name: About Me
+              name: About Me with Sprite Lab
             Aquatic Conditionals in Minecraft:
               name: Aquatic Conditionals in Minecraft
             Access Ability:
-              name: Access Ability
+              name: Designing for Accessibility
             Digital Sharing:
               name: Digital Sharing
             Simon Says:

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -9942,7 +9942,7 @@ en:
           description_audience: 'Ages: 7-11'
           stages:
             'Algorithms: Graph Paper Programming':
-              name: 'Algorithms: Graph Paper Programming'
+              name: Graph Paper Programming
               description_student: ''
               description_teacher: ''
             Introduction to Online Puzzles:
@@ -9954,7 +9954,7 @@ en:
               description_student: ''
               description_teacher: ''
             Debugging in Collector:
-              name: Debugging in Collector
+              name: Debugging with Laurel
               description_student: ''
               description_teacher: ''
             Events in Bounce:
@@ -9966,11 +9966,11 @@ en:
               description_student: ''
               description_teacher: ''
             Loops in Artist:
-              name: Loops in Artist
+              name: Drawing Shapes with Loops
               description_student: ''
               description_teacher: ''
             Nested Loops in Bee:
-              name: Nested Loops in Bee
+              name: Nested Loops in Maze
               description_student: ''
               description_teacher: ''
             Nested Loops in Artist:
@@ -9994,11 +9994,11 @@ en:
               description_student: ''
               description_teacher: ''
             Conditionals in Bee:
-              name: Conditionals in Bee
+              name: 'If/Else with Bee'
               description_student: ''
               description_teacher: ''
             Conditionals & Loops in Harvester:
-              name: Conditionals & Loops in Harvester
+              name: Harvesting with Conditionals
               description_student: ''
               description_teacher: ''
             Digital Citizenship:
@@ -10010,7 +10010,7 @@ en:
               description_student: ''
               description_teacher: ''
             'Unplugged: Binary':
-              name: 'Unplugged: Binary'
+              name: Binary Images
               description_student: ''
               description_teacher: ''
             Artist Binary:

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -10460,12 +10460,8 @@ en:
           description_short: Learn the basics of computer science and create your own art, stories, and games.
           description_audience: 'Ages: 6-10'
           stages:
-            Building a Foundation:
-              name: Building a Foundation
-              description_student: ''
-              description_teacher: ''
             Programming in Maze:
-              name: Programming in Maze
+              name: Programming with Angry Birds
               description_student: ''
               description_teacher: ''
             Debugging in Maze:
@@ -10477,11 +10473,11 @@ en:
               description_student: ''
               description_teacher: ''
             Programming in Collector:
-              name: Programming in Collector
+              name: Collecting Treasure with Laurel
               description_student: ''
               description_teacher: ''
             Programming in Artist:
-              name: Programming in Artist
+              name: Creating Art with Code
               description_student: ''
               description_teacher: ''
             'Loops: Getting Loopy':
@@ -10497,11 +10493,11 @@ en:
               description_student: ''
               description_teacher: ''
             Loops in Harvester:
-              name: Loops in Harvester
+              name: Harvesting Crops with Loops
               description_student: ''
               description_teacher: ''
             'Events: The Big Event':
-              name: 'Events: The Big Event'
+              name: The Big Event
               description_student: ''
               description_teacher: ''
             Build a Flappy Game:
@@ -10513,27 +10509,25 @@ en:
               description_student: ''
               description_teacher: ''
             Events in Play Lab:
-              name: Events in Play Lab
+              name: Chase Game with Events
               description_student: ''
               description_teacher: ''
             Looking Ahead:
-              name: Looking Ahead
+              name: Looking Ahead with Minecraft
               description_student: ''
               description_teacher: ''
             Binary Bracelets:
               name: Binary Bracelets
               description_student: ''
               description_teacher: ''
-            'End of Course Project: Play Lab':
-              name: 'End of Course Project: Play Lab'
             Create a Design with Loops:
               name: Create a Design with Loops
             'End of Course Project: Create a Play Lab Game':
-              name: 'End of Course Project: Create a Play Lab Game'
+              name: End of Course Project
             'Programming: My Robotic Friends':
-              name: 'Programming: My Robotic Friends'
+              name: 'My Robotic Friends Jr.'
             'Loops: My Loopy Robotic Friends':
-              name: 'Loops: My Loopy Robotic Friends'
+              name: 'My Loopy Robotic Friends Jr.'
             Graphing Data:
               name: Graphing Data
             Powerful Passwords:

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -10661,33 +10661,33 @@ en:
               description_student: ''
               description_teacher: ''
             Loops in Collector:
-              name: Loops in Collector
+              name: Loops with Laurel
               description_student: ''
               description_teacher: ''
             Loops in Artist:
-              name: Loops in Artist
+              name: Drawing Gardnes with Loops
               description_student: ''
               description_teacher: ''
             'Events: The Big Event':
-              name: 'Events: The Big Event'
+              name: 'The Big Event Jr.'
               description_student: ''
               description_teacher: ''
             Events in Play Lab:
-              name: Events in Play Lab
+              name: A Royal Battle with Events
               description_student: ''
               description_teacher: ''
             'Loops: Getting Loopy':
-              name: 'Loops: Getting Loopy'
+              name: Getting Loopy
             The Right App:
               name: The Right App
             Loops in Harvester:
-              name: Loops in Harvester
+              name: Loops with Harvester
             Programming in Maze:
-              name: Programming in Maze
+              name: Programming with Angry Birds
             Programming in Harvester:
-              name: Programming in Harvester
+              name: Programming with Harvester
             Sequencing in Maze:
-              name: Sequencing in Maze
+              name: Sequencing with Angry Birds
         pre-express-2019:
           title: Pre-reader Express (2019)
           description: Learn the basics of computer science and internet safety. At the end of the course, create your very own game or story you can share.


### PR DESCRIPTION
Update all lesson names to match curriculum builder. Side note, this is a gross way to change names that we should fix. I started by attempting to remove unused stage names but gave up when it became too hard to track what was part of the script and what wasn't