### PR TITLE
Add curriculum_umbrella property to scripts 

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -29,7 +29,7 @@ const styles = {
 
 const VIDEO_KEY_REGEX = /video_key_for_next_level/g;
 
-const CURRICULUM_UMBRELLAS = ['CSF', 'CSD', 'CSP'];
+const CURRICULUM_UMBRELLAS = ['', 'CSF', 'CSD', 'CSP'];
 
 /**
  * Component for editing course scripts.
@@ -145,7 +145,12 @@ export default class ScriptEditor extends React.Component {
         <h2>Basic Settings</h2>
         <label>
           Is this script part of one of the core courses?
-          <select style={{marginLeft: 20}}>
+          <select
+            name="curriculum_umbrella"
+            style={{marginLeft: 20}}
+            defaultValue={this.props.curriculumUmbrella}
+            ref={select => (this.curriculumUmbrellaSelect = select)}
+          >
             {CURRICULUM_UMBRELLAS.map(curriculumUmbrella => (
               <option value={curriculumUmbrella}>{curriculumUmbrella}</option>
             ))}

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -29,6 +29,8 @@ const styles = {
 
 const VIDEO_KEY_REGEX = /video_key_for_next_level/g;
 
+const CURRICULUM_UMBRELLAS = ['CSF', 'CSD', 'CSP'];
+
 /**
  * Component for editing course scripts.
  */
@@ -56,7 +58,8 @@ export default class ScriptEditor extends React.Component {
     announcements: PropTypes.arrayOf(announcementShape),
     supportedLocales: PropTypes.arrayOf(PropTypes.string),
     locales: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
-    projectSharing: PropTypes.bool
+    projectSharing: PropTypes.bool,
+    curriculumUmbrella: PropTypes.oneOf(CURRICULUM_UMBRELLAS)
   };
 
   handleClearProjectWidgetSelectClick = () => {
@@ -140,6 +143,18 @@ export default class ScriptEditor extends React.Component {
           inputStyle={styles.input}
         />
         <h2>Basic Settings</h2>
+        <label>
+          Is this script part of one of the core courses?
+          <select style={{marginLeft: 20}}>
+            {CURRICULUM_UMBRELLAS.map(curriculumUmbrella => (
+              <option value={curriculumUmbrella}>{curriculumUmbrella}</option>
+            ))}
+          </select>
+          <p>
+            By selecting one of the above, this script will have a property,
+            curriculum_umbrella, specific to that course regardless of version.
+          </p>
+        </label>
         <label>
           Visible in Teacher Dashboard
           <input

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -152,7 +152,9 @@ export default class ScriptEditor extends React.Component {
             ref={select => (this.curriculumUmbrellaSelect = select)}
           >
             {CURRICULUM_UMBRELLAS.map(curriculumUmbrella => (
-              <option value={curriculumUmbrella}>{curriculumUmbrella}</option>
+              <option key={curriculumUmbrella} value={curriculumUmbrella}>
+                {curriculumUmbrella}
+              </option>
             ))}
           </select>
           <p>

--- a/apps/src/sites/studio/pages/levelbuilder_edit_script.js
+++ b/apps/src/sites/studio/pages/levelbuilder_edit_script.js
@@ -48,6 +48,7 @@ export default function initPage(scriptEditorData) {
         supportedLocales={scriptData.supported_locales}
         locales={locales}
         projectSharing={scriptData.project_sharing}
+        curriculumUmbrella={scriptData.curriculum_umbrella}
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -141,6 +141,7 @@ class ScriptsController < ApplicationController
   def general_params
     h = params.permit(
       :visible_to_teachers,
+      :curriculum_umbrella,
       :project_sharing,
       :login_required,
       :hideable_stages,

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -32,6 +32,7 @@ class ScriptDSL < BaseDSL
     @supported_locales = []
     @pilot_experiment = nil
     @project_sharing = nil
+    @curriculum_umbrella = nil
   end
 
   integer :id
@@ -57,6 +58,7 @@ class ScriptDSL < BaseDSL
   string :version_year
   string :curriculum_path
   string :pilot_experiment
+  string :curriculum_umbrella
 
   def teacher_resources(resources)
     @teacher_resources = resources
@@ -118,7 +120,8 @@ class ScriptDSL < BaseDSL
       is_stable: @is_stable,
       supported_locales: @supported_locales,
       pilot_experiment: @pilot_experiment,
-      project_sharing: @project_sharing
+      project_sharing: @project_sharing,
+      curriculum_umbrella: @curriculum_umbrella
     }
   end
 
@@ -295,6 +298,7 @@ class ScriptDSL < BaseDSL
     s << "supported_locales #{script.supported_locales}" if script.supported_locales
     s << "pilot_experiment '#{script.pilot_experiment}'" if script.pilot_experiment
     s << 'project_sharing true' if script.project_sharing
+    s << "curriculum_umbrella '#{script.curriculum_umbrella}'" if script.curriculum_umbrella
 
     s << '' unless s.empty?
     s << serialize_stages(script)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1626,16 +1626,4 @@ class Script < ActiveRecord::Base
     return true if user.permission?(UserPermission::LEVELBUILDER)
     all_scripts.any? {|script| script.has_pilot_experiment?(user)}
   end
-
-  def csf?
-    return true if curriculum_umbrella == 'CSF'
-  end
-
-  def csd?
-    return true if curriculum_umbrella == 'CSD'
-  end
-
-  def csp?
-    return true if curriculum_umbrella == 'CSP'
-  end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1324,7 +1324,8 @@ class Script < ActiveRecord::Base
       section_hidden_unit_info: section_hidden_unit_info(user),
       pilot_experiment: pilot_experiment,
       show_assign_button: assignable?(user),
-      project_sharing: project_sharing
+      project_sharing: project_sharing,
+      curriculum_umbrella: curriculum_umbrella
     }
 
     summary[:stages] = stages.map {|stage| stage.summarize(include_bonus_levels)} if include_stages
@@ -1460,7 +1461,8 @@ class Script < ActiveRecord::Base
       is_stable: script_data[:is_stable],
       supported_locales: script_data[:supported_locales],
       pilot_experiment: script_data[:pilot_experiment],
-      project_sharing: !!script_data[:project_sharing]
+      project_sharing: !!script_data[:project_sharing],
+      curriculum_umbrella: script_data[:curriculum_umbrella]
     }.compact
   end
 
@@ -1622,5 +1624,17 @@ class Script < ActiveRecord::Base
     return false unless user&.teacher?
     return true if user.permission?(UserPermission::LEVELBUILDER)
     all_scripts.any? {|script| script.has_pilot_experiment?(user)}
+  end
+
+  def csf?
+    return true if curriculum_umbrella == 'CSF'
+  end
+
+  def csd?
+    return true if curriculum_umbrella == 'CSD'
+  end
+
+  def csp?
+    return true if curriculum_umbrella == 'CSP'
   end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -148,6 +148,7 @@ class Script < ActiveRecord::Base
     supported_locales
     pilot_experiment
     project_sharing
+    curriculum_umbrella
   )
 
   def self.twenty_hour_script

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -252,6 +252,7 @@ class ScriptsControllerTest < ActionController::TestCase
       hideable_stages true
       wrapup_video 'hoc_wrapup'
       project_sharing true
+      curriculum_umbrella 'CSP'
 
     TEXT
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
@@ -266,7 +267,8 @@ class ScriptsControllerTest < ActionController::TestCase
       login_required: true,
       hideable_stages: true,
       wrapup_video: 'hoc_wrapup',
-      project_sharing: 'on'
+      project_sharing: 'on',
+      curriculum_umbrella: 'CSP'
     }
     assert_redirected_to script_path id: 'test-script-create'
 
@@ -276,6 +278,7 @@ class ScriptsControllerTest < ActionController::TestCase
     assert script.login_required
     assert script.hideable_stages
     assert script.project_sharing
+    asser script.curriculum_umbrella
   end
 
   test 'destroy raises exception for evil filenames' do
@@ -375,6 +378,30 @@ class ScriptsControllerTest < ActionController::TestCase
       script_text: ''
     }
     refute Script.find_by_name(script.name).project_sharing
