### PR TITLE
Prevent this/other sprite from crashing project when used outside scope

### DIFF
--- a/dashboard/config/libraries/GameLabJr.interpreted.js
+++ b/dashboard/config/libraries/GameLabJr.interpreted.js
@@ -1,3 +1,5 @@
+var extraArgs = null;
+
 function draw() {
   executeDrawLoopAndCallbacks();
 }

--- a/dashboard/config/libraries/NativeSpriteLab.interpreted.js
+++ b/dashboard/config/libraries/NativeSpriteLab.interpreted.js
@@ -1,3 +1,5 @@
+var extraArgs = null;
+
 function draw() {
   executeDrawLoopAndCallbacks();
 }

--- a/dashboard/config/libraries/SpriteLab2Beta.interpreted.js
+++ b/dashboard/config/libraries/SpriteLab2Beta.interpreted.js
@@ -1,3 +1,5 @@
+var extraArgs = null;
+
 function draw() {
   executeDrawLoopAndCallbacks();
 }


### PR DESCRIPTION
`extraArgs` is a parameter passed to the event callback from the native event handling code, and this block only really makes sense when used under and event block. However, we don't want to entirely crash the program when it's used incorrectly. If we just define `extraArgs` in the library, at least it won't be an undeclared variable, and all the other functions already handle being passed null/undefined seamlessly, so using this/other sprite outside an event block will now just be a no-op.

Old:
![image](https://user-images.githubusercontent.com/8787187/59874225-9bae3f00-9352-11e9-99d2-fbf284842ec6.png)

New:
![image](https://user-images.githubusercontent.com/8787187/59874284-c7312980-9352-11e9-85e8-980758f746b5.png)

