### PR TITLE
Tests: Make workshop dashboard tests ready for enzyme 3

### DIFF
--- a/apps/test/unit/code-studio/pd/workshop_dashboard/attendance/session_attendance_test.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/attendance/session_attendance_test.jsx
@@ -98,6 +98,7 @@ describe('SessionAttendance', () => {
 
     // After the server responds
     server.respond();
+    wrapper.update();
     // Has expected columns:
     expect(
       wrapper.containsMatchingElement(
@@ -126,6 +127,7 @@ describe('SessionAttendance', () => {
 
     // After the server responds
     server.respond();
+    wrapper.update();
     // Has expected columns:
     expect(
       wrapper.containsMatchingElement(
@@ -151,6 +153,7 @@ describe('SessionAttendance', () => {
 
     // After the server responds
     server.respond();
+    wrapper.update();
     // Has expected columns:
     expect(
       wrapper.containsMatchingElement(

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/local_summer_workshop_survey_resultsTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/local_summer_workshop_survey_resultsTest.js
@@ -106,6 +106,7 @@ describe('Local Summer Workshop Management', () => {
       );
 
       server.respond();
+      localSummerWorkshopSurveyResults.update();
 
       expect(server.requests.length).to.equal(1);
       expect(localSummerWorkshopSurveyResults.state('loading')).to.be.false;
@@ -137,6 +138,7 @@ describe('Local Summer Workshop Management', () => {
       );
 
       server.respond();
+      localSummerWorkshopSurveyResults.update();
 
       expect(server.requests.length).to.equal(1);
       expect(localSummerWorkshopSurveyResults.state('loading')).to.be.false;


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.