### PR TITLE
Added requested apis to allow-list. Removed unsupported yahoo api.

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -31,6 +31,8 @@ class XhrProxyController < ApplicationController
     api.coinmarketcap.com
     api.data.gov
     api.datamuse.com
+    api.energidataservice.dk
+    api.exchangeratesapi.io
     api.football-data.org
     api.foursquare.com
     api.nasa.gov
@@ -62,7 +64,6 @@ class XhrProxyController < ApplicationController
     lakeside-cs.org
     qrng.anu.edu.au
     quandl.com
-    query.yahooapis.com
     quizlet.com
     rejseplanen.dk
     noaa.gov


### PR DESCRIPTION
query.yahooapis.com was deprecated in January 2019. This removes it from the allowed hostnames list. 
Additionally
https://codeorg.zendesk.com/agent/tickets/241174 requested api.energidataservice.dk
https://codeorg.zendesk.com/agent/tickets/242740 requested api.exchangeratesapi.io