### PR TITLE
PL: allow resend of principal email for waitlisted applications

### DIFF
--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -138,6 +138,10 @@ module Pd::Application
       status == 'pending'
     end
 
+    def waitlisted?
+      status == 'waitlisted'
+    end
+
     def update_accepted_date
       self.accepted_at = accepted? ? Time.now : nil
     end

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -339,8 +339,8 @@ module Pd::Application
 
       # Do we allow manually sending/resending the principal email?
 
-      # Only if this teacher application is currently unreviewed or pending.
-      return false unless unreviewed? || pending?
+      # Only if this teacher application is currently unreviewed, pending, or waitlisted.
+      return false unless unreviewed? || pending? || waitlisted?
 
       # Only if the principal approval is required.
       return false if principal_approval_not_required

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -359,6 +359,10 @@ module Pd::Application
 
       # Do we allow the cron job to send a reminder email to the teacher?
 
+      # Only if this teacher application is currently unreviewed or pending.
+      # (Unlike allow_sending_principal_email?, don't allow for waitlisted.)
+      return false unless unreviewed? || pending?
+
       # Only if we haven't already sent one.
       return false if reminder_emails.any?
 

--- a/dashboard/test/models/pd/application/teacher1920_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher1920_application_test.rb
@@ -988,7 +988,22 @@ module Pd::Application
       application = create :pd_teacher1920_application
       assert application.allow_sending_principal_email?
 
-      # If we're no longer unreviewed/pending, we can't send.
+      # If we are unreviewed, we can send.
+      application = create :pd_teacher1920_application
+      application.update!(status: 'unreviewed')
+      assert application.allow_sending_principal_email?
+
+      # If we are pending, we can send.
+      application = create :pd_teacher1920_application
+      application.update!(status: 'pending')
+      assert application.allow_sending_principal_email?
+
+      # If we are waitlisted, we can send.
+      application = create :pd_teacher1920_application
+      application.update!(status: 'waitlisted')
+      assert application.allow_sending_principal_email?
+
+      # If we're no longer unreviewed/pending/waitlisted, we can't send.
       application = create :pd_teacher1920_application
       application.update!(status: 'accepted_no_cost_registration')
       refute application.allow_sending_principal_email?
@@ -1019,24 +1034,46 @@ module Pd::Application
       application = create :pd_teacher1920_application
       refute application.allow_sending_principal_approval_teacher_reminder_email?
 
-      # If we created a teacher reminder email any time before, we can't send.
+      # If we are unreviewed, we can send.
       application = create :pd_teacher1920_application
-      create :pd_application_email, application: application, email_type: 'principal_approval_teacher_reminder', created_at: 14.days.ago
+      application.update!(status: 'unreviewed')
+      create :pd_application_email, application: application, email_type: 'principal_approval', created_at: 6.days.ago
+      assert application.allow_sending_principal_approval_teacher_reminder_email?
+
+      # If we are pending, we can send.
+      application = create :pd_teacher1920_application
+      application.update!(status: 'pending')
+      create :pd_application_email, application: application, email_type: 'principal_approval', created_at: 6.days.ago
+      assert application.allow_sending_principal_approval_teacher_reminder_email?
+
+      # If we are waitlisted, we can't send.
+      application = create :pd_teacher1920_application
+      application.update!(status: 'waitlisted')
+      create :pd_application_email, application: application, email_type: 'principal_approval', created_at: 6.days.ago
       refute application.allow_sending_principal_approval_teacher_reminder_email?
 
       # If we're no longer unreviewed/pending, we can't send.
       application = create :pd_teacher1920_application
       application.update!(status: 'accepted_no_cost_registration')
+      create :pd_application_email, application: application, email_type: 'principal_approval', created_at: 6.days.ago
+      refute application.allow_sending_principal_approval_teacher_reminder_email?
+
+      # If we created a teacher reminder email any time before, we can't send.
+      application = create :pd_teacher1920_application
+      create :pd_application_email, application: application, email_type: 'principal_approval_teacher_reminder', created_at: 14.days.ago
+      create :pd_application_email, application: application, email_type: 'principal_approval', created_at: 6.days.ago
       refute application.allow_sending_principal_approval_teacher_reminder_email?
 
       # If principal approval is not required, we can't send.
       application = create :pd_teacher1920_application
       application.update!(principal_approval_not_required: true)
+      create :pd_application_email, application: application, email_type: 'principal_approval', created_at: 6.days.ago
       refute application.allow_sending_principal_approval_teacher_reminder_email?
 
       # If we already have a principal response, we can't send.
       application = create :pd_teacher1920_application
       create :pd_principal_approval1920_application, teacher_application: application
+      create :pd_application_email, application: application, email_type: 'principal_approval', created_at: 6.days.ago
       refute application.allow_sending_principal_approval_teacher_reminder_email?
 
       # If we created a principal email < 5 days ago, we can't send.


### PR DESCRIPTION
The button to send/resend a principal email (added in https://github.com/code-dot-org/code-dot-org/pull/28103) now works for waitlisted applications.  Previously it only worked for unreviewed and pending applications.

The related logic that determines who gets an automated teacher reminder email when a principal has not yet submitted an approval (added in https://github.com/code-dot-org/code-dot-org/pull/28148) still only sends that email for unreviewed and pending applications.

Also, improved the unit testing to add more parameters required for success to the cases that exercise failure, to help ensure we're actually hitting the desired failure cases.
