### PR TITLE
Add curriculum_umbrella property to CSF scripts

### DIFF
--- a/dashboard/config/scripts/20-hour.script
+++ b/dashboard/config/scripts/20-hour.script
@@ -1,6 +1,7 @@
 id '1'
 hidden false
 hideable_stages true
+curriculum_umbrella 'CSF'
 
 stage 'Introduction to Computer Science'
 concepts 'sequence'

--- a/dashboard/config/scripts/Course4pre.script
+++ b/dashboard/config/scripts/Course4pre.script
@@ -1,3 +1,5 @@
+curriculum_umbrella 'CSF'
+
 stage 'Maze: Sequence'
 level '2-3 Maze 1'
 level '2-3 Maze 2'

--- a/dashboard/config/scripts/course-e-2018.script
+++ b/dashboard/config/scripts/course-e-2018.script
@@ -1,3 +1,5 @@
+curriculum_umbrella 'CSF'
+
 stage 'Programming: My Robotic Friends', flex_category: 'csf_e_1'
 level 'courseB_unplugged_MRF_2018'
 

--- a/dashboard/config/scripts/course-f-2018.script
+++ b/dashboard/config/scripts/course-f-2018.script
@@ -1,3 +1,5 @@
+curriculum_umbrella 'CSF'
+
 stage 'Programming: My Robotic Friends', flex_category: 'csf_f_1'
 level 'courseB_unplugged_MRF_2018'
 

--- a/dashboard/config/scripts/course1.script
+++ b/dashboard/config/scripts/course1.script
@@ -5,6 +5,7 @@ project_widget_visible true
 has_lesson_plan true
 curriculum_path 'https://code.org/curriculum/course1/{LESSON}/Teacher'
 project_widget_types ["playlab_k1", "artist_k1"]
+curriculum_umbrella 'CSF'
 
 stage 'Happy Maps'
 level 'UnplugHappyMaps'

--- a/dashboard/config/scripts/course2.script
+++ b/dashboard/config/scripts/course2.script
@@ -5,6 +5,7 @@ project_widget_visible true
 has_lesson_plan true
 curriculum_path 'https://code.org/curriculum/course2/{LESSON}/Teacher'
 project_widget_types ["playlab", "artist"]
+curriculum_umbrella 'CSF'
 
 stage 'Graph Paper Programming'
 level 'GraphPaperProgramming'

--- a/dashboard/config/scripts/course3.script
+++ b/dashboard/config/scripts/course3.script
@@ -5,6 +5,7 @@ project_widget_visible true
 has_lesson_plan true
 curriculum_path 'https://code.org/curriculum/course3/{LESSON}/Teacher'
 project_widget_types ["playlab", "artist"]
+curriculum_umbrella 'CSF'
 
 stage 'Computational Thinking'
 level 'ComputationalThinking'

--- a/dashboard/config/scripts/course4.script
+++ b/dashboard/config/scripts/course4.script
@@ -2,6 +2,7 @@ hidden false
 hideable_stages true
 has_lesson_plan true
 curriculum_path 'https://code.org/curriculum/course4/{LESSON}/Teacher'
+curriculum_umbrella 'CSF'
 
 stage 'Unplugged: Tangrams'
 level 'TangramAlgorithms'

