### PR TITLE
treat readonly assessment levels as completed

### DIFF
--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -142,6 +142,7 @@ export function summarizeProgressInStage(levelsWithStatus) {
       case LevelStatus.submitted:
       case LevelStatus.free_play_complete:
       case LevelStatus.completed_assessment:
+      case LevelStatus.readonly:
         statusCounts.completed = statusCounts.completed + 1;
         break;
       case LevelStatus.not_tried:

--- a/apps/test/unit/templates/progress/progressHelpersTest.js
+++ b/apps/test/unit/templates/progress/progressHelpersTest.js
@@ -264,14 +264,16 @@ describe('progressHelpers', () => {
     });
 
     it('summarizes all completed levels', () => {
-      const levels = fakeLevels(4).map(level => ({
-        ...level,
-        status: LevelStatus.perfect
-      }));
+      const levels = fakeLevels(3);
+      levels[0].status = LevelStatus.perfect;
+      levels[1].status = LevelStatus.submitted;
+      levels[2].status = LevelStatus.readonly;
+
       const summarizedStage = summarizeProgressInStage(levels);
-      assert.equal(summarizedStage.total, 4);
+      assert.equal(summarizedStage.total, 3);
       assert.equal(summarizedStage.incomplete, 0);
-      assert.equal(summarizedStage.completed, 4);
+      assert.equal(summarizedStage.completed, 3);
+      assert.equal(summarizedStage.attempted, 0);
     });
 
     it('summarizes all attempted levels', () => {


### PR DESCRIPTION
### Background

Fixes https://codedotorg.atlassian.net/browse/LP-209 "Progress detail view displaying inconsistent assessment data". Specifically, the summary view shows "readonly" assessments as empty/white squares, while the details view shows them as purple.

### Description

Treat "readonly" assessment levels as "completed" in the summary progress view. This makes the behaviors consistent with the details view.