### PR TITLE
Refactor UI-test application logic to run through XMLHttpRequests

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -59,13 +59,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def reset_session_endpoint
-    client_state.reset
-    sign_out if current_user
-    reset_session
-    render text: 'OK <script>sessionStorage.clear()</script>'
-  end
-
   rescue_from CanCan::AccessDenied do
     if !current_user && request.format == :html
       # we don't know who you are, you can try to sign in

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -63,6 +63,14 @@ class SessionsController < Devise::SessionsController
     end
   end
 
+  # GET /reset_session
+  def reset
+    client_state.reset
+    sign_out if current_user
+    reset_session
+    render layout: false
+  end
+
   private
 
   # Override default Devise sign_out path method

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -1,0 +1,57 @@
+# Controller actions used only to facilitate UI tests.
+class TestController < ApplicationController
+  layout false
+
+  def hidden_script_access
+    return unless (user = current_user)
+    user.permission = UserPermission::HIDDEN_SCRIPT_ACCESS
+    user.save!
+    head :ok
+  end
+
+  def enroll_in_plc_course
+    return unless (user = current_user)
+    course = Course.find_by(name: 'All The PLC Things')
+    enrollment = Plc::UserCourseEnrollment.create(user: user, plc_course: course.plc_course)
+    enrollment.plc_unit_assignments.update_all(status: Plc::EnrollmentUnitAssignment::IN_PROGRESS)
+    head :ok
+  end
+
+  def fake_completion_assessment
+    return unless (user = current_user)
+    unit_assignment = Plc::EnrollmentUnitAssignment.find_by(user: user)
+    unit_assignment.enroll_user_in_unit_with_learning_modules(
+      [
+        unit_assignment.plc_course_unit.plc_learning_modules.find_by(module_type: Plc::LearningModule::CONTENT_MODULE),
+        unit_assignment.plc_course_unit.plc_learning_modules.find_by(module_type: Plc::LearningModule::PRACTICE_MODULE)
+      ]
+    )
+  end
+
+  def assign_script_as_student
+    return unless (user = current_user)
+    script = Script.find_by_name(params.require(:script_name))
+
+    name = "Fake User"
+    email = "user#{Time.now.to_i}_#{rand(1_000_000)}@test.xx"
+    password = name + "password"
+    attributes = {
+      name: name,
+      email: email,
+      password: password,
+      user_type: "teacher",
+      age: "21+"
+    }
+    fake_user = User.create!(attributes)
+
+    section = Section.create(name: "New Section", user: fake_user, script: script)
+    section.students << user
+    section.save!
+    head :ok
+  end
+
+  def get_i18n_t
+    locale = params[:locale] || request.env['cdo.locale']
+    render plain: I18n.t(params.require(:key), locale: locale)
+  end
+end

--- a/dashboard/app/views/sessions/reset.html.haml
+++ b/dashboard/app/views/sessions/reset.html.haml
@@ -1,0 +1,9 @@
+!!! 5
+%html
+  %head
+    = csrf_meta_tags
+    :javascript
+      sessionStorage.clear();
+      localStorage.clear();
+  %body
+    OK

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -152,6 +152,7 @@ Dashboard::Application.routes.draw do
     get '/users/migrate_to_multi_auth', to: 'registrations#migrate_to_multi_auth'
     get '/users/demigrate_from_multi_auth', to: 'registrations#demigrate_from_multi_auth'
     get '/users/to_destroy', to: 'registrations#users_to_destroy'
