### PR TITLE
Measure contact rollups job

### DIFF
--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -16,8 +16,8 @@ def main
   log_object = LogObject.new
 
   # Delete clone database cluster if it was left behind by the last execution of Contact Rollups.
-  log_object.time!('Delete db clone') {ContactRollups.delete_database_clone}
-  log_object.time!('Create db clone') {ContactRollups.create_database_clone}
+  # log_object.time!('Delete db clone') {ContactRollups.delete_database_clone}
+  # log_object.time!('Create db clone') {ContactRollups.create_database_clone}
 
   # Build new daily table of contact rollups
   log_object.time!('Build contact rollups') {ContactRollups.build_contact_rollups(log_object)}
@@ -45,7 +45,7 @@ def main
 rescue => e
   log_object.record_exception(e)
 ensure
-  log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
+  # log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
 
   log_object.info("Script finished with #{log_object.error_count} error(s) in #{Time.now - time_start} seconds.")
 

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -43,19 +43,23 @@ def main
 rescue => e
   log_collector.record_exception(e)
 ensure
+  # Use time instead of time! so failure in cleaning up clone db
+  # will not stop reporting tasks following it.
   log_collector.time('Clean up db clone') {ContactRollups.delete_database_clone}
+
   log_collector.info("Script finished with #{log_collector.errors.size} caught exception(s) in"\
     " #{LogCollector.get_friendly_time(Time.now - start_time)}."
   )
 
   ChatClient.message(CHAT_CHANNEL, log_collector.to_s)
 
-  # Notify HoneyBadger about the last caught exception.
-  Honeybadger.notify(log_collector.errors.last) unless log_collector.ok?
+  # Notify HoneyBadger about all caught exceptions.
+  log_collector.errors.each do |error|
+    Honeybadger.notify(error)
+  end
 
   # TODO: remove before merge
-  puts log_collector.to_s unless log_collector.ok?
-  puts log_collector.errors.inspect unless log_collector.ok?
+  puts log_collector.to_s
 end
 
 main if only_one_running?(__FILE__)

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -16,8 +16,8 @@ def main
   log_object = LogObject.new
 
   # Delete clone database cluster if it was left behind by the last execution of Contact Rollups.
-  # log_object.time!('Delete db clone') {ContactRollups.delete_database_clone}
-  # log_object.time!('Create db clone') {ContactRollups.create_database_clone}
+  log_object.time!('Delete db clone') {ContactRollups.delete_database_clone}
+  log_object.time!('Create db clone') {ContactRollups.create_database_clone}
 
   # Build new daily table of contact rollups
   log_object.time!('Build contact rollups') {ContactRollups.build_contact_rollups(log_object)}
@@ -32,7 +32,6 @@ def main
   # Sync daily rollup to master rollup and compute deltas
   log_object.time!('Sync to main db') {ContactRollups.sync_contact_rollups_to_main}
 
-  # TODO: uncomment before running in production
   # Sync deltas into Pardot
   # log_object.time!('Sync to Pardot') do
   #   sync_results = Pardot.sync_contact_rollups_to_pardot
@@ -40,22 +39,21 @@ def main
   #     "Syncing completed: #{sync_results[:num_inserts]} inserts, #{sync_results[:num_updates]} updates."
   #   )
   # end if log_object.ok?
-
-  raise 'test'
 rescue => e
   log_object.record_exception(e)
 ensure
   # log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
 
-  log_object.info("Script finished with #{log_object.error_count} caught exception(s) in #{Time.now - time_start} seconds.")
+  log_object.info("Script finished with #{log_object.errors.size} caught exception(s) in #{Time.now - time_start} seconds.")
 
   ChatClient.message(CHAT_CHANNEL, log_object.to_s)
-  puts log_object.to_s  # TODO: remove
+  # TODO: remove
+  puts log_object.to_s
 
   # TODO: uncomment before running in production
-  # Notify HoneyBadger if there is caught error/exception.
-  # raise log_object.error_str unless log_object.ok?
-  puts "To be raised to HB: #{log_object.error_str}"
+  # Notify HoneyBadger about the last caught error/exception.
+  # raise log_object.errors.last unless log_object.ok?
+  puts "To be raised to HB: #{log_object.errors.last}"
 end
 
 main if only_one_running?(__FILE__)

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -12,52 +12,49 @@ require 'cdo/log_object'
 CHAT_CHANNEL = "cron-daily".freeze
 
 def main
-  # time_start = Time.now
-
-  # Delete clone database cluster if it was left behind by the last execution of Contact Rollups.
-  # TODO: log timing after each main task. Always write to Slack. do not bail out.
-  # Result/Log object: log level
-
+  time_start = Time.now
   log_object = LogObject.new
 
-  # log_object.time('Delete db clone') {ContactRollups.delete_database_clone}
-  # log_object.time('Create db clone') {ContactRollups.create_database_clone}
+  # Delete clone database cluster if it was left behind by the last execution of Contact Rollups.
+  log_object.time!('Delete db clone') {ContactRollups.delete_database_clone}
+  log_object.time!('Create db clone') {ContactRollups.create_database_clone}
 
   # Build new daily table of contact rollups
-  log_object.time('Build contact rollups') {ContactRollups.build_contact_rollups(log_object)}
+  log_object.time!('Build contact rollups') {ContactRollups.build_contact_rollups(log_object)}
 
   # Validate that daily contact rollups meets sanity expectations
-  # TODO: how to propagate result up
-  # results = ContactRollupsValidation.validate_contact_rollups
-  # unless results[:pass]
-  #   message = "Contact rollups process failed. "\
-  #             "Validation of daily rollup failed:\n#{results[:output]}"
-  #   ChatClient.message(CHAT_CHANNEL, message)
-  #   # Raise exception so this goes to HoneyBadger
-  #   raise message
-  # end
+  log_object.time!('Validate contact rollups') do
+    validation_results = ContactRollupsValidation.validate_contact_rollups
 
-  # # Sync daily rollup to master rollup and compute deltas
-  # ContactRollups.sync_contact_rollups_to_main
+    raise "Validation of daily rollup failed:\n#{validation_results[:output]}" unless validation_results[:pass]
+  end
 
-  # # Sync deltas into Pardot
-  # results = Pardot.sync_contact_rollups_to_pardot
+  # Sync daily rollup to master rollup and compute deltas
+  log_object.time!('Sync to main db') {ContactRollups.sync_contact_rollups_to_main}
 
-  # time_elapsed = (Time.now - time_start).to_i
-  # message = "Contact rollups process complete. #{results[:num_inserts]} "\
-  #   "inserts and #{results[:num_updates]} updates to Pardot. "\
-  #   "Total time: #{time_elapsed} sec"
+  # TODO: uncomment before running in production
+  # Sync deltas into Pardot
+  # log_object.time!('Sync to Pardot') do
+  #   sync_results = Pardot.sync_contact_rollups_to_pardot
+  #   log_object.info(
+  #     "Syncing completed: #{sync_results[:num_inserts]} inserts, #{sync_results[:num_updates]} updates."
+  #   )
+  # end if log_object.ok?
 
-  # ChatClient.message(CHAT_CHANNEL, message)
-
-  # Any other failures along the way will be unrescued exceptions that
-  # go to HoneyBadger
-
-  # TODO: notify honeybadger if there are errors
+  raise 'test'
+rescue => e
+  log_object.record_exception(e)
 ensure
-  # log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
-  puts log_object.to_s
+  log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
+
+  log_object.info("Script finished with #{log_object.error_count} error(s) in #{Time.now - time_start} seconds.")
+
+  ChatClient.message(CHAT_CHANNEL, log_object.to_s)
+  puts log_object.to_s  # TODO: remove
+
+  # TODO: uncomment before running in production
+  # Notify HoneyBadger if there is caught error/exception.
+  # raise log_object.error_str unless log_object.ok?
 end
 
