### PR TITLE
Display circular objects in game lab's debug console

### DIFF
--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -212,8 +212,10 @@ export default connect(
     displayOutputToConsole() {
       if (this.props.logOutput.size > 0) {
         return this.props.logOutput.map((output, i) => {
-          if (typeof output === 'object') {
+          try {
             output = output.toJS();
+          } catch (error) {
+            return <Inspector key={i} data={output} />;
           }
           return <Inspector key={i} data={output} />;
         });

--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -212,10 +212,8 @@ export default connect(
     displayOutputToConsole() {
       if (this.props.logOutput.size > 0) {
         return this.props.logOutput.map((output, i) => {
-          try {
+          if ('function' === typeof output.toJS) {
             output = output.toJS();
-          } catch (error) {
-            return <Inspector key={i} data={output} />;
           }
           return <Inspector key={i} data={output} />;
         });


### PR DESCRIPTION
- **What** and **Where** it changed:
  This PR changes how debug console handles self referential objects for App lab and Game lab. Currently, if a user tries to log **sprite, camera, or group** you get an error message. When this PR gets merged, debug console displays the properties of sprite, camera, and group. Discussed with Ryan and Elizabeth about how it will be helpful if students can actually see properties of the sprite and etc.

- **Why** are we making this change?
  Error shown to students from logging those self referential/circular objects aren't helpful to students. Also, this will be another improvement to the debug console as those sprite, camera, and group will go through the react-inspector tag which will make it easier for students to explore each property. 

  One thing to note is that that console logging p5 returns `undefined` because p5 is included in the list of properties that should not go through CustomMarshallingInterpreter: 
<img width="507" alt="Screen Shot 2019-05-29 at 5 48 36 PM" src="https://user-images.githubusercontent.com/17921445/58600574-067bc700-823a-11e9-8bc2-10042167009e.png">
<img width="462" alt="Screen Shot 2019-05-29 at 5 48 30 PM" src="https://user-images.githubusercontent.com/17921445/58600576-0a0f4e00-823a-11e9-8569-3df906ead0fe.png">

- **How I tested the change**:
   Manually tested in app lab and game lab.

- **What's next**?
   - Testing. 

- **Screenshots**:
    Current error that gets displayed when flag is off:
     <img width="507" alt="Screen Shot 2019-05-29 at 4 28 35 PM" src="https://user-images.githubusercontent.com/17921445/58597887-d8dd5080-822e-11e9-9d52-aace1ddda698.png">

    Output when flag is on:
    <img width="388" alt="Screen Shot 2019-05-29 at 4 40 26 PM" src="https://user-images.githubusercontent.com/17921445/58598284-7f762100-8230-11e9-882d-5a19473dc158.png">