### PR TITLE
Language-specific profanity filtering

### DIFF
--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -1,14 +1,33 @@
 require 'cdo/web_purify'
 
 class ProfanityFilter
+  # List of words that should be allowed only in specific languages.
+  #
+  # Entries are in the format
+  #   foobar: %w(en es)
+  # Where the key "foobar" is the word in question,
+  # and the value is a list of languages that should allow that word.
+  #
+  # Words in this list will be blocked for all languages _except_ for those
+  # listed along with the word.
+  # Words in this list should be _unblocked_ on WebPurify, since we are
+  # handling them with our custom code, here.
+  LANGUAGE_SPECIFIC_ALLOWLIST = {
+    fu: %w(it), # past-tense "to be" in Italian
+    fick: %w(sv) # "got" in Swedish
+  }
+
   # Look for profanity in a given text, return the first expletive found
   # or nil if no profanity is found.
   #
   # @param [String] text to check for profanity
   # @param [String] language_code a two-character ISO 639-1 language code
   def self.find_potential_profanity(text, language_code)
-    return 'fu' if /\bfu\b/i =~ text && language_code != 'it'
-    return 'fick' if /\bfick\b/i =~ text && language_code != 'sv'
+    LANGUAGE_SPECIFIC_ALLOWLIST.each do |word, languages|
+      next if languages.include? language_code
+      r = Regexp.new "\\b#{word}\\b", Regexp::IGNORECASE
+      return word.to_s if r =~ text
+    end
     WebPurify.find_potential_profanity(text, ['en', language_code])
   end
 end

--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -1,0 +1,14 @@
+require 'cdo/web_purify'
+
+class ProfanityFilter
+  # Look for profanity in a given text, return the first expletive found
+  # or nil if no profanity is found.
+  #
+  # @param [String] text to check for profanity
+  # @param [String] language_code a two-character ISO 639-1 language code
+  def self.find_potential_profanity(text, language_code)
+    return 'fu' if /\bfu\b/i =~ text && language_code != 'it'
+    return 'fick' if /\bfick\b/i =~ text && language_code != 'sv'
+    WebPurify.find_potential_profanity(text, ['en', language_code])
+  end
+end

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -1,6 +1,6 @@
 require 'cdo/regexp'
 require 'cdo/geocoder'
-require 'cdo/web_purify'
+require 'cdo/profanity_filter'
 require 'dynamic_config/gatekeeper'
 
 USER_ENTERED_TEXT_INDICATORS = ['TITLE', 'TEXT', 'title name\=\"VAL\"'].freeze
@@ -41,7 +41,7 @@ module ShareFiltering
     phone_number = RegexpUtils.find_potential_phone_number(program_tags_removed)
     return ShareFailure.new(FailureType::PHONE, phone_number) if phone_number
 
-    expletive = WebPurify.find_potential_profanity(program_tags_removed, ['en', locale])
+    expletive = ProfanityFilter.find_potential_profanity(program_tags_removed, locale)
     return ShareFailure.new(FailureType::PROFANITY, expletive) if expletive
 
     nil

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -23,6 +23,9 @@ module ShareFiltering
   #
   # May throw OpenURI::HTTPError, IO::EAGAINWaitReadable depending on
   # service availability.
+  #
+  # @param [String] program the student's program text
+  # @param [String] locale a two-character ISO 639-1 language code
   def self.find_share_failure(program, locale)
     return nil unless should_filter_program(program)
 

--- a/lib/test/cdo/test_share_filtering.rb
+++ b/lib/test/cdo/test_share_filtering.rb
@@ -66,7 +66,7 @@ class ShareFilteringTest < Minitest::Test
     )
   end
 
-  def test_find_share_failure_with_custom_profanity
+  def test_find_share_failure_with_italian_nonprofanity
     # "fu" is a past-tense "to be" in Italian, but should be blocked
     # as profanity in English.  WebPurify doesn't support this, so we
     # have custom filtering that takes locale into account for this word.
@@ -90,6 +90,33 @@ class ShareFilteringTest < Minitest::Test
     # Allow program in Italian
     assert_nil(
       ShareFiltering.find_share_failure(program, 'it')
+    )
+  end
+
+  def test_find_share_failure_with_swedish_nonprofanity
+    # "fick" means "got" in Swedish, but should be blocked
+    # as profanity in English.  WebPurify doesn't support this, so we
+    # have custom filtering that takes locale into account for this word.
+    program = generate_program('My Custom Profanity', 'fick')
+
+    # Stub WebPurify because we expect our custom blocking to handle this case.
+    WebPurify.stubs(:find_potential_profanity).returns(nil)
+
+    # Block program in English
+    assert_equal(
+      ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'fick'),
+      ShareFiltering.find_share_failure(program, 'en')
+    )
+
+    # Block program in Italian
+    assert_equal(
+      ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'fick'),
+      ShareFiltering.find_share_failure(program, 'it')
+    )
+
+    # Allow program in Italian
+    assert_nil(
+      ShareFiltering.find_share_failure(program, 'sv')
     )
   end
 

--- a/lib/test/cdo/test_share_filtering.rb
+++ b/lib/test/cdo/test_share_filtering.rb
@@ -66,57 +66,69 @@ class ShareFilteringTest < Minitest::Test
     )
   end
 
