### PR TITLE
Remove restriction on directories for staging commits [ci skip]

### DIFF
--- a/tools/hooks/restrict_staging_changes.rb
+++ b/tools/hooks/restrict_staging_changes.rb
@@ -3,15 +3,12 @@ require_relative 'hooks_utils.rb'
 REPO_DIR = File.expand_path('../../../', __FILE__).freeze
 
 # Returns whether a filename should be prohibited from a staging commit. Reasons for this:
-#   * any file not in pegasus or cookbooks. Content scoop changes should all be in pegasus, and the
-#     update_cookbook_versions script commits changes in the cookbooks directory.
 #   * any file with an extension in {.mp4, .mov} (e.g., 'dashboard/dir/my_bad_file.mov')
 #   * any file with non-lowercase letters in the extension (e.g., 'dashboard/dir/my_bad_file.PnG')
 #   * any file with spaces in the name
 # @param filename [String] A filename.
 # @return [Boolean] Whether the filename should be prohibited in a commit.
 def prohibited?(filename)
-  return true unless filename.delete_prefix(REPO_DIR).start_with?('/pegasus', '/cookbooks')
   return true if ['.mp4', '.mov'].include? File.extname(filename)
   return true if File.extname(filename) != File.extname(filename).downcase
   return true if filename.include?(' ')


### PR DESCRIPTION
Removing this check (which I just added on monday in https://github.com/code-dot-org/code-dot-org/commit/1131cbae2beb62d0b7e815eb86c736b4f20be24c#diff-7b1b6c6776f15b4de6ae1de2692332e4 ) instead of trying to track down all the places that commit changes on staging.