### PR TITLE
Explicitly attempt to resolve i18n-specific and english-fallback documents as two separate steps

### DIFF
--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -226,7 +226,8 @@ class Documents < Sinatra::Base
 
   # Documents
   get_head_or_post '*' do |uri|
-    pass unless path = resolve_document(uri)
+    path = resolve_document("#{uri}.#{request.locale}") || resolve_document(uri)
+    pass unless path
     if defined? NewRelic
       transaction_name = uri
       transaction_name = transaction_name.sub(request.env[:splat_path_info], '') if request.env[:splat_path_info]
@@ -417,7 +418,7 @@ class Documents < Sinatra::Base
     end
 
     def resolve_document(uri)
-      extnames = settings.non_static_extnames + [".#{request.locale}.md"]
+      extnames = settings.non_static_extnames
 
       path = resolve_template('public', extnames, uri, true)
       return path if path


### PR DESCRIPTION
The current way we attempt to find localized templates leverages
extension names to make the localized version visible, and relies on
search ordering to make sure it gets selected first.

We'd like to implement some tweaks to the way we handle extension names
to allow for more dynamic template processing, but that becomes
difficult to do when the locale is also handled as an extension name.

With this change, we explicitly attempt to find the locale-specific
version of a file first by treating the locale as part of the
_filename_, not the extension name. This will both unblock us to make
tweaks to extension names and make the locale-vs-fallback functionality
more explicit.