### PR TITLE
Hide overlay when teacher viewing student work

### DIFF
--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -126,6 +126,7 @@ const styles = {
 
 class InstructionsCSF extends React.Component {
   static propTypes = {
+    teacherViewingStudentWork: PropTypes.bool,
     handleClickCollapser: PropTypes.func,
     adjustMaxNeededHeight: PropTypes.func,
     overlayVisible: PropTypes.bool,
@@ -192,6 +193,11 @@ class InstructionsCSF extends React.Component {
    * Calculate our initial height (based off of rendered height of instructions)
    */
   componentDidMount() {
+    //Overlay is not needed when a teacher is viewing the students work
+    if (this.props.teacherViewingStudentWork) {
+      this.props.hideOverlay();
+    }
+
     // Might want to increase the size of our instructions after our icon image
     // has loaded, to make sure the image fits
     $(ReactDOM.findDOMNode(this.icon)).load(

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -670,6 +670,9 @@ class TopInstructions extends Component {
                     handleClickCollapser={this.handleClickCollapser}
                     adjustMaxNeededHeight={this.adjustMaxNeededHeight}
                     isEmbedView={this.props.isEmbedView}
+                    teacherViewingStudentWork={
+                      this.state.teacherViewingStudentWork
+                    }
                   />
                 )}
               {!this.props.hasContainedLevels &&


### PR DESCRIPTION
CSF levels try to force students to read the instructions by showing them in an overlay with an okay button but this is annoying when you are a teacher trying to look at student work. So this hides the overlay when you are a teacher viewing student work.


# Before
<img width="987" alt="Screen Shot 2019-06-13 at 10 22 33 AM" src="https://user-images.githubusercontent.com/208083/59440565-30e68c00-8dc5-11e9-9ed4-36a2af7315b7.png">


# After

<img width="993" alt="Screen Shot 2019-06-13 at 10 18 02 AM" src="https://user-images.githubusercontent.com/208083/59440364-d9e0b700-8dc4-11e9-9229-25fd4012bcfd.png">
