### PR TITLE
Applab: prevent students from creating element ids with spaces

### DIFF
--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -125,12 +125,11 @@ function apiValidateDomIdExistence(
       outputWarning(invalidIdMessage(funcName, varName, id, message));
     }
 
-    if (-1 !== id.search(/\s/)) {
+    var idContainsWhiteSpace = -1 !== id.search(/\s/);
+    if (idContainsWhiteSpace) {
       valid = false;
-      message = `contains whitespace. Change the id name to ("${id.replace(
-        /\s+/g,
-        ''
-      )}")`;
+      var validId = id.replace(/\s+/g, '');
+      message = `contains whitespace. Change the id name to ("${validId}")`;
       outputWarning(invalidIdMessage(funcName, varName, id, message));
     }
     opts[validatedDomKey] = valid;

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -117,8 +117,8 @@ function apiValidateDomIdExistence(
     }
 
     if (
-      (!callback || !callback(existsInApplab)) &&
-      shouldExist !== existsInApplab
+      shouldExist !== existsInApplab &&
+      (!callback || !callback(existsInApplab))
     ) {
       valid = false;
       message = existsInApplab ? 'already exists.' : 'does not exist.';

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -108,32 +108,30 @@ function apiValidateDomIdExistence(
     };
     var existsOutsideApplab = !elementUtils.isIdAvailable(id, options);
 
-    var valid = !existsOutsideApplab && shouldExist === existsInApplab;
+    var valid = true;
+    var message;
+    if (existsOutsideApplab) {
+      message =
+        'is already being used outside of App Lab. Please use a different id.';
+      throw new Error(invalidIdMessage(funcName, varName, id, message));
+    }
 
-    if (!valid) {
-      var errorString = '';
-      if (existsOutsideApplab) {
-        errorString =
-          funcName +
-          '() ' +
-          varName +
-          ' parameter refers to an id ("' +
-          id +
-          '") which is already being used outside of App Lab. Please use a different id.';
-        throw new Error(errorString);
-      } else {
-        if (!callback || !callback(existsInApplab)) {
-          outputWarning(
-            funcName +
-              '() ' +
-              varName +
-              ' parameter refers to an id ("' +
-              id +
-              '") which ' +
-              (existsInApplab ? 'already exists.' : 'does not exist.')
-          );
-        }
-      }
+    if (
+      (!callback || !callback(existsInApplab)) &&
+      shouldExist !== existsInApplab
+    ) {
+      valid = false;
+      message = existsInApplab ? 'already exists.' : 'does not exist.';
+      outputWarning(invalidIdMessage(funcName, varName, id, message));
+    }
+
+    if (-1 !== id.search(/\s/)) {
+      valid = false;
+      message = `contains whitespace. Change the id name to ("${id.replace(
+        /\s+/g,
+        ''
+      )}")`;
+      outputWarning(invalidIdMessage(funcName, varName, id, message));
     }
     opts[validatedDomKey] = valid;
   }
@@ -1352,6 +1350,10 @@ function setSize_(elementId, width, height) {
   }
 }
 
+function invalidIdMessage(functionName, variableName, id, message) {
+  return `The ${functionName}() ${variableName} parameter refers to an id ("${id}") which ${message}`;
+}
+
 applabCommands.setProperty = function(opts) {
   apiValidateDomIdExistence(
     opts,
@@ -1360,15 +1362,10 @@ applabCommands.setProperty = function(opts) {
     opts.elementId,
     true,
     exists => {
+      var idExistsMessage = exists ? 'already exists.' : 'does not exist.';
+      var warningMessage = `${idExistsMessage} You should be able to find the list of all the possible ids in the dropdown (unless you created the element inside your code).`;
       outputWarning(
-        `The setProperty() id parameter refers to an id (“${
-          opts.elementId
-        }”) ` +
-          `which ${
-            exists ? 'already exists.' : 'does not exist.'
-          } You should be able to ` +
-          'find the list of all the possible ids in the dropdown (unless you created the ' +
-          'element inside your code).'
+        invalidIdMessage('setProperty', 'id', opts.elementId, warningMessage)
       );
       return true;
     }

--- a/apps/src/applab/designElements/PropertyRow.jsx
+++ b/apps/src/applab/designElements/PropertyRow.jsx
@@ -55,8 +55,12 @@ export default class PropertyRow extends React.Component {
   }
 
   handleChangeInternal = event => {
-    const value = event.target.value;
-    const isValidValue = !this.props.isIdRow || this.isIdAvailable(value);
+    var isIdRow = this.props.isIdRow;
+    var value = event.target.value;
+    if (isIdRow) {
+      value = value.replace(/\s+/g, '');
+    }
+    const isValidValue = !isIdRow || this.isIdAvailable(value);
     this.setValue(value, isValidValue);
   };
 

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -228,7 +228,6 @@ designMode.updateProperty = function(
   }
   switch (name) {
     case 'id':
-      value = value.trim();
       elementUtils.setId(element, value);
       if (
         elementLibrary.getElementType(element) ===

--- a/apps/test/integration/levelSolutions/applab/ec_uicontrols.js
+++ b/apps/test/integration/levelSolutions/applab/ec_uicontrols.js
@@ -241,7 +241,7 @@ module.exports = {
           var debugOutput = document.getElementById('debug-output');
           assert.equal(
             debugOutput.textContent,
-            'WARNING: Line: 1: button() id parameter refers to an id ("button1") which already exists.'
+            'WARNING: Line: 1: The button() id parameter refers to an id ("button1") which already exists.'
           );
           Applab.onPuzzleComplete();
         });
@@ -263,7 +263,7 @@ module.exports = {
         var debugOutput = document.getElementById('debug-output');
         assert.equal(
           debugOutput.textContent,
-          'ERROR: Line: 1: Error: button() id parameter refers to an id ' +
+          'ERROR: Line: 1: Error: The button() id parameter refers to an id ' +
             '("runButton") which is already being used outside of App Lab. Please use a different id.'
         );
         assert(
@@ -289,7 +289,7 @@ module.exports = {
         var debugOutput = document.getElementById('debug-output');
         assert.equal(
           debugOutput.textContent,
-          'ERROR: Line: 1: Error: button() id parameter refers to an id ' +
+          'ERROR: Line: 1: Error: The button() id parameter refers to an id ' +
             '("submitButton") which is already being used outside of App Lab. Please use a different id.'
         );
         assert(

--- a/apps/test/unit/applab/commandsTest.js
+++ b/apps/test/unit/applab/commandsTest.js
@@ -83,7 +83,7 @@ describe('setSelectionRange', () => {
       selectionEnd: 0
     });
     expect(errorHandler.outputWarning).to.have.been.calledOnce.and.calledWith(
-      'setSelectionRange() elementId parameter refers to ' +
+      'The setSelectionRange() elementId parameter refers to ' +
         'an id ("fakeElementId") which does not exist.'
     );
   });

--- a/apps/test/unit/applab/designElements/propertyRowTest.js
+++ b/apps/test/unit/applab/designElements/propertyRowTest.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import {expect} from '../../../util/reconfiguredChai';
+import PropertyRow from '@cdo/apps/applab/designElements/PropertyRow';
+import {shallow} from 'enzyme';
+
+describe('applab property row', function() {
+  it('does not change an id row when a space is added', () => {
+    var initialValue = 'HelloWorld';
+    const wrapper = shallow(
+      <PropertyRow
+        desc={'id'}
+        isIdRow={true}
+        initialValue={initialValue}
+        handleChange={() => {}}
+      />
+    );
+    expect(wrapper.state().value).to.equal(initialValue);
+    wrapper.instance().handleChangeInternal({target: {value: 'Hello World'}});
+    wrapper.update();
+    expect(wrapper.state().value).to.equal(initialValue);
+  });
+
+  it('changes an id row when edited', () => {
+    var initialValue = 'HelloWorld';
+    const wrapper = shallow(
+      <PropertyRow
+        desc={'id'}
+        isIdRow={true}
+        initialValue={initialValue}
+        handleChange={() => {}}
+      />
+    );
+    expect(wrapper.state().value).to.equal(initialValue);
+    wrapper
+      .instance()
+      .handleChangeInternal({target: {value: initialValue + 's'}});
+    wrapper.update();
+    expect(wrapper.state().value).to.equal(initialValue + 's');
+  });
+
+  it('changes a row when edited', () => {
+    var initialValue = 'text';
+    var targetValue = 'Hello World';
+    const wrapper = shallow(
+      <PropertyRow
+        desc={'text'}
+        initialValue={initialValue}
+        handleChange={() => {}}
+      />
+    );
+    expect(wrapper.state().value).to.equal(initialValue);
+    wrapper.instance().handleChangeInternal({target: {value: targetValue}});
+    wrapper.update();
+    expect(wrapper.state().value).to.equal(targetValue);
+  });
+});


### PR DESCRIPTION
ids on HTML elements should not have spaces ([Living HTML spec](https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute)). This prevents students from adding spaces to their elements while in design mode. Additionally, if they create an element in code mode with a space, it will warn them. Also fixes this bug: https://codedotorg.atlassian.net/browse/STAR-412
![image](https://user-images.githubusercontent.com/8324574/59314927-4d22e580-8c6c-11e9-9ce2-55c1a516e4d9.png)
