### PR TITLE
UI test runner: fix browser_config bug for --local

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/object/blank'
 require_relative '../../utils/selenium_browser'
 require 'retryable'
 
-$browser_config = JSON.load(open("browsers.json")).detect {|b| b['name'] == ENV['BROWSER_CONFIG']}
+$browser_config = JSON.load(open("browsers.json")).detect {|b| b['name'] == ENV['BROWSER_CONFIG']} || {}
 
 MAX_CONNECT_RETRIES = 3
 


### PR DESCRIPTION
Followup to #28255, this fixes a regression in the `--local` option of our UI-test runner.