### PR TITLE
Fix assign course dialog not closing 

### DIFF
--- a/apps/src/templates/courseOverview/AssignToSection.js
+++ b/apps/src/templates/courseOverview/AssignToSection.js
@@ -69,7 +69,9 @@ class AssignToSection extends Component {
       })
     })
       .done(result => {
-        updateHiddenScript(section.id, scriptId, false);
+        if (scriptId) {
+          updateHiddenScript(section.id, scriptId, false);
+        }
         this.setState({
           sectionIndexToAssign: null
         });


### PR DESCRIPTION
[LP-240](https://codedotorg.atlassian.net/browse/LP-240)

When assigning a course to a section from the course overview page, a confirmation dialog pops up.  Clicking "Assign" in this dialog assigned the course to the section, but the dialog did not close. The dialog was not closing because part of the `onClose` function, `  updateHiddenScript` was expecting to be passed a `scriptId`. If `scriptId` is undefined, we get this error:
<img width="770" alt="Screen Shot 2019-04-29 at 4 55 31 PM" src="https://user-images.githubusercontent.com/12300669/56934110-b1fcf480-6a9f-11e9-85c3-682b52bfeaae.png">


In the scenario where we want to assign a course, we don't have a `scriptId`, only a `courseId`.   To fix, I check for `scriptId`  and only call `updateHiddenScript` if we have one. Now the course is assigned, there's not an error and the dialog closes.  

![assign dialog fix](https://user-images.githubusercontent.com/12300669/56933974-02c01d80-6a9f-11e9-9032-5e1f7f3984dc.gif)
