### PR TITLE
PL: Second fix for multi-select in JotForm survey results

### DIFF
--- a/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
+++ b/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
@@ -457,6 +457,8 @@ module Pd::WorkshopSurveyResultsHelper
         histogram_for_all_my_workshops = (question_group[:all_ids] || [question_group[:primary_id]]).map {|x| flattened_all_my_workshop_histograms[x]}.compact.first
         histogram_for_all_my_workshops = histogram_for_all_my_workshops.try(:[], facilitator) || histogram_for_all_my_workshops
 
+        histogram_for_all_my_workshops.except!("num_respondents") if histogram_for_all_my_workshops
+
         # Now that we have the histogram, the average is just the sum of option values
         # divided by the total number of responses for this particular question
         total_responses_for_this_workshop = histogram_for_this_workshop.values.reduce(:+) || 0

--- a/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
+++ b/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
@@ -457,6 +457,8 @@ module Pd::WorkshopSurveyResultsHelper
         histogram_for_all_my_workshops = (question_group[:all_ids] || [question_group[:primary_id]]).map {|x| flattened_all_my_workshop_histograms[x]}.compact.first
         histogram_for_all_my_workshops = histogram_for_all_my_workshops.try(:[], facilitator) || histogram_for_all_my_workshops
 
+        # Similar to above, clear the num_respondent entry that is alongside
+        # the answer entries.
         histogram_for_all_my_workshops.except!("num_respondents") if histogram_for_all_my_workshops
 
         # Now that we have the histogram, the average is just the sum of option values

--- a/dashboard/test/helpers/pd/workshop_survey_results_helper_test.rb
+++ b/dashboard/test/helpers/pd/workshop_survey_results_helper_test.rb
@@ -879,7 +879,8 @@ class Pd::WorkshopSurveyResultsHelperTest < ActionView::TestCase
               'Quite a bit' => 9,
               'Some' => 8,
               'A little bit' => 7,
-              'Almost nothing' => 1
+              'Almost nothing' => 1,
+              'num_respondents' => 2  # This should get filtered out.
             }
           },
           facilitator: {


### PR DESCRIPTION
This is the same fix as https://github.com/code-dot-org/code-dot-org/pull/28531 but for the averages generated for all of a facilitator's workshops.