### PR TITLE
Remove ScriptConstants::CATEGORIES[:full_course]

### DIFF
--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -117,6 +117,12 @@ class Course < ApplicationRecord
     end
   end
 
+  # A course is considered a "full course" if it belongs to a family of courses
+  # (i.e., CSD and CSP).
+  def full_course?
+    family_name?
+  end
+
   # This method updates both our localizeable strings related to this course, and
   # the set of scripts that are in the course, then writes out our serialization
   # @param scripts [Array<String>] - Updated list of names of scripts in this course
@@ -189,7 +195,7 @@ class Course < ApplicationRecord
   # Get the assignable info for this course, then update translations
   # @return AssignableInfo
   def assignable_info(user = nil)
-    info = ScriptConstants.assignable_info(self)
+    info = ScriptConstants.assignable_course_info(self)
     # ScriptConstants gives us untranslated versions of our course name, and the
     # category it's in. Set translated strings here
     info[:name] = localized_title

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -232,7 +232,7 @@ class Course < ApplicationRecord
   # any alternate scripts based on any experiments the user belongs to.
   def self.valid_courses_without_cache(user: nil)
     course_infos = Course.
-      where(name: ScriptConstants::CATEGORIES[:full_course]).
+      where("properties -> '$.family_name' is not null").
       map {|course| course.assignable_info(user)}
 
     # Only return stable course versions.

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -195,7 +195,7 @@ class Course < ApplicationRecord
   # Get the assignable info for this course, then update translations
   # @return AssignableInfo
   def assignable_info(user = nil)
-    info = ScriptConstants.assignable_course_info(self)
+    info = ScriptConstants.assignable_info(self, full_course: full_course?)
     # ScriptConstants gives us untranslated versions of our course name, and the
     # category it's in. Set translated strings here
     info[:name] = localized_title

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1514,7 +1514,7 @@ class Script < ActiveRecord::Base
 
   # @return {AssignableInfo} with strings translated
   def assignable_info
-    info = ScriptConstants.assignable_script_info(self)
+    info = ScriptConstants.assignable_info(self)
     info[:name] = I18n.t("data.script.name.#{info[:name]}.title", default: info[:name])
     info[:name] += " *" if hidden
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1514,7 +1514,7 @@ class Script < ActiveRecord::Base
 
   # @return {AssignableInfo} with strings translated
   def assignable_info
-    info = ScriptConstants.assignable_info(self)
+    info = ScriptConstants.assignable_script_info(self)
     info[:name] = I18n.t("data.script.name.#{info[:name]}.title", default: info[:name])
     info[:name] += " *" if hidden
 

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -516,7 +516,7 @@ class CourseTest < ActiveSupport::TestCase
     # has fields from ScriptConstants::Assignable_Info
     assert_equal csp.id, csp_assign_info[:id]
     assert_equal 'csp-2017', csp_assign_info[:script_name]
-    assert_equal(0, csp_assign_info[:category_priority])
+    assert_equal 0, csp_assign_info[:category_priority]
 
     # has localized name, category
     assert_equal "Computer Science Principles ('17-'18)", csp_assign_info[:name]
@@ -579,7 +579,7 @@ class CourseTest < ActiveSupport::TestCase
     # has fields from ScriptConstants::Assignable_Info
     assert_equal csp.id, csp_assign_info[:id]
     assert_equal 'csp-2017', csp_assign_info[:script_name]
-    assert_equal(0, csp_assign_info[:category_priority])
+    assert_equal 0, csp_assign_info[:category_priority]
 
     # has localized name, category
     assert_equal "Computer Science Principles ('17-'18)", csp_assign_info[:name]

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -74,6 +74,14 @@ class CourseTest < ActiveSupport::TestCase
     assert obj['properties']['is_stable']
   end
 
+  test "full_course?: true if course has family_name" do
+    assert build(:course, family_name: 'my-fam').full_course?
+  end
+
+  test "full_course?: false if course family_name is nil" do
+    refute build(:course).full_course?
+  end
+
   test "stable?: true if course has plc_course" do
     course = Course.new(family_name: 'plc')
     course.plc_course = Plc::Course.new(course: course)
@@ -477,13 +485,12 @@ class CourseTest < ActiveSupport::TestCase
   end
 
   test "valid_courses" do
