### PR TITLE
Refactor UI-test Selenium Client logic

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -4,23 +4,6 @@ DEFAULT_WAIT_TIMEOUT = 2.minutes
 SHORT_WAIT_TIMEOUT = 30.seconds
 MODULE_PROGRESS_COLOR_MAP = {not_started: 'rgb(255, 255, 255)', in_progress: 'rgb(239, 205, 28)', completed: 'rgb(14, 190, 14)'}
 
-def http_client
-  $browser.send(:bridge).http.send(:http)
-rescue
-  nil
-end
-
-# Set HTTP read timeout to the specified wait timeout during the block.
-def with_read_timeout(timeout)
-  if (http = http_client)
-    read_timeout = http.read_timeout
-    http.read_timeout = timeout
-  end
-  yield
-ensure
-  http.read_timeout = read_timeout if http
-end
-
 def wait_until(timeout = DEFAULT_WAIT_TIMEOUT)
   Selenium::WebDriver::Wait.new(timeout: timeout).until do
     yield

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -1,5 +1,4 @@
 require 'selenium/webdriver'
-require 'selenium/webdriver/remote/http/persistent'
 require 'cgi'
 require 'httparty'
 require_relative '../../../../../deployment'
@@ -7,7 +6,7 @@ require 'active_support/core_ext/object/blank'
 require_relative '../../utils/selenium_browser'
 require 'retryable'
 
-$browser_configs = JSON.load(open("browsers.json"))
+$browser_config = JSON.load(open("browsers.json")).detect {|b| b['name'] == ENV['BROWSER_CONFIG']}
 
 MAX_CONNECT_RETRIES = 3
 
@@ -16,23 +15,13 @@ def slow_browser?
 end
 
 def saucelabs_browser(test_run_name)
-  if CDO.saucelabs_username.blank?
-    raise "Please define CDO.saucelabs_username"
-  end
-
-  if CDO.saucelabs_authkey.blank?
-    raise "Please define CDO.saucelabs_authkey"
-  end
+  raise "Please define CDO.saucelabs_username" if CDO.saucelabs_username.blank?
+  raise "Please define CDO.saucelabs_authkey"  if CDO.saucelabs_authkey.blank?
 
   is_tunnel = ENV['CIRCLE_BUILD_NUM']
   url = "http://#{CDO.saucelabs_username}:#{CDO.saucelabs_authkey}@#{is_tunnel ? 'localhost:4445' : 'ondemand.saucelabs.com:80'}/wd/hub"
 
-  capabilities = Selenium::WebDriver::Remote::Capabilities.new
-  browser_config = $browser_configs.detect {|b| b['name'] == ENV['BROWSER_CONFIG']}
-
-  browser_config.each do |key, value|
-    capabilities[key] = value
-  end
+  capabilities = Selenium::WebDriver::Remote::Capabilities.new($browser_config)
 
   capabilities[:javascript_enabled] = 'true'
   capabilities[:tunnelIdentifier] = CDO.circle_run_identifier if CDO.circle_run_identifier
@@ -40,66 +29,48 @@ def saucelabs_browser(test_run_name)
   capabilities[:tags] = [ENV['GIT_BRANCH']]
   capabilities[:build] = CDO.circle_run_identifier || ENV['BUILD']
   capabilities[:idleTimeout] = 600
-
   very_verbose "DEBUG: Capabilities: #{CGI.escapeHTML capabilities.inspect}"
 
-  browser = nil
-  Time.now.to_i.tap do |start_time|
-    retries = 0
-    begin
-      http_client = Selenium::WebDriver::Remote::Http::Persistent.new
-
-      # Temporarily increase read timeout to acquire a new browser session.
-      http_client.read_timeout = 5.minutes
-
-      browser = Selenium::WebDriver.for(:remote,
-        url: url,
-        desired_capabilities: capabilities,
-        http_client: http_client
-      )
-
-      # Time to wait for any page loading to complete (default 5 minutes).
-      browser.manage.timeouts.page_load = 2.minutes
-
-      # Time to wait for any command (default 1 minute).
-      http_client.send(:http).read_timeout = 2.minutes
-
-      # Shorter idle_timeout to avoid "too many connection resets" error
-      # and generally increases stability, reduces re-runs.
-      # https://docs.omniref.com/ruby/gems/net-http-persistent/2.9.4/symbols/Net::HTTP::Persistent::Error#line=108
-      http_client.send(:http).idle_timeout = 3
-    rescue StandardError
-      raise if retries >= MAX_CONNECT_RETRIES
-      puts 'Failed to get browser, retrying...'
-      retries += 1
-      retry
-    end
-    very_verbose "DEBUG: Got browser in #{Time.now.to_i - start_time}s with #{retries} retries"
+  $http_client = SeleniumBrowser::Client.new(read_timeout: 2.minutes)
+  with_read_timeout(5.minutes) do
+    Selenium::WebDriver.for(:remote,
+      url: url,
+      desired_capabilities: capabilities,
+      http_client: $http_client
+    )
   end
+end
 
