### PR TITLE
Fix error on teacher panel render for BubbleChoice with no progress

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -405,7 +405,7 @@ class ScriptLevel < ActiveRecord::Base
     contained = contained_levels.any?
 
     levels = if bubble_choice?
-               [level.best_result_sublevel(student)]
+               [level.best_result_sublevel(student) || level]
              elsif contained
                contained_levels
              else

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -112,22 +112,31 @@ class ScriptLevelTest < ActiveSupport::TestCase
     sublevel2 = create :level, name: 'choice_2'
     bubble_choice = create :bubble_choice_level, sublevels: [sublevel1, sublevel2]
     script_level = create :script_level, levels: [bubble_choice]
-    ul = create :user_level, user: student, level: sublevel1, best_result: 100
 
     expected_summary = {
       contained: false,
       submitLevel: false,
-      paired: false,
+      paired: nil,
       driver: nil,
       navigator: nil,
       isConceptLevel: false,
       user_id: student.id,
-      passed: true,
-      status: LEVEL_STATUS.perfect,
+      passed: false,
+      status: LEVEL_STATUS.not_tried,
       levelNumber: script_level.position,
       assessment: nil,
       bonus: nil
     }
+
+    # With no progress
+    summary = script_level.summarize_for_teacher_panel(student)
+    assert_equal expected_summary, summary
+
+    # With progress on a BubbleChoice sublevel
+    ul = create :user_level, user: student, level: sublevel1, best_result: 100
+    expected_summary[:paired] = false
+    expected_summary[:passed] = true
+    expected_summary[:status] = LEVEL_STATUS.perfect
     expected_summary.merge!(ul.attributes)
     summary = script_level.summarize_for_teacher_panel(student)
     assert_equal expected_summary, summary


### PR DESCRIPTION
Fixes [this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/51017080).

If a student has no progress on a BubbleChoice level, return the level itself instead of throwing a NilException when no sublevel progress is found.