### PR TITLE
Levelbuilder Level Page Clean Up: Expand All/ Collapse All button

### DIFF
--- a/dashboard/app/views/levels/_form.html.haml
+++ b/dashboard/app/views/levels/_form.html.haml
@@ -4,6 +4,9 @@
 .field
   = link_to 'Find documentation for levelbuilder and its processes here', 'https://github.com/code-dot-org/code-dot-org/wiki/%5BLevelbuilder%5D-Welcome-to-Levelbuilder', target: '_blank'
 
+// Allows levelbuilders to expand all the categories if they want to use command-f
+%button.expandcollapse Expand All
+
 %pre#validation-error.validation-error{style: 'background-color: yellow; display: none'}
 = form_for [@level], method: @level.new_record? ? :post : :patch, remote: true do |f|
   = f.hidden_field :type, value: @type_class.to_s.presence || @level.type
@@ -96,4 +99,18 @@
         return "You have unsaved changes, are you sure you want to leave?";
       }
     }
+  });
+
+  $('.expandcollapse').click(function() {
+
+    $('.collapse').each(function(index) {
+        $(this).collapse("toggle");
+    });
+
+    if ($(this).html() == "Expand All") {
+        $(this).html("Collapse All");
+    }
+    else {
+        $(this).html("Expand All");
+    };
   });

--- a/dashboard/app/views/levels/editors/_all.html.haml
+++ b/dashboard/app/views/levels/editors/_all.html.haml
@@ -42,10 +42,10 @@
 = render partial: 'levels/editors/sub_level_types', locals: {f: f}
 
 - if @level.is_a?(Weblab) || (@level.uses_droplet?) || @level.is_a?(Blockly) || @level.respond_to?(:disable_sharing)
-  %legend.control-legend{data: {toggle: "collapse", target: "#shareAndRemix"}}
+  %legend.control-legend{data: {toggle: "collapse", target: "#share_and_remix"}}
     Share and Remix Settings
 
-  #shareAndRemix.collapse
+  #share_and_remix.collapse
     -if @level.is_a?(Weblab) || (@level.uses_droplet?) || @level.is_a?(Blockly)
       = render partial: 'levels/editors/hide_share_and_remix', locals: {f: f}
 

--- a/dashboard/app/views/levels/editors/_applab.html.haml
+++ b/dashboard/app/views/levels/editors/_applab.html.haml
@@ -79,7 +79,7 @@
 %legend.control-legend{data: {toggle: "collapse", target: "#applab"}}
   App Lab Options
 
-%p Turtle settings. API settings. Conditions for level completion.
+%p App lab start Library. Turtle settings. API settings. Conditions for level completion.
 
 #applab.collapse
   .field

--- a/dashboard/app/views/levels/editors/_applab.html.haml
+++ b/dashboard/app/views/levels/editors/_applab.html.haml
@@ -9,10 +9,10 @@
 
 = render partial: 'levels/editors/helper_libraries', locals: {f: f}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#dataTab"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#data_tab"}}
   Data Tab
 
-#dataTab.collapse
+#data_tab.collapse
   .field
     = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_view_data_button, description: "Hide Data Button"}
 
@@ -46,10 +46,10 @@
     :javascript
       levelbuilder.initializeCodeMirror('level_data_properties', 'javascript');
 
