### PR TITLE
Add curriculum_umbrella to CSP scripts

### DIFF
--- a/dashboard/config/scripts/csp-create-2017.script
+++ b/dashboard/config/scripts/csp-create-2017.script
@@ -10,6 +10,7 @@ family_name 'csp-create'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Create PT Prep - Reviewing the Task', flex_category: 'csp_ap_3'
 level 'U6 Create PT Review - Student Links', progression: 'Create PT -  Review - Student Links'

--- a/dashboard/config/scripts/csp-create-2018.script
+++ b/dashboard/config/scripts/csp-create-2018.script
@@ -11,6 +11,7 @@ family_name 'csp-create'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Create PT Prep - Reviewing the Task', flex_category: 'csp_ap_3'
 level 'CSP CreateL01 SFLP', named: true

--- a/dashboard/config/scripts/csp-create-2019.script
+++ b/dashboard/config/scripts/csp-create-2019.script
@@ -9,6 +9,7 @@ has_lesson_plan true
 family_name 'csp-create'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Create PT Prep - Reviewing the Task', flex_category: 'csp_ap_3'
 level 'CSP CreateL01 SFLP_2019', named: true

--- a/dashboard/config/scripts/csp-explore-2017.script
+++ b/dashboard/config/scripts/csp-explore-2017.script
@@ -10,6 +10,7 @@ family_name 'csp-explore'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Explore PT Prep - Reviewing the Task', flex_category: 'csp_ap_2'
 level 'U6 Explore PT Review - Student Links', progression: 'Explore PT - Review the Task'

--- a/dashboard/config/scripts/csp-explore-2018.script
+++ b/dashboard/config/scripts/csp-explore-2018.script
@@ -11,6 +11,7 @@ family_name 'csp-explore'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Explore PT Prep - Reviewing the Task', flex_category: 'csp_ap_2'
 level 'CSP ExploreL01 SFLP', named: true

--- a/dashboard/config/scripts/csp-explore-2019.script
+++ b/dashboard/config/scripts/csp-explore-2019.script
@@ -9,6 +9,7 @@ has_lesson_plan true
 family_name 'csp-explore'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Explore PT Prep - Reviewing the Task', flex_category: 'csp_ap_2'
 level 'CSP ExploreL01 SFLP_2019', named: true

--- a/dashboard/config/scripts/csp1-2017.script
+++ b/dashboard/config/scripts/csp1-2017.script
@@ -11,6 +11,7 @@ family_name 'csp1'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'CS Principles Pre-survey', lockable: true, flex_category: 'cspSurvey'
 level 'csp-pre-survey-2017-levelgroup', assessment: true

--- a/dashboard/config/scripts/csp1-2018.script
+++ b/dashboard/config/scripts/csp1-2018.script
@@ -11,6 +11,7 @@ family_name 'csp1'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'CS Principles Pre-survey', lockable: true, flex_category: 'cspSurvey'
 level 'csp-pre-survey-2017-levelgroup_2018', assessment: true

--- a/dashboard/config/scripts/csp1-2019.script
+++ b/dashboard/config/scripts/csp1-2019.script
@@ -9,6 +9,7 @@ has_lesson_plan true
 family_name 'csp1'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'CS Principles Pre-survey', lockable: true, flex_category: 'cspSurvey'
 level 'csp-pre-survey-2017-levelgroup_2018_2019', assessment: true

--- a/dashboard/config/scripts/csp1-pilot-staging.script
+++ b/dashboard/config/scripts/csp1-pilot-staging.script
@@ -1,5 +1,6 @@
 hidden false
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'

--- a/dashboard/config/scripts/csp10-pilot-staging.script
+++ b/dashboard/config/scripts/csp10-pilot-staging.script
@@ -1,4 +1,5 @@
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'

--- a/dashboard/config/scripts/csp2-2017.script
+++ b/dashboard/config/scripts/csp2-2017.script
@@ -11,6 +11,7 @@ family_name 'csp2'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Bytes and File Sizes', flex_category: 'csp2_1'
 level 'v2 U2L1 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'

--- a/dashboard/config/scripts/csp2-2018.script
+++ b/dashboard/config/scripts/csp2-2018.script
@@ -11,6 +11,7 @@ family_name 'csp2'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Bytes and File Sizes', flex_category: 'csp2_1_2018'
 level 'CSP U2L01 SFLP', named: true

