### PR TITLE
Projects: Add sharing disabled to project admin panel

### DIFF
--- a/apps/src/code-studio/showProjectAdmin.js
+++ b/apps/src/code-studio/showProjectAdmin.js
@@ -91,6 +91,11 @@ export default project => {
     }
   }
 
+  if ($('.admin-sharing').length) {
+    var sharingDisabled = project.getSharingDisabled();
+    $('.admin-sharing-disabled').text(sharingDisabled);
+  }
+
   $('#disable-auto-moderation').click(async function() {
     await project.disableAutoContentModeration();
     $('#disable-auto-moderation').hide();

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -133,6 +133,11 @@
       .admin-report-abuse{ style: 'display: none;' }
         = link_to 'Report Abuse', '/report_abuse'
 
+      %br
+      .admin-sharing
+        Sharing disabled?
+        %span.admin-sharing-disabled
+
       #disable-auto-moderation{'style' => ('display: none;' if content_moderation_disabled)}
         %br
         %button{id: "disable-auto-moderation", class: "btn btn-default btn-sm"}


### PR DESCRIPTION
Partial work for [LP-286](https://codedotorg.atlassian.net/browse/LP-352)
We'd like to make it easier for Josh to diagnose settings related to a specific project to better diagnose issues in Zendesk reports without an engineer.  This changes provides information about whether sharing is disabled or not for a given project in the admin panel. 
<img width="291" alt="Screen Shot 2019-06-07 at 8 16 11 AM" src="https://user-images.githubusercontent.com/12300669/59116115-a7841500-88ff-11e9-8d01-ca969de2906b.png">
