### PR TITLE
Add custom parameter group for Aurora test stack [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -701,7 +701,7 @@ Resources:
     Type: AWS::RDS::DBCluster
     Properties:
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
-      DBClusterParameterGroupName: default.aurora-mysql5.7
+      DBClusterParameterGroupName: !Ref AuroraClusterDBParameters
       Engine: aurora-mysql
       # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with cluster.
       EngineVersion: 5.7.12
@@ -720,6 +720,13 @@ Resources:
       Engine: aurora-mysql
       # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with instance.
       EngineVersion: 5.7.12
+
+  AuroraClusterDBParameters:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Properties:
+      Description: !Sub "Aurora DB Cluster Parameters for ${AWS::StackName}."
+      Family: aurora-mysql5.7
+      Parameters: {'innodb_monitor_enable': 'all'}
 
   DatabaseSecret:
     Type: AWS::SecretsManager::Secret


### PR DESCRIPTION
Not sure whether it was best to create a parameter group per stack, or just one in the data stack. If the latter is better I'll change this.

validate output:
```
circleci@183349f5f1c6:~/code-dot-org$ RAILS_ENV=test bundle exec rake stack:validate
AWS CloudFormation Template for Code.org application
Listing changes to existing stack `test`:
Modify AuroraCluster [AWS::RDS::DBCluster] Properties (DBClusterParameterGroupName, DBClusterParameterGroupName)
Add AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup]
```