### PR TITLE
PL: show resend principal email in application detail

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -1200,6 +1200,13 @@ export class DetailViewContents extends React.Component {
               {principalApprovalUrl}
             </a>
           </p>
+          <PrincipalApprovalButtons
+            applicationId={this.props.applicationId}
+            showResendEmailButton={
+              this.props.applicationData.allow_sending_principal_email
+            }
+            onChange={this.handlePrincipalApprovalChange}
+          />
         </div>
       );
     }

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -46,7 +46,8 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
     :status_change_log,
     :scholarship_status,
     :all_scores,
-    :total_score
+    :total_score,
+    :allow_sending_principal_email
   )
 
   def email
@@ -230,5 +231,9 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
 
   def scholarship_status
     object.try(:scholarship_status)
+  end
+
+  def allow_sending_principal_email
+    object.try(:allow_sending_principal_email?)
   end
 end


### PR DESCRIPTION
This brings the button to resend an email to the principal from the application grid (say at `/pd/application_dashboard/csp_teachers`, added in https://github.com/code-dot-org/code-dot-org/pull/28103) to the application detail view (say at `/pd/application_dashboard/csp_teachers/31`).

## On the page
![Screenshot 2019-05-03 13 31 57](https://user-images.githubusercontent.com/2205926/57164747-ec210b80-6da9-11e9-8fcc-db164f5b887a.png)

## Confirmation dialog
![Screenshot 2019-05-03 13 32 17](https://user-images.githubusercontent.com/2205926/57164754-f04d2900-6da9-11e9-8589-5a0abf8d8b53.png)