-  very_verbose "DEBUG: Browser: #{CGI.escapeHTML browser.inspect}"
-
-  # Maximize the window on desktop, as some tests require 1280px width.
-  unless ENV['MOBILE']
-    max_width, max_height = browser.execute_script("return [window.screen.availWidth, window.screen.availHeight];")
-    browser.manage.window.resize_to(max_width, max_height)
-  end
-
-  $session_id = browser.session_id
-  visual_log_url = "https://saucelabs.com/tests/#{$session_id}"
-  puts "visual log on sauce labs: <a href='#{visual_log_url}'>#{visual_log_url}</a>"
-
-  browser
+# Set HTTP read timeout to the specified value during the block.
+def with_read_timeout(timeout, &block)
+  $http_client ?
+    $http_client.with_read_timeout(timeout, &block) :
+    yield
 end
 
 def get_browser(test_run_name)
+  browser = nil
   if ENV['TEST_LOCAL'] == 'true'
     headless = ENV['TEST_LOCAL_HEADLESS'] == 'true'
-    # Run a local headless browser instead of Saucelabs.
-    SeleniumBrowser.local_browser(headless, ENV['BROWSER_CONFIG'])
+    browser = SeleniumBrowser.local(headless, ENV['BROWSER_CONFIG'])
   else
-    saucelabs_browser test_run_name
+    browser = Retryable.retryable(tries: MAX_CONNECT_RETRIES) do
+      saucelabs_browser(test_run_name)
+    end
+    $session_id = browser.session_id
+    visual_log_url = "https://saucelabs.com/tests/#{$session_id}"
+    puts "visual log on sauce labs: <a href='#{visual_log_url}'>#{visual_log_url}</a>"
   end
+
+  # Time to wait for page loads to complete (default 5 minutes).
+  browser.manage.timeouts.page_load = 2.minutes
+
+  # Maximize the window on desktop, as some tests require 1280px width.
+  unless ENV['MOBILE']
+    max_width, max_height = browser.execute_script('return [window.screen.availWidth, window.screen.availHeight];')
+    browser.manage.window.resize_to(max_width, max_height)
+  end
+  browser
 end
 
 $browser = nil

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -2,21 +2,60 @@ require 'selenium/webdriver'
 require 'webdrivers'
 
 module SeleniumBrowser
-  def self.local_browser(headless=true, browser=:chrome)
+  def self.local(headless=true, browser=:chrome)
     browser = browser.to_sym
     options = {}
     if browser == :chrome
       options[:options] = Selenium::WebDriver::Chrome::Options.new
-      options[:options].add_argument('--headless') if headless
+      options[:options].add_argument('headless') if headless
+      options[:options].add_argument('window-size=1280,1024')
     elsif browser == :firefox
       options[:options] = Selenium::WebDriver::Firefox::Options.new
       options[:options].headless! if headless
+      options[:options].add_argument('window-size=1280,1024')
     end
-    browser = Selenium::WebDriver.for browser, options
-    if ENV['MAXIMIZE_LOCAL']
-      max_width, max_height = browser.execute_script('return [window.screen.availWidth, window.screen.availHeight];')
-      browser.manage.window.resize_to(max_width, max_height)
+    Selenium::WebDriver.for browser, options
+  end
+
+  require 'net/http/persistent'
+  # Replaces the misleading 'too many connection resets' error message for read timeouts.
+  class HttpClient < Net::HTTP::Persistent
+    def request_failed(exception, req, connection)
+      if exception.is_a?(Net::ReadTimeout)
+        backtrace = exception.backtrace
+        exception = Net::ReadTimeout.new("No response after #{read_timeout} seconds")
+        exception.set_backtrace(backtrace)
+      end
+      finish connection
+      raise exception
     end
-    browser
+  end
+
+  require 'selenium/webdriver/remote/http/persistent'
+  class Client < Selenium::WebDriver::Remote::Http::Persistent
+    # Replaces 'unexpected response' message with the actual parsed error from the JSON response, if provided.
+    def create_response(code, body, content_type)
+      super
+    rescue Selenium::WebDriver::Error::WebDriverError => e
+      if (msg = e.message.match(/unexpected response, code=(?<code>\d+).*\n(?<error>.*)/))
+        error = msg[:error]
+        error = JSON.parse(error)['value']['error'] rescue error
+        e.message.replace("Error #{msg[:code]}: #{error}")
+      end
+      raise
+    end
+
+    def new_http_client
+      HttpClient.new name: 'webdriver'
+    end
+
+    # Set HTTP read timeout within the specified block.
+    def with_read_timeout(timeout)
+      old_timeout = read_timeout
+      self.read_timeout = timeout
+      yield
+    ensure
+      self.read_timeout = old_timeout
+    end
   end
 end


### PR DESCRIPTION
- Add more descriptive output for read timeouts. Instead of raising:
```
too many connection resets (due to Net::ReadTimeout - Net::ReadTimeout) after 123 requests on 37930160, last used 125.100643653 seconds ago (Net::HTTP::Persistent::Error)
```
Instead raise: `No response after 120 seconds (Net::ReadTimeout)`

- Add more descriptive output for remote webdriver errors
- Various other refactoring to make some of the WebDriver remote-connection code a bit more manageable.