+    get '/reset_session', to: 'sessions#reset'
   end
   devise_for :users, controllers: {
     omniauth_callbacks: 'omniauth_callbacks',
@@ -273,8 +274,6 @@ Dashboard::Application.routes.draw do
   get '/course/:course_name', to: redirect('/courses/%{course_name}')
 
   get '/beta', to: redirect('/')
-
-  get 'reset_session', to: 'application#reset_session_endpoint'
 
   get '/hoc/reset', to: 'script_levels#reset', script_id: Script::HOC_NAME, as: 'hoc_reset'
   get '/hoc/:chapter', to: 'script_levels#show', script_id: Script::HOC_NAME, as: 'hoc_chapter', format: false
@@ -579,6 +578,17 @@ Dashboard::Application.routes.draw do
   namespace :api do
     api_methods.each do |action|
       get action, action: action
+    end
+  end
+
+  if rack_env?(:development, :test)
+    scope '/api' do
+      namespace :test, defaults: {format: 'json'} do
+        TestController.instance_methods(false).each do |action|
+          method = action.to_s.start_with?('get') ? :get : :post
+          send(method, action, action: action)
+        end
+      end
     end
   end
 

--- a/dashboard/test/ui/features/algebra.feature
+++ b/dashboard/test/ui/features/algebra.feature
@@ -4,7 +4,6 @@ Feature: Looking at Algebra levels with Applitools Eyes
 Background:
   Given I am on "http://studio.code.org/reset_session"
 
-@dashboard_db_access
 Scenario:
   Given I am a student
   And I open my eyes to test "embedded ninjacat"
@@ -21,7 +20,6 @@ Scenario:
   And I close my eyes
   And I sign out
 
-@dashboard_db_access
 Scenario:
   Given I am a student
   And I open my eyes to test "calc expression evaluation"
@@ -37,7 +35,6 @@ Scenario:
   And I close my eyes
   And I sign out
 
-@dashboard_db_access
 Scenario:
   Given I am a student
   And I open my eyes to test "calc variable"

--- a/dashboard/test/ui/features/applab/data_blocks.feature
+++ b/dashboard/test/ui/features/applab/data_blocks.feature
@@ -1,5 +1,4 @@
 @no_mobile
-@dashboard_db_access
 @as_student
 Feature: App Lab Data Blocks
 

--- a/dashboard/test/ui/features/applab/embed.feature
+++ b/dashboard/test/ui/features/applab/embed.feature
@@ -1,6 +1,5 @@
 # Brad (2018-11-14) Skip on IE due to blocked pop-ups and possible "new document" issues
 @no_ie
-@dashboard_db_access
 @as_student
 @no_mobile
 Feature: App Lab Embed

--- a/dashboard/test/ui/features/applab/eyes1.feature
+++ b/dashboard/test/ui/features/applab/eyes1.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 @as_student
 Feature: App Lab Eyes -  Part 1
 

--- a/dashboard/test/ui/features/applab/eyes2.feature
+++ b/dashboard/test/ui/features/applab/eyes2.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 @as_student
 Feature: App Lab Eyes - Part 2
 

--- a/dashboard/test/ui/features/applab/eyes3.feature
+++ b/dashboard/test/ui/features/applab/eyes3.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 @as_student
 Feature: App Lab Eyes -  Part 3
 

--- a/dashboard/test/ui/features/applab/eyes4.feature
+++ b/dashboard/test/ui/features/applab/eyes4.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 @as_student
 Feature: App Lab Eyes -  Part 4
 

--- a/dashboard/test/ui/features/applab/html_sanitization.feature
+++ b/dashboard/test/ui/features/applab/html_sanitization.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: App Lab HTML Sanitization
 

--- a/dashboard/test/ui/features/applab/level_options.feature
+++ b/dashboard/test/ui/features/applab/level_options.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: App Lab Level Options
 

--- a/dashboard/test/ui/features/applab/scenarios.feature
+++ b/dashboard/test/ui/features/applab/scenarios.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: App Lab Scenarios
 

--- a/dashboard/test/ui/features/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/applab/shared_apps.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: App Lab Scenarios
 

--- a/dashboard/test/ui/features/applab/sharing_from_script_level.feature
+++ b/dashboard/test/ui/features/applab/sharing_from_script_level.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: sharingFromScriptLevel
 

--- a/dashboard/test/ui/features/applab/template_backed.feature
+++ b/dashboard/test/ui/features/applab/template_backed.feature
@@ -1,5 +1,4 @@
 @no_mobile
-@dashboard_db_access
 @as_student
 Feature: App Lab Scenarios
 

--- a/dashboard/test/ui/features/applab/tooltips.feature
+++ b/dashboard/test/ui/features/applab/tooltips.feature
@@ -32,7 +32,7 @@ Feature: Applab visualization overlay tooltips
     And I set input "xpos" to "10"
     And I set input "ypos" to "270"
 
-  @eyes @dashboard_db_access @as_student
+  @eyes @as_student
   Scenario: Hovering over elements in design mode
     Given I open my eyes to test "tooltips in design mode"
     And I switch to design mode
@@ -85,7 +85,7 @@ Feature: Applab visualization overlay tooltips
 
     And I close my eyes
 
-  @eyes @dashboard_db_access @as_student
+  @eyes @as_student
   Scenario: Hovering over elements in code mode
     Given I open my eyes to test "tooltips in code mode"
     And I switch to code mode

--- a/dashboard/test/ui/features/applab/versions.feature
+++ b/dashboard/test/ui/features/applab/versions.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: App Lab Versions
 

--- a/dashboard/test/ui/features/big_game_remix.feature
+++ b/dashboard/test/ui/features/big_game_remix.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: Big Game Remix
 

--- a/dashboard/test/ui/features/big_game_versions.feature
+++ b/dashboard/test/ui/features/big_game_versions.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: Big Game Versions
 

--- a/dashboard/test/ui/features/contract_editor.feature
+++ b/dashboard/test/ui/features/contract_editor.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 @eyes
 Feature: Opening the contract editor

--- a/dashboard/test/ui/features/contract_editor_sections.feature
+++ b/dashboard/test/ui/features/contract_editor_sections.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: Contract Editor section configuration and manipulation
 

--- a/dashboard/test/ui/features/contract_examples.feature
+++ b/dashboard/test/ui/features/contract_examples.feature
@@ -1,5 +1,4 @@
 @no_ie
-@dashboard_db_access
 @as_student
 Feature: Editing examples in the contract editor
 

--- a/dashboard/test/ui/features/courses_eyes.feature
+++ b/dashboard/test/ui/features/courses_eyes.feature
@@ -1,10 +1,10 @@
 @eyes
-@dashboard_db_access
 @no_mobile
 Feature: Courses page
 
 @as_student
 Scenario: Student courses
+  Given I am on "http://studio.code.org/home"
   When I open my eyes to test "student courses"
   And I wait to see ".headerlinks"
   And I see "#header-student-courses"
@@ -15,6 +15,7 @@ Scenario: Student courses
 
 @as_teacher
 Scenario: Teacher courses
+  Given I am on "http://studio.code.org/home"
   When I open my eyes to test "teacher courses"
   And I wait to see ".headerlinks"
   And I see "#header-teacher-courses"

--- a/dashboard/test/ui/features/create_dropdown.feature
+++ b/dashboard/test/ui/features/create_dropdown.feature
@@ -20,7 +20,7 @@ Scenario: Signed Out - Correct Create Links
   And I wait until element "#view_all_projects" is visible
 
 Scenario: Teacher - Correct Create Links
-  Given I am a teacher
+  Given I am a teacher and go home
   And I wait until element ".create_menu" is visible
   And I click selector ".create_menu"
   And I wait until element "#create_dropdown_spritelab" is visible
@@ -32,7 +32,7 @@ Scenario: Teacher - Correct Create Links
   And I wait until element "#view_all_projects" is visible
 
 Scenario: Student, Age 13+ - Correct Create Links
-  Given I create a student named "16 Year Old"
+  Given I create a student named "16 Year Old" and go home
   And I wait until element ".create_menu" is visible
   And I click selector ".create_menu"
   And I wait until element "#create_dropdown_spritelab" is visible
@@ -44,7 +44,7 @@ Scenario: Student, Age 13+ - Correct Create Links
   And I wait until element "#view_all_projects" is visible
 
 Scenario: Young Student, Not in Section - Correct Create Links
-  Given I create a young student named "10 Year Old"
+  Given I create a young student named "10 Year Old" and go home
   And I wait until element ".create_menu" is visible
   And I click selector ".create_menu"
   And I wait until element "#create_dropdown_spritelab" is visible
@@ -57,10 +57,7 @@ Scenario: Young Student, Not in Section - Correct Create Links
 
 Scenario: Young Student, In Section - Correct Create Links
   Given I create a teacher named "Ms_Frizzle"
-  Then I see the section set up box
   And I create a new section
-  And I save the section url
-  Then I sign out
   Given I create a young student named "Young Student - In Section"
   And I navigate to the section url
   And I wait until element ".create_menu" is visible

--- a/dashboard/test/ui/features/droplet.feature
+++ b/dashboard/test/ui/features/droplet.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: Droplet levels work as expected
   Background:

--- a/dashboard/test/ui/features/fallback_player_caption_dialog_link.feature
+++ b/dashboard/test/ui/features/fallback_player_caption_dialog_link.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @no_mobile
 
 Feature: Fallback player caption dialog link

--- a/dashboard/test/ui/features/feedback.feature
+++ b/dashboard/test/ui/features/feedback.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: Recommended/Required Blocks Feedback
 

--- a/dashboard/test/ui/features/footer.feature
+++ b/dashboard/test/ui/features/footer.feature
@@ -153,7 +153,7 @@ Feature: Checking the footer appearance
 
     Then I close my eyes
 
-  @eyes @dashboard_db_access @as_student
+  @eyes @as_student
   Scenario: Desktop Applab share small footer
     Given I start a new Applab project
     And I navigate to the shared version of my project
@@ -228,7 +228,7 @@ Feature: Checking the footer appearance
 
     Then I close my eyes
 
-  @eyes_mobile @dashboard_db_access @as_student
+  @eyes_mobile @as_student
   Scenario: Mobile Applab share small footer
     Given I am on "http://studio.code.org/home"
     And I rotate to landscape

--- a/dashboard/test/ui/features/gamelab/eyes.feature
+++ b/dashboard/test/ui/features/gamelab/eyes.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 @as_student
 Feature: Game Lab Eyes
 

--- a/dashboard/test/ui/features/gamelab/level_options.feature
+++ b/dashboard/test/ui/features/gamelab/level_options.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: Game Lab Level Options
 

--- a/dashboard/test/ui/features/gdpr_dialog.feature
+++ b/dashboard/test/ui/features/gdpr_dialog.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @no_mobile
 
 Feature: GDPR Dialog - data transfer agreement
@@ -43,7 +42,6 @@ Feature: GDPR Dialog - data transfer agreement
     Then I click selector ".ui-test-gdpr-dialog-accept"
     Then element ".ui-test-gdpr-dialog" is not visible
     Then I sign out
-    Given I sign in as "Madame Maxime"
-    Given I am on "http://studio.code.org/home"
+    Given I sign in as "Madame Maxime" and go home
     Then I wait to see ".header_user"
     Then element ".ui-test-gdpr-dialog" is not visible

--- a/dashboard/test/ui/features/hamburger.feature
+++ b/dashboard/test/ui/features/hamburger.feature
@@ -8,8 +8,7 @@ Feature: Hamburger dropdown
     Then element "#hamburger-icon" is not visible
 
   Scenario: Student viewing hamburger dropdown in English on desktop
-    Given I create a student named "Sally Student"
-    Then I wait until I am on "http://studio.code.org/home"
+    Given I create a student named "Sally Student" and go home
     Then I wait to see "#hamburger-icon"
     And I click selector "#hamburger-icon"
     Then I wait to see "#hamburger-contents"
@@ -23,8 +22,7 @@ Feature: Hamburger dropdown
     And I see "#educate_entries"
 
   Scenario: Teacher viewing hamburger dropdown (with expanded options) in English on desktop
-    Given I create a teacher named "Tessa Teacher"
-    Then I wait until I am on "http://studio.code.org/home"
+    Given I create a teacher named "Tessa Teacher" and go home
     Then I wait to see "#hamburger-icon"
     And I click selector "#hamburger-icon"
     Then I wait to see "#hamburger-contents"
@@ -116,7 +114,6 @@ Scenario: Signed out user viewing hamburger dropdown in Spanish on desktop
 
 Scenario: Student viewing hamburger dropdown in Spanish on desktop
   Given I create a student named "Eva Estudiante"
-  Then I wait until I am on "http://studio.code.org/home"
   Given I am on "http://studio.code.org/home/lang/es"
   Then I wait until I am on "http://studio.code.org/home"
   And I wait to see "#hamburger-icon"
@@ -136,7 +133,6 @@ Scenario: Student viewing hamburger dropdown in Spanish on desktop
 
 Scenario: Teacher viewing hamburger dropdown in Spanish on desktop
   Given I create a teacher named "Pabla Profesora"
-  Then I wait until I am on "http://studio.code.org/home"
   Given I am on "http://studio.code.org/home/lang/es"
   Then I wait until I am on "http://studio.code.org/home"
   Then I wait to see "#hamburger-icon"

--- a/dashboard/test/ui/features/header.feature
+++ b/dashboard/test/ui/features/header.feature
@@ -19,8 +19,7 @@ Scenario: Signed out user in English should see 6 header links
   And element "#header-en-projects" contains text "Projects"
 
 Scenario: Student in English should see 2 header links
-  Given I create a student named "Sally Student"
-  Then check that I am on "http://studio.code.org/home"
+  Given I create a student named "Sally Student" and go home
   And I wait to see ".headerlinks"
   And I see "#header-student-courses"
   And element "#header-student-courses" contains text "Course Catalog"
@@ -28,8 +27,7 @@ Scenario: Student in English should see 2 header links
   And element "#header-student-projects" contains text "Projects"
 
 Scenario: Teacher in English should see 5 header links
-  Given I create a teacher named "Tessa Teacher"
-  Then check that I am on "http://studio.code.org/home"
+  Given I create a teacher named "Tessa Teacher" and go home
   And I wait to see ".headerlinks"
   And I see "#header-teacher-home"
   And element "#header-teacher-home" contains text "My Dashboard"
@@ -55,7 +53,6 @@ Scenario: Signed out user in Spanish should see 3 header links
 
 Scenario: Student in Spanish should see 3 header links
   Given I create a student named "Eva Estudiante"
-  Then check that I am on "http://studio.code.org/home"
   Given I am on "http://studio.code.org/courses/lang/es"
   Then check that I am on "http://studio.code.org/courses"
   And I wait to see ".headerlinks"
@@ -68,7 +65,6 @@ Scenario: Student in Spanish should see 3 header links
 
 Scenario: Teacher in Spanish should see 5 header links
   Given I create a teacher named "Pabla Profesora"
-  Then check that I am on "http://studio.code.org/home"
   Given I am on "http://studio.code.org/home/lang/es"
   Then check that I am on "http://studio.code.org/home"
   And I wait to see ".headerlinks"

--- a/dashboard/test/ui/features/hidden_scripts_eyes.feature
+++ b/dashboard/test/ui/features/hidden_scripts_eyes.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 Feature: Hidden Scripts
 
 Scenario: Hidden Scripts

--- a/dashboard/test/ui/features/hidden_stages_eyes.feature
+++ b/dashboard/test/ui/features/hidden_stages_eyes.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 Feature: Hidden Stages
 
 Scenario: Hidden Stages

--- a/dashboard/test/ui/features/hour_of_code_dot_com.feature
+++ b/dashboard/test/ui/features/hour_of_code_dot_com.feature
@@ -4,7 +4,6 @@ Feature: Looking at hourofcode.com with Applitools Eyes
   Background:
     Given I am on "http://studio.code.org/reset_session"
 
-@dashboard_db_access
 Scenario Outline: Logged in simple page view
   Given I am on "http://studio.code.org/"
   And I am a student

--- a/dashboard/test/ui/features/hour_of_code_signed_in.feature
+++ b/dashboard/test/ui/features/hour_of_code_signed_in.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: Hour of Code tests for users that are signed in
 

--- a/dashboard/test/ui/features/initial_page_views.feature
+++ b/dashboard/test/ui/features/initial_page_views.feature
@@ -4,7 +4,6 @@ Feature: Looking at a few things with Applitools Eyes - Part 1
   Background:
     Given I am on "http://studio.code.org/reset_session"
 
-  @dashboard_db_access
   Scenario Outline: Simple blockly level page view
     Given I am on "http://studio.code.org/"
     And I am a student

--- a/dashboard/test/ui/features/initial_page_views2.feature
+++ b/dashboard/test/ui/features/initial_page_views2.feature
@@ -5,7 +5,6 @@ Feature: Looking at a few things with Applitools Eyes - Part 2
   Background:
     Given I am on "http://studio.code.org/reset_session"
 
-  @dashboard_db_access
   Scenario Outline: Logged in simple page view without instructions dialog
     Given I am on "http://studio.code.org/"
     And I am a student

--- a/dashboard/test/ui/features/initial_page_views3.feature
+++ b/dashboard/test/ui/features/initial_page_views3.feature
@@ -5,7 +5,6 @@ Feature: Looking at a few things with Applitools Eyes - Part 3
     Given I am on "http://studio.code.org/reset_session"
 
   @no_circle
-  @dashboard_db_access
   Scenario Outline: Temporarily circle disabled simple page view without instructions dialog
     Given I am on "http://studio.code.org/"
     And I am a student

--- a/dashboard/test/ui/features/initial_page_views_csf.feature
+++ b/dashboard/test/ui/features/initial_page_views_csf.feature
@@ -4,7 +4,6 @@ Feature: Looking at a few things with Applitools Eyes - CSF Levels
   Background:
     Given I am on "http://studio.code.org/reset_session"
 
-  @dashboard_db_access
   Scenario Outline: Simple blockly level page view
     Given I am on "http://studio.code.org/"
     And I am a student

--- a/dashboard/test/ui/features/lesson_extras_teacher_panel.feature
+++ b/dashboard/test/ui/features/lesson_extras_teacher_panel.feature
@@ -1,11 +1,9 @@
-@dashboard_db_access
 @no_mobile
 Feature: Lesson extras teacher panel
 
   Scenario: View student lesson extras progress
     Given I create an authorized teacher-associated student named "Sally"
-    And I sign out
-    When I sign in as "Teacher_Sally"
+    When I sign in as "Teacher_Sally" and go home
     And I wait until element ".uitest-owned-sections" is visible
     Then I save the section id from row 0 of the section table
 

--- a/dashboard/test/ui/features/level_group.feature
+++ b/dashboard/test/ui/features/level_group.feature
@@ -30,7 +30,6 @@ Scenario: Submit three answers.
   And element ".level-group-content:nth(2) #checked_0" is visible
 
 @no_ie
-@dashboard_db_access
 Scenario: Match levels within level group
   Given I create a teacher-associated student named "Lilian"
   Given I am on "http://studio.code.org/s/allthethings/stage/33/puzzle/1?noautoplay=true"

--- a/dashboard/test/ui/features/pd/regional_partner_mini_contact.feature
+++ b/dashboard/test/ui/features/pd/regional_partner_mini_contact.feature
@@ -1,5 +1,3 @@
-@dashboard_db_access
-
 # We need "press keys" to type into the React form's fields, but that doesn't work on IE.
 @no_ie
 

--- a/dashboard/test/ui/features/pixelation.feature
+++ b/dashboard/test/ui/features/pixelation.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @no_mobile
 Feature: Pixelation levels
   # Brad (2018-11-14) Skip on IE due to blocked pop-ups

--- a/dashboard/test/ui/features/plc/course_unit_navigation.feature
+++ b/dashboard/test/ui/features/plc/course_unit_navigation.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 Feature: Basic navigation for PLC stuff
 
 Background:

--- a/dashboard/test/ui/features/projects/applab_project.feature
+++ b/dashboard/test/ui/features/projects/applab_project.feature
@@ -1,11 +1,10 @@
 Feature: Applab Project
 
-# dashboard_db_access for sign in
 # as_student to actually perform sign-in/out before/after scenario
 # no_mobile because we don't end up with open-workspace on mobile
 # no_ie because applab is broken on IE9, and on IE10 this test crashes when we
 #   try to execute any JS after our redirect on line 42
-@dashboard_db_access @as_student
+@as_student
 @no_mobile @no_ie
 Scenario: Applab Flow
   Given I am on "http://studio.code.org/projects/applab"
@@ -140,7 +139,7 @@ Scenario: Save Script Level After Signing Out
   And I ensure droplet is in text mode
   Then ace editor code is equal to "// turtle 1"
 
-@dashboard_db_access @as_student
+@as_student
 @no_mobile
 Scenario: Remix project creates and redirects to new channel
   Given I am on "http://studio.code.org/projects/applab"

--- a/dashboard/test/ui/features/projects/gamelab_project.feature
+++ b/dashboard/test/ui/features/projects/gamelab_project.feature
@@ -1,6 +1,6 @@
 Feature: Gamelab Projects
 
-@dashboard_db_access @as_student @no_mobile
+@as_student @no_mobile
 Scenario: Gamelab Flow
   Given I am on "http://studio.code.org/projects/gamelab"
   And I get redirected to "/projects/gamelab/([^\/]*?)/edit" via "dashboard"
@@ -101,7 +101,7 @@ Scenario: Gamelab Flow
   And I wait to see "#codeWorkspace"
   And selector "#codeWorkspace" has class "readonly"
 
-@dashboard_db_access @as_student
+@as_student
 @no_mobile
 Scenario: Remix project creates and redirects to new channel
   Given I am on "http://studio.code.org/projects/gamelab"

--- a/dashboard/test/ui/features/projects/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/projects/personal_project_gallery.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @no_mobile
 
 Feature: Personal Project Gallery

--- a/dashboard/test/ui/features/projects/starwars_project.feature
+++ b/dashboard/test/ui/features/projects/starwars_project.feature
@@ -1,6 +1,6 @@
 Feature: Starwars Project
 
-@dashboard_db_access @as_student @no_mobile
+@as_student @no_mobile
 Scenario: Starwars Flow
   Given I am on "http://studio.code.org/projects/starwars"
   And I get redirected to "/projects/starwars/([^\/]*?)/edit" via "dashboard"

--- a/dashboard/test/ui/features/race_interstitial.feature
+++ b/dashboard/test/ui/features/race_interstitial.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 @as_student
 Feature: Race Interstitial
 

--- a/dashboard/test/ui/features/script_overview.feature
+++ b/dashboard/test/ui/features/script_overview.feature
@@ -1,9 +1,7 @@
-@dashboard_db_access
 Feature: Script overview page
 
   Scenario: Viewing student progress
     Given I create an authorized teacher-associated student named "Sally"
-    And I give user "Teacher_Sally" hidden script access
 
     # Make progress as student
     And I complete the level on "http://studio.code.org/s/allthethings/stage/2/puzzle/1"

--- a/dashboard/test/ui/features/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/section_action_dropdown.feature
@@ -4,13 +4,12 @@ Feature: Using the SectionActionDropdown
   # * Check that we get redirected to the right page
   Scenario: Viewing progress from SectionActionDropdown
     Given I create a teacher-associated student named "Sally"
-    And I give user "Teacher_Sally" hidden script access
     And I complete the level on "http://studio.code.org/s/allthethings/stage/2/puzzle/1"
     And I complete the free response on "http://studio.code.org/s/allthethings/stage/27/puzzle/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/stage/33/puzzle/1"
     And I sign out
 
-    When I sign in as "Teacher_Sally"
+    When I sign in as "Teacher_Sally" and go home
     And I open the section action dropdown
     And I press the child number 0 of class ".pop-up-menu-item"
     And I wait until current URL contains "/progress"
@@ -18,8 +17,7 @@ Feature: Using the SectionActionDropdown
   # * Check that we get redirected to the right page
   Scenario: Managing students from SectionActionDropdown
     Given I am a teacher
-    And I am on "http://studio.code.org/"
-    And I create a new section
+    And I create a new section and go home
     And I open the section action dropdown
     And I press the child number 1 of class ".pop-up-menu-item"
     And I wait until current URL contains "/manage"
@@ -27,8 +25,7 @@ Feature: Using the SectionActionDropdown
   # * Check that we get redirected to the right page
   Scenario: Printing Login Cards from SectionActionDropdown
     Given I am a teacher
-    And I am on "http://studio.code.org/"
-    And I create a new section
+    And I create a new section and go home
     And I open the section action dropdown
     And I press the child number 2 of class ".pop-up-menu-item"
     And I wait until current URL contains "/login_info"
@@ -38,8 +35,7 @@ Feature: Using the SectionActionDropdown
   #     * If the save button cannot be pressed, we do not have focus in the right dialog.
   Scenario: Editing Section Information from SectionActionDropdown
     Given I am a teacher
-    And I am on "http://studio.code.org/"
-    And I create a new section
+    And I create a new section and go home
     And I open the section action dropdown
     And I press the child number 3 of class ".pop-up-menu-item"
     And I press the first ".uitest-saveButton" element
@@ -52,8 +48,7 @@ Feature: Using the SectionActionDropdown
   #   * Check that the option to hide the section is available again
   Scenario: Hiding/Showing Section from SectionActionDropdown
     Given I am a teacher
-    And I am on "http://studio.code.org/"
-    And I create a new section
+    And I create a new section and go home
     And I open the section action dropdown
     And I press the child number 4 of class ".pop-up-menu-item"
     And I wait until I don't see selector ".ui-test-section-dropdown"

--- a/dashboard/test/ui/features/signing_in.feature
+++ b/dashboard/test/ui/features/signing_in.feature
@@ -1,12 +1,9 @@
-@dashboard_db_access
-@no_mobile
+# @no_mobile
 
 Feature: Signing in and signing out
 
 Scenario: Student sign in from code.org
-  Given I am on "http://code.org/"
-  And I set the language cookie
-  And I create a student named "Bob"
+  Given I create a student named "Bob"
   And I sign out
   Given I am on "http://code.org/"
   And I reload the page
@@ -14,16 +11,14 @@ Scenario: Student sign in from code.org
   Then I click ".header_user"
   And I wait to see "#signin"
   And I fill in username and password for "Bob"
-  And I click "#signin-button"
+  And I click "#signin-button" to load a new page
   Then I wait until I am on "http://studio.code.org/home"
   Then I wait to see ".user_menu"
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Bob"
 
 Scenario: Student sign in from studio.code.org
-  Given I am on "http://studio.code.org/"
-  And I set the language cookie
-  And I create a student named "Alice"
+  Given I create a student named "Alice"
   And I sign out
   Given I am on "http://studio.code.org/"
   And I reload the page
@@ -31,16 +26,14 @@ Scenario: Student sign in from studio.code.org
   Then I click ".header_user"
   And I wait to see "#signin"
   And I fill in username and password for "Alice"
-  And I click "#signin-button"
+  And I click "#signin-button" to load a new page
   Then I wait until I am on "http://studio.code.org/home"
   Then I wait to see ".user_menu"
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Alice"
 
 Scenario: Student sign in from studio.code.org in the eu
-  Given I am on "http://studio.code.org/"
-  And I set the language cookie
-  And I create a student in the eu named "Alice"
+  Given I create a student in the eu named "Alice"
   And I sign out
   Given I am on "http://studio.code.org/"
   And I reload the page
@@ -48,16 +41,14 @@ Scenario: Student sign in from studio.code.org in the eu
   Then I click ".header_user"
   And I wait to see "#signin"
   And I fill in username and password for "Alice"
-  And I click "#signin-button"
+  And I click "#signin-button" to load a new page
   Then I wait until I am on "http://studio.code.org/home"
   Then I wait to see ".user_menu"
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Alice"
 
 Scenario: Teacher sign in from studio.code.org
-  Given I am on "http://studio.code.org/"
-  And I set the language cookie
-  And I create a teacher named "Casey"
+  Given I create a teacher named "Casey"
   And I sign out
   Given I am on "http://code.org/"
   And I reload the page
@@ -74,7 +65,7 @@ Scenario: Teacher sign in from studio.code.org
 Scenario: Join non-existent section from sign in page shows error
   Given I am on "http://studio.code.org/users/sign_in/"
   And I type "9999999999" into "#section_code"
-  And I click ".section-sign-in button"
+  And I click ".section-sign-in button" to load a new page
   Then I wait until I am on "http://studio.code.org/courses"
   Then I wait to see ".alert-danger"
   And element ".alert-danger" contains text "Could not find a section with code"
@@ -84,7 +75,6 @@ Scenario: Join existing section from sign in page goes to section join page
   Given I sign out
   Given I am on "http://studio.code.org/users/sign_in/"
   And I type the section code into "#section_code"
-  And I click ".section-sign-in button"
-  Then I wait until current URL contains "http://studio.code.org/join"
+  And I click ".section-sign-in button" to load a new page
   Then I wait to see ".main"
   And element ".main" contains text "Register to join the class"

--- a/dashboard/test/ui/features/spritelab/eyes.feature
+++ b/dashboard/test/ui/features/spritelab/eyes.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 @as_student
 Feature: Sprite Lab Eyes
 

--- a/dashboard/test/ui/features/stage_lock.feature
+++ b/dashboard/test/ui/features/stage_lock.feature
@@ -1,4 +1,3 @@
-@dashboard_db_access
 Feature: Stage Locking
 
 Background:

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -910,30 +910,21 @@ And(/^I set the pagemode cookie to "([^"]*)"$/) do |cookie_value|
   @browser.manage.add_cookie params
 end
 
