### PR TITLE
Tests: Make SectionProjectsListTest Enzyme-3-ready

### DIFF
--- a/apps/test/unit/templates/projects/SectionProjectsListTest.js
+++ b/apps/test/unit/templates/projects/SectionProjectsListTest.js
@@ -5,7 +5,7 @@ import {
   COLUMNS_WITHOUT_THUMBNAILS
 } from '@cdo/apps/templates/projects/ProjectsList';
 import {mount} from 'enzyme';
-import {expect} from '../../../util/configuredChai';
+import {expect} from '../../../util/reconfiguredChai';
 
 const CAT_IMAGE_URL = '/base/static/common_images/stickers/cat.png';
 
@@ -43,75 +43,6 @@ const STUB_PROJECTS_DATA = [
 
 const STUDIO_URL_PREFIX = '//foo-studio.code.org';
 
-/**
- * @param {HTMLTableRowElement} rowElement HTML row element in the projects list table
- * @param {string} projectName Expected project name
- * @param {string} studentName Expected student name
- * @param {string} appType Expected app type (App Lab, Game Lab, etc)
- * @param {string} lastEdited Expected last edited date (Month DD, YYYY). Note that this
- *   format is used only in unit tests due to incorrect date formatting in PhantomJS.
- *   The desired date format which we will show in all browsers is MM/DD/YYYY.
- */
-function assertRowContents(
-  rowElement,
-  thumbnailUrl,
-  projectName,
-  studentName,
-  appType,
-  lastEdited
-) {
-  assertRowThumbnail(rowElement, thumbnailUrl);
-  expect(rowElement.childNodes[COLUMNS.PROJECT_NAME].innerText).to.equal(
-    projectName
-  );
-  expect(rowElement.childNodes[COLUMNS.STUDENT_NAME].innerText).to.equal(
-    studentName
-  );
-  expect(rowElement.childNodes[COLUMNS.APP_TYPE].innerText).to.equal(appType);
-  // Temporarily comment out this line to make tests pass locally in Chrome
-  expect(rowElement.childNodes[COLUMNS.LAST_EDITED].innerText).to.equal(
-    lastEdited
-  );
-}
-
-function assertRowThumbnail(rowElement, thumbnailUrl) {
-  const td = rowElement.childNodes[COLUMNS.THUMBNAIL];
-  const img = td.querySelector('img');
-  const src = img && img.getAttribute('src');
-  expect(src).to.equal(thumbnailUrl);
-}
-
-/**
- * @param {HTMLTableRowElement} rowElement HTML row element in the projects list table
- * @param {string} projectName Expected project name
- * @param {string} studentName Expected student name
- * @param {string} appType Expected app type (App Lab, Game Lab, etc)
- * @param {string} lastEdited Expected last edited date (Month DD, YYYY). Note that this
- *   format is used only in unit tests due to incorrect date formatting in PhantomJS.
- *   The desired date format which we will show in all browsers is MM/DD/YYYY.
- */
-function assertRowContentsWithoutThumbnail(
-  rowElement,
-  projectName,
-  studentName,
-  appType,
-  lastEdited
-) {
-  expect(
-    rowElement.childNodes[COLUMNS_WITHOUT_THUMBNAILS.PROJECT_NAME].innerText
-  ).to.equal(projectName);
-  expect(
-    rowElement.childNodes[COLUMNS_WITHOUT_THUMBNAILS.STUDENT_NAME].innerText
-  ).to.equal(studentName);
-  expect(
-    rowElement.childNodes[COLUMNS_WITHOUT_THUMBNAILS.APP_TYPE].innerText
-  ).to.equal(appType);
-  // Temporarily comment out this line to make tests pass locally in Chrome
-  expect(
-    rowElement.childNodes[COLUMNS_WITHOUT_THUMBNAILS.LAST_EDITED].innerText
-  ).to.equal(lastEdited);
-}
-
 describe('SectionProjectsList', () => {
   let root;
 
@@ -138,11 +69,6 @@ describe('SectionProjectsList', () => {
         expect(date.getUTCHours()).to.equal(11);
       }
     });
-
-    it('is compatible with the time zone of the test browser', () => {
-      const date = new Date(STUB_PROJECTS_DATA[0].updatedAt);
-      expect(date.toLocaleDateString()).to.equal('December 29, 2016');
-    });
   });
 
   it('hide thumbnail column when showProjectThumbnails is disabled', () => {
@@ -158,35 +84,35 @@ describe('SectionProjectsList', () => {
     expect(rows).to.have.length(5);
 
     assertRowContentsWithoutThumbnail(
-      rows.nodes[0],
+      rows.at(0).instance(),
       'Project Name',
       'Student Name',
       'Type',
       'Last Edited'
     );
     assertRowContentsWithoutThumbnail(
-      rows.nodes[1],
+      rows.at(1).instance(),
       'Dominoes',
       'Bob',
       'Game Lab',
       'January 1, 2017'
     );
     assertRowContentsWithoutThumbnail(
-      rows.nodes[2],
+      rows.at(2).instance(),
       'Antelope Freeway',
       'Alice',
       'Web Lab',
       'December 29, 2016'
     );
     assertRowContentsWithoutThumbnail(
-      rows.nodes[3],
+      rows.at(3).instance(),
       'Cats and Kittens',
       'Charlie',
       'Web Lab',
       'November 30, 2016'
     );
     assertRowContentsWithoutThumbnail(
-      rows.nodes[4],
+      rows.at(4).instance(),
       'A1 Locksmith',
       'Alice',
       'App Lab',
@@ -198,7 +124,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -206,7 +132,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'Dominoes',
       'Bob',
@@ -214,7 +140,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -222,7 +148,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[3],
+      rows.at(3).instance(),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -230,7 +156,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.nodes[4],
+      rows.at(4).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -239,7 +165,7 @@ describe('SectionProjectsList', () => {
     );
 
     const lastEditedHeader = root.find('th').at(COLUMNS.LAST_EDITED);
-    expect(lastEditedHeader.node.innerText).to.contain('Last Edited');
+    expect(lastEditedHeader.instance().innerText).to.contain('Last Edited');
 
     // Show least recently edited first
     lastEditedHeader.simulate('click');
@@ -247,7 +173,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -255,7 +181,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -263,7 +189,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -271,7 +197,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.nodes[3],
+      rows.at(3).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -279,7 +205,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[4],
+      rows.at(4).instance(),
       null,
       'Dominoes',
       'Bob',
@@ -290,7 +216,7 @@ describe('SectionProjectsList', () => {
 
   it('can be sorted by project name', () => {
     const projectNameHeader = root.find('th').at(COLUMNS.PROJECT_NAME);
-    expect(projectNameHeader.node.innerText).to.contain('Project Name');
+    expect(projectNameHeader.instance().innerText).to.contain('Project Name');
 
     // Sort in ascending order by project name
     projectNameHeader.simulate('click');
@@ -298,7 +224,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -306,7 +232,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -314,7 +240,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -322,7 +248,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[3],
+      rows.at(3).instance(),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -330,7 +256,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.nodes[4],
+      rows.at(4).instance(),
       null,
       'Dominoes',
       'Bob',
@@ -344,7 +270,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -352,7 +278,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'Dominoes',
       'Bob',
@@ -360,7 +286,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -368,7 +294,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.nodes[3],
+      rows.at(3).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -376,7 +302,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[4],
+      rows.at(4).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -387,7 +313,7 @@ describe('SectionProjectsList', () => {
 
   it('can be sorted by student name', () => {
     const projectNameHeader = root.find('th').at(COLUMNS.STUDENT_NAME);
-    expect(projectNameHeader.node.innerText).to.contain('Student Name');
+    expect(projectNameHeader.instance().innerText).to.contain('Student Name');
 
     // Sort in ascending order by student name
     projectNameHeader.simulate('click');
@@ -395,7 +321,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -403,7 +329,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -411,7 +337,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -419,7 +345,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.nodes[3],
+      rows.at(3).instance(),
       null,
       'Dominoes',
       'Bob',
@@ -427,7 +353,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.nodes[4],
+      rows.at(4).instance(),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -441,7 +367,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -449,7 +375,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -457,7 +383,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       null,
       'Dominoes',
       'Bob',
@@ -467,7 +393,7 @@ describe('SectionProjectsList', () => {
     // There is no secondary sort key. When the sort by name is reversed, elements with the same
     // primary sort key do not change in order relative to each other.
     assertRowContents(
-      rows.nodes[3],
+      rows.at(3).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -475,7 +401,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[4],
+      rows.at(4).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -486,7 +412,7 @@ describe('SectionProjectsList', () => {
 
   it('can be sorted by app type', () => {
     const appTypeHeader = root.find('th').at(COLUMNS.APP_TYPE);
-    expect(appTypeHeader.node.innerText).to.contain('Type');
+    expect(appTypeHeader.instance().innerText).to.contain('Type');
 
     // Sort in ascending order by app type
     appTypeHeader.simulate('click');
@@ -494,7 +420,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -502,7 +428,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -510,7 +436,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       null,
       'Dominoes',
       'Bob',
@@ -518,7 +444,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.nodes[3],
+      rows.at(3).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -526,7 +452,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[4],
+      rows.at(4).instance(),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -540,7 +466,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -550,7 +476,7 @@ describe('SectionProjectsList', () => {
     // There is no secondary sort key. When the sort by name is reversed, elements with the same
     // primary sort key do not change in order relative to each other.
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -558,7 +484,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -566,7 +492,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.nodes[3],
+      rows.at(3).instance(),
       null,
       'Dominoes',
       'Bob',
@@ -574,7 +500,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.nodes[4],
+      rows.at(4).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -586,24 +512,24 @@ describe('SectionProjectsList', () => {
   it('shows the correct list of students in the student filter dropdown', () => {
     const options = root.find('option');
     expect(options).to.have.length(4);
-    expect(options.nodes[0].innerText).to.equal('All students');
-    expect(options.nodes[1].innerText).to.equal('Alice');
-    expect(options.nodes[2].innerText).to.equal('Bob');
-    expect(options.nodes[3].innerText).to.equal('Charlie');
+    expect(options.at(0).instance().innerText).to.equal('All students');
+    expect(options.at(1).instance().innerText).to.equal('Alice');
+    expect(options.at(2).instance().innerText).to.equal('Bob');
+    expect(options.at(3).instance().innerText).to.equal('Charlie');
 
     const select = root.find('select');
-    expect(select.nodes[0].value).to.equal('_all_students');
+    expect(select.at(0).instance().value).to.equal('_all_students');
   });
 
   it('filters projects when a student is selected from the dropdown', () => {
     const select = root.find('select');
     select.simulate('change', {target: {value: 'Alice'}});
-    expect(select.nodes[0].value).to.equal('Alice');
+    expect(select.at(0).instance().value).to.equal('Alice');
 
     const rows = root.find('tr');
     expect(rows).to.have.length(3);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -611,7 +537,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -619,7 +545,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -631,10 +557,10 @@ describe('SectionProjectsList', () => {
   it('can filter by student and then sort by app type', () => {
     const select = root.find('select');
     select.simulate('change', {target: {value: 'Alice'}});
-    expect(select.nodes[0].value).to.equal('Alice');
+    expect(select.at(0).instance().value).to.equal('Alice');
 
     const appTypeHeader = root.find('th').at(COLUMNS.APP_TYPE);
-    expect(appTypeHeader.node.innerText).to.contain('Type');
+    expect(appTypeHeader.instance().innerText).to.contain('Type');
 
     // Sort in ascending order by app type
     appTypeHeader.simulate('click');
@@ -642,7 +568,7 @@ describe('SectionProjectsList', () => {
     const rows = root.find('tr');
     expect(rows).to.have.length(3);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -650,7 +576,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -658,7 +584,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -670,12 +596,12 @@ describe('SectionProjectsList', () => {
   it('shows all students projects if the current students projects all disappear', () => {
     const select = root.find('select');
     select.simulate('change', {target: {value: 'Charlie'}});
-    expect(select.nodes[0].value).to.equal('Charlie');
+    expect(select.at(0).instance().value).to.equal('Charlie');
 
     let rows = root.find('tr');
     expect(rows).to.have.length(2);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -683,7 +609,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -701,10 +627,10 @@ describe('SectionProjectsList', () => {
 
     // We should now see all students projects, except Charlie's
     rows = root.find('tr');
-    expect(select.nodes[0].value).to.equal('_all_students');
+    expect(select.at(0).instance().value).to.equal('_all_students');
     expect(rows).to.have.length(4);
     assertRowContents(
-      rows.nodes[0],
+      rows.at(0).instance(),
       null,
       'Project Name',
       'Student Name',
@@ -712,7 +638,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.nodes[1],
+      rows.at(1).instance(),
       null,
       'Dominoes',
       'Bob',
@@ -720,7 +646,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.nodes[2],
+      rows.at(2).instance(),
       null,
       'Antelope Freeway',
       'Alice',
@@ -728,7 +654,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.nodes[3],
+      rows.at(3).instance(),
       null,
       'A1 Locksmith',
       'Alice',
@@ -739,9 +665,9 @@ describe('SectionProjectsList', () => {
     // Charlie should no longer appear in the dropdown
     const options = root.find('option');
     expect(options).to.have.length(3);
-    expect(options.nodes[0].innerText).to.equal('All students');
-    expect(options.nodes[1].innerText).to.equal('Alice');
-    expect(options.nodes[2].innerText).to.equal('Bob');
+    expect(options.at(0).instance().innerText).to.equal('All students');
+    expect(options.at(1).instance().innerText).to.equal('Alice');
+    expect(options.at(2).instance().innerText).to.equal('Bob');
   });
 
   describe('getStudentNames', () => {
@@ -751,4 +677,83 @@ describe('SectionProjectsList', () => {
       ).to.deep.equal(['Alice', 'Bob', 'Charlie']);
     });
   });
+
+  /**
+   * @param {HTMLTableRowElement} rowElement HTML row element in the projects list table
+   * @param {string} projectName Expected project name
+   * @param {string} studentName Expected student name
+   * @param {string} appType Expected app type (App Lab, Game Lab, etc)
+   * @param {string} lastEdited Expected last edited date (Month DD, YYYY). Note that this
+   *   format is used only in unit tests due to incorrect date formatting in PhantomJS.
+   *   The desired date format which we will show in all browsers is MM/DD/YYYY.
+   */
+  function assertRowContents(
+    rowElement,
+    thumbnailUrl,
+    projectName,
+    studentName,
+    appType,
+    lastEdited
+  ) {
+    assertRowThumbnail(rowElement, thumbnailUrl);
+    assertRowContentsWithoutThumbnail(
+      rowElement,
+      projectName,
+      studentName,
+      appType,
+      lastEdited,
+      COLUMNS
+    );
+  }
+
+  /**
+   * @param {HTMLTableRowElement} rowElement HTML row element in the projects list table
+   * @param {string} projectName Expected project name
+   * @param {string} studentName Expected student name
+   * @param {string} appType Expected app type (App Lab, Game Lab, etc)
+   * @param {string} lastEdited Expected last edited date (Month DD, YYYY). Note that this
+   *   format is used only in unit tests due to incorrect date formatting in PhantomJS.
+   *   The desired date format which we will show in all browsers is MM/DD/YYYY.
+   * @param {object} [columnMap] Optional custom column map to use when comparing expected
+   *   and actual values.
+   */
+  function assertRowContentsWithoutThumbnail(
+    rowElement,
+    projectName,
+    studentName,
+    appType,
+    lastEdited,
+    columnMap = COLUMNS_WITHOUT_THUMBNAILS
+  ) {
+    const projectNameActual =
+      rowElement.childNodes[columnMap.PROJECT_NAME].innerText;
+    const studentNameActual =
+      rowElement.childNodes[columnMap.STUDENT_NAME].innerText;
+    const appTypeActual = rowElement.childNodes[columnMap.APP_TYPE].innerText;
+    const lastEditedActual =
+      rowElement.childNodes[columnMap.LAST_EDITED].innerText;
+
+    expect(projectNameActual).to.equal(projectName);
+    expect(studentNameActual).to.equal(studentName);
+    expect(appTypeActual).to.equal(appType);
+    assertDatesMatch(lastEdited, lastEditedActual);
+  }
+
+  function assertDatesMatch(expected, actual) {
+    if (isNaN(Date.parse(expected))) {
+      // If we're checking against non-date text (a header) just do an equality check
+      expect(actual).to.equal(expected);
+    } else {
+      // Otherwise convert our 'expected' value to a locale string, so tests are not
+      // browser-implementation-dependent
+      expect(actual).to.equal(new Date(expected).toLocaleDateString());
+    }
+  }
+
+  function assertRowThumbnail(rowElement, thumbnailUrl) {
+    const td = rowElement.childNodes[COLUMNS.THUMBNAIL];
+    const img = td.querySelector('img');
+    const src = img && img.getAttribute('src');
+    expect(src).to.equal(thumbnailUrl);
+  }
 });

--- a/apps/test/unit/templates/projects/SectionProjectsListTest.js
+++ b/apps/test/unit/templates/projects/SectionProjectsListTest.js
@@ -84,35 +84,35 @@ describe('SectionProjectsList', () => {
     expect(rows).to.have.length(5);
 
     assertRowContentsWithoutThumbnail(
-      rows.at(0).instance(),
+      rows.get(0),
       'Project Name',
       'Student Name',
       'Type',
       'Last Edited'
     );
     assertRowContentsWithoutThumbnail(
-      rows.at(1).instance(),
+      rows.get(1),
       'Dominoes',
       'Bob',
       'Game Lab',
       'January 1, 2017'
     );
     assertRowContentsWithoutThumbnail(
-      rows.at(2).instance(),
+      rows.get(2),
       'Antelope Freeway',
       'Alice',
       'Web Lab',
       'December 29, 2016'
     );
     assertRowContentsWithoutThumbnail(
-      rows.at(3).instance(),
+      rows.get(3),
       'Cats and Kittens',
       'Charlie',
       'Web Lab',
       'November 30, 2016'
     );
     assertRowContentsWithoutThumbnail(
-      rows.at(4).instance(),
+      rows.get(4),
       'A1 Locksmith',
       'Alice',
       'App Lab',
@@ -124,7 +124,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -132,7 +132,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'Dominoes',
       'Bob',
@@ -140,7 +140,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       null,
       'Antelope Freeway',
       'Alice',
@@ -148,7 +148,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(3).instance(),
+      rows.get(3),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -156,7 +156,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.at(4).instance(),
+      rows.get(4),
       null,
       'A1 Locksmith',
       'Alice',
@@ -165,7 +165,7 @@ describe('SectionProjectsList', () => {
     );
 
     const lastEditedHeader = root.find('th').at(COLUMNS.LAST_EDITED);
-    expect(lastEditedHeader.instance().innerText).to.contain('Last Edited');
+    expect(lastEditedHeader.get(0).innerText).to.contain('Last Edited');
 
     // Show least recently edited first
     lastEditedHeader.simulate('click');
@@ -173,7 +173,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -181,7 +181,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'A1 Locksmith',
       'Alice',
@@ -189,7 +189,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -197,7 +197,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.at(3).instance(),
+      rows.get(3),
       null,
       'Antelope Freeway',
       'Alice',
@@ -205,7 +205,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(4).instance(),
+      rows.get(4),
       null,
       'Dominoes',
       'Bob',
@@ -216,7 +216,7 @@ describe('SectionProjectsList', () => {
 
   it('can be sorted by project name', () => {
     const projectNameHeader = root.find('th').at(COLUMNS.PROJECT_NAME);
-    expect(projectNameHeader.instance().innerText).to.contain('Project Name');
+    expect(projectNameHeader.get(0).innerText).to.contain('Project Name');
 
     // Sort in ascending order by project name
     projectNameHeader.simulate('click');
@@ -224,7 +224,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -232,7 +232,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'A1 Locksmith',
       'Alice',
@@ -240,7 +240,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       null,
       'Antelope Freeway',
       'Alice',
@@ -248,7 +248,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(3).instance(),
+      rows.get(3),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -256,7 +256,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.at(4).instance(),
+      rows.get(4),
       null,
       'Dominoes',
       'Bob',
@@ -270,7 +270,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -278,7 +278,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'Dominoes',
       'Bob',
@@ -286,7 +286,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -294,7 +294,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.at(3).instance(),
+      rows.get(3),
       null,
       'Antelope Freeway',
       'Alice',
@@ -302,7 +302,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(4).instance(),
+      rows.get(4),
       null,
       'A1 Locksmith',
       'Alice',
@@ -313,7 +313,7 @@ describe('SectionProjectsList', () => {
 
   it('can be sorted by student name', () => {
     const projectNameHeader = root.find('th').at(COLUMNS.STUDENT_NAME);
-    expect(projectNameHeader.instance().innerText).to.contain('Student Name');
+    expect(projectNameHeader.get(0).innerText).to.contain('Student Name');
 
     // Sort in ascending order by student name
     projectNameHeader.simulate('click');
@@ -321,7 +321,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -329,7 +329,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'Antelope Freeway',
       'Alice',
@@ -337,7 +337,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       null,
       'A1 Locksmith',
       'Alice',
@@ -345,7 +345,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.at(3).instance(),
+      rows.get(3),
       null,
       'Dominoes',
       'Bob',
@@ -353,7 +353,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.at(4).instance(),
+      rows.get(4),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -367,7 +367,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -375,7 +375,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -383,7 +383,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       null,
       'Dominoes',
       'Bob',
@@ -393,7 +393,7 @@ describe('SectionProjectsList', () => {
     // There is no secondary sort key. When the sort by name is reversed, elements with the same
     // primary sort key do not change in order relative to each other.
     assertRowContents(
-      rows.at(3).instance(),
+      rows.get(3),
       null,
       'Antelope Freeway',
       'Alice',
@@ -401,7 +401,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(4).instance(),
+      rows.get(4),
       null,
       'A1 Locksmith',
       'Alice',
@@ -412,7 +412,7 @@ describe('SectionProjectsList', () => {
 
   it('can be sorted by app type', () => {
     const appTypeHeader = root.find('th').at(COLUMNS.APP_TYPE);
-    expect(appTypeHeader.instance().innerText).to.contain('Type');
+    expect(appTypeHeader.get(0).innerText).to.contain('Type');
 
     // Sort in ascending order by app type
     appTypeHeader.simulate('click');
@@ -420,7 +420,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -428,7 +428,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'A1 Locksmith',
       'Alice',
@@ -436,7 +436,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       null,
       'Dominoes',
       'Bob',
@@ -444,7 +444,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.at(3).instance(),
+      rows.get(3),
       null,
       'Antelope Freeway',
       'Alice',
@@ -452,7 +452,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(4).instance(),
+      rows.get(4),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -466,7 +466,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -476,7 +476,7 @@ describe('SectionProjectsList', () => {
     // There is no secondary sort key. When the sort by name is reversed, elements with the same
     // primary sort key do not change in order relative to each other.
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'Antelope Freeway',
       'Alice',
@@ -484,7 +484,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -492,7 +492,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.at(3).instance(),
+      rows.get(3),
       null,
       'Dominoes',
       'Bob',
@@ -500,7 +500,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.at(4).instance(),
+      rows.get(4),
       null,
       'A1 Locksmith',
       'Alice',
@@ -512,24 +512,24 @@ describe('SectionProjectsList', () => {
   it('shows the correct list of students in the student filter dropdown', () => {
     const options = root.find('option');
     expect(options).to.have.length(4);
-    expect(options.at(0).instance().innerText).to.equal('All students');
-    expect(options.at(1).instance().innerText).to.equal('Alice');
-    expect(options.at(2).instance().innerText).to.equal('Bob');
-    expect(options.at(3).instance().innerText).to.equal('Charlie');
+    expect(options.get(0).innerText).to.equal('All students');
+    expect(options.get(1).innerText).to.equal('Alice');
+    expect(options.get(2).innerText).to.equal('Bob');
+    expect(options.get(3).innerText).to.equal('Charlie');
 
     const select = root.find('select');
-    expect(select.at(0).instance().value).to.equal('_all_students');
+    expect(select.get(0).value).to.equal('_all_students');
   });
 
   it('filters projects when a student is selected from the dropdown', () => {
     const select = root.find('select');
     select.simulate('change', {target: {value: 'Alice'}});
-    expect(select.at(0).instance().value).to.equal('Alice');
+    expect(select.get(0).value).to.equal('Alice');
 
     const rows = root.find('tr');
     expect(rows).to.have.length(3);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -537,7 +537,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'Antelope Freeway',
       'Alice',
@@ -545,7 +545,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       null,
       'A1 Locksmith',
       'Alice',
@@ -557,10 +557,10 @@ describe('SectionProjectsList', () => {
   it('can filter by student and then sort by app type', () => {
     const select = root.find('select');
     select.simulate('change', {target: {value: 'Alice'}});
-    expect(select.at(0).instance().value).to.equal('Alice');
+    expect(select.get(0).value).to.equal('Alice');
 
     const appTypeHeader = root.find('th').at(COLUMNS.APP_TYPE);
-    expect(appTypeHeader.instance().innerText).to.contain('Type');
+    expect(appTypeHeader.get(0).innerText).to.contain('Type');
 
     // Sort in ascending order by app type
     appTypeHeader.simulate('click');
@@ -568,7 +568,7 @@ describe('SectionProjectsList', () => {
     const rows = root.find('tr');
     expect(rows).to.have.length(3);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -576,7 +576,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'A1 Locksmith',
       'Alice',
@@ -584,7 +584,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       null,
       'Antelope Freeway',
       'Alice',
@@ -596,12 +596,12 @@ describe('SectionProjectsList', () => {
   it('shows all students projects if the current students projects all disappear', () => {
     const select = root.find('select');
     select.simulate('change', {target: {value: 'Charlie'}});
-    expect(select.at(0).instance().value).to.equal('Charlie');
+    expect(select.get(0).value).to.equal('Charlie');
 
     let rows = root.find('tr');
     expect(rows).to.have.length(2);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -609,7 +609,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -627,10 +627,10 @@ describe('SectionProjectsList', () => {
 
     // We should now see all students projects, except Charlie's
     rows = root.find('tr');
-    expect(select.at(0).instance().value).to.equal('_all_students');
+    expect(select.get(0).value).to.equal('_all_students');
     expect(rows).to.have.length(4);
     assertRowContents(
-      rows.at(0).instance(),
+      rows.get(0),
       null,
       'Project Name',
       'Student Name',
@@ -638,7 +638,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.at(1).instance(),
+      rows.get(1),
       null,
       'Dominoes',
       'Bob',
@@ -646,7 +646,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.at(2).instance(),
+      rows.get(2),
       null,
       'Antelope Freeway',
       'Alice',
@@ -654,7 +654,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.at(3).instance(),
+      rows.get(3),
       null,
       'A1 Locksmith',
       'Alice',
@@ -665,9 +665,9 @@ describe('SectionProjectsList', () => {
     // Charlie should no longer appear in the dropdown
     const options = root.find('option');
     expect(options).to.have.length(3);
-    expect(options.at(0).instance().innerText).to.equal('All students');
-    expect(options.at(1).instance().innerText).to.equal('Alice');
-    expect(options.at(2).instance().innerText).to.equal('Bob');
+    expect(options.get(0).innerText).to.equal('All students');
+    expect(options.get(1).innerText).to.equal('Alice');
+    expect(options.get(2).innerText).to.equal('Bob');
   });
 
   describe('getStudentNames', () => {

--- a/apps/test/unit/templates/projects/SectionProjectsListTest.js
+++ b/apps/test/unit/templates/projects/SectionProjectsListTest.js
@@ -84,35 +84,35 @@ describe('SectionProjectsList', () => {
     expect(rows).to.have.length(5);
 
     assertRowContentsWithoutThumbnail(
-      rows.get(0),
+      getNode(rows, 0),
       'Project Name',
       'Student Name',
       'Type',
       'Last Edited'
     );
     assertRowContentsWithoutThumbnail(
-      rows.get(1),
+      getNode(rows, 1),
       'Dominoes',
       'Bob',
       'Game Lab',
       'January 1, 2017'
     );
     assertRowContentsWithoutThumbnail(
-      rows.get(2),
+      getNode(rows, 2),
       'Antelope Freeway',
       'Alice',
       'Web Lab',
       'December 29, 2016'
     );
     assertRowContentsWithoutThumbnail(
-      rows.get(3),
+      getNode(rows, 3),
       'Cats and Kittens',
       'Charlie',
       'Web Lab',
       'November 30, 2016'
     );
     assertRowContentsWithoutThumbnail(
-      rows.get(4),
+      getNode(rows, 4),
       'A1 Locksmith',
       'Alice',
       'App Lab',
@@ -124,7 +124,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -132,7 +132,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'Dominoes',
       'Bob',
@@ -140,7 +140,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       null,
       'Antelope Freeway',
       'Alice',
@@ -148,7 +148,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(3),
+      getNode(rows, 3),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -156,7 +156,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.get(4),
+      getNode(rows, 4),
       null,
       'A1 Locksmith',
       'Alice',
@@ -165,7 +165,7 @@ describe('SectionProjectsList', () => {
     );
 
     const lastEditedHeader = root.find('th').at(COLUMNS.LAST_EDITED);
-    expect(lastEditedHeader.get(0).innerText).to.contain('Last Edited');
+    expect(getNode(lastEditedHeader).innerText).to.contain('Last Edited');
 
     // Show least recently edited first
     lastEditedHeader.simulate('click');
@@ -173,7 +173,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -181,7 +181,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'A1 Locksmith',
       'Alice',
@@ -189,7 +189,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -197,7 +197,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.get(3),
+      getNode(rows, 3),
       null,
       'Antelope Freeway',
       'Alice',
@@ -205,7 +205,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(4),
+      getNode(rows, 4),
       null,
       'Dominoes',
       'Bob',
@@ -216,7 +216,7 @@ describe('SectionProjectsList', () => {
 
   it('can be sorted by project name', () => {
     const projectNameHeader = root.find('th').at(COLUMNS.PROJECT_NAME);
-    expect(projectNameHeader.get(0).innerText).to.contain('Project Name');
+    expect(getNode(projectNameHeader).innerText).to.contain('Project Name');
 
     // Sort in ascending order by project name
     projectNameHeader.simulate('click');
@@ -224,7 +224,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -232,7 +232,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'A1 Locksmith',
       'Alice',
@@ -240,7 +240,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       null,
       'Antelope Freeway',
       'Alice',
@@ -248,7 +248,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(3),
+      getNode(rows, 3),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -256,7 +256,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.get(4),
+      getNode(rows, 4),
       null,
       'Dominoes',
       'Bob',
@@ -270,7 +270,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -278,7 +278,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'Dominoes',
       'Bob',
@@ -286,7 +286,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -294,7 +294,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.get(3),
+      getNode(rows, 3),
       null,
       'Antelope Freeway',
       'Alice',
@@ -302,7 +302,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(4),
+      getNode(rows, 4),
       null,
       'A1 Locksmith',
       'Alice',
@@ -313,7 +313,7 @@ describe('SectionProjectsList', () => {
 
   it('can be sorted by student name', () => {
     const projectNameHeader = root.find('th').at(COLUMNS.STUDENT_NAME);
-    expect(projectNameHeader.get(0).innerText).to.contain('Student Name');
+    expect(getNode(projectNameHeader).innerText).to.contain('Student Name');
 
     // Sort in ascending order by student name
     projectNameHeader.simulate('click');
@@ -321,7 +321,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -329,7 +329,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'Antelope Freeway',
       'Alice',
@@ -337,7 +337,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       null,
       'A1 Locksmith',
       'Alice',
@@ -345,7 +345,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.get(3),
+      getNode(rows, 3),
       null,
       'Dominoes',
       'Bob',
@@ -353,7 +353,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.get(4),
+      getNode(rows, 4),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -367,7 +367,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -375,7 +375,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -383,7 +383,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       null,
       'Dominoes',
       'Bob',
@@ -393,7 +393,7 @@ describe('SectionProjectsList', () => {
     // There is no secondary sort key. When the sort by name is reversed, elements with the same
     // primary sort key do not change in order relative to each other.
     assertRowContents(
-      rows.get(3),
+      getNode(rows, 3),
       null,
       'Antelope Freeway',
       'Alice',
@@ -401,7 +401,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(4),
+      getNode(rows, 4),
       null,
       'A1 Locksmith',
       'Alice',
@@ -412,7 +412,7 @@ describe('SectionProjectsList', () => {
 
   it('can be sorted by app type', () => {
     const appTypeHeader = root.find('th').at(COLUMNS.APP_TYPE);
-    expect(appTypeHeader.get(0).innerText).to.contain('Type');
+    expect(getNode(appTypeHeader).innerText).to.contain('Type');
 
     // Sort in ascending order by app type
     appTypeHeader.simulate('click');
@@ -420,7 +420,7 @@ describe('SectionProjectsList', () => {
     let rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -428,7 +428,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'A1 Locksmith',
       'Alice',
@@ -436,7 +436,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       null,
       'Dominoes',
       'Bob',
@@ -444,7 +444,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.get(3),
+      getNode(rows, 3),
       null,
       'Antelope Freeway',
       'Alice',
@@ -452,7 +452,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(4),
+      getNode(rows, 4),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -466,7 +466,7 @@ describe('SectionProjectsList', () => {
     rows = root.find('tr');
     expect(rows).to.have.length(5);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -476,7 +476,7 @@ describe('SectionProjectsList', () => {
     // There is no secondary sort key. When the sort by name is reversed, elements with the same
     // primary sort key do not change in order relative to each other.
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'Antelope Freeway',
       'Alice',
@@ -484,7 +484,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -492,7 +492,7 @@ describe('SectionProjectsList', () => {
       'November 30, 2016'
     );
     assertRowContents(
-      rows.get(3),
+      getNode(rows, 3),
       null,
       'Dominoes',
       'Bob',
@@ -500,7 +500,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.get(4),
+      getNode(rows, 4),
       null,
       'A1 Locksmith',
       'Alice',
@@ -512,24 +512,24 @@ describe('SectionProjectsList', () => {
   it('shows the correct list of students in the student filter dropdown', () => {
     const options = root.find('option');
     expect(options).to.have.length(4);
-    expect(options.get(0).innerText).to.equal('All students');
-    expect(options.get(1).innerText).to.equal('Alice');
-    expect(options.get(2).innerText).to.equal('Bob');
-    expect(options.get(3).innerText).to.equal('Charlie');
+    expect(getNode(options, 0).innerText).to.equal('All students');
+    expect(getNode(options, 1).innerText).to.equal('Alice');
+    expect(getNode(options, 2).innerText).to.equal('Bob');
+    expect(getNode(options, 3).innerText).to.equal('Charlie');
 
     const select = root.find('select');
-    expect(select.get(0).value).to.equal('_all_students');
+    expect(getNode(select).value).to.equal('_all_students');
   });
 
   it('filters projects when a student is selected from the dropdown', () => {
     const select = root.find('select');
     select.simulate('change', {target: {value: 'Alice'}});
-    expect(select.get(0).value).to.equal('Alice');
+    expect(getNode(select).value).to.equal('Alice');
 
     const rows = root.find('tr');
     expect(rows).to.have.length(3);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -537,7 +537,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'Antelope Freeway',
       'Alice',
@@ -545,7 +545,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       null,
       'A1 Locksmith',
       'Alice',
@@ -557,10 +557,10 @@ describe('SectionProjectsList', () => {
   it('can filter by student and then sort by app type', () => {
     const select = root.find('select');
     select.simulate('change', {target: {value: 'Alice'}});
-    expect(select.get(0).value).to.equal('Alice');
+    expect(getNode(select).value).to.equal('Alice');
 
     const appTypeHeader = root.find('th').at(COLUMNS.APP_TYPE);
-    expect(appTypeHeader.get(0).innerText).to.contain('Type');
+    expect(getNode(appTypeHeader).innerText).to.contain('Type');
 
     // Sort in ascending order by app type
     appTypeHeader.simulate('click');
@@ -568,7 +568,7 @@ describe('SectionProjectsList', () => {
     const rows = root.find('tr');
     expect(rows).to.have.length(3);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -576,7 +576,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'A1 Locksmith',
       'Alice',
@@ -584,7 +584,7 @@ describe('SectionProjectsList', () => {
       'October 29, 2016'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       null,
       'Antelope Freeway',
       'Alice',
@@ -596,12 +596,12 @@ describe('SectionProjectsList', () => {
   it('shows all students projects if the current students projects all disappear', () => {
     const select = root.find('select');
     select.simulate('change', {target: {value: 'Charlie'}});
-    expect(select.get(0).value).to.equal('Charlie');
+    expect(getNode(select).value).to.equal('Charlie');
 
     let rows = root.find('tr');
     expect(rows).to.have.length(2);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -609,7 +609,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       CAT_IMAGE_URL,
       'Cats and Kittens',
       'Charlie',
@@ -627,10 +627,10 @@ describe('SectionProjectsList', () => {
 
     // We should now see all students projects, except Charlie's
     rows = root.find('tr');
-    expect(select.get(0).value).to.equal('_all_students');
+    expect(getNode(select).value).to.equal('_all_students');
     expect(rows).to.have.length(4);
     assertRowContents(
-      rows.get(0),
+      getNode(rows, 0),
       null,
       'Project Name',
       'Student Name',
@@ -638,7 +638,7 @@ describe('SectionProjectsList', () => {
       'Last Edited'
     );
     assertRowContents(
-      rows.get(1),
+      getNode(rows, 1),
       null,
       'Dominoes',
       'Bob',
@@ -646,7 +646,7 @@ describe('SectionProjectsList', () => {
       'January 1, 2017'
     );
     assertRowContents(
-      rows.get(2),
+      getNode(rows, 2),
       null,
       'Antelope Freeway',
       'Alice',
@@ -654,7 +654,7 @@ describe('SectionProjectsList', () => {
       'December 29, 2016'
     );
     assertRowContents(
-      rows.get(3),
+      getNode(rows, 3),
       null,
       'A1 Locksmith',
       'Alice',
@@ -665,9 +665,9 @@ describe('SectionProjectsList', () => {
     // Charlie should no longer appear in the dropdown
     const options = root.find('option');
     expect(options).to.have.length(3);
-    expect(options.get(0).innerText).to.equal('All students');
-    expect(options.get(1).innerText).to.equal('Alice');
-    expect(options.get(2).innerText).to.equal('Bob');
+    expect(getNode(options, 0).innerText).to.equal('All students');
+    expect(getNode(options, 1).innerText).to.equal('Alice');
+    expect(getNode(options, 2).innerText).to.equal('Bob');
   });
 
   describe('getStudentNames', () => {
@@ -755,5 +755,13 @@ describe('SectionProjectsList', () => {
     const img = td.querySelector('img');
     const src = img && img.getAttribute('src');
     expect(src).to.equal(thumbnailUrl);
+  }
+
+  /**
+   * Get a particular DOM node out of a react wrapper in a way that's
+   * both compatible with Enzyme 2.x and 3.x.
+   */
+  function getNode(wrapper, index = 0) {
+    return wrapper.at(index).getDOMNode();
   }
 });


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.

I ended up doing quite a bit of refactoring on these tests, trying to resolve two issues:

1. There's some work to check that dates are formatted with `toLocaleDateString()` that was dependent on the PhantomJS implementation of that method.  PhantomJS won't run on my machine anymore, so I changed the tests so they should work on both Phantom and Chrome - reviewers, maybe spot-check here that I didn't weaken any assertions in the process.
2. These tests made extensive use of `ReactWrapper.node` or `ReactWrapper.nodes[i]` which was always supposed to be private, and Enzyme 3 now enforces that.  The solution in this case is to use `wrapper.instance()` or `wrapper.at(i).instance()` respectively.

I also moved the assertion helpers to the end of the file, did some deduplication among them (I found myself having to fix things in multiple places, so it was worth doing), and removed a test that was checking for the PhantomJS-specific date format.