### PR TITLE
Assessment Re-design: Fix assessment icon on diamond bubbles

### DIFF
--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -236,7 +236,9 @@ class ProgressBubble extends React.Component {
             {inMiniRubricExperiment &&
               levelIsAssessment &&
               !smallBubble &&
-              !hideAssessmentIcon && <SmallAssessmentIcon />}
+              !hideAssessmentIcon && (
+                <SmallAssessmentIcon isDiamond={level.isConceptLevel} />
+              )}
           </div>
           {!this.props.hideToolTips && tooltip}
         </div>

--- a/apps/src/templates/progress/SmallAssessmentIcon.jsx
+++ b/apps/src/templates/progress/SmallAssessmentIcon.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '../FontAwesome';
 
@@ -13,6 +14,14 @@ const styles = {
     right: -6,
     fontSize: 10
   },
+  iconContainerDiamond: {
+    position: 'absolute',
+    top: -14,
+    right: 2,
+    fontSize: 10,
+    // undo the rotation from the parent
+    transform: 'rotate(-45deg)'
+  },
   assessmentIconBackground: {
     color: color.purple
   },
@@ -25,9 +34,20 @@ const styles = {
 };
 
 export class SmallAssessmentIcon extends React.Component {
+  static propTypes = {
+    isDiamond: PropTypes.bool
+  };
+
   render() {
     return (
-      <span className="fa-stack" style={styles.iconContainer}>
+      <span
+        className="fa-stack"
+        style={
+          this.props.isDiamond
+            ? styles.iconContainerDiamond
+            : styles.iconContainer
+        }
+      >
         <FontAwesome
           icon="circle"
           className="fa-stack-2x"


### PR DESCRIPTION
Since diamond bubbles are actually rotated the icon was also getting rotated. Fix by rotating back and shifting the position of the icon on the diamond bubbles.

# Before
<img width="902" alt="Screen Shot 2019-04-25 at 5 09 30 PM" src="https://user-images.githubusercontent.com/208083/56768641-eb222580-677c-11e9-9032-0d9a7ffdfa94.png">


# After
<img width="901" alt="Screen Shot 2019-04-25 at 5 02 39 PM" src="https://user-images.githubusercontent.com/208083/56768640-eb222580-677c-11e9-99a1-2da74c1b38e8.png">
