### PR TITLE
Revert "Projects: flagged text in admin panel"

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -85,7 +85,6 @@ let newSourceVersionInterval = 15 * 60 * 1000; // 15 minutes
 var currentAbuseScore = 0;
 var sharingDisabled = false;
 var currentHasPrivacyProfanityViolation = false;
-var currentShareFailure = false;
 var isEditing = false;
 let initialSaveComplete = false;
 let initialCaptureComplete = false;
@@ -347,10 +346,6 @@ var projects = (module.exports = {
    */
   hasPrivacyProfanityViolation() {
     return currentHasPrivacyProfanityViolation;
-  },
-
-  privacyProfanityDetails() {
-    return currentShareFailure;
   },
 
   /**
@@ -1425,9 +1420,6 @@ var projects = (module.exports = {
                 fetchAbuseScoreAndPrivacyViolations(this, function() {
                   deferred.resolve();
                 });
-                fetchShareFailure(this, function() {
-                  deferred.resolve();
-                });
               },
               queryParams('version'),
               sourcesApi
@@ -1449,9 +1441,6 @@ var projects = (module.exports = {
             () => {
               projects.showHeaderForProjectBacked();
               fetchAbuseScoreAndPrivacyViolations(this, function() {
-                deferred.resolve();
-              });
-              fetchShareFailure(this, function() {
                 deferred.resolve();
               });
             },
@@ -1616,21 +1605,6 @@ function fetchAbuseScore(resolve) {
 function fetchSharingDisabled(resolve) {
   channels.fetch(current.id + '/sharing_disabled', function(err, data) {
     sharingDisabled = (data && data.sharing_disabled) || sharingDisabled;
-    resolve();
-    if (err) {
-      // Throw an error so that things like New Relic see this. This shouldn't
-      // affect anything else
-      throw err;
-    }
-  });
-}
-
-function fetchShareFailure(resolve) {
-  channels.fetch(current.id + '/share-failure', (err, data) => {
-    currentShareFailure =
-      data && data.share_failure && data.share_failure.content
-        ? data.share_failure.content
-        : currentShareFailure;
     resolve();
     if (err) {
       // Throw an error so that things like New Relic see this. This shouldn't

--- a/apps/src/code-studio/showProjectAdmin.js
+++ b/apps/src/code-studio/showProjectAdmin.js
@@ -92,9 +92,6 @@ export default project => {
       }
       if (privateOrProfane) {
         $('.privacy-profanity').show();
-        var textViolation = project.privacyProfanityDetails();
-        $('.privacy-profanity-details').text(textViolation);
-        $('.privacy-profanity-details').show();
       }
       if (abusive) {
         // The image moderation service sets the abuse score to 15 to

--- a/apps/test/unit/code-studio/showProjectAdminTest.js
+++ b/apps/test/unit/code-studio/showProjectAdminTest.js
@@ -15,8 +15,7 @@ describe('showProjectAdmin', () => {
         getAbuseScore: sinon.stub(),
         exceedsAbuseThreshold: sinon.stub(),
         getSharingDisabled: sinon.stub(),
-        hasPrivacyProfanityViolation: sinon.stub(),
-        privacyProfanityDetails: sinon.stub()
+        hasPrivacyProfanityViolation: sinon.stub()
       };
 
       rootElement = document.createElement('div');
@@ -36,7 +35,6 @@ describe('showProjectAdmin', () => {
           </li>
           <li class="privacy-profanity" style="display: none">
             Private or profane text
-            <div class="privacy-profanity-details"></div>
           </li>
           <li class="abusive-image" style="display: none">
             Inappropriate image
@@ -175,7 +173,6 @@ describe('showProjectAdmin', () => {
             project.exceedsAbuseThreshold.returns(false);
             project.hasPrivacyProfanityViolation.returns(true);
             project.getSharingDisabled.returns(false);
-            project.privacyProfanityDetails.returns('fu');
           });
 
           it('shows sharing blocked message', () => {
@@ -189,7 +186,6 @@ describe('showProjectAdmin', () => {
             assertVisible('.blocked-reasons');
             assertHidden('.admin-sharing');
             assertVisible('.privacy-profanity');
-            assertVisible('.privacy-profanity-details');
             assertHidden('.abusive-image');
             assertHidden('.reported-abuse');
           });

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -131,13 +131,11 @@
           This project is safe to share.
         .blocked{ style: 'display: none;' }
           This project is blocked from sharing.
-      %br
       %ul.blocked-reasons{ style: 'display: none;' }
         %li.admin-sharing{ style: 'display: none;' }
           Sharing is disabled
         %li.privacy-profanity{ style: 'display: none;' }
-          Private or profane text:
-          .privacy-profanity-details
+          Private or profane text
         %li.abusive-image{ style: 'display: none;' }
           Inappropriate image
           .image-mod-controls{ style: 'display: none;' }
@@ -160,6 +158,6 @@
         Abuse score:
         %span.admin-abuse-score
         = link_to 'Reset', '#', { class: 'admin-abuse-reset' }
-      %br
+
       .admin-report-abuse
         = link_to 'Report Abuse', '/report_abuse'

--- a/shared/middleware/channels_api.rb
+++ b/shared/middleware/channels_api.rb
@@ -251,18 +251,6 @@ class ChannelsApi < Sinatra::Base
   end
 
   #
-  # GET /v3/channels/<channel-id>/share-failure
-  #
-  # Get an indication of why a project can't be shared.
-  #
-  get %r{/v3/channels/([^/]+)/share-failure} do |id|
-    dont_cache
-    content_type :json
-
-    value = explain_share_failure(id)
-    {share_failure: value}.to_json
-  end
-  #
   #
   # GET /v3/channels/<channel-id>/sharing_disabled
   #

--- a/shared/middleware/helpers/profanity_privacy_helper.rb
+++ b/shared/middleware/helpers/profanity_privacy_helper.rb
@@ -18,6 +18,12 @@ def channel_policy_violation?(channel_id)
   profanity_privacy_violation?(BLOCKLY_SOURCE_FILENAME, body)
 end
 
+#
+# This method is designed to be an easy way for support staff or a dev to
+# figure out why sharing was automatically blocked for a particular project.
+# It's designed for use from dashboard-console, which is why it has no usages
+# within our repo.
+#
 # @example
 #   explain_share_failure 'kkbjvA8CUoWEAJ0inKpzTQ'
 #


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#29080

Causing a JS error that's potentially related to a UI test failure, reverting while I investigate more thoroughly. 