### PR TITLE
Fixed the trailing space issue

### DIFF
--- a/dashboard/config/scripts/express-2019.script
+++ b/dashboard/config/scripts/express-2019.script
@@ -141,7 +141,7 @@ level 'courseD_artist_4_2018_2019'
 level 'courseD_artist_5_2018_2019'
 level 'courseD_artist_6_2018_2019'
 
-stage 'Concept Practice with Minecraft', flex_category: 'csf_loops'
+stage 'Concept Practice with Minecraft ', flex_category: 'csf_loops'
 level 'Overworld Move to Sheep_2019'
 level 'Overworld Chop Tree_2019'
 level 'Overworld Shear Sheep_2019'


### PR DESCRIPTION
Fixed the trailing space issue by adding the space back in on the levelbuilder database. This commit adds the space back in to the script file (as is expected by the databases).