### PR TITLE
log firehose event via server after failing to log via client

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -441,6 +441,20 @@ class ApiController < ApplicationController
     head :ok
   end
 
+  # PUT /api/firehose_unreachable
+  def firehose_unreachable
+    original_data = params.require(:original_data)
+    event = original_data['event']
+    project_id = original_data['project_id'] || nil
+    FirehoseClient.instance.put_record(
+      study: 'firehose-error-unreachable',
+      event: event,
+      project_id: project_id,
+      data_string: params.require(:error_text),
+      data_json: original_data.to_json
+    )
+  end
+
   private
 
   def load_student(student_id)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -575,6 +575,7 @@ Dashboard::Application.routes.draw do
   get '/api/user_progress/:script', to: 'api#user_progress', as: 'user_progress'
   get '/api/user_progress/:script/:stage_position/:level_position', to: 'api#user_progress_for_stage', as: 'user_progress_for_stage'
   get '/api/user_progress/:script/:stage_position/:level_position/:level', to: 'api#user_progress_for_stage', as: 'user_progress_for_stage_and_level'
+  put '/api/firehose_unreachable', to: 'api#firehose_unreachable'
   namespace :api do
     api_methods.each do |action|
       get action, action: action


### PR DESCRIPTION
### Background

Data loss issues seem to affect certain classrooms, and we suspect this may have to do with their network configurations. We try to log many firehose event types to help diagnose these issues, however some classrooms with data loss problems do not show any of these events in the logs. One complicating factor is that some classrooms might not allow log messages to the firehose servers, which hit amazon urls directly via ajax requests. To work around this, the idea is to detect failed log attempts from the client, and to ask our server (which must already be allowed on the classroom's network) to log to firehose for us.

### Description

Whenever a firehose event is logged on the client, if the log attempt fails and no callback was specified, use our own callback to ask our servers to log a firehose event. the server request includes all the original details from the failed client request.

### Sample output

sample server log event after failing to save channel for standalone project:
```
{
  "study": "firehose-error-unreachable",
  "event": "save-channel-error",
  "project_id": "350J0x1aMhcD4hYxewRuZA",
  "data_json": "{\"study\":\"project-data-integrity\",\"study_group\":\"v4\",\"event\":\"save-channel-error\",\"data_int\":1,\"project_id\":\"350J0x1aMhcD4hYxewRuZA\",\"data_string\":\"Error: status: error; error: \",\"data_json\":\"{\\\"errorCount\\\":1,\\\"errorText\\\":\\\"Error: status: error; error: \\\",\\\"isOwner\\\":true,\\\"currentUrl\\\":\\\"http://localhost-studio.code.org:3000/projects/applab/350J0x1aMhcD4hYxewRuZA/edit\\\",\\\"shareUrl\\\":\\\"http://localhost-studio.code.org:3000/projects/applab/350J0x1aMhcD4hYxewRuZA\\\",\\\"currentSourceVersionId\\\":\\\"YAiX5Ct5zjuKcF1iz5DY_yx.wLqQMB2c\\\"}\",\"created_at\":\"2019-05-17T23:14:22.635Z\",\"environment\":\"development\",\"uuid\":\"71f5c40a-87b1-4116-b365-b152c3a65423\",\"device\":\"{\\\"user_agent\\\":\\\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36\\\",\\\"window_width\\\":974,\\\"window_height\\\":776,\\\"hostname\\\":\\\"localhost-studio.code.org\\\",\\\"full_path\\\":\\\"http://localhost-studio.code.org:3000/projects/applab/350J0x1aMhcD4hYxewRuZA/edit\\\"}\",\"user_id\":1,\"script_id\":null,\"level_id\":null}",
  "data_string": "NetworkingError: Network Failure"
}
```