-Given(/^I sign in as "([^"]*)"$/) do |name|
-  steps %Q{
-    Given I am on "http://studio.code.org/reset_session"
-    Then I am on "http://studio.code.org/"
-    And I wait to see "#signin_button"
-    Then I click ".header_user"
-    And I wait to see "#signin"
-    And I fill in username and password for "#{name}"
-    And I click "#signin-button" to load a new page
-    And I wait to see ".header_user"
-  }
+Given(/^I sign in as "([^"]*)"( and go home)?$/) do |name, home|
+  navigate_to replace_hostname('http://studio.code.org/reset_session')
+  user = @users[name]
+  email = user[:email]
+  password = user[:password]
+  url = "/users/sign_in"
+  browser_request(url: url, method: 'POST', body: {user: {login: email, password: password}})
+
+  redirect = 'http://studio.code.org/home'
+  navigate_to replace_hostname(redirect) if home
 end
 
 Given(/^I sign out and sign in as "([^"]*)"$/) do |name|
-  individual_steps %Q{
-    Given I am on "http://studio.code.org/reset_session"
-    And I wait for 5 seconds
-    Then I am on "http://studio.code.org/"
-    And I wait to see "#signin_button"
-    Then I click ".header_user"
-    And I wait to see "#signin"
-    And I fill in username and password for "#{name}"
-    And I click "#signin-button"
-    And I wait to see ".header_user"
+  steps %Q{
+    And I sign in as "#{name}"
   }
 end
 
@@ -947,64 +938,31 @@ Given(/^I sign in as "([^"]*)" from the sign in page$/) do |name|
   }
 end
 
