### PR TITLE
Fix custom waiter for DB Cluster Deleted

### DIFF
--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -1082,8 +1082,10 @@ class ContactRollups
       attempts += 1
       sleep delay
     end
-    raise StandardError.new("Timeout after waiting #{max_attempts * delay} seconds for cluster" \
-      " #{DATABASE_CLUSTER_CLONE_ID} deletion to complete.  Current cluster status - #{cluster_state}"
-    )
+    unless cluster_state == 'deleted'
+      raise StandardError.new("Timeout after waiting #{max_attempts * delay} seconds for cluster" \
+        " #{DATABASE_CLUSTER_CLONE_ID} deletion to complete.  Current cluster status - #{cluster_state}"
+      )
+    end
   end
 end


### PR DESCRIPTION
Contact Rollups is always raising an error on the very last line of execution, even when the DBCluster was deleted successfully within the max_attempts:
https://app.honeybadger.io/projects/45435/faults/50378191