### PR TITLE
Levelbuilder Clean Up: Headers Searchable and Spacing Improvements

### DIFF
--- a/apps/style/code-studio/levelbuilder.scss
+++ b/apps/style/code-studio/levelbuilder.scss
@@ -154,8 +154,12 @@ table.checkboxes {
 
  [data-toggle="collapse"] {
    cursor: pointer;
-   padding: 2%;
+   padding: 15px;
    padding-left: 0;
+   line-height: 18px;
+   margin-bottom: 10px;
+   font-size: 18px;
+   border-bottom: 1px solid #e5e5e5;
 
   &:after {
     content: "\25B2";

--- a/dashboard/app/views/levels/editors/_all.html.haml
+++ b/dashboard/app/views/levels/editors/_all.html.haml
@@ -31,7 +31,7 @@
     %p If specified this error message will be used to replace ALL error messages in the puzzle. Be certain this is what you want before using.
     = f.text_field :failure_message_override, style: 'width: 600px;', placeholder: 'Type Override Failure Message Here'
 
-%legend.control-legend{data: {toggle: "collapse", target: "#audit_log_info"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#audit_log_info"}}
   Audit Log
 
 %p A log of the people who most recently edited this level (up to the last 10 people)
@@ -43,7 +43,7 @@
   = render partial: 'levels/editors/sub_level_types', locals: {f: f}
 
 - if @level.is_a?(Weblab) || (@level.uses_droplet?) || @level.is_a?(Blockly) || @level.respond_to?(:disable_sharing)
-  %legend.control-legend{data: {toggle: "collapse", target: "#share_and_remix"}}
+  %h1.control-legend{data: {toggle: "collapse", target: "#share_and_remix"}}
     Share and Remix Settings
 
   #share_and_remix.collapse
@@ -55,7 +55,7 @@
         = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :disable_sharing, description: "Disable sharing"}
         %p If set, this level cannot be shared or saved to galleries even if it's free play.
 
-%legend.control-legend{data: {toggle: "collapse", target: "#concepts"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#concepts"}}
   Concepts
 
 #concepts.collapse
@@ -89,7 +89,7 @@
               %td
                 = select_tag "level[level_concept_difficulty_attributes][#{concept}]", options_for_select((1..LevelConceptDifficulty::MAXIMUM_CONCEPT_DIFFICULTY).to_a, difficulty), include_blank: true
 
-%legend.control-legend{data: {toggle: "collapse", target: "#reference"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#reference"}}
   Video & Reference Materials
 
 %p Video settings. Map reference. Reference Links.
@@ -126,7 +126,7 @@
           = text_area_tag 'level[reference_links]', @level.reference_links.join("\r\n"), rows: 6, class: "input-block-level", placeholder: 'Additional Reference Link'
 
 - if (@level.uses_droplet?) || @level.is_a?(Blockly)
-  %legend.control-legend{data: {toggle: "collapse", target: "#assets"}}
+  %h1.control-legend{data: {toggle: "collapse", target: "#assets"}}
     Preload Asset List
 
   #assets.collapse

--- a/dashboard/app/views/levels/editors/_animation.html.haml
+++ b/dashboard/app/views/levels/editors/_animation.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#animations"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#animations"}}
   Animations
 
 #animations.collapse

--- a/dashboard/app/views/levels/editors/_applab.html.haml
+++ b/dashboard/app/views/levels/editors/_applab.html.haml
@@ -9,7 +9,7 @@
 
 = render partial: 'levels/editors/helper_libraries', locals: {f: f}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#data_tab"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#data_tab"}}
   Data Tab
 
 #data_tab.collapse
@@ -46,7 +46,7 @@
     :javascript
       levelbuilder.initializeCodeMirror('level_data_properties', 'javascript');
 
-%legend.control-legend{data: {toggle: "collapse", target: "#design_mode"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#design_mode"}}
   Design Mode
 
 #design_mode.collapse
@@ -70,13 +70,13 @@
     :javascript
       levelbuilder.initializeCodeMirror('level_start_html', 'html');
 
-%legend.control-legend{data: {toggle: "collapse", target: "#maker_toolkit"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#maker_toolkit"}}
   Maker Toolkit
 
 #maker_toolkit.collapse
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :makerlab_enabled, description: "Enable Maker APIs"}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#applab"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#applab"}}
   App Lab Options
 
 %p App lab start Library. Turtle settings. API settings. Conditions for level completion.

--- a/dashboard/app/views/levels/editors/_artist.html.haml
+++ b/dashboard/app/views/levels/editors/_artist.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'artist'}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#artist_options"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#artist_options"}}
   Artist Options
 
 %p Start settings. Speed slider. Auto rerun. Etc.

--- a/dashboard/app/views/levels/editors/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/_blockly.html.haml
@@ -5,7 +5,7 @@
     = javascript_include_tag "js/en_us/common_locale"
     = javascript_include_tag "js/en_us/#{@level.game.app}_locale"
 
-%legend.control-legend{data: {toggle: "collapse", target: "#blockly"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#blockly"}}
   Blockly Options
 
 %p Ideal block number. Blockly block settings. Speed slider. Workspace height.

--- a/dashboard/app/views/levels/editors/_blockly_xml_editors.html.haml
+++ b/dashboard/app/views/levels/editors/_blockly_xml_editors.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#blockly_editors"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#blockly_editors"}}
   Blockly Workspace Editors
 
 %p

--- a/dashboard/app/views/levels/editors/_bounce.html.haml
+++ b/dashboard/app/views/levels/editors/_bounce.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'levels/editors/control_buttons', locals: {f: f}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#success"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#success"}}
   Success and Failure Conditions
 
 #success.collapse
@@ -21,7 +21,7 @@
     %p condition(s), which if true at any point, indicates the puzzle is complete (indicating failure if success condition not met)
     = f.text_area :failure_condition, rows: 4
 
-%legend.control-legend{data: {toggle: "collapse", target: "#bounce_options"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#bounce_options"}}
   Bounce Options
 
 %p Ball settings. Theme. Use flag goal.

--- a/dashboard/app/views/levels/editors/_callouts.html.haml
+++ b/dashboard/app/views/levels/editors/_callouts.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#callout_editor"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#callout_editor"}}
   Callouts
 
 #callout_editor.collapse

--- a/dashboard/app/views/levels/editors/_control_buttons.html.haml
+++ b/dashboard/app/views/levels/editors/_control_buttons.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#control_buttons"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#control_buttons"}}
   Control Buttons
 
 #control_buttons.collapse

--- a/dashboard/app/views/levels/editors/_craft.html.haml
+++ b/dashboard/app/views/levels/editors/_craft.html.haml
@@ -1,7 +1,7 @@
 - content_for(:head) do
   %script{src: minifiable_asset_path('js/levelbuilder_craft.js')}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#minecraft_options"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#minecraft_options"}}
   Minecraft Options
 
 %p All settings specific to a minecraft type level.

--- a/dashboard/app/views/levels/editors/_cs_in_a.html.haml
+++ b/dashboard/app/views/levels/editors/_cs_in_a.html.haml
@@ -1,5 +1,5 @@
 //CS in A stuff
-%legend.control-legend{data: {toggle: "collapse", target: "#cs_in_a"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#cs_in_a"}}
   CS in A Options
 
 #cs_in_a.collapse

--- a/dashboard/app/views/levels/editors/_dance.html.haml
+++ b/dashboard/app/views/levels/editors/_dance.html.haml
@@ -8,7 +8,7 @@
 
 = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'dance'}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#default_song"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#default_song"}}
   Default Song
 
 #default_song.collapse

--- a/dashboard/app/views/levels/editors/_debugger.html.haml
+++ b/dashboard/app/views/levels/editors/_debugger.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#debugging_tools"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#debugging_tools"}}
   Debugger Settings
 
 #debugging_tools.collapse

--- a/dashboard/app/views/levels/editors/_droplet.html.haml
+++ b/dashboard/app/views/levels/editors/_droplet.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#droplet_palette"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#droplet_palette"}}
   Starting Block Palette (Droplet)
 
 #droplet_palette.collapse
@@ -14,7 +14,7 @@
   = f.label :code_functions, 'Edit Droplet Palette'
   = f.text_area :code_functions, placeholder: 'Droplet Palette', rows: 4, value: @level.code_functions ? JSON.pretty_generate(@level.code_functions) : ''
 
-%legend.control-legend{data: {toggle: "collapse", target: "#starter_code"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#starter_code"}}
   Starter Code
 
 %p Javascript starter code. Starting code view: block/text.

--- a/dashboard/app/views/levels/editors/_encrypted_examples.html.haml
+++ b/dashboard/app/views/levels/editors/_encrypted_examples.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#example_solutions"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#example_solutions"}}
   Example Solutions
 
 #example_solutions.collapse

--- a/dashboard/app/views/levels/editors/_flappy.html.haml
+++ b/dashboard/app/views/levels/editors/_flappy.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#flappy_options"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#flappy_options"}}
   Flappy Options
 
 %p All the settings specific to a flappy type level.
@@ -33,7 +33,7 @@
         whether the goal stays in one spot or moves at level's speed
     = f.text_area :goal, rows: 9, placeholder: Flappy.default_goal
 
-%legend.control-legend{data: {toggle: "collapse", target: "#success"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#success"}}
   Success and Failure Conditions
 
 #success.collapse

--- a/dashboard/app/views/levels/editors/_gamelab.html.haml
+++ b/dashboard/app/views/levels/editors/_gamelab.html.haml
@@ -9,7 +9,7 @@
 
 = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'gamelab'}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#data_tab"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#data_tab"}}
   Data Tab
 
 #data_tab.collapse

--- a/dashboard/app/views/levels/editors/_grid.html.haml
+++ b/dashboard/app/views/levels/editors/_grid.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#grid_editor_container"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#grid_editor_container"}}
   Grid Editor
 
 #grid_editor_container.collapse

--- a/dashboard/app/views/levels/editors/_helper_libraries.html.haml
+++ b/dashboard/app/views/levels/editors/_helper_libraries.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#helper_libraries"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#helper_libraries"}}
   Helper Libraries & Block Pools
 
 #helper_libraries.collapse

--- a/dashboard/app/views/levels/editors/_instructions.haml
+++ b/dashboard/app/views/levels/editors/_instructions.haml
@@ -1,6 +1,6 @@
 %fieldset.control-group
 
-  %legend.control-legend{data: {toggle: "collapse", target: "#instructions"}}
+  %h1.control-legend{data: {toggle: "collapse", target: "#instructions"}}
     Instructions
 
   %p Edit the instructions for a level (CSF hints, CSF skin, long/short instructions, TTS)

--- a/dashboard/app/views/levels/editors/_karel.html.haml
+++ b/dashboard/app/views/levels/editors/_karel.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#karel_options"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#karel_options"}}
   Collector Options
 
 %p Flower type. Nectar or honey goal. Minimum to collect. Animation speed.

--- a/dashboard/app/views/levels/editors/_maze.html.haml
+++ b/dashboard/app/views/levels/editors/_maze.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#maze_options"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#maze_options"}}
   Maze Options
 
 %p Start direction. Step mode. Random rotation of puzzle.

--- a/dashboard/app/views/levels/editors/_mini_rubric.html.haml
+++ b/dashboard/app/views/levels/editors/_mini_rubric.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#mini_rubric"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#mini_rubric"}}
   Mini Rubric
 
 #mini_rubric.collapse

--- a/dashboard/app/views/levels/editors/_playlab.html.haml
+++ b/dashboard/app/views/levels/editors/_playlab.html.haml
@@ -5,7 +5,7 @@
 
 = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'playlab'}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#custom_game"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#custom_game"}}
   Custom Game Type
 
 #custom_game.collapse
@@ -13,7 +13,7 @@
   %p Used to tell playlab we want to run some of our custom onTick logic.
   = f.select :custom_game_type, options_for_select(["", "Big Game", "Rocket Height", "Sam the Bat", "Ninja Cat"], @level.custom_game_type)
 
-%legend.control-legend{data: {toggle: "collapse", target: "#background"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#background"}}
   Background Settings
 
 #background.collapse
@@ -25,7 +25,7 @@
     .field
       = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :coordinate_grid_background, description: "Coordinate grid background"}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#success"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#success"}}
   Success and Failure Conditions
 
 #success.collapse
@@ -38,7 +38,7 @@
     %p Optional JavaScript function to run every tick. If the function ever return true, the level immediately fails.
     = f.text_area :failure_condition, rows: 4
 
-%legend.control-legend{data: {toggle: "collapse", target: "#sprites"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#sprites"}}
   Sprite Settings
 
 #sprites.collapse
@@ -55,7 +55,7 @@
   .field
     = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :sprites_hidden_to_start, description: "Sprites hidden to start"}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#timeout"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#timeout"}}
   Timeout Settings
 
 #timeout.collapse
@@ -67,7 +67,7 @@
     = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :timeout_after_when_run, description: "Timeout after all blocks run"}
     %p When set, if the only event block that had children is when_run, and those commands are finished executing, don't wait for the timeout. If we have additional event blocks that DO have children, we keeping running until timeoutFailureTick or a success/failure condition is met
 
-%legend.control-legend{data: {toggle: "collapse", target: "#collision"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#collision"}}
   Collision Rules
 
 #collision.collapse

--- a/dashboard/app/views/levels/editors/_spritelab.html.haml
+++ b/dashboard/app/views/levels/editors/_spritelab.html.haml
@@ -4,7 +4,7 @@
 
 = render partial: 'levels/editors/helper_libraries', locals: {f: f}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#setup_code"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#setup_code"}}
   Setup Code
 
 %p Create custom setup code. Immediately show results of setup code in playspace

--- a/dashboard/app/views/levels/editors/_sub_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/_sub_level_types.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#special_level"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#special_level"}}
   Special Level Types
 
 %p Project Template Levels. Contained (Predict) Levels. Free Play Levels. Embed Levels.

--- a/dashboard/app/views/levels/editors/_submittable.html.haml
+++ b/dashboard/app/views/levels/editors/_submittable.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#submit_level"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#submit_level"}}
   Submittable
 
 #submit_level.collapse

--- a/dashboard/app/views/levels/editors/_teacher_only_markdown.haml
+++ b/dashboard/app/views/levels/editors/_teacher_only_markdown.haml
@@ -5,7 +5,7 @@
     padding: 10px;
   }
 
-%legend.control-legend{data: {toggle: "collapse", target: "#teacher_only_markdown"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#teacher_only_markdown"}}
   Teacher Only Markdown
 
 #teacher_only_markdown.collapse

--- a/dashboard/app/views/levels/editors/_validation_code.html.haml
+++ b/dashboard/app/views/levels/editors/_validation_code.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#validation"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#validation"}}
   Validation
 
 #validation.collapse

--- a/dashboard/app/views/levels/editors/_weblab.html.haml
+++ b/dashboard/app/views/levels/editors/_weblab.html.haml
@@ -1,4 +1,4 @@
-%legend.control-legend{data: {toggle: "collapse", target: "#weblab_starting_sources"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#weblab_starting_sources"}}
   Web Lab Starting Sources
 
 #weblab_starting_sources.collapse
@@ -9,7 +9,7 @@
 
 = render partial: 'levels/editors/submittable', locals: {f: f}
 
-%legend.control-legend{data: {toggle: "collapse", target: "#project_template_level"}}
+%h1.control-legend{data: {toggle: "collapse", target: "#project_template_level"}}
   Project Template Level
 
 #project_template_level.collapse


### PR DESCRIPTION
Change all the collapsers to h1 so they are searchable and shrink the space they take up so you can see more headers at once.

# Searchable

## Before

<img width="1007" alt="Screen Shot 2019-06-16 at 1 42 27 PM" src="https://user-images.githubusercontent.com/208083/59567498-ab6d1100-903c-11e9-962e-f1f772b84a9c.png">

## After

<img width="1064" alt="Screen Shot 2019-06-16 at 1 42 13 PM" src="https://user-images.githubusercontent.com/208083/59567497-ab6d1100-903c-11e9-9c67-0d6e2d697181.png">

# Style Improvement

## Before

<img width="1023" alt="Screen Shot 2019-06-16 at 1 41 48 PM" src="https://user-images.githubusercontent.com/208083/59567502-ba53c380-903c-11e9-8584-9e5cc557444e.png">

## After

<img width="1002" alt="Screen Shot 2019-06-16 at 1 41 39 PM" src="https://user-images.githubusercontent.com/208083/59567504-be7fe100-903c-11e9-9279-1013400f4f4b.png">


