### PR TITLE
Include space in stage name to fix seeding problem

### DIFF
--- a/dashboard/config/scripts/express-2019.script
+++ b/dashboard/config/scripts/express-2019.script
@@ -141,7 +141,7 @@ level 'courseD_artist_4_2018_2019'
 level 'courseD_artist_5_2018_2019'
 level 'courseD_artist_6_2018_2019'
 
-stage 'Concept Practice with Minecraft', flex_category: 'csf_loops'
+stage 'Concept Practice with Minecraft ', flex_category: 'csf_loops'
 level 'Overworld Move to Sheep_2019'
 level 'Overworld Chop Tree_2019'
 level 'Overworld Shear Sheep_2019'


### PR DESCRIPTION
After the Levelbuilder content was pulled into Staging today Staging failed to build because scripts could not seed.  Scripts could not seed because a stage name had been changed - a white space was stripped from the end of Concept Practice with Minecraft.  Fixed directly on the staging machine which unblocked the seed step; making this PR to keep them in sync. 

* We should find a way to prevent this in the future! Nkiru will address in DotD email. 