### PR TITLE
UI test refactoring page and tab loading

### DIFF
--- a/dashboard/test/ui/features/applab/embed.feature
+++ b/dashboard/test/ui/features/applab/embed.feature
@@ -26,9 +26,8 @@ Feature: App Lab Embed
     Then I wait until element "a.more-link" is visible
     And I click selector "a.more-link"
     Then I wait until element "a:contains('How it Works (View Code)')" is visible
-    And I click selector "a:contains('How it Works (View Code)')"
+    And I click selector "a:contains('How it Works (View Code)')" to load a new tab
 
-    And I go to the newly opened tab
     And I wait for the page to fully load
     And I wait to see Applab code mode
 

--- a/dashboard/test/ui/features/applab/versions.feature
+++ b/dashboard/test/ui/features/applab/versions.feature
@@ -121,8 +121,7 @@ Scenario: Project page refreshes when other client adds a newer version
   And I press "runButton"
   Then element ".project_updated_at" eventually contains text "Saved"
 
-  When I open a new tab
-  And I go to the newly opened tab
+  When I go to a new tab
   And I am on "http://studio.code.org/projects/applab/"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
   And I wait for the page to fully load
@@ -136,7 +135,6 @@ Scenario: Project page refreshes when other client adds a newer version
   And element ".project_updated_at" eventually contains text "Saved"
 
   When I close the current tab
-  And I switch to tab index 0
   Then ace editor code is equal to "// comment X"
 
   # Browser tab 0 tries to write version Z, which fails because tab 1 has
@@ -164,8 +162,7 @@ Scenario: Project page refreshes when other client replaces current version
   And I press "resetButton"
 
   # Browser tab 1 loads version Alpha
-  When I open a new tab
-  And I go to the newly opened tab
+  When I go to a new tab
   And I am on "http://studio.code.org/projects/applab/"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"
   And I wait for the page to fully load
@@ -173,7 +170,7 @@ Scenario: Project page refreshes when other client replaces current version
   And ace editor code is equal to "// Alpha"
 
   # Browser tab 0 writes version Bravo.
-  When I switch to tab index 0
+  When I switch tabs
   And ace editor code is equal to "// Alpha"
   And I add code "// Bravo" to ace editor
   And ace editor code is equal to "// Alpha// Bravo"
@@ -185,7 +182,7 @@ Scenario: Project page refreshes when other client replaces current version
 
   # Browser tab 1 tries to write version Charlie, which fails because
   # tab 0 has already replaced the latest version known to tab 1.
-  When I switch to tab index 1
+  When I switch tabs
   And ace editor code is equal to "// Alpha"
   And I add code "// Charlie" to ace editor
   And I click selector "#runButton" to load a new page

--- a/dashboard/test/ui/features/dance/dance_party.feature
+++ b/dashboard/test/ui/features/dance/dance_party.feature
@@ -86,7 +86,7 @@ Feature: Dance Party
     Then element "#runButton" is visible
     And element "#resetButton" is hidden
 
-    And I select the "How it Works (View Code)" small footer item
+    And I select the "How it Works (View Code)" small footer item to load a new page
     And I wait for the song selector to load
     And element "#song_selector" has value "cheapthrills_sia"
 

--- a/dashboard/test/ui/features/gdpr_dialog.feature
+++ b/dashboard/test/ui/features/gdpr_dialog.feature
@@ -33,8 +33,7 @@ Feature: GDPR Dialog - data transfer agreement
     Given I am a teacher
     Given I am on "http://studio.code.org/home?force_in_eu=1"
     Then element ".ui-test-gdpr-dialog" is visible
-    Then I click selector ".ui-test-gdpr-dialog-privacy-link"
-    Then I go to the newly opened tab
+    Then I press the first ".ui-test-gdpr-dialog-privacy-link" element to load a new tab
     Then check that I am on "http://code.org/privacy"
 
   Scenario: Accept, sign out, sign in again, no dialog

--- a/dashboard/test/ui/features/lesson_extras_teacher_panel.feature
+++ b/dashboard/test/ui/features/lesson_extras_teacher_panel.feature
@@ -15,10 +15,10 @@ Feature: Lesson extras teacher panel
     And check that the URL contains "section_id="
     And I wait until element "h4:contains(Untitled Section)" is visible
     And I wait until element "td.name:contains(Sally)" is visible
