### PR TITLE
Enable aurora snapshot backup cron job

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -103,6 +103,7 @@
 
       # RDS backup window is 08:50-09:20, so by 11:50 backups should definitely be ready
       cronjob at:'50 11 * * *', do:deploy_dir('bin', 'cron', 'push_latest_rds_backup_to_secondary_account')
+      cronjob at:'50 11 * * *', do:deploy_dir('bin', 'cron', 'push_latest_aurora_backup_to_secondary_account')
     end
 
     # 'daemons' in all environments.


### PR DESCRIPTION
Successfully ran on production daemon:

```
production-daemAPP [4:30 PM]
Beginning cross-account RDS backup

production-daemAPP [5:00 PM]
Completed cross account RDS backup: production-aurora-cluster-2019-06-10-05-30
```