### PR TITLE
Allow bonus levels to be accessed by level name

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -204,6 +204,18 @@ class ScriptLevelsController < ApplicationController
       return
     end
 
+    if params[:level_name]
+      @level = Level.find_by_name params[:level_name]
+      @script = Script.get_from_cache(params[:script_id])
+      @stage = @script.stage_by_relative_position(params[:stage_position].to_i)
+      @script_level = @level.script_levels.find_by_script_id(@script.id)
+      if @script_level
+        @game = @level.game
+        present_level
+        return
+      end
+    end
+
     @stage = Script.get_from_cache(params[:script_id]).stage_by_relative_position(params[:stage_position].to_i)
     @script = @stage.script
     @stage_extras = {

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -193,27 +193,21 @@ class ScriptLevelsController < ApplicationController
       end
     end
 
+    @script = Script.get_from_cache(params[:script_id])
+    @stage = @script.stage_by_relative_position(params[:stage_position].to_i)
+
     if params[:id]
       @script_level = Script.cache_find_script_level params[:id]
       @level = @script_level.level
-      @script = Script.get_from_cache(params[:script_id])
-      @stage = @script.stage_by_relative_position(params[:stage_position].to_i)
-      @game = @level.game
-
-      present_level
-      return
+    elsif params[:level_name]
+      @level = Level.find_by_name params[:level_name]
+      @script_level = @level.script_levels.find_by_script_id(@script.id)
     end
 
-    if params[:level_name]
-      @level = Level.find_by_name params[:level_name]
-      @script = Script.get_from_cache(params[:script_id])
-      @stage = @script.stage_by_relative_position(params[:stage_position].to_i)
-      @script_level = @level.script_levels.find_by_script_id(@script.id)
-      if @script_level
-        @game = @level.game
-        present_level
-        return
-      end
+    if @level
+      @game = @level.game
+      present_level
+      return
     end
 
     @stage = Script.get_from_cache(params[:script_id]).stage_by_relative_position(params[:stage_position].to_i)

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1506,6 +1506,36 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_nil assigns(:view_options)[:is_challenge_level]
   end
 
+  test "specifying a bonus level name will direct to that level" do
+    script_level = create :script_level
+    script_level.bonus = true
+    script_level.save!
+    get :stage_extras, params: {
+      script_id: script_level.script,
+      stage_position: 1,
+      level_name: script_level.level.name
+    }
+    assert_response :success
+    assert_equal script_level.level.id, assigns(:view_options)[:server_level_id]
+  end
+
+  test "a bonus scriptlevel id takes precedence over level name" do
+    script_level_by_id = create :script_level
+    script_level_by_name = create :script_level, script: script_level_by_id.script
+    script_level_by_id.bonus = true
+    script_level_by_name.bonus = true
+    script_level_by_id.save!
+    script_level_by_name.save!
+    get :stage_extras, params: {
+      script_id: script_level_by_id.script,
+      stage_position: 1,
+      id: script_level_by_id.id,
+      level_name: script_level_by_name.level.name
+    }
+    assert_response :success
+    assert_equal script_level_by_id.level.id, assigns(:view_options)[:server_level_id]
+  end
+
   test_user_gets_response_for :show, response: :redirect, user: nil,
     params: -> {script_level_params(@pilot_script_level)},
     name: 'signed out user cannot view pilot script level'


### PR DESCRIPTION
We're currently refactoring the i18n pipeline to use puzzle URLs as keys to provide better context for translators. In this process, we found that we could not determine the production URL for lesson extras on the server we run the i18n sync on. This change allows us to use level name instead of id to direct to the lesson extras.

Note that bonus levels can still be accessed by ScriptLevel id and that will take precedence. This change would allow us to determine the URL for bonus levels on any environment, which would unblock work on the i18n pipeline that keys strings by the URL.