### PR TITLE
unhide csd-post-survey-2018 and show under CSD in dropdowns

### DIFF
--- a/dashboard/config/courses/csd-2018.course
+++ b/dashboard/config/courses/csd-2018.course
@@ -6,7 +6,8 @@
     "csd3-2018",
     "csd4-2018",
     "csd5-2018",
-    "csd6-2018"
+    "csd6-2018",
+    "csd-post-survey-2018"
   ],
   "properties": {
     "teacher_resources": [

--- a/dashboard/config/scripts/csd-post-survey-2018.script
+++ b/dashboard/config/scripts/csd-post-survey-2018.script
@@ -1,3 +1,4 @@
+hidden false
 login_required true
 exclude_csf_column_in_legend true
 has_verified_resources true

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -114,6 +114,7 @@ module ScriptConstants
       CSD4_2018_NAME = 'csd4-2018'.freeze,
       CSD5_2018_NAME = 'csd5-2018'.freeze,
       CSD6_2018_NAME = 'csd6-2018'.freeze,
+      CSD_POST_SURVEY_2018_NAME = 'csd-post-survey-2018'.freeze,
     ],
     csd: [
       CSD1_NAME = 'csd1-2017'.freeze,


### PR DESCRIPTION
This is needed in order to show the csd post survey in the following places:
* Course overview page
  <img width="1007" alt="Screen Shot 2019-05-06 at 11 28 43 AM" src="https://user-images.githubusercontent.com/8001765/57246449-22e96280-6ff2-11e9-88fb-b20da3da036b.png">


* AssignmentSelector in EditSectionForm
  <img width="587" alt="Screen Shot 2019-05-06 at 11 27 51 AM" src="https://user-images.githubusercontent.com/8001765/57246413-0cdba200-6ff2-11e9-96e5-e65a02567ef8.png">


* course dropdown in Progress and Assessment tabs
  <img width="528" alt="Screen Shot 2019-05-06 at 11 11 16 AM" src="https://user-images.githubusercontent.com/8001765/57246058-347e3a80-6ff1-11e9-81cc-82d71efdea3b.png">
