### PR TITLE
Teacher Panel Iterator Take 2

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
@@ -94,11 +94,20 @@ class ScriptTeacherPanel extends React.Component {
         currentStudent = sectionData.section.students.find(
           student => this.props.getSelectedUserId() === student.id
         );
-      }
-      if (currentSectionScriptLevels && currentStudent) {
-        currentStudentScriptLevel = currentSectionScriptLevels.find(
-          level => this.props.getSelectedUserId() === level.user_id
-        );
+
+        if (currentStudent) {
+          if (currentSectionScriptLevels) {
+            currentStudentScriptLevel = currentSectionScriptLevels.find(
+              level => this.props.getSelectedUserId() === level.user_id
+            );
+          }
+        } else {
+          currentStudent = {
+            id: null,
+            name: i18n.studentTableTeacherDemo()
+          };
+          currentStudentScriptLevel = sectionData.teacher_level;
+        }
       }
     }
 
@@ -111,8 +120,11 @@ class ScriptTeacherPanel extends React.Component {
           <ViewAsToggle />
           {currentStudent && (
             <SelectedStudentInfo
+              students={students}
               selectedStudent={currentStudent}
               level={currentStudentScriptLevel}
+              onSelectUser={this.props.onSelectUser}
+              getSelectedUserId={this.props.getSelectedUserId}
             />
           )}
           {sectionData && sectionData.level_examples && (

--- a/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
@@ -118,7 +118,7 @@ class ScriptTeacherPanel extends React.Component {
         <h3>{i18n.teacherPanel()}</h3>
         <div style={styles.scrollable}>
           <ViewAsToggle />
-          {currentStudent && (
+          {viewAs === ViewType.Teacher && currentStudent && (
             <SelectedStudentInfo
               students={students}
               selectedStudent={currentStudent}
@@ -127,19 +127,21 @@ class ScriptTeacherPanel extends React.Component {
               getSelectedUserId={this.props.getSelectedUserId}
             />
           )}
-          {sectionData && sectionData.level_examples && (
-            <div style={styles.exampleSolutions}>
-              {sectionData.level_examples.map((example, index) => (
-                <Button
-                  key={index}
-                  text={i18n.exampleSolution({number: index + 1})}
-                  color="blue"
-                  href={example}
-                  target="_blank"
-                />
-              ))}
-            </div>
-          )}
+          {viewAs === ViewType.Teacher &&
+            sectionData &&
+            sectionData.level_examples && (
+              <div style={styles.exampleSolutions}>
+                {sectionData.level_examples.map((example, index) => (
+                  <Button
+                    key={index}
+                    text={i18n.exampleSolution({number: index + 1})}
+                    color="blue"
+                    href={example}
+                    target="_blank"
+                  />
+                ))}
+              </div>
+            )}
           {!sectionsAreLoaded && (
             <div style={styles.text}>{i18n.loading()}</div>
           )}

--- a/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
+++ b/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
@@ -4,16 +4,27 @@ import i18n from '@cdo/locale';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import Button from '@cdo/apps/templates/Button';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
+import Radium from 'radium';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {studentShape} from './StudentTable';
+
+const RadiumFontAwesome = Radium(FontAwesome);
 
 const styles = {
   main: {
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'row'
+  },
+  studentInfo: {
+    width: 150,
     textAlign: 'center',
     display: 'flex',
     justifyContent: 'center',
     flexDirection: 'column'
   },
   bubble: {
-    marginLeft: 81
+    marginLeft: 56
   },
   name: {
     fontFamily: '"Gotham 5r", sans-serif',
@@ -23,13 +34,22 @@ const styles = {
   timeHeader: {
     fontFamily: '"Gotham 5r", sans-serif',
     fontWeight: 'bold'
+  },
+  arrow: {
+    fontSize: 40,
+    cursor: 'pointer',
+    position: 'relative',
+    top: 30
   }
 };
 
 export class SelectedStudentInfo extends React.Component {
   static propTypes = {
+    students: PropTypes.arrayOf(studentShape).isRequired,
     selectedStudent: PropTypes.object,
-    level: PropTypes.object
+    level: PropTypes.object,
+    onSelectUser: PropTypes.func.isRequired,
+    getSelectedUserId: PropTypes.func.isRequired
   };
 
   onUnsubmit = () => {
@@ -62,67 +82,105 @@ export class SelectedStudentInfo extends React.Component {
       .fail(err => console.error(err));
   };
 
+  nextStudent = () => {
+    const currentUserId = this.props.getSelectedUserId();
+    const currentStudentIndex = this.props.students.findIndex(
+      student => student.id === currentUserId
+    );
+    if (currentStudentIndex === this.props.students.length - 1) {
+      this.props.onSelectUser(null);
+    } else {
+      this.props.onSelectUser(this.props.students[currentStudentIndex + 1].id);
+    }
+  };
+
+  previousStudent = () => {
+    const currentUserId = this.props.getSelectedUserId();
+    const currentStudentIndex = this.props.students.findIndex(
+      student => student.id === currentUserId
+    );
+    if (currentStudentIndex === 0) {
+      this.props.onSelectUser(null);
+    } else if (currentStudentIndex === -1) {
+      this.props.onSelectUser(
+        this.props.students[this.props.students.length - 1].id
+      );
+    } else {
+      this.props.onSelectUser(this.props.students[currentStudentIndex - 1].id);
+    }
+  };
+
   render() {
     const {selectedStudent, level} = this.props;
 
     return (
       <div style={styles.main}>
-        <div style={styles.name}>{selectedStudent.name}</div>
-        {level.paired && (
-          <div>
-            <div>{i18n.workedWith()}</div>
-            {level.navigator && (
-              <div key={level.navigator}>
-                {i18n.partner({partner: level.navigator})}
-              </div>
-            )}
-            {level.driver && (
-              <div key={level.driver}>
-                {i18n.loggedIn({partner: level.driver})}
-              </div>
-            )}
-          </div>
-        )}
-        <div style={styles.bubble}>
-          <TeacherPanelProgressBubble level={level} />
-        </div>
-        {!level.submitLevel && (
-          <div>
-            <div style={styles.timeHeader}>{i18n.lastUpdatedNoTime()}</div>
+        <RadiumFontAwesome
+          icon="caret-left"
+          onClick={this.previousStudent}
+          style={styles.arrow}
+        />
+        <div style={styles.studentInfo}>
+          <div style={styles.name}>{selectedStudent.name}</div>
+          {level.paired && (
             <div>
-              {level.status !== LevelStatus.not_tried
-                ? new Date(level.updated_at).toLocaleString()
-                : i18n.notApplicable()}
+              <div>{i18n.workedWith()}</div>
+              {level.navigator && (
+                <div key={level.navigator}>
+                  {i18n.partner({partner: level.navigator})}
+                </div>
+              )}
+              {level.driver && (
+                <div key={level.driver}>
+                  {i18n.loggedIn({partner: level.driver})}
+                </div>
+              )}
             </div>
+          )}
+          <div style={styles.bubble}>
+            <TeacherPanelProgressBubble level={level} />
           </div>
-        )}
-        {level.submitLevel && (
-          <div>
-            <div style={styles.timeHeader}>{i18n.submittedOn()}</div>
+          {!level.submitLevel && (
             <div>
-              {level.status === LevelStatus.submitted
-                ? new Date(level.updated_at).toLocaleString()
-                : i18n.notApplicable()}
+              <div style={styles.timeHeader}>{i18n.lastUpdatedNoTime()}</div>
+              <div>
+                {level.status !== LevelStatus.not_tried
+                  ? new Date(level.updated_at).toLocaleString()
+                  : i18n.notApplicable()}
+              </div>
             </div>
-            <Button
-              text={i18n.unsubmit()}
-              color="blue"
-              onClick={this.onUnsubmit}
-              id="unsubmit-button-uitest"
-              disabled={level.status !== LevelStatus.submitted}
-            />
-          </div>
-        )}
-        {level.contained && (
-          <div>
+          )}
+          {level.submitLevel && (
+            <div>
+              <div style={styles.timeHeader}>{i18n.submittedOn()}</div>
+              <div>
+                {level.status === LevelStatus.submitted
+                  ? new Date(level.updated_at).toLocaleString()
+                  : i18n.notApplicable()}
+              </div>
+              <Button
+                text={i18n.unsubmit()}
+                color="blue"
+                onClick={this.onUnsubmit}
+                id="unsubmit-button-uitest"
+                disabled={level.status !== LevelStatus.submitted}
+              />
+            </div>
+          )}
+          {level.contained && (
             <Button
               text={i18n.clearResponse()}
               color="blue"
               onClick={this.onClearResponse}
               disabled={level.status === LevelStatus.not_tried}
             />
-          </div>
-        )}
+          )}
+        </div>
+        <RadiumFontAwesome
+          icon="caret-right"
+          onClick={this.nextStudent}
+          style={styles.arrow}
+        />
       </div>
     );
   }

--- a/apps/test/unit/code-studio/components/progress/ScriptTeacherPanelTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ScriptTeacherPanelTest.jsx
@@ -9,6 +9,8 @@ import ViewAsToggle from '@cdo/apps/code-studio/components/progress/ViewAsToggle
 import i18n from '@cdo/locale';
 import FontAwesome from '../../../../../src/templates/FontAwesome';
 
+const students = [{id: 1, name: 'Student 1'}, {id: 2, name: 'Student 2'}];
+
 const MINIMUM_PROPS = {
   viewAs: ViewType.Student,
   hasSections: false,
@@ -18,10 +20,9 @@ const MINIMUM_PROPS = {
   unlockedStageNames: [],
   sectionData: null,
   onSelectUser: () => {},
-  getSelectedUserId: () => {}
+  getSelectedUserId: () => {},
+  students: null
 };
-
-const students = [{id: 1, name: 'Student 1'}, {id: 2, name: 'Student 2'}];
 
 describe('ScriptTeacherPanel', () => {
   describe('on script page', () => {
@@ -240,6 +241,7 @@ describe('ScriptTeacherPanel', () => {
         const wrapper = shallow(
           <ScriptTeacherPanel
             {...MINIMUM_PROPS}
+            students={students}
             viewAs={ViewType.Teacher}
             sectionData={{
               level_examples: [
@@ -259,6 +261,7 @@ describe('ScriptTeacherPanel', () => {
         const wrapper = shallow(
           <ScriptTeacherPanel
             {...MINIMUM_PROPS}
+            students={students}
             viewAs={ViewType.Teacher}
             sectionData={{
               level_examples: null,

--- a/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
@@ -17,7 +17,10 @@ const defaultProps = {
     passed: false,
     status: LevelStatus.not_tried,
     user_id: 1
-  }
+  },
+  students: [{id: 1, name: 'Student 1'}, {id: 2, name: 'Student 2'}],
+  onSelectUser: () => {},
+  getSelectedUserId: () => {}
 };
 
 describe('SelectedStudentInfo', () => {

--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -4,6 +4,11 @@
 - data[:section] = @section&.summarize
 - data[:stage_extra] = @stage_extras
 
+- if @stage_extras
+  - data[:teacher_level] = ScriptLevel.summarize_as_bonus_for_teacher_panel(@stage.script, @bonus_level_ids, @current_user)
+- else
+  - data[:teacher_level] = @script_level&.summarize_for_teacher_panel(@current_user)
+
 - if @level && @script_level
   - if @level.try(:examples).present? && current_user.authorized_teacher? # 'solutions' for applab-type levels
     - level_example_links = @level.examples.map do |example|


### PR DESCRIPTION
Re-implements https://github.com/code-dot-org/code-dot-org/pull/28967 but fixes an issue with the view as student mode.

# Issue: View as student mode showed teacher example solutions (in production) and selected student info (not in production - was bug in new code)

## Before

<img width="1347" alt="59230517-871fb900-8b92-11e9-8141-5eb4192e9810" src="https://user-images.githubusercontent.com/208083/59279012-2b583d00-8c31-11e9-88a2-9b1ba7248956.png">

<img width="199" alt="Screen Shot 2019-06-11 at 10 11 57 AM" src="https://user-images.githubusercontent.com/208083/59279147-66f30700-8c31-11e9-9f0e-6a7ba28b679a.png">


## After

<img width="203" alt="Screen Shot 2019-06-11 at 10 10 26 AM" src="https://user-images.githubusercontent.com/208083/59279003-27c4b600-8c31-11e9-8e33-44ca470ff51d.png">
