### PR TITLE
Script family cache

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -29,8 +29,7 @@ class ScriptLevelsController < ApplicationController
 
   # Return true if request is one that can be publicly cached.
   def self.cachable_request?(request)
-    script_id = request.params[:script_id]
-    script = Script.get_from_cache(script_id) if script_id
+    script = ScriptLevelsController.get_script(request)
     script && ScriptConfig.allows_public_caching_for_script(script.name) &&
       !ScriptConfig.uncached_script_level_path?(request.path)
   end
@@ -59,7 +58,8 @@ class ScriptLevelsController < ApplicationController
 
   def next
     authorize! :read, ScriptLevel
-    set_script
+    @script = ScriptLevelsController.get_script(request)
+
     if @script.redirect_to?
       redirect_to "/s/#{@script.redirect_to}/next"
       return
@@ -77,7 +77,7 @@ class ScriptLevelsController < ApplicationController
   def show
     @current_user = current_user && User.includes(:teachers).where(id: current_user.id).first
     authorize! :read, ScriptLevel
-    set_script(version_year: DEFAULT_VERSION_YEAR)
+    @script = ScriptLevelsController.get_script(request, version_year: DEFAULT_VERSION_YEAR)
 
     # Redirect to the same script level within @script.redirect_to.
     # There are too many variations of the script level path to use
@@ -226,6 +226,16 @@ class ScriptLevelsController < ApplicationController
       end
 
     render json: stage.summary_for_lesson_plans
+  end
+
+  def self.get_script(request, version_year: nil)
+    script_id = request.params[:script_id]
+    script = ScriptConstants::FAMILY_NAMES.include?(script_id) ?
+      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale) :
+      Script.get_from_cache(script_id, version_year: version_year)
+
+    raise ActiveRecord::RecordNotFound unless script
+    script
   end
 
   private
@@ -439,15 +449,6 @@ class ScriptLevelsController < ApplicationController
   # Don't try to generate the CSRF token for forms on this page because it's cached.
   def protect_against_forgery?
     return false
-  end
-
-  def set_script(version_year: nil)
-    if ScriptConstants::FAMILY_NAMES.include?(params[:script_id])
-      @script = Script.get_script_family_redirect_for_user(params[:script_id], user: current_user, locale: request.locale)
-      return
-    end
-
-    @script = Script.get_from_cache(params[:script_id], version_year: version_year)
   end
 
   def set_redirect_override

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -129,9 +129,11 @@ class ScriptsController < ApplicationController
   end
 
   def set_script_for_show
-    is_family_name = ScriptConstants::FAMILY_NAMES.include?(params[:id])
-    return set_script unless is_family_name
-    @script = Script.get_script_family_redirect_for_user(params[:id], user: current_user, locale: request.locale)
+    if ScriptConstants::FAMILY_NAMES.include?(params[:id])
+      @script = Script.get_script_family_redirect_for_user(params[:id], user: current_user, locale: request.locale)
+    else
+      set_script
+    end
   end
 
   def script_params

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -13,13 +13,6 @@ class ScriptsController < ApplicationController
   before_action :set_script_file, only: [:edit, :update]
 
   def show
-    if @script.redirect_to?
-      redirect_path = script_path(Script.get_from_cache(@script.redirect_to))
-      redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
-      redirect_to "#{redirect_path}#{redirect_query_string}"
-      return
-    end
-
     if request.path != (canonical_path = script_path(@script))
       # return a temporary redirect rather than a permanent one, to avoid ever
       # serving a permanent redirect from a script's new location to its old

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -119,13 +119,13 @@ class ScriptsController < ApplicationController
   end
 
   def set_script
-    if ScriptConstants::FAMILY_NAMES.include?(params[:id])
-      @script = Script.get_script_family_redirect_for_user(params[:id], user: current_user, locale: request.locale)
-      return
-    end
+    script_id = params[:id]
+    @script = ScriptConstants::FAMILY_NAMES.include?(script_id) ?
+      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale) :
+      Script.get_from_cache(script_id)
+    raise ActiveRecord::RecordNotFound unless @script
 
-    @script = Script.get_from_cache(params[:id])
-    if current_user && @script&.pilot? && !@script.has_pilot_access?(current_user)
+    if current_user && @script.pilot? && !@script.has_pilot_access?(current_user)
       render :no_access
     end
   end

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -13,6 +13,13 @@ class ScriptsController < ApplicationController
   before_action :set_script_file, only: [:edit, :update]
 
   def show
+    if @script.redirect_to?
+      redirect_path = script_path(Script.get_from_cache(@script.redirect_to))
+      redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
+      redirect_to "#{redirect_path}#{redirect_query_string}"
+      return
+    end
+
     if request.path != (canonical_path = script_path(@script))
       # return a temporary redirect rather than a permanent one, to avoid ever
       # serving a permanent redirect from a script's new location to its old

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -426,14 +426,7 @@ class Script < ActiveRecord::Base
     script = Script.with_associated_models.find_by(find_by => id_or_name)
     return script if script
 
-    unless is_id
-      # We didn't find a script matching id_or_name. Next, look for a script
-      # in the id_or_name script family to redirect to, e.g. csp1 --> csp1-2017.
-      script_with_redirect = Script.get_script_family_redirect(id_or_name, version_year: version_year)
-      return script_with_redirect if script_with_redirect
-    end
-
-    raise ActiveRecord::RecordNotFound.new("Couldn't find Script with id|name|family_name=#{id_or_name}")
+    raise ActiveRecord::RecordNotFound.new("Couldn't find Script with id|name=#{id_or_name}")
   end
 
   # Returns the script with the specified id, or a script with the specified
