### PR TITLE
UI test browser config: add 'w3c' tags to Firefox + Safari

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -13,7 +13,8 @@
     "name": "Safari",
     "browserName": "Safari",
     "platform": "macOS 10.14",
-    "version": "12.0"
+    "version": "12.0",
+    "w3c": true
   },
   {
     "name": "IE11",
@@ -25,7 +26,8 @@
     "name": "Firefox",
     "browserName": "firefox",
     "version": "latest",
-    "platform": "Windows 10"
+    "platform": "Windows 10",
+    "w3c": true
   },
   {
     "name": "iPhone",


### PR DESCRIPTION
Followup to #28084. The `w3c` tag is needed in the browser config in order to enable the w3c-compatible options. This PR adds the missing `w3c` tag to Firefox and Safari configs where it is needed.