### PR TITLE
Cleanup and Unit Tests for getList

### DIFF
--- a/apps/src/applab/getListDropdown.js
+++ b/apps/src/applab/getListDropdown.js
@@ -14,12 +14,12 @@ export function getListColumnDropdown() {
 }
 
 function getColumnsForTable(tableName) {
-  for (let dataset of datasetLibrary.datasets) {
-    if (`"${dataset.name}"` === tableName) {
-      return dataset.columns.split(',');
-    }
+  let dataset = datasetLibrary.datasets.find(d => `"${d.name}"` === tableName);
+  if (dataset) {
+    return dataset.columns.split(',');
+  } else {
+    return [];
   }
-  return [];
 }
 
 export var __TestInterface = {

--- a/apps/src/applab/getListDropdown.js
+++ b/apps/src/applab/getListDropdown.js
@@ -21,3 +21,7 @@ function getColumnsForTable(tableName) {
   }
   return [];
 }
+
+export var __TestInterface = {
+  getColumnsForTable: getColumnsForTable
+};

--- a/apps/src/applab/getListDropdown.js
+++ b/apps/src/applab/getListDropdown.js
@@ -4,7 +4,7 @@ import {getFirstParam} from '../dropletUtils';
 export function getListColumnDropdown() {
   return function(aceEditor) {
     const tableName = getFirstParam('getList', this.parent, aceEditor);
-    const columns = getColumnsForTable(tableName);
+    const columns = getColumnsForTable(tableName, datasetLibrary.datasets);
     const opts = [];
     columns.forEach(columnName =>
       opts.push({display: `"${columnName}"`, text: `"${columnName}"`})
@@ -13,8 +13,8 @@ export function getListColumnDropdown() {
   };
 }
 
-function getColumnsForTable(tableName) {
-  let dataset = datasetLibrary.datasets.find(d => `"${d.name}"` === tableName);
+function getColumnsForTable(tableName, datasets) {
+  let dataset = datasets.find(d => `"${d.name}"` === tableName);
   if (dataset) {
     return dataset.columns.split(',');
   } else {

--- a/apps/src/code-studio/datasetLibrary.json
+++ b/apps/src/code-studio/datasetLibrary.json
@@ -4,31 +4,31 @@
       "name": "dogs",
       "description": "Different breeds of dogs, including images and rankings on different qualities like size and friendliness",
       "url": "/api/v1/dataset-library/dogBreeds.csv",
-      "columns": "name,size,dogFriendly,imgURL"
+      "columns": "Name,Size,Kid Friendly,Dog Friendly,Low Shedding,Easy to Groom,High Energy,Good Health,Low Barking,Intelligence,Easy to Train,Tolerates Hot,Tolerates Cold,Image URL"
     },
     {
       "name": "words",
       "description": "The 1000 most commonly used English words and their parts of speech",
       "url": "/api/v1/dataset-library/words.csv",
-      "columns": "word,partOfSpeech"
+      "columns": "Word,Part of Speech,Frequency,Rank"
     },
     {
       "name": "countries",
       "description": "Information about different countries, images of their flags, and MP3 of their anthem",
       "url": "/api/v1/dataset-library/countries.csv",
-      "columns": "Country,flagImgURL,Capital,anthemMP3"
+      "columns": "Country,Code,Flag Image URL,Population,GDP Per Person,Continent,Region,Latitude,Longitude,Capital,National Anthem MP3"
     },
     {
       "name": "spotify",
       "description": "The top 20 songs in many regions of the world, including 30 second MP3 links to most songs",
       "url": "/api/v1/dataset-library/spotify.csv",
-      "columns": "Track Name,Artist,Streams,songURL,Album Image,previewMP3,Position,Region,Country Code"
+      "columns": "Track Name,Artist,Streams,Song URL,Album Image,Preview MP3,Position,Region,Country Code"
     },
     {
       "name": "weather",
       "description": "Daily weather forecasts for the next five days for a selection of US cities.",
       "url": "/api/v1/dataset-library/weather.csv",
-      "columns": "city,date,lowTemp,highTemp,condition,icon"
+      "columns": "City,Date,Low Temp,High Temp,Condition,Icon"
     }
   ]
 }

--- a/apps/test/unit/applab/getListDropdownTest.js
+++ b/apps/test/unit/applab/getListDropdownTest.js
@@ -1,0 +1,24 @@
+import {expect} from '../../util/configuredChai';
+
+var getListDropdown = require('@cdo/apps/applab/getListDropdown');
+
+describe('getListDropdown', function() {
+  var getColumnsForTable = getListDropdown.__TestInterface.getColumnsForTable;
+  it('getColumnsForTable', function() {
+    expect(getColumnsForTable('"NonExistentTable"')).to.deep.equal([]);
+    expect(getColumnsForTable('"words"')).to.deep.equal([
+      'Word',
+      'Part of Speech',
+      'Frequency',
+      'Rank'
+    ]);
+    expect(getColumnsForTable('"weather"')).to.deep.equal([
+      'City',
+      'Date',
+      'Low Temp',
+      'High Temp',
+      'Condition',
+      'Icon'
+    ]);
+  });
+});

--- a/apps/test/unit/applab/getListDropdownTest.js
+++ b/apps/test/unit/applab/getListDropdownTest.js
@@ -4,21 +4,25 @@ var getListDropdown = require('@cdo/apps/applab/getListDropdown');
 
 describe('getListDropdown', function() {
   var getColumnsForTable = getListDropdown.__TestInterface.getColumnsForTable;
+  const testDatasets = [
+    {name: 'dataset1', columns: 'column1,column2,column3'},
+    {name: 'dataset2', columns: 'column3,column4,column5,column6,column7'}
+  ];
   it('getColumnsForTable', function() {
-    expect(getColumnsForTable('"NonExistentTable"')).to.deep.equal([]);
-    expect(getColumnsForTable('"words"')).to.deep.equal([
-      'Word',
-      'Part of Speech',
-      'Frequency',
-      'Rank'
+    expect(
+      getColumnsForTable('"NonExistentTable"', testDatasets)
+    ).to.deep.equal([]);
+    expect(getColumnsForTable('"dataset1"', testDatasets)).to.deep.equal([
+      'column1',
+      'column2',
+      'column3'
     ]);
-    expect(getColumnsForTable('"weather"')).to.deep.equal([
-      'City',
-      'Date',
-      'Low Temp',
-      'High Temp',
-      'Condition',
-      'Icon'
+    expect(getColumnsForTable('"dataset2"', testDatasets)).to.deep.equal([
+      'column3',
+      'column4',
+      'column5',
+      'column6',
+      'column7'
     ]);
   });
 });


### PR DESCRIPTION
This is some follow up work created by https://github.com/code-dot-org/code-dot-org/pull/28498 and https://github.com/code-dot-org/code-dot-org/pull/28509
- Updates dataset column descriptors to have consistent capitalization and additional columns.
- Use Array.find() instead of for loop to get dataset columns for the dropdown.
- Unit test for getList column dropdown
- Unit test for firebaseStorage.importDataset()