--- a/dashboard/config/scripts/csp2-2019.script
+++ b/dashboard/config/scripts/csp2-2019.script
@@ -9,6 +9,7 @@ has_lesson_plan true
 family_name 'csp2'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Bytes and File Sizes', flex_category: 'csp2_1_2018'
 level 'CSP U2L01 SFLP_2019', named: true

--- a/dashboard/config/scripts/csp2-pilot-staging.script
+++ b/dashboard/config/scripts/csp2-pilot-staging.script
@@ -1,4 +1,5 @@
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'

--- a/dashboard/config/scripts/csp3-2017.script
+++ b/dashboard/config/scripts/csp3-2017.script
@@ -11,6 +11,7 @@ family_name 'csp3'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1'
 level 'v2 U3L01 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'

--- a/dashboard/config/scripts/csp3-2018.script
+++ b/dashboard/config/scripts/csp3-2018.script
@@ -11,6 +11,7 @@ family_name 'csp3'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1_2018'
 level 'CSP U3L01 SFLP', named: true

--- a/dashboard/config/scripts/csp3-2019.script
+++ b/dashboard/config/scripts/csp3-2019.script
@@ -9,6 +9,7 @@ has_lesson_plan true
 family_name 'csp3'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1_2018'
 level 'CSP U3L01 SFLP_2019', named: true

--- a/dashboard/config/scripts/csp3-a.script
+++ b/dashboard/config/scripts/csp3-a.script
@@ -1,4 +1,5 @@
 login_required true
+curriculum_umbrella 'CSP'
 
 stage 'CSP3A: Using Simple Commands', flex_category: 'csp3_1'
 level 'subgoal v2 U3L04 Student Lesson Introduction'

--- a/dashboard/config/scripts/csp3-pilot-staging.script
+++ b/dashboard/config/scripts/csp3-pilot-staging.script
@@ -1,4 +1,5 @@
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'

--- a/dashboard/config/scripts/csp3-research-mxghyt.script
+++ b/dashboard/config/scripts/csp3-research-mxghyt.script
@@ -5,6 +5,7 @@ student_detail_progress_view true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csp/unit3/"], ["teacherForum", "https://forum.code.org/c/csp3"], ["vocabulary", "https://curriculum.code.org/csp/unit3/vocab/"], ["codeIntroduced", "https://curriculum.code.org/csp/unit3/code/"], ["standardMappings", "https://curriculum.code.org/csp/unit3/standards/"], ["professionalLearning", "https://studio.code.org/s/csp3-support"]]
 has_lesson_plan true
 script_announcements [{"notice"=>"Check out the CSP mid-course survey", "details"=>"We recently added a mid-course survey to the end of Unit 3.  Please allow your students some time to complete it.", "link"=>"", "type"=>"success"}]
+curriculum_umbrella 'CSP'
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1'
 level 'v2 U3L01 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'

--- a/dashboard/config/scripts/csp3-staging.script
+++ b/dashboard/config/scripts/csp3-staging.script
@@ -2,6 +2,7 @@ login_required true
 hideable_stages true
 student_detail_progress_view true
 has_verified_resources true
+curriculum_umbrella 'CSP'
 
 stage 'The Need For Programming Languages', flex_category: 'csp3_1'
 level 'v2 U3L01 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'

--- a/dashboard/config/scripts/csp4-2017.script
+++ b/dashboard/config/scripts/csp4-2017.script
@@ -11,6 +11,7 @@ family_name 'csp4'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'What is Big Data?', flex_category: 'csp4_1'
 level 'Unit 4 Lesson 1 Introduction', progression: 'Lesson Vocabulary & Resources'

--- a/dashboard/config/scripts/csp4-2018.script
+++ b/dashboard/config/scripts/csp4-2018.script
@@ -11,6 +11,7 @@ family_name 'csp4'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'What is Big Data?', flex_category: 'csp4_1_2018'
 level 'CSP U4L01 SFLP', named: true

--- a/dashboard/config/scripts/csp4-2019.script
+++ b/dashboard/config/scripts/csp4-2019.script
@@ -9,6 +9,7 @@ has_lesson_plan true
 family_name 'csp4'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'What is Big Data?', flex_category: 'csp4_1_2018'
 level 'CSP U4L01 SFLP_2019', named: true

