### PR TITLE
User level bigint migrations

### DIFF
--- a/dashboard/app/models/gallery_activity.rb
+++ b/dashboard/app/models/gallery_activity.rb
@@ -4,7 +4,7 @@
 #
 #  id              :integer          not null, primary key
 #  user_id         :integer          not null
-#  user_level_id   :integer
+#  user_level_id   :integer          unsigned
 #  level_source_id :integer
 #  created_at      :datetime
 #  updated_at      :datetime

--- a/dashboard/app/models/paired_user_level.rb
+++ b/dashboard/app/models/paired_user_level.rb
@@ -3,8 +3,8 @@
 # Table name: paired_user_levels
 #
 #  id                      :integer          not null, primary key
-#  driver_user_level_id    :integer
-#  navigator_user_level_id :integer
+#  driver_user_level_id    :integer          unsigned
+#  navigator_user_level_id :integer          unsigned
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #

--- a/dashboard/db/migrate/20190517000300_change_integer_to_bigint_in_paired_user_levels.rb
+++ b/dashboard/db/migrate/20190517000300_change_integer_to_bigint_in_paired_user_levels.rb
@@ -1,0 +1,11 @@
+class ChangeIntegerToBigintInPairedUserLevels < ActiveRecord::Migration[5.0]
+  def up
+    change_column :paired_user_levels, :driver_user_level_id, 'BIGINT(11) UNSIGNED'
+    change_column :paired_user_levels, :navigator_user_level_id, 'BIGINT(11) UNSIGNED'
+  end
+
+  def down
+    change_column :paired_user_levels, :navigator_user_level_id, :integer
+    change_column :paired_user_levels, :driver_user_level_id, :integer
+  end
+end

--- a/dashboard/db/migrate/20190517002900_change_integer_to_bigint_in_gallery_activities.rb
+++ b/dashboard/db/migrate/20190517002900_change_integer_to_bigint_in_gallery_activities.rb
@@ -1,0 +1,9 @@
+class ChangeIntegerToBigintInGalleryActivities < ActiveRecord::Migration[5.0]
+  def up
+    change_column :gallery_activities, :user_level_id, 'BIGINT(11) UNSIGNED'
+  end
+
+  def down
+    change_column :gallery_activities, :user_level_id, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190517000300) do
+ActiveRecord::Schema.define(version: 20190517002900) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -348,7 +348,7 @@ ActiveRecord::Schema.define(version: 20190517000300) do
 
   create_table "gallery_activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id",                            null: false
-    t.integer  "user_level_id"
+    t.bigint   "user_level_id",                                   unsigned: true
     t.integer  "level_source_id"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190515203100) do
+ActiveRecord::Schema.define(version: 20190517000300) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -501,8 +501,8 @@ ActiveRecord::Schema.define(version: 20190515203100) do
   end
 
   create_table "paired_user_levels", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer  "driver_user_level_id"
-    t.integer  "navigator_user_level_id"
+    t.bigint   "driver_user_level_id",                 unsigned: true
+    t.bigint   "navigator_user_level_id",              unsigned: true
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
     t.index ["driver_user_level_id"], name: "index_paired_user_levels_on_driver_user_level_id", using: :btree


### PR DESCRIPTION
This PR contains two Rails migrations to update the schema of columns referencing `user_levels` to use a `bigint` instead of `integer`.