-Given(/^I am a (student|teacher)$/) do |user_type|
+Given(/^I am a (student|teacher)( and go home)?$/) do |user_type, home|
   random_name = "Test#{user_type.capitalize} " + SecureRandom.base64
   steps %Q{
-    And I create a #{user_type} named "#{random_name}"
+    And I create a #{user_type} named "#{random_name}"#{home}
   }
 end
 
-def enroll_in_plc_course(user_email)
-  require_rails_env
-  user = User.find_by_email_or_hashed_email(user_email)
-  course = Course.find_by(name: 'All The PLC Things')
-  enrollment = Plc::UserCourseEnrollment.create(user: user, plc_course: course.plc_course)
-  enrollment.plc_unit_assignments.update_all(status: Plc::EnrollmentUnitAssignment::IN_PROGRESS)
-end
-
 Given(/^I am enrolled in a plc course$/) do
-  enroll_in_plc_course(@users.first[1][:email])
-end
-
-def create_user(**args)
-  name = "Fake User"
-  email, password = generate_user(name)
-  attributes = {
-    name: name,
-    email: email,
-    password: password,
-    user_type: "teacher",
-    age: "21+"
-  }.merge!(args)
-  user = User.new(attributes)
-  user.save ? user : nil
-end
-
-def assign_script_as_student(user_email, script_name)
-  require_rails_env
-  script = Script.find_by_name(script_name)
-  section = Section.create(name: "New Section", user: create_user, script: script)
-  user = User.find_by_email_or_hashed_email(user_email)
-  section.students << user
+  browser_request(url: '/api/test/enroll_in_plc_course', method: 'POST')
 end
 
 Given(/^I am assigned to script "([^"]*)"$/) do |script_name|
