### PR TITLE
Backfill scholarship course

### DIFF
--- a/bin/oneoff/backfill_data/backfill_scholarship_course
+++ b/bin/oneoff/backfill_data/backfill_scholarship_course
@@ -2,6 +2,8 @@
 
 require_relative '../../../dashboard/config/environment'
 
+# If they have an accepted teacher application from this year, get the course
+# from the application.
 def course_from_current_teacher_accepted_app(si)
   app = Pd::Application::Teacher1920Application.find_by(user_id: si.user_id)
   if app && Pd::SharedApplicationConstants::COHORT_CALCULATOR_STATUSES.include?(app.status)
@@ -10,11 +12,15 @@ def course_from_current_teacher_accepted_app(si)
   nil
 end
 
+# If they have a local summer workshop enrollment for this year, and do not
+# have an accepted facilitator application for this year, then they are a
+# teacher who applied through a partner that didn't use our system.
+# Get the course from the workshop they are enrolled in.
 def course_from_current_teacher_lsw_enrollment(si)
   enrollments = Pd::Enrollment.where(user_id: si.user_id)
   course = nil
   enrollments.each do |e|
-    next unless e.workshop.local_summer? && e.workshop.summer_workshop_school_year == "2019-2020"
+    next unless e.workshop.local_summer? && e.workshop.summer_workshop_school_year == Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR
 
     if Pd::Application::Facilitator1920Application.find_by(user_id: si.user_id)&.status == 'accepted'
       puts "user #{si.user_id} new facilitator, app #{Pd::Application::Facilitator1920Application.find_by(user_id: si.user_id).id}"
@@ -34,7 +40,7 @@ ActiveRecord::Base.transaction do
     course = course_from_current_teacher_accepted_app(si) || course_from_current_teacher_lsw_enrollment(si)
     if course
       puts "#{si.id} #{course}"
-      # This script is a dry run unless we comment out this update line
+      # This script is a dry run unless we uncomment this update line
       # si.update!(course: course)
       count += 1
     else

--- a/bin/oneoff/backfill_data/backfill_scholarship_course
+++ b/bin/oneoff/backfill_data/backfill_scholarship_course
@@ -2,32 +2,48 @@
 
 require_relative '../../../dashboard/config/environment'
 
-count = 0
-Pd::ScholarshipInfo.find_each do |si|
-  course = nil
+def course_from_current_teacher_accepted_app(si)
   app = Pd::Application::Teacher1920Application.find_by(user_id: si.user_id)
-  if app
-    course = app.course
-  else
-    # get enrollment in local summer workshop for this year
-    enrollments = Pd::Enrollment.where(user_id: si.user_id)
-    enrollments.each do |e|
-      if e.workshop.local_summer? && e.workshop.summer_workshop_school_year == "2019-2020"
-        if e.workshop.course == "CS Discoveries"
-          course = 'csd'
-        elsif e.workshop.course == 'CS Principles'
-          course = 'csp'
-        end
-      end
+  if app && Pd::SharedApplicationConstants::COHORT_CALCULATOR_STATUSES.include?(app.status)
+    return app.course
+  end
+  nil
+end
+
+def course_from_current_teacher_lsw_enrollment(si)
+  enrollments = Pd::Enrollment.where(user_id: si.user_id)
+  course = nil
+  enrollments.each do |e|
+    next unless e.workshop.local_summer? && e.workshop.summer_workshop_school_year == "2019-2020"
+
+    if Pd::Application::Facilitator1920Application.find_by(user_id: si.user_id)&.status == 'accepted'
+      puts "user #{si.user_id} new facilitator, app #{Pd::Application::Facilitator1920Application.find_by(user_id: si.user_id).id}"
+    end
+    if e.workshop.course == "CS Discoveries"
+      course = 'csd'
+    elsif e.workshop.course == 'CS Principles'
+      course = 'csp'
+    end
+  end
+  course
+end
+
+ActiveRecord::Base.transaction do
+  count = 0
+  Pd::ScholarshipInfo.find_each do |si|
+    course = course_from_current_teacher_accepted_app(si) || course_from_current_teacher_lsw_enrollment(si)
+    if course
+      puts "#{si.id} #{course}"
+      # This script is a dry run unless we comment out this update line
+      # si.update!(course: course)
+      count += 1
+    else
+      puts "no application or enrollment found for user #{si.user_id}"
     end
   end
 
-  if course
-    si.update!(course: course)
-  else
-    puts "no application or enrollment found for user #{si.user_id}"
-  end
-  count += 1
-end
+  puts "#{count} scholarshipInfos updated with course"
 
-puts "#{count} scholarshipInfos updated with course"
+  # This script is a dry-run unless we comment out this last line
+  raise ActiveRecord::Rollback.new, "Intentional rollback"
+end

--- a/bin/oneoff/backfill_data/backfill_scholarship_course
+++ b/bin/oneoff/backfill_data/backfill_scholarship_course
@@ -38,7 +38,7 @@ ActiveRecord::Base.transaction do
       # si.update!(course: course)
       count += 1
     else
-      puts "no application or enrollment found for user #{si.user_id}"
+      puts "no current teacher application or teacher lsw enrollment found for user #{si.user_id}"
     end
   end
 

--- a/bin/oneoff/backfill_data/backfill_scholarship_course
+++ b/bin/oneoff/backfill_data/backfill_scholarship_course
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../dashboard/config/environment'
+
+count = 0
+Pd::ScholarshipInfo.find_each do |si|
+  course = nil
+  app = Pd::Application::Teacher1920Application.find_by(user_id: si.user_id)
+  if app
+    course = app.course
+  else
+    # get enrollment in local summer workshop for this year
+    enrollments = Pd::Enrollment.where(user_id: si.user_id)
+    enrollments.each do |e|
+      if e.workshop.local_summer? && e.workshop.summer_workshop_school_year == "2019-2020"
+        if e.workshop.course == "CS Discoveries"
+          course = 'csd'
+        elsif e.workshop.course == 'CS Principles'
+          course = 'csp'
+        end
+      end
+    end
+  end
+
+  if course
+    si.update!(course: course)
+  else
+    puts "no application or enrollment found for user #{si.user_id}"
+  end
+  count += 1
+end
+
+puts "#{count} scholarshipInfos updated with course"


### PR DESCRIPTION
Another step in [PLC-165](https://codedotorg.atlassian.net/browse/PLC-165)

This script fills in the newly added `course`column on the `ScholarshipInfo` table. If the user has an accepted `Teacher1920Application`, we use the course from the application. If they have an enrollment in a local summer workshop for this year, we check to make sure they aren't a new facilitator (with an accepted `Facilitator1920Application`). If they are, we don't update that `ScholarshipInfo` (because they shouldn't have one) and print a message to the console. If they are not, then they are a teacher whose partner did not use our application system and we use the course from their enrollment.