### PR TITLE
Tests: Make CertificateTest enzyme 3 ready and fix minecraft certificate bug

### DIFF
--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -97,7 +97,9 @@ class Certificate extends Component {
       dashboard.CODE_ORG_URL
     }/api/hour/certificate/${certificate}.jpg`;
     const blankCertificate =
-      blankCertificates[tutorial] || blankCertificates.hourOfCode;
+      blankCertificates[tutorial] ||
+      (isMinecraft && blankCertificates.minecraft) ||
+      blankCertificates.hourOfCode;
     const imgSrc = this.state.personalized
       ? personalizedCertificate
       : blankCertificate;

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -62,9 +62,10 @@ class Certificate extends Component {
     randomDonorTwitter: PropTypes.string,
     responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']).isRequired,
     under13: PropTypes.bool,
-    isMinecraft: PropTypes.bool.isRequired,
     children: PropTypes.node
   };
+
+  isMinecraft = () => /mc|minecraft|hero|aquatic/.test(this.props.tutorial);
 
   personalizeCertificate(session) {
     $.ajax({
@@ -89,7 +90,6 @@ class Certificate extends Component {
       certificateId,
       randomDonorTwitter,
       under13,
-      isMinecraft,
       children
     } = this.props;
     const certificate = certificateId || 'blank';
@@ -98,7 +98,7 @@ class Certificate extends Component {
     }/api/hour/certificate/${certificate}.jpg`;
     const blankCertificate =
       blankCertificates[tutorial] ||
-      (isMinecraft && blankCertificates.minecraft) ||
+      (this.isMinecraft() && blankCertificates.minecraft) ||
       blankCertificates.hourOfCode;
     const imgSrc = this.state.personalized
       ? personalizedCertificate
@@ -125,7 +125,7 @@ class Certificate extends Component {
     });
 
     let print = `${dashboard.CODE_ORG_URL}/printcertificate/${certificate}`;