-  def test_find_share_failure_with_italian_nonprofanity
+  def test_profanity_with_italian_edge_case
     # "fu" is a past-tense "to be" in Italian, but should be blocked
     # as profanity in English.  WebPurify doesn't support this, so we
     # have custom filtering that takes locale into account for this word.
     program = generate_program('My Custom Profanity', 'fu')
+    innocent_program = generate_program('My Innocent Program', 'funny tofu')
 
     # Stub WebPurify because we expect our custom blocking to handle this case.
     WebPurify.stubs(:find_potential_profanity).returns(nil)
 
-    # Block program in English
+    # Blocked in English
     assert_equal(
       ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'fu'),
       ShareFiltering.find_share_failure(program, 'en')
     )
 
-    # Block program in Spanish
+    # But the innocent program is fine
+    assert_nil(
+      ShareFiltering.find_share_failure(innocent_program, 'en')
+    )
+
+    # Blocked in Spanish
     assert_equal(
       ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'fu'),
       ShareFiltering.find_share_failure(program, 'es')
     )
 
-    # Allow program in Italian
+    # Allowed in Italian
     assert_nil(
       ShareFiltering.find_share_failure(program, 'it')
     )
   end
 
-  def test_find_share_failure_with_swedish_nonprofanity
+  def test_profanity_with_swedish_edge_case
     # "fick" means "got" in Swedish, but should be blocked
     # as profanity in English.  WebPurify doesn't support this, so we
     # have custom filtering that takes locale into account for this word.
-    program = generate_program('My Custom Profanity', 'fick')
+    questionable_program = generate_program('My Custom Profanity', 'fick')
+    innocent_program = generate_program('My Innocent Program', 'fickle')
 
     # Stub WebPurify because we expect our custom blocking to handle this case.
     WebPurify.stubs(:find_potential_profanity).returns(nil)
 
-    # Block program in English
+    # Blocked in English
     assert_equal(
       ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'fick'),
-      ShareFiltering.find_share_failure(program, 'en')
+      ShareFiltering.find_share_failure(questionable_program, 'en')
     )
 
-    # Block program in Italian
-    assert_equal(
-      ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'fick'),
-      ShareFiltering.find_share_failure(program, 'it')
-    )
-
-    # Allow program in Italian
+    # But the innocent program is fine
     assert_nil(
-      ShareFiltering.find_share_failure(program, 'sv')
+      ShareFiltering.find_share_failure(innocent_program, 'en')
+    )
+
+    # Blocked in Italian
+    assert_equal(
+      ShareFailure.new(ShareFiltering::FailureType::PROFANITY, 'fick'),
+      ShareFiltering.find_share_failure(questionable_program, 'it')
+    )
+
+    # Allowed in Swedish
+    assert_nil(
+      ShareFiltering.find_share_failure(questionable_program, 'sv')
     )
   end
 


### PR DESCRIPTION
[LP-401](https://codedotorg.atlassian.net/browse/LP-401) Provide a wrapper around WebPurify that allows us to maintain a small language-specific custom profanity list.

**How we currently filter profanity**

When a user asks to view a project, we [perform our own PII checks](https://github.com/code-dot-org/code-dot-org/blob/4ba0d0adbb90cd1845d7253e8ca6e31ec63eb00a/lib/cdo/share_filtering.rb#L32-L42) and then ask WebPurify to check for profanity in the viewer's selected language _and_ English.

**What we can't do right now**

WebPurify already has [support for multiple languages](https://www.webpurify.com/documentation/additional/language/) in their default profanity check.  In the past we've used the built-in allowlist/blocklist feature to handle edge-case words we've found. Unfortunately, WebPurify does not support language-specific custom allowlists or blocklists.  We've run into a few specific cases where a word we'd like to continue blocking in some languages (in particular for English viewers) should clearly be unblocked in others.  For example:

- [**fu**](https://translate.google.com/#view=home&op=translate&sl=it&tl=en&text=fu), Italian for "it was."
- [**fick**](https://translate.google.com/#view=home&op=translate&sl=sv&tl=en&text=fick), Swedish for "got" or "received."

These are coming back blocked, probably because we're checking them in both English and the viewer's language.  We want to continue using that extra-careful strategy, but be able to add exceptions as they arise.

**This solution**

I've added a small wrapper around our WebPurify call that checks our own language-aware blocklist first, giving us more fine-grained control over edge cases.  Now, we can choose to block a word for all languages _except_ a specified few.

The procedure for adding a new word with a language-specific allow rule is:

1. Add the word to the `LANGUAGE_SPECIFIC_ALLOWLIST` configuration at the top of profanity_filter.rb, along with the set of [ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for the languages that should allow it.
2. Add the word to our WebPurify project's allowlist through their dashboard.
   ![image](https://user-images.githubusercontent.com/1615761/58840046-13712f80-8619-11e9-9930-28cbc2139e30.png)

A possible concern is the maintenance cost of a custom word list.  To give a sense of the expected size of that list: Since we started using WebPurify in October 2014, we've added two blocklist words and six allowlist words in their dashboard.  This PR adds two more.  I suspect we'll have less than twenty words on this custom list for a long, long time.

We may want to follow this work with a review of the words currently on our WebPurify allow/block lists and see if we want to introduce finer rules for any of them.