-    And I click selector "td.name:contains(Sally) > a" once I see it
+    And I click selector "td.name:contains(Sally) > a" once I see it to load a new page
 
     # Lesson extras individual puzzle page
-    And I click selector "button:contains(Try it):eq(0)" once I see it
+    And I click selector "button:contains(Try it):eq(0)" once I see it to load a new page
     When I wait for the page to fully load
     And I wait until element ".teacher-panel" is visible
     And check that the URL contains "section_id="

--- a/dashboard/test/ui/features/manage_assets.feature
+++ b/dashboard/test/ui/features/manage_assets.feature
@@ -35,8 +35,7 @@ Feature: Manage Assets
     And I upload the file named "artist_image_1.png"
     And I wait until element ".assetRow td:contains(artist_image_1.png)" is visible
 
-    And I press "ui-image-thumbnail"
-    And I go to the newly opened tab
+    And I press "ui-image-thumbnail" to load a new tab
     And check that the URL matches "/v3/assets/.*/artist_image_1.png"
 
   Scenario: From WebLab, the manage assets dialog does not contain the option to record audio.

--- a/dashboard/test/ui/features/netsim_lobby.feature
+++ b/dashboard/test/ui/features/netsim_lobby.feature
@@ -54,6 +54,7 @@ Feature: Using the Internet Simulator Lobby
 
     # Join a router and click the side instructions to re-open the dialog
     When I enter the netsim name "Greg"
+    And I wait until element ".join-button" is visible
     And I press the first ".join-button" element
     And I wait until element "#tab_instructions" is visible
     And I press the first ".netsim-bubble" element

--- a/dashboard/test/ui/features/public_key_cryptography/continue_button.feature
+++ b/dashboard/test/ui/features/public_key_cryptography/continue_button.feature
@@ -5,6 +5,6 @@ Feature: Public Key Cryptography - Continue Button
   # again. -Brad
   Scenario: Clicking the continue button
     Given I am on the 1st Public Key Cryptography test level
-    When I press the last button with text "Continue"
+    When I press the last button with text "Continue" to load a new page
     And I wait until "#public-key-cryptography-mount" contains text "Pick a character"
     Then check that I am on "http://studio.code.org/s/allthethings/stage/31/puzzle/2"

--- a/dashboard/test/ui/features/script_overview.feature
+++ b/dashboard/test/ui/features/script_overview.feature
@@ -22,7 +22,7 @@ Feature: Script overview page
     And I am on "http://studio.code.org/s/allthethings"
     And I wait until element ".teacher-panel" is visible
     Then I verify progress for stage 29 level 4 is "perfect"
-    When I click selector ".teacher-panel table td:contains(Sally)" once I see it
+    When I click selector ".teacher-panel table td:contains(Sally)" once I see it to load a new page
     And I wait until element "td:contains(Maze)" is visible
     Then I verify progress for stage 2 level 1 is "perfect"
     Then I verify progress for stage 2 level 2 is "not_tried"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -48,12 +48,23 @@ rescue Selenium::WebDriver::Error::StaleElementReferenceError
   true
 end
 
-def page_load(wait_until_unload)
-  if wait_until_unload
-    html = @browser.find_element(tag_name: 'html')
+def page_load(wait = true, blank_tab: false)
+  if wait
+    root = @browser.find_element(css: ':root')
+    tabs = @browser.window_handles if wait == 'tab'
     yield
-    wait_until {element_stale?(html)}
-    navigate_to(@browser.current_url)
+    if tabs
+      new_tab = wait_until {(@browser.window_handles - tabs).first}
+      @browser.switch_to.window(new_tab)
+    end
+    wait_until {element_stale?(root)}
+    unless blank_tab
+      wait_until do
+        (url = @browser.current_url) != '' &&
+           url != 'about:blank' &&
+          @browser.execute_script('return document.readyState;') == 'complete'
+      end
+    end
   else
     yield
   end
@@ -98,26 +109,21 @@ When /^I wait to see (?:an? )?"([.#])([^"]*)"$/ do |selector_symbol, name|
   wait_until {!@browser.find_elements(selection_criteria).empty?}
 end
 
