### PR TITLE
Poste: improve logging in deliver_poste_messages cron job

### DIFF
--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -318,14 +318,14 @@ def main
       begin
         deliverer.send delivery
       rescue Net::SMTPSyntaxError, Net::SMTPFatalError => e
-        puts "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+        CDO.log.info "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
         deliverer.reset_connection
         sent_at = 0
       rescue AbortEmailError => e
-        puts "Abandoning delivery of #{delivery[:id]} because '#{e.message.to_s.strip}'"
+        CDO.log.info "Abandoning delivery of #{delivery[:id]} because '#{e.message.to_s.strip}'"
         sent_at = 0
       rescue => e
-        puts "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+        CDO.log.info "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
         raise
       end
 


### PR DESCRIPTION
In particular, we want to make sure we appropriately log failed attempts at sending an email.