### PR TITLE
Reset all circuit playground components

### DIFF
--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -9,6 +9,7 @@ import Firmata from 'firmata';
 import {
   createCircuitPlaygroundComponents,
   destroyCircuitPlaygroundComponents,
+  resetCircuitPlaygroundComponents,
   componentConstructors
 } from './PlaygroundComponents';
 import {
@@ -205,10 +206,7 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
   }
 
   reset() {
-    const {led, buzzer, colorLeds} = this.prewiredComponents_;
-    led.off();
-    colorLeds.forEach(led => led.off());
-    buzzer.off();
+    resetCircuitPlaygroundComponents(this.prewiredComponents_);
   }
 
   /**

--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -8,8 +8,7 @@ import Playground from 'playground-io';
 import Firmata from 'firmata';
 import {
   createCircuitPlaygroundComponents,
-  destroyCircuitPlaygroundComponents,
-  resetCircuitPlaygroundComponents,
+  cleanupCircuitPlaygroundComponents,
   componentConstructors
 } from './PlaygroundComponents';
 import {
@@ -152,7 +151,10 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
     this.dynamicComponents_.length = 0;
 
     if (this.prewiredComponents_) {
-      destroyCircuitPlaygroundComponents(this.prewiredComponents_);
+      cleanupCircuitPlaygroundComponents(
+        this.prewiredComponents_,
+        true /* shouldDestroyComponents */
+      );
     }
     this.prewiredComponents_ = null;
 
