### PR TITLE
Tests: Make FormControllerTest enzyme 3 ready

### DIFF
--- a/apps/test/unit/code-studio/pd/form_components/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/FormControllerTest.js
@@ -138,13 +138,13 @@ describe('FormController', () => {
 
       describe('Submitting', () => {
         let server;
-        let submitButton;
+
+        const submitButton = () =>
+          form.find('button').filterWhere(button => button.text() === 'Submit');
+
         beforeEach(() => {
           server = sinon.fakeServer.create();
           form.setState({currentPage: 2});
-          submitButton = form
-            .find('button')
-            .findWhere(button => button.text() === 'Submit');
         });
         afterEach(() => {
           server.restore();
@@ -152,15 +152,16 @@ describe('FormController', () => {
 
         it('Does not submit when the last page has errors', () => {
           validateCurrentPageRequiredFields.returns(false);
-          submitButton.simulate('submit');
+          submitButton().simulate('submit');
 
+          form.update();
           expect(validateCurrentPageRequiredFields).to.have.been.calledOnce;
           expect(server.requests).to.be.empty;
         });
 
         it('Submits when the last page has no errors', () => {
           validateCurrentPageRequiredFields.returns(true);
-          submitButton.simulate('submit');
+          submitButton().simulate('submit');
 
           expect(validateCurrentPageRequiredFields).to.have.been.calledOnce;
           expect(server.requests).to.have.length(1);
@@ -169,9 +170,9 @@ describe('FormController', () => {
 
         it('Disables the submit button during submit', () => {
           validateCurrentPageRequiredFields.returns(true);
-          submitButton.simulate('submit');
+          submitButton().simulate('submit');
           expect(form.state('submitting')).to.be.true;
-          expect(submitButton.prop('disabled')).to.be.true;
+          expect(submitButton().prop('disabled')).to.be.true;
         });
 
         it('Re-enables the submit button on error', () => {
@@ -184,7 +185,7 @@ describe('FormController', () => {
             })
           ]);
 
-          submitButton.simulate('submit');
+          submitButton().simulate('submit');
           server.respond();
           expect(form.state('submitting')).to.be.false;
           expect(form.state('errors')).to.eql(['an error']);
@@ -202,11 +203,11 @@ describe('FormController', () => {
             'onSuccessfulSubmit'
           );
 
-          submitButton.simulate('submit');
+          submitButton().simulate('submit');
           server.respond();
 
           expect(form.state('submitting')).to.be.true;
-          expect(submitButton.prop('disabled')).to.be.true;
+          expect(submitButton().prop('disabled')).to.be.true;
           expect(onSuccessfulSubmit).to.be.calledOnce;
         });
       });
@@ -242,7 +243,7 @@ describe('FormController', () => {
         stubRequiedFields(['included', 'excluded']);
         DummyPage1.associatedFields = ['included'];
 
-        const validated = form.getNode().validateCurrentPageRequiredFields();
+        const validated = form.instance().validateCurrentPageRequiredFields();
         expect(validated).to.be.false;
         expect(form.state('errors')).to.eql(['included']);
       });
@@ -266,7 +267,7 @@ describe('FormController', () => {
           'onlySpaces'
         ];
 
-        form.getNode().validateCurrentPageRequiredFields();
+        form.instance().validateCurrentPageRequiredFields();
         expect(form.state('data')).to.deep.eql({
           textFieldWithSpace: 'trim',
           textFieldWithNoSpace: 'nothing to trim',
@@ -303,7 +304,7 @@ describe('FormController', () => {
           }
         });
 
-        form.getNode().validateCurrentPageRequiredFields();
+        form.instance().validateCurrentPageRequiredFields();
         expect(processPageData).to.be.calledOnce;
         expect(form.state('data')).to.deep.eql({
           page1Field1: 'value1',


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.