### PR TITLE
Load webpack-runtime for embedded videos

### DIFF
--- a/dashboard/app/views/videos/embed.html.haml
+++ b/dashboard/app/views/videos/embed.html.haml
@@ -8,6 +8,7 @@
   = javascript_include_tag 'application'
   = javascript_include_tag "js/#{js_locale}/common_locale"
   %script{src: minifiable_asset_path('js/embedVideo.js')}
+  %script{src: minifiable_asset_path('js/webpack-runtime.js')}
 %html{:dir => locale_dir}
   :css
     #video-container {


### PR DESCRIPTION
This fixes the black PD videos locally but I don't know if there's a better place to load this.