### PR TITLE
Move teacher only markdown to its own tab in instructions area

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1362,6 +1362,7 @@
   "teacherCourseHocLinkText": "View more Hour of Code tutorials",
   "teacherForum": "Teacher Forum",
   "teacherHomePage": "Teacher home page",
+  "teacherInstructions": "Teacher Instructions",
   "teacherPanel": "Teacher Panel",
   "teacherResources": "Teacher resources",
   "teacherTabAssessments": "Assessments/Surveys",

--- a/apps/src/templates/instructions/TopInstructionsCSP.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSP.jsx
@@ -23,7 +23,7 @@ import commonStyles from '../../commonStyles';
 import Instructions from './Instructions';
 import CollapserIcon from './CollapserIcon';
 import HeightResizer from './HeightResizer';
-import msg from '@cdo/locale';
+import i18n from '@cdo/locale';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import experiments from '@cdo/apps/util/experiments';
 import queryString from 'query-string';
@@ -36,7 +36,8 @@ const MIN_HEIGHT = RESIZER_HEIGHT + 60;
 const TabType = {
   INSTRUCTIONS: 'instructions',
   RESOURCES: 'resources',
-  COMMENTS: 'comments'
+  COMMENTS: 'comments',
+  TEACHER_ONLY: 'teacher-only'
 };
 
 const styles = {
@@ -123,7 +124,8 @@ class TopInstructionsCSP extends Component {
     viewAs: PropTypes.oneOf(Object.keys(ViewType)),
     readOnlyWorkspace: PropTypes.bool,
     serverLevelId: PropTypes.number,
-    user: PropTypes.number
+    user: PropTypes.number,
+    teacherMarkdown: PropTypes.string
   };
 
   constructor(props) {
@@ -281,6 +283,9 @@ class TopInstructionsCSP extends Component {
       case TabType.COMMENTS:
         element = this.refs.commentTab;
         break;
+      case TabType.TEACHER_ONLY:
+        element = this.refs.teacherOnlyTab;
+        break;
     }
     const maxNeededHeight =
       $(ReactDOM.findDOMNode(element)).outerHeight(true) +
@@ -330,6 +335,10 @@ class TopInstructionsCSP extends Component {
     );
   };
 
+  handleTeacherOnlyTabClick = () => {
+    this.setState({tabSelected: TabType.TEACHER_ONLY});
+  };
+
   render() {
     const mainStyle = [
       styles.main,
@@ -369,7 +378,7 @@ class TopInstructionsCSP extends Component {
       ((this.props.viewAs === ViewType.Student && !studentHasFeedback) ||
         (this.props.viewAs === ViewType.Teacher &&
           !this.state.teacherViewingStudentWork));
-    const feedbackTabText = displayKeyConcept ? 'Key Concept' : msg.feedback();
+    const feedbackTabText = displayKeyConcept ? 'Key Concept' : i18n.feedback();
 
     const displayFeedback =
       displayKeyConcept ||
@@ -392,7 +401,7 @@ class TopInstructionsCSP extends Component {
               this.state.tabSelected !== TabType.COMMENTS && (
                 <PaneButton
                   iconClass="fa fa-book"
-                  label={msg.documentation()}
+                  label={i18n.documentation()}
                   isRtl={false}
                   headerHasFocus={false}
                   onClick={this.handleDocumentationClick}
@@ -403,7 +412,7 @@ class TopInstructionsCSP extends Component {
                 className="uitest-instructionsTab"
                 onClick={this.handleInstructionTabClick}
                 selected={this.state.tabSelected === TabType.INSTRUCTIONS}
-                text={msg.instructions()}
+                text={i18n.instructions()}
                 teacherOnly={teacherOnly}
               />
               {displayHelpTab && (
@@ -411,7 +420,7 @@ class TopInstructionsCSP extends Component {
                   className="uitest-helpTab"
                   onClick={this.handleHelpTabClick}
                   selected={this.state.tabSelected === TabType.RESOURCES}
-                  text={msg.helpTips()}
+                  text={i18n.helpTips()}
                   teacherOnly={teacherOnly}
                 />
               )}
@@ -424,6 +433,16 @@ class TopInstructionsCSP extends Component {
                   teacherOnly={teacherOnly}
                 />
               )}
+              {this.props.teacherMarkdown &&
+                (!this.state.fetchingData || teacherOnly) && (
+                  <InstructionsTab
+                    className="uitest-teacherOnlyTab"
+                    onClick={this.handleTeacherOnlyTabClick}
+                    selected={this.state.tabSelected === TabType.TEACHER_ONLY}
+                    text={i18n.teacherInstructions()}
+                    teacherOnly={teacherOnly}
+                  />
+                )}
             </div>
             {!this.props.isEmbedView && (
               <CollapserIcon
@@ -452,7 +471,6 @@ class TopInstructionsCSP extends Component {
                       onResize={this.adjustMaxNeededHeight}
                       inTopPane
                     />
-                    <TeacherOnlyMarkdown />
                   </div>
                 )}
             </div>
@@ -479,6 +497,10 @@ class TopInstructionsCSP extends Component {
                 token={this.state.token}
               />
             )}
+            {this.props.teacherMarkdown &&
+              this.state.tabSelected === TabType.TEACHER_ONLY && (
+                <TeacherOnlyMarkdown ref="teacherOnlyTab" />
+              )}
           </div>
           {!this.props.isEmbedView && (
             <HeightResizer
@@ -515,7 +537,8 @@ export default connect(
     viewAs: state.viewAs,
     readOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace,
     serverLevelId: state.pageConstants.serverLevelId,
-    user: state.pageConstants.userId
+    user: state.pageConstants.userId,
+    teacherMarkdown: state.instructions.teacherMarkdown
   }),
   dispatch => ({
     toggleInstructionsCollapsed() {

--- a/apps/src/templates/instructions/TopInstructionsCSP.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSP.jsx
@@ -433,8 +433,8 @@ class TopInstructionsCSP extends Component {
                   teacherOnly={teacherOnly}
                 />
               )}
-              {this.props.teacherMarkdown &&
-                (!this.state.fetchingData || teacherOnly) && (
+              {this.props.viewAs === ViewType.Teacher &&
+                this.props.teacherMarkdown && (
                   <InstructionsTab
                     className="uitest-teacherOnlyTab"
                     onClick={this.handleTeacherOnlyTabClick}
@@ -497,7 +497,8 @@ class TopInstructionsCSP extends Component {
                 token={this.state.token}
               />
             )}
-            {this.props.teacherMarkdown &&
+            {this.props.viewAs === ViewType.Teacher &&
+              this.props.teacherMarkdown &&
               this.state.tabSelected === TabType.TEACHER_ONLY && (
                 <TeacherOnlyMarkdown ref="teacherOnlyTab" />
               )}

--- a/apps/test/unit/templates/instructions/TopInstructionsCSPTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsCSPTest.jsx
@@ -21,7 +21,8 @@ const DEFAULT_PROPS = {
   viewAs: 'Teacher',
   readOnlyWorkspace: false,
   serverLevelId: 123,
-  user: 5
+  user: 5,
+  teacherMarkdown: 'Some teacher only markdown'
 };
 
 describe('TopInstructionsCSP', () => {
@@ -117,6 +118,67 @@ describe('TopInstructionsCSP', () => {
         });
 
         expect(wrapper.find('.uitest-feedback')).to.have.lengthOf(0);
+      });
+    });
+  });
+  describe('viewing the Teacher Instructions Tab', () => {
+    describe('as a teacher', () => {
+      it('does not show the Teacher Instructions tab on a level with no markdown', () => {
+        const wrapper = shallow(
+          <TopInstructionsCSP {...DEFAULT_PROPS} teacherMarkdown={null} />
+        );
+
+        wrapper.setState({
+          tabSelected: 'instructions',
+          feedbacks: [],
+          rubric: null,
+          teacherViewingStudentWork: false,
+          studentId: null,
+          fetchingData: false,
+          token: null
+        });
+
+        expect(wrapper.find('.uitest-teacherOnlyTab')).to.have.lengthOf(0);
+      });
+
+      it('shows the Teacher Instructions on a level with markdown', () => {
+        const wrapper = shallow(<TopInstructionsCSP {...DEFAULT_PROPS} />);
+
+        wrapper.setState({
+          tabSelected: 'instructions',
+          feedbacks: [],
+          rubric: null,
+          teacherViewingStudentWork: false,
+          studentId: null,
+          fetchingData: false,
+          token: null
+        });
+
+        expect(wrapper.find('.uitest-teacherOnlyTab')).to.have.lengthOf(1);
+      });
+    });
+
+    describe('as a student', () => {
+      it('does not show the Teacher Instructions tab', () => {
+        const wrapper = shallow(
+          <TopInstructionsCSP
+            {...DEFAULT_PROPS}
+            viewAs={'Student'}
+            teacherMarkdown={null}
+          />
+        );
+
+        wrapper.setState({
+          tabSelected: 'instructions',
+          feedbacks: [],
+          rubric: null,
+          teacherViewingStudentWork: false,
+          studentId: 1,
+          fetchingData: false,
+          token: null
+        });
+
+        expect(wrapper.find('.uitest-teacherOnlyTab')).to.have.lengthOf(0);
       });
     });
   });


### PR DESCRIPTION
The teacher only markdown has been buried below the fold in the instructions tab for a while. This makes it harder for teachers to know it exists. 

This change moves the teacher only blue box into its own tab in the instructions area. 
This only applies to CSD and CSP programming levels. 
The tab will only show up if:
* you are a verified teacher and
* there is teacher only markdown for that level.

# Before (For Verified Teacher)
<img width="991" alt="Screen Shot 2019-05-08 at 4 22 57 PM" src="https://user-images.githubusercontent.com/208083/57405900-92578180-71ad-11e9-99b0-654f224bdb1a.png">
<img width="989" alt="Screen Shot 2019-05-08 at 4 22 51 PM" src="https://user-images.githubusercontent.com/208083/57405901-92578180-71ad-11e9-885a-9a9006d4bc6d.png">

# After

## Teacher

### Verified Teacher

#### Level with Teacher Only Markdown
<img width="717" alt="Screen Shot 2019-05-08 at 4 09 19 PM" src="https://user-images.githubusercontent.com/208083/57405947-b0bd7d00-71ad-11e9-9940-21539dcf53e4.png">
<img width="719" alt="Screen Shot 2019-05-08 at 4 09 11 PM" src="https://user-images.githubusercontent.com/208083/57405948-b0bd7d00-71ad-11e9-80ed-74f1611d3243.png">

#### Level without Teacher Only Markdown
<img width="1037" alt="Screen Shot 2019-05-08 at 4 09 29 PM" src="https://user-images.githubusercontent.com/208083/57405923-a4392480-71ad-11e9-93b6-c64e8c309d84.png">

### Not Verified Teacher
<img width="723" alt="Screen Shot 2019-05-08 at 4 07 47 PM" src="https://user-images.githubusercontent.com/208083/57405973-b7e48b00-71ad-11e9-8595-7a9ab5343bae.png">

## Student

<img width="723" alt="Screen Shot 2019-05-08 at 4 07 47 PM" src="https://user-images.githubusercontent.com/208083/57405982-bc10a880-71ad-11e9-82ed-bdb423e51bbc.png">
