### PR TITLE
Fix broken link to home on /lesson_plans

### DIFF
--- a/pegasus/sites.v3/code.org/public/lesson_plans.haml
+++ b/pegasus/sites.v3/code.org/public/lesson_plans.haml
@@ -5,7 +5,7 @@ theme: responsive
 ---
 #breadcrumb
   %br/
-  %a{href: '/home'}= I18n.t :dashboard_navigation_home_page
+  %a{href: CDO.studio_url('/home')}= I18n.t :dashboard_navigation_home_page
   %span{style: "opacity:0.5"} &nbsp; &#9654; &nbsp;
   %b{style: "color: #ff8b02;"}= I18n.t :dashboard_navigation_lesson_plans_resources
 


### PR DESCRIPTION
From code.org/lesson_plans there was a relative link to /home, which lives on studio.code.org so the link 404'ed. 

Before: 
![home-link-lesson-plans](https://user-images.githubusercontent.com/12300669/57338868-d8481300-70e3-11e9-8c12-73f5713c2631.gif)

I used the CDO.studio_url helper to fix so now the home link goes to the correct page.

After:
![home-link-lesson-plans-fixed](https://user-images.githubusercontent.com/12300669/57338866-d67e4f80-70e3-11e9-9285-a5ecb17b4e10.gif)
