### PR TITLE
correctly compute whether course is stable in summarize_versions

### DIFF
--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -304,7 +304,7 @@ class Course < ApplicationRecord
           version_year: c.version_year,
           version_title: c.localized_version_title,
           can_view_version: c.can_view_version?(user),
-          is_stable: stable?
+          is_stable: c.stable?
         }
       end
 

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -191,6 +191,20 @@ class CourseTest < ActiveSupport::TestCase
     assert_nil summary[:scripts][0]['stageDescriptions']
   end
 
+  test 'summarize_version' do
+    create(:course, name: 'csp-2017', family_name: 'csp', version_year: '2017', is_stable: true)
+    csp_2018 = create(:course, name: 'csp-2018', family_name: 'csp', version_year: '2018', is_stable: true)
+    csp_2019 = create(:course, name: 'csp-2019', family_name: 'csp', version_year: '2019')
+
+    summary = csp_2018.summarize_versions
+    assert_equal ['csp-2019', 'csp-2018', 'csp-2017'], summary.map {|h| h[:name]}
+    assert_equal [false, true, true], summary.map {|h| h[:is_stable]}
+
+    summary = csp_2019.summarize_versions
+    assert_equal ['csp-2019', 'csp-2018', 'csp-2017'], summary.map {|h| h[:name]}
+    assert_equal [false, true, true], summary.map {|h| h[:is_stable]}
+  end
+
   class SelectCourseScriptTests < ActiveSupport::TestCase
     setup do
       @course = create(:course, name: 'my-course')


### PR DESCRIPTION
### Background

Fixes https://codedotorg.atlassian.net/browse/LP-389

Previously, `Course#summarize_versions` was calling `stable?` (implicitly on the current course) rather than calling it on each course in its family. This resulted in all versions appearing to be stable, and 2019 therefore being recommended.

### Before

<img width="1011" alt="Screen Shot 2019-05-03 at 12 05 23 PM" src="https://user-images.githubusercontent.com/8001765/57159825-d9073f00-6d9b-11e9-9143-c13bc997b8ae.png">

### After

<img width="1007" alt="Screen Shot 2019-05-03 at 12 05 58 PM" src="https://user-images.githubusercontent.com/8001765/57159831-dd335c80-6d9b-11e9-9c1a-163d1cf38b62.png">


