### PR TITLE
Projects Page: Show the full number of projects

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1087,7 +1087,7 @@
   "projectsViewAll": "View all projects",
   "projectsViewProjectGallery": "View projects",
   "projects": "Projects",
-  "projectsSubHeading": "Over {project_count} million projects created",
+  "projectsSubHeading": "{project_count} projects created",
   "print": "Print",
   "privacyPolicy": "Privacy Policy",
   "projectWarning": "Note: You are on a level that is part of a longer project. Changes made on this level will also appear in other levels in the project.",

--- a/apps/src/templates/projects/ProjectHeader.jsx
+++ b/apps/src/templates/projects/ProjectHeader.jsx
@@ -12,13 +12,15 @@ export default class ProjectHeader extends React.Component {
   };
 
   render() {
+    const projectCountWithCommas = this.props.projectCount.toLocaleString();
+
     return (
       <div>
         <HeaderBanner
           short={true}
           headingText={i18n.projects()}
           subHeadingText={i18n.projectsSubHeading({
-            project_count: this.props.projectCount
+            project_count: projectCountWithCommas
           })}
         />
         <StartNewProject

--- a/apps/test/unit/templates/projects/ProjectHeaderTest.js
+++ b/apps/test/unit/templates/projects/ProjectHeaderTest.js
@@ -1,26 +1,20 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import {assert} from '../../../util/configuredChai';
 import ProjectHeader from '@cdo/apps/templates/projects/ProjectHeader.jsx';
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
-import {Provider} from 'react-redux';
-import {stubRedux, restoreRedux, getStore} from '@cdo/apps/redux';
 
 describe('ProjectHeader', () => {
-  beforeEach(stubRedux);
-  afterEach(restoreRedux);
-
-  const store = getStore();
-
   it('Project count data renders properly in subheading ', () => {
-    const wrapper = mount(
-      <Provider store={store}>
-        <ProjectHeader canViewAdvancedTools={true} projectCount={10} />
-      </Provider>
+    const wrapper = shallow(
+      <ProjectHeader canViewAdvancedTools={true} projectCount={10000000} />
     );
+
+    // Note because we don't have a locale in the test we get an unformatted number
+    // Example 10000000 instead of 10,000,000
     assert.equal(
       wrapper.find(HeaderBanner).props().subHeadingText,
-      'Over 10 million projects created'
+      '10000000 projects created'
     );
   });
 });

--- a/dashboard/app/views/projects/index.html.haml
+++ b/dashboard/app/views/projects/index.html.haml
@@ -3,7 +3,7 @@
   is_public = local_assigns[:is_public]
   projects_data = {}
   projects_data[:limitedGallery] = local_assigns[:limited_gallery]
-  projects_data[:projectCount] = fetch_project_count['rounded_down_millions']
+  projects_data[:projectCount] = fetch_project_count['total_projects']
 
   if current_user
     projects_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)

--- a/dashboard/app/views/projects/public.html.haml
+++ b/dashboard/app/views/projects/public.html.haml
@@ -1,7 +1,7 @@
 - limited_gallery = local_assigns[:limited_gallery]
 - projects_data = {}
 - projects_data[:limitedGallery] = limited_gallery
-- projects_data[:projectCount] = fetch_project_count['rounded_down_millions']
+- projects_data[:projectCount] = fetch_project_count['total_projects']
 
 - if current_user
   - projects_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)


### PR DESCRIPTION
Instead of rounding the project count on the projects page we now show the full number. (Note: The number on my local environment just defaults to the default value of 35 million).

# Before
<img width="1019" alt="Screen Shot 2019-04-25 at 4 38 24 PM" src="https://user-images.githubusercontent.com/208083/56766925-941a5180-6778-11e9-8d05-0558f672e997.png">

# After
<img width="1020" alt="Screen Shot 2019-04-25 at 4 36 23 PM" src="https://user-images.githubusercontent.com/208083/56766853-66350d00-6778-11e9-9f48-5821584a4593.png">
