### PR TITLE
Recover missing continue button on external levels without videos

### DIFF
--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -19,9 +19,8 @@
     - unless in_level_group
       - if @script.try(:professional_learning_course?) && @script_level
         = link_to @script_level.end_of_stage? ? t('done_with_module') : t('next_resource'), @script_level.next_level_or_redirect_path_for_user(current_user), class: 'btn btn-large pull-right btn-primary submitButton'
-      - elsif !@level.has_submit_button?
-        - unless video && use_large_video_player
-          %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
+      - elsif !@level.has_submit_button? && !(video && use_large_video_player)
+        %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
 
   = render partial: 'levels/content', locals: {app: 'external', data: level_props, content_class: level_props['options'].try(:[], 'css'), postcontent: postcontent}
   = render partial: 'levels/teacher_markdown', locals: {data: level_props}

--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -19,8 +19,9 @@
     - unless in_level_group
       - if @script.try(:professional_learning_course?) && @script_level
         = link_to @script_level.end_of_stage? ? t('done_with_module') : t('next_resource'), @script_level.next_level_or_redirect_path_for_user(current_user), class: 'btn btn-large pull-right btn-primary submitButton'
-      - elsif !@level.has_submit_button? && !use_large_video_player
-        %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
+      - elsif !@level.has_submit_button?
+        - unless video && use_large_video_player
+          %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
 
   = render partial: 'levels/content', locals: {app: 'external', data: level_props, content_class: level_props['options'].try(:[], 'css'), postcontent: postcontent}
   = render partial: 'levels/teacher_markdown', locals: {data: level_props}


### PR DESCRIPTION
Follow up to fix a regression from https://github.com/code-dot-org/code-dot-org/pull/28553.
In cases where `use_large_video_player == true` for a script, but the level isn't a video level the continue button was missing.  I fixed by checking for `video` so the logic for hiding/showing the top and bottom continue buttons is consistent. 

BEFORE: 
<img width="1035" alt="Screen Shot 2019-05-24 at 9 45 05 AM" src="https://user-images.githubusercontent.com/12300669/58345132-82c27480-7e0c-11e9-9207-ca24e1bcd7c8.png">

AFTER: 
<img width="1010" alt="Screen Shot 2019-05-24 at 9 44 51 AM" src="https://user-images.githubusercontent.com/12300669/58345060-4abb3180-7e0c-11e9-947e-d3a30419665c.png">
