### PR TITLE
Fix test

### DIFF
--- a/dashboard/test/ui/features/gamelab/level_options.feature
+++ b/dashboard/test/ui/features/gamelab/level_options.feature
@@ -24,4 +24,4 @@ Scenario: Initial animations are usable with no animation tab
 Scenario: Initial animations show up in the animation tab
   Given I am on the 2nd Game Lab test level
   When I switch to the animation tab
-  Then I see 3 animations in the animation column
+  Then I see 2 animations in the animation column


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/28446 removed an animation. The test now needs to be updated to expect 2 instead of 3 animations in the list.