### PR TITLE
PL: handle missing subquestion text in surveys

### DIFF
--- a/dashboard/lib/pd/jot_form/matrix_question.rb
+++ b/dashboard/lib/pd/jot_form/matrix_question.rb
@@ -50,7 +50,6 @@ module Pd
 
         # Matrix answer is a Hash of sub_question => string_answer.
         # Validate each answer and convert each key to sub_question_index.
-        # We .compact at the end
         result = answer.reject {|_, v| v.blank?}.map do |sub_question, sub_answer|
           sub_question_index = sub_questions.index(sub_question)
 

--- a/dashboard/lib/pd/jot_form/matrix_question.rb
+++ b/dashboard/lib/pd/jot_form/matrix_question.rb
@@ -74,7 +74,7 @@ module Pd
         # However, in the case that we weren't able to find the sub-question,
         # matching by text, in the corresponding Pd::SurveyQuestion (likely
         # because its text was changed in JotForm since this answer was
-        # submitted, then we end up with a nil key like this:
+        # submitted), then we end up with a nil key like this:
         #   {0=>"1", nil=>"3", 2=>"6", 3=>"1", 4=>"3"}
         #
         # It appears to be harmless, but to keep things tidy we will filter it

--- a/dashboard/lib/pd/jot_form/matrix_question.rb
+++ b/dashboard/lib/pd/jot_form/matrix_question.rb
@@ -48,17 +48,40 @@ module Pd
       def get_value(answer)
         raise "Unable to process matrix answer: #{answer}" unless answer.is_a? Hash
 
-        # Matrix answer is a Hash of sub_question => string_answer
-        # Validate each answer and convert each key to sub_question_index
-        answer.reject {|_, v| v.blank?}.map do |sub_question, sub_answer|
+        # Matrix answer is a Hash of sub_question => string_answer.
+        # Validate each answer and convert each key to sub_question_index.
+        # We .compact at the end
+        result = answer.reject {|_, v| v.blank?}.map do |sub_question, sub_answer|
           sub_question_index = sub_questions.index(sub_question)
-          raise "Unable to find sub-question '#{sub_question}' in matrix question #{id}" unless sub_question_index
+
+          # TODO: Log somewhere that our sub-questions no longer have matching
+          # text for this sub-answer.  This is likely because the text was
+          # changed in JotForm since the survey was submitted.
+          # Previously we raised an exception:
+          #   raise "Unable to find sub-question '#{sub_question}' in matrix question #{id}" unless sub_question_index
 
           raise "Unable to find '#{sub_answer}' in the options for matrix question #{id}" unless options.include? sub_answer
 
           # Return a 1-based value
           [sub_question_index, sub_answer]
         end.to_h
+
+        # At this point we have a result hash with keys as sub-question indexes and
+        # values as their matching sub-answers, such as
+        #   {0=>"Agree", 1=>"Agree", 2=>"Slightly Agree", 3=>"Slightly Agree"}
+        # or
+        #   {0=>"4", 1=>"4", 2=>"6"}
+        #
+        # However, in the case that we weren't able to find the sub-question,
+        # matching by text, in the corresponding Pd::SurveyQuestion (likely
+        # because its text was changed in JotForm since this answer was
+        # submitted, then we end up with a nil key like this:
+        #   {0=>"1", nil=>"3", 2=>"6", 3=>"1", 4=>"3"}
+        #
+        # It appears to be harmless, but to keep things tidy we will filter it
+        # out before returning results.
+
+        result.delete_if {|k| k.nil?}
       end
 
       def summarize

--- a/dashboard/test/lib/pd/jot_form/matrix_question_test.rb
+++ b/dashboard/test/lib/pd/jot_form/matrix_question_test.rb
@@ -56,11 +56,6 @@ module Pd
         )
 
         e = assert_raises do
-          question.get_value({'Nonexistent Question' => 'Agree'})
-        end
-        assert_equal "Unable to find sub-question 'Nonexistent Question' in matrix question 1", e.message
-
-        e = assert_raises do
           question.get_value('Question 1' => 'Nonexistent Answer')
         end
         assert_equal "Unable to find 'Nonexistent Answer' in the options for matrix question 1", e.message

--- a/dashboard/test/lib/pd/jot_form/matrix_question_test.rb
+++ b/dashboard/test/lib/pd/jot_form/matrix_question_test.rb
@@ -48,6 +48,25 @@ module Pd
         )
       end
 
+      test 'get_value missing subquestion' do
+        question = MatrixQuestion.new(
+          id: 1,
+          options: %w(Agree Neutral Disagree),
+          sub_questions: ['Question 1', 'Question 2', 'Question 3']
+        )
+
+        answer = {
+          'Question 1' => 'Neutral',
+          'Question 2 X' => 'Disagree', # Unknown sub-question should be ignored
+          'Question 3' => 'Agree'
+        }
+
+        assert_equal(
+          {0 => 'Neutral', 2 => 'Agree'},
+          question.get_value(answer)
+        )
+      end
+
       test 'get_value errors' do
         question = MatrixQuestion.new(
           id: 1,


### PR DESCRIPTION
We encountered a problem today in which retrieving survey results at https://studio.code.org/pd/workshop_dashboard/daily_survey_results/[workshop_id], via the https://studio.code.org/api/v1/pd/workshops/[workshop_id]/local_workshop_daily_survey_report API, failed due to an exception being raised.

It turns out that the survey had a "matrix question" (known in the JotForm editing UI as an "Input Table") and one of its sub-questions' text changed after the survey went live.  Some surveys were submitted using the old text and when we tried to match the submitted answers to the original question, they couldn't be found.  An exception was thrown.

It turns out, we can survive without that exception being thrown.  In the UI, we simply don't see those older answers counted.   Here, only one response of two submissions is counted because of this:

![Screenshot 2019-06-03 22 41 03](https://user-images.githubusercontent.com/2205926/58855449-f8241580-8654-11e9-9862-0b0a2fd25c53.png)

In contrast, another question that didn't have any text changed shows responses from both submissions:

![Screenshot 2019-06-03 22 41 19](https://user-images.githubusercontent.com/2205926/58855448-f8241580-8654-11e9-88b1-b85c74b2732f.png)

Setting up a local repro of this issue was a bunch of work, partly because creating a new `Pd::WorkshopDailySurvey` validates against the questions in `Pd::SurveyQuestion`.  To repro the case in which the questions actually changed, it was a matter of putting the original questions in place first before storing the older response, and then putting the newer questions in place before storing the newer response.

An alternate option was to ingest these surveys with `sync_jotform`, which hasn't been done for a long time, but it turns out that we hit a couple exceptions, [here](https://github.com/code-dot-org/code-dot-org/blob/4ba0d0adbb90cd1845d7253e8ca6e31ec63eb00a/dashboard/lib/pd/jot_form/form_questions.rb#L44) probably due to some question IDs being used in early submissions that no longer exist in our lists of questions (another good reason to use `name` rather than `id` for questions!), and [here](https://github.com/code-dot-org/code-dot-org/blob/4ba0d0adbb90cd1845d7253e8ca6e31ec63eb00a/dashboard/lib/pd/jot_form/select_question.rb#L44) due to the missing matrix sub-question again.

