### PR TITLE
PL: fix to help diversity survey show on staging & test

### DIFF
--- a/dashboard/app/helpers/survey_results_helper.rb
+++ b/dashboard/app/helpers/survey_results_helper.rb
@@ -41,8 +41,8 @@ module SurveyResultsHelper
   end
 
   def country_us?
-    us_code_for_env = Rails.env.production? ? 'US' : 'RD'
-    request.location.try(:country_code) == us_code_for_env
+    request.location.try(:country_code) == 'US' ||
+      (!Rails.env.production? && request.location.try(:country_code) == 'RD')
   end
 
   def has_any_students?


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/28025.  It turns out that localhost does have a `request` location of `"RD"` but staging (and presumably test) get a location of `"US"`.

This logic now matches some existing logic here: https://github.com/code-dot-org/code-dot-org/blob/e4170aaae1b0656ea84e9ab6824b5751fbd79f25/dashboard/app/helpers/levels_helper.rb#L575-L576.