### PR TITLE
School Info Interstitial - set font size to 13 px

### DIFF
--- a/apps/src/lib/ui/SchoolInfoInterstitial.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.jsx
@@ -13,7 +13,8 @@ import firehoseClient from '../util/firehose';
 const styles = {
   container: {
     margin: 20,
-    color: color.charcoal
+    color: color.charcoal,
+    fontSize: 15
   },
   heading: {
     fontSize: 16,

--- a/apps/src/lib/ui/SchoolInfoInterstitial.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.jsx
@@ -14,7 +14,7 @@ const styles = {
   container: {
     margin: 20,
     color: color.charcoal,
-    fontSize: 15
+    fontSize: 13
   },
   heading: {
     fontSize: 16,


### PR DESCRIPTION

When a user hits "No, update" button in the school info confirmation dialog, the school info interstitial is rendered.  Upon inspection, the font size of country and school fields in the interstitial is set to 24 px.  To override this font setting, a font size of 13px was set in the styles object located in the school info interstitial component.

### Before:
![school_info_conf_dialog_no_update](https://user-images.githubusercontent.com/30066710/57638859-80862d80-7563-11e9-9a0d-69e6a9d8eb31.gif)


### After:
![school_info_interstitial_font_change1](https://user-images.githubusercontent.com/30066710/58280202-e9845700-7d54-11e9-9cbe-ec6efd4d2a85.gif)
