### PR TITLE
Tests: Stub File.write in levelbuilder mode script test

### DIFF
--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -242,8 +242,6 @@ class ScriptsControllerTest < ActionController::TestCase
     assert script.login_required
     assert script.hideable_stages
     assert script.project_sharing
-
-    File.unstub(:write)
   end
 
   test 'destroy raises exception for evil filenames' do
@@ -325,6 +323,7 @@ class ScriptsControllerTest < ActionController::TestCase
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     script = create :script
+    File.stubs(:write).with {|filename, _| filename == "config/scripts/#{script.name}.script" || filename.end_with?('scripts.en.yml')}
 
     assert_nil Script.find_by_name(script.name).project_sharing
 
@@ -398,8 +397,6 @@ class ScriptsControllerTest < ActionController::TestCase
     script = Script.find_by_name('test-script-create')
     assert_equal 'test-script-create', script.name
     assert script.has_lesson_plan?
-
-    File.unstub(:write)
   end
 
   test 'can update with has_lesson_plan param' do


### PR DESCRIPTION
We were seeing some changes on the local filesystem on test after running dashboard unit tests.  @wjordan narrowed the problem down to this test case that wasn't stubbing `File.write`, which meant it would write to scripts.en.yml and the .script file during the test case when the script was updated via the API.