### PR TITLE
Provision aurora db for levelbuilder [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -24,7 +24,7 @@ commit = ENV['COMMIT'] || `git ls-remote origin #{branch}`.split.first
 ami = commit[0..4]
 
 frontends = @frontends = rack_env?(:production) || ENV['FRONTENDS']
-database = @database = [:staging, :test].include?(rack_env) || ENV['DATABASE']
+database = @database = [:staging, :test, :levelbuilder].include?(rack_env) || ENV['DATABASE']
 load_balancer = @load_balancer = !rack_env?(:adhoc) || ENV['FRONTENDS']
 
 unless dry_run


### PR DESCRIPTION
Levelbuilder migration plan:

1. Before levelbuilder deployment - add database_username: master to locals.yml on levelbuilder so it can be picked up as a cloudformation parameter
2. After deployment - manually provision db users on levelbuilder
3. Start scheduled downtime at 6/14, 5 pm (ok'd by @mrjoshida)
4. Copy databases from local mysql to aurora db: https://dev.mysql.com/doc/refman/5.7/en/copying-databases.html
5. Add config in locals.yml to have levelbuilder app talk to aurora db, restart levelbuilder services
6. Validate functionality by manually editing an unused level and saving it (level to edit provided by @davidsbailey)
7. The next day, if things are working fine, add config to cdo-secrets in chef and remove from locals.yml