### PR TITLE
Remove extra space in function name translation that's causing errors

### DIFF
--- a/dashboard/config/locales/function_names.tr-TR.yml
+++ b/dashboard/config/locales/function_names.tr-TR.yml
@@ -25,7 +25,7 @@ tr:
       draw E: E çiz
       big gear: büyük dişli
       small gear: küçük dişli
-      draw a hexagon: " altıgen çiz"
+      draw a hexagon: "altıgen çiz"
       draw a flower: çiçek çiz
       draw a square: bir kare çiz
       draw a snowflake: bir kar tanesi çiz

--- a/i18n/locales/tr-TR/dashboard/function_names.yml
+++ b/i18n/locales/tr-TR/dashboard/function_names.yml
@@ -24,7 +24,7 @@ tr:
       draw E: E çiz
       big gear: büyük dişli
       small gear: küçük dişli
-      draw a hexagon: ' altıgen çiz'
+      draw a hexagon: 'altıgen çiz'
       draw a flower: çiçek çiz
       draw a square: bir kare çiz
       draw a snowflake: bir kar tanesi çiz


### PR DESCRIPTION
Already fixed in Crowdin. Fixes [FND-436](https://codedotorg.atlassian.net/browse/FND-456)