### PR TITLE
Add share setting to admin table of users

### DIFF
--- a/dashboard/app/views/admin_search/find_students.html.haml
+++ b/dashboard/app/views/admin_search/find_students.html.haml
@@ -43,15 +43,19 @@
   = paginate @users, total_pages: (@total_count / AdminSearchController::MAX_PAGE_SIZE.to_f).ceil
   %table.users
     %tr
-      - ['ID', 'Name', 'Email', 'Provider', 'Deleted At', 'Undelete'].each do |field|
+      - ['ID', 'Name', 'Email', 'Provider', 'Can Share?', 'Deleted At', 'Undelete'].each do |field|
         %th
           %span= field
     - @users.each do |user|
       %tr
-        - [:id, :name, :email, :provider, :deleted_at].each do |field|
+        - [:id, :name, :email, :provider].each do |field|
           %td
             %span= user[field]
+        %td
+          %span= !user.sharing_disabled?
         - if user.deleted?
+          %td
+            %span= user[:deleted_at]
           %td
             =link_to 'Undelete User', undelete_user_path(user_id: user[:id]), method: :post, class: "btn", data: {confirm: "Are you sure?"}
 - else


### PR DESCRIPTION
In an effort to help address Zendesk tickets more efficiently this change allows admins to easily see if a user is allowed to share projects via an additional column in the table on `/admin/find_students`.

<img width="757" alt="Screen Shot 2019-05-02 at 8 44 42 PM" src="https://user-images.githubusercontent.com/12300669/57119001-d36a1480-6d1b-11e9-8d15-e6f3ffccde9b.png">

If this proves useful, we can add functionality to toggle the share setting from this table. 
