### PR TITLE
Consolidate user and create menu styles into shared stylesheet

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -320,17 +320,8 @@ img.video_thumbnail {
 
   .user_menu, .create_menu {
     margin-top: 6px;
-    height: 38px;
-    user-select: none;
 
     .create_button, .display_name, .pairing_name {
-      max-width: 120px;
-      display: inline-block;
-      float: left;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-
       html[dir=rtl] & {
         float: right;
       }
@@ -343,76 +334,9 @@ img.video_thumbnail {
       padding-top: 3px;
     }
 
-    .user_menu_arrow_down,
-    .user_menu_arrow_up,
-    .create_menu_arrow_down,
-    .create_menu_arrow_up, {
-      font-size: 30px;
-    }
-
     .user_options {
-      position: absolute;
-      top: 55px;
-      right: 55px;
       font-size: 14px;
       line-height: 20px;
-    }
-
-    .create_options {
-      position: absolute;
-      top: 55px;
-      right: 55px;
-      background-color: $white;
-      width: max-content;
-      z-index: 10000;
-      border: 1px solid $charcoal;
-      border-bottom: 0;
-      a {
-        color: $charcoal;
-        font-family: 'Gotham 5r', sans-serif;
-        min-width: 240px;
-        font-size: 14px;
-        border-bottom: 1px solid $charcoal;
-        box-sizing: content-box;
-        white-space: nowrap;
-        cursor: pointer;
-      }
-      a:hover {
-        background-color: $lightest_gray;
-      }
-      img {
-        height: 70px;
-        width: 70px;
-      }
-      .project_link_box {
-        display: block;
-      }
-      .project_link {
-        display: inline-block;
-        padding: 0 10px 0 4px;
-        line-height: 67px;
-      }
-      #view_all_projects {
-        height: 70px;
-        padding-left: 10px;
-      }
-    }
-
-    .user_menu_arrow_down,
-    .user_menu_arrow_up,
-    .create_menu_arrow_down,
-    .create_menu_arrow_up, {
-      font-size: 25px;
-    }
-
-    .user_menu_arrow_up,
-    .create_menu_arrow_up {
-      margin-top: -3px;
-    }
-
-    .user_menu_arrow_down,
-    .create_menu_arrow_down {
-      margin-top: -2px;
     }
   }
 
@@ -730,7 +654,6 @@ $small-footer-standard-width: 400px;
 
 .user_options {
   display: none;
-  background-color: $white;
   a:link {
     color: $black;
   }
@@ -747,19 +670,8 @@ $small-footer-standard-width: 400px;
     background-color: $dark_color;
   }
   border: 1px solid $black;
-  z-index: 100001;
-  text-align: left;
-  white-space: nowrap;
   color: $black;
-  position: absolute;
-  right: 0;
   padding: 10px;
-  left: auto;
-  bottom: auto;
-}
-
-.user_options a {
-  color: $black;
 }
 
 .user_options .pairing_summary {

--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -1,5 +1,8 @@
 /* Despite being in /shared/, this styling is currently only used for the Pegasus
  * header.
+
+ * Shared
+ *= require user-menu
  */
 
 @import 'color';
@@ -122,81 +125,13 @@
     color: $white;
     background-color: transparent;
     border: 2px solid $white;
-    height: 38px;
-    user-select: none;
 
     .pairing_name, .display_name, .create_button {
       font-family: 'Gotham 4r', sans-serif;
-      max-width: 120px;
-      display: inline-block;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-      float: left;
     }
 
     .user_options, .create_options {
-      position: absolute;
       font-size: 14px;
-      top: 55px;
-      right: 55px;
-    }
-
-    .user_menu_arrow_down,
-    .user_menu_arrow_up,
-    .create_menu_arrow_up,
-    .create_menu_arrow_down
-    {
-      font-size: 25px;
-    }
-
-    .user_menu_arrow_up,
-    .user_menu_arrow_down,
-    .create_menu_arrow_up,
-    .create_menu_arrow_down {
-      margin-top: -3px;
-    }
-  }
-
-  .create_options {
-    position: absolute;
-    top: 55px;
-    right: 55px;
-    background-color: $white;
-    width: max-content;
-    z-index: 10000;
-    border: 1px solid $charcoal;
-    border-bottom: 0;
-    a {
-      color: $teal;
-      font-family: 'Gotham 5r', sans-serif;
-      min-width: 240px;
-      font-size: 14px;
-      border-bottom: 1px solid $charcoal;
-      box-sizing: content-box;
-      white-space: nowrap;
-    }
-    a:hover {
-      color: $teal;
-      font-weight: 900;
-      background-color: $white;
-      cursor: pointer;
-    }
-    img {
-      height: 70px;
-      width: 70px;
-    }
-    .project_link_box {
-      display: block;
-    }
-    .project_link {
-      display: inline-block;
-      padding: 0 10px 0 4px;
-      line-height: 67px;
-    }
-    #view_all_projects {
-      height: 70px;
-      padding-left: 10px;
     }
   }
 

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -1,18 +1,57 @@
 @import 'color';
 @import 'font';
