### PR TITLE
Fix connect to MS account

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -93,7 +93,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         oauth_refresh_token: auth_hash.credentials.refresh_token
       }.to_json
     end
-    email = auth_hash.info.email
+    email = auth_hash.info.email || ""
     hashed_email = nil
     hashed_email = User.hash_email(email) unless email.blank?
     auth_option = AuthenticationOption.new(


### PR DESCRIPTION
The auth_hash info response upon linking to a microsoft account doesn't
include email info, so as currently implemented we attempt to create an
AuthenticationOption with a `nil` email value, which is invalid; we
expect AOs without emails to use an empty string instead.

TODO (after merging): take down the `fix-connect-to-ms-account` adhoc and the "Code.org - Temporary Testing" azure application