### PR TITLE
Increase query timeout in Contact Rollups multi-statement connection

### DIFF
--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -46,6 +46,16 @@ class ContactRollups
     query_timeout: MAX_EXECUTION_TIME_SEC
   )
 
+  def self.mysql_multi_connection
+    # return a connection with the MULTI_STATEMENTS flag set that allows multiple statements in one DB call
+    sequel_connect(
+      CDO.pegasus_reporting_db_writer,
+      CDO.pegasus_reporting_db_writer,
+      query_timeout: MAX_EXECUTION_TIME_SEC,
+      multi_statements: true
+    )
+  end
+
   # Columns to disregard
   EXCLUDED_COLUMNS = %w(id pardot_id pardot_sync_at updated_at).freeze
 
@@ -678,11 +688,6 @@ class ContactRollups
       ELSE #{DEST_TABLE_NAME}.professional_learning_attended
     END
     WHERE #{DEST_TABLE_NAME}.email = src.email"
-  end
-
-  def self.mysql_multi_connection
-    # return a connection with the MULTI_STATEMENTS flag set that allows multiple statements in one DB call
-    Sequel.connect(CDO.pegasus_reporting_db_writer.sub('mysql:', 'mysql2:'), flags: ::Mysql2::Client::MULTI_STATEMENTS)
   end
 
   # Extracts and formats address data from form data

--- a/lib/cdo/db.rb
+++ b/lib/cdo/db.rb
@@ -10,7 +10,7 @@ require pegasus_dir 'data/static_models'
 # @param validation_frequency [number] How often to validate the connection. If set to -1,
 #   validate each time a request is made.
 # @param query_timeout [number] The execution timeout for SELECT statements, in seconds.
-def sequel_connect(writer, reader, validation_frequency: nil, query_timeout: nil)
+def sequel_connect(writer, reader, validation_frequency: nil, query_timeout: nil, multi_statements: false)
   reader = reader.gsub 'mysql:', 'mysql2:'
   writer = writer.gsub 'mysql:', 'mysql2:'
 
@@ -60,6 +60,11 @@ def sequel_connect(writer, reader, validation_frequency: nil, query_timeout: nil
   if query_timeout
     db_options[:read_timeout] = query_timeout
     db_options[:init_command] = "SET SESSION MAX_EXECUTION_TIME = #{query_timeout * 1000}"
+  end
+
+  if multi_statements
+    # Configure connection with the MULTI_STATEMENTS flag set that allows multiple statements in one database call.
+    db_options[:flags] = ::Mysql2::Client::MULTI_STATEMENTS
   end
 
   if (reader_uri = URI(reader)).host != URI(writer).host


### PR DESCRIPTION
All of the database connections in Contact Rollups were recently configured to use an increased max query execution timeout, except the multi-statement connection.  Add the execution timeout to the multi statement connection as well to resolve a timeout that is causing the nightly Contact Rollups process to fail frequently: https://app.honeybadger.io/projects/45435/faults/45615747#notice-summary