### PR TITLE
Update Clever API endpoints to 2.1

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -20,7 +20,7 @@ class ApiController < ApplicationController
     return head :forbidden unless current_user
 
     uid = current_user.uid_for_provider(AuthenticationOption::CLEVER)
-    query_clever_service("v1.1/teachers/#{uid}/sections") do |response|
+    query_clever_service("v2.1/teachers/#{uid}/sections") do |response|
       json = response.map do |section|
         data = section['data']
         {
@@ -41,7 +41,7 @@ class ApiController < ApplicationController
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
 
-    query_clever_service("v1.1/sections/#{course_id}/students") do |students|
+    query_clever_service("v2.1/sections/#{course_id}/students") do |students|
       section = CleverSection.from_service(course_id, current_user.id, students, course_name)
       render json: section.summarize
     end

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1113,7 +1113,7 @@ class ApiControllerTest < ActionController::TestCase
     teacher = create :teacher, :sso_provider, :demigrated, provider: AuthenticationOption::CLEVER
     sign_in teacher
 
-    expected_uri = "https://api.clever.com/v1.1/teachers/#{teacher.uid}/sections"
+    expected_uri = "https://api.clever.com/v2.1/teachers/#{teacher.uid}/sections"
     auth = {authorization: "Bearer #{teacher.oauth_token}"}
     mock_response = {data: []}.to_json
     RestClient.expects(:get).with(expected_uri, auth).returns(mock_response)
@@ -1126,7 +1126,7 @@ class ApiControllerTest < ActionController::TestCase
     sign_in teacher
     assert_nil teacher.uid
 
-    expected_uri = "https://api.clever.com/v1.1/teachers/#{auth_option.authentication_id}/sections"
+    expected_uri = "https://api.clever.com/v2.1/teachers/#{auth_option.authentication_id}/sections"
     auth = {authorization: "Bearer #{auth_option.data_hash[:oauth_token]}"}
     mock_response = {data: []}.to_json
     RestClient.expects(:get).with(expected_uri, auth).returns(mock_response)


### PR DESCRIPTION
[LP-387](https://codedotorg.atlassian.net/browse/LP-387): [A teacher reported](https://codeorg.zendesk.com/agent/tickets/238529) that 5 sections were missing from his list of Clever sections upon trying to create a new Clever section. After talking with someone in Clever support, we found out that it is because we are using v1.1 of the Clever API, and we need to update our code to hit the v2.2 Clever API ([here](https://github.com/code-dot-org/code-dot-org/blob/a3d2940c0fba1ab5235df23240f942818ce8a9ce/dashboard/app/controllers/api_controller.rb#L23) and [here](https://github.com/code-dot-org/code-dot-org/blob/a3d2940c0fba1ab5235df23240f942818ce8a9ce/dashboard/app/controllers/api_controller.rb#L44)).

[Clever docs on upgrading from v1.1 to v2.1](https://dev.clever.com/docs/upgrading-version#section-upgrading-from-v11) happily verified that we don't need to make any changes to support the new API besides updating the url.

Rebased on update-rest-client branch (see #28436) to resolve `key not found: :ciphers` error (found by debugging on localhost with breakpoint in the `query_clever_service` method. Tested two user pathways - `clever_classrooms` (displays available classrooms to sync new section with) and `import_clever_classroom` (imports data on a clever section) - successfully.

- Brad did the dictating, Bryan the driving >:D

## Manual testing steps

1. Launch local development server with development `dashboard_clever_key` and `dashboard_clever_secret` configured in locals.yml.  Make sure you are signed out.
2. Sign in to the [Clever Application Partner dashboard](https://apps.clever.com/login) using the Code.org Dev credentials shared in LastPass.
3. Switch to the "Code.org - Dev" application in the Clever dashboard.
4. Magnifying glass to browse schools:
   ![image](https://user-images.githubusercontent.com/1615761/57414783-74d6e780-71ae-11e9-976f-5ad0f8e4fa76.png)
5. Locate a teacher in the "Code.org test district"
6. Click the "Log in as..." link at the top of the details view for that teacher
   ![image](https://user-images.githubusercontent.com/1615761/57414873-c5e6db80-71ae-11e9-9477-f88fad470d79.png)
7. You should be signed into localhost as that teacher (who is probably a new user on your local machine).  Create a section:
   ![image](https://user-images.githubusercontent.com/1615761/57414925-047c9600-71af-11e9-80ff-32c0c4a50dd0.png)
8. Pick the "Clever" section type:
   ![image](https://user-images.githubusercontent.com/1615761/57414943-14947580-71af-11e9-854e-788e48035e76.png)
9. You should get a list of Clever sections available for import - this tests the API request made by the `clever_classrooms` method.
   ![image](https://user-images.githubusercontent.com/1615761/57414968-2d9d2680-71af-11e9-9737-d793d04372a2.png)
10. Follow the instructions to finish importing the section.  This should pull in fake student data, testing the API request made by the `import_clever_classroom` method.