### PR TITLE
Add DaemonSecurityGroup for SSH access to frontends from daemon

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -678,7 +678,7 @@ Resources:
         SubnetId: !ImportValue VPC-PublicSubnet<%=azs.first%>
         GroupSet:
           - !ImportValue VPC-FrontendSecurityGroup
-          - !ImportValue VPC-GatewaySecurityGroup
+          - !ImportValue VPC-DaemonSecurityGroup # SSH access to frontends
 <%  unless load_balancer -%>
           - !ImportValue VPC-ELBSecurityGroup # Accept HTTP traffic on daemon
 <%  end -%>

--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -101,6 +101,11 @@ Resources:
           FromPort: 22
           ToPort: 22
           CidrIp: <%=ssh_ip%>
+  DaemonSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access to frontends from daemon.
+      VpcId: {Ref: VPC}
   ELBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -142,6 +147,10 @@ Resources:
           FromPort: 22
           ToPort: 22
           SourceSecurityGroupId: {Ref: GatewaySecurityGroup}
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          SourceSecurityGroupId: {Ref: DaemonSecurityGroup}
   RedisSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -312,6 +321,10 @@ Outputs:
     Description: Security group for DMS
     Value: !Ref DMSSecurityGroup
     Export: {Name: !Sub "${AWS::StackName}-DMSSecurityGroup"}
+  DaemonSecurityGroup:
+    Description: Security group for Daemon
+    Value: !Ref DaemonSecurityGroup
+    Export: {Name: !Sub "${AWS::StackName}-DaemonSecurityGroup"}
 <%
   AVAILABILITY_ZONES.each_with_index do |zone, i|
     az = zone[-1].upcase


### PR DESCRIPTION
This PR adds an extra security group `DaemonSecurityGroup` used to provide SSH access to frontends from `daemon` in each environment. (For context, `daemon` requires occasional SSH access to frontends for running arbitrary fan-out commands and invoking Varnish cache flushes.)

This will allow more fine-grained security controls for `daemon`, specifically allowing us to temporarily disable DB access from all application-servers (frontends and daemon) without also disabling access from `gateway`.

Because the daemon instances are currently manually provisioned, the security groups on existing daemon instances will need to be updated manually.