### PR TITLE
Levelbuilder Level Page Clean Up: App Lab and Web Lab

### DIFF
--- a/dashboard/app/views/levels/editors/_applab.html.haml
+++ b/dashboard/app/views/levels/editors/_applab.html.haml
@@ -1,120 +1,119 @@
 - content_for(:head) do
   %script{src: minifiable_asset_path('js/levelbuilder_applab.js')}
 
-.field
-  = f.label :start_libraries,'Applab Start Library'
-  = f.text_area :start_libraries, value: @level.start_libraries ? JSON.pretty_generate(@level.start_libraries) : ''
-.field
-  = f.label :slider_speed, 'Slider speed'
-  %p Number from 0.0 to 1.0 for how fast Applab runs by default while in the IDE. If not set, default is 1.0
-  = f.number_field :slider_speed, :step => 0.1
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :show_turtle_before_run, description: "Show turtle before Run is pressed"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :design_mode_at_start, description: "Start in Design Mode"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_design_mode, description: "Hide Design Mode"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :makerlab_enabled, description: "Enable Maker APIs"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :expand_debugger, description: "Expand Debugger by Default"}
-
-= render partial: 'levels/editors/watchers_ui', locals: {f: f}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :autocomplete_palette_apis_only, description: "Autocomplete palette APIs only"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :execute_palette_apis_only, description: "Execute palette APIs only"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :beginner_mode, description: "Beginner mode for loops"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :submittable, description: "Submittable"}
-  %p
-    If checked, students with teachers can "submit" a solution for
-    grading. Submitting a solution means that it is marked as
-    submitted and they can no longer edit it (unless a teacher returns
-    it).
-.field
-  = f.label :start_html, 'Starting design mode html'
-  %p
-    This should be equivalent to the level html created by design mode. Learn how to how to make them
-    =link_to 'here', 'https://github.com/code-dot-org/code-dot-org/wiki/%5BLevelbuilder%5D-Adding-Preloaded-Design-Elements-in-App-Lab', target: '_blank'
-
-  %p
-    IMPORTANT WARNING: If you have referenced images in the HTML and/or  CODE, then you need to get fully-qualified
-    code.org https URLS for these assets and update the HTML and the code to reflect these. You can quickly get full
-    image urls by drag-dropping the image into the markdown section of a dummy level in levelbuilder.
-    Copy the result and paste it here (it should start with something like
-    #{html_escape("<div xmlns='http://www.w3.org/1999/xhtml' id='divApplab'")}...)
-  = f.text_area :start_html, placeholder: 'Start html', rows: 4, value: @level.start_html
-  :javascript
-    levelbuilder.initializeCodeMirror('level_start_html', 'html');
-
 = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'applab'}
 
