### PR TITLE
PL: adjust text on zip form on middle-high page

### DIFF
--- a/pegasus/sites.v3/code.org/views/regional_partner_zip_form.haml
+++ b/pegasus/sites.v3/code.org/views/regional_partner_zip_form.haml
@@ -2,7 +2,7 @@
 - link += "?nominated=true" if params[:nominated]
 
 - body = capture_haml do
-  %p Generous scholarships or discounts are available across the country for the Code.org Professional Learning Program.
+  %p For most schools, attending Code.org professional learning is free of charge. Apply and see if you and your school qualify.
   %p
     %b Enter your school’s zip code to learn more.
   %form.linktag#pl-zip-form{action: "/educate/professional-learning/program-information", method: "get"}
@@ -12,4 +12,4 @@
       %input{type: "text", name: "nominated", value: params[:nominated], hidden: "true"}
     %input{type: "submit", value: "Submit", style: "color:white; background-color:orange; padding:10px; font-size:1.2em"}
 
-= view :course_wide_block, cta_link: link, img: CDO.code_org_url('/shared/images/banners/small-teal-icons.png'), title: 'Scholarships Available', description: body
+= view :course_wide_block, cta_link: link, img: CDO.code_org_url('/shared/images/banners/small-teal-icons.png'), title: 'Attend at no cost!', description: body


### PR DESCRIPTION
This adjusts the text on the zip form of https://code.org/educate/professional-learning/middle-high after some moderate success in an a/b test.

### before

![Screenshot 2019-05-06 19 11 09](https://user-images.githubusercontent.com/2205926/57267085-a9726400-7033-11e9-85c9-8d467ac74e6a.png)

### after

![Screenshot 2019-05-06 19 14 13](https://user-images.githubusercontent.com/2205926/57267084-a9726400-7033-11e9-8c40-2d688ce79723.png)
