### PR TITLE
Applab: fix design mode screen copy/paste

### DIFF
--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -564,7 +564,8 @@ designMode.readProperty = function(element, name) {
 designMode.onDuplicate = function(element, event) {
   let isScreen = $(element).hasClass('screen');
   if (isScreen) {
-    return duplicateScreen(element);
+    const newScreenId = duplicateScreen(element);
+    return elementUtils.getPrefixedElementById(newScreenId);
   }
 
   var duplicateElement = $(element).clone(true)[0];
@@ -1485,6 +1486,27 @@ designMode.addScreenIfNecessary = function(html) {
   return rootDiv[0].outerHTML;
 };
 
+designMode.setAsClipboardElement = function(element) {
+  if (!element) {
+    return;
+  }
+  let madeUndraggable;
+  const jqueryElement = $(element);
+  const isScreen = jqueryElement.hasClass('screen');
+  if (isScreen) {
+    // Unwrap the draggable wrappers around the child elements:
+    madeUndraggable = makeUndraggable(jqueryElement.children());
+  }
+
+  // Remember the current element on the clipboard
+  clipboardElement = jqueryElement.clone(true)[0];
+
+  // Restore the draggable wrappers on the child elements:
+  if (isScreen && madeUndraggable) {
+    makeDraggable(jqueryElement.children());
+  }
+};
+
 designMode.addKeyboardHandlers = function() {
   $('#designModeViz').keydown(function(event) {
     if (!Applab.isInDesignMode() || Applab.isRunning()) {
@@ -1495,31 +1517,13 @@ designMode.addKeyboardHandlers = function() {
     if (event.altKey || event.ctrlKey || event.metaKey) {
       switch (event.which) {
         case KeyCodes.COPY:
-          if (currentlyEditedElement) {
-            let madeUndraggable;
-            const currentElement = $(currentlyEditedElement);
-            const isScreen = currentElement.hasClass('screen');
-            if (isScreen) {
-              // Unwrap the draggable wrappers around the child elements:
-              madeUndraggable = makeUndraggable(currentElement.children());
-            }
-
-            // Remember the current element on the clipboard
-            clipboardElement = currentElement.clone(true)[0];
-
-            // Restore the draggable wrappers on the child elements:
-            if (isScreen && madeUndraggable) {
-              makeDraggable(currentElement.children());
-            }
-          }
+          designMode.setAsClipboardElement(currentlyEditedElement);
           break;
         case KeyCodes.PASTE:
           // Paste the clipboard element with updated position and ID
           if (clipboardElement) {
-            let duplicateElement = designMode.onDuplicate(clipboardElement);
-            if (duplicateElement) {
-              clipboardElement = $(duplicateElement).clone(true)[0];
-            }
+            const duplicateElement = designMode.onDuplicate(clipboardElement);
+            designMode.setAsClipboardElement(duplicateElement);
           }
           break;
         default:

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1496,8 +1496,21 @@ designMode.addKeyboardHandlers = function() {
       switch (event.which) {
         case KeyCodes.COPY:
           if (currentlyEditedElement) {
+            let madeUndraggable;
+            const currentElement = $(currentlyEditedElement);
+            const isScreen = currentElement.hasClass('screen');
+            if (isScreen) {
+              // Unwrap the draggable wrappers around the child elements:
+              madeUndraggable = makeUndraggable(currentElement.children());
+            }
+
             // Remember the current element on the clipboard
-            clipboardElement = $(currentlyEditedElement).clone(true)[0];
+            clipboardElement = currentElement.clone(true)[0];
+
+            // Restore the draggable wrappers on the child elements:
+            if (isScreen && madeUndraggable) {
+              makeDraggable(currentElement.children());
+            }
           }
           break;
         case KeyCodes.PASTE:


### PR DESCRIPTION
* Copy/paste in applab design mode is implemented by cloning the `currentlyEditedElement` to `clipboardElement`. Since design mode has jquery "draggable" wrappers around the actual elements, the code that sets `currentlyEditedElement` ensures that we have the inner element (not the wrapper). This code lives in `designMode.onDesignModeVizClick()`.
* However, in the case where we having copied a "screen" to the clipboard, the resizable wrappers are not removed from the child elements before storing the screen as `clipboardElement`. This causes problems later in `onDuplicate()` when "paste" occurs. `onDuplicate()` expects that it can remove the "draggable" wrappers around the child elements, but `makeUndraggable()` doesn't work as expecte when operating on detached DOM elements.

The result is we end up with `<div>` wrappers around child elements in the previous (copied) screen in the design mode HTML and the new screen has extra elements that are leftover pieces of the jquery wrappers.

* Fixed by ensuring that when a "screen" is cloned/detached to become the `clipboardElement`, it is cloned while it has all of its children's "draggable" wrappers removed.

* Bonus fix: you couldn't Paste a copied screen twice. After a paste, we would update `clipboardElement` with the result from the `onDuplicate()` call, which is supposed to return an element. But when duplicating a screen, we returned a string (the id) and not the element. Fixed now!!