### PR TITLE
UI-test timeout updates/fixes

### DIFF
--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -37,7 +37,7 @@ def saucelabs_browser(test_run_name)
     name: test_run_name,
     tags: [ENV['GIT_BRANCH']],
     build: CDO.circle_run_identifier || ENV['BUILD'],
-    idleTimeout: 30
+    idleTimeout: 60
   }
   sauce_capabilities[:tunnelIdentifier] = CDO.circle_run_identifier if CDO.circle_run_identifier
   sauce_capabilities[:priority] = ENV['PRIORITY'].to_i if ENV['PRIORITY']

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -49,6 +49,11 @@ module SeleniumBrowser
       HttpClient.new name: 'webdriver'
     end
 
+    def read_timeout=(timeout)
+      super
+      @http&.read_timeout = timeout
+    end
+
     # Set HTTP read timeout within the specified block.
     def with_read_timeout(timeout)
       old_timeout = read_timeout


### PR DESCRIPTION
One configuration change, one bugfix in UI-test timeouts in hopes of greater client-connection stability:
- Fix setting `read_timeout` on http client (fixes regression in #28254 that caused `with_read_timeout` to no longer be effective, causing the timeout to be stuck at 5 minutes instead of much shorter.)
- Increase `idleTimeout` from 30 to 60 seconds. (This should prevent tests from failing when there are intermittent hangs or network-interruptions in the 30-60 seconds range).