### PR TITLE
UI test runner: add --breakpoint option

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -137,9 +137,13 @@ rescue => e
 end
 
 # Quit current browser session.
-def quit_browser
+def quit_browser(failed = false)
   with_read_timeout(5.seconds) do
-    $browser&.quit
+    if ENV['BREAKPOINT'] && failed
+      $browser&.execute_script('sauce: break')
+    else
+      $browser&.quit
+    end
   rescue => e
     puts "Error quitting browser session: #{e}"
   end
@@ -159,7 +163,7 @@ After do |scenario|
     end
   else
     log_result scenario.passed?
-    quit_browser
+    quit_browser scenario.failed?
   end
 end
 
@@ -196,7 +200,7 @@ end
 
 at_exit do
   log_result $all_passed if single_session?
-  quit_browser
+  quit_browser !$all_passed
 end
 
 def very_verbose(msg)

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -224,6 +224,9 @@ def parse_options
       opts.on("--priority priority", "Set priority level for Sauce Labs jobs.") do |priority|
         options.priority = priority
       end
+      opts.on("--breakpoint", "Send breakpoint to Sauce Labs for failing scenarios") do
+        options.breakpoint = true
+      end
       opts.on_tail("-h", "--help", "Show this message") do
         puts opts
         exit
@@ -720,6 +723,7 @@ def run_feature(browser, feature, options)
   run_environment['TEST_RUN_NAME'] = test_run_string
   run_environment['IS_CIRCLE'] = options.is_circle ? "true" : "false"
   run_environment['PRIORITY'] = options.priority
+  run_environment['BREAKPOINT'] = '1' if options.breakpoint
 
   # disable some stuff to make require_rails_env run faster within cucumber.
   # These things won't be disabled in the dashboard instance we're testing against.


### PR DESCRIPTION
Sauce Labs supports a [JavaScript annotation](https://wiki.saucelabs.com/display/DOCS/Annotating+Tests+with+Selenium%27s+JavaScript+Executor#AnnotatingTestswithSelenium'sJavaScriptExecutor-Methods) `sauce: break`, which pauses the running browser session allowing you to interactively control the session to [diagnose flaky tests](https://wiki.saucelabs.com/display/DOCS/Best+Practices+for+Running+Tests#BestPracticesforRunningTests-UseBreakpointstoDiagnoseFlakyTests).

This PR adds a `--breakpoint` option to our test runner, to allow pausing Sauce Labs browser sessions on failing scenarios for interactive debugging.