### PR TITLE
Skip responses with no user id

### DIFF
--- a/bin/cron/process_jotform_data
+++ b/bin/cron/process_jotform_data
@@ -124,7 +124,7 @@ def main
       survey_answers = []
       submissions.each do |submission|
         # skipping blank submissions
-        if submission.answers == "{}"
+        if submission.answers == "{}" || submission.user_id.nil?
           next
         end
         answers = submission.form_data_hash


### PR DESCRIPTION
Process failing b/c of 3 submissions with no user id -- should fix [this honeybadger error](https://app.honeybadger.io/projects/45435/faults/50020613).

Merging without CI, as this is only changes a cronjob.