### PR TITLE
Remove duplicate video keys in level edit form

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -690,7 +690,7 @@ module LevelsHelper
   end
 
   def video_key_choices
-    Video.pluck(:key)
+    Video.uniq.pluck(:key)
   end
 
   # Constructs pairs of [filename, asset path] for a dropdown menu of available ani-gifs

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -690,7 +690,7 @@ module LevelsHelper
   end
 
   def video_key_choices
-    Video.uniq.pluck(:key)
+    Video.distinct.pluck(:key)
   end
 
   # Constructs pairs of [filename, asset path] for a dropdown menu of available ani-gifs

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -98,7 +98,7 @@ class LevelsHelperTest < ActionView::TestCase
 
   test "get video choices" do
     choices_cached = video_key_choices
-    assert_equal(choices_cached.count, Video.count)
+    assert_equal(choices_cached.count, Video.where(locale: 'en-US').count)
     Video.all.each {|video| assert_includes(choices_cached, video.key)}
   end
 


### PR DESCRIPTION
Before:
![Screenshot from 2019-05-14 14-20-19](https://user-images.githubusercontent.com/46464143/57738967-86186c00-7666-11e9-8db8-e89a7bced279.png)

After:
![Screenshot 2019-05-14 at 4 35 36 PM](https://user-images.githubusercontent.com/46464143/57738952-76992300-7666-11e9-9235-2f9fda9f1ffb.png)
