### PR TITLE
Allow inline styles in markdown

### DIFF
--- a/apps/src/templates/UnsafeRenderedMarkdown.jsx
+++ b/apps/src/templates/UnsafeRenderedMarkdown.jsx
@@ -20,7 +20,7 @@ const schema = Object.assign({}, defaultSanitizationSchema);
 
 // We use a _lot_ of image formatting stuff in our
 // instructions, particularly in CSP
-schema.attributes.img.push('style', 'height', 'width');
+schema.attributes.img.push('height', 'width');
 
 // Add support for expandableImages
 schema.tagNames.push('span');
@@ -29,7 +29,7 @@ schema.attributes.span = ['dataUrl', 'className'];
 // Add support for inline styles (gross)
 // TODO replace all inline styles in our curriculum content with
 // semantically-significant content
-schema.attributes['*'].push('style');
+schema.attributes['*'].push('style', 'class');
 
 // Add support for Blockly XML
 schema.clobber = [];

--- a/apps/src/templates/UnsafeRenderedMarkdown.jsx
+++ b/apps/src/templates/UnsafeRenderedMarkdown.jsx
@@ -26,6 +26,11 @@ schema.attributes.img.push('style', 'height', 'width');
 schema.tagNames.push('span');
 schema.attributes.span = ['dataUrl', 'className'];
 
+// Add support for inline styles (gross)
+// TODO replace all inline styles in our curriculum content with
+// semantically-significant content
+schema.attributes['*'].push('style');
+
 // Add support for Blockly XML
 schema.clobber = [];
 schema.tagNames.push(


### PR DESCRIPTION
We use inline styles extensively in our curriculum content. Until we can
replace all those with something more semantic, we have to allow inline
style attributes.

Originally disabled in https://github.com/code-dot-org/code-dot-org/pull/28155