### PR TITLE
UI test: reduce idle timeout from 10 minutes to 30 seconds

### DIFF
--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -151,4 +151,5 @@ Dashboard::Application.configure do
       'post_workshop' => 12
     }
   }
+  config.experiment_cache_time_seconds = 0
 end

--- a/dashboard/test/ui/features/step_definitions/experiment_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/experiment_steps.rb
@@ -7,7 +7,3 @@ When /^I enable the "([^"]*)" course experiment$/ do |experiment_name|
     Then element ".alert-success" contains text "You have successfully joined the experiment"
   STEPS
 end
-
-When /^I wait for the pegasus and dashboard experiment caches to expire$/ do
-  steps 'And I wait for 61 seconds'
-end

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -29,7 +29,7 @@ def saucelabs_browser(test_run_name)
   capabilities[:name] = test_run_name
   capabilities[:tags] = [ENV['GIT_BRANCH']]
   capabilities[:build] = CDO.circle_run_identifier || ENV['BUILD']
-  capabilities[:idleTimeout] = 600
+  capabilities[:idleTimeout] = 30
   very_verbose "DEBUG: Capabilities: #{CGI.escapeHTML capabilities.inspect}"
 
   $http_client = SeleniumBrowser::Client.new(read_timeout: 2.minutes)

--- a/dashboard/test/ui/features/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_homepage.feature
@@ -17,7 +17,6 @@ Feature: Using the teacher homepage sections feature
   Scenario: Loading teacher homepage with course experiment enabled
     Given I am on "http://studio.code.org/home"
     Given I enable the "subgoals-group-a" course experiment
-    And I wait for the pegasus and dashboard experiment caches to expire
     And I reload the page
     And I wait to see ".uitest-newsection"
     And check that the URL contains "/home"


### PR DESCRIPTION
Quicker timeout results in greater utilization of limited concurrent browser sessions.

In order to be able to reduce the timeout less than 60 seconds, I modified the experiment cache in `test` from 60 seconds to 0, since the cache required an explicit wait of 61 seconds in a teacher homepage test.