### PR TITLE
School Info Confirmation Dialog: update helper method

### DIFF
--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -36,7 +36,7 @@ module SchoolInfoInterstitialHelper
 
     school_info = user_school_info.school_info
 
-    check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && complete?(school_info)
+    check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && complete?(school_info) && school_info.usa?
 
     check_last_confirmation_date = user_school_info.last_confirmation_date.to_datetime < 1.year.ago
 

--- a/dashboard/lib/school_info_interstitial_helper.rb
+++ b/dashboard/lib/school_info_interstitial_helper.rb
@@ -36,11 +36,22 @@ module SchoolInfoInterstitialHelper
 
     school_info = user_school_info.school_info
 
-    check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && SchoolInfoInterstitialHelper.complete?(school_info)
+    check_school_type = (school_info.public_school? || school_info.private_school? || school_info.charter_school?) && complete?(school_info)
 
     check_last_confirmation_date = user_school_info.last_confirmation_date.to_datetime < 1.year.ago
 
-    check_last_confirmation_date && check_school_type
+    check_last_seen_school_info_interstitial = user.last_seen_school_info_interstitial&.to_datetime.nil? ||
+      user.last_seen_school_info_interstitial.to_datetime < 7.days.ago
+
+    show_dialog = check_last_seen_school_info_interstitial && check_last_confirmation_date && check_school_type
+
+    if show_dialog
+      # Check to ensure last seen school info interstitial is saved.
+      user.last_seen_school_info_interstitial = DateTime.now
+      user.save(validate: false)
+    end
+
+    show_dialog
   end
 
   # Decides whether the school info is complete enough to stop bugging the

--- a/dashboard/test/lib/school_info_interstitial_helper_test.rb
+++ b/dashboard/test/lib/school_info_interstitial_helper_test.rb
@@ -101,6 +101,22 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     assert SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
   end
 
+  test 'last_seen_school_info_interstitial is updated' do
+    user = create :teacher, last_seen_school_info_interstitial: 7.days.ago
+
+    original_value = user.last_seen_school_info_interstitial
+
+    school_info = create :school_info
+
+    create :user_school_info, school_info_id: school_info.id, user_id: user.id, last_confirmation_date: 2.years.ago, start_date: user.created_at
+
+    assert SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
+
+    updated_value = user.last_seen_school_info_interstitial
+
+    refute_equal original_value, updated_value
+  end
+
   test 'school info confirmation dialog is not shown when the US school type is not private, public or charter' do
     user = create :teacher, last_seen_school_info_interstitial: 7.days.ago
 

--- a/dashboard/test/lib/school_info_interstitial_helper_test.rb
+++ b/dashboard/test/lib/school_info_interstitial_helper_test.rb
@@ -89,30 +89,85 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     refute SchoolInfoInterstitialHelper.complete? school_info
   end
 
+  test 'school info confirmation dialog is shown when all information is provided' do
+    user = create :teacher, last_seen_school_info_interstitial: 7.days.ago
+
+    school_info = create :school_info
+
+    assert_equal school_info.school_type, SchoolInfo::SCHOOL_TYPE_PUBLIC
+
+    create :user_school_info, school_info_id: school_info.id, user_id: user.id, last_confirmation_date: 2.years.ago, start_date: user.created_at
+
+    assert SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
+  end
+
+  test 'school info confirmation dialog is not shown when the US school type is not private, public or charter' do
+    user = create :teacher, last_seen_school_info_interstitial: 7.days.ago
+
+    school_info = create :school_info_us_homeschool
+
+    create :user_school_info, school_info_id: school_info.id, user_id: user.id, last_confirmation_date: 2.years.ago, start_date: user.created_at
+
+    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
+  end
+
+  test 'school info confirmation dialog is not shown when the country is non-US' do
+    user = create :teacher, last_seen_school_info_interstitial: 7.days.ago
+
+    school_info = create :school_info_non_us
+
+    create :user_school_info, school_info_id: school_info.id, user_id: user.id, last_confirmation_date: 2.years.ago, start_date: user.created_at
+
+    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
+  end
+
+  test 'school info confirmation dialog is not shown if the last seen school interstitial is less than 7 days' do
+    user = create :teacher, last_seen_school_info_interstitial: 6.days.ago
+
+    school_info = create :school_info
+
+    create :user_school_info, school_info_id: school_info.id, user_id: user.id, last_confirmation_date: 2.years.ago, start_date: user.created_at
+
+    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
+  end
+
+  test 'for form completeness' do
+    user = create :teacher, last_seen_school_info_interstitial: 7.days.ago
+
+    school_info = create :school_info, school_id: nil, country: nil, validation_type: SchoolInfo::VALIDATION_NONE
+
+    create :user_school_info, school_info_id: school_info.id, user_id: user.id, last_confirmation_date: 2.years.ago, start_date: user.created_at
+
+    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
+  end
+
   test 'school info confirmation dialog is not shown when the user school infos table is empty' do
-    user = create :user
-    user.user_type = 'teacher'
-    user.save
+    user = create :teacher, last_seen_school_info_interstitial: 7.days.ago
 
     user.user_school_infos = []
 
     assert_nil user.school_info
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog?(user)
+    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
   end
 
   test 'does not show school info confirmation dialog if user is not a teacher' do
     user = create :user
 
+    school_info = create :school_info
+
+    create :user_school_info, school_info_id: school_info.id, user_id: user.id, last_confirmation_date: 2.years.ago, start_date: user.created_at
+
     assert_equal user.user_type, 'student'
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog?(user)
+    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
   end
 
   test 'does not show school info confirmation dialog when last confirmation date is less than a year' do
-    user_school_info = create :user_school_info
+    user = create :teacher, last_seen_school_info_interstitial: 7.days.ago
 
-    user_school_info.last_confirmation_date = 1.day.ago
-    user_school_info.save
+    school_info = create :school_info
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog?(user_school_info.user)
+    create :user_school_info, school_info_id: school_info.id, user_id: user.id, last_confirmation_date: 1.day.ago, start_date: user.created_at
+
+    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
   end
 end

--- a/dashboard/test/lib/school_info_interstitial_helper_test.rb
+++ b/dashboard/test/lib/school_info_interstitial_helper_test.rb
@@ -117,6 +117,22 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     refute_equal original_value, updated_value
   end
 
+  test 'last_seen_school_info_interstitial is not updated when dialog is not shown' do
+    user = create :teacher, last_seen_school_info_interstitial: 6.days.ago
+
+    original_value = user.last_seen_school_info_interstitial
+
+    school_info = create :school_info
+
+    create :user_school_info, school_info_id: school_info.id, user_id: user.id, last_confirmation_date: 2.years.ago, start_date: user.created_at
+
+    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
+
+    updated_value = user.last_seen_school_info_interstitial
+
+    assert_equal original_value, updated_value
+  end
+
   test 'school info confirmation dialog is not shown when the US school type is not private, public or charter' do
     user = create :teacher, last_seen_school_info_interstitial: 7.days.ago
 


### PR DESCRIPTION
The show school info confirmation dialog is updated to include a check to determine when a user has seen the school info interstitial form.   

This PR also includes passing tests.