### PR TITLE
More logging for project data loss

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1500,7 +1500,12 @@ function fetchSource(channelData, callback, version, sourcesApi) {
     }
     sourcesApi.fetch(url, function(err, data, jqXHR) {
       if (err) {
-        console.warn('unable to fetch project source file', err);
+        this.logError_(
+          'load-sources-error',
+          null,
+          `unable to fetch project source file: ${err}`
+        );
+        console.warn();
         data = {
           source: '',
           html: '',

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1089,6 +1089,15 @@ var projects = (module.exports = {
         err + ''
       );
       return;
+    } else if (saveChannelErrorCount) {
+      // If the previous errors occurred due to network problems, we may not
+      // have been able to report them. Try to report them once more, now that
+      // the network appears to be working again.
+      this.logError_(
+        'channel-saved-after-errors',
+        saveChannelErrorCount,
+        `channel save succeeded after ${saveChannelErrorCount} consecutive failures`
+      );
     }
     saveChannelErrorCount = 0;
 

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -926,6 +926,15 @@ var projects = (module.exports = {
               );
               return;
             }
+          } else if (saveSourcesErrorCount > 0) {
+            // If the previous errors occurred due to network problems, we may not
+            // have been able to report them. Try to report them once more, now that
+            // the network appears to be working again.
+            this.logError_(
+              'sources-saved-after-errors',
+              saveSourcesErrorCount,
+              `sources saved after ${saveSourcesErrorCount} consecutive failures`
+            );
           }
           saveSourcesErrorCount = 0;
           if (!firstSaveTimestamp) {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1053,6 +1053,9 @@ var projects = (module.exports = {
   },
   showSaveError_(errorType, errorCount, errorText) {
     header.showProjectSaveError();
+    this.logError_(errorType, errorCount, errorText);
+  },
+  logError_: function(errorType, errorCount, errorText) {
     firehoseClient.putRecord(
       {
         study: 'project-data-integrity',


### PR DESCRIPTION
add logging in the following situations:
1. channel fails to save, but then succeeds on subsequent attempt
2. source fails to save, but then succeeds on subsequent attempt
3. [LP-421](https://codedotorg.atlassian.net/browse/LP-421) source fails to load 

the idea with scenarios 1 and 2 is that the save may fail due to network problems, and we may have better luck logging these failures once the network is working again.

scenario 3 is important to log because when sources fail to load, we currently replace the previous source code with blank source code.  although the previous source code can be found in version history, this can be alarming to the user if they don't think to look there.