### PR TITLE
Show why a project is blocked in the admin panel

### DIFF
--- a/apps/src/code-studio/showProjectAdmin.js
+++ b/apps/src/code-studio/showProjectAdmin.js
@@ -75,13 +75,17 @@ export default project => {
     });
   }
 
-  if ($('.admin-project-sharing').length) {
+  if (
+    $('.admin-project-sharing').length &&
+    (project.isProjectLevel() || !project.shouldHideShareAndRemix())
+  ) {
     var sharingDisabled = project.getSharingDisabled();
     var privateOrProfane = project.hasPrivacyProfanityViolation();
     var abuseScore = project.getAbuseScore();
     var abusive = project.exceedsAbuseThreshold();
     if (sharingDisabled || privateOrProfane || abusive) {
       $('.blocked').show();
+      $('.blocked-reasons').show();
       $('.unblocked').hide();
       if (sharingDisabled) {
         $('.admin-sharing').show();

--- a/apps/src/code-studio/showProjectAdmin.js
+++ b/apps/src/code-studio/showProjectAdmin.js
@@ -75,25 +75,39 @@ export default project => {
     });
   }
 
-  if (
-    $('.admin-abuse').length &&
-    (project.isProjectLevel() || !project.shouldHideShareAndRemix())
-  ) {
-    var abuseScore = project.getAbuseScore();
-    if (abuseScore) {
-      $('.admin-abuse').show();
-      $('.admin-abuse-score').text(abuseScore);
-      $('.admin-abuse-reset').click(function() {
-        project.adminResetAbuseScore();
-      });
-    } else {
-      $('.admin-report-abuse').show();
-    }
-  }
-
-  if ($('.admin-sharing').length) {
+  if ($('.admin-project-sharing').length) {
     var sharingDisabled = project.getSharingDisabled();
-    $('.admin-sharing-disabled').text(sharingDisabled);
+    var privateOrProfane = project.hasPrivacyProfanityViolation();
+    var abuseScore = project.getAbuseScore();
+    var abusive = project.exceedsAbuseThreshold();
+    if (sharingDisabled || privateOrProfane || abusive) {
+      $('.blocked').show();
+      $('.unblocked').hide();
+      if (sharingDisabled) {
+        $('.admin-sharing').show();
+      }
+      if (privateOrProfane) {
+        $('.privacy-profanity').show();
+      }
+      if (abusive) {
+        // The image moderation service sets the abuse score to 15 to
+        // differentiate from manual reports.
+        if (abuseScore === 15) {
+          $('.abusive-image').show();
+        } else {
+          $('.reported-abuse').show();
+        }
+        $('.admin-abuse').show();
+        $('.admin-abuse-score').text(abuseScore);
+        $('.admin-abuse-reset').click(function() {
+          project.adminResetAbuseScore();
+        });
+      }
+    } else {
+      $('.unblocked').show();
+      $('.blocked').hide();
+      $('.blocked-reasons').hide();
+    }
   }
 
   $('#disable-auto-moderation').click(async function() {

--- a/apps/test/unit/code-studio/showProjectAdminTest.js
+++ b/apps/test/unit/code-studio/showProjectAdminTest.js
@@ -12,22 +12,46 @@ describe('showProjectAdmin', () => {
         isPublished: sinon.spy(),
         isProjectLevel: sinon.stub(),
         shouldHideShareAndRemix: sinon.stub(),
-        getAbuseScore: sinon.stub()
+        getAbuseScore: sinon.stub(),
+        exceedsAbuseThreshold: sinon.stub(),
+        getSharingDisabled: sinon.stub(),
+        hasPrivacyProfanityViolation: sinon.stub()
       };
 
       rootElement = document.createElement('div');
       rootElement.innerHTML = `
       <div class="content">
+        <div class="admin-project-sharing">
+          <div class="unblocked" style="display: none">
+            This project is safe to share.
+          </div>
+          <div class="blocked" style="display: none">
+            This project is blocked from sharing.
+          </div>
+        </div>
+        <ul class="blocked-reasons" style= "display: none">
+          <li class="admin-sharing" style="display: none">
+            Sharing is disabled
+          </li>
+          <li class="privacy-profanity" style="display: none">
+            Private or profane text
+          </li>
+          <li class="abusive-image" style="display: none">
+            Inappropriate image
+          </li>
+          <li class="reported-abuse" style="display: none">
+            Manually reported abusive
+          </li>
+        </ul>
         <div class="admin-abuse" style="display: none">
           Abuse score:
           <span class="admin-abuse-score"></span>
           <a class="admin-abuse-reset" href="#">Reset</a>
         </div>
-        <div class="admin-report-abuse" style="display: none">
+        <div class="admin-report-abuse">
           <a href="/report_abuse">Report Abuse</a>
         </div>
-      </div>
-      `;
+      </div>`;
       document.body.appendChild(rootElement);
     });
 
@@ -58,18 +82,41 @@ describe('showProjectAdmin', () => {
           project.shouldHideShareAndRemix.returns(true);
         });
 
-        it('shows no abuse controls', () => {
+        it('does not show sharing and abuse information', () => {
           showProjectAdmin(project);
-          assertHidden('.admin-report-abuse');
-          assertHidden('.admin-abuse');
-          assertHidden('.admin-abuse-score');
-          assertHidden('.admin-abuse-reset');
+          assertHidden('.unblocked');
+          assertHidden('.blocked');
+          assertHidden('.blocked-reasons');
+          assertHidden('.admin-sharing');
+          assertHidden('.privacy-profanity');
+          assertHidden('.abusive-image');
+          assertHidden('.reported-abuse');
         });
       });
 
       function testAbuseControlBehaviors() {
-        describe('with zero abuse score', () => {
-          beforeEach(() => project.getAbuseScore.returns(0));
+        describe('project is safe to share', () => {
+          beforeEach(() => {
+            project.getAbuseScore.returns(0);
+            project.exceedsAbuseThreshold.returns(false);
+            project.hasPrivacyProfanityViolation.returns(false);
+            project.getSharingDisabled.returns(false);
+          });
+
+          it('shows sharing unblocked message', () => {
+            showProjectAdmin(project);
+            assertVisible('.unblocked');
+            assertHidden('.blocked');
+          });
+
+          it('does not show sharing blocked reasons', () => {
+            showProjectAdmin(project);
+            assertHidden('.blocked-reasons');
+            assertHidden('.admin-sharing');
+            assertHidden('.privacy-profanity');
+            assertHidden('.abusive-image');
+            assertHidden('.reported-abuse');
+          });
 
           it('shows report abuse link', () => {
             showProjectAdmin(project);
@@ -84,12 +131,140 @@ describe('showProjectAdmin', () => {
           });
         });
 
-        describe('with a positive abuse score', () => {
-          beforeEach(() => project.getAbuseScore.returns(10));
+        describe('sharing is disabled', () => {
+          beforeEach(() => {
+            project.getAbuseScore.returns(0);
+            project.exceedsAbuseThreshold.returns(false);
+            project.hasPrivacyProfanityViolation.returns(false);
+            project.getSharingDisabled.returns(true);
+          });
 
-          it('does not show report abuse link', () => {
+          it('shows sharing blocked message', () => {
             showProjectAdmin(project);
-            assertHidden('.admin-report-abuse');
+            assertVisible('.blocked');
+            assertHidden('.unblocked');
+          });
+
+          it('shows sharing blocked reasons, sharing disabled', () => {
+            showProjectAdmin(project);
+            assertVisible('.blocked-reasons');
+            assertVisible('.admin-sharing');
+            assertHidden('.privacy-profanity');
+            assertHidden('.abusive-image');
+            assertHidden('.reported-abuse');
+          });
+
+          it('shows report abuse link', () => {
+            showProjectAdmin(project);
+            assertVisible('.admin-report-abuse');
+          });
+
+          it('does not show reset abuse control', () => {
+            showProjectAdmin(project);
+            assertHidden('.admin-abuse');
+            assertHidden('.admin-abuse-score');
+            assertHidden('.admin-abuse-reset');
+          });
+        });
+
+        describe('text moderation flagged project', () => {
+          beforeEach(() => {
+            project.getAbuseScore.returns(0);
+            project.exceedsAbuseThreshold.returns(false);
+            project.hasPrivacyProfanityViolation.returns(true);
+            project.getSharingDisabled.returns(false);
+          });
+
+          it('shows sharing blocked message', () => {
+            showProjectAdmin(project);
+            assertVisible('.blocked');
+            assertHidden('.unblocked');
+          });
+
+          it('shows sharing blocked reasons, privacy or profanity', () => {
+            showProjectAdmin(project);
+            assertVisible('.blocked-reasons');
+            assertHidden('.admin-sharing');
+            assertVisible('.privacy-profanity');
+            assertHidden('.abusive-image');
+            assertHidden('.reported-abuse');
+          });
+
+          it('shows report abuse link', () => {
+            showProjectAdmin(project);
+            assertVisible('.admin-report-abuse');
+          });
+
+          it('does not show reset abuse control', () => {
+            showProjectAdmin(project);
+            assertHidden('.admin-abuse');
+            assertHidden('.admin-abuse-score');
+            assertHidden('.admin-abuse-reset');
+          });
+        });
+
+        describe('image moderation flagged project', () => {
+          beforeEach(() => {
+            project.getAbuseScore.returns(15);
+            project.exceedsAbuseThreshold.returns(true);
+            project.hasPrivacyProfanityViolation.returns(false);
+            project.getSharingDisabled.returns(false);
+          });
+
+          it('shows sharing blocked message', () => {
+            showProjectAdmin(project);
+            assertVisible('.blocked');
+            assertHidden('.unblocked');
+          });
+
+          it('shows sharing blocked reasons, abusive image', () => {
+            showProjectAdmin(project);
+            assertVisible('.blocked-reasons');
+            assertHidden('.admin-sharing');
+            assertHidden('.privacy-profanity');
+            assertVisible('.abusive-image');
+            assertHidden('.reported-abuse');
+          });
+
+          it('shows report abuse link', () => {
+            showProjectAdmin(project);
+            assertVisible('.admin-report-abuse');
+          });
+
+          it('shows reset abuse control', () => {
+            showProjectAdmin(project);
+            assertVisible('.admin-abuse');
+            assertVisible('.admin-abuse-score');
+            assertVisible('.admin-abuse-reset');
+          });
+        });
+
+        describe('with a manually reported positive abuse score above threshold', () => {
+          beforeEach(() => {
+            project.getAbuseScore.returns(20);
+            project.exceedsAbuseThreshold.returns(true);
+            project.hasPrivacyProfanityViolation.returns(false);
+            project.getSharingDisabled.returns(false);
+          });
+
+          it('shows sharing blocked message', () => {
+            showProjectAdmin(project);
+            assertVisible('.blocked');
+            assertHidden('.unblocked');
+          });
+
+          it('shows sharing blocked reasons, reported abuse', () => {
+            showProjectAdmin(project);
+            assertVisible('.blocked-reasons');
+            assertHidden('.admin-sharing');
+            assertHidden('.privacy-profanity');
+            assertHidden('.abusive-image');
+            assertVisible('.reported-abuse');
+          });
+
+          it('shows report abuse link', () => {
+            showProjectAdmin(project);
+            assertVisible('.admin-report-abuse');
           });
 
           it('shows reset abuse control', () => {

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -126,17 +126,28 @@
 
     - if current_user.project_validator?
       %br
-      %div.admin-abuse{ :style => "display: none" }
-        Abuse score:
-        %span.admin-abuse-score
-        = link_to 'Reset', '#', { class: 'admin-abuse-reset' }
-      .admin-report-abuse{ style: 'display: none;' }
-        = link_to 'Report Abuse', '/report_abuse'
+      .admin-project-sharing
+        .unblocked{ style: 'display: none;' }
+          This project is safe to share.
+        .blocked{ style: 'display: none;' }
+          This project is blocked from sharing.
+      %ul.blocked-reasons
+        %li.admin-sharing{ style: 'display: none;' }
+          Sharing is disabled
+        %li.privacy-profanity{ style: 'display: none;' }
+          Private or profane text
+        %li.abusive-image{ style: 'display: none;' }
+          Inapproprate image
+        %li.reported-abuse{ style: 'display: none;' }
+          Manually reported abusive
+          .admin-abuse{ :style => "display: none" }
+            Abuse score:
+            %span.admin-abuse-score
+            = link_to 'Reset', '#', { class: 'admin-abuse-reset' }
 
       %br
-      .admin-sharing
-        Sharing disabled?
-        %span.admin-sharing-disabled
+      .admin-report-abuse
+        = link_to 'Report Abuse', '/report_abuse'
 
       #disable-auto-moderation{'style' => ('display: none;' if content_moderation_disabled)}
         %br

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -131,21 +131,21 @@
           This project is safe to share.
         .blocked{ style: 'display: none;' }
           This project is blocked from sharing.
-      %ul.blocked-reasons
+      %ul.blocked-reasons{ style: 'display: none;' }
         %li.admin-sharing{ style: 'display: none;' }
           Sharing is disabled
         %li.privacy-profanity{ style: 'display: none;' }
           Private or profane text
         %li.abusive-image{ style: 'display: none;' }
-          Inapproprate image
+          Inappropriate image
         %li.reported-abuse{ style: 'display: none;' }
           Manually reported abusive
-          .admin-abuse{ :style => "display: none" }
-            Abuse score:
-            %span.admin-abuse-score
-            = link_to 'Reset', '#', { class: 'admin-abuse-reset' }
 
-      %br
+      .admin-abuse{ :style => "display: none" }
+        Abuse score:
+        %span.admin-abuse-score
+        = link_to 'Reset', '#', { class: 'admin-abuse-reset' }
+
       .admin-report-abuse
         = link_to 'Report Abuse', '/report_abuse'
 


### PR DESCRIPTION
[LP-352](https://codedotorg.atlassian.net/browse/LP-352)

We'd like to give admins more insight into why a project is blocked from sharing. There are four reason why a project could be blocked: 
1.) Sharing is disabled for the owner 
2.) There is potentially profane or private information in the project text, caught by WebPurify
3.) There is a potentially inappropriate image associate with the project, caught by image moderation
4.) The project has been manually reported for abuse enough that the abuse threshold is reached 

In this change, I expose which (if any) of these criteria have been met in the admin panel for projects. 

**Examples**

Safe to share: 
<img width="284" alt="Screen Shot 2019-06-10 at 1 02 44 PM" src="https://user-images.githubusercontent.com/12300669/59224216-bb8b7900-8b82-11e9-9ac5-07d80e35f81b.png">

Sharing is disabled: 
<img width="267" alt="Screen Shot 2019-06-10 at 1 07 53 PM" src="https://user-images.githubusercontent.com/12300669/59224283-dd84fb80-8b82-11e9-828e-472bdfe1d8a1.png">

Manual abuse reports: 
<img width="259" alt="Screen Shot 2019-06-10 at 1 01 43 PM" src="https://user-images.githubusercontent.com/12300669/59224294-e2e24600-8b82-11e9-8129-fb66d40c6dc9.png">

Both sharing is disabled and manual abuse reports: 
<img width="249" alt="Screen Shot 2019-06-10 at 1 09 16 PM" src="https://user-images.githubusercontent.com/12300669/59224299-e70e6380-8b82-11e9-9af6-4cc757a75328.png">

Upcoming work: 
- [ ] displaying which term was flagged by the profanity/privacy text filter 
- [ ] only showing enable/disable content moderation buttons when applicable based on project type

