### PR TITLE
Tests: Make PopUpMenuTest enzyme 3 ready

### DIFF
--- a/apps/test/unit/lib/ui/PopUpMenuTest.js
+++ b/apps/test/unit/lib/ui/PopUpMenuTest.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import sinon from 'sinon';
 import msg from '@cdo/locale';
-import {expect} from '../../../util/configuredChai';
+import {expect} from '../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import PopUpMenu, {MenuBubble} from '@cdo/apps/lib/ui/PopUpMenu';
 
@@ -38,9 +38,7 @@ describe('PopUpMenu', () => {
       </MenuBubble>
     );
     wrapper
-      .find(PopUpMenu.Item)
-      .first()
-      .children()
+      .find('div[onClick]')
       .first()
       .simulate('click');
     expect(spy1).to.have.been.calledOnce;


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.