### PR TITLE
Add CSD and CSP units to hardcoded list of TTS enabled 

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -787,6 +787,10 @@ class Script < ActiveRecord::Base
       Script::CSD3_2018_NAME,
       Script::CSD4_2018_NAME,
       Script::CSD6_2018_NAME,
+      Script::CSD2_2019_NAME,
+      Script::CSD3_2019_NAME,
+      Script::CSD4_2019_NAME,
+      Script::CSD6_2019_NAME
     ].include?(name)
   end
 
@@ -798,6 +802,9 @@ class Script < ActiveRecord::Base
       Script::CSP3_2018_NAME,
       Script::CSP5_2018_NAME,
       Script::CSP_POSTAP_2018_NAME,
+      Script::CSP3_2019_NAME,
+      Script::CSP5_2019_NAME,
+      Script::CSP_POSTAP_2019_NAME
     ].include?(name)
   end
 

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -134,12 +134,6 @@ module ScriptConstants
       CSD5_NAME = 'csd5-2017'.freeze,
       CSD6_NAME = 'csd6-2017'.freeze,
     ],
-    # Currently only used for TTS.
-    csp_2019: [
-      CSP3_2019_NAME = 'csp3-2019'.freeze,
-      CSP5_2019_NAME = 'csp5-2019'.freeze,
-      CSP_POSTAP_2019_NAME = 'csppostap-2019'.freeze,
-    ],
     csp_2018: [
       CSP1_2018_NAME = 'csp1-2018'.freeze,
       CSP2_2018_NAME = 'csp2-2018'.freeze,

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -134,6 +134,12 @@ module ScriptConstants
       CSD5_NAME = 'csd5-2017'.freeze,
       CSD6_NAME = 'csd6-2017'.freeze,
     ],
+    # Currently only used for TTS.
+    csp_2019: [
+      CSP3_2019_NAME = 'csp3-2019'.freeze,
+      CSP5_2019_NAME = 'csp5-2019'.freeze,
+      CSP_POSTAP_2019_NAME = 'csppostap-2019'.freeze,
+    ],
     csp_2018: [
       CSP1_2018_NAME = 'csp1-2018'.freeze,
       CSP2_2018_NAME = 'csp2-2018'.freeze,


### PR DESCRIPTION
While we figure out enabling TTS for all the curriculum, this enables the 2019 versions of CSD and CSP units consistent with those enabled in past versions. 