### PR TITLE
Fix blockly shared functions edit page

### DIFF
--- a/apps/src/gamelab/blocks.js
+++ b/apps/src/gamelab/blocks.js
@@ -9,7 +9,7 @@ import {changeInterfaceMode} from './actions';
 import experiments from '@cdo/apps/util/experiments';
 import {Goal, show} from './AnimationPicker/animationPickerModule';
 
-export function sprites() {
+function sprites() {
   const animationList = getStore().getState().animationList;
   if (!animationList || animationList.orderedKeys.length === 0) {
     console.warn('No sprites available');
@@ -254,6 +254,7 @@ const customInputTypes = {
 };
 
 export default {
+  sprites,
   customInputTypes,
   install(blockly, blockInstallOptions) {
     // Legacy style block definitions :(


### PR DESCRIPTION
Surprisingly, when commit c227863c5272ad9a73d1efe597741eab46892c9c added an export it affected the shape of `export default { ... }` in the exported object.

Before:

![image](https://user-images.githubusercontent.com/413693/57037243-7ed77400-6c0b-11e9-815a-9d5a81761305.png)

After:

![image](https://user-images.githubusercontent.com/413693/57037381-e68dbf00-6c0b-11e9-91c3-a99a090a5bf6.png)