### PR TITLE
Create BubbleChoice sub-activity page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -504,6 +504,8 @@ describe('entry tests', () => {
     'levels/_external_link':
       './src/sites/studio/pages/levels/_external_link.js',
     'levels/show': './src/sites/studio/pages/levels/show.js',
+    'levels/_bubble_choice':
+      './src/sites/studio/pages/levels/_bubble_choice.js',
     'levels/_teacher_panel':
       './src/sites/studio/pages/levels/_teacher_panel.js',
     'projects/index': './src/sites/studio/pages/projects/index.js',

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -185,6 +185,7 @@
   "changeUserTypeModal_title": "Update account type",
   "changeUserTypeModal_unexpectedError": "An unexpected error has occurred.  Please wait a moment and try again.",
   "choose": "Choose",
+  "chooseActivity": "Choose from the following activities:",
   "choosePrefix": "Choose...",
   "chooseSection": "Choose your section",
   "clearPuzzle": "Start Over",

--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -1,17 +1,80 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import i18n from '@cdo/locale';
+import color from '@cdo/apps/util/color';
+import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
+
+const THUMBNAIL_IMAGE_SIZE = 150;
+const MARGIN = 10;
+
+const styles = {
+  h2: {
+    color: color.charcoal,
+    padding: `${MARGIN}px 0`
+  },
+  row: {
+    display: 'flex',
+    marginBottom: MARGIN
+  },
+  thumbnail: {
+    width: THUMBNAIL_IMAGE_SIZE
+  },
+  placeholderThumbnail: {
+    width: THUMBNAIL_IMAGE_SIZE,
+    height: THUMBNAIL_IMAGE_SIZE,
+    backgroundColor: color.lighter_gray
+  },
+  column: {
+    marginLeft: MARGIN * 2
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: '"Gotham 5r"',
+    color: color.teal
+  }
+};
 
 export default class BubbleChoice extends React.Component {
   static propTypes = {
     level: PropTypes.shape({
       title: PropTypes.string.isRequired,
       description: PropTypes.string.isRequired,
-      // TODO: create shape for sublevels
-      sublevels: PropTypes.array
+      sublevels: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.number.isRequired,
+          title: PropTypes.string.isRequired,
+          thumbnail_url: PropTypes.string
+        })
+      )
     })
   };
 
+  renderThumbnail = sublevel => {
+    if (sublevel.thumbnail_url) {
+      return <img src={sublevel.thumbnail_url} style={styles.thumbnail} />;
+    } else {
+      // Render a square-shaped placeholder if we don't have a thumbnail.
+      return <div style={styles.placeholderThumbnail} />;
+    }
+  };
+
   render() {
-    return <div>Bubble Choice placeholder</div>;
+    const {level} = this.props;
+
+    return (
+      <div>
+        <h1>{level.title}</h1>
+        <UnsafeRenderedMarkdown markdown={level.description} />
+        <h2 style={styles.h2}>{i18n.chooseActivity()}</h2>
+        {level.sublevels.map(sublevel => (
+          <div key={sublevel.id} style={styles.row}>
+            {this.renderThumbnail(sublevel)}
+            <div style={styles.column}>
+              <span style={styles.title}>{sublevel.title}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
   }
 }

--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class BubbleChoice extends React.Component {
+  static propTypes = {
+    level: PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
+      // TODO: create shape for sublevels
+      sublevels: PropTypes.array
+    })
+  };
+
+  render() {
+    return <div>Bubble Choice placeholder</div>;
+  }
+}

--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -54,7 +54,9 @@ export default class BubbleChoice extends React.Component {
       return <img src={sublevel.thumbnail_url} style={styles.thumbnail} />;
     } else {
       // Render a square-shaped placeholder if we don't have a thumbnail.
-      return <div style={styles.placeholderThumbnail} />;
+      return (
+        <div style={styles.placeholderThumbnail} className="placeholder" />
+      );
     }
   };
 

--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -49,17 +49,6 @@ export default class BubbleChoice extends React.Component {
     })
   };
 
