### PR TITLE
Projects: image moderation buttons in admin panel

### DIFF
--- a/apps/src/code-studio/showProjectAdmin.js
+++ b/apps/src/code-studio/showProjectAdmin.js
@@ -101,6 +101,7 @@ export default project => {
         // differentiate from manual reports.
         if (abuseScore === 15) {
           $('.abusive-image').show();
+          $('.image-mod-controls').show();
         } else {
           $('.reported-abuse').show();
         }

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -140,6 +140,19 @@
           .privacy-profanity-details
         %li.abusive-image{ style: 'display: none;' }
           Inappropriate image
+          .image-mod-controls{ style: 'display: none;' }
+            #disable-auto-moderation{'style' => ('display: none;' if content_moderation_disabled)}
+              %br
+              %button{id: "disable-auto-moderation", class: "btn btn-default btn-sm"}
+                Disable automated moderation
+
+            #moderation-explanation{style: 'margin-top: 20px; width: 250px;'}
+              Disabling automated moderation will prevent our content moderation service from flagging this project. Disable automated moderation if the service has inaccurately flagged this project before.
+
+            #enable-auto-moderation{'style' => ('display: none;' unless content_moderation_disabled)}
+              %br
+              %button{id: "enable-auto-moderation", class: "btn btn-default btn-sm"}
+                Enable automated moderation
         %li.reported-abuse{ style: 'display: none;' }
           Manually reported abusive
 
@@ -150,16 +163,3 @@
       %br
       .admin-report-abuse
         = link_to 'Report Abuse', '/report_abuse'
-
-      #disable-auto-moderation{'style' => ('display: none;' if content_moderation_disabled)}
-        %br
-        %button{id: "disable-auto-moderation", class: "btn btn-default btn-sm"}
-          Disable automated moderation
-
-      #moderation-explanation{style: 'margin-top: 20px; width: 250px;'}
-        Disabling automated moderation will prevent our content moderation service from flagging this project. Disable automated moderation if the service has inaccurately flagged this project before.
-
-      #enable-auto-moderation{'style' => ('display: none;' unless content_moderation_disabled)}
-        %br
-        %button{id: "enable-auto-moderation", class: "btn btn-default btn-sm"}
-          Enable automated moderation


### PR DESCRIPTION
[LP-352](https://codedotorg.atlassian.net/browse/LP-352), continuation of #29030

Currently in the admin panel for projects we always show the en/disable content moderation buttons.  This doesn't really make sense because only certain project types - App Lab and Game Lab - have image moderation and these options only apply if the project has an image violation. 

I updated the admin panel so that we will only show these buttons when a project has an inappropriate image. 
![content-mod-buttons](https://user-images.githubusercontent.com/12300669/59324259-ea911000-8c92-11e9-9657-6db4b20aaa0e.gif)
