### PR TITLE
point to /projects/frozen for exemplars on frozen-themed artist levels

### DIFF
--- a/dashboard/app/views/levels/editors/_artist.html.haml
+++ b/dashboard/app/views/levels/editors/_artist.html.haml
@@ -1,5 +1,6 @@
 .field
-  = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: 'artist'}
+  - level_type = ['anna', 'elsa'].include?(@level.skin) ? 'frozen' : 'artist'
+  = render partial: 'levels/editors/encrypted_examples', locals: {f: f, level_type: level_type}
 .field
   = f.label :slider_speed, 'Slider speed (artist only)'
   %p Number from 0.0 to 1.0 for how fast artist runs. If not set, default is 1.0


### PR DESCRIPTION
### background

fixes https://codedotorg.atlassian.net/browse/LP-536

### before

<img width="977" alt="Screen Shot 2019-06-19 at 11 31 15 AM" src="https://user-images.githubusercontent.com/8001765/59790909-d5654400-9285-11e9-8140-e0ad71b83979.png">

### after

<img width="982" alt="Screen Shot 2019-06-19 at 11 28 43 AM" src="https://user-images.githubusercontent.com/8001765/59790903-d1d1bd00-9285-11e9-9d4c-1d2ffcdad44e.png">

### verification

manually checked level edit page for artist levels with `anna`, `elsa`, and `artist` skins.