### PR TITLE
Applab theme padding

### DIFF
--- a/apps/src/applab/designElements/dropdown.jsx
+++ b/apps/src/applab/designElements/dropdown.jsx
@@ -188,6 +188,9 @@ const svgArrowUrl = color =>
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 448" enable-background="new 0 0 256 448"><style type="text/css">.arrow{fill:${color};}</style><path class="arrow" d="M255.9 168c0-4.2-1.6-7.9-4.8-11.2-3.2-3.2-6.9-4.8-11.2-4.8H16c-4.2 0-7.9 1.6-11.2 4.8S0 163.8 0 168c0 4.4 1.6 8.2 4.8 11.4l112 112c3.1 3.1 6.8 4.6 11.2 4.6 4.4 0 8.2-1.5 11.4-4.6l112-112c3-3.2 4.5-7 4.5-11.4z"/></svg>`
   )})`;
 
+const CLASSIC_DROPDOWN_PADDING = '0 30px 0 10px';
+const NEW_THEME_DROPDOWN_PADDING = '0 30px 0 15px';
+
 export default {
   PropertyTab: DropdownProperties,
   EventTab: DropdownEvents,
@@ -267,6 +270,22 @@ export default {
       millennial: 13,
       robot: 13,
       classic: 14
+    },
+    padding: {
+      default: NEW_THEME_DROPDOWN_PADDING,
+      orange: NEW_THEME_DROPDOWN_PADDING,
+      citrus: NEW_THEME_DROPDOWN_PADDING,
+      ketchupAndMustard: NEW_THEME_DROPDOWN_PADDING,
+      lemonade: NEW_THEME_DROPDOWN_PADDING,
+      forest: NEW_THEME_DROPDOWN_PADDING,
+      watermelon: NEW_THEME_DROPDOWN_PADDING,
+      area51: NEW_THEME_DROPDOWN_PADDING,
+      polar: NEW_THEME_DROPDOWN_PADDING,
+      glowInTheDark: NEW_THEME_DROPDOWN_PADDING,
+      bubblegum: NEW_THEME_DROPDOWN_PADDING,
+      millennial: NEW_THEME_DROPDOWN_PADDING,
+      robot: NEW_THEME_DROPDOWN_PADDING,
+      classic: CLASSIC_DROPDOWN_PADDING
     }
   },
 
@@ -303,13 +322,19 @@ export default {
   onDeserialize: function(element) {
     // Set border styles for older projects that didn't set them on create:
     elementUtils.setDefaultBorderStyles(element);
-    // Set the font family for older projects that didn't set them on create:
+    // Set the font family for older projects that didn't set it on create:
     elementUtils.setDefaultFontFamilyStyle(element);
     // Set the dropdown SVG for older projects that didn't have them:
     if (!element.style.backgroundImage) {
       element.style.backgroundImage = svgArrowUrl(
         new RGBColor(element.style.color).toHex()
       );
+    }
+    if (experiments.isEnabled('applabThemes')) {
+      // Set the padding for older projects that didn't set it on create:
+      if (element.style.padding === '') {
+        element.style.padding = CLASSIC_DROPDOWN_PADDING;
+      }
     }
 
     // In the future we may want to trigger this on focus events as well.

--- a/apps/src/applab/designElements/elementUtils.js
+++ b/apps/src/applab/designElements/elementUtils.js
@@ -227,3 +227,56 @@ export function setDefaultBorderStyles(element, options = {}) {
     element.style.borderRadius = '0px';
   }
 }
+
+/**
+ * Parse a padding string and return the total horizontal padding and
+ * total vertical padding.
+ * @param {string} cssPaddingString value from element.style.padding
+ */
+export function calculatePadding(cssPaddingString) {
+  const paddingRegEx = /\s*?(\d*)(px)?\s*(\d*)?(px)?\s*(\d*)?(px)?\s*(\d*)?(px)?\s*?/i;
+  const paddingResult = paddingRegEx.exec(cssPaddingString);
+
+  const paddingValues = [
+    parseInt(paddingResult[1], 10),
+    parseInt(paddingResult[3], 10),
+    parseInt(paddingResult[5], 10),
+    parseInt(paddingResult[7], 10)
+  ];
+  for (
+    var validPaddingValues = 0;
+    validPaddingValues < paddingValues.length;
+    validPaddingValues++
+  ) {
+    if (isNaN(paddingValues[validPaddingValues])) {
+      break;
+    }
+  }
+
+  // See https://developer.mozilla.org/en-US/docs/Web/CSS/padding#Syntax
+  let horizontalPadding, verticalPadding;
+  switch (validPaddingValues) {
+    case 1:
+      horizontalPadding = verticalPadding = 2 * paddingValues[0];
+      break;
+    case 2:
+      verticalPadding = 2 * paddingValues[0];
+      horizontalPadding = 2 * paddingValues[1];
+      break;
+    case 3:
+      verticalPadding = paddingValues[0] + paddingValues[2];
+      horizontalPadding = 2 * paddingValues[1];
+      break;
+    case 4:
+      verticalPadding = paddingValues[0] + paddingValues[2];
+      horizontalPadding = paddingValues[1] + paddingValues[3];
+      break;
+    default:
+      horizontalPadding = verticalPadding = 0;
+      break;
+  }
+  return {
+    horizontalPadding,
+    verticalPadding
+  };
+}

--- a/apps/src/applab/designElements/label.jsx
+++ b/apps/src/applab/designElements/label.jsx
@@ -191,6 +191,9 @@ class LabelEvents extends React.Component {
  */
 const STILL_FITS = 5;
 
+const CLASSIC_LABEL_PADDING = '2px';
+const NEW_THEME_LABEL_PADDING = '2px 15px';
+
 export default {
   PropertyTab: LabelProperties,
   EventTab: LabelEvents,
@@ -270,13 +273,28 @@ export default {
       millennial: 13,
       robot: 13,
       classic: 14
+    },
+    padding: {
+      default: NEW_THEME_LABEL_PADDING,
+      orange: NEW_THEME_LABEL_PADDING,
+      citrus: NEW_THEME_LABEL_PADDING,
+      ketchupAndMustard: NEW_THEME_LABEL_PADDING,
+      lemonade: NEW_THEME_LABEL_PADDING,
+      forest: NEW_THEME_LABEL_PADDING,
+      watermelon: NEW_THEME_LABEL_PADDING,
+      area51: NEW_THEME_LABEL_PADDING,
+      polar: NEW_THEME_LABEL_PADDING,
+      glowInTheDark: NEW_THEME_LABEL_PADDING,
+      bubblegum: NEW_THEME_LABEL_PADDING,
+      millennial: NEW_THEME_LABEL_PADDING,
+      robot: NEW_THEME_LABEL_PADDING,
+      classic: CLASSIC_LABEL_PADDING
     }
   },
 
   create: function() {
     const element = document.createElement('label');
     element.style.margin = '0px';
-    element.style.padding = '2px';
     element.style.lineHeight = '1';
     element.style.overflow = 'hidden';
     element.style.wordWrap = 'break-word';
@@ -286,6 +304,7 @@ export default {
       element.style.borderStyle = 'solid';
       elementLibrary.applyCurrentTheme(element, designMode.activeScreen());
     } else {
+      element.style.padding = CLASSIC_LABEL_PADDING;
       element.style.backgroundColor = themeColor.labelBackground.classic;
       element.style.fontFamily = applabConstants.fontFamilyStyles[0];
       element.style.fontSize = applabConstants.defaultFontSizeStyle;
@@ -354,14 +373,17 @@ export default {
         })
         .appendTo($(document.body));
 
-      const padding = parseInt(element.style.padding, 10);
+      const {
+        horizontalPadding,
+        verticalPadding
+      } = elementUtils.calculatePadding(element.style.padding);
 
       if (!widthLocked) {
         // Truncate the width before it runs off the edge of the screen
-        size.width = Math.min(clone.width() + 1 + 2 * padding, maxWidth);
+        size.width = Math.min(clone.width() + 1 + horizontalPadding, maxWidth);
       }
       if (!heightLocked) {
-        size.height = clone.height() + 1 + 2 * padding;
+        size.height = clone.height() + 1 + verticalPadding;
       }
 
       clone.remove();
@@ -400,19 +422,41 @@ export default {
     element.style.height = size.height + 'px';
   },
 
+  _lastFitsExactly: {},
+
   /**
    * Returns whether this element perfectly fits its bounding size, if that is needed in onPropertyChange.
    */
-  beforePropertyChange: function(element, name) {
-    if (name !== 'text' && name !== 'fontSize') {
-      return null;
+  beforePropertyChange: function(element, name, batchChangeId) {
+    switch (name) {
+      case 'padding':
+      case 'text':
+      case 'fontFamily':
+      case 'fontSize': {
+        const {
+          batchId = -1,
+          previouslyFitExactly: batchPreviouslyFitExactly
+        } = this._lastFitsExactly;
+        if (batchId === batchChangeId) {
+          // We've already computed previouslyFitExactly for this batch of property updates:
+          return batchPreviouslyFitExactly;
+        }
+        const currentSize = this.getCurrentSize(element);
+        const bestSize = this.getBestSize(element);
+        const previouslyFitExactly =
+          Math.abs(currentSize.width - bestSize.width) < STILL_FITS &&
+          Math.abs(currentSize.height - bestSize.height) < STILL_FITS;
+        this._lastFitsExactly = batchChangeId
+          ? {
+              batchId: batchChangeId,
+              previouslyFitExactly
+            }
+          : {};
+        return previouslyFitExactly;
+      }
+      default:
+        return null;
     }
-    const currentSize = this.getCurrentSize(element);
-    const bestSize = this.getBestSize(element);
-    return (
-      Math.abs(currentSize.width - bestSize.width) < STILL_FITS &&
-      Math.abs(currentSize.height - bestSize.height) < STILL_FITS
-    );
   },
 
   /**
@@ -421,7 +465,9 @@ export default {
   onPropertyChange: function(element, name, value, previouslyFitExactly) {
     switch (name) {
       case 'text':
+      case 'fontFamily':
       case 'fontSize':
+      case 'padding':
         if (previouslyFitExactly) {
           this.resizeToFitText(element);
         }

--- a/apps/src/applab/designElements/library.js
+++ b/apps/src/applab/designElements/library.js
@@ -200,10 +200,14 @@ export default {
    * Gets data from an element before it is changed, should it be necessary to do so. This data will be passed to the
    * typeSpecificPropertyChange method below.
    */
-  getPreChangeData: function(element, name) {
+  getPreChangeData: function(element, name, batchChangeId) {
     var elementType = this.getElementType(element);
     if (elements[elementType].beforePropertyChange) {
-      return elements[elementType].beforePropertyChange(element, name);
+      return elements[elementType].beforePropertyChange(
+        element,
+        name,
+        batchChangeId
+      );
     }
     return null;
   },

--- a/apps/src/applab/designElements/textInput.jsx
+++ b/apps/src/applab/designElements/textInput.jsx
@@ -206,6 +206,9 @@ class TextInputEvents extends React.Component {
   }
 }
 
+const CLASSIC_TEXT_INPUT_PADDING = '5px';
+const NEW_THEME_TEXT_INPUT_PADDING = '5px 15px';
+
 export default {
   PropertyTab: TextInputProperties,
   EventTab: TextInputEvents,
@@ -285,6 +288,22 @@ export default {
       millennial: 13,
       robot: 13,
       classic: 14
+    },
+    padding: {
+      default: NEW_THEME_TEXT_INPUT_PADDING,
+      orange: NEW_THEME_TEXT_INPUT_PADDING,
+      citrus: NEW_THEME_TEXT_INPUT_PADDING,
+      ketchupAndMustard: NEW_THEME_TEXT_INPUT_PADDING,
+      lemonade: NEW_THEME_TEXT_INPUT_PADDING,
+      forest: NEW_THEME_TEXT_INPUT_PADDING,
+      watermelon: NEW_THEME_TEXT_INPUT_PADDING,
+      area51: NEW_THEME_TEXT_INPUT_PADDING,
+      polar: NEW_THEME_TEXT_INPUT_PADDING,
+      glowInTheDark: NEW_THEME_TEXT_INPUT_PADDING,
+      bubblegum: NEW_THEME_TEXT_INPUT_PADDING,
+      millennial: NEW_THEME_TEXT_INPUT_PADDING,
+      robot: NEW_THEME_TEXT_INPUT_PADDING,
+      classic: CLASSIC_TEXT_INPUT_PADDING
     }
   },
 
@@ -316,6 +335,10 @@ export default {
     // Set the font family for older projects that didn't set it on create:
     elementUtils.setDefaultFontFamilyStyle(element);
     if (experiments.isEnabled('applabThemes')) {
+      // Set the padding for older projects that didn't set it on create:
+      if (element.style.padding === '') {
+        element.style.padding = CLASSIC_TEXT_INPUT_PADDING;
+      }
       // Set the background color for older projects that didn't set it on create:
       if (element.style.backgroundColor === '') {
         element.style.backgroundColor = this.themeValues.backgroundColor[

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -192,6 +192,9 @@ class TextAreaEvents extends React.Component {
   }
 }
 
+const CLASSIC_TEXT_AREA_PADDING = '5px';
+const NEW_THEME_TEXT_AREA_PADDING = '5px 15px';
+
 export default {
   PropertyTab: TextAreaProperties,
   EventTab: TextAreaEvents,
@@ -271,6 +274,22 @@ export default {
       millennial: 13,
       robot: 13,
       classic: 14
+    },
+    padding: {
+      default: NEW_THEME_TEXT_AREA_PADDING,
+      orange: NEW_THEME_TEXT_AREA_PADDING,
+      citrus: NEW_THEME_TEXT_AREA_PADDING,
+      ketchupAndMustard: NEW_THEME_TEXT_AREA_PADDING,
+      lemonade: NEW_THEME_TEXT_AREA_PADDING,
+      forest: NEW_THEME_TEXT_AREA_PADDING,
+      watermelon: NEW_THEME_TEXT_AREA_PADDING,
+      area51: NEW_THEME_TEXT_AREA_PADDING,
+      polar: NEW_THEME_TEXT_AREA_PADDING,
+      glowInTheDark: NEW_THEME_TEXT_AREA_PADDING,
+      bubblegum: NEW_THEME_TEXT_AREA_PADDING,
+      millennial: NEW_THEME_TEXT_AREA_PADDING,
+      robot: NEW_THEME_TEXT_AREA_PADDING,
+      classic: CLASSIC_TEXT_AREA_PADDING
     }
   },
 
@@ -303,8 +322,14 @@ export default {
   onDeserialize: function(element) {
     // Set border styles for older projects that didn't set them on create:
     elementUtils.setDefaultBorderStyles(element, {textInput: true});
-    // Set the font family for older projects that didn't set them on create:
+    // Set the font family for older projects that didn't set it on create:
     elementUtils.setDefaultFontFamilyStyle(element);
+    if (experiments.isEnabled('applabThemes')) {
+      // Set the padding for older projects that didn't set it on create:
+      if (element.style.padding === '') {
+        element.style.padding = CLASSIC_TEXT_AREA_PADDING;
+      }
+    }
 
     $(element).addClass('textArea');
 

--- a/apps/test/unit/applab/designElements/elementUtilsTest.js
+++ b/apps/test/unit/applab/designElements/elementUtilsTest.js
@@ -1,0 +1,115 @@
+import {expect} from '../../../util/configuredChai';
+
+import * as elementUtils from '@cdo/apps/applab/designElements/elementUtils';
+
+describe('Applab designElements/elementUtils', function() {
+  describe('calculatePadding', () => {
+    it('returns (0,0) for empty padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('');
+      expect(verticalPadding).is.equal(0);
+      expect(horizontalPadding).is.equal(0);
+    });
+
+    it('returns (0,0) for undefined padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding();
+      expect(verticalPadding).is.equal(0);
+      expect(horizontalPadding).is.equal(0);
+    });
+
+    it('returns (0,0) for "0" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('0');
+      expect(verticalPadding).is.equal(0);
+      expect(horizontalPadding).is.equal(0);
+    });
+
+    it('returns (0,0) for "0px" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('0px');
+      expect(verticalPadding).is.equal(0);
+      expect(horizontalPadding).is.equal(0);
+    });
+
+    it('returns (0,0) for "0 0px" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('0 0px');
+      expect(verticalPadding).is.equal(0);
+      expect(horizontalPadding).is.equal(0);
+    });
+
+    it('returns (0,0) for "0px 0" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('0px 0');
+      expect(verticalPadding).is.equal(0);
+      expect(horizontalPadding).is.equal(0);
+    });
+
+    it('returns (2,0) for "1px 0" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('1px 0');
+      expect(verticalPadding).is.equal(2);
+      expect(horizontalPadding).is.equal(0);
+    });
+
+    it('returns (0,2) for "0 1px" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('0 1px');
+      expect(verticalPadding).is.equal(0);
+      expect(horizontalPadding).is.equal(2);
+    });
+
+    it('returns (2,2) for "1px 1px" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('1px 1px');
+      expect(verticalPadding).is.equal(2);
+      expect(horizontalPadding).is.equal(2);
+    });
+
+    it('returns (3,0) for "1px 0 2px" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('1px 0 2px');
+      expect(verticalPadding).is.equal(3);
+      expect(horizontalPadding).is.equal(0);
+    });
+
+    it('returns (3,7) for "1px 0 2px 7px" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('1px 0 2px 7px');
+      expect(verticalPadding).is.equal(3);
+      expect(horizontalPadding).is.equal(7);
+    });
+
+    it('returns (3,17) for "1px 10px 2px 7px" padding string', () => {
+      const {
+        verticalPadding,
+        horizontalPadding
+      } = elementUtils.calculatePadding('1px 10px 2px 7px');
+      expect(verticalPadding).is.equal(3);
+      expect(horizontalPadding).is.equal(17);
+    });
+  });
+});


### PR DESCRIPTION
_Context_

* Applab elements have always had some padding, but the values were usually specified in CSS outside of the applab scope. The new theme comps include consistent padding of `15px` on the sides so that the text isn't hugging against the edge of the element.

_Considerations_
* Introducing padding as a student configurable property on elements is not desirable at this time. To do it properly would require four separate properties, which would introduce a lot of complexity in the design mode editor.
* Changing the existing padding values for all projects will create compatibility issues

_Design Plan_
* Introduce padding as an internal-only property that can be set/retrieved only as part of changing themes. The syntax of the padding value will match the CSS spec, so we can maintain a single padding string value.
* Preserve (and explicitly backfill) the historical padding values for each element as part of the `Classic` theme, which ensures that we don't introduce any compatibility issues. Students will not need to deal with truncated text or resizing elements until they try changing themes (still currently under an experiment).
* Set the same padding values for all of our new themes. Once the themes experiment is permanently enabled, all new projects will create screens in the `Default` theme and all elements placed on the screen will have the new padding values. Changing to any theme other than `Classic` will preserve the new padding values.
* The `label` element now has padding on the left and right sides, even when the label has a transparent background. This consistency makes it easier to align `label` text above `dropdown`, `textInput`, and `textArea` elements. It also simplifies theme changes, ensuring that the label text stays in the same left-aligned position.

_Bonus updates to label resizing_
* The `label` element has some special magic to resize automatically if the element was deemed to be sized exactly to match the text. I've updated this logic to account for `padding` changes and the recently introduced `fontFamily` property. I've also added the notion of a `batchChangeId` during `updateProperty()` calls. This optional parameter is set when property values are changed in batches during theme changes. It allows the `label` to be smart about measuring just once at the beginning of a batch of a property updates (to determine if the element was previously "sized to fit").


_Example screenshots (note: buttons are not impacted by padding changes)_
<img width="424" alt="Screen Shot 2019-05-01 at 11 42 18 AM" src="https://user-images.githubusercontent.com/5429146/57035192-45e8d080-6c06-11e9-863c-2025f478895a.png">
<img width="419" alt="Screen Shot 2019-05-01 at 11 42 40 AM" src="https://user-images.githubusercontent.com/5429146/57035201-4aad8480-6c06-11e9-83c7-dcf60179e7cb.png">
