### PR TITLE
Don't try to to_sym if we don't have a performance value

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1591,8 +1591,8 @@ class Script < ActiveRecord::Base
           stageName: script_level.stage.localized_title,
           levelNum: script_level.position.to_s,
           keyConcept: (current_level.rubric_key_concept || ''),
-          performanceLevelDetails: (current_level.properties[rubric_performance_json_to_ruby[temp_feedback.performance.to_sym]] || ''),
-          performance: rubric_performance_headers[temp_feedback.performance.to_sym],
+          performanceLevelDetails: (current_level.properties[rubric_performance_json_to_ruby[temp_feedback.performance&.to_sym]] || ''),
+          performance: rubric_performance_headers[temp_feedback.performance&.to_sym],
           comment: temp_feedback.comment,
           timestamp: temp_feedback.updated_at.localtime.strftime("%D at %r")
         }


### PR DESCRIPTION
Fixes the following honeybadger errors:

https://app.honeybadger.io/projects/3240/faults/48494767
https://app.honeybadger.io/projects/3240/faults/48555104
https://app.honeybadger.io/projects/3240/faults/48546982