### PR TITLE
Use curriculum_umbrella to replace hardcode CSF list in script_config

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1626,4 +1626,8 @@ class Script < ActiveRecord::Base
     return true if user.permission?(UserPermission::LEVELBUILDER)
     all_scripts.any? {|script| script.has_pilot_experiment?(user)}
   end
+
+  def self.script_names_by_curriculum_umbrella(curriculum_umbrella)
+    Script.all.select {|script| script.curriculum_umbrella == curriculum_umbrella}.pluck(:name)
+  end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1628,6 +1628,6 @@ class Script < ActiveRecord::Base
   end
 
   def self.script_names_by_curriculum_umbrella(curriculum_umbrella)
-    Script.all.select {|script| script.curriculum_umbrella == curriculum_umbrella}.pluck(:name)
+    Script.where("properties -> '$.curriculum_umbrella' = ?", curriculum_umbrella).pluck(:name)
   end
 end

--- a/dashboard/config/scripts/Course4pre.script
+++ b/dashboard/config/scripts/Course4pre.script
@@ -1,5 +1,3 @@
-curriculum_umbrella 'CSF'
-
 stage 'Maze: Sequence'
 level '2-3 Maze 1'
 level '2-3 Maze 2'

--- a/dashboard/config/scripts/course-e-2018.script
+++ b/dashboard/config/scripts/course-e-2018.script
@@ -1,5 +1,3 @@
-curriculum_umbrella 'CSF'
-
 stage 'Programming: My Robotic Friends', flex_category: 'csf_e_1'
 level 'courseB_unplugged_MRF_2018'
 

--- a/dashboard/config/scripts/course-f-2018.script
+++ b/dashboard/config/scripts/course-f-2018.script
@@ -1,5 +1,3 @@
-curriculum_umbrella 'CSF'
-
 stage 'Programming: My Robotic Friends', flex_category: 'csf_f_1'
 level 'courseB_unplugged_MRF_2018'
 

--- a/dashboard/config/scripts/coursea-draft.script
+++ b/dashboard/config/scripts/coursea-draft.script
@@ -1,6 +1,5 @@
 login_required true
 has_lesson_plan true
-curriculum_umbrella 'CSF'
 
 stage 'Debugging: Unspotted Bugs'
 level 'courseB_video_Unspotted'

--- a/dashboard/config/scripts/courseb-draft.script
+++ b/dashboard/config/scripts/courseb-draft.script
@@ -1,6 +1,5 @@
 login_required true
 has_lesson_plan true
-curriculum_umbrella 'CSF'
 
 stage 'Debugging: Unspotted Bugs'
 level 'courseB_video_Unspotted'

--- a/dashboard/config/scripts/coursec-draft.script
+++ b/dashboard/config/scripts/coursec-draft.script
@@ -1,5 +1,4 @@
 has_lesson_plan true
-curriculum_umbrella 'CSF'
 
 stage 'Building a Foundation'
 level 'BuildingAFoundation'

--- a/dashboard/config/scripts/coursed-draft.script
+++ b/dashboard/config/scripts/coursed-draft.script
@@ -1,6 +1,5 @@
 login_required true
 has_lesson_plan true
-curriculum_umbrella 'CSF'
 
 stage 'Introduction'
 level 'courseD_video_ramp1'

--- a/dashboard/config/scripts/coursed-ramp.script
+++ b/dashboard/config/scripts/coursed-ramp.script
@@ -1,5 +1,4 @@
 hideable_stages true
-curriculum_umbrella 'CSF'
 
 stage 'Introduction'
 level 'courseD_video_ramp1'

--- a/dashboard/config/scripts/coursee-draft.script
+++ b/dashboard/config/scripts/coursee-draft.script
@@ -1,6 +1,5 @@
 login_required true
 has_lesson_plan true
-curriculum_umbrella 'CSF'
 
 stage 'Algorithms: Dice Race'
 level 'DiceRace'

--- a/dashboard/config/scripts/coursee-ramp.script
+++ b/dashboard/config/scripts/coursee-ramp.script
@@ -1,6 +1,5 @@
 stage 'Real Life Algorithms: Dice Race'
 level 'DiceRace'
-curriculum_umbrella 'CSF'
 
 stage 'Introduction'
 level 'courseE_video_ramp1'

