### PR TITLE
Display progress for BubbleChoice levels

### DIFF
--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -265,10 +265,10 @@ module UsersHelper
       sl.level_ids.each do |level_id|
         # if we have a contained level or BubbleChoice level, use that to represent progress
         level = Level.cache_find(level_id)
+        sublevel_id = level.is_a?(BubbleChoice) ? level.best_result_sublevel(user)&.id : nil
         contained_level_id = level.contained_levels.try(:first).try(:id)
-        sublevel_id = level.is_a?(BubbleChoice) ? level.best_result_sublevel_id(user) : nil
 
-        ul = user_levels_by_level.try(:[], contained_level_id || sublevel_id || level_id)
+        ul = user_levels_by_level.try(:[], sublevel_id || contained_level_id || level_id)
         completion_status = activity_css_class(ul)
         # a UL is submitted if the state is submitted UNLESS it is a peer reviewable level that has been reviewed
         submitted = !!ul.try(:submitted) &&

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -265,7 +265,7 @@ module UsersHelper
       sl.level_ids.each do |level_id|
         # if we have a contained level or BubbleChoice level, use that to represent progress
         level = Level.cache_find(level_id)
-        sublevel_id = level.is_a?(BubbleChoice) ? level.best_result_sublevel(user)&.id : nil
+        sublevel_id = sl.bubble_choice? ? level.best_result_sublevel(user)&.id : nil
         contained_level_id = level.contained_levels.try(:first).try(:id)
 
         ul = user_levels_by_level.try(:[], sublevel_id || contained_level_id || level_id)

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -263,7 +263,7 @@ module UsersHelper
     levels = {}
     script.script_levels.each do |sl|
       sl.level_ids.each do |level_id|
-        # if we have a contained level or sublevels, use that to represent progress
+        # if we have a contained level or BubbleChoice level, use that to represent progress
         level = Level.cache_find(level_id)
         contained_level_id = level.contained_levels.try(:first).try(:id)
         sublevel_id = level.is_a?(BubbleChoice) ? level.best_result_sublevel_id(user) : nil

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -263,9 +263,12 @@ module UsersHelper
     levels = {}
     script.script_levels.each do |sl|
       sl.level_ids.each do |level_id|
-        # if we have a contained level, use that to represent progress
-        contained_level_id = Level.cache_find(level_id).contained_levels.try(:first).try(:id)
-        ul = user_levels_by_level.try(:[], contained_level_id || level_id)
+        # if we have a contained level or sublevels, use that to represent progress
+        level = Level.cache_find(level_id)
+        contained_level_id = level.contained_levels.try(:first).try(:id)
+        sublevel_id = level.is_a?(BubbleChoice) ? level.best_result_sublevel_id(user) : nil
+
+        ul = user_levels_by_level.try(:[], contained_level_id || sublevel_id || level_id)
         completion_status = activity_css_class(ul)
         # a UL is submitted if the state is submitted UNLESS it is a peer reviewable level that has been reviewed
         submitted = !!ul.try(:submitted) &&

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -103,4 +103,12 @@ ruby
 
     summary
   end
+
+  # Returns the sublevel id for a user that has the highest best_result.
+  # @param [User]
+  # @return [Integer]
+  def best_result_sublevel_id(user)
+    ul = user.user_levels.where(level: sublevels).order(best_result: :desc)
+    ul&.first&.level&.id
+  end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -108,7 +108,7 @@ ruby
   # @param [User]
   # @return [Integer]
   def best_result_sublevel_id(user)
-    ul = user.user_levels.where(level: sublevels).order(best_result: :desc)
-    ul&.first&.level&.id
+    ul = user.user_levels.where(level: sublevels).max_by(&:best_result)
+    ul&.level&.id
   end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -107,8 +107,8 @@ ruby
   # Returns the sublevel id for a user that has the highest best_result.
   # @param [User]
   # @return [Integer]
-  def best_result_sublevel_id(user)
+  def best_result_sublevel(user)
     ul = user.user_levels.where(level: sublevels).max_by(&:best_result)
-    ul&.level&.id
+    ul&.level
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -403,10 +403,16 @@ class ScriptLevel < ActiveRecord::Base
   def summarize_for_teacher_panel(student)
     contained_levels = levels.map(&:contained_levels).flatten
     contained = contained_levels.any?
-    levels = contained ? contained_levels : [level]
+
+    levels = if bubble_choice?
+               [level.best_result_sublevel(student)]
+             elsif contained
+               contained_levels
+             else
+               [level]
+             end
 
     user_level = student.last_attempt_for_any(levels)
-
     status = activity_css_class(user_level)
     passed = [SharedConstants::LEVEL_STATUS.passed, SharedConstants::LEVEL_STATUS.perfect].include?(status)
 

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -132,6 +132,6 @@ DSL
     create :user_level, user: student, level: @sublevel2, best_result: 100
     create :user_level, user: student, level: @sublevel1, best_result: 20
 
