### PR TITLE
UI test: Retry PD create_enrollment teacher creation step

### DIFF
--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -462,7 +462,9 @@ end
 def create_enrollment(workshop, name=nil)
   first_name = name.nil? ? "First - #{SecureRandom.hex}" : name
   last_name = name.nil? ? "Last - #{SecureRandom.hex}" : "Last"
-  user = FactoryGirl.create :teacher
+  user = Retryable.retryable(on: [ActiveRecord::RecordInvalid], tries: 5) do
+    FactoryGirl.create :teacher
+  end
   enrollment = Pd::Enrollment.create!(
     first_name: first_name,
     last_name: last_name,


### PR DESCRIPTION
Retry on `Validation failed: Email has already been taken` errors in eyes tests ([example](https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_pd_dashboard_view_eyes_output.html?versionId=G9P7pIURLUkJhFC_Q5YNLLyEVHkyEwTQ)).