### PR TITLE
Pilot (Student Libraries): Log imported libraries to firehose

### DIFF
--- a/apps/src/code-studio/components/LibraryPicker.jsx
+++ b/apps/src/code-studio/components/LibraryPicker.jsx
@@ -6,6 +6,7 @@ import clientApi from '@cdo/apps/code-studio/initApp/clientApi';
 import {addApplabLibrary} from './applabLibraryRedux';
 import {connect} from 'react-redux';
 import project from '../initApp/project';
+import firehoseClient from '../../lib/util/firehose';
 
 const styles = {
   root: {
@@ -90,6 +91,16 @@ class LibraryPicker extends React.Component {
     libraryPilot.fetch(
       this.state.libraryId + '/library.json',
       (error, data) => {
+        firehoseClient.putRecord({
+          study: 'library_pilot',
+          study_group: 'pilot',
+          event: 'import_library',
+          data_json: JSON.stringify({
+            importedLibrary: this.state.libraryId,
+            projectId: project.getCurrentId()
+          })
+        });
+
         if (error) {
           this.setState({
             displayError: true,


### PR DESCRIPTION
This adds firehose logging when students import libraries.

Spec for reference: https://docs.google.com/document/d/1jMLm_ghCshFen-h9vInAuXwEGXI-HPMjSP8dYeISfM0/edit?pli=1#

This code is largely experimental. If we go forward with Student Libraries, all code here will go through a second CR for production quality review. Review this PR to evaluate the following:
 - Isolation: Will the reviewed code affect parts of the product that are not part of the pilot?
 - Will the code fail in ways that will cause the pilot to be unsuccessful?
 - Is there an obviously easier or better way to implement the piloted feature?

Although the piloting process is still under review, I am following the procedures in this doc: https://docs.google.com/document/d/10QvRAVOTEenFJa1wwrY0Twkd0anTDpkkzNeGnT_HH0o/edit