### PR TITLE
Add some logic to update TTS for a level when its contained level changes

### DIFF
--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -194,8 +194,12 @@ module TextToSpeech
   end
 
   def tts_should_update_long_instructions?
+    # Long instruction audio should be updated if the relevant long
+    # instructions property on the level itself was updated, or if the levels
+    # contained by this level were updated (since we treat contained level
+    # content as long instructions for TTS purposes)
     relevant_property = tts_long_instructions_override ? 'tts_long_instructions_override' : 'long_instructions'
-    return tts_should_update(relevant_property)
+    return tts_should_update(relevant_property) || tts_should_update('contained_level_names')
   end
 
   def tts_authored_hints_texts

--- a/dashboard/test/models/concerns/text_to_speech_test.rb
+++ b/dashboard/test/models/concerns/text_to_speech_test.rb
@@ -157,4 +157,37 @@ class TextToSpeechTest < ActiveSupport::TestCase
     I18n.backend.store_translations test_locale, custom_i18n
     assert_equal "regular instructions in another language\n", translatable_level.tts_short_instructions_text
   end
+
+  test 'updating the long instructions for a level should cause it to create new long instructions audio' do
+    level = create :level,
+      name: 'level 1',
+      type: 'Blockly',
+      long_instructions: "test long instructions",
+      published: true
+    level.save
+
+    level.stubs(:write_to_file?).returns(true)
+
+    refute level.tts_should_update_long_instructions?
+    level.long_instructions = "test long instructions updated"
+    assert level.tts_should_update_long_instructions?
+  end
+
+  test 'updating the contained level for a level should cause it to create new long instructions audio' do
+    contained_level_one = create :level, name: 'contained level 1', type: 'FreeResponse', properties: {
+      long_instructions: "This is the first contained"
+    }
+    contained_level_two = create :level, name: 'contained level 2', type: 'FreeResponse', properties: {
+      long_instructions: "This is the second contained"
+    }
+    outer_level = create :level, name: 'level 1', type: 'Blockly', published: true
+    outer_level.contained_level_names = [contained_level_one.name]
+    outer_level.save
+
+    outer_level.stubs(:write_to_file?).returns(true)
+
+    refute outer_level.tts_should_update_long_instructions?
+    outer_level.contained_level_names = [contained_level_two.name]
+    assert outer_level.tts_should_update_long_instructions?
+  end
 end


### PR DESCRIPTION
Specifically, when the "contained_level_names" property changes. Note
that this WILL NOT catch the situation when the content of the contained
level itself changes, which is the situation that represents the vast
majority of contained level changes.

That work is still in progress; this is just an incremental improvement
along the way.