### PR TITLE
Levelbuilder: fix disappearing videos on external levels 

### DIFF
--- a/dashboard/app/dsl/content_dsl.rb
+++ b/dashboard/app/dsl/content_dsl.rb
@@ -12,6 +12,7 @@ class ContentDSL < BaseDSL
   def display_as_unplugged(text) @hash[:display_as_unplugged] = text end
   def use_large_video_player(text) @hash[:use_large_video_player] = text end
   def hide_reference_area(text) @hash[:hide_reference_area] = text end
+  def video_key(text) @hash[:video_key] = text end
 
   # legacy
   def description(text) @hash[:content1] = text end

--- a/dashboard/app/views/levels/editors/_all.html.haml
+++ b/dashboard/app/views/levels/editors/_all.html.haml
@@ -69,10 +69,10 @@
   %p
     Add new videos by going to
     %a{href:"/videos/new"} the add video page
-  - if @level.is_a?(DSLDefined)
-    %p Warning: This is a DSL defined level. You can use the dropdown to find the video key that you'd like to use, but selecting in the dropdown will NOT be sufficient to associate the video with the level. If you'd like to add a video to this level you need to add video_key 'video_key' to the DSL box.
-    = f.select :video_key, options_for_select(video_key_choices, @level.video_key), {include_blank: true}, {class: 'video-dropdown'}
-    .video-preview{style: 'display: block'}
+    - if @level.is_a?(DSLDefined)
+      %p Warning: This is a DSL defined level. You can use the dropdown to find the video key that you'd like to use, but selecting in the dropdown will NOT be sufficient to associate the video with the level. If you'd like to add a video to this level you need to add video_key 'video_key' to the DSL box.
+  = f.select :video_key, options_for_select(video_key_choices, @level.video_key), {include_blank: true}, {class: 'video-dropdown'}
+  .video-preview{style: 'display: block'}
 
 .field
   = f.label :map_reference, 'Map Reference'

--- a/dashboard/app/views/levels/editors/_all.html.haml
+++ b/dashboard/app/views/levels/editors/_all.html.haml
@@ -69,8 +69,10 @@
   %p
     Add new videos by going to
     %a{href:"/videos/new"} the add video page
-  = f.select :video_key, options_for_select(video_key_choices, @level.video_key), {include_blank: true}, {class: 'video-dropdown'}
-  .video-preview{style: 'display: block'}
+  - if @level.is_a?(DSLDefined)
+    %p Warning: This is a DSL defined level. You can use the dropdown to find the video key that you'd like to use, but selecting in the dropdown will NOT be sufficient to associate the video with the level. If you'd like to add a video to this level you need to add video_key 'video_key' to the DSL box.
+    = f.select :video_key, options_for_select(video_key_choices, @level.video_key), {include_blank: true}, {class: 'video-dropdown'}
+    .video-preview{style: 'display: block'}
 
 .field
   = f.label :map_reference, 'Map Reference'


### PR DESCRIPTION
I recently implemented a [change ](https://github.com/code-dot-org/code-dot-org/pull/28398) that allows Levelbuilders to optionally use the large video player on external levels. The Curriculum team noticed that videos were disappearing on these levels - the video would appear on the levelbuilder pages, but vanish in other environments.  

Levels reference videos through `video_key`. In order to store `video_key` as a property on a DSL level that will persist in the database, and .external files across environments, it needed to be added to [content_dsl.rb](dashboard/app/dsl/content_dsl.rb). 

This change provides a work-around for Levelbuilders. They can add `video_key` and their video of choice to the DSL editing box. 
<img width="1020" alt="video-in-dsl-box" src="https://user-images.githubusercontent.com/12300669/57893166-bc84f100-77f6-11e9-9cee-e4efaffdf35e.png">

This is currently the _only_ way to permanently associated a video with an external level, which is confusing; therefore I also added a warning for levelbuilders that the video dropdown will not work as one might expect given how it works on non-DSL levels. 
<img width="997" alt="LB-video-warning" src="https://user-images.githubusercontent.com/12300669/57893361-78462080-77f7-11e9-913e-71933db2d50f.png">

There is a larger (hopefully upcoming) work item being tracked to improve the Levelbuilder UI for DSL levels; I advocate that video selection be at the top of that list. 