-  assign_script_as_student(@users.first[1][:email], script_name)
-end
-
-Then(/^I fake completion of the assessment$/) do
-  user = User.find_by_email_or_hashed_email(@users.first[1][:email])
-  unit_assignment = Plc::EnrollmentUnitAssignment.find_by(user: user)
-  unit_assignment.enroll_user_in_unit_with_learning_modules(
-    [
-      unit_assignment.plc_course_unit.plc_learning_modules.find_by(module_type: Plc::LearningModule::CONTENT_MODULE),
-      unit_assignment.plc_course_unit.plc_learning_modules.find_by(module_type: Plc::LearningModule::PRACTICE_MODULE)
-    ]
+  browser_request(
+    url: '/api/test/assign_script_as_student',
+    method: 'POST',
+    body: {script_name: script_name}
   )
 end
 
+Then(/^I fake completion of the assessment$/) do
+  browser_request(url: '/api/test/fake_completion_assessment', method: 'POST', code: 204)
+end
+
 def generate_user(name)
-  email = "user#{Time.now.to_i}_#{rand(1000)}@testing.xx"
+  email = "user#{Time.now.to_i}_#{rand(1_000_000)}@test.xx"
   password = name + "password" # hack
   @users ||= {}
   @users[name] = {
@@ -1014,94 +972,16 @@ def generate_user(name)
   return email, password
 end
 
-def create_section_and_join_as_student(name, email, password, u13 = false)
-  age = u13 ? 10 : 16
-  individual_steps %Q{
-    Then I am on "http://studio.code.org/home"
-    And I dismiss the language selector
-
-    Then I see the section set up box
-    And I create a new section
-    And I save the section url
-
-    Then I sign out
-    And I navigate to the section url
-    And I wait until I am on the join page
-    And I wait to see "#user_name"
-    And I type "#{name}" into "#user_name"
-    And I type "#{email}" into "#user_email"
-    And I type "#{password}" into "#user_password"
-    And I type "#{password}" into "#user_password_confirmation"
-    And I select the "#{age}" option in dropdown "user_age"
-    And I click selector "input[type=submit]" once I see it
-    And I wait until I am on "http://studio.code.org/home"
-  }
-end
-
-def generate_teacher_student(name, teacher_authorized, student_u13 = false)
-  email, password = generate_user(name)
-
-  steps %Q{
-    Given I create a teacher named "Teacher_#{name}"
-  }
-
-  # enroll in a plc course as a way of becoming an authorized teacher
-  enroll_in_plc_course(@users["Teacher_#{name}"][:email]) if teacher_authorized
-
-  create_section_and_join_as_student(name, email, password, student_u13)
-end
-
-def generate_two_teachers_per_student(name, teacher_authorized)
-  email, password = generate_user(name)
-
-  steps %Q{
-    Given I create a teacher named "First_Teacher"
-  }
-
-  # enroll in a plc course as a way of becoming an authorized teacher
-  enroll_in_plc_course(@users["First_Teacher"][:email]) if teacher_authorized
-
-  create_section_and_join_as_student(name, email, password)
-
-  steps %Q{
-    Given I create a teacher named "Second_Teacher"
-  }
-
-  # enroll in a plc course as a way of becoming an authorized teacher
-  enroll_in_plc_course(@users["Second_Teacher"][:email]) if teacher_authorized
-
-  individual_steps %Q{
-    Then I am on "http://studio.code.org/home"
-    And I dismiss the language selector
-
-    Then I see the section set up box
-    And I create a new section
-    And I save the section url
-  }
-  individual_steps %Q{
-    Then I sign out
-    And I sign in as "#{name}"
-    And I am on "#{@section_url}"
-    And I wait until I am on "http://studio.code.org/home"
-  }
-end
-
 And /^I check the pegasus URL$/ do
   pegasus_url = @browser.execute_script('return window.dashboard.CODE_ORG_URL')
   puts "Pegasus URL is #{pegasus_url}"
 end
 
-And /^I create a new section$/ do
-  individual_steps %Q{
-    When I see the section set up box
-    When I press the new section button
-    Then I should see the new section dialog
-
-    When I select email login
-    And I press the save button to create a new section
-    And I wait for the dialog to close
-    Then I should see the section table
-  }
+And /^I create a new section( and go home)?$/ do |home|
+  section = JSON.parse(browser_request(url: '/dashboardapi/sections', method: 'POST', body: {login_type: 'email'}))
+  section_code = section['code']
+  @section_url = "http://studio.code.org/join/#{section_code}"
+  navigate_to replace_hostname('http://studio.code.org') if home
 end
 
 And /^I create a new section with course "([^"]*)", version "([^"]*)"(?: and unit "([^"]*)")?$/ do |assignment_family, version_year, secondary|
@@ -1140,95 +1020,133 @@ And /^I dismiss the language selector$/ do
   }
 end
 
