### PR TITLE
UI test updates: Remove redundant 'sign out' steps

### DIFF
--- a/dashboard/test/ui/features/hidden_scripts_eyes.feature
+++ b/dashboard/test/ui/features/hidden_scripts_eyes.feature
@@ -4,13 +4,11 @@ Feature: Hidden Scripts
 Scenario: Hidden Scripts
   When I open my eyes to test "hidden scripts"
   Given I create an authorized teacher-associated student named "bobby"
-  And I sign out
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/courses/allthethingscourse"
   And I wait to see ".uitest-togglehidden"
   Then I click selector ".uitest-togglehidden:nth(0) div:contains('Hidden')"
   And I see no difference for "teacher overview with hidden script"
-  And I sign out
   Then I sign in as "bobby"
   And I am on "http://studio.code.org/courses/allthethingscourse"
   And I see no difference for "student course overview with hidden script"

--- a/dashboard/test/ui/features/hidden_stages_eyes.feature
+++ b/dashboard/test/ui/features/hidden_stages_eyes.feature
@@ -4,14 +4,12 @@ Feature: Hidden Stages
 Scenario: Hidden Stages
   When I open my eyes to test "hidden stages"
   Given I create an authorized teacher-associated student named "bobby"
-  And I sign out
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/s/allthethings"
   And I select the first section
   And I wait to see ".uitest-togglehidden"
   Then I click selector ".uitest-togglehidden:nth(1) div:contains('Hidden')"
   And I see no difference for "teacher overview with hidden stage"
-  And I sign out
   Then I sign in as "bobby"
   And I am on "http://studio.code.org/s/allthethings"
   And I see no difference for "student overview with hidden stage"

--- a/dashboard/test/ui/features/i18n.feature
+++ b/dashboard/test/ui/features/i18n.feature
@@ -10,8 +10,6 @@ Scenario: HoC tutorial in Spanish
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
   Then element ".csf-top-instructions p" has "es" text from key "data.level.instructions.maze_2_14"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Frozen tutorial in Spanish
   Given I am on "http://studio.code.org/s/frozen/stage/1/puzzle/2/lang/es"
@@ -21,8 +19,6 @@ Scenario: Frozen tutorial in Spanish
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
   Then element ".csf-top-instructions p" has "es" text from key "data.short_instructions.frozen perpendicular"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Minecraft:Agent tutorial in Spanish
   Given I am on "http://studio.code.org/s/hero/stage/1/puzzle/1/lang/es"
@@ -32,8 +28,6 @@ Scenario: Minecraft:Agent tutorial in Spanish
   And I click selector "#toggleButton"
   And I wait until element ".csf-top-instructions p" is visible
   And element ".csf-top-instructions p" has "es" text from key "data.short_instructions.MC_HOC_2017_01_RETRY"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Toolbox Categories in Spanish
   Given I am on "http://studio.code.org/s/allthethings/stage/3/puzzle/7/lang/es"
@@ -48,8 +42,6 @@ Scenario: Toolbox Categories in Spanish
   Then element ".blocklyTreeRoot #\\\:7" has "es" text from key "data.block_categories.Logic"
   Then element ".blocklyTreeRoot #\\\:8" has "es" text from key "data.block_categories.Math"
   Then element ".blocklyTreeRoot #\\\:9" has "es" text from key "data.block_categories.Text"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Translated function names in Spanish
   Given I am on "http://studio.code.org/s/allthethings/stage/3/puzzle/3/lang/es"
@@ -61,8 +53,6 @@ Scenario: Translated function names in Spanish
   And element "[block-id=28] .blocklyText" has "es" text from key "data.function_names.draw a square"
   # Workspace definition block is translated
   And element "[block-id=29] > .blocklyNonEditableText > .blocklyText" has "es" text from key "data.function_names.draw a square"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: HoC tutorial in Portuguese
   Given I am on "http://studio.code.org/hoc/15/lang/pt-br"
@@ -72,8 +62,6 @@ Scenario: HoC tutorial in Portuguese
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
   Then element ".csf-top-instructions p" has "pt-BR" text from key "data.level.instructions.maze_2_14"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 @no_circle
 Scenario: Frozen tutorial in Portuguese
@@ -84,8 +72,6 @@ Scenario: Frozen tutorial in Portuguese
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
   Then element ".csf-top-instructions p" has "pt-BR" text from key "data.short_instructions.frozen perpendicular"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Minecraft:Agent tutorial in Portuguese
   Given I am on "http://studio.code.org/s/hero/stage/1/puzzle/1/lang/pt-br"
@@ -95,8 +81,6 @@ Scenario: Minecraft:Agent tutorial in Portuguese
   And I click selector "#toggleButton"
   And I wait until element ".csf-top-instructions p" is visible
   And element ".csf-top-instructions p" has "pt-BR" text from key "data.short_instructions.MC_HOC_2017_01_RETRY"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Toolbox Categories in Portuguese
   Given I am on "http://studio.code.org/s/allthethings/stage/3/puzzle/7/lang/pt-br"
@@ -111,8 +95,6 @@ Scenario: Toolbox Categories in Portuguese
   Then element ".blocklyTreeRoot #\\:7" has "pt-BR" text from key "data.block_categories.Logic"
   Then element ".blocklyTreeRoot #\\:8" has "pt-BR" text from key "data.block_categories.Math"
   Then element ".blocklyTreeRoot #\\:9" has "pt-BR" text from key "data.block_categories.Text"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Translated function names in Portuguese
   Given I am on "http://studio.code.org/s/allthethings/stage/3/puzzle/3/lang/pt-BR"
