### PR TITLE
Pilot (Student Libraries): Create UI for exporting shared libraries

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -371,6 +371,7 @@ Applab.init = function(config) {
   // replace studioApp methods with our own
   studioApp().reset = this.reset.bind(this);
   studioApp().runButtonClick = this.runButtonClick.bind(this);
+  config.getLibrary = getLibrary;
 
   config.runButtonClickWrapper = runButtonClickWrapper;
 
@@ -1088,6 +1089,15 @@ Applab.onReportComplete = function(response) {
   studioApp().onReportComplete(response);
   displayFeedback();
 };
+
+/**
+ * Generates a library from the functions in the project code
+ */
+function getLibrary() {
+  var temporaryInterpreter = new JSInterpreter({studioApp: studioApp()});
+  temporaryInterpreter.parse({code: studioApp().getCode()});
+  return temporaryInterpreter.getFunctionsAndParams(studioApp().getCode());
+}
 
 /**
  * Execute the app

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -128,7 +128,8 @@ class AdvancedShareOptions extends React.Component {
       iframeHeight: PropTypes.number.isRequired,
       iframeWidth: PropTypes.number.isRequired
     }).isRequired,
-    openPublishLibraryDialog: PropTypes.func
+    openPublishLibraryDialog: PropTypes.func,
+    libraryName: PropTypes.string
   };
 
   constructor(props) {
@@ -290,7 +291,7 @@ class AdvancedShareOptions extends React.Component {
           libraries to your project by going to the Settings icon in your
           Toolbox, and choosing "Manage Libraries."
         </p>
-        <p style={style.libraryName}>Library name:</p>
+        <p style={style.libraryName}>Library name: {this.props.libraryName}</p>
         <button
           type="button"
           onClick={this.props.openPublishLibraryDialog}
@@ -582,7 +583,9 @@ class AdvancedShareOptions extends React.Component {
 
 export const UnconnectedAdvancedShareOptions = Radium(AdvancedShareOptions);
 export default connect(
-  state => ({}),
+  state => ({
+    libraryName: state.libraryShareDialog.libraryName
+  }),
   dispatch => ({
     openPublishLibraryDialog() {
       dispatch(showLibraryShareDialog());

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import Radium from 'radium';
+import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import QRCode from 'qrcode.react';
 import * as color from '../../util/color';
 import {CIPHER, ALPHABET} from '../../constants';
+import experiments from '@cdo/apps/util/experiments';
+import {hideShareDialog} from './shareDialogRedux';
+import {showLibraryShareDialog} from './libraryShareDialogRedux';
 
 const INSTRUCTIONS_LINK =
   'https://codeorg.zendesk.com/knowledge/articles/360004789872';
@@ -35,6 +39,12 @@ const style = {
     fontSize: 'inherit',
     lineHeight: 'inherit',
     color: 'inherit'
+  },
+  libraryName: {
+    fontSize: 'large',
+    lineHeight: 'inherit',
+    color: 'inherit',
+    fontWeight: 'bold'
   },
   bold: {
     fontFamily: "'Gotham 7r', sans-serif"
@@ -90,6 +100,18 @@ const style = {
   },
   qrCode: {
     marginRight: 20
+  },
+  publishButton: {
+    marginLeft: 0,
+    backgroundColor: color.cyan,
+    color: color.white
+  },
+  closeButton: {
+    marginRight: 0,
+    backgroundColor: color.orange,
+    color: color.white,
+    position: 'absolute',
+    right: 0
   }
 };
 
@@ -105,7 +127,8 @@ class AdvancedShareOptions extends React.Component {
     embedOptions: PropTypes.shape({
       iframeHeight: PropTypes.number.isRequired,
       iframeWidth: PropTypes.number.isRequired
-    }).isRequired
+    }).isRequired,
+    openPublishLibraryDialog: PropTypes.func
   };
 
   constructor(props) {
@@ -255,6 +278,26 @@ class AdvancedShareOptions extends React.Component {
           />
           <span style={{marginLeft: 5}}>Hide ability to view code</span>
         </label>
+      </div>
+    );
+  }
+
+  renderLibraryTab() {
+    return (
+      <div>
+        <p style={style.p}>
+          Library links let you add libraries to other projects. You can add
+          libraries to your project by going to the Settings icon in your
+          Toolbox, and choosing "Manage Libraries."
+        </p>
+        <p style={style.libraryName}>Library name:</p>
+        <button
+          type="button"
+          onClick={this.props.openPublishLibraryDialog}
+          style={style.publishButton}
+        >
+          Publish
+        </button>
       </div>
     );
   }
@@ -491,6 +534,18 @@ class AdvancedShareOptions extends React.Component {
             {exportExpoTab}
             {exportTab}
             {embedTab}
+            {experiments.isEnabled('student-libraries') && (
+              <li
+                style={[
+                  style.nav.li,
+                  this.state.selectedOption === 'library' &&
+                    style.nav.selectedLi
+                ]}
+                onClick={() => this.setState({selectedOption: 'library'})}
+              >
+                Library
+              </li>
+            )}
           </ul>
         </div>
       );
@@ -503,6 +558,9 @@ class AdvancedShareOptions extends React.Component {
           break;
         case 'embed':
           selectedOption = this.renderEmbedTab();
+          break;
+        case 'library':
+          selectedOption = this.renderLibraryTab();
           break;
       }
     }
@@ -522,4 +580,13 @@ class AdvancedShareOptions extends React.Component {
   }
 }
 
-export default Radium(AdvancedShareOptions);
+export const UnconnectedAdvancedShareOptions = Radium(AdvancedShareOptions);
+export default connect(
+  state => ({}),
+  dispatch => ({
+    openPublishLibraryDialog() {
+      dispatch(showLibraryShareDialog());
+      dispatch(hideShareDialog());
+    }
+  })
+)(Radium(AdvancedShareOptions));

--- a/apps/src/code-studio/components/PublishLibraryDialog.jsx
+++ b/apps/src/code-studio/components/PublishLibraryDialog.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import BaseDialog from '../../templates/BaseDialog';
+import {connect} from 'react-redux';
+import {hideLibraryShareDialog} from './libraryShareDialogRedux';
+import color from '../../util/color';
+
+const styles = {
+  root: {
+    margin: '10px'
+  },
+  checkbox: {
+    margin: '4px',
+    width: 24,
+    height: 24
+  },
+  publishButton: {
+    marginLeft: 0,
+    backgroundColor: color.cyan,
+    color: color.white,
+    float: 'right',
+    margin: 10,
+    marginRight: 0
+  },
+  functionName: {
+    fontSize: '16px',
+    fontFamily: 'monospace'
+  }
+};
+
+class PublishLibraryDialog extends React.Component {
+  static propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    libraryFunctions: PropTypes.object.isRequired
+  };
+
+  state = {
+    showShareLink: false
+  };
+
+  displayFunctions() {
+    if (!this.props.libraryFunctions) {
+      return <div>You have no functions to export :(</div>;
+    }
+
+    return Object.keys(this.props.libraryFunctions).map(key => {
+      var params = '(' + this.props.libraryFunctions[key].join(', ') + ')';
+      return (
+        <div key={key}>
+          <input type="checkbox" style={styles.checkbox} />
+          <span style={styles.functionName}>
+            {key}
+            {params}
+          </span>
+        </div>
+      );
+    });
+  }
+
+  displayShareLink = () => {
+    this.setState({showShareLink: true});
+  };
+
+  select = event => event.target.select();
+
+  shareLink() {
+    return (
+      this.state.showShareLink && (
+        <div>
+          <p style={{fontSize: 20}}>
+            To share your library, send this link to a friend:
+          </p>
+          <input
+            type="text"
+            onClick={this.select}
+            readOnly="true"
+            value={'https://studio.code.org'}
+            style={{cursor: 'copy', width: 500}}
+          />
+        </div>
+      )
+    );
+  }
+
+  close = () => {
+    this.setState(state => ({showShareLink: false}));
+    this.props.onClose();
+  };
+
+  render() {
+    return (
+      <BaseDialog
+        isOpen={this.props.isOpen}
+        handleClose={this.close}
+        useUpdatedStyles
+      >
+        <div className="modal-content" style={styles.root}>
+          <p className="dialog-title">
+            Which functions would you like to share?
+          </p>
+          {this.displayFunctions()}
+          <button
+            type="button"
+            id="jessie-test"
+            onClick={this.displayShareLink}
+            style={styles.publishButton}
+          >
+            Publish
+          </button>
+          {this.shareLink()}
+        </div>
+      </BaseDialog>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    isOpen: state.libraryShareDialog.isOpen,
+    libraryFunctions: state.libraryShareDialog.libraryFunctions
+  }),
+  dispatch => ({
+    onClose() {
+      dispatch(hideLibraryShareDialog());
+    }
+  })
+)(PublishLibraryDialog);

--- a/apps/src/code-studio/components/PublishLibraryDialog.jsx
+++ b/apps/src/code-studio/components/PublishLibraryDialog.jsx
@@ -102,7 +102,6 @@ class PublishLibraryDialog extends React.Component {
           {this.displayFunctions()}
           <button
             type="button"
-            id="jessie-test"
             onClick={this.displayShareLink}
             style={styles.publishButton}
           >

--- a/apps/src/code-studio/components/PublishLibraryDialog.jsx
+++ b/apps/src/code-studio/components/PublishLibraryDialog.jsx
@@ -40,8 +40,13 @@ class PublishLibraryDialog extends React.Component {
   };
 
   displayFunctions() {
-    if (!this.props.libraryFunctions) {
-      return <div>You have no functions to export :(</div>;
+    if (Object.keys(this.props.libraryFunctions).length === 0) {
+      return (
+        <div>
+          A library can only export functions. Your program does not have any
+          functions to export.
+        </div>
+      );
     }
 
     return Object.keys(this.props.libraryFunctions).map(key => {

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -19,6 +19,7 @@ import PublishDialog from '../../templates/projects/publishDialog/PublishDialog'
 import {createHiddenPrintWindow} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import PublishLibraryDialog from './PublishLibraryDialog';
 
 function recordShare(type) {
   if (!window.dashboard) {
@@ -497,6 +498,7 @@ class ShareAllowedDialog extends React.Component {
           )}
         </BaseDialog>
         <PublishDialog />
+        <PublishLibraryDialog />
       </div>
     );
   }

--- a/apps/src/code-studio/components/ShareAllowedDialog.story.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.story.jsx
@@ -4,6 +4,7 @@ import {action} from '@storybook/addon-actions';
 import publishDialog from '@cdo/apps/templates/projects/publishDialog/publishDialogRedux';
 import pageConstants from '@cdo/apps/redux/pageConstants';
 import shareDialog from '@cdo/apps/code-studio/components/shareDialogRedux';
+import libraryShareDialog from '@cdo/apps/code-studio/components/libraryShareDialogRedux';
 
 const fakei18n = {
   t(s) {
@@ -27,7 +28,12 @@ const fakei18n = {
 export default storybook => {
   storybook
     .storiesOf('ShareAllowedDialog', module)
-    .withReduxStore({publishDialog, pageConstants, shareDialog})
+    .withReduxStore({
+      publishDialog,
+      pageConstants,
+      shareDialog,
+      libraryShareDialog
+    })
     .addStoryTable([
       {
         name: 'basic example',

--- a/apps/src/code-studio/components/libraryShareDialogRedux.js
+++ b/apps/src/code-studio/components/libraryShareDialogRedux.js
@@ -1,11 +1,26 @@
 const SET_LIBRARY_FUNCTIONS = 'libraryShareDialog/SET_LIBRARY_FUNCTIONS';
+const SHOW_LIBRARY_SHARE_DIALOG =
+  'libraryShareDialog/SHOW_LIBRARY_SHARE_DIALOG';
+const HIDE_LIBRARY_SHARE_DIALOG =
+  'libraryShareDialog/HIDE_LIBRARY_SHARE_DIALOG';
 
 export default function reducer(state, action) {
   state = state || {
-    libraryFunctions: {}
+    libraryFunctions: {},
+    isOpen: false
   };
 
   switch (action.type) {
+    case SHOW_LIBRARY_SHARE_DIALOG:
+      return {
+        ...state,
+        isOpen: true
+      };
+    case HIDE_LIBRARY_SHARE_DIALOG:
+      return {
+        ...state,
+        isOpen: false
+      };
     case SET_LIBRARY_FUNCTIONS:
       return {
         ...state,
@@ -14,6 +29,14 @@ export default function reducer(state, action) {
     default:
       return state;
   }
+}
+
+export function showLibraryShareDialog() {
+  return {type: SHOW_LIBRARY_SHARE_DIALOG};
+}
+
+export function hideLibraryShareDialog() {
+  return {type: HIDE_LIBRARY_SHARE_DIALOG};
 }
 
 export function setLibraryFunctions(functions) {

--- a/apps/src/code-studio/components/libraryShareDialogRedux.js
+++ b/apps/src/code-studio/components/libraryShareDialogRedux.js
@@ -3,11 +3,13 @@ const SHOW_LIBRARY_SHARE_DIALOG =
   'libraryShareDialog/SHOW_LIBRARY_SHARE_DIALOG';
 const HIDE_LIBRARY_SHARE_DIALOG =
   'libraryShareDialog/HIDE_LIBRARY_SHARE_DIALOG';
+const SET_LIBRARY_NAME = 'libraryShareDialog/SET_LIBRARY_NAME';
 
 export default function reducer(state, action) {
   state = state || {
     libraryFunctions: {},
-    isOpen: false
+    isOpen: false,
+    libraryName: ''
   };
 
   switch (action.type) {
@@ -26,6 +28,11 @@ export default function reducer(state, action) {
         ...state,
         libraryFunctions: action.libraryFunctions
       };
+    case SET_LIBRARY_NAME:
+      return {
+        ...state,
+        libraryName: action.libraryName
+      };
     default:
       return state;
   }
@@ -43,5 +50,12 @@ export function setLibraryFunctions(functions) {
   return {
     type: SET_LIBRARY_FUNCTIONS,
     libraryFunctions: functions
+  };
+}
+
+export function setLibraryName(name) {
+  return {
+    type: SET_LIBRARY_NAME,
+    libraryName: name
   };
 }

--- a/apps/src/code-studio/components/libraryShareDialogRedux.js
+++ b/apps/src/code-studio/components/libraryShareDialogRedux.js
@@ -5,36 +5,43 @@ const HIDE_LIBRARY_SHARE_DIALOG =
   'libraryShareDialog/HIDE_LIBRARY_SHARE_DIALOG';
 const SET_LIBRARY_NAME = 'libraryShareDialog/SET_LIBRARY_NAME';
 
-export default function reducer(state, action) {
-  state = state || {
-    libraryFunctions: {},
-    isOpen: false,
-    libraryName: ''
-  };
+const initialState = {
+  libraryFunctions: {},
+  isOpen: false,
+  libraryName: ''
+};
 
+export default function reducer(state, action) {
   switch (action.type) {
     case SHOW_LIBRARY_SHARE_DIALOG:
       return {
+        ...initialState,
         ...state,
         isOpen: true
       };
     case HIDE_LIBRARY_SHARE_DIALOG:
       return {
+        ...initialState,
         ...state,
         isOpen: false
       };
     case SET_LIBRARY_FUNCTIONS:
       return {
+        ...initialState,
         ...state,
         libraryFunctions: action.libraryFunctions
       };
     case SET_LIBRARY_NAME:
       return {
+        ...initialState,
         ...state,
         libraryName: action.libraryName
       };
     default:
-      return state;
+      return {
+        ...initialState,
+        ...state
+      };
   }
 }
 

--- a/apps/src/code-studio/components/libraryShareDialogRedux.js
+++ b/apps/src/code-studio/components/libraryShareDialogRedux.js
@@ -1,0 +1,24 @@
+const SET_LIBRARY_FUNCTIONS = 'libraryShareDialog/SET_LIBRARY_FUNCTIONS';
+
+export default function reducer(state, action) {
+  state = state || {
+    libraryFunctions: {}
+  };
+
+  switch (action.type) {
+    case SET_LIBRARY_FUNCTIONS:
+      return {
+        ...state,
+        libraryFunctions: action.libraryFunctions
+      };
+    default:
+      return state;
+  }
+}
+
+export function setLibraryFunctions(functions) {
+  return {
+    type: SET_LIBRARY_FUNCTIONS,
+    libraryFunctions: functions
+  };
+}

--- a/apps/src/code-studio/headerShare.js
+++ b/apps/src/code-studio/headerShare.js
@@ -7,7 +7,10 @@ import ShareDialog from './components/ShareDialog';
 import {Provider} from 'react-redux';
 import {getStore} from '../redux';
 import {showShareDialog} from './components/shareDialogRedux';
-import {setLibraryFunctions} from './components/libraryShareDialogRedux';
+import {
+  setLibraryFunctions,
+  setLibraryName
+} from './components/libraryShareDialogRedux';
 import {AllPublishableProjectTypes} from '../util/sharedConstants';
 import experiments from '@cdo/apps/util/experiments';
 
@@ -18,6 +21,10 @@ export function shareProject(shareUrl) {
       getStore().dispatch(
         setLibraryFunctions(dashboard.project.getLibraryFromApp())
       );
+      var projectName = dashboard.project.getCurrentName().replace(/\s+/g, '');
+      var libraryName =
+        projectName.charAt(0).toUpperCase() + projectName.slice(1);
+      getStore().dispatch(setLibraryName(libraryName));
     }
     var i18n = window.dashboard.i18n;
 

--- a/apps/src/code-studio/headerShare.js
+++ b/apps/src/code-studio/headerShare.js
@@ -21,7 +21,18 @@ export function shareProject(shareUrl) {
       getStore().dispatch(
         setLibraryFunctions(dashboard.project.getLibraryFromApp())
       );
-      var projectName = dashboard.project.getCurrentName().replace(/\s+/g, '');
+
+      // strip whitespace and non alphanumeric characters (underscores are preserved)
+      var projectName = dashboard.project
+        .getCurrentName()
+        .replace(/\s+/g, '')
+        .replace(/\W/g, '');
+      if (projectName.length === 0 || !isNaN(projectName.charAt(0))) {
+        // if all characters are now gone or the library starts with a number, prepend 'Lib'.
+        projectName = 'Lib' + projectName;
+      }
+
+      // Make the first character uppercase
       var libraryName =
         projectName.charAt(0).toUpperCase() + projectName.slice(1);
       getStore().dispatch(setLibraryName(libraryName));

--- a/apps/src/code-studio/headerShare.js
+++ b/apps/src/code-studio/headerShare.js
@@ -7,10 +7,18 @@ import ShareDialog from './components/ShareDialog';
 import {Provider} from 'react-redux';
 import {getStore} from '../redux';
 import {showShareDialog} from './components/shareDialogRedux';
+import {setLibraryFunctions} from './components/libraryShareDialogRedux';
 import {AllPublishableProjectTypes} from '../util/sharedConstants';
+import experiments from '@cdo/apps/util/experiments';
 
 export function shareProject(shareUrl) {
   dashboard.project.saveIfSourcesChanged().then(() => {
+    const appType = dashboard.project.getStandaloneApp();
+    if (appType === 'applab' && experiments.isEnabled('student-libraries')) {
+      getStore().dispatch(
+        setLibraryFunctions(dashboard.project.getLibraryFromApp())
+      );
+    }
     var i18n = window.dashboard.i18n;
 
     var dialogDom = document.getElementById('project-share-dialog');
@@ -20,7 +28,6 @@ export function shareProject(shareUrl) {
       document.body.appendChild(dialogDom);
     }
 
-    const appType = dashboard.project.getStandaloneApp();
     const selectedSong = dashboard.project.getSelectedSong();
 
     // The AgeDialog used by Dance Party stores an 'ad_anon_over13' cookie for signed out users,

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -472,6 +472,9 @@ const sourceHandler = {
   getLevelHtml() {
     return window.Applab && Applab.getHtml();
   },
+  getLibrary() {
+    return getAppOptions().getLibrary();
+  },
   setInitialLevelSource(levelSource) {
     getAppOptions().level.lastAttempt = levelSource;
   },

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1009,6 +1009,13 @@ var projects = (module.exports = {
   },
 
   /**
+   * Asks the sourceHandler for the list of functions in an app
+   */
+  getLibraryFromApp() {
+    return this.sourceHandler.getLibrary();
+  },
+
+  /**
    * Ask the configured sourceHandler for the latest project save data and
    * pass it to the provided callback.
    * @param {function} callback

--- a/apps/src/code-studio/redux.js
+++ b/apps/src/code-studio/redux.js
@@ -8,6 +8,7 @@ import viewAs from './viewAsRedux';
 import shareDialog from './components/shareDialogRedux';
 import hiddenStage from './hiddenStageRedux';
 import isRtl from './isRtlRedux';
+import libraryShareDialog from './components/libraryShareDialogRedux';
 import responsive from './responsiveRedux';
 import publishDialog from '../templates/projects/publishDialog/publishDialogRedux';
 import verifiedTeacher from './verifiedTeacherRedux';
@@ -21,6 +22,7 @@ registerReducers({
   shareDialog,
   hiddenStage,
   isRtl,
+  libraryShareDialog,
   responsive,
   publishDialog,
   verifiedTeacher

--- a/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
@@ -242,6 +242,27 @@ export default class JSInterpreter {
   }
 
   /**
+   * Finds all functions within a section of code and returns on object
+   * representing them and their input parameters.
+   *
+   * @param {string} [code] - a string containing the code to be parsed for functions.
+   */
+  getFunctionsAndParams(code) {
+    this.parse({code: code});
+    var functionsWithParms = {};
+    var functions = this.interpreter.ast.body.filter(obj => {
+      return obj.type === 'FunctionDeclaration';
+    });
+    functions.map(obj => {
+      functionsWithParms[obj.id.name] = obj.params.map(param => {
+        return param.name;
+      });
+    });
+
+    return functionsWithParms;
+  }
+
+  /**
    * Init `this.codeInfo` with cumulative length info (used to locate breakpoints).
    * @param {!Object} options
    * @param {!string} options.code - Code to be executed by the interpreter.


### PR DESCRIPTION
This is the export libraries feature. This does not include the backend component (and therefore export links are stubbed). Additionally, this does not include the import component. This adds a "Library" option to the Share menu, allows you to select which functions you wish to export, and presents you with a link to your new library (this link is not yet populated).

Spec for reference: https://docs.google.com/document/d/1jMLm_ghCshFen-h9vInAuXwEGXI-HPMjSP8dYeISfM0/edit?pli=1#

This code is largely experimental. If we go forward with Student Libraries, all code here will go through a second CR for production quality review. Review this PR to evaluate the following:
- Isolation: Will the reviewed code affect parts of the product that are not part of the pilot?
- Will the code fail in ways that will cause the pilot to be unsuccessful?
- Is there an obviously easier or better way to implement the piloted feature?

Although the piloting process is still under review, I am following the procedures in this doc: https://docs.google.com/document/d/10QvRAVOTEenFJa1wwrY0Twkd0anTDpkkzNeGnT_HH0o/edit 