### PR TITLE
Levelbuilder Level Page Clean Up: Blockly Editors, Callouts, Instructions

### DIFF
--- a/dashboard/app/views/levels/editors/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/_blockly.html.haml
@@ -5,54 +5,58 @@
     = javascript_include_tag "js/en_us/common_locale"
     = javascript_include_tag "js/en_us/#{@level.game.app}_locale"
 
-%legend.control-legend.levelTypeHeader
+%legend.control-legend{data: {toggle: "collapse", target: "#blockly"}}
   Blockly Options
 
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :use_modal_function_editor, description: "Use modal function editor"}
-.field
-  = f.label :open_function_definition, 'Auto-open function definition'
-  = f.text_field :open_function_definition, placeholder: 'name of function to open'
-.field.aligned-input-group
-  = f.check_box :disable_param_editing, {}, 'false', 'true'
-  = f.label :disable_param_editing, 'Enable param editing in function blocks'
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :disable_variable_editing, description: "Disable editing of variable names and creation of new variables"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :disable_if_else_editing, description: "Don\'t let users mutate (add or remove) branches to if/else blocks"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :show_type_hints, description: "Show a small visual hint for what type of block a connection accepts"}
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :disable_procedure_autopopulate, description: "Disable autopopulation of Functions category with default toolbox blocks"}
-  %p
-    By default, Functions categories in Blockly will be automatically populated
-    with blocks for three default procedure definitions (noreturn, return, and
-    ifreturn), as well as the call blocks for any procedures that have already
-    been defined. Any XML manually included in the toolbox category will be ignored.
-  %p
-    With this setting enabled, only the call blocks will be injected into this
-    category and NOT the default definition blocks. Any XML manually included in
-    the toolbox category will be included, allowing you to specify a subset of
-    the definition blocks that you would like to include for this level.
-.field
-  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :top_level_procedure_autopopulate, description: "Autopopulate function call blocks for non-categorized toolboxes"}
-  %p
-    This adds a call block to the end of the toolbox for each function defined
-    in the workspace (including hidden start blocks).
+%p Ideal block number. Blockly block settings. Speed slider. Workspace height.
+
+#blockly.collapse
+  .field
+    = f.label :ideal, 'Ideal block number'
+    = f.number_field :ideal
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :use_modal_function_editor, description: "Use modal function editor"}
+  .field
+    = f.label :open_function_definition, 'Auto-open function definition'
+    = f.text_field :open_function_definition, placeholder: 'name of function to open'
+  .field.aligned-input-group
+    = f.check_box :disable_param_editing, {}, 'false', 'true'
+    = f.label :disable_param_editing, 'Enable param editing in function blocks'
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :disable_variable_editing, description: "Disable editing of variable names and creation of new variables"}
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :disable_if_else_editing, description: "Don\'t let users mutate (add or remove) branches to if/else blocks"}
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :show_type_hints, description: "Show a small visual hint for what type of block a connection accepts"}
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :disable_procedure_autopopulate, description: "Disable autopopulation of Functions category with default toolbox blocks"}
+    %p
+      By default, Functions categories in Blockly will be automatically populated
+      with blocks for three default procedure definitions (noreturn, return, and
+      ifreturn), as well as the call blocks for any procedures that have already
+      been defined. Any XML manually included in the toolbox category will be ignored.
+    %p
+      With this setting enabled, only the call blocks will be injected into this
+      category and NOT the default definition blocks. Any XML manually included in
+      the toolbox category will be included, allowing you to specify a subset of
+      the definition blocks that you would like to include for this level.
+  .field
+    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :top_level_procedure_autopopulate, description: "Autopopulate function call blocks for non-categorized toolboxes"}
+    %p
+      This adds a call block to the end of the toolbox for each function defined
+      in the workspace (including hidden start blocks).
+
+  .field
+    = f.label :min_workspace_height, 'Min workspace height'
+    = f.number_field :min_workspace_height
+  - unless @level.is_a? GamelabJr
+    .field
+      = f.label :step_speed, 'Step speed'
+      %p Number is a multiplier for how long each step takes (so higher numbers are slower). Default is 5 for Maze, 2 for Bee.
+      = f.number_field :step_speed
 
 = render partial: 'levels/editors/blockly_xml_editors', locals:{f: f}
 
-.field
-  = f.label :ideal, 'Ideal block number'
-  = f.number_field :ideal
-.field
-  = f.label :min_workspace_height, 'Min workspace height'
-  = f.number_field :min_workspace_height
-- unless @level.is_a? GamelabJr
-  .field
-    = f.label :step_speed, 'Step speed'
-    %p Number is a multiplier for how long each step takes (so higher numbers are slower). Default is 5 for Maze, 2 for Bee.
-    = f.number_field :step_speed
 
 :ruby
   script_data = {
@@ -69,3 +73,4 @@
   }
 %script{src: minifiable_asset_path('js/levels/editors/_blockly.js'),
         data: script_data}
