### PR TITLE
Add curriculum_umbrella to CSD scripts

### DIFF
--- a/dashboard/config/scripts/csd1-2017.script
+++ b/dashboard/config/scripts/csd1-2017.script
@@ -12,6 +12,7 @@ family_name 'csd1'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'CS Discoveries Pre-survey', lockable: true, flex_category: 'cspSurvey'
 level 'csd-pre-survey-2017-levelgroup', assessment: true

--- a/dashboard/config/scripts/csd1-2018.script
+++ b/dashboard/config/scripts/csd1-2018.script
@@ -10,6 +10,7 @@ family_name 'csd1'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'CS Discoveries Pre-survey', lockable: true, flex_category: 'cspSurvey'
 level 'csd-pre-survey-2017-levelgroup_2018', assessment: true

--- a/dashboard/config/scripts/csd1-2019.script
+++ b/dashboard/config/scripts/csd1-2019.script
@@ -10,6 +10,7 @@ curriculum_path 'https://curriculum.code.org/csd-19/unit1/{LESSON}'
 family_name 'csd1'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'CS Discoveries Pre-survey', lockable: true, flex_category: 'cspSurvey'
 level 'csd-pre-survey-2017-levelgroup_2018_2019', assessment: true

--- a/dashboard/config/scripts/csd2-2017.script
+++ b/dashboard/config/scripts/csd2-2017.script
@@ -11,6 +11,7 @@ family_name 'csd2'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Exploring Websites', flex_category: 'csd2_1'
 level 'CSD U2 L1 Overview', named: true

--- a/dashboard/config/scripts/csd2-2018.script
+++ b/dashboard/config/scripts/csd2-2018.script
@@ -11,6 +11,7 @@ family_name 'csd2'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Exploring Websites', flex_category: 'csd2_1'
 level 'CSD U2L01 TFMD_2018', named: true

--- a/dashboard/config/scripts/csd2-2019.script
+++ b/dashboard/config/scripts/csd2-2019.script
@@ -10,6 +10,7 @@ curriculum_path 'https://curriculum.code.org/csd-19/unit2/{LESSON}'
 family_name 'csd2'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Exploring Websites', flex_category: 'csd2_1'
 level 'CSD U2L01 TFMD_2019', named: true

--- a/dashboard/config/scripts/csd3-2017.script
+++ b/dashboard/config/scripts/csd3-2017.script
@@ -11,6 +11,7 @@ family_name 'csd3'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Programming for Entertainment', flex_category: 'csd3_1'
 level 'CSD U3 Lesson Overview 1', named: true

--- a/dashboard/config/scripts/csd3-2018.script
+++ b/dashboard/config/scripts/csd3-2018.script
@@ -14,6 +14,7 @@ family_name 'csd3'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Programming for Entertainment', flex_category: 'csd3_1'
 level 'CSD U3L01 TFMD_2018', named: true

--- a/dashboard/config/scripts/csd3-2019.script
+++ b/dashboard/config/scripts/csd3-2019.script
@@ -12,6 +12,7 @@ project_widget_types ["gamelab", "weblab"]
 family_name 'csd3'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Programming for Entertainment', flex_category: 'csd3_1'
 level 'CSD U3L01 TFMD_2019', named: true

--- a/dashboard/config/scripts/csd4-2017.script
+++ b/dashboard/config/scripts/csd4-2017.script
@@ -11,6 +11,7 @@ family_name 'csd4'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Analysis of Design', flex_category: 'csd4_1'
 level 'CSD U4L01 SFLP', named: true

--- a/dashboard/config/scripts/csd4-2018.script
+++ b/dashboard/config/scripts/csd4-2018.script
@@ -11,6 +11,7 @@ family_name 'csd4'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Analysis of Design', flex_category: 'csd4_1'
 level 'CSD U4L01 autoSFLP_2018', named: true

--- a/dashboard/config/scripts/csd4-2019.script
+++ b/dashboard/config/scripts/csd4-2019.script
@@ -9,6 +9,7 @@ has_lesson_plan true
 family_name 'csd4'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Analysis of Design', flex_category: 'csd4_1'
 level 'CSD U4L01 autoSFLP_2019', named: true

--- a/dashboard/config/scripts/csd5-2017.script
+++ b/dashboard/config/scripts/csd5-2017.script
@@ -11,6 +11,7 @@ family_name 'csd5'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Representation Matters', flex_category: 'csd5_1'
 level 'CSD-U5-SFLP Representation Matters', named: true

--- a/dashboard/config/scripts/csd5-2018.script
+++ b/dashboard/config/scripts/csd5-2018.script
@@ -11,6 +11,7 @@ family_name 'csd5'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Representation Matters', flex_category: 'csd5_1'
 level 'CSD U5L01 autoSFLP_2018', named: true

--- a/dashboard/config/scripts/csd5-2019.script
+++ b/dashboard/config/scripts/csd5-2019.script
@@ -9,6 +9,7 @@ has_lesson_plan true
 family_name 'csd5'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Representation Matters', flex_category: 'csd5_1'
 level 'CSD U5L01 autoSFLP_2019', named: true

--- a/dashboard/config/scripts/csd6-2017.script
+++ b/dashboard/config/scripts/csd6-2017.script
@@ -12,6 +12,7 @@ family_name 'csd6'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Innovations in Computing_', flex_category: 'csd6_1'
 level 'CSD U6L01 TFMD', named: true

--- a/dashboard/config/scripts/csd6-2018.script
+++ b/dashboard/config/scripts/csd6-2018.script
@@ -14,6 +14,7 @@ family_name 'csd6'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Innovations in Computing', flex_category: 'csd6_1'
 level 'CSD U6L01 TFMD_2018', named: true

--- a/dashboard/config/scripts/csd6-2019.script
+++ b/dashboard/config/scripts/csd6-2019.script
@@ -12,6 +12,7 @@ project_widget_types ["applab", "gamelab", "weblab"]
 family_name 'csd6'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSD'
 
 stage 'Innovations in Computing', flex_category: 'csd6_1'
 level 'CSD U6L01 TFMD_2019', named: true


### PR DESCRIPTION
Similar to #28689. Adds `curriculum_umbrella 'CSD'` to CSD scripts 1-6 from all version years.  