### PR TITLE
Use dangerouslySetInnerHTML for SmallFooter language selector

### DIFF
--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -220,8 +220,10 @@ export default class SmallFooter extends React.Component {
           style={combinedBaseStyle}
           onClick={this.clickBase}
         >
-          <UnsafeRenderedMarkdown
-            markdown={decodeURIComponent(this.props.i18nDropdown)}
+          <div
+            dangerouslySetInnerHTML={{
+              __html: decodeURIComponent(this.props.i18nDropdown)
+            }}
           />
           <small>
             {this.renderPrivacy(styles)}


### PR DESCRIPTION
Since that is actually rendering a serverside-generated HTML form, so we don't want to sanitize it, and as of https://github.com/code-dot-org/code-dot-org/pull/28155 we are sanitizing things rendered by UnsafeRenderedMarkdown

See https://github.com/code-dot-org/code-dot-org/pull/28374 for more context.