### PR TITLE
Fix app lab sounds not working

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1008,6 +1008,7 @@ Applab.serializeAndSave = function(callback) {
  */
 // XXX This is the only method used by the templates!
 Applab.runButtonClick = function() {
+  Sounds.getSingleton().unmuteURLs();
   studioApp().toggleRunReset('reset');
   if (studioApp().isUsingBlockly()) {
     Blockly.mainBlockSpace.traceOn(true);


### PR DESCRIPTION
I added a way to mute/unmute sounds for sprite lab so that sounds didn’t play in preview. As part of that change, I did https://github.com/code-dot-org/code-dot-org/pull/27773/files which unmutes (and then remutes) sounds to play a sound preview. But applab doesn’t use mute/unmute, so if you play a sound preview, you end up in a muted state, and your sounds stop working.
The fix here is just to unmute when you click run in app lab.