### PR TITLE
Pilot (Student Libraries): Require comments to publish libraries

### DIFF
--- a/apps/src/code-studio/components/PublishLibraryDialog.jsx
+++ b/apps/src/code-studio/components/PublishLibraryDialog.jsx
@@ -148,7 +148,7 @@ class PublishLibraryDialog extends React.Component {
       return !this.state.functionComments[selectedFunction.name];
     });
     if (withoutComments.length > 0) {
-      this.setState({showWarningMessage: true});
+      this.setState({showWarningMessage: true, showShareLink: false});
       return;
     }
     this.setState({showWarningMessage: false});

--- a/apps/src/code-studio/components/PublishLibraryDialog.jsx
+++ b/apps/src/code-studio/components/PublishLibraryDialog.jsx
@@ -32,6 +32,12 @@ const styles = {
   comment: {
     margin: 4,
     flex: 1
+  },
+  warningMessage: {
+    color: color.red,
+    marginTop: 20,
+    marginLeft: 4,
+    fontSize: 'large'
   }
 };
 
@@ -49,7 +55,8 @@ class PublishLibraryDialog extends React.Component {
     showShareLink: false,
     selectedFunctions: {},
     functionComments: {},
-    shareLink: ''
+    shareLink: '',
+    showWarningMessage: false
   };
 
   componentDidUpdate(prevProps) {
@@ -137,6 +144,14 @@ class PublishLibraryDialog extends React.Component {
     var functionNames = selectedFunctions.map(
       selectedFunction => selectedFunction.name
     );
+    var withoutComments = selectedFunctions.filter(selectedFunction => {
+      return !this.state.functionComments[selectedFunction.name];
+    });
+    if (withoutComments.length > 0) {
+      this.setState({showWarningMessage: true});
+      return;
+    }
+    this.setState({showWarningMessage: false});
     var dropletConfig = selectedFunctions.map(selectedFunction => {
       var config = {
         func: this.props.libraryName + '.' + selectedFunction.name,
@@ -190,7 +205,7 @@ class PublishLibraryDialog extends React.Component {
   }
 
   close = () => {
-    this.setState(state => ({showShareLink: false}));
+    this.setState(state => ({showShareLink: false, showWarningMessage: false}));
     this.props.onClose();
   };
 
@@ -213,6 +228,11 @@ class PublishLibraryDialog extends React.Component {
           >
             Publish
           </button>
+          {this.state.showWarningMessage && (
+            <div style={styles.warningMessage}>
+              You must add comments for all shared functions
+            </div>
+          )}
           {this.shareLink()}
         </div>
       </BaseDialog>


### PR DESCRIPTION
This requires comments on every exported library function.

For reference, this was the original PR that added comments: https://github.com/code-dot-org/code-dot-org/pull/28783

![requireComments](https://user-images.githubusercontent.com/8324574/58737082-123fc880-83b5-11e9-9c7c-99c814f29124.gif)

Spec for reference: https://docs.google.com/document/d/1jMLm_ghCshFen-h9vInAuXwEGXI-HPMjSP8dYeISfM0/edit?pli=1#

This code is largely experimental. If we go forward with Student Libraries, all code here will go through a second CR for production quality review. Review this PR to evaluate the following:
 - Isolation: Will the reviewed code affect parts of the product that are not part of the pilot?
 - Will the code fail in ways that will cause the pilot to be unsuccessful?
 - Is there an obviously easier or better way to implement the piloted feature?

Although the piloting process is still under review, I am following the procedures in this doc: https://docs.google.com/document/d/10QvRAVOTEenFJa1wwrY0Twkd0anTDpkkzNeGnT_HH0o/edit