### PR TITLE
Example Solutions: Dance Lab Levels

### DIFF
--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -13,10 +13,13 @@
   - if @level.try(:examples).present? && current_user.authorized_teacher? # 'solutions' for applab-type levels
     - level_example_links = @level.examples.map do |example|
       // We treat Sprite Lab levels as a sub-set of game lab levels right now which breaks their examples solutions
-      // as level.game.app gets "gamelab" which makes the examples for sprite lab try to open in game lab
+      // as level.game.app gets "gamelab" which makes the examples for sprite lab try to open in game lab.
+      // We treat Dancelab as a sub-set of Sprite Lab levels so have to check and set that before GamelabJr
       // Artist levels have @level.game.app of "turtle" and Playlab levels have @level.game.app of "studio"
       // so need to set those too
-      - if @level.is_a?(GamelabJr)
+      - if @level.is_a?(Dancelab)
+        - send("#{"dance"}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
+      - elsif @level.is_a?(GamelabJr)
         - send("#{"spritelab"}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
       - elsif @level.is_a?(Artist)
         - send("#{"artist"}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)

--- a/dashboard/app/views/levels/editors/_gamelab_jr.html.haml
+++ b/dashboard/app/views/levels/editors/_gamelab_jr.html.haml
@@ -1,7 +1,11 @@
 %legend.control-legend.levelTypeHeader
   Sprite Lab Options
 
-= render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'spritelab'}
+// Dance lab is a subset of GamelabJr aka Sprite Lab levels
+- if @level.is_a?(Dancelab)
+  = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'dance'}
+- elsif @level.is_a?(GamelabJr)
+  = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'spritelab'}
 
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :include_shared_functions, description: "Make shared functions and behaviors available"}


### PR DESCRIPTION
Following up to adding multiple example solutions to Artist, Playlab and Sprite Lab. This allows levelbuilder to add multiple solutions to Dance Lab levels.

<img width="995" alt="Screen Shot 2019-06-11 at 3 14 32 PM" src="https://user-images.githubusercontent.com/208083/59299983-03ca9a00-8c5c-11e9-9b28-8b4b10b92ff9.png">
<img width="1429" alt="Screen Shot 2019-06-11 at 3 14 49 PM" src="https://user-images.githubusercontent.com/208083/59299984-03ca9a00-8c5c-11e9-965f-12fc9e9504aa.png">
