### PR TITLE
Open-Url Block - Bug Fix for Over Quota

### DIFF
--- a/lib/cdo/safe_browsing.rb
+++ b/lib/cdo/safe_browsing.rb
@@ -52,7 +52,8 @@ module SafeBrowsing
 
     # Safe Browsing API returns empty JSON object is no threat matches found
     # Do not determine safe if response is nil
-    # Determine safe if bad request (response code is 400)
-    response.nil? ? false : (response.code === '400' || response_value)
+    # Determine safe if bad request (response code is 400) or if rate-limited (429)
+    error_response = response.nil? ? false : (response.code === '400' || response.code === '429')
+    response.nil? ? false : (error_response || response_value)
   end
 end

--- a/lib/cdo/safe_browsing.rb
+++ b/lib/cdo/safe_browsing.rb
@@ -52,6 +52,7 @@ module SafeBrowsing
 
     # Safe Browsing API returns empty JSON object is no threat matches found
     # Do not determine safe if response is nil
-    response.nil? ? false : response_value
+    # Determine safe if bad request (response code is 400)
+    response.nil? ? false : (response.code === '400' || response_value)
   end
 end

--- a/lib/cdo/safe_browsing.rb
+++ b/lib/cdo/safe_browsing.rb
@@ -53,7 +53,7 @@ module SafeBrowsing
     # Safe Browsing API returns empty JSON object is no threat matches found
     # Do not determine safe if response is nil
     # Determine safe if bad request (response code is 400) or if rate-limited (429)
-    error_response = response.nil? ? false : (response.code === '400' || response.code === '429')
+    error_response = response.nil? ? false : (response.code == '400' || response.code == '429')
     response.nil? ? false : (error_response || response_value)
   end
 end

--- a/lib/test/cdo/test_safe_browsing.rb
+++ b/lib/test/cdo/test_safe_browsing.rb
@@ -23,13 +23,13 @@ class SafeBrowsingTest < Minitest::Test
 
   def test_safe_with_bad_request
     stub_request(:post,     "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=" + CDO.google_safe_browsing_key).
-        to_return({status: 400}, {body: "{}"}, {headers: {}})
+        to_return({status: 400, body: "{}", headers: {}})
     assert SafeBrowsing.determine_safe_to_open("http://testsafebrowsing.appspot.com/s/phishing.html")
   end
 
   def test_safe_with_rate_limit
     stub_request(:post,     "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=" + CDO.google_safe_browsing_key).
-        to_return({status: 429}, {body: "{}"}, {headers: {}})
+        to_return({status: 429, body: "{}", headers: {}})
     assert SafeBrowsing.determine_safe_to_open("http://testsafebrowsing.appspot.com/s/phishing.html")
   end
 end

--- a/lib/test/cdo/test_safe_browsing.rb
+++ b/lib/test/cdo/test_safe_browsing.rb
@@ -1,5 +1,6 @@
 require_relative '../test_helper'
 require_relative '../../cdo/safe_browsing'
+require 'webmock/minitest'
 
 class SafeBrowsingTest < Minitest::Test
   include SetupTest
@@ -18,5 +19,17 @@ class SafeBrowsingTest < Minitest::Test
 
   def test_determine_unsafe_website
     refute SafeBrowsing.determine_safe_to_open("http://testsafebrowsing.appspot.com/s/phishing.html")
+  end
+
+  def test_safe_with_bad_request
+    stub_request(:post,     "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=" + CDO.google_safe_browsing_key).
+        to_return({status: 400}, {body: "{}"}, {headers: {}})
+    assert SafeBrowsing.determine_safe_to_open("http://testsafebrowsing.appspot.com/s/phishing.html")
+  end
+
+  def test_safe_with_rate_limit
+    stub_request(:post,     "https://safebrowsing.googleapis.com/v4/threatMatches:find?key=" + CDO.google_safe_browsing_key).
+        to_return({status: 429}, {body: "{}"}, {headers: {}})
+    assert SafeBrowsing.determine_safe_to_open("http://testsafebrowsing.appspot.com/s/phishing.html")
   end
 end

--- a/shared/test/fixtures/vcr/safebrowsing/determine_safe_website.yml
+++ b/shared/test/fixtures/vcr/safebrowsing/determine_safe_website.yml
@@ -15,24 +15,24 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Sat, 02 Mar 2019 01:01:09 GMT
+      - Fri, 10 May 2019 18:42:26 GMT
       Server:
       - ESF
       Cache-Control:
       - private
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       X-Frame-Options:
       - SAMEORIGIN
       X-Content-Type-Options:
       - nosniff
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39"
+      - quic=":443"; ma=2592000; v="46,44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
       string: "{}\n"
     http_version: 
-  recorded_at: Sat, 02 Mar 2019 01:01:09 GMT
+  recorded_at: Fri, 10 May 2019 18:42:26 GMT
 recorded_with: VCR 3.0.3

--- a/shared/test/fixtures/vcr/safebrowsing/determine_safe_website.yml
+++ b/shared/test/fixtures/vcr/safebrowsing/determine_safe_website.yml
@@ -15,7 +15,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 10 May 2019 18:42:26 GMT
+      - Fri, 10 May 2019 20:35:46 GMT
       Server:
       - ESF
       Cache-Control:
@@ -34,5 +34,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}\n"
     http_version: 
-  recorded_at: Fri, 10 May 2019 18:42:26 GMT
+  recorded_at: Fri, 10 May 2019 20:35:46 GMT
 recorded_with: VCR 3.0.3

--- a/shared/test/fixtures/vcr/safebrowsing/determine_unsafe_website.yml
+++ b/shared/test/fixtures/vcr/safebrowsing/determine_unsafe_website.yml
@@ -15,19 +15,19 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Sat, 02 Mar 2019 01:01:10 GMT
+      - Fri, 10 May 2019 18:42:26 GMT
       Server:
       - ESF
       Cache-Control:
       - private
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       X-Frame-Options:
       - SAMEORIGIN
       X-Content-Type-Options:
       - nosniff
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39"
+      - quic=":443"; ma=2592000; v="46,44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -47,5 +47,5 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Sat, 02 Mar 2019 01:01:10 GMT
+  recorded_at: Fri, 10 May 2019 18:42:26 GMT
 recorded_with: VCR 3.0.3

--- a/shared/test/fixtures/vcr/safebrowsing/determine_unsafe_website.yml
+++ b/shared/test/fixtures/vcr/safebrowsing/determine_unsafe_website.yml
@@ -15,7 +15,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 10 May 2019 18:42:26 GMT
+      - Fri, 10 May 2019 20:35:46 GMT
       Server:
       - ESF
       Cache-Control:
@@ -47,5 +47,5 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Fri, 10 May 2019 18:42:26 GMT
+  recorded_at: Fri, 10 May 2019 20:35:46 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Today we went over our quota for the api requests in our Open-Url Block. We requested (and got approved) for doubling our quota through Google Console. However, if this situation happens again, this PR should protect us by classifying responses returned as bad-requests or rate-limits as 'approved' to open. This means the user will receive a message letting them know what site they are going to and the user can make an informed choice.

![Screenshot from 2019-03-06 12-04-38](https://user-images.githubusercontent.com/2959170/57550033-fe56f880-7319-11e9-95f4-3e82170c26ed.png)

Includes tests