### PR TITLE
Add warning messages for invalid table/column in getList

### DIFF
--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1791,16 +1791,41 @@ applabCommands.handleReadValue = function(opts, value) {
 };
 
 applabCommands.getList = function(opts) {
+  validateGetListArgs(opts.tableName, opts.columnName);
   var onSuccess = handleGetListSync.bind(this, opts);
   var onError = handleGetListSyncError.bind(this, opts);
   Applab.storage.readRecords(opts.tableName, {}, onSuccess, onError);
+};
+
+var validateGetListArgs = function(tableName, columnName) {
+  let dataset = datasetLibrary.datasets.find(d => d.name === tableName);
+  if (!dataset) {
+    outputWarning(
+      tableName +
+        ' is not a data set in this project. Check the Data tab to see the names of your tables'
+    );
+    return;
+  }
+  const columnList = dataset.columns.split(',');
+  if (columnList.indexOf(columnName) === -1) {
+    outputWarning(
+      columnName +
+        ' is not a column in ' +
+        tableName +
+        '. Check the Data tab to see the names of the columns in that table.'
+    );
+  }
 };
 
 var handleGetListSync = function(opts, values) {
   let columnList = [];
 
   if (values.length > 0) {
-    values.forEach(row => columnList.push(row[opts.columnName]));
+    values.forEach(row => {
+      if (row.hasOwnProperty(opts.columnName)) {
+        columnList.push(row[opts.columnName]);
+      }
+    });
     opts.callback(columnList);
     return;
   }


### PR DESCRIPTION
Right now, if you call `getList` with a table name or column name that doesn't exist, it will just return an empty list, but not give any errors or warnings indicating that something has gone wrong. Adding these warning messages will help students be able to debug if something goes wrong.

Column does not exist warning:
![image](https://user-images.githubusercontent.com/8787187/57661590-6c145600-75a0-11e9-8295-c0b96b00139b.png)


Table does not exist warning:
![image](https://user-images.githubusercontent.com/8787187/57661599-70d90a00-75a0-11e9-9a02-9967ce777953.png)
