### PR TITLE
Fix validation for Fish Tank 5 and 6

### DIFF
--- a/apps/src/gamelab/spritelab/commands.js
+++ b/apps/src/gamelab/spritelab/commands.js
@@ -213,6 +213,10 @@ export const commands = {
     return validationCommands.getBehaviorsForAnimation(animation);
   },
 
+  getBehaviorsForSpriteId(spriteId) {
+    return validationCommands.getBehaviorsForSpriteId(spriteId);
+  },
+
   getSpriteIdsInUse() {
     return validationCommands.getSpriteIdsInUse();
   }

--- a/apps/src/gamelab/spritelab/spriteUtils.js
+++ b/apps/src/gamelab/spritelab/spriteUtils.js
@@ -75,6 +75,20 @@ export function getBehaviorsForAnimation(animation) {
   return numBehaviors;
 }
 
+/**
+ * @param {number} spriteId
+ * @return {number} Number of behaviors associated with the specified sprite
+ */
+export function getBehaviorsForSpriteId(spriteId) {
+  let numBehaviors = 0;
+  behaviors.forEach(behavior => {
+    if (behavior.sprite.id === spriteId) {
+      numBehaviors++;
+    }
+  });
+  return numBehaviors;
+}
+
 export function getSpriteIdsInUse() {
   let spriteIds = [];
   Object.keys(nativeSpriteMap).forEach(spriteId =>

--- a/apps/src/gamelab/spritelab/validationCommands.js
+++ b/apps/src/gamelab/spritelab/validationCommands.js
@@ -17,6 +17,10 @@ export const commands = {
     return spriteUtils.getBehaviorsForAnimation(animation);
   },
 
+  getBehaviorsForSpriteId(spriteId) {
+    return spriteUtils.getBehaviorsForSpriteId(spriteId);
+  },
+
   getSpriteIdsInUse() {
     return spriteUtils.getSpriteIdsInUse();
   }

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated.level
@@ -47,7 +47,7 @@
     "parent_level_id": 12609,
     "auto_run_setup": "DRAW_LOOP",
     "show_type_hints": "true",
-    "validation_code": "if (World.frameCount > 50) {\r\n  if (World.allSprites.length > 5) {\r\n    levelSuccess(0);\r\n  } else {\r\n    levelSuccess(3);\r\n  }\r\n}",
+    "validation_code": "if (World.frameCount > 50) {\r\n  if (getSpriteIdsInUse().length > 1) {\r\n    levelSuccess(0);\r\n  } else {\r\n    levelSuccess(3);\r\n  }\r\n}",
     "project_template_level_name": "Fish Tank Template",
     "short_instructions": "Our fish is getting a little lonely. Add another sprite to the fish tank.",
     "block_pool": "gamelab",

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated.level
@@ -48,7 +48,7 @@
     "parent_level_id": 12610,
     "auto_run_setup": "DRAW_LOOP",
     "show_type_hints": "true",
-    "validation_code": "if (World.frameCount > 50) {\r\n  var sprites_with_behaviors = 0;\r\n  \r\n  // Check through all sprites in case student changed the sprite name\r\n  for (var i=0; i<World.allSprites.length; i++) {\r\n    var sprite = World.allSprites[i];\r\n    // ignore edge sprites\r\n    if (!edges.contains(sprite)) {\r\n      if (sprite.behaviors.length > 0) {\r\n        sprites_with_behaviors++;\r\n      }\r\n    }\r\n  }\r\n  if (sprites_with_behaviors < 2) {\r\n  \tlevelSuccess(3);\r\n  } else {\r\n    levelSuccess(0);\r\n  }\r\n}",
+    "validation_code": "if (World.frameCount > 50) {\r\n  var sprites_with_behaviors = 0;\r\n\r\n  var spriteIds = getSpriteIdsInUse();\r\n  for (var i = 0; i < spriteIds.length; i++) {\r\n    if (getBehaviorsForSpriteId(spriteIds[i]) > 0) {\r\n      sprites_with_behaviors++;\r\n    }\r\n  }\r\n\r\n  if (sprites_with_behaviors < 2) {\r\n  \tlevelSuccess(3);\r\n  } else {\r\n    levelSuccess(0);\r\n  }\r\n}",
     "project_template_level_name": "Fish Tank Template",
     "short_instructions": "Add a behavior to the fish's new friend.",
     "include_shared_functions": "false",


### PR DESCRIPTION
This PR fixes broken validation on two sprite lab levels: Fish Tank 5-validated and Fish Tank 6-validated. I accidentally missed updating the validation code for these levels when we switched sprite lab to run natively in PR #28948

It also adds a new validation command, which is necessary for Fish Tank 6. `getBehaviorsForSpriteId` returns the number of behaviors associated with the specified sprite id. This allows the Fish Tank 6 validation code to check that there are at least two sprites with behaviors.