--- a/dashboard/config/scripts/coursea-2017.script
+++ b/dashboard/config/scripts/coursea-2017.script
@@ -10,6 +10,7 @@ family_name 'coursea'
 version_year '2017'
 is_stable true
 supported_locales ["es-ES", "es-MX", "sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Debugging: Unspotted Bugs'
 level 'courseB_video_Unspotted'

--- a/dashboard/config/scripts/coursea-2018.script
+++ b/dashboard/config/scripts/coursea-2018.script
@@ -11,6 +11,7 @@ family_name 'coursea'
 version_year '2018'
 is_stable true
 supported_locales ["sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Debugging: Unspotted Bugs'
 level 'courseB_video_Unspotted_2018'

--- a/dashboard/config/scripts/coursea-2019.script
+++ b/dashboard/config/scripts/coursea-2019.script
@@ -8,6 +8,7 @@ project_widget_visible true
 project_widget_types ["playlab_k1", "artist_k1"]
 family_name 'coursea'
 version_year '2019'
+curriculum_umbrella 'CSF'
 
 stage 'Going Places Safely', flex_category: 'csf_digcit'
 level 'GoingPlacesSafely-unplugged'

--- a/dashboard/config/scripts/coursea-draft.script
+++ b/dashboard/config/scripts/coursea-draft.script
@@ -1,5 +1,6 @@
 login_required true
 has_lesson_plan true
+curriculum_umbrella 'CSF'
 
 stage 'Debugging: Unspotted Bugs'
 level 'courseB_video_Unspotted'

--- a/dashboard/config/scripts/courseb-2017.script
+++ b/dashboard/config/scripts/courseb-2017.script
@@ -10,6 +10,7 @@ family_name 'courseb'
 version_year '2017'
 is_stable true
 supported_locales ["es-ES", "es-MX", "sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Debugging: Unspotted Bugs'
 level 'courseB_video_Unspotted'

--- a/dashboard/config/scripts/courseb-2018.script
+++ b/dashboard/config/scripts/courseb-2018.script
@@ -11,6 +11,7 @@ family_name 'courseb'
 version_year '2018'
 is_stable true
 supported_locales ["sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Move It, Move It'
 level 'MoveItMoveIt_2018'

--- a/dashboard/config/scripts/courseb-2019.script
+++ b/dashboard/config/scripts/courseb-2019.script
@@ -9,6 +9,7 @@ project_widget_types ["playlab_k1", "artist_k1"]
 script_announcements [{"notice"=>"Our 2019 CS Fundamentals Curriculum Guide is Live", "details"=>"Click \"Learn More\" to download the PDF, including unplugged lesson plans for Courses A-F.", "link"=>"https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview", "type"=>"bullhorn"}]
 family_name 'courseb'
 version_year '2019'
+curriculum_umbrella 'CSF'
 
 stage 'Your Digital Footprint', flex_category: 'csf_digcit'
 level 'DigitalFootprint-Unplugged'

--- a/dashboard/config/scripts/courseb-draft.script
+++ b/dashboard/config/scripts/courseb-draft.script
@@ -1,5 +1,6 @@
 login_required true
 has_lesson_plan true
+curriculum_umbrella 'CSF'
 
 stage 'Debugging: Unspotted Bugs'
 level 'courseB_video_Unspotted'

--- a/dashboard/config/scripts/coursec-2017.script
+++ b/dashboard/config/scripts/coursec-2017.script
@@ -10,6 +10,7 @@ family_name 'coursec'
 version_year '2017'
 is_stable true
 supported_locales ["es-ES", "es-MX", "sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Building a Foundation'
 level 'BuildingAFoundation'

--- a/dashboard/config/scripts/coursec-2018.script
+++ b/dashboard/config/scripts/coursec-2018.script
@@ -11,6 +11,7 @@ family_name 'coursec'
 version_year '2018'
 is_stable true
 supported_locales ["sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Building a Foundation'
 level 'BuildingAFoundation_2018'

--- a/dashboard/config/scripts/coursec-2019.script
+++ b/dashboard/config/scripts/coursec-2019.script
@@ -8,6 +8,7 @@ project_widget_visible true
 project_widget_types ["playlab", "artist"]
 family_name 'coursec'
 version_year '2019'
+curriculum_umbrella 'CSF'
 
 stage 'Screen Out the Mean', flex_category: 'csf_digcit'
 level 'ScreenOutTheMean-Unplugged'

--- a/dashboard/config/scripts/coursec-draft.script
+++ b/dashboard/config/scripts/coursec-draft.script
@@ -1,4 +1,5 @@
 has_lesson_plan true
+curriculum_umbrella 'CSF'
 
 stage 'Building a Foundation'
 level 'BuildingAFoundation'

--- a/dashboard/config/scripts/coursed-2017.script
+++ b/dashboard/config/scripts/coursed-2017.script
@@ -10,6 +10,7 @@ family_name 'coursed'
 version_year '2017'
 is_stable true
 supported_locales ["es-ES", "es-MX", "sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Algorithms: Graph Paper Programming'
 level 'GraphPaperProgramming'

--- a/dashboard/config/scripts/coursed-2018.script
+++ b/dashboard/config/scripts/coursed-2018.script
@@ -9,6 +9,7 @@ family_name 'coursed'
 version_year '2018'
 is_stable true
 supported_locales ["sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Algorithms: Graph Paper Programming'
 level 'GraphPaperProgramming_2018'

--- a/dashboard/config/scripts/coursed-2019.script
+++ b/dashboard/config/scripts/coursed-2019.script
@@ -6,6 +6,7 @@ has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-19/coursed/{LESSON}'
 family_name 'coursed'
 version_year '2019'
+curriculum_umbrella 'CSF'
 
 stage 'Algorithms: Graph Paper Programming', flex_category: 'csf_sequencing'
 level 'GraphPaperProgramming-Unplugged'

--- a/dashboard/config/scripts/coursed-draft.script
+++ b/dashboard/config/scripts/coursed-draft.script
@@ -1,5 +1,6 @@
 login_required true
 has_lesson_plan true
+curriculum_umbrella 'CSF'
 
 stage 'Introduction'
 level 'courseD_video_ramp1'

--- a/dashboard/config/scripts/coursed-ramp.script
+++ b/dashboard/config/scripts/coursed-ramp.script
@@ -1,4 +1,5 @@
 hideable_stages true
+curriculum_umbrella 'CSF'
 
 stage 'Introduction'
 level 'courseD_video_ramp1'

--- a/dashboard/config/scripts/coursee-2017.script
+++ b/dashboard/config/scripts/coursee-2017.script
@@ -10,6 +10,7 @@ family_name 'coursee'
 version_year '2017'
 is_stable true
 supported_locales ["es-ES", "es-MX", "sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Programming: My Robotic Friends', flex_category: 'csf_e_1'
 level 'courseB_unplugged_MRF'

--- a/dashboard/config/scripts/coursee-2018.script
+++ b/dashboard/config/scripts/coursee-2018.script
@@ -11,6 +11,7 @@ family_name 'coursee'
 version_year '2018'
 is_stable true
 supported_locales ["sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Programming: My Robotic Friends', flex_category: 'csf_e_1'
 level 'courseB_unplugged_MRF_2018'

--- a/dashboard/config/scripts/coursee-2019.script
+++ b/dashboard/config/scripts/coursee-2019.script
@@ -8,6 +8,7 @@ project_widget_visible true
 project_widget_types ["playlab", "artist"]
 family_name 'coursee'
 version_year '2019'
+curriculum_umbrella 'CSF'
 
 stage 'Sequencing in the Maze', flex_category: 'ramp_up'
 level 'courseD_video_ramp1_2019', progression: 'Maze Intro: Programming with Blocks'

--- a/dashboard/config/scripts/coursee-draft.script
+++ b/dashboard/config/scripts/coursee-draft.script
@@ -1,5 +1,6 @@
 login_required true
 has_lesson_plan true
+curriculum_umbrella 'CSF'
 
 stage 'Algorithms: Dice Race'
 level 'DiceRace'

--- a/dashboard/config/scripts/coursee-ramp.script
+++ b/dashboard/config/scripts/coursee-ramp.script
@@ -1,5 +1,6 @@
 stage 'Real Life Algorithms: Dice Race'
 level 'DiceRace'
+curriculum_umbrella 'CSF'
 
 stage 'Introduction'
 level 'courseE_video_ramp1'

--- a/dashboard/config/scripts/coursef-2017.script
+++ b/dashboard/config/scripts/coursef-2017.script
@@ -10,6 +10,7 @@ family_name 'coursef'
 version_year '2017'
 is_stable true
 supported_locales ["es-ES", "es-MX", "sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Programming: My Robotic Friends', flex_category: 'csf_f_1'
 level 'courseB_unplugged_MRF'

--- a/dashboard/config/scripts/coursef-2018.script
+++ b/dashboard/config/scripts/coursef-2018.script
@@ -11,6 +11,7 @@ family_name 'coursef'
 version_year '2018'
 is_stable true
 supported_locales ["sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Programming: My Robotic Friends', flex_category: 'csf_f_1'
 level 'courseB_unplugged_MRF_2018'

--- a/dashboard/config/scripts/coursef-2019.script
+++ b/dashboard/config/scripts/coursef-2019.script
@@ -8,6 +8,7 @@ project_widget_visible true
 project_widget_types ["playlab", "artist"]
 family_name 'coursef'
 version_year '2019'
+curriculum_umbrella 'CSF'
 
 stage 'Functions in Minecraft', flex_category: 'ramp_up'
 level 'MC_HOC_2017_01_RETRY_2019', progression: 'Practice'

--- a/dashboard/config/scripts/coursef-draft.script
+++ b/dashboard/config/scripts/coursef-draft.script
@@ -1,5 +1,6 @@
 login_required true
 has_lesson_plan true
+curriculum_umbrella 'CSF'
 
 stage 'Algorithms: Tangrams'
 level 'TangramAlgorithms'

--- a/dashboard/config/scripts/coursef-ramp.script
+++ b/dashboard/config/scripts/coursef-ramp.script
@@ -1,3 +1,5 @@
+curriculum_umbrella 'CSF'
+
 stage 'Algorithms: Tangrams'
 level 'TangramAlgorithms'
 

--- a/dashboard/config/scripts/express-2017.script
+++ b/dashboard/config/scripts/express-2017.script
@@ -10,6 +10,7 @@ family_name 'express'
 version_year '2017'
 is_stable true
 supported_locales ["es-ES", "es-MX", "sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Algorithms: Graph Paper Programming'
 level 'GraphPaperProgramming'

--- a/dashboard/config/scripts/express-2018-vn.script
+++ b/dashboard/config/scripts/express-2018-vn.script
@@ -1,5 +1,6 @@
 hidden false
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/express/"], ["vocabulary", "https://curriculum.code.org/csf-18/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/express/standards/"]]
+curriculum_umbrella 'CSF'
 
 stage 'Programming in Maze'
 level 'courseC_video_maze_2018'

--- a/dashboard/config/scripts/express-2018.script
+++ b/dashboard/config/scripts/express-2018.script
@@ -11,6 +11,7 @@ family_name 'express'
 version_year '2018'
 is_stable true
 supported_locales ["sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Graph Paper Programming'
 level 'GraphPaperProgramming_2018'

--- a/dashboard/config/scripts/express-2019.script
+++ b/dashboard/config/scripts/express-2019.script
@@ -8,6 +8,7 @@ project_widget_visible true
 project_widget_types ["playlab", "artist"]
 family_name 'express'
 version_year '2019'
+curriculum_umbrella 'CSF'
 
 stage 'Dance Party', flex_category: 'csf_warmup'
 level 'CourseD_Dance_Party_01'

--- a/dashboard/config/scripts/pre-express-2017.script
+++ b/dashboard/config/scripts/pre-express-2017.script
@@ -10,6 +10,7 @@ family_name 'pre-express'
 version_year '2017'
 is_stable true
 supported_locales ["es-ES", "es-MX", "sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Debugging: Unspotted Bugs'
 level 'courseB_video_Unspotted'

--- a/dashboard/config/scripts/pre-express-2018.script
+++ b/dashboard/config/scripts/pre-express-2018.script
@@ -10,6 +10,7 @@ family_name 'pre-express'
 version_year '2018'
 is_stable true
 supported_locales ["sk-SK"]
+curriculum_umbrella 'CSF'
 
 stage 'Debugging: Unspotted Bugs'
 level 'courseB_video_Unspotted_2018'

--- a/dashboard/config/scripts/pre-express-2019.script
+++ b/dashboard/config/scripts/pre-express-2019.script
@@ -7,6 +7,7 @@ project_widget_visible true
 project_widget_types ["playlab_k1", "artist_k1"]
 family_name 'pre-express'
 version_year '2019'
+curriculum_umbrella 'CSF'
 
 stage 'Learn to Drag and Drop'
 skin 'jigsaw'


### PR DESCRIPTION
This adds `curriculum_umbrella 'CSF'` to:
- courses a-f scripts from 2017, 2018, 2019
- express and pre-express scripts from 2017, 2018, 2019
- courses 1-4
- 20-hour 

`curriculum_umbrella`, a new property introduced in https://github.com/code-dot-org/code-dot-org/pull/28678, will be used to reference all scripts related to a given curriculum (CSF, CSD or CSP) regardless of version year. 

I'll add for CSD and CSP in follow-ups.