### PR TITLE
Chaining facilitator survey(s) to CSF201 post survey

### DIFF
--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -225,19 +225,27 @@ module Pd
       render :new_general
     end
 
+    # Display CSF201 (Deep Dive) pre-workshop survey.
     # GET workshop_survey/csf/pre201
     def new_csf_pre201
+      # Find the closest CSF 201 workshop the current user enrolled in.
       workshop = Pd::Workshop.
         where(course: COURSE_CSF, subject: SUBJECT_CSF_201).
         enrolled_in_by(current_user).nearest
 
       return render :not_enrolled unless workshop
       return render :too_late unless workshop.state != STATE_ENDED
+
       render_csf_survey(PRE_DEEPDIVE_SURVEY, workshop)
     end
 
+    # Display CSF201 (Deep Dive) post-workshop survey.
+    # The JotForm survey, on submit, will redirect to the new_facilitator route for user
+    # to submit facilitator surveys.
     # GET workshop_survey/csf/post201(/:enrollment_code)
     def new_csf_post201
+      # Use enrollment_code to find a specific workshop
+      # or search all CSF201 workshops the current user enrolled in.
       enrolled_workshops = nil
       if params[:enrollment_code].present?
         enrolled_workshops = Workshop.joins(:enrollments).
@@ -254,6 +262,7 @@ module Pd
 
       attended_workshop = enrolled_workshops.with_nearest_attendance_by(current_user)
       return render :no_attendance unless attended_workshop
+
       render_csf_survey(POST_DEEPDIVE_SURVEY, attended_workshop)
     end
 

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -297,7 +297,7 @@ module Pd
       if next_facilitator_index.between?(1, session.workshop.facilitators.size - 1)
         redirect_to action: :new_facilitator, session_id: session.id, facilitator_index: next_facilitator_index
       # No facilitators left. Academic workshops redirect to post if its the last day
-      elsif !session.workshop.summer? && key_params[:day].to_i == session.workshop.sessions.size
+      elsif !session.workshop.summer? && !session.workshop.csf_201? && key_params[:day].to_i == session.workshop.sessions.size
         redirect_to action: :new_post, enrollment_code: Pd::Enrollment.find_by(user: current_user, workshop: session.workshop).code
       else
         redirect_to action: :thanks
@@ -315,12 +315,14 @@ module Pd
 
     def render_csf_survey(survey_name, workshop)
       @form_id = WorkshopDailySurvey.get_form_id CSF_CATEGORY, survey_name
+      session = survey_name == POST_DEEPDIVE_SURVEY ? workshop.sessions.first : nil
 
       key_params = {
         environment: Rails.env,
         userId: current_user.id,
         workshopId: workshop.id,
         day: CSF_SURVEY_INDEXES[survey_name],
+        sessionId: session&.id,
         formId: @form_id
       }
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -587,6 +587,10 @@ class Pd::Workshop < ActiveRecord::Base
     course == COURSE_CSF
   end
 
+  def csf_201?
+    course == COURSE_CSF && subject == SUBJECT_CSF_201
+  end
+
   def funded_csf?
     course == COURSE_CSF && funded
   end

--- a/dashboard/app/models/pd/workshop_facilitator_daily_survey.rb
+++ b/dashboard/app/models/pd/workshop_facilitator_daily_survey.rb
@@ -72,6 +72,7 @@ module Pd
       ACADEMIC_YEAR_4_CATEGORY => [1].freeze,
       ACADEMIC_YEAR_1_2_CATEGORY => [1, 2].freeze,
       ACADEMIC_YEAR_3_4_CATEGORY => [1, 2].freeze,
+      CSF_CATEGORY => CSF_SURVEY_INDEXES.values.freeze
     }
 
     validate :day_for_subject


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/PLC-279

**TODO**
- [x] Add CSF facilitator form id to Chef after code is checked in.

**Context**
We can have more than 1 facilitator for CSF 201 workshop. This means we have to split Facilitator survey out of Post-ws survey and enable chaining (embedding) multiple facilitator surveys to post-ws survey for users to fill out.

User flow will be:\
Staring from post-workshop survey -> submit -> Get survey for the 1st facilitator -> submit -> Get survey for the 2nd facilitator -> submit -> Thanks page.

<img width="813" alt="Screen Shot 2019-05-22 at 4 43 54 PM" src="https://user-images.githubusercontent.com/46507039/58215917-f3ed1500-7cb0-11e9-99e7-f772b7a566e8.png">
<img width="823" alt="Screen Shot 2019-05-22 at 4 44 16 PM" src="https://user-images.githubusercontent.com/46507039/58215918-f485ab80-7cb0-11e9-8e12-fe4c67970b73.png">
<img width="825" alt="Screen Shot 2019-05-22 at 4 44 31 PM" src="https://user-images.githubusercontent.com/46507039/58215919-f485ab80-7cb0-11e9-9e85-55175b19821e.png">
<img width="717" alt="Screen Shot 2019-05-22 at 4 44 44 PM" src="https://user-images.githubusercontent.com/46507039/58215920-f485ab80-7cb0-11e9-93db-eccbdc23e0e6.png">


**How tested**
- Unit test: `bundle exec rails test test/controllers/pd/workshop_daily_survey_controller_test.rb`
- Manual test
  - Set up workshop and user in rails console
      ```ruby
      include FactoryGirl::Syntax::Methods

      # create workshop, enroll teacher and mark attendance
      u = User.find_by_email('ha@code.org')
      ws = create :pd_workshop,
        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: (create :regional_partner),
        num_sessions: 1, facilitators: (create_list :facilitator, 2), started_at: DateTime.now

      enroll = create :pd_enrollment, :from_user, user: u, workshop: ws
      enroll.code
      attend = create :pd_attendance, session: ws.sessions[0], teacher: u

      # verify survey submissions
      Pd::WorkshopDailySurvey.count
      Pd::WorkshopDailySurvey.last
      Pd::WorkshopFacilitatorDailySurvey.count
      Pd::WorkshopFacilitatorDailySurvey.last

      # clear up last submissions
      Pd::WorkshopDailySurvey.last.destroy!
      Pd::WorkshopDailySurvey.destroy_all
      Pd::WorkshopFacilitatorDailySurvey.destroy_all
      ```
  - Open these links
      - Post-ws survey: http://localhost-studio.code.org:3000/pd/workshop_survey/csf/post201
      - Facilitator-specific survey: http://localhost-studio.code.org:3000/pd/workshop_survey/facilitators/[sessionid]/[facilitatorIndex] (e.g. http://localhost-studio.code.org:3000/pd/workshop_survey/facilitators/160/0)
      - Pre-ws survey: http://localhost-studio.code.org:3000/pd/workshop_survey/csf/pre201/