### PR TITLE
Surveys: Show help when load fails

### DIFF
--- a/apps/src/sites/studio/pages/jotformLoader.js
+++ b/apps/src/sites/studio/pages/jotformLoader.js
@@ -59,6 +59,7 @@ function checkJotFormFrameLoaded(context) {
 
     const timeoutKey = setTimeout(function() {
       console.log(`JotForm failed to load in 5s`);
+      showHelp();
       resolve(false);
     }, 5000);
   });
@@ -82,6 +83,21 @@ function checkReachability(url) {
     const startTime = performance.now();
     img.src = `${url}?__cacheBust=${Math.random()}`;
   });
+}
+
+function showHelp() {
+  const iframe = document.querySelector('iframe');
+  const helpText = document.createElement('div');
+  helpText.innerHTML = `
+    <div style="text-align: center;">
+      Having trouble loading the survey?
+      <a href="javascript:location.reload()">Reload to try again.</a>
+      <br/>
+      If that doesn't work, please try another browser,
+      or temporarily disable your adblocker on our site.
+    </div>
+  `;
+  iframe.parentNode.insertBefore(helpText, iframe);
 }
 
 main(window);


### PR DESCRIPTION
@hacodeorg observed that JotForm sometimes failed to load on his own machine because [Privacy Badger](https://www.eff.org/privacybadger) was blocking relevant requests.  This seems like a viable explanation for load failures, so we'd like to help our audience catch this case and work around it.  Credit to Ha for the simple help text idea.

This PR hooks into our existing load failure detection, and adds a message (below) that will appear when we detect "load failure" (no success after five seconds) suggesting the guest try another browser or temporarily disable their adblocker on our site.  (I'm making an assumption that "adblocker" is enough of a clue for the broad category of privacy-protecting extensions that might block requests to JotForm domains.)

![Screenshot from 2019-05-01 16-26-47](https://user-images.githubusercontent.com/1615761/57049713-18b01880-6c2e-11e9-9d25-fab458871ccb.png)

Open questions:
- Do we think this will help?
- Are we at all squeamish about asking guests to disable a privacy tool to use our site?

Tested locally by blocking JotForm domains with devtools.