### PR TITLE
Fix UI Test failures in App Lab Versions

### DIFF
--- a/dashboard/test/ui/features/applab/versions.feature
+++ b/dashboard/test/ui/features/applab/versions.feature
@@ -48,6 +48,7 @@ Scenario: Project Load and Reload
   And I wait for the page to fully load
   And I press "versions-header"
   And I wait until element "button:contains(Current Version)" is visible
+  And I save the timestamp from ".versionTimestamp"
 
   # There is currently no guarantee that Version History will initially be
   # empty, because we don't necessarily clear past project data from S3 between
@@ -67,7 +68,10 @@ Scenario: Project Load and Reload
   And element ".project_updated_at" eventually contains text "Saved"
   And I press "versions-header"
   And I wait until element "button:contains(Current Version)" is visible
-  Then element "#showVersionsModal tr:contains(a minute ago):contains(Restore this Version):eq(0)" is visible
+
+  Then ".versionRow:nth-child(2) .versionTimestamp" contains the saved timestamp
+  And element ".versionRow:nth-child(2) .btn-info" contains text "Restore this Version"
+
   And element "#showVersionsModal tr:contains(a minute ago):contains(Restore this Version):eq(1)" is not visible
 
 @no_ie
@@ -89,6 +93,7 @@ Scenario: Project Version Checkpoints
   # The dialog contains only the initial version and the current version, and
   # possibly some versions created more than 90 seconds ago which we ignore.
   Then element "#showVersionsModal tr:contains(a minute ago):contains(Restore this Version)" is not visible
+  And I save the timestamp from ".versionTimestamp"
 
   When I close the dialog
   And I set the project version interval to 1 second
@@ -102,7 +107,8 @@ Scenario: Project Version Checkpoints
   And I wait until element "button:contains(Current Version)" is visible
   # The version containing "comment A" is saved as a checkpoint, because the
   # project version interval time period had passed.
-  Then element "#showVersionsModal tr:contains(a minute ago):contains(Restore this Version):eq(0)" is visible
+  Then ".versionRow:nth-child(2) .versionTimestamp" contains the saved timestamp
+  And element ".versionRow:nth-child(2) .btn-info" contains text "Restore this Version"
   And element "#showVersionsModal tr:contains(a minute ago):contains(Restore this Version):eq(1)" is not visible
 
 # Brad (2018-11-14) Skip on IE due to blocked pop-ups

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1591,6 +1591,15 @@ Then /^I wait for initial project save to complete$/ do
   end
 end
 
+Then /^I save the timestamp from "([^"]*)"$/ do |css|
+  @timestamp = @browser.find_element(css: css)['timestamp']
+end
+
+Then /^"([^"]*)" contains the saved timestamp$/ do |css|
+  timestamp = @browser.find_element(css: css)['timestamp']
+  expect(@timestamp).to eq(timestamp)
+end
+
 When /^I switch to text mode$/ do
   steps <<-STEPS
     When I press "show-code-header"


### PR DESCRIPTION
App Lab Versions was a source of flaky failures related to a check for time-sensitive "a minute ago" text appearing in Versions history. This PR updates two UI tests to instead check for the presence of specific saved timestamps in the HTML element.