### PR TITLE
Show csd-post-survey-2018 script in csd-2018 course

### DIFF
--- a/dashboard/config/courses/csd-2018.course
+++ b/dashboard/config/courses/csd-2018.course
@@ -6,7 +6,8 @@
     "csd3-2018",
     "csd4-2018",
     "csd5-2018",
-    "csd6-2018"
+    "csd6-2018",
+    "csd-post-survey-2018"
   ],
   "properties": {
     "teacher_resources": [

--- a/dashboard/config/scripts/csd-post-survey-2018.script
+++ b/dashboard/config/scripts/csd-post-survey-2018.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 exclude_csf_column_in_legend true
 has_verified_resources true


### PR DESCRIPTION
### Background

Finishes https://codedotorg.atlassian.net/browse/LP-373

Yesterday, I created https://levelbuilder-studio.code.org/s/csd-post-survey-2018 on levelbuilder. This script contains a single level group which is a shallow copy of the [csd 2017 post-course survey level group](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/scripts/csd_post_survey_2017_levelgroup_2018_2nd_semester.level_group). 

Shallow copy means that levels are shared between the 2017 and 2018 post-course survey level groups. This is important because it allows for Mary and Ben to analyze survey data more easily. Usually, sharing levels across script versions is not allowed because an update to the more recent script could break the older, stable script. However, we allow it because they promise not to change any of these sublevels directly. if they want to change a question for future years, they will copy the level first and then update the newer copy.

### Description

All this PR does is unhide /s/csd-post-survey-2018 and add it to /courses/csd-2018 . 

### Launch Plan

This will be tested on adhoc-lp on Thursday and shipped on Friday.