### PR TITLE
Projects: fix thumbnail styling in Featured Projects Table

### DIFF
--- a/apps/src/templates/projects/FeaturedProjectsTable.jsx
+++ b/apps/src/templates/projects/FeaturedProjectsTable.jsx
@@ -41,7 +41,8 @@ export const styles = {
   cellThumbnail: {
     width: THUMBNAIL_SIZE,
     minWidth: THUMBNAIL_SIZE,
-    padding: 2
+    padding: 2,
+    overflow: 'hidden'
   },
   headerCellThumbnail: {
     padding: 0


### PR DESCRIPTION
Thumbnails for certain project types, for example App Lab, are not square and overflow the box in which they are displayed in projects tables. This little change hides the overflow of these thumbnails to tidy up the featured projects tables. 

Before: 
<img width="1009" alt="before" src="https://user-images.githubusercontent.com/12300669/57950066-06271780-789b-11e9-84cb-a37aecc0cba8.png">

After: 
<img width="1003" alt="after" src="https://user-images.githubusercontent.com/12300669/57950063-045d5400-789b-11e9-89d9-6b4c805c14df.png">