+.user_menu, .create_menu {
+  user-select: none;
+  height: 38px;
+
+  .create_button, .display_name, .pairing_name {
+    max-width: 120px;
+    display: inline-block;
+    float: left;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .user_menu_arrow_down,
+  .user_menu_arrow_up,
+  .create_menu_arrow_down,
+  .create_menu_arrow_up, {
+    font-size: 25px;
+    margin-top: -3px;
+  }
+
+  .user_options, .create_options {
+    position: absolute;
+    top: 55px;
+    right: 55px;
+    background-color: $white;
+    border: 1px solid $charcoal;
+
+    a {
+      color: $charcoal !important;
+
+      $transition: background-color 0.2s ease-out, border-color 0.2s ease-out, color 0.2s ease-out;
+      transition: $transition;
+      -moz-transition: $transition;
+      -webkit-transition: $transition;
+      -o-transition: $transition;
+    }
+
+    a:hover {
+      background-color: $lightest_gray;
+      text-decoration: none;
+    }
+  }
+}
 
 .user_menu {
   padding: 7px 14px;
 
   .user_options {
-    background-color: white;
-    border: 1px solid $charcoal;
     z-index: 100001;
     text-align: left;
     white-space: nowrap;
-    position: absolute;
-    right: -14px;
-    top: 7px;
     padding: 0;
 
     .display_name {
@@ -28,23 +67,43 @@
       display: block;
       padding: 10px;
       font-family: $gotham-bold;
-      color: $charcoal !important;
-
-      $transition: background-color .2s ease-out, border-color .2s ease-out, color .2s ease-out;
-      transition: $transition;
-      -moz-transition: $transition;
-      -webkit-transition: $transition;
-      -o-transition: $transition;
-    }
-
-    a:hover {
-      background-color: $lightest_gray;
-      color: $charcoal;
-      text-decoration: none;
     }
 
     a + a {
       border-top: 1px solid $charcoal;
+    }
+  }
+}
+
+.create_menu {
+  .create_options {
+    width: max-content;
+    z-index: 10000;
+    border-bottom: 0;
+    a {
+      font-family: 'Gotham 5r', sans-serif;
+      min-width: 240px;
+      font-size: 14px;
+      border-bottom: 1px solid $charcoal;
+      box-sizing: content-box;
+      white-space: nowrap;
+      cursor: pointer;
+    }
+    img {
+      height: 70px;
+      width: 70px;
+    }
+    .project_link_box {
+      display: block;
+    }
+    .project_link {
+      display: inline-block;
+      padding: 0 10px 0 4px;
+      line-height: 67px;
+    }
+    #view_all_projects {
+      height: 70px;
+      padding-left: 10px;
     }
   }
 }


