### PR TITLE
UI-test @single_session tag

### DIFF
--- a/dashboard/test/ui/features/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/applab/shared_apps.feature
@@ -1,3 +1,4 @@
+@single_session
 @as_student
 Feature: App Lab Scenarios
 

--- a/dashboard/test/ui/features/block_trashing.feature
+++ b/dashboard/test/ui/features/block_trashing.feature
@@ -1,3 +1,4 @@
+@single_session
 Feature: Blocks can be trashed in certain circumstances
 
 Background:

--- a/dashboard/test/ui/features/bounce.feature
+++ b/dashboard/test/ui/features/bounce.feature
@@ -1,5 +1,6 @@
 # Brad (2018-11-14) Skip on IE due to webdriver exception
 @no_ie
+@single_session
 Feature: Complete a bounce level
 
 Scenario: Complete Level 1

--- a/dashboard/test/ui/features/callouts.feature
+++ b/dashboard/test/ui/features/callouts.feature
@@ -1,3 +1,4 @@
+@single_session
 Feature: Callouts
 
   Background:

--- a/dashboard/test/ui/features/create_dropdown.feature
+++ b/dashboard/test/ui/features/create_dropdown.feature
@@ -1,4 +1,5 @@
 @no_mobile
+@single_session
 Feature: Create Dropdown in Header
 
 Scenario: Create Dropdown does NOT show on level pages

--- a/dashboard/test/ui/features/hamburger.feature
+++ b/dashboard/test/ui/features/hamburger.feature
@@ -1,4 +1,5 @@
 @no_mobile
+@single_session
 Feature: Hamburger dropdown
 
   Scenario: Signed out user in English should not see hamburger on desktop

--- a/dashboard/test/ui/features/header.feature
+++ b/dashboard/test/ui/features/header.feature
@@ -1,4 +1,5 @@
 @no_mobile
+@single_session
 Feature: Header navigation bar
 
 Scenario: Signed out user in English should see 6 header links

--- a/dashboard/test/ui/features/i18n.feature
+++ b/dashboard/test/ui/features/i18n.feature
@@ -1,4 +1,5 @@
 @no_circle
+@single_session
 Feature: Hour of Code, Frozen, and Minecraft:Agent tutorials in various languages
 
 Scenario: HoC tutorial in Spanish

--- a/dashboard/test/ui/features/instructions/csp_instructions.feature
+++ b/dashboard/test/ui/features/instructions/csp_instructions.feature
@@ -1,4 +1,5 @@
 @no_mobile
+@single_session
 Feature: CSP Instructions
 
 Background:

--- a/dashboard/test/ui/features/projects/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/projects/personal_project_gallery.feature
@@ -1,5 +1,5 @@
 @no_mobile
-
+@single_session
 Feature: Personal Project Gallery
 
 Background:

--- a/dashboard/test/ui/features/projects/public_project_gallery_project_validator.feature
+++ b/dashboard/test/ui/features/projects/public_project_gallery_project_validator.feature
@@ -3,6 +3,7 @@
 # only run in one browser, because multiple simultaneously-running instances of
 # this feature can interfere with each other.
 @only_one_browser
+@single_session
 Feature: Public Project Gallery - Project Validator
 
 Background:

--- a/dashboard/test/ui/features/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/section_action_dropdown.feature
@@ -1,3 +1,4 @@
+@single_session
 Feature: Using the SectionActionDropdown
 
   @no_ie

--- a/dashboard/test/ui/features/sharepage_logo.feature
+++ b/dashboard/test/ui/features/sharepage_logo.feature
@@ -1,6 +1,7 @@
 # Brad (2018-11-14) Skip on IE due to inconsistent failures clicking the share link, maybe timing?
 @no_ie
 @as_student
+@single_session
 Feature: Lab share page logo
 
   @no_mobile

--- a/dashboard/test/ui/features/signing_in.feature
+++ b/dashboard/test/ui/features/signing_in.feature
@@ -1,5 +1,5 @@
 # @no_mobile
-
+@single_session
 Feature: Signing in and signing out
 
 Scenario: Student sign in from code.org

--- a/dashboard/test/ui/features/starwars.feature
+++ b/dashboard/test/ui/features/starwars.feature
@@ -1,3 +1,4 @@
+@single_session
 Feature: Hour of Code 2015 tutorial is completable
 
   @no_ie @no_mobile

--- a/dashboard/test/ui/features/tutorial_landing_pages.feature
+++ b/dashboard/test/ui/features/tutorial_landing_pages.feature
@@ -1,4 +1,5 @@
 @eyes
+@single_session
 Feature: Looking at tutorial landing pages on Pegasus
 
 Scenario Outline: Simple page view


### PR DESCRIPTION
Currently, we run all feature-scenarios in a single browser session only on iOS browsers, because this platform takes a long time to acquire a new browser session. However, for some features with many short scenarios, running a feature in a single session can help improve performance in other browsers as well. 

This PR adds a `@single_session` tag to mark features to run all scenarios in a single browser session across all browsers, improving performance for features containing a large number of short scenarios.

In the future, we may consider running _all_ features in single-session mode, or we might narrow down the exact trade-off in more detail- for now, this tag is an incremental improvement for some features.