### PR TITLE
make signed-out user lose project ownership after storage id cookie takeover

### DIFF
--- a/dashboard/test/ui/features/projects/projects.feature
+++ b/dashboard/test/ui/features/projects/projects.feature
@@ -16,3 +16,25 @@ Scenario: My Projects
   And I wait until element "a[href='/projects/gumball/new']" is visible
   Then I see no difference for "view full list of new project types"
   And I close my eyes
+
+Scenario: Project Ownership
+  Given I am on "http://studio.code.org/projects/artist/new"
+  And I wait for the page to fully load
+  And check that the URL matches "/edit$"
+  And I save the URL
+
+  # The storage_id cookie is sent with this account creation request,
+  # leading to a storage_id cookie takeover.
+
+  When I create a student named "Takeover"
+  And I navigate to the saved URL
+  And I wait for the page to fully load
+  And check that the URL matches "/edit$"
+
+  # Verify existing buggy behavior. A signed-out user now owns the projects of
+  # the user who took over the storage id.
+
+  When I sign out
+  And I navigate to the saved URL
+  And I wait for the page to fully load
+  And check that the URL matches "/edit$"

--- a/dashboard/test/ui/features/projects/projects.feature
+++ b/dashboard/test/ui/features/projects/projects.feature
@@ -23,6 +23,12 @@ Scenario: Project Ownership
   And check that the URL matches "/edit$"
   And I save the URL
 
+  # Make sure that project ownership persists via storage_id cookie.
+
+  And I reload the page
+  And I wait for the page to fully load
+  And check that the URL matches "/edit$"
+
   # The storage_id cookie is sent with this account creation request,
   # leading to a storage_id cookie takeover.
 
@@ -31,10 +37,9 @@ Scenario: Project Ownership
   And I wait for the page to fully load
   And check that the URL matches "/edit$"
 
-  # Verify existing buggy behavior. A signed-out user now owns the projects of
-  # the user who took over the storage id.
+  # After takeover, the signed-out user no longer owns the project.
 
   When I sign out
   And I navigate to the saved URL
   And I wait for the page to fully load
-  And check that the URL matches "/edit$"
+  And check that the URL matches "/view$"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1679,6 +1679,10 @@ Then /^current URL is different from the last saved URL$/ do
   expect(@browser.current_url).not_to include(saved_url)
 end
 
+Then /^I navigate to the saved URL$/ do
+  steps %Q{Then I am on "#{saved_url}"}
+end
+
 Then /^I sign out using jquery$/ do
   code = <<-JAVASCRIPT
     window.signOutComplete = false;

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -157,6 +157,7 @@ def storage_id_from_cookie
   return nil if encrypted.empty?
   storage_id = storage_decrypt_id(encrypted)
   return nil if storage_id == 0
+  return nil unless user_storage_ids_table.where(id: storage_id, user_id: nil).first
   storage_id
 end
 

--- a/shared/test/middleware/helpers/test_storage_id.rb
+++ b/shared/test/middleware/helpers/test_storage_id.rb
@@ -92,4 +92,21 @@ class StorageIdTest < Minitest::Test
     assert_nil storage_id
     assert_nil @user_storage_ids_table.where(user_id: user_id).first
   end
+
+  def test_storage_id_from_cookie
+    request = mock
+    stubs(:request).returns(request)
+
+    cookie_storage_id = 3
+    cookie_value = CGI.escape(storage_encrypt_id(cookie_storage_id))
+    request.stubs(:cookies).returns({storage_id_cookie_name => cookie_value})
+
+    assert_equal cookie_storage_id, storage_id_from_cookie
+
+    @user_storage_ids_table.insert(user_id: nil, id: cookie_storage_id)
+    assert_equal cookie_storage_id, storage_id_from_cookie
+
+    @user_storage_ids_table.where(id: cookie_storage_id).update(user_id: 2)
+    assert_equal cookie_storage_id, storage_id_from_cookie
+  end
 end

--- a/shared/test/middleware/helpers/test_storage_id.rb
+++ b/shared/test/middleware/helpers/test_storage_id.rb
@@ -101,12 +101,15 @@ class StorageIdTest < Minitest::Test
     cookie_value = CGI.escape(storage_encrypt_id(cookie_storage_id))
     request.stubs(:cookies).returns({storage_id_cookie_name => cookie_value})
 
-    assert_equal cookie_storage_id, storage_id_from_cookie
+    # returns nil if storage id is invalid
+    assert_nil storage_id_from_cookie
 
+    # returns storage id from cookie if unowned
     @user_storage_ids_table.insert(user_id: nil, id: cookie_storage_id)
     assert_equal cookie_storage_id, storage_id_from_cookie
 
+    # returns nil if storage id from cookie is owned by a user
     @user_storage_ids_table.where(id: cookie_storage_id).update(user_id: 2)
-    assert_equal cookie_storage_id, storage_id_from_cookie
+    assert_nil storage_id_from_cookie
   end
 end


### PR DESCRIPTION
### Background

Signed out users can own projects. the credentials for ownership are stored in the storage_id cookie. When a user creates an account and this cookie is present, the new user "takes over" the existing storage id found in that cookie, and we begin using the user_storage_ids table to track the user as the owner of that cookie.

Recently, some whiteboarding with Amanda led to the realization that we may not have good boundaries between ownership of projects when a takeover happens (see [repro steps](https://codedotorg.slack.com/archives/CA3KCSGTD/p1557532666306900)). Specifically, the signed-out user still appears to own those projects after the user has taken them over.

### Description

Make sure that after a user takes over a storage_id cookie, the storage_id cookie no longer grants ownership to those projects that now belong to that user.

### Testing

Take a look at intermediate commits to see the previously-existing buggy behavior.