### PR TITLE
[WIP] fail UI tests on JS errors

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -84,13 +84,14 @@ def navigate_to(url)
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, sleep: 10, tries: 3) do
     with_read_timeout(DEFAULT_WAIT_TIMEOUT + 5.seconds) do
       @browser.navigate.to url
-      wait_until do
-        @browser.execute_script('return document.readyState;') == 'complete'
-      end
     end
     refute_bad_gateway_or_site_unreachable
   end
-  install_js_error_recorder
+  if @browser.browser == :Chrome
+    check_window_for_js_errors('after navigation')
+  else
+    install_js_error_recorder
+  end
 end
 
 Given /^I am on "([^"]*)"$/ do |url|


### PR DESCRIPTION
This PR makes a slight change to enforce zero JS errors in all of our UI Tests, by failing (instead of just printing 'ERROR' in the test log) when the JS error log is not empty.

Also in this PR:
- Use browser-logs API to get JS Console from supported browsers (chrome)

This is still a WIP, because the Chrome JS Console reports network errors on non-success status codes (including 404), and several of our pages currently return 404 responses for some ajax requests that are non-errors. I believe that we should fix these various routes (to return 200 response codes in any non-error case) before merging this PR.