--- a/dashboard/config/scripts/coursef-draft.script
+++ b/dashboard/config/scripts/coursef-draft.script
@@ -1,6 +1,5 @@
 login_required true
 has_lesson_plan true
-curriculum_umbrella 'CSF'
 
 stage 'Algorithms: Tangrams'
 level 'TangramAlgorithms'

--- a/dashboard/config/scripts/coursef-ramp.script
+++ b/dashboard/config/scripts/coursef-ramp.script
@@ -1,5 +1,3 @@
-curriculum_umbrella 'CSF'
-
 stage 'Algorithms: Tangrams'
 level 'TangramAlgorithms'
 

--- a/dashboard/config/scripts/express-2018-vn.script
+++ b/dashboard/config/scripts/express-2018-vn.script
@@ -1,6 +1,5 @@
 hidden false
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/express/"], ["vocabulary", "https://curriculum.code.org/csf-18/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/express/standards/"]]
-curriculum_umbrella 'CSF'
 
 stage 'Programming in Maze'
 level 'courseC_video_maze_2018'

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -642,6 +642,27 @@ FactoryGirl.define do
 
   factory :script do
     sequence(:name) {|n| "bogus-script-#{n}"}
+
+    factory :csf_script do
+      after(:create) do |csf_script|
+        csf_script.curriculum_umbrella = 'CSF'
+        csf_script.save
+      end
+    end
+
+    factory :csd_script do
+      after(:create) do |csd_script|
+        csd_script.curriculum_umbrella = 'CSD'
+        csd_script.save
+      end
+    end
+
+    factory :csp_script do
+      after(:create) do |csp_script|
+        csp_script.curriculum_umbrella = 'CSP'
+        csp_script.save
+      end
+    end
   end
 
   factory :featured_project do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1714,15 +1714,18 @@ endvariants
   end
 
   test "script_names_by_curriculum_umbrella returns the correct script names" do
-    assert Script.script_names_by_curriculum_umbrella('CSF').include?(@csf_script.name)
-    refute Script.script_names_by_curriculum_umbrella('CSF').include?(@csd_script.name)
-    refute Script.script_names_by_curriculum_umbrella('CSF').include?(@csp_script.name)
-    assert Script.script_names_by_curriculum_umbrella('CSD').include?(@csd_script.name)
-    refute Script.script_names_by_curriculum_umbrella('CSD').include?(@csf_script.name)
-    refute Script.script_names_by_curriculum_umbrella('CSD').include?(@csp_script.name)
-    assert Script.script_names_by_curriculum_umbrella('CSP').include?(@csp_script.name)
-    refute Script.script_names_by_curriculum_umbrella('CSP').include?(@csf_script.name)
-    refute Script.script_names_by_curriculum_umbrella('CSP').include?(@csd_script.name)
+    assert_equal(
+      [@csf_script.name],
+      Script.script_names_by_curriculum_umbrella('CSF')
+    )
+    assert_equal(
+      [@csd_script.name],
+      Script.script_names_by_curriculum_umbrella('CSD')
+    )
+    assert_equal(
+      [@csp_script.name],
+      Script.script_names_by_curriculum_umbrella('CSP')
+    )
   end
 
   private

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -20,6 +20,10 @@ class ScriptTest < ActiveSupport::TestCase
     @script_2017 = create :script, name: 'script-2017', family_name: 'family-cache-test', version_year: '2017'
     @script_2018 = create :script, name: 'script-2018', family_name: 'family-cache-test', version_year: '2018'
 
+    @csf_script = create :csf_script, name: 'csf1'
+    @csd_script = create :csd_script, name: 'csd1'
+    @csp_script = create :csp_script, name: 'csp1'
+
     # ensure that we have freshly generated caches with this course/script
     Course.clear_cache
     Script.clear_cache
@@ -1707,6 +1711,18 @@ endvariants
     refute Script.has_any_pilot_access?(teacher)
     assert Script.has_any_pilot_access?(pilot_teacher)
     assert Script.has_any_pilot_access?(levelbuilder)
