### PR TITLE
Pegasus: remove mobile carousel from various pages

### DIFF
--- a/pegasus/sites.v3/code.org/views/learn_carousels.haml
+++ b/pegasus/sites.v3/code.org/views/learn_carousels.haml
@@ -1,6 +1,6 @@
 :ruby
   all_categories = {}
-  
+
   all_categories['learn'] = []
   all_categories['learn'] << {tag:"JavaScript", name: I18n.t(:carousel_heading_javascript)}
   all_categories['learn'] << {tag:"Beginner", name: I18n.t(:carousel_heading_beginners)}
@@ -8,7 +8,7 @@
   all_categories['learn'] << {tag:"Apps", name: I18n.t(:carousel_heading_devices)}
   all_categories['learn'] << {tag:"OtherLang", name: I18n.t(:carousel_heading_languages)}
   all_categories['learn'] << {tag:"Teacherled", name: I18n.t(:teach_led_lesson_plans)}
-  
+
   all_categories['beyond'] = []
   all_categories['beyond'] << {tag:"Beginner", name: I18n.t(:carousel_heading_beyond_beginners)}
   all_categories['beyond'] << {tag:"JavaScript", name: I18n.t(:carousel_heading_beyond_javascript)}
@@ -19,7 +19,7 @@
   all_categories['beyond'] << {tag:"Web", name: I18n.t(:carousel_heading_webpages)}
   all_categories['beyond'] << {tag:"Robot", name: I18n.t(:carousel_heading_robots)}
   all_categories['beyond'] << {tag:"IDE", name: I18n.t(:carousel_heading_ide)}
-  
+
   all_categories['elementary'] = []
   all_categories['elementary'] << {tag:"Desktop", name: I18n.t(:carousel_heading_desktop)}
   all_categories['elementary'] << {tag:"MobTabElem", name: I18n.t(:carousel_heading_mobtabelem)}
@@ -27,7 +27,7 @@
   all_categories['elementary'] << {tag:"BeyondBlocks", name: I18n.t(:carousel_heading_beyondblocks)}
   all_categories['elementary'] << {tag:"NoInternet", name: I18n.t(:carousel_heading_nointernet)}
   all_categories['elementary'] << {tag:"RobotsElem", name: I18n.t(:carousel_heading_robots)}
-  
+
   all_categories['middle_high'] = []
   all_categories['middle_high'] << {tag:"JavaScript", name: I18n.t(:carousel_heading_beyond_javascript)}
   all_categories['middle_high'] << {tag:"BeginnerMid", name: I18n.t(:carousel_heading_beyond_beginners)}
@@ -35,7 +35,7 @@
   all_categories['middle_high'] << {tag:"OtherLang", name: I18n.t(:carousel_heading_beyond_languages)}
   all_categories['middle_high'] << {tag:"MobTabMid", name: I18n.t(:carousel_heading_beyond_devices)}
   all_categories['middle_high'] << {tag:"RobotsMid", name: I18n.t(:carousel_heading_robots)}
-  
+
   all_categories['university'] = []
   all_categories['university'] << {tag:"Univ", name: I18n.t(:carousel_heading_university)}
   all_categories['university'] << {tag:"WebUniv", name: I18n.t(:carousel_heading_webpages)}
@@ -44,16 +44,13 @@
   all_categories['university'] << {tag:"RobotsUniv", name: I18n.t(:carousel_heading_robots)}
 
   tutorials = Tutorials.new(variation=='learn' ? :tutorials : :beyond_tutorials)
-  
+
   @variation = variation
 
 %div{style: "clear:both"}
 
 #carousel-ie8{:style=>'display:none'}
   = view :learn_carousel, :heading=>I18n.t(:older_systems), :subheading=>I18n.t(:older_systems_subheading), :tag=>'IE8', :tutorials=>tutorials, :id=>'collection-ie8', :check_language=>true
-
-#carousel-mobile{:style=>'display:none'}
-  = view :learn_carousel, :heading=>I18n.t(:mobile_devices), :tag=>'Mobile', :tutorials=>tutorials, :id=>'collection-mobile', :check_language=>true
 
 #carousel-international{:style=>'display:none'}
   = view :learn_carousel, :heading=>I18n.t(:carousel_heading_international), :tag=>'International', :tutorials=>tutorials, :id=>'collection-international', :international_layout=>true, :check_language=>true
@@ -81,9 +78,6 @@
   %br
 
 :javascript
-
-  if (window.mobilecheck())
-    $('#carousel-mobile').show();
 
   // Older systems
   var ua = navigator.userAgent;

--- a/pegasus/sites.v3/hourofcode.com/views/learn_carousels.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/learn_carousels.haml
@@ -26,9 +26,6 @@
 #carousel-ie8{:style=>'display:none'}
   = view :learn_carousel, :heading=>I18n.t(:older_systems), :subheading=>I18n.t(:older_systems_subheading), :tag=>'IE8', :tutorials=>tutorials, :id=>'collection-ie8', :check_language=>true
 
-#carousel-mobile{:style=>'display:none'}
-  = view :learn_carousel, :heading=>I18n.t(:mobile_devices), :tag=>'Mobile', :tutorials=>tutorials, :id=>'collection-mobile', :check_language=>true
-
 #carousel-international{:style=>'display:none'}
   = view :learn_carousel, :heading=>I18n.t(:carousel_heading_international), :tag=>'International', :tutorials=>tutorials, :id=>'collection-international', :international_layout=>true, :check_language=>true
   %br
@@ -53,9 +50,6 @@
       = I18n.t(:learn_footer_all_tutorials)
 
 :javascript
-
-  //if (window.mobilecheck())
-  //  $('#carousel-mobile').show();
 
   // Older systems
   var ua = navigator.userAgent;


### PR DESCRIPTION
This removes the mobile carousel from these pages:

code.org/student/university
code.org/student/middle-high
code.org/student/elementary

And deletes the non-functional code for it here:

hourofcode.com/beyond

## before

![Screenshot 2019-05-10 13 51 05](https://user-images.githubusercontent.com/2205926/57556168-1d11bb00-732b-11e9-840b-db6870859ebf.png)
