### PR TITLE
Provide an env argument for a simpler CI build

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -96,7 +96,20 @@ end
 
 desc 'Update the server as part of continuous integration.'
 task :ci do
-  ChatClient.wrap('CI build', backtrace: true) {Rake::Task[rack_env?(:test) ? 'ci:test' : 'ci:all'].invoke}
+  # In the test environment, we want to build everything with tests. In most
+  # other environments, we want to do a full build including server
+  # redeployment, but in some environments (like the i18n server) we just want
+  # to run the build with no other actions.
+  desired_task =
+    if ENV['CI_ONLY_BUILD']
+      'ci:build'
+    elsif rack_env?(:test)
+      'ci:test'
+    else
+      'ci:all'
+    end
+
+  ChatClient.wrap('CI build', backtrace: true) {Rake::Task[desired_task].invoke}
 end
 
 # Returns true if upgrade succeeded, false if failed.


### PR DESCRIPTION
For the i18n server we would like to be able to regularly rebuild from
latest staging with `ci_build`, but don't need or want to run a server.
Specifically, we want to be able to run the `ci:build` task rather than
the `ci:all` task for that specific server.

With this approach, we can do that by simply enabling an environment
variable in the crontab