### PR TITLE
avoid invalid invalidations when flushing cache on adhocs

### DIFF
--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -91,6 +91,7 @@ module AWS
       invalidations = CONFIG.keys.map do |app|
         hostname = CDO.method("#{app}_hostname").call
         id = get_distribution_id(cloudfront, hostname)
+        next unless id
         invalidation = cloudfront.create_invalidation(
           {
             distribution_id: id,
@@ -105,7 +106,8 @@ module AWS
         ).invalidation.id
         [app, id, invalidation]
       end
-      puts 'Invalidations created.'
+      invalidations.compact!
+      puts "Invalidations created: #{invalidations.count}"
       invalidations.map do |app, id, invalidation|
         cloudfront.wait_until(:invalidation_completed, distribution_id: id, id: invalidation) do |waiter|
           waiter.max_attempts = 120 # wait up to 40 minutes for invalidations


### PR DESCRIPTION
When building on an adhoc which does not have cloudfront, the bin/flush_cache step fails as follows:
```
bin/flush_cache
rake aborted!
'bin/flush_cache' returned 1
Flushing Varnish cache on daemon...
sudo varnishadm -T localhost:6082 -S /etc/varnish/secret 'ban obj.status ~ .'
[GEM]/gems/aws-sdk-core-3.48.1/lib/aws-sdk-core/param_validator.rb:33:in `validate!': missing required parameter params[:distribution_id] (ArgumentError)
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/aws-sdk-core/param_validator.rb:13:in `validate!'
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/aws-sdk-core/plugins/param_validator.rb:23:in `call'
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/aws-sdk-core/plugins/logging.rb:39:in `call'
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/aws-sdk-core/plugins/idempotency_token.rb:17:in `call'
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/aws-sdk-core/plugins/param_converter.rb:24:in `call'
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call'
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/seahorse/client/plugins/response_target.rb:23:in `call'
	from [GEM]/gems/aws-sdk-core-3.48.1/lib/seahorse/client/request.rb:70:in `send_request'
	from [GEM]/gems/aws-sdk-cloudfront-1.4.0/lib/aws-sdk-cloudfront/client.rb:1090:in `create_invalidation'
	from [CDO]/lib/cdo/aws/cloudfront.rb:94:in `block in invalidate_caches'
	from [CDO]/lib/cdo/aws/cloudfront.rb:91:in `map'
	from [CDO]/lib/cdo/aws/cloudfront.rb:91:in `invalidate_caches'
	from bin/flush_cache:28:in `<main>'
Flushing CloudFront caches (up to 15 min)...
Creating CloudFront cache invalidations...
Tasks: TOP => ci:all => ci:flush_cache
(See full trace by running task with --trace)
```

This PR is one way to fix it, but I'm open to others. Sample output:
```
ubuntu@adhoc-lp:~/adhoc$ bin/flush_cache
Flushing Varnish cache on daemon...
sudo varnishadm -T localhost:6082 -S /etc/varnish/secret 'ban obj.status ~ .'
Flushing CloudFront caches (up to 15 min)...
Creating CloudFront cache invalidations...
Invalidations created: 0
All done!
ubuntu@adhoc-lp:~/adhoc$ 
```
