### PR TITLE
Move continue button below video in external levels

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2155,6 +2155,10 @@ a.download-video {
   overflow: hidden;
 }
 
+.external-video-container {
+  margin-left: 93px;
+}
+
 .peer-review input[type=radio] {
   margin: 0 3px 3px 5px;
 }

--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -19,7 +19,7 @@
     - unless in_level_group
       - if @script.try(:professional_learning_course?) && @script_level
         = link_to @script_level.end_of_stage? ? t('done_with_module') : t('next_resource'), @script_level.next_level_or_redirect_path_for_user(current_user), class: 'btn btn-large pull-right btn-primary submitButton'
-      - elsif !@level.has_submit_button?
+      - elsif !@level.has_submit_button? && !use_large_video_player
         %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
 
   = render partial: 'levels/content', locals: {app: 'external', data: level_props, content_class: level_props['options'].try(:[], 'css'), postcontent: postcontent}
@@ -32,7 +32,8 @@
 
 - if video && use_large_video_player
   .clear
-  .video-container
+  .video-container.external-video-container
+  %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
 
 .clear
 


### PR DESCRIPTION
Request from the Curriculum team to move the "Continue" button below the large video player in external levels.  Also included is a styling tweak to nudge the video player in line with the page title. 

Before: 
<img width="1140" alt="Screen Shot 2019-05-14 at 3 18 54 PM" src="https://user-images.githubusercontent.com/12300669/57736193-f8d01a00-765b-11e9-95fd-9d7489319700.png">

After: 
<img width="1101" alt="Screen Shot 2019-05-14 at 3 15 51 PM" src="https://user-images.githubusercontent.com/12300669/57736196-fa99dd80-765b-11e9-93be-05884049787c.png">
