### PR TITLE
Minor fixes for survey pipeline 

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -12,6 +12,7 @@ import WorkshopManagement from './workshop_management';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
 import {workshopShape} from '../types.js';
 import {Button} from 'react-bootstrap';
+import {CSF, CSD, CSP} from '../../application/ApplicationConstants';
 
 const styles = {
   container: {
@@ -292,8 +293,9 @@ export default class WorkshopTable extends React.Component {
         onDelete={state !== 'Ended' ? this.props.onDelete : null}
         showSurveyUrl={
           state === 'Ended' ||
-          (['CS Discoveries', 'CS Principles'].includes(course) &&
-            subject !== 'Code.org Facilitator Weekend')
+          ([CSD, CSP].includes(course) &&
+            subject !== 'Code.org Facilitator Weekend') ||
+          (course === CSF && subject === 'Deep Dive')
         }
       />
     );

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_decorator.rb
@@ -5,11 +5,11 @@ module Pd::SurveyPipeline
     FORM_IDS_TO_NAMES = {
       90_066_184_161_150 => {
         full_name: 'CS Fundamentals Deep Dive Pre-survey',
-        short_name: 'Pre-workshop'
+        short_name: 'Pre Workshop'
       },
       90_065_524_560_150 => {
         full_name: 'CS Fundamentals Deep Dive Post-survey',
-        short_name: 'Post-workshop'
+        short_name: 'Post Workshop'
       },
       91_405_279_991_164 => {
         full_name: 'Facilitator Feedback Survey',

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -285,6 +285,7 @@ module Api::V1::Pd
 
       WorkshopSurveyReportController.any_instance.expects(:create_csf_survey_report).never
       WorkshopSurveyReportController.any_instance.expects(:local_workshop_daily_survey_report).never
+      Honeybadger.expects(:notify)
 
       sign_in @admin
       get :generic_survey_report, params: {workshop_id: csf_101_ws.id}
@@ -305,7 +306,8 @@ module Api::V1::Pd
     end
 
     test 'generic_survey_report: academic-year workshop uses old pipeline' do
-      new_academic_ws = create :pd_workshop, course: COURSE_CSP, num_sessions: 1, started_at: Date.new(2019, 8, 1)
+      new_academic_ws = create :pd_workshop, course: COURSE_CSP, num_sessions: 1,
+        started_at: Date.new(2019, 8, 1)
 
       WorkshopSurveyReportController.any_instance.expects(:create_csf_survey_report).never
       WorkshopSurveyReportController.any_instance.expects(:local_workshop_daily_survey_report)

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -7,7 +7,7 @@ module Pd::SurveyPipeline
 
     test 'decorate survey summary for one form for one workshop' do
       form_id = 90_066_184_161_150
-      form_name = 'Pre-workshop'
+      form_name = 'Pre Workshop'
       workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201
 
       parsed_data = {}


### PR DESCRIPTION
Minor fixes after putting the new survey pipeline into service [PR 28846](https://github.com/code-dot-org/code-dot-org/pull/28846)
- Enable viewing survey results in dashboard for not-started Deep dive workshop.
- Remove dashes in form short names, which will become tab names in survey dashboard.
- Add honeybadger expectation in test.
<img width="841" alt="Screen Shot 2019-06-04 at 5 37 23 PM" src="https://user-images.githubusercontent.com/46507039/58922426-a8465c80-86ef-11e9-86dd-cf070f5c47f7.png">
