### PR TITLE
Output arrow stabilized

### DIFF
--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -67,7 +67,7 @@ const style = {
     boxShadow: 'none'
   },
   inspector: {
-    display: 'inline-block'
+    display: 'inline-flex'
   }
 };
 


### PR DESCRIPTION
**Summary**:
Had a bug where the output arrow moves when the object or list is expanded when the expandable arrow is clicked. It was because the arrow and the div tag of the inspector was connected by inline-block instead of inline-flex. Screenshot of change to inline-flex is shown below:
**Bug**:
<img width="118" alt="Screen Shot 2019-06-17 at 10 41 21 AM" src="https://user-images.githubusercontent.com/17921445/59624771-820bbe00-90ec-11e9-9ed3-cf453b423cb6.png">

**Fix**:
<img width="380" alt="Screen Shot 2019-06-17 at 10 16 42 AM" src="https://user-images.githubusercontent.com/17921445/59624519-ce0a3300-90eb-11e9-905f-8567a460d485.png">
