### PR TITLE
Teacher Dashboard: Assessments Don't Always Load When Switch Tabs

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -22,9 +22,7 @@ import stats, {
 import textResponses, {
   asyncLoadTextResponses
 } from '@cdo/apps/templates/textResponses/textResponsesRedux';
-import sectionAssessments, {
-  asyncLoadAssessments
-} from '@cdo/apps/templates/sectionAssessments/sectionAssessmentsRedux';
+import sectionAssessments from '@cdo/apps/templates/sectionAssessments/sectionAssessmentsRedux';
 import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import scriptSelection, {
   loadValidScripts
@@ -88,7 +86,6 @@ $(document).ready(function() {
     store.dispatch(loadValidScripts(section, validScripts)).then(() => {
       const scriptId = store.getState().scriptSelection.scriptId;
       store.dispatch(asyncLoadTextResponses(section.id, scriptId));
-      store.dispatch(asyncLoadAssessments(section.id, scriptId));
 
       renderTeacherDashboard();
     });

--- a/apps/src/templates/sectionAssessments/SectionAssessments.jsx
+++ b/apps/src/templates/sectionAssessments/SectionAssessments.jsx
@@ -107,6 +107,11 @@ class SectionAssessments extends Component {
     multipleChoiceDetailDialogOpen: false
   };
 
+  componentWillMount() {
+    const {scriptId, asyncLoadAssessments, sectionId} = this.props;
+    asyncLoadAssessments(sectionId, scriptId);
+  }
+
   onChangeScript = scriptId => {
     const {setScriptId, asyncLoadAssessments, sectionId} = this.props;
     asyncLoadAssessments(sectionId, scriptId);


### PR DESCRIPTION
This fixes a bug in Teacher Dashboard where if you switched to a different script in the Progress Tab (besides the one you started on) and then switched to the Assessment Tab the list of assessments would not populate correctly. We now load that list of assessments in `componentWillMount` for the Assessment Tab (`SectionAssessments`) instead of loading it when we load Teacher Dashboard.

# Before
![Before-Assessment-Dropdown](https://user-images.githubusercontent.com/208083/56762188-477d4900-676d-11e9-93a9-69610c639c51.gif)

# After
![After-Assessment-Dropdown](https://user-images.githubusercontent.com/208083/56762189-477d4900-676d-11e9-9891-f70989d6789c.gif)