+  end
+
+  test "script_names_by_curriculum_umbrella returns the correct script names" do
+    assert Script.script_names_by_curriculum_umbrella('CSF').include?(@csf_script.name)
+    refute Script.script_names_by_curriculum_umbrella('CSF').include?(@csd_script.name)
+    refute Script.script_names_by_curriculum_umbrella('CSF').include?(@csp_script.name)
+    assert Script.script_names_by_curriculum_umbrella('CSD').include?(@csd_script.name)
+    refute Script.script_names_by_curriculum_umbrella('CSD').include?(@csf_script.name)
+    refute Script.script_names_by_curriculum_umbrella('CSD').include?(@csp_script.name)
+    assert Script.script_names_by_curriculum_umbrella('CSP').include?(@csp_script.name)
+    refute Script.script_names_by_curriculum_umbrella('CSP').include?(@csf_script.name)
+    refute Script.script_names_by_curriculum_umbrella('CSP').include?(@csd_script.name)
   end
 
   private

--- a/lib/cdo/script_config.rb
+++ b/lib/cdo/script_config.rb
@@ -26,6 +26,6 @@ class ScriptConfig
   end
 
   def self.csf_scripts
-    ScriptConstants::CATEGORIES.fetch_values(:csf, :csf_2018, :csf_international, :twenty_hour).flatten.uniq
+    Script.script_names_by_curriculum_umbrella('CSF')
   end
 end


### PR DESCRIPTION
[LP-386](https://codedotorg.atlassian.net/browse/LP-386)

`self.csf_scripts` in script_config previously used a hardcoded list of CSF version categories to find the names of CSF scripts that are used in the feature mode manager. 

Originally the method returned: ["coursea-2017", "courseb-2017", "coursec-2017", "coursed-2017", "coursee-2017", "coursef-2017", "express-2017", "pre-express-2017", "coursea-2018", "courseb-2018", "coursec-2018", "coursed-2018", "coursee-2018", "coursef-2018", "express-2018", "pre-express-2018", "course1", "course2", "course3", "course4", "20-hour"]

We wanted a way to update this to include the 2019 CSF course names without having to add the 2019 CSF categories and update the hardcoded list, which is why I [introduced the `curriculum_umbrella` property ](https://github.com/code-dot-org/code-dot-org/pull/28678) and [added `curriculum_umbrella = 'CSF'` to a bunch of CSF scripts](https://github.com/code-dot-org/code-dot-org/pull/28689).

In this PR, I introduce a new method `script_names_by_curriculum_umbrella` which I then use in `self.csf_scripts` in script_config, which returned: 

["20-hour", "Course4pre", "course1", "course2", "course3", "course4", "coursea-draft", "courseb-draft", "coursec-draft", "coursed-draft", "coursed-ramp", "coursee-draft", "coursee-ramp", "coursef-draft", "coursef-ramp", "course-e-2018", "course-f-2018", "coursea-2017", "coursea-2018", "courseb-2017", "courseb-2018", "coursec-2017", "coursec-2018", "coursed-2017", "coursed-2018", "coursee-2017", "coursee-2018", "coursef-2017", "coursef-2018", "express-2017", "express-2018", "pre-express-2017", "pre-express-2018", "coursed-2019", "coursee-2019", "coursef-2019", "express-2019", "coursec-2019", "coursea-2019", "courseb-2019", "pre-express-2019", "csf-umbrella", "express-2018-vn"]

The above result had more script names than are necessary, so I removed `curriculum_umbrella = 'CSF'` from the irrelevant CSF-ish files. These files included drafts, ramps, and course-x-year (versus coursex-year) file names. 

After seeding scripts to pick up the removals of `curriculum_umbrella = 'CSF'`, `self.csf_scripts` in script_config now returns: 

["20-hour", "course1", "course2", "course3", "course4", "coursea-2017", "coursea-2018", "courseb-2017", "courseb-2018", "coursec-2017", "coursec-2018", "coursed-2017", "coursed-2018", "coursee-2017", "coursee-2018", "coursef-2017", "coursef-2018", "express-2017", "express-2018", "pre-express-2017", "pre-express-2018", "coursed-2019", "coursee-2019", "coursef-2019", "express-2019", "coursec-2019", "coursea-2019", "courseb-2019", "pre-express-2019"]

This is what we want because it includes all of the script names that were originally returned plus the equivalent ones for 2019. 

**Note** The scripts in which I deleted curriculum_umbrella might be good candidates for deleting entirely.  I'll track investigating their removal separately as part of a scripts clean up work item. 