### PR TITLE
Add full_course to Course properties

### DIFF
--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -38,6 +38,7 @@ class Course < ApplicationRecord
     family_name
     version_year
     is_stable
+    full_course
   )
 
   def to_param

--- a/dashboard/config/courses/csd-2017.course
+++ b/dashboard/config/courses/csd-2017.course
@@ -22,6 +22,7 @@
     "has_verified_resources": true,
     "family_name": "csd",
     "version_year": "2017",
-    "is_stable": true
+    "is_stable": true,
+    "full_course": true
   }
 }

--- a/dashboard/config/courses/csd-2018.course
+++ b/dashboard/config/courses/csd-2018.course
@@ -23,6 +23,7 @@
     "has_verified_resources": true,
     "family_name": "csd",
     "version_year": "2018",
-    "is_stable": true
+    "is_stable": true,
+    "full_course": true
   }
 }

--- a/dashboard/config/courses/csd-2019.course
+++ b/dashboard/config/courses/csd-2019.course
@@ -22,6 +22,7 @@
     "has_verified_resources": true,
     "family_name": "csd",
     "version_year": "2019",
-    "is_stable": true
+    "is_stable": true,
+    "full_course": true
   }
 }

--- a/dashboard/config/courses/csp-2017.course
+++ b/dashboard/config/courses/csp-2017.course
@@ -41,6 +41,7 @@
     "has_verified_resources": true,
     "family_name": "csp",
     "version_year": "2017",
-    "is_stable": true
+    "is_stable": true,
+    "full_course": true
   }
 }

--- a/dashboard/config/courses/csp-2018.course
+++ b/dashboard/config/courses/csp-2018.course
@@ -25,6 +25,7 @@
     "has_verified_resources": true,
     "family_name": "csp",
     "version_year": "2018",
-    "is_stable": true
+    "is_stable": true,
+    "full_course": true
   }
 }

--- a/dashboard/config/courses/csp-2019.course
+++ b/dashboard/config/courses/csp-2019.course
@@ -24,6 +24,7 @@
     "has_verified_resources": true,
     "family_name": "csp",
     "version_year": "2019",
-    "is_stable": true
+    "is_stable": true,
+    "full_course": true
   }
 }

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -61,7 +61,7 @@ class CourseTest < ActiveSupport::TestCase
   end
 
   test "should serialize to json" do
-    course = create(:course, name: 'my-course', is_stable: true)
+    course = create(:course, name: 'my-course', is_stable: true, full_course: true)
     create(:course_script, course: course, position: 1, script: create(:script, name: "script1"))
     create(:course_script, course: course, position: 2, script: create(:script, name: "script2"))
     create(:course_script, course: course, position: 3, script: create(:script, name: "script3"))
@@ -72,6 +72,7 @@ class CourseTest < ActiveSupport::TestCase
     assert_equal 'my-course', obj['name']
     assert_equal ['script1', 'script2', 'script3'], obj['script_names']
     assert obj['properties']['is_stable']
+    assert obj['properties']['full_course']
   end
 
   test "stable?: true if course has plc_course" do


### PR DESCRIPTION
**What it does:**
- Adds `full_course` to `course.properties`
- Updates CSD/CSP courses (2017-2019) to include the `full_course` property

The end goal is to use this property instead of [`ScriptConstants::CATEGORIES[:full_course]`](https://github.com/code-dot-org/code-dot-org/blob/6d0e2ee0a65e9e00b75733a6a5be82c690e931b4/lib/cdo/script_constants.rb#L22-L29) so we no longer have to manage this constant separately.