### PR TITLE
Add warning messages for getList if table/column doesn't exist

### DIFF
--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1799,25 +1799,28 @@ applabCommands.getList = function(opts) {
 var handleGetListSync = function(opts, values) {
   let columnList = [];
 
-  if (values.length === 0) {
-    let url;
-    datasetLibrary.datasets.forEach(dataset => {
-      if (dataset.name === opts.tableName) {
-        url = dataset.url;
-      }
-    });
-    if (url) {
-      Applab.storage.importDataset(
-        opts.tableName,
-        url,
-        () => applabCommands.getList(opts),
-        () => console.log('error')
-      );
-    } else {
-      opts.callback(columnList);
-    }
-  } else {
+  if (values.length > 0) {
     values.forEach(row => columnList.push(row[opts.columnName]));
+    opts.callback(columnList);
+    return;
+  }
+
+  let url;
+  datasetLibrary.datasets.forEach(dataset => {
+    if (dataset.name === opts.tableName) {
+      url = dataset.url;
+    }
+  });
+  if (url) {
+    // Import the dataset, then try getList again.
+    Applab.storage.importDataset(
+      opts.tableName,
+      url,
+      () => applabCommands.getList(opts),
+      () => console.log('error')
+    );
+  } else {
+    // No dataset with the specified name, call back into interpreter and return the empty list.
     opts.callback(columnList);
   }
 };

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -26,6 +26,7 @@ import {getAppOptions} from '@cdo/apps/code-studio/initApp/loadApp';
 import {AllowedWebRequestHeaders} from '@cdo/apps/util/sharedConstants';
 import {actions} from './redux/applab';
 import {getStore} from '../redux';
+import datasetLibrary from '@cdo/apps/code-studio/datasetLibrary.json';
 import $ from 'jquery';
 
 // For proxying non-https xhr requests
@@ -1797,8 +1798,28 @@ applabCommands.getList = function(opts) {
 
 var handleGetListSync = function(opts, values) {
   let columnList = [];
-  values.forEach(row => columnList.push(row[opts.columnName]));
-  opts.callback(columnList);
+
+  if (values.length === 0) {
+    let url;
+    datasetLibrary.datasets.forEach(dataset => {
+      if (dataset.name === opts.tableName) {
+        url = dataset.url;
+      }
+    });
+    if (url) {
+      Applab.storage.importDataset(
+        opts.tableName,
+        url,
+        () => applabCommands.getList(opts),
+        () => console.log('error')
+      );
+    } else {
+      opts.callback(columnList);
+    }
+  } else {
+    values.forEach(row => columnList.push(row[opts.columnName]));
+    opts.callback(columnList);
+  }
 };
 
 var handleGetListSyncError = function(opts, values) {

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1791,16 +1791,45 @@ applabCommands.handleReadValue = function(opts, value) {
 };
 
 applabCommands.getList = function(opts) {
+  validateGetListArgs(opts.tableName, opts.columnName);
   var onSuccess = handleGetListSync.bind(this, opts);
   var onError = handleGetListSyncError.bind(this, opts);
   Applab.storage.readRecords(opts.tableName, {}, onSuccess, onError);
+};
+
+var validateGetListArgs = function(tableName, columnName) {
+  const datasetNames = datasetLibrary.datasets.map(d => d.name);
+  if (datasetNames.indexOf(tableName) === -1) {
+    outputWarning(
+      tableName +
+        ' is not a data set in this project.' +
+        ' Check the Data tab to see the names of your tables.'
+    );
+  }
+  for (let dataset of datasetLibrary.datasets) {
+    if (dataset.name === tableName) {
+      const columnList = dataset.columns.split(',');
+      if (columnList.indexOf(columnName) === -1) {
+        outputWarning(
+          columnName +
+            ' is not a column in ' +
+            tableName +
+            'Check the Data tab for the names of the columns in that table.'
+        );
+      }
+    }
+  }
 };
 
 var handleGetListSync = function(opts, values) {
   let columnList = [];
 
   if (values.length > 0) {
-    values.forEach(row => columnList.push(row[opts.columnName]));
+    values.forEach(row => {
+      if (row.hasOwnProperty(opts.columnName)) {
+        columnList.push(row[opts.columnName]);
+      }
+    });
     opts.callback(columnList);
     return;
   }

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1814,7 +1814,7 @@ var validateGetListArgs = function(tableName, columnName) {
           columnName +
             ' is not a column in ' +
             tableName +
-            'Check the Data tab for the names of the columns in that table.'
+            '. Check the Data tab for the names of the columns in that table.'
         );
       }
     }

--- a/apps/src/code-studio/components/DatasetPicker.jsx
+++ b/apps/src/code-studio/components/DatasetPicker.jsx
@@ -24,31 +24,13 @@ export default class DatasetPicker extends React.Component {
     assetChosen: PropTypes.func.isRequired
   };
 
-  importCsvFromUrl = (name, url) => {
-    var request = new XMLHttpRequest();
-    request.open('GET', url, true);
-    request.responseType = 'text';
-    request.onload = function() {
-      FirebaseStorage.importCsv(
-        name,
-        request.response,
-        () => console.log('importCsv onSuccess'),
-        () => console.log('importCsv onError')
-      );
-    };
-    request.onerror = function() {
-      console.log('onerror');
-    };
-    request.send();
-  };
-
   chooseAsset = (name, url) => {
-    FirebaseStorage.createTable(
+    FirebaseStorage.importDataset(
       name,
-      () => console.log('createTable onSuccess'),
-      () => console.log('createTable onError')
+      url,
+      () => console.log('importDataset onSuccess'),
+      () => console.log('importDataset onError')
     );
-    this.importCsvFromUrl(name, url);
     this.props.assetChosen(name);
   };
 

--- a/apps/src/code-studio/datasetLibrary.json
+++ b/apps/src/code-studio/datasetLibrary.json
@@ -3,22 +3,26 @@
     {
       "name": "dogs",
       "description": "Different breeds of dogs, including images and rankings on different qualities like size and friendliness",
-      "url": "/api/v1/dataset-library/dogBreeds.csv"
+      "url": "/api/v1/dataset-library/dogBreeds.csv",
+      "columns": "name,size,dogFriendly,imgURL"
     },
     {
       "name": "words",
       "description": "The 1000 most commonly used English words and their parts of speech",
-      "url": "/api/v1/dataset-library/words.csv"
+      "url": "/api/v1/dataset-library/words.csv",
+      "columns": "word,partOfSpeech"
     },
     {
       "name": "countries",
       "description": "Information about different countries, images of their flags, and MP3 of their anthem",
-      "url": "/api/v1/dataset-library/countries.csv"
+      "url": "/api/v1/dataset-library/countries.csv",
+      "columns": "Country,flagImgURL,Capital,anthemMP3"
     },
     {
       "name": "spotify",
       "description": "The top 20 songs in many regions of the world, including 30 second MP3 links to most songs",
-      "url": "/api/v1/dataset-library/spotify.csv"
+      "url": "/api/v1/dataset-library/spotify.csv",
+      "columns": "Track Name,Artist,Streams,songURL,Album Image,previewMP3,Position,Region,Country Code"
     }
   ]
 }

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -901,6 +901,26 @@ FirebaseStorage.importCsv = function(
     .then(onSuccess, onError);
 };
 
+FirebaseStorage.importDataset = function(tableName, url, onSuccess, onError) {
+  let request = new XMLHttpRequest();
+  request.open('GET', url, true);
+  request.responseType = 'text';
+  request.onload = function() {
+    FirebaseStorage.createTable(
+      tableName,
+      () =>
+        FirebaseStorage.importCsv(
+          tableName,
+          request.response,
+          onSuccess,
+          onError
+        ),
+      onError
+    );
+  };
+  request.send();
+};
+
 export default FirebaseStorage;
 
 export function initFirebaseStorage(config) {

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -901,6 +901,14 @@ FirebaseStorage.importCsv = function(
     .then(onSuccess, onError);
 };
 
+/**
+ * Imports a dataset specified by a URL. Used by the dataset picker modal to allow users to import
+ * Code.org provided datasets.
+ * @param {string} tableName
+ * @param {string} url
+ * @param onSuccess
+ * @param onError
+ */
 FirebaseStorage.importDataset = function(tableName, url, onSuccess, onError) {
   let request = new XMLHttpRequest();
   request.open('GET', url, true);

--- a/apps/test/unit/code-studio/components/DatasetPickerTest.js
+++ b/apps/test/unit/code-studio/components/DatasetPickerTest.js
@@ -20,21 +20,11 @@ describe('DatasetPicker', () => {
 
   it('calls Firebase on chooseAsset', () => {
     const wrapper = mount(<DatasetPicker {...defaultProps} />);
-    var xhr = sinon.useFakeXMLHttpRequest();
-    var requests = [];
-    xhr.onCreate = function(xhr) {
-      requests.push(xhr);
-    };
-    var createStub = sinon.stub(FirebaseStorage, 'createTable');
-    var importStub = sinon.stub(FirebaseStorage, 'importCsv');
+    var importDatasetStub = sinon.stub(FirebaseStorage, 'importDataset');
 
     wrapper.instance().chooseAsset('name', 'url');
-    requests[0].respond(200);
 
-    assert.isTrue(createStub.called);
-    assert.isTrue(importStub.called);
-    xhr.restore();
-    createStub.restore();
-    importStub.restore();
+    assert.isTrue(importDatasetStub.called);
+    importDatasetStub.restore();
   });
 });


### PR DESCRIPTION
Right now, if you call `getList` with a table name or column name that doesn't exist, it will just return an empty list, but not give any errors or warnings indicating that something has gone wrong. Adding these warning messages will help students be able to debug if something goes wrong.

Table does not exist warning:
![image](https://user-images.githubusercontent.com/8787187/57653724-59d9ee00-7587-11e9-8943-393f35857303.png)

Column does not exist warning:
![image](https://user-images.githubusercontent.com/8787187/57653740-64948300-7587-11e9-9f7c-11e3938c1a9e.png)
