### PR TITLE
Sanitize XML

### DIFF
--- a/apps/src/templates/UnsafeRenderedMarkdown.jsx
+++ b/apps/src/templates/UnsafeRenderedMarkdown.jsx
@@ -33,7 +33,7 @@ schema.attributes['*'].push('style', 'className');
 
 // Add support for Blockly XML
 schema.clobber = [];
-schema.tagNames.push(
+const blocklyTags = [
   'block',
   'functional_input',
   'mutation',
@@ -42,7 +42,11 @@ schema.tagNames.push(
   'title',
   'value',
   'xml'
-);
+];
+schema.tagNames = schema.tagNames.concat(blocklyTags);
+blocklyTags.forEach(tag => {
+  schema.attributes[tag] = ['block_text', 'id', 'inline', 'name', 'type'];
+});
 
 const markdownToReact = Parser.create()
   .getParser()


### PR DESCRIPTION
Sanitize XML in Markdown to allow only those tags and attributes we need
for Blockly.

Note that this list was generated based on an analysis of the Blockly
XML we _currently_ use, not on all the possible XML we _could_ use. It
could be that this list is inadequately permissive.