### PR TITLE
Enzyme Upgrade: fix StudentHomepageTest

### DIFF
--- a/apps/test/unit/templates/studioHomepages/SectionsAsStudentTableTest.js
+++ b/apps/test/unit/templates/studioHomepages/SectionsAsStudentTableTest.js
@@ -75,4 +75,18 @@ describe('SectionsAsStudentTable', () => {
       expect(wrapper).to.containMatchingElement(<td>{section.teacherName}</td>);
     });
   });
+
+  it('shows section codes correctly', () => {
+    const wrapper = shallow(
+      <SectionsAsStudentTable sections={joinedSections} canLeave={false} />,
+      {context: {store}}
+    ).dive();
+
+    expect(wrapper).to.containMatchingElement(<td>ClassOneCode</td>);
+    expect(wrapper).to.containMatchingElement(<td>ClassTwoCode</td>);
+    expect(wrapper).to.containMatchingElement(<td>Google Classroom</td>);
+    expect(wrapper).to.not.containMatchingElement(<td>DoNotShowThis</td>);
+    expect(wrapper).to.containMatchingElement(<td>Clever</td>);
+    expect(wrapper).to.not.containMatchingElement(<td>OrThisEither</td>);
+  });
 });

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -1,13 +1,10 @@
 import React from 'react';
-import {assert, expect} from 'chai';
+import {assert, expect} from '../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import StudentHomepage from '@cdo/apps/templates/studioHomepages/StudentHomepage';
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
-import SectionsAsStudentTable from '@cdo/apps/templates/studioHomepages/SectionsAsStudentTable';
 import StudentSections from '@cdo/apps/templates/studioHomepages/StudentSections';
 import {courses, topCourse, joinedSections} from './homepagesTestData';
-import {combineReducers, createStore} from 'redux';
-import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 
 describe('StudentHomepage', () => {
   it('shows a non-extended Header Banner that says My Dashboard', () => {
@@ -80,28 +77,5 @@ describe('StudentHomepage', () => {
     assert.deepEqual(studentSections.props(), {
       initialSections: joinedSections
     });
-  });
-
-  it('shows section codes correctly', () => {
-    const store = createStore(combineReducers({isRtl}));
-    const wrapper = shallow(
-      <StudentHomepage
-        courses={courses}
-        topCourse={topCourse}
-        sections={joinedSections}
-        codeOrgUrlPrefix="http://localhost:3000/"
-      />
-    )
-      .find(StudentSections)
-      .dive()
-      .find(SectionsAsStudentTable)
-      .dive({context: {store}})
-      .dive();
-    expect(wrapper).to.containMatchingElement(<td>ClassOneCode</td>);
-    expect(wrapper).to.containMatchingElement(<td>ClassTwoCode</td>);
-    expect(wrapper).to.containMatchingElement(<td>Google Classroom</td>);
-    expect(wrapper).to.not.containMatchingElement(<td>DoNotShowThis</td>);
-    expect(wrapper).to.containMatchingElement(<td>Clever</td>);
-    expect(wrapper).to.not.containMatchingElement(<td>OrThisEither</td>);
   });
 });


### PR DESCRIPTION
In preparation for [the upgrade to Enzyme 3](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) we needed to fix `StudentHomepageTest` because the `'shows section codes correctly'` test was failing. Instead of diving into the component and setting up the necessary store for the children and grandchildren etc.,  I moved that test into `SectionsAsStudentTableTest`. Now each of these tests will pass with the upgrade and each will be responsible for checking that its own direct children will be rendered correctly. 