### PR TITLE
Bump rest-client to 2.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -273,7 +273,11 @@ gem 'net-scp'
 gem 'net-ssh'
 gem 'oj'
 
-gem 'rest-client', '~> 2.0'
+gem 'rest-client', '~> 2.0.1'
+
+# A rest-client dependency
+# This is the latest version that's installing successfully
+gem 'unf_ext', '0.0.7.2'
 
 # Generate SSL certificates.
 gem 'acmesmith', '~> 0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,7 @@ GEM
       devise (>= 3.2.0)
     diff-lcs (1.3)
     docile (1.1.5)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     eventmachine (1.2.5)
@@ -477,7 +477,7 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     httparty (0.13.7)
       json (~> 1.8)
@@ -708,7 +708,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rest-client (2.0.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -1004,7 +1004,7 @@ DEPENDENCIES
   require_all
   rerun
   responders (~> 2.0)
-  rest-client (~> 2.0)
+  rest-client (~> 2.0.1)
   retryable
   rinku
   rmagick
@@ -1037,6 +1037,7 @@ DEPENDENCIES
   timecop
   twilio-ruby
   uglifier (>= 1.3.0)
+  unf_ext (= 0.0.7.2)
   unicorn (~> 5.1.0)
   user_agent_parser
   validates_email_format_of


### PR DESCRIPTION
Fix for [`key not found: :ciphers (KeyError)` issue in the `rest-client` gem](https://github.com/rest-client/rest-client/issues/612#issuecomment-313034465).

Re-pushing this after hour of code. See original request in #26112, which I think we rejected during Hour of Code triage as not being particularly necessary.

Doing this now as it seems to be a prerequisite for upgrading our Clever API in https://github.com/code-dot-org/code-dot-org/pull/28437. (Or at least for my local testing thereof.)

Pair: @dju90 