### PR TITLE
Fix createTreeWalker for IE

### DIFF
--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -72,7 +72,8 @@ export function shrinkBlockSpaceContainer(blockSpace, withPadding) {
 function removeCommentNodes(root) {
   const commentWalker = document.createTreeWalker(
     root,
-    NodeFilter.SHOW_COMMENT
+    NodeFilter.SHOW_COMMENT,
+    {acceptNode: node => NodeFilter.FILTER_ACCEPT}
   );
   // commentWalker.currentNode will always equal the root to start with, so
   // call nextNode to move it on to the first Comment node


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/28155

The 'filter' argument to createTreeWalker is not optional for IE, so we
explicitly pass in a no-op filter.

See https://developer.mozilla.org/en-US/docs/Web/API/Document/createTreeWalker#Example