### PR TITLE
Fix script family redirect for students with progress and teachers

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -481,7 +481,9 @@ class Script < ActiveRecord::Base
     # Only students should be redirected based on script progress and/or section assignments.
     if user&.student?
       assigned_script_ids = user.section_scripts.pluck(:id)
-      script_name = family_scripts.select {|s| assigned_script_ids.include?(s.id)}&.first&.name
+      progress_script_ids = user.user_levels.map(&:script_id)
+      script_ids = assigned_script_ids.concat(progress_script_ids).compact.uniq
+      script_name = family_scripts.select {|s| script_ids.include?(s.id)}&.first&.name
       return Script.new(redirect_to: script_name) if script_name
     end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -478,7 +478,8 @@ class Script < ActiveRecord::Base
 
     family_scripts = Script.get_family_from_cache(family_name).sort_by(&:version_year).reverse
 
-    if user
+    # Only students should be redirected based on script progress and/or section assignments.
+    if user&.student?
       assigned_script_ids = user.section_scripts.pluck(:id)
       script_name = family_scripts.select {|s| assigned_script_ids.include?(s.id)}&.first&.name
       return Script.new(redirect_to: script_name) if script_name


### PR DESCRIPTION
Fixes 2 bugs in `Script.get_script_family_redirect_for_user` (introduced in #27999):

- [LP-459](https://codedotorg.atlassian.net/browse/LP-459) - Teachers were being redirected based on assignments for their sections. Teachers should always be redirected to the latest stable version. Example:
  1. Teacher visits `/s/coursea` 
  2. Teacher is redirected to `/s/coursea-2019` (correct behavior)
  3. Teacher creates a section that is assigned to coursea-2017
  4. Teacher visits `/s/coursea`
  5. Teacher is redirected to `/s/coursea-2017` (incorrect behavior -- should still go to `/s/coursea-2019`)

- [LP-460](https://codedotorg.atlassian.net/browse/LP-460) - Students were being redirected based on section assignments only. Students should be redirected to the latest stable script version in which they are assigned _or have progress_. Student progress is taken into account.