-# main if only_one_running?(__FILE__)
-main
+main if only_one_running?(__FILE__)

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -6,47 +6,56 @@ require 'cdo/contact_rollups_validation'
 require 'cdo/pardot'
 require 'cdo/chat_client'
 require 'cdo/only_one'
-require 'aws-sdk-rds'
+# require 'aws-sdk-rds'
+require 'cdo/log_object'
 
 CHAT_CHANNEL = "cron-daily".freeze
 
 def main
-  time_start = Time.now
+  # time_start = Time.now
 
   # Delete clone database cluster if it was left behind by the last execution of Contact Rollups.
-  ContactRollups.delete_database_clone
-  ContactRollups.create_database_clone
+  # TODO: log timing after each main task. Always write to Slack. do not bail out.
+  # Result/Log object: log level
+
+  log_object = LogObject.new
+
+  # log_object.time('Delete db clone') {ContactRollups.delete_database_clone}
+  # log_object.time('Create db clone') {ContactRollups.create_database_clone}
 
   # Build new daily table of contact rollups
-  ContactRollups.build_contact_rollups
+  log_object.time('Build contact rollups') {ContactRollups.build_contact_rollups(log_object)}
 
   # Validate that daily contact rollups meets sanity expectations
-  results = ContactRollupsValidation.validate_contact_rollups
-  unless results[:pass]
-    message = "Contact rollups process failed. "\
-              "Validation of daily rollup failed:\n#{results[:output]}"
-    ChatClient.message(CHAT_CHANNEL, message)
-    # Raise exception so this goes to HoneyBadger
-    raise message
-  end
+  # TODO: how to propagate result up
+  # results = ContactRollupsValidation.validate_contact_rollups
+  # unless results[:pass]
+  #   message = "Contact rollups process failed. "\
+  #             "Validation of daily rollup failed:\n#{results[:output]}"
+  #   ChatClient.message(CHAT_CHANNEL, message)
+  #   # Raise exception so this goes to HoneyBadger
+  #   raise message
+  # end
 
-  # Sync daily rollup to master rollup and compute deltas
-  ContactRollups.sync_contact_rollups_to_main
+  # # Sync daily rollup to master rollup and compute deltas
+  # ContactRollups.sync_contact_rollups_to_main
 
-  # Sync deltas into Pardot
-  results = Pardot.sync_contact_rollups_to_pardot
+  # # Sync deltas into Pardot
+  # results = Pardot.sync_contact_rollups_to_pardot
 
-  time_elapsed = (Time.now - time_start).to_i
-  message = "Contact rollups process complete. #{results[:num_inserts]} "\
-    "inserts and #{results[:num_updates]} updates to Pardot. "\
-    "Total time: #{time_elapsed} sec"
+  # time_elapsed = (Time.now - time_start).to_i
+  # message = "Contact rollups process complete. #{results[:num_inserts]} "\
+  #   "inserts and #{results[:num_updates]} updates to Pardot. "\
+  #   "Total time: #{time_elapsed} sec"
 
-  ChatClient.message(CHAT_CHANNEL, message)
+  # ChatClient.message(CHAT_CHANNEL, message)
 
   # Any other failures along the way will be unrescued exceptions that
   # go to HoneyBadger
 ensure
-  ContactRollups.delete_database_clone
+  # log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
+  puts log_object.to_s
 end
 
-main if only_one_running?(__FILE__)
+# main if only_one_running?(__FILE__)
+main

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -6,7 +6,7 @@ require 'cdo/contact_rollups_validation'
 require 'cdo/pardot'
 require 'cdo/chat_client'
 require 'cdo/only_one'
-# require 'aws-sdk-rds'
+require 'aws-sdk-rds'
 require 'cdo/log_object'
 
 CHAT_CHANNEL = "cron-daily".freeze
@@ -52,6 +52,8 @@ def main
 
   # Any other failures along the way will be unrescued exceptions that
   # go to HoneyBadger
+
+  # TODO: notify honeybadger if there are errors
 ensure
   # log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
   puts log_object.to_s

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -14,7 +14,7 @@ CHAT_CHANNEL = "cron-daily".freeze
 
 def main
   start_time = Time.now
-  log_collector = LogCollector.new
+  log_collector = LogCollector.new "Build contact rollups"
 
   # Delete clone database cluster if it was left behind by the last execution of Contact Rollups.
   log_collector.time!('Delete db clone') {ContactRollups.delete_database_clone}

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -6,51 +6,56 @@ require 'cdo/contact_rollups_validation'
 require 'cdo/pardot'
 require 'cdo/chat_client'
 require 'cdo/only_one'
+require 'cdo/log_collector'
 require 'aws-sdk-rds'
-require 'cdo/log_object'
+require 'honeybadger/ruby'
 
 CHAT_CHANNEL = "cron-daily".freeze
 
 def main
-  time_start = Time.now
-  log_object = LogObject.new
+  start_time = Time.now
+  log_collector = LogCollector.new
 
   # Delete clone database cluster if it was left behind by the last execution of Contact Rollups.
-  log_object.time!('Delete db clone') {ContactRollups.delete_database_clone}
-  log_object.time!('Create db clone') {ContactRollups.create_database_clone}
+  log_collector.time!('Delete db clone') {ContactRollups.delete_database_clone}
+  log_collector.time!('Create db clone') {ContactRollups.create_database_clone}
 
   # Build new daily table of contact rollups
-  log_object.time!('Build contact rollups') {ContactRollups.build_contact_rollups(log_object)}
+  log_collector.time!('Build contact rollups') {ContactRollups.build_contact_rollups(log_collector)}
 
   # Validate that daily contact rollups meets sanity expectations
-  log_object.time!('Validate contact rollups') do
+  log_collector.time!('Validate contact rollups') do
     validation_results = ContactRollupsValidation.validate_contact_rollups
 
     raise "Validation of daily rollup failed:\n#{validation_results[:output]}" unless validation_results[:pass]
   end
 
   # Sync daily rollup to master rollup and compute deltas
-  log_object.time!('Sync to main db') {ContactRollups.sync_contact_rollups_to_main}
+  log_collector.time!('Sync to main db') {ContactRollups.sync_contact_rollups_to_main(log_collector)}
 
   # Sync deltas into Pardot
-  log_object.time!('Sync to Pardot') do
+  log_collector.time!('Sync to Pardot') do
     sync_results = Pardot.sync_contact_rollups_to_pardot
