### PR TITLE
School Info Confirmation Dialog - close the modal when x is clicked

### DIFF
--- a/apps/src/lib/ui/SchoolInfoConfirmationDialog.jsx
+++ b/apps/src/lib/ui/SchoolInfoConfirmationDialog.jsx
@@ -41,6 +41,10 @@ class SchoolInfoConfirmationDialog extends Component {
     };
   }
 
+  closeModal = () => {
+    this.setState({isOpen: false});
+  };
+
   handleClickYes = () => {
     const {authTokenName, authTokenValue} = this.props.scriptData;
     fetch(
@@ -119,7 +123,7 @@ class SchoolInfoConfirmationDialog extends Component {
   render() {
     const {showSchoolInterstitial, isOpen} = this.state;
     return (
-      <Dialog isOpen={isOpen}>
+      <Dialog isOpen={isOpen} handleClose={this.closeModal}>
         {!showSchoolInterstitial
           ? this.renderInitialContent()
           : this.renderSchoolInformationForm()}


### PR DESCRIPTION
The  'x-close' was added to the upper right corner of the modal.  This gives the user an option to either select the button that is applicable or close the modal to make a selection when prompted again. 

#### Before:
'x-close' does not exist.

[See spec](https://docs.google.com/document/d/1pvyCDwdiyxWJsbLN83iKTtE_dlMVxKfEKTYZTjvQg98/edit#bookmark=id.7nphav4c1558)

#### Implementation
When a user clicks the "X" it closes the modal and no fields are updated in the database.  In 7 days, when the user signs in, the school confirmation dialog will be shown.

![close_modal](https://user-images.githubusercontent.com/30066710/58281748-b80d8a80-7d58-11e9-8f18-e7abd6b3c1e0.gif)
