### PR TITLE
Only show record button on chrome/firefox

### DIFF
--- a/apps/src/code-studio/components/AddAssetButtonRow.jsx
+++ b/apps/src/code-studio/components/AddAssetButtonRow.jsx
@@ -58,6 +58,13 @@ export default class AddAssetButtonRow extends React.Component {
   };
 
   render() {
+    let shouldShowRecordButton = !this.props.hideAudioRecording;
+    if (
+      navigator.userAgent.indexOf('Firefox') === -1 &&
+      navigator.userAgent.indexOf('Chrome') === -1
+    ) {
+      shouldShowRecordButton = false;
+    }
     return (
       <div style={assetButtonStyles.buttonRow}>
         <AssetUploader
@@ -68,7 +75,7 @@ export default class AddAssetButtonRow extends React.Component {
           onUploadDone={this.props.onUploadDone}
           onUploadError={this.props.onUploadError}
         />
-        {!this.props.hideAudioRecording && (
+        {shouldShowRecordButton && (
           <RecordButton
             onSelectRecord={this.props.onSelectRecord}
             disabled={!this.props.uploadsEnabled || this.props.recordDisabled}

--- a/dashboard/test/ui/features/manage_assets.feature
+++ b/dashboard/test/ui/features/manage_assets.feature
@@ -1,15 +1,22 @@
 @no_mobile
 Feature: Manage Assets
 
-  # Skip on Safari and IE. MediaRecorder is not supported so we are removing the record button.
-  @no_safari_yosemite @no_ie
-  Scenario: The manage assets dialog contains the option to record audio.
+  @no_safari @no_ie
+  Scenario: The manage assets dialog contains the option to record audio on Chrome and Firefox.
     Given I am a student
     And I start a new Game Lab project
     And I wait for the page to fully load
     And I open the Manage Assets dialog
     Then I click selector "#record-asset" once I see it
     And I wait until element ".modal-content" contains text "Your computer is not set-up to record audio."
+    
+  @no_chrome @no_firefox
+  Scenario: The manage assets dialog contains the option to record audio on Safari or IE.
+    Given I am a student
+    And I start a new Game Lab project
+    And I wait for the page to fully load
+    And I open the Manage Assets dialog
+    Then I wait until element "#record-asset" is not visible
 
   Scenario: The manage assets dialog displays the audio preview, and toggles between play and pause button.
     Given I am a student

--- a/dashboard/test/ui/features/manage_assets.feature
+++ b/dashboard/test/ui/features/manage_assets.feature
@@ -1,6 +1,7 @@
 @no_mobile
 Feature: Manage Assets
 
+  @no_safari_yosemite
   Scenario: The manage assets dialog contains the option to record audio.
     Given I am a student
     And I start a new Game Lab project

--- a/dashboard/test/ui/features/manage_assets.feature
+++ b/dashboard/test/ui/features/manage_assets.feature
@@ -1,7 +1,8 @@
 @no_mobile
 Feature: Manage Assets
 
-  @no_safari_yosemite
+  # Skip on Safari and IE. MediaRecorder is not supported so we are removing the record button.
+  @no_safari_yosemite @no_ie
   Scenario: The manage assets dialog contains the option to record audio.
     Given I am a student
     And I start a new Game Lab project


### PR DESCRIPTION
Quick mitigation because recording sounds is not supported on all browsers

Chrome:
![image](https://user-images.githubusercontent.com/8787187/59806138-37cf3c00-92a8-11e9-9863-3b5c094bf123.png)


Safari:
![image](https://user-images.githubusercontent.com/8787187/59806119-29812000-92a8-11e9-835e-2858bcaa5d06.png)
