### PR TITLE
Testing: ImageTest is ready for enzyme 3

### DIFF
--- a/apps/test/unit/tutorialExplorer/imageTest.jsx
+++ b/apps/test/unit/tutorialExplorer/imageTest.jsx
@@ -1,24 +1,30 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../util/configuredChai';
+import {assert} from '../../util/reconfiguredChai';
 import Image from '@cdo/apps/tutorialExplorer/image';
 
 describe('Image', () => {
   it('renders with minimum opacity at first', () => {
-    const wrapper = shallow(<Image style={{}} />);
-    expect(wrapper).to.containMatchingElement(<img style={{opacity: 0.1}} />);
+    const wrapper = shallow(<Image style={{}} />, {
+      disableLifecycleMethods: true
+    });
+    assert(wrapper.containsMatchingElement(<img style={{opacity: 0.1}} />));
   });
 
   it('renders with a transition to full opacity after image loads', () => {
-    const wrapper = shallow(<Image style={{}} />);
+    const wrapper = shallow(<Image style={{}} />, {
+      disableLifecycleMethods: true
+    });
     wrapper.instance().onImageLoad();
-    expect(wrapper).to.containMatchingElement(
-      <img
-        style={{
-          opacity: 1,
-          transition: 'opacity 200ms ease-in'
-        }}
-      />
+    assert(
+      wrapper.containsMatchingElement(
+        <img
+          style={{
+            opacity: 1,
+            transition: 'opacity 200ms ease-in'
+          }}
+        />
+      )
     );
   });
 });


### PR DESCRIPTION
Following [these instructions](https://docs.google.com/document/d/1D-5CR0OrExDZEsiMJ6obkRFoqp835GO2LEuCCkz8SCs/edit) and reviewing [this list](https://docs.google.com/spreadsheets/d/1xWHtfLmfUmBPsq-vJ44fEucqMG64N0RfLAhCBXjDrTQ/edit#gid=0) I'm fixing up a few more tests to be ready for the Enzyme 3 upgrade.

I believe these are fixed in a backwards-compatible way; letting Drone confirm that.