+  end
+
+  test 'updates curriculum_umbrella' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    script = create :script
+    File.stubs(:write).with {|filename, _| filename == "config/scripts/#{script.name}.script" || filename.end_with?('scripts.en.yml')}
+
+    assert_nil Script.find_by_name(script.name).curriculum_umbrella
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: '',
+      curriculum_umbrella: 'CSF'
+    }
+    assert_equal Script.find_by_name(script.name).curriculum_umbrella, 'CSF'
+
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: ''
+    }
+    refute Script.find_by_name(script.name).curriculum_umbrella
   end
 
   no_access_msg = "You don&#39;t have access to this unit."

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -399,7 +399,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: script.id,
       script: {name: script.name},
-      script_text: ''
+      script_text: '',
+      curriculum_umbrella: ''
     }
     refute Script.find_by_name(script.name).curriculum_umbrella
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -278,7 +278,7 @@ class ScriptsControllerTest < ActionController::TestCase
     assert script.login_required
     assert script.hideable_stages
     assert script.project_sharing
-    asser script.curriculum_umbrella
+    assert_equal "CSP", script.curriculum_umbrella
   end
 
   test 'destroy raises exception for evil filenames' do

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -648,6 +648,7 @@ SCRIPT
     expected = <<-SCRIPT
 hidden false
 curriculum_umbrella 'CSP'
