### PR TITLE
Poste: remove support for comma-separated addresses

### DIFF
--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -245,20 +245,37 @@ class Deliverer
     @templates[name] = Poste::Template.new IO.read(path), engine
   end
 
-  def parse_addresses(string)
-    string.split(', ').map do |user_string|
-      if user_string.include? '<'
-        user_string =~ /^([^<]*)<([^>]*)>$/
-        {name: $1.strip, email: $2}
-      else
-        {name: nil, email: user_string}
-      end
+  def parse_address_string(string)
+    # A comma without surrounding double-quotes isn't necessarily bad, since it
+    # might be like this:
+    #   friendly name, phd <email@code.org>
+    #
+    # Though in such a case, it should really be provided like this:
+    #   "friendly name, phd", <email@code.org>
+    #
+    # But we are alerting just in case a sender has attempted to provide multiple
+    # email addresses like this:
+    #   friendly name <email@code.org>, second person <email2@code.org>
+    #
+    # Because we deprecated support for this pattern, believing that we've never
+    # actually used it.
+    if /,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/ =~ string
+      Honeybadger.notify(
+        error_message: "Comma outside of surrounding double-quotes detected in address string: #{string}"
+      )
+    end
+
+    if string.include? '<'
+      string =~ /^([^<]*)<([^>]*)>$/
+      {name: $1.strip, email: $2}
+    else
+      {name: nil, email: string}
     end
   end
 
   def parse_address(address, defaults={})
     address = address.to_s.strip
-    return parse_addresses(address).first unless address.empty?
+    return parse_address_string(address) unless address.empty?
 
     # Student accounts don't have a stored email in contacts,
     # so we use the temporary email here when email doesn't exist.
@@ -318,14 +335,23 @@ def main
       begin
         deliverer.send delivery
       rescue Net::SMTPSyntaxError, Net::SMTPFatalError => e
-        CDO.log.info "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+        Honeybadger.notify(
+          e,
+          error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+        )
         deliverer.reset_connection
         sent_at = 0
       rescue AbortEmailError => e
-        CDO.log.info "Abandoning delivery of #{delivery[:id]} because '#{e.message.to_s.strip}'"
+        Honeybadger.notify(
+          e,
+          error_message: "Abandoning delivery of #{delivery[:id]} because '#{e.message.to_s.strip}'"
+        )
         sent_at = 0
       rescue => e
-        CDO.log.info "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+        Honeybadger.notify(
+          e,
+          error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+        )
         raise
       end
 

--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -2,6 +2,7 @@
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'retryable'
 require 'cdo/only_one'
+require 'cdo/parse_email_address_string'
 require 'cdo/poste'
 require 'base64'
 require 'nokogiri'
@@ -245,37 +246,9 @@ class Deliverer
     @templates[name] = Poste::Template.new IO.read(path), engine
   end
 
-  def parse_address_string(string)
-    # A comma without surrounding double-quotes isn't necessarily bad, since it
-    # might be like this:
-    #   friendly name, phd <email@code.org>
-    #
-    # Though in such a case, it should really be provided like this:
-    #   "friendly name, phd", <email@code.org>
-    #
-    # But we are alerting just in case a sender has attempted to provide multiple
-    # email addresses like this:
-    #   friendly name <email@code.org>, second person <email2@code.org>
-    #
-    # Because we deprecated support for this pattern, believing that we've never
-    # actually used it.
-    if /,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/ =~ string
-      Honeybadger.notify(
-        error_message: "Comma outside of surrounding double-quotes detected in address string: #{string}"
-      )
-    end
-
-    if string.include? '<'
-      string =~ /^([^<]*)<([^>]*)>$/
-      {name: $1.strip, email: $2}
-    else
-      {name: nil, email: string}
-    end
-  end
-
   def parse_address(address, defaults={})
     address = address.to_s.strip
-    return parse_address_string(address) unless address.empty?
+    return parse_email_address_string(address) unless address.empty?
 
     # Student accounts don't have a stored email in contacts,
     # so we use the temporary email here when email doesn't exist.

--- a/lib/cdo/parse_email_address_string.rb
+++ b/lib/cdo/parse_email_address_string.rb
@@ -29,7 +29,7 @@ def parse_email_address_string(string)
   # without them being confused with the < > wrapping the email address at the end.
   #
   # Or just treat the entire string as an email address.
-  if (/(.*)<(.*)>$/ =~ string) != nil
+  if !(/(.*)<(.*)>$/ =~ string).nil?
     {name: $1.strip, email: $2}
   else
     {name: nil, email: string}

--- a/lib/cdo/parse_email_address_string.rb
+++ b/lib/cdo/parse_email_address_string.rb
@@ -1,0 +1,37 @@
+def parse_email_address_string(string)
+  # A comma without surrounding double-quotes isn't necessarily bad, since it
+  # might be like this:
+  #   friendly name, phd <email@code.org>
+  #
+  # Though in such a case, it should really be provided like this:
+  #   "friendly name, phd" <email@code.org>
+  #
+  # But we are alerting just in case a sender has attempted to provide multiple
+  # email addresses like this:
+  #   friendly name <email@code.org>, second person <email2@code.org>
+  #
+  # Because we deprecated support for this pattern, believing that we've never
+  # actually used it.
+  #
+  # The regular expression itself matches commas unless they are surrounded
+  # by a pair of double-quotes, and is adapted from
+  # https://stackoverflow.com/a/18893443.
+  if /,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/ =~ string
+    Honeybadger.notify(
+      error_message: "Comma outside of surrounding double-quotes detected in address string: #{string}"
+    )
+    return ""
+  end
+
+  # Match the friendly name followed by an email address wrapped in < > at the end of
+  # the string.
+  # This means that the friendly name can contain additional < or > characters
+  # without them being confused with the < > wrapping the email address at the end.
+  #
+  # Or just treat the entire string as an email address.
+  if (/(.*)<(.*)>$/ =~ string) != nil
+    {name: $1.strip, email: $2}
+  else
+    {name: nil, email: string}
+  end
+end

--- a/lib/test/cdo/test_parse_email_address_string.rb
+++ b/lib/test/cdo/test_parse_email_address_string.rb
@@ -1,0 +1,28 @@
+require_relative '../test_helper'
+require 'cdo/parse_email_address_string'
+
+class HashTest < Minitest::Test
+  def test_parse_email_address_string
+    assert_equal parse_email_address_string("friendly name, phd <email@code.org>"), ""
+
+    assert_equal \
+      parse_email_address_string("email@code.org"),
+      {name: nil, email: "email@code.org"}
+
+    assert_equal \
+      parse_email_address_string("\"friendly name, phd\" <email@code.org>"),
+      {name: "\"friendly name, phd\"", email: "email@code.org"}
+
+    assert_equal \
+      parse_email_address_string("friendly name <email@code.org>"),
+      {name: "friendly name", email: "email@code.org"}
+
+    assert_equal \
+      parse_email_address_string("i <3 you <email@code.org>"),
+      {name: "i <3 you", email: "email@code.org"}
+
+    assert_equal \
+      parse_email_address_string("i <see> you <email@code.org>"),
+      {name: "i <see> you", email: "email@code.org"}
+  end
+end


### PR DESCRIPTION
This removes support for splitting multiple addresses in a field by comma, since an audit of our entire `poste_deliveries` table shows that we never used the functionality.

We now log a Honeybadger error if we do detect a comma provided outside of surrounding double-quotes, helping us to catch any attempt at using that functionality.