### PR TITLE
Don't pull latest staging during sync in

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -18,9 +18,6 @@ if [ "$branch" != "staging" ]; then
   exit
 fi
 
-# Do a pull to make sure we're up to date
-git pull
-
 ### Dashboard
 
 orig_dir=dashboard/config/locales


### PR DESCRIPTION
For a couple reasons:

  1. We are now generating a lot of our i18n content from the DB, not
  just the filesystem, so pulling is no longer sufficient to make sure
  we're syncing the latest data.
  2. Because of point 1, we are now running the i18n sync from a server
  which automatically updates itself and seeds its database. So pulling
  is now no longer necessary, since the server takes care of that.
  3. Because of the specific way our automatic build process works, it's
  entirely possible that pulling latest updates outside of the build can
  break the build, by introducing a new bundle dependency (without
  installing it) that causes the next iteration of the build to fail.