### PR TITLE
Update hardcoded CSD/CSP redirect in courses#show

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -25,9 +25,8 @@ class CoursesController < ApplicationController
   end
 
   def show
-    # csp and csd are each "course families", each containing two "course versions",
-    # one with version year 2017 and one with version year 2018. When the url
-    # of a course family is requested, redirect to a specific course version.
+    # csp and csd are each "course families", each containing multiple "course versions".
+    # When the url of a course family is requested, redirect to a specific course version.
     #
     # For now, Hard-code the redirection logic because there are only two course
     # families to worry about. In the future we will want to make this redirect
@@ -35,10 +34,10 @@ class CoursesController < ApplicationController
     redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
     case params[:course_name]
     when 'csd'
-      redirect_to "/courses/csd-2018#{redirect_query_string}"
+      redirect_to "/courses/csd-2019#{redirect_query_string}"
       return
     when 'csp'
-      redirect_to "/courses/csp-2018#{redirect_query_string}"
+      redirect_to "/courses/csp-2019#{redirect_query_string}"
       return
     end
 

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -63,15 +63,15 @@ class CoursesControllerTest < ActionController::TestCase
   # This test ensures that hard-coded logic is not removed without being replaced
   # by the appropriate db-driven redirection logic.
   test "show: redirect to latest stable version in course family" do
-    create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017'
     create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018'
+    create :course, name: 'csp-2019', family_name: 'csp', version_year: '2019'
     get :show, params: {course_name: 'csp'}
-    assert_redirected_to '/courses/csp-2018'
+    assert_redirected_to '/courses/csp-2019'
 
-    create :course, name: 'csd-2017', family_name: 'csd', version_year: '2017'
     create :course, name: 'csd-2018', family_name: 'csd', version_year: '2018'
+    create :course, name: 'csd-2019', family_name: 'csd', version_year: '2019'
     get :show, params: {course_name: 'csd'}
-    assert_redirected_to '/courses/csd-2018'
+    assert_redirected_to '/courses/csd-2019'
   end
 
   test "show: redirect to latest stable version in course family for logged out user" do


### PR DESCRIPTION
[LP-457](https://codedotorg.atlassian.net/browse/LP-457)

~Updates logic in courses#show to redirect to the latest stable version for CSD/CSP, instead of always redirecting to the 2018 versions.~ Edit: To avoid an extra database call (to get `Course.latest_stable_version(family_name)` from the db), we are going to continue hardcoding for the time being and will refactor to get the latest stable version from the course cache in the future.

Dave left lots of good/foreboding comments around this, and I somehow still missed it! 😂 