### PR TITLE
honor data_tables from project template level

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -361,6 +361,7 @@ class Blockly < Level
 
       if is_a? Applab
         level_prop['startHtml'] = try(:project_template_level).try(:start_html) || start_html
+        level_prop['dataTables'] = try(:project_template_level).try(:data_tables) || data_tables
       end
 
       if is_a? Gamelab

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -208,6 +208,43 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal '<div><label id="label1">real_level html</label></div>', level_options['startHtml']
   end
 
+  test 'project template level sets data tables when defined' do
+    template_level = create :applab
+    template_level.data_tables = '{"key":"expected"}'
+    template_level.save!
+
+    real_level = create :applab
+    real_level.project_template_level_name = template_level.name
+    real_level.data_tables = '{"key":"wrong"}'
+    real_level.save!
+
+    sl = create :script_level, levels: [real_level]
+    get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
+
+    assert_response :success
+    # data tables comes from project_level not real_level
+    level_options = assigns(:level).blockly_level_options
+    assert_equal '{"key":"expected"}', level_options['dataTables']
+  end
+
+  test 'project template level does not set data tables when not defined' do
+    template_level = create :applab
+    template_level.save!
+
+    real_level = create :applab
+    real_level.project_template_level_name = template_level.name
+    real_level.data_tables = '{"key":"real"}'
+    real_level.save!
+
+    sl = create :script_level, levels: [real_level]
+    get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
+
+    assert_response :success
+    # data tables comes from real_level not project_level
+    level_options = assigns(:level).blockly_level_options
+    assert_equal '{"key":"real"}', level_options['dataTables']
+  end
+
   test 'project template level sets start animations when defined' do
     template_animations_json = '{"orderedKeys":["expected"],"propsByKey":{"expected":{}}}'
     template_level = create :gamelab


### PR DESCRIPTION
* If the current level has a project template level with `dataTables` populated, allow that to override the current level's `dataTables` (this mimics what we do for `startSources`, `startBlocks`, `toolbox`, `codeFunctions`, `startHtml`, and `startAnimations`)