### PR TITLE
Revert "Merge pull request #28294 from code-dot-org/fix-blockly-glitchy-rendering"

### DIFF
--- a/apps/src/gamelab/GameLabVisualizationHeader.jsx
+++ b/apps/src/gamelab/GameLabVisualizationHeader.jsx
@@ -1,5 +1,4 @@
 /** @file Row of controls above the visualization. */
-import * as utils from '../utils';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {changeInterfaceMode} from './actions';
@@ -30,27 +29,15 @@ class GameLabVisualizationHeader extends React.Component {
     spriteLab: PropTypes.bool.isRequired
   };
 
-  changeInterfaceMode = mode => {
-    if (!this.props.spriteLab) {
-      // Add a resize event to Gamelab (i.e. droplet) to ensure code is rendered
-      // correctly if it was in the middle of a transition from code to block mode
-      // when the interface mode was changed. Blockly already fires resize events
-      // so this is not needed for spriteLab - too many resize events seem to
-      // conflict with each other.
-      setTimeout(() => utils.fireResizeEvent(), 0);
-    }
-
-    this.props.onInterfaceModeChange(mode);
-  };
-
   render() {
-    const {interfaceMode, allowAnimationMode} = this.props;
+    const {
+      interfaceMode,
+      allowAnimationMode,
+      onInterfaceModeChange
+    } = this.props;
     return (
       <div style={styles.main} id="playSpaceHeader">
-        <ToggleGroup
-          selected={interfaceMode}
-          onChange={this.changeInterfaceMode}
-        >
+        <ToggleGroup selected={interfaceMode} onChange={onInterfaceModeChange}>
           <button type="button" value={GameLabInterfaceMode.CODE} id="codeMode">
             {msg.codeMode()}
           </button>

--- a/apps/src/gamelab/actions.js
+++ b/apps/src/gamelab/actions.js
@@ -1,6 +1,7 @@
 /** @file Redux action-creators for Game Lab.
  *  @see http://redux.js.org/docs/basics/Actions.html */
 import $ from 'jquery';
+import * as utils from '../utils';
 
 /** @enum {string} */
 export const CHANGE_INTERFACE_MODE = 'CHANGE_INTERFACE_MODE';
@@ -24,6 +25,9 @@ export const ADD_MESSAGE = 'spritelab/ADD_MESSAGE';
  * @returns {function}
  */
 export function changeInterfaceMode(interfaceMode) {
+  //Add a resize event on each call to changeInterfaceMode to ensure
+  //proper rendering of droplet and code mode. Similar solution in applab.
+  setTimeout(() => utils.fireResizeEvent(), 0);
   return function(dispatch) {
     $(window).trigger('appModeChanged');
     dispatch({


### PR DESCRIPTION
This reverts commit c1e7a0190aaefaf932ebace71c1f5ba368bfd7b6, reversing
changes made to acb848a6121ab6288290b3dbaedad0284d510b2c.

This change was originally pushed because it fixed a rendering issue in projects/spritelab/new where the toolbox rendered over top of the blocks when switching from the costume tab. This change introduced a different bug, however, where blocks are completely missing in projects that are part of a level progression. Reverting this change.

![image](https://user-images.githubusercontent.com/8324574/57166512-525c5d00-6daf-11e9-8331-89165c5b2008.png)