-When /^I go to the newly opened tab$/ do
-  wait_short_until {@browser.window_handles.length > 1}
-
-  @browser.switch_to.window(@browser.window_handles.last)
-
-  # Wait for Safari to finish switching to the new tab. We can't wait_short
-  # because @browser.title takes 30 seconds to timeout.
-  wait_until {@browser.title rescue nil}
-end
-
-When /^I open a new tab$/ do
-  @browser.execute_script('window.open();')
+When /^I go to a new tab$/ do
+  page_load('tab', blank_tab: true) do
+    @browser.execute_script('window.open();')
+  end
 end
 
 When /^I close the current tab$/ do
   @browser.close
+  tabs = @browser.window_handles
+  @browser.switch_to.window(tabs.first) if tabs.any?
 end
 
-When /^I switch to tab index (\d+)$/ do |tab_index|
-  @browser.switch_to.window(@browser.window_handles[tab_index.to_i])
+When /^I switch tabs$/ do
+  tab = @browser.window_handle
+  @browser.switch_to.window(@browser.window_handles.detect {|handle| handle != tab})
 end
 
 When /^I switch to the first iframe$/ do
@@ -127,7 +133,7 @@ end
 
 # Can switch out of iframe content
 When /^I switch to the default content$/ do
-  @browser.switch_to.window $default_window
+  @browser.switch_to.default_content
 end
 
 When /^I close the instructions overlay if it exists$/ do
@@ -284,7 +290,7 @@ When /^I rotate to portrait$/ do
   end
 end
 
-When /^I press "([^"]*)"( to load a new page)?$/ do |button, load|
+When /^I press "([^"]*)"(?: to load a new (page|tab))?$/ do |button, load|
   wait_short_until do
     @button = @browser.find_element(id: button)
   end
@@ -306,7 +312,7 @@ When /^I press the child number (.*) of class "([^"]*)"( to load a new page)?$/ 
   end
 end
 
-When /^I press the first "([^"]*)" element( to load a new page)?$/ do |selector, load|
+When /^I press the first "([^"]*)" element(?: to load a new (page|tab))?$/ do |selector, load|
   wait_short_until do
     @element = @browser.find_element(:css, selector)
   end
@@ -336,9 +342,11 @@ When /^I press SVG selector "([^"]*)"$/ do |selector|
   @browser.execute_script("$(#{selector.dump}).simulate('drag', function(){});")
 end
 
-When /^I press the last button with text "([^"]*)"$/ do |name|
+When /^I press the last button with text "([^"]*)"( to load a new page)?$/ do |name, load|
   name_selector = "button:contains(#{name})"
-  @browser.execute_script("$('" + name_selector + "').simulate('drag', function(){});")
+  page_load(load) do
+    @browser.execute_script("$('" + name_selector + "').simulate('drag', function(){});")
+  end
 end
 
 When /^I (?:open|close) the small footer menu$/ do
@@ -373,11 +381,13 @@ When /^I press the settings cog menu item "([^"]*)"$/ do |item_text|
   }
 end
 
-When /^I select the "([^"]*)" small footer item$/ do |menu_item_text|
-  steps %{
-    Then I open the small footer menu
-    And I press menu item "#{menu_item_text}"
-  }
+When /^I select the "([^"]*)" small footer item( to load a new page)?$/ do |menu_item_text, load|
+  page_load(load) do
+    steps %{
+      Then I open the small footer menu
+      And I press menu item "#{menu_item_text}"
+    }
+  end
 end
 
 When /^I press the SVG text "([^"]*)"$/ do |name|
@@ -450,13 +460,13 @@ end
 
 # Prefer clicking with selenium over jquery, since selenium clicks will fail
 # if the target element is obscured by another element.
-When /^I click "([^"]*)"( to load a new page)?$/ do |selector, load|
-  page_load(load) do
-    @browser.find_element(:css, selector).click
-  end
+When /^I click "([^"]*)"( once it exists)?(?: to load a new (page|tab))?$/ do |selector, wait, load|
+  find = -> {@browser.find_element(:css, selector)}
+  element = wait ? wait_until(&find) : find.call
+  page_load(load) {element.click}
 end
 
