### PR TITLE
Pilot (Student Libraries): Let students replace levelbuilder libraries with their own. Also, get the levelbuilder library back when they 'start over'

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -682,9 +682,6 @@ Applab.init = function(config) {
 
   var librariesExist = level.libraries && level.libraries.length > 0;
 
-  // Temporarily, always use the levelbuilder-created libraries if they
-  // exist. Once 'Start Over' is implemented for libraries, allow
-  // student-created libraries. (Add check for !librariesExist)
   if (
     !librariesExist &&
     level.startLibraries &&

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -521,6 +521,7 @@ Applab.init = function(config) {
   config.afterClearPuzzle = function() {
     designMode.resetIds();
     Applab.setLevelHtml(config.level.startHtml || '');
+    getStore().dispatch(setApplabLibraries(config.level.startLibraries));
     Applab.storage.populateTable(level.dataTables, true, () => {}, outputError); // overwrite = true
     Applab.storage.populateKeyValue(
       level.dataProperties,
@@ -684,7 +685,11 @@ Applab.init = function(config) {
   // Temporarily, always use the levelbuilder-created libraries if they
   // exist. Once 'Start Over' is implemented for libraries, allow
   // student-created libraries. (Add check for !librariesExist)
-  if (level.startLibraries && level.startLibraries.length > 0) {
+  if (
+    !librariesExist &&
+    level.startLibraries &&
+    level.startLibraries.length > 0
+  ) {
     level.libraries = level.startLibraries;
     librariesExist = true;
   }

--- a/apps/src/code-studio/components/applabLibraryRedux.jsx
+++ b/apps/src/code-studio/components/applabLibraryRedux.jsx
@@ -6,7 +6,7 @@ export default function reducer(state, action) {
   switch (action.type) {
     case SET_LIBRARIES:
       return {
-        libraries: action.libraries
+        libraries: action.libraries || []
       };
     case ADD_LIBRARY:
       // For now (during the pilot), you can only import one library at a time.


### PR DESCRIPTION
Previously, students could not import a library on a level that contained a levelbuilder-defined library. Now, they are able to do this. Also, if they start the level over, they will get the levelbuilder-defined library back.

Spec for reference: https://docs.google.com/document/d/1jMLm_ghCshFen-h9vInAuXwEGXI-HPMjSP8dYeISfM0/edit?pli=1#

This code is largely experimental. If we go forward with Student Libraries, all code here will go through a second CR for production quality review. Review this PR to evaluate the following:
- Isolation: Will the reviewed code affect parts of the product that are not part of the pilot?
- Will the code fail in ways that will cause the pilot to be unsuccessful?
- Is there an obviously easier or better way to implement the piloted feature?

Although the piloting process is still under review, I am following the procedures in this doc: https://docs.google.com/document/d/10QvRAVOTEenFJa1wwrY0Twkd0anTDpkkzNeGnT_HH0o/edit