### PR TITLE
Tests: Use vanilla chai in most integration tests

### DIFF
--- a/apps/test/integration/blockUtilTests.js
+++ b/apps/test/integration/blockUtilTests.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 import {setupTestBlockly} from './util/testBlockly';
 import {parseElement} from '@cdo/apps/xml';
 

--- a/apps/test/integration/condBlockTest.js
+++ b/apps/test/integration/condBlockTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 import {setupTestBlockly, getStudioAppSingleton} from './util/testBlockly';
 import CustomMarshalingInterpreter from '@cdo/apps/lib/tools/jsinterpreter/CustomMarshalingInterpreter';
 

--- a/apps/test/integration/dropletIntegrationTests.js
+++ b/apps/test/integration/dropletIntegrationTests.js
@@ -1,4 +1,4 @@
-import {assert, expect} from '../util/configuredChai';
+import {assert, expect} from 'chai';
 import * as dropletUtils from '@cdo/apps/dropletUtils';
 import {
   singleton as studioApp,

--- a/apps/test/integration/duplicateVariablesTest.js
+++ b/apps/test/integration/duplicateVariablesTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 import {setupTestBlockly, getStudioAppSingleton} from './util/testBlockly';
 
 describe('hasDuplicateVariablesInForLoops', function() {

--- a/apps/test/integration/feedbackTests.js
+++ b/apps/test/integration/feedbackTests.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 var testUtils = require('../util/testUtils');
 import {setupTestBlockly, getStudioAppSingleton} from './util/testBlockly';
 

--- a/apps/test/integration/levelSolutions/applab/ec_setprop.js
+++ b/apps/test/integration/levelSolutions/applab/ec_setprop.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 var testUtils = require('../../../util/testUtils');
 var tickWrapper = require('../../util/tickWrapper');
 import {TestResults} from '@cdo/apps/constants';
-import {expect} from '../../../util/configuredChai';
+import {expect} from 'chai';
 
 // take advantage of the fact that we expose the filesystem via
 // localhost

--- a/apps/test/integration/levelSolutions/applab/ec_thumbnail.js
+++ b/apps/test/integration/levelSolutions/applab/ec_thumbnail.js
@@ -1,7 +1,7 @@
 import tickWrapper from '../../util/tickWrapper';
 import {TestResults} from '@cdo/apps/constants';
 import sinon from 'sinon';
-import {expect} from '../../../util/configuredChai';
+import {expect} from '../../../util/reconfiguredChai';
 import project from '@cdo/apps/code-studio/initApp/project';
 import * as htmlToCanvasWrapper from '@cdo/apps/util/htmlToCanvasWrapper';
 import {CAPTURE_TICK_COUNT} from '@cdo/apps/applab/constants';

--- a/apps/test/integration/levelTests.js
+++ b/apps/test/integration/levelTests.js
@@ -9,7 +9,7 @@
 // todo - should we also have tests around which blocks to show as part of the
 // feedback when a user gets the puzzle wrong?
 
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 import sinon from 'sinon';
 import {stubRedux, restoreRedux, registerReducers} from '@cdo/apps/redux';
 import jQuery from 'jquery';

--- a/apps/test/integration/studio/blocksTest.js
+++ b/apps/test/integration/studio/blocksTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import {parseElement} from '@cdo/apps/xml';
 import {setupTestBlockly, getStudioAppSingleton} from '../util/testBlockly';
 import blocksCommon from '@cdo/apps/blocksCommon';

--- a/apps/test/integration/util/runLevelTest.js
+++ b/apps/test/integration/util/runLevelTest.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import _ from 'lodash';
 import LegacyDialog from '@cdo/apps/code-studio/LegacyDialog';
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import {getConfigRef, getDatabase} from '@cdo/apps/storage/firebaseUtils';
 import Firebase from 'firebase';
 import MockFirebase from '../../util/MockFirebase';

--- a/apps/test/integration/util/testBlockly.js
+++ b/apps/test/integration/util/testBlockly.js
@@ -1,6 +1,6 @@
 // Note: Putting ES6 in this test file breaks the test build, for reasons I
 // haven't figured out yet (bbuchanan).  It's got something to do with require-globify.
-var assert = require('../../util/configuredChai').assert;
+var assert = require('chai').assert;
 var testBlockFactory = require('./testBlockFactory');
 
 /** @type {StudioApp} instance reference internal to this module  */

--- a/apps/test/scratch/scratchProjectTest.js
+++ b/apps/test/scratch/scratchProjectTest.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import * as testUtils from '../util/testUtils';
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 import loadScratch from '@cdo/apps/sites/studio/pages/init/loadScratch';
 import {__TestInterface} from '@cdo/apps/scratch/scratch';
 
@@ -269,7 +269,7 @@ describe('scratch', function() {
   // Skip test because no current scratch levels in use and was
   // breaking the move of CSF instructions into tabs for just this
   // level type
-  it.skip('Scratch movement test', function(done) {
+  it('Scratch movement test', function(done) {
     loadScratch({
       containerId: 'app',
       baseUrl: '/base/build/package/',

--- a/apps/test/unit/ObservableEventDEPRECATEDTest.js
+++ b/apps/test/unit/ObservableEventDEPRECATEDTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 
 describe('ObservableEventDEPRECATED', function() {
   var ObservableEventDEPRECATED = require('@cdo/apps/ObservableEventDEPRECATED');

--- a/apps/test/unit/ObserverTest.js
+++ b/apps/test/unit/ObserverTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 
 describe('Observer', function() {
   var Observer = require('@cdo/apps/Observer');

--- a/apps/test/unit/acemodeTest.js
+++ b/apps/test/unit/acemodeTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 
 var errorMapper = require('@cdo/apps/acemode/errorMapper');
 

--- a/apps/test/unit/applab/ChartApiTest.js
+++ b/apps/test/unit/applab/ChartApiTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var ChartApi = require('@cdo/apps/applab/ChartApi');
 var GoogleChart = require('@cdo/apps/applab/GoogleChart');
 

--- a/apps/test/unit/applab/EventSandboxerTest.js
+++ b/apps/test/unit/applab/EventSandboxerTest.js
@@ -1,5 +1,5 @@
 /** @file Tests of App Lab event sanitization. */
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var EventSandboxer = require('@cdo/apps/applab/EventSandboxer');
 
 describe('EventSandboxer', function() {

--- a/apps/test/unit/applab/ExporterTest.js
+++ b/apps/test/unit/applab/ExporterTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import sinon from 'sinon';
 import fakeFetch from 'fake-fetch';
 

--- a/apps/test/unit/applab/exportTest.js
+++ b/apps/test/unit/applab/exportTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import {blocks as applabBlocks} from '@cdo/apps/applab/dropletConfig';
 import {getExportedGlobals} from '@cdo/apps/applab/export';
 import {dropletGlobalConfigBlocks} from '@cdo/apps/dropletUtils';

--- a/apps/test/unit/applab/setPropertyDropdownTest.js
+++ b/apps/test/unit/applab/setPropertyDropdownTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var testUtils = require('../../util/testUtils');
 
 var setPropertyDropdown = require('@cdo/apps/applab/setPropertyDropdown');

--- a/apps/test/unit/authoredHintUtilsTest.js
+++ b/apps/test/unit/authoredHintUtilsTest.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 
 var authoredHintUtils = require('@cdo/apps/authoredHintUtils');
 

--- a/apps/test/unit/calc/calcTests.js
+++ b/apps/test/unit/calc/calcTests.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 
 var testUtils = require('../../util/testUtils');
 

--- a/apps/test/unit/calc/equationSetTests.js
+++ b/apps/test/unit/calc/equationSetTests.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 
 var ExpressionNode = require('@cdo/apps/calc/expressionNode');
 var EquationSet = require('@cdo/apps/calc/equationSet');

--- a/apps/test/unit/calc/expressionNodeTests.js
+++ b/apps/test/unit/calc/expressionNodeTests.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 
 var ExpressionNode = require('@cdo/apps/calc/expressionNode');
 var Token = require('@cdo/apps/calc/token');

--- a/apps/test/unit/calc/iteratorTests.js
+++ b/apps/test/unit/calc/iteratorTests.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 
 var InputIterator = require('@cdo/apps/calc/inputIterator');
 

--- a/apps/test/unit/calc/tokenTests.js
+++ b/apps/test/unit/calc/tokenTests.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 
 var Token = require('@cdo/apps/calc/token');
 var jsnums = require('@code-dot-org/js-numbers');

--- a/apps/test/unit/containedLevelsTest.js
+++ b/apps/test/unit/containedLevelsTest.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 import sinon from 'sinon';
 import * as codeStudioLevels from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import * as callouts from '@cdo/apps/code-studio/callouts';

--- a/apps/test/unit/craft/craftTest.js
+++ b/apps/test/unit/craft/craftTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import sinon from 'sinon';
 import {
   getStore,

--- a/apps/test/unit/ejsTest.js
+++ b/apps/test/unit/ejsTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 // nonstandard EJS behavior we rely upon in our templates
 describe('ejs test', function() {
   it('renders empty string on undefined object property access', function() {

--- a/apps/test/unit/evalTests.js
+++ b/apps/test/unit/evalTests.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 
 var Eval = require('@cdo/apps/eval/eval');
 var EvalText = require('@cdo/apps/eval/evalText');

--- a/apps/test/unit/experimentTest.js
+++ b/apps/test/unit/experimentTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 import {setExternalGlobals} from '../util/testUtils';
 import experiments from '@cdo/apps/util/experiments';
 import sinon from 'sinon';

--- a/apps/test/unit/gridUtilsTest.js
+++ b/apps/test/unit/gridUtilsTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 
 var gridUtils = require('@cdo/apps/applab/gridUtils');
 

--- a/apps/test/unit/instructionsTest.js
+++ b/apps/test/unit/instructionsTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 var testUtils = require('./../util/testUtils');
 
 import instructions, {

--- a/apps/test/unit/lib/kits/maker/ui/DiscountCodeSchoolChoiceTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/DiscountCodeSchoolChoiceTest.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {assert} from '../../../../../util/configuredChai';
+import {assert} from 'chai';
 import DiscountCodeSchoolChoice from '@cdo/apps/lib/kits/maker/ui/DiscountCodeSchoolChoice';
 
 describe('DiscountCodeSchoolChoice', () => {

--- a/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {assert} from '../../../../../util/configuredChai';
+import {assert} from 'chai';
 import EligibilityChecklist from '@cdo/apps/lib/kits/maker/ui/EligibilityChecklist';
 import {Status} from '@cdo/apps/lib/ui/ValidationStep';
 import {Unit6Intention} from '@cdo/apps/lib/kits/maker/util/discountLogic';

--- a/apps/test/unit/lib/kits/maker/ui/EligibilityConfirmDialogTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/EligibilityConfirmDialogTest.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import {assert} from '../../../../../util/configuredChai';
+import {assert} from 'chai';
 import EligibilityConfirmDialog from '@cdo/apps/lib/kits/maker/ui/EligibilityConfirmDialog';
 
 describe('EligibilityConfirmDialog', () => {

--- a/apps/test/unit/lib/kits/maker/ui/Unit6ValidationStepTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/Unit6ValidationStepTest.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {assert} from '../../../../../util/configuredChai';
+import {assert} from 'chai';
 import Unit6ValidationStep from '@cdo/apps/lib/kits/maker/ui/Unit6ValidationStep';
 import {Status} from '@cdo/apps/lib/ui/ValidationStep';
 import {Unit6Intention} from '@cdo/apps/lib/kits/maker/util/discountLogic';

--- a/apps/test/unit/lib/script-editor/ScriptAnnouncementsEditorTests.js
+++ b/apps/test/unit/lib/script-editor/ScriptAnnouncementsEditorTests.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {assert} from '../../../util/reconfiguredChai';
+import {assert} from 'chai';
 import ScriptAnnouncementsEditor from '@cdo/apps/lib/script-editor/ScriptAnnouncementsEditor';
 
 const sampleAnnouncement = {

--- a/apps/test/unit/lib/tools/jsinterpreter/codegenTest.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/codegenTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../../util/configuredChai';
+import {assert} from 'chai';
 import * as codegen from '@cdo/apps/lib/tools/jsinterpreter/codegen';
 
 describe('codegen', function() {

--- a/apps/test/unit/logConditionsTest.js
+++ b/apps/test/unit/logConditionsTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 import {TestResults} from '@cdo/apps/constants';
 
 var executionLog = require('@cdo/apps/executionLog');

--- a/apps/test/unit/netsim/ArgumentUtils.js
+++ b/apps/test/unit/netsim/ArgumentUtils.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var ArgumentUtils = require('@cdo/apps/netsim/ArgumentUtils');
 
 describe('ArgumentUtils', function() {

--- a/apps/test/unit/netsim/NetSimEntity.js
+++ b/apps/test/unit/netsim/NetSimEntity.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimEntity = require('@cdo/apps/netsim/NetSimEntity');
 var NetSimClientNode = require('@cdo/apps/netsim/NetSimClientNode');

--- a/apps/test/unit/netsim/NetSimLocalClientNode.js
+++ b/apps/test/unit/netsim/NetSimLocalClientNode.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimGlobals = require('@cdo/apps/netsim/NetSimGlobals');
 var NetSimLogger = require('@cdo/apps/netsim/NetSimLogger');

--- a/apps/test/unit/netsim/NetSimLogEntry.js
+++ b/apps/test/unit/netsim/NetSimLogEntry.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var DataConverters = require('@cdo/apps/netsim/DataConverters');
 var NetSimLogEntry = require('@cdo/apps/netsim/NetSimLogEntry');
 var NetSimGlobals = require('@cdo/apps/netsim/NetSimGlobals');

--- a/apps/test/unit/netsim/NetSimLogPanel.js
+++ b/apps/test/unit/netsim/NetSimLogPanel.js
@@ -1,6 +1,6 @@
 /** @file Tests for NetSimLogPanel */
 import $ from 'jquery';
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimLogPanel = require('@cdo/apps/netsim/NetSimLogPanel');
 var DataConverters = require('@cdo/apps/netsim/DataConverters');

--- a/apps/test/unit/netsim/NetSimLogger.js
+++ b/apps/test/unit/netsim/NetSimLogger.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimLogger = require('@cdo/apps/netsim/NetSimLogger');
 
 // Simple console that only has 'log' method

--- a/apps/test/unit/netsim/NetSimMessage.js
+++ b/apps/test/unit/netsim/NetSimMessage.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import {assertOwnProperty} from '../../util/assertions';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimMessage = require('@cdo/apps/netsim/NetSimMessage');

--- a/apps/test/unit/netsim/NetSimPacketEditor.js
+++ b/apps/test/unit/netsim/NetSimPacketEditor.js
@@ -1,5 +1,5 @@
 /** @file Tests for NetSimPacketEditor */
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimPacketEditor = require('@cdo/apps/netsim/NetSimPacketEditor');
 var DataConverters = require('@cdo/apps/netsim/DataConverters');

--- a/apps/test/unit/netsim/NetSimRemoteNodeSelectionPanel.js
+++ b/apps/test/unit/netsim/NetSimRemoteNodeSelectionPanel.js
@@ -1,6 +1,6 @@
 /** @file Tests for NetSimRemoteNodeSelectionPanel */
 import $ from 'jquery';
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimRemoteNodeSelectionPanel = require('@cdo/apps/netsim/NetSimRemoteNodeSelectionPanel');
 var NetSimClientNode = require('@cdo/apps/netsim/NetSimClientNode');

--- a/apps/test/unit/netsim/NetSimRouterNode.js
+++ b/apps/test/unit/netsim/NetSimRouterNode.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import {assertOwnProperty} from '../../util/assertions';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var _ = require('lodash');

--- a/apps/test/unit/netsim/NetSimSendPanel.js
+++ b/apps/test/unit/netsim/NetSimSendPanel.js
@@ -1,6 +1,6 @@
 /** @file Tests for NetSimLogPanel */
 import $ from 'jquery';
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import {KeyCodes} from '@cdo/apps/constants';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimSendPanel = require('@cdo/apps/netsim/NetSimSendPanel');

--- a/apps/test/unit/netsim/NetSimSlider.js
+++ b/apps/test/unit/netsim/NetSimSlider.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimSlider = require('@cdo/apps/netsim/NetSimSlider');
 
 describe('NetSimSlider', function() {

--- a/apps/test/unit/netsim/NetSimTable.js
+++ b/apps/test/unit/netsim/NetSimTable.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import sinon from 'sinon';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimTable = require('@cdo/apps/netsim/NetSimTable');

--- a/apps/test/unit/netsim/NetSimVisualization.js
+++ b/apps/test/unit/netsim/NetSimVisualization.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimVisualization = require('@cdo/apps/netsim/NetSimVisualization');
 var NetSim = require('@cdo/apps/netsim/netsim');

--- a/apps/test/unit/netsim/NetSimVizAutoDnsNode.js
+++ b/apps/test/unit/netsim/NetSimVizAutoDnsNode.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimGlobals = require('@cdo/apps/netsim/NetSimGlobals');
 var NetSimVizElement = require('@cdo/apps/netsim/NetSimVizElement');

--- a/apps/test/unit/netsim/NetSimVizElement.js
+++ b/apps/test/unit/netsim/NetSimVizElement.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimVizElement = require('@cdo/apps/netsim/NetSimVizElement');
 
 describe('NetSimVizElement', function() {

--- a/apps/test/unit/netsim/NetSimVizNode.js
+++ b/apps/test/unit/netsim/NetSimVizNode.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimVizElement = require('@cdo/apps/netsim/NetSimVizElement');
 var NetSimVizNode = require('@cdo/apps/netsim/NetSimVizNode');
 

--- a/apps/test/unit/netsim/NetSimVizSimulationNode.js
+++ b/apps/test/unit/netsim/NetSimVizSimulationNode.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimGlobals = require('@cdo/apps/netsim/NetSimGlobals');
 var NetSimLocalClientNode = require('@cdo/apps/netsim/NetSimLocalClientNode');

--- a/apps/test/unit/netsim/NetSimVizSimulationWire.js
+++ b/apps/test/unit/netsim/NetSimVizSimulationWire.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimGlobals = require('@cdo/apps/netsim/NetSimGlobals');
 var NetSimLocalClientNode = require('@cdo/apps/netsim/NetSimLocalClientNode');

--- a/apps/test/unit/netsim/NetSimVizWire.js
+++ b/apps/test/unit/netsim/NetSimVizWire.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimVizElement = require('@cdo/apps/netsim/NetSimVizElement');
 var NetSimVizNode = require('@cdo/apps/netsim/NetSimVizNode');
 var NetSimVizWire = require('@cdo/apps/netsim/NetSimVizWire');

--- a/apps/test/unit/netsim/NetSimWire.js
+++ b/apps/test/unit/netsim/NetSimWire.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import {assertOwnProperty} from '../../util/assertions';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var NetSimWire = require('@cdo/apps/netsim/NetSimWire');

--- a/apps/test/unit/netsim/Packet.js
+++ b/apps/test/unit/netsim/Packet.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
 var Packet = require('@cdo/apps/netsim/Packet');
 

--- a/apps/test/unit/netsim/dataConverters.js
+++ b/apps/test/unit/netsim/dataConverters.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 var DataConverters = require('@cdo/apps/netsim/DataConverters');
 
 describe('DataConverters', function() {

--- a/apps/test/unit/puzzleRatingUtilsTest.js
+++ b/apps/test/unit/puzzleRatingUtilsTest.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 
 var puzzleRatingUtils = require('@cdo/apps/puzzleRatingUtils');
 

--- a/apps/test/unit/redux/scriptSelectionReduxTest.js
+++ b/apps/test/unit/redux/scriptSelectionReduxTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/reconfiguredChai';
+import {assert} from 'chai';
 import scriptSelection, {
   setValidScripts,
   setScriptId,

--- a/apps/test/unit/redux/sectionDataReduxTest.js
+++ b/apps/test/unit/redux/sectionDataReduxTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/reconfiguredChai';
+import {assert} from 'chai';
 import sectionData, {setSection} from '@cdo/apps/redux/sectionDataRedux';
 
 const fakeSectionData = {

--- a/apps/test/unit/runStateTest.js
+++ b/apps/test/unit/runStateTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 import JSInterpreter from '@cdo/apps/lib/tools/jsinterpreter/JSInterpreter';
 var testUtils = require('./../util/testUtils');
 

--- a/apps/test/unit/templates/AgeDialogTest.js
+++ b/apps/test/unit/templates/AgeDialogTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {UnconnectedAgeDialog as AgeDialog} from '@cdo/apps/templates/AgeDialog';
 import {shallow} from 'enzyme';

--- a/apps/test/unit/templates/ButtonTest.js
+++ b/apps/test/unit/templates/ButtonTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import Button from '@cdo/apps/templates/Button';

--- a/apps/test/unit/templates/DropdownButtonTest.js
+++ b/apps/test/unit/templates/DropdownButtonTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';

--- a/apps/test/unit/templates/SignInOrAgeDialogTest.js
+++ b/apps/test/unit/templates/SignInOrAgeDialogTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {UnconnectedSignInOrAgeDialog as SignInOrAgeDialog} from '@cdo/apps/templates/SignInOrAgeDialog';
 import {shallow} from 'enzyme';

--- a/apps/test/unit/templates/courseOverview/AssignToSectionTest.js
+++ b/apps/test/unit/templates/courseOverview/AssignToSectionTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import {UnconnectedAssignToSection as AssignToSection} from '@cdo/apps/templates/courseOverview/AssignToSection';

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import CourseOverviewTopRow from '@cdo/apps/templates/courseOverview/CourseOverviewTopRow';

--- a/apps/test/unit/templates/courseOverview/ResourcesEditorTest.js
+++ b/apps/test/unit/templates/courseOverview/ResourcesEditorTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import ResourcesEditor from '@cdo/apps/templates/courseOverview/ResourcesEditor';

--- a/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
+++ b/apps/test/unit/templates/manageStudents/manageStudentsReduxTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import manageStudents, {
   setLoginType,
   setStudents,

--- a/apps/test/unit/templates/plugins/detailsTest.js
+++ b/apps/test/unit/templates/plugins/detailsTest.js
@@ -1,5 +1,5 @@
 import Parser from '@code-dot-org/redactable-markdown';
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 
 import details from '@cdo/apps/templates/plugins/details';
 

--- a/apps/test/unit/templates/plugins/externalLinksTest.js
+++ b/apps/test/unit/templates/plugins/externalLinksTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import {isExternalLink} from '@cdo/apps/templates/plugins/externalLinks';
 
 describe('external links remark plugin', () => {

--- a/apps/test/unit/templates/progress/DetailProgressTableTest.js
+++ b/apps/test/unit/templates/progress/DetailProgressTableTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import DetailProgressTable from '@cdo/apps/templates/progress/DetailProgressTable';

--- a/apps/test/unit/templates/progress/ProgressLessonContentTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonContentTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import ProgressLessonContent from '@cdo/apps/templates/progress/ProgressLessonContent';

--- a/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import Immutable from 'immutable';
 import {shallow} from 'enzyme';

--- a/apps/test/unit/templates/progress/ProgressLessonTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import {UnconnectedProgressLesson as ProgressLesson} from '@cdo/apps/templates/progress/ProgressLesson';

--- a/apps/test/unit/templates/progress/ProgressLevelSetTest.js
+++ b/apps/test/unit/templates/progress/ProgressLevelSetTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import ProgressLevelSet from '@cdo/apps/templates/progress/ProgressLevelSet';

--- a/apps/test/unit/templates/progress/SummaryProgressRowTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressRowTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import SummaryProgressRow from '@cdo/apps/templates/progress/SummaryProgressRow';

--- a/apps/test/unit/templates/progress/SummaryProgressTableTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressTableTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import {UnconnectedSummaryProgressTable as SummaryProgressTable} from '@cdo/apps/templates/progress/SummaryProgressTable';

--- a/apps/test/unit/templates/projects/ProjectHeaderTest.js
+++ b/apps/test/unit/templates/projects/ProjectHeaderTest.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import ProjectHeader from '@cdo/apps/templates/projects/ProjectHeader.jsx';
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
 

--- a/apps/test/unit/templates/projects/projectsReduxTest.js
+++ b/apps/test/unit/templates/projects/projectsReduxTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import projects, {
   setPersonalProjectsList,
   publishSuccess,

--- a/apps/test/unit/templates/studioHomepages/SetUpCoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpCoursesTest.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import SetUpCourses from '@cdo/apps/templates/studioHomepages/SetUpCourses';
 import SetUpMessage from '@cdo/apps/templates/studioHomepages/SetUpMessage';
 

--- a/apps/test/unit/templates/teacherDashboard/PrintCertificatesTest.js
+++ b/apps/test/unit/templates/teacherDashboard/PrintCertificatesTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';

--- a/apps/test/unit/templates/teacherDashboard/statsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/statsReduxTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import stats, {
   setCompletedLevelCount
 } from '@cdo/apps/templates/teacherDashboard/statsRedux';

--- a/apps/test/unit/templates/textResponses/textResponsesReduxTest.js
+++ b/apps/test/unit/templates/textResponses/textResponsesReduxTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/configuredChai';
+import {assert} from 'chai';
 import textResponses, {
   setTextResponses,
   startLoadingResponses,

--- a/apps/test/unit/tickWrapperTest.js
+++ b/apps/test/unit/tickWrapperTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../util/configuredChai';
+import {assert} from 'chai';
 var tickWrapper = require('./../integration/util/tickWrapper');
 
 function createFakeApp() {


### PR DESCRIPTION
While doing work to move more tests from `configuredChai` over to `reconfiguredChai` I realized that it would be a relatively small lift to simply move all of our integration tests to vanilla `chai`, dropping several (admittedly small) dependencies from that bundle.

I don't feel a strong need to build future-enforcement for this; it satisfies the current goal of dropping `chai-enzyme` as a dependency from these tests, and there may be good reason to reintroduce other chai extensions in the future.

_Update:_ Per discussion below, one of the integration tests still benefits from the use of `sinon-chai` so I'm leaving that test using the new `reconfiguredChai.js` file for now.  It may be worth clarifying our vision around test dependencies, and in particular our assertion libraries, in the future, but this is not a pressing need (and it's a fairly big win bundle-wise to get `chai-enzyme` removed anyway).