### PR TITLE
Projects: Increase abuse score threshold from 10 to 15

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -9,7 +9,7 @@ import firehoseClient from '@cdo/apps/lib/util/firehose';
 // Attempt to save projects every 30 seconds
 var AUTOSAVE_INTERVAL = 30 * 1000;
 
-var ABUSE_THRESHOLD = 10;
+var ABUSE_THRESHOLD = 15;
 
 var hasProjectChanged = false;
 


### PR DESCRIPTION
Part 1 of [LP-52](https://codedotorg.atlassian.net/browse/LP-52)

For all projects, set the threshold for a project being blocked abuse_score >= 15 so that there have to be multiple reports of abuse before we take the project down to prevent kids from spamming Zendesk. 