### PR TITLE
UI Test: Add retries to pd step definition

### DIFF
--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -502,16 +502,18 @@ And(/^I create a workshop for course "([^"]*)" ([a-z]+) by "([^"]*)" with (\d+) 
       )
     end
 
-  workshop = FactoryGirl.create(:pd_workshop, :funded,
-    on_map: true,
-    course: course,
-    organizer_id: organizer.id,
-    capacity: number.to_i,
-    location_name: 'Buffalo',
-    num_sessions: 1,
-    sessions_from: Date.new(2018, 4, 1),
-    enrolled_and_attending_users: number_type == 'people' ? number.to_i : 0
-  )
+  workshop = Retryable.retryable(on: [ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid], tries: 5) do
+    FactoryGirl.create(:pd_workshop, :funded,
+      on_map: true,
+      course: course,
+      organizer_id: organizer.id,
+      capacity: number.to_i,
+      location_name: 'Buffalo',
+      num_sessions: 1,
+      sessions_from: Date.new(2018, 4, 1),
+      enrolled_and_attending_users: number_type == 'people' ? number.to_i : 0
+    )
+  end
 
   # Facilitators
   if number_type == 'facilitators'


### PR DESCRIPTION
The `pd_workshop` factory is frequently causing flaky-test failures ([example](https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_pd_dashboard_view_eyes_output.html?versionId=7KiLZErwRbyLVf_97eYSJM1bCv0anuSx)), because various related factories create their `school_district` associations by id in a non-concurrent-safe fashion: https://github.com/code-dot-org/code-dot-org/blob/e72f499b69362f4b2488c31ec6938d4d489bdae7/dashboard/test/factories/factories.rb#L918-L919

I tried to disentangle these manually-provided `id` associations to instead use the default (autoincrement) values, but couldn't get it to work with the way the framework builds/creates factory associations in relation to validations / foreign-keys. Instead, I've wrapped the step definition within a `Retryable` block as a workaround that seems to work for these flaky failures for now.

Assigned @Hamms just because your name showed up in the Git blame, but feel free to pull in / pass along to anyone else who might have more context on this test/feature.