-And(/^I create a teacher-associated student named "([^"]*)"$/) do |name|
-  generate_teacher_student(name, false)
+And(/^I create a(n authorized)? teacher-associated( under-13)? student named "([^"]*)"$/) do |authorized, under_13, name|
+  steps "Given I create a teacher named \"Teacher_#{name}\""
+  # enroll in a plc course as a way of becoming an authorized teacher
+  steps 'And I am enrolled in a plc course' if authorized
+
+  section = JSON.parse(browser_request(url: '/dashboardapi/sections', method: 'POST', body: {login_type: 'email'}))
+  section_code = section['code']
+  @section_url = "http://studio.code.org/join/#{section_code}"
+  create_user(name, url: "/join/#{section_code}", code: 200, age: under_13 ? '10' : '16')
 end
 
-And(/^I create a teacher-associated under-13 student named "([^"]*)"$/) do |name|
-  generate_teacher_student(name, false, true)
-end
+def sign_up(name)
+  wait_proc = proc do
+    opacity = @browser.execute_script <<JS
+field = document.querySelector('#email-block > .error_in_field');
+return field ? parseInt(window.getComputedStyle(field).opacity) : 0;
+JS
+    expect(opacity).to eq(0)
+  end
+  page_load(wait_proc: wait_proc) do
+    steps %Q{
+      And I click selector "#signup-button"
+    }
+  end
+rescue RSpec::Expectations::ExpectationNotMetError
+  tries ||= 0
+  raise if (tries += 1) >= 5
+  sleep 1
 
-And(/^I create two teachers associated with a student named "([^"]*)"$/) do |name|
-  generate_two_teachers_per_student(name, false)
-end
-
-And(/^I create an authorized teacher-associated student named "([^"]*)"$/) do |name|
-  generate_teacher_student(name, true)
-end
-
-And(/^I create a student named "([^"]*)"$/) do |name|
-  email, password = generate_user(name)
-
+  email, _ = generate_user(name)
   steps %Q{
-    Given I am on "http://studio.code.org/users/sign_up"
-    And I wait to see "#user_name"
-    And I select the "Student" option in dropdown "user_user_type"
-    And I type "#{name}" into "#user_name"
     And I type "#{email}" into "#user_email"
-    And I type "#{password}" into "#user_password"
-    And I type "#{password}" into "#user_password_confirmation"
-    And I select the "16" option in dropdown "user_user_age"
-    And I click selector "#user_terms_of_service_version"
-    And I click selector "#signup-button"
-    And I wait until I am on "http://studio.code.org/home"
   }
+  retry
+end
+
+# Call `execute_async_script` on the provided `js` code.
+# Provides a workaround for Appium (mobile) which doesn't support execute_async_script on HTTPS.
+# For Appium, wrap `execute_script` with a polling wait on a window variable that records the result.
+def js_async(js, *args, callback_fn: 'callback', finished_var: 'window.asyncCallbackFinished')
+  supports_async = !@browser.capabilities['mobile']
+  if supports_async
+    js = "var #{callback_fn} = arguments[arguments.length - 1];\n#{js}"
+    @browser.execute_async_script(js, *args)
+  else
+    js = <<-JS
+#{finished_var} = undefined;
+var #{callback_fn} = function(result) { #{finished_var} = result; };
+#{js}
+    JS
+    @browser.execute_script(js, *args)
+    wait_short_until {@browser.execute_script("return #{finished_var};")}
+  end
+end
+
+# Send an asynchronous XmlHttpRequest from the browser.
+def browser_request(url:, method: 'GET', headers: {}, body: nil, code: 200, tries: 3)
+  if body
+    headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    body = "'#{body.to_param}'" if body
+  end
+
+  js = <<-JS
+var xhr = new XMLHttpRequest();
+xhr.open('#{method}', '#{url}', true);
+#{headers.map {|k, v| "xhr.setRequestHeader('#{k}', '#{v}');"}.join("\n")}
+var csrf = document.head.querySelector("meta[name='csrf-token']")
+if (csrf) {
+  xhr.setRequestHeader('X-Csrf-Token', csrf.content)
+}
+xhr.onreadystatechange = function() {
+  if (xhr.readyState === 4) {
+    callback(JSON.stringify({
+      status: xhr.status,
+      response: xhr.responseText
+    }));
+  }
+};
+xhr.send(#{body});
+  JS
+  Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, tries: tries) do
+    result = js_async(js)
+    status, response = JSON.parse(result).slice('status', 'response').values
+    expect(status).to eq(code), "Error code #{status}:\n#{response}"
+    response
+  end
+end
+
+def create_user(name, url: '/users.json', code: 201, **user_opts)
+  navigate_to replace_hostname('http://studio.code.org/reset_session')
+  Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, tries: 3) do
+    email, password = generate_user(name)
+    browser_request(
+      url: url,
+      method: 'POST',
+      body: {
+        user: {
+          user_type: 'student',
+          email: email,
+          password: password,
+          password_confirmation: password,
+          name: name,
+          age: '16',
+          terms_of_service_version: '1'
+        }.merge(user_opts)
+      },
+      code: code
+    )
+  end
+end
+
+And(/^I create a (young )?student named "([^"]*)"( and go home)?$/) do |young, name, home|
+  age = young ? '10' : '16'
+  create_user(name, age: age)
+  navigate_to replace_hostname('http://studio.code.org') if home
 end
 
 And(/^I create a student in the eu named "([^"]*)"$/) do |name|
-  email, password = generate_user(name)
-
-  steps %Q{
-    Given I am on "http://studio.code.org/users/sign_up?force_in_eu=1"
-    And I wait to see "#user_name"
-    And I select the "Student" option in dropdown "user_user_type"
-    And I type "#{name}" into "#user_name"
-    And I type "#{email}" into "#user_email"
-    And I type "#{password}" into "#user_password"
-    And I type "#{password}" into "#user_password_confirmation"
-    And I select the "16" option in dropdown "user_user_age"
-    And I click selector "#user_terms_of_service_version"
-    And I click selector "#user_data_transfer_agreement_accepted"
-    And I click selector "#signup-button"
-    And I wait until I am on "http://studio.code.org/home"
-  }
+  create_user(name,
+    data_transfer_agreement_required: '1',
+    data_transfer_agreement_accepted: '1'
+  )
 end
 
-And(/^I create a young student named "([^"]*)"$/) do |name|
-  email, password = generate_user(name)
-
-  steps %Q{
-    Given I am on "http://studio.code.org/users/sign_up"
-    And I wait to see "#user_name"
-    And I select the "Student" option in dropdown "user_user_type"
-    And I type "#{name}" into "#user_name"
-    And I type "#{email}" into "#user_email"
-    And I type "#{password}" into "#user_password"
-    And I type "#{password}" into "#user_password_confirmation"
-    And I select the "10" option in dropdown "user_user_age"
-    And I click selector "#user_terms_of_service_version"
-    And I click selector "#signup-button"
-    And I wait until I am on "http://studio.code.org/home"
-  }
-end
-
-And(/^I create a teacher named "([^"]*)"$/) do |name|
-  email, password = generate_user(name)
-
-  steps %Q{
-    Given I am on "http://studio.code.org/reset_session"
-    Given I am on "http://studio.code.org/users/sign_up"
-    And I wait to see "#user_name"
-    And I select the "Teacher" option in dropdown "user_user_type"
-    And I wait to see "#schooldropdown-block"
-    And I type "#{name}" into "#user_name"
-    And I type "#{email}" into "#user_email"
-    And I type "#{password}" into "#user_password"
-    And I type "#{password}" into "#user_password_confirmation"
-    And I select the "Yes" option in dropdown "user_email_preference_opt_in"
-    And I click selector "#user_terms_of_service_version"
-    And I click selector "#signup-button" to load a new page
-    And I wait until I am on "http://studio.code.org/home"
-  }
+And(/^I create a teacher named "([^"]*)"( and go home)?$/) do |name, home|
+  create_user(name, age: '21+', user_type: 'teacher', email_preference_opt_in: 'yes')
+  navigate_to replace_hostname('http://studio.code.org') if home
 end
 
 And(/^I submit this level$/) do
@@ -1241,10 +1159,8 @@ And(/^I submit this level$/) do
   }
 end
 
-And(/^I give user "([^"]*)" hidden script access$/) do |name|
-  require_rails_env
-  user = User.find_by_email_or_hashed_email(@users[name][:email])
-  user.permission = UserPermission::HIDDEN_SCRIPT_ACCESS
+And(/^I get hidden script access$/) do
+  browser_request(url: '/api/test/hidden_script_access', method: 'POST')
 end
 
 And(/^I save the section url$/) do
@@ -1309,10 +1225,12 @@ And(/I type the section code into "([^"]*)"$/) do |selector|
 end
 
 When(/^I sign out$/) do
