### PR TITLE
don't show extra hidden questions on day 5

### DIFF
--- a/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
+++ b/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
@@ -385,9 +385,7 @@ module Pd::WorkshopSurveyResultsHelper
         ),
         facilitator: get_summary_for_form(
           Pd::WorkshopFacilitatorDailySurvey.form_id(workshop.subject),
-          workshop,
-          # the facilitator effectiveness questions are on the day 5 survey and hidden otherwise
-          show_hidden_questions: day == 5
+          workshop
         )
       }
     end

--- a/dashboard/test/helpers/pd/workshop_survey_results_helper_test.rb
+++ b/dashboard/test/helpers/pd/workshop_survey_results_helper_test.rb
@@ -187,36 +187,6 @@ class Pd::WorkshopSurveyResultsHelperTest < ActionView::TestCase
       }
     }
 
-    # day 5 includes hidden questions
-    expected_day_5_questions = {
-      general: {
-        'sampleDailyScale' => {
-          text: 'How was your day?',
-          answer_type: ANSWER_SCALE,
-          min_value: 1,
-          max_value: 5,
-          options: ['1 - Poor', '2', '3', '4', '5 - Excellent']
-        },
-      },
-      facilitator: {
-        'sampleFacilitatorText' => {
-          text: 'How was the facilitator?',
-          answer_type: ANSWER_TEXT
-        },
-        'sampleFacilitatorScale' => {
-          text: 'How do you rate the facilitators skills?',
-          answer_type: ANSWER_SCALE,
-          min_value: 1,
-          max_value: 5,
-          options: ['1 - Weak', '2', '3', '4', '5 - Amazing']
-        },
-        'facilitatorId' => {
-          text: 'facilitatorId',
-          answer_type: 'text'
-        }
-      }
-    }
-
     @expected_questions = {
       'Pre Workshop' => {
         general: {
@@ -251,7 +221,7 @@ class Pd::WorkshopSurveyResultsHelperTest < ActionView::TestCase
       'Day 2' => expected_daily_questions,
       'Day 3' => expected_daily_questions,
       'Day 4' => expected_daily_questions,
-      'Day 5' => expected_day_5_questions
+      'Day 5' => expected_daily_questions
     }
 
     @expected_academic_year_questions = {
@@ -598,19 +568,6 @@ class Pd::WorkshopSurveyResultsHelperTest < ActionView::TestCase
       }
     }
 
-    # day 5 shows the hidden questions
-    day_5_expected_results = {
-      response_count: 0,
-      general: {
-        'sampleDailyScale' => {}
-      },
-      facilitator: {
-        'sampleFacilitatorText' => {},
-        'sampleFacilitatorScale' => {},
-        'facilitatorId' => {}
-      }
-    }
-
     all_expected_results = {
       'Pre Workshop' => {
         response_count: 3,
@@ -651,7 +608,7 @@ class Pd::WorkshopSurveyResultsHelperTest < ActionView::TestCase
       'Day 2' => daily_expected_results,
       'Day 3' => daily_expected_results,
       'Day 4' => daily_expected_results,
-      'Day 5' => day_5_expected_results
+      'Day 5' => daily_expected_results
     }
 
     assert_equal(all_expected_results, generate_workshops_survey_summary([@workshop], @expected_questions))


### PR DESCRIPTION
**This change needs to happen in conjunction with updating the [facilitator survey](https://www.jotform.com/build/91372090131144) in jotform** to have the `facilitator_effectiveness` matrix question shown by default, and hidden on all days except day 5 of CSP/D 5-day summer workshops - coordinate with Jordyn to make this change.

Issue: We were displaying all hidden fields in the day 5 summer workshop survey results.
Fix: Make the question we care about not hidden by default in the survey, and update the dashboard to not show hidden questions.