### PR TITLE
Teacher Panel - Section with No Students

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/ScriptTeacherPanel.jsx
@@ -118,15 +118,17 @@ class ScriptTeacherPanel extends React.Component {
         <h3>{i18n.teacherPanel()}</h3>
         <div style={styles.scrollable}>
           <ViewAsToggle />
-          {viewAs === ViewType.Teacher && currentStudent && (
-            <SelectedStudentInfo
-              students={students}
-              selectedStudent={currentStudent}
-              level={currentStudentScriptLevel}
-              onSelectUser={this.props.onSelectUser}
-              getSelectedUserId={this.props.getSelectedUserId}
-            />
-          )}
+          {viewAs === ViewType.Teacher &&
+            currentStudent &&
+            (students || []).length > 0 && (
+              <SelectedStudentInfo
+                students={students}
+                selectedStudent={currentStudent}
+                level={currentStudentScriptLevel}
+                onSelectUser={this.props.onSelectUser}
+                getSelectedUserId={this.props.getSelectedUserId}
+              />
+            )}
           {viewAs === ViewType.Teacher &&
             sectionData &&
             sectionData.level_examples && (


### PR DESCRIPTION
Don't show the selected student info if there are no students in the section selected.

# Before
<img width="198" alt="Screen Shot 2019-06-11 at 3 43 40 PM" src="https://user-images.githubusercontent.com/208083/59301489-b8b28600-8c5f-11e9-8b91-2e657eb5883f.png">


# After

<img width="200" alt="Screen Shot 2019-06-11 at 3 42 12 PM" src="https://user-images.githubusercontent.com/208083/59301494-bbad7680-8c5f-11e9-96ee-e434d0a60e69.png">
