### PR TITLE
Don't start in feedback tab for CSF

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -191,9 +191,11 @@ class TopInstructions extends Component {
       window.location.search.includes('user_id');
 
     this.state = {
-      tabSelected: teacherViewingStudentWork
-        ? TabType.COMMENTS
-        : TabType.INSTRUCTIONS,
+      // We don't want to start in the comments tab for CSF since its hidden
+      tabSelected:
+        teacherViewingStudentWork && this.props.noInstructionsWhenCollapsed
+          ? TabType.COMMENTS
+          : TabType.INSTRUCTIONS,
       feedbacks: [],
       rubric: null,
       studentId: studentId,


### PR DESCRIPTION
Found a bug where if you were viewing students work we were showing the contents of the feedback tab even though we don't allow the tab to be shown. This fixes that.

# Before

<img width="1440" alt="Screen Shot 2019-06-12 at 3 28 08 PM" src="https://user-images.githubusercontent.com/208083/59380445-207fd400-8d27-11e9-927b-fca48de490e8.png">


# After

<img width="1440" alt="Screen Shot 2019-06-12 at 3 28 23 PM" src="https://user-images.githubusercontent.com/208083/59380453-237ac480-8d27-11e9-8c24-4414c3fe39bc.png">
