### PR TITLE
School Info Confirmation Dialog - check if user has seen interstitial

### DIFF
--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -25,7 +25,7 @@ module SchoolInfoInterstitialHelper
   end
 
   # Determine if a user has seen the school info interstitial.
-  def check_last_seen_school_info_interstitial?(user)
+  def self.check_last_seen_school_info_interstitial?(user)
     return true if user.last_seen_school_info_interstitial.nil?
 
     return true if user.last_seen_school_info_interstitial >= 7

--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -24,6 +24,16 @@ module SchoolInfoInterstitialHelper
     return true
   end
 
+  # Helper method to determine if last seen school info interstitial is nil
+  def check_last_seen_school_info_interstitial?
+    # the user has never seen it
+    return true if last_seen_school_info_interstitial.nil?
+    # the user has seen it, but it has been more than a week
+    return true if user.last_seen_school_info_interstitial >= 7
+
+    return false
+  end
+
   # Show the school info confirmation dialog when a teacher has either completely
   # filled out the school info interstitial for a US public, private, or charter school
   # or confirmed current school over a year ago.
@@ -36,11 +46,9 @@ module SchoolInfoInterstitialHelper
 
     school_info = user_school_info.school_info
 
-    check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && SchoolInfoInterstitialHelper.complete?(school_info)
+    check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && complete?(school_info)
 
-    check_last_confirmation_date = (DateTime.now - user_school_info.last_confirmation_date.to_datetime > 365) &&
-    ((user.last_seen_school_info_interstitial.nil? || user.last_seen_school_info_interstitial >= 7 unless
-             user.last_seen_school_info_interstitial.nil?))
+    check_last_confirmation_date = (DateTime.now - user_school_info.last_confirmation_date.to_datetime > 365) && check_last_seen_school_info_interstitial?
 
     check_last_confirmation_date && check_school_type
   end

--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -25,8 +25,8 @@ module SchoolInfoInterstitialHelper
   end
 
   # Determine if a user has seen the school info interstitial.
-  def check_last_seen_school_info_interstitial?
-    return true if last_seen_school_info_interstitial.nil?
+  def check_last_seen_school_info_interstitial?(user)
+    return true if user.last_seen_school_info_interstitial.nil?
 
     return true if user.last_seen_school_info_interstitial >= 7
 

--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -38,7 +38,9 @@ module SchoolInfoInterstitialHelper
 
     check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && SchoolInfoInterstitialHelper.complete?(school_info)
 
-    check_last_confirmation_date = user_school_info.last_confirmation_date.to_datetime < 1.year.ago
+    check_last_confirmation_date = (DateTime.now - user_school_info.last_confirmation_date.to_datetime > 365) &&
+    ((user.last_seen_school_info_interstitial.nil? || user.last_seen_school_info_interstitial >= 7 unless
+             user.last_seen_school_info_interstitial.nil?))
 
     check_last_confirmation_date && check_school_type
   end

--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -24,11 +24,10 @@ module SchoolInfoInterstitialHelper
     return true
   end
 
-  # Helper method to determine if last seen school info interstitial is nil
+  # Determine if a user has seen the school info interstitial.
   def check_last_seen_school_info_interstitial?
-    # the user has never seen it
     return true if last_seen_school_info_interstitial.nil?
-    # the user has seen it, but it has been more than a week
+
     return true if user.last_seen_school_info_interstitial >= 7
 
     return false


### PR DESCRIPTION
The "show_school_confirmation_dialog?" is refactored to check if a user has seen the school info interstitial.

Conditions checked:
If a user has never seen the school info interstitial
If a user has seen the school info interstitial but it has been more than a week
If a user has seen the school info interstitial but it is within the last week

