### PR TITLE
Debounce TopInstructions resize handler

### DIFF
--- a/apps/src/templates/instructions/TopInstructionsCSF.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSF.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import classNames from 'classnames';
 import {connect} from 'react-redux';
+import debounce from 'lodash/debounce';
 var instructions = require('../../redux/instructions');
 var color = require('../../util/color');
 var styleConstants = require('../../styleConstants');
@@ -438,7 +439,7 @@ class TopInstructions extends React.Component {
    * entire instructions visible and update store with this value.
    * @returns {number}
    */
-  adjustMaxNeededHeight = () => {
+  adjustMaxNeededHeight = debounce(() => {
     const minHeight = this.getMinHeight();
     const instructionsContent = this.instructions;
     const maxNeededHeight =
@@ -451,7 +452,7 @@ class TopInstructions extends React.Component {
       Math.max(minHeight, maxNeededHeight)
     );
     return maxNeededHeight;
-  };
+  }, 100);
 
   /**
    * Handle a click to our collapser icon by changing our collapse state, and

--- a/apps/src/templates/instructions/TopInstructionsCSP.jsx
+++ b/apps/src/templates/instructions/TopInstructionsCSP.jsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import {connect} from 'react-redux';
-import _ from 'lodash';
+import debounce from 'lodash/debounce';
 import TeacherOnlyMarkdown from './TeacherOnlyMarkdown';
 import TeacherFeedback from './TeacherFeedback';
 import InlineAudio from './InlineAudio';
@@ -271,7 +271,7 @@ class TopInstructionsCSP extends Component {
    * @returns {number}
    */
 
-  adjustMaxNeededHeight = () => {
+  adjustMaxNeededHeight = debounce(() => {
     let element;
     switch (this.state.tabSelected) {
       case TabType.RESOURCES:
@@ -291,7 +291,7 @@ class TopInstructionsCSP extends Component {
 
     this.props.setInstructionsMaxHeightNeeded(maxNeededHeight);
     return maxNeededHeight;
-  };
+  }, 100);
 
   /**
    * Handle a click of our collapser button by changing our collapse state, and
@@ -345,7 +345,7 @@ class TopInstructionsCSP extends Component {
    * 5000ms to avoid recording metrics from a user clicking back-and-forth between
    * tabs too often.
    */
-  incrementFeedbackVisitCount = _.debounce(
+  incrementFeedbackVisitCount = debounce(
     () => {
       const latestFeedback = this.state.feedbacks[0];
       if (!this.state.teacherViewingStudentWork && latestFeedback) {


### PR DESCRIPTION
Same idea as PR https://github.com/code-dot-org/code-dot-org/pull/23376.

Before:

![image](https://user-images.githubusercontent.com/413693/58756774-e5bea600-84b3-11e9-9d34-3f859cc79f3d.png)

After:

![image](https://user-images.githubusercontent.com/413693/58756769-d7708a00-84b3-11e9-9558-820b8cc75f60.png)

The pink `TopInstructions._this.adjustMaxNeededHeight` is no longer called every time a resize event is fired.