-.field
-  = f.label 'Log Conditions'
-  Create a JSON array resembling the example if you want to add requirements that certain functions were executed. These will be checked when the Finish button is pressed.
-  %pre
-    = preserve do
-      :escaped
-        Example:
-        [
-          { "entries": ["function1", "function2"], "matchType": "exact", "minTimes": 1, "message": "You need to call both functions." },
-          { "entries": ["[forTest]", "moveTo", "randomNumber", "randomNumber"], "matchType": "inexact", "minTimes": 20, "message": "You need to call moveTo in a for loop." }
-        ]
-  = f.text_area 'log_conditions', placeholder: 'Insert JSON Data', rows: 4, value: @level.log_conditions ? JSON.pretty_generate(@level.log_conditions) : ''
-  :javascript
-    levelbuilder.initializeCodeMirror('level_log_conditions', 'javascript');
+= render partial: 'levels/editors/debugger', locals: {f: f}
 
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: 'fail_on_lint_errors', description: "Fail on lint errors"}
-  %p
-    Lint warnings and errors (in the editor's gutter area) will prevent the student from continuing when the Finish button is pressed.
+= render partial: 'levels/editors/submittable', locals: {f: f}
 
-.field
-  = f.label 'Table Data'
-  Step 1: Create a project at studio.code.org/p/applab and edit the data for a table in the data browser. Step 2: Copy the data via the debug area at the bottom of the table. Step 3: Paste the data below in the format { "tablename": <paste> }
-  %pre
-    = preserve do
-      :escaped
-        Example:
-        {
-          "table_name": [{ "name": "Trevor", "age": 30 }, { "name": "Hadi", "age": 72}],
-          "table_name2": [{ "city": "Seattle", "state": "WA" }, { "city": "Chicago", "state": "IL"}]
-        }
-  = f.text_area 'data_tables', placeholder: 'Insert JSON Data', rows: 4, value: @level.data_tables or ''
-  :javascript
-    levelbuilder.initializeCodeMirror('level_data_tables', 'javascript');
+= render partial: 'levels/editors/helper_libraries', locals: {f: f}
 
-.field
-  = f.label 'Key-Value Data'
-  You can copy the data array from the debug view in the Data tab in App Lab.
-  %pre
-    = preserve do
-      :escaped
-        Example:
-        {
-          "click_count": 5,
-          "button_color": "blue"
-        }
-  = f.text_area 'data_properties', placeholder: 'Insert JSON Key-Value Data', rows: 4, value: @level.data_properties or ''
-  :javascript
-    levelbuilder.initializeCodeMirror('level_data_properties', 'javascript');
+%legend.control-legend{data: {toggle: "collapse", target: "#dataTab"}}
+  Data Tab
 
+#dataTab.collapse
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_view_data_button, description: "Hide Data Button"}
 
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_view_data_button, description: "Hide Data Button"}
+  .field
+    = f.label 'Table Data'
+    Step 1: Create a project at studio.code.org/p/applab and edit the data for a table in the data browser. Step 2: Copy the data via the debug area at the bottom of the table. Step 3: Paste the data below in the format { "tablename": <paste> }
+    %pre
+      = preserve do
+        :escaped
+          Example:
+          {
+            "table_name": [{ "name": "Trevor", "age": 30 }, { "name": "Hadi", "age": 72}],
+            "table_name2": [{ "city": "Seattle", "state": "WA" }, { "city": "Chicago", "state": "IL"}]
+          }
+    = f.text_area 'data_tables', placeholder: 'Insert JSON Data', rows: 4, value: @level.data_tables or ''
+    :javascript
+      levelbuilder.initializeCodeMirror('level_data_tables', 'javascript');
 
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :debugger_disabled, description: "Disable code debugger (Console is still enabled)"}
+  .field
+    = f.label 'Key-Value Data'
+    You can copy the data array from the debug view in the Data tab in App Lab.
+    %pre
+      = preserve do
+        :escaped
+          Example:
+          {
+            "click_count": 5,
+            "button_color": "blue"
+          }
+    = f.text_area 'data_properties', placeholder: 'Insert JSON Key-Value Data', rows: 4, value: @level.data_properties or ''
+    :javascript
+      levelbuilder.initializeCodeMirror('level_data_properties', 'javascript');
 
+%legend.control-legend{data: {toggle: "collapse", target: "#designMode"}}
+  Design Mode
 
-.field
-  = f.label :helper_libraries
-  %p
-    Select
-    %a.select_all{href: '#'} all
-    \/
-    %a.select_none{href: '#'} none
-    (shift-click or cmd-click to select multiple).
-  = f.select :helper_libraries, (Library.distinct.pluck(:name) + (@level.helper_libraries || [])).uniq.sort, {}, {multiple: true}
+#designMode.collapse
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :design_mode_at_start, description: "Start in Design Mode"}
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_design_mode, description: "Hide Design Mode"}
+  .field
+    = f.label :start_html, 'Starting design mode html'
+    %p
+      This should be equivalent to the level html created by design mode. Learn how to how to make them
+      =link_to 'here', 'https://github.com/code-dot-org/code-dot-org/wiki/%5BLevelbuilder%5D-Adding-Preloaded-Design-Elements-in-App-Lab', target: '_blank'
+
+    %p
+      IMPORTANT WARNING: If you have referenced images in the HTML and/or  CODE, then you need to get fully-qualified
+      code.org https URLS for these assets and update the HTML and the code to reflect these. You can quickly get full
+      image urls by drag-dropping the image into the markdown section of a dummy level in levelbuilder.
+      Copy the result and paste it here (it should start with something like
+      #{html_escape("<div xmlns='http://www.w3.org/1999/xhtml' id='divApplab'")}...)
+    = f.text_area :start_html, placeholder: 'Start html', rows: 4, value: @level.start_html
+    :javascript
+      levelbuilder.initializeCodeMirror('level_start_html', 'html');
+
+%legend.control-legend{data: {toggle: "collapse", target: "#makerToolkit"}}
+  Maker Toolkit
+
+#makerToolkit.collapse
+  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :makerlab_enabled, description: "Enable Maker APIs"}
+
+%legend.control-legend{data: {toggle: "collapse", target: "#applab"}}
+  App Lab Options
+
+%p Turtle settings. API settings. Conditions for level completion.
+
+#applab.collapse
+  .field
+    = f.label :start_libraries,'Applab Start Library'
+    = f.text_area :start_libraries, value: @level.start_libraries ? JSON.pretty_generate(@level.start_libraries) : ''
+  .field
+    = f.label :slider_speed, 'Slider speed'
+    %p Number from 0.0 to 1.0 for how fast Applab runs by default while in the IDE. If not set, default is 1.0
+    = f.number_field :slider_speed, :step => 0.1
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :show_turtle_before_run, description: "Show turtle before Run is pressed"}
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :autocomplete_palette_apis_only, description: "Autocomplete palette APIs only"}
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :execute_palette_apis_only, description: "Execute palette APIs only"}
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :beginner_mode, description: "Beginner mode for loops"}
+
+  .field
+    = f.label 'Log Conditions'
+    Create a JSON array resembling the example if you want to add requirements that certain functions were executed. These will be checked when the Finish button is pressed.
+    %pre
+      = preserve do
+        :escaped
+          Example:
+          [
+            { "entries": ["function1", "function2"], "matchType": "exact", "minTimes": 1, "message": "You need to call both functions." },
+            { "entries": ["[forTest]", "moveTo", "randomNumber", "randomNumber"], "matchType": "inexact", "minTimes": 20, "message": "You need to call moveTo in a for loop." }
+          ]
+    = f.text_area 'log_conditions', placeholder: 'Insert JSON Data', rows: 4, value: @level.log_conditions ? JSON.pretty_generate(@level.log_conditions) : ''
+    :javascript
+      levelbuilder.initializeCodeMirror('level_log_conditions', 'javascript');
+
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: 'fail_on_lint_errors', description: "Fail on lint errors"}
+    %p
+      Lint warnings and errors (in the editor's gutter area) will prevent the student from continuing when the Finish button is pressed.

--- a/dashboard/app/views/levels/editors/_mini_rubric.html.haml
+++ b/dashboard/app/views/levels/editors/_mini_rubric.html.haml
@@ -1,7 +1,7 @@
 %legend.control-legend{data: {toggle: "collapse", target: "#mini_rubric"}}
   Mini Rubric
 
-#mini_rubric.in.collapse
+#mini_rubric.collapse
   %p
     These levels may contain an optional mini-rubric that teachers can use to evaluate student learning.
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :mini_rubric, description: "Show a mini-rubric on this level"}

