### PR TITLE
PL: reenable ingestion of PostCourseSurvey from JotForm

### DIFF
--- a/dashboard/app/models/pd/post_course_survey.rb
+++ b/dashboard/app/models/pd/post_course_survey.rb
@@ -25,8 +25,7 @@ module Pd
     include JotFormBackedForm
 
     VALID_YEARS = [
-      YEAR_18_19 = '2018-2019'.freeze,
-      YEAR_19_20 = '2019-2020'.freeze
+      YEAR_18_19 = '2018-2019'.freeze
     ].freeze
 
     VALID_COURSES = [

--- a/dashboard/app/models/pd/post_course_survey.rb
+++ b/dashboard/app/models/pd/post_course_survey.rb
@@ -25,7 +25,8 @@ module Pd
     include JotFormBackedForm
 
     VALID_YEARS = [
-      YEAR_18_19 = '2018-2019'.freeze
+      YEAR_18_19 = '2018-2019'.freeze,
+      YEAR_19_20 = '2019-2020'.freeze
     ].freeze
 
     VALID_COURSES = [

--- a/dashboard/bin/fill_jotform_placeholders
+++ b/dashboard/bin/fill_jotform_placeholders
@@ -12,7 +12,7 @@ require_relative '../config/environment'
 JOT_FORM_CLASSES = [
   Pd::WorkshopDailySurvey,
   Pd::WorkshopFacilitatorDailySurvey,
-  # Pd::PostCourseSurvey -- don't sync this one until we support the datetime control
+  Pd::PostCourseSurvey
 ].freeze
 
 def main

--- a/dashboard/bin/sync_jotforms
+++ b/dashboard/bin/sync_jotforms
@@ -11,7 +11,7 @@ require_relative '../config/environment'
 JOT_FORM_CLASSES = [
   Pd::WorkshopDailySurvey,
   Pd::WorkshopFacilitatorDailySurvey,
-  # Pd::PostCourseSurvey -- don't sync this one until we support the datetime control
+  Pd::PostCourseSurvey
 ].freeze
 
 def main


### PR DESCRIPTION
The current 19-20 post-course survey apparently isn't using the problematic datetime control and retrieves successfully.