### PR TITLE
Set extraArgs.target correctly

### DIFF
--- a/apps/src/gamelab/spritelab/spriteUtils.js
+++ b/apps/src/gamelab/spritelab/spriteUtils.js
@@ -128,7 +128,7 @@ function whenTouchEvent(inputEvent) {
     targets.forEach(target => {
       if (sprite.overlap(target)) {
         extraArgs.sprite = sprite.id;
-        extraArgs.target = sprite.id;
+        extraArgs.target = target.id;
         overlap = true;
       }
     });


### PR DESCRIPTION
Was accidentally setting `extraArgs.target` to `sprite.id`, not `target.id`. This causes problems if you try to use `other sprite` in the event block.