### PR TITLE
Add a new property, display_as_unplugged, to External levels

### DIFF
--- a/dashboard/app/models/levels/external.rb
+++ b/dashboard/app/models/levels/external.rb
@@ -24,6 +24,9 @@
 #
 
 class External < DSLDefined
+  serialized_attrs %w(
+    display_as_unplugged
+  )
   # This string gets replaced with the user's id in markdown.
   USER_ID_REPLACE_STRING = '<user_id/>'.freeze
 
@@ -50,6 +53,10 @@ class External < DSLDefined
 
   def concept_level?
     true
+  end
+
+  def display_as_unplugged
+    properties.merge({'display_as_unplugged' => !properties['display_as_unplugged']})
   end
 
   # returns a properties hash in which USER_ID_REPLACE_STRING is replaced by the current user's id

--- a/dashboard/app/models/levels/external.rb
+++ b/dashboard/app/models/levels/external.rb
@@ -55,10 +55,6 @@ class External < DSLDefined
     true
   end
 
-  def display_as_unplugged
-    properties.merge({'display_as_unplugged' => !properties['display_as_unplugged']})
-  end
-
   # returns a properties hash in which USER_ID_REPLACE_STRING is replaced by the current user's id
   # in markdown
   def properties_with_replaced_markdown(user)

--- a/dashboard/app/views/levels/editors/_all.html.haml
+++ b/dashboard/app/views/levels/editors/_all.html.haml
@@ -33,6 +33,11 @@
   #audit_log_info.collapse
     = render partial: 'levels/editors/audit_log', locals: {f: f}
 
+  - if @level.is_a?(External)
+    .field
+      = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :display_as_unplugged, description: "Display as Unplugged"}
+      %p If set, this level's bubble will appear as an "Unplugged" level
+
 .field
   = f.label 'concepts'
   %p


### PR DESCRIPTION
Working on: [LP-278 ](https://codedotorg.atlassian.net/browse/LP-278)

Levelbuilders would like to enable markdown / external html level types to be shown as "unplugged" levels if a check mark is checked accordingly in Levelbuilder. This PR adds that checkbox to the level creation page for external levels and uses its value to set a new property, `display_as_unplugged`.  

<img width="589" alt="Screen Shot 2019-05-01 at 11 29 34 AM" src="https://user-images.githubusercontent.com/12300669/57034495-821b3180-6c04-11e9-933d-62a9d779d71b.png">

If unchecked: 
<img width="1013" alt="unchecked-display-as-unplugged" src="https://user-images.githubusercontent.com/12300669/57034634-e938e600-6c04-11e9-86ab-21a9835137fe.png">

If checked: 
<img width="1017" alt="checked-display-as-unplugged" src="https://user-images.githubusercontent.com/12300669/57034626-e50cc880-6c04-11e9-8d38-2655e7f45d8e.png">

Up next: this new property will be used to make the level bubble appear the same as an "unplugged" level.