### PR TITLE
Text display console no longer gets in the way of the costume tab buttons

### DIFF
--- a/apps/src/gamelab/GameLabVisualizationColumn.jsx
+++ b/apps/src/gamelab/GameLabVisualizationColumn.jsx
@@ -147,7 +147,7 @@ class GameLabVisualizationColumn extends React.Component {
     const spriteLab = this.props.spriteLab;
 
     return (
-      <span>
+      <div style={{position: 'relative'}}>
         <ProtectedVisualizationDiv>
           <Pointable
             id="divGameLab"
@@ -192,7 +192,7 @@ class GameLabVisualizationColumn extends React.Component {
             onClick={() => this.props.cancelPicker()}
           />
         )}
-      </span>
+      </div>
     );
   }
 }


### PR DESCRIPTION
In the past, the text would render over top of the code and costume buttons. This PR fixes that issue.

![image](https://user-images.githubusercontent.com/8324574/59385637-a563f100-8d19-11e9-9aa9-c3279d600e56.png)

https://codedotorg.atlassian.net/browse/STAR-394
