### PR TITLE
Update pre-workshop surveys to link to the new curriculum

### DIFF
--- a/dashboard/app/models/pd/workshop_constants.rb
+++ b/dashboard/app/models/pd/workshop_constants.rb
@@ -84,8 +84,8 @@ module Pd
     #  - course_name : the name of the Course object associated with that workshop.
     # Only courses with a pre-survey will have an entry here
     PRE_SURVEY_BY_COURSE = {
-      COURSE_CSD => {course_name: 'csd-2018'},
-      COURSE_CSP => {course_name: 'csp-2018'}
+      COURSE_CSD => {course_name: 'csd-2019'},
+      COURSE_CSP => {course_name: 'csp-2019'}
     }.freeze
 
     CSF_201_PILOT_END_DATE = Date.new(2019, 5, 20)


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/PLC-205
CSD and CSP pre-ws surveys for 2019 curriculum

<img width="1010" alt="Screen Shot 2019-05-20 at 9 45 44 AM" src="https://user-images.githubusercontent.com/46507039/58039686-4e874500-7ae8-11e9-8473-39ac9ce2da6f.png">
<img width="1015" alt="Screen Shot 2019-05-20 at 10 03 27 AM" src="https://user-images.githubusercontent.com/46507039/58039687-4e874500-7ae8-11e9-94ac-83d0979d5621.png">

**How tested**:
- Unit tests
    - `bundle exec rails test test/models/pd/workshop_test.rb`
    - `bundle exec rails test test/controllers/pd/pre_workshop_survey_controller_test.rb`
    - `bundle exec rails test test/models/pd/pre_workshop_survey_test.rb`

- Manual tests
    - From dashboard folder, run `bundle exec rake seed:all` to get the latest courses.
    - Create workshops & enrollments from console
        ```
        include FactoryGirl::Syntax::Methods
        u = User.find_by_email('ha@code.org')
        ws = create :pd_workshop, course: Pd::Workshop::COURSE_CSD, num_sessions: 1
        en = create :pd_enrollment, workshop: ws, user: u
        en.code
        ws2 = create :pd_workshop, course: Pd::Workshop::COURSE_CSP, num_sessions: 1
        en2 = create :pd_enrollment, workshop: ws2, user: u
        en2.code
        ```
    - Use enrollment codes to see pre-ws surveys
      - http://localhost-studio.code.org:3000/pd/pre_workshop_survey/[csd-enrollment-code]
      - http://localhost-studio.code.org:3000/pd/pre_workshop_survey/[csp-enrollment-code]