### PR TITLE
Update redirection rules for CurriculumBuilder so 2019 URLs are current

### DIFF
--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -20,7 +20,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "csp-18/"
+      replace_key_prefix_with: "csp-19/"
     }
   },
   {
@@ -38,7 +38,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "csd-18/"
+      replace_key_prefix_with: "csd-19/"
     }
   },
   {
@@ -56,7 +56,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "csf-18/"
+      replace_key_prefix_with: "csf-19/"
     }
   },
   {


### PR DESCRIPTION
[LP-304](https://codedotorg.atlassian.net/browse/LP-304)

Updates`redirection_rules.rb` added in #26361 so that "current" points to 2019 versions in CurriculumBuilder.