### PR TITLE
applications of any status can have scholarship info

### DIFF
--- a/bin/oneoff/backfill_data/backfill_scholarship_course
+++ b/bin/oneoff/backfill_data/backfill_scholarship_course
@@ -6,7 +6,7 @@ require_relative '../../../dashboard/config/environment'
 # from the application.
 def course_from_current_teacher_accepted_app(si)
   app = Pd::Application::Teacher1920Application.find_by(user_id: si.user_id)
-  if app && Pd::SharedApplicationConstants::COHORT_CALCULATOR_STATUSES.include?(app.status)
+  if app
     return app.course
   end
   nil


### PR DESCRIPTION
Teacher applications with any status can have scholarship information, so I updated the script to reflect that. This is the version of the script that I ran on 5/3/19 (although I ran it as not a dry-run).