### PR DESCRIPTION
Also fix some inconsistencies:

- The create dropdown should always use the same coloring and shading styles as the user dropdown (right now they're consistent on Dashboard, but inconsistent on Pegasus)
- The up/down arrows should always be consistently placed (right now they function differently between Dashboard and Pegasus)

--- | Before | After
--- | --- | ---
signed-out pegasus | ![image](https://user-images.githubusercontent.com/244100/57957695-04b51980-78b2-11e9-94d8-95dfbc5c579e.png) | ![image](https://user-images.githubusercontent.com/244100/57957700-0b439100-78b2-11e9-8324-a52eec7e198f.png)
signed-out pegasus with dropdown | ![Screen Shot 2019-05-17 at 14 43 54](https://user-images.githubusercontent.com/244100/57957764-43e36a80-78b2-11e9-9295-7f9a472707a3.png) | ![Screen Shot 2019-05-17 at 14 44 05](https://user-images.githubusercontent.com/244100/57957765-43e36a80-78b2-11e9-86de-bccf810c9e03.png)
signed-in pegasus | ![Screen Shot 2019-05-17 at 14 45 47](https://user-images.githubusercontent.com/244100/57957890-c1a77600-78b2-11e9-95b0-c56f34c2e004.png) | ![Screen Shot 2019-05-17 at 14 45 50](https://user-images.githubusercontent.com/244100/57957891-c1a77600-78b2-11e9-8437-c147d257e3a8.png)
signed-in pegasus with dropdown | ![Screen Shot 2019-05-17 at 14 45 55](https://user-images.githubusercontent.com/244100/57957892-c1a77600-78b2-11e9-8ae3-d949893a95b3.png) | ![Screen Shot 2019-05-17 at 14 45 59](https://user-images.githubusercontent.com/244100/57957893-c2400c80-78b2-11e9-9568-92838f4eae99.png)
signed-in dashboard | ![Screen Shot 2019-05-17 at 14 46 32](https://user-images.githubusercontent.com/244100/57957854-a472a780-78b2-11e9-9f0b-5efa2af5e1f5.png) | ![Screen Shot 2019-05-17 at 14 46 34](https://user-images.githubusercontent.com/244100/57957855-a472a780-78b2-11e9-8756-4cb38ca3de68.png)
signed-in dashboard with create dropdown | ![Screen Shot 2019-05-17 at 14 46 38](https://user-images.githubusercontent.com/244100/57957856-a472a780-78b2-11e9-9846-3652c7a4456d.png) | ![Screen Shot 2019-05-17 at 14 46 41](https://user-images.githubusercontent.com/244100/57957858-a50b3e00-78b2-11e9-815d-f4790084e371.png)
signed-in dashboard with user dropdown | ![Screen Shot 2019-05-17 at 14 46 45](https://user-images.githubusercontent.com/244100/57957859-a50b3e00-78b2-11e9-9af7-1a8b93eaa16c.png) | ![Screen Shot 2019-05-17 at 14 46 48](https://user-images.githubusercontent.com/244100/57957860-a50b3e00-78b2-11e9-947a-19ebdcebca8d.png)
signed-out dashboard | ![Screen Shot 2019-05-17 at 14 50 06](https://user-images.githubusercontent.com/244100/57957974-1a770e80-78b3-11e9-88a9-660b7273306f.png) | ![Screen Shot 2019-05-17 at 14 50 07](https://user-images.githubusercontent.com/244100/57957975-1a770e80-78b3-11e9-9695-22e8aea2000b.png)
signed-out dashboard with create dropdown | ![Screen Shot 2019-05-17 at 14 50 11](https://user-images.githubusercontent.com/244100/57957976-1a770e80-78b3-11e9-99ad-b4aa6a37c89b.png) | ![Screen Shot 2019-05-17 at 14 50 14](https://user-images.githubusercontent.com/244100/57957977-1a770e80-78b3-11e9-8985-02091c56d986.png)





