### PR TITLE
Update binglog_row_image to FULL to workaround Aurora defect

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -91,8 +91,11 @@ Primary: &primary
   # If disabled, transactions may be committed in parallel.
   # In some cases, disabling this variable might produce a performance increment.
   binlog_order_commits: 0
-  # Log only changed columns, and columns needed to identify rows.
-  binlog_row_image: minimal
+  # Typically set to MINIMAL on MySQL to log only changed columns and columns needed to identify rows to reduce I/O.
+  # Set to FULL in advance of migration from MySQL to Aurora because the future Aurora production server replicating
+  # from the production MySQL server has a defect that causes it to occasionally crash if it is replicating from
+  # a binlog that uses MINIMAL (and there is an index on a JSON generated column).
+  binlog_row_image: FULL
   # Disable synchronization of the binary log to disk.
   # Reduces durability for better performance.
   sync_binlog: 0


### PR DESCRIPTION
See AWS Support Case 5960788541.  When binlog_row_image = minimal on a MySQL 5.7 server, an Aurora cluster that is replicating from that MySQL server will crash when applying certain types of updates to a table that has a JSON generated column with an index on it.