### PR TITLE
Add version_year and family_name to course edit page in levelbuilder

### DIFF
--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -17,6 +17,8 @@ function showCourseEditor() {
     <CourseEditor
       name={courseEditorData.course_summary.name}
       title={courseEditorData.course_summary.title}
+      familyName={courseEditorData.course_summary.family_name}
+      versionYear={courseEditorData.course_summary.version_year}
       descriptionShort={courseEditorData.course_summary.description_short}
       descriptionStudent={courseEditorData.course_summary.description_student}
       descriptionTeacher={courseEditorData.course_summary.description_teacher}

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -30,6 +30,7 @@ function showCourseEditor() {
       hasVerifiedResources={
         courseEditorData.course_summary.has_verified_resources
       }
+      courseFamilies={courseEditorData.course_families}
     />,
     document.getElementById('course_editor')
   );

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -31,6 +31,7 @@ function showCourseEditor() {
         courseEditorData.course_summary.has_verified_resources
       }
       courseFamilies={courseEditorData.course_families}
+      versionYearOptions={courseEditorData.version_year_options}
     />,
     document.getElementById('course_editor')
   );

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -18,6 +18,9 @@ const styles = {
   },
   checkbox: {
     margin: '0 0 0 7px'
+  },
+  dropdown: {
+    margin: '0 6px'
   }
 };
 
