### PR TITLE
Mini contact form: Mention that it's US only (for now)

### DIFF
--- a/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
+++ b/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
@@ -157,7 +157,7 @@ export class RegionalPartnerMiniContact extends React.Component {
           )}
           <FieldGroup
             id="zip"
-            label="School ZIP Code"
+            label="School ZIP Code (US only)"
             type="text"
             required={true}
             onChange={this.handleChange}


### PR DESCRIPTION
[PLC-217](https://codedotorg.atlassian.net/browse/PLC-217): We've had some mini contact submissions from international users that are putting random numbers into the required school zip code field which we use to match the message to a regional partner.  We're investigating a better solution, but as a stopgap we're just adding "US only" to the zip code label as a nudge that this may be the wrong form to fill out.