-    # The data here must be in sync with the data in ScriptConstants.rb
-    csp = create(:course, name: 'csp-2017')
+    csp = create(:course, name: 'csp-2017', family_name: 'csp')
     csp1 = create(:script, name: 'csp1')
     csp2 = create(:script, name: 'csp2')
     csp2_alt = create(:script, name: 'csp2-alt', hidden: true)
     csp3 = create(:script, name: 'csp3')
-    csd = create(:course, name: 'csd-2017')
+    csd = create(:course, name: 'csd-2017', family_name: 'csd')
     create(:course, name: 'madeup')
 
     create(:course_script, position: 1, course: csp, script: csp1)
@@ -499,7 +506,7 @@ class CourseTest < ActiveSupport::TestCase
 
     courses = Course.valid_courses
 
-    # one entry for each 2017 course that is in ScriptConstants
+    # one entry for each 2017 course that is a full_course
     assert_equal 2, courses.length
     assert_equal csd.id, courses[0][:id]
     assert_equal csp.id, courses[1][:id]
@@ -509,7 +516,6 @@ class CourseTest < ActiveSupport::TestCase
     # has fields from ScriptConstants::Assignable_Info
     assert_equal csp.id, csp_assign_info[:id]
     assert_equal 'csp-2017', csp_assign_info[:script_name]
-    assert_equal 0, csp_assign_info[:position]
     assert_equal(0, csp_assign_info[:category_priority])
 
     # has localized name, category
@@ -538,14 +544,14 @@ class CourseTest < ActiveSupport::TestCase
 
   test "valid_courses all versions" do
     # The data here must be in sync with the data in ScriptConstants.rb
-    csp = create(:course, name: 'csp-2017')
+    csp = create(:course, name: 'csp-2017', family_name: 'csp')
     csp1 = create(:script, name: 'csp1')
     csp2 = create(:script, name: 'csp2')
     csp2_alt = create(:script, name: 'csp2-alt', hidden: true)
     csp3 = create(:script, name: 'csp3')
-    csp18 = create(:course, name: 'csp-2018')
-    csd = create(:course, name: 'csd-2017')
-    csd18 = create(:course, name: 'csd-2018')
+    csp18 = create(:course, name: 'csp-2018', family_name: 'csp')
+    csd = create(:course, name: 'csd-2017', family_name: 'csd')
+    csd18 = create(:course, name: 'csd-2018', family_name: 'csd')
     create(:course, name: 'madeup')
 
     create(:course_script, position: 1, course: csp, script: csp1)
@@ -561,7 +567,7 @@ class CourseTest < ActiveSupport::TestCase
 
     courses = Course.valid_courses
 
-    # one entry for each 2017 and 2018 course in ScriptConstants
+    # one entry for each 2017 and 2018 course that is a full_course
     assert_equal 4, courses.length
     assert_equal csd.id, courses[0][:id]
     assert_equal csd18.id, courses[1][:id]
@@ -573,7 +579,6 @@ class CourseTest < ActiveSupport::TestCase
     # has fields from ScriptConstants::Assignable_Info
     assert_equal csp.id, csp_assign_info[:id]
     assert_equal 'csp-2017', csp_assign_info[:script_name]
