### PR TITLE
Halt preview audio when navigating away from Sound List

### DIFF
--- a/apps/src/code-studio/components/SoundLibrary.jsx
+++ b/apps/src/code-studio/components/SoundLibrary.jsx
@@ -144,6 +144,7 @@ export default class SoundLibrary extends React.Component {
       category: '',
       search: ''
     });
+    this.sounds.stopAllAudio();
   };
 
   animationCategoriesRendering() {

--- a/apps/src/code-studio/components/SoundPicker.jsx
+++ b/apps/src/code-studio/components/SoundPicker.jsx
@@ -8,6 +8,7 @@ import {
 } from '../../assetManagement/assetPrefix';
 import SoundLibrary from './SoundLibrary';
 import i18n from '@cdo/locale';
+import Sounds from '../../Sounds';
 
 const audioExtension = '.mp3';
 const styles = {
@@ -55,7 +56,11 @@ export default class SoundPicker extends React.Component {
 
   setSoundMode = () => this.setState({mode: MODE.sounds});
 
-  setFileMode = () => this.setState({mode: MODE.files});
+  setFileMode = () => {
+    let sounds = Sounds.getSingleton();
+    sounds.stopAllAudio();
+    this.setState({mode: MODE.files});
+  };
 
   render() {
     const isFileMode = this.state.mode === MODE.files;


### PR DESCRIPTION
![Screenshot from 2019-05-13 11-06-01](https://user-images.githubusercontent.com/2959170/57644155-5c7d1900-7570-11e9-94eb-6cd84f61d176.png)

When previewing an audio clip, this PR halts the preview when the user navigates to "All Categories" or "Make New Sounds". This prevents users accidentally having multiple audio tracks overlaying each other and also just makes it less annoying to preview a long audio file.