### PR TITLE
Replicate jotform data to redshift [ci skip]

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -13,6 +13,8 @@ cron-pii:
 - dashboard.peer_reviews
 - dashboard.circuit_playground_discount_applications
 - dashboard.circuit_playground_discount_codes
+- dashboard.survey_questions
+- dashboard.survey_answers
 cron:
 - dashboard.experiments
 - dashboard.authored_hint_view_requests

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -86,7 +86,7 @@
       cronjob at:'10 */12 * * *', do:dashboard_dir('bin','refresh_pd_workshop_material_orders')
       cronjob at:'*/1 * * * *', do:dashboard_dir('bin', 'fill_jotform_placeholders')
       cronjob at:'30 0 * * *', do:dashboard_dir('bin', 'sync_jotforms')
-      cronjob at:'0 7 * * *', do:dashboard_dir('bin', 'process_jotform_data')
+      cronjob at:'0 7 * * *', do:dashboard_dir('bin', 'cron', 'process_jotform_data')
       cronjob at:'25 7 * * *', do:deploy_dir('bin', 'cron', 'update_hoc_map')
       cronjob at:'19 4 * * *', do:deploy_dir('bin', 'cron', 'update_census_map')
       cronjob at:'0 9 * * 1-5', do:deploy_dir('bin', 'cron', 'check_for_census_inaccuracy_reports')


### PR DESCRIPTION
1. Uses correct path for Jotform reshaping cron (addresses [this Honeybadger error](https://app.honeybadger.io/projects/45435/faults/44710818))
2. Replicates the new tables to Redshift.