--- a/dashboard/app/views/levels/editors/_teacher_only_markdown.haml
+++ b/dashboard/app/views/levels/editors/_teacher_only_markdown.haml
@@ -8,7 +8,7 @@
 %legend.control-legend{data: {toggle: "collapse", target: "#teacher_only_markdown"}}
   Teacher Only Markdown
 
-#teacher_only_markdown.in.collapse
+#teacher_only_markdown.collapse
   .field.teacher-only-markdown
     %p Edit Teacher Only Markdown (visible only to authorized teachers):
     = f.text_area 'teacher_markdown', placeholder: 'Enter teacher only markdown here', rows: 4, value: @level.teacher_markdown or ''

--- a/dashboard/app/views/levels/editors/_weblab.html.haml
+++ b/dashboard/app/views/levels/editors/_weblab.html.haml
@@ -1,17 +1,18 @@
-.field
+%legend.control-legend{data: {toggle: "collapse", target: "#weblabStartingSources"}}
+  Web Lab Starting Sources
+
+#weblabStartingSources.collapse
   = f.label :start_sources, 'Starting sources'
   %p
     Sources
-= f.text_area :start_sources, placeholder: 'Starting sources', rows: 40, class: "input-block-level", value: @level.start_sources
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :submittable, description: "Submittable"}
-  %p
-    If checked, students with teachers can "submit" a solution for
-    grading. Submitting a solution means that it is marked as
-    submitted and they can no longer edit it (unless a teacher returns
-    it).
+  = f.text_area :start_sources, placeholder: 'Starting sources', rows: 40, class: "input-block-level", value: @level.start_sources
 
-.field
+= render partial: 'levels/editors/submittable', locals: {f: f}
+
+%legend.control-legend{data: {toggle: "collapse", target: "#projectTemplateLevel"}}
+  Project Template Level
+
+#projectTemplateLevel.collapse
   = f.label :project_template_level_name, 'Project Template Level Name'
   %p What this does:
   %ul
@@ -19,7 +20,6 @@
     %li autocreate a project that is shared with all levels with the same project template level
   %p (Leave blank if you do not want all of this)
   = f.text_field :project_template_level_name, placeholder: 'name of level you want to use as the project template'
-
 
 = render partial: 'levels/editors/hide_share_and_remix', locals: {f: f}
 


### PR DESCRIPTION
Updates the App Lab and Web Lab edit pages for the areas specific to those types of levels to be more organized into categories that start collapsed.

Also has mini rubrics and teacher only markdown start collapsed instead of open.

# App Lab

<img width="818" alt="Screen Shot 2019-06-14 at 12 54 41 PM" src="https://user-images.githubusercontent.com/208083/59525191-b3de1400-8ea3-11e9-98e5-23b9fbfee7f2.png">


# Web Lab

<img width="924" alt="Screen Shot 2019-06-14 at 12 54 31 PM" src="https://user-images.githubusercontent.com/208083/59525203-bfc9d600-8ea3-11e9-8186-a451d33854d3.png">
