### PR TITLE
set self.use_transactional_test_case in more places

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/application/facilitator_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/facilitator_applications_controller_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module Api::V1::Pd::Application
   class FacilitatorApplicationsControllerTest < ::ActionController::TestCase
+    self.use_transactional_test_case = true
+
     include Pd::Application::ActiveApplicationModels
     setup_all do
       @test_params = {

--- a/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
@@ -5,6 +5,8 @@ module Api::V1::Pd::Application
     include Pd::Application::ActiveApplicationModels
     include Pd::Application::ApplicationConstants
 
+    self.use_transactional_test_case = true
+
     setup_all do
       @teacher_application = create TEACHER_APPLICATION_FACTORY, application_guid: SecureRandom.uuid
       @test_params = {

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -5,6 +5,8 @@ module Api::V1::Pd::Application
     include Pd::Application::ApplicationConstants
     include Pd::Application::ActiveApplicationModels
 
+    self.use_transactional_test_case = true
+
     setup_all do
       @test_params = {
         form_data: build(TEACHER_APPLICATION_HASH_FACTORY)

--- a/dashboard/test/controllers/api/v1/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/regional_partners_controller_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class Api::V1::RegionalPartnersControllerTest < ActionController::TestCase
   COURSES = ['csd', 'csp']
 
+  self.use_transactional_test_case = true
+
   setup_all do
     @workshop_admin = create :workshop_admin
     @workshop_organizer = create :workshop_organizer

--- a/dashboard/test/controllers/teacher_dashboard_controller_test.rb
+++ b/dashboard/test/controllers/teacher_dashboard_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class TeacherDashboardControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     @teacher = create :teacher
     @sections = create_list :section, 3, user: @teacher

--- a/dashboard/test/integration/home_test.rb
+++ b/dashboard/test/integration/home_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class HomeTest < ActionDispatch::IntegrationTest
+  self.use_transactional_test_case = true
+
   setup_all do
     @student = create :student
     @teacher = create :teacher

--- a/dashboard/test/integration/stage_lock_test.rb
+++ b/dashboard/test/integration/stage_lock_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class StageLockTest < ActionDispatch::IntegrationTest
   include LevelsHelper # for build_script_level_path
 
+  self.use_transactional_test_case = true
+
   setup_all do
     @student = create :student
     @teacher = create :authorized_teacher

--- a/dashboard/test/lib/version_redirect_overrider_test.rb
+++ b/dashboard/test/lib/version_redirect_overrider_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class VersionRedirectOverriderTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     # stub writes so that we dont actually make updates to filesystem
     File.stubs(:write)

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class BubbleChoiceTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     create :game, name: 'BubbleChoice'
     Rails.application.config.stubs(:levelbuilder_mode).returns false

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 require_relative '../../../shared/middleware/helpers/storage_apps'
 
 class ChannelTokenTest < ActiveSupport::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     @level = create :level
     @fake_ip = '127.0.0.1'


### PR DESCRIPTION
Per discussion in https://github.com/code-dot-org/code-dot-org/pull/29143, my understanding is that the test cases in this PR might not be cleaning up after themselves. I am not the expert here -- all I am bringing to the table here is finding and updating all the places I can find which might have the same problem according to that discussion. @sureshc @wjordan @hacodeorg , do you have a sense of whether this change is correct for each of these files?