### PR TITLE
add links to assets/animations/files buckets in admin panel

### DIFF
--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -80,6 +80,10 @@
       %ul
         - owner_storage_id, storage_app_id = storage_decrypt_channel_id(params[:channel_id]) rescue [nil, nil]
         - sources_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.sources_s3_bucket}/#{CDO.sources_s3_directory}/#{owner_storage_id}/#{storage_app_id}/"
+        - assets_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.assets_s3_bucket}/#{CDO.assets_s3_directory}/#{owner_storage_id}/#{storage_app_id}/"
+        - animations_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.animations_s3_bucket}/#{CDO.animations_s3_directory}/#{owner_storage_id}/#{storage_app_id}/"
+        - files_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.files_s3_bucket}/#{CDO.files_s3_directory}/#{owner_storage_id}/#{storage_app_id}/"
+
         %li= "project owner: #{User.find_channel_owner(params[:channel_id]).try(:username)}"
         %li= "owner storage id: #{owner_storage_id}"
         %li= "storage app id: #{storage_app_id}"
@@ -90,8 +94,14 @@
         - storage_apps = StorageApps.new(get_storage_id)
         - content_moderation_disabled = storage_apps.content_moderation_disabled?(params[:channel_id])
         %li
-          S3 link:
+          S3 links:
           = link_to 'sources', sources_link, target: '_blank'
+          - if @level.is_a? Applab
+            = link_to 'assets', assets_link, target: '_blank'
+          - elsif @level.is_a? Gamelab
+            = link_to 'animations', animations_link, target: '_blank'
+          - elsif @level.is_a? Weblab
+            = link_to 'files', files_link, target: '_blank'
         - remix_ancestry = StorageApps.remix_ancestry(params[:channel_id], depth: 5)
         - if remix_ancestry.empty?
           %li Not a remix.


### PR DESCRIPTION
when viewing applab/gamelab/weblab projects, show a link to the s3 bucket for assets/animations/files, respectively, in addition to the existing link to the sources bucket.

applab
<img width="285" alt="Screen Shot 2019-06-03 at 3 19 48 PM" src="https://user-images.githubusercontent.com/8001765/58838321-3698e080-8613-11e9-946b-839d4403f0eb.png">

gamelab
<img width="282" alt="Screen Shot 2019-06-03 at 3 19 57 PM" src="https://user-images.githubusercontent.com/8001765/58838325-3993d100-8613-11e9-917b-ca0e20139116.png">

weblab
<img width="284" alt="Screen Shot 2019-06-03 at 3 19 34 PM" src="https://user-images.githubusercontent.com/8001765/58838318-326cc300-8613-11e9-9d65-7310ba93c778.png">
