### PR TITLE
Use the same worker base class and context object

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
@@ -6,8 +6,9 @@ import Results from './results';
 import color from '@cdo/apps/util/color';
 
 const styles = {
-  errorBox: {
-    margin: 15
+  errorContainer: {
+    marginTop: 15,
+    marginLeft: 15
   },
   errorDetailsBox: {
     backgroundColor: color.lightest_gray,
@@ -62,7 +63,7 @@ export class ResultsLoader extends React.Component {
 
   renderErrors() {
     return (
-      <div id="error_list" style={styles.errorBox}>
+      <div id="error_list" style={styles.errorContainer}>
         <h1>An error occurred</h1>
         <p>
           Unfortunately this request could not be processed. Our team has been

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_joiner.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_joiner.rb
@@ -7,10 +7,15 @@ module Pd::SurveyPipeline
     REQUIRED_INPUT_KEYS = [:questions, :submissions]
     OUTPUT_KEYS = [:question_answer_joined]
 
-    # TODO: summary, explain input param, raise.
+    # @param context [Hash] contains necessary input for this worker to process.
+    #   Results are added back to the context object.
+    #
+    # @return [Hash] the same context object.
+    #
+    # @raise [RuntimeError] if required input keys are missing.
+    #
     def self.process_data(context)
-      missing_keys = REQUIRED_INPUT_KEYS - context.keys
-      raise "Missing required input key(s) in #{self.class.name}: #{missing_keys}" if missing_keys.present?
+      check_required_input_keys REQUIRED_INPUT_KEYS, context
 
       results = transform_data context.slice(*REQUIRED_INPUT_KEYS)
 
@@ -26,12 +31,12 @@ module Pd::SurveyPipeline
     # so they can be summarized later.
     #
     # @param questions [Hash{form_id => {question_id => question_content}}]
-    # @param answers [Hash{form_id => {submission_id => submission_content}}]
+    # @param submissions [Hash{form_id => {submission_id => submission_content}}]
     #
-    # @return [Array<Hash>]
-    #   Hash has following keys: form_id, submission_id,
+    # @return [Hash{:question_answer_joined => Array<Hash>}]
+    #   Each hash in value array has following keys: form_id, submission_id,
     #   user_id, pd_session_id, pd_workshop_id, day, facilitator_id, answer,
-    #   qid, type, name, text, order, hidden, options, max_value, parent
+    #   qid, type, name, text, order, hidden, options, max_value, parent.
     #
     # @note This method could change input data such as adding sub questions into
     # question list.

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_parser.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_parser.rb
@@ -3,12 +3,17 @@ module Pd::SurveyPipeline
     include Pd::JotForm::Constants
 
     REQUIRED_INPUT_KEYS = [:survey_questions, :workshop_submissions, :facilitator_submissions]
-    OUTPUT_KEYS = [:questions, :submissions]
+    OUTPUT_KEYS = [:parsed_questions, :parsed_submissions]
 
-    # TODO: summary, explain input param, raise.
+    # @param context [Hash] contains necessary input for this worker to process.
+    #   Results are added back to the context object.
+    #
+    # @return [Hash] the same context object.
+    #
+    # @raise [RuntimeError] if required input keys are missing.
+    #
     def self.process_data(context)
-      missing_keys = REQUIRED_INPUT_KEYS - context.keys
-      raise "Missing required input key(s) in #{self.class.name}: #{missing_keys}" if missing_keys.present?
+      check_required_input_keys REQUIRED_INPUT_KEYS, context
 
       results = transform_data context.slice(*REQUIRED_INPUT_KEYS)
 
@@ -33,8 +38,8 @@ module Pd::SurveyPipeline
       facilitator_submissions = parse_submissions(facilitator_submissions)
 
       {
-        questions: parse_questions(survey_questions),
-        submissions: workshop_submissions.merge(facilitator_submissions)
+        parsed_questions: parse_questions(survey_questions),
+        parsed_submissions: workshop_submissions.merge(facilitator_submissions)
       }
     end
 

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_parser.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_parser.rb
@@ -1,8 +1,24 @@
-require_relative 'transformer.rb'
-
 module Pd::SurveyPipeline
-  class DailySurveyParser < TransformerBase
+  class DailySurveyParser < SurveyPipelineWorker
     include Pd::JotForm::Constants
+
+    REQUIRED_INPUT_KEYS = [:survey_questions, :workshop_submissions, :facilitator_submissions]
+    OUTPUT_KEYS = [:questions, :submissions]
+
+    # TODO: summary, explain input param, raise.
+    def self.process_data(context)
+      missing_keys = REQUIRED_INPUT_KEYS - context.keys
+      raise "Missing required input key(s) in #{self.class.name}: #{missing_keys}" if missing_keys.present?
+
+      results = transform_data context.slice(*REQUIRED_INPUT_KEYS)
+
+      OUTPUT_KEYS.each do |key|
+        context[key] ||= {}
+        context[key].merge! results[key]
+      end
+
+      context
+    end
 
     # Parse input records into hashes.
     #
@@ -11,19 +27,15 @@ module Pd::SurveyPipeline
     # @param facilitator_submissions [Array<Pd::WorkshopFacilitatorDailySurvey>]
     #
     # @return [Hash{:questions, :submissions => Hash}]
-    #   @see output of parse_survey and parse_submissions for the structures of those hash values.
+    #
     def self.transform_data(survey_questions:, workshop_submissions:, facilitator_submissions:)
-      raise 'Invalid input parameter' unless survey_questions &&
-        workshop_submissions && facilitator_submissions
-
-      # Parse questions in surveys
-      questions = parse_survey(survey_questions)
-
-      # Parse submissions
       workshop_submissions = parse_submissions(workshop_submissions)
       facilitator_submissions = parse_submissions(facilitator_submissions)
 
-      {questions: questions, submissions: workshop_submissions.merge(facilitator_submissions)}
+      {
+        questions: parse_questions(survey_questions),
+        submissions: workshop_submissions.merge(facilitator_submissions)
+      }
     end
 
     # Parse an array of submissions into hashes.
@@ -36,6 +48,7 @@ module Pd::SurveyPipeline
     #   submission_content[:answer] is Hash{qid => answer_content}.
     #   answer_content is Array<Hash{:text, :answer => String}> for matrix question, and string
     #   for other question types.
+    #
     def self.parse_submissions(survey_submissions)
       parsed_submissions = {}
 
@@ -86,7 +99,8 @@ module Pd::SurveyPipeline
     # @return [Hash{form_id => {question_id => question_content}}]
     #   question_content is Hash{:type, :name, :text, :order, :hidden}.
     #   It could also have question-specific keys such as :options, :sub_questions etc.
-    def self.parse_survey(survey_questions)
+    #
+    def self.parse_questions(survey_questions)
       parsed_questions = {}
 
       # questions field in Pd::SurveyQuestion is an array of hashes, with each hash is

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_retriever.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_retriever.rb
@@ -3,17 +3,15 @@ module Pd::SurveyPipeline
     REQUIRED_INPUT_KEYS = [:filters]
     OUTPUT_KEYS = [:survey_questions, :workshop_submissions, :facilitator_submissions]
 
-    # TODO: summary, explain input param, raise.
-    # @param context [Hash]
-    # @return the same context
-    # @raise
+    # @param context [Hash] contains necessary input for this worker to process.
+    #   Results are added back to the context object.
     #
-    # @note This function modifies content of input parameter.
+    # @return [Hash] the same context object.
+    #
+    # @raise [RuntimeError] if required input keys are missing.
     #
     def self.process_data(context)
-      missing_keys = REQUIRED_INPUT_KEYS - context.keys
-      # TODO: raise ArgumentError and write test
-      raise "Missing required input key(s) in #{self.class.name}: #{missing_keys}" if missing_keys.present?
+      check_required_input_keys REQUIRED_INPUT_KEYS, context
 
       results = retrieve_data context.slice(*REQUIRED_INPUT_KEYS)
 

--- a/dashboard/lib/pd/survey_pipeline/decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/decorator.rb
@@ -1,7 +1,0 @@
-module Pd::SurveyPipeline
-  class DecoratorBase
-    def self.decorate(*)
-      raise 'Must override in derived class'
-    end
-  end
-end

--- a/dashboard/lib/pd/survey_pipeline/mapper.rb
+++ b/dashboard/lib/pd/survey_pipeline/mapper.rb
@@ -1,15 +1,13 @@
 require_relative 'reducer.rb'
 
 module Pd::SurveyPipeline
-  class MapperBase
-    def map_reduce(*)
-      raise 'Must override in derived class'
-    end
-  end
-
-  class GenericMapper < MapperBase
+  class GenericMapper < SurveyPipelineWorker
     attr_reader :group_config, :map_config
 
+    REQUIRED_INPUT_KEYS = [:question_answer_joined]
+    OUTPUT_KEYS = [:summaries]
+
+    # TODO: summary
     # @param group_config [Array<key>] an array of keys in data going to be processed.
     # @param map_config [Array<Hash{:condition, :field, :reducers => lambda, key, Array}>]
     #   an array of rules that specify what reducers to apply on what fields when what
@@ -17,23 +15,39 @@ module Pd::SurveyPipeline
     #   :condition is a lambda.
     #   :field is a key in data going to be processed.
     #   :reducers is an array of ReducerBase-derived classes.
+    #
     def initialize(group_config:, map_config:)
       @group_config = group_config
       @map_config = map_config
     end
 
+    def process_data(context)
+      missing_keys = REQUIRED_INPUT_KEYS - context.keys
+      raise "Missing required input key(s) in #{self.class.name}: #{missing_keys}" if missing_keys.present?
+
+      results = map_reduce context.slice(*REQUIRED_INPUT_KEYS)
+
+      OUTPUT_KEYS.each do |key|
+        context[key] ||= []
+        context[key] += results[key]
+      end
+
+      context
+    end
+
+    # TODO: update @return
     # Summarize input data using groupping and mapping configurations.
     #
-    # @param data [Array<Hash{}>] an array of hashes,
+    # @param question_answer_joined [Array<Hash{}>] an array of hashes,
     #   each contains submission, question, and answer info.
     #
-    # @return [Array<Hash>] an array of summarization results. Each hash contains
-    #   all fields in group_config, reducer name and reducer result.
-    def map_reduce(data)
-      return unless data.is_a? Enumerable
-
-      groups = group_data data
-      map_to_reducers groups
+    # @return [Hash{:summaries => Array<Hash>}] contains an array of summarization results.
+    #   Each result contains all fields in group_config, reducer name and reducer result.
+    #
+    def map_reduce(question_answer_joined:)
+      # TODO: use generic input name `data`?
+      groups = group_data question_answer_joined
+      {summaries: map_to_reducers(groups)}
     end
 
     # Break data into groups using groupping configuration.

--- a/dashboard/lib/pd/survey_pipeline/mapper.rb
+++ b/dashboard/lib/pd/survey_pipeline/mapper.rb
@@ -7,7 +7,8 @@ module Pd::SurveyPipeline
     REQUIRED_INPUT_KEYS = [:question_answer_joined]
     OUTPUT_KEYS = [:summaries]
 
-    # TODO: summary
+    # Configure mapper object.
+    #
     # @param group_config [Array<key>] an array of keys in data going to be processed.
     # @param map_config [Array<Hash{:condition, :field, :reducers => lambda, key, Array}>]
     #   an array of rules that specify what reducers to apply on what fields when what
@@ -21,9 +22,15 @@ module Pd::SurveyPipeline
       @map_config = map_config
     end
 
+    # @param context [Hash] contains necessary input for this worker to process.
+    #   Results are added back to the context object.
+    #
+    # @return [Hash] the same context object.
+    #
+    # @raise [RuntimeError] if required input keys are missing.
+    #
     def process_data(context)
-      missing_keys = REQUIRED_INPUT_KEYS - context.keys
-      raise "Missing required input key(s) in #{self.class.name}: #{missing_keys}" if missing_keys.present?
+      self.class.check_required_input_keys REQUIRED_INPUT_KEYS, context
 
       results = map_reduce context.slice(*REQUIRED_INPUT_KEYS)
 
@@ -35,17 +42,15 @@ module Pd::SurveyPipeline
       context
     end
 
-    # TODO: update @return
     # Summarize input data using groupping and mapping configurations.
     #
     # @param question_answer_joined [Array<Hash{}>] an array of hashes,
     #   each contains submission, question, and answer info.
     #
-    # @return [Hash{:summaries => Array<Hash>}] contains an array of summarization results.
-    #   Each result contains all fields in group_config, reducer name and reducer result.
+    # @return [Hash{:summaries => Array<Hash>}] a collection of survey summaries.
+    #   Each summary contains all fields in group_config, reducer name and reducer result.
     #
     def map_reduce(question_answer_joined:)
-      # TODO: use generic input name `data`?
       groups = group_data question_answer_joined
       {summaries: map_to_reducers(groups)}
     end

--- a/dashboard/lib/pd/survey_pipeline/retriever.rb
+++ b/dashboard/lib/pd/survey_pipeline/retriever.rb
@@ -1,7 +1,0 @@
-module Pd::SurveyPipeline
-  class RetrieverBase
-    def retrieve_data(*)
-      raise 'Must override in derived class'
-    end
-  end
-end

--- a/dashboard/lib/pd/survey_pipeline/survey_pipeline_worker.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_pipeline_worker.rb
@@ -3,5 +3,11 @@ module Pd::SurveyPipeline
     def self.process_data(*)
       raise 'Must override in derived class'
     end
+
+    def self.check_required_input_keys(required_keys, input)
+      missing_keys = required_keys - input.keys
+      raise "Missing required input key(s) in #{self}: #{missing_keys}" if
+        missing_keys.present?
+    end
   end
 end

--- a/dashboard/lib/pd/survey_pipeline/survey_pipeline_worker.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_pipeline_worker.rb
@@ -1,0 +1,7 @@
+module Pd::SurveyPipeline
+  class SurveyPipelineWorker
+    def self.process_data(*)
+      raise 'Must override in derived class'
+    end
+  end
+end

--- a/dashboard/lib/pd/survey_pipeline/transformer.rb
+++ b/dashboard/lib/pd/survey_pipeline/transformer.rb
@@ -1,7 +1,0 @@
-module Pd::SurveyPipeline
-  class TransformerBase
-    def transform_data(*)
-      raise 'Must override in derived class'
-    end
-  end
-end

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -278,8 +278,8 @@ module Api::V1::Pd
       get :generic_survey_report, params: {workshop_id: csf_201_ws.id}
       result = JSON.parse(@response.body).slice(*expected_result.keys)
 
-      assert_equal expected_result, result
       assert_response :success
+      assert_equal expected_result, result
     end
 
     test 'generic_survey_report: CSF101 workshop cannot invoke this action' do

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -278,8 +278,8 @@ module Api::V1::Pd
       get :generic_survey_report, params: {workshop_id: csf_201_ws.id}
       result = JSON.parse(@response.body).slice(*expected_result.keys)
 
-      assert_response :success
       assert_equal expected_result, result
+      assert_response :success
     end
 
     test 'generic_survey_report: CSF101 workshop cannot invoke this action' do

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -95,8 +95,8 @@ module Pd::SurveyPipeline
 
       context = {
         summaries: summary_data,
-        questions: parsed_questions,
-        submissions: parsed_submissions,
+        parsed_questions: parsed_questions,
+        parsed_submissions: parsed_submissions,
         current_user: @workshop_admin
       }
 
@@ -165,8 +165,8 @@ module Pd::SurveyPipeline
 
       context = {
         summaries: summary_data,
-        questions: parsed_questions,
-        submissions: parsed_submissions,
+        parsed_questions: parsed_questions,
+        parsed_submissions: parsed_submissions,
         current_user: @workshop_admin
       }
 

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'pd/survey_pipeline/daily_survey_decorator.rb'
 
 module Pd::SurveyPipeline
-  class DailySurveyParserTest < ActiveSupport::TestCase
+  class DailySurveyDecoratorTest < ActiveSupport::TestCase
     include Pd::WorkshopConstants
 
     self.use_transactional_test_case = true
@@ -25,8 +25,7 @@ module Pd::SurveyPipeline
       form_id = "91405279991164".to_i
       form_name = 'Facilitator'
 
-      parsed_data = {}
-      parsed_data[:questions] = {
+      parsed_questions = {
         form_id => {
           '1' => {type: 'radio', name: 'importance', text: 'CS is important?', order: 1,
             options: ['Disagree', 'Neutral', 'Agree'],
@@ -36,7 +35,7 @@ module Pd::SurveyPipeline
         }
       }
 
-      parsed_data[:submissions] = {
+      parsed_submissions = {
         form_id => {
           1 => {workshop_id: @workshop.id, user_id: 1, facilitator_id: @facilitators.first.id,
             answers: {'1' => 'Agree', '2' => 'Feedback 1'}},
@@ -66,8 +65,8 @@ module Pd::SurveyPipeline
           form_name => {
             general: {},
             facilitator: {
-              'importance' => parsed_data[:questions][form_id]['1'].except(:name),
-              'feedback' => parsed_data[:questions][form_id]['2'].except(:name),
+              'importance' => parsed_questions[form_id]['1'].except(:name),
+              'feedback' => parsed_questions[form_id]['2'].except(:name),
             }
           }
         },
@@ -90,22 +89,27 @@ module Pd::SurveyPipeline
         all_my_workshops: {},
         facilitators: {},
         facilitator_averages: {},
-        facilitator_response_counts: {}
+        facilitator_response_counts: {},
+        errors: []
       }
 
-      result = DailySurveyDecorator.decorate summary_data: summary_data,
-        parsed_data: parsed_data,
+      context = {
+        summaries: summary_data,
+        questions: parsed_questions,
+        submissions: parsed_submissions,
         current_user: @workshop_admin
+      }
 
-      assert_equal expected_result, result
+      DailySurveyDecorator.process_data context
+
+      assert_equal expected_result, context[:decorated_summaries]
     end
 
     test 'decorate general survey results' do
       form_id = "90066184161150".to_i
       form_name = 'Pre Workshop'
 
-      parsed_data = {}
-      parsed_data[:questions] = {
+      parsed_questions = {
         form_id => {
           '1' => {type: 'radio', name: 'importance', text: 'CS is important?', order: 1,
             options: ['Disagree', 'Neutral', 'Agree'],
@@ -115,7 +119,7 @@ module Pd::SurveyPipeline
         }
       }
 
-      parsed_data[:submissions] = {
+      parsed_submissions = {
         form_id => {
           1 => {workshop_id: @workshop.id, user_id: 1, answers: {'1' => 'Agree', '2' => 'Feedback 1'}},
           2 => {workshop_id: @workshop.id, user_id: 2, answers: {'1' => 'Agree', '2' => 'Feedback 2'}},
@@ -136,8 +140,8 @@ module Pd::SurveyPipeline
         questions: {
           form_name => {
             general: {
-              'importance' => parsed_data[:questions][form_id]['1'].except(:name),
-              'feedback' => parsed_data[:questions][form_id]['2'].except(:name),
+              'importance' => parsed_questions[form_id]['1'].except(:name),
+              'feedback' => parsed_questions[form_id]['2'].except(:name),
             },
             facilitator: {}
           }
@@ -155,14 +159,20 @@ module Pd::SurveyPipeline
         all_my_workshops: {},
         facilitators: {},
         facilitator_averages: {},
-        facilitator_response_counts: {}
+        facilitator_response_counts: {},
+        errors: []
       }
 
-      result = DailySurveyDecorator.decorate summary_data: summary_data,
-        parsed_data: parsed_data,
+      context = {
+        summaries: summary_data,
+        questions: parsed_questions,
+        submissions: parsed_submissions,
         current_user: @workshop_admin
+      }
 
-      assert_equal expected_result, result
+      DailySurveyDecorator.process_data context
+
+      assert_equal expected_result, context[:decorated_summaries]
     end
 
     test 'index questions by form ids and question names' do

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
@@ -20,17 +20,6 @@ module Pd::SurveyPipeline
       }
     end
 
-    test 'raise if missing input keys' do
-      context = {}
-
-      # TODO: check class name in error message is correct and enough to find where the issue is
-      exception = assert_raises RuntimeError do
-        DailySurveyJoiner.process_data context
-      end
-
-      assert exception.message.start_with?('Missing required input key')
-    end
-
     test 'join submission and non-matrix questions' do
       # Set up questions for 1 form
       question_content = {

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
@@ -20,6 +20,17 @@ module Pd::SurveyPipeline
       }
     end
 
+    test 'raise if missing input keys' do
+      context = {}
+
+      # TODO: check class name in error message is correct and enough to find where the issue is
+      exception = assert_raises RuntimeError do
+        DailySurveyJoiner.process_data context
+      end
+
+      assert exception.message.start_with?('Missing required input key')
+    end
+
     test 'join submission and non-matrix questions' do
       # Set up questions for 1 form
       question_content = {
@@ -52,9 +63,10 @@ module Pd::SurveyPipeline
         submission_no_content.merge(question_content['Q3']).merge(qid: 'Q3', answer: 'Like it')
       ]
 
-      result = DailySurveyJoiner.transform_data questions: questions, submissions: submissions
+      context = {questions: questions, submissions: submissions}
+      DailySurveyJoiner.process_data context
 
-      assert_equal expected_result, result
+      assert_equal expected_result, context[:question_answer_joined]
     end
 
     test 'join submission and matrix questions' do
@@ -105,9 +117,10 @@ module Pd::SurveyPipeline
           )
       end
 
-      result = DailySurveyJoiner.transform_data questions: questions, submissions: submissions
+      context = {questions: questions, submissions: submissions}
+      DailySurveyJoiner.process_data context
 
-      assert_equal expected_result, result
+      assert_equal expected_result, context[:question_answer_joined]
     end
   end
 end

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
@@ -52,7 +52,7 @@ module Pd::SurveyPipeline
         submission_no_content.merge(question_content['Q3']).merge(qid: 'Q3', answer: 'Like it')
       ]
 
-      context = {questions: questions, submissions: submissions}
+      context = {parsed_questions: questions, parsed_submissions: submissions}
       DailySurveyJoiner.process_data context
 
       assert_equal expected_result, context[:question_answer_joined]
@@ -106,7 +106,7 @@ module Pd::SurveyPipeline
           )
       end
 
-      context = {questions: questions, submissions: submissions}
+      context = {parsed_questions: questions, parsed_submissions: submissions}
       DailySurveyJoiner.process_data context
 
       assert_equal expected_result, context[:question_answer_joined]

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_parser_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_parser_test.rb
@@ -32,16 +32,6 @@ module Pd::SurveyPipeline
           '{"Sub question 1": "Option 1", "Sub question 2": "Option 2", "Sub question 3": "Option 3"}}'
     end
 
-    test 'raise if missing input keys' do
-      context = {}
-
-      exception = assert_raises RuntimeError do
-        DailySurveyParser.process_data context
-      end
-
-      assert exception.message.start_with?('Missing required input key')
-    end
-
     test 'produce output keys' do
       context = {
         survey_questions: [@ws_survey_questions],
@@ -51,8 +41,8 @@ module Pd::SurveyPipeline
 
       DailySurveyParser.process_data context
 
-      assert context[:questions].present?
-      assert context[:submissions].present?
+      assert context[:parsed_questions].present?
+      assert context[:parsed_submissions].present?
     end
 
     test 'can parse questions' do

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_parser_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_parser_test.rb
@@ -9,13 +9,13 @@ module Pd::SurveyPipeline
     self.use_transactional_test_case = true
 
     setup_all do
-      @ws_form_id = 11_000_000_000_000
+      @ws_form_id = "11000000000000".to_i
 
       ws = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201, num_sessions: 1
       teacher = create :teacher
       day = 0
 
-      @ws_survey = create :pd_survey_question, form_id: @ws_form_id,
+      @ws_survey_questions = create :pd_survey_question, form_id: @ws_form_id,
         questions: '['\
           '{"id": 1, "type": "number", "name": "overallRating", "text": "Overall rating"},'\
           '{"id": 2, "type": "dropdown", "name": "selectOption", "text": "Select one of the options",'\
@@ -32,7 +32,30 @@ module Pd::SurveyPipeline
           '{"Sub question 1": "Option 1", "Sub question 2": "Option 2", "Sub question 3": "Option 3"}}'
     end
 
-    test 'can parse survey' do
+    test 'raise if missing input keys' do
+      context = {}
+
+      exception = assert_raises RuntimeError do
+        DailySurveyParser.process_data context
+      end
+
+      assert exception.message.start_with?('Missing required input key')
+    end
+
+    test 'produce output keys' do
+      context = {
+        survey_questions: [@ws_survey_questions],
+        workshop_submissions: [@ws_submission],
+        facilitator_submissions: []
+      }
+
+      DailySurveyParser.process_data context
+
+      assert context[:questions].present?
+      assert context[:submissions].present?
+    end
+
+    test 'can parse questions' do
       expected_result = {
         @ws_form_id => {
           '1' => {type: 'number', name: 'overallRating', text: 'Overall rating',
@@ -51,7 +74,7 @@ module Pd::SurveyPipeline
         }
       }
 
-      result = DailySurveyParser.parse_survey([@ws_survey])
+      result = DailySurveyParser.parse_questions([@ws_survey_questions])
 
       assert_equal expected_result, result
     end

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_retriever_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_retriever_test.rb
@@ -36,76 +36,75 @@ module Pd::SurveyPipeline
       end
     end
 
+    test 'raise if missing input key' do
+      context = {}
+
+      exception = assert_raises RuntimeError do
+        DailySurveyRetriever.process_data context
+      end
+
+      assert exception.message.start_with?('Missing required input key')
+    end
+
     test 'can retrieve all data if no filter' do
-      retriever = Pd::SurveyPipeline::DailySurveyRetriever.new
+      context = {filters: {}}
+      DailySurveyRetriever.process_data context
 
-      result = retriever.retrieve_data
-
-      assert_equal @workshop_submissions.length, result[:workshop_submissions]&.length
-      assert_equal @facilitator_submissions.length, result[:facilitator_submissions]&.length
-      assert_equal @survey_questions.length, result[:survey_questions]&.length
+      assert_equal @workshop_submissions.length, context[:workshop_submissions]&.length
+      assert_equal @facilitator_submissions.length, context[:facilitator_submissions]&.length
+      assert_equal @survey_questions.length, context[:survey_questions]&.length
     end
 
     test 'can retrieve data using workshop id filter' do
-      filter = {workshop_ids: @workshops.first.id}
-      retriever = Pd::SurveyPipeline::DailySurveyRetriever.new filter
-
-      result = retriever.retrieve_data
+      context = {filters: {workshop_ids: @workshops.first.id}}
+      DailySurveyRetriever.process_data context
 
       assert_equal @workshop_submissions.length / @workshops.length,
-        result[:workshop_submissions]&.length
+        context[:workshop_submissions]&.length
       assert_equal @facilitator_submissions.length / @workshops.length,
-        result[:facilitator_submissions]&.length
+        context[:facilitator_submissions]&.length
       assert_equal @workshop_form_ids.length + @facilitator_form_ids.length,
-        result[:survey_questions]&.length
+        context[:survey_questions]&.length
     end
 
     test 'can retrieve data using form id filter' do
-      filter = {form_ids: @workshop_form_ids.first}
-      retriever = Pd::SurveyPipeline::DailySurveyRetriever.new filter
-
-      result = retriever.retrieve_data
+      context = {filters: {form_ids: @workshop_form_ids.first}}
+      DailySurveyRetriever.process_data context
 
       assert_equal @workshop_submissions.length / @workshop_form_ids.length,
-        result[:workshop_submissions]&.length
-      assert_equal 0, result[:facilitator_submissions]&.length
-      assert_equal 1, result[:survey_questions]&.length
+        context[:workshop_submissions]&.length
+      assert_equal 0, context[:facilitator_submissions]&.length
+      assert_equal 1, context[:survey_questions]&.length
     end
 
     test 'can retrieve data using both workshop id and form id filters' do
-      filter = {workshop_ids: @workshops.first.id, form_ids: @facilitator_form_ids.first}
-      retriever = Pd::SurveyPipeline::DailySurveyRetriever.new filter
+      context = {filters: {workshop_ids: @workshops.first.id, form_ids: @facilitator_form_ids.first}}
+      DailySurveyRetriever.process_data context
 
-      result = retriever.retrieve_data
-
-      assert_equal 0, result[:workshop_submissions]&.length
+      assert_equal 0, context[:workshop_submissions]&.length
       assert_equal @facilitator_submissions.size / (@workshops.length * @facilitator_form_ids.size),
-        result[:facilitator_submissions]&.length
-      assert_equal 1, result[:survey_questions]&.length
+        context[:facilitator_submissions]&.length
+      assert_equal 1, context[:survey_questions]&.length
     end
 
     test 'return empty if workshop does not have submission' do
       # Use non-existence workshop id as filter
-      filter = {workshop_ids: @workshops.pluck(:id).max + 1}
-      retriever = Pd::SurveyPipeline::DailySurveyRetriever.new filter
+      context = {filters: {workshop_ids: @workshops.pluck(:id).max + 1}}
+      DailySurveyRetriever.process_data context
 
-      result = retriever.retrieve_data
-
-      assert_equal 0, result[:workshop_submissions]&.length
-      assert_equal 0, result[:facilitator_submissions]&.length
-      assert_equal 0, result[:survey_questions]&.length
+      assert_equal 0, context[:workshop_submissions]&.length
+      assert_equal 0, context[:facilitator_submissions]&.length
+      assert_equal 0, context[:survey_questions]&.length
     end
 
     test 'return empty if form does not have submission' do
       # Use non-existence form id as filter
-      filter = {form_ids: @workshop_form_ids.max + 1}
-      retriever = Pd::SurveyPipeline::DailySurveyRetriever.new filter
+      context = {filters: {form_ids: @workshop_form_ids.max + 1}}
+      DailySurveyRetriever.process_data context
 
-      result = retriever.retrieve_data
-
-      assert_equal 0, result[:workshop_submissions]&.length
-      assert_equal 0, result[:facilitator_submissions]&.length
-      assert_equal 0, result[:survey_questions]&.length
+      assert_equal 0, context[:workshop_submissions]&.length
+      assert_equal 0, context[:facilitator_submissions]&.length
+      assert_equal 0, context[:survey_questions]&.length
     end
   end
 end

--- a/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
@@ -23,6 +23,8 @@ module Pd::SurveyPipeline
       }
     end
 
+    # TODO: test main `map_reduce` function. It doesn't even run
+
     test 'group data using no key' do
       # Empty group config returns 1 group with all data
       summary = group_and_summarize([])

--- a/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
@@ -28,7 +28,7 @@ module Pd::SurveyPipeline
       always_true = lambda {|_| true}
       map_config = [{condition: always_true, field: :c, reducers: [Pd::SurveyPipeline::AvgReducer]}]
 
-      # Average value of field :c in @data, groupped by field :a and :b
+      # Average value of field :c in @data, grouped by field :a and :b
       expected_avg = 0.5
 
       context = {question_answer_joined: @data}

--- a/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
@@ -23,7 +23,21 @@ module Pd::SurveyPipeline
       }
     end
 
-    # TODO: test main `map_reduce` function. It doesn't even run
+    test 'map and reduce basic data' do
+      group_config = [:a, :b]
+      always_true = lambda {|_| true}
+      map_config = [{condition: always_true, field: :c, reducers: [Pd::SurveyPipeline::AvgReducer]}]
+
+      # Average value of field :c in @data, groupped by field :a and :b
+      expected_avg = 0.5
+
+      context = {question_answer_joined: @data}
+
+      mapper = GenericMapper.new(group_config: group_config, map_config: map_config)
+      mapper.process_data context
+
+      assert_equal [expected_avg], context[:summaries].pluck(:reducer_result).uniq
+    end
 
     test 'group data using no key' do
       # Empty group config returns 1 group with all data

--- a/dashboard/test/lib/pd/survey_pipeline/survey_pipeline_worker_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/survey_pipeline_worker_test.rb
@@ -1,0 +1,14 @@
+module Pd::SurveyPipeline
+  class DailySurveyDecoratorTest < ActiveSupport::TestCase
+    test 'raise if missing input key' do
+      input = {key1: nil}
+      required_keys = [:key1, :key2, :key3]
+
+      exception = assert_raises RuntimeError do
+        SurveyPipelineWorker.check_required_input_keys required_keys, input
+      end
+
+      assert exception.message.start_with?('Missing required input key')
+    end
+  end
+end


### PR DESCRIPTION
[PLC-316](https://codedotorg.atlassian.net/browse/PLC-316)

### What
- All components in the survey pipeline (Retriever, Parser, Joiner, Mapper, Decorator) are now derived from the same base class `SurveyPipelineWorker`, have the same function signature `process_data(context)` and read from/write to the same object `context`.

### Why
- Previously, each component in the pipeline has different set of input parameters, making it less flexible to write generic code to chain them together. Now all components have the same function signature and can be connected in any order in a single line of code `workers.each { |w| w.process_data context }`. This makes it much easier to calculate roll-up scores or do other special calculation later.

- Previously, non-fatal errors in components or sub-components are not surfaced up to higher layer and to presentation layer. Presentation layer can't warn user about potentially incorrect result or guide user to troubleshoot. Using the same `context` object among all components allow them to easily bubble up and compile non-fatal errors in 1 place. The results are then sent to presentation layer.

### How tested
- Unit tests
  - bundle exec rails test test/lib/pd/survey_pipeline/survey_pipeline_worker_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/mapper_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_parser_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_retriever_test.rb
  - bundle exec rails test test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb

- Manual integration test
  - Create CSF 201 workshop (6482) with workshop and facilitator daily surveys locally.
  - API check: http://localhost-studio.code.org:3000/api/v1/pd/workshops/6482/generic_survey_report
  - UI check: http://localhost-studio.code.org:3000/pd/workshop_dashboard/daily_survey_results/6482

### Note
This PR looks bigger than it should be since a lot of it are comments and variable name changes. The real logic changes are in the base class `SurveyPipelineWorker`, the component signature `process_data(context)`, and a few more tests.