-%legend.control-legend{data: {toggle: "collapse", target: "#designMode"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#design_mode"}}
   Design Mode
 
-#designMode.collapse
+#design_mode.collapse
   .field
     = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :design_mode_at_start, description: "Start in Design Mode"}
   .field
@@ -70,10 +70,10 @@
     :javascript
       levelbuilder.initializeCodeMirror('level_start_html', 'html');
 
-%legend.control-legend{data: {toggle: "collapse", target: "#makerToolkit"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#maker_toolkit"}}
   Maker Toolkit
 
-#makerToolkit.collapse
+#maker_toolkit.collapse
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :makerlab_enabled, description: "Enable Maker APIs"}
 
 %legend.control-legend{data: {toggle: "collapse", target: "#applab"}}

--- a/dashboard/app/views/levels/editors/_artist.html.haml
+++ b/dashboard/app/views/levels/editors/_artist.html.haml
@@ -1,11 +1,11 @@
 = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'artist'}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#artistOptions"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#artist_options"}}
   Artist Options
 
 %p Start settings. Speed slider. Auto rerun. Etc.
 
-#artistOptions.collapse
+#artist_options.collapse
   .field
     = f.label :slider_speed, 'Slider speed (artist only)'
     %p Number from 0.0 to 1.0 for how fast artist runs. If not set, default is 1.0

--- a/dashboard/app/views/levels/editors/_bounce.html.haml
+++ b/dashboard/app/views/levels/editors/_bounce.html.haml
@@ -21,12 +21,12 @@
     %p condition(s), which if true at any point, indicates the puzzle is complete (indicating failure if success condition not met)
     = f.text_area :failure_condition, rows: 4
 
-%legend.control-legend{data: {toggle: "collapse", target: "#bounceOptions"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#bounce_options"}}
   Bounce Options
 
 %p Ball settings. Theme. Use flag goal.
 
-#bounceOptions.collapse
+#bounce_options.collapse
   .field
     = f.label :timeout_failiure_tick, 'Timeout Failure Tick'
     %p How many ticks before the game declares the level failed. Defaults to Infinity.

--- a/dashboard/app/views/levels/editors/_control_buttons.html.haml
+++ b/dashboard/app/views/levels/editors/_control_buttons.html.haml
@@ -1,7 +1,7 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#controlButtons"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#control_buttons"}}
   Control Buttons
 
-#controlButtons.collapse
+#control_buttons.collapse
   = f.label :soft_buttons, 'Controls buttons'
   %p
     Select

--- a/dashboard/app/views/levels/editors/_craft.html.haml
+++ b/dashboard/app/views/levels/editors/_craft.html.haml
@@ -1,12 +1,12 @@
 - content_for(:head) do
   %script{src: minifiable_asset_path('js/levelbuilder_craft.js')}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#minecraftOptions"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#minecraft_options"}}
   Minecraft Options
 
 %p All settings specific to a minecraft type level.
 
-#minecraftOptions.collapse
+#minecraft_options.collapse
 
   .field
     = f.label :player_start_position, 'Player Start Position in format [x, y]'

--- a/dashboard/app/views/levels/editors/_cs_in_a.html.haml
+++ b/dashboard/app/views/levels/editors/_cs_in_a.html.haml
@@ -1,8 +1,8 @@
 //CS in A stuff
-%legend.control-legend{data: {toggle: "collapse", target: "#csInA"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#cs_in_a"}}
   CS in A Options
 
-#csInA.collapse
+#cs_in_a.collapse
   .field
     = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :use_contract_editor, description: "Use MSM contract editor"}
   .field

--- a/dashboard/app/views/levels/editors/_dance.html.haml
+++ b/dashboard/app/views/levels/editors/_dance.html.haml
@@ -8,9 +8,9 @@
 
 = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'dance'}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#defaultSong"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#default_song"}}
   Default Song
 
-#defaultSong.collapse
+#default_song.collapse
   = f.label :default_song, 'Default Song'
   = f.select :default_song, options_for_select(@level.class.hoc_songs, @level.default_song)

--- a/dashboard/app/views/levels/editors/_debugger.html.haml
+++ b/dashboard/app/views/levels/editors/_debugger.html.haml
@@ -1,7 +1,7 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#debuggingTools"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#debugging_tools"}}
   Debugger Settings
 
-#debuggingTools.collapse
+#debugging_tools.collapse
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :expand_debugger, description: "Expand Debugger by Default"}
 
   = render partial: 'levels/editors/watchers_ui', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_droplet.html.haml
+++ b/dashboard/app/views/levels/editors/_droplet.html.haml
@@ -1,7 +1,7 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#dropletPalette"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#droplet_palette"}}
   Starting Block Palette (Droplet)
 
-#dropletPalette.collapse
+#droplet_palette.collapse
   .field
     = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :droplet_tooltips_disabled, description: "Hide droplet documentation tooltips"}
   .field
@@ -14,12 +14,12 @@
   = f.label :code_functions, 'Edit Droplet Palette'
   = f.text_area :code_functions, placeholder: 'Droplet Palette', rows: 4, value: @level.code_functions ? JSON.pretty_generate(@level.code_functions) : ''
 
-%legend.control-legend{data: {toggle: "collapse", target: "#starterCode"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#starter_code"}}
   Starter Code
 
 %p Javascript starter code. Starting code view: block/text.
 
-#starterCode.collapse
+#starter_code.collapse
   = f.label :start_blocks, 'Edit Starting JavaScript Program'
   .row
     .span8

--- a/dashboard/app/views/levels/editors/_droplet.html.haml
+++ b/dashboard/app/views/levels/editors/_droplet.html.haml
@@ -2,20 +2,22 @@
   Starting Block Palette (Droplet)
 
 #dropletPalette.collapse
-  = f.label :code_functions, 'Edit Droplet Palette'
-  = f.text_area :code_functions, placeholder: 'Droplet Palette', rows: 4, value: @level.code_functions ? JSON.pretty_generate(@level.code_functions) : ''
-
-  .field
-    = f.label :palette_category_at_start
-    = f.select :palette_category_at_start, options_for_select(@level.class.palette_categories, @level.palette_category_at_start), {include_blank: true}
-
   .field
     = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :droplet_tooltips_disabled, description: "Hide droplet documentation tooltips"}
   .field
     = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :lock_zero_param_functions, description: "Don't allow parameters to be added to user-defined functions with no parameters"}
 
+  .field
+    = f.label :palette_category_at_start
+    = f.select :palette_category_at_start, options_for_select(@level.class.palette_categories, @level.palette_category_at_start), {include_blank: true}
+
+  = f.label :code_functions, 'Edit Droplet Palette'
+  = f.text_area :code_functions, placeholder: 'Droplet Palette', rows: 4, value: @level.code_functions ? JSON.pretty_generate(@level.code_functions) : ''
+
 %legend.control-legend{data: {toggle: "collapse", target: "#starterCode"}}
   Starter Code
+
+%p Javascript starter code. Starting code view: block/text.
 
 #starterCode.collapse
   = f.label :start_blocks, 'Edit Starting JavaScript Program'

--- a/dashboard/app/views/levels/editors/_encrypted_examples.html.haml
+++ b/dashboard/app/views/levels/editors/_encrypted_examples.html.haml
@@ -1,7 +1,7 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#exampleSolutions"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#example_solutions"}}
   Example Solutions
 
-#exampleSolutions.collapse
+#example_solutions.collapse
   = f.label :examples, 'Example solutions'
   %p
     Go to

--- a/dashboard/app/views/levels/editors/_flappy.html.haml
+++ b/dashboard/app/views/levels/editors/_flappy.html.haml
@@ -1,9 +1,9 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#flappyOptions"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#flappy_options"}}
   Flappy Options
 
 %p All the settings specific to a flappy type level.
 
-#flappyOptions.collapse
+#flappy_options.collapse
   .field
     = f.label :default_flap, 'Default Flap Amount'
     = f.select :default_flap, options_for_select(@level.class.flap_amounts, @level.default_flap || "NORMAL")

--- a/dashboard/app/views/levels/editors/_gamelab.html.haml
+++ b/dashboard/app/views/levels/editors/_gamelab.html.haml
@@ -9,10 +9,10 @@
 
 = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'gamelab'}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#dataTab"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#data_tab"}}
   Data Tab
 
