### PR TITLE
Hide the help button on small screens

### DIFF
--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -3,6 +3,8 @@
 # As part of this content, it also provides CSS classes which determine
 # responsive visibility for the header itself and the items inside it.
 
+require_relative 'help_header'
+
 class Hamburger
   # These are the CSS classes applied to items in the hamburger,
   # and to the hamburger itself.

--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -22,6 +22,7 @@ class Hamburger
     show_signed_out_options = HIDE_ALWAYS
     show_pegasus_options = HIDE_ALWAYS
     show_intl_about = SHOW_MOBILE
+    show_help_options = SHOW_MOBILE
 
     if options[:level]
       # The header is taken over by level-related UI, so we need the hamburger
@@ -79,7 +80,8 @@ class Hamburger
       show_student_options: show_student_options,
       show_signed_out_options: show_signed_out_options,
       show_pegasus_options: show_pegasus_options,
-      show_intl_about: show_intl_about
+      show_intl_about: show_intl_about,
+      show_help_options: show_help_options
     }
   end
 
@@ -177,14 +179,18 @@ class Hamburger
 
     if options[:user_type] == "teacher"
       entries = entries.concat teacher_entries.each {|e| e[:class] = visibility[:show_teacher_options]}
-      entries << {type: "divider", class: get_divider_visibility(visibility[:show_teacher_options], visibility[:show_pegasus_options]), id: "after-teacher"}
+      entries << {type: "divider", class: get_divider_visibility(visibility[:show_teacher_options], visibility[:show_help_options]), id: "after-teacher"}
     elsif options[:user_type] == "student"
       entries = entries.concat student_entries.each {|e| e[:class] = visibility[:show_student_options]}
-      entries << {type: "divider", class: get_divider_visibility(visibility[:show_student_options], visibility[:show_pegasus_options]), id: "after-student"}
+      entries << {type: "divider", class: get_divider_visibility(visibility[:show_student_options], visibility[:show_help_options]), id: "after-student"}
     else
       entries = entries.concat signed_out_entries.each {|e| e[:class] = visibility[:show_signed_out_options]}
-      entries << {type: "divider", class: get_divider_visibility(visibility[:show_signed_out_options], visibility[:show_pegasus_options]), id: "after-signed-out"}
+      entries << {type: "divider", class: get_divider_visibility(visibility[:show_signed_out_options], visibility[:show_help_options]), id: "after-signed-out"}
     end
+
+    help_contents = HelpHeader.get_help_contents(options)
+    entries.concat help_contents.each {|e| e[:class] = visibility[:show_help_options]}
+    entries << {type: "divider", class: get_divider_visibility(visibility[:show_help_options], visibility[:show_pegasus_options]), id: "after-help"}
 
     # Pegasus options.
 

--- a/lib/test/test_hamburger.rb
+++ b/lib/test/test_hamburger.rb
@@ -17,6 +17,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::SHOW_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_level_teacher_nonen
@@ -27,6 +28,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::HIDE_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_level_student_en
@@ -37,6 +39,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::SHOW_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::SHOW_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_level_student_nonen
@@ -47,6 +50,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::SHOW_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::HIDE_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_level_nobody_en
@@ -57,6 +61,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::SHOW_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::SHOW_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_level_nobody_nonen
@@ -67,6 +72,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::SHOW_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::HIDE_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_nonlevel_teacher_en
@@ -77,6 +83,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::SHOW_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_nonlevel_teacher_nonen
@@ -87,6 +94,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::HIDE_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_nonlevel_student_en
@@ -97,6 +105,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::SHOW_MOBILE
     assert_equal visibility[:show_signed_out_options],  Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::SHOW_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_nonlevel_student_nonen
@@ -107,6 +116,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::SHOW_MOBILE
     assert_equal visibility[:show_signed_out_options],  Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_pegasus_options],     Hamburger::HIDE_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_nonlevel_nobody_en
@@ -117,6 +127,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::SHOW_MOBILE
     assert_equal visibility[:show_pegasus_options],     Hamburger::SHOW_MOBILE
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   def test_nonlevel_nobody_nonen
@@ -127,6 +138,7 @@ class HamburgerTest < Minitest::Test
     assert_equal visibility[:show_student_options],     Hamburger::HIDE_ALWAYS
     assert_equal visibility[:show_signed_out_options],  Hamburger::SHOW_MOBILE
     assert_equal visibility[:show_pegasus_options],     Hamburger::HIDE_ALWAYS
+    assert_equal visibility[:show_help_options],        Hamburger::SHOW_MOBILE
   end
 
   # Hamburger content tests.
@@ -144,6 +156,11 @@ class HamburgerTest < Minitest::Test
   def test_hamburger_content_nolevel
     contents = Hamburger.get_hamburger_contents({level: nil, script_level: nil, user_type: nil, language: "en"})
     assert_includes_id contents[:entries], "learn"
+  end
+
+  def test_hamburger_content_nolevel
+    contents = Hamburger.get_hamburger_contents({level: nil, script_level: nil, user_type: nil, language: "en"})
+    assert_includes_id contents[:entries], "report-bug"
   end
 
   def test_hamburger_content_expandable_en

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -213,12 +213,15 @@
     .hide-mobile {
       display: none;
     }
-    #hamburger-contents, #help-contents {
+    #hamburger-contents {
       font-size: 18px;
     }
     #hamburger {
       padding-left: 0;
     }
+    #help-button {
+      display: none;
+    } 
   }
 }
 
@@ -289,11 +292,3 @@
     height: 25px;
   }
 }
-
-@media(max-width: 970px) {
-    #help-button {
-      display: none;
-    }
-  }
-
-

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -16,6 +16,10 @@
     display: none;
   }
 
+  &.hide-mobile {
+    display: block;
+  }
+
   &.show-always {
     display: block;
   }
@@ -26,6 +30,10 @@
 
   .show-mobile {
     display: none;
+  }
+
+  .hide-mobile {
+    display: block;
   }
 
   .show-always {
@@ -199,8 +207,17 @@
     .show-mobile {
       display: block;
     }
+    &.hide-mobile {
+      display: none;
+    }
+    .hide-mobile {
+      display: none;
+    }
     #hamburger-contents, #help-contents {
       font-size: 18px;
+    }
+    #hamburger {
+      padding-left: 0;
     }
   }
 }
@@ -272,3 +289,11 @@
     height: 25px;
   }
 }
+
+@media(max-width: 970px) {
+    #help-button {
+      display: none;
+    }
+  }
+
+

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -29,15 +29,15 @@
   #hamburger-icon.clicktag{class: contents[:visibility]}
     %span{style: "pointer-events: none"}
 
-#help-button{class: "show-always"}
+#help-button{class: "hide-mobile"}
   #help-contents.hide-responsive-menu
     - help_items.each do |entry|
-      %div{class: "show-always"}
+      %div{class: "hide-mobile"}
         .item
           - target = entry[:target] ? entry[:target] : "_self"
           %a{id: entry[:id], href: entry[:url], target: target}= entry[:title]
 
-  %i#help-icon.clicktag{class: "fa fa-question-circle show-always"}
+  %i#help-icon.clicktag{class: "fa fa-question-circle hide-mobile"}
     %span{style: "pointer-events: none"}
 
 


### PR DESCRIPTION
[Jira](https://codedotorg.atlassian.net/browse/FND-446)

On small screens, add the help options into the hamburger menu and hide the help button. 
![Screenshot 2019-06-05 at 6 04 55 PM](https://user-images.githubusercontent.com/46464143/58999793-764efc00-87bc-11e9-9a77-de838a09540a.png)

