### PR TITLE
Provision aurora database for staging [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -24,7 +24,7 @@ commit = ENV['COMMIT'] || `git ls-remote origin #{branch}`.split.first
 ami = commit[0..4]
 
 frontends = @frontends = rack_env?(:production) || ENV['FRONTENDS']
-database = @database = rack_env?(:test) || ENV['DATABASE']
+database = @database = [:staging, :test].include?(rack_env) || ENV['DATABASE']
 load_balancer = @load_balancer = !rack_env?(:adhoc) || ENV['FRONTENDS']
 
 unless dry_run


### PR DESCRIPTION
```
circleci@5fdaef40040b:~/code-dot-org$ bundle exec rake stack:validate RAILS_ENV=test
AWS CloudFormation Template for Code.org application
Listing changes to existing stack `test`:
Modify DaemonRole [AWS::IAM::Role] Properties (Policies)
```
```
circleci@5fdaef40040b:~/code-dot-org$ bundle exec rake stack:validate RAILS_ENV=staging
AWS CloudFormation Template for Code.org application
Parameters:
DatabaseUsername: master
Listing changes to existing stack `staging`:
Add AuroraCluster [AWS::RDS::DBCluster] 
Add AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] 
Add AuroraMaster [AWS::RDS::DBInstance] 
Modify CDOPolicy [AWS::IAM::ManagedPolicy] Properties (PolicyDocument, PolicyDocument)
Modify DaemonRole [AWS::IAM::Role] Properties (Policies)
Add DatabaseSecret [AWS::SecretsManager::Secret] 
```

The `Modify DaemonRole` changes are since this hasn't deployed yet: https://github.com/code-dot-org/code-dot-org/pull/28927

Manual steps needed for this deployment:

1. Before staging deployment - add `database_username: master` to locals.yml on staging so it can be picked up as a cloudformation parameter
2. After deployment - provision db users on staging
3. Copy databases from local mysql to aurora db: https://dev.mysql.com/doc/refman/5.7/en/copying-databases.html
4. Add config in locals.yml to have staging app talk to aurora db
5. The next day, if things are working fine, add config to cdo-secrets in chef and remove from locals.yml