### PR TITLE
Testing: filterGroupContainerTest.jsx uses reconfiguredChai

### DIFF
--- a/apps/test/unit/tutorialExplorer/filterGroupContainerTest.jsx
+++ b/apps/test/unit/tutorialExplorer/filterGroupContainerTest.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../util/configuredChai';
+import {assert} from '../../util/reconfiguredChai';
 import FilterGroupContainer from '@cdo/apps/tutorialExplorer/filterGroupContainer';
 
 describe('FilterGroupContainer', () => {
@@ -16,11 +16,13 @@ describe('FilterGroupContainer', () => {
     const wrapper = shallow(
       <FilterGroupContainer text={title}>{content}</FilterGroupContainer>
     );
-    expect(wrapper).to.containMatchingElement(
-      <div>
-        <div>{title}</div>
-        {content}
-      </div>
+    assert(
+      wrapper.containsMatchingElement(
+        <div>
+          <div>{title}</div>
+          {content}
+        </div>
+      )
     );
   });
 });


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.