-#dataTab.collapse
+#data_tab.collapse
   .field
     = f.label 'Key-Value Data'
     This data can be accessed via the getKeyValue and setKeyValue blocks in Game Lab.

--- a/dashboard/app/views/levels/editors/_grid.html.haml
+++ b/dashboard/app/views/levels/editors/_grid.html.haml
@@ -1,7 +1,7 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#gridEditorContainer"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#grid_editor_container"}}
   Grid Editor
 
-#gridEditorContainer.collapse
+#grid_editor_container.collapse
   = hidden_field_tag :size, 8
   = f.hidden_field :maze_data
   .field#grid

--- a/dashboard/app/views/levels/editors/_helper_libraries.html.haml
+++ b/dashboard/app/views/levels/editors/_helper_libraries.html.haml
@@ -1,7 +1,7 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#helperLibraries"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#helper_libraries"}}
   Helper Libraries & Block Pools
 
-#helperLibraries.collapse
+#helper_libraries.collapse
   = f.label :helper_libraries
   %p
     Select

--- a/dashboard/app/views/levels/editors/_karel.html.haml
+++ b/dashboard/app/views/levels/editors/_karel.html.haml
@@ -1,9 +1,9 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#karelOptions"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#karel_options"}}
   Collector Options
 
 %p Flower type. Nectar or honey goal. Minimum to collect. Animation speed.
 
