### PR TITLE
BubbleChoice basic navigation

### DIFF
--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -43,7 +43,8 @@ export default class BubbleChoice extends React.Component {
         PropTypes.shape({
           id: PropTypes.number.isRequired,
           title: PropTypes.string.isRequired,
-          thumbnail_url: PropTypes.string
+          thumbnail_url: PropTypes.string,
+          url: PropTypes.string.isRequired
         })
       )
     })
@@ -69,7 +70,9 @@ export default class BubbleChoice extends React.Component {
               />
             )}
             <div style={styles.column}>
-              <span style={styles.title}>{sublevel.title}</span>
+              <a href={sublevel.url + location.search} style={styles.title}>
+                {sublevel.title}
+              </a>
             </div>
           </div>
         ))}

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -4,8 +4,18 @@ import {assert} from '../../../util/reconfiguredChai';
 import BubbleChoice from '@cdo/apps/code-studio/components/BubbleChoice';
 
 const fakeSublevels = [
-  {id: 1, title: 'Choice 1', thumbnail_url: 'some-fake.url/kittens.png'},
-  {id: 2, title: 'Choice 2', thumbnail_url: null}
+  {
+    id: 1,
+    title: 'Choice 1',
+    thumbnail_url: 'some-fake.url/kittens.png',
+    url: '/s/script/stage/1/puzzle/1/sublevel/1'
+  },
+  {
+    id: 2,
+    title: 'Choice 2',
+    thumbnail_url: null,
+    url: '/s/script/stage/1/puzzle/1/sublevel/2'
+  }
 ];
 
 const DEFAULT_PROPS = {

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -370,10 +370,8 @@ class ScriptLevelsController < ApplicationController
   def select_level
     # If a BubbleChoice level's sublevel has been requested, return it.
     if @script_level.bubble_choice? && params[:sublevel_position]
-      sublevel_index = params[:sublevel_position].to_i - 1
-      # TODO: cache sublevels
-      sublevel = @script_level.level.sublevels[sublevel_index]
-      return sublevel if sublevel.present?
+      sublevel = @script_level.level.sublevel_at(params[:sublevel_position].to_i - 1)
+      return sublevel if sublevel
     end
 
     # If there's only one level in this scriptlevel, use that

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -20,6 +20,8 @@ module LevelsHelper
       else
         puzzle_page_script_stage_script_level_path(script_level.script, script_level.stage, script_level, params[:puzzle_page])
       end
+    elsif params[:sublevel_position]
+      sublevel_script_stage_script_level_path(script_level.script, script_level.stage, script_level, params[:sublevel_position])
     elsif script_level.stage.lockable?
       script_lockable_stage_script_level_path(script_level.script, script_level.stage, script_level, params)
     elsif script_level.bonus

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -50,6 +50,10 @@ ruby
     Level.where(name: properties['sublevels']).sort_by {|l| properties['sublevels'].index(l.name)}
   end
 
+  def sublevel_at(index)
+    sublevels[index]
+  end
+
   def summarize(script_level: nil)
     {
       title: title,

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -24,6 +24,8 @@
 #
 
 class BubbleChoice < DSLDefined
+  include LevelsHelper
+  include Rails.application.routes.url_helpers
   include SerializedProperties
 
   serialized_attrs %w(
@@ -48,19 +50,30 @@ ruby
     Level.where(name: properties['sublevels']).sort_by {|l| properties['sublevels'].index(l.name)}
   end
 
-  def summarize
-    sublevel_summary = sublevels.map do |level|
-      {
+  def summarize(script_level: nil)
+    {
+      title: title,
+      description: description,
+      sublevels: summarize_sublevels(script_level: script_level)
+    }
+  end
+
+  def summarize_sublevels(script_level: nil)
+    summary = []
+    sublevels.each_with_index do |level, index|
+      level_info = {
         id: level.id,
         title: level.display_name || level.name,
         thumbnail_url: level.try(:thumbnail_url)
       }
+
+      if script_level
+        level_info[:url] = build_script_level_url(script_level, {sublevel_position: index + 1})
+      end
+
+      summary << level_info
     end
 
-    {
-      title: title,
-      description: description,
-      sublevels: sublevel_summary
-    }
+    summary
   end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -62,6 +62,10 @@ ruby
     }
   end
 
+  # Summarizes the level's sublevels.
+  # @param [ScriptLevel] script_level. Optional. If provided, the URLs for sublevels
+  # will be included in the summary.
+  # @return [Hash[]]
   def summarize_sublevels(script_level: nil)
     summary = []
     sublevels.each_with_index do |level, index|

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -128,11 +128,14 @@ class ScriptLevel < ActiveRecord::Base
   end
 
   def next_level_or_redirect_path_for_user(user, extras_stage=nil)
-    # if we're coming from an unplugged level, it's ok to continue to unplugged
-    # level (example: if you start a sequence of assessments associated with an
-    # unplugged level you should continue on that sequence instead of skipping to
-    # next stage)
-    if valid_progression_level?(user)
+    if bubble_choice?
+      # Redirect user back to the BubbleChoice activity page.
+      level_to_follow = self
+    elsif valid_progression_level?(user)
+      # if we're coming from an unplugged level, it's ok to continue to unplugged
+      # level (example: if you start a sequence of assessments associated with an
+      # unplugged level you should continue on that sequence instead of skipping to
+      # next stage)
       level_to_follow = next_progression_level(user)
     else
       # don't ever continue continue to a locked/hidden level

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -233,6 +233,10 @@ class ScriptLevel < ActiveRecord::Base
     return level.properties["anonymous"] == "true"
   end
 
+  def bubble_choice?
+    level.is_a? BubbleChoice
+  end
+
   def name
     stage.localized_name
   end

--- a/dashboard/app/views/levels/_bubble_choice.html.haml
+++ b/dashboard/app/views/levels/_bubble_choice.html.haml
@@ -1,6 +1,6 @@
 %div#bubble-choice
 
 - data = {}
-- data[:level] = @level.summarize
+- data[:level] = @level.summarize(script_level: @script_level)
 
 %script{src: minifiable_asset_path('js/levels/_bubble_choice.js'), data: {bubblechoice: data.to_json}}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -249,6 +249,8 @@ Dashboard::Application.routes.draw do
         member do
           # /s/xxx/stage/yyy/puzzle/zzz/page/ppp
           get 'page/:puzzle_page', to: 'script_levels#show', as: 'puzzle_page', format: false
+          # /s/xxx/stage/yyy/puzzle/zzz/sublevel/sss
+          get 'sublevel/:sublevel_position', to: 'script_levels#show', as: 'sublevel', format: false
         end
       end
     end

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -134,6 +134,22 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_redirected_to_sign_in
   end
 
+  test "should render sublevel for BubbleChoice script_level with sublevel_position param" do
+    script = create :script
+    level = create(:bubble_choice_level, :with_sublevels)
+    script_level = create :script_level, script: script, levels: [level]
+    sublevel_position = 1
+
+    get :show, params: {
+      script_id: script,
+      stage_position: script_level.stage.relative_position,
+      id: script_level.position,
+      sublevel_position: sublevel_position
+    }
+    assert_response :success
+    assert_equal level.sublevels[sublevel_position - 1], assigns(:level)
+  end
+
   test 'project template level sets start blocks when defined' do
     template_level = create :level
     template_level.start_blocks = '<xml/>'

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -845,6 +845,20 @@ FactoryGirl.define do
     end
   end
 
+  factory :bubble_choice_level, class: BubbleChoice do
+    game {create(:game, app: "bubble_choice")}
+    name 'name'
+    title 'title'
+
+    trait :with_sublevels do
+      after(:create) do |bc|
+        sublevels = create_list(:sublevel, 3)
+        bc.properties['sublevels'] = sublevels.pluck(:name)
+        bc.save!
+      end
+    end
+  end
+
   factory :survey_result do
     user {create :teacher}
     kind 'Diversity2016'

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -849,10 +849,19 @@ FactoryGirl.define do
     game {create(:game, app: "bubble_choice")}
     name 'name'
     title 'title'
+    transient do
+      sublevels []
+    end
+    properties do
+      {
+        title: title,
+        sublevels: sublevels.pluck(:name)
+      }
+    end
 
     trait :with_sublevels do
       after(:create) do |bc|
-        sublevels = create_list(:sublevel, 3)
+        sublevels = create_list(:level, 3)
         bc.properties['sublevels'] = sublevels.pluck(:name)
         bc.save!
       end

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -375,6 +375,11 @@ class ScriptLevelTest < ActiveSupport::TestCase
     assert_equal "/s/#{script_level.script.name}/stage/1/extras", script_level.next_level_or_redirect_path_for_user(nil)
   end
 
+  test 'next_level_or_redirect_path_for_user returns to bubble choice activity page for BubbleChoice levels' do
+    script_level = create :script_level, levels: [create(:bubble_choice_level)]
+    assert_equal "/s/#{script_level.script.name}/stage/1/puzzle/1", script_level.next_level_or_redirect_path_for_user(nil)
+  end
+
   test 'end of stage' do
     script = Script.find_by_name('course1')
 


### PR DESCRIPTION
[LP-318](https://codedotorg.atlassian.net/browse/LP-318) / [Spec](https://docs.google.com/document/d/1jKIQ6fwdDEt7rz659poRZUBli4zAyOOnMAsSb_D3EDE/edit?ts=5cfe9b31#bookmark=id.fi6muxrwwuf6)

Allows users to navigate through the sublevels of a BubbleChoice level.

**Satisfies the following bullets from the spec above:**
- If you’re advancing from a bubble choice sublevel, you should go back to the “bubble choice activity” page before advancing to the next level
- Clicking on a bubble-choice bubble in the level progression above must take you to the “bubble-choice activity” page

**Example:** For a BubbleChoice level with 3 sublevels: 
1. the user lands on `/s/:script_name/stage/:stage_num/puzzle/:puzzle_num` ("bubble choice activity" page)
2. the user clicks a sublevel and is directed to `/s/:script_name/stage/:stage_num/puzzle/:puzzle_num/sublevel/:sublevel_num`
3. the user completes the level, clicks "finish", and is directed back to `/s/:script_name/stage/:stage_num/puzzle/:puzzle_num`
4. repeat steps 2 & 3

![out2](https://user-images.githubusercontent.com/9812299/59392214-b6b5f900-8d2b-11e9-8432-c7d6d68d87b1.gif)

**Up next:**
- Navigation to/from BubbleChoice levels from other levels in a script