### PR TITLE
Require deployment env in i18n sync script

### DIFF
--- a/bin/i18n/sync-codeorg-all.rb
+++ b/bin/i18n/sync-codeorg-all.rb
@@ -19,6 +19,7 @@
 # Otherwise, if run with one of the "command" flags, will run a single step of
 # the full sync
 
+require_relative '../../deployment'
 require_relative '../../lib/cdo/only_one'
 require_relative '../../lib/cdo/github'
 


### PR DESCRIPTION
So we don't have to bundle exec it

Capturing changes that are already on i18n server, so the build doesn't fail with a merge conflict