### PR TITLE
Pilot (Student Libraries): Create the UI for importing shared libraries

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -74,6 +74,7 @@ import header from '../code-studio/header';
 import {TestResults, ResultType} from '../constants';
 import i18n from '../code-studio/i18n';
 import {generateExpoApk} from '../util/exporter';
+import sampleApplabLibrary from '../code-studio/sampleApplabLibrary.json';
 
 /**
  * Create a namespace for the application.
@@ -671,6 +672,18 @@ Applab.init = function(config) {
     });
   }
 
+  if (experiments.isEnabled('student-libraries')) {
+    let importedConfigs = sampleApplabLibrary.libraries
+      .map(library => library.dropletConfig)
+      .reduce((a, b) => a.concat(b));
+    if (importedConfigs) {
+      Object.keys(importedConfigs).map(key => {
+        config.dropletConfig.blocks.push(importedConfigs[key]);
+        level.codeFunctions[importedConfigs[key].func] = null;
+      });
+    }
+  }
+
   // Set the custom set of blocks (may have had maker blocks merged in) so
   // we can later pass the custom set to the interpreter.
   config.level.levelBlocks = config.dropletConfig.blocks;
@@ -1130,6 +1143,26 @@ Applab.execute = function() {
       jsInterpreterLogger.attachTo(Applab.JSInterpreter);
     }
     getStore().dispatch(jsDebugger.attach(Applab.JSInterpreter));
+
+    // Set up student-created libraries
+    if (experiments.isEnabled('student-libraries')) {
+      sampleApplabLibrary.libraries.map(library => {
+        var functionNames = library.functionNames
+          .map(name => {
+            return name + ': ' + name;
+          })
+          .join(',');
+        var libraryClosure =
+          'var ' +
+          library.name +
+          ' = (function() {\n' +
+          library.source +
+          '\nreturn {' +
+          functionNames +
+          '};})();';
+        codeWhenRun = libraryClosure + codeWhenRun;
+      });
+    }
 
     // Initialize the interpreter and parse the student code
     Applab.JSInterpreter.parse({

--- a/apps/src/code-studio/assets/show.js
+++ b/apps/src/code-studio/assets/show.js
@@ -5,6 +5,7 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var ImagePicker = require('../components/ImagePicker');
 var SoundPicker = require('../components/SoundPicker');
+var LibraryPicker = require('../components/LibraryPicker');
 var DatasetPicker = require('../components/DatasetPicker');
 var Dialog = require('../LegacyDialog');
 
@@ -46,6 +47,7 @@ module.exports = function showAssetManager(
     const pickersByType = {
       audio: SoundPicker,
       image: ImagePicker,
+      library: LibraryPicker,
       dataset: DatasetPicker,
       default: ImagePicker
     };

--- a/apps/src/code-studio/components/LibraryPicker.jsx
+++ b/apps/src/code-studio/components/LibraryPicker.jsx
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import BaseDialog from '../../templates/BaseDialog';
+import color from '../../util/color';
+
+const styles = {
+  root: {
+    margin: '10px',
+    textAlign: 'left'
+  },
+  addButton: {
+    color: color.white,
+    backgroundColor: color.orange,
+    position: 'absolute',
+    right: 0,
+    bottom: 0,
+    margin: 10
+  },
+  text: {
+    fontSize: 'inherit',
+    color: color.dark_charcoal
+  },
+  linkBox: {
+    cursor: 'auto',
+    width: '600px',
+    height: '32px',
+    marginBottom: 0
+  }
+};
+
+export default class LibraryPicker extends React.Component {
+  static propTypes = {
+    onClose: PropTypes.func,
+    isOpen: PropTypes.bool
+  };
+
+  select = event => event.target.select();
+
+  shareLink() {
+    return (
+      <div>
+        <p style={styles.text}>
+          Paste in the library link for a project to add its functions in your
+          toolbox.
+        </p>
+        <input type="text" onClick={this.select} style={styles.linkBox} />
+      </div>
+    );
+  }
+
+  addLibrary = () => {
+    console.log('Added your library!');
+    this.props.onClose();
+  };
+
+  render() {
+    return (
+      <BaseDialog
+        isOpen={this.props.isOpen}
+        handleClose={this.props.onClose}
+        useUpdatedStyles
+      >
+        <div className="modal-content" style={styles.root}>
+          <p className="dialog-title">Manage Libraries</p>
+          {this.shareLink()}
+          <button
+            onClick={this.addLibrary}
+            style={styles.addButton}
+            type="button"
+          >
+            Add
+          </button>
+        </div>
+      </BaseDialog>
+    );
+  }
+}

--- a/apps/src/code-studio/sampleApplabLibrary.json
+++ b/apps/src/code-studio/sampleApplabLibrary.json
@@ -1,0 +1,38 @@
+{
+  "libraries": [
+    {
+      "name": "mySampleLibrary",
+      "functionNames": ["publicMethod1", "myFunction", "coolFunc"],
+      "dropletConfig": [
+        {
+          "func": "mySampleLibrary.publicMethod1",
+          "category": "Functions"
+        },
+        {
+          "func": "mySampleLibrary.myFunction",
+          "category": "Functions",
+          "paletteParams": ["one", "two"],
+          "params": ["one", "two"]
+        },
+        {
+          "func": "mySampleLibrary.coolFunc",
+          "category": "Functions"
+        }
+      ],
+      "source": "console.log(\"message\");\nfunction myFunction(foo,bar) {\n  console.log(foo);\n  console.log(bar);\n}\n \nmyFunction(\"one\",\"two\")\n \nvar test = function(baz) {\n  console.log(baz); \n}\nmyFunction(\"three\")\n\nfunction coolFunc() {\n  console.log(\"cool\")\n}\n\n//If there is code that is outside a function definition inside the library, \n//it will still be run. So when this library is initialized, this\n//console log still gets executed once:\nconsole.log(\"this is not inside a function, it is just at the top-level of the library\");\n\n//even though this is not exported, methods inside RyansLibrary can access it\n//This can't be accessed outside RyansLibrary\nvar thisIsAPrivateVariable=100;\n\n//this method will run if the consuming program calls it\nfunction publicMethod1() {\n  console.log(\"this is a public method. The internal variable is: \"+thisIsAPrivateVariable);\n}\n  \n//this method was not exported, but can be accessed within RyansLibrary\nfunction privateHelper() {\n  console.log(\"this is private!\");\n}\nonEvent(\"button1\", \"click\", function( ) {\n  var text = getProperty(\"text_area1\", \"text\")\n  console.log(text);\nconsole.log(JSON.stringify(text));\n  \n});\n"
+    },
+    {
+      "name": "sample2",
+      "functionNames": ["myFunc2"],
+      "dropletConfig": [
+        {
+          "func": "sample2.myFunc2",
+          "category": "Functions",
+          "paletteParams": ["\"one\"", "\"two\""],
+          "params": ["\"one\"", "\"two\""]
+        }
+      ],
+      "source": "function myFunc2(foo,bar) {\n  console.log(foo);\n  console.log(bar);\n}"
+    }
+  ]
+}

--- a/apps/src/lib/ui/SettingsCog.jsx
+++ b/apps/src/lib/ui/SettingsCog.jsx
@@ -12,6 +12,8 @@ import * as makerToolkitRedux from '../kits/maker/redux';
 import PopUpMenu from './PopUpMenu';
 import ConfirmEnableMakerDialog from './ConfirmEnableMakerDialog';
 import {getStore} from '../../redux';
+import experiments from '@cdo/apps/util/experiments';
+import LibraryPicker from '../../code-studio/components/LibraryPicker';
 
 const style = {
   iconContainer: {
@@ -42,7 +44,8 @@ class SettingsCog extends Component {
   static propTypes = {
     isRunning: PropTypes.bool,
     runModeIndicators: PropTypes.bool,
-    showMakerToggle: PropTypes.bool
+    showMakerToggle: PropTypes.bool,
+    openLibraryPicker: PropTypes.func
   };
 
   // This ugly two-flag state is a workaround for an event-handling bug in
@@ -53,7 +56,8 @@ class SettingsCog extends Component {
   state = {
     open: false,
     canOpen: true,
-    confirmingEnableMaker: false
+    confirmingEnableMaker: false,
+    libraryPickerOpen: false
   };
 
   open = () => this.setState({open: true, canOpen: false});
@@ -68,6 +72,15 @@ class SettingsCog extends Component {
   manageAssets = () => {
     this.close();
     assets.showAssetManager();
+  };
+
+  openLibraryPicker = () => {
+    this.close();
+    this.setState({libraryPickerOpen: true});
+  };
+
+  closeLibraryPicker = () => {
+    this.setState({libraryPickerOpen: false});
   };
 
   toggleMakerToolkit = () => {
@@ -129,6 +142,9 @@ class SettingsCog extends Component {
           showTail={true}
         >
           <ManageAssets onClick={this.manageAssets} />
+          {experiments.isEnabled('student-libraries') && (
+            <ManageLibraries onClick={this.openLibraryPicker} />
+          )}
           {this.props.showMakerToggle && (
             <ToggleMaker onClick={this.toggleMakerToolkit} />
           )}
@@ -137,6 +153,10 @@ class SettingsCog extends Component {
           isOpen={this.state.confirmingEnableMaker}
           handleConfirm={this.confirmEnableMaker}
           handleCancel={this.hideConfirmation}
+        />
+        <LibraryPicker
+          isOpen={this.state.libraryPickerOpen}
+          onClose={this.closeLibraryPicker}
         />
       </span>
     );
@@ -152,6 +172,10 @@ ManageAssets.propTypes = {
   first: PropTypes.bool,
   last: PropTypes.bool
 };
+
+export function ManageLibraries(props) {
+  return <PopUpMenu.Item {...props}>Manage Libraries</PopUpMenu.Item>;
+}
 
 export function ToggleMaker(props) {
   const reduxState = getStore().getState();


### PR DESCRIPTION
This is the import portion of the libraries feature. This does not include the backend component (and therefore import links are stubbed). Additionally, this does not include the export component. This adds a "Manage Libraries" option to the Manage Assets menu, allows you to paste a link to a library you wish to import, and adds the functions in those libraries to the toolbox. The functions are then usable in your project. Since the backend component is not yet implemented, the library that is added is a sample of what a student created library might look like.
![addLibrary](https://user-images.githubusercontent.com/8324574/58125779-3ede2e00-7bc6-11e9-97d4-f7950edede30.gif)


Spec for reference: https://docs.google.com/document/d/1jMLm_ghCshFen-h9vInAuXwEGXI-HPMjSP8dYeISfM0/edit?pli=1#

This code is largely experimental. If we go forward with Student Libraries, all code here will go through a second CR for production quality review. Review this PR to evaluate the following:

Isolation: Will the reviewed code affect parts of the product that are not part of the pilot?
Will the code fail in ways that will cause the pilot to be unsuccessful?
Is there an obviously easier or better way to implement the piloted feature?
Although the piloting process is still under review, I am following the procedures in this doc: https://docs.google.com/document/d/10QvRAVOTEenFJa1wwrY0Twkd0anTDpkkzNeGnT_HH0o/edit