### PR TITLE
Projects: include abuse score in create_or_replace in files_api

### DIFF
--- a/shared/middleware/channels_api.rb
+++ b/shared/middleware/channels_api.rb
@@ -297,7 +297,7 @@ class ChannelsApi < Sinatra::Base
     dont_cache
     content_type :json
     begin
-      value = StorageApps.new(get_storage_id).get_abuse(id)
+      value = StorageApps.get_abuse(id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -315,7 +315,6 @@ class FilesApi < Sinatra::Base
 
   def put_file(endpoint, encrypted_channel_id, filename, body)
     not_authorized unless owns_channel?(encrypted_channel_id)
-
     file_too_large(endpoint) unless body.length < max_file_size
 
     buckets = get_bucket_impl(endpoint).new
@@ -348,7 +347,10 @@ class FilesApi < Sinatra::Base
     tab_id = params['tabId']
     conflict unless buckets.check_current_version(encrypted_channel_id, filename, current_version, should_replace, timestamp, tab_id, current_user_id)
 
-    response = buckets.create_or_replace(encrypted_channel_id, filename, body, version_to_replace)
+    storage_apps = StorageApps.new(get_storage_id)
+    abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+
+    response = buckets.create_or_replace(encrypted_channel_id, filename, body, version_to_replace, abuse_score)
 
     {
       filename: filename,
@@ -648,11 +650,15 @@ class FilesApi < Sinatra::Base
 
     # write the manifest (assuming the entry changed)
     unless manifest_is_unchanged
+      storage_apps = StorageApps.new(get_storage_id)
+      abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+
       response = bucket.create_or_replace(
         encrypted_channel_id,
         FileBucket::MANIFEST_FILENAME,
         manifest.to_json,
-        params['files-version']
+        params['files-version'],
+        abuse_score
       )
       new_entry_hash['filesVersionId'] = response.version_id
     end
@@ -725,8 +731,11 @@ class FilesApi < Sinatra::Base
     return {filesVersionId: ""}.to_json if manifest_result[:status] == 'NOT_FOUND'
     manifest = JSON.load manifest_result[:body]
 
+    storage_apps = StorageApps.new(get_storage_id)
+    abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+
     # overwrite the manifest file with an empty list
-    response = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, [].to_json, params['files-version'])
+    response = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, [].to_json, params['files-version'], abuse_score)
 
     # delete the files
     bucket.delete_multiple(encrypted_channel_id, manifest.map {|e| e['filename'].downcase}) unless manifest.empty?
@@ -758,8 +767,11 @@ class FilesApi < Sinatra::Base
     reject_result = manifest.reject! {|e| e['filename'].downcase == manifest_delete_comparison_filename}
     not_found if reject_result.nil?
 
+    storage_apps = StorageApps.new(get_storage_id)
+    abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+
     # write the manifest
-    response = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, manifest.to_json, params['files-version'])
+    response = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, manifest.to_json, params['files-version'], abuse_score)
 
     # delete the file
     bucket.delete(encrypted_channel_id, filename.downcase)
@@ -803,9 +815,12 @@ class FilesApi < Sinatra::Base
       entry['versionId'] = response.version_id
     end
 
+    storage_apps = StorageApps.new(get_storage_id)
+    abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+
     # save the new manifest
     manifest_json = manifest.to_json
-    result = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, manifest_json)
+    result = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, manifest_json, abuse_score)
 
     {"filesVersionId": result[:version_id], "files": manifest}.to_json
   end

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -347,8 +347,7 @@ class FilesApi < Sinatra::Base
     tab_id = params['tabId']
     conflict unless buckets.check_current_version(encrypted_channel_id, filename, current_version, should_replace, timestamp, tab_id, current_user_id)
 
-    storage_apps = StorageApps.new(get_storage_id)
-    abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+    abuse_score = StorageApps.get_abuse(encrypted_channel_id)
 
     response = buckets.create_or_replace(encrypted_channel_id, filename, body, version_to_replace, abuse_score)
 
@@ -650,8 +649,7 @@ class FilesApi < Sinatra::Base
 
     # write the manifest (assuming the entry changed)
     unless manifest_is_unchanged
