### PR TITLE
Fix createTreeWalker for IE

### DIFF
--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -73,7 +73,8 @@ function removeCommentNodes(root) {
   const commentWalker = document.createTreeWalker(
     root,
     NodeFilter.SHOW_COMMENT,
-    {acceptNode: node => NodeFilter.FILTER_ACCEPT}
+    {acceptNode: node => NodeFilter.FILTER_ACCEPT},
+    false
   );
   // commentWalker.currentNode will always equal the root to start with, so
   // call nextNode to move it on to the first Comment node


### PR DESCRIPTION
The 'filter' and 'entityReferenceExpansion' arguments to createTreeWalker are not optional for IE, so we explicitly pass in no-op versions of them

See https://developer.mozilla.org/en-US/docs/Web/API/Document/createTreeWalker#Example