### PR TITLE
Process survey responses for individual facilitators and post-course surveys

### DIFF
--- a/bin/cron/process_jotform_data
+++ b/bin/cron/process_jotform_data
@@ -5,6 +5,12 @@ require 'cdo/only_one'
 
 TIME_NOW = DateTime.now.strftime('%F %T').freeze
 
+JOTFORM_SURVEY_RESPONSE_CLASSES = [
+  Pd::WorkshopDailySurvey,
+  Pd::WorkshopFacilitatorDailySurvey,
+  Pd::PostCourseSurvey
+]
+
 # @param unsanitized [String, nil] the unsanitized string
 # @returns [String, nil] the sanitized version of the string, with newlines stripped and double
 #   quotations escaped. Returns nil on nil input.
@@ -36,20 +42,23 @@ def main
   # Get list of hashes containing responses to survey questions.
   # One row per question answered.
   survey_answers = []
-  Pd::WorkshopDailySurvey.find_each do |submission|
-    answers = submission.form_data_hash
-    answers.each do |question_key, answer_value|
-      survey_answers << {
-        user_id: submission.user_id,
-        form_id: submission.form_id,
-        submission_id: submission.submission_id,
-        question_id: question_key,
-        answer_value:  sanitize_string_for_db(answer_value.to_s)
-      }
+
+  JOTFORM_SURVEY_RESPONSE_CLASSES.each do |jotform_survey_response_class|
+    jotform_survey_response_class.find_each do |submission|
+      answers = submission.form_data_hash
+      answers.each do |question_key, answer_value|
+        survey_answers << {
+          user_id: submission.user_id,
+          form_id: submission.form_id,
+          submission_id: submission.submission_id,
+          question_id: question_key,
+          answer_value:  sanitize_string_for_db(answer_value.to_s)
+        }
+      end
     end
   end
 
-  raise "processed_answers too big: #{survey_answers.size} rows exceeds limit of 100,000,000" if survey_answers.size > 100_000_000
+  raise "processed_answers too big: #{survey_answers.size} rows exceeds limit of 10,000,000" if survey_answers.size > 10_000_000
   raise "processed_surveys too big: #{survey_questions.size} rows exceeds limit of 10,000" if survey_questions.size > 10_000
 
   # Truncate the existing tables.

--- a/bin/cron/process_jotform_data
+++ b/bin/cron/process_jotform_data
@@ -122,6 +122,10 @@ def main
       # one row per question answered
       survey_answers = []
       submissions.each do |submission|
