### PR TITLE
unhide CSP/CSD 2019 courses and units

### DIFF
--- a/dashboard/config/locales/courses.en.yml
+++ b/dashboard/config/locales/courses.en.yml
@@ -39,11 +39,13 @@ en:
           description_teacher: In fall 2016, the College Board launched its newest AP® course, AP Computer Science Principles. The course introduces students to the foundational concepts of computer science and challenges them to explore how computing and technology can impact the world. The AP Program designed AP Computer Science Principles with the goal of creating leaders in computer science fields and attracting and engaging those who are traditionally underrepresented with essential computing tools and multidisciplinary opportunities.
         csp-2019:
           title: Computer Science Principles ('19-'20)
+          version_title: "'19-'20"
           description_short: Learn foundational computer science concepts.
           description_student: In fall 2016, the College Board launched its newest AP® course, AP Computer Science Principles. The course introduces students to the foundational concepts of computer science and challenges them to explore how computing and technology can impact the world. The AP Program designed AP Computer Science Principles with the goal of creating leaders in computer science fields and attracting and engaging those who are traditionally underrepresented with essential computing tools and multidisciplinary opportunities.
           description_teacher: In fall 2016, the College Board launched its newest AP® course, AP Computer Science Principles. The course introduces students to the foundational concepts of computer science and challenges them to explore how computing and technology can impact the world. The AP Program designed AP Computer Science Principles with the goal of creating leaders in computer science fields and attracting and engaging those who are traditionally underrepresented with essential computing tools and multidisciplinary opportunities.
         csd-2019:
           title: Computer Science Discoveries ('19-'20)
+          version_title: "'19-'20"
           description_short: An introductory computer science course that empowers students to create authentic artifacts.
           description_student: Computer Science Discoveries (CS Discoveries) is an introductory computer science course that empowers students to create authentic artifacts and engage with computer science as a medium for creativity, communication, problem solving, and fun.
           description_teacher: Computer Science Discoveries (CS Discoveries) is an introductory computer science course that empowers students to create authentic artifacts and engage with computer science as a medium for creativity, communication, problem solving, and fun.

--- a/dashboard/config/scripts/csd1-2019.script
+++ b/dashboard/config/scripts/csd1-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csd2-2019.script
+++ b/dashboard/config/scripts/csd2-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csd3-2019.script
+++ b/dashboard/config/scripts/csd3-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csd4-2019.script
+++ b/dashboard/config/scripts/csd4-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csd5-2019.script
+++ b/dashboard/config/scripts/csd5-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csd6-2019.script
+++ b/dashboard/config/scripts/csd6-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csp-create-2019.script
+++ b/dashboard/config/scripts/csp-create-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csp-explore-2019.script
+++ b/dashboard/config/scripts/csp-explore-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csp1-2019.script
+++ b/dashboard/config/scripts/csp1-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csp2-2019.script
+++ b/dashboard/config/scripts/csp2-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csp3-2019.script
+++ b/dashboard/config/scripts/csp3-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csp4-2019.script
+++ b/dashboard/config/scripts/csp4-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csp5-2019.script
+++ b/dashboard/config/scripts/csp5-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/dashboard/config/scripts/csppostap-2019.script
+++ b/dashboard/config/scripts/csppostap-2019.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 hideable_stages true
 exclude_csf_column_in_legend true

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -22,8 +22,10 @@ module ScriptConstants
     full_course: [
       CSP_2017 = 'csp-2017'.freeze,
       CSP_2018 = 'csp-2018'.freeze,
+      CSP_2019 = 'csp-2019'.freeze,
       CSD_2017 = 'csd-2017'.freeze,
       CSD_2018 = 'csd-2018'.freeze,
+      CSD_2019 = 'csd-2019'.freeze,
     ],
     csf: [
       COURSEA_NAME = 'coursea-2017'.freeze,


### PR DESCRIPTION
### Background

Finishes [LP-289](https://codedotorg.atlassian.net/browse/LP-289). Also see https://github.com/code-dot-org/code-dot-org/pull/28299

### Description

* make CSP/CSD courses appear in the assignment selector dropdown by adding them to the `full_course` list
* unhide CSP/CSD 2019 units

### Screenshots

CSD 2019 appears in the assignment selector as "in development" and not "recommended":
<img width="992" alt="Screen Shot 2019-05-01 at 12 51 16 PM" src="https://user-images.githubusercontent.com/8001765/57039019-5bfb8e80-6c10-11e9-9f8a-242163accc82.png">

CSD 2019 contains the correct units in the assignment selector:
<img width="460" alt="Screen Shot 2019-05-01 at 12 51 34 PM" src="https://user-images.githubusercontent.com/8001765/57039025-5f8f1580-6c10-11e9-9130-e902656a0b5e.png">

### Testing

Manually verified the following redirects:
* /courses/csd --> /courses/csd-2018
* /s/csd1 --> /s/csd1-2018
* /s/csd1-2019 --> /s/csd1-2018 (for students only)

Script redirects are also reasonably well unit-tested starting here: https://github.com/code-dot-org/code-dot-org/blob/f23b4e1e291d98f16558357f9eb5932c7164a83c/dashboard/test/models/script_test.rb#L405

### Launch Plan

We'll manually test this on adhoc-lp on Thursday, then ship it on Friday.