### PR TITLE
Wrap sprite methods destroy, setTint, removeTint

### DIFF
--- a/dashboard/config/blocks/GamelabJr/gamelab_destroy.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_destroy.json
@@ -9,8 +9,10 @@
     "func": "destroy",
     "blockText": "remove {THIS}",
     "args": [
-
-    ],
-    "methodCall": true
+      {
+        "name": "THIS",
+        "type": "Sprite"
+      }
+    ]
   }
 }

--- a/dashboard/config/blocks/GamelabJr/gamelab_removeTint.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_removeTint.json
@@ -9,8 +9,10 @@
     "func": "removeTint",
     "blockText": "remove color from {THIS}",
     "args": [
-
-    ],
-    "methodCall": true
+      {
+        "name": "THIS",
+        "type": "Sprite"
+      }
+    ]
   }
 }

--- a/dashboard/config/blocks/GamelabJr/gamelab_setTint.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_setTint.json
@@ -10,10 +10,13 @@
     "blockText": "change color of {THIS} to {COLOR}",
     "args": [
       {
+        "name": "THIS",
+        "type": "Sprite"
+      },
+      {
         "name": "COLOR",
         "type": "Colour"
       }
-    ],
-    "methodCall": true
+    ]
   }
 }

--- a/dashboard/config/libraries/GameLabJr.interpreted.js
+++ b/dashboard/config/libraries/GameLabJr.interpreted.js
@@ -44,6 +44,19 @@ function initialize(setupHandler) {
   setupHandler();
 }
 
+// Temporary wrappers for sprite methods, to facilitate transition to native.
+function destroy(sprite) {
+  sprite.destroy();
+}
+
+function setTint(sprite, color) {
+  sprite.setTint(color);
+}
+
+function removeTint(sprite) {
+  sprite.removeTint();
+}
+
 // Behaviors
 function addBehavior(sprite, behavior) {
   if (sprite && behavior) {

--- a/dashboard/config/libraries/SpriteLab2Beta.interpreted.js
+++ b/dashboard/config/libraries/SpriteLab2Beta.interpreted.js
@@ -44,6 +44,19 @@ function initialize(setupHandler) {
   setupHandler();
 }
 
+// Temporary wrappers for sprite methods, to facilitate transition to native.
+function destroy(sprite) {
+  sprite.destroy();
+}
+
+function setTint(sprite, color) {
+  sprite.setTint(color);
+}
+
+function removeTint(sprite) {
+  sprite.removeTint();
+}
+
 // Behaviors
 function addBehavior(sprite, behavior) {
   if (sprite && behavior) {


### PR DESCRIPTION
I think the issue earlier was that I renamed the parameter in the block config from `THIS` to `SPRITE`. Leaving the parameter name the same, but making it not a `methodCall` seems to work as expected. 
Blocks render correctly: 
![image](https://user-images.githubusercontent.com/8787187/58733262-e4ed1d80-83a8-11e9-9761-e0aea20fd1b6.png)

Then I just added little wrapper functions in the interpreted libraries so that the methods are still called.

This change is necessary to enable moving the sprite lab library to run natively.