### PR TITLE
Update version redirect text to say 'different'

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1117,7 +1117,7 @@
   "recording": "Recording",
   "recordAudio": "Record Audio",
   "redirectConfirm": "Do you want to open this website? {url}",
-  "redirectCourseVersionWarningDetails": "It looks like you accidentally went to an outdated version of the course. You've been redirected to the recommended version or the version assigned by your teacher.",
+  "redirectCourseVersionWarningDetails": "It looks like you accidentally went to an outdated or unstable version of the course. You've been redirected to the recommended version or the version assigned by your teacher.",
   "redirectExplanation": "This is a link to an external website not operated or reviewed by Code.org and it does not follow the Code.org privacy policy. Please report this app if it is linking to content that is inappropriate or unsafe: ",
   "redirectRejectExplanation": "This app is trying to open a website that appears to be unsafe.",
   "redirectRejectTitle": "Navigation to Unsafe Site Detected",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1117,7 +1117,7 @@
   "recording": "Recording",
   "recordAudio": "Record Audio",
   "redirectConfirm": "Do you want to open this website? {url}",
-  "redirectCourseVersionWarningDetails": "It looks like you accidentally went to an outdated or unstable version of the course. You've been redirected to the recommended version or the version assigned by your teacher.",
+  "redirectCourseVersionWarningDetails": "It looks like you accidentally went to a different version of the course. You've been redirected to the recommended version or the version assigned by your teacher.",
   "redirectExplanation": "This is a link to an external website not operated or reviewed by Code.org and it does not follow the Code.org privacy policy. Please report this app if it is linking to content that is inappropriate or unsafe: ",
   "redirectRejectExplanation": "This app is trying to open a website that appears to be unsafe.",
   "redirectRejectTitle": "Navigation to Unsafe Site Detected",


### PR DESCRIPTION
When we redirect a user away from a particular version of a course or script, we display this notification banner after redirecting:
<img width="1215" alt="Screen Shot 2019-05-02 at 9 26 17 AM" src="https://user-images.githubusercontent.com/9812299/57099070-6d0bd480-6cd0-11e9-8376-29d9a160f1ff.png">

Dave noticed this morning that the text in this notification doesn't make sense when we're redirecting a user away from a newer version of a course/script, so we've updated the following:

**Original text:** "It looks like you accidentally went to an outdated version of the course. You've been redirected to the recommended version or the version assigned by your teacher."

**New text:** "It looks like you accidentally went to a different version of the course. You've been redirected to the recommended version or the version assigned by your teacher."