### PR TITLE
Allow major version upgrades on replication instance [ci skip]

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -57,6 +57,7 @@ Resources:
   TableauSync:
     Type: AWS::DMS::ReplicationInstance
     Properties:
+      AllowMajorVersionUpgrade: true
       AllocatedStorage: 250
       EngineVersion: 3.1.3
       MultiAZ: true


### PR DESCRIPTION
Allows us to upgrade from version 2.x.x to 3.x.x on replication instance.