### PR TITLE
Add enrollment code to pre-summer-workshop survey link

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -95,7 +95,7 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @is_reminder = true
     @pre_survey_url = @workshop.local_summer? ?
       url_for(action: 'new_general', controller: 'pd/workshop_daily_survey', day: 0,
-        enrollment_code: @enrollment.code
+        enrollmentCode: @enrollment.code
       ) :
       pd_new_pre_workshop_survey_url(enrollment_code: @enrollment.code)
     @is_first_pre_survey_email = days_before == INITIAL_PRE_SURVEY_DAYS_BEFORE

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -94,7 +94,9 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @cancel_url = url_for controller: 'pd/workshop_enrollment', action: :cancel, code: enrollment.code
     @is_reminder = true
     @pre_survey_url = @workshop.local_summer? ?
-      url_for(action: 'new_general', controller: 'pd/workshop_daily_survey', day: 0) :
+      url_for(action: 'new_general', controller: 'pd/workshop_daily_survey', day: 0,
+        enrollment_code: @enrollment.code
+      ) :
       pd_new_pre_workshop_survey_url(enrollment_code: @enrollment.code)
     @is_first_pre_survey_email = days_before == INITIAL_PRE_SURVEY_DAYS_BEFORE
 


### PR DESCRIPTION
### What
Pre-workshop survey link in CSD/CSP summer workshop reminders email will change from `https://studio.code.org/pd/workshop_survey/day/0` to `https://studio.code.org/pd/workshop_survey/day/0?enrollmentCode=[10-character-code]`

### Why
Teacher going to CSD/CSP summer workshops when accessing pre-workshop survey link `https://studio.code.org/pd/workshop_survey/day/0` will be redirected to wrong workshop if they had attended any CSD/CSP workshops (as teacher) before. Issue first reported in this [Slack thread](https://codedotorg.slack.com/archives/C0T10H26N/p1559925751077400).

The reason is this [line](https://github.com/code-dot-org/code-dot-org/blob/9a48df3dcc881f474bd4983a7e026c75671ca1a6/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb#L32), which calls this [check](https://github.com/code-dot-org/code-dot-org/blob/9a48df3dcc881f474bd4983a7e026c75671ca1a6/dashboard/app/models/pd/workshop.rb#L241) returns the most recent workshop users attended instead of the one they are going to attend. This change enables workshop matching using enrollment code instead of guessing.

### How tested
- Unit tests: 
  - `bundle exec rails test test/mailers/pd/workshop_mailer_test.rb`
  - `bundle exec rails test test/mailers/pd/*`
- Content tests:
  - http://localhost-studio.code.org:3000/rails/mailers/ --> \*enrollment_reminder\*summer_workshop\* (4 previews for CSD/CSP x 3/10 days)

  - Run `bin/oneoff/diff_email_previews` to check for unintentional side effect
      - in staging branch, download email previews : `bin/oneoff/diff_email_previews download base`
      - in feature branch, download email previews with new changes: `bin/oneoff/diff_email_previews download new`
      - compare: `bin/oneoff/diff_email_previews base new` --> Only see expected changes in reminder emails for CSD/CSP summer workshops.