### PR TITLE
Fixing undefined error affecting previewing blocks

### DIFF
--- a/apps/src/gamelab/blocks.js
+++ b/apps/src/gamelab/blocks.js
@@ -153,7 +153,10 @@ const customInputTypes = {
   costumePicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       let buttons;
-      if (getStore().getState().pageConstants.showAnimationMode) {
+      if (
+        getStore().getState().pageConstants &&
+        getStore().getState().pageConstants.showAnimationMode
+      ) {
         buttons = [
           {
             text: 'Draw',


### PR DESCRIPTION
Recently added a conditional that was referencing a pageConstant that could be undefined. This was causing some block previews to fail. 
![Screenshot from 2019-05-15 17-01-52](https://user-images.githubusercontent.com/2959170/57817299-8f233f00-7733-11e9-9c22-8b711f51d3af.png)

This just adds a check that pageConstants is defined before checking for showAnimationMode.