### PR TITLE
Testing: Make instructionsComponentsTest.js ready for Enzyme 3

### DIFF
--- a/apps/test/unit/instructionsComponentsTest.js
+++ b/apps/test/unit/instructionsComponentsTest.js
@@ -52,7 +52,11 @@ describe('instructions components', () => {
           />
         </div>
       );
-      var elements = dom.childAt(0).children();
+      var elements = dom
+        .find(NonMarkdownInstructions)
+        .find('div')
+        .first()
+        .children();
       expect(elements.length).to.equal(2);
       expect(elements.first())
         .text()
@@ -72,11 +76,15 @@ describe('instructions components', () => {
           />
         </div>
       );
-      var elements = dom.childAt(0).children();
+      var elements = dom
+        .find(NonMarkdownInstructions)
+        .find('div')
+        .first()
+        .children();
       expect(elements.length).to.equal(3);
-      expect(elements.get(0).textContent).to.equal('title');
-      expect(elements.get(1).textContent).to.equal('instructions');
-      expect(elements.get(2).textContent).to.equal('instructions2');
+      expect(elements.at(0).text()).to.equal('title');
+      expect(elements.at(1).text()).to.equal('instructions');
+      expect(elements.at(2).text()).to.equal('instructions2');
     });
   });
 });

--- a/apps/test/unit/instructionsComponentsTest.js
+++ b/apps/test/unit/instructionsComponentsTest.js
@@ -11,14 +11,12 @@ describe('instructions components', () => {
   describe('MarkdownInstructions', function() {
     it('standard case had top padding and no left margin', function() {
       const wrapper = mount(
-        <div>
-          <StatelessMarkdownInstructions
-            markdown="md"
-            markdownClassicMargins={false}
-            inTopPane={false}
-            noInstructionsWhenCollapsed={true}
-          />
-        </div>
+        <StatelessMarkdownInstructions
+          markdown="md"
+          markdownClassicMargins={false}
+          inTopPane={false}
+          noInstructionsWhenCollapsed={true}
+        />
       );
       var element = wrapper.find('.instructions-markdown').first();
       expect(element.props().style.paddingTop).to.equal(19);
@@ -29,13 +27,11 @@ describe('instructions components', () => {
 
     it('inTopPane has no top padding', function() {
       const wrapper = mount(
-        <div>
-          <StatelessMarkdownInstructions
-            markdown="md"
-            inTopPane={true}
-            noInstructionsWhenCollapsed={true}
-          />
-        </div>
+        <StatelessMarkdownInstructions
+          markdown="md"
+          inTopPane={true}
+          noInstructionsWhenCollapsed={true}
+        />
       );
       var element = wrapper.find('.instructions-markdown').first();
       expect(element.props().style.paddingTop).to.equal(0);
@@ -45,12 +41,10 @@ describe('instructions components', () => {
   describe('NonMarkdownInstructions', function() {
     it('can have just instructions', function() {
       const wrapper = mount(
-        <div>
-          <NonMarkdownInstructions
-            puzzleTitle="title"
-            shortInstructions="instructions"
-          />
-        </div>
+        <NonMarkdownInstructions
+          puzzleTitle="title"
+          shortInstructions="instructions"
+        />
       );
       var elements = wrapper
         .find(NonMarkdownInstructions)
@@ -64,13 +58,11 @@ describe('instructions components', () => {
 
     it('can have both instructions and instructions2', function() {
       const wrapper = mount(
-        <div>
-          <NonMarkdownInstructions
-            puzzleTitle="title"
-            shortInstructions="instructions"
-            instructions2="instructions2"
-          />
-        </div>
+        <NonMarkdownInstructions
+          puzzleTitle="title"
+          shortInstructions="instructions"
+          instructions2="instructions2"
+        />
       );
       var elements = wrapper
         .find(NonMarkdownInstructions)

--- a/apps/test/unit/instructionsComponentsTest.js
+++ b/apps/test/unit/instructionsComponentsTest.js
@@ -1,4 +1,4 @@
-import {expect} from '../util/configuredChai';
+import {expect} from '../util/reconfiguredChai';
 var testUtils = require('./../util/testUtils');
 import React from 'react';
 import {mount} from 'enzyme';
@@ -58,12 +58,8 @@ describe('instructions components', () => {
         .first()
         .children();
       expect(elements.length).to.equal(2);
-      expect(elements.first())
-        .text()
-        .to.equal('title');
-      expect(elements.last())
-        .text()
-        .to.equal('instructions');
+      expect(elements.first().text()).to.equal('title');
+      expect(elements.last().text()).to.equal('instructions');
     });
 
     it('can have both instructions and instructions2', function() {

--- a/apps/test/unit/instructionsComponentsTest.js
+++ b/apps/test/unit/instructionsComponentsTest.js
@@ -10,7 +10,7 @@ describe('instructions components', () => {
 
   describe('MarkdownInstructions', function() {
     it('standard case had top padding and no left margin', function() {
-      var dom = mount(
+      const wrapper = mount(
         <div>
           <StatelessMarkdownInstructions
             markdown="md"
@@ -20,7 +20,7 @@ describe('instructions components', () => {
           />
         </div>
       );
-      var element = dom.find('.instructions-markdown').first();
+      var element = wrapper.find('.instructions-markdown').first();
       expect(element.props().style.paddingTop).to.equal(19);
       expect(element.props().style.marginBottom).to.equal(35);
       expect(element.props().style.marginLeft).to.equal(undefined);
@@ -28,7 +28,7 @@ describe('instructions components', () => {
     });
 
     it('inTopPane has no top padding', function() {
-      var dom = mount(
+      const wrapper = mount(
         <div>
           <StatelessMarkdownInstructions
             markdown="md"
@@ -37,14 +37,14 @@ describe('instructions components', () => {
           />
         </div>
       );
-      var element = dom.find('.instructions-markdown').first();
+      var element = wrapper.find('.instructions-markdown').first();
       expect(element.props().style.paddingTop).to.equal(0);
     });
   });
 
   describe('NonMarkdownInstructions', function() {
     it('can have just instructions', function() {
-      var dom = mount(
+      const wrapper = mount(
         <div>
           <NonMarkdownInstructions
             puzzleTitle="title"
@@ -52,7 +52,7 @@ describe('instructions components', () => {
           />
         </div>
       );
-      var elements = dom
+      var elements = wrapper
         .find(NonMarkdownInstructions)
         .find('div')
         .first()
@@ -63,7 +63,7 @@ describe('instructions components', () => {
     });
 
     it('can have both instructions and instructions2', function() {
-      var dom = mount(
+      const wrapper = mount(
         <div>
           <NonMarkdownInstructions
             puzzleTitle="title"
@@ -72,7 +72,7 @@ describe('instructions components', () => {
           />
         </div>
       );
-      var elements = dom
+      var elements = wrapper
         .find(NonMarkdownInstructions)
         .find('div')
         .first()

--- a/apps/test/unit/instructionsComponentsTest.js
+++ b/apps/test/unit/instructionsComponentsTest.js
@@ -18,7 +18,7 @@ describe('instructions components', () => {
           noInstructionsWhenCollapsed={true}
         />
       );
-      var element = wrapper.find('.instructions-markdown').first();
+      const element = wrapper.find('.instructions-markdown').first();
       expect(element.props().style.paddingTop).to.equal(19);
       expect(element.props().style.marginBottom).to.equal(35);
       expect(element.props().style.marginLeft).to.equal(undefined);
@@ -33,7 +33,7 @@ describe('instructions components', () => {
           noInstructionsWhenCollapsed={true}
         />
       );
-      var element = wrapper.find('.instructions-markdown').first();
+      const element = wrapper.find('.instructions-markdown').first();
       expect(element.props().style.paddingTop).to.equal(0);
     });
   });
@@ -46,7 +46,7 @@ describe('instructions components', () => {
           shortInstructions="instructions"
         />
       );
-      var elements = wrapper
+      const elements = wrapper
         .find(NonMarkdownInstructions)
         .find('div')
         .first()
@@ -64,7 +64,7 @@ describe('instructions components', () => {
           instructions2="instructions2"
         />
       );
-      var elements = wrapper
+      const elements = wrapper
         .find(NonMarkdownInstructions)
         .find('div')
         .first()

--- a/apps/test/unit/instructionsComponentsTest.js
+++ b/apps/test/unit/instructionsComponentsTest.js
@@ -47,7 +47,6 @@ describe('instructions components', () => {
         />
       );
       const elements = wrapper
-        .find(NonMarkdownInstructions)
         .find('div')
         .first()
         .children();
@@ -65,7 +64,6 @@ describe('instructions components', () => {
         />
       );
       const elements = wrapper
-        .find(NonMarkdownInstructions)
         .find('div')
         .first()
         .children();


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.

I decided a little additional cleanup made sense in this case - annotated inline.