### PR TITLE
Remove rogue backslashes affecting DB import

### DIFF
--- a/bin/cron/process_jotform_data
+++ b/bin/cron/process_jotform_data
@@ -16,7 +16,7 @@ JOTFORM_SURVEY_RESPONSE_CLASSES = [
 #   quotations escaped. Returns nil on nil input.
 def sanitize_string_for_db(unsanitized)
   return nil if unsanitized.nil?
-  unsanitized.gsub(/[\r\n]+/, '').gsub(/"/, '\"')
+  unsanitized.gsub(/[\r\n\\]+/, '').gsub(/"/, '\"')
 end
 
 def insert_survey_answers(survey_answers)


### PR DESCRIPTION
Traced this [HB error](https://app.honeybadger.io/projects/45435/faults/50020613) to a rogue backslash in a teacher's survey response. Removing backslashes before DB import. FYI @breville 