### PR TITLE
Handle server error more gracefully

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -79,6 +79,7 @@ def main
     CONDITIONALLY_PUBLISHABLE_PROJECT_TYPES
     ALLOWED_WEB_REQUEST_HEADERS
     ABUSE_CONSTANTS
+    ERROR_SEVERITY_LEVELS
   )
 
   generate_shared_js_file(shared_content, "#{REPO_DIR}/apps/src/util/sharedConstants.js")

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
@@ -3,6 +3,19 @@ import React from 'react';
 import $ from 'jquery';
 import Spinner from '../../../components/spinner';
 import Results from './results';
+import color from '@cdo/apps/util/color';
+
+const styles = {
+  errorBox: {
+    margin: 15
+  },
+  errorDetailsBox: {
+    backgroundColor: color.lightest_gray,
+    padding: 20,
+    maxWidth: 550,
+    marginTop: 20
+  }
+};
 
 export class ResultsLoader extends React.Component {
   static propTypes = {
@@ -49,14 +62,20 @@ export class ResultsLoader extends React.Component {
 
   renderErrors() {
     return (
-      <div id="error_list">
-        Sorry we couldn't process this request. Server encountered the following
-        error(s):
-        <ul>
-          {this.state.errors.map((error, index) => (
-            <li key={index}>{error.message}</li>
-          ))}
-        </ul>
+      <div id="error_list" style={styles.errorBox}>
+        <h1>An error occurred</h1>
+        <p>
+          Unfortunately this request could not be processed. Our team has been
+          notified.
+        </p>
+        <div style={styles.errorDetailsBox}>
+          Error details:
+          <ul>
+            {this.state.errors.map((error, index) => (
+              <li key={index}>{error.message}</li>
+            ))}
+          </ul>
+        </div>
       </div>
     );
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
@@ -11,7 +11,7 @@ export class ResultsLoader extends React.Component {
     })
   };
 
-  state = {loading: true};
+  state = {loading: true, errors: null};
 
   componentDidMount() {
     this.load();
@@ -22,27 +22,47 @@ export class ResultsLoader extends React.Component {
       this.props.params['workshopId']
     }/generic_survey_report`;
 
-    // TODO: Handle server failure gracefully; right now it just shows a infinite spinning wheel.
     this.loadRequest = $.ajax({
       method: 'GET',
       url: url,
       dataType: 'json'
-    }).done(data => {
-      this.setState({
-        loading: false,
-        questions: data['questions'],
-        thisWorkshop: data['this_workshop'],
-        sessions: Object.keys(data['this_workshop']),
-        facilitators: data['facilitators'],
-        facilitatorAverages: data['facilitator_averages'],
-        facilitatorResponseCounts: data['facilitator_response_counts'],
-        courseName: data['course_name']
+    })
+      .done(data => {
+        this.setState({
+          loading: false,
+          questions: data['questions'],
+          thisWorkshop: data['this_workshop'],
+          sessions: Object.keys(data['this_workshop']),
+          facilitators: data['facilitators'],
+          facilitatorAverages: data['facilitator_averages'],
+          facilitatorResponseCounts: data['facilitator_response_counts'],
+          courseName: data['course_name']
+        });
+      })
+      .fail(jqXHR => {
+        this.setState({
+          loading: false,
+          errors: (jqXHR.responseJSON || {}).errors
+        });
       });
-    });
+  }
+
+  renderErrors() {
+    return (
+      <div id="error_list">
+        Sorry we couldn't process this request. Server encountered the following
+        error(s):
+        <ul>
+          {this.state.errors.map((error, index) => (
+            <li key={index}>{error.message}</li>
+          ))}
+        </ul>
+      </div>
+    );
   }
 
   render() {
-    const {loading, ...data} = this.state;
+    const {loading, errors, ...data} = this.state;
 
     if (loading) {
       return (
@@ -50,6 +70,8 @@ export class ResultsLoader extends React.Component {
           <Spinner />
         </div>
       );
+    } else if (errors) {
+      return this.renderErrors();
     } else {
       return <Results {...data} />;
     }

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -113,12 +113,17 @@ module Api::V1::Pd
 
     # GET /api/v1/pd/workshops/:id/generic_survey_report
     def generic_survey_report
+      # Default HTTP status code to return to client if
+      # we encouter an exception processing this request.
+      error_status_code = :internal_server_error
+
       return local_workshop_daily_survey_report if @workshop.summer? ||
         ([COURSE_CSP, COURSE_CSD].include?(@workshop.course) &&
         @workshop.workshop_starting_date > Date.new(2018, 8, 1))
 
       return create_csf_survey_report if @workshop.csf? && @workshop.subject == SUBJECT_CSF_201
 
+      error_status_code = :bad_request
       raise 'Action generic_survey_report should not be used for this workshop'
     rescue => e
       Honeybadger.notify(
@@ -130,7 +135,7 @@ module Api::V1::Pd
         }
       )
 
-      render status: :bad_request, json: {
+      render status: error_status_code, json: {
         errors: [
           {
             severity: Logger::Severity::ERROR,

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -139,8 +139,8 @@ module Api::V1::Pd
         errors: [
           {
             severity: Logger::Severity::ERROR,
-            message: "#{e.message}. Workshop id #{@workshop.id},"\
-              " course #{@workshop.course}, subject #{@workshop.subject}."
+            message: "#{e.message}. Workshop id: #{@workshop.id},"\
+              " course: #{@workshop.course}, subject: #{@workshop.subject}."
           }
         ]
       }

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -119,8 +119,10 @@ module Api::V1::Pd
 
       return create_csf_survey_report if @workshop.csf? && @workshop.subject == SUBJECT_CSF_201
 
+      raise 'Action generic_survey_report should not be used for this workshop'
+    rescue => e
       Honeybadger.notify(
-        error_message: 'Action generic_survey_report should not be used for this workshop',
+        error_message: e.message,
         context: {
           workshop_id: @workshop.id,
           course: @workshop.course,
@@ -129,8 +131,13 @@ module Api::V1::Pd
       )
 
       render status: :bad_request, json: {
-        error: "Do not know how to process survey results for this workshop "\
-          "#{@workshop.course} #{@workshop.subject}"
+        errors: [
+          {
+            severity: Logger::Severity::ERROR,
+            message: "#{e.message}. Workshop id #{@workshop.id},"\
+              " course #{@workshop.course}, subject #{@workshop.subject}."
+          }
+        ]
       }
     end
 

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -208,15 +208,17 @@ module Api::V1::Pd
     end
 
     test 'facilitators cannot see results for other types of workshops' do
-      workshop = create :pd_workshop, facilitators: [@facilitator]
+      workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_101,
+        facilitators: [@facilitator]
       sign_in @facilitator
 
       get :generic_survey_report, params: {workshop_id: workshop.id}
+      result = JSON.parse(@response.body)
+
       assert_response :bad_request
-      assert_equal(
-        {'error' => "Do not know how to process survey results for this workshop"\
-          " #{workshop.course} #{workshop.subject}"},
-        JSON.parse(@response.body)
+      assert result['errors']&.present?
+      assert result['errors'].first["message"]&.start_with?(
+        'Action generic_survey_report should not be used for this workshop'
       )
     end
 

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -560,4 +560,16 @@ module SharedConstants
   JSON
 
   ALLOWED_WEB_REQUEST_HEADERS = HttpCache::ALLOWED_WEB_REQUEST_HEADERS
+
+  # Subset of Ruby Logger::Severity constants.
+  # https://github.com/ruby/ruby/blob/trunk/lib/logger.rb
+  # We don't use 2 irrelevant severity levels DEBUG (0) and INFO (1).
+  ERROR_SEVERITY_LEVELS = {
+    # A warning.
+    WARN: 2,
+    # A handleable error condition.
+    ERROR: 3,
+    # An unhandleable error that results in a program crash.
+    FATAL: 4
+  }.freeze
 end


### PR DESCRIPTION
### What
Gracefully handle sever error when displaying local summer workshop survey results (old pipeline) and CSF deep dive results (new pipeline).

Currently, if there is a server error, user will see a forever spinning wheel.

Now they will see an error message with details (more transparent). They will also know that we are already notified.
<img width="623" alt="Screen Shot 2019-06-18 at 5 24 37 PM" src="https://user-images.githubusercontent.com/46507039/59728256-27f32180-91ee-11e9-9799-de66efaa18ad.png">

### Why
- Improve user experience.
- Save time when we have to investigate issue. Users can send the error details when requesting help.
- Being able to tolerate non-fatal server errors when processing requests. This is the most important incentive for this work. Currently, if there is a non-fatal server error, we either swallow it (users won't know about it) or stop processing the request (users get no result). With the ability to display error messages on client side, we can still try our best to process the request and still notify users about any non-fatal errors.

### How tested
- Server unit test 
  `bundle exec rails test test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb`

- Manual test: 
  Open this link `http://localhost-studio.code.org:3000/pd/workshop_dashboard/daily_survey_results/<workshop_id>` for a CSF 201 workshop, CSD local summer workshop, and a CSF 101 workshop. CSF201 & CSD workshops will get proper results, while CSF 101 will get 400 response and detailed error messages.