### PR TITLE
Speed up "migrate user" script

### DIFF
--- a/bin/oneoff/migrate_users_to_multi_auth.rb
+++ b/bin/oneoff/migrate_users_to_multi_auth.rb
@@ -14,13 +14,8 @@ def migrate_batches(limit=nil)
   slice_count = 0
   puts "Migrating #{limit || 'all'} slice(s)"
   unmigrated_users.find_in_batches(batch_size: SLICE_SIZE) do |slice|
-    puts "\tSLICE_COUNT: #{slice_count + 1} of ~#{unmigrated_users_count / SLICE_SIZE}..."
-    successes = 0
-    slice.each do |user|
-      user.migrate_to_multi_auth
-      successes += 1 if user.valid? && user.provider == User::PROVIDER_MIGRATED
-    end
-    puts "\t\tsuccessful migrations: #{successes} / #{SLICE_SIZE}"
+    puts "\tSLICE_COUNT: #{slice_count + 1} of #{limit || "~#{unmigrated_users_count / SLICE_SIZE}"}..."
+    slice.each(&:migrate_to_multi_auth)
     slice_count += 1
 
     if limit && slice_count >= limit

--- a/bin/oneoff/migrate_users_to_multi_auth.rb
+++ b/bin/oneoff/migrate_users_to_multi_auth.rb
@@ -2,7 +2,9 @@
 
 require_relative '../../dashboard/config/environment'
 
-SLICE_SIZE = 1_000
+# Tested slice sizes of 10k, 1k, 100, 10, and 1, and 100 seemed to be the
+# fastest per-user
+SLICE_SIZE = 100
 
 def migrate_batches(limit=nil)
   limit = limit.to_i if limit

--- a/bin/oneoff/migrate_users_to_multi_auth.rb
+++ b/bin/oneoff/migrate_users_to_multi_auth.rb
@@ -9,7 +9,7 @@ SLICE_SIZE = 100
 def migrate_batches(limit=nil)
   limit = limit.to_i if limit
   unmigrated_users = User.where.not(provider: User::PROVIDER_MIGRATED)
-  unmigrated_users_count = 40_000_000 # estimate
+  unmigrated_users_count = 10_000_000 # estimate
 
   slice_count = 0
   puts "Migrating #{limit || 'all'} slice(s)"


### PR DESCRIPTION
Now that all sponsored users have been migrated, we only have about 10 million users left to migrate. At ~10ms/user, it should take only about 30 hours to migrate all of those, which we should be able to do in a couple batches.