### PR TITLE
Detect board disconnecting so that we can reestablish connection

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1141,7 +1141,6 @@ Applab.execute = function() {
         interpreter: Applab.JSInterpreter,
         onDisconnect: () => {
           studioApp().resetButtonClick();
-          makerToolkit.disconnectBoard();
         }
       })
       .then(Applab.beginVisualizationRun)

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1139,7 +1139,10 @@ Applab.execute = function() {
     makerToolkit
       .connect({
         interpreter: Applab.JSInterpreter,
-        onDisconnect: () => studioApp().resetButtonClick()
+        onDisconnect: () => {
+          studioApp().resetButtonClick();
+          makerToolkit.disconnectBoard();
+        }
       })
       .then(Applab.beginVisualizationRun)
       .catch(error => {

--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -130,6 +130,8 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
       );
     }
 
+    this.fiveBoard_.on('close', () => this.emit('disconnect'));
+
     this.fiveBoard_.on('disconnect', () => this.emit('disconnect'));
   }
 

--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -9,6 +9,7 @@ import Firmata from 'firmata';
 import {
   createCircuitPlaygroundComponents,
   destroyCircuitPlaygroundComponents,
+  resetCircuitPlaygroundComponents,
   componentConstructors
 } from './PlaygroundComponents';
 import {
@@ -207,10 +208,7 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
   }
 
   reset() {
-    const {led, buzzer, colorLeds} = this.prewiredComponents_;
-    led.off();
-    colorLeds.forEach(led => led.off());
-    buzzer.off();
+    resetCircuitPlaygroundComponents(this.prewiredComponents_);
   }
 
   /**

--- a/apps/src/lib/kits/maker/PlaygroundComponents.js
+++ b/apps/src/lib/kits/maker/PlaygroundComponents.js
@@ -70,6 +70,46 @@ export function createCircuitPlaygroundComponents(board) {
 }
 
 /**
+ * reset state on circuit playground components, but don't delete them.
+ */
+export function resetCircuitPlaygroundComponents(components) {
+  if (components.colorLeds) {
+    components.colorLeds.forEach(led => {
+      led.color('white');
+      led.intensity(100);
+      led.off();
+      led.stop();
+    });
+  }
+
+  if (components.led) {
+    components.led.off();
+    components.led.stop();
+  }
+
+  if (components.buzzer) {
+    components.buzzer.off();
+    components.buzzer.stop();
+  }
+
+  if (components.soundSensor) {
+    components.soundSensor.disable();
+  }
+
+  if (components.lightSensor) {
+    components.lightSensor.disable();
+  }
+
+  if (components.tempSensor) {
+    components.tempSensor.disable();
+  }
+
+  if (components.accelerometer) {
+    components.accelerometer.stop();
+  }
+}
+
+/**
  * De-initializes any Johnny-Five components that might have been created
  * by createCircuitPlaygroundComponents
  * @param {Object} components - map of components, as originally returned by

--- a/apps/src/lib/kits/maker/toolkit.js
+++ b/apps/src/lib/kits/maker/toolkit.js
@@ -146,11 +146,20 @@ function shouldRunWithFakeBoard() {
 
 /**
  * Called when execution of the student app ends.
- * Resets the board state, disconnects and destroys the current board controller,
+ * Resets the board state
  * and puts maker UI back in a default state.
  */
 export function reset() {
   if (currentBoard) {
     currentBoard.reset();
   }
+}
+
+/**
+ * Called when the board disconnects
+ * Throw away reference to the currentBoard, so that next time we run
+ * we make a new board.
+ */
+export function disconnectBoard() {
+  currentBoard = null;
 }

--- a/apps/src/lib/kits/maker/toolkit.js
+++ b/apps/src/lib/kits/maker/toolkit.js
@@ -90,7 +90,7 @@ export function connect({interpreter, onDisconnect}) {
       commands.injectBoardController(currentBoard);
       currentBoard.installOnInterpreter(interpreter);
       if (typeof onDisconnect === 'function') {
-        currentBoard.once('disconnect', onDisconnect);
+        currentBoard.once('disconnect', () => disconnect(onDisconnect));
       }
       dispatch(redux.reportConnected());
       trackEvent('Maker', 'ConnectionSuccess');
@@ -107,6 +107,28 @@ export function connect({interpreter, onDisconnect}) {
         return Promise.reject(error);
       }
     });
+}
+
+/**
+ * Called when the board disconnects
+ * Throw away reference to the currentBoard, so that next time we run
+ * we make a new board.
+ */
+function disconnect(onDisconnect) {
+  onDisconnect();
+  if (!redux.isEnabled(getStore().getState())) {
+    return;
+  }
+
+  const setDisconnected = () => {
+    currentBoard = null;
+    getStore().dispatch(redux.disconnect);
+  };
+  if (currentBoard) {
+    currentBoard.destroy().then(setDisconnected);
+  } else {
+    setDisconnected();
+  }
 }
 
 /**
@@ -153,13 +175,4 @@ export function reset() {
   if (currentBoard) {
     currentBoard.reset();
   }
-}
-
-/**
- * Called when the board disconnects
- * Throw away reference to the currentBoard, so that next time we run
- * we make a new board.
- */
-export function disconnectBoard() {
-  currentBoard = null;
 }


### PR DESCRIPTION
With PR https://github.com/code-dot-org/code-dot-org/pull/28037 we now keep a constant connection to the board, instead of reconnecting on every run/reset.

We think this is overall better for stability, but one downside is that (if the board gets into a bad state) the only way to reconnect the board is to reload the page.

With this change, we throw away the reference to the board on disconnect and close events, so that a new board is created on the next run.