### PR TITLE
Add a version of the Droplet list block that uses numbers instead of str

### DIFF
--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -864,6 +864,12 @@ export var blocks = [
     type: 'value'
   },
   {
+    func: 'declareAssign_list_123',
+    block: 'var list = [1, 2, 3];',
+    category: 'Variables',
+    noAutocomplete: true
+  },
+  {
     func: 'declareAssign_list_abd',
     block: 'var list = ["a", "b", "d"];',
     category: 'Variables',

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -268,6 +268,7 @@ module SharedConstants
       "toUpperCase": null,
       "toLowerCase": null,
       "declareAssign_list_abd": null,
+      "declareAssign_list_123": null,
       "accessListItem": null,
       "listLength": null,
       "insertItem": null,


### PR DESCRIPTION
@gtw @lindyroo this was the sample block we prototyped while talking about list blocks.

![image](https://user-images.githubusercontent.com/413693/57552442-bf787100-7320-11e9-87cb-7276f6e182fb.png)