--- a/dashboard/config/scripts/csp4-pilot-staging.script
+++ b/dashboard/config/scripts/csp4-pilot-staging.script
@@ -1,4 +1,5 @@
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'

--- a/dashboard/config/scripts/csp4-pilot.script
+++ b/dashboard/config/scripts/csp4-pilot.script
@@ -2,6 +2,7 @@ login_required true
 hideable_stages true
 has_verified_resources true
 pilot_experiment 'csp-piloters'
+curriculum_umbrella 'CSP'
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'

--- a/dashboard/config/scripts/csp5-2017.script
+++ b/dashboard/config/scripts/csp5-2017.script
@@ -11,6 +11,7 @@ family_name 'csp5'
 version_year '2017'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Buttons and Events', flex_category: 'csp5_1'
 level 'Unit 5 Lesson 1 Introduction', progression: 'Lesson Vocabulary & Resources'

--- a/dashboard/config/scripts/csp5-2018.script
+++ b/dashboard/config/scripts/csp5-2018.script
@@ -11,6 +11,7 @@ family_name 'csp5'
 version_year '2018'
 is_stable true
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Buttons and Events', flex_category: 'csp5_1'
 level 'CSP U5L01 SFLP', named: true

--- a/dashboard/config/scripts/csp5-2019.script
+++ b/dashboard/config/scripts/csp5-2019.script
@@ -10,6 +10,7 @@ curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-19/unit5/{LESSON}'
 family_name 'csp5'
 version_year '2019'
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Buttons and Events', flex_category: 'csp5_1'
 level 'CSP U5L01 SFLP_2019', named: true

--- a/dashboard/config/scripts/csp5-pilot-staging.script
+++ b/dashboard/config/scripts/csp5-pilot-staging.script
@@ -1,4 +1,5 @@
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Lists Explore', flex_category: 'csp_lists'
 level 'csp-20-21-u5-assess-lists', progression: 'Check Your Understanding', assessment: true

--- a/dashboard/config/scripts/csp5-pilot.script
+++ b/dashboard/config/scripts/csp5-pilot.script
@@ -2,6 +2,7 @@ login_required true
 hideable_stages true
 has_verified_resources true
 pilot_experiment 'csp-piloters'
+curriculum_umbrella 'CSP'
 
 stage 'Lists Explore', flex_category: 'csp_lists'
 level 'csp-20-21-u5-assess-lists', progression: 'Check Your Understanding', assessment: true

--- a/dashboard/config/scripts/csp6-pilot-staging.script
+++ b/dashboard/config/scripts/csp6-pilot-staging.script
@@ -1,4 +1,5 @@
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'

--- a/dashboard/config/scripts/csp6.script
+++ b/dashboard/config/scripts/csp6.script
@@ -3,6 +3,7 @@ hideable_stages true
 exclude_csf_column_in_legend true
 student_detail_progress_view true
 has_lesson_plan true
+curriculum_umbrella 'CSP'
 
 stage 'Tech Setup - Your AP Digital Portfolio and Other Tools'
 level 'U6 AP Performance Task Tech Setup - Student Links', progression: 'U6 AP Performance Task Tech Setup - Student Links'

--- a/dashboard/config/scripts/csp7-pilot-staging.script
+++ b/dashboard/config/scripts/csp7-pilot-staging.script
@@ -1,4 +1,5 @@
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Parameters and Return Values Explore', flex_category: 'csp_parameters_and_return_values'
 level 'U7 L01 More with Functions', progression: 'More with Functions'

--- a/dashboard/config/scripts/csp8-pilot-staging.script
+++ b/dashboard/config/scripts/csp8-pilot-staging.script
@@ -1,4 +1,5 @@
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'

--- a/dashboard/config/scripts/csp9-pilot-staging.script
+++ b/dashboard/config/scripts/csp9-pilot-staging.script
@@ -1,4 +1,5 @@
 project_sharing true
+curriculum_umbrella 'CSP'
 
 stage 'Variables Explore', flex_category: 'csp_variables'
 level 'CSP U4 My Pet Rock Example App', progression: 'Sample Apps'


### PR DESCRIPTION
Similar to #28689. Adds curriculum_umbrella 'CSP' to CSP scripts from all version years.