### PR TITLE
Update applab screen duplication to include background color and images

### DIFF
--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -674,8 +674,23 @@ designMode.changeThemeForCurrentScreen = function(prevThemeValue, themeValue) {
 function duplicateScreen(element) {
   const sourceScreen = $(element);
   const sourceScreenId = elementUtils.getId(element);
-  const newScreen = designMode.createScreen();
-  designMode.changeScreen(newScreen);
+  const newScreenId = designMode.createScreen();
+  const newScreenElement = elementUtils.getPrefixedElementById(newScreenId);
+  const sourceElement = elementUtils.getPrefixedElementById(sourceScreenId);
+  const backgroundColor = 'backgroundColor';
+  designMode.updateProperty(
+    newScreenElement,
+    backgroundColor,
+    designMode.readProperty(sourceElement, backgroundColor)
+  );
+
+  const backgroundImage = 'screen-image';
+  const sourceImage = designMode.readProperty(sourceElement, backgroundImage);
+  if (sourceImage) {
+    designMode.updateProperty(newScreenElement, backgroundImage, sourceImage);
+  }
+
+  designMode.changeScreen(newScreenId);
 
   // Unwrap the draggable wrappers around the elements in the source screen:
   const madeUndraggable = makeUndraggable(sourceScreen.children());
@@ -700,12 +715,12 @@ function duplicateScreen(element) {
   };
   const alert = (
     <div style={styles}>
-      Duplicated <b>{sourceScreenId}</b> to <b>{newScreen}</b>
+      Duplicated <b>{sourceScreenId}</b> to <b>{newScreenId}</b>
     </div>
   );
   studioApp().displayPlayspaceNotification(alert);
 
-  return newScreen;
+  return newScreenId;
 }
 
 designMode.onCopyElementToScreen = function(element, destScreen) {

--- a/apps/test/unit/applab/designModeTest.js
+++ b/apps/test/unit/applab/designModeTest.js
@@ -116,6 +116,10 @@ describe('onDuplicate screen', () => {
     designModeElement.appendChild(originalScreen);
   });
 
+  afterEach(() => {
+    document.body.removeChild(designModeElement);
+  });
+
   it('duplicates the background color of the screen', () => {
     designMode.updateProperty(originalScreen, colorProperty, color);
     var newScreen = designMode.onDuplicate(originalScreen);

--- a/apps/test/unit/applab/designModeTest.js
+++ b/apps/test/unit/applab/designModeTest.js
@@ -1,5 +1,6 @@
 import {expect} from '../../util/configuredChai';
 import designMode from '@cdo/apps/applab/designMode';
+import elementLibrary from '@cdo/apps/applab/designElements/library';
 
 describe('appendPx', () => {
   it('returns a valid css positive integer', function() {
@@ -97,6 +98,47 @@ describe('makeUrlProtocolRelative', () => {
     ].forEach(({input, expected}) => {
       expect(makeUrlProtocolRelative(input)).to.equal(expected);
     });
+  });
+});
+
+describe('onDuplicate screen', () => {
+  let designModeElement, originalScreen;
+  const colorProperty = 'backgroundColor';
+  const imageProperty = 'screen-image';
+  const color = 'rgb(0, 0, 255)';
+  const image = 'image.png';
+  beforeEach(() => {
+    designModeElement = document.createElement('div');
+    designModeElement.setAttribute('id', 'designModeViz');
+    document.body.appendChild(designModeElement);
+
+    originalScreen = elementLibrary.createElement('SCREEN', 0, 0);
+    designModeElement.appendChild(originalScreen);
+  });
+
+  it('duplicates the background color of the screen', () => {
+    designMode.updateProperty(originalScreen, colorProperty, color);
+    var newScreen = designMode.onDuplicate(originalScreen);
+    expect(designMode.readProperty(newScreen, colorProperty)).to.equal(color);
+  });
+
+  it('duplicates the background image of the screen', () => {
+    designMode.updateProperty(originalScreen, imageProperty, image);
+    var newScreen = designMode.onDuplicate(originalScreen);
+    expect(designMode.readProperty(newScreen, imageProperty)).to.equal(image);
+  });
+
+  it('duplicates background color and image of the screen', () => {
+    designMode.updateProperty(originalScreen, imageProperty, image);
+    designMode.updateProperty(originalScreen, colorProperty, color);
+    var newScreen = designMode.onDuplicate(originalScreen);
+    expect(designMode.readProperty(newScreen, colorProperty)).to.equal(color);
+    expect(designMode.readProperty(newScreen, imageProperty)).to.equal(image);
+  });
+
+  it('does not duplicate the background image when none is set', () => {
+    var newScreen = designMode.onDuplicate(originalScreen);
+    expect(designMode.readProperty(newScreen, imageProperty)).to.be.null;
   });
 });
 


### PR DESCRIPTION
In the past, screen duplication would miss the image and the background color. Now both are duplicated.
![duplicateScreen](https://user-images.githubusercontent.com/8324574/59394823-0ac5db00-8d36-11e9-8170-2aa102393d68.gif)
