### PR TITLE
PL: support multi-select when viewing JotForm survey results

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.jsx
@@ -17,7 +17,7 @@ export default class ChoiceResponses extends React.Component {
     otherText: PropTypes.string
   };
 
-  getTotalResponses() {
+  getTotalRespondents() {
     if (this.props.perFacilitator) {
       return Object.values(this.props.answers).reduce((sum, answers) => {
         return (
@@ -36,7 +36,10 @@ export default class ChoiceResponses extends React.Component {
         // There are still multiple paths through summarize_workshop_surveys on
         // the server which return results without telling us how many
         // respondents there were, and so we maintain this behavior for
-        // backwards compatibility.
+        // backwards compatibility.  This technique counts the number of answers
+        // provided, but for non-multiSelect questions this works out the same
+        // as the number of respondents to a question, since there can only be
+        // one response given per question.
         return Object.values(this.props.answers).reduce((sum, x) => sum + x, 0);
       }
     }
@@ -70,7 +73,7 @@ export default class ChoiceResponses extends React.Component {
 
       return (
         <tr key={i}>
-          <td>{this.formatPercentage(count / this.getTotalResponses())}</td>
+          <td>{this.formatPercentage(count / this.getTotalRespondents())}</td>
           <td style={{paddingLeft: '20px'}}>{count}</td>
           <td style={{paddingLeft: '20px'}}>{possibleAnswer}</td>
         </tr>
@@ -134,7 +137,7 @@ export default class ChoiceResponses extends React.Component {
           {showTotalCount && (
             <td style={{paddingLeft: '4px'}}>
               {`(${this.formatPercentage(
-                totalCount / this.getTotalResponses()
+                totalCount / this.getTotalRespondents()
               )})`}
             </td>
           )}
@@ -180,7 +183,7 @@ export default class ChoiceResponses extends React.Component {
               <tr>
                 <td>
                   {this.formatPercentage(
-                    otherAnswers.length / this.getTotalResponses()
+                    otherAnswers.length / this.getTotalRespondents()
                   )}
                 </td>
                 <td style={{paddingLeft: '20px'}}>{otherAnswers.length}</td>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.jsx
@@ -3,18 +3,21 @@ import React from 'react';
 import _ from 'lodash';
 import {Panel} from 'react-bootstrap';
 
-export default class SingleChoiceResponses extends React.Component {
+// This component renders a survey answer for answer_type of 'scale',
+// 'singleSelect', or 'multiSelect'.
+
+export default class ChoiceResponses extends React.Component {
   static propTypes = {
     question: PropTypes.string.isRequired,
     answers: PropTypes.object.isRequired,
     perFacilitator: PropTypes.bool,
-    numRespondents: PropTypes.number.isRequired,
+    numRespondents: PropTypes.number,
     answerType: PropTypes.string.isRequired,
     possibleAnswers: PropTypes.array.isRequired,
     otherText: PropTypes.string
   };
 
-  getTotalAnswers() {
+  getTotalResponses() {
     if (this.props.perFacilitator) {
       return Object.values(this.props.answers).reduce((sum, answers) => {
         return (
@@ -30,6 +33,10 @@ export default class SingleChoiceResponses extends React.Component {
         // answers, though it continues to work for single-select questions.)
         return this.props.numRespondents;
       } else {
+        // There are still multiple paths through summarize_workshop_surveys on
+        // the server which return results without telling us how many
+        // respondents there were, and so we maintain this behavior for
+        // backwards compatibility.
         return Object.values(this.props.answers).reduce((sum, x) => sum + x, 0);
       }
     }
@@ -63,7 +70,7 @@ export default class SingleChoiceResponses extends React.Component {
 
       return (
         <tr key={i}>
-          <td>{this.formatPercentage(count / this.getTotalAnswers())}</td>
+          <td>{this.formatPercentage(count / this.getTotalResponses())}</td>
           <td style={{paddingLeft: '20px'}}>{count}</td>
           <td style={{paddingLeft: '20px'}}>{possibleAnswer}</td>
         </tr>
@@ -127,7 +134,7 @@ export default class SingleChoiceResponses extends React.Component {
           {showTotalCount && (
             <td style={{paddingLeft: '4px'}}>
               {`(${this.formatPercentage(
-                totalCount / this.getTotalAnswers()
+                totalCount / this.getTotalResponses()
               )})`}
             </td>
           )}
@@ -173,7 +180,7 @@ export default class SingleChoiceResponses extends React.Component {
               <tr>
                 <td>
                   {this.formatPercentage(
-                    otherAnswers.length / this.getTotalAnswers()
+                    otherAnswers.length / this.getTotalResponses()
                   )}
                 </td>
                 <td style={{paddingLeft: '20px'}}>{otherAnswers.length}</td>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.story.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import SingleChoiceResponses from './single_choice_responses';
+import ChoiceResponses from './choice_responses';
 import reactBootstrapStoryDecorator from '../../../reactBootstrapStoryDecorator';
 
 export default storybook => {
   storybook
-    .storiesOf('Single choice responses', module)
+    .storiesOf('Choice responses', module)
     .addDecorator(reactBootstrapStoryDecorator)
     .addStoryTable([
       {
-        name: 'Single choice responses without other',
+        name: 'Choice responses without other',
         story: () => (
-          <SingleChoiceResponses
+          <ChoiceResponses
             question="What is your favorite pizza topping?"
             answers={{
               Peppers: 4,
@@ -32,9 +32,9 @@ export default storybook => {
         )
       },
       {
-        name: 'Single choice responses with others',
+        name: 'Choice responses with others',
         story: () => (
-          <SingleChoiceResponses
+          <ChoiceResponses
             question={
               'What is your favorite pizza topping? Please provide the topping if it is not listed here'
             }
@@ -62,9 +62,9 @@ export default storybook => {
         )
       },
       {
-        name: 'Single choice selectValue response',
+        name: 'Choice selectValue response',
         story: () => (
-          <SingleChoiceResponses
+          <ChoiceResponses
             question={'What do you think about pineapples on pizza?'}
             answers={{
               1: 10,
@@ -87,7 +87,7 @@ export default storybook => {
       {
         name: 'Scale ratings',
         story: () => (
-          <SingleChoiceResponses
+          <ChoiceResponses
             question={'How do you feel about deep dish?'}
             answers={{
               1: 1,
@@ -102,13 +102,13 @@ export default storybook => {
     ]);
 
   storybook
-    .storiesOf('Single choice per-facilitator responses', module)
+    .storiesOf('Choice per-facilitator responses', module)
     .addDecorator(reactBootstrapStoryDecorator)
     .addStoryTable([
       {
-        name: 'Single choice responses for only one facilitator',
+        name: 'Choice responses for only one facilitator',
         story: () => (
-          <SingleChoiceResponses
+          <ChoiceResponses
             question="What is your favorite pizza topping?"
             perFacilitator={true}
             answers={{
@@ -132,9 +132,9 @@ export default storybook => {
         )
       },
       {
-        name: 'Single choice responses without other',
+        name: 'Choice responses without other',
         story: () => (
-          <SingleChoiceResponses
+          <ChoiceResponses
             question="What is your favorite pizza topping?"
             perFacilitator={true}
             answers={{
@@ -167,9 +167,9 @@ export default storybook => {
         )
       },
       {
-        name: 'Single choice responses with others',
+        name: 'Choice responses with others',
         story: () => (
-          <SingleChoiceResponses
+          <ChoiceResponses
             question={
               'What is your favorite pizza topping? Please provide the topping if it is not listed here'
             }
@@ -211,9 +211,9 @@ export default storybook => {
         )
       },
       {
-        name: 'Single choice selectValue response',
+        name: 'Choice selectValue response',
         story: () => (
-          <SingleChoiceResponses
+          <ChoiceResponses
             question={'What do you think about pineapples on pizza?'}
             perFacilitator={true}
             answers={{
@@ -249,7 +249,7 @@ export default storybook => {
       {
         name: 'Scale ratings',
         story: () => (
-          <SingleChoiceResponses
+          <ChoiceResponses
             question={'How do you feel about deep dish?'}
             perFacilitator={true}
             answers={{

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/single_choice_responses.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/single_choice_responses.jsx
@@ -8,6 +8,7 @@ export default class SingleChoiceResponses extends React.Component {
     question: PropTypes.string.isRequired,
     answers: PropTypes.object.isRequired,
     perFacilitator: PropTypes.bool,
+    numRespondents: PropTypes.number.isRequired,
     answerType: PropTypes.string.isRequired,
     possibleAnswers: PropTypes.array.isRequired,
     otherText: PropTypes.string
@@ -21,7 +22,16 @@ export default class SingleChoiceResponses extends React.Component {
         );
       }, 0);
     } else {
-      return Object.values(this.props.answers).reduce((sum, x) => sum + x, 0);
+      if (this.props.numRespondents !== undefined) {
+        // Multi-select questions will tell us how many respondents there were,
+        // so that we can correctly show the percentage of respondents who
+        // gave a certain answer.  (The default technique of counting the number
+        // of answers doesn't work when a single respondent can choose multiple
+        // answers, though it continues to work for single-select questions.)
+        return this.props.numRespondents;
+      } else {
+        return Object.values(this.props.answers).reduce((sum, x) => sum + x, 0);
+      }
     }
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -33,7 +33,11 @@ export default class Results extends React.Component {
           return null;
         }
 
-        if (['scale', 'singleSelect'].includes(question['answer_type'])) {
+        if (
+          ['scale', 'singleSelect', 'multiSelect'].includes(
+            question['answer_type']
+          )
+        ) {
           return (
             <SingleChoiceResponses
               perFacilitator={section === 'facilitator'}

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Tab, Tabs} from 'react-bootstrap';
-import SingleChoiceResponses from '../../components/survey_results/single_choice_responses';
+import ChoiceResponses from '../../components/survey_results/choice_responses';
 import FacilitatorAveragesTable from '../../components/survey_results/facilitator_averages_table';
 import TextResponses from '../../components/survey_results/text_responses';
 import _ from 'lodash';
@@ -48,7 +48,7 @@ export default class Results extends React.Component {
           );
 
           return (
-            <SingleChoiceResponses
+            <ChoiceResponses
               perFacilitator={section === 'facilitator'}
               numRespondents={numRespondents}
               question={question['text']}

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -38,11 +38,21 @@ export default class Results extends React.Component {
             question['answer_type']
           )
         ) {
+          // numRespondents will get either a value (for multiSelect) or undefined.
+          const numRespondents = answers[questionId].num_respondents;
+
+          // Make a copy of the answers without the num_respondents field.
+          const filteredAnswers = _.omit(
+            answers[questionId],
+            'num_respondents'
+          );
+
           return (
             <SingleChoiceResponses
               perFacilitator={section === 'facilitator'}
+              numRespondents={numRespondents}
               question={question['text']}
-              answers={answers[questionId]}
+              answers={filteredAnswers}
               possibleAnswers={question['options']}
               key={i}
               answerType={question['answer_type']}

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/resultsTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/resultsTest.js
@@ -149,10 +149,10 @@ describe('Local Summer Workshop Daily Survey Results class', () => {
     let firstTab = results.find('Tab').first();
     let secondTab = results.find('Tab').at(1);
 
-    expect(firstTab.find('SingleChoiceResponses')).to.have.length(3);
+    expect(firstTab.find('ChoiceResponses')).to.have.length(3);
     expect(firstTab.find('TextResponses')).to.have.length(2);
 
-    expect(secondTab.find('SingleChoiceResponses')).to.have.length(2);
+    expect(secondTab.find('ChoiceResponses')).to.have.length(2);
     expect(secondTab.find('TextResponses')).to.have.length(3);
 
     expect(firstTab.find('h3').map(x => x.text())).to.deep.equal([

--- a/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
+++ b/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
@@ -292,7 +292,7 @@ module Pd::WorkshopSurveyResultsHelper
 
               session_summary[:facilitator][q_key] = facilitator_responses.transform_keys {|k| facilitator_map[k]}
             else
-              summary = surveys_for_session[response_section].map {|survey| survey[q_key]}.group_by {|v| v}.transform_values(&:size)
+              summary = surveys_for_session[response_section].map {|survey| survey[q_key]}.flatten.group_by {|v| v}.transform_values(&:size)
               session_summary[response_section][q_key] = summary.reject {|k, _| k.nil?}
             end
           end

--- a/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
+++ b/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
@@ -292,8 +292,7 @@ module Pd::WorkshopSurveyResultsHelper
 
               session_summary[:facilitator][q_key] = facilitator_responses.transform_keys {|k| facilitator_map[k]}
             else
-              summary = surveys_for_session[response_section].map {|survey| survey[q_key]}.flatten.group_by {|v| v}.transform_values(&:size)
-              session_summary[response_section][q_key] = summary.reject {|k, _| k.nil?}
+              session_summary[response_section][q_key] = get_session_summary(surveys_for_session[response_section], q_key)
             end
           end
         end
@@ -303,6 +302,26 @@ module Pd::WorkshopSurveyResultsHelper
     end
 
     workshop_summary
+  end
+
+  # Given an array of survey submissions for a session, and a question key, return a
+  # summary of how many responses per question, as well as how many respondents per question.
+  #
+  # See the unit test for example inputs & outputs.
+  #
+  # The return value is a hash with the answers as keys and the values as the counts of those answers.
+  # An additional key of num_respondents is added, which gives the number of respondents for
+  # a given question, which is needed for displaying results for multi-choice questions in particular.
+  # The client filters out num_respondents so that it's not shown as one of the answers.
+
+  def get_session_summary(survey_for_session, q_key)
+    summary = survey_for_session.map {|survey| survey[q_key]}.flatten.group_by {|v| v}.transform_values(&:size)
+    session_summary = summary.reject {|k, _| k.nil?}
+
+    num_respondents = survey_for_session.select {|item| item.key?(q_key)}.count
+    session_summary["num_respondents"] = num_respondents unless num_respondents == 0
+
+    session_summary
   end
 
   def get_surveys_for_workshops(workshops)


### PR DESCRIPTION
This adds support for multi-select answers when viewing  workshop per-day JotForm survey results.  After a long day of diving into this code, I'm surprised at how small the fix is, and am also not yet sure whether it's the right or complete fix.

But here's why the simple addition of a `.flatten` seems to have worked.  Almost everything came down to this line in the controller:

```
summary = surveys_for_session[response_section].map {|survey| survey[q_key]}.group_by {|v| v}.transform_values(&:size)
```

For these examples, we'll take `surveys_for_session[response_section]` to be this, which represents two surveys, each with the same four questions answered:
```
[{"type_of_last_pd"=>
   ["I completed an online course/webinar.",
    "I participated in a professional learning community/lesson study/teacher study group.",
    "I received assistance or feedback from a formally designated coach/mentor.",
    "I took a formal course for college credit."],
  "reasons_for_no_PD"=>["Did not have school/admin support", "my other text"],
  "wouldYou220"=>"No, thanks.",
  "permission"=>"No, I do not give permission to quote me."},
 {"type_of_last_pd"=>
   ["I completed an online course/webinar.",
    "I participated in a professional learning community/lesson study/teacher study group.",
    "I received assistance or feedback from a formally designated coach/mentor."],
  "reasons_for_no_PD"=>["Did not have financial support", "second other text"],
  "wouldYou220"=>"No, thanks.",
  "permission"=>"No, I do not give permission to quote me."}]
```

For a single-select, the transformation worked like this:

```
r.map {|survey| survey["permission"]}
=> ["No, I do not give permission to quote me.", "No, I do not give permission to quote me."]

r.map {|survey| survey["permission"]}.group_by {|v| v}
=> {"No, I do not give permission to quote me."=>["No, I do not give permission to quote me.", "No, I do not give permission to quote me."]}

r.map {|survey| survey["permission"]}.group_by {|v| v}.transform_values(&:size)
=> {"No, I do not give permission to quote me."=>2}
```

For a multi-select, the same transformation worked like this:

```
r.map {|survey| survey["reasons_for_no_PD"]}
=> [["Did not have school/admin support", "my other text"], ["Did not have financial support", "second other text"]]

r.map {|survey| survey["reasons_for_no_PD"]}.group_by {|v| v}
=> {["Did not have school/admin support", "my other text"]=>[["Did not have school/admin support", "my other text"]], ["Did not have financial support", "second other text"]=>[["Did not have financial support", "second other text"]]}

r.map {|survey| survey["reasons_for_no_PD"]}.group_by {|v| v}.transform_values(&:size)
=> {["Did not have school/admin support", "my other text"]=>1, ["Did not have financial support", "second other text"]=>1}
```
which was not what we wanted, and didn't group answers properly on the client.

But with the addition of the `.flatten`, we see this:

```
r.map {|survey| survey["reasons_for_no_PD"]}.flatten
=> ["Did not have school/admin support", "my other text", "Did not have financial support", "second other text"]

r.map {|survey| survey["reasons_for_no_PD"]}.flatten.group_by {|v| v}
=> {"Did not have school/admin support"=>["Did not have school/admin support"], "my other text"=>["my other text"], "Did not have financial support"=>["Did not have financial support"], "second other text"=>["second other text"]}

r.map {|survey| survey["reasons_for_no_PD"]}.flatten.group_by {|v| v}.transform_values(&:size)
=> {"Did not have school/admin support"=>1, "my other text"=>1, "Did not have financial support"=>1, "second other text"=>1}
```

This looks closer to what we're after.

Taking a look at the view for this data at `/pd/workshop_dashboard/daily_survey_results/ID`, with only a small change made to render `SingleChoiceResponses` for `multiSelect` answers as well, things amazingly seem to work with no further changes:

![Screenshot 2019-05-08 19 05 00](https://user-images.githubusercontent.com/2205926/57422887-a22f8f80-71c6-11e9-95d1-0fb166bf5751.png)

Except the eagle-eyed will notice that the percentages aren't right here, because the logic for `singleSelect` questions looked at the number of answers supplied by one respondent divided by the number of answers supplied by all respondents.  In the case of `multiSelect`, we want to divide by the number of respondents to that question, rather than the number of answers.  A second commit handles this:

![Screenshot 2019-05-10 12 09 09](https://user-images.githubusercontent.com/2205926/57550984-b1285600-731c-11e9-8752-b208d7ded56a.png)
