### PR TITLE
UI test: add --priority option

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -40,6 +40,7 @@ def saucelabs_browser(test_run_name)
     idleTimeout: 30
   }
   sauce_capabilities[:tunnelIdentifier] = CDO.circle_run_identifier if CDO.circle_run_identifier
+  sauce_capabilities[:priority] = ENV['PRIORITY'].to_i if ENV['PRIORITY']
 
   # Use w3c-spec sauce:options capabilities format for compatible browsers.
   # Ref: https://wiki.saucelabs.com/display/DOCS/Selenium+W3C+Capabilities+Support+-+Beta

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -108,6 +108,7 @@ def parse_options
     options.magic_retry = false
     options.parallel_limit = 1
     options.abort_when_failures_exceed = Float::INFINITY
+    options.priority = '99'
 
     # start supporting some basic command line filtering of which browsers we run against
     opt_parser = OptionParser.new do |opts|
@@ -219,6 +220,9 @@ def parse_options
       end
       opts.on("--dry-run", "Process features without running any actual steps.") do
         options.dry_run = true
+      end
+      opts.on("--priority priority", "Set priority level for Sauce Labs jobs.") do |priority|
+        options.priority = priority
       end
       opts.on_tail("-h", "--help", "Show this message") do
         puts opts
@@ -715,6 +719,7 @@ def run_feature(browser, feature, options)
   run_environment['MOBILE'] = browser['mobile'] ? "true" : "false"
   run_environment['TEST_RUN_NAME'] = test_run_string
   run_environment['IS_CIRCLE'] = options.is_circle ? "true" : "false"
+  run_environment['PRIORITY'] = options.priority
 
   # disable some stuff to make require_rails_env run faster within cucumber.
   # These things won't be disabled in the dashboard instance we're testing against.

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -32,7 +32,8 @@ namespace :test do
         '--parallel', '120',
         '--magic_retry',
         '--with-status-page',
-        '--fail_fast'
+        '--fail_fast',
+        '--priority 0'
       )
       if failed_browser_count == 0
         message = '┬──┬ ﻿ノ( ゜-゜ノ) UI tests for <b>dashboard</b> succeeded.'


### PR DESCRIPTION
Sauce Labs provides an internal [test configuration option](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions) [`priority`](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-PrioritizeJobs), which allows you to prioritize jobs within the internal Sauce Labs queue:

> If you have multiple new jobs waiting to start, for example across a collection of sub-accounts, jobs with a lower priority number take precedence over jobs with a higher number. So, for example, if you have multiple jobs simultaneously waiting to start, we'll first attempt to find resources to start all the jobs with priority 0, then all the jobs with priority 1, etc. When we run out of available virtual machines, or when you hit your concurrency limit, any jobs not yet started will wait. Within each priority level, jobs that have been waiting the longest take precedence.

This PR adds the test-runner option `--priority` to control session priority within Sauce Labs queue, and runs `test:regular_ui` jobs (e.g., runs from our `test` server builds) at highest (`0`) priority.

This should help improve the overall UI-test execution time in `test` deploys by prioritizing those sessions over sessions from PR builds.