### PR TITLE
Remove workshop organizer validation from contact rollups

### DIFF
--- a/lib/cdo/contact_rollups_validation.rb
+++ b/lib/cdo/contact_rollups_validation.rb
@@ -54,13 +54,6 @@ class ContactRollupsValidation
       max: 4_000
     },
     {
-      name: "Workshop Organizer count",
-      query: "SELECT COUNT(*) from contact_rollups_daily WHERE roles
-              LIKE '%Workshop Organizer%'",
-      min: 250,
-      max: 2_500
-    },
-    {
       name: "District Contact count",
       query: "SELECT COUNT(*) from contact_rollups_daily WHERE roles
               LIKE '%District Contact%'",


### PR DESCRIPTION
The Workshop Organizer role is being deprecated in favor of the Program Manager role.  The Professional Learning team has been cleaning up permissions and there are now fewer than 250 users with the Workshop Organizer role.  Eventually there will be none.  Removing this validation, which is preventing Contact Rollups from completing execution.