### PR TITLE
Enable InnoDB monitoring counters for Aurora [ci skip]

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -157,6 +157,9 @@ AuroraCluster:
   # Enable slow query log.
   slow_query_log: 1
 
+  # Enable InnoDB monitoring counters: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Monitoring.html
+  innodb_monitor_enable: all
+
 # System variables for the Aurora DB writer.
 AuroraWriter:
   # Enable Performance Schema.


### PR DESCRIPTION
Needed for ActiveTransactions metric: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Monitoring.html

This value is also set to `all` for our current prod parameter group.