### PR TITLE
Projects: prevent report abuse spam

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import url from 'url';
 import {Provider} from 'react-redux';
 import trackEvent from './util/trackEvent';
+import cookies from 'js-cookie';
 
 // Make sure polyfills are available in all code studio apps and level tests.
 import './polyfills';
@@ -195,7 +196,6 @@ class StudioApp extends EventEmitter {
     this.libraries = {};
   }
 }
-
 /**
  * Configure StudioApp options
  */
@@ -825,9 +825,11 @@ export function makeFooterMenuItems() {
   }
 
   //Removes 'Report Abuse' if this user already reported this project
-  _.remove(footerMenuItems, function(menuItem) {
-    return menuItem.key === 'reportAbuse';
-  });
+  if (_.includes(JSON.parse(cookies.get('reported_abuse')), project.getCurrentId())) {
+    _.pull(footerMenuItems, function(menuItem) {
+     return menuItem.key === 'reportAbuse';
+   });
+  }
 
   return footerMenuItems;
 }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -797,6 +797,7 @@ export function makeFooterMenuItems() {
       newWindow: false
     },
     {
+      key: 'reportAbuse',
       text: i18n.t('footer.report_abuse'),
       link: '/report_abuse',
       newWindow: true
@@ -822,6 +823,11 @@ export function makeFooterMenuItems() {
   if (project.getStandaloneApp() === 'gamelab') {
     footerMenuItems.shift();
   }
+
+  //Removes 'Report Abuse' if this user already reported this project
+  _.remove(footerMenuItems, function(menuItem) {
+    return menuItem.key === 'reportAbuse';
+  });
 
   return footerMenuItems;
 }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -825,10 +825,15 @@ export function makeFooterMenuItems() {
   }
 
   //Removes 'Report Abuse' if this user already reported this project
-  if (_.includes(JSON.parse(cookies.get('reported_abuse')), project.getCurrentId())) {
-    _.pull(footerMenuItems, function(menuItem) {
-     return menuItem.key === 'reportAbuse';
-   });
+  if (
+    _.includes(
+      JSON.parse(cookies.get('reported_abuse')),
+      project.getCurrentId()
+    )
+  ) {
+    _.remove(footerMenuItems, function(menuItem) {
+      return menuItem.key === 'reportAbuse';
+    });
   }
 
   return footerMenuItems;

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -824,10 +824,12 @@ export function makeFooterMenuItems() {
     footerMenuItems.shift();
   }
 
-  var userAlreadyReportedAbuse = _.includes(
-    JSON.parse(cookies.get('reported_abuse')),
-    project.getCurrentId()
-  );
+  var userAlreadyReportedAbuse =
+    cookies.get('reported_abuse') &&
+    _.includes(
+      JSON.parse(cookies.get('reported_abuse')),
+      project.getCurrentId()
+    );
 
   if (userAlreadyReportedAbuse) {
     _.remove(footerMenuItems, function(menuItem) {

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -824,13 +824,12 @@ export function makeFooterMenuItems() {
     footerMenuItems.shift();
   }
 
-  //Removes 'Report Abuse' if this user already reported this project
-  if (
-    _.includes(
-      JSON.parse(cookies.get('reported_abuse')),
-      project.getCurrentId()
-    )
-  ) {
+  var userAlreadyReportedAbuse = _.includes(
+    JSON.parse(cookies.get('reported_abuse')),
+    project.getCurrentId()
+  );
+
+  if (userAlreadyReportedAbuse) {
     _.remove(footerMenuItems, function(menuItem) {
       return menuItem.key === 'reportAbuse';
     });

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -792,12 +792,13 @@ export function makeFooterMenuItems() {
       newWindow: true
     },
     {
+      key: 'how-it-works',
       text: i18n.t('footer.how_it_works'),
       link: project.getProjectUrl('/edit'),
       newWindow: false
     },
     {
-      key: 'reportAbuse',
+      key: 'report-abuse',
       text: i18n.t('footer.report_abuse'),
       link: '/report_abuse',
       newWindow: true

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -834,7 +834,7 @@ export function makeFooterMenuItems() {
 
   if (userAlreadyReportedAbuse) {
     _.remove(footerMenuItems, function(menuItem) {
-      return menuItem.key === 'reportAbuse';
+      return menuItem.key === 'report-abuse';
     });
   }
 

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -204,10 +204,12 @@ Applab.makeFooterMenuItems = function(isIframeEmbed) {
     }
   ].filter(item => item);
 
-  var userAlreadyReportedAbuse = _.includes(
-    JSON.parse(cookies.get('reported_abuse')),
-    project.getCurrentId()
-  );
+  var userAlreadyReportedAbuse =
+    cookies.get('reported_abuse') &&
+    _.includes(
+      JSON.parse(cookies.get('reported_abuse')),
+      project.getCurrentId()
+    );
 
   if (userAlreadyReportedAbuse) {
     _.remove(footerMenuItems, function(menuItem) {

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -5,6 +5,8 @@
  *
  */
 import $ from 'jquery';
+import cookies from 'js-cookie';
+import _ from 'lodash';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {singleton as studioApp} from '../StudioApp';
@@ -185,6 +187,7 @@ Applab.makeFooterMenuItems = function(isIframeEmbed) {
         link: '/projects/applab/new'
       },
     {
+      key: 'reportAbuse',
       text: commonMsg.reportAbuse(),
       link: '/report_abuse',
       newWindow: true
@@ -200,6 +203,19 @@ Applab.makeFooterMenuItems = function(isIframeEmbed) {
       newWindow: true
     }
   ].filter(item => item);
+
+  //Removes 'Report Abuse' if this user already reported this project
+  if (
+    _.includes(
+      JSON.parse(cookies.get('reported_abuse')),
+      project.getCurrentId()
+    )
+  ) {
+    _.remove(footerMenuItems, function(menuItem) {
+      return menuItem.key === 'reportAbuse';
+    });
+  }
+
   return footerMenuItems;
 };
 

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -204,13 +204,12 @@ Applab.makeFooterMenuItems = function(isIframeEmbed) {
     }
   ].filter(item => item);
 
-  //Removes 'Report Abuse' if this user already reported this project
-  if (
-    _.includes(
-      JSON.parse(cookies.get('reported_abuse')),
-      project.getCurrentId()
-    )
-  ) {
+  var userAlreadyReportedAbuse = _.includes(
+    JSON.parse(cookies.get('reported_abuse')),
+    project.getCurrentId()
+  );
+
+  if (userAlreadyReportedAbuse) {
     _.remove(footerMenuItems, function(menuItem) {
       return menuItem.key === 'reportAbuse';
     });

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -177,6 +177,7 @@ function shouldRenderFooter() {
 Applab.makeFooterMenuItems = function(isIframeEmbed) {
   const footerMenuItems = [
     window.location.search.indexOf('nosource') < 0 && {
+      key: 'how-it-works',
       text: i18n.t('footer.how_it_works'),
       link: project.getProjectUrl('/view'),
       newWindow: true
@@ -187,7 +188,7 @@ Applab.makeFooterMenuItems = function(isIframeEmbed) {
         link: '/projects/applab/new'
       },
     {
-      key: 'reportAbuse',
+      key: 'report-abuse',
       text: commonMsg.reportAbuse(),
       link: '/report_abuse',
       newWindow: true
@@ -213,7 +214,7 @@ Applab.makeFooterMenuItems = function(isIframeEmbed) {
 
   if (userAlreadyReportedAbuse) {
     _.remove(footerMenuItems, function(menuItem) {
-      return menuItem.key === 'reportAbuse';
+      return menuItem.key === 'report-abuse';
     });
   }
 

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -6,7 +6,6 @@ import ReactDOM from 'react-dom';
 import AgeDropdown from '@cdo/apps/templates/AgeDropdown';
 import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 
-
 /**
  * A component containing some text/links for projects that have had abuse
  * reported. This is used in our blocking AbuseBox, in the share dialog, and
@@ -54,16 +53,13 @@ export default class ReportAbuseForm extends React.Component {
   }
 
   writeCookie() {
-    //cookies.remove("reported_abuse")
-    console.log("cookies before: ", cookies.get())
     if (cookies.get('reported_abuse')) {
-      var reportedProjectIds = JSON.parse(cookies.get("reported_abuse"))
-      reportedProjectIds.push(this.getChannelId())
-      cookies.set('reported_abuse', _.uniq(reportedProjectIds))
+      const reportedProjectIds = JSON.parse(cookies.get('reported_abuse'));
+      reportedProjectIds.push(this.getChannelId());
+      cookies.set('reported_abuse', _.uniq(reportedProjectIds));
     } else {
       cookies.set('reported_abuse', [this.getChannelId()]);
     }
-    console.log("cookies after: ", cookies.get())
   }
 
   handleSubmit = event => {
@@ -91,7 +87,7 @@ export default class ReportAbuseForm extends React.Component {
       event.preventDefault();
       return;
     }
-    this.writeCookie()
+    this.writeCookie();
   };
 
   render() {

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -1,8 +1,11 @@
+import cookies from 'js-cookie';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import AgeDropdown from '@cdo/apps/templates/AgeDropdown';
 import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
+
 
 /**
  * A component containing some text/links for projects that have had abuse
@@ -50,6 +53,19 @@ export default class ReportAbuseForm extends React.Component {
     return getChannelIdFromUrl(abuseUrl);
   }
 
+  writeCookie() {
+    //cookies.remove("reported_abuse")
+    console.log("cookies before: ", cookies.get())
+    if (cookies.get('reported_abuse')) {
+      var reportedProjectIds = JSON.parse(cookies.get("reported_abuse"))
+      reportedProjectIds.push(this.getChannelId())
+      cookies.set('reported_abuse', _.uniq(reportedProjectIds))
+    } else {
+      cookies.set('reported_abuse', [this.getChannelId()]);
+    }
+    console.log("cookies after: ", cookies.get())
+  }
+
   handleSubmit = event => {
     const i18n = this.props.i18n;
     if (this.refs.email.value === '') {
@@ -75,6 +91,7 @@ export default class ReportAbuseForm extends React.Component {
       event.preventDefault();
       return;
     }
+    this.writeCookie()
   };
 
   render() {

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -1,4 +1,6 @@
 import $ from 'jquery';
+import cookies from 'js-cookie';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import debounce from 'lodash/debounce';
@@ -43,7 +45,8 @@ export default class SmallFooter extends React.Component {
     className: PropTypes.string,
     fontSize: PropTypes.number,
     rowHeight: PropTypes.number,
-    fullWidth: PropTypes.bool
+    fullWidth: PropTypes.bool,
+    channel: PropTypes.string
   };
 
   state = {
@@ -306,6 +309,17 @@ export default class SmallFooter extends React.Component {
   }
 
   renderMoreMenu(styles) {
+    const userAlreadyReportedAbuse = _.includes(
+      JSON.parse(cookies.get('reported_abuse')),
+      this.props.channel
+    );
+
+    if (userAlreadyReportedAbuse) {
+      _.remove(this.props.menuItems, function(menuItem) {
+        return menuItem.key === 'report-abuse';
+      });
+    }
+
     const menuItemElements = this.props.menuItems.map(
       function(item, index) {
         return (

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -309,10 +309,14 @@ export default class SmallFooter extends React.Component {
   }
 
   renderMoreMenu(styles) {
-    const userAlreadyReportedAbuse = _.includes(
-      JSON.parse(cookies.get('reported_abuse')),
-      this.props.channel
-    );
+
+    const userAlreadyReportedAbuse =
+    cookies.get('reported_abuse') ?
+      null :
+      _.includes(
+        JSON.parse(cookies.get('reported_abuse')),
+        this.props.channel
+      );
 
     if (userAlreadyReportedAbuse) {
       _.remove(this.props.menuItems, function(menuItem) {

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -309,14 +309,9 @@ export default class SmallFooter extends React.Component {
   }
 
   renderMoreMenu(styles) {
-
     const userAlreadyReportedAbuse =
-    cookies.get('reported_abuse') ?
-      null :
-      _.includes(
-        JSON.parse(cookies.get('reported_abuse')),
-        this.props.channel
-      );
+      cookies.get('reported_abuse') &&
+      _.includes(JSON.parse(cookies.get('reported_abuse')), this.props.channel);
 
     if (userAlreadyReportedAbuse) {
       _.remove(this.props.menuItems, function(menuItem) {

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -322,7 +322,11 @@ export default class SmallFooter extends React.Component {
     const menuItemElements = this.props.menuItems.map(
       function(item, index) {
         return (
-          <li key={index} style={styles.listItem}>
+          <li
+            key={index}
+            style={styles.listItem}
+            className={`ui-test-${item.key}`}
+          >
             <a
               href={item.link}
               ref={item.copyright ? 'menuCopyright' : undefined}

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -85,7 +85,7 @@ class ReportAbuseController < ApplicationController
       )
     end
 
-    # redirect_to "https://support.code.org"
+    redirect_to "https://support.code.org"
   end
 
   def report_abuse_form

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -85,7 +85,7 @@ class ReportAbuseController < ApplicationController
       )
     end
 
-    redirect_to "https://support.code.org"
+    # redirect_to "https://support.code.org"
   end
 
   def report_abuse_form

--- a/dashboard/app/views/layouts/_small_footer.html.haml
+++ b/dashboard/app/views/layouts/_small_footer.html.haml
@@ -2,6 +2,34 @@
 
 :ruby
   full_width = local_assigns[:full_width]
+  channel = local_assigns[:channel]
+
+  menu_items = [
+    {
+      key: 'report-abuse',
+      text: I18n.t('footer.report_abuse'),
+      link: '/report_abuse',
+      newWindow: true
+    },
+    {
+      key: 'help-support',
+      text: I18n.t('landing.help_support'),
+      link: "https://support.code.org",
+      newWindow: true
+    },
+    {
+      key: 'translate',
+      text: I18n.t('footer.translate'),
+      link: "https://code.org/translate",
+      newWindow: true
+    },
+    {
+      key: 'tos',
+      text: I18n.t('footer.tos'),
+      link: "https://code.org/tos",
+      newWindow: true
+    }
+  ]
 
   reactProps = {
     i18nDropdown: (view_options[:has_i18n] ? URI.encode(i18n_dropdown.to_str) : ''),
@@ -10,32 +38,12 @@
     basePrivacyPolicyString: I18n.t('footer.privacy'),
     baseCopyrightString: I18n.t('footer.copyright'),
     baseMoreMenuString: I18n.t('footer.more'),
-    menuItems: [
-      {
-        text: I18n.t('footer.report_abuse'),
-        link: '/report_abuse',
-        newWindow: true
-      },
-      {
-        text: I18n.t('landing.help_support'),
-        link: "https://support.code.org",
-        newWindow: true
-      },
-      {
-        text: I18n.t('footer.translate'),
-        link: "https://code.org/translate",
-        newWindow: true
-      },
-      {
-        text: I18n.t('footer.tos'),
-        link: "https://code.org/tos",
-        newWindow: true
-      }
-    ],
+    menuItems: menu_items,
     copyrightStrings: build_copyright_strings,
     # false because we're not rendering into a phone wireframe here
     phoneFooter: false,
-    fullWidth: full_width
+    fullWidth: full_width,
+    channel: channel
   }
 
 :javascript

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -78,7 +78,7 @@
           .push
 
       - if view_options[:small_footer]
-        = render partial: 'layouts/small_footer'
+        = render partial: 'layouts/small_footer', locals: {channel: view_options[:channel]}
 
       - if view_options[:responsive_content]
         .responsive-content-mobile-footer

--- a/dashboard/test/ui/features/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/projects/prevent_report_abuse_spam.feature
@@ -24,7 +24,6 @@ Scenario: Report Abuse link hidden if the user already reported AppLab project -
   Then I open the small footer menu
   And element ".ui-test-how-it-works" is visible
   And element ".ui-test-report-abuse" is visible
-  Then I open the small footer menu
   And I press menu item "Report Abuse"
   Then I report abuse on the project
   Then I wait until current URL contains "projects"
@@ -54,7 +53,6 @@ Scenario: Report Abuse link hidden if the user already reported Game Lab project
   Then I open the small footer menu
   And element ".ui-test-how-it-works" is visible
   And element ".ui-test-report-abuse" is visible
-  Then I open the small footer menu
   And I press menu item "Report Abuse"
   Then I report abuse on the project
   Then I wait until current URL contains "projects"

--- a/dashboard/test/ui/features/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/projects/prevent_report_abuse_spam.feature
@@ -1,0 +1,31 @@
+Feature: Prevent Report Abuse Spam
+
+Scenario: Report Abuse link hidden if the user already reported AppLab project - mini link
+  Given I create a student named "Project Maker"
+  And I make a "applab" project named "App Lab Project 1"
+  Then I open the small footer menu
+  And element ".ui-test-help-support" is visible
+  And element ".ui-test-report-abuse" is visible
+  And I press menu item "Report Abuse"
+  Then I report abuse on the project
+  Then I wait until current URL contains "projects"
+  Then I reload the page
+  Then I open the small footer menu
+  And element ".ui-test-help-support" is visible
+  And element ".ui-test-report-abuse" is not visible
+
+Scenario: Report Abuse link hidden if the user already reported AppLab project - share page
+  Given I create a student named "Project Maker"
+  And I make a "applab" project named "App Lab Project 2"
+  Then I navigate to the shared version of my project
+  Then I open the small footer menu
+  And element ".ui-test-how-it-works" is visible
+  And element ".ui-test-report-abuse" is visible
+  Then I open the small footer menu
+  And I press menu item "Report Abuse"
+  Then I report abuse on the project
+  Then I wait until current URL contains "projects"
+  Then I reload the page
+  Then I open the small footer menu
+  And element ".ui-test-how-it-works" is visible
+  And element ".ui-test-report-abuse" is not visible

--- a/dashboard/test/ui/features/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/projects/prevent_report_abuse_spam.feature
@@ -1,5 +1,8 @@
 Feature: Prevent Report Abuse Spam
 
+# If someone has already reported abuse on a specific project, we hide the
+# report abuse link so they can't spam Zendesk.
+
 Scenario: Report Abuse link hidden if the user already reported AppLab project - mini link
   Given I create a student named "Project Maker"
   And I make a "applab" project named "App Lab Project 1"
@@ -17,6 +20,36 @@ Scenario: Report Abuse link hidden if the user already reported AppLab project -
 Scenario: Report Abuse link hidden if the user already reported AppLab project - share page
   Given I create a student named "Project Maker"
   And I make a "applab" project named "App Lab Project 2"
+  Then I navigate to the shared version of my project
+  Then I open the small footer menu
+  And element ".ui-test-how-it-works" is visible
+  And element ".ui-test-report-abuse" is visible
+  Then I open the small footer menu
+  And I press menu item "Report Abuse"
+  Then I report abuse on the project
+  Then I wait until current URL contains "projects"
+  Then I reload the page
+  Then I open the small footer menu
+  And element ".ui-test-how-it-works" is visible
+  And element ".ui-test-report-abuse" is not visible
+
+Scenario: Report Abuse link hidden if the user already reported GameLab project - mini link
+  Given I create a student named "Project Maker"
+  And I make a "gamelab" project named "Game Lab Project 1"
+  Then I open the small footer menu
+  And element ".ui-test-help-support" is visible
+  And element ".ui-test-report-abuse" is visible
+  And I press menu item "Report Abuse"
+  Then I report abuse on the project
+  Then I wait until current URL contains "projects"
+  Then I reload the page
+  Then I open the small footer menu
+  And element ".ui-test-help-support" is visible
+  And element ".ui-test-report-abuse" is not visible
+
+Scenario: Report Abuse link hidden if the user already reported Game Lab project - share page
+  Given I create a student named "Project Maker"
+  And I make a "applab" project named "Game Lab Project 2"
   Then I navigate to the shared version of my project
   Then I open the small footer menu
   And element ".ui-test-how-it-works" is visible

--- a/dashboard/test/ui/features/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/projects/prevent_report_abuse_spam.feature
@@ -49,7 +49,7 @@ Scenario: Report Abuse link hidden if the user already reported GameLab project 
 
 Scenario: Report Abuse link hidden if the user already reported Game Lab project - share page
   Given I create a student named "Project Maker"
-  And I make a "applab" project named "Game Lab Project 2"
+  And I make a "gamelab" project named "Game Lab Project 2"
   Then I navigate to the shared version of my project
   Then I open the small footer menu
   And element ".ui-test-how-it-works" is visible

--- a/dashboard/test/ui/features/step_definitions/projects.rb
+++ b/dashboard/test/ui/features/step_definitions/projects.rb
@@ -41,6 +41,25 @@ Then(/^I scroll the Play Lab gallery section into view$/) do
   @browser.execute_script('$(".ui-playlab")[0].scrollIntoView(true)')
 end
 
+Then(/^I make a "([^"]*)" project named "([^"]*)"$/) do |project_type, name|
+  steps %Q{
+    Then I am on "http://studio.code.org/projects/#{project_type}/new"
+    And I get redirected to "/projects/#{project_type}/([^\/]*?)/edit" via "dashboard"
+    And I wait for the page to fully load
+    And element "#runButton" is visible
+    And element ".project_updated_at" eventually contains text "Saved"
+    And I click selector ".project_edit"
+    And I type "#{name}" into "input.project_name"
+    And I click selector ".project_save"
+    And I wait until element ".project_edit" is visible
+<Erin - you left off here! You need to make this more generic and then use it.>
+    Then I should see title "#{name} - Play Lab"
+    And I press "#runButton" using jQuery
+    And I wait until element ".project_updated_at" contains text "Saved"
+    And I wait until initial thumbnail capture is complete
+  }
+end
+
 Then(/^I make a playlab project named "([^"]*)"$/) do |name|
   steps %Q{
     Then I am on "http://studio.code.org/projects/playlab/new"

--- a/dashboard/test/ui/features/step_definitions/projects.rb
+++ b/dashboard/test/ui/features/step_definitions/projects.rb
@@ -52,11 +52,22 @@ Then(/^I make a "([^"]*)" project named "([^"]*)"$/) do |project_type, name|
     And I type "#{name}" into "input.project_name"
     And I click selector ".project_save"
     And I wait until element ".project_edit" is visible
-<Erin - you left off here! You need to make this more generic and then use it.>
-    Then I should see title "#{name} - Play Lab"
     And I press "#runButton" using jQuery
     And I wait until element ".project_updated_at" contains text "Saved"
     And I wait until initial thumbnail capture is complete
+  }
+end
+
+Then(/^I report abuse on the project$/) do
+  steps %Q{
+    Then I switch tabs
+    Then I wait until current URL contains "report_abuse"
+    And I type "abuse_reporter@school.edu" into "#uitest-email"
+    And I select the "Other" option in dropdown "uitest-abuse-type"
+    And I type "I just don't like it." into "#uitest-abuse-detail"
+    Then I click selector "#uitest-submit-report-abuse" once I see it
+    Then I wait until current URL contains "support.code.org"
+    Then I switch tabs
   }
 end
 


### PR DESCRIPTION
[LP-52](https://codedotorg.atlassian.net/browse/LP-52)

Kids are overzealous with the report abuse feature; they will often report abuse on the same project multiple times when the project isn't abusive, which is a pain because it floods Zendesk with tickets. To help alleviate this issue, I'm preventing users from re-reporting abuse on projects.  If a user has already reported a project, the report abuse link will be hidden on that project for that user. To do this, each time a project is reported for abuse, I store the project's channel id in a cookie `reported_abuse` for the user. 
<img width="1109" alt="Screen Shot 2019-05-30 at 3 15 22 PM" src="https://user-images.githubusercontent.com/12300669/58672359-6d14e980-82fb-11e9-87cd-be55b9551dd7.png">

There are 3 places where this change will affect: 

1.) The footer menu on a project view page for App Lab 
<img width="404" alt="Screen Shot 2019-05-24 at 12 22 29 PM" src="https://user-images.githubusercontent.com/12300669/58364278-c3e77280-7e66-11e9-8bd5-fd5798f834d7.png">

2.) The footer menu on a project view page for all other project types 
<img width="432" alt="Screen Shot 2019-05-24 at 4 29 51 PM" src="https://user-images.githubusercontent.com/12300669/58364283-de215080-7e66-11e9-91fc-ed345f6ed274.png">

3.) The mini footer menu on a project edit page for all project types
<img width="288" alt="Screen Shot 2019-05-30 at 3 25 41 PM" src="https://user-images.githubusercontent.com/12300669/58672350-64241800-82fb-11e9-91e4-e7a682f579b1.png">

While working on this, I found that we generate the contents of the footer in 3 separate places. We should investigate if these can be consolidated: [STAR-464](https://codedotorg.atlassian.net/browse/STAR-464)

Also, I'm intentionally not handing the report abuse link in the admin panel.  If you're an admin, you're internal and we trust you not to excessively spam Zendesk. 🙂