### PR TITLE
Congrats: remove the social network widgets

### DIFF
--- a/pegasus/sites.v3/code.org/public/congrats.haml
+++ b/pegasus/sites.v3/code.org/public/congrats.haml
@@ -103,13 +103,6 @@ max_age: 60
   }
 
   $(document).ready(function() {
-    $('#share-fb a').bind('click', function() {
-      $("#share-fb").hide(); $("#like-fb").css('display', 'inline-block');
-    });
-    $('#share-twitter a').bind('click', function() {
-      $("#share-twitter").hide(); $("#follow-twitter").css('display', 'inline-block');
-    });
-
     // Only show the Frozen "Print your Ice Art" section if we came from a
     // page with "Frozen" in the URL
     // TODO: This is a _terrible_ way to check which certificate we want

--- a/pegasus/sites.v3/code.org/public/js/csf-congrats.js
+++ b/pegasus/sites.v3/code.org/public/js/csf-congrats.js
@@ -13,13 +13,6 @@ function processResponse(data)
 
 $(document).ready(function()
 {
-  $('#share-fb a').bind('click', function() {
-    $("#share-fb").hide(); $("#like-fb").css('display', 'inline-block');
-  });
-  $('#share-twitter a').bind('click', function() {
-    $("#share-twitter").hide(); $("#follow-twitter").css('display', 'inline-block');
-  });
-
   // placeholder text for non-HTML5 browsers
   $('input[type=text], textarea').placeholder();
   $('input[type=email], textarea').placeholder();

--- a/pegasus/sites.v3/code.org/views/congrats_share.haml
+++ b/pegasus/sites.v3/code.org/views/congrats_share.haml
@@ -35,14 +35,8 @@
             %i{:class=>"fa fa-facebook"}<
             =I18n.t(:share_on_facebook)
 
-      %span#like-fb{:style=>'display: none; margin-bottom: 10px; margin-right: 20px'}
-        %iframe{allowtransparency: "true", frameborder: "0", scrolling: "no", src: "//www.facebook.com/plugins/like.php?href=https%3A%2F%2Fwww.facebook.com%2FCode.org&width=200&layout=standard&action=like&show_faces=true&share=true&height=80&appId=293113697493179", style: "border:none; overflow:hidden; width:200px; height:80px; vertical-align:top"}
-
       %span#share-twitter.share-button-twitter-link{:style=>"display: none; margin-top: 10px"}
         %a.window-popup{:href=>"https://twitter.com/share?#{twitter.to_query}", onclick: "trackSocialEvent('twitter');"}<
           %button.button-color-share.share-button-twitter<
             %i{:class=>"fa fa-twitter"}<
             =I18n.t(:share_on_twitter)
-
-      %span#follow-twitter{:style=>'display: none; margin-top: 10px'}
-        %iframe{allowtransparency: "true", frameborder: "0", scrolling: "no", src: "//platform.twitter.com/widgets/follow_button.html?screen_name=codeorg", style: "width:200px; height:20px; vertical-align:top"}


### PR DESCRIPTION
The legacy `/congrats` (and `/congrats/course1`-style CSF variants) had a long-standing feature in which, after clicking a share button to Facebook or Twitter, it would be replaced by a widget from the respective site prompting the user to Like/Follow us.  This replacement no longer happens, and the buttons remain in place after being clicked.