### PR TITLE
Adjust title of /student/beyondk12 page

### DIFF
--- a/pegasus/sites.v3/code.org/public/student/beyondk12.haml
+++ b/pegasus/sites.v3/code.org/public/student/beyondk12.haml
@@ -1,5 +1,5 @@
 ---
-title: Computer Science Curriculum for University+
+title: Computer Science Beyond K-12
 theme: responsive
 ---
 
@@ -9,7 +9,7 @@ theme: responsive
 .solid-block-header
   Beyond K-12
 
-Code.org does not make post secondary courses, but there are great options to 
+Code.org does not make post secondary courses, but there are great options to
 learn computer science at any age. Here are some we recommend:
 
 = view :learn_carousels, variation:'university'


### PR DESCRIPTION
"Computer Science Curriculum for University+" becomes "Computer Science Beyond K-12"