### PR TITLE
Add missing permissions for Aurora snapshot backup [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -627,7 +627,11 @@ Resources:
                 Action: rds:CopyDBClusterSnapshot
                 Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster-snapshot:rds:<%=CDO.db_cluster_id%>*"
               - Effect: Allow
-                Action: rds:ModifyDBClusterSnapshotAttribute
+                Action:
+                  - rds:ModifyDBClusterSnapshotAttribute
+                  - rds:CopyDBClusterSnapshot
+                  - rds:DeleteDBClusterSnapshot
+                  - rds:DescribeDBClusterSnapshotAttributes
                 Resource: !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster-snapshot:temp-snapshot*"
               - Effect: Allow
                 Action:


### PR DESCRIPTION
Error with current permissions:

```
/var/lib/gems/2.5.0/gems/aws-sdk-core-3.54.0/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call': User: arn:aws:sts::475661607190:assumed-role/autoscale-prod-DaemonRole-12O6KQEI8XR81/i-436d69dd is not authorized to perform: rds:CopyDBClusterSnapshot on resource: arn:aws:rds:us-east-1:475661607190:cluster-snapshot:temp-snapshot-1559779958 (Aws::RDS::Errors::AccessDenied)
```

Have not tested on `production-daemon` yet since I don't want to manually update the stack, since the error page changes haven't deployed yet:

```
circleci@ad7dbf823dcc:~/code-dot-org$ bundle exec rake stack:validate RAILS_ENV=production
AWS CloudFormation Template for Code.org application
Listing changes to existing stack `autoscale-prod`:
Modify DaemonRole [AWS::IAM::Role] Properties (Policies)
Modify DashboardCDN [AWS::CloudFront::Distribution] Properties Replacement: Conditional (DistributionConfig)
Modify DashboardDNS [AWS::Route53::RecordSetGroup] Properties (RecordSets)
Modify PegasusCDN [AWS::CloudFront::Distribution] Properties Replacement: Conditional (DistributionConfig)
Modify PegasusDNS [AWS::Route53::RecordSetGroup] Properties (RecordSets)
```

Will do once those are (or once these are deployed).