### PR TITLE
LB videos page_width -> small_video_page_width

### DIFF
--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -39,6 +39,6 @@
 - if video
   :javascript
     var videoOptions = #{video.summarize(false).to_json};
-    var videoHeight = #{page_width} / (16 / 9);
+    var videoHeight = #{small_video_page_width} / (16 / 9);
 
     window.dashboard.videos.createVideoWithFallback($('.video-container'), videoOptions, #{small_video_page_width}, videoHeight);


### PR DESCRIPTION
I renamed `page_width` to `small_video_page_width` in https://github.com/code-dot-org/code-dot-org/pull/28398/files, and missed one. This is the fix! 