-  renderThumbnail = sublevel => {
-    if (sublevel.thumbnail_url) {
-      return <img src={sublevel.thumbnail_url} style={styles.thumbnail} />;
-    } else {
-      // Render a square-shaped placeholder if we don't have a thumbnail.
-      return (
-        <div style={styles.placeholderThumbnail} className="placeholder" />
-      );
-    }
-  };
-
   render() {
     const {level} = this.props;
 
@@ -70,7 +59,15 @@ export default class BubbleChoice extends React.Component {
         <h2 style={styles.h2}>{i18n.chooseActivity()}</h2>
         {level.sublevels.map(sublevel => (
           <div key={sublevel.id} style={styles.row}>
-            {this.renderThumbnail(sublevel)}
+            {/* Render a square-shaped placeholder if we don't have a thumbnail. */}
+            {sublevel.thumbnail_url ? (
+              <img src={sublevel.thumbnail_url} style={styles.thumbnail} />
+            ) : (
+              <div
+                style={styles.placeholderThumbnail}
+                className="placeholder"
+              />
+            )}
             <div style={styles.column}>
               <span style={styles.title}>{sublevel.title}</span>
             </div>

--- a/apps/src/sites/studio/pages/levels/_bubble_choice.js
+++ b/apps/src/sites/studio/pages/levels/_bubble_choice.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import BubbleChoice from '@cdo/apps/code-studio/components/BubbleChoice';
+
+const script = document.querySelector('script[data-bubblechoice]');
+const data = JSON.parse(script.dataset.bubblechoice);
+
+ReactDOM.render(
+  <BubbleChoice level={data.level} />,
+  document.querySelector('#bubble-choice')
+);

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {assert} from '../../../util/reconfiguredChai';
+import BubbleChoice from '@cdo/apps/code-studio/components/BubbleChoice';
+
+const fakeSublevels = [
+  {id: 1, title: 'Choice 1', thumbnail_url: 'some-fake.url/kittens.png'},
+  {id: 2, title: 'Choice 2', thumbnail_url: null}
+];
+
+const DEFAULT_PROPS = {
+  level: {
+    title: 'Bubble Choice',
+    description: 'Choose one or more levels!',
+    sublevels: fakeSublevels
+  }
+};
+
+describe('BubbleChoice', () => {
+  it('renders level information', () => {
+    const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} />);
+    assert.equal(DEFAULT_PROPS.level.title, wrapper.find('h1').text());
+    assert.equal(
+      DEFAULT_PROPS.level.description,
+      wrapper.find('UnsafeRenderedMarkdown').text()
+    );
+  });
+
+  it('renders sublevel thumbnail if present', () => {
+    const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} />);
+    const thumbnails = wrapper.find('img');
+    assert.equal(1, thumbnails.length);
+    assert(thumbnails.at(0).node.src.includes(fakeSublevels[0].thumbnail_url));
+  });
+
+  it('renders a placeholder div if sublevel thumbnail is not present', () => {
+    const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} />);
+    const placeholderThumbnails = wrapper.find('.placeholder');
+    assert.equal(1, placeholderThumbnails.length);
+  });
+});

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -49,10 +49,18 @@ ruby
   end
 
   def summarize
+    sublevel_summary = sublevels.map do |level|
+      {
+        id: level.id,
+        title: level.display_name || level.name,
+        thumbnail_url: level.try(:thumbnail_url)
+      }
+    end
+
     {
       title: title,
       description: description,
-      sublevels: sublevels
+      sublevels: sublevel_summary
     }
   end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -47,4 +47,12 @@ ruby
   def sublevels
     Level.where(name: properties['sublevels']).sort_by {|l| properties['sublevels'].index(l.name)}
   end
+
+  def summarize
+    {
+      title: title,
+      description: description,
+      sublevels: sublevels
+    }
+  end
 end

--- a/dashboard/app/views/levels/_bubble_choice.html.haml
+++ b/dashboard/app/views/levels/_bubble_choice.html.haml
@@ -1,0 +1,6 @@
+%div#bubble-choice
+
+- data = {}
+- data[:level] = @level.summarize
+
+%script{src: minifiable_asset_path('js/levels/_bubble_choice.js'), data: {bubblechoice: data.to_json}}

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -73,4 +73,24 @@ DSL
     level = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
     assert_equal [sublevel1, sublevel2, sublevel3], level.sublevels
   end
+
+  test 'summarize' do
+    sublevel1 = create :level, name: 'choice_1', display_name: 'Choice 1!', thumbnail_url: 'some-fake.url/kittens.png'
+    sublevel2 = create :level, name: 'choice_2'
+    bubble_choice = BubbleChoice.create(name: 'bubble_choices', title: 'Bubble Choices', description: 'Choose one or more!')
+    bubble_choice.properties['sublevels'] = [sublevel1.name, sublevel2.name]
+    bubble_choice.save!
+
+    summary = bubble_choice.summarize
+    expected_summary = {
+      title: bubble_choice.title,
+      description: bubble_choice.description,
+      sublevels: [
+        {id: sublevel1.id, title: sublevel1.display_name, thumbnail_url: sublevel1.thumbnail_url},
+        {id: sublevel2.id, title: sublevel2.name, thumbnail_url: nil}
+      ]
+    }
+
+    assert_equal expected_summary, summary
+  end
 end


### PR DESCRIPTION
[LP-316](https://codedotorg.atlassian.net/browse/LP-316) / [Spec](https://docs.google.com/document/d/1jKIQ6fwdDEt7rz659poRZUBli4zAyOOnMAsSb_D3EDE/edit#bookmark=id.3buot7tbv5kd)

Initial implementation of the BubbleChoice level sub-activity page.

When a user goes to the levels#show route for a BubbleChoice level, they will now see the sub-activity page (i.e., a landing page with information about the level and its sublevels).

#### Things to note
- The BubbleChoice level description can contain markdown
- If the sublevel does not have a `thumbnail_url`, we display a placeholder (shown in the 3 sublevels below)
- If the sublevel does not have a `display_name`, we display the internal name (shown in sublevels 2 & 3 below)

<img width="1501" alt="Screen Shot 2019-06-07 at 10 45 23 AM" src="https://user-images.githubusercontent.com/9812299/59130271-d6ac7d80-8923-11e9-88d1-14c363861f33.png">

#### Follow-up Work
- Make sublevels clickable (part of [LP-318](https://codedotorg.atlassian.net/browse/LP-318))
- Add user progress to the main navbar (part of [LP-317](https://codedotorg.atlassian.net/browse/LP-317))
- Add sublevel descriptions (a little bit about why you may want to choose that sublevel)