### PR TITLE
Grant policies to daemon role for Contact Rollups

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -537,6 +537,15 @@ Resources:
                   - 'rds:DeleteDBCluster'
                   - 'rds:DescribeDBClusterEndpoints'
                 Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:<%=CDO.db_cluster_id%>*"
+              - Effect: Allow
+                Action:
+                  - 'rds:CreateDBInstance'
+                  - 'rds:DeleteDBInstance'
+                Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:<%=CDO.db_cluster_id%>*"
+              - Effect: Allow
+                Action:
+                  - 'rds:DescribeDBInstances'
+                Resource: '*'
 <% end -%>
               # SQS queues for Asynchronous batch processing by the `process_queues` service.
               - Effect: Allow

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -528,6 +528,16 @@ Resources:
         - PolicyName: Daemon
           PolicyDocument:
             Statement:
+<% if CDO.db_cluster_id -%>
+              # Create, Describe, Delete Database Clusters for Contact Rollups
+              - Effect: Allow
+                Action:
+                  - 'rds:DescribeDBClusters'
+                  - 'rds:RestoreDBClusterToPointInTime'
+                  - 'rds:DeleteDBCluster'
+                  - 'rds:DescribeDBClusterEndpoints'
+                Resource: Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:<%=CDO.db_cluster_id%>*"
+<% end -%>
               # SQS queues for Asynchronous batch processing by the `process_queues` service.
               - Effect: Allow
                 Action:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -536,7 +536,7 @@ Resources:
                   - 'rds:RestoreDBClusterToPointInTime'
                   - 'rds:DeleteDBCluster'
                   - 'rds:DescribeDBClusterEndpoints'
-                Resource: Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:<%=CDO.db_cluster_id%>*"
+                Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:<%=CDO.db_cluster_id%>*"
 <% end -%>
               # SQS queues for Asynchronous batch processing by the `process_queues` service.
               - Effect: Allow


### PR DESCRIPTION
Grant policies to daemon role so that Contact Rollups can clone the Aurora cluster, and then delete it.