+        # skipping blank submissions
+        if submission.answers == "{}"
+          next
+        end
         answers = submission.form_data_hash
         answers.each do |question_key, answer_value|
           survey_answers << {

--- a/bin/cron/process_jotform_data
+++ b/bin/cron/process_jotform_data
@@ -19,59 +19,7 @@ def sanitize_string_for_db(unsanitized)
   unsanitized.gsub(/[\r\n]+/, '').gsub(/"/, '\"')
 end
 
-def main
-  # Get list of hashes containing survey questions themselves.
-  # One hash per question.
-  survey_questions = []
-  Pd::SurveyQuestion.find_each do |survey|
-    survey.summarize.each do |key, value|
-      row = {
-        form_id: survey.form_id,
-        question_id: key.to_s,
-        preamble: (value.key?(:parent) ? sanitize_string_for_db(survey[value[:parent]].text) : nil),
-        question_text: sanitize_string_for_db(value[:text]),
-        answer_type: value[:answer_type],
-        answer_options: sanitize_string_for_db(value[:options].to_s),
-        min_value: value[:min_value].to_i,
-        max_value: value[:max_value].to_i
-      }
-      survey_questions << row
-    end
-  end
-
-  # Get list of hashes containing responses to survey questions.
-  # One row per question answered.
-  survey_answers = []
-
-  JOTFORM_SURVEY_RESPONSE_CLASSES.each do |jotform_survey_response_class|
-    jotform_survey_response_class.find_each do |submission|
-      answers = submission.form_data_hash
-      answers.each do |question_key, answer_value|
-        survey_answers << {
-          user_id: submission.user_id,
-          form_id: submission.form_id,
-          submission_id: submission.submission_id,
-          question_id: question_key,
-          answer_value:  sanitize_string_for_db(answer_value.to_s)
-        }
-      end
-    end
-  end
-
-  raise "processed_answers too big: #{survey_answers.size} rows exceeds limit of 10,000,000" if survey_answers.size > 10_000_000
-  raise "processed_surveys too big: #{survey_questions.size} rows exceeds limit of 10,000" if survey_questions.size > 10_000
-
-  # Truncate the existing tables.
-  %w(
-    survey_answers
-    survey_questions
-  ).each do |table_name|
-    ActiveRecord::Base.connection.execute(
-      "TRUNCATE #{table_name}"
-    )
-  end
-
-  # Write the data to the DB tables.
+def insert_survey_answers(survey_answers)
   ActiveRecord::Base.transaction do
     survey_answers.each do |survey_answer_row|
       ActiveRecord::Base.connection.execute(
@@ -98,7 +46,9 @@ SQL
       )
     end
   end
+end
 
+def insert_survey_questions(survey_questions)
   ActiveRecord::Base.transaction do
     survey_questions.each do |survey_question_row|
       ActiveRecord::Base.connection.execute(
@@ -129,6 +79,61 @@ SQL
           )
 SQL
       )
+    end
+  end
+end
+
+def main
+  # Truncate the existing tables.
+  %w(
+    survey_questions
+    survey_answers
+  ).each do |table_name|
+    ActiveRecord::Base.connection.execute(
+      "TRUNCATE #{table_name}"
+    )
+  end
+
+  # Get list of hashes containing survey questions themselves.
+  # One hash per question.
+  survey_questions = []
+  Pd::SurveyQuestion.find_each do |survey|
+    survey.summarize.each do |key, value|
+      row = {
+        form_id: survey.form_id,
+        question_id: key.to_s,
+        preamble: (value.key?(:parent) ? sanitize_string_for_db(survey[value[:parent]].text) : nil),
+        question_text: sanitize_string_for_db(value[:text]),
+        answer_type: value[:answer_type],
+        answer_options: sanitize_string_for_db(value[:options].to_s),
+        min_value: value[:min_value].to_i,
+        max_value: value[:max_value].to_i
+      }
+      survey_questions << row
+    end
+  end
+  insert_survey_questions(survey_questions)
+
+  JOTFORM_SURVEY_RESPONSE_CLASSES.each do |jotform_survey_response_class|
+    # using find_in_batches as it allows to do writes after each batch,
+    # whereas find_each does not
+    jotform_survey_response_class.find_in_batches(batch_size: 1000) do |submissions|
+      # get list of hashes containing survey answers
+      # one row per question answered
+      survey_answers = []
+      submissions.each do |submission|
+        answers = submission.form_data_hash
+        answers.each do |question_key, answer_value|
+          survey_answers << {
+            user_id: submission.user_id,
+            form_id: submission.form_id,
+            submission_id: submission.submission_id,
+            question_id: question_key,
+            answer_value:  sanitize_string_for_db(answer_value.to_s)
+          }
+        end
+      end
+      insert_survey_answers(survey_answers)
     end
   end
 end


### PR DESCRIPTION
Modifies existing script that reshapes Jotform data for analysis to do the same for other models that contain Jotform data (`PdPostCourseSurvey` and `PdWorkshopDailySurvey`).

Realized during this process that even with just data collected via the `PdWorkshopDailySurvey` model (which I downloaded to my local DB), I'm filling up more than 1 GB of my memory during this process. This will just get even bigger with the addition of these new models and another summer of surveys conducted.

As a result, it probably needs to be modified to only append new rows (instead of putting all data into an array in memory). Thoughts on easiest way to do this? Thinking I take advantage of active record's `find_each`, which already batches records -- maybe I can move the write portion of this into each iteration of `find_each`?