### PR TITLE
Prevent (but not entirely fix) another pathway to multiple account creation

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -38,7 +38,17 @@ $(document).ready(() => {
     renderSchoolInfo();
   }
 
+  let alreadySubmitted = false;
   $('.finish-signup').submit(function() {
+    // prevent multiple submission. We want to do this to defend against
+    // attempting to create multiple accounts, and it's valid to simply disable
+    // after the first attempt here since this form is submitted via HTML and
+    // will therefore initiate a page load after submission.
+    if (alreadySubmitted) {
+      return false;
+    }
+
+    alreadySubmitted = true;
     // Clean up school data and set age for teachers.
     if (getUserType() === 'teacher') {
       cleanSchoolInfo();


### PR DESCRIPTION
Specifically, https://app.honeybadger.io/projects/3240/faults/51067761

By only allowing the form to be submitted once per page load, we hope to
prevent the sending of multiple requests to the "create" endpoint, which
can in rare race conditions result in multiple accounts being created.

Two things to note:

1. It's valid to only disable and never reenable, since this form
   submits via HTML rather than JS, and so expects a page load upon
   response
2. This does not actually fix the underlying issue, which is that a race
   condition in requests may result in multiple invalid accounts being
   created. That issue will need to be fixed as a followup work item.