### PR TITLE
Native Collision detection

### DIFF
--- a/apps/src/gamelab/GameLabSprite.js
+++ b/apps/src/gamelab/GameLabSprite.js
@@ -20,6 +20,12 @@ module.exports.createSprite = function(x, y, width, height) {
     s.debug = true;
   }
 
+  // Now that sprite lab is running natively, we need a collision function that
+  // does not peek at the JS interpreter state.
+  // For now, we are only doing single sprite overlap detection, so this just wraps
+  // _collideWithOne and exposes it for spritelab.
+  s.nativeOverlap = nativeOverlap;
+
   // Define these native properties that may be called by the Sprite class
   // (ensures hasOwnProperty() will return true, signalling to CustomMarshaler
   // that we need this to be stored on the "native" object)
@@ -104,6 +110,10 @@ function bounce(target, callback) {
 
 function bounceOff(target, callback) {
   return this.createGroupState('bounceOff', target, callback);
+}
+
+function nativeOverlap(p5Inst, target) {
+  return this._collideWithOne('overlap', target);
 }
 
 /* eslint-disable */

--- a/apps/src/gamelab/GameLabSprite.js
+++ b/apps/src/gamelab/GameLabSprite.js
@@ -20,10 +20,6 @@ module.exports.createSprite = function(x, y, width, height) {
     s.debug = true;
   }
 
-  // Now that sprite lab is running natively, we need a collision function that
-  // does not peek at the JS interpreter state.
-  // For now, we are only doing single sprite overlap detection, so this just wraps
-  // _collideWithOne and exposes it for spritelab.
   s.nativeOverlap = nativeOverlap;
 
   // Define these native properties that may be called by the Sprite class
@@ -112,6 +108,10 @@ function bounceOff(target, callback) {
   return this.createGroupState('bounceOff', target, callback);
 }
 
+// Now that sprite lab is running natively, we need a collision function that
+// does not peek at the JS interpreter state.
+// For now, we are only doing single sprite overlap detection, so this just wraps
+// _collideWithOne and exposes it for spritelab.
 function nativeOverlap(p5Inst, target) {
   return this._collideWithOne('overlap', target);
 }


### PR DESCRIPTION
This will be needed for moving collision detection to run natively for spritelab. We override `sprite.overlap()` and it looks at the JS interpreter stack, but when running natively, that's causing problems. This is a simple wrapper for `_collideWithOne()` to allow spritelab to run collision detection natively. 