### PR TITLE
Pilot (Student Libraries): Added S3 component of student libraries feature so students can share libraries between projects

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -677,12 +677,15 @@ Applab.init = function(config) {
     });
   }
 
-  if (
-    experiments.isEnabled('student-libraries') &&
-    level.libraries &&
-    level.libraries.length > 0
-  ) {
+  // Libraries should be added to redux whether the experiment is enabled or
+  // not. This prevents work from being lost if a levelbuilder toggles the
+  // experiment flag.
+  var librariesExist = level.libraries && level.libraries.length > 0;
+  if (librariesExist) {
     getStore().dispatch(setApplabLibraries(level.libraries));
+  }
+
+  if (experiments.isEnabled('student-libraries') && librariesExist) {
     let importedConfigs = level.libraries
       .map(library => library.dropletConfig)
       .reduce((a, b) => a.concat(b));

--- a/apps/src/code-studio/components/LibraryPicker.jsx
+++ b/apps/src/code-studio/components/LibraryPicker.jsx
@@ -2,6 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import BaseDialog from '../../templates/BaseDialog';
 import color from '../../util/color';
+import clientApi from '@cdo/apps/code-studio/initApp/clientApi';
+import {addApplabLibrary} from './applabLibraryRedux';
+import {connect} from 'react-redux';
+import project from '../initApp/project';
 
 const styles = {
   root: {
@@ -28,10 +32,19 @@ const styles = {
   }
 };
 
-export default class LibraryPicker extends React.Component {
+class LibraryPicker extends React.Component {
   static propTypes = {
     onClose: PropTypes.func,
-    isOpen: PropTypes.bool
+    isOpen: PropTypes.bool,
+    addLibrary: PropTypes.func
+  };
+
+  state = {
+    libraryId: ''
+  };
+
+  changeLibraryId = event => {
+    this.setState({libraryId: event.target.value});
   };
 
   select = event => event.target.select();
@@ -43,12 +56,23 @@ export default class LibraryPicker extends React.Component {
           Paste in the library link for a project to add its functions in your
           toolbox.
         </p>
-        <input type="text" onClick={this.select} style={styles.linkBox} />
+        <input
+          type="text"
+          onClick={this.select}
+          style={styles.linkBox}
+          value={this.state.libraryId}
+          onChange={this.changeLibraryId}
+        />
       </div>
     );
   }
 
   addLibrary = () => {
+    var libraryPilot = clientApi.create('/v3/librarypilot');
+    libraryPilot.fetch(this.state.libraryId + '/library.json', (foo, data) => {
+      this.props.addLibrary(data);
+      project.addLibrary(data);
+    });
     console.log('Added your library!');
     this.props.onClose();
   };
@@ -75,3 +99,12 @@ export default class LibraryPicker extends React.Component {
     );
   }
 }
+
+export default connect(
+  state => ({}),
+  dispatch => ({
+    addLibrary(data) {
+      dispatch(addApplabLibrary(data));
+    }
+  })
+)(LibraryPicker);

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -20,6 +20,7 @@ import {createHiddenPrintWindow} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import PublishLibraryDialog from './PublishLibraryDialog';
+import experiments from '@cdo/apps/util/experiments';
 
 function recordShare(type) {
   if (!window.dashboard) {
@@ -498,7 +499,9 @@ class ShareAllowedDialog extends React.Component {
           )}
         </BaseDialog>
         <PublishDialog />
-        <PublishLibraryDialog channelId={this.props.channelId} />
+        {experiments.isEnabled('student-libraries') && (
+          <PublishLibraryDialog channelId={this.props.channelId} />
+        )}
       </div>
     );
   }

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -498,7 +498,7 @@ class ShareAllowedDialog extends React.Component {
           )}
         </BaseDialog>
         <PublishDialog />
-        <PublishLibraryDialog />
+        <PublishLibraryDialog channelId={this.props.channelId} />
       </div>
     );
   }

