### PR TITLE
Split survey results per facilitator

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -197,7 +197,11 @@ module Api::V1::Pd
         summary_data += mapper.map_reduce joined_data
       end
 
-      render json: decorator.decorate(summary_data: summary_data, parsed_data: parsed_data)
+      render json: decorator.decorate(
+        summary_data: summary_data,
+        parsed_data: parsed_data,
+        current_user: current_user
+      )
     end
 
     # We want to filter facilitator-specific responses if the user is a facilitator and

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -155,7 +155,7 @@ module Api::V1::Pd
       joiner = Pd::SurveyPipeline::DailySurveyJoiner
 
       # Mapper + Reducers
-      group_config = [:workshop_id, :form_id, :name, :type, :answer_type]
+      group_config = [:workshop_id, :form_id, :facilitator_id, :name, :type, :answer_type]
 
       is_single_select_answer = lambda {|hash| hash.dig(:answer_type) == 'singleSelect'}
       is_free_format_question = lambda {|hash| ['textbox', 'textarea'].include?(hash[:type])}

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_joiner.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_joiner.rb
@@ -52,7 +52,7 @@ module Pd::SurveyPipeline
                 # Its id and name are generated based on the parent's id and name.
                 new_qid = compute_descendant_key(qid, sub_ans[:text])
                 new_name = compute_descendant_key(question[:name], sub_ans[:text])
