### PR TITLE
Pilot (Student Libraries): Fix json parsing bug with student created libraries

### DIFF
--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -109,8 +109,9 @@ class Applab < Blockly
   def update_json_fields
     palette_result = update_palette
     log_conditions_result = parse_json_property_field('log_conditions')
+    start_libraries_result = parse_json_property_field('start_libraries')
 
-    success = palette_result && log_conditions_result
+    success = palette_result && log_conditions_result && start_libraries_result
     throw :abort unless success
   end
 

--- a/dashboard/app/views/levels/editors/_applab.html.haml
+++ b/dashboard/app/views/levels/editors/_applab.html.haml
@@ -3,7 +3,7 @@
 
 .field
   = f.label :start_libraries,'Applab Start Library'
-  = f.text_area :start_libraries, value: @level.start_libraries
+  = f.text_area :start_libraries, value: @level.start_libraries ? JSON.pretty_generate(@level.start_libraries) : ''
 .field
   = f.label :slider_speed, 'Slider speed'
   %p Number from 0.0 to 1.0 for how fast Applab runs by default while in the IDE. If not set, default is 1.0


### PR DESCRIPTION
In the past, levelbuilder would display the JS student-library object as a non-json string. Then, when saving the levelbuilder edit page, it would overwrite the JS student-library object with that string. This fixes that issue.