--- a/apps/src/code-studio/components/applabLibraryRedux.jsx
+++ b/apps/src/code-studio/components/applabLibraryRedux.jsx
@@ -1,0 +1,33 @@
+const ADD_LIBRARY = 'applabLibrary/ADD_LIBRARY';
+const SET_LIBRARIES = 'applabLibrary/SET_LIBRARIES';
+
+export default function reducer(state, action) {
+  var currentState = state || {libraries: []};
+  switch (action.type) {
+    case SET_LIBRARIES:
+      return {
+        libraries: action.libraries
+      };
+    case ADD_LIBRARY:
+      // For now (during the pilot), you can only import one library at a time.
+      return {
+        libraries: [action.library]
+      };
+    default:
+      return currentState;
+  }
+}
+
+export function setApplabLibraries(libraries) {
+  return {
+    type: SET_LIBRARIES,
+    libraries: libraries
+  };
+}
+
+export function addApplabLibrary(library) {
+  return {
+    type: ADD_LIBRARY,
+    library: library
+  };
+}

--- a/apps/src/code-studio/components/libraryShareDialogRedux.js
+++ b/apps/src/code-studio/components/libraryShareDialogRedux.js
@@ -4,11 +4,13 @@ const SHOW_LIBRARY_SHARE_DIALOG =
 const HIDE_LIBRARY_SHARE_DIALOG =
   'libraryShareDialog/HIDE_LIBRARY_SHARE_DIALOG';
 const SET_LIBRARY_NAME = 'libraryShareDialog/SET_LIBRARY_NAME';