-                new_text = "#{question[:text]}->#{sub_ans[:text]}"
+                new_text = "#{question[:text]} -> #{sub_ans[:text]}"
 
                 new_question = question.except(:sub_questions).merge(
                   name: new_name, text: new_text, type: TYPE_RADIO,

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -5,10 +5,15 @@ module Pd::SurveyPipeline
   class DailySurveyParserTest < ActiveSupport::TestCase
     include Pd::WorkshopConstants
 
-    test 'decorate survey summary for one form for one workshop' do
-      form_id = 90_066_184_161_150
-      form_name = 'Pre Workshop'
-      workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201
+    setup_all do
+      @facilitators = create_list :facilitator, 2
+      @workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201,
+        num_sessions: 1, facilitators: @facilitators
+    end
+
+    test 'decorate facilitator survey results' do
+      form_id = "91405279991164".to_i
+      form_name = 'Facilitator'
 
       parsed_data = {}
       parsed_data[:questions] = {
@@ -23,25 +28,34 @@ module Pd::SurveyPipeline
 
       parsed_data[:submissions] = {
         form_id => {
-          1 => {workshop_id: workshop.id, user_id: 1, answers: {'1' => 'Agree', '2' => 'Feedback 1'}},
-          2 => {workshop_id: workshop.id, user_id: 2, answers: {'1' => 'Agree', '2' => 'Feedback 2'}},
-          3 => {workshop_id: workshop.id, user_id: 3, answers: {'1' => 'Neutral', '2' => 'Feedback 3'}},
-          4 => {workshop_id: workshop.id, user_id: 4, answers: {'1' => 'Disagree', '2' => ''}},
+          1 => {workshop_id: @workshop.id, user_id: 1, facilitator_id: @facilitators.first.id,
+            answers: {'1' => 'Agree', '2' => 'Feedback 1'}},
+          2 => {workshop_id: @workshop.id, user_id: 1, facilitator_id: @facilitators.last.id,
+            answers: {'1' => 'Agree', '2' => 'Feedback 2'}},
+          3 => {workshop_id: @workshop.id, user_id: 2, facilitator_id: @facilitators.first.id,
+            answers: {'1' => 'Neutral', '2' => 'Feedback 3'}},
+          4 => {workshop_id: @workshop.id, user_id: 2, facilitator_id: @facilitators.last.id,
+            answers: {'1' => 'Disagree', '2' => ''}},
         }
       }
 
       summary_data = [
-        {workshop_id: workshop.id, form_id: form_id, name: 'importance',
-          reducer: 'histogram', reducer_result: {'Agree': 2, 'Neutral': 1, 'Disagree': 1}},
-        {workshop_id: workshop.id, form_id: form_id, name: 'feedback',
-          reducer: 'no_op', reducer_result: ['Feedback 1', 'Feedback 2', 'Feedback 3']}
+        {workshop_id: @workshop.id, form_id: form_id, facilitator_id: @facilitators.first.id,
+          name: 'importance', reducer: 'histogram', reducer_result: {'Agree': 2}},
+        {workshop_id: @workshop.id, form_id: form_id, facilitator_id: @facilitators.first.id,
+          name: 'feedback', reducer: 'no_op', reducer_result: ['Feedback 1', 'Feedback 2']},
+        {workshop_id: @workshop.id, form_id: form_id, facilitator_id: @facilitators.last.id,
+          name: 'importance', reducer: 'histogram', reducer_result: {'Neutral': 1, 'Disagree': 1}},
+        {workshop_id: @workshop.id, form_id: form_id, facilitator_id: @facilitators.last.id,
+          name: 'feedback', reducer: 'no_op', reducer_result: ['Feedback 3']}
       ]
 
       expected_result = {
         course_name: COURSE_CSF,
         questions: {
           form_name => {
-            general: {
+            general: {},
+            facilitator: {
               'importance' => parsed_data[:questions][form_id]['1'].except(:name),
               'feedback' => parsed_data[:questions][form_id]['2'].except(:name),
             }
@@ -50,9 +64,16 @@ module Pd::SurveyPipeline
         this_workshop: {
           form_name => {
             response_count: 4,
-            general: {
-              'importance' => {'Agree': 2, 'Neutral': 1, 'Disagree': 1},
-              'feedback' => ['Feedback 1', 'Feedback 2', 'Feedback 3']
+            general: {},
+            facilitator: {
+              'importance' => {
+                @facilitators.first.name => {'Agree': 2},
+                @facilitators.last.name => {'Neutral': 1, 'Disagree': 1}
+              },
+              'feedback' => {
+                @facilitators.first.name => ['Feedback 1', 'Feedback 2'],
+                @facilitators.last.name => ['Feedback 3']
+              }
             }
           }
         },
@@ -63,6 +84,100 @@ module Pd::SurveyPipeline
       }
 
       result = DailySurveyDecorator.decorate summary_data: summary_data, parsed_data: parsed_data
+
+      assert_equal expected_result, result
+    end
+
+    test 'decorate general survey results' do
+      form_id = "90066184161150".to_i
+      form_name = 'Pre Workshop'
+      @workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201
+
+      parsed_data = {}
+      parsed_data[:questions] = {
+        form_id => {
+          '1' => {type: 'radio', name: 'importance', text: 'CS is important?', order: 1,
+            options: ['Disagree', 'Neutral', 'Agree'],
+            option_map: {'Disagree': 1, 'Neutral': 2, 'Agree': 3}, answer_type: 'singleSelect'},
+          '2' => {type: 'textarea', name: 'feedback', text: 'Free-format feedback', order: 2,
+            answer_type: 'text'}
+        }
+      }
+
+      parsed_data[:submissions] = {
+        form_id => {
+          1 => {workshop_id: @workshop.id, user_id: 1, answers: {'1' => 'Agree', '2' => 'Feedback 1'}},
+          2 => {workshop_id: @workshop.id, user_id: 2, answers: {'1' => 'Agree', '2' => 'Feedback 2'}},
+          3 => {workshop_id: @workshop.id, user_id: 3, answers: {'1' => 'Neutral', '2' => 'Feedback 3'}},
+          4 => {workshop_id: @workshop.id, user_id: 4, answers: {'1' => 'Disagree', '2' => ''}},
+        }
+      }
+
+      summary_data = [
+        {workshop_id: @workshop.id, form_id: form_id, name: 'importance',
+          reducer: 'histogram', reducer_result: {'Agree': 2, 'Neutral': 1, 'Disagree': 1}},
+        {workshop_id: @workshop.id, form_id: form_id, name: 'feedback',
+          reducer: 'no_op', reducer_result: ['Feedback 1', 'Feedback 2', 'Feedback 3']}
+      ]
+
+      expected_result = {
+        course_name: COURSE_CSF,
+        questions: {
+          form_name => {
+            general: {
+              'importance' => parsed_data[:questions][form_id]['1'].except(:name),
+              'feedback' => parsed_data[:questions][form_id]['2'].except(:name),
+            },
+            facilitator: {}
+          }
+        },
+        this_workshop: {
+          form_name => {
+            response_count: 4,
+            general: {
+              'importance' => {'Agree': 2, 'Neutral': 1, 'Disagree': 1},
+              'feedback' => ['Feedback 1', 'Feedback 2', 'Feedback 3']
+            },
+            facilitator: {}
+          }
+        },
+        all_my_workshops: {},
+        facilitators: {},
+        facilitator_averages: {},
+        facilitator_response_counts: {}
+      }
+
+      result = DailySurveyDecorator.decorate summary_data: summary_data, parsed_data: parsed_data
+
+      assert_equal expected_result, result
+    end
+
+    test 'index questions by form ids and question names' do
+      form_ids = %w(90066184161150 90065524560150).map(&:to_i)
+
+      questions = {
+        form_ids.first => {
+          '1' => {name: 'importance', type: 'radio'},
+          '2' => {name: 'feedback', type: 'textarea'}
+        },
+        form_ids.last => {
+          '3' => {name: 'complex', type: 'matrix'},
+          '4' => {name: 'rating', type: 'scale'}
+        }
+      }
+
+      expected_result = {
+        form_ids.first => {
+          'importance' => {type: 'radio'},
+          'feedback' => {type: 'textarea'}
+        },
+        form_ids.last => {
+          'complex' => {type: 'matrix'},
+          'rating' => {type: 'scale'}
+        }
+      }
+
+      result = DailySurveyDecorator.index_question_by_names(questions)
 
       assert_equal expected_result, result
     end

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
@@ -96,7 +96,7 @@ module Pd::SurveyPipeline
           merge(
             qid: DailySurveyJoiner.compute_descendant_key(qid, "Sub question #{i + 1}"),
             name: DailySurveyJoiner.compute_descendant_key(qname, "Sub question #{i + 1}"),
-            text: "#{qtext}->Sub question #{i + 1}",
+            text: "#{qtext} -> Sub question #{i + 1}",
             type: TYPE_RADIO,
             answer: "Option #{i + 1}",
             answer_type: ANSWER_SINGLE_SELECT,


### PR DESCRIPTION
This change in the new survey pipeline enables displaying facilitator results per facilitator. It also enables permission check, i.e. facilitator cannot see other facilitator's result while program manager and workshop admin can see all results.

This change currently impacts only viewing CSF 201 Deep Dive workshop survey results.

## Examples
**Before** (from [real data](https://studio.code.org/pd/workshop_dashboard/daily_survey_results/6482) in production): All facilitator responds are combined. 
Results can be viewed by `workshop_admin`, `program_manager` and `facilitator`.

<img width="678" alt="Screen Shot 2019-06-05 at 5 13 36 PM" src="https://user-images.githubusercontent.com/46507039/58998406-6d0e6100-87b5-11e9-87c0-00a32ed09f4a.png">

**After** (development env): Results are displayed per-facilitator. 
`workshop_admin` and `program_manager` can see all facilitator results.
<img width="668" alt="Screen Shot 2019-06-06 at 3 59 41 PM" src="https://user-images.githubusercontent.com/46507039/59071621-4bc07a00-8874-11e9-9cdf-49ccda8f8cf4.png">

`facilitator` can only see his/her own results
<img width="608" alt="Screen Shot 2019-06-06 at 3 57 32 PM" src="https://user-images.githubusercontent.com/46507039/59071750-d7d2a180-8874-11e9-8ba6-953d0923265f.png">


## How tested
- Unit tests: Run all tests for new survey pipeline
  - `bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_retriever_test.rb test/lib/pd/survey_pipeline/daily_survey_parser_test.rb test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb test/lib/pd/survey_pipeline/mapper_test.rb test/lib/pd/survey_pipeline/reducer_test.rb test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb`

- Manual tests: 
  - Download survey responds for pre/post/facilitator CSF201 forms for workshop 6482 to Pd::SurveyQuestion and Pd::WorkshopDailySurvey and Pd::WorkshopFacilitatorDailySurvey.
  - API check: `http://localhost-studio.code.org:3000/api/v1/pd/workshops/6482/generic_survey_report`
  - UI check: `http://localhost-studio.code.org:3000/pd/workshop_dashboard/daily_survey_results/6482`