-    assert_equal 0, csp_assign_info[:position]
     assert_equal(0, csp_assign_info[:category_priority])
 
     # has localized name, category

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -19,14 +19,6 @@ module ScriptConstants
   # a category will be the order in which they appear in the dropdown, and the
   # order of the categories will be their order in the dropdown.
   CATEGORIES = {
-    full_course: [
-      CSP_2017 = 'csp-2017'.freeze,
-      CSP_2018 = 'csp-2018'.freeze,
-      CSP_2019 = 'csp-2019'.freeze,
-      CSD_2017 = 'csd-2017'.freeze,
-      CSD_2018 = 'csd-2018'.freeze,
-      CSD_2019 = 'csd-2019'.freeze,
-    ],
     csf: [
       COURSEA_NAME = 'coursea-2017'.freeze,
       COURSEB_NAME = 'courseb-2017'.freeze,

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -274,7 +274,6 @@ module ScriptConstants
   # we could have two different translations).
   # @param course_or_script [Course|Script] A row object from either our courses
   #   or scripts dashboard db tables.
-  # @param hidden [Boolean] True if the passed in item is hidden
   # @return {AssignableInfo} without strings translated
   def self.assignable_info(course_or_script)
     name = ScriptConstants.teacher_dashboard_name(course_or_script[:name])

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -271,29 +271,25 @@ module ScriptConstants
 
   # Sections can be assigned to both courses and scripts. We want to make sure
   # we give teacher dashboard the same information for both sets of assignables.
-  # We also expect to be in a mixed world for a time where this info is asked for
-  # both by dashboard and pegasus, and we want to keep that in sync. We accomplish
-  # most of that through this shared method, leaving it to dashboard/pegasus
-  # to take care of translating name/cateogry (with the unfortunate effect that
-  # we could have two different translations).
-  # @param course_or_script [Course|Script] A row object from either our courses
-  #   or scripts dashboard db tables.
+  # @param script [Script] A row object from our script dashboard db table.
   # @return {AssignableInfo} without strings translated
-  def self.assignable_info(course_or_script)
-    name = ScriptConstants.teacher_dashboard_name(course_or_script[:name])
-    first_category = ScriptConstants.categories(course_or_script[:name])[0] ||
+  def self.assignable_script_info(script)
+    name = ScriptConstants.teacher_dashboard_name(script[:name])
+    first_category = ScriptConstants.categories(script[:name])[0] ||
         OTHER_CATEGORY_NAME
     {
-      id: course_or_script[:id],
+      id: script[:id],
       name: name,
       # Would better be called something like assignable_name
-      script_name: course_or_script[:name],
+      script_name: script[:name],
       category: first_category,
-      position: ScriptConstants.position_in_category(course_or_script[:name], first_category),
+      position: ScriptConstants.position_in_category(script[:name], first_category),
       category_priority: ScriptConstants.category_priority(first_category),
     }
   end
 
+  # Sections can be assigned to both courses and scripts. We want to make sure
+  # we give teacher dashboard the same information for both sets of assignables.
   # @param course [Course] A row object from our course dashboard db table.
   # @return {AssignableInfo} without strings translated
   def self.assignable_course_info(course)

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -18,7 +18,6 @@ module ScriptConstants
   # the category it belongs to in course dropdowns. The order of scripts within
   # a category will be the order in which they appear in the dropdown, and the
   # order of the categories will be their order in the dropdown.
-  # Note: This is only for scripts. Courses that have a family_name will always come first.
   # See ScriptConstants#category_priority for more details on prioritization.
   CATEGORIES = {
     csf: [

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -294,6 +294,8 @@ module ScriptConstants
     }
   end
 
+  # @param course [Course] A row object from our course dashboard db table.
+  # @return {AssignableInfo} without strings translated
   def self.assignable_course_info(course)
     {
       id: course[:id],

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -18,6 +18,8 @@ module ScriptConstants
   # the category it belongs to in course dropdowns. The order of scripts within
   # a category will be the order in which they appear in the dropdown, and the
   # order of the categories will be their order in the dropdown.
+  # Note: This is only for scripts. Courses that have a family_name will always come first.
+  # See ScriptConstants#category_priority for more details on prioritization.
   CATEGORIES = {
     csf: [
       COURSEA_NAME = 'coursea-2017'.freeze,
@@ -245,11 +247,13 @@ module ScriptConstants
     CATEGORIES[category.to_sym] ? CATEGORIES[category.to_sym].find_index(script) : nil
   end
 
-  def self.category_priority(category)
-    if category == OTHER_CATEGORY_NAME
-      CATEGORIES.keys.length # 'other' goes at the end
+  def self.category_priority(category, full_course: false)
+    if full_course
+      0 # full courses (i.e., CSD and CSP) always come first
+    elsif category == OTHER_CATEGORY_NAME
+      CATEGORIES.keys.length + 1 # 'other' goes at the end
     else
-      CATEGORIES.keys.find_index(category.to_sym)
+      CATEGORIES.keys.find_index(category.to_sym) + 1
     end
   end
 
@@ -287,6 +291,16 @@ module ScriptConstants
       category: first_category,
       position: ScriptConstants.position_in_category(course_or_script[:name], first_category),
       category_priority: ScriptConstants.category_priority(first_category),
+    }
+  end
+
+  def self.assignable_course_info(course)
+    {
+      id: course[:id],
+      name: ScriptConstants.teacher_dashboard_name(course[:name]),
+      # Would better be called something like assignable_name
+      script_name: course[:name],
+      category_priority: ScriptConstants.category_priority(nil, full_course: course.full_course?),
     }
   end
 

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -273,23 +273,19 @@ module ScriptConstants
   # @param script [Course|Script] A row object from our course or script dashboard db table.
   # @return {AssignableInfo} without strings translated
   def self.assignable_info(course_or_script, full_course: false)
-    info = {
+    category = full_course ?
+      nil :
+      (ScriptConstants.categories(course_or_script[:name])[0] || OTHER_CATEGORY_NAME)
+
+    {
       id: course_or_script[:id],
       name: ScriptConstants.teacher_dashboard_name(course_or_script[:name]),
       # Would better be called something like assignable_name
-      script_name: course_or_script[:name]
+      script_name: course_or_script[:name],
+      category: category,
+      position: ScriptConstants.position_in_category(course_or_script[:name], category),
+      category_priority: ScriptConstants.category_priority(category, full_course: full_course)
     }
-
-    if full_course
-      info[:category_priority] = ScriptConstants.category_priority(nil, full_course: full_course)
-    else
-      first_category = ScriptConstants.categories(course_or_script[:name])[0] || OTHER_CATEGORY_NAME
-      info[:category] = first_category
-      info[:position] = ScriptConstants.position_in_category(course_or_script[:name], first_category)
-      info[:category_priority] = ScriptConstants.category_priority(first_category)
-    end
-
-    info
   end
 
   def self.has_congrats_page?(script)

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -271,35 +271,26 @@ module ScriptConstants
 
   # Sections can be assigned to both courses and scripts. We want to make sure
   # we give teacher dashboard the same information for both sets of assignables.
-  # @param script [Script] A row object from our script dashboard db table.
+  # @param script [Course|Script] A row object from our course or script dashboard db table.
   # @return {AssignableInfo} without strings translated
-  def self.assignable_script_info(script)
-    name = ScriptConstants.teacher_dashboard_name(script[:name])
-    first_category = ScriptConstants.categories(script[:name])[0] ||
-        OTHER_CATEGORY_NAME
-    {
-      id: script[:id],
-      name: name,
+  def self.assignable_info(course_or_script, full_course: false)
+    info = {
+      id: course_or_script[:id],
+      name: ScriptConstants.teacher_dashboard_name(course_or_script[:name]),
       # Would better be called something like assignable_name
-      script_name: script[:name],
-      category: first_category,
-      position: ScriptConstants.position_in_category(script[:name], first_category),
-      category_priority: ScriptConstants.category_priority(first_category),
+      script_name: course_or_script[:name]
     }
-  end
 
-  # Sections can be assigned to both courses and scripts. We want to make sure
-  # we give teacher dashboard the same information for both sets of assignables.
-  # @param course [Course] A row object from our course dashboard db table.
-  # @return {AssignableInfo} without strings translated
-  def self.assignable_course_info(course)
-    {
-      id: course[:id],
-      name: ScriptConstants.teacher_dashboard_name(course[:name]),
-      # Would better be called something like assignable_name
-      script_name: course[:name],
-      category_priority: ScriptConstants.category_priority(nil, full_course: course.full_course?),
-    }
+    if full_course
+      info[:category_priority] = ScriptConstants.category_priority(nil, full_course: full_course)
+    else
+      first_category = ScriptConstants.categories(course_or_script[:name])[0] || OTHER_CATEGORY_NAME
+      info[:category] = first_category
+      info[:position] = ScriptConstants.position_in_category(course_or_script[:name], first_category)
+      info[:category_priority] = ScriptConstants.category_priority(first_category)
+    end
+
+    info
   end
 
   def self.has_congrats_page?(script)

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -243,7 +243,7 @@ module ScriptConstants
   end
 
   def self.position_in_category(script, category)
-    CATEGORIES[category.to_sym] ? CATEGORIES[category.to_sym].find_index(script) : nil
+    CATEGORIES[category&.to_sym] ? CATEGORIES[category.to_sym].find_index(script) : nil
   end
 
   def self.category_priority(category, full_course: false)

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -61,9 +61,8 @@ class ScriptConstantsTest < Minitest::Test
   end
 
   def test_category_priority
-    assert_equal 0, ScriptConstants.category_priority(:full_course)
-    assert_equal 5, ScriptConstants.category_priority(:csf_international)
-    assert_equal 7, ScriptConstants.category_priority(:research_studies)
+    assert_equal 4, ScriptConstants.category_priority(:csf_international)
+    assert_equal 6, ScriptConstants.category_priority(:research_studies)
   end
 
   def test_assignable_info

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -66,13 +66,15 @@ class ScriptConstantsTest < Minitest::Test
     assert_equal 7, ScriptConstants.category_priority(:research_studies)
   end
 
-  def test_assignable_script_info
-    assert_equal 1, ScriptConstants.assignable_script_info({name: 'dance'})[:position]
-    assert_equal 2, ScriptConstants.assignable_script_info({name: 'dance-extras'})[:position]
-    assert_equal 3, ScriptConstants.assignable_script_info({name: 'aquatic'})[:position]
-    assert_equal 4, ScriptConstants.assignable_script_info({name: 'hero'})[:position]
-    assert_equal 5, ScriptConstants.assignable_script_info({name: 'mc'})[:position]
-    assert_equal 6, ScriptConstants.assignable_script_info({name: 'minecraft'})[:position]
+  def test_assignable_info
+    assert_equal 1, ScriptConstants.assignable_info({name: 'dance'})[:position]
+    assert_equal 2, ScriptConstants.assignable_info({name: 'dance-extras'})[:position]
+    assert_equal 3, ScriptConstants.assignable_info({name: 'aquatic'})[:position]
+    assert_equal 4, ScriptConstants.assignable_info({name: 'hero'})[:position]
+    assert_equal 5, ScriptConstants.assignable_info({name: 'mc'})[:position]
+    assert_equal 6, ScriptConstants.assignable_info({name: 'minecraft'})[:position]
+
+    assert_equal 0, ScriptConstants.assignable_info({name: 'csd'}, full_course: true)[:category_priority]
   end
 
   describe 'ScriptConstants::script_in_any_category?' do

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -61,8 +61,9 @@ class ScriptConstantsTest < Minitest::Test
   end
 
   def test_category_priority
-    assert_equal 4, ScriptConstants.category_priority(:csf_international)
-    assert_equal 6, ScriptConstants.category_priority(:research_studies)
+    assert_equal 0, ScriptConstants.category_priority(nil, full_course: true)
+    assert_equal 5, ScriptConstants.category_priority(:csf_international)
+    assert_equal 7, ScriptConstants.category_priority(:research_studies)
   end
 
   def test_assignable_info

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -66,13 +66,13 @@ class ScriptConstantsTest < Minitest::Test
     assert_equal 7, ScriptConstants.category_priority(:research_studies)
   end
 
-  def test_assignable_info
-    assert_equal 1, ScriptConstants.assignable_info({name: 'dance'})[:position]
-    assert_equal 2, ScriptConstants.assignable_info({name: 'dance-extras'})[:position]
-    assert_equal 3, ScriptConstants.assignable_info({name: 'aquatic'})[:position]
-    assert_equal 4, ScriptConstants.assignable_info({name: 'hero'})[:position]
-    assert_equal 5, ScriptConstants.assignable_info({name: 'mc'})[:position]
-    assert_equal 6, ScriptConstants.assignable_info({name: 'minecraft'})[:position]
+  def test_assignable_script_info
+    assert_equal 1, ScriptConstants.assignable_script_info({name: 'dance'})[:position]
+    assert_equal 2, ScriptConstants.assignable_script_info({name: 'dance-extras'})[:position]
+    assert_equal 3, ScriptConstants.assignable_script_info({name: 'aquatic'})[:position]
+    assert_equal 4, ScriptConstants.assignable_script_info({name: 'hero'})[:position]
+    assert_equal 5, ScriptConstants.assignable_script_info({name: 'mc'})[:position]
+    assert_equal 6, ScriptConstants.assignable_script_info({name: 'minecraft'})[:position]
   end
 
   describe 'ScriptConstants::script_in_any_category?' do


### PR DESCRIPTION
Closed #28874 in favor of this implementation.

Removes `ScriptConstants::CATEGORIES[:full_course]` constant in favor of using the presence of `family_name` on a course to denote that it is a "full course."

This does remove our dependency on a hardcoded list of strings, but it was an overall tricky refactor and I'm not sure it's the best solution, so give me lots of feedback, please!