### PR TITLE
Limit Scope Bleed of Mini-Toolbox

### DIFF
--- a/dashboard/config/libraries/SpriteLab2Beta.interpreted.js
+++ b/dashboard/config/libraries/SpriteLab2Beta.interpreted.js
@@ -856,12 +856,14 @@ function runInputEvents() {
         if(eventType(param)) {
           thisSprite = param;
           event();
+          thisSprite = null;
         }
       } else {
         for(var j = 0; j < param.length; j++) {
           if(eventType(param[j])) {
             thisSprite = param[j];
             event();
+            thisSprite = null;
           }
         }
       }
@@ -878,6 +880,8 @@ function createCollisionHandler (collisionEvent) {
     if (!collisionEvent.touching || collisionEvent.keepFiring) {
       collisionEvent.event(sprite1, sprite2);
     }
+    thisSprite = null;
+    otherSprite = null;
   };
 }
 


### PR DESCRIPTION
Set thisSprite and otherSprite to null after events to limit their scope
Previous Behavior: When a `clickedSprite` block was referenced outside of its hat block, the `clickedSprite` block would still reference the sprite and could affect it.

New behavior:
![noreferencespriteclicked](https://user-images.githubusercontent.com/2959170/57108280-0e9e2080-6ce7-11e9-8bc1-7e1fe92bf334.gif)
