### PR TITLE
Update references to courses in contact rollups for curriculum ship

### DIFF
--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -93,6 +93,12 @@ class ContactRollups
     course2
     course3
     course4
+    coursea-2017
+    courseb-2017
+    coursec-2017
+    coursed-2017
+    coursee-2017
+    coursef-2017
     coursea-2018
     courseb-2018
     coursec-2018
@@ -102,6 +108,8 @@ class ContactRollups
     20-hour
     express-2018
     pre-express-2018
+    express-2017
+    pre-express-2017
   ).freeze
 
   CSF_SCRIPT_LIST = CSF_SCRIPT_ARRAY.map {|x| "'#{x}'"}.join(',')
@@ -494,6 +502,8 @@ class ContactRollups
     add_role_from_script_sections_taught("CSF Teacher", CSF_SCRIPT_LIST)
     # CSD and CSP scripts are mapped to course - identify CSD/CSP teachers
     # that way
+    add_role_from_course_sections_taught("CSD Teacher", "csd-2017")
+    add_role_from_course_sections_taught("CSP Teacher", "csp-2017")
     add_role_from_course_sections_taught("CSD Teacher", "csd-2018")
     add_role_from_course_sections_taught("CSP Teacher", "csp-2018")
     log_completion(start)

--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -93,15 +93,15 @@ class ContactRollups
     course2
     course3
     course4
-    coursea-2017
-    courseb-2017
-    coursec-2017
-    coursed-2017
-    coursee-2017
-    coursef-2017
+    coursea-2018
+    courseb-2018
+    coursec-2018
+    coursed-2018
+    coursee-2018
+    coursef-2018
     20-hour
-    express-2017
-    pre-express-2017
+    express-2018
+    pre-express-2018
   ).freeze
 
   CSF_SCRIPT_LIST = CSF_SCRIPT_ARRAY.map {|x| "'#{x}'"}.join(',')
@@ -128,7 +128,7 @@ class ContactRollups
     ProfessionalDevelopmentWorkshopSignup
   ).map {|s| "'#{s}'"}.join(',').freeze
 
-  hoc_year = DCDO.get("hoc_year", 2017)
+  hoc_year = DCDO.get("hoc_year", 2018)
 
   # Information about presence of which forms submitted by a user get recorded in which
   # rollup field with which value
@@ -494,8 +494,8 @@ class ContactRollups
     add_role_from_script_sections_taught("CSF Teacher", CSF_SCRIPT_LIST)
     # CSD and CSP scripts are mapped to course - identify CSD/CSP teachers
     # that way
-    add_role_from_course_sections_taught("CSD Teacher", "csd-2017")
-    add_role_from_course_sections_taught("CSP Teacher", "csp-2017")
+    add_role_from_course_sections_taught("CSD Teacher", "csd-2018")
+    add_role_from_course_sections_taught("CSP Teacher", "csp-2018")
     log_completion(start)
   end
 


### PR DESCRIPTION
[PLC-206](https://codedotorg.atlassian.net/browse/PLC-206)

Update the course names referenced in contact rollups to include the [new curriculum versions](https://codedotorg.atlassian.net/browse/LP-296).