### PR TITLE
PL: principal approval application gets updated text (again)

### DIFF
--- a/bin/oneoff/backfill_data/principalapproval1920_application_pay_fee_changes.rb
+++ b/bin/oneoff/backfill_data/principalapproval1920_application_pay_fee_changes.rb
@@ -2,29 +2,35 @@
 
 require_relative '../../../dashboard/config/environment'
 
-total_updated = 0
-errors = []
-puts "Backfilling :pay_fee question changes..."
-Pd::Application::PrincipalApproval1920Application.find_each do |application|
-  print '.'
-  pay_fee = application.form_data_hash["payFee"]
+ActiveRecord::Base.transaction do
+  total_updated = 0
+  errors = []
+  puts "Backfilling :pay_fee question changes..."
 
-  if pay_fee == 'Yes, my school or teacher will be able to pay the full program fee.'
-    new_pay_fee = 'Yes, my school will be able to pay the full program fee.'
-  elsif pay_fee == 'No, my school or teacher will not be able to pay the program fee. We would like to be considered for a scholarship.'
-    new_pay_fee = 'No, my school will not be able to pay the program fee. We would like to be considered for a scholarship.'
-  else
-    next
+  Pd::Application::PrincipalApproval1920Application.find_each do |application|
+    print '.'
+    pay_fee = application.form_data_hash["payFee"]
+
+    if pay_fee == 'Yes, my school or teacher will be able to pay the full program fee.'
+      new_pay_fee = 'Yes, my school will be able to pay the full program fee.'
+    elsif pay_fee == 'No, my school or teacher will not be able to pay the program fee. We would like to be considered for a scholarship.'
+      new_pay_fee = 'No, my school will not be able to pay the program fee. We would like to be considered for a scholarship.'
+    else
+      next
+    end
+
+    application.update_form_data_hash({"payFee": new_pay_fee})
+    if application.save
+      total_updated += 1
+    else
+      errors << "\nError: Principal Approval Application #{application.id} with value #{pay_fee.inspect} couldn't be updated"
+    end
   end
 
-  application.update_form_data_hash({"payFee": new_pay_fee})
-  if application.save
-    total_updated += 1
-  else
-    errors << "\nError: Principal Approval Application #{application.id} with value #{pay_fee.inspect} couldn't be updated"
-  end
+  errors.each {|e| puts e}
+
+  puts "\nSuccessfully updated pay_fee info for #{total_updated} principal approval applications, with #{errors.count} errors."
+
+  # This script is a dry-run unless we comment out this last line
+  raise ActiveRecord::Rollback.new, "Intentional rollback"
 end
-
-errors.each {|e| puts e}
-
-puts "\nSuccessfully updated pay_fee info for #{total_updated} principal approval applications, with #{errors.count} errors."

--- a/bin/oneoff/backfill_data/principalapproval1920_application_pay_fee_changes.rb
+++ b/bin/oneoff/backfill_data/principalapproval1920_application_pay_fee_changes.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../dashboard/config/environment'
+
+total_updated = 0
+errors = []
+puts "Backfilling :pay_fee question changes..."
+Pd::Application::PrincipalApproval1920Application.find_each do |application|
+  print '.'
+  pay_fee = application.form_data_hash["payFee"]
+
+  if pay_fee == 'Yes, my school or teacher will be able to pay the full program fee.'
+    new_pay_fee = 'Yes, my school will be able to pay the full program fee.'
+  elsif pay_fee == 'No, my school or teacher will not be able to pay the program fee. We would like to be considered for a scholarship.'
+    new_pay_fee = 'No, my school will not be able to pay the program fee. We would like to be considered for a scholarship.'
+  else
+    next
+  end
+
+  application.update_form_data_hash({"payFee": new_pay_fee})
+  if application.save
+    total_updated += 1
+  else
+    errors << "\nError: Principal Approval Application #{application.id} with value #{pay_fee.inspect} couldn't be updated"
+  end
+end
+
+errors.each {|e| puts e}
+
+puts "\nSuccessfully updated pay_fee info for #{total_updated} principal approval applications, with #{errors.count} errors."

--- a/dashboard/app/models/pd/application/principal_approval1920_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval1920_application.rb
@@ -133,8 +133,8 @@ module Pd::Application
         ],
         committed_to_diversity: [YES, NO, TEXT_FIELDS[:other_please_explain]],
         pay_fee: [
-          'Yes, my school or teacher will be able to pay the full program fee.',
-          'No, my school or teacher will not be able to pay the program fee. We would like to be considered for a scholarship.',
+          'Yes, my school will be able to pay the full program fee.',
+          'No, my school will not be able to pay the program fee. We would like to be considered for a scholarship.',
           'Not applicable: there is no fee for the program for teachers in my region.',
           'Not applicable: there is no Regional Partner in my region.'
         ]

--- a/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
@@ -50,7 +50,7 @@ module Api::V1::Pd::Application
         principal_free_lunch_percent: '50.00%',
         principal_underrepresented_minority_percent: '52.00%',
         principal_wont_replace_existing_course: PRINCIPAL_APPROVAL_APPLICATION_CLASS.options[:replace_course][1],
-        principal_pay_fee: 'Yes, my school or teacher will be able to pay the full program fee.'
+        principal_pay_fee: 'Yes, my school will be able to pay the full program fee.'
       }
       actual_principal_fields = @teacher_application.sanitize_form_data_hash.slice(*expected_principal_fields.keys)
       assert_equal expected_principal_fields, actual_principal_fields

--- a/lib/cdo/shared_constants/pd/principal_approval1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/principal_approval1920_application_constants.rb
@@ -20,7 +20,7 @@ module Pd
       replace_which_course_csp: 'Which existing course or curriculum will CS Principles replace? Mark all that apply.',
       replace_which_course_csd: 'Which existing course or curriculum will CS Discoveries replace? Mark all that apply.',
       understand_fee: 'By checking this box, you indicate that you understand there may be a fee for the professional learning program your teacher attends.',
-      pay_fee: 'If there is a fee for the program, will your teacher or your school be able to pay for the fee?',
+      pay_fee: 'If there is a fee for the program, will your school be able to pay for the fee?',
       contact_invoicing: "Contact name for invoicing (if applicable)",
       contact_invoicing_detail: "Contact email or phone number for invoicing (if applicable)",
       confirm_principal: 'By submitting this application, I confirm that I am the principal of this school and agree to share my contact info, school info, and this application with my local Code.org Regional Partner.',


### PR DESCRIPTION
Second attempt at https://github.com/code-dot-org/code-dot-org/pull/28400 which was reverted in  https://github.com/code-dot-org/code-dot-org/pull/28418.

This time we include a one-off backfill script that will update the prior answers to the new text.

