### PR TITLE
Reduce Aurora durability for better write performance

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -165,6 +165,11 @@ AuroraCluster:
 
   # Improve insert/update concurrency for autoincrement tables.
   innodb_autoinc_lock_mode: 2 # not dynamic
+  
+  # With a setting of 0, logs are written and flushed to disk once per second.
+  # Transactions for which logs have not been flushed can be lost in a crash.
+  # Reduces durability for better performance.
+  innodb_flush_log_at_trx_commit: 0
 
 # System variables for the Aurora DB writer.
 AuroraWriter:


### PR DESCRIPTION
```
MacBook:code-dot-org suresh$ bundle exec rake stack:data:validate RAILS_ENV=production
Data layer including RedShift cluster configuration and synchronization with RDS instance.
Listing changes to existing stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
```