### PR TITLE
Clicking 'more'-'draw my own' puts new sprite at top of list

### DIFF
--- a/apps/src/gamelab/animationListModule.js
+++ b/apps/src/gamelab/animationListModule.js
@@ -655,7 +655,7 @@ function loadAnimationFromSource(key, callback) {
  */
 export function addAnimationAction(key, props, index) {
   // Spritelab projects add animation at the beginning of animation list
-  if (index >= 0) {
+  if (index === 0) {
     return {
       type: ADD_ANIMATION_AT,
       key,

--- a/apps/src/gamelab/animationListModule.js
+++ b/apps/src/gamelab/animationListModule.js
@@ -364,7 +364,7 @@ export function appendBlankFrame() {
 }
 
 /**
- * Add an animation to the project (at the end of the list).
+ * Add an animation to the project (at the end of the list, unless a spritelab project).
  * @param {!AnimationKey} key
  * @param {!SerializedAnimation} props
  */
@@ -372,7 +372,11 @@ export function addAnimation(key, props) {
   // TODO: Validate that key is not already in use?
   // TODO: Validate props format?
   return (dispatch, getState) => {
-    dispatch(addAnimationAction(key, {...props, looping: true}));
+    if (getState().pageConstants && getState().pageConstants.isBlockly) {
+      dispatch(addAnimationAction(key, {...props, looping: true}, 0));
+    } else {
+      dispatch(addAnimationAction(key, {...props, looping: true}));
+    }
     dispatch(
       loadAnimationFromSource(key, () => {
         dispatch(selectAnimation(key));
@@ -402,13 +406,17 @@ export function appendCustomFrames(props) {
 }
 
 /**
- * Add a library animation to the project.
+ * Add a library animation to the project (at the end of the list, unless a spritelab project).
  * @param {!SerializedAnimation} props
  */
 export function addLibraryAnimation(props) {
   return (dispatch, getState) => {
     const key = createUuid();
-    dispatch(addAnimationAction(key, props));
+    if (getState().pageConstants && getState().pageConstants.isBlockly) {
+      dispatch(addAnimationAction(key, props, 0));
+    } else {
+      dispatch(addAnimationAction(key, props));
+    }
     dispatch(
       loadAnimationFromSource(key, () => {
         dispatch(selectAnimation(key));
@@ -646,9 +654,19 @@ function loadAnimationFromSource(key, callback) {
  * Action creator for adding an animation.
  * @param {!AnimationKey} key
  * @param {SerializedAnimation} props
+ * @param {number} [index]
  * @returns {{type: string, key: AnimationKey, props: SerializedAnimation}}
  */
-export function addAnimationAction(key, props) {
+export function addAnimationAction(key, props, index) {
+  // Spritelab projects add animation at the beginning of animation list
+  if (index >= 0) {
+    return {
+      type: ADD_ANIMATION_AT,
+      key,
+      props,
+      index
+    };
+  }
   return {
     type: ADD_ANIMATION,
     key,

--- a/apps/src/gamelab/animationListModule.js
+++ b/apps/src/gamelab/animationListModule.js
@@ -364,7 +364,7 @@ export function appendBlankFrame() {
 }
 
 /**
- * Add an animation to the project (at the end of the list, unless a spritelab project).
+ * Add an animation to the project (at the end of the list).
  * @param {!AnimationKey} key
  * @param {!SerializedAnimation} props
  */
@@ -372,11 +372,7 @@ export function addAnimation(key, props) {
   // TODO: Validate that key is not already in use?
   // TODO: Validate props format?
   return (dispatch, getState) => {
-    if (getState().pageConstants && getState().pageConstants.isBlockly) {
-      dispatch(addAnimationAction(key, {...props, looping: true}, 0));
-    } else {
-      dispatch(addAnimationAction(key, {...props, looping: true}));
-    }
+    dispatch(addAnimationAction(key, {...props, looping: true}));
     dispatch(
       loadAnimationFromSource(key, () => {
         dispatch(selectAnimation(key));

--- a/apps/test/unit/gamelab/animationListModuleTest.js
+++ b/apps/test/unit/gamelab/animationListModuleTest.js
@@ -20,7 +20,10 @@ import {EMPTY_IMAGE} from '@cdo/apps/gamelab/constants';
 import {createStore} from '../../util/redux';
 import {expect} from '../../util/configuredChai';
 import {setExternalGlobals} from '../../util/testUtils';
+import commonReducers from '@cdo/apps/redux/commonReducers';
+import {setPageConstants} from '@cdo/apps/redux/pageConstants';
 const project = require('@cdo/apps/code-studio/initApp/project');
+import _ from 'lodash';
 
 describe('animationListModule', function() {
   setExternalGlobals(beforeEach, afterEach);
@@ -490,7 +493,9 @@ describe('animationListModule', function() {
       server = sinon.fakeServer.create();
       server.respondWith('imageBody');
       store = createStore(
-        combineReducers({animationList: reducer, animationTab}),
+        combineReducers(
+          _.assign({}, commonReducers, {animationTab}, {animationList: reducer})
+        ),
         {}
       );
     });
@@ -535,6 +540,32 @@ describe('animationListModule', function() {
       expect(
         store.getState().animationList.propsByKey[blankAnimationKey4].name
       ).to.equal('library_animation_2');
+    });
+
+    it('adds animation at front of list in Game Lab', function() {
+      store.dispatch(addLibraryAnimation({name: 'first'}));
+      store.dispatch(addLibraryAnimation({name: 'second'}));
+      store.dispatch(addLibraryAnimation({name: 'third'}));
+      let firstAnimation = store.getState().animationList.orderedKeys[0];
+      expect(
+        store.getState().animationList.propsByKey[firstAnimation].name
+      ).to.equal('first_1');
+    });
+
+    it('adds animation at front of list in Sprite Lab', function() {
+      store.dispatch(
+        setPageConstants({
+          isBlockly: true
+        })
+      );
+
+      store.dispatch(addLibraryAnimation({name: 'first'}));
+      store.dispatch(addLibraryAnimation({name: 'second'}));
+      store.dispatch(addLibraryAnimation({name: 'third'}));
+      let firstAnimation = store.getState().animationList.orderedKeys[0];
+      expect(
+        store.getState().animationList.propsByKey[firstAnimation].name
+      ).to.equal('third_1');
     });
   });
 


### PR DESCRIPTION
For Spritelab, we add 'new' animations to the 'front/top' of the animation list. For Gamelab, we continue to add to the end. Includes tests.

New SpriteLab behavior:
![spritelabani](https://user-images.githubusercontent.com/2959170/57810778-73ad3980-771d-11e9-8caa-88de946e93ef.gif)

Unchanged GameLab behavior:
![gamelabani](https://user-images.githubusercontent.com/2959170/57810780-76a82a00-771d-11e9-88ad-eb2fb6381cb8.gif)
