### PR TITLE
Move new animation option to the top of the animation list in spritelab

### DIFF
--- a/apps/src/gamelab/AnimationTab/AnimationList.jsx
+++ b/apps/src/gamelab/AnimationTab/AnimationList.jsx
@@ -35,8 +35,16 @@ class AnimationList extends React.Component {
   };
 
   render() {
+    let addAnimation = (
+      <NewListItem
+        key="new_animation"
+        label={this.props.spriteLab ? i18n.newCostume() : i18n.newAnimation()}
+        onClick={this.props.onNewItemClick}
+      />
+    );
     return (
       <ScrollableList style={styles.root} className="animationList">
+        {this.props.spriteLab && addAnimation}
         {this.props.animationList.orderedKeys.map(key => (
           <AnimationListItem
             key={key}
@@ -46,11 +54,7 @@ class AnimationList extends React.Component {
             animationList={this.props.animationList}
           />
         ))}
-        <NewListItem
-          key="new_animation"
-          label={this.props.spriteLab ? i18n.newCostume() : i18n.newAnimation()}
-          onClick={this.props.onNewItemClick}
-        />
+        {!this.props.spriteLab && addAnimation}
       </ScrollableList>
     );
   }


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/STAR-373
Move new animation option to the top of the animation list in spritelab

Gamelab:
![Screenshot from 2019-04-26 10-47-48](https://user-images.githubusercontent.com/2959170/56826548-5f0e0d80-6811-11e9-9155-a11b75f02ca9.png)

Spritelab:
![Screenshot from 2019-04-26 10-47-36](https://user-images.githubusercontent.com/2959170/56826555-63d2c180-6811-11e9-90ea-7698cd10aa49.png)


