### PR TITLE
Add CSF 2019 to hardcoded i18n? method

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -295,6 +295,7 @@ module ScriptConstants
     ScriptConstants.script_in_category?(:csf_international, script) ||
       ScriptConstants.script_in_category?(:csf, script) ||
       ScriptConstants.script_in_category?(:csf_2018, script) ||
-      ScriptConstants.script_in_category?(:twenty_hour, script)
+      ScriptConstants.script_in_category?(:twenty_hour, script) ||
+      ScriptConstants.script_in_category?(:csf_2019, script)
   end
 end


### PR DESCRIPTION
Now that we've launched the 2019 curriculum, I think we need to update this helper method in script_constants since it has a hardcoded list of the other versions of CSF. 