-      storage_apps = StorageApps.new(get_storage_id)
-      abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+      abuse_score = StorageApps.get_abuse(encrypted_channel_id)
 
       response = bucket.create_or_replace(
         encrypted_channel_id,
@@ -731,8 +729,7 @@ class FilesApi < Sinatra::Base
     return {filesVersionId: ""}.to_json if manifest_result[:status] == 'NOT_FOUND'
     manifest = JSON.load manifest_result[:body]
 
-    storage_apps = StorageApps.new(get_storage_id)
-    abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+    abuse_score = StorageApps.get_abuse(encrypted_channel_id)
 
     # overwrite the manifest file with an empty list
     response = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, [].to_json, params['files-version'], abuse_score)
@@ -767,8 +764,7 @@ class FilesApi < Sinatra::Base
     reject_result = manifest.reject! {|e| e['filename'].downcase == manifest_delete_comparison_filename}
     not_found if reject_result.nil?
 
-    storage_apps = StorageApps.new(get_storage_id)
-    abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+    abuse_score = StorageApps.get_abuse(encrypted_channel_id)
 
     # write the manifest
     response = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, manifest.to_json, params['files-version'], abuse_score)
@@ -815,8 +811,7 @@ class FilesApi < Sinatra::Base
       entry['versionId'] = response.version_id
     end
 
-    storage_apps = StorageApps.new(get_storage_id)
-    abuse_score = storage_apps.get_abuse(encrypted_channel_id)
+    abuse_score = StorageApps.get_abuse(encrypted_channel_id)
 
     # save the new manifest
     manifest_json = manifest.to_json

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -815,7 +815,7 @@ class FilesApi < Sinatra::Base
 
     # save the new manifest
     manifest_json = manifest.to_json
-    result = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, manifest_json, abuse_score)
+    result = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, manifest_json, nil, abuse_score)
 
     {"filesVersionId": result[:version_id], "files": manifest}.to_json
   end

--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -132,15 +132,6 @@ class StorageApps
     raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
   end
 
-  def get_abuse(channel_id)
-    _owner, storage_app_id = storage_decrypt_channel_id(channel_id)
-
-    row = @table.where(id: storage_app_id).exclude(state: 'deleted').first
-    raise NotFound, "channel `#{channel_id}` not found" unless row
-
-    row[:abuse_score]
-  end
-
   # Determine if the current user can view the project
   def get_sharing_disabled(channel_id, current_user_id)
     owner_storage_id, storage_app_id = storage_decrypt_channel_id(channel_id)

--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -334,6 +334,12 @@ class StorageApps
     []
   end
 
+  def self.get_abuse(channel_id)
+    _, storage_app_id = storage_decrypt_channel_id(channel_id)
+    project_info = PEGASUS_DB[:storage_apps].where(id: storage_app_id).first
+    project_info[:abuse_score]
+  end
+
   private
 
   #

--- a/shared/test/middleware/helpers/test_storage_apps.rb
+++ b/shared/test/middleware/helpers/test_storage_apps.rb
@@ -155,8 +155,8 @@ class StorageAppsTest < Minitest::Test
     # Create a new typeless project
     # abuse_score should be 0 by default on project creation for projects of any type.
     new_project_channel_id = storage_apps.create({}, ip: 123)
-    assert_equal 0, storage_apps.get_abuse(new_project_channel_id)
+    assert_equal 0, StorageApps.get_abuse(new_project_channel_id)
     storage_apps.buffer_abuse_score(new_project_channel_id)
-    assert_equal (-50), storage_apps.get_abuse(new_project_channel_id)
+    assert_equal (-50), StorageApps.get_abuse(new_project_channel_id)
   end
 end


### PR DESCRIPTION
Addresses[ feedback ](https://github.com/code-dot-org/code-dot-org/pull/28899#pullrequestreview-245167637) on  #28899, [LP-499](https://codedotorg.atlassian.net/browse/LP-499)

Currently, if a project is featured we set the abuse score of the project to -50 to prevent students from spamming report abuse. However, if an asset is added to the featured project, the abuse score of the asset is set to 0.  To keep the assets' abuse scores and project's abuse scores consistent, I've updated the calls to `create_or_replace` in `files_api` to include the abuse score of the project. 