### PR TITLE
PL: tweak criteria used to send a teacher reminder email

### DIFF
--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -339,19 +339,19 @@ module Pd::Application
 
       # Do we allow manually sending/resending the principal email?
 
-      # Don't allow unless this teacher application is currently unreviewed or pending.
+      # Only if this teacher application is currently unreviewed or pending.
       return false unless unreviewed? || pending?
 
-      # Don't allow if the principal approval is required.
+      # Only if the principal approval is required.
       return false if principal_approval_not_required
 
-      # Don't allow if we haven't gotten a principal response yet.
+      # Only if we haven't gotten a principal response yet.
       return false if response
 
-      # Don't allow unless we've sent at least one principal approval email before.
+      # Only if we've sent at least one principal approval email before.
       return false unless last_principal_approval_email_created_at
 
-      # Don't allow if it's been more than 5 days since we last created an email for the principal.
+      # Only if it's been more than 5 days since we last created an email for the principal.
       return false if last_principal_approval_email_created_at && last_principal_approval_email_created_at > 5.days.ago
 
       true

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -348,9 +348,6 @@ module Pd::Application
       # Only if we haven't gotten a principal response yet.
       return false if response
 
-      # Only if we've sent at least one principal approval email before.
-      return false unless last_principal_approval_email_created_at
-
       # Only if it's been more than 5 days since we last created an email for the principal.
       return false if last_principal_approval_email_created_at && last_principal_approval_email_created_at > 5.days.ago
 
@@ -358,12 +355,18 @@ module Pd::Application
     end
 
     def allow_sending_principal_approval_teacher_reminder_email?
+      last_principal_approval_email = emails.where(email_type: 'principal_approval').order(:created_at).last
+      last_principal_approval_email_created_at = last_principal_approval_email&.created_at
+
       reminder_emails = emails.where(email_type: 'principal_approval_teacher_reminder')
 
       # Do we allow the cron job to send a reminder email to the teacher?
 
       # Only if we haven't already sent one.
       return false if reminder_emails.any?
+
+      # Only if we've sent at least one principal approval email before.
+      return false unless last_principal_approval_email_created_at
 
       # If it's valid to send another principal email at this time.
       return allow_sending_principal_email?

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -355,9 +355,6 @@ module Pd::Application
     end
 
     def allow_sending_principal_approval_teacher_reminder_email?
-      last_principal_approval_email = emails.where(email_type: 'principal_approval').order(:created_at).last
-      last_principal_approval_email_created_at = last_principal_approval_email&.created_at
-
       reminder_emails = emails.where(email_type: 'principal_approval_teacher_reminder')
 
       # Do we allow the cron job to send a reminder email to the teacher?
@@ -366,7 +363,7 @@ module Pd::Application
       return false if reminder_emails.any?
 
       # Only if we've sent at least one principal approval email before.
-      return false unless last_principal_approval_email_created_at
+      return false unless emails.where(email_type: 'principal_approval').exists?
 
       # If it's valid to send another principal email at this time.
       return allow_sending_principal_email?

--- a/dashboard/test/models/pd/application/teacher1920_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher1920_application_test.rb
@@ -984,9 +984,9 @@ module Pd::Application
     private
 
     test 'test allow_sending_principal_email?' do
-      # By default we can't send.
+      # By default we can send.
       application = create :pd_teacher1920_application
-      refute application.allow_sending_principal_email?
+      assert application.allow_sending_principal_email?
 
       # If we're no longer unreviewed/pending, we can't send.
       application = create :pd_teacher1920_application

--- a/dashboard/test/models/pd/application/teacher1920_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher1920_application_test.rb
@@ -984,9 +984,9 @@ module Pd::Application
     private
 
     test 'test allow_sending_principal_email?' do
-      # By default we can send.
+      # By default we can't send.
       application = create :pd_teacher1920_application
-      assert application.allow_sending_principal_email?
+      refute application.allow_sending_principal_email?
 
       # If we're no longer unreviewed/pending, we can't send.
       application = create :pd_teacher1920_application
@@ -1015,9 +1015,9 @@ module Pd::Application
     end
 
     test 'test allow_sending_principal_approval_teacher_reminder_email?' do
-      # By default we can send.
+      # By default we can't send.
       application = create :pd_teacher1920_application
-      assert application.allow_sending_principal_approval_teacher_reminder_email?
+      refute application.allow_sending_principal_approval_teacher_reminder_email?
 
       # If we created a teacher reminder email any time before, we can't send.
       application = create :pd_teacher1920_application


### PR DESCRIPTION
This tweaks the criteria used to allow sending an email to a teacher that reminds them to get their principal's approval.  Now, it's only possible if a principal approval email has previously been sent.

This is a followup to https://github.com/code-dot-org/code-dot-org/pull/28103 and directly impacts https://github.com/code-dot-org/code-dot-org/pull/28148.

When doing a test run of the script in the second PR, we discovered that we would send a few too many emails, in particular for teacher applications for a regional partner who had principal approval set as `"required_per_teacher"` rather than `"all_teachers_required"` (that is, the regional partner didn't necessarily want principal approval required for all teachers, but might only want it for some teachers).

By checking that a principal approval email has previously been sent, we avoid sending the reminder email to teachers who don't need it.

### Note

We also attempted a different criterion:

```
return false if regional_partner&.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL && principal_approval_not_required != false
```

That is, we would not allow sending another reminder email if the regional partner had principal approval set as `"required_per_teacher"` but for this teacher application the `principal_approval_not_required` value was `nil` (the default) or `true` (when the workshop administrator explicitly set the user to not require principal approval).  This would leave the value of `false` to allow another email to be sent.  However, we discovered that teacher applications for such a regional partner can have had a principal approval email sent without changing `principal_approval_not_required` to `false`, and so we decided to use the criteria in the PR, not this different one, to allow an email resend.  

This is pretty confusing stuff that would be great to clean up in the future.
