### PR TITLE
Center the help button in signed out mode

### DIFF
--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -262,12 +262,13 @@
 }
 
 #help-button {
-  padding-left: 20px;
+  padding-left: 15px;
   padding-top: 4px;
 
   #help-icon {
     padding: 9px 0 16px 0;
     font-size: 26px;
     color: $white;
+    height: 25px;
   }
 }


### PR DESCRIPTION
[FND-441](https://codedotorg.atlassian.net/browse/FND-441)

Made the icon a bit larger and shifted the margins. Tested in signed out mode and signed in as a student and it is centered with the hamburger in signed in mode and with the "Sign In" button in signed out mode.

![Screenshot 2019-05-16 at 9 38 34 AM](https://user-images.githubusercontent.com/46464143/57871754-ecb09d80-77be-11e9-9ad2-bd66cca7c772.png)


![Screenshot 2019-05-10 at 2 21 34 PM](https://user-images.githubusercontent.com/46464143/57818976-26d85b80-773b-11e9-9e1c-5b5057159d9e.png)


