### PR TITLE
Fix alignment of checkboxes in Levelbuilder

### DIFF
--- a/apps/style/code-studio/levelbuilder.scss
+++ b/apps/style/code-studio/levelbuilder.scss
@@ -178,6 +178,7 @@ table.checkboxes {
 
   label {
     padding-left: 1%;
+    margin-top: 15px;
   }
 }
 .collapsed_area_header{


### PR DESCRIPTION
While working on [LP-278](https://codedotorg.atlassian.net/browse/LP-278) I noticed that the checkboxes on Levelbuilder script creation and editing pages are not aligned with their labels.

For example: 
<img width="589" alt="Screen Shot 2019-04-30 at 2 53 19 PM" src="https://user-images.githubusercontent.com/12300669/56996136-7d993f00-6b58-11e9-8732-dd30d4b2b666.png">

So, I fixed their styling: 
<img width="623" alt="Screen Shot 2019-04-30 at 2 51 58 PM" src="https://user-images.githubusercontent.com/12300669/56996145-7ffb9900-6b58-11e9-8991-3965c1f8ce6a.png">

