### PR TITLE
Console.log from code workspace in game lab now works like app lab

### DIFF
--- a/apps/src/gamelab/GameLab.js
+++ b/apps/src/gamelab/GameLab.js
@@ -168,9 +168,20 @@ module.exports = GameLab;
  * @param {string} logLevel
  */
 GameLab.prototype.log = function(object, logLevel) {
-  this.consoleLogger_.log(object);
+  this.consoleLogger_.log(
+    experiments.isEnabled('react-inspector')
+      ? {output: object, fromConsoleLog: true}
+      : object
+  );
   if (this.debuggerEnabled) {
-    getStore().dispatch(jsDebugger.appendLog(object, logLevel));
+    getStore().dispatch(
+      jsDebugger.appendLog(
+        experiments.isEnabled('react-inspector')
+          ? {output: object, fromConsoleLog: true}
+          : object,
+        logLevel
+      )
+    );
   }
 };
 


### PR DESCRIPTION
- **What** and **Where** it changed:
  This PR is in addition to this PR: https://github.com/code-dot-org/code-dot-org/pull/28741. <- PR changes the way how inputs are handled when a student console.logging from the code workspace in app lab. The first PR only changed app lab's input from code workspace so this PR changes game lab's input.

- **Why** are we making this change?
 The changes in this PR allows game lab's console.logs from the code workspace to not be prepended with an arrow like the javascript console. If the input is `console.log("w"), 1` then the `1` would have an `<` arrow but the `"w"` would not. The output would be prepended with an expandable arrow if it is an array or an object.
 
- **How I tested the change**:
   Manually tested in game lab and this PR passes the unit tests in this PR: https://github.com/code-dot-org/code-dot-org/pull/28930.

- **Screenshots**:
    Game lab's debug console displays nothing with the changes to the PR mentioned above. This PR displays outputs like below:
    <img width="384" alt="Screen Shot 2019-05-29 at 5 19 25 PM" src="https://user-images.githubusercontent.com/17921445/58599622-f1049e00-8235-11e9-93e6-7c92a7c2031c.png">
