### PR TITLE
Add deprecated note to unplugged in Levelbuilder

### DIFF
--- a/dashboard/app/views/levels/new.html.haml
+++ b/dashboard/app/views/levels/new.html.haml
@@ -25,7 +25,7 @@
 %h2 Content
 %ul
   %li= link_to 'Build a Standalone Video Level', new_level_path(type: 'StandaloneVideo')
-  %li= link_to 'Build an Unplugged Level', new_level_path(type: 'Unplugged')
+  %li= link_to 'Build an Unplugged Level (deprecated)', new_level_path(type: 'Unplugged')
 
 %h2 DSL-Defined
 %ul


### PR DESCRIPTION
Currently, Levelbuilders can't make Unplugged levels via Levelbuilder without an assist from engineering. Which means we don't really support making Unplugged levels via Levelbuilder so this is a little note to say that type is deprecated on /levels/new. It doesn't stop anyone from making an Unplugged level, because this type still needs to exist for backwards compatibility.

<img width="332" alt="Screen Shot 2019-04-29 at 2 33 43 PM" src="https://user-images.githubusercontent.com/12300669/56929991-24fe6f00-6a90-11e9-8806-39f729ba8c34.png">

Partially addresses [LP-278](https://codedotorg.atlassian.net/browse/LP-278)