### PR TITLE
replace all instances of $.timeago with moment.fromNow

### DIFF
--- a/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
+++ b/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import msg from '@cdo/locale';
-import moment from 'moment';
+
+import TimeAgo from '@cdo/apps/templates/TimeAgo';
 
 import {projectUpdatedStatuses as statuses} from '../../headerRedux';
 
@@ -15,7 +16,6 @@ const styles = {
 
 class ProjectUpdatedAt extends React.Component {
   static propTypes = {
-    locale: PropTypes.string,
     status: PropTypes.oneOf(Object.values(statuses)),
     updatedAt: PropTypes.string
   };
@@ -38,16 +38,11 @@ class ProjectUpdatedAt extends React.Component {
     }
 
     if (this.props.status === statuses.saved) {
-      if (this.props.locale) {
-        moment.locale(this.props.locale);
-      }
       return (
         <div>
           {msg.savedToGallery()}{' '}
           {this.props.updatedAt && (
-            <span title={this.props.updatedAt}>
-              {moment(this.props.updatedAt).fromNow()}
-            </span>
+            <TimeAgo dateString={this.props.updatedAt} />
           )}
         </div>
       );
@@ -66,7 +61,6 @@ class ProjectUpdatedAt extends React.Component {
 }
 
 export default connect(state => ({
-  locale: state.pageConstants && state.pageConstants.locale,
   status: state.header.projectUpdatedStatus,
   updatedAt: state.header.projectUpdatedAt
 }))(ProjectUpdatedAt);

--- a/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
+++ b/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import msg from '@cdo/locale';
+import moment from 'moment';
 
 import {projectUpdatedStatuses as statuses} from '../../headerRedux';
 
@@ -14,15 +15,10 @@ const styles = {
 
 class ProjectUpdatedAt extends React.Component {
   static propTypes = {
+    locale: PropTypes.string,
     status: PropTypes.oneOf(Object.values(statuses)),
     updatedAt: PropTypes.string
   };
-
-  componentDidUpdate() {
-    if (this.props.updatedAt) {
-      $('.project_updated_at span.timestamp').timeago();
-    }
-  }
 
   renderText() {
     if (this.props.status === statuses.error) {
@@ -42,11 +38,16 @@ class ProjectUpdatedAt extends React.Component {
     }
 
     if (this.props.status === statuses.saved) {
+      if (this.props.locale) {
+        moment.locale(this.props.locale);
+      }
       return (
         <div>
           {msg.savedToGallery()}{' '}
           {this.props.updatedAt && (
-            <span className="timestamp" title={this.props.updatedAt} />
+            <span title={this.props.updatedAt}>
+              {moment(this.props.updatedAt).fromNow()}
+            </span>
           )}
         </div>
       );
@@ -65,6 +66,7 @@ class ProjectUpdatedAt extends React.Component {
 }
 
 export default connect(state => ({
+  locale: state.pageConstants && state.pageConstants.locale,
   status: state.header.projectUpdatedStatus,
   updatedAt: state.header.projectUpdatedAt
 }))(ProjectUpdatedAt);

--- a/apps/src/templates/TimeAgo.jsx
+++ b/apps/src/templates/TimeAgo.jsx
@@ -23,6 +23,12 @@ class TimeAgo extends React.Component {
   }
 }
 
+// expose the "unconnected" version of the component as specifically
+// "unlocalized", to support usage in places where we don't have access to the
+// redux store or the locale and to make it clear what we lose in that
+// situation
+export const UnlocalizedTimeAgo = TimeAgo;
+
 export default connect(state => ({
   locale: state.pageConstants && state.pageConstants.locale
 }))(TimeAgo);

--- a/apps/src/templates/TimeAgo.jsx
+++ b/apps/src/templates/TimeAgo.jsx
@@ -26,10 +26,10 @@ class TimeAgo extends React.Component {
   }
 }
 
-// expose the "unconnected" version of the component as specifically
+// Expose the "unconnected" version of the component as specifically
 // "unlocalized", to support usage in places where we don't have access to the
 // redux store or the locale and to make it clear what we lose in that
-// situation
+// situation.
 export const UnlocalizedTimeAgo = TimeAgo;
 
 export default connect(state => ({

--- a/apps/src/templates/TimeAgo.jsx
+++ b/apps/src/templates/TimeAgo.jsx
@@ -5,7 +5,10 @@ import moment from 'moment';
 
 class TimeAgo extends React.Component {
   static propTypes = {
-    dateString: PropTypes.string.isRequired,
+    dateString: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.instanceOf(Date)
+    ]).isRequired,
     locale: PropTypes.string,
     style: PropTypes.object
   };

--- a/apps/src/templates/TimeAgo.jsx
+++ b/apps/src/templates/TimeAgo.jsx
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import moment from 'moment';
+
+class TimeAgo extends React.Component {
+  static propTypes = {
+    dateString: PropTypes.string.isRequired,
+    locale: PropTypes.string,
+    style: PropTypes.object
+  };
+
+  render() {
+    if (this.props.locale) {
+      moment.locale(this.props.locale);
+    }
+
+    return (
+      <time style={this.props.style || {}} dateTime={this.props.dateString}>
+        {moment(this.props.dateString).fromNow()}
+      </time>
+    );
+  }
+}
+
+export default connect(state => ({
+  locale: state.pageConstants && state.pageConstants.locale
+}))(TimeAgo);

--- a/apps/src/templates/VersionRow.jsx
+++ b/apps/src/templates/VersionRow.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import msg from '@cdo/locale';
 
-import TimeAgo from './TimeAgo';
+import {UnlocalizedTimeAgo} from './TimeAgo';
 
 /**
  * A single row in the VersionHistory dialog, describing one version of a project.
@@ -67,7 +67,7 @@ export default class VersionRow extends React.Component {
       <tr className="versionRow">
         <td>
           <p>
-            Saved <TimeAgo dateString={this.props.lastModified} />
+            Saved <UnlocalizedTimeAgo dateString={this.props.lastModified} />
           </p>
           {this.getLastModifiedTimestamp()}
         </td>

--- a/apps/src/templates/VersionRow.jsx
+++ b/apps/src/templates/VersionRow.jsx
@@ -1,7 +1,8 @@
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import msg from '@cdo/locale';
+
+import TimeAgo from './TimeAgo';
 
 /**
  * A single row in the VersionHistory dialog, describing one version of a project.
@@ -13,10 +14,6 @@ export default class VersionRow extends React.Component {
     isLatest: PropTypes.bool,
     onChoose: PropTypes.func
   };
-
-  componentDidMount() {
-    $('.versionTimestamp').timeago();
-  }
 
   getLastModifiedTimestamp() {
     const timestamp = this.props.lastModified;
@@ -70,13 +67,7 @@ export default class VersionRow extends React.Component {
       <tr className="versionRow">
         <td>
           <p>
-            Saved{' '}
-            <time
-              className="versionTimestamp"
-              dateTime={this.props.lastModified.toISOString()}
-            >
-              {this.getLastModifiedTimestamp()}
-            </time>
+            Saved <TimeAgo dateString={this.props.lastModified} />
           </p>
           {this.getLastModifiedTimestamp()}
         </td>

--- a/apps/src/templates/projects/ProjectCard.jsx
+++ b/apps/src/templates/projects/ProjectCard.jsx
@@ -3,9 +3,10 @@ import React from 'react';
 import color from '../../util/color';
 import i18n from '@cdo/locale';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
-import $ from 'jquery';
 
 const PROJECT_DEFAULT_IMAGE = '/blockly/media/projects/project_default.png';
+
+import TimeAgo from '../TimeAgo';
 
 const styles = {
   card: {
@@ -85,19 +86,6 @@ export default class ProjectCard extends React.Component {
     isDetailView: PropTypes.bool
   };
 
-  getLastModifiedTimestamp(timestamp) {
-    if (timestamp.toLocaleString) {
-      return timestamp.toLocaleString();
-    }
-    return timestamp.toString();
-  }
-
-  componentDidMount() {
-    if ($('.versionTimestamp').timeago) {
-      $('.versionTimestamp').timeago();
-    }
-  }
-
   render() {
     const {projectData, currentGallery, isDetailView} = this.props;
     const {type, channel} = this.props.projectData;
@@ -160,25 +148,16 @@ export default class ProjectCard extends React.Component {
           {shouldShowPublishedAt && (
             <div style={styles.lastEdit}>
               {i18n.published()}:&nbsp;
-              <time
+              <TimeAgo
                 style={styles.bold}
-                className="versionTimestamp"
-                dateTime={projectData.publishedAt}
-              >
-                {this.getLastModifiedTimestamp(projectData.publishedAt)}
-              </time>
+                dateString={projectData.publishedAt}
+              />
             </div>
           )}
           {isPersonalGallery && projectData.updatedAt && (
             <div style={styles.lastEdit}>
               {i18n.projectLastUpdated()}:&nbsp;
-              <time
-                style={styles.bold}
-                className="versionTimestamp"
-                dateTime={projectData.updatedAt}
-              >
-                {this.getLastModifiedTimestamp(projectData.updatedAt)}
-              </time>
+              <TimeAgo style={styles.bold} dateString={projectData.updatedAt} />
             </div>
           )}
         </div>

--- a/apps/src/templates/projects/ProjectCard.jsx
+++ b/apps/src/templates/projects/ProjectCard.jsx
@@ -6,7 +6,7 @@ import {studio} from '@cdo/apps/lib/util/urlHelpers';
 
 const PROJECT_DEFAULT_IMAGE = '/blockly/media/projects/project_default.png';
 
-import TimeAgo from '../TimeAgo';
+import {UnlocalizedTimeAgo} from '../TimeAgo';
 
 const styles = {
   card: {
@@ -148,7 +148,7 @@ export default class ProjectCard extends React.Component {
           {shouldShowPublishedAt && (
             <div style={styles.lastEdit}>
               {i18n.published()}:&nbsp;
-              <TimeAgo
+              <UnlocalizedTimeAgo
                 style={styles.bold}
                 dateString={projectData.publishedAt}
               />
@@ -157,7 +157,10 @@ export default class ProjectCard extends React.Component {
           {isPersonalGallery && projectData.updatedAt && (
             <div style={styles.lastEdit}>
               {i18n.projectLastUpdated()}:&nbsp;
-              <TimeAgo style={styles.bold} dateString={projectData.updatedAt} />
+              <UnlocalizedTimeAgo
+                style={styles.bold}
+                dateString={projectData.updatedAt}
+              />
             </div>
           )}
         </div>

--- a/apps/src/templates/projects/ProjectCard.story.jsx
+++ b/apps/src/templates/projects/ProjectCard.story.jsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import ProjectCard from './ProjectCard';
 
-// publishedAt data is normally a timestamp, but for Storybook
-// display purposes, use a descriptive string
 const defaultData = {
   channel: 'abcdef',
   name: 'Puppy Playdate',
   studentName: 'Penelope',
   studentAgeRange: '8+',
   type: 'applab',
-  publishedAt: 'a day ago',
-  updatedAt: 'about a week ago'
+  publishedAt: new Date(),
+  updatedAt: new Date()
 };
 
 export default storybook => {

--- a/apps/src/templates/projects/generateFakeProjects.js
+++ b/apps/src/templates/projects/generateFakeProjects.js
@@ -6,7 +6,7 @@ import _ from 'lodash';
 export function generateFakePersonalProjects(n) {
   return _.range(n).map(i => ({
     name: 'Personal ' + i,
-    updatedAt: 'a day ago',
+    updatedAt: new Date().toISOString(),
     projectType: 'gamelab',
     id: 'abcd'
   }));

--- a/apps/test/unit/templates/VersionHistoryTest.jsx
+++ b/apps/test/unit/templates/VersionHistoryTest.jsx
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import React from 'react';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
@@ -29,11 +28,6 @@ const FAKE_VERSION_LIST_RESPONSE = {
 
 describe('VersionHistory', () => {
   let wrapper;
-
-  before(() => {
-    // Stub jQuery timeago plugin
-    $.fn.timeago = () => {};
-  });
 
   beforeEach(() => {
     sinon.stub(utils, 'reload');

--- a/dashboard/test/ui/features/applab/versions.feature
+++ b/dashboard/test/ui/features/applab/versions.feature
@@ -47,7 +47,7 @@ Scenario: Project Load and Reload
   And I wait for the page to fully load
   And I press "versions-header"
   And I wait until element "button:contains(Current Version)" is visible
-  And I save the timestamp from ".versionTimestamp"
+  And I save the timestamp from ".versionRow:nth-child(1) time"
 
   # There is currently no guarantee that Version History will initially be
   # empty, because we don't necessarily clear past project data from S3 between
@@ -68,7 +68,7 @@ Scenario: Project Load and Reload
   And I press "versions-header"
   And I wait until element "button:contains(Current Version)" is visible
 
-  Then ".versionRow:nth-child(2) .versionTimestamp" contains the saved timestamp
+  Then ".versionRow:nth-child(2) time" contains the saved timestamp
   And element ".versionRow:nth-child(2) .btn-info" contains text "Restore this Version"
 
   And element "#showVersionsModal tr:contains(a minute ago):contains(Restore this Version):eq(1)" is not visible

--- a/dashboard/test/ui/features/applab/versions.feature
+++ b/dashboard/test/ui/features/applab/versions.feature
@@ -92,7 +92,7 @@ Scenario: Project Version Checkpoints
   # The dialog contains only the initial version and the current version, and
   # possibly some versions created more than 90 seconds ago which we ignore.
   Then element "#showVersionsModal tr:contains(a minute ago):contains(Restore this Version)" is not visible
-  And I save the timestamp from ".versionTimestamp"
+  And I save the timestamp from ".versionRow:nth-child(1) time"
 
   When I close the dialog
   And I set the project version interval to 1 second
@@ -106,7 +106,7 @@ Scenario: Project Version Checkpoints
   And I wait until element "button:contains(Current Version)" is visible
   # The version containing "comment A" is saved as a checkpoint, because the
   # project version interval time period had passed.
-  Then ".versionRow:nth-child(2) .versionTimestamp" contains the saved timestamp
+  Then ".versionRow:nth-child(2) time" contains the saved timestamp
   And element ".versionRow:nth-child(2) .btn-info" contains text "Restore this Version"
   And element "#showVersionsModal tr:contains(a minute ago):contains(Restore this Version):eq(1)" is not visible
 


### PR DESCRIPTION
So the result can be internationalized

Screenshots
| --- |
![image](https://user-images.githubusercontent.com/244100/57961306-dee44080-78c2-11e9-95f5-4020b15d8f6b.png) |
![image](https://user-images.githubusercontent.com/244100/57961313-ec012f80-78c2-11e9-97ee-d327f98257aa.png) |
![image](https://user-images.githubusercontent.com/244100/57961780-0b4d8c00-78c6-11e9-8a6a-47a13bc33f60.png)

Note that although ProjectCard is using the new component, it won't be internationalized since the `/projects` page doesn't load pageConstants (or provide any other way of determining the locale)