-    if (isMinecraft && !this.state.personalized) {
+    if (this.isMinecraft() && !this.state.personalized) {
       // Correct the minecraft print url for non-personalized certificates.
       print = `${dashboard.CODE_ORG_URL}/printcertificate?s=${tutorial}`;
     }

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -97,9 +97,7 @@ class Certificate extends Component {
       dashboard.CODE_ORG_URL
     }/api/hour/certificate/${certificate}.jpg`;
     const blankCertificate =
-      blankCertificates[tutorial] ||
-      (this.isMinecraft() && blankCertificates.minecraft) ||
-      blankCertificates.hourOfCode;
+      blankCertificates[tutorial] || blankCertificates.hourOfCode;
     const imgSrc = this.state.personalized
       ? personalizedCertificate
       : blankCertificate;

--- a/apps/src/templates/Congrats.jsx
+++ b/apps/src/templates/Congrats.jsx
@@ -50,8 +50,6 @@ export default class Congrats extends Component {
         mc: 'pre2017Minecraft'
       }[tutorial] || 'other';
 
-    const isMinecraft = /mc|minecraft|hero|aquatic/.test(tutorial);
-
     return (
       <div style={styles.container}>
         <Certificate
@@ -59,7 +57,6 @@ export default class Congrats extends Component {
           certificateId={certificateId}
           randomDonorTwitter={randomDonorTwitter}
           under13={under13}
-          isMinecraft={isMinecraft}
         />
         {userType === 'teacher' && isEnglish && <TeachersBeyondHoc />}
         <StudentsBeyondHoc

--- a/apps/test/unit/templates/CertificateTest.js
+++ b/apps/test/unit/templates/CertificateTest.js
@@ -7,30 +7,35 @@ import responsive from '@cdo/apps/code-studio/responsiveRedux';
 
 describe('Certificate', () => {
   const store = createStore(combineReducers({responsive}));
+  let storedWindowDashboard;
+
+  beforeEach(() => {
+    storedWindowDashboard = window.dashboard;
+    window.dashboard = {
+      CODE_ORG_URL: 'https://code.org'
+    };
+  });
+
+  afterEach(() => {
+    window.dashboard = storedWindowDashboard;
+  });
 
   it('renders a Minecraft certificate for new Minecraft tutorials', () => {
     const wrapper = shallow(
       <Certificate tutorial="minecraft" isMinecraft={true} />,
       {context: {store}}
     ).dive();
-    expect(
-      wrapper
-        .find('img')
-        .html()
-        .includes('MC_Hour_Of_Code_Certificate')
+    expect(wrapper.find('img').html()).to.include(
+      'MC_Hour_Of_Code_Certificate'
     );
   });
 
   it('renders a Minecraft certificate for older Minecraft tutorials', () => {
-    const wrapper = shallow(
-      <Certificate type="minecraft" isMinecraft={true} />,
-      {context: {store}}
-    ).dive();
-    expect(
-      wrapper
-        .find('img')
-        .html()
-        .includes('MC_Hour_Of_Code_Certificate')
+    const wrapper = shallow(<Certificate isMinecraft={true} />, {
+      context: {store}
+    }).dive();
+    expect(wrapper.find('img').html()).to.include(
+      'MC_Hour_Of_Code_Certificate'
     );
   });
 
@@ -39,11 +44,6 @@ describe('Certificate', () => {
       <Certificate tutorial="frozen" isMinecraft={false} />,
       {context: {store}}
     ).dive();
-    expect(
-      wrapper
-        .find('img')
-        .html()
-        .includes('hour_of_code_certificate')
-    );
+    expect(wrapper.find('img').html()).to.include('hour_of_code_certificate');
   });
 });

--- a/apps/test/unit/templates/CertificateTest.js
+++ b/apps/test/unit/templates/CertificateTest.js
@@ -20,7 +20,16 @@ describe('Certificate', () => {
     window.dashboard = storedWindowDashboard;
   });
 
-  it('renders a Minecraft certificate for new Minecraft tutorials', () => {
+  it('renders Minecraft certificate for Minecraft Adventurer', () => {
+    const wrapper = shallow(<Certificate tutorial="mc" />, {
+      context: {store}
+    }).dive();
+    expect(wrapper.find('img').html()).to.include(
+      'MC_Hour_Of_Code_Certificate'
+    );
+  });
+
+  it('renders Minecraft certificate for Minecraft Designer', () => {
     const wrapper = shallow(<Certificate tutorial="minecraft" />, {
       context: {store}
     }).dive();
@@ -29,10 +38,30 @@ describe('Certificate', () => {
     );
   });
 
-  it('renders a default certificate for all other tutorials', () => {
-    const wrapper = shallow(<Certificate tutorial="frozen" />, {
+  it("renders unique certificate for Minecraft Hero's Journey", () => {
+    const wrapper = shallow(<Certificate tutorial="hero" />, {
       context: {store}
     }).dive();
-    expect(wrapper.find('img').html()).to.include('hour_of_code_certificate');
+    expect(wrapper.find('img').html()).to.include(
+      'MC_Hour_Of_Code_Certificate_Hero'
+    );
+  });
+
+  it('renders unique certificate for Minecraft Voyage Aquatic', () => {
+    const wrapper = shallow(<Certificate tutorial="aquatic" />, {
+      context: {store}
+    }).dive();
+    expect(wrapper.find('img').html()).to.include(
+      'MC_Hour_Of_Code_Certificate_Aquatic'
+    );
+  });
+
+  it('renders default certificate for all other tutorials', () => {
+    ['applab-intro', 'dance', 'flappy', 'frozen'].forEach(tutorial => {
+      const wrapper = shallow(<Certificate tutorial={tutorial} />, {
+        context: {store}
+      }).dive();
+      expect(wrapper.find('img').html()).to.include('hour_of_code_certificate');
+    });
   });
 });

--- a/apps/test/unit/templates/CertificateTest.js
+++ b/apps/test/unit/templates/CertificateTest.js
@@ -21,17 +21,7 @@ describe('Certificate', () => {
   });
 
   it('renders a Minecraft certificate for new Minecraft tutorials', () => {
-    const wrapper = shallow(
-      <Certificate tutorial="minecraft" isMinecraft={true} />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper.find('img').html()).to.include(
-      'MC_Hour_Of_Code_Certificate'
-    );
-  });
-
-  it('renders a Minecraft certificate for older Minecraft tutorials', () => {
-    const wrapper = shallow(<Certificate isMinecraft={true} />, {
+    const wrapper = shallow(<Certificate tutorial="minecraft" />, {
       context: {store}
     }).dive();
     expect(wrapper.find('img').html()).to.include(
@@ -40,10 +30,9 @@ describe('Certificate', () => {
   });
 
   it('renders a default certificate for all other tutorials', () => {
-    const wrapper = shallow(
-      <Certificate tutorial="frozen" isMinecraft={false} />,
-      {context: {store}}
-    ).dive();
+    const wrapper = shallow(<Certificate tutorial="frozen" />, {
+      context: {store}
+    }).dive();
     expect(wrapper.find('img').html()).to.include('hour_of_code_certificate');
   });
 });


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.

It turns out these tests weren't actually asserting anything, because `expect(false)` is not a failing assertion!  (Note to self: Find a linter for this.) So I fixed the assertions, which revealed a failing test, so I fixed the bug too.

I considered removing the second test case entirely because the `type` prop went away in https://github.com/code-dot-org/code-dot-org/pull/19240/files. However, I think it still captures a valid case with the `isMinecraft` prop overriding the tutorial setting.  Let me know if I'm missing context here.