### PR TITLE
return 404 when stage extras for an unversioned course url are requested

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -193,6 +193,10 @@ class ScriptLevelsController < ApplicationController
       end
     end
 
+    # Explicitly return 404 here so that we don't get a 5xx in get_from_cache.
+    # A 404 (or 410) tells search engine crawlers to stop requesting these URLs.
+    return head :not_found if ScriptConstants::FAMILY_NAMES.include?(params[:script_id])
+
     @script = Script.get_from_cache(params[:script_id])
     @stage = @script.stage_by_relative_position(params[:stage_position].to_i)
 


### PR DESCRIPTION
### Background

Fixes https://app.honeybadger.io/projects/3240/faults/50002356

Investigation into the honeybadger error revealed that they all had one of the following two settings in the "parameters" section:
*   "HTTP_FROM" => "bingbot(at)microsoft.com",
*   "HTTP_FROM" => "googlebot(at)googlebot.com",

Internet research revealed that these search engine crawlers will keep requesting urls that return a 5xx, and need to receive a 404 or 410 in order to be told to stop requesting them.

### Description

Return 404 for any request to an unversioned stage extras url such as those listed in the honeybadger events.