-    log_object.info(
+    log_collector.info(
       "Syncing completed: #{sync_results[:num_inserts]} inserts, #{sync_results[:num_updates]} updates."
     )
   end
 rescue => e
-  log_object.record_exception(e)
+  log_collector.record_exception(e)
 ensure
-  log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
-  log_object.info("Script finished with #{log_object.errors.size} caught exception(s) in"\
-    " #{Time.now - time_start} seconds."
+  log_collector.time('Clean up db clone') {ContactRollups.delete_database_clone}
+  log_collector.info("Script finished with #{log_collector.errors.size} caught exception(s) in"\
+    " #{LogCollector.get_friendly_time(Time.now - start_time)}."
   )
 
-  ChatClient.message(CHAT_CHANNEL, log_object.to_s)
+  ChatClient.message(CHAT_CHANNEL, log_collector.to_s)
 
-  # Notify HoneyBadger about the last caught error/exception.
-  raise log_object.errors.last unless log_object.ok?
+  # Notify HoneyBadger about the last caught exception.
+  Honeybadger.notify(log_collector.errors.last) unless log_collector.ok?
+
+  # TODO: remove before merge
+  puts log_collector.to_s unless log_collector.ok?
+  puts log_collector.errors.inspect unless log_collector.ok?
 end
 
 main if only_one_running?(__FILE__)

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -33,27 +33,24 @@ def main
   log_object.time!('Sync to main db') {ContactRollups.sync_contact_rollups_to_main}
 
   # Sync deltas into Pardot
-  # log_object.time!('Sync to Pardot') do
-  #   sync_results = Pardot.sync_contact_rollups_to_pardot
-  #   log_object.info(
-  #     "Syncing completed: #{sync_results[:num_inserts]} inserts, #{sync_results[:num_updates]} updates."
-  #   )
-  # end if log_object.ok?
+  log_object.time!('Sync to Pardot') do
+    sync_results = Pardot.sync_contact_rollups_to_pardot
+    log_object.info(
+      "Syncing completed: #{sync_results[:num_inserts]} inserts, #{sync_results[:num_updates]} updates."
+    )
+  end
 rescue => e
   log_object.record_exception(e)
 ensure
-  # log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
-
-  log_object.info("Script finished with #{log_object.errors.size} caught exception(s) in #{Time.now - time_start} seconds.")
+  log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
+  log_object.info("Script finished with #{log_object.errors.size} caught exception(s) in"\
+    " #{Time.now - time_start} seconds."
+  )
 
   ChatClient.message(CHAT_CHANNEL, log_object.to_s)
-  # TODO: remove
-  puts log_object.to_s
 
-  # TODO: uncomment before running in production
   # Notify HoneyBadger about the last caught error/exception.
-  # raise log_object.errors.last unless log_object.ok?
-  puts "To be raised to HB: #{log_object.errors.last}"
+  raise log_object.errors.last unless log_object.ok?
 end
 
 main if only_one_running?(__FILE__)

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -47,7 +47,7 @@ rescue => e
 ensure
   # log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
 
-  log_object.info("Script finished with #{log_object.error_count} caught error(s) in #{Time.now - time_start} seconds.")
+  log_object.info("Script finished with #{log_object.error_count} caught exception(s) in #{Time.now - time_start} seconds.")
 
   ChatClient.message(CHAT_CHANNEL, log_object.to_s)
   puts log_object.to_s  # TODO: remove

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -47,7 +47,7 @@ rescue => e
 ensure
   # log_object.time('Clean up db clone') {ContactRollups.delete_database_clone}
 
-  log_object.info("Script finished with #{log_object.error_count} error(s) in #{Time.now - time_start} seconds.")
+  log_object.info("Script finished with #{log_object.error_count} caught error(s) in #{Time.now - time_start} seconds.")
 
   ChatClient.message(CHAT_CHANNEL, log_object.to_s)
   puts log_object.to_s  # TODO: remove
@@ -55,6 +55,7 @@ ensure
   # TODO: uncomment before running in production
   # Notify HoneyBadger if there is caught error/exception.
   # raise log_object.error_str unless log_object.ok?
+  puts "To be raised to HB: #{log_object.error_str}"
 end
 
 main if only_one_running?(__FILE__)

--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -138,10 +138,10 @@ class ContactRollups
   ROLE_FORM_SUBMITTER = "Form Submitter".freeze
   CENSUS_FORM_NAME = "Census".freeze
 
-  def self.build_contact_rollups(log_object)
+  def self.build_contact_rollups(log_collector)
     start = Time.now
 
-    log_object.time!('initialize_connections_to_database_clone') {initialize_connections_to_database_clone}
+    log_collector.time!('initialize_connections_to_database_clone') {initialize_connections_to_database_clone}
 
     @@pegasus_clone_db_writer.run "SET SQL_SAFE_UPDATES = 0"
     # set READ UNCOMMITTED transaction isolation level on both read connections to avoid taking locks
@@ -149,21 +149,21 @@ class ContactRollups
     @@dashboard_clone_db_reader.run "SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"
     ActiveRecord::Base.connection.execute "SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"
 
-    log_object.time!('create_destination_table') {create_destination_table}
-    log_object.time!('insert_from_pegasus_forms') {insert_from_pegasus_forms}
-    log_object.time!('insert_from_dashboard_contacts') {insert_from_dashboard_contacts}
-    log_object.time!('insert_from_dashboard_pd_enrollments') {insert_from_dashboard_pd_enrollments}
-    log_object.time!('insert_from_dashboard_census_submissions') {insert_from_dashboard_census_submissions}
-    log_object.time!('update_geo_from_school_data') {update_geo_from_school_data}
-    log_object.time!('update_unsubscribe_info') {update_unsubscribe_info}
-    log_object.time!('update_roles') {update_roles}
-    log_object.time!('update_grades_taught') {update_grades_taught}
-    log_object.time!('update_ages_taught') {update_ages_taught}
-    log_object.time!('update_district') {update_district}
-    log_object.time!('update_school') {update_school}
-    log_object.time!('update_courses_facilitated') {update_courses_facilitated}
-    log_object.time!('update_professional_learning_enrollment') {update_professional_learning_enrollment}
-    log_object.time!('update_professional_learning_attendance') {update_professional_learning_attendance}
+    log_collector.time!('create_destination_table') {create_destination_table}
+    log_collector.time!('insert_from_pegasus_forms') {insert_from_pegasus_forms}
+    log_collector.time!('insert_from_dashboard_contacts') {insert_from_dashboard_contacts}
+    log_collector.time!('insert_from_dashboard_pd_enrollments') {insert_from_dashboard_pd_enrollments}
+    log_collector.time!('insert_from_dashboard_census_submissions') {insert_from_dashboard_census_submissions}
+    log_collector.time!('update_geo_from_school_data') {update_geo_from_school_data}
+    log_collector.time!('update_unsubscribe_info') {update_unsubscribe_info}
+    log_collector.time!('update_roles') {update_roles}
+    log_collector.time!('update_grades_taught') {update_grades_taught}
+    log_collector.time!('update_ages_taught') {update_ages_taught}
+    log_collector.time!('update_district') {update_district}
+    log_collector.time!('update_school') {update_school}
+    log_collector.time!('update_courses_facilitated') {update_courses_facilitated}
+    log_collector.time!('update_professional_learning_enrollment') {update_professional_learning_enrollment}
+    log_collector.time!('update_professional_learning_attendance') {update_professional_learning_attendance}
 
     # record contacts' interactions with us based on forms
     FORM_INFOS.each do |form_info|
@@ -172,23 +172,23 @@ class ContactRollups
 
     # parse all forms that collect user-reported address/location or other data of interest
     FORM_KINDS_WITH_DATA.each do |kind|
-      log_object.time!("update_data_from_forms kind=#{kind}") {update_data_from_forms(kind)}
+      log_collector.time!("update_data_from_forms kind=#{kind}") {update_data_from_forms(kind)}
     end
 
     # Add contacts to the Teacher role based on form responses
-    log_object.time!('update_teachers_from_forms') {update_teachers_from_forms}
-    log_object.time!('update_teachers_from_census_submissions') {update_teachers_from_census_submissions}
+    log_collector.time!('update_teachers_from_forms') {update_teachers_from_forms}
+    log_collector.time!('update_teachers_from_census_submissions') {update_teachers_from_census_submissions}
 
     # Set opt_in based on information collected in Dashboard Email Preference.
-    log_object.time!('update_email_preferences') {update_email_preferences}
+    log_collector.time!('update_email_preferences') {update_email_preferences}
 
     count = @@pegasus_clone_db_reader["select count(*) as cnt from #{PEGASUS_DB_NAME}.#{DEST_TABLE_NAME}"].first[:cnt]
     log "Done. Total overall time: #{Time.now - start} seconds. #{count} records created in contact_rollups_daily table."
 
-    log_object.info("#{count} records created in contact_rollups_daily table")
+    log_collector.info("#{count} records created in contact_rollups_daily table")
   end
 
-  def self.sync_contact_rollups_to_main
+  def self.sync_contact_rollups_to_main(log_collector)
     log("#{Time.now} Starting")
 
     num_inserts = 0
@@ -280,6 +280,7 @@ class ContactRollups
     end
 
     log("#{Time.now} Completed. #{num_total} source rows processed. #{num_inserts} insert(s), #{num_updates} update(s), #{num_unchanged} unchanged.")
+    log_collector.info("#{num_total} source rows processed. #{num_inserts} insert(s), #{num_updates} update(s), #{num_unchanged} unchanged.")
   end
 
   def self.create_destination_table

--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -141,28 +141,29 @@ class ContactRollups
   def self.build_contact_rollups(log_object = nil)
     start = Time.now
 
-    log_object.time('initialize_connections_to_database_clone') {initialize_connections_to_database_clone}
+    log_object.time!('initialize_connections_to_database_clone') {initialize_connections_to_database_clone}
 
     @@pegasus_clone_db_writer.run "SET SQL_SAFE_UPDATES = 0"
     # set READ UNCOMMITTED transaction isolation level on both read connections to avoid taking locks
     # on tables we are reading from during what can be multi-minute operations
     @@dashboard_clone_db_reader.run "SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"
     ActiveRecord::Base.connection.execute "SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"
-    log_object.time('create_destination_table') {create_destination_table}
-    log_object.time('insert_from_pegasus_forms') {insert_from_pegasus_forms}
-    log_object.time('insert_from_dashboard_contacts') {insert_from_dashboard_contacts}
-    log_object.time('insert_from_dashboard_pd_enrollments') {insert_from_dashboard_pd_enrollments}
-    log_object.time('insert_from_dashboard_census_submissions') {insert_from_dashboard_census_submissions}
-    log_object.time('update_geo_from_school_data') {update_geo_from_school_data}
-    log_object.time('update_unsubscribe_info') {update_unsubscribe_info}
-    log_object.time('update_roles') {update_roles}
-    log_object.time('update_grades_taught') {update_grades_taught}
-    log_object.time('update_ages_taught') {update_ages_taught}
-    log_object.time('update_district') {update_district}
-    log_object.time('update_school') {update_school}
-    log_object.time('update_courses_facilitated') {update_courses_facilitated}
-    log_object.time('update_professional_learning_enrollment') {update_professional_learning_enrollment}
-    log_object.time('update_professional_learning_attendance') {update_professional_learning_attendance}
+
+    log_object.time!('create_destination_table') {create_destination_table}
+    log_object.time!('insert_from_pegasus_forms') {insert_from_pegasus_forms}
+    log_object.time!('insert_from_dashboard_contacts') {insert_from_dashboard_contacts}
+    log_object.time!('insert_from_dashboard_pd_enrollments') {insert_from_dashboard_pd_enrollments}
+    log_object.time!('insert_from_dashboard_census_submissions') {insert_from_dashboard_census_submissions}
+    log_object.time!('update_geo_from_school_data') {update_geo_from_school_data}
+    log_object.time!('update_unsubscribe_info') {update_unsubscribe_info}
+    log_object.time!('update_roles') {update_roles}
+    log_object.time!('update_grades_taught') {update_grades_taught}
+    log_object.time!('update_ages_taught') {update_ages_taught}
+    log_object.time!('update_district') {update_district}
+    log_object.time!('update_school') {update_school}
+    log_object.time!('update_courses_facilitated') {update_courses_facilitated}
+    log_object.time!('update_professional_learning_enrollment') {update_professional_learning_enrollment}
+    log_object.time!('update_professional_learning_attendance') {update_professional_learning_attendance}
 
     # record contacts' interactions with us based on forms
     FORM_INFOS.each do |form_info|
@@ -171,15 +172,15 @@ class ContactRollups
 
     # parse all forms that collect user-reported address/location or other data of interest
     FORM_KINDS_WITH_DATA.each do |kind|
-      log_object.time("update_data_from_forms #{kind}") {update_data_from_forms(kind)}
+      log_object.time!("update_data_from_forms #{kind}") {update_data_from_forms(kind)}
     end
 
     # Add contacts to the Teacher role based on form responses
-    log_object.time('update_teachers_from_forms') {update_teachers_from_forms}
-    log_object.time('update_teachers_from_census_submissions') {update_teachers_from_census_submissions}
+    log_object.time!('update_teachers_from_forms') {update_teachers_from_forms}
+    log_object.time!('update_teachers_from_census_submissions') {update_teachers_from_census_submissions}
 
     # Set opt_in based on information collected in Dashboard Email Preference.
-    log_object.time('update_email_preferences') {update_email_preferences}
+    log_object.time!('update_email_preferences') {update_email_preferences}
 
     count = @@pegasus_clone_db_reader["select count(*) as cnt from #{PEGASUS_DB_NAME}.#{DEST_TABLE_NAME}"].first[:cnt]
     log "Done. Total overall time: #{Time.now - start} seconds. #{count} records created in contact_rollups_daily table."

--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -7,9 +7,9 @@ require 'json'
 require 'aws-sdk-rds'
 
 class ContactRollups
-  # Production database has a global max query execution timeout setting.  This 20 minute setting can be used
+  # Production database has a global max query execution timeout setting. This 30 minute setting can be used
   # to override the timeout for a specific session or query.
-  MAX_EXECUTION_TIME = 1_200_000
+  MAX_EXECUTION_TIME = 1_800_000
   MAX_EXECUTION_TIME_SEC = MAX_EXECUTION_TIME / 1000
 
   DATABASE_CLUSTER_CLONE_ID = "#{CDO.db_cluster_id}-temporary-clone"

--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -138,31 +138,31 @@ class ContactRollups
   ROLE_FORM_SUBMITTER = "Form Submitter".freeze
   CENSUS_FORM_NAME = "Census".freeze
 
-  def self.build_contact_rollups
+  def self.build_contact_rollups(log_object = nil)
     start = Time.now
 
-    initialize_connections_to_database_clone
+    log_object.time('initialize_connections_to_database_clone') {initialize_connections_to_database_clone}
 
     @@pegasus_clone_db_writer.run "SET SQL_SAFE_UPDATES = 0"
     # set READ UNCOMMITTED transaction isolation level on both read connections to avoid taking locks
     # on tables we are reading from during what can be multi-minute operations
     @@dashboard_clone_db_reader.run "SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"
     ActiveRecord::Base.connection.execute "SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"
-    create_destination_table
-    insert_from_pegasus_forms
-    insert_from_dashboard_contacts
-    insert_from_dashboard_pd_enrollments
-    insert_from_dashboard_census_submissions
-    update_geo_from_school_data
-    update_unsubscribe_info
-    update_roles
-    update_grades_taught
-    update_ages_taught
-    update_district
-    update_school
-    update_courses_facilitated
-    update_professional_learning_enrollment
-    update_professional_learning_attendance
+    log_object.time('create_destination_table') {create_destination_table}
+    log_object.time('insert_from_pegasus_forms') {insert_from_pegasus_forms}
+    log_object.time('insert_from_dashboard_contacts') {insert_from_dashboard_contacts}
+    log_object.time('insert_from_dashboard_pd_enrollments') {insert_from_dashboard_pd_enrollments}
+    log_object.time('insert_from_dashboard_census_submissions') {insert_from_dashboard_census_submissions}
+    log_object.time('update_geo_from_school_data') {update_geo_from_school_data}
+    log_object.time('update_unsubscribe_info') {update_unsubscribe_info}
+    log_object.time('update_roles') {update_roles}
+    log_object.time('update_grades_taught') {update_grades_taught}
+    log_object.time('update_ages_taught') {update_ages_taught}
+    log_object.time('update_district') {update_district}
+    log_object.time('update_school') {update_school}
+    log_object.time('update_courses_facilitated') {update_courses_facilitated}
+    log_object.time('update_professional_learning_enrollment') {update_professional_learning_enrollment}
+    log_object.time('update_professional_learning_attendance') {update_professional_learning_attendance}
 
     # record contacts' interactions with us based on forms
     FORM_INFOS.each do |form_info|
@@ -171,18 +171,20 @@ class ContactRollups
 
     # parse all forms that collect user-reported address/location or other data of interest
     FORM_KINDS_WITH_DATA.each do |kind|
-      update_data_from_forms(kind)
+      log_object.time("update_data_from_forms #{kind}") {update_data_from_forms(kind)}
     end
 
     # Add contacts to the Teacher role based on form responses
-    update_teachers_from_forms
-    update_teachers_from_census_submissions
+    log_object.time('update_teachers_from_forms') {update_teachers_from_forms}
+    log_object.time('update_teachers_from_census_submissions') {update_teachers_from_census_submissions}
 
     # Set opt_in based on information collected in Dashboard Email Preference.
-    update_email_preferences
+    log_object.time('update_email_preferences') {update_email_preferences}
 
     count = @@pegasus_clone_db_reader["select count(*) as cnt from #{PEGASUS_DB_NAME}.#{DEST_TABLE_NAME}"].first[:cnt]
     log "Done. Total overall time: #{Time.now - start} seconds. #{count} records created in contact_rollups_daily table."
+
+    log_object.info("#{count} records created in contact_rollups_daily table")
   end
 
   def self.sync_contact_rollups_to_main

--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -138,7 +138,7 @@ class ContactRollups
   ROLE_FORM_SUBMITTER = "Form Submitter".freeze
   CENSUS_FORM_NAME = "Census".freeze
 
-  def self.build_contact_rollups(log_object = nil)
+  def self.build_contact_rollups(log_object)
     start = Time.now
 
     log_object.time!('initialize_connections_to_database_clone') {initialize_connections_to_database_clone}
@@ -172,7 +172,7 @@ class ContactRollups
 
     # parse all forms that collect user-reported address/location or other data of interest
     FORM_KINDS_WITH_DATA.each do |kind|
-      log_object.time!("update_data_from_forms #{kind}") {update_data_from_forms(kind)}
+      log_object.time!("update_data_from_forms kind=#{kind}") {update_data_from_forms(kind)}
     end
 
     # Add contacts to the Teacher role based on form responses

--- a/lib/cdo/log_collector.rb
+++ b/lib/cdo/log_collector.rb
@@ -1,17 +1,19 @@
-# LogObject is a simple container to save errors and important info
+# LogCollector is a simple container that collects errors and important info
 # when executing a process. It can also time block execution and log the result.
 #
-# LogObject is helpful when we want to
+# LogCollector is helpful when we want to
 # - Prevent non-fatal errors from stopping process execution but still want to know about them.
-# - Bubble up combined errors and info from lower levels to higher levels.
-#   Even to external components such as HoneyBadger or Slack channel.
+# - Bubble up combined errors and info from lower levels to higher levels, or to external components
+#   such as HoneyBadger and Slack.
 
-class LogObject
+class LogCollector
   attr_reader :errors, :logs
 
   def initialize
-    @errors = []  # List of rescued error objects
-    @logs = []    # List of message logs
+    # List of rescued error objects
+    @errors = []
+    # List of message logs
+    @logs = []
   end
 
   # Execute a block and time it.
@@ -19,17 +21,17 @@ class LogObject
   #
   # @param action_name [string] a friendly name of the block being executed
   def time(action_name = nil)
-    start_time = Time.now
     return unless block_given?
+    start_time = Time.now
 
     yield
 
     info("#{action_name || 'Unnamed'} action completed without error in"\
-      " #{Time.now - start_time} seconds."
+      " #{self.class.get_friendly_time(Time.now - start_time)}."
     )
   rescue StandardError => e
     error("#{action_name || 'Unnamed'} action exited with error in"\
-      " #{Time.now - start_time} seconds."
+      " #{self.class.get_friendly_time(Time.now - start_time)}."
     )
     record_exception(e)
   end
@@ -41,25 +43,25 @@ class LogObject
   #
   # @raise [StandardError] error encoutered when executing the given block
   def time!(action_name = nil)
-    start_time = Time.now
     return unless block_given?
+    start_time = Time.now
 
     yield
 
     info("#{action_name || 'Unnamed'} action completed without error in"\
-      " #{Time.now - start_time} seconds."
+      " #{self.class.get_friendly_time(Time.now - start_time)}."
     )
   rescue StandardError => e
     error("#{action_name || 'Unnamed'} action exited with error in"\
-      " #{Time.now - start_time} seconds. Exception re-raised!"
+      " #{self.class.get_friendly_time(Time.now - start_time)}. Exception re-raised!"
     )
 
-    # To be handle by caller
+    # To be handled by caller
     raise e
   end
 
   def info(message)
-    logs << "[#{Time.now}]  INFO: #{message}"
+    logs << "[#{Time.now}] INFO: #{message}"
   end
 
   def error(message)
@@ -82,4 +84,8 @@ class LogObject
   end
 
   alias_method :inspect, :to_s
+
+  def self.get_friendly_time(value)
+    "#{value.round(2)} seconds" if value.respond_to?(:round)
+  end
 end

--- a/lib/cdo/log_collector.rb
+++ b/lib/cdo/log_collector.rb
@@ -5,7 +5,7 @@
 # - Prevent non-fatal errors from stopping process execution but still want to know about them.
 # - Bubble up combined errors and info from lower levels to higher levels, or to external components
 #   such as HoneyBadger and Slack.
-
+#
 class LogCollector
   attr_reader :errors, :logs
 

--- a/lib/cdo/log_collector.rb
+++ b/lib/cdo/log_collector.rb
@@ -70,7 +70,7 @@ class LogCollector
 
   def record_exception(e)
     errors << e
-    error("Exception caught: #{e.inspect}.")
+    error("Exception caught: #{e.inspect}. Stack trace:\n#{e.backtrace.join("\n")}")
   end
 
   def ok?

--- a/lib/cdo/log_collector.rb
+++ b/lib/cdo/log_collector.rb
@@ -1,5 +1,5 @@
 # LogCollector is a simple container that collects errors and important info
-# when executing a process. It can also time block execution and log the result.
+# when executing a task. It can also time block execution and log the result.
 #
 # LogCollector is helpful when we want to
 # - Prevent non-fatal errors from stopping process execution but still want to know about them.
@@ -7,11 +7,14 @@
 #   such as HoneyBadger and Slack.
 #
 class LogCollector
-  attr_reader :errors, :logs
+  attr_reader :errors, :logs, :task_name
 
-  def initialize
+  def initialize(task_name = nil)
+    @task_name = task_name
+
     # List of rescued error objects
     @errors = []
+
     # List of message logs
     @logs = []
   end
@@ -51,13 +54,13 @@ class LogCollector
     info("#{action_name || 'Unnamed'} action completed without error in"\
       " #{self.class.get_friendly_time(Time.now - start_time)}."
     )
-  rescue StandardError => e
+  rescue StandardError
     error("#{action_name || 'Unnamed'} action exited with error in"\
       " #{self.class.get_friendly_time(Time.now - start_time)}. Exception re-raised!"
     )
 
     # To be handled by caller
-    raise e
+    raise
   end
 
   def info(message)
@@ -78,7 +81,7 @@ class LogCollector
   end
 
   def to_s
-    str = "Recorded #{errors.size} errors and #{logs.size} log messages."
+    str = "#{task_name} task recorded #{errors.size} error(s) and #{logs.size} log message(s)."
     logs.each {|log| str.concat("\n#{log}")}
     str
   end

--- a/lib/cdo/log_object.rb
+++ b/lib/cdo/log_object.rb
@@ -1,35 +1,72 @@
 class LogObject
   def initialize
-    @errors = []
-    @logs = []
+    @errors = []  # List of rescued error objects
+    @logs = []    # List of message logs
   end
 
+  # Save exception if caught, do not re-raise. Continue with the caller flow.
   def time(action_name = nil)
     start_time = Time.now
     yield if block_given?
     info("#{action_name || 'Unnamed'} action completed in #{Time.now - start_time} seconds.")
-  rescue => e
-    # @note this catchs all standard errors and exception
+  rescue StandardError => e
     error("#{action_name || 'Unnamed'} action exited with error "\
       "in #{Time.now - start_time} seconds.\n"\
       "Error = #{e.inspect}."
     )
+
+    @errors << e
+  end
+
+  # Re-raise execption if caught. Disrupt the caller flow.
+  def time!(action_name = nil)
+    start_time = Time.now
+    yield if block_given?
+    info("#{action_name || 'Unnamed'} action completed in #{Time.now - start_time} seconds.")
+  rescue StandardError => e
+    error("#{action_name || 'Unnamed'} action exited with error "\
+      "in #{Time.now - start_time} seconds.\n"\
+      "Error = #{e.inspect}."
+    )
+
+    # To be handle by caller
+    raise e
   end
 
   def to_s
-    str = "Recorded #{@errors.size} error messages and #{@logs.size} log messages."
-    @errors.each {|error| str.concat("\n#{error}")}
+    str = "Recorded #{@errors.size} errors and #{@logs.size} log messages."
     @logs.each {|log| str.concat("\n#{log}")}
+    # @errors.each {|error| str.concat("\n#{error}")}
+    # str.concat(error_str)
     str
   end
+
+  alias_method :inspect, :to_s
 
   def info(message)
     @logs << "[#{Time.now}]  INFO: #{message}"
   end
 
   def error(message)
-    @errors << "[#{Time.now}] ERROR: #{message}"
+    @logs << "[#{Time.now}] ERROR: #{message}"
   end
 
-  alias_method :inspect, :to_s
+  def record_exception(e)
+    @errors << e
+    error("Caught exception #{e.inspect}")
+  end
+
+  def ok?
+    @errors.blank?
+  end
+
+  def error_count
+    @errors.size
+  end
+
+  def error_str
+    return '' if @errors.blank?
+
+    @errors.map(&:inspect).join('\n')
+  end
 end

--- a/lib/cdo/log_object.rb
+++ b/lib/cdo/log_object.rb
@@ -1,0 +1,34 @@
+class LogObject
+  def initialize
+    @errors = []
+    @logs = []
+  end
+
+  def time(message = nil)
+    start_time = Time.now
+    yield if block_given?
+    info("#{message || 'Unnamed'} action completed in #{Time.now - start_time} seconds")
+  rescue => e
+    # TODO: this catchs all standard errors and exception
+    @errors << e
+    error("#{message || 'Unnamed'} action exited with error(s) in #{Time.now - start_time} seconds")
+  end
+
+  def to_s
+    str = "#{@errors.size} error massages and #{@logs.size} log messages."
+    # TODO: print error messages (not stack traces)
+    @errors.each {|error| str.concat("\n#{error.message}")}
+    @logs.each {|log| str.concat("\n#{log}")}
+    str
+  end
+
+  def info(message)
+    @logs << "[#{Time.now}]  INFO: #{message}"
+  end
+
+  def error(message)
+    @logs << "[#{Time.now}] ERROR: #{message}"
+  end
+
+  alias_method :inspect, :to_s
+end

--- a/lib/cdo/log_object.rb
+++ b/lib/cdo/log_object.rb
@@ -4,20 +4,21 @@ class LogObject
     @logs = []
   end
 
-  def time(message = nil)
+  def time(action_name = nil)
     start_time = Time.now
     yield if block_given?
-    info("#{message || 'Unnamed'} action completed in #{Time.now - start_time} seconds")
+    info("#{action_name || 'Unnamed'} action completed in #{Time.now - start_time} seconds.")
   rescue => e
-    # TODO: this catchs all standard errors and exception
-    @errors << e
-    error("#{message || 'Unnamed'} action exited with error(s) in #{Time.now - start_time} seconds")
+    # @note this catchs all standard errors and exception
+    error("#{action_name || 'Unnamed'} action exited with error "\
+      "in #{Time.now - start_time} seconds.\n"\
+      "Error = #{e.inspect}."
+    )
   end
 
   def to_s
-    str = "#{@errors.size} error massages and #{@logs.size} log messages."
-    # TODO: print error messages (not stack traces)
-    @errors.each {|error| str.concat("\n#{error.message}")}
+    str = "Recorded #{@errors.size} error messages and #{@logs.size} log messages."
+    @errors.each {|error| str.concat("\n#{error}")}
     @logs.each {|log| str.concat("\n#{log}")}
     str
   end
@@ -27,7 +28,7 @@ class LogObject
   end
 
   def error(message)
-    @logs << "[#{Time.now}] ERROR: #{message}"
+    @errors << "[#{Time.now}] ERROR: #{message}"
   end
 
   alias_method :inspect, :to_s

--- a/lib/cdo/log_object.rb
+++ b/lib/cdo/log_object.rb
@@ -1,67 +1,77 @@
 class LogObject
+  attr_reader :errors, :logs
+
   def initialize
     @errors = []  # List of rescued error objects
     @logs = []    # List of message logs
   end
 
-  # Save exception if caught, do not re-raise. Continue with the caller flow.
+  # Execute a block and time it.
+  # Save exception if caught, do not re-raise. Caller's flow will continue as normal.
+  #
+  # @param action_name [string] a friendly name of the block being executed
   def time(action_name = nil)
     start_time = Time.now
-    yield if block_given?
-    info("#{action_name || 'Unnamed'} action completed without error in #{Time.now - start_time} seconds.")
-  rescue StandardError => e
-    error("#{action_name || 'Unnamed'} action exited with error in #{Time.now - start_time} seconds.")
+    return unless block_given?
 
+    yield
+
+    info("#{action_name || 'Unnamed'} action completed without error in"\
+      " #{Time.now - start_time} seconds."
+    )
+  rescue StandardError => e
+    error("#{action_name || 'Unnamed'} action exited with error in"\
+      " #{Time.now - start_time} seconds."
+    )
     record_exception(e)
   end
 
-  # Re-raise execption if caught. Disrupt the caller flow.
+  # Execute a block and time it.
+  # Re-raise execption if caught, do not save. This will disrupt the caller's flow.
+  #
+  # @param action_name [string] friendly name for the given block
+  #
+  # @raise [StandardError] error encoutered when executing the given block
   def time!(action_name = nil)
     start_time = Time.now
-    yield if block_given?
-    info("#{action_name || 'Unnamed'} action completed without error in #{Time.now - start_time} seconds.")
+    return unless block_given?
+
+    yield
+
+    info("#{action_name || 'Unnamed'} action completed without error in"\
+      " #{Time.now - start_time} seconds."
+    )
   rescue StandardError => e
-    error("#{action_name || 'Unnamed'} action exited with error in #{Time.now - start_time} seconds."\
-      " Exception re-raised!"
+    error("#{action_name || 'Unnamed'} action exited with error in"\
+      " #{Time.now - start_time} seconds. Exception re-raised!"
     )
 
     # To be handle by caller
     raise e
   end
 
+  def info(message)
+    logs << "[#{Time.now}]  INFO: #{message}"
+  end
+
+  def error(message)
+    logs << "[#{Time.now}] ERROR: #{message}"
+  end
+
+  def record_exception(e)
+    errors << e
+    error("Exception caught: #{e.inspect}.")
+  end
+
+  def ok?
+    errors.blank?
+  end
+
   def to_s
-    str = "Recorded #{@errors.size} errors and #{@logs.size} log messages."
-    @logs.each {|log| str.concat("\n#{log}")}
+    str = "Recorded #{errors.size} errors and #{logs.size} log messages."
+    logs.each {|log| str.concat("\n#{log}")}
     str
   end
 
   alias_method :inspect, :to_s
-
-  def info(message)
-    @logs << "[#{Time.now}]  INFO: #{message}"
-  end
-
-  def error(message)
-    @logs << "[#{Time.now}] ERROR: #{message}"
-  end
-
-  def record_exception(e)
-    @errors << e
-    error("Exception caught: #{e.inspect}.")
-    # error("Exception caught: #{e.inspect}.\nStack trace joined: #{e.backtrace.join('\n')}.")
-  end
-
-  def ok?
-    @errors.blank?
-  end
-
-  def error_count
-    @errors.size
-  end
-
-  def error_str
-    return '' if @errors.blank?
-
-    @errors.map(&:inspect).join('\n')
-  end
 end

--- a/lib/cdo/log_object.rb
+++ b/lib/cdo/log_object.rb
@@ -8,7 +8,7 @@ class LogObject
   def time(action_name = nil)
     start_time = Time.now
     yield if block_given?
-    info("#{action_name || 'Unnamed'} action completed in #{Time.now - start_time} seconds.")
+    info("#{action_name || 'Unnamed'} action completed without error in #{Time.now - start_time} seconds.")
   rescue StandardError => e
     error("#{action_name || 'Unnamed'} action exited with error "\
       "in #{Time.now - start_time} seconds.\n"\
@@ -22,7 +22,7 @@ class LogObject
   def time!(action_name = nil)
     start_time = Time.now
     yield if block_given?
-    info("#{action_name || 'Unnamed'} action completed in #{Time.now - start_time} seconds.")
+    info("#{action_name || 'Unnamed'} action completed  without error in #{Time.now - start_time} seconds.")
   rescue StandardError => e
     error("#{action_name || 'Unnamed'} action exited with error "\
       "in #{Time.now - start_time} seconds.\n"\

--- a/lib/cdo/log_object.rb
+++ b/lib/cdo/log_object.rb
@@ -1,3 +1,11 @@
+# LogObject is a simple container to save errors and important info
+# when executing a process. It can also time block execution and log the result.
+#
+# LogObject is helpful when we want to
+# - Prevent non-fatal errors from stopping process execution but still want to know about them.
+# - Bubble up combined errors and info from lower levels to higher levels.
+#   Even to external components such as HoneyBadger or Slack channel.
+
 class LogObject
   attr_reader :errors, :logs
 

--- a/lib/cdo/log_object.rb
+++ b/lib/cdo/log_object.rb
@@ -10,10 +10,7 @@ class LogObject
     yield if block_given?
     info("#{action_name || 'Unnamed'} action completed without error in #{Time.now - start_time} seconds.")
   rescue StandardError => e
-    error("#{action_name || 'Unnamed'} action exited with error "\
-      "in #{Time.now - start_time} seconds.\n"\
-      "Error = #{e.inspect}."
-    )
+    error("#{action_name || 'Unnamed'} action exited with error in #{Time.now - start_time} seconds.")
 
     record_exception(e)
   end
@@ -24,9 +21,8 @@ class LogObject
     yield if block_given?
     info("#{action_name || 'Unnamed'} action completed without error in #{Time.now - start_time} seconds.")
   rescue StandardError => e
-    error("#{action_name || 'Unnamed'} action exited with error "\
-      "in #{Time.now - start_time} seconds.\n"\
-      "Error = #{e.inspect}."
+    error("#{action_name || 'Unnamed'} action exited with error in #{Time.now - start_time} seconds."\
+      " Exception re-raised!"
     )
 
     # To be handle by caller
@@ -51,8 +47,8 @@ class LogObject
 
   def record_exception(e)
     @errors << e
-    error("Caught error: #{e.inspect}.")
-    # error("Caught error: #{e.inspect}.\nStack trace joined: #{e.backtrace.join('\n')}.")
+    error("Exception caught: #{e.inspect}.")
+    # error("Exception caught: #{e.inspect}.\nStack trace joined: #{e.backtrace.join('\n')}.")
   end
 
   def ok?

--- a/lib/cdo/log_object.rb
+++ b/lib/cdo/log_object.rb
@@ -15,14 +15,14 @@ class LogObject
       "Error = #{e.inspect}."
     )
 
-    @errors << e
+    record_exception(e)
   end
 
   # Re-raise execption if caught. Disrupt the caller flow.
   def time!(action_name = nil)
     start_time = Time.now
     yield if block_given?
-    info("#{action_name || 'Unnamed'} action completed  without error in #{Time.now - start_time} seconds.")
+    info("#{action_name || 'Unnamed'} action completed without error in #{Time.now - start_time} seconds.")
   rescue StandardError => e
     error("#{action_name || 'Unnamed'} action exited with error "\
       "in #{Time.now - start_time} seconds.\n"\
@@ -36,8 +36,6 @@ class LogObject
   def to_s
     str = "Recorded #{@errors.size} errors and #{@logs.size} log messages."
     @logs.each {|log| str.concat("\n#{log}")}
-    # @errors.each {|error| str.concat("\n#{error}")}
-    # str.concat(error_str)
     str
   end
 
@@ -53,7 +51,8 @@ class LogObject
 
   def record_exception(e)
     @errors << e
-    error("Caught exception #{e.inspect}")
+    error("Caught error: #{e.inspect}.")
+    # error("Caught error: #{e.inspect}.\nStack trace joined: #{e.backtrace.join('\n')}.")
   end
 
   def ok?

--- a/lib/cdo/pardot.rb
+++ b/lib/cdo/pardot.rb
@@ -90,24 +90,26 @@ class Pardot
 
   # Perform inserts, updates and reconciliation from contact rollups into Pardot
   # @return [Hash] Hash containing number of insert and update operations performed
-  def self.sync_contact_rollups_to_pardot
+  def self.sync_contact_rollups_to_pardot(log_object)
     # In case previous process was interrupted, first look in Pardot to see if
     # it has any Pardot IDs that we have not yet recorded on our side. This will
     # keep us from erroneously creating a new prospect when it should be an
     # update.
-    update_pardot_ids_of_new_contacts
+    log_object.time!('update_pardot_ids_of_new_contacts') {update_pardot_ids_of_new_contacts}
 
     # Handle any new contacts and create corresponding prospects in Pardot.
-    num_inserts = sync_new_contacts_with_pardot
+    num_inserts = 0
+    log_object.time!('sync_new_contacts_with_pardot') {num_inserts = sync_new_contacts_with_pardot}
 
     # Retrieve Pardot IDs for newly created contacts and store them in our DB.
     # We do this as a separate pass for efficient batching of API calls to help
     # ensure we don't hit our 25K/day limit.
-    update_pardot_ids_of_new_contacts
+    log_object.time!('update_pardot_ids_of_new_contacts') {update_pardot_ids_of_new_contacts}
 
     # Handle any contact changes that should update existing prospects in
     # Pardot.
-    num_updates = sync_updated_contacts_with_pardot
+    num_updates = 0
+    log_object.time!('sync_updated_contacts_with_pardot') {num_updates = sync_updated_contacts_with_pardot}
 
     {num_inserts: num_inserts, num_updates: num_updates}
   end

--- a/lib/cdo/pardot.rb
+++ b/lib/cdo/pardot.rb
@@ -90,26 +90,26 @@ class Pardot
 
   # Perform inserts, updates and reconciliation from contact rollups into Pardot
   # @return [Hash] Hash containing number of insert and update operations performed
-  def self.sync_contact_rollups_to_pardot(log_object)
+  def self.sync_contact_rollups_to_pardot(log_collector)
     # In case previous process was interrupted, first look in Pardot to see if
     # it has any Pardot IDs that we have not yet recorded on our side. This will
     # keep us from erroneously creating a new prospect when it should be an
     # update.
-    log_object.time!('update_pardot_ids_of_new_contacts') {update_pardot_ids_of_new_contacts}
+    log_collector.time!('update_pardot_ids_of_new_contacts') {update_pardot_ids_of_new_contacts}
 
     # Handle any new contacts and create corresponding prospects in Pardot.
     num_inserts = 0
-    log_object.time!('sync_new_contacts_with_pardot') {num_inserts = sync_new_contacts_with_pardot}
+    log_collector.time!('sync_new_contacts_with_pardot') {num_inserts = sync_new_contacts_with_pardot}
 
     # Retrieve Pardot IDs for newly created contacts and store them in our DB.
     # We do this as a separate pass for efficient batching of API calls to help
     # ensure we don't hit our 25K/day limit.
-    log_object.time!('update_pardot_ids_of_new_contacts') {update_pardot_ids_of_new_contacts}
+    log_collector.time!('update_pardot_ids_of_new_contacts') {update_pardot_ids_of_new_contacts}
 
     # Handle any contact changes that should update existing prospects in
     # Pardot.
     num_updates = 0
-    log_object.time!('sync_updated_contacts_with_pardot') {num_updates = sync_updated_contacts_with_pardot}
+    log_collector.time!('sync_updated_contacts_with_pardot') {num_updates = sync_updated_contacts_with_pardot}
 
     {num_inserts: num_inserts, num_updates: num_updates}
   end

--- a/lib/test/cdo/test_log_collector.rb
+++ b/lib/test/cdo/test_log_collector.rb
@@ -1,9 +1,9 @@
 require_relative '../test_helper'
-require 'cdo/log_object'
+require 'cdo/log_collector'
 
-class LogObjectTest < Minitest::Test
+class LogCollectorTest < Minitest::Test
   def test_time_a_function
-    log_object = LogObject.new
+    log_object = LogCollector.new
     log_object.time('Do something') {do_something}
 
     assert log_object.ok?
@@ -11,7 +11,7 @@ class LogObjectTest < Minitest::Test
   end
 
   def test_time_a_function_that_errors
-    log_object = LogObject.new
+    log_object = LogCollector.new
     log_object.time('Do something that errors') {do_something_that_errors}
 
     refute log_object.ok?
@@ -19,7 +19,7 @@ class LogObjectTest < Minitest::Test
   end
 
   def test_time_a_function_that_errors_then_reraise
-    log_object = LogObject.new
+    log_object = LogCollector.new
 
     assert_raises do
       log_object.time!('Do something that errors') {do_something_that_errors}

--- a/lib/test/cdo/test_log_object.rb
+++ b/lib/test/cdo/test_log_object.rb
@@ -1,0 +1,23 @@
+# copy skeleton from lib/test/cdo/test_safe_names.rb
+# bundle exec ruby lib/test/cdo/test_log_object.rb
+
+require_relative '../test_helper'
+require 'cdo/log_object'
+
+class LogObjectTest < Minitest::Test
+  def test_time_a_function
+    lo = LogObject.new
+    lo.time('increase once') {increase_by_one}
+    repetition = 10000
+    lo.time("increase #{repetition} times") {increase_by_one(repetition)}
+    puts lo.to_s
+  end
+
+  private
+
+  def increase_by_one(repetition = 1)
+    result = 0
+    repetition.times {result += 1}
+    result
+  end
+end

--- a/lib/test/cdo/test_log_object.rb
+++ b/lib/test/cdo/test_log_object.rb
@@ -1,23 +1,41 @@
-# TODO: remove
-# bundle exec ruby lib/test/cdo/test_log_object.rb
-
 require_relative '../test_helper'
 require 'cdo/log_object'
 
 class LogObjectTest < Minitest::Test
   def test_time_a_function
-    lo = LogObject.new
-    lo.time('increase once') {increase_by_one}
-    repetition = 10000
-    lo.time("increase #{repetition} times") {increase_by_one(repetition)}
-    puts lo.to_s
+    log_object = LogObject.new
+    log_object.time('Do something') {do_something}
+
+    assert log_object.ok?
+    assert_equal 1, log_object.logs.size
+  end
+
+  def test_time_a_function_that_errors
+    log_object = LogObject.new
+    log_object.time('Do something that errors') {do_something_that_errors}
+
+    refute log_object.ok?
+    assert_equal 2, log_object.logs.size
+  end
+
+  def test_time_a_function_that_errors_then_reraise
+    log_object = LogObject.new
+
+    assert_raises do
+      log_object.time!('Do something that errors') {do_something_that_errors}
+    end
+
+    assert_equal 1, log_object.logs.size
   end
 
   private
 
-  def increase_by_one(repetition = 1)
-    result = 0
-    repetition.times {result += 1}
-    result
+  # Dummy function to be used in a block
+  def do_something
+    1
+  end
+
+  def do_something_that_errors
+    raise 'error'
   end
 end

--- a/lib/test/cdo/test_log_object.rb
+++ b/lib/test/cdo/test_log_object.rb
@@ -1,4 +1,4 @@
-# copy skeleton from lib/test/cdo/test_safe_names.rb
+# TODO: remove
 # bundle exec ruby lib/test/cdo/test_log_object.rb
 
 require_relative '../test_helper'


### PR DESCRIPTION
[PLC-258](https://codedotorg.atlassian.net/browse/PLC-258)

### What
- Time major steps in Contact Rollups job. Propagate results directly to `cron-daily` Slack channel ([example](https://codedotorg.slack.com/archives/C3S8AJY9K/p1560413138006100)).
- Raise HoneyBadger error when validation fails so the job cannot fail silently.

### Why
- Contact Rollups is a long running and resource intensive job (~3h, cannot run directly on production db) and has no test. It sometime failed for more than 1 week without notice. It has been a major tech debt and we will soon have to re-architect it. 
- The first few steps are 
  - Time important steps in the process to identify bottlenecks.
  - Collect important metrics such as # of new/updated rows to identify which steps are still valuable to keep.

### How tested
- Test LogCollector `bundle exec ruby lib/test/cdo/test_log_collector.rb`
- Test run in `test` server
  - Check out (cherry-pick) files in feature branch into test machine
  - Comment out Syncing to Pardot section so changes happen only in local db.
  - Start a `screen` section so job will still run even connection to test server breaks.
  - Run `bin/cron/build_contact_rollups`. 
  - (Detach = `ctrl+a+d`, resume section = `screen -r <sessions_name>`, list = `screen -ls`)

### Note
I add all PLC to this PR since Contact Rollups is in PLC land now and anyone of us may have to work on it in the future.

### TO DO
- [x] Remove stdout prints before merging.
