### PR TITLE
Add additional scripts to i18n allow-list

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -47,6 +47,16 @@ module ScriptConstants
       EXPRESS_2018_NAME = 'express-2018'.freeze,
       PRE_READER_EXPRESS_2018_NAME = 'pre-express-2018'.freeze,
     ],
+    csf_2019: [
+      COURSEA_2019_NAME = 'coursea-2019'.freeze,
+      COURSEB_2019_NAME = 'courseb-2019'.freeze,
+      COURSEC_2019_NAME = 'coursec-2019'.freeze,
+      COURSED_2019_NAME = 'coursed-2019'.freeze,
+      COURSEE_2019_NAME = 'coursee-2019'.freeze,
+      COURSEF_2019_NAME = 'coursef-2019'.freeze,
+      EXPRESS_2019_NAME = 'express-2019'.freeze,
+      PRE_READER_EXPRESS_2019_NAME = 'pre-express-2019'.freeze,
+    ],
     hoc: [
       # Note that now multiple scripts can be an 'hour of code' script.
       # If adding a script here,
@@ -175,6 +185,22 @@ module ScriptConstants
     ],
   }.freeze
 
+  ADDITIONAL_I18N_SCRIPTS = [
+    APPLAB_1HOUR = 'applab-1hour'.freeze,
+    APPLAB_2HOUR = 'applab-2hour'.freeze,
+    CSD_POST_SURVEY = 'csd-post-survey'.freeze,
+    DEEPDIVE_DEBUGGING = 'deepdive-debugging'.freeze,
+    FESBINARY = 'fesbinary'.freeze,
+    FREQUENCY_ANALYSIS = 'frequency_analysis'.freeze,
+    GAMELAB = 'gamelab'.freeze,
+    K1HOC_2017 = 'k1hoc2017'.freeze,
+    K5_ONLINE_PD = 'K5-OnlinePD'.freeze,
+    NETSIM = 'netsim'.freeze,
+    ODOMETER = 'odometer'.freeze,
+    PIXELATION = 'pixelation'.freeze,
+    VIGENERE = 'vigenere'.freeze
+  ]
+
   DEFAULT_VERSION_YEAR = '2017'
 
   # A whitelist of all family names for scripts.
@@ -284,6 +310,13 @@ module ScriptConstants
     ScriptConstants.script_in_category?(:csf_international, script) ||
       ScriptConstants.script_in_category?(:csf, script) ||
       ScriptConstants.script_in_category?(:csf_2018, script) ||
-      ScriptConstants.script_in_category?(:twenty_hour, script)
+      ScriptConstants.script_in_category?(:csf_2019, script) ||
+      ScriptConstants.script_in_category?(:csd, script) ||
+      ScriptConstants.script_in_category?(:csd_2018, script) ||
+      ScriptConstants.script_in_category?(:csd_2019, script) ||
+      ScriptConstants.script_in_category?(:twenty_hour, script) ||
+      ScriptConstants.script_in_category?(:hoc, script) ||
+      JIGSAW_NAME == script ||
+      ADDITIONAL_I18N_SCRIPTS.include?(script)
   end
 end

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -85,4 +85,10 @@ class ScriptConstantsTest < Minitest::Test
       refute ScriptConstants.script_in_any_category?('foo')
     end
   end
+
+  describe 'ScriptConstants::i18n' do
+    it 'finds course1 in i18n' do
+      assert ScriptConstants.i18n?('course1')
+    end
+  end
 end


### PR DESCRIPTION
This will match Bryan's [doc](https://docs.google.com/spreadsheets/d/1ygjTkqyJMNZwTYVT1RB3LCIc4UeVLswSbvn5VZHB_L0/edit#gid=0) (and will add two extra -- `Hour of Code` and `csd-post-survey` -- which doesn't seem like it would be a problem).

This is needed as I plan to query the database for the lessons to translate, like we do for DSL files. 

I'm not a big fan of the approach of just patching together a list of scripts to translate but this will work for now. It would probably be a good idea to think of ways we can denote this in a more maintainable way (like a field in `Script` itself) but the work in this PR should work for the short term.
