### PR TITLE
Set board sampling interval to 100

### DIFF
--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -85,6 +85,7 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
       board.once('ready', () => {
         this.serialPort_ = serialPort;
         this.fiveBoard_ = board;
+        this.fiveBoard_.samplingInterval(100);
         resolve();
       });
       board.on('error', reject);


### PR DESCRIPTION
This should help with observed laggy behavior on low-end devices using the accelerometer.