+const SET_LIBRARY_SOURCE = 'libraryShareDialog/SET_LIBRARY_SOURCE';
 
 const initialState = {
-  libraryFunctions: {},
+  libraryFunctions: [],
   isOpen: false,
-  libraryName: ''
+  libraryName: '',
+  librarySource: ''
 };
 
 export default function reducer(state, action) {
@@ -37,6 +39,12 @@ export default function reducer(state, action) {
         ...state,
         libraryName: action.libraryName
       };
+    case SET_LIBRARY_SOURCE:
+      return {
+        ...initialState,
+        ...state,
+        librarySource: action.librarySource
+      };
     default:
       return {
         ...initialState,
@@ -64,5 +72,12 @@ export function setLibraryName(name) {
   return {
     type: SET_LIBRARY_NAME,
     libraryName: name
+  };
+}
+
+export function setLibrarySource(source) {
+  return {
+    type: SET_LIBRARY_SOURCE,
+    librarySource: source
   };
 }

--- a/apps/src/code-studio/headerShare.js
+++ b/apps/src/code-studio/headerShare.js
@@ -9,7 +9,8 @@ import {getStore} from '../redux';
 import {showShareDialog} from './components/shareDialogRedux';
 import {
   setLibraryFunctions,
-  setLibraryName
+  setLibraryName,
+  setLibrarySource
 } from './components/libraryShareDialogRedux';
 import {AllPublishableProjectTypes} from '../util/sharedConstants';
 import experiments from '@cdo/apps/util/experiments';
@@ -36,6 +37,9 @@ export function shareProject(shareUrl) {
       var libraryName =
         projectName.charAt(0).toUpperCase() + projectName.slice(1);
       getStore().dispatch(setLibraryName(libraryName));
+      dashboard.project.getUpdatedSourceAndHtml_(response =>
+        getStore().dispatch(setLibrarySource(response.source))
+      );
     }
     var i18n = window.dashboard.i18n;
 

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -475,6 +475,12 @@ const sourceHandler = {
   getLibrary() {
     return getAppOptions().getLibrary();
   },
+  setInitialLevelLibraries(libraries) {
+    getAppOptions().level.libraries = libraries;
+  },
+  getLevelLibraries() {
+    return window.Applab && Applab.getLibraries();
+  },
   setInitialLevelSource(levelSource) {
     getAppOptions().level.lastAttempt = levelSource;
   },

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -120,7 +120,8 @@ function unpackSources(data) {
     html: data.html,
     animations: data.animations,
     makerAPIsEnabled: data.makerAPIsEnabled,
-    selectedSong: data.selectedSong
+    selectedSong: data.selectedSong,
+    libraries: data.libraries
   };
 }
 
@@ -527,6 +528,10 @@ var projects = (module.exports = {
 
       if (currentSources.animations) {
         sourceHandler.setInitialAnimationList(currentSources.animations);
+      }
+
+      if (currentSources.libraries) {
+        sourceHandler.setInitialLevelLibraries(currentSources.libraries);
       }
 
       if (isEditing) {
@@ -1037,7 +1042,15 @@ var projects = (module.exports = {
         const html = this.sourceHandler.getLevelHtml();
         const makerAPIsEnabled = this.sourceHandler.getMakerAPIsEnabled();
         const selectedSong = this.sourceHandler.getSelectedSong();
-        callback({source, html, animations, makerAPIsEnabled, selectedSong});
+        const libraries = this.sourceHandler.getLevelLibraries();
+        callback({
+          source,
+          html,
+          animations,
+          makerAPIsEnabled,
+          selectedSong,
+          libraries
+        });
       })
     );
   },
@@ -1058,6 +1071,23 @@ var projects = (module.exports = {
           {
             ...sourceAndHtml,
             makerAPIsEnabled: !sourceAndHtml.makerAPIsEnabled
+          },
+          () => {
+            resolve();
+            utils.reload();
+          }
+        );
+      });
+    });
+  },
+
+  addLibrary(data) {
+    return new Promise(resolve => {
+      this.getUpdatedSourceAndHtml_(sourceAndHtml => {
+        this.saveSourceAndHtml_(
+          {
+            ...sourceAndHtml,
+            libraries: [data]
           },
           () => {
             resolve();

--- a/apps/src/code-studio/redux.js
+++ b/apps/src/code-studio/redux.js
@@ -9,11 +9,13 @@ import shareDialog from './components/shareDialogRedux';
 import hiddenStage from './hiddenStageRedux';
 import isRtl from './isRtlRedux';
 import libraryShareDialog from './components/libraryShareDialogRedux';
+import applabLibrary from './components/applabLibraryRedux';
 import responsive from './responsiveRedux';
 import publishDialog from '../templates/projects/publishDialog/publishDialogRedux';
 import verifiedTeacher from './verifiedTeacherRedux';
 
 registerReducers({
+  applabLibrary,
   header,
   progress,
   teacherSections,

--- a/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
@@ -249,14 +249,16 @@ export default class JSInterpreter {
    */
   getFunctionsAndParams(code) {
     this.parse({code: code});
-    var functionsWithParms = {};
     var functions = this.interpreter.ast.body.filter(obj => {
       return obj.type === 'FunctionDeclaration';
     });
-    functions.map(obj => {
-      functionsWithParms[obj.id.name] = obj.params.map(param => {
+
+    var functionsWithParms = functions.map(obj => {
+      var name = obj.id.name;
+      var params = obj.params.map(param => {
         return param.name;
       });
+      return {name: name, params: params};
     });
 
     return functionsWithParms;

--- a/apps/src/lib/ui/SettingsCog.jsx
+++ b/apps/src/lib/ui/SettingsCog.jsx
@@ -154,10 +154,12 @@ class SettingsCog extends Component {
           handleConfirm={this.confirmEnableMaker}
           handleCancel={this.hideConfirmation}
         />
-        <LibraryPicker
-          isOpen={this.state.libraryPickerOpen}
-          onClose={this.closeLibraryPicker}
-        />
+        {experiments.isEnabled('student-libraries') && (
+          <LibraryPicker
+            isOpen={this.state.libraryPickerOpen}
+            onClose={this.closeLibraryPicker}
+          />
+        )}
       </span>
     );
   }

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -771,6 +771,8 @@ function createStubSourceHandler() {
     getLevelHtml: sinon.stub(),
     setInitialLevelSource: sinon.stub(),
     getLevelSource: sinon.stub().resolves(),
+    setInitialLevelLibraries: sinon.stub(),
+    getLevelLibraries: sinon.stub().resolves(),
     setInitialAnimationList: sinon.stub(),
     getAnimationList: sinon.stub().callsFake(cb => cb({})),
     setMakerAPIsEnabled: sinon.stub(),

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -162,6 +162,7 @@ class HttpCache
               /v3/assets/*
               /v3/animations/*
               /v3/files/*
+              /v3/librarypilot/*
             ),
             headers: WHITELISTED_HEADERS,
             cookies: whitelisted_cookies

--- a/deployment.rb
+++ b/deployment.rb
@@ -116,6 +116,8 @@ def load_configuration
     'animations_s3_directory'     => rack_env == :production ? 'animations' : "animations_#{rack_env}",
     'assets_s3_bucket'            => 'cdo-v3-assets',
     'assets_s3_directory'         => rack_env == :production ? 'assets' : "assets_#{rack_env}",
+    'librarypilot_s3_bucket'      => 'cdo-v3-librarypilot',
+    'librarypilot_s3_directory'   => rack_env == :production ? 'librarypilot' : "librarypilot_#{rack_env}",
     'sources_s3_bucket'           => 'cdo-v3-sources',
     'sources_s3_directory'        => sources_s3_dir(rack_env, root_dir),
     'use_pusher'                  => false,

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -29,6 +29,8 @@ class FilesApi < Sinatra::Base
       FileBucket
     when 'sources'
       SourceBucket
+    when 'librarypilot'
+      LibraryPilotBucket
     else
       not_found
     end
@@ -107,7 +109,7 @@ class FilesApi < Sinatra::Base
   end
 
   helpers do
-    %w(core.rb bucket_helper.rb animation_bucket.rb file_bucket.rb asset_bucket.rb source_bucket.rb storage_id.rb auth_helpers.rb profanity_privacy_helper.rb).each do |file|
+    %w(core.rb bucket_helper.rb animation_bucket.rb file_bucket.rb librarypilot_bucket.rb asset_bucket.rb source_bucket.rb storage_id.rb auth_helpers.rb profanity_privacy_helper.rb).each do |file|
       load(CDO.dir('shared', 'middleware', 'helpers', file))
     end
   end
@@ -135,11 +137,11 @@ class FilesApi < Sinatra::Base
   end
 
   #
-  # GET /v3/(animations|assets|sources|files)/<channel-id>/<filename>?version=<version-id>
+  # GET /v3/(animations|assets|sources|librarypilot|files)/<channel-id>/<filename>?version=<version-id>
   #
   # Read a file. Optionally get a specific version instead of the most recent.
   #
-  get %r{/v3/(animations|assets|sources|files)/([^/]+)/([^/]+)$} do |endpoint, encrypted_channel_id, filename|
+  get %r{/v3/(animations|assets|sources|librarypilot|files)/([^/]+)/([^/]+)$} do |endpoint, encrypted_channel_id, filename|
     get_file(endpoint, encrypted_channel_id, filename)
   end
 
@@ -394,10 +396,11 @@ class FilesApi < Sinatra::Base
   #
   # PUT /v3/(sources)/<channel-id>/<filename>?version=<version-id>
   # PUT /v3/(assets)/<channel-id>/<filename>
+  # PUT /v3/(librarypilot)/<channel-id>/<filename>
   #
   # Create or replace a file. For sources endpoint, optionally overwrite a specific version.
   #
-  put %r{/v3/(sources|assets)/([^/]+)/([^/]+)$} do |endpoint, encrypted_channel_id, filename|
+  put %r{/v3/(sources|librarypilot|assets)/([^/]+)/([^/]+)$} do |endpoint, encrypted_channel_id, filename|
     dont_cache
     content_type :json
 

--- a/shared/middleware/helpers/librarypilot_bucket.rb
+++ b/shared/middleware/helpers/librarypilot_bucket.rb
@@ -1,0 +1,16 @@
+#
+# LibraryPilotBucket
+#
+class LibraryPilotBucket < BucketHelper
+  def initialize
+    super CDO.librarypilot_s3_bucket, CDO.librarypilot_s3_directory
+  end
+
+  def allowed_file_types
+    %w(.json)
+  end
+
+  def cache_duration_seconds
+    3600
+  end
+end


### PR DESCRIPTION
This is just the S3 portion. The UI portions are here: https://github.com/code-dot-org/code-dot-org/pull/28659 https://github.com/code-dot-org/code-dot-org/pull/28672 

![studentLibrariesFeature](https://user-images.githubusercontent.com/8324574/58286293-45ee7300-7d63-11e9-9731-76cdb05b2f66.gif)

Spec for reference: https://docs.google.com/document/d/1jMLm_ghCshFen-h9vInAuXwEGXI-HPMjSP8dYeISfM0/edit?pli=1#

This code is largely experimental. If we go forward with Student Libraries, all code here will go through a second CR for production quality review. Review this PR to evaluate the following:
- Isolation: Will the reviewed code affect parts of the product that are not part of the pilot?
- Will the code fail in ways that will cause the pilot to be unsuccessful?
- Is there an obviously easier or better way to implement the piloted feature?

Although the piloting process is still under review, I am following the procedures in this doc: https://docs.google.com/document/d/10QvRAVOTEenFJa1wwrY0Twkd0anTDpkkzNeGnT_HH0o/edit