-    assert_equal @sublevel2.id, @bubble_choice.best_result_sublevel_id(student)
+    assert_equal @sublevel2, @bubble_choice.best_result_sublevel(student)
   end
 end

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -126,4 +126,12 @@ DSL
     refute_nil sublevel_summary.first[:url]
     refute_nil sublevel_summary.last[:url]
   end
+
+  test 'best_result_sublevel_id returns sublevel id with highest best_result for user' do
+    student = create :student
+    create :user_level, user: student, level: @sublevel1, best_result: 20
+    create :user_level, user: student, level: @sublevel2, best_result: 100
+
+    assert_equal @sublevel2.id, @bubble_choice.best_result_sublevel_id(student)
+  end
 end

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -129,8 +129,8 @@ DSL
 
   test 'best_result_sublevel_id returns sublevel id with highest best_result for user' do
     student = create :student
-    create :user_level, user: student, level: @sublevel1, best_result: 20
     create :user_level, user: student, level: @sublevel2, best_result: 100
+    create :user_level, user: student, level: @sublevel1, best_result: 20
 
     assert_equal @sublevel2.id, @bubble_choice.best_result_sublevel_id(student)
   end

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -127,7 +127,7 @@ DSL
     refute_nil sublevel_summary.last[:url]
   end
 
-  test 'best_result_sublevel_id returns sublevel id with highest best_result for user' do
+  test 'best_result_sublevel_id returns sublevel with highest best_result for user' do
     student = create :student
     create :user_level, user: student, level: @sublevel2, best_result: 100
     create :user_level, user: student, level: @sublevel1, best_result: 20

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -106,6 +106,33 @@ class ScriptLevelTest < ActiveSupport::TestCase
     assert_equal student.id, summary[:user_id]
   end
 
+  test 'teacher panel summarize for BubbleChoice level' do
+    student = create :student
+    sublevel1 = create :level, name: 'choice_1'
+    sublevel2 = create :level, name: 'choice_2'
+    bubble_choice = create :bubble_choice_level, sublevels: [sublevel1, sublevel2]
+    script_level = create :script_level, levels: [bubble_choice]
+    ul = create :user_level, user: student, level: sublevel1, best_result: 100
+
+    expected_summary = {
+      contained: false,
+      submitLevel: false,
+      paired: false,
+      driver: nil,
+      navigator: nil,
+      isConceptLevel: false,
+      user_id: student.id,
+      passed: true,
+      status: LEVEL_STATUS.perfect,
+      levelNumber: script_level.position,
+      assessment: nil,
+      bonus: nil
+    }
+    expected_summary.merge!(ul.attributes)
+    summary = script_level.summarize_for_teacher_panel(student)
+    assert_equal expected_summary, summary
+  end
+
   test 'teacher panel summarize for contained level' do
     student = create :student
     contained_level_1 = create :level, name: 'contained level 1', type: 'FreeResponse'


### PR DESCRIPTION
[LP-317](https://codedotorg.atlassian.net/browse/LP-317) / [Spec](https://docs.google.com/document/d/1jKIQ6fwdDEt7rz659poRZUBli4zAyOOnMAsSb_D3EDE/edit?usp=sharing)

**Satisfies the following spec requirements:**
- P0: We should be able to see the BubbleChoice level as a single bubble
- P0: The bubble should turn green when a student completes at least one of the sub-activities for that level
- P2: Whether completing the parent level affects the % done in the condensed view doesn’t matter right now, but it’d be nice if it did

### Examples
Previously, progress for a BubbleChoice level was always "not_tried" (bubble with no color / gray outline).

In all of the examples below, the following is true:
- The BubbleChoice level is in position 1
- The currently-signed-in user completed the BubbleChoice level (by completing sublevels 1 & 2)
- "my student" user completed the BubbleChoice level (by completing sublevel 1)
- "other student" user attempted the BubbleChoice level (by attempting sublevel 3, did not complete any sublevels)

#### Teacher Panel / progress bubbles
![Screen Shot 2019-06-17 at 5 04 56 PM](https://user-images.githubusercontent.com/9812299/59644770-3fb1a380-9123-11e9-815b-81f9d2dbe682.png)

#### Teacher Dashboard "Progress" tab
![Screen Shot 2019-06-17 at 5 06 12 PM](https://user-images.githubusercontent.com/9812299/59644554-3d027e80-9122-11e9-8723-55827d687875.png)

![Screen Shot 2019-06-17 at 5 06 05 PM](https://user-images.githubusercontent.com/9812299/59644556-3d027e80-9122-11e9-8c43-ef97898c4243.png)

