### PR TITLE
Miscellaneous site content changes

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -273,7 +273,7 @@
   "courseBlocksGradeBandsMiddle": "Middle School",
   "courseBlocksGradeBandsMiddleDescription": "Our new middle school course can be offered as a semester or year-long introduction to computer science for all students.",
   "courseBlocksGradeBandsUniversity": "Beyond K-12",
-  "courseBlocksGradeBandsUniversityDescription": "Go beyond Code.org and take university courses online or learn a new programming language.",
+  "courseBlocksGradeBandsUniversityDescription": "Go beyond Code.org and continue your path in computer science. Browse online schools and courses.",
   "courseBlocksInternationalGradeBandsContainerDescription": "Below is the catalog of all of our courses and great options from third parties. Please note that some of these are only in English. Don't worry -- we're working on getting these courses translated into your language. Thanks for your patience!",
   "courseBlocksInternationalGradeBandsContainerHeading": "Full course catalog (English only)",
   "courseBlocksInternationalGradeBandsElementary": "Ages 4-11",

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -301,7 +301,7 @@ export default class EnrollForm extends React.Component {
       <div>
         What grades are you teaching this year? (Select all that apply)
         <span className="form-required-field"> *</span>
-        <p>This workshop is intended for teachers for Grades K-5.</p>
+        <p>This workshop is intended for teachers of grades K-5.</p>
       </div>
     );
     const coursesPlannedLabel = (

--- a/dashboard/app/views/pd/workshop_enrollment/logged_out.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/logged_out.haml
@@ -16,7 +16,7 @@
 
   .paragraph
     If you’d like more information about the program before you start your enrollment, please check out the
-    = link_to("Professional Learning Program overview", CDO.code_org_url('/educate/professional-learning/middle-high'), target: "_blank")
+    = link_to("Professional Learning Program overview", CDO.code_org_url('/educate/professional-learning'), target: "_blank")
     or
     = succeed "." do
       #regional-partner-mini-contact-popup-link-container{"data-source-page-id" => "workshop-enrollment-logged-out", "data-options" => {notes: "Please tell me more about the professional learning program!"}, "data-link-text" => "contact your local regional partner"}

--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -3,6 +3,10 @@ title: "<%= I18n.t(:hoc2018_dance_party_landing_title) %>"
 theme: responsive
 ---
 
+:javascript
+  window.pegasus = window.pegasus || {};
+  window.pegasus.STUDIO_URL = "#{CDO.studio_url}";
+
 - js_locale = request.locale.to_s.downcase.tr('-', '_')
 %script{src: asset_path("js/#{js_locale}/common_locale.js")}
 %script{src: minifiable_asset_path('js/code.org/public/dance.js')}

--- a/pegasus/sites.v3/code.org/views/course_wide_block.haml
+++ b/pegasus/sites.v3/code.org/views/course_wide_block.haml
@@ -10,7 +10,7 @@
   #courseblock-content{style: 'padding-left: 20px; padding-right: 20px;'}
     - unless ages.nil?
       %h4= ages
-    .smalltext{style: 'height: 120px; margin-bottom: 10px;'}= description
+    .smalltext{style: 'min-height: 120px; margin-bottom: 10px;'}= description
     - unless cta_text.nil?
       %a{:href=>cta_link}
         %button{style: "margin-left: 10px; margin-top: 20px;"}!= cta_text

--- a/pegasus/sites.v3/code.org/views/minecraft_2018.haml
+++ b/pegasus/sites.v3/code.org/views/minecraft_2018.haml
@@ -85,12 +85,12 @@
 .tile-container-responsive{style: "padding: 5px"}
   .col-50
     .tutorial-tile
-      %a{href: "https://www.microsoft.com/youthsparkprograms", target: '_blank'}
+      %a{href: "https://www.microsoft.com/en-us/store/locations/events-for-students", target: '_blank'}
         %img.tutorial-tile-img{src: CDO.code_org_url("/images/fill-485x260/mc/minecraft_teacher_small1.jpg")}
       .tutorial-info
         %h3{style: "margin-top: 0px;"}= I18n.t(:hoc2018_mc_educators_box3_title)
         .smalltext= I18n.t(:hoc2018_mc_educators_box3_desc)
-        %a{href: "https://www.microsoft.com/youthsparkprograms", target: '_blank'}
+        %a{href: "https://www.microsoft.com/en-us/store/locations/events-for-students", target: '_blank'}
           %button.tutorial-info-start.tutorial-gray= I18n.t(:hoc2018_mc_educators_box3_button)
         .clear
 

--- a/pegasus/sites.v3/code.org/views/stats_homepage.haml
+++ b/pegasus/sites.v3/code.org/views/stats_homepage.haml
@@ -35,7 +35,7 @@
   showing_below_hero_announcement = Homepage.get_below_hero_announcement[:showing]
 
 - if !showing_below_hero_announcement
-  .make-difference We're making a difference
+  .make-difference Every student in every school
 
 .statistics
   %a.nounderscorehover.col-20.stats-box.linktag{href: CDO.studio_url('/courses'), id: "stats-0"}

--- a/pegasus/sites.v3/code.org/views/stats_homepage.haml
+++ b/pegasus/sites.v3/code.org/views/stats_homepage.haml
@@ -27,7 +27,7 @@
     },
     {
       number: states_policy_change,
-      phrase: "U.S. states changed policy to support computer science",
+      phrase: "U.S. states (+ D.C.) now support computer science",
       link: '/advocacy'
     },
   ]


### PR DESCRIPTION
- homepage: update state stat text
- homepage: We're making a difference -> Every student in every school

![Screenshot 2019-06-10 14 20 33](https://user-images.githubusercontent.com/2205926/59227966-7750a680-8b8b-11e9-913d-b5cd850cc62e.png)

- Fix /minecraft event links
- dance: make project links on /dance work again
- PL: fix typo in workshop enrollment form
- PL: update link on workshop enrollment logged out page, to general PL page
- courses: update text in "Beyond K-12" block on /courses

![Screenshot 2019-06-10 12 31 12](https://user-images.githubusercontent.com/2205926/59227974-7c155a80-8b8b-11e9-96bf-20e97082253c.png)

- course wide block: specify min-height to fix button overlapping text
  - This prevents the button overlapping the text on a box on /educate/curriculum/elementary-school, while the use of a min-height still ensures that most of the time the block occupies its previous height, which especially makes side-by-side blocks still look good.