+

--- a/dashboard/app/views/levels/editors/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/_blockly.html.haml
@@ -7,15 +7,7 @@
 
 %legend.control-legend.levelTypeHeader
   Blockly Options
-= render partial: 'levels/editors/authored_hints', locals: {f: f}
 
-= render partial: 'levels/editors/ani_gif', locals: {f: f}
-.field
-  = f.label :skin
-  = f.select :skin, options_for_select(@level.class.skins, @level.skin)
-- unless @level.is_a? GamelabJr
-  .field
-    = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :is_k1, description: "Is K1 level"}
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :use_modal_function_editor, description: "Use modal function editor"}
 .field

--- a/dashboard/app/views/levels/editors/_blockly_xml_editors.html.haml
+++ b/dashboard/app/views/levels/editors/_blockly_xml_editors.html.haml
@@ -1,7 +1,11 @@
 %legend.control-legend{data: {toggle: "collapse", target: "#blockly_editors"}}
-  Blockly Editors
+  Blockly Workspace Editors
 
-#blockly_editors.in.collapse
+%p
+  These editors allow you to directly edit the XML of toolbox, start, required, recommended, initialization,
+  and solution blocks. These can also be changed in a UI in the Admin Box, which appears on the level view.
+
+#blockly_editors.collapse
 
   %p
     These editors allow you to directly edit the XML of toolbox, start, required, recommended, initialization,

--- a/dashboard/app/views/levels/editors/_callouts.html.haml
+++ b/dashboard/app/views/levels/editors/_callouts.html.haml
@@ -1,11 +1,11 @@
 %legend.control-legend{data: {toggle: "collapse", target: "#callout_editor"}}
   Callouts
 
-%p
-  Need help? Have questions? Learn how to create callouts
-  =link_to 'here', 'https://github.com/code-dot-org/code-dot-org/wiki/%5BLevelbuilder%5D-Creating-a-Callout', target:'_blank'
+#callout_editor.collapse
+  %p
+    Need help? Have questions? Learn how to create callouts
+    =link_to 'here', 'https://github.com/code-dot-org/code-dot-org/wiki/%5BLevelbuilder%5D-Creating-a-Callout', target:'_blank'
 
-#callout_editor.field.in.collapse
   .json_editor
     .json_template
       .callout_space

--- a/dashboard/app/views/levels/editors/_csf_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/_csf_instructions.html.haml
@@ -1,0 +1,11 @@
+.field
+
+  = render partial: 'levels/editors/authored_hints', locals: {f: f}
+
+  = render partial: 'levels/editors/ani_gif', locals: {f: f}
+  .field
+    = f.label :skin
+    = f.select :skin, options_for_select(@level.class.skins, @level.skin)
+  - unless @level.is_a? GamelabJr
+    .field
+      = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :is_k1, description: "Is K1 level"}

--- a/dashboard/app/views/levels/editors/_instructions.haml
+++ b/dashboard/app/views/levels/editors/_instructions.haml
@@ -3,7 +3,9 @@
   %legend.control-legend{data: {toggle: "collapse", target: "#instructions"}}
     Instructions
 
-  #instructions.in.collapse
+  %p Edit the instructions for a level (CSF hints, CSF skin, long/short instructions, TTS)
+
+  #instructions.collapse
 
     %p
       Every level can have a combination of short and long instructions. When both
@@ -51,6 +53,9 @@
         and start solving without looking at the instructions first?
 
     = render partial: 'levels/editors/tts', locals: {f: f}
+
+    - if !(@level.uses_droplet?) && @level.is_a?(Blockly)
+      = render partial: 'levels/editors/csf_instructions', locals: {f: f}
 
 :javascript
   var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', {


### PR DESCRIPTION
This cleans up some editors that are used on several different level types. 

1. Block Editors - Used on most CSF style levels. 
2. Callouts - Used on most (maybe all) programming levels.
3. Instructions - Used on all programming levels. 


For the most part this just moves existing features inside collapsed areas but there were a couple things that were csf instructions specific that I moved to the instructions area after talking to Mike.

# Blockly

<img width="835" alt="Screen Shot 2019-06-14 at 1 46 07 PM" src="https://user-images.githubusercontent.com/208083/59527917-dde70480-8eaa-11e9-97c4-81825a30760f.png">

# Callouts

<img width="822" alt="Screen Shot 2019-06-14 at 1 46 15 PM" src="https://user-images.githubusercontent.com/208083/59527923-e17a8b80-8eaa-11e9-8833-11eaa7a7679b.png">


# Instructions

<img width="818" alt="Screen Shot 2019-06-14 at 1 45 49 PM" src="https://user-images.githubusercontent.com/208083/59527909-da537d80-8eaa-11e9-9e6a-761e8f1bfc11.png">
