### PR TITLE
Restrict Piskel tools in Spritelab

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -52,7 +52,7 @@
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "1.1.0",
     "@code-dot-org/p5.play": "1.3.4-cdo",
-    "@code-dot-org/piskel": "0.13.0-cdo.3",
+    "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",
     "@storybook/addon-info": "3.2.11",
     "@storybook/addon-options": "^3.3.15",

--- a/apps/src/gamelab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/gamelab/AnimationTab/PiskelEditor.jsx
@@ -34,7 +34,8 @@ class PiskelEditor extends React.Component {
     allAnimationsSingleFrame: PropTypes.bool.isRequired,
     onNewFrameClick: PropTypes.func.isRequired,
     pendingFrames: PropTypes.object,
-    removePendingFrames: PropTypes.func.isRequired
+    removePendingFrames: PropTypes.func.isRequired,
+    isBlockly: PropTypes.bool
   };
 
   componentDidMount() {
@@ -181,6 +182,9 @@ class PiskelEditor extends React.Component {
 
   onPiskelReady = () => {
     this.isPiskelReady_ = true;
+    if (this.props.isBlockly) {
+      this.piskel.restrictTools();
+    }
     if (this.props.allAnimationsSingleFrame) {
       this.piskel.toggleFrameColumn(true);
     }
@@ -217,7 +221,8 @@ export default connect(
     animationList: state.animationList,
     channelId: state.pageConstants.channelId,
     allAnimationsSingleFrame: !!state.pageConstants.allAnimationsSingleFrame,
-    pendingFrames: state.animationList.pendingFrames
+    pendingFrames: state.animationList.pendingFrames,
+    isBlockly: state.pageConstants.isBlockly
   }),
   dispatch => ({
     editAnimation: (key, props) => dispatch(editAnimation(key, props)),

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -220,9 +220,9 @@
   version "1.3.4-cdo"
   resolved "https://registry.yarnpkg.com/@code-dot-org/p5.play/-/p5.play-1.3.4-cdo.tgz#acf32a39dd1203332244e396f92e497adba5b824"
 
-"@code-dot-org/piskel@0.13.0-cdo.3":
-  version "0.13.0-cdo.3"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.3.tgz#dfda56a2aa8a4dbe449aac55ef81bc6762287f0c"
+"@code-dot-org/piskel@0.13.0-cdo.6":
+  version "0.13.0-cdo.6"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.6.tgz#0e919b94e76f9d33dce673e980ac18f3395a62fc"
 
 "@code-dot-org/redactable-markdown@0.4.0":
   version "0.4.0"


### PR DESCRIPTION
Part of: https://docs.google.com/document/d/1GBeHLqyTA0nHtD77LgpxIUAvB9xcGfMshb78Ucsn7jw/edit
Paired with this Piskel change: https://github.com/code-dot-org/piskel/pull/31

![restrictedPiskel](https://user-images.githubusercontent.com/2959170/56751960-10427400-673c-11e9-929f-95444f37d388.png)

Goal here is the restrict the tools available in piskel to a subset of what is available in Gamelab.