@@ -33,7 +36,8 @@ export default class CourseEditor extends Component {
     scriptsInCourse: PropTypes.arrayOf(PropTypes.string).isRequired,
     scriptNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     teacherResources: PropTypes.arrayOf(resourceShape).isRequired,
-    hasVerifiedResources: PropTypes.bool.isRequired
+    hasVerifiedResources: PropTypes.bool.isRequired,
+    courseFamilies: PropTypes.arrayOf(PropTypes.string).isRequired
   };
 
   render() {
@@ -47,7 +51,8 @@ export default class CourseEditor extends Component {
       descriptionTeacher,
       scriptsInCourse,
       scriptNames,
-      teacherResources
+      teacherResources,
+      courseFamilies
     } = this.props;
     return (
       <div>
@@ -63,12 +68,18 @@ export default class CourseEditor extends Component {
         </label>
         <label>
           Family Name
-          <input
-            type="text"
+          <select
             name="family_name"
             defaultValue={familyName}
-            style={styles.input}
-          />
+            style={styles.dropdown}
+          >
+            <option value="">(None)</option>
+            {courseFamilies.map(familyOption => (
+              <option key={familyOption} value={familyOption}>
+                {familyOption}
+              </option>
+            ))}
+          </select>
         </label>
         <label>
           Version Year

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -25,6 +25,8 @@ export default class CourseEditor extends Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
+    familyName: PropTypes.string,
+    versionYear: PropTypes.string,
     descriptionShort: PropTypes.string,
     descriptionStudent: PropTypes.string,
     descriptionTeacher: PropTypes.string,
@@ -38,6 +40,8 @@ export default class CourseEditor extends Component {
     const {
       name,
       title,
+      familyName,
+      versionYear,
       descriptionShort,
       descriptionStudent,
       descriptionTeacher,
@@ -54,6 +58,24 @@ export default class CourseEditor extends Component {
             type="text"
             name="title"
             defaultValue={title}
+            style={styles.input}
+          />
+        </label>
+        <label>
+          Family Name
+          <input
+            type="text"
+            name="family_name"
+            defaultValue={familyName}
+            style={styles.input}
+          />
+        </label>
+        <label>
+          Version Year
+          <input
+            type="text"
+            name="version_year"
+            defaultValue={versionYear}
             style={styles.input}
           />
         </label>

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -37,7 +37,8 @@ export default class CourseEditor extends Component {
     scriptNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     teacherResources: PropTypes.arrayOf(resourceShape).isRequired,
     hasVerifiedResources: PropTypes.bool.isRequired,
-    courseFamilies: PropTypes.arrayOf(PropTypes.string).isRequired
+    courseFamilies: PropTypes.arrayOf(PropTypes.string).isRequired,
+    versionYearOptions: PropTypes.arrayOf(PropTypes.string).isRequired
   };
 
   render() {
@@ -52,7 +53,8 @@ export default class CourseEditor extends Component {
       scriptsInCourse,
       scriptNames,
       teacherResources,
-      courseFamilies
+      courseFamilies,
+      versionYearOptions
     } = this.props;
     return (
       <div>
@@ -83,12 +85,18 @@ export default class CourseEditor extends Component {
         </label>
         <label>
           Version Year
-          <input
-            type="text"
+          <select
             name="version_year"
             defaultValue={versionYear}
-            style={styles.input}
-          />
+            style={styles.dropdown}
+          >
+            <option value="">(None)</option>
+            {versionYearOptions.map(year => (
+              <option key={year} value={year}>
+                {year}
+              </option>
+            ))}
+          </select>
         </label>
         <label>
           Short Description (used in course cards on homepage)

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -89,7 +89,9 @@ class CoursesController < ApplicationController
     course = Course.find_by_name!(params[:course_name])
     course.persist_strings_and_scripts_changes(params[:scripts], params[:alternate_scripts], i18n_params)
     course.update_teacher_resources(params[:resourceTypes], params[:resourceLinks])
-    course.update_attribute(:has_verified_resources, !!params[:has_verified_resources])
+    # Convert has_verified_resources from a string ("on") to a boolean.
+    params[:has_verified_resources] = !!params[:has_verified_resources]
+    course.update(course_params)
     redirect_to course
   end
 
@@ -111,6 +113,10 @@ class CoursesController < ApplicationController
   end
 
   private
+
+  def course_params
+    params.permit(:version_year, :family_name, :has_verified_resources).to_h
+  end
 
   def set_redirect_override
     if params[:course_name] && params[:no_redirect]

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -543,4 +543,10 @@ class Course < ApplicationRecord
       course_cache[id_or_name.to_s] = get_without_cache(id_or_name)
     end
   end
+
+  # Returns an array of version year strings, starting with 2017 and ending 1 year
+  # from the current year.
+  def self.get_version_year_options
+    (2017..(DateTime.now.year + 1)).to_a.map(&:to_s)
+  end
 end

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -25,6 +25,11 @@ class Course < ApplicationRecord
 
   scope :with_associated_models, -> {includes([:plc_course, :default_course_scripts])}
 
+  FAMILY_NAMES = [
+    CSD = 'csd'.freeze,
+    CSP = 'csp'.freeze
+  ].freeze
+
   def skip_name_format_validation
     !!plc_course
   end

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -265,6 +265,8 @@ class Course < ApplicationRecord
       id: id,
       title: localized_title,
       assignment_family_title: localized_assignment_family_title,
+      family_name: family_name,
+      version_year: version_year,
       description_short: I18n.t("data.course.name.#{name}.description_short", default: ''),
       description_student: I18n.t("data.course.name.#{name}.description_student", default: ''),
       description_teacher: I18n.t("data.course.name.#{name}.description_teacher", default: ''),

--- a/dashboard/app/views/courses/edit.html.haml
+++ b/dashboard/app/views/courses/edit.html.haml
@@ -1,7 +1,8 @@
 - course = local_assigns[:course]
 - course_editor_data = {course_summary: course.summarize,
                         script_names: Script.all.map(&:name),
-                        course_families: Course::FAMILY_NAMES}
+                        course_families: Course::FAMILY_NAMES,
+                        version_year_options: Course.get_version_year_options}
 - content_for(:head) do
   %script{ src: minifiable_asset_path('js/courses/edit.js'), data: {course_editor: course_editor_data.to_json}}
 = form_for(course) do |f|

--- a/dashboard/app/views/courses/edit.html.haml
+++ b/dashboard/app/views/courses/edit.html.haml
@@ -1,6 +1,7 @@
 - course = local_assigns[:course]
 - course_editor_data = {course_summary: course.summarize,
-                        script_names: Script.all.map(&:name)}
+                        script_names: Script.all.map(&:name),
+                        course_families: Course::FAMILY_NAMES}
 - content_for(:head) do
   %script{ src: minifiable_asset_path('js/courses/edit.js'), data: {course_editor: course_editor_data.to_json}}
 = form_for(course) do |f|

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -239,6 +239,28 @@ class CoursesControllerTest < ActionController::TestCase
     assert_equal "Computer Science Principles ('17-'18)", Course.find_by_name!('csp-2017').summarize[:title]
   end
 
+  test "update: persists changes to course_params" do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    course = create :course, name: 'csp-2019'
+
+    assert_nil course.version_year
+    assert_nil course.family_name
+    refute course.has_verified_resources
+
+    post :update, params: {
+      course_name: course.name,
+      version_year: '2019',
+      family_name: 'csp',
+      has_verified_resources: 'on'
+    }
+    course.reload
+
+    assert_equal '2019', course.version_year
+    assert_equal 'csp', course.family_name
+    assert course.has_verified_resources
+  end
+
   # tests for edit
 
   test "edit: does not work for plc_course" do

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -166,6 +166,7 @@ class CourseTest < ActiveSupport::TestCase
     summary = course.summarize
 
     assert_equal [:name, :id, :title, :assignment_family_title,
+                  :family_name, :version_year,
                   :description_short, :description_student,
                   :description_teacher, :scripts, :teacher_resources,
                   :has_verified_resources, :versions, :show_assign_button], summary.keys


### PR DESCRIPTION
[LP-466](https://codedotorg.atlassian.net/browse/LP-466)

Adds `family_name` and `version_year` to the levelbuilder UI for courses:
<img width="1019" alt="Screen Shot 2019-06-05 at 2 42 03 PM" src="https://user-images.githubusercontent.com/9812299/58992639-3a0da280-87a0-11e9-8565-f24255660550.png">

