### PR TITLE
Add 2019 CSF 2019 names to script_constants and csf_congrats

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -47,6 +47,16 @@ module ScriptConstants
       EXPRESS_2018_NAME = 'express-2018'.freeze,
       PRE_READER_EXPRESS_2018_NAME = 'pre-express-2018'.freeze,
     ],
+    csf_2019: [
+      COURSEA_2019_NAME = 'coursea-2019'.freeze,
+      COURSEB_2019_NAME = 'courseb-2019'.freeze,
+      COURSEC_2019_NAME = 'coursec-2019'.freeze,
+      COURSED_2019_NAME = 'coursed-2019'.freeze,
+      COURSEE_2019_NAME = 'coursee-2019'.freeze,
+      COURSEF_2019_NAME = 'coursef-2019'.freeze,
+      EXPRESS_2019_NAME = 'express-2019'.freeze,
+      PRE_READER_EXPRESS_2019_NAME = 'pre-express-2019'.freeze,
+    ],
     hoc: [
       # Note that now multiple scripts can be an 'hour of code' script.
       # If adding a script here,
@@ -277,7 +287,8 @@ module ScriptConstants
     script == ACCELERATED_NAME ||
       ScriptConstants.script_in_category?(:csf_international, script) ||
       ScriptConstants.script_in_category?(:csf, script) ||
-      ScriptConstants.script_in_category?(:csf_2018, script)
+      ScriptConstants.script_in_category?(:csf_2018, script) ||
+      ScriptConstants.script_in_category?(:csf_2019, script)
   end
 
   def self.i18n?(script)

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -62,8 +62,8 @@ class ScriptConstantsTest < Minitest::Test
 
   def test_category_priority
     assert_equal 0, ScriptConstants.category_priority(:full_course)
-    assert_equal 4, ScriptConstants.category_priority(:csf_international)
-    assert_equal 6, ScriptConstants.category_priority(:research_studies)
+    assert_equal 5, ScriptConstants.category_priority(:csf_international)
+    assert_equal 7, ScriptConstants.category_priority(:research_studies)
   end
 
   def test_assignable_info

--- a/pegasus/sites.v3/code.org/views/csf_congrats.haml
+++ b/pegasus/sites.v3/code.org/views/csf_congrats.haml
@@ -37,6 +37,15 @@
     ScriptConstants::COURSEE_2018_NAME => ScriptConstants::COURSEF_2018_NAME,
     ScriptConstants::COURSEF_2018_NAME => "applab",
     ScriptConstants::EXPRESS_2018_NAME => "applab",
+
+    ScriptConstants::COURSEA_2019_NAME => ScriptConstants::COURSEB_2019_NAME,
+    ScriptConstants::COURSEB_2019_NAME => ScriptConstants::COURSEC_2019_NAME,
+    ScriptConstants::PRE_READER_EXPRESS_2019_NAME => ScriptConstants::COURSEC_2019_NAME,
+    ScriptConstants::COURSEC_2019_NAME => ScriptConstants::COURSED_2019_NAME,
+    ScriptConstants::COURSED_2019_NAME => ScriptConstants::COURSEE_2019_NAME,
+    ScriptConstants::COURSEE_2019_NAME => ScriptConstants::COURSEF_2019_NAME,
+    ScriptConstants::COURSEF_2019_NAME => "applab",
+    ScriptConstants::EXPRESS_2019_NAME => "applab",
   }
 
   rec_third_party = {
@@ -64,6 +73,15 @@
     ScriptConstants::COURSED_2018_NAME => "csf_next",
     ScriptConstants::COURSEE_2018_NAME => "csf_next",
     ScriptConstants::COURSEF_2018_NAME => "csf_next",
+
+    ScriptConstants::EXPRESS_2019_NAME => "csf_next",
+    ScriptConstants::PRE_READER_EXPRESS_2019_NAME => "csf_next",
+    ScriptConstants::COURSEA_2019_NAME => "csf_next",
+    ScriptConstants::COURSEB_2019_NAME => "csf_next",
+    ScriptConstants::COURSEC_2019_NAME => "csf_next",
+    ScriptConstants::COURSED_2019_NAME => "csf_next",
+    ScriptConstants::COURSEE_2019_NAME => "csf_next",
+    ScriptConstants::COURSEF_2019_NAME => "csf_next",
   }
 
 #congrats.mobile-pad{:style=>'margin: 0 auto;'}
@@ -101,6 +119,6 @@
 
   %div{:style=>'clear: both; height:30px;'}
   %hr
-  = view :petition_expand 
+  = view :petition_expand
 
 = view 'popup_window.js'


### PR DESCRIPTION
[LP-442](https://codedotorg.atlassian.net/browse/LP-442)

Upon completing a CSF course, the user is taken to a code.org/congrats page specific to that course. Right now this is broken for CSF 2019. This PR adds CSF 2019 names to `script_constants`, `csf_congrats` and the [i18n gsheet](https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit#gid=0&range=918:918) so that completion of CSF 2019 will take the user to the congrats page. 

Given time constraints for the launch of 2019 courses, I've added to hardcoded lists 🙁. However, I've outlined a better long term solution (to consolidate studio.code.org/congrats and code.org/congrats) in the above linked Jira ticket and that work is being tracked in [LP-451](https://codedotorg.atlassian.net/browse/LP-442).