-When /^I click selector "([^"]*)"( to load a new page)?$/ do |jquery_selector, load|
+When /^I click selector "([^"]*)"(?: to load a new (page|tab))?$/ do |jquery_selector, load|
   # normal a href links can only be clicked this way
   page_load(load) do
     @browser.execute_script("$(\"#{jquery_selector}\")[0].click();")
@@ -469,11 +479,13 @@ When /^I click selector "([^"]*)" if it exists$/ do |jquery_selector|
   end
 end
 
-When /^I click selector "([^"]*)" once I see it$/ do |selector|
+When /^I click selector "([^"]*)" once I see it(?: to load a new (page|tab))?$/ do |selector, load|
   wait_until do
     @browser.execute_script("return $(\"#{selector}:visible\").length != 0;")
   end
-  @browser.execute_script("$(\"#{selector}\")[0].click();")
+  page_load(load) do
+    @browser.execute_script("$(\"#{selector}\")[0].click();")
+  end
 end
 
 When /^I click selector "([^"]*)" if I see it$/ do |selector|

--- a/dashboard/test/ui/features/studio.feature
+++ b/dashboard/test/ui/features/studio.feature
@@ -27,6 +27,7 @@ Scenario: Resizing Sprites
   And the 15th sprite image has height "100"
 
   When I press "runButton"
+  Then I wait to see a ".congrats"
   And I press "again-button"
   Then the 0th sprite image has height "50"
   And the 15th sprite image has height "150"

--- a/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard.feature
@@ -10,7 +10,7 @@ Feature: Using the teacher dashboard
     And I sign out
 
     When I sign in as "Teacher_Sally"
-    When I click selector "a:contains(Untitled Section)" once I see it
+    When I click selector "a:contains(Untitled Section)" once I see it to load a new page
     And I wait until element "#uitest-teacher-dashboard-nav" is visible
     And check that the URL contains "/teacher_dashboard/sections/"
     And I wait until element "#uitest-course-dropdown" contains text "All the Things! *"
@@ -91,9 +91,9 @@ Feature: Using the teacher dashboard
     Then I navigate to teacher dashboard for the section I saved
     And I click selector "#uitest-teacher-dashboard-nav a:contains(Projects)" once I see it
     And I wait until element "#uitest-projects-table" is visible
-    And I click selector "a:contains('thumb wars')" once I see it
-    And I go to the newly opened tab
-    And I wait until element ".project_name.header_text:contains('thumb wars')" is visible
+    And I click selector "a:contains('thumb wars')" once I see it to load a new tab
+    And I wait until element ".project_name.header_text" is visible
+    And element ".project_name.header_text" contains text "thumb wars"
 
   Scenario: Toggling student progress
     Given I create an authorized teacher-associated student named "Sally"

--- a/dashboard/test/ui/features/user_menu.feature
+++ b/dashboard/test/ui/features/user_menu.feature
@@ -22,7 +22,7 @@ Scenario: Teacher Signed In - shows display name with correct links
   And I click selector ".display_name"
   And I wait until element "#user-edit" is visible
   And I wait until element "#user-signout" is visible
-  Then I sign out
+  Then I press "user-signout" to load a new page
   And I wait until element "#signin_button" is visible
   And I wait until element ".display_name" is not visible
 
@@ -47,7 +47,7 @@ Scenario: Student Signed In - shows display name with correct links
   And I wait until element ".display_name" is visible
   And I click selector ".display_name"
   And I wait until element "#user-signout" is visible
-  And I press "user-signout"
+  And I press "user-signout" to load a new page
   And I wait until element "#signin_button" is visible
   And I wait until element ".display_name" is not visible
 


### PR DESCRIPTION
According to the [WebDriver spec](https://www.w3.org/TR/webdriver1/) the order in which [`window_handles`](https://www.w3.org/TR/webdriver1/#get-window-handles) are returned is arbitrary, so test failures can occur from tests that assume tabs are switchable based on the order of IDs in the `window_handles` array.
To resolve, this PR updates our tests to switch to the newly-created tab as part of the page-load step, so we know that the newly-added window handle is the newly-created tab.

I've also added a few other tweaks and fixes to address various flaky failures related to waiting for new pages to load correctly.

- Add "to load a new tab" definitions to handle tab-switching after click
- Replace "I switch to tab index" with "I switch tabs"
- Add 'to load a new (page|tab)' to various existing steps that require it