### PR TITLE
Seed csp-post-survey-2018 in drone ui tests

### DIFF
--- a/dashboard/config/courses/csp-2018.course
+++ b/dashboard/config/courses/csp-2018.course
@@ -8,7 +8,8 @@
     "csp-explore-2018",
     "csp5-2018",
     "csp-create-2018",
-    "csppostap-2018"
+    "csppostap-2018",
+    "csp-post-survey-2018"
   ],
   "properties": {
     "teacher_resources": [

--- a/dashboard/config/courses/csp-2018.course
+++ b/dashboard/config/courses/csp-2018.course
@@ -8,8 +8,7 @@
     "csp-explore-2018",
     "csp5-2018",
     "csp-create-2018",
-    "csppostap-2018",
-    "csp-post-survey-2018"
+    "csppostap-2018"
   ],
   "properties": {
     "teacher_resources": [

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -12257,7 +12257,7 @@ en:
           stages:
             CSP post-course survey:
               name: CSP post-course survey
-          title: CSP Student Post-Course Survey ('17-'18)
+          title: CSP Student Post-Course Survey ('18-'19)
           description_audience: CSP Students
           description_short: CSP Student Post Course Survey
           description: Welcome to the Code.org CS Principles Post-Course Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -12257,7 +12257,7 @@ en:
           stages:
             CSP post-course survey:
               name: CSP post-course survey
-          title: CSP Student Post-Course Survey ('18-'19)
+          title: CSP Student Post-Course Survey ('17-'18)
           description_audience: CSP Students
           description_short: CSP Student Post Course Survey
           description: Welcome to the Code.org CS Principles Post-Course Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.

--- a/dashboard/config/scripts/csp-post-survey-2018.script
+++ b/dashboard/config/scripts/csp-post-survey-2018.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 exclude_csf_column_in_legend true
 has_verified_resources true

--- a/dashboard/config/scripts/csp-post-survey-2018.script
+++ b/dashboard/config/scripts/csp-post-survey-2018.script
@@ -1,4 +1,3 @@
-hidden false
 login_required true
 exclude_csf_column_in_legend true
 has_verified_resources true

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -59,6 +59,7 @@ namespace :seed do
     'csp-explore-2018',
     'csp-create-2018',
     'csppostap-2018',
+    'csp-post-survey-2018',
     'dance',
     'events',
     'express-2017',


### PR DESCRIPTION
### Background

~Finishes~ related to [LP-374](https://codedotorg.atlassian.net/browse/LP-374). Baker will do the actual work via levelbuilder to unhide the post course survey. additional context in https://github.com/code-dot-org/code-dot-org/pull/28316. 

### Description

All this PR does now is make sure tests don't break when Baker adds the post course survey to csp-2018, by adding csp-post-survey-2018 to the list of courses to seed in drone ui tests.

### Verification

From the trail of commits and drone runs, you can see that this will allow tests to pass once the post survey is added to csp 2018.