@@ -124,8 +106,6 @@ Scenario: Translated function names in Portuguese
   And element "[block-id=28] .blocklyText" has "pt-BR" text from key "data.function_names.draw a square"
   # Workspace definition block is translated
   And element "[block-id=29] > .blocklyNonEditableText > .blocklyText" has "pt-BR" text from key "data.function_names.draw a square"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: HoC tutorial in Arabic (RTL)
   Given I am on "http://studio.code.org/hoc/15/lang/ar-sa"
@@ -135,8 +115,6 @@ Scenario: HoC tutorial in Arabic (RTL)
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
   Then element ".csf-top-instructions p" has "ar-SA" text from key "data.level.instructions.maze_2_14"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Frozen tutorial in Arabic (RTL)
   Given I am on "http://studio.code.org/s/frozen/stage/1/puzzle/2/lang/ar-sa"
@@ -146,8 +124,6 @@ Scenario: Frozen tutorial in Arabic (RTL)
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
   Then element ".csf-top-instructions p" has "ar-SA" text from key "data.short_instructions.frozen perpendicular"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Minecraft:Agent tutorial in Arabic (RTL)
   Given I am on "http://studio.code.org/s/hero/stage/1/puzzle/1/lang/ar-sa"
@@ -157,8 +133,6 @@ Scenario: Minecraft:Agent tutorial in Arabic (RTL)
   And I click selector "#toggleButton"
   And I wait until element ".csf-top-instructions p" is visible
   Then element ".csf-top-instructions p" has "ar-SA" text from key "data.short_instructions.MC_HOC_2017_01_RETRY"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Translated function names in Arabic
   Given I am on "http://studio.code.org/s/allthethings/stage/3/puzzle/3/lang/ar-SA"
@@ -170,8 +144,6 @@ Scenario: Translated function names in Arabic
   And element "[block-id=28] .blocklyText" has "ar-SA" text from key "data.function_names.draw a square"
   # Workspace definition block is translated
   And element "[block-id=29] > .blocklyNonEditableText > .blocklyText" has "ar-SA" text from key "data.function_names.draw a square"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: Toolbox Categories in Arabic (RTL)
   Given I am on "http://studio.code.org/s/allthethings/stage/3/puzzle/7/lang/ar-sa"
@@ -186,8 +158,6 @@ Scenario: Toolbox Categories in Arabic (RTL)
   Then element ".blocklyTreeRoot #\\:7" has "ar-SA" text from key "data.block_categories.Logic"
   Then element ".blocklyTreeRoot #\\:8" has "ar-SA" text from key "data.block_categories.Math"
   Then element ".blocklyTreeRoot #\\:9" has "ar-SA" text from key "data.block_categories.Text"
-  Given I am on "http://studio.code.org/reset_session/lang/en"
-  And I wait for 2 seconds
 
 Scenario: English fallback for missing dashboard or pegasus strings in Azerbaijani
   Given I am on "http://studio.code.org/lang/az-az"

--- a/dashboard/test/ui/features/stage_lock.feature
+++ b/dashboard/test/ui/features/stage_lock.feature
@@ -6,7 +6,6 @@ Background:
 @eyes
 Scenario: Stage Locking Dialog
   When I open my eyes to test "stage locking"
-  And I sign out
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/s/allthethings"
   And I select the first section
@@ -32,7 +31,6 @@ Scenario: Lock settings for students
 
   # teacher unlocks
 
-  When I sign out
   And I sign in as "Teacher_bobby"
   And I am on "http://studio.code.org/s/allthethings"
   # Wait until detail view loads
@@ -40,7 +38,6 @@ Scenario: Lock settings for students
   And I open the stage lock dialog
   And I unlock the stage for students
   And I wait until element ".modal-backdrop" is gone
-  And I sign out
 
   # now unlocked/not tried for student
 
@@ -69,7 +66,6 @@ Scenario: Lock settings for students
 
   # teacher marks readonly
 
-  When I sign out
   And I sign in as "Teacher_bobby"
   And I am on "http://studio.code.org/s/allthethings"
   # Wait until detail view loads
@@ -77,7 +73,6 @@ Scenario: Lock settings for students
   And I open the stage lock dialog
   And I show stage answers for students
   And I wait until element ".modal-backdrop" is gone
-  And I sign out
 
   # now unlocked/submitted for student
 

--- a/dashboard/test/ui/features/teacher_student_toggle.feature
+++ b/dashboard/test/ui/features/teacher_student_toggle.feature
@@ -4,7 +4,6 @@ Feature: Teacher Student Toggle
 Scenario: Toggle on Multi Level
   When I open my eyes to test "toggle on multi level"
   Given I create an authorized teacher-associated student named "Daenerys"
-  And I sign out
   Then I sign in as "Teacher_Daenerys"
   Then I am on "http://studio.code.org/s/allthethings/stage/9/puzzle/1"
   And I see no difference for "page load"
@@ -26,7 +25,6 @@ Scenario: Toggle on Multi Level
 Scenario: Toggle on Hidden Maze Level
   When I open my eyes to test "toggle on hidden maze level"
   Given I create an authorized teacher-associated student named "Arya"
-  And I sign out
   Then I sign in as "Teacher_Arya"
   Then I am on "http://studio.code.org/s/allthethings"
   And I select the first section
@@ -45,7 +43,6 @@ Scenario: Toggle on Hidden Maze Level
 Scenario: Toggle on Lockable Level
   When I open my eyes to test "toggle on a lockable level"
   Given I create an authorized teacher-associated student named "Joffrey"
-  And I sign out
   Then I sign in as "Teacher_Joffrey"
 
   Then I am on "http://studio.code.org/s/allthethings/lockable/1/puzzle/1/page/1?noautoplay=true"


### PR DESCRIPTION
Follow-up to #28251 