### PR TITLE
Jotform: Reachability check to submit.jotform.us

### DIFF
--- a/apps/src/sites/studio/pages/jotformLoader.js
+++ b/apps/src/sites/studio/pages/jotformLoader.js
@@ -16,7 +16,9 @@ function main(context) {
     // www.jotform.com     https://www.jotform.com/favicon.ico        887B
     checkReachability('https://www.jotform.com/favicon.ico'),
     // api.jotform.com     https://api.jotform.com/favicon.ico        592B
-    checkReachability('https://api.jotform.com/favicon.ico')
+    checkReachability('https://api.jotform.com/favicon.ico'),
+    // submit.jotform.us   https://submit.jotform.us/favicon.ico      1.5KB
+    checkReachability('https://submit.jotform.us/favicon.ico')
     // Not using these yet, they're likely to fall under the same policy as www.jotform.com
     // events.jotform.com
     // files.jotform.com
@@ -26,7 +28,8 @@ function main(context) {
       jotFormFrameLoadedMs,
       cdnjotformsMs,
       wwwjotformcomMs,
-      apijotformcomMs
+      apijotformcomMs,
+      submitjotformusMs
     ]) => {
       if (jotFormFrameLoadedMs === false) {
         // Load failed if we specifically got 'false'
@@ -35,9 +38,11 @@ function main(context) {
           reachedCdnjotforms: false !== cdnjotformsMs,
           reachedWwwjotformcom: false !== wwwjotformcomMs,
           reachedApijotformcom: false !== apijotformcomMs,
+          reachedSubmitjotformus: false !== submitjotformusMs,
           cdnjotformsMs,
           wwwjotformcomMs,
-          apijotformcomMs
+          apijotformcomMs,
+          submitjotformusMs
         });
       } else {
         logToCloud.addPageAction(logToCloud.PageAction.JotFormFrameLoaded, {
@@ -45,7 +50,8 @@ function main(context) {
           jotFormFrameLoadedMs,
           cdnjotformsMs,
           wwwjotformcomMs,
-          apijotformcomMs
+          apijotformcomMs,
+          submitjotformusMs
         });
       }
     }

--- a/apps/src/sites/studio/pages/jotformLoader.js
+++ b/apps/src/sites/studio/pages/jotformLoader.js
@@ -10,52 +10,19 @@ import logToCloud from '../../../logToCloud';
 function main(context) {
   Promise.all([
     checkJotFormFrameLoaded(context),
-    // Domains used by Jotform:
-    // cdn.jotfor.ms       https://cdn.jotfor.ms/images/calendar.png  817B
-    checkReachability('https://cdn.jotfor.ms/images/calendar.png'),
-    // www.jotform.com     https://www.jotform.com/favicon.ico        887B
-    checkReachability('https://www.jotform.com/favicon.ico'),
-    // api.jotform.com     https://api.jotform.com/favicon.ico        592B
-    checkReachability('https://api.jotform.com/favicon.ico'),
-    // submit.jotform.us   https://submit.jotform.us/favicon.ico      1.5KB
-    checkReachability('https://submit.jotform.us/favicon.ico')
-    // Not using these yet, they're likely to fall under the same policy as www.jotform.com
-    // events.jotform.com
-    // files.jotform.com
-    // form.jotform.com
-  ]).then(
-    ([
+    checkJotFormReachability()
+  ]).then(([jotFormFrameLoadedMs, jotformReachability]) => {
+    const pageAction =
+      jotFormFrameLoadedMs === false
+        ? logToCloud.PageAction.JotFormLoadFailed
+        : logToCloud.PageAction.JotFormFrameLoaded;
+    const eventData = {
+      route: `GET ${context.location.pathname}`,
       jotFormFrameLoadedMs,
-      cdnjotformsMs,
-      wwwjotformcomMs,
-      apijotformcomMs,
-      submitjotformusMs
-    ]) => {
-      if (jotFormFrameLoadedMs === false) {
-        // Load failed if we specifically got 'false'
-        logToCloud.addPageAction(logToCloud.PageAction.JotFormLoadFailed, {
-          route: `GET ${context.location.pathname}`,
-          reachedCdnjotforms: false !== cdnjotformsMs,
-          reachedWwwjotformcom: false !== wwwjotformcomMs,
-          reachedApijotformcom: false !== apijotformcomMs,
-          reachedSubmitjotformus: false !== submitjotformusMs,
-          cdnjotformsMs,
-          wwwjotformcomMs,
-          apijotformcomMs,
-          submitjotformusMs
-        });
-      } else {
-        logToCloud.addPageAction(logToCloud.PageAction.JotFormFrameLoaded, {
-          route: `GET ${context.location.pathname}`,
-          jotFormFrameLoadedMs,
-          cdnjotformsMs,
-          wwwjotformcomMs,
-          apijotformcomMs,
-          submitjotformusMs
-        });
-      }
-    }
-  );
+      ...jotformReachability
+    };
+    logToCloud.addPageAction(pageAction, eventData);
+  });
 }
 
 /**
@@ -80,6 +47,40 @@ function checkJotFormFrameLoaded(context) {
       resolve(false);
     }, 5000);
   });
+}
+
+/**
+ * Check a whole set of JotForm domains to see if they're reachable from this client.
+ * @returns {Promise<object>} Resolves to a results object when all reachability checks are done,
+ *   in the form:
+ *   {
+ *     wwwjotformcomReached: <boolean, whether reachable>,
+ *     wwwjotformcomMs: <(number|false), time to load in ms, or false if load failed>,
+ *     ...and so on for each domain
+ *   }
+ */
+function checkJotFormReachability() {
+  // Small (<2KB) files on domains used by JotForm:
+  const jotformUrls = [
+    'https://cdn.jotfor.ms/favicon.ico',
+    'https://www.jotform.com/favicon.ico',
+    'https://api.jotform.com/favicon.ico',
+    'https://submit.jotform.us/favicon.ico'
+    // Not using these yet, they're likely to fall under the same policy as www.jotform.com
+    // events.jotform.com
+    // files.jotform.com
+    // form.jotform.com
+  ];
+  const anchor = document.createElement('a'); // For URL manipulation
+  return Promise.all(jotformUrls.map(checkReachability)).then(loadTimes =>
+    loadTimes.reduce((result, timeMs, i) => {
+      anchor.src = jotformUrls[i];
+      const origin = anchor.hostname.toLowerCase();
+      result[`${origin}Reached`] = false !== timeMs;
+      result[`${origin}Ms`] = timeMs;
+      return result;
+    }, {})
+  );
 }
 
 /**


### PR DESCRIPTION
I noticed today in Brendan's repro for the JotForm submit issues that his machine was hitting `submit.jotform.us` over and over. This change adds `submit.jotform.us` to the set of domains for which we perform reachability checks when monitoring JotForm loading.  Then I realized we've got four of these, and I should probably refactor the code to make it easier to add more in the future.

See also prior work in https://github.com/code-dot-org/code-dot-org/pull/27764 and https://github.com/code-dot-org/code-dot-org/pull/28478.