### PR TITLE
Testing: Make VersionHistoryTest Enzyme 3 ready

### DIFF
--- a/apps/test/unit/templates/VersionHistoryTest.jsx
+++ b/apps/test/unit/templates/VersionHistoryTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
-import {expect} from '../../util/configuredChai';
+import {assert, expect} from '../../util/reconfiguredChai';
 import VersionHistory from '@cdo/apps/templates/VersionHistory';
 import VersionRow from '@cdo/apps/templates/VersionRow';
 import {sources as sourcesApi, files as filesApi} from '@cdo/apps/clientApi';
@@ -109,25 +109,30 @@ describe('VersionHistory', () => {
   }) {
     it('renders loading spinner at first', () => {
       wrapper = mount(<VersionHistory {...props} />);
-      expect(wrapper).to.containMatchingElement(
-        <i className="fa fa-spinner fa-spin" style={{fontSize: '32px'}} />
+      assert(
+        wrapper.containsMatchingElement(
+          <i className="fa fa-spinner fa-spin" style={{fontSize: '32px'}} />
+        )
       );
     });
 
     it('renders an error on failed version history load', () => {
       wrapper = mount(<VersionHistory {...props} />);
       failVersionHistoryLoad();
-      expect(wrapper).to.contain.text('An error occurred.');
+      expect(wrapper.text()).to.include('An error occurred.');
     });
 
     it('renders a version list on successful version history load', () => {
       wrapper = mount(<VersionHistory {...props} />);
       // Call third argument, the success handler
       finishVersionHistoryLoad();
+      wrapper.update();
 
       // Spinner goes away
-      expect(wrapper).not.to.containMatchingElement(
-        <i className="fa fa-spinner fa-spin" style={{fontSize: '32px'}} />
+      assert(
+        !wrapper.containsMatchingElement(
+          <i className="fa fa-spinner fa-spin" style={{fontSize: '32px'}} />
+        )
       );
 
       // Rendered two version rows
@@ -137,6 +142,7 @@ describe('VersionHistory', () => {
     it('attempts to restore a chosen version when clicking restore button', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
+      wrapper.update();
       expect(restoreSpy()).not.to.have.been.called;
 
       wrapper
@@ -149,18 +155,20 @@ describe('VersionHistory', () => {
     it('renders an error on failed restore', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
+      wrapper.update();
       wrapper
         .find('.btn-info')
         .first()
         .simulate('click');
 
       failRestoreVersion();
-      expect(wrapper).to.contain.text('An error occurred.');
+      expect(wrapper.text()).to.include('An error occurred.');
     });
 
     it('reloads the page on successful restore', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
+      wrapper.update();
       wrapper
         .find('.btn-info')
         .first()
@@ -174,42 +182,52 @@ describe('VersionHistory', () => {
     it('shows a confirmation after clicking Start Over', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
+      wrapper.update();
 
       // Click "Start Over"
       wrapper.find('.btn-danger').simulate('click');
 
       // Expect confirmation to show
-      expect(wrapper).to.containMatchingElement(
-        <div>
-          <p>Are you sure you want to clear all progress for this level&#63;</p>
-          <button type="button" id="confirm-button">
-            Start Over
-          </button>
-          <button type="button" id="again-button">
-            Cancel
-          </button>
-        </div>
+      assert(
+        wrapper.containsMatchingElement(
+          <div>
+            <p>
+              Are you sure you want to clear all progress for this level&#63;
+            </p>
+            <button type="button" id="confirm-button">
+              Start Over
+            </button>
+            <button type="button" id="again-button">
+              Cancel
+            </button>
+          </div>
+        )
       );
     });
 
     it('goes back to version list after cancelling Start Over', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
+      wrapper.update();
 
       // Click "Start Over"
       wrapper.find('.btn-danger').simulate('click');
 
       // Expect confirmation to show
-      expect(wrapper).to.containMatchingElement(
-        <div>
-          <p>Are you sure you want to clear all progress for this level&#63;</p>
-          <button type="button" id="confirm-button">
-            Start Over
-          </button>
-          <button type="button" id="again-button">
-            Cancel
-          </button>
-        </div>
+      expect(
+        wrapper.containsMatchingElement(
+          <div>
+            <p>
+              Are you sure you want to clear all progress for this level&#63;
+            </p>
+            <button type="button" id="confirm-button">
+              Start Over
+            </button>
+            <button type="button" id="again-button">
+              Cancel
+            </button>
+          </div>
+        )
       );
 
       // Click "Cancel"
@@ -237,6 +255,7 @@ describe('VersionHistory', () => {
           <VersionHistory {...props} handleClearPuzzle={handleClearPuzzle} />
         );
         finishVersionHistoryLoad();
+        wrapper.update();
         wrapper.find('.btn-danger').simulate('click');
         wrapper.find('#confirm-button').simulate('click');
       });
@@ -252,8 +271,10 @@ describe('VersionHistory', () => {
       });
 
       it('immediately renders spinner', () => {
-        expect(wrapper).to.containMatchingElement(
-          <i className="fa fa-spinner fa-spin" style={{fontSize: '32px'}} />
+        expect(
+          wrapper.containsMatchingElement(
+            <i className="fa fa-spinner fa-spin" style={{fontSize: '32px'}} />
+          )
         );
       });
 

--- a/apps/test/unit/templates/VersionHistoryTest.jsx
+++ b/apps/test/unit/templates/VersionHistoryTest.jsx
@@ -58,8 +58,10 @@ describe('VersionHistory', () => {
         handleClearPuzzle: () => {},
         useFilesApi: false
       },
-      finishVersionHistoryLoad: () =>
-        sourcesApi.ajax.firstCall.args[2](FAKE_VERSION_LIST_RESPONSE),
+      finishVersionHistoryLoad: () => {
+        sourcesApi.ajax.firstCall.args[2](FAKE_VERSION_LIST_RESPONSE);
+        wrapper.update();
+      },
       failVersionHistoryLoad: () => sourcesApi.ajax.firstCall.args[3](),
       restoreSpy: () => sourcesApi.restorePreviousFileVersion,
       finishRestoreVersion: () =>
@@ -85,10 +87,12 @@ describe('VersionHistory', () => {
         handleClearPuzzle: () => {},
         useFilesApi: true
       },
-      finishVersionHistoryLoad: () =>
+      finishVersionHistoryLoad: () => {
         filesApi.getVersionHistory.firstCall.args[0](
           FAKE_VERSION_LIST_RESPONSE
-        ),
+        );
+        wrapper.update();
+      },
       failVersionHistoryLoad: () =>
         filesApi.getVersionHistory.firstCall.args[1](),
       restoreSpy: () => filesApi.restorePreviousVersion,
@@ -126,7 +130,6 @@ describe('VersionHistory', () => {
       wrapper = mount(<VersionHistory {...props} />);
       // Call third argument, the success handler
       finishVersionHistoryLoad();
-      wrapper.update();
 
       // Spinner goes away
       assert(
@@ -142,7 +145,6 @@ describe('VersionHistory', () => {
     it('attempts to restore a chosen version when clicking restore button', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
-      wrapper.update();
       expect(restoreSpy()).not.to.have.been.called;
 
       wrapper
@@ -155,7 +157,6 @@ describe('VersionHistory', () => {
     it('renders an error on failed restore', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
-      wrapper.update();
       wrapper
         .find('.btn-info')
         .first()
@@ -168,7 +169,6 @@ describe('VersionHistory', () => {
     it('reloads the page on successful restore', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
-      wrapper.update();
       wrapper
         .find('.btn-info')
         .first()
@@ -182,7 +182,6 @@ describe('VersionHistory', () => {
     it('shows a confirmation after clicking Start Over', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
-      wrapper.update();
 
       // Click "Start Over"
       wrapper.find('.btn-danger').simulate('click');
@@ -208,7 +207,6 @@ describe('VersionHistory', () => {
     it('goes back to version list after cancelling Start Over', () => {
       wrapper = mount(<VersionHistory {...props} />);
       finishVersionHistoryLoad();
-      wrapper.update();
 
       // Click "Start Over"
       wrapper.find('.btn-danger').simulate('click');
@@ -238,7 +236,7 @@ describe('VersionHistory', () => {
     });
 
     describe('confirming Start Over', () => {
-      let wrapper, handleClearPuzzle;
+      let handleClearPuzzle;
 
       beforeEach(() => {
         sinon.stub(firehoseClient, 'putRecord');
@@ -255,7 +253,6 @@ describe('VersionHistory', () => {
           <VersionHistory {...props} handleClearPuzzle={handleClearPuzzle} />
         );
         finishVersionHistoryLoad();
-        wrapper.update();
         wrapper.find('.btn-danger').simulate('click');
         wrapper.find('#confirm-button').simulate('click');
       });


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.