-#karelOptions.collapse
+#karel_options.collapse
   .field
     = f.label :flower_type, 'Flower Type (bee only)'
     = f.select :flower_type, options_for_select(@level.class.flower_types, @level.flower_type)

--- a/dashboard/app/views/levels/editors/_maze.html.haml
+++ b/dashboard/app/views/levels/editors/_maze.html.haml
@@ -1,9 +1,9 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#mazeOptions"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#maze_options"}}
   Maze Options
 
 %p Start direction. Step mode. Random rotation of puzzle.
 
-#mazeOptions.collapse
+#maze_options.collapse
   .field
     = f.label :start_direction
     = f.select :start_direction, options_for_select(@level.class.start_directions, @level.start_direction)

--- a/dashboard/app/views/levels/editors/_playlab.html.haml
+++ b/dashboard/app/views/levels/editors/_playlab.html.haml
@@ -5,10 +5,10 @@
 
 = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'playlab'}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#customGame"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#custom_game"}}
   Custom Game Type
 
-#customGame.collapse
+#custom_game.collapse
   = f.label :custom_game_type, 'Custom game type'
   %p Used to tell playlab we want to run some of our custom onTick logic.
   = f.select :custom_game_type, options_for_select(["", "Big Game", "Rocket Height", "Sam the Bat", "Ninja Cat"], @level.custom_game_type)

--- a/dashboard/app/views/levels/editors/_spritelab.html.haml
+++ b/dashboard/app/views/levels/editors/_spritelab.html.haml
@@ -4,12 +4,12 @@
 
 = render partial: 'levels/editors/helper_libraries', locals: {f: f}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#setupCode"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#setup_code"}}
   Setup Code
 
 %p Create custom setup code. Immediately show results of setup code in playspace
 
-#setupCode.collapse
+#setup_code.collapse
   = f.label 'Immediately show the results of setup code changes in the playspace?'
   :ruby
     selector = f.select :auto_run_setup, options_for_select([

--- a/dashboard/app/views/levels/editors/_sub_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/_sub_level_types.html.haml
@@ -1,9 +1,9 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#specialLevel"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#special_level"}}
   Special Level Types
 
 %p Project Template Levels. Contained (Predict) Levels. Free Play Levels. Embed Levels.
 
-#specialLevel.collapse
+#special_level.collapse
   - if @level.respond_to? :free_play
     .field
       = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :free_play, description: "Free Play"}

--- a/dashboard/app/views/levels/editors/_submittable.html.haml
+++ b/dashboard/app/views/levels/editors/_submittable.html.haml
@@ -1,7 +1,7 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#submitlevel"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#submit_level"}}
   Submittable
 
-#submitlevel.collapse
+#submit_level.collapse
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :submittable, description: "Submittable"}
   %p
     If checked, students with teachers can "submit" a solution for

--- a/dashboard/app/views/levels/editors/_weblab.html.haml
+++ b/dashboard/app/views/levels/editors/_weblab.html.haml
@@ -1,7 +1,7 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#weblabStartingSources"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#weblab_starting_sources"}}
   Web Lab Starting Sources
 
-#weblabStartingSources.collapse
+#weblab_starting_sources.collapse
   = f.label :start_sources, 'Starting sources'
   %p
     Sources
@@ -9,10 +9,10 @@
 
 = render partial: 'levels/editors/submittable', locals: {f: f}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#projectTemplateLevel"}}
+%legend.control-legend{data: {toggle: "collapse", target: "#project_template_level"}}
   Project Template Level
 
-#projectTemplateLevel.collapse
+#project_template_level.collapse
   = f.label :project_template_level_name, 'Project Template Level Name'
   %p What this does:
   %ul


### PR DESCRIPTION
Add some more subheader and a expand all/collapse all button at the top of the page so if someone wants to just command-f the page they can.  Re-organized the order of things in the droplet area so that a bunch of options aren't "hidden" by the huge block palette area.

<img width="906" alt="Screen Shot 2019-06-14 at 3 46 11 PM" src="https://user-images.githubusercontent.com/208083/59534331-fdd2f400-8ebb-11e9-9cb3-58eef2adecfe.png">
