### PR TITLE
Spritelab Fix: toolbox displays on top of block layout when switching out of the costume tab

### DIFF
--- a/apps/src/gamelab/GameLabVisualizationHeader.jsx
+++ b/apps/src/gamelab/GameLabVisualizationHeader.jsx
@@ -1,4 +1,5 @@
 /** @file Row of controls above the visualization. */
+import * as utils from '../utils';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {changeInterfaceMode} from './actions';
@@ -29,15 +30,27 @@ class GameLabVisualizationHeader extends React.Component {
     spriteLab: PropTypes.bool.isRequired
   };
 
+  changeInterfaceMode = mode => {
+    if (!this.props.spriteLab) {
+      // Add a resize event to Gamelab (i.e. droplet) to ensure code is rendered
+      // correctly if it was in the middle of a transition from code to block mode
+      // when the interface mode was changed. Blockly already fires resize events
+      // so this is not needed for spriteLab - too many resize events seem to
+      // conflict with each other.
+      setTimeout(() => utils.fireResizeEvent(), 0);
+    }
+
+    this.props.onInterfaceModeChange(mode);
+  };
+
   render() {
-    const {
-      interfaceMode,
-      allowAnimationMode,
-      onInterfaceModeChange
-    } = this.props;
+    const {interfaceMode, allowAnimationMode} = this.props;
     return (
       <div style={styles.main} id="playSpaceHeader">
-        <ToggleGroup selected={interfaceMode} onChange={onInterfaceModeChange}>
+        <ToggleGroup
+          selected={interfaceMode}
+          onChange={this.changeInterfaceMode}
+        >
           <button type="button" value={GameLabInterfaceMode.CODE} id="codeMode">
             {msg.codeMode()}
           </button>

--- a/apps/src/gamelab/actions.js
+++ b/apps/src/gamelab/actions.js
@@ -1,7 +1,6 @@
 /** @file Redux action-creators for Game Lab.
  *  @see http://redux.js.org/docs/basics/Actions.html */
 import $ from 'jquery';
-import * as utils from '../utils';
 
 /** @enum {string} */
 export const CHANGE_INTERFACE_MODE = 'CHANGE_INTERFACE_MODE';
@@ -25,9 +24,6 @@ export const ADD_MESSAGE = 'spritelab/ADD_MESSAGE';
  * @returns {function}
  */
 export function changeInterfaceMode(interfaceMode) {
-  //Add a resize event on each call to changeInterfaceMode to ensure
-  //proper rendering of droplet and code mode. Similar solution in applab.
-  setTimeout(() => utils.fireResizeEvent(), 0);
   return function(dispatch) {
     $(window).trigger('appModeChanged');
     dispatch({


### PR DESCRIPTION
Bug: https://codedotorg.atlassian.net/browse/STAR-371
This PR only fixes the toolbox overlay on top of the blocks. The gray, L-shaped section will be fixed in a future task: https://codedotorg.atlassian.net/browse/STAR-397

OLD:
![image](https://user-images.githubusercontent.com/8324574/56997538-f3070e80-6b5c-11e9-9fe9-c9fa2a0bf1f9.png)

NEW:
![image](https://user-images.githubusercontent.com/8324574/56997575-17fb8180-6b5d-11e9-9034-62e5fe4326e5.png)

