### PR TITLE
Sprite Lab Levels : Multiple Example Solutions

### DIFF
--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -7,7 +7,12 @@
 - if @level && @script_level
   - if @level.try(:examples).present? && current_user.authorized_teacher? # 'solutions' for applab-type levels
     - level_example_links = @level.examples.map do |example|
-      - send("#{@level.game.app}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
+      // We treat Sprite Lab levels as a sub-set of game lab levels right now which breaks their examples solutions
+      // as level.game.app gets "gamelab" which makes the examples for sprite lab try to open in game lab
+      - if @level.is_a?(GamelabJr)
+        - send("#{"spritelab"}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
+      - else
+        - send("#{@level.game.app}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
   - if @level.ideal_level_source_id && @script # 'solutions' for blockly-type levels
     -level_example_links = []
     -level_example_links.push(build_script_level_url(@script_level, {solution: true}.merge(@section ? {section_id: @section.id} : {})))

--- a/dashboard/app/views/levels/editors/_gamelab.html.haml
+++ b/dashboard/app/views/levels/editors/_gamelab.html.haml
@@ -10,7 +10,9 @@
 %legend.control-legend.levelTypeHeader
   Game Lab Options
 
-= render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'gamelab'}
+// See gamelab_jr.html.haml for examples for Sprite Lab
+- if !@level.is_a?(GamelabJr)
+  = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'gamelab'}
 
 %legend.control-legend{data: {toggle: "collapse", target: "#debuggingTools"}}
   Debugging

--- a/dashboard/app/views/levels/editors/_gamelab_jr.html.haml
+++ b/dashboard/app/views/levels/editors/_gamelab_jr.html.haml
@@ -1,5 +1,8 @@
 %legend.control-legend.levelTypeHeader
   Sprite Lab Options
+
+= render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'spritelab'}
+
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :include_shared_functions, description: "Make shared functions and behaviors available"}
 


### PR DESCRIPTION
Makes multiple example solutions work for sprite lab levels.

# Can have multiple example levels for sprite lab level
![Sprite-Lab-Multi-Examples](https://user-images.githubusercontent.com/208083/59285296-c1916080-8c3b-11e9-999c-11d51e4e3212.gif)

<img width="1432" alt="Screen Shot 2019-06-11 at 11 18 21 AM" src="https://user-images.githubusercontent.com/208083/59285294-c0f8ca00-8c3b-11e9-95ff-aa9a63f57dd7.png">

# Adds edit area for Sprite Lab Example Levels (Removes game lab one)
<img width="1032" alt="Screen Shot 2019-06-11 at 11 21 35 AM" src="https://user-images.githubusercontent.com/208083/59285305-c48c5100-8c3b-11e9-8e46-ddd401a52634.png">
