### PR TITLE
WIP: testing for react-inspector

### DIFF
--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -139,7 +139,10 @@ export default connect(
         e.preventDefault();
         this.props.commandHistory.push(input);
         e.target.value = '';
-        this.appendLog('> ' + input);
+        this.props.showReactInspector
+          ? this.appendLog(input)
+          : this.appendLog('> ' + input);
+
         if (0 === input.indexOf(WATCH_COMMAND_PREFIX)) {
           this.props.addWatchExpression(
             input.substring(WATCH_COMMAND_PREFIX.length)

--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -16,6 +16,7 @@ import {
 import CommandHistory from './CommandHistory';
 import {actions, selectors} from './redux';
 import color from '../../../util/color';
+import Inspector from 'react-inspector';
 
 const DEBUG_INPUT_HEIGHT = 16;
 const DEBUG_CONSOLE_LEFT_PADDING = 3;
@@ -98,6 +99,7 @@ export default connect(
     commandHistory: selectors.getCommandHistory(state),
     jsInterpreter: selectors.getJSInterpreter(state),
     logOutput: selectors.getLogOutput(state),
+    logOutputList: selectors.getLogOutputList(state),
     maxLogLevel: selectors.getMaxLogLevel(state),
     isAttached: selectors.isAttached(state)
   }),
@@ -115,6 +117,8 @@ export default connect(
       // from redux
       commandHistory: PropTypes.instanceOf(CommandHistory),
       logOutput: PropTypes.string.isRequired,
+      logOutputList: PropTypes.oneOfType([PropTypes.array, PropTypes.object])
+        .isRequired,
       maxLogLevel: PropTypes.string.isRequired,
       isAttached: PropTypes.bool.isRequired,
       addWatchExpression: PropTypes.func.isRequired,
@@ -125,7 +129,8 @@ export default connect(
       // passed from above
       debugButtons: PropTypes.bool,
       debugWatch: PropTypes.bool,
-      style: PropTypes.object
+      style: PropTypes.object,
+      showReactInspector: PropTypes.bool
     };
 
     onInputKeyDown = e => {
@@ -205,6 +210,17 @@ export default connect(
       }
     }
 
+    displayOutputToConsole() {
+      if (this.props.logOutputList.size > 0) {
+        return this.props.logOutputList.map((output, i) => {
+          if (typeof output === 'object') {
+            output = output.toJS();
+          }
+          return <Inspector key={i} data={output} />;
+        });
+      }
+    }
+
     render() {
       let classes = 'debug-console';
       if (!this.props.debugButtons) {
@@ -242,7 +258,9 @@ export default connect(
               ...this.getDebugOutputBackgroundStyle()
             }}
           >
-            {this.props.logOutput}
+            {this.props.showReactInspector
+              ? this.displayOutputToConsole()
+              : this.props.logOutput}
           </div>
           <div style={style.debugInputWrapper}>
             <span style={style.debugInputPrompt} onClick={this.focus}>

--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -26,6 +26,7 @@ import {
 } from '../../../redux/watchedExpressions';
 import DebugConsole from './DebugConsole';
 import DebugButtons from './DebugButtons';
+import experiments from '../../../util/experiments';
 
 import {
   // actions
@@ -609,6 +610,9 @@ class JsDebugger extends React.Component {
             debugButtons={this.props.debugButtons}
             debugWatch={showWatchPane}
             ref={debugConsole => (this._debugConsole = debugConsole)}
+            showReactInspector={
+              experiments.isEnabled('react-inspector') ? true : false
+            }
           />
         )}
         <div style={{display: showWatchPane ? 'initial' : 'none'}}>

--- a/apps/src/lib/tools/jsdebugger/redux.js
+++ b/apps/src/lib/tools/jsdebugger/redux.js
@@ -22,7 +22,9 @@ const JSDebuggerState = Immutable.Record({
   observer: null,
   watchIntervalId: null,
   commandHistory: null,
+  // TODO: remove logOutput after flag is removed
   logOutput: '',
+  logOutputList: [],
   maxLogLevel: '',
   isOpen: false
 });
@@ -70,8 +72,13 @@ export function canRunNext(state) {
   );
 }
 
+// TODO: remove getlogOutput after flag is removed
 export function getLogOutput(state) {
   return getRoot(state).logOutput;
+}
+
+export function getLogOutputList(state) {
+  return getRoot(state).logOutputList;
 }
 
 export function getMaxLogLevel(state) {
@@ -85,7 +92,9 @@ export const selectors = {
   isPaused,
   isAttached,
   canRunNext,
+  // TODO: remove getlogOutput after flag is removed
   getLogOutput,
+  getLogOutputList,
   getMaxLogLevel,
   isOpen
 };
@@ -253,6 +262,17 @@ function appendLogOutput(logOutput, output) {
   return logOutput;
 }
 
+function appendLogOutputList(logOutputList, output, type) {
+  logOutputList = logOutputList || [];
+  switch (type) {
+    case APPEND_LOG:
+      return [...logOutputList, output];
+
+    default:
+      return logOutputList;
+  }
+}
+
 function computeNewMaxLogLevel(prevMaxLogLevel, newLogLevel) {
   if (newLogLevel === 'error' || prevMaxLogLevel === 'error') {
     return 'error';
@@ -282,11 +302,22 @@ export function reducer(state, action) {
     });
   } else if (action.type === APPEND_LOG) {
     return state.merge({
-      logOutput: appendLogOutput(state.logOutput, action.output),
+      // TODO: remove logOutput after flag is removed
+      logOutput: appendLogOutput(state.logOutput, action.output, action.type),
+      logOutputList: appendLogOutputList(
+        state.logOutputList,
+        action.output,
+        action.type
+      ),
       maxLogLevel: computeNewMaxLogLevel(state.maxLogLevel, action.logLevel)
     });
   } else if (action.type === CLEAR_LOG) {
-    return state.merge({logOutput: '', maxLogLevel: ''});
+    return state.merge({
+      // TODO: remove logOutput after flag is removed
+      logOutput: '',
+      logOutputList: [],
+      maxLogLevel: ''
+    });
   } else if (action.type === DETACH) {
     return state.merge({
       jsInterpreter: null,

--- a/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
@@ -13,9 +13,10 @@ import {
 } from '@cdo/apps/redux';
 import {KeyCodes} from '@cdo/apps/constants';
 import JSInterpreter from '@cdo/apps/lib/tools/jsinterpreter/JSInterpreter';
+import Inspector from 'react-inspector';
 
 describe('The DebugConsole component', () => {
-  let root;
+  let root, debugConsole;
 
   beforeEach(() => {
     stubRedux();
@@ -26,6 +27,8 @@ describe('The DebugConsole component', () => {
         <DebugConsole />
       </Provider>
     );
+
+    debugConsole = root.find('DebugConsole').get(0);
   });
 
   afterEach(() => {
@@ -236,3 +239,102 @@ describe('The DebugConsole component', () => {
     });
   });
 });
+
+describe.only('when react-inspector flag is on', () => {
+  let root, debugConsole;
+
+  beforeEach(() => {
+    stubRedux();
+    registerReducers(reducers);
+    getStore().dispatch(actions.appendLog(['test']));
+    // getStore().dispatch(actions.initialize(sinon.spy()));
+
+    root = mount(
+      <Provider store={getStore()}>
+        <DebugConsole showReactInspector={true} />
+      </Provider>
+    );
+
+    debugConsole = root.find('DebugConsole').get(0);
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
+  const debugOutput = () => root.find('#debug-output');
+  const debugInput = () => root.find('#debug-input');
+  function typeKey(keyCode) {
+    debugInput().simulate('keydown', {
+      target: debugInput().get(0),
+      keyCode: keyCode
+    });
+  }
+  function type(text) {
+    for (let i = 0; i < text.length; i++) {
+      debugInput().get(0).value += text[i];
+      typeKey(text[i]);
+    }
+  }
+
+  function submit(text) {
+    type(text);
+    typeKey(KeyCodes.ENTER);
+  }
+
+  it('an array input outputs an array', () => {
+    //   let interpreter = new JSInterpreter({
+    //     shouldRunAtMaxSpeed: () => true,
+    //     studioApp: {hideSource: true}
+    //   });
+    //   const code = `["foo", "bar"]`;
+    //   // interpreter.calculateCodeInfo({code});
+    //
+    //   interpreter.calculateCodeInfo({code});
+    //   interpreter.parse({code});
+    //   expect(interpreter.initialized()).to.equal(true);
+    //   // interpreter.paused = false;
+    //   // interpreter.nextStep = JSInterpreter.StepType.IN;
+    //   interpreter.executeInterpreter(true);
+    //   // debugConsole.setProps({showReactInspector: true});
+    //   getStore().dispatch(actions.attach(interpreter));
+    //   // submit(`["foo", "bar"]`);
+    //   getStore().dispatch(actions.appendLogL(2));
+    expect(debugOutput().text()).to.equal('["test"]');
+    //   // expect(debugConsole.contains(<Inspector data={2} />)).to.equal(fal);
+  });
+  //
+  // it('a string input outputs a string', () => {
+  //   expect(root.contains(<Inspector data={'hello world'} />)).to.equal(true);
+  //   expect(root.text()).to.equal('"hello world"');
+  // });
+  //
+  // it('an integer or mathematical operation input outputs an integer', () => {
+  //   expect(root.contains(<Inspector data={1 + 1} />)).to.equal(true);
+  //   expect(root.text()).to.equal('2');
+  // });
+  //
+  // it('an object input outputs an object', () => {
+  //   expect(root.contains(<Inspector data={{foo: 'bar'}} />)).to.equal(true);
+  //   expect(root.text()).to.equal('▶Object {foo:"bar"}');
+  // });
+});
+
+// describe.only('react-inspector component returns', () => {
+//   it('an array input outputs an array', () => {});
+//
+//   it('a string input outputs a string', () => {
+//     expect(root.contains(<Inspector data={'hello world'} />)).to.equal(true);
+//     expect(root.text()).to.equal('"hello world"');
+//   });
+//
+//   it('an integer or mathematical operation input outputs an integer', () => {
+//     expect(root.contains(<Inspector data={1 + 1} />)).to.equal(true);
+//     expect(root.text()).to.equal('2');
+//   });
+//
+//   it('an object input outputs an object', () => {
+//     expect(root.contains(<Inspector data={{foo: 'bar'}} />)).to.equal(true);
+//     expect(root.text()).to.equal('▶Object {foo:"bar"}');
+//   });
+// });

--- a/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
@@ -13,10 +13,10 @@ import {
 } from '@cdo/apps/redux';
 import {KeyCodes} from '@cdo/apps/constants';
 import JSInterpreter from '@cdo/apps/lib/tools/jsinterpreter/JSInterpreter';
-import Inspector from 'react-inspector';
+// import Inspector from 'react-inspector';
 
 describe('The DebugConsole component', () => {
-  let root, debugConsole;
+  let root;
 
   beforeEach(() => {
     stubRedux();
@@ -27,8 +27,6 @@ describe('The DebugConsole component', () => {
         <DebugConsole />
       </Provider>
     );
-
-    debugConsole = root.find('DebugConsole').get(0);
   });
 
   afterEach(() => {
@@ -240,22 +238,18 @@ describe('The DebugConsole component', () => {
   });
 });
 
-describe.only('when react-inspector flag is on', () => {
-  let root, debugConsole;
+describe('when react-inspector flag is on', () => {
+  let root;
 
   beforeEach(() => {
     stubRedux();
     registerReducers(reducers);
-    getStore().dispatch(actions.appendLog(['test']));
-    // getStore().dispatch(actions.initialize(sinon.spy()));
 
     root = mount(
       <Provider store={getStore()}>
         <DebugConsole showReactInspector={true} />
       </Provider>
     );
-
-    debugConsole = root.find('DebugConsole').get(0);
   });
 
   afterEach(() => {
@@ -263,65 +257,36 @@ describe.only('when react-inspector flag is on', () => {
   });
 
   const debugOutput = () => root.find('#debug-output');
-  const debugInput = () => root.find('#debug-input');
-  function typeKey(keyCode) {
-    debugInput().simulate('keydown', {
-      target: debugInput().get(0),
-      keyCode: keyCode
+
+  describe('inputs from code workspace returns', () => {
+    it('an array input outputs an array', () => {
+      getStore().dispatch(actions.appendLog(['test']));
+      expect(debugOutput().text()).to.equal('▶["test"]');
     });
-  }
-  function type(text) {
-    for (let i = 0; i < text.length; i++) {
-      debugInput().get(0).value += text[i];
-      typeKey(text[i]);
-    }
-  }
 
-  function submit(text) {
-    type(text);
-    typeKey(KeyCodes.ENTER);
-  }
+    it('a string input outputs a string', () => {
+      getStore().dispatch(actions.appendLog('hello world'));
+      expect(debugOutput().text()).to.equal('"hello world"');
+    });
 
-  it('an array input outputs an array', () => {
-    //   let interpreter = new JSInterpreter({
-    //     shouldRunAtMaxSpeed: () => true,
-    //     studioApp: {hideSource: true}
-    //   });
-    //   const code = `["foo", "bar"]`;
-    //   // interpreter.calculateCodeInfo({code});
-    //
-    //   interpreter.calculateCodeInfo({code});
-    //   interpreter.parse({code});
-    //   expect(interpreter.initialized()).to.equal(true);
-    //   // interpreter.paused = false;
-    //   // interpreter.nextStep = JSInterpreter.StepType.IN;
-    //   interpreter.executeInterpreter(true);
-    //   // debugConsole.setProps({showReactInspector: true});
-    //   getStore().dispatch(actions.attach(interpreter));
-    //   // submit(`["foo", "bar"]`);
-    //   getStore().dispatch(actions.appendLogL(2));
-    expect(debugOutput().text()).to.equal('["test"]');
-    //   // expect(debugConsole.contains(<Inspector data={2} />)).to.equal(fal);
+    it('an integer or mathematical operation input outputs an integer', () => {
+      getStore().dispatch(actions.appendLog(1 + 1));
+      expect(debugOutput().text()).to.equal('2');
+    });
+
+    it('an object input outputs an object', () => {
+      getStore().dispatch(actions.appendLog({foo: 'bar'}));
+      expect(debugOutput().text()).to.deep.equal('▶Object {foo: "bar"}');
+    });
   });
-  //
-  // it('a string input outputs a string', () => {
-  //   expect(root.contains(<Inspector data={'hello world'} />)).to.equal(true);
-  //   expect(root.text()).to.equal('"hello world"');
-  // });
-  //
-  // it('an integer or mathematical operation input outputs an integer', () => {
-  //   expect(root.contains(<Inspector data={1 + 1} />)).to.equal(true);
-  //   expect(root.text()).to.equal('2');
-  // });
-  //
-  // it('an object input outputs an object', () => {
-  //   expect(root.contains(<Inspector data={{foo: 'bar'}} />)).to.equal(true);
-  //   expect(root.text()).to.equal('▶Object {foo:"bar"}');
-  // });
 });
 
+// The tests below were written for simply checking
+// what the expected behavior of the inspector component is.
+// The root was simply the Inspector tag when the test below was written which is no longer the case.
+
 // describe.only('react-inspector component returns', () => {
-//   it('an array input outputs an array', () => {});
+//   // it('an array input outputs an array', () => {});
 //
 //   it('a string input outputs a string', () => {
 //     expect(root.contains(<Inspector data={'hello world'} />)).to.equal(true);

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -12073,7 +12073,7 @@ react-input-autosize@^2.1.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-inspector@^2.3.0:
+react-inspector@2.3.1, react-inspector@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.3.1.tgz#f0eb7f520669b545b441af9d38ec6d706e5f649c"
   dependencies:


### PR DESCRIPTION
The test shown in this PR was written for a while ago when the code written for the react-inspector in the DebugConsole.jsx was at its early stage. That's why the PR can't be auto-merged and that is fine because this PR is just a discussion point of how to move forward with testing for the current progress we have with the DebugConsole.jsx. This PR won't be merged. The PRs that are open right now have the latest updates to DebugConsole and how arrows are handled in the output.

This test only tests what the **output** looks like when input is coming from the code workspace from game lab and app lab. In order to test what the output looks like with the flag on, a suggestion was made to use a prop as a boolean to pass into the DebugConsole.jsx.