### PR TITLE
Tests: Make BubbleChoiceTest enzyme 3 ready

### DIFF
--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -40,7 +40,12 @@ describe('BubbleChoice', () => {
     const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} />);
     const thumbnails = wrapper.find('img');
     assert.equal(1, thumbnails.length);
-    assert(thumbnails.at(0).node.src.includes(fakeSublevels[0].thumbnail_url));
+    assert(
+      thumbnails
+        .at(0)
+        .getDOMNode()
+        .src.includes(fakeSublevels[0].thumbnail_url)
+    );
   });
 
   it('renders a placeholder div if sublevel thumbnail is not present', () => {


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.