+
 SCRIPT
 
     assert_equal expected, script_text

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -648,10 +648,41 @@ SCRIPT
     expected = <<-SCRIPT
 hidden false
 curriculum_umbrella 'CSP'
-
 SCRIPT
 
     assert_equal expected, script_text
+  end
+
+  test 'Script DSL with new_name, family_name, version_year and is_stable' do
+    input_dsl = <<DSL
+new_name 'new name'
+family_name 'family name'
+version_year '3035'
+is_stable true
+stage 'Stage1'
+level 'Level 1'
+level 'Level 2'
+DSL
+    expected = DEFAULT_PROPS.merge(
+      {
+        new_name: "new name",
+        family_name: "family name",
+        version_year: "3035",
+        is_stable: true,
+        stages: [
+          {
+            stage: "Stage1",
+            scriptlevels: [
+              {stage: "Stage1", levels: [{name: "Level 1"}]},
+              {stage: "Stage1", levels: [{name: "Level 2"}]},
+            ]
+          }
+        ]
+      }
+    )
+
+    output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    assert_equal expected, output
   end
 
   test 'serialize new_name, family_name, version_year and is_stable' do

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -33,6 +33,7 @@ class DslTest < ActiveSupport::TestCase
     supported_locales: [],
     pilot_experiment: nil,
     project_sharing: nil,
+    curriculum_umbrella: nil
   }
 
   test 'test Script DSL' do
@@ -628,36 +629,29 @@ SCRIPT
     assert_equal expected, script_text
   end
 
-  test 'Script DSL with new_name, family_name, version_year and is_stable' do
-    input_dsl = <<DSL
-new_name 'new name'
-family_name 'family name'
-version_year '3035'
-is_stable true
-stage 'Stage1'
-level 'Level 1'
-level 'Level 2'
-DSL
+  test 'Script DSL with curriculum_umbrella' do
+    input_dsl = "curriculum_umbrella 'CSF'"
     expected = DEFAULT_PROPS.merge(
       {
-        new_name: "new name",
-        family_name: "family name",
-        version_year: "3035",
-        is_stable: true,
-        stages: [
-          {
-            stage: "Stage1",
-            scriptlevels: [
-              {stage: "Stage1", levels: [{name: "Level 1"}]},
-              {stage: "Stage1", levels: [{name: "Level 2"}]},
-            ]
-          }
-        ]
+        stages: [],
+        curriculum_umbrella: 'CSF'
       }
     )
 
     output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
     assert_equal expected, output
+  end
+
+  test 'serialize curriculum_umbrella' do
+    script = create :script, curriculum_umbrella: 'CSP'
+    script_text = ScriptDSL.serialize_to_string(script)
+    expected = <<-SCRIPT
+hidden false
+curriculum_umbrella 'CSP'
+
+SCRIPT
+
+    assert_equal expected, script_text
   end
 
   test 'serialize new_name, family_name, version_year and is_stable' do


### PR DESCRIPTION
Work for: [LP-386](https://codedotorg.atlassian.net/browse/LP-386)

This PR adds the ability for Levelbuilders to add a new property, `curriculum_umbrella` to a script that currently can be set to nil, 'CSF', 'CSD' or 'CSP'.  This property will allow us to more easily reference any script that is part of one of these curricula regardless of version year, which means less code to maintain and update, such as [hardcoded lists of CSF scripts](https://github.com/code-dot-org/code-dot-org/blob/3cea1f1ff168e5b0ef294befe337819acf69f58c/lib/cdo/script_config.rb#L28),  when we switch versions. 

![curriculum_umbrella_dropdown](https://user-images.githubusercontent.com/12300669/58133197-2840d280-7bd8-11e9-8ad3-48dbdacd78e6.gif)

Naming things is tricky, especially as it relates to scripts/courses, in part because we have different names across the org for the same concept. Here's a [handy summary of current course terminology](https://docs.google.com/spreadsheets/d/1naiSH_RfWw-RijhbWKy4ZwNOctZBtd2Cm7RegL0bPdY/edit#gid=0). 

 I selected `curriculum_umbrella` because I think: 
1.) it avoids continued overloading/confusion with the word "course" 
2.) umbrella immediately denotes that this is a large, catchall category 
3.) it directly references curriculum, which is how the curriculum team refers to CSF/CSD/CSP and this new term will be used in the context of Levelbuilder, which is their tool 
4.) it's big enough and fresh enough that in could, in the future, hold CSX, or some other not-yet-invented "chunk" of content.