@@ -206,7 +208,10 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
   }
 
   reset() {
-    resetCircuitPlaygroundComponents(this.prewiredComponents_);
+    cleanupCircuitPlaygroundComponents(
+      this.prewiredComponents_,
+      false /* shouldDestroyComponents */
+    );
   }
 
   /**

--- a/apps/src/lib/kits/maker/PlaygroundComponents.js
+++ b/apps/src/lib/kits/maker/PlaygroundComponents.js
@@ -69,6 +69,44 @@ export function createCircuitPlaygroundComponents(board) {
   });
 }
 
+export function resetCircuitPlaygroundComponents(components) {
+  if (components.colorLeds) {
+    components.colorLeds.forEach(led => {
+      led.color('white');
+      led.intensity(100);
+      led.stop();
+      led.off();
+    });
+  }
+
+  if (components.led) {
+    components.led.intensity(100);
+    components.led.off();
+    components.led.stop();
+  }
+
+  if (components.buzzer) {
+    components.buzzer.off();
+    components.buzzer.stop();
+  }
+
+  if (components.soundSensor) {
+    components.soundSensor.disable();
+  }
+
+  if (components.lightSensor) {
+    components.lightSensor.disable();
+  }
+
+  if (components.tempSensor) {
+    components.tempSensor.disable();
+  }
+
+  if (components.accelerometer) {
+    components.accelerometer.stop();
+  }
+}
+
 /**
  * De-initializes any Johnny-Five components that might have been created
  * by createCircuitPlaygroundComponents

--- a/apps/src/lib/kits/maker/PlaygroundComponents.js
+++ b/apps/src/lib/kits/maker/PlaygroundComponents.js
@@ -69,20 +69,31 @@ export function createCircuitPlaygroundComponents(board) {
   });
 }
 
-export function resetCircuitPlaygroundComponents(components) {
+/**
+ * De-initializes any Johnny-Five components that might have been created
+ * by createCircuitPlaygroundComponents
+ * @param {Object} components - map of components, as originally returned by
+ *   createCircuitPlaygroundComponents.  This object will be mutated: Destroyed
+ *   components will be removed. Additional members of this object will be
+ *   ignored.
+ * @param {boolean} shouldDestroyComponents - whether or not to fully delete the
+ *   components, or just reset to their initial state.
+ */
+export function cleanupCircuitPlaygroundComponents(
+  components,
+  shouldDestroyComponents
+) {
   if (components.colorLeds) {
     components.colorLeds.forEach(led => {
       led.color('white');
       led.intensity(100);
-      led.stop();
       led.off();
     });
   }
 
   if (components.led) {
-    components.led.intensity(100);
+    components.led.intensity(0);
     components.led.off();
-    components.led.stop();
   }
 
   if (components.buzzer) {
@@ -105,64 +116,24 @@ export function resetCircuitPlaygroundComponents(components) {
   if (components.accelerometer) {
     components.accelerometer.stop();
   }
-}
+  if (shouldDestroyComponents) {
+    delete components.colorLeds;
+    delete components.led;
+    delete components.toggleSwitch;
+    delete components.buzzer;
+    delete components.soundSensor;
+    delete components.lightSensor;
+    delete components.tempSensor;
+    delete components.accelerometer;
+    delete components.buttonL;
+    delete components.buttonR;
 
-/**
- * De-initializes any Johnny-Five components that might have been created
- * by createCircuitPlaygroundComponents
- * @param {Object} components - map of components, as originally returned by
- *   createCircuitPlaygroundComponents.  This object will be mutated: Destroyed
- *   components will be removed. Additional members of this object will be
- *   ignored.
- */
-export function destroyCircuitPlaygroundComponents(components) {
-  if (components.colorLeds) {
-    components.colorLeds.forEach(led => led.stop());
-  }
-  delete components.colorLeds;
-
-  if (components.led) {
-    components.led.stop();
-  }
-  delete components.led;
-
-  // No reset needed for Switch
-  delete components.toggleSwitch;
-
-  if (components.buzzer) {
-    components.buzzer.stop();
-  }
-  delete components.buzzer;
-
-  if (components.soundSensor) {
-    components.soundSensor.disable();
-  }
-  delete components.soundSensor;
-
-  if (components.lightSensor) {
-    components.lightSensor.disable();
-  }
-  delete components.lightSensor;
-
-  if (components.tempSensor) {
-    components.tempSensor.disable();
-  }
-  delete components.tempSensor;
-
-  if (components.accelerometer) {
-    components.accelerometer.stop();
-  }
-  delete components.accelerometer;
-
-  // No reset needed for Button
-  delete components.buttonL;
-  delete components.buttonR;
-
-  if (experiments.isEnabled('maker-captouch')) {
-    // Remove listeners from each TouchSensor
-    TOUCH_PINS.forEach(pin => {
-      delete components[`touchPad${pin}`];
-    });
+    if (experiments.isEnabled('maker-captouch')) {
+      // Remove listeners from each TouchSensor
+      TOUCH_PINS.forEach(pin => {
+        delete components[`touchPad${pin}`];
+      });
+    }
   }
 }
 

--- a/apps/test/unit/lib/kits/maker/PlaygroundComponentsTest.js
+++ b/apps/test/unit/lib/kits/maker/PlaygroundComponentsTest.js
@@ -6,7 +6,7 @@ import {expect} from '../../../../util/configuredChai';
 import sinon from 'sinon';
 import {
   createCircuitPlaygroundComponents,
-  destroyCircuitPlaygroundComponents,
+  cleanupCircuitPlaygroundComponents,
   componentConstructors
 } from '@cdo/apps/lib/kits/maker/PlaygroundComponents';
 import Piezo from '@cdo/apps/lib/kits/maker/Piezo';
@@ -619,7 +619,7 @@ describe('Circuit Playground Components', () => {
   });
 
   // TODO (bbuchanan): Remove this whole describe block when maker-captouch is on by default.
-  describe('destroyCircuitPlaygroundComponents() with capTouch enabled', () => {
+  describe('cleanupCircuitPlaygroundComponents() with capTouch enabled', () => {
     let components;
 
     before(() => experiments.setEnabled('maker-captouch', true));
@@ -633,20 +633,26 @@ describe('Circuit Playground Components', () => {
 
     it('destroys everything that createCircuitPlaygroundComponents creates', () => {
       expect(Object.keys(components)).to.have.length(17);
-      destroyCircuitPlaygroundComponents(components);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
       expect(Object.keys(components)).to.have.length(0);
     });
 
     it('does not destroy components not created by createCircuitPlaygroundComponents', () => {
       components.someOtherComponent = {};
       expect(Object.keys(components)).to.have.length(18);
-      destroyCircuitPlaygroundComponents(components);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
       expect(Object.keys(components)).to.have.length(1);
       expect(components).to.haveOwnProperty('someOtherComponent');
     });
   });
 
-  describe('destroyCircuitPlaygroundComponents()', () => {
+  describe('cleanupCircuitPlaygroundComponents()', () => {
     let components;
 
     beforeEach(() => {
@@ -657,28 +663,48 @@ describe('Circuit Playground Components', () => {
 
     it('can be safely called on empty object', () => {
       expect(() => {
-        destroyCircuitPlaygroundComponents({});
+        cleanupCircuitPlaygroundComponents({});
       }).not.to.throw;
     });
 
     it('destroys everything that createCircuitPlaygroundComponents creates', () => {
       expect(Object.keys(components)).to.have.length(10);
-      destroyCircuitPlaygroundComponents(components);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
       expect(Object.keys(components)).to.have.length(0);
+    });
+
+    it('does not destroy components if shouldDestroyComponents is false', () => {
+      expect(Object.keys(components)).to.have.length(10);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        false /* shouldDestroyComponents */
+      );
+      expect(Object.keys(components)).to.have.length(10);
     });
 
     it('does not destroy components not created by createCircuitPlaygroundComponents', () => {
       components.someOtherComponent = {};
       expect(Object.keys(components)).to.have.length(11);
-      destroyCircuitPlaygroundComponents(components);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
       expect(Object.keys(components)).to.have.length(1);
       expect(components).to.haveOwnProperty('someOtherComponent');
     });
 
-    it('calls stop on every color LED', () => {
-      const spies = components.colorLeds.map(led => sinon.spy(led, 'stop'));
-      destroyCircuitPlaygroundComponents(components);
-      spies.forEach(spy => expect(spy).to.have.been.calledOnce);
+    it('calls off and stop on every color LED', () => {
+      const stopSpies = components.colorLeds.map(led => sinon.spy(led, 'stop'));
+      const offSpies = components.colorLeds.map(led => sinon.spy(led, 'off'));
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
+      stopSpies.forEach(spy => expect(spy).to.have.been.calledOnce);
+      offSpies.forEach(spy => expect(spy).to.have.been.calledOnce);
     });
 
     it('stops Led.RGB.blink()', () => {
@@ -696,7 +722,10 @@ describe('Circuit Playground Components', () => {
       expect(spy).to.have.been.calledTwice;
 
       // Now destroy the component
-      destroyCircuitPlaygroundComponents(components);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
 
       // Blink should no longer be calling toggle().
       clock.tick(50);
@@ -705,10 +734,15 @@ describe('Circuit Playground Components', () => {
       expect(spy).to.have.been.calledTwice;
     });
 
-    it('calls stop on the red LED', () => {
-      const spy = sinon.spy(components.led, 'stop');
-      destroyCircuitPlaygroundComponents(components);
-      expect(spy).to.have.been.calledOnce;
+    it('calls off and stop on the red LED', () => {
+      const stopSpy = sinon.spy(components.led, 'stop');
+      const offSpy = sinon.spy(components.led, 'off');
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
+      expect(stopSpy).to.have.been.calledOnce;
+      expect(offSpy).to.have.been.calledOnce;
     });
 
     it('stops Led.blink()', () => {
@@ -726,7 +760,10 @@ describe('Circuit Playground Components', () => {
       expect(spy).to.have.been.calledTwice;
 
       // Now destroy the component
-      destroyCircuitPlaygroundComponents(components);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
 
       // Blink should no longer be calling toggle().
       clock.tick(50);
@@ -735,10 +772,15 @@ describe('Circuit Playground Components', () => {
       expect(spy).to.have.been.calledTwice;
     });
 
-    it('calls stop on the buzzer', () => {
-      const spy = sinon.spy(components.buzzer, 'stop');
-      destroyCircuitPlaygroundComponents(components);
-      expect(spy).to.have.been.calledOnce;
+    it('calls off and stop on the buzzer', () => {
+      const stopSpy = sinon.spy(components.buzzer, 'stop');
+      const offSpy = sinon.spy(components.buzzer, 'off');
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
+      expect(stopSpy).to.have.been.calledOnce;
+      expect(offSpy).to.have.been.calledOnce;
     });
 
     ['play', 'playSong', 'playNotes'].forEach(methodUnderTest => {
@@ -773,7 +815,10 @@ describe('Circuit Playground Components', () => {
             expect(frequencySpy).to.have.been.calledThrice;
 
             // Now destroy the component(s)
-            destroyCircuitPlaygroundComponents({buzzer});
+            cleanupCircuitPlaygroundComponents(
+              {buzzer},
+              true /* shouldDestroyComponents */
+            );
 
             // And ensure the song has stopped
             clock.tick(msPerBeat);
@@ -787,19 +832,28 @@ describe('Circuit Playground Components', () => {
 
     it('calls disable on the soundSensor', () => {
       const spy = sinon.spy(components.soundSensor, 'disable');
-      destroyCircuitPlaygroundComponents(components);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
       expect(spy).to.have.been.calledOnce;
     });
 
     it('calls disable on the lightSensor', () => {
       const spy = sinon.spy(components.lightSensor, 'disable');
-      destroyCircuitPlaygroundComponents(components);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
       expect(spy).to.have.been.calledOnce;
     });
 
     it('calls disable on the tempSensor', () => {
       const spy = sinon.spy(components.tempSensor, 'disable');
-      destroyCircuitPlaygroundComponents(components);
+      cleanupCircuitPlaygroundComponents(
+        components,
+        true /* shouldDestroyComponents */
+      );
       expect(spy).to.have.been.calledOnce;
     });
 
@@ -808,7 +862,10 @@ describe('Circuit Playground Components', () => {
       // the returned component.
       const spy = sinon.spy(Playground.Accelerometer.stop, 'value');
       return createCircuitPlaygroundComponents(board).then(components => {
-        destroyCircuitPlaygroundComponents(components);
+        cleanupCircuitPlaygroundComponents(
+          components,
+          true /* shouldDestroyComponents */
+        );
 
         let assertionError;
         try {


### PR DESCRIPTION
~Do not submit until https://github.com/code-dot-org/chrome-serial-app/pull/2 is in. That PR fixes the remaining issues with sending too much at once across the wire. This change requires sending a bunch of commands across the wire to reset the state, so we need to fix the flakiness before submitting this.~

This is my attempt at resetting all state on each component. It was a little hard to track down some of the state, so if you can think of anything I may have missed please let me know! In particular, I'm a little worried that the sensors may still be sending readings across the wire, but I'm not sure how to check for this.
