### PR TITLE
Refactor test flakiness calculations

### DIFF
--- a/bin/test_flakiness
+++ b/bin/test_flakiness
@@ -7,8 +7,9 @@
 require_relative '../deployment'
 require 'cdo/test_flakiness'
 require 'optparse'
+require 'fileutils'
 
-options = {limit: -1, reruns: false, recalc: false}
+options = {limit: -1, reruns: false, recalc: false, method: :test_flakiness}
 OptionParser.new do |opts|
   opts.banner = "Usage: #{File.basename(__FILE__)} [options]"
   opts.on('-n', '--limit N', 'Top N flakiest tests.') do |n|
@@ -20,21 +21,25 @@ OptionParser.new do |opts|
   opts.on('-c', '--recalc', 'Re-calculate from SauceLabs API.') do
     options[:recalc] = true
   end
+  opts.on('-d', '--duration', 'Show and sort by duration instead of flakiness.') do
+    options[:method] = :test_duration
+  end
+  opts.on('-e', '--estimate', 'Show and sort by flakiness-adjusted estimated duration.') do
+    options[:method] = :test_estimate
+  end
   opts.on('-h', '--help', 'Prints this help') do
     puts opts
     exit
   end
 end.parse!
 
-results = options[:recalc] ?
-  TestFlakiness.calculate_test_flakiness :
-  TestFlakiness.test_flakiness
+FileUtils.rm(TestFlakiness::CACHE_FILENAME) if options[:recalc]
 
-results.to_a.sort_by(&:last).reverse[0..options[:limit]].map do |name, flakiness|
+results = TestFlakiness.method(options[:method]).call
+results.to_a.sort_by(&:last).reverse[0..options[:limit]].map do |name, value|
+  result = [value, name]
   if options[:reruns]
-    max_reruns, confidence = TestFlakiness.recommend_reruns(flakiness)
-    puts "#{flakiness}\t#{max_reruns}\t#{confidence}\t#{name}"
-  else
-    puts "#{flakiness}\t#{name}"
+    result.insert(1, *TestFlakiness.recommend_reruns(TestFlakiness.test_flakiness[name]))
   end
+  puts result.join("\t")
 end

--- a/lib/cdo/test_flakiness.rb
+++ b/lib/cdo/test_flakiness.rb
@@ -1,4 +1,5 @@
 require 'rest-client'
+require 'cdo/cache_method'
 
 class TestFlakiness
   def self.sauce_username
@@ -39,31 +40,24 @@ class TestFlakiness
   # Summarizes the job results from SauceLabs.
   # @param num_requests [Integer] The number of API calls.
   # @param per_request [Integer] The number of results per call.
-  # @return [Array] Of summary including name, and total and failed counts.
+  # @return [Hash] Of summary by name including total and failed counts.
   def self.summarize_by_job(num_requests = NUM_REQUESTS, per_request = PER_REQUEST)
     jobs = []
     num_requests.times do
       jobs += get_jobs(limit: per_request, skip: jobs.count)
     end
     jobs.group_by {|job| job['name']}.map do |name, samples|
-      {
-        name: name,
-        total: samples.count,
-        failed: samples.count {|job| !job["passed"]}
+      passed = samples.select {|job| job['passed']}
+      next if passed.empty?
+      summary = {
+        'name' => name,
+        'total' => samples.count,
+        'failed' => samples.count - passed.count,
+        'fail_rate' => (1.0 * (samples.count - passed.count) / samples.count).round(2),
+        'duration' => 1.0 * passed.sum {|job| job['end_time'] - job['start_time']} / passed.count
       }
-    end
-  end
-
-  # Calculates the flakiness per test
-  # @return [Hash] The test name to flakiness score.
-  def self.calculate_test_flakiness
-    name_to_flakiness = {}
-    summarize_by_job.each do |summary|
-      if summary[:total] > MIN_SAMPLES
-        name_to_flakiness[summary[:name]] = (1.0 * summary[:failed] / summary[:total]).round(2)
-      end
-    end
-    name_to_flakiness
+      [name, summary]
+    end.compact.to_h
   end
 
   # Recommends a number of re-runs based on the flakiness score.
@@ -76,23 +70,52 @@ class TestFlakiness
     return [max_reruns, confidence]
   end
 
-  CACHE_FILENAME = (File.dirname(__FILE__) + "/../../dashboard/tmp/cache/flakiness.json").freeze
+  CACHE_FILENAME = (File.dirname(__FILE__) + "/../../dashboard/tmp/cache/test_summary.json").freeze
   CACHE_TTL = 86400 # 1 day of seconds
 
-  def self.cache_test_flakiness
+  using CacheMethod
+
+  cached def self.test_summary
     if File.exist?(CACHE_FILENAME) &&
         (Time.now - File.mtime(CACHE_FILENAME)) < CACHE_TTL
       return JSON.parse(File.read(CACHE_FILENAME))
     end
 
-    @@test_flakiness = calculate_test_flakiness
-
-    File.open(CACHE_FILENAME, 'w') {|f| f.write(JSON.dump(@@test_flakiness))}
-
-    @@test_flakiness
+    summarize_by_job.reject {|_, s| s['total'] < MIN_SAMPLES}.tap do |summary|
+      File.write(CACHE_FILENAME, JSON.dump(summary))
+    end
   end
 
-  def self.test_flakiness
-    @@test_flakiness ||= cache_test_flakiness
+  cached def self.test_flakiness
+    test_summary.transform_values {|s| s['fail_rate']}
+  end
+
+  cached def self.test_duration
+    test_summary.transform_values {|s| s['duration'].round(2)}
+  end
+
+  cached def self.test_estimate
+    test_summary.transform_values {|s| (recommend_reruns(s['fail_rate']).first * s['duration']).round(2)}
+  end
+
+  # Retrieves / calculates flakiness for given test run identifier.
+  # Combines all values containing the provided identifier as a prefix into a combined summary.
+  cached def self.summary_for(method, test_run_identifier)
+    flakiness = self.method(method).call
+
+    # Combine all scenario-specific identifiers.
+    scenario_estimates = flakiness.select {|name, _| name =~ /#{test_run_identifier}.+/}
+    scenario = scenario_estimates.values.sum
+    scenario = scenario.to_f / scenario_estimates.length if method == :test_flakiness
+
+    feature = flakiness[test_run_identifier]
+    if scenario_estimates.empty?
+      feature
+    elsif feature.nil?
+      scenario
+    else
+      # If values for scenarios and feature both exist, average the two.
+      (scenario + feature) / 2.0
+    end
   end
 end


### PR DESCRIPTION
The current test-flakiness calculation used by our UI-test runner was broken, since scenario-specific browser sessions contained the scenario name appended to its job identifier, and these weren't included in the flakiness calculations. This PR fixes this issue by combining all scenario-specific data into an average feature-wide metric.
This PR additionally collects 'duration' information from passed jobs, and uses a combined 'duration * recommended-reruns' `estimate` metric for ordering test runs more efficiently than ordering just on flakiness alone. (We want to run reliable-but-long tests early on.)

_None_ of this code has test-coverage (!), and although I refactored a few things quite heavily, I didn't add any. I used the `bin/test_flakiness` to test a bit, and also added a `--dry-run` flag to `runner.rb` to help a bit further with manual testing.