### PR TITLE
Pilot (Student Libraries): Added error handling for when students upload a non-existant library

### DIFF
--- a/apps/src/code-studio/components/LibraryPicker.jsx
+++ b/apps/src/code-studio/components/LibraryPicker.jsx
@@ -26,9 +26,12 @@ const styles = {
   },
   linkBox: {
     cursor: 'auto',
-    width: '600px',
+    width: '300px',
     height: '32px',
     marginBottom: 0
+  },
+  error: {
+    color: color.red
   }
 };
 
@@ -40,11 +43,16 @@ class LibraryPicker extends React.Component {
   };
 
   state = {
-    libraryId: ''
+    libraryId: '',
+    displayError: false,
+    loading: false
   };
 
   changeLibraryId = event => {
-    this.setState({libraryId: event.target.value});
+    this.setState({
+      libraryId: event.target.value,
+      displayError: false
+    });
   };
 
   select = event => event.target.select();
@@ -56,6 +64,11 @@ class LibraryPicker extends React.Component {
           Paste in the library link for a project to add its functions in your
           toolbox.
         </p>
+        {this.state.displayError && (
+          <p style={{...styles.text, ...styles.error}}>
+            We couldn't find that library ID. Try a different ID.
+          </p>
+        )}
         <input
           type="text"
           onClick={this.select}
@@ -68,14 +81,40 @@ class LibraryPicker extends React.Component {
   }
 
   addLibrary = () => {
-    var libraryPilot = clientApi.create('/v3/librarypilot');
-    libraryPilot.fetch(this.state.libraryId + '/library.json', (foo, data) => {
-      this.props.addLibrary(data);
-      project.addLibrary(data);
-    });
-    console.log('Added your library!');
-    this.props.onClose();
+    if (this.state.loading) {
+      return;
+    }
+
+    this.setState({loading: true});
+    var libraryPilot = clientApi.create('/v3/librarypilot', () => {});
+    libraryPilot.fetch(
+      this.state.libraryId + '/library.json',
+      (error, data) => {
+        if (error) {
+          this.setState({
+            displayError: true,
+            loading: false
+          });
+          console.log('failed to add library with message:\n' + error);
+          return;
+        }
+
+        this.props.addLibrary(data);
+        project.addLibrary(data);
+      }
+    );
+
+    console.log('Finished add operation!');
   };
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.isOpen && this.props.isOpen) {
+      this.setState({
+        displayError: false,
+        loading: false
+      });
+    }
+  }
 
   render() {
     return (
@@ -92,6 +131,7 @@ class LibraryPicker extends React.Component {
             style={styles.addButton}
             type="button"
           >
+            {this.state.loading && <i className="fa fa-spinner fa-spin" />}
             Add
           </button>
         </div>

--- a/apps/src/code-studio/components/LibraryPicker.jsx
+++ b/apps/src/code-studio/components/LibraryPicker.jsx
@@ -26,7 +26,7 @@ const styles = {
   },
   linkBox: {
     cursor: 'auto',
-    width: '300px',
+    width: '450px',
     height: '32px',
     marginBottom: 0
   },


### PR DESCRIPTION
In the past, if students imported an invalid library ID, their project would be unusable. Now, an error message is displayed, and the library isn't imported.

![studentLibrariesErrorUploadMessage](https://user-images.githubusercontent.com/8324574/58518660-dc0c0a00-8164-11e9-9929-dbe3edc3cad4.gif)

Spec for reference: https://docs.google.com/document/d/1jMLm_ghCshFen-h9vInAuXwEGXI-HPMjSP8dYeISfM0/edit?pli=1#

This code is largely experimental. If we go forward with Student Libraries, all code here will go through a second CR for production quality review. Review this PR to evaluate the following:

Isolation: Will the reviewed code affect parts of the product that are not part of the pilot?
Will the code fail in ways that will cause the pilot to be unsuccessful?
Is there an obviously easier or better way to implement the piloted feature?
Although the piloting process is still under review, I am following the procedures in this doc: https://docs.google.com/document/d/10QvRAVOTEenFJa1wwrY0Twkd0anTDpkkzNeGnT_HH0o/edit