-  steps %Q{
-    And I am on "http://studio.code.org/users/sign_out"
-    And I wait until current URL contains "http://code.org/"
-  }
+  if @browser.current_url.include?('studio')
+    browser_request(url: replace_hostname('/users/sign_out.json'), code: 204)
+    @browser.execute_script("sessionStorage.clear(); localStorage.clear();")
+  else
+    navigate_to replace_hostname('http://studio.code.org/reset_session')
+  end
 end
 
 When(/^I am not signed in/) do
@@ -1634,6 +1552,7 @@ Then /^I should see the section table$/ do
 end
 
 Then /^the section table should have (\d+) rows?$/ do |expected_row_count|
+  wait_short_until {steps 'Then I should see the section table'}
   row_count = @browser.execute_script(<<-SCRIPT)
     return document.querySelectorAll('.uitest-owned-sections tbody tr').length;
   SCRIPT

--- a/dashboard/test/ui/features/submittable_eyes.feature
+++ b/dashboard/test/ui/features/submittable_eyes.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 @as_authorized_taught_student
 Feature: Submittable level
 

--- a/dashboard/test/ui/features/support/browser_helpers.rb
+++ b/dashboard/test/ui/features/support/browser_helpers.rb
@@ -12,11 +12,12 @@ module BrowserHelpers
   end
 
   def element_has_i18n_text(selector, language, loc_key)
-    require_rails_env
     loc_key.gsub!('\"', '"')
     # grab text from the browser, replacing non-breaking spaces with regular ones
     text = @browser.execute_script("return $(\"#{selector}\").text().replace(/\u00a0/g, ' ');")
-    text.should eq I18n.t loc_key, locale: language
+    # Get localized text from server
+    response = HTTParty.get(replace_hostname("http://studio.code.org/api/test/get_i18n_t?key=#{loc_key}&locale=#{language}")).parsed_response
+    text.should eq response
   end
 
   def element_text(selector)

--- a/dashboard/test/ui/features/support/dashboard_helpers.rb
+++ b/dashboard/test/ui/features/support/dashboard_helpers.rb
@@ -1,11 +1,13 @@
 module DashboardHelpers
   # Requires the full rails environment. Use sparingly, known to take 20-30s.
   def require_rails_env
+    return if @rails_loaded
     puts 'Requiring rails env'
     start = Time.now
     require File.expand_path('../../../../../config/environment.rb', __FILE__)
     finish = Time.now
     puts "Requiring rails env took #{finish - start} seconds"
+    @rails_loaded = true
   end
 end
 

--- a/dashboard/test/ui/features/support/hooks.rb
+++ b/dashboard/test/ui/features/support/hooks.rb
@@ -2,45 +2,20 @@ Before('@as_student') do
   steps "Given I create a student named \"Test #{rand(100000)}_Student\""
 end
 
-After('@as_student') do |scenario|
-  check_window_for_js_errors('after @as_student')
-  steps 'When I sign out' if scenario.passed?
-end
-
 Before('@as_young_student') do
   steps "Given I create a young student named \"Test #{rand(100000)}_Student\""
-end
-
-After('@as_young_student') do |scenario|
-  check_window_for_js_errors('after @as_young_student')
-  steps 'When I sign out' if scenario.passed?
 end
 
 Before('@as_taught_student') do
   steps "Given I create a teacher-associated student named \"Taught #{rand(100000)}_Student\""
 end
 
-After('@as_taught_student') do |scenario|
-  check_window_for_js_errors('after @as_taught_student')
-  steps 'When I sign out' if scenario.passed?
-end
-
 Before('@as_authorized_taught_student') do
   steps "Given I create an authorized teacher-associated student named \"Taught #{rand(100000)}_Student\""
 end
 
-After('@as_authorized_taught_student') do |scenario|
-  check_window_for_js_errors('after @as_authorized_taught_student')
-  steps 'When I sign out' if scenario.passed?
-end
-
 Before('@as_teacher') do
   steps 'Given I am a teacher'
-end
-
-After('@as_teacher') do |scenario|
-  check_window_for_js_errors('after @as_teacher')
-  steps 'When I sign out' if scenario.passed?
 end
 
 # Add After hook as the last one, which results in it being run before

--- a/dashboard/test/ui/features/teacher_dashboard/assessment_feedback_download.feature
+++ b/dashboard/test/ui/features/teacher_dashboard/assessment_feedback_download.feature
@@ -1,11 +1,8 @@
 @no_mobile
-@dashboard_db_access
 Feature: Using the assessments tab in the teacher dashboard to get feedback for script
 
   Background:
     Given I create an authorized teacher-associated student named "Sally"
-    And I give user "Teacher_Sally" hidden script access
-    And I sign out
 
   Scenario: Assessments tab has feedback download
     # Assign a script with a survey but no assessment
@@ -42,8 +39,7 @@ Feature: Using the assessments tab in the teacher dashboard to get feedback for 
   Scenario: Assessments tab does not have feedback download
 
    # Assign a script without feedback
-    When I sign in as "Teacher_Sally"
-    And I am on "http://studio.code.org/home"
+    When I sign in as "Teacher_Sally" and go home
     And I click selector ".ui-test-section-dropdown" once I see it
     And I click selector ".edit-section-details-link"
     And I wait until element "#uitest-assignment-family" is visible

--- a/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard.feature
@@ -1,15 +1,12 @@
 @no_mobile
-@dashboard_db_access
-@pegasus_db_access
 Feature: Using the teacher dashboard
 
   Scenario: Visiting student name URLs in old and new teacher dashboard
     Given I create an authorized teacher-associated student named "Sally"
-    And I give user "Teacher_Sally" hidden script access
     And I complete the level on "http://studio.code.org/s/allthethings/stage/2/puzzle/1"
-    And I sign out
 
-    When I sign in as "Teacher_Sally"
+    When I sign in as "Teacher_Sally" and go home
+    And I get hidden script access
     When I click selector "a:contains(Untitled Section)" once I see it to load a new page
     And I wait until element "#uitest-teacher-dashboard-nav" is visible
     And check that the URL contains "/teacher_dashboard/sections/"
@@ -22,15 +19,13 @@ Feature: Using the teacher dashboard
 
   Scenario: Viewing a student
     Given I create an authorized teacher-associated student named "Sally"
-    And I give user "Teacher_Sally" hidden script access
     And I complete the level on "http://studio.code.org/s/allthethings/stage/2/puzzle/1"
     And I complete the free response on "http://studio.code.org/s/allthethings/stage/27/puzzle/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/stage/33/puzzle/1"
-    And I sign out
 
     # Progress tab
-    When I sign in as "Teacher_Sally"
-    And I am on "http://studio.code.org/home"
+    When I sign in as "Teacher_Sally" and go home
+    And I get hidden script access
     And I wait until element "a:contains('Untitled Section')" is visible
     And I save the section id from row 0 of the section table
     Then I navigate to teacher dashboard for the section I saved
@@ -83,9 +78,8 @@ Feature: Using the teacher dashboard
 
     And I wait until element ".project_edit" is visible
     Then element ".project_name.header_text" contains text "thumb wars"
-    And I sign out
 
-    When I sign in as "Teacher_Sally"
+    When I sign in as "Teacher_Sally" and go home
     And I wait until element "a:contains('Untitled Section')" is visible
     And I save the section id from row 0 of the section table
     Then I navigate to teacher dashboard for the section I saved
@@ -97,15 +91,13 @@ Feature: Using the teacher dashboard
 
   Scenario: Toggling student progress
     Given I create an authorized teacher-associated student named "Sally"
-    And I give user "Teacher_Sally" hidden script access
     And I complete the level on "http://studio.code.org/s/allthethings/stage/2/puzzle/1"
     And I complete the free response on "http://studio.code.org/s/allthethings/stage/27/puzzle/1"
     And I submit the assessment on "http://studio.code.org/s/allthethings/stage/33/puzzle/1"
-    And I sign out
 
     # Progress tab
-    When I sign in as "Teacher_Sally"
-    And I am on "http://studio.code.org/home"
+    When I sign in as "Teacher_Sally" and go home
+    And I get hidden script access
     And I wait until element "a:contains('Untitled Section')" is visible
     And I save the section id from row 0 of the section table
     Then I navigate to teacher dashboard for the section I saved
