### PR TITLE
School Info Confirmation Dialog: modify school info interstitial helper method

### DIFF
--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -294,6 +294,6 @@ class SchoolInfo < ActiveRecord::Base
   # Check if school info is complete to stop showing
   # school info interstitial
   def school_info_complete?
-    school_type.present? && school_name.present? && country.eql?('US')
+    school_type.present? && school_name.present? && country.eql?('United States')
   end
 end

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -290,10 +290,4 @@ class SchoolInfo < ActiveRecord::Base
   def charter_school?
     school_type.eql? SCHOOL_TYPE_CHARTER
   end
-
-  # Check if school info is complete to stop showing
-  # school info interstitial
-  def school_info_complete?
-    school_type.present? && school_name.present? && country.eql?('United States')
-  end
 end

--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -32,11 +32,13 @@ module SchoolInfoInterstitialHelper
 
     return true if user.user_school_infos.empty?
 
-    school_info = user.user_school_infos.last
+    user_school_info = user.user_school_infos.last
+
+    school_info = user_school_info.school_info
 
     check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && school_info.school_info_complete?
 
-    check_last_confirmation_date = user.user_school_infos.find(user.school_info_id).last_confirmation_date.to_datetime < 1.year.ago
+    check_last_confirmation_date = user_school_info.last_confirmation_date.to_datetime < 1.year.ago
 
     check_last_confirmation_date && check_school_type
   end

--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -36,7 +36,7 @@ module SchoolInfoInterstitialHelper
 
     school_info = user_school_info.school_info
 
-    check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && school_info.school_info_complete?
+    check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && SchoolInfoInterstitialHelper.complete?(school_info)
 
     check_last_confirmation_date = user_school_info.last_confirmation_date.to_datetime < 1.year.ago
 

--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -30,9 +30,9 @@ module SchoolInfoInterstitialHelper
   def self.show_school_info_confirmation_dialog?(user)
     return false unless user.teacher?
 
-    return true if user.school_info.nil?
+    return true if user.user_school_infos.empty?
 
-    school_info = user.school_info
+    school_info = user.user_school_infos.last
 
     check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && school_info.school_info_complete?
 

--- a/dashboard/test/lib/school_info_interstitial_helper_test.rb
+++ b/dashboard/test/lib/school_info_interstitial_helper_test.rb
@@ -89,12 +89,12 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     refute SchoolInfoInterstitialHelper.complete? school_info
   end
 
-  test 'shows school info confirmation dialog when user school info is nil' do
+  test 'shows school info confirmation dialog when user school infos table is empty' do
     user = create :user
     user.user_type = 'teacher'
     user.save
 
-    user.school_info = nil
+    user.user_school_infos = []
 
     assert_nil user.school_info
     assert SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog?(user)
@@ -105,5 +105,14 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
 
     assert_equal user.user_type, 'student'
     refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog?(user)
+  end
+
+  test 'does not show school info confirmation dialog when last confirmation date is less than a year' do
+    user_school_info = create :user_school_info
+
+    user_school_info.last_confirmation_date = 1.day.ago
+    user_school_info.save
+
+    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog?(user_school_info.user)
   end
 end


### PR DESCRIPTION
The "show_school_info_confirmation_dialog?" method is used to determine when the school info confirmation dialog is rendered.  The method was updated to search through the user school infos collection for the most current school_info for a user.

The school info interstitial helper tests were also updated.

[Previous PR](https://github.com/code-dot-org/code-dot-org/pull/28470)