### PR TITLE
Add a Markdown plugin and new syntax for rendering the Details element

### DIFF
--- a/apps/src/templates/UnsafeRenderedMarkdown.jsx
+++ b/apps/src/templates/UnsafeRenderedMarkdown.jsx
@@ -9,9 +9,10 @@ import rehypeSanitize from 'rehype-sanitize';
 import rehypeReact from 'rehype-react';
 import defaultSanitizationSchema from 'hast-util-sanitize/lib/github.json';
 
+import details from './plugins/details';
 import expandableImages from './plugins/expandableImages';
-import xmlAsTopLevelBlock from './plugins/xmlAsTopLevelBlock';
 import externalLinks from './plugins/externalLinks';
+import xmlAsTopLevelBlock from './plugins/xmlAsTopLevelBlock';
 
 // create custom sanitization schema as per
 // https://github.com/syntax-tree/hast-util-sanitize#schema
@@ -47,7 +48,7 @@ schema.tagNames.push(
 const markdownToReact = Parser.create()
   .getParser()
   // include custom plugins
-  .use([xmlAsTopLevelBlock, expandableImages])
+  .use([xmlAsTopLevelBlock, expandableImages, details])
   // convert markdown to an HTML Abstract Syntax Tree (HAST)
   .use(remarkRehype, {
     // include any raw HTML in the markdown as raw HTML nodes in the HAST

--- a/apps/src/templates/plugins/details.js
+++ b/apps/src/templates/plugins/details.js
@@ -26,7 +26,29 @@ module.exports = function details() {
   const restorationMethods = Parser.prototype.restorationMethods;
 
   restorationMethods.details = function(add, nodes, content, children) {
-    // TODO
+    const open = add({
+      type: 'paragraph',
+      children: [
+        {
+          type: 'rawtext',
+          value: `::: details [${content}]`
+        }
+      ]
+    });
+
+    const childNodes = children.map(child => add(child));
+
+    const close = add({
+      type: 'paragraph',
+      children: [
+        {
+          type: 'rawtext',
+          value: ':::'
+        }
+      ]
+    });
+
+    return [open, ...childNodes, close];
   };
   redact = Parser.prototype.options.redact;
   tokenizers.details = tokenizeDetails;

--- a/apps/src/templates/plugins/details.js
+++ b/apps/src/templates/plugins/details.js
@@ -148,8 +148,8 @@ function tokenizeDetails(eat, value, silent) {
     const open = add({
       type: 'redaction',
       redactionType: 'details',
-      summary: summary,
-      block: true
+      block: true,
+      children: summary
     });
 
     const contents = body.map(content => add(content));

--- a/apps/src/templates/plugins/details.js
+++ b/apps/src/templates/plugins/details.js
@@ -17,6 +17,13 @@
  * :::
  */
 
+const colon = ':';
+const openBracket = '[';
+const closeBracket = ']';
+const newline = '\n';
+const space = ' ';
+const tab = '\t';
+
 let redact;
 
 module.exports = function details() {
@@ -26,12 +33,13 @@ module.exports = function details() {
   const restorationMethods = Parser.prototype.restorationMethods;
 
   restorationMethods.details = function(add, nodes, content, children) {
+    const colonCount = nodes.open.openingColonCount;
     const open = add({
       type: 'paragraph',
       children: [
         {
           type: 'rawtext',
-          value: `::: details [${content}]`
+          value: `${colon.repeat(colonCount)} details [${content}]`
         }
       ]
     });
@@ -43,7 +51,7 @@ module.exports = function details() {
       children: [
         {
           type: 'rawtext',
-          value: ':::'
+          value: colon.repeat(colonCount)
         }
       ]
     });
@@ -56,13 +64,6 @@ module.exports = function details() {
   /* Run it just before `paragraph`. */
   methods.splice(methods.indexOf('paragraph'), 0, 'details');
 };
-
-const colon = ':';
-const openBracket = '[';
-const closeBracket = ']';
-const newline = '\n';
-const space = ' ';
-const tab = '\t';
 
 function tokenizeDetails(eat, value, silent) {
   let index = 0;
@@ -171,7 +172,8 @@ function tokenizeDetails(eat, value, silent) {
       type: 'redaction',
       redactionType: 'details',
       block: true,
-      children: summary
+      children: summary,
+      openingColonCount
     });
 
     const contents = body.map(content => add(content));

--- a/apps/src/templates/plugins/details.js
+++ b/apps/src/templates/plugins/details.js
@@ -1,0 +1,183 @@
+/**
+ * # Details
+ *
+ * This plugin provides support for custom markdown syntax implementing [the
+ * Details element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details).
+ *
+ * The syntax is inspired by [this proposal for generic directives in
+ * CommonMark](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444).
+ * In a potential future in which we want to implement these generic
+ * directives, it should be a relatively simple matter to update this plugin to
+ * be cross-compatible.
+ *
+ * The proposed syntax for the details element is:
+ *
+ * ::: details [summary-content]
+ * contents, which are sometimes further block elements
+ * :::
+ */
+
+let redact;
+
+module.exports = function details() {
+  const Parser = this.Parser;
+  const tokenizers = Parser.prototype.blockTokenizers;
+  const methods = Parser.prototype.blockMethods;
+  const restorationMethods = Parser.prototype.restorationMethods;
+
+  restorationMethods.details = function(add, nodes, content, children) {
+    // TODO
+  };
+  redact = Parser.prototype.options.redact;
+  tokenizers.details = tokenizeDetails;
+
+  /* Run it just before `paragraph`. */
+  methods.splice(methods.indexOf('paragraph'), 0, 'details');
+};
+
+const colon = ':';
+const openBracket = '[';
+const closeBracket = ']';
+const newline = '\n';
+const space = ' ';
+const tab = '\t';
+
+function tokenizeDetails(eat, value, silent) {
+  let index = 0;
+  let character = value.charAt(index);
+  let subvalue = '';
+
+  if (character !== colon) {
+    return false;
+  }
+
+  const eatOne = function() {
+    subvalue += character;
+    index++;
+    character = value.charAt(index);
+  };
+
+  const eatUntil = function(condition) {
+    let eatenValue = '';
+    while (index < value.length) {
+      if (condition()) {
+        break;
+      }
+
+      eatenValue += character;
+      eatOne();
+    }
+
+    return eatenValue;
+  };
+
+  const eatWhitespace = function() {
+    return eatUntil(() => !(character === space || character === tab));
+  };
+
+  const eatLine = function() {
+    const line = eatUntil(() => character === newline) + character;
+    eatOne();
+    return line;
+  };
+
+  // 1/6: Eat opening colons
+  eatUntil(() => character !== colon);
+  if (index < 3) {
+    return;
+  }
+  const openingColonCount = index;
+
+  // 2/6: Eat whitespace and "details"
+  eatWhitespace();
+  const name = eatUntil(() => character === space || character === tab);
+  if (name !== 'details') {
+    return;
+  }
+  eatWhitespace();
+
+  // 3/6: Eat summary content
+  if (character !== openBracket) {
+    return false;
+  }
+  eatOne();
+  const summaryContent = eatUntil(() => character === closeBracket);
+  eatOne();
+
+  // 4/6: Eat trailing colons
+  eatWhitespace();
+  eatUntil(() => character !== colon);
+  eatWhitespace();
+  if (character !== newline) {
+    return false;
+  }
+  eatOne();
+
+  // 5/6: Eat body content and closing colons
+  let bodyContent = '';
+  let closed = false;
+  while (index < value.length) {
+    const prevCharacter = character;
+    const prevIndex = index;
+    const prevSubvalue = subvalue;
+    const closingColons = eatUntil(() => character !== colon);
+    if (closingColons.length >= openingColonCount) {
+      closed = true;
+      break;
+    } else {
+      character = prevCharacter;
+      index = prevIndex;
+      subvalue = prevSubvalue;
+    }
+
+    bodyContent += eatLine();
+  }
+  if (!closed) {
+    return false;
+  }
+
+  // 6/6 Consume and return parsed content
+  const now = eat.now();
+  const add = eat(subvalue);
+  const summary = this.tokenizeInline(summaryContent, now);
+  const exit = this.enterBlock();
+  const body = this.tokenizeBlock(bodyContent, now);
+  exit();
+
+  if (redact) {
+    const open = add({
+      type: 'redaction',
+      redactionType: 'details',
+      summary: summary,
+      block: true
+    });
+
+    const contents = body.map(content => add(content));
+
+    const close = add({
+      type: 'redaction',
+      block: true,
+      closing: true
+    });
+
+    return [open, ...contents, close];
+  }
+
+  return add({
+    type: 'details',
+    data: {
+      hName: 'details'
+    },
+    children: [
+      {
+        type: 'summary',
+        data: {
+          hName: 'summary'
+        },
+        children: summary
+      }
+    ].concat(body)
+  });
+}
+
+tokenizeDetails.notInLink = true;

--- a/apps/test/unit/templates/plugins/detailsTest.js
+++ b/apps/test/unit/templates/plugins/detailsTest.js
@@ -147,5 +147,24 @@ describe('details plugin', () => {
     assert.equal(rendered, expected);
   });
 
-  it('can restore', () => {});
+  it('can restore', () => {
+    const original =
+      '::: details [summary-content]\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::';
+    const translated =
+      '[contenu sommaire][0]\n' +
+      '\n' +
+      'contenu, qui sont parfois des éléments de bloc supplémentaires\n' +
+      '\n' +
+      '[/][0]\n';
+    const expected =
+      '::: details [contenu sommaire]\n' +
+      '\n' +
+      'contenu, qui sont parfois des éléments de bloc supplémentaires\n' +
+      '\n' +
+      ':::\n';
+    const restored = parser.sourceAndRedactedToMarkdown(original, translated);
+    assert.equal(restored, expected);
+  });
 });

--- a/apps/test/unit/templates/plugins/detailsTest.js
+++ b/apps/test/unit/templates/plugins/detailsTest.js
@@ -147,6 +147,28 @@ describe('details plugin', () => {
     assert.equal(rendered, expected);
   });
 
+  it('can redact nested', () => {
+    const markdown =
+      ':::: details [outer]\n' +
+      '::: details [inner]\n' +
+      'innermost content\n' +
+      ':::\n' +
+      '::::';
+    const expected =
+      '[outer][0]\n' +
+      '\n' +
+      '[inner][1]\n' +
+      '\n' +
+      'innermost content\n' +
+      '\n' +
+      '[/][1]\n' +
+      '\n' +
+      '[/][0]\n';
+
+    const rendered = parser.sourceToRedacted(markdown);
+    assert.equal(rendered, expected);
+  });
+
   it('can restore', () => {
     const original =
       '::: details [summary-content]\n' +
@@ -164,6 +186,38 @@ describe('details plugin', () => {
       'contenu, qui sont parfois des éléments de bloc supplémentaires\n' +
       '\n' +
       ':::\n';
+    const restored = parser.sourceAndRedactedToMarkdown(original, translated);
+    assert.equal(restored, expected);
+  });
+
+  it('can restore nested', () => {
+    const original =
+      ':::: details [outer]\n' +
+      '::: details [inner]\n' +
+      'innermost content\n' +
+      ':::\n' +
+      '::::';
+    const translated =
+      '[extérieur][0]\n' +
+      '\n' +
+      '[interne][1]\n' +
+      '\n' +
+      'contenu le plus profond\n' +
+      '\n' +
+      '[/][1]\n' +
+      '\n' +
+      '[/][0]\n';
+    // Note the relative colon counts are preserved
+    const expected =
+      ':::: details [extérieur]\n' +
+      '\n' +
+      '::: details [interne]\n' +
+      '\n' +
+      'contenu le plus profond\n' +
+      '\n' +
+      ':::\n' +
+      '\n' +
+      '::::\n';
     const restored = parser.sourceAndRedactedToMarkdown(original, translated);
     assert.equal(restored, expected);
   });

--- a/apps/test/unit/templates/plugins/detailsTest.js
+++ b/apps/test/unit/templates/plugins/detailsTest.js
@@ -53,7 +53,11 @@ describe('details plugin', () => {
       '- markdown\n' +
       ':::';
     const expected =
-      '<details><summary>summary-content</summary><h1>Contents</h1><ul>\n<li>can</li>\n<li>be</li>\n<li>markdown</li>\n</ul></details>\n';
+      '<details><summary>summary-content</summary><h1>Contents</h1><ul>\n' +
+      '<li>can</li>\n' +
+      '<li>be</li>\n' +
+      '<li>markdown</li>\n' +
+      '</ul></details>\n';
 
     const rendered = parser.sourceToHtml(markdown);
     assert.equal(rendered, expected);
@@ -93,7 +97,9 @@ describe('details plugin', () => {
       'contents, which are sometimes further block elements\n' +
       ':::';
     const expected =
-      '<p>::: details\ncontents, which are sometimes further block elements\n:::</p>\n';
+      '<p>::: details\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::</p>\n';
 
     const rendered = parser.sourceToHtml(markdown);
     assert.equal(rendered, expected);
@@ -105,7 +111,9 @@ describe('details plugin', () => {
       'contents, which are sometimes further block elements\n' +
       ':::';
     const expected =
-      '<p>:: details [summary-content]\ncontents, which are sometimes further block elements\n:::</p>\n';
+      '<p>:: details [summary-content]\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::</p>\n';
 
     const rendered = parser.sourceToHtml(markdown);
     assert.equal(rendered, expected);
@@ -116,9 +124,28 @@ describe('details plugin', () => {
       '::: details [summary-content]\n' +
       'contents, which are sometimes further block elements\n';
     const expected =
-      '<p>::: details [summary-content]\ncontents, which are sometimes further block elements</p>\n';
+      '<p>::: details [summary-content]\n' +
+      'contents, which are sometimes further block elements</p>\n';
 
     const rendered = parser.sourceToHtml(markdown);
     assert.equal(rendered, expected);
   });
+
+  it('can redact', () => {
+    const markdown =
+      '::: details [summary-content]\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::';
+    const expected =
+      '[summary-content][0]\n' +
+      '\n' +
+      'contents, which are sometimes further block elements\n' +
+      '\n' +
+      '[/][0]\n';
+
+    const rendered = parser.sourceToRedacted(markdown);
+    assert.equal(rendered, expected);
+  });
+
+  it('can restore', () => {});
 });

--- a/apps/test/unit/templates/plugins/detailsTest.js
+++ b/apps/test/unit/templates/plugins/detailsTest.js
@@ -1,0 +1,124 @@
+import Parser from '@code-dot-org/redactable-markdown';
+import {assert} from '../../../util/configuredChai';
+
+import details from '@cdo/apps/templates/plugins/details';
+
+describe('details plugin', () => {
+  const parser = Parser.create();
+  parser.parser.use(details);
+
+  it('can render', () => {
+    const markdown =
+      '::: details [summary-content]\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::';
+    const expected =
+      '<details><summary>summary-content</summary><p>contents, which are sometimes further block elements</p></details>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+
+  it('can have a variable number of opening colons', () => {
+    const markdown =
+      ':::::::: details [summary-content]\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::::::::::::';
+    const expected =
+      '<details><summary>summary-content</summary><p>contents, which are sometimes further block elements</p></details>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+
+  it('can render markdown syntax in the summary', () => {
+    const markdown =
+      '::: details [**summary** _content_]\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::';
+    const expected =
+      '<details><summary><strong>summary</strong> <em>content</em></summary><p>contents, which are sometimes further block elements</p></details>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+
+  it('can render markdown syntax in the body', () => {
+    const markdown =
+      '::: details [summary-content]\n' +
+      '\n' +
+      '# Contents\n' +
+      '- can\n' +
+      '- be\n' +
+      '- markdown\n' +
+      ':::';
+    const expected =
+      '<details><summary>summary-content</summary><h1>Contents</h1><ul>\n<li>can</li>\n<li>be</li>\n<li>markdown</li>\n</ul></details>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+
+  it('ignores excess whitespace', () => {
+    const markdown =
+      ':::      details       [summary-content]          \n' +
+      '\n' +
+      'contents, which are sometimes further block elements\n' +
+      '\n' +
+      ':::';
+    const expected =
+      '<details><summary>summary-content</summary><p>contents, which are sometimes further block elements</p></details>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+
+  it('can nest', () => {
+    const markdown =
+      ':::: details [outer]\n' +
+      '::: details [inner]\n' +
+      'innermost content\n' +
+      ':::\n' +
+      '::::';
+    const expected =
+      '<details><summary>outer</summary><details><summary>inner</summary><p>innermost content</p></details></details>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+
+  it('requires a summary block', () => {
+    const markdown =
+      '::: details\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::';
+    const expected =
+      '<p>::: details\ncontents, which are sometimes further block elements\n:::</p>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+
+  it('requires at least three opening colons', () => {
+    const markdown =
+      ':: details [summary-content]\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::';
+    const expected =
+      '<p>:: details [summary-content]\ncontents, which are sometimes further block elements\n:::</p>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+
+  it('requires closing colons', () => {
+    const markdown =
+      '::: details [summary-content]\n' +
+      'contents, which are sometimes further block elements\n';
+    const expected =
+      '<p>::: details [summary-content]\ncontents, which are sometimes further block elements</p>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+});

--- a/apps/test/unit/templates/plugins/detailsTest.js
+++ b/apps/test/unit/templates/plugins/detailsTest.js
@@ -63,6 +63,19 @@ describe('details plugin', () => {
     assert.equal(rendered, expected);
   });
 
+  it('ignores trailing colons', () => {
+    // Look how pretty this can be!
+    const markdown =
+      '::::::::::::: details [summary-content] :::::::::::::\n' +
+      'contents, which are sometimes further block elements\n' +
+      ':::::::::::::::::::::::::::::::::::::::::::::::::::::';
+    const expected =
+      '<details><summary>summary-content</summary><p>contents, which are sometimes further block elements</p></details>\n';
+
+    const rendered = parser.sourceToHtml(markdown);
+    assert.equal(rendered, expected);
+  });
+
   it('ignores excess whitespace', () => {
     const markdown =
       ':::      details       [summary-content]          \n' +


### PR DESCRIPTION
This plugin adds a new Markdown syntax for rendering details and summary tags, a pattern we use extensively in our course content. The proposed syntax is inspired by [this proposal for a generic directives syntax](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444), and is intended to be sufficiently generic that we could in the future add more syntaxes matching this pattern.

Specifically, we implement a version of the **Container Block Directives** in the proposal, with the following changes:

1. The generic "name" tag must always be the exact string `"details"`
2. Generic attributes (key-value pairs) are not supported
3. The content block is required

For example, the following `details` element (from https://studio.code.org/s/csd2-2019/stage/3/puzzle/8):

```html
<details>

<summary>
<strong>What is a paragraph element?</strong>
</summary>

Paragraphs are marked by opening(`<p>`) and closing(`</p>`) tags. Paragraphs in HTML can be any length of text from one word to a bunch of sentences. Paragraphs group together sets of sentences and put some space between that group of text and the next group of text.

</details>
```

Could be written as:

```
::: details [**What is a paragraph element?**]
Paragraphs are marked by opening(`<p>`) and closing(`</p>`) tags. Paragraphs in HTML can be any length of text from one word to a bunch of sentences. Paragraphs group together sets of sentences and put some space between that group of text and the next group of text.
:::
```

Note that in the original, the summary text had to be bolded in HTML rather than with markdown syntax, and the body content had to be separated from the tags by newlines in order for the markdown syntax to be parsed correctly. With this new syntax, neither of those are necessary.

See the new unit test for more examples of what this syntax is capable of.