### PR TITLE
Replace unsafe chars in uploaded applab asset filenames

### DIFF
--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -431,7 +431,8 @@ class FilesApi < Sinatra::Base
 
     bad_request unless file[:filename] && file[:tempfile]
 
-    put_file('assets', encrypted_channel_id, file[:filename], file[:tempfile].read)
+    filename = BucketHelper.replace_unsafe_chars(file[:filename])
+    put_file('assets', encrypted_channel_id, filename, file[:tempfile].read)
   end
 
   # POST /v3/copy-assets/<channel-id>?src_channel=<src-channel-id>&src_files=<src-filenames-json>

--- a/shared/middleware/helpers/bucket_helper.rb
+++ b/shared/middleware/helpers/bucket_helper.rb
@@ -451,6 +451,16 @@ class BucketHelper
     response.to_h
   end
 
+  # Regex matching every character except those which are url-safe and
+  # recommended for use in S3 key names:
+  # https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-key-guidelines-safe-characters
+  UNSAFE_CHAR_REGEX = /[^0-9A-Za-z!\-_.*'()]/
+
+  # Replace any unsafe characters with dashes.
+  def self.replace_unsafe_chars(str)
+    str.gsub(UNSAFE_CHAR_REGEX, '-')
+  end
+
   protected
 
   #

--- a/shared/test/fixtures/vcr/assets/assets_copy_all.yml
+++ b/shared/test/fixtures/vcr/assets/assets_copy_all.yml
@@ -4,7 +4,7 @@ http_interactions:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -15,7 +15,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:39 GMT
+      - Fri, 07 Jun 2019 23:17:03 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -30,12 +30,12 @@ http_interactions:
         <?xml version="1.0" encoding="UTF-8"?>
         <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:38 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:02 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/2
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -46,7 +46,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:39 GMT
+      - Fri, 07 Jun 2019 23:17:03 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -59,14 +59,58 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/2</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/2</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/2/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T22:59:44.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/2/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2019-06-07T22:59:44.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:39 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:02 GMT
+- request:
+    method: post
+    uri: https://cdo-v3-assets.s3.amazonaws.com/?delete
+    body:
+      encoding: UTF-8
+      string: |
+        <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Object>
+            <Key>assets_test/1/2/-atac0a7f8c2faac49775a6.jpg</Key>
+          </Object>
+          <Object>
+            <Key>assets_test/1/2/woofc0cc21d843b34e9afb52.mp3</Key>
+          </Object>
+          <Quiet>true</Quiet>
+        </Delete>
+    headers:
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - l/jIjhb43z8DR/TZtWXu7g==
+      Content-Length:
+      - '254'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Jun 2019 23:17:03 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>
+    http_version: 
+  recorded_at: Fri, 07 Jun 2019 23:17:03 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -77,7 +121,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:40 GMT
+      - Fri, 07 Jun 2019 23:17:04 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -92,10 +136,10 @@ http_interactions:
         <?xml version="1.0" encoding="UTF-8"?>
         <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:39 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:03 GMT
 - request:
     method: put
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
     body:
       encoding: ASCII-8BIT
       string: stub-image-contents
@@ -114,7 +158,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:40 GMT
+      - Fri, 07 Jun 2019 23:17:04 GMT
+      X-Amz-Version-Id:
+      - NIFXKi04I4KzPb8CFjhfdpt_KW0wgSNb
       Etag:
       - '"593f84d5c5f5f6b80161676517701886"'
       Content-Length:
@@ -125,12 +171,12 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:39 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:03 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -141,7 +187,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:41 GMT
+      - Fri, 07 Jun 2019 23:17:05 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -154,9 +200,9 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg</Key><LastModified>2015-11-16T23:11:40.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T23:17:04.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:40 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:04 GMT
 - request:
     method: put
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
@@ -178,7 +224,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:41 GMT
+      - Fri, 07 Jun 2019 23:17:05 GMT
+      X-Amz-Version-Id:
+      - F_gkHErVt9ajrXkudxcPP.j.iNnWGmeB
       Etag:
       - '"f1a31c5ccd5bc6f0aa6912e3cadeb91c"'
       Content-Length:
@@ -189,12 +237,12 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:40 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:04 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -205,7 +253,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:42 GMT
+      - Fri, 07 Jun 2019 23:17:05 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -218,84 +266,14 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2015-11-16T23:11:41.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg</Key><LastModified>2015-11-16T23:11:40.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T23:17:04.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2019-06-07T23:17:05.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:41 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:04 GMT
 - request:
     method: get
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 16 Nov 2015 23:11:42 GMT
-      X-Amz-Meta-Abuse-Score:
-      - '0'
-      Last-Modified:
-      - Mon, 16 Nov 2015 23:11:41 GMT
-      Etag:
-      - '"f1a31c5ccd5bc6f0aa6912e3cadeb91c"'
-      Accept-Ranges:
-      - bytes
-      Content-Type:
-      - ''
-      Content-Length:
-      - '19'
-      Server:
-      - AmazonS3
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
     body:
       encoding: UTF-8
-      string: stub-sound-contents
-    http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:41 GMT
-- request:
-    method: put
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      X-Amz-Copy-Source:
-      - cdo-v3-assets/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
-      X-Amz-Meta-Abuse-Score:
-      - '10'
-      X-Amz-Metadata-Directive:
-      - REPLACE
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 16 Nov 2015 23:11:43 GMT
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '234'
-      Server:
-      - AmazonS3
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2015-11-16T23:11:43.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag></CopyObjectResult>
-    http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:42 GMT
-- request:
-    method: get
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
-    body:
-      encoding: ASCII-8BIT
       string: ''
     headers:
       Content-Length:
@@ -306,13 +284,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:43 GMT
-      X-Amz-Meta-Abuse-Score:
-      - '0'
+      - Fri, 07 Jun 2019 23:17:06 GMT
       Last-Modified:
-      - Mon, 16 Nov 2015 23:11:40 GMT
+      - Fri, 07 Jun 2019 23:17:04 GMT
       Etag:
       - '"593f84d5c5f5f6b80161676517701886"'
+      X-Amz-Meta-Abuse-Score:
+      - '0'
+      X-Amz-Version-Id:
+      - NIFXKi04I4KzPb8CFjhfdpt_KW0wgSNb
       Accept-Ranges:
       - bytes
       Content-Type:
@@ -325,16 +305,16 @@ http_interactions:
       encoding: UTF-8
       string: stub-image-contents
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:42 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:05 GMT
 - request:
     method: put
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       X-Amz-Copy-Source:
-      - cdo-v3-assets/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
+      - cdo-v3-assets/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
       X-Amz-Meta-Abuse-Score:
       - '10'
       X-Amz-Metadata-Directive:
@@ -347,7 +327,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:43 GMT
+      - Fri, 07 Jun 2019 23:17:06 GMT
+      X-Amz-Copy-Source-Version-Id:
+      - NIFXKi04I4KzPb8CFjhfdpt_KW0wgSNb
+      X-Amz-Version-Id:
+      - FHNkH2pikgGjcFP172IFygM1n048ZC5n
       Content-Type:
       - application/xml
       Content-Length:
@@ -358,14 +342,14 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2015-11-16T23:11:43.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag></CopyObjectResult>
+        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2019-06-07T23:17:06.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag></CopyObjectResult>
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:42 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:05 GMT
 - request:
     method: get
-    uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -376,7 +360,83 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:44 GMT
+      - Fri, 07 Jun 2019 23:17:06 GMT
+      Last-Modified:
+      - Fri, 07 Jun 2019 23:17:05 GMT
+      Etag:
+      - '"f1a31c5ccd5bc6f0aa6912e3cadeb91c"'
+      X-Amz-Meta-Abuse-Score:
+      - '0'
+      X-Amz-Version-Id:
+      - F_gkHErVt9ajrXkudxcPP.j.iNnWGmeB
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - ''
+      Content-Length:
+      - '19'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: stub-sound-contents
+    http_version: 
+  recorded_at: Fri, 07 Jun 2019 23:17:05 GMT
+- request:
+    method: put
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Amz-Copy-Source:
+      - cdo-v3-assets/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
+      X-Amz-Meta-Abuse-Score:
+      - '10'
+      X-Amz-Metadata-Directive:
+      - REPLACE
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Jun 2019 23:17:07 GMT
+      X-Amz-Copy-Source-Version-Id:
+      - F_gkHErVt9ajrXkudxcPP.j.iNnWGmeB
+      X-Amz-Version-Id:
+      - PLwC6M4pwcpf.gL2NZgYHHacVLVy.PLU
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '234'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2019-06-07T23:17:07.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag></CopyObjectResult>
+    http_version: 
+  recorded_at: Fri, 07 Jun 2019 23:17:06 GMT
+- request:
+    method: get
+    uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Jun 2019 23:17:07 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -389,14 +449,51 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2015-11-16T23:11:43.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg</Key><LastModified>2015-11-16T23:11:43.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T23:17:06.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2019-06-07T23:17:07.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:43 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:06 GMT
+- request:
+    method: put
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/-atac0a7f8c2faac49775a6.jpg
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Amz-Copy-Source:
+      - cdo-v3-assets/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
+      X-Amz-Metadata-Directive:
+      - REPLACE
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Jun 2019 23:17:07 GMT
+      X-Amz-Copy-Source-Version-Id:
+      - FHNkH2pikgGjcFP172IFygM1n048ZC5n
+      X-Amz-Version-Id:
+      - haN5bjLs0IQRlXd4jWVsXzNF.LkbPRuX
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '234'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2019-06-07T23:17:07.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag></CopyObjectResult>
+    http_version: 
+  recorded_at: Fri, 07 Jun 2019 23:17:06 GMT
 - request:
     method: put
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/woofc0cc21d843b34e9afb52.mp3
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       X-Amz-Copy-Source:
@@ -411,7 +508,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:44 GMT
+      - Fri, 07 Jun 2019 23:17:08 GMT
+      X-Amz-Copy-Source-Version-Id:
+      - PLwC6M4pwcpf.gL2NZgYHHacVLVy.PLU
+      X-Amz-Version-Id:
+      - iYAitry3PjhpjJ6I18IGBG7GjqinY5Sf
       Content-Type:
       - application/xml
       Content-Length:
@@ -422,47 +523,14 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2015-11-16T23:11:44.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag></CopyObjectResult>
+        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2019-06-07T23:17:08.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag></CopyObjectResult>
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:43 GMT
-- request:
-    method: put
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/%C3%A7atac0a7f8c2faac49775a6.jpg
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      X-Amz-Copy-Source:
-      - cdo-v3-assets/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
-      X-Amz-Metadata-Directive:
-      - REPLACE
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 16 Nov 2015 23:11:45 GMT
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '234'
-      Server:
-      - AmazonS3
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2015-11-16T23:11:45.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag></CopyObjectResult>
-    http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:44 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:07 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/2/
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -473,7 +541,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:45 GMT
+      - Fri, 07 Jun 2019 23:17:08 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -486,14 +554,14 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/2/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/2/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2015-11-16T23:11:44.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/2/%C3%A7atac0a7f8c2faac49775a6.jpg</Key><LastModified>2015-11-16T23:11:45.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/2/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/2/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T23:17:07.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/2/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2019-06-07T23:17:08.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:44 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:07 GMT
 - request:
     method: get
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/%C3%A7atac0a7f8c2faac49775a6.jpg
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/-atac0a7f8c2faac49775a6.jpg
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -504,11 +572,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:45 GMT
+      - Fri, 07 Jun 2019 23:17:08 GMT
       Last-Modified:
-      - Mon, 16 Nov 2015 23:11:45 GMT
+      - Fri, 07 Jun 2019 23:17:07 GMT
       Etag:
       - '"593f84d5c5f5f6b80161676517701886"'
+      X-Amz-Version-Id:
+      - haN5bjLs0IQRlXd4jWVsXzNF.LkbPRuX
       Accept-Ranges:
       - bytes
       Content-Type:
@@ -521,12 +591,12 @@ http_interactions:
       encoding: UTF-8
       string: stub-image-contents
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:44 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:07 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/woofc0cc21d843b34e9afb52.mp3
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -537,11 +607,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:46 GMT
+      - Fri, 07 Jun 2019 23:17:09 GMT
       Last-Modified:
-      - Mon, 16 Nov 2015 23:11:44 GMT
+      - Fri, 07 Jun 2019 23:17:08 GMT
       Etag:
       - '"f1a31c5ccd5bc6f0aa6912e3cadeb91c"'
+      X-Amz-Version-Id:
+      - iYAitry3PjhpjJ6I18IGBG7GjqinY5Sf
       Accept-Ranges:
       - bytes
       Content-Type:
@@ -554,12 +626,12 @@ http_interactions:
       encoding: UTF-8
       string: stub-sound-contents
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:45 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:08 GMT
 - request:
     method: delete
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -570,19 +642,23 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:46 GMT
+      - Fri, 07 Jun 2019 23:17:09 GMT
+      X-Amz-Version-Id:
+      - xWrhiFytfUcSNRBo76yXdoxTZpIZHtzJ
+      X-Amz-Delete-Marker:
+      - 'true'
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:45 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:08 GMT
 - request:
     method: delete
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -593,19 +669,23 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:47 GMT
+      - Fri, 07 Jun 2019 23:17:09 GMT
+      X-Amz-Version-Id:
+      - ObJ7s40MXi1NKQQui_aFfvB2xIftk6HS
+      X-Amz-Delete-Marker:
+      - 'true'
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:46 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:08 GMT
 - request:
     method: delete
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/%C3%A7atac0a7f8c2faac49775a6.jpg
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/-atac0a7f8c2faac49775a6.jpg
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -616,19 +696,23 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:47 GMT
+      - Fri, 07 Jun 2019 23:17:10 GMT
+      X-Amz-Version-Id:
+      - GOSzdO.i9CYeLcC1DdI2hGGSLJ7lbRtx
+      X-Amz-Delete-Marker:
+      - 'true'
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:46 GMT
+  recorded_at: Fri, 07 Jun 2019 23:17:09 GMT
 - request:
     method: delete
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/woofc0cc21d843b34e9afb52.mp3
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -639,12 +723,16 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 16 Nov 2015 23:11:47 GMT
+      - Fri, 07 Jun 2019 23:17:10 GMT
+      X-Amz-Version-Id:
+      - BRo4FvqZjvSfHi6vWcj5aLA7muVkPRH.
+      X-Amz-Delete-Marker:
+      - 'true'
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 16 Nov 2015 23:11:46 GMT
-recorded_with: VCR 3.0.0
+  recorded_at: Fri, 07 Jun 2019 23:17:09 GMT
+recorded_with: VCR 3.0.3

--- a/shared/test/fixtures/vcr/assets/assets_copy_some.yml
+++ b/shared/test/fixtures/vcr/assets/assets_copy_some.yml
@@ -4,7 +4,7 @@ http_interactions:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -15,7 +15,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:15 GMT
+      - Fri, 07 Jun 2019 22:32:40 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -28,9 +28,9 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2016-06-20T19:29:29.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg</Key><LastModified>2016-06-20T19:29:30.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T22:32:33.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2019-06-07T22:32:34.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:14 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:39 GMT
 - request:
     method: post
     uri: https://cdo-v3-assets.s3.amazonaws.com/?delete
@@ -39,10 +39,10 @@ http_interactions:
       string: |
         <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
           <Object>
-            <Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key>
+            <Key>assets_test/1/1/-atac0a7f8c2faac49775a6.jpg</Key>
           </Object>
           <Object>
-            <Key>assets_test/1/1/çatac0a7f8c2faac49775a6.jpg</Key>
+            <Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key>
           </Object>
           <Quiet>true</Quiet>
         </Delete>
@@ -50,16 +50,16 @@ http_interactions:
       Expect:
       - 100-continue
       Content-Md5:
-      - Z7cxj6CJu0XbBxoa0/Ahgw==
+      - jTRc+yo8oR4q7YyYXf4CfQ==
       Content-Length:
-      - '255'
+      - '254'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:16 GMT
+      - Fri, 07 Jun 2019 22:32:40 GMT
       Connection:
       - close
       Content-Type:
@@ -74,12 +74,12 @@ http_interactions:
         <?xml version="1.0" encoding="UTF-8"?>
         <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:15 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:39 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/2
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -90,7 +90,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:16 GMT
+      - Fri, 07 Jun 2019 22:32:40 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -103,14 +103,58 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/2</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/2</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/2/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T22:32:34.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/2/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2019-06-07T22:32:35.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:15 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:40 GMT
+- request:
+    method: post
+    uri: https://cdo-v3-assets.s3.amazonaws.com/?delete
+    body:
+      encoding: UTF-8
+      string: |
+        <Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Object>
+            <Key>assets_test/1/2/-atac0a7f8c2faac49775a6.jpg</Key>
+          </Object>
+          <Object>
+            <Key>assets_test/1/2/woofc0cc21d843b34e9afb52.mp3</Key>
+          </Object>
+          <Quiet>true</Quiet>
+        </Delete>
+    headers:
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - l/jIjhb43z8DR/TZtWXu7g==
+      Content-Length:
+      - '254'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Jun 2019 22:32:41 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>
+    http_version: 
+  recorded_at: Fri, 07 Jun 2019 22:32:40 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -121,7 +165,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:17 GMT
+      - Fri, 07 Jun 2019 22:32:41 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -136,10 +180,10 @@ http_interactions:
         <?xml version="1.0" encoding="UTF-8"?>
         <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:16 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:40 GMT
 - request:
     method: put
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
     body:
       encoding: ASCII-8BIT
       string: stub-image-contents
@@ -158,7 +202,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:17 GMT
+      - Fri, 07 Jun 2019 22:32:42 GMT
+      X-Amz-Version-Id:
+      - BlFJaWnDJfZ0Jjuy_z.mtZbxGPHMN7S5
       Etag:
       - '"593f84d5c5f5f6b80161676517701886"'
       Content-Length:
@@ -169,12 +215,12 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:16 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:41 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -185,7 +231,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:18 GMT
+      - Fri, 07 Jun 2019 22:32:42 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -198,9 +244,9 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg</Key><LastModified>2016-06-20T19:54:17.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T22:32:42.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:17 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:41 GMT
 - request:
     method: put
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
@@ -222,7 +268,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:18 GMT
+      - Fri, 07 Jun 2019 22:32:42 GMT
+      X-Amz-Version-Id:
+      - KPxcD9SnQjxeLkaycNLoxP.aMBVpd0r1
       Etag:
       - '"f1a31c5ccd5bc6f0aa6912e3cadeb91c"'
       Content-Length:
@@ -233,12 +281,12 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:17 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:41 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -249,7 +297,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:19 GMT
+      - Fri, 07 Jun 2019 22:32:43 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -262,84 +310,14 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2016-06-20T19:54:18.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg</Key><LastModified>2016-06-20T19:54:17.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T22:32:42.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2019-06-07T22:32:42.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:18 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:42 GMT
 - request:
     method: get
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 20 Jun 2016 19:54:19 GMT
-      X-Amz-Meta-Abuse-Score:
-      - '0'
-      Last-Modified:
-      - Mon, 20 Jun 2016 19:54:18 GMT
-      Etag:
-      - '"f1a31c5ccd5bc6f0aa6912e3cadeb91c"'
-      Accept-Ranges:
-      - bytes
-      Content-Type:
-      - ''
-      Content-Length:
-      - '19'
-      Server:
-      - AmazonS3
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
     body:
       encoding: UTF-8
-      string: stub-sound-contents
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:18 GMT
-- request:
-    method: put
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      X-Amz-Copy-Source:
-      - cdo-v3-assets/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
-      X-Amz-Meta-Abuse-Score:
-      - '10'
-      X-Amz-Metadata-Directive:
-      - REPLACE
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 20 Jun 2016 19:54:20 GMT
-      Content-Type:
-      - application/xml
-      Content-Length:
-      - '234'
-      Server:
-      - AmazonS3
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0" encoding="UTF-8"?>
-        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2016-06-20T19:54:20.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag></CopyObjectResult>
-    http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:19 GMT
-- request:
-    method: get
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
-    body:
-      encoding: ASCII-8BIT
       string: ''
     headers:
       Content-Length:
@@ -350,13 +328,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:20 GMT
-      X-Amz-Meta-Abuse-Score:
-      - '0'
+      - Fri, 07 Jun 2019 22:32:43 GMT
       Last-Modified:
-      - Mon, 20 Jun 2016 19:54:17 GMT
+      - Fri, 07 Jun 2019 22:32:42 GMT
       Etag:
       - '"593f84d5c5f5f6b80161676517701886"'
+      X-Amz-Meta-Abuse-Score:
+      - '0'
+      X-Amz-Version-Id:
+      - BlFJaWnDJfZ0Jjuy_z.mtZbxGPHMN7S5
       Accept-Ranges:
       - bytes
       Content-Type:
@@ -369,16 +349,16 @@ http_interactions:
       encoding: UTF-8
       string: stub-image-contents
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:19 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:42 GMT
 - request:
     method: put
-    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       X-Amz-Copy-Source:
-      - cdo-v3-assets/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
+      - cdo-v3-assets/assets_test/1/1/-atac0a7f8c2faac49775a6.jpg
       X-Amz-Meta-Abuse-Score:
       - '10'
       X-Amz-Metadata-Directive:
@@ -391,25 +371,29 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:20 GMT
+      - Fri, 07 Jun 2019 22:32:43 GMT
+      X-Amz-Copy-Source-Version-Id:
+      - BlFJaWnDJfZ0Jjuy_z.mtZbxGPHMN7S5
+      X-Amz-Version-Id:
+      - DHFgjBEw9wkn9kR6iTnrP2I8P82C4h4K
       Content-Type:
       - application/xml
-      Content-Length:
-      - '234'
+      Transfer-Encoding:
+      - chunked
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2016-06-20T19:54:20.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag></CopyObjectResult>
+        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2019-06-07T22:32:43.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag></CopyObjectResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:20 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:42 GMT
 - request:
     method: get
-    uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -420,7 +404,83 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:21 GMT
+      - Fri, 07 Jun 2019 22:32:43 GMT
+      Last-Modified:
+      - Fri, 07 Jun 2019 22:32:42 GMT
+      Etag:
+      - '"f1a31c5ccd5bc6f0aa6912e3cadeb91c"'
+      X-Amz-Meta-Abuse-Score:
+      - '0'
+      X-Amz-Version-Id:
+      - KPxcD9SnQjxeLkaycNLoxP.aMBVpd0r1
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - ''
+      Content-Length:
+      - '19'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: stub-sound-contents
+    http_version: 
+  recorded_at: Fri, 07 Jun 2019 22:32:43 GMT
+- request:
+    method: put
+    uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      X-Amz-Copy-Source:
+      - cdo-v3-assets/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
+      X-Amz-Meta-Abuse-Score:
+      - '10'
+      X-Amz-Metadata-Directive:
+      - REPLACE
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Jun 2019 22:32:44 GMT
+      X-Amz-Copy-Source-Version-Id:
+      - KPxcD9SnQjxeLkaycNLoxP.aMBVpd0r1
+      X-Amz-Version-Id:
+      - _bN8MTNscfl99R.2ZNlxeOf7PtebMPur
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '234'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2019-06-07T22:32:44.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag></CopyObjectResult>
+    http_version: 
+  recorded_at: Fri, 07 Jun 2019 22:32:43 GMT
+- request:
+    method: get
+    uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/1/
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Jun 2019 22:32:44 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -433,14 +493,14 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2016-06-20T19:54:20.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg</Key><LastModified>2016-06-20T19:54:20.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/1/-atac0a7f8c2faac49775a6.jpg</Key><LastModified>2019-06-07T22:32:43.000Z</LastModified><ETag>&quot;593f84d5c5f5f6b80161676517701886&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>assets_test/1/1/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2019-06-07T22:32:44.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:20 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:43 GMT
 - request:
     method: put
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/woofc0cc21d843b34e9afb52.mp3
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       X-Amz-Copy-Source:
@@ -455,7 +515,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:21 GMT
+      - Fri, 07 Jun 2019 22:32:44 GMT
+      X-Amz-Copy-Source-Version-Id:
+      - _bN8MTNscfl99R.2ZNlxeOf7PtebMPur
+      X-Amz-Version-Id:
+      - WlZ_UVGT9sWhMEJ5C.AJjLW7Q2UmrwQn
       Content-Type:
       - application/xml
       Content-Length:
@@ -466,14 +530,14 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2016-06-20T19:54:21.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag></CopyObjectResult>
+        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2019-06-07T22:32:44.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag></CopyObjectResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:20 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:44 GMT
 - request:
     method: get
     uri: https://cdo-v3-assets.s3.amazonaws.com/?encoding-type=url&prefix=assets_test/1/2/
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -484,7 +548,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:22 GMT
+      - Fri, 07 Jun 2019 22:32:45 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -497,14 +561,14 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/2/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/2/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2016-06-20T19:54:21.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-assets</Name><Prefix>assets_test/1/2/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>assets_test/1/2/woofc0cc21d843b34e9afb52.mp3</Key><LastModified>2019-06-07T22:32:44.000Z</LastModified><ETag>&quot;f1a31c5ccd5bc6f0aa6912e3cadeb91c&quot;</ETag><Size>19</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:21 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:44 GMT
 - request:
     method: delete
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/%C3%A7atac0a7f8c2faac49775a6.jpg
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -515,19 +579,23 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:22 GMT
+      - Fri, 07 Jun 2019 22:32:45 GMT
+      X-Amz-Version-Id:
+      - 6sr1kmK6oFFj4Eelh0tAfJj9LluAXsAY
+      X-Amz-Delete-Marker:
+      - 'true'
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:21 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:44 GMT
 - request:
     method: delete
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/1/woofc0cc21d843b34e9afb52.mp3
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -538,19 +606,23 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:23 GMT
+      - Fri, 07 Jun 2019 22:32:45 GMT
+      X-Amz-Version-Id:
+      - sPfrAiPYG3.1PZlgrpleKjI2BDlVUu6a
+      X-Amz-Delete-Marker:
+      - 'true'
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:22 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:45 GMT
 - request:
     method: delete
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/%C3%A7atac0a7f8c2faac49775a6.jpg
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -561,19 +633,23 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:24 GMT
+      - Fri, 07 Jun 2019 22:32:46 GMT
+      X-Amz-Version-Id:
+      - tSP6Ep0URuZkGGBjSoUcwMQOgkUXu1aQ
+      X-Amz-Delete-Marker:
+      - 'true'
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:23 GMT
+  recorded_at: Fri, 07 Jun 2019 22:32:45 GMT
 - request:
     method: delete
     uri: https://cdo-v3-assets.s3.amazonaws.com/assets_test/1/2/woofc0cc21d843b34e9afb52.mp3
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: ''
     headers:
       Content-Length:
@@ -584,12 +660,16 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 20 Jun 2016 19:54:24 GMT
+      - Fri, 07 Jun 2019 22:32:46 GMT
+      X-Amz-Version-Id:
+      - j.bxgW7Hyx_Jn5LKwPGEEzZDxHaqe3as
+      X-Amz-Delete-Marker:
+      - 'true'
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 20 Jun 2016 19:54:23 GMT
-recorded_with: VCR 3.0.0
+  recorded_at: Fri, 07 Jun 2019 22:32:45 GMT
+recorded_with: VCR 3.0.3

--- a/shared/test/middleware/helpers/test_bucket_helper.rb
+++ b/shared/test/middleware/helpers/test_bucket_helper.rb
@@ -1,0 +1,13 @@
+require_relative '../../test_helper'
+require_relative '../../../middleware/helpers/bucket_helper'
+
+class BucketHelperTest < Minitest::Test
+  def test_replace_unsafe_chars
+    safe_string = "the-quick_brown'fox'jumped(over)the*lazy-dog"
+    assert_equal safe_string, BucketHelper.replace_unsafe_chars(safe_string)
+
+    unsafe_string = 'a?b$c%d<e"f&g h'
+    safe_string = 'a-b-c-d-e-f-g-h'
+    assert_equal safe_string, BucketHelper.replace_unsafe_chars(unsafe_string)
+  end
+end

--- a/shared/test/test_assets.rb
+++ b/shared/test/test_assets.rb
@@ -314,8 +314,10 @@ class AssetsTest < FilesApiTestBase
     sound_filename = 'woof.mp3'
     sound_body = 'stub-sound-contents'
 
-    _, image_filename = post_asset_file(src_api, image_filename, image_body, 'image/jpeg')
-    _, sound_filename = post_asset_file(src_api, sound_filename, sound_body, 'audio/mpeg')
+    response, _ = post_asset_file(src_api, image_filename, image_body, 'image/jpeg')
+    image_filename = JSON.parse(response)['filename']
+    response, _ = post_asset_file(src_api, sound_filename, sound_body, 'audio/mpeg')
+    sound_filename = JSON.parse(response)['filename']
     src_api.patch_abuse(10)
 
     expected_image_info = {'filename' =>  image_filename, 'category' => 'image', 'size' => image_body.length}
@@ -324,10 +326,10 @@ class AssetsTest < FilesApiTestBase
     copy_file_infos = JSON.parse(copy_all(@channel_id, dest_channel_id))
     dest_file_infos = dest_api.list_objects
 
-    assert_fileinfo_equal(expected_image_info, copy_file_infos[1])
-    assert_fileinfo_equal(expected_sound_info, copy_file_infos[0])
-    assert_fileinfo_equal(expected_image_info, dest_file_infos[1])
-    assert_fileinfo_equal(expected_sound_info, dest_file_infos[0])
+    assert_fileinfo_equal(expected_image_info, copy_file_infos[0])
+    assert_fileinfo_equal(expected_sound_info, copy_file_infos[1])
+    assert_fileinfo_equal(expected_image_info, dest_file_infos[0])
+    assert_fileinfo_equal(expected_sound_info, dest_file_infos[1])
 
     # abuse score didn't carry over
     assert_equal 0, AssetBucket.new.get_abuse_score(dest_channel_id, image_filename)


### PR DESCRIPTION
### Background

partially addresses https://codedotorg.atlassian.net/browse/LP-438

### Description

This is a targeted fix to improve handling of asset filenames in applab which have special characters. because the asset names are not editable in the UI, this PR just blanks out any special characters (as defined in code comments) with the `-` character. Generally speaking, this makes these filenames immune to any inconsistencies in how we url encode/decode filenames in our files APIs.

### Screenshots

#### before

<img width="817" alt="Screen Shot 2019-06-19 at 1 44 16 PM" src="https://user-images.githubusercontent.com/8001765/59799063-6ba26580-9298-11e9-98db-d0c4ed20187f.png">


#### after

<img width="825" alt="Screen Shot 2019-06-19 at 1 44 25 PM" src="https://user-images.githubusercontent.com/8001765/59799055-66451b00-9298-11e9-981e-4c97bf7e0a7b.png">


### Future work
* apply the same measure to weblab file uploads (may be trickier since the UI allows renaming)
* consider using https://stackoverflow.com/questions/225471/how-do-i-replace-accented-latin-characters-in-ruby to make renaming less lossy, e.g. `çat` --> `cat` instead of or `-at`