### PR TITLE
Update DaemonRole permissions for Aurora snapshot backup script [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -612,7 +612,10 @@ Resources:
           PolicyDocument:
             Statement:
               - Effect: Allow
-                Action: rds:DescribeDBInstances
+                Action:
+                  - rds:DescribeDBInstances
+                  - rds:DescribeDBClusters
+                  - rds:DescribeDBClusterSnapshots
                 Resource: '*'
               - Effect: Allow
                 Action: rds:DescribeDBSnapshots
@@ -620,6 +623,12 @@ Resources:
               - Effect: Allow
                 Action: rds:CopyDBSnapshot
                 Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:snapshot:rds:production-*"
+              - Effect: Allow
+                Action: rds:CopyDBClusterSnapshot
+                Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster-snapshot:rds:<%=CDO.db_cluster_id%>*"
+              - Effect: Allow
+                Action: rds:ModifyDBClusterSnapshotAttribute
+                Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster-snapshot:temp-snapshot*"
               - Effect: Allow
                 Action:
                   - rds:CopyDBSnapshot


### PR DESCRIPTION
Additional permissions needed for: https://github.com/code-dot-org/code-dot-org/pull/28864

```
circleci@6fdb53c39593:~/code-dot-org$ bundle exec rake stack:validate RAILS_ENV=test
AWS CloudFormation Template for Code.org application
Listing changes to existing stack `test`:
Modify DaemonRole [AWS::IAM::Role] Properties (Policies)
circleci@6fdb53c39593:~/code-dot-org$ bundle exec rake stack:validate RAILS_ENV=production
AWS CloudFormation Template for Code.org application
Listing changes to existing stack `autoscale-prod`:
Modify DaemonRole [AWS::IAM::Role] Properties (Policies)
```