@@ -449,6 +442,10 @@ class Script < ActiveRecord::Base
   # @param version_year [String] If specified, when looking for a script to redirect
   #   to within a script family, redirect to this version rather than the latest.
   def self.get_from_cache(id_or_name, version_year: nil)
+    if ScriptConstants::FAMILY_NAMES.include?(id_or_name)
+      raise "Do not call Script.get_from_cache with a family_name. Call Script.get_script_family_redirect_for_user instead.  Family: #{id_or_name}"
+    end
+
     return get_without_cache(id_or_name, version_year: version_year) unless should_cache?
     cache_key_suffix = version_year ? "/#{version_year}" : ''
     cache_key = "#{id_or_name}#{cache_key_suffix}"

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1687,29 +1687,23 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'should redirect to 2017 version in script family' do
-    cats1 = create :script, name: 'cats1', family_name: 'cats', version_year: '2017'
+    cats1 = create :script, name: 'cats1', family_name: 'coursea', version_year: '2017'
 
     assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {script_id: 'cats', stage_position: 1, id: 1}
+      get :show, params: {script_id: 'coursea', stage_position: 1, id: 1}
     end
 
     cats1.update!(is_stable: true)
-    get :show, params: {script_id: 'cats', stage_position: 1, id: 1}
+    get :show, params: {script_id: 'coursea', stage_position: 1, id: 1}
     assert_redirected_to "/s/cats1/stage/1/puzzle/1"
 
-    create :script, name: 'cats2', family_name: 'cats', version_year: '2018', is_stable: true
-    get :show, params: {script_id: 'cats', stage_position: 1, id: 1}
-    assert_redirected_to "/s/cats1/stage/1/puzzle/1"
+    create :script, name: 'cats2', family_name: 'coursea', version_year: '2018', is_stable: true
+    get :show, params: {script_id: 'coursea', stage_position: 1, id: 1}
+    assert_redirected_to "/s/cats2/stage/1/puzzle/1"
 
     # next redirects to latest version in a script family
-    get :next, params: {script_id: 'cats'}
+    get :next, params: {script_id: 'coursea'}
     assert_redirected_to "/s/cats2/next"
-
-    # do not redirect within script family if the requested script exists
-    cats = create :script, name: 'cats'
-    create :script_level, script: cats
-    get :show, params: {script_id: 'cats', stage_position: 1, id: 1}
-    assert_response :success
   end
 
   test "should indicate challenge levels as challenge levels" do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -455,27 +455,22 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'should redirect to latest stable version in script family' do
-    dogs1 = create :script, name: 'dogs1', family_name: 'dogs', version_year: '1901'
+    dogs1 = create :script, name: 'dogs1', family_name: 'coursea', version_year: '1901'
 
     assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {id: 'dogs'}
+      get :show, params: {id: 'coursea'}
     end
 
     dogs1.update!(is_stable: true)
-    get :show, params: {id: 'dogs'}
+    get :show, params: {id: 'coursea'}
     assert_redirected_to "/s/dogs1"
 
-    create :script, name: 'dogs2', family_name: 'dogs', version_year: '1902', is_stable: true
-    get :show, params: {id: 'dogs'}
+    create :script, name: 'dogs2', family_name: 'coursea', version_year: '1902', is_stable: true
+    get :show, params: {id: 'coursea'}
     assert_redirected_to "/s/dogs2"
 
-    create :script, name: 'dogs3', family_name: 'dogs', version_year: '1899', is_stable: true
-    get :show, params: {id: 'dogs'}
+    create :script, name: 'dogs3', family_name: 'coursea', version_year: '1899', is_stable: true
+    get :show, params: {id: 'coursea'}
     assert_redirected_to "/s/dogs2"
-
-    # do not redirect within script family if the requested script exists
-    create :script, name: 'dogs'
-    get :show, params: {id: 'dogs'}
-    assert_response :success
   end
 end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -314,6 +314,13 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal frozen, Script.get_from_cache(frozen_id)
   end
 
+  test 'get_from_cache raises if called with a family_name' do
+    error = assert_raises do
+      Script.get_from_cache('coursea')
+    end
+    assert_equal 'Do not call Script.get_from_cache with a family_name. Call Script.get_script_family_redirect_for_user instead.  Family: coursea', error.message
+  end
+
   test 'get_family_from_cache uses script_family_cache' do
     family_scripts = Script.where(family_name: 'family-cache-test')
     assert_equal [@script_2017.name, @script_2018.name], family_scripts.map(&:name)

--- a/dashboard/test/ui/features/course_versions.feature
+++ b/dashboard/test/ui/features/course_versions.feature
@@ -126,13 +126,3 @@ Scenario: Switch versions using dropdown on script overview page
 Scenario: Course unit family names redirect to their latest stable version
   When I am on "http://studio.code.org/s/csp3"
   And I get redirected to "/s/csp3-2018" via "dashboard"
-
-@as_student
-@no_mobile
-Scenario: Script levels in renamed scripts redirect to their original version
-  Given I am assigned to script "csp3-2017"
-  When I am on "http://studio.code.org/s/csp3/stage/9/puzzle/11"
-  # Keep redirecting to the original version of a script level after a later
-  # script version becomes stable, because a user with a deep link to a specific
-  # level will most likely expect to see their previous progress there.
-  And I get redirected to "/s/csp3-2017/stage/9/puzzle/11" via "dashboard"


### PR DESCRIPTION
[LP-345](https://codedotorg.atlassian.net/browse/LP-345)

Follow-up to #27999.

`Script#get_from_cache` will now raise an error if called with a family_name (i.e., it is present in `ScriptConstants::FAMILY_NAMES`) to avoid any future confusion and keep our caches organized!