### PR TITLE
Fix "Create" dropdown on /promote

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/interactive-map.css
+++ b/pegasus/sites.v3/code.org/public/css/interactive-map.css
@@ -6,7 +6,7 @@
   margin-top: 100px;
 }
 
-#right {
+#map-right {
   float: right;
   overflow: hidden;
 }

--- a/pegasus/sites.v3/code.org/views/interactive_map.haml
+++ b/pegasus/sites.v3/code.org/views/interactive_map.haml
@@ -22,7 +22,7 @@
         %option{value:abbr}= state
 
 #map.tablet-feature
-#right.col-33
+#map-right.col-33
   #infobox
     %p.info
       Computer science drives innovation throughout the US economy, but it remains marginalized throughout K-12 education.


### PR DESCRIPTION
The /promote pages uses some custom CSS for a bunch of special
visualizations, including the interactive map component. One of the
things the interactive map was doing is creating a div with the id
`#right`, then styling that to create the right-aligned infobox in the
interactive map.

Unfortunately, we also use `#right` in the header to render the user
menu and Create dropdown, so the interactive map style was having
unintended side effects. Renaming the interactive map element to a
more-specific id is the simple fix.