### PR TITLE
Don't show the scholarship dropdown for new facilitators attending summer workshops

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -103,6 +103,10 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
   }
 
   scholarshipInfo(enrollment) {
+    if (enrollment.new_facilitator) {
+      return <td>No (New Facilitator)</td>;
+    }
+
     if (
       this.props.permissionList.has(ProgramManager) ||
       this.props.permissionList.has(WorkshopAdmin)

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -103,8 +103,8 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
   }
 
   scholarshipInfo(enrollment) {
-    if (enrollment.new_facilitator) {
-      return <td>No (New Facilitator)</td>;
+    if (enrollment.scholarship_ineligible_reason) {
+      return <td>{enrollment.scholarship_ineligible_reason}</td>;
     }
 
     if (

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -35,6 +35,7 @@ class Pd::Enrollment < ActiveRecord::Base
   include Pd::SharedWorkshopConstants
   include Pd::WorkshopSurveyConstants
   include SerializedProperties
+  include Pd::Application::ActiveApplicationModels
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 
@@ -267,6 +268,14 @@ class Pd::Enrollment < ActiveRecord::Base
     if workshop.local_summer?
       Pd::ScholarshipInfo.find_by(user: user, application_year: workshop.summer_workshop_school_year)&.scholarship_status
     end
+  end
+
+  # Returns true if this enrollment is for a novice or apprentice facilitator (accepted this year)
+  # attending a local summer workshop as a participant to observe the facilitation techniques
+  def newly_accepted_facilitator?
+    workshop.local_summer? &&
+      workshop.summer_workshop_school_year == APPLICATION_CURRENT_YEAR &&
+      FACILITATOR_APPLICATION_CLASS.where(user_id: user_id).first&.status == 'accepted'
   end
 
   # Removes the name and email information stored within this Pd::Enrollment.

--- a/dashboard/app/models/pd/enrollment_constants.rb
+++ b/dashboard/app/models/pd/enrollment_constants.rb
@@ -1,0 +1,5 @@
+module Pd
+  module EnrollmentConstants
+    NO_NEW_FACILITATOR = "No (New Facilitator)"
+  end
+end

--- a/dashboard/app/models/pd/enrollment_constants.rb
+++ b/dashboard/app/models/pd/enrollment_constants.rb
@@ -1,5 +1,5 @@
 module Pd
   module EnrollmentConstants
-    NO_NEW_FACILITATOR = "No (New Facilitator)"
+    SCHOLARSHIP_INELIGIBLE_NEW_FACILITATOR = "No (New Facilitator)"
   end
 end

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -1,10 +1,9 @@
 class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
-  include Pd::Application::ActiveApplicationModels
   attributes :id, :first_name, :last_name, :email, :district_name, :school, :role,
     :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
     :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
     :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
-    :scholarship_status, :new_facilitator
+    :scholarship_status, :scholarship_ineligible_reason
 
   def user_id
     user = object.resolve_user
@@ -35,9 +34,7 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
     object.attendances.count
   end
 
-  def new_facilitator
-    object.workshop.local_summer? &&
-      object.workshop.summer_workshop_school_year == APPLICATION_CURRENT_YEAR &&
-      FACILITATOR_APPLICATION_CLASS.where(user_id: object.user_id).first&.status == 'accepted'
+  def scholarship_ineligible_reason
+    object.newly_accepted_facilitator? ? "No (New Facilitator)" : nil
   end
 end

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -35,6 +35,6 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
   end
 
   def scholarship_ineligible_reason
-    object.newly_accepted_facilitator? ? Pd::EnrollmentConstants::NO_NEW_FACILITATOR : nil
+    object.newly_accepted_facilitator? ? Pd::EnrollmentConstants::SCHOLARSHIP_INELIGIBLE_NEW_FACILITATOR : nil
   end
 end

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -1,9 +1,10 @@
 class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
+  include Pd::Application::ActiveApplicationModels
   attributes :id, :first_name, :last_name, :email, :district_name, :school, :role,
     :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
     :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
     :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
-    :scholarship_status
+    :scholarship_status, :new_facilitator
 
   def user_id
     user = object.resolve_user
@@ -32,5 +33,11 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
 
   def attendances
     object.attendances.count
+  end
+
+  def new_facilitator
+    object.workshop.local_summer? &&
+      object.workshop.summer_workshop_school_year == APPLICATION_CURRENT_YEAR &&
+      FACILITATOR_APPLICATION_CLASS.where(user_id: object.user_id).first&.status == 'accepted'
   end
 end

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -35,6 +35,6 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
   end
 
   def scholarship_ineligible_reason
-    object.newly_accepted_facilitator? ? "No (New Facilitator)" : nil
+    object.newly_accepted_facilitator? ? Pd::EnrollmentConstants::NO_NEW_FACILITATOR : nil
   end
 end

--- a/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
@@ -38,6 +38,6 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCa
     fac_app.update(status: 'accepted')
 
     serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(summer_workshop.enrollments.first).attributes
-    assert_equal NO_NEW_FACILITATOR, serialized[:scholarship_ineligible_reason]
+    assert_equal SCHOLARSHIP_INELIGIBLE_NEW_FACILITATOR, serialized[:scholarship_ineligible_reason]
   end
 end

--- a/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCase
   include Pd::Application::ActiveApplicationModels
+  include Pd::EnrollmentConstants
+
   test 'serialized workshop enrollment has expected attributes' do
     enrollment = create :pd_enrollment
     expected_attributes = [
@@ -9,7 +11,7 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCa
       :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
       :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
       :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
-      :scholarship_status, :new_facilitator
+      :scholarship_status, :scholarship_ineligible_reason
     ]
 
     serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(enrollment).attributes
@@ -25,17 +27,17 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCa
     assert_equal enrollment.attendances.count, serialized[:attendances]
   end
 
-  test 'new_facilitator' do
+  test 'scholarship_ineligible_reason' do
     summer_workshop = create :pd_workshop, :local_summer_workshop_upcoming
     enrollment = create :pd_enrollment, :from_user, workshop: summer_workshop
 
     serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(summer_workshop.enrollments.first).attributes
-    refute serialized[:new_facilitator]
+    assert_nil serialized[:scholarship_ineligible_reason]
 
     fac_app = create FACILITATOR_APPLICATION_FACTORY, user: enrollment.user
     fac_app.update(status: 'accepted')
 
     serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(summer_workshop.enrollments.first).attributes
-    assert serialized[:new_facilitator]
+    assert_equal NO_NEW_FACILITATOR, serialized[:scholarship_ineligible_reason]
   end
 end

--- a/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCase
+  include Pd::Application::ActiveApplicationModels
   test 'serialized workshop enrollment has expected attributes' do
     enrollment = create :pd_enrollment
     expected_attributes = [
@@ -8,7 +9,7 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCa
       :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
       :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
       :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
-      :scholarship_status
+      :scholarship_status, :new_facilitator
     ]
 
     serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(enrollment).attributes
@@ -22,5 +23,19 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCa
 
     serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(workshop.enrollments.first).attributes
     assert_equal enrollment.attendances.count, serialized[:attendances]
+  end
+
+  test 'new_facilitator' do
+    summer_workshop = create :pd_workshop, :local_summer_workshop_upcoming
+    enrollment = create :pd_enrollment, :from_user, workshop: summer_workshop
+
+    serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(summer_workshop.enrollments.first).attributes
+    refute serialized[:new_facilitator]
+
+    fac_app = create FACILITATOR_APPLICATION_FACTORY, user: enrollment.user
+    fac_app.update(status: 'accepted')
+
+    serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(summer_workshop.enrollments.first).attributes
+    assert serialized[:new_facilitator]
   end
 end


### PR DESCRIPTION
Another piece of [PLC-165](https://codedotorg.atlassian.net/browse/PLC-165)

New facilitators attend local summer workshops to observe and learn how to facilitate. This change hides the scholarship dropdown next to their name in the workshop dashboard, since facilitators do not receive scholarships.

<img width="1160" alt="Screen Shot 2019-04-26 at 4 43 06 PM" src="https://user-images.githubusercontent.com/224089/56841407-6a2d6180-6842-11e9-8d54-b66757c4dc0e.png">
