### PR TITLE
Fixed toolbox overlay issue in spritelab.

### DIFF
--- a/apps/src/gamelab/GameLabVisualizationHeader.jsx
+++ b/apps/src/gamelab/GameLabVisualizationHeader.jsx
@@ -8,6 +8,7 @@ import msg from '@cdo/locale';
 import ToggleGroup from '../templates/ToggleGroup';
 import styleConstants from '../styleConstants';
 import {allowAnimationMode} from './stateQueries';
+import * as utils from '../utils';
 
 const styles = {
   main: {
@@ -29,15 +30,27 @@ class GameLabVisualizationHeader extends React.Component {
     spriteLab: PropTypes.bool.isRequired
   };
 
+  changeInterfaceMode = mode => {
+    if (!this.props.spriteLab) {
+      // Add a resize event to Gamelab (i.e. droplet) to ensure code is rendered
+      // correctly if it was in the middle of a transition from code to block mode
+      // when the interface mode was changed. Blockly already fires resize events
+      // so this is not needed for spriteLab - too many resize events seem to
+      // conflict with each other.
+      setTimeout(() => utils.fireResizeEvent(), 0);
+    }
+
+    this.props.onInterfaceModeChange(mode);
+  };
+
   render() {
-    const {
-      interfaceMode,
-      allowAnimationMode,
-      onInterfaceModeChange
-    } = this.props;
+    const {interfaceMode, allowAnimationMode} = this.props;
     return (
       <div style={styles.main} id="playSpaceHeader">
-        <ToggleGroup selected={interfaceMode} onChange={onInterfaceModeChange}>
+        <ToggleGroup
+          selected={interfaceMode}
+          onChange={this.changeInterfaceMode}
+        >
           <button type="button" value={GameLabInterfaceMode.CODE} id="codeMode">
             {msg.codeMode()}
           </button>

--- a/apps/src/gamelab/actions.js
+++ b/apps/src/gamelab/actions.js
@@ -1,7 +1,6 @@
 /** @file Redux action-creators for Game Lab.
  *  @see http://redux.js.org/docs/basics/Actions.html */
 import $ from 'jquery';
-import * as utils from '../utils';
 
 /** @enum {string} */
 export const CHANGE_INTERFACE_MODE = 'CHANGE_INTERFACE_MODE';
@@ -25,9 +24,6 @@ export const ADD_MESSAGE = 'spritelab/ADD_MESSAGE';
  * @returns {function}
  */
 export function changeInterfaceMode(interfaceMode) {
-  //Add a resize event on each call to changeInterfaceMode to ensure
-  //proper rendering of droplet and code mode. Similar solution in applab.
-  setTimeout(() => utils.fireResizeEvent(), 0);
   return function(dispatch) {
     $(window).trigger('appModeChanged');
     dispatch({

--- a/apps/src/templates/instructions/TopInstructionsCSF.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSF.jsx
@@ -246,8 +246,6 @@ class TopInstructions extends React.Component {
    * Calculate our initial height (based off of rendered height of instructions)
    */
   componentDidMount() {
-    window.addEventListener('resize', this.adjustMaxNeededHeight);
-
     // Might want to increase the size of our instructions after our icon image
     // has loaded, to make sure the image fits
     $(ReactDOM.findDOMNode(this.icon)).load(
@@ -275,7 +273,7 @@ class TopInstructions extends React.Component {
    */
   componentWillReceiveProps(nextProps) {
     const minHeight = this.getMinHeight(nextProps.collapsed);
-    const newHeight = Math.min(nextProps.maxHeight, minHeight);
+    const newHeight = minHeight;
 
     const shouldUpdateHeight = nextProps.collapsed
       ? newHeight !== this.props.height
@@ -322,8 +320,6 @@ class TopInstructions extends React.Component {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({rightColWidth});
     }
-
-    this.adjustMaxNeededHeight();
 
     if (this.instructions) {
       const contentContainer = this.instructions.parentElement;
@@ -415,6 +411,7 @@ class TopInstructions extends React.Component {
    * @returns {number} How much we actually changed
    */
   handleHeightResize = (delta = 0) => {
+    this.adjustMaxNeededHeight();
     const minHeight = this.getMinHeight();
     const currentHeight = this.props.height;
 
@@ -428,7 +425,6 @@ class TopInstructions extends React.Component {
     } else {
       newHeight = Math.min(newHeight, this.props.maxHeight);
     }
-
     this.props.setInstructionsRenderedHeight(newHeight);
     return newHeight - currentHeight;
   };


### PR DESCRIPTION
Spritelab top instructions had a bug where the instruction space would resize when switching between code and animation mode. This bug had always existed, but was not exercised until animation mode was added. The issue was not visibly recognized because resize events were being called extra times. In project mode, however, the resize events were causing rendering problems with the toolbox. This PR removes the extra resize events and resizes the instruction space only when needed.

Note: The red text difference in the 'instruction resize' gifs is due to a known issue in staging. Not due to this change.

Manual sanity checks performed: 
- dancelab is unchanged
- gamelab is unchanged
- hints still render as expected
- expand/collapse still works as expected

OLD instruction resize:
![shrinkingInstructionsOld](https://user-images.githubusercontent.com/8324574/57246351-ed447980-6ff1-11e9-8b5d-69884310ec22.gif)

NEW instruction resize:
![shrinkingInstructionsNew](https://user-images.githubusercontent.com/8324574/57247013-99d32b00-6ff3-11e9-86b8-6309ba8e78ae.gif)

OLD toolbox rendering:
![image](https://user-images.githubusercontent.com/8324574/57246396-fe8d8600-6ff1-11e9-8ee5-6247728e44d6.png)

NEW toolbox rendering:
![image](https://user-images.githubusercontent.com/8324574/57252876-284ea900-7002-11e9-8314-28c57551e80f.png)