@@ -204,12 +196,9 @@ Feature: Using the teacher dashboard
     # Wait for the thumbnail URL to be sent to the server.
     And I wait until element ".project_updated_at" contains text "Saved"
 
-    And I sign out
-
     # Load the section projects page
 
-    When I sign in as "Teacher_Sally"
-    Then I am on "http://studio.code.org/home"
+    When I sign in as "Teacher_Sally" and go home
     And I wait until element "a:contains('Untitled Section')" is visible
     And I save the section id from row 0 of the section table
     Then I navigate to teacher dashboard for the section I saved

--- a/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard_assessments1.feature
+++ b/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard_assessments1.feature
@@ -1,16 +1,12 @@
 @no_mobile
-@dashboard_db_access
-@pegasus_db_access
 Feature: Using the assessments tab in the teacher dashboard
 
   Scenario: Assessments tab initialization
     Given I create an authorized teacher-associated student named "Sally"
-    And I give user "Teacher_Sally" hidden script access
-    And I sign out
 
     # Assign a script with a survey but no assessment
-    When I sign in as "Teacher_Sally"
-    And I am on "http://studio.code.org/home"
+    When I sign in as "Teacher_Sally" and go home
+    And I get hidden script access
     And I click selector ".ui-test-section-dropdown" once I see it
     And I click selector ".edit-section-details-link"
     And I wait until element "#uitest-assignment-family" is visible

--- a/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard_assessments2.feature
@@ -1,37 +1,29 @@
 @no_mobile
-@dashboard_db_access
-@pegasus_db_access
 Feature: Using the assessments tab in the teacher dashboard
 
   Scenario: Assessments tab survey submissions
     Given I create an authorized teacher-associated student named "Sally"
-    And I give user "Teacher_Sally" hidden script access
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
-    And I sign out
 
     And I create a student named "Student2"
     And I navigate to the section url
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
-    And I sign out
 
     And I create a student named "Student3"
     And I navigate to the section url
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
-    And I sign out
 
     And I create a student named "Student4"
     And I navigate to the section url
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
-    And I sign out
 
     And I create a student named "Student5"
     And I navigate to the section url
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
-    And I sign out
 
     # Assign a script with an unlocked survey
-    When I sign in as "Teacher_Sally"
-    And I am on "http://studio.code.org/home"
+    When I sign in as "Teacher_Sally" and go home
+    And I get hidden script access
     And I click selector ".ui-test-section-dropdown" once I see it
     And I click selector ".edit-section-details-link"
     And I wait until element "#uitest-assignment-family" is visible

--- a/dashboard/test/ui/features/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_homepage.feature
@@ -1,23 +1,21 @@
-@dashboard_db_access
-@pegasus_db_access
 @as_teacher
 @no_mobile
 Feature: Using the teacher homepage sections feature
 
   Scenario: Loading the teacher homepage with new sections
     # Create my first section (via the SetUpSections component)
-    When I see the section set up box
-    And I create a new section
+    When I create a new section and go home
     Then the section table should have 1 row
 
     And I wait until element "a:contains(Untitled Section)" is visible
     And the href of selector "a:contains(Untitled Section)" contains "/teacher_dashboard/sections/"
 
     # Create my second section (via the button in OwnedSections)
-    When I create a new section
+    When I create a new section and go home
     Then the section table should have 2 rows
 
   Scenario: Loading teacher homepage with course experiment enabled
+    Given I am on "http://studio.code.org/home"
     Given I enable the "subgoals-group-a" course experiment
     And I wait for the pegasus and dashboard experiment caches to expire
     And I reload the page
@@ -28,9 +26,10 @@ Feature: Using the teacher homepage sections feature
     And the section table row at index 0 has secondary assignment path "/s/csp3-a"
 
   Scenario: Navigate to course and unit pages
+    Given I am on "http://studio.code.org/home"
     When I see the section set up box
     And I create a new section with course "Computer Science Principles", version "'17-'18" and unit "CSP Unit 1 - The Internet ('17-'18)"
-    And I create a new section
+    And I create a new section and go home
     Then the section table should have 2 rows
 
     # save the older section id, from the last row of the table
@@ -91,6 +90,7 @@ Feature: Using the teacher homepage sections feature
     And element ".uitest-sectionselect" has value ""
 
   Scenario: Assign hidden unit to section
+    Given I am on "http://studio.code.org/home"
     And I create a new section with course "Computer Science Principles", version "'17-'18" and unit "CSP Unit 1 - The Internet ('17-'18)"
     Then the section table should have 1 rows
     And I save the section id from row 0 of the section table
@@ -173,7 +173,7 @@ Feature: Using the teacher homepage sections feature
 
   Scenario: Loading the print certificates page for a section
     Given I create a teacher-associated student named "Sally"
-    And I sign in as "Teacher_Sally"
+    And I sign in as "Teacher_Sally" and go home
     And I click selector ".ui-test-section-dropdown" once I see it
 
     And I click selector ".uitest-certs-link" once I see it

--- a/dashboard/test/ui/features/teacher_student_toggle.feature
+++ b/dashboard/test/ui/features/teacher_student_toggle.feature
@@ -1,5 +1,4 @@
 @eyes
-@dashboard_db_access
 Feature: Teacher Student Toggle
 
 Scenario: Toggle on Multi Level

--- a/dashboard/test/ui/features/user_menu.feature
+++ b/dashboard/test/ui/features/user_menu.feature
@@ -8,7 +8,7 @@ Scenario: Signed Out - sign in button shows
   And I wait until element ".display_name" is not visible
 
 Scenario: Teacher Signed In - shows display name with correct links
-  Given I create a teacher named "Ms_Frizzle"
+  Given I create a teacher named "Ms_Frizzle" and go home
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Ms_Frizzle"
   And I click selector ".display_name"
@@ -27,7 +27,7 @@ Scenario: Teacher Signed In - shows display name with correct links
   And I wait until element ".display_name" is not visible
 
 Scenario: Student Signed In - shows display name with correct links
-  Given I create a student named "Arnold"
+  Given I create a student named "Arnold" and go home
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Arnold"
   And I click selector ".display_name"
@@ -53,13 +53,9 @@ Scenario: Student Signed In - shows display name with correct links
 
 Scenario: Pair Programming
   Given I create a teacher named "Dr_Seuss"
-  Then I see the section set up box
   And I create a new section
-  And I save the section url
-  Then I sign out
   Given I create a student named "Thing_One"
   And I navigate to the section url
-  Then I sign out
   Given I create a student named "Thing_Two"
   And I navigate to the section url
   Given I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/7?noautoplay=true"

--- a/dashboard/test/ui/features/weblab/versions.feature
+++ b/dashboard/test/ui/features/weblab/versions.feature
@@ -1,7 +1,6 @@
 # Brad investigating (2018-04-25)
 @skip
 @no_circle
-@dashboard_db_access
 @as_student
 Feature: Weblab Versions
 

--- a/lib/cdo/rack/whitelist.rb
+++ b/lib/cdo/rack/whitelist.rb
@@ -95,6 +95,7 @@ module Rack
           request_cookies.keys.each do |key|
             response.add_header 'Vary', "X-COOKIE-#{key.tr('_', '-')}"
           end
+          response.add_header 'Vary', 'Cookie'
         end
         response.finish
       end


### PR DESCRIPTION
This PR refactors various UI test logic to trigger [TestController](https://github.com/code-dot-org/code-dot-org/pull/28251/files#diff-d4e8903f58c1830edd37ef247966089b) actions through `XMLHttpRequest` sent from the WebDriver-controlled browser. This eliminates the need to load the Rails environment in each UI test runner to perform these actions, simplifying the UI-test runners and speeding up the tests.

- Refactor sign-in / sign-out steps to use XHR endpoints instead of clicking through HTML form, to speed up overall test runs.
- Refactor teacher-associated section and student creation to use XHR endpoints.
- Add 'and go home' to steps that depend on navigation. (This speeds up tests that can skip the extra home-page navigation step, e.g., they care about a different page instead.)
- Remove redundant sign-out steps. (The sign-in step now clears the session on its own, so sign-out is only needed when explicitly testing signed-out pages, not when switching between sessions.)
- Remove @dashboard_db_access tags that are no longer needed. (These were only required when local database-access is needed, which will be much rarer with this PR change.)
- Run `require_rails_env` in a `Before` hook for all remaining `@dashboard_db_access` tags. (Rails loads _before_ a browser session is loaded so we don't occupy a browser session during this step.)