### PR TITLE
Update Blockly for Dropdown Buttons

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -43,7 +43,7 @@
     "@cdo/apps": "file:src",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.4.5",
+    "@code-dot-org/blockly": "3.4.6",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "0.0.42",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -124,9 +124,9 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.4.5":
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.4.5.tgz#4da705a1f01f8b5c21ec5d4e4eff25c24ed0ad38"
+"@code-dot-org/blockly@3.4.6":
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.4.6.tgz#cb501b02171169d78bbfa24271f70cc0fe40f8e5"
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
Update Blockly in the cdo repo to get the changes that allow buttons in the field image dropdown