### PR TITLE
Pilot (Student Libraries): Added ability for students to add comments

### DIFF
--- a/apps/src/blockTooltips/DropletFunctionTooltip.html.ejs
+++ b/apps/src/blockTooltips/DropletFunctionTooltip.html.ejs
@@ -15,7 +15,13 @@
     <%= getPrefixedName() %>(<% for (var i = 0; i < locals.parameters.length; i++) { -%><%- locals.parameters[i].name -%><% if (i < locals.parameters.length - 1) { -%>, <% } -%><% } -%>)
   <% } %>
 </div>
-<% if (locals.functionShortDescription) { %><div><%= locals.functionShortDescription %></div><% } %>
+<% if (locals.functionShortDescription) { %>
+  <% locals.functionShortDescription.split('\n').map(function(descriptionLine) { %>
+    <div>
+      <%= descriptionLine %>
+    </div>
+  <% }) %>
+<% } %>
 <% if (locals.showExamplesLink) { %>
   <div class="tooltip-example-link">
     <a href="javascript:void(0);">See examples</a>

--- a/apps/src/blockTooltips/DropletFunctionTooltip.js
+++ b/apps/src/blockTooltips/DropletFunctionTooltip.js
@@ -63,9 +63,11 @@ var DropletFunctionTooltip = function(appMsg, definition) {
   /** @type {?string} */
   this.customDocURL = definition.customDocURL;
 
-  var description = this.getLocalization(this.descriptionKey());
-  if (description) {
-    this.description = description();
+  var localizedDescription = this.getLocalization(this.descriptionKey());
+  if (definition.description) {
+    this.description = definition.description;
+  } else if (localizedDescription) {
+    this.description = localizedDescription();
   }
 
   var signatureOverride = this.getLocalization(this.signatureOverrideKey());

--- a/apps/src/code-studio/components/PublishLibraryDialog.jsx
+++ b/apps/src/code-studio/components/PublishLibraryDialog.jsx
@@ -12,8 +12,8 @@ const styles = {
   },
   checkbox: {
     margin: '4px',
-    width: 24,
-    height: 24
+    width: 28,
+    height: 28
   },
   publishButton: {
     marginLeft: 0,
@@ -25,7 +25,13 @@ const styles = {
   },
   functionName: {
     fontSize: '16px',
-    fontFamily: 'monospace'
+    fontFamily: 'monospace',
+    marginTop: 10,
+    color: color.charcoal
+  },
+  comment: {
+    margin: 4,
+    flex: 1
   }
 };
 
@@ -42,6 +48,7 @@ class PublishLibraryDialog extends React.Component {
   state = {
     showShareLink: false,
     selectedFunctions: {},
+    functionComments: {},
     shareLink: ''
   };
 
@@ -65,6 +72,14 @@ class PublishLibraryDialog extends React.Component {
     });
   };
 
+  commentAdded(name, event) {
+    var value = event.target.value;
+    this.setState(state => {
+      state.functionComments[name] = value;
+      return state;
+    });
+  }
+
   displayFunctions() {
     if (this.props.libraryFunctions.length === 0) {
       return (
@@ -75,11 +90,11 @@ class PublishLibraryDialog extends React.Component {
       );
     }
 
-    return this.props.libraryFunctions.map(libraryFunction => {
+    var functions = this.props.libraryFunctions.map(libraryFunction => {
       var name = libraryFunction.name;
       var params = '(' + libraryFunction.params.join(', ') + ')';
       return (
-        <div key={name}>
+        <div key={name} style={{display: 'flex'}}>
           <input
             type="checkbox"
             name={name}
@@ -91,9 +106,26 @@ class PublishLibraryDialog extends React.Component {
             {name}
             {params}
           </span>
+          {this.state.selectedFunctions[name] && (
+            <textarea
+              name={name}
+              value={this.state.functionComments[name] || ''}
+              onChange={this.commentAdded.bind(this, name)}
+              style={styles.comment}
+            />
+          )}
         </div>
       );
     });
+
+    return (
+      <div>
+        <div style={{margin: 4}}>
+          Use the text boxes to add comments to your functions before sharing.
+        </div>
+        {functions}
+      </div>
+    );
   }
 
   displayShareLink = () => {
@@ -108,6 +140,7 @@ class PublishLibraryDialog extends React.Component {
     var dropletConfig = selectedFunctions.map(selectedFunction => {
       var config = {
         func: this.props.libraryName + '.' + selectedFunction.name,
+        description: this.state.functionComments[selectedFunction.name],
         category: 'Functions'
       };
 


### PR DESCRIPTION
Adds ability to use comments in student libraries.

![studentLibrariesComments](https://user-images.githubusercontent.com/8324574/58512721-a0684480-8152-11e9-8c53-95dca5d15633.gif)

Spec for reference: https://docs.google.com/document/d/1jMLm_ghCshFen-h9vInAuXwEGXI-HPMjSP8dYeISfM0/edit?pli=1#

This code is largely experimental. If we go forward with Student Libraries, all code here will go through a second CR for production quality review. Review this PR to evaluate the following:

Isolation: Will the reviewed code affect parts of the product that are not part of the pilot?
Will the code fail in ways that will cause the pilot to be unsuccessful?
Is there an obviously easier or better way to implement the piloted feature?
Although the piloting process is still under review, I am following the procedures in this doc: https://docs.google.com/document/d/10QvRAVOTEenFJa1wwrY0Twkd0anTDpkkzNeGnT_HH0o/edit