### PR TITLE
BubbleChoice landing page UI polish

### DIFF
--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -73,6 +73,8 @@ export default class BubbleChoice extends React.Component {
 
   render() {
     const {level} = this.props;
+    const backButtonUrl = level.previous_level_url || level.script_url;
+    const continueButtonUrl = level.next_level_url || level.script_url;
 
     return (
       <div>
@@ -98,24 +100,24 @@ export default class BubbleChoice extends React.Component {
           </div>
         ))}
         <div style={styles.btnContainer}>
-          <button
-            type="button"
-            onClick={() =>
-              this.goToUrl(level.previous_level_url || level.script_url)
-            }
-            style={styles.btn}
-          >
-            {i18n.back()}
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              this.goToUrl(level.next_level_url || level.script_url)
-            }
-            style={{...styles.btn, ...styles.btnOrange}}
-          >
-            {level.next_level_url ? i18n.continue() : i18n.finish()}
-          </button>
+          {backButtonUrl && (
+            <button
+              type="button"
+              onClick={() => this.goToUrl(backButtonUrl)}
+              style={styles.btn}
+            >
+              {i18n.back()}
+            </button>
+          )}
+          {continueButtonUrl && (
+            <button
+              type="button"
+              onClick={() => this.goToUrl(continueButtonUrl)}
+              style={{...styles.btn, ...styles.btnOrange}}
+            >
+              {level.next_level_url ? i18n.continue() : i18n.finish()}
+            </button>
+          )}
         </div>
       </div>
     );

--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -35,7 +35,7 @@ const styles = {
   },
   check: {
     fontSize: THUMBNAIL_IMAGE_SIZE,
-    color: '#fff',
+    color: color.white,
     opacity: 0.8
   },
   column: {

--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import {navigateToHref} from '@cdo/apps/utils';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import UnsafeRenderedMarkdown from '@cdo/apps/templates/UnsafeRenderedMarkdown';
 
 const THUMBNAIL_IMAGE_SIZE = 150;
@@ -25,6 +26,17 @@ const styles = {
     width: THUMBNAIL_IMAGE_SIZE,
     height: THUMBNAIL_IMAGE_SIZE,
     backgroundColor: color.lighter_gray
+  },
+  thumbnailOverlay: {
+    position: 'absolute',
+    width: THUMBNAIL_IMAGE_SIZE,
+    height: THUMBNAIL_IMAGE_SIZE,
+    backgroundColor: 'rgba(0, 255, 0, 0.3)'
+  },
+  check: {
+    fontSize: THUMBNAIL_IMAGE_SIZE,
+    color: '#fff',
+    opacity: 0.8
   },
   column: {
     marginLeft: MARGIN * 2
@@ -58,7 +70,8 @@ export default class BubbleChoice extends React.Component {
           id: PropTypes.number.isRequired,
           title: PropTypes.string.isRequired,
           thumbnail_url: PropTypes.string,
-          url: PropTypes.string.isRequired
+          url: PropTypes.string.isRequired,
+          perfect: PropTypes.bool
         })
       )
     })
@@ -108,6 +121,11 @@ export default class BubbleChoice extends React.Component {
         <h2 style={styles.h2}>{i18n.chooseActivity()}</h2>
         {level.sublevels.map(sublevel => (
           <div key={sublevel.id} style={styles.row}>
+            {sublevel.perfect && (
+              <div style={styles.thumbnailOverlay}>
+                <FontAwesome icon="check" style={styles.check} />
+              </div>
+            )}
             {/* Render a square-shaped placeholder if we don't have a thumbnail. */}
             {sublevel.thumbnail_url ? (
               <img src={sublevel.thumbnail_url} style={styles.thumbnail} />

--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -34,9 +34,6 @@ const styles = {
     fontFamily: '"Gotham 5r"',
     color: color.teal
   },
-  btnContainer: {
-    float: 'right'
-  },
   btn: {
     color: color.white,
     backgroundColor: color.lighter_gray,
@@ -71,15 +68,43 @@ export default class BubbleChoice extends React.Component {
     navigateToHref(url + location.search);
   };
 
-  render() {
+  renderButtons = () => {
     const {level} = this.props;
     const backButtonUrl = level.previous_level_url || level.script_url;
     const continueButtonUrl = level.next_level_url || level.script_url;
 
     return (
       <div>
+        {backButtonUrl && (
+          <button
+            type="button"
+            onClick={() => this.goToUrl(backButtonUrl)}
+            style={styles.btn}
+          >
+            {i18n.back()}
+          </button>
+        )}
+        {continueButtonUrl && (
+          <button
+            type="button"
+            onClick={() => this.goToUrl(continueButtonUrl)}
+            style={{...styles.btn, ...styles.btnOrange}}
+          >
+            {level.next_level_url ? i18n.continue() : i18n.finish()}
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  render() {
+    const {level} = this.props;
+
+    return (
+      <div>
         <h1>{level.title}</h1>
         <UnsafeRenderedMarkdown markdown={level.description} />
+        {this.renderButtons()}
         <h2 style={styles.h2}>{i18n.chooseActivity()}</h2>
         {level.sublevels.map(sublevel => (
           <div key={sublevel.id} style={styles.row}>
@@ -99,26 +124,7 @@ export default class BubbleChoice extends React.Component {
             </div>
           </div>
         ))}
-        <div style={styles.btnContainer}>
-          {backButtonUrl && (
-            <button
-              type="button"
-              onClick={() => this.goToUrl(backButtonUrl)}
-              style={styles.btn}
-            >
-              {i18n.back()}
-            </button>
-          )}
-          {continueButtonUrl && (
-            <button
-              type="button"
-              onClick={() => this.goToUrl(continueButtonUrl)}
-              style={{...styles.btn, ...styles.btnOrange}}
-            >
-              {level.next_level_url ? i18n.continue() : i18n.finish()}
-            </button>
-          )}
-        </div>
+        {this.renderButtons()}
       </div>
     );
   }

--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -18,7 +18,8 @@ const styles = {
     marginBottom: MARGIN
   },
   thumbnail: {
-    width: THUMBNAIL_IMAGE_SIZE
+    width: THUMBNAIL_IMAGE_SIZE,
+    height: THUMBNAIL_IMAGE_SIZE
   },
   placeholderThumbnail: {
     width: THUMBNAIL_IMAGE_SIZE,

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -71,7 +71,8 @@ describe('BubbleChoice', () => {
     it('redirect to previous/next levels', () => {
       const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} />);
 
-      assert.equal(2, wrapper.find('button').length);
+      // 4 buttons - 2 "back" and 2 "continue/finish"
+      assert.equal(4, wrapper.find('button').length);
 
       const backButton = wrapper.find('button').at(0);
       backButton.simulate('click');
@@ -95,7 +96,8 @@ describe('BubbleChoice', () => {
       };
       const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} level={level} />);
 
-      assert.equal(2, wrapper.find('button').length);
+      // 4 buttons - 2 "back" and 2 "continue/finish"
+      assert.equal(4, wrapper.find('button').length);
 
       const backButton = wrapper.find('button').at(0);
       backButton.simulate('click');
@@ -120,8 +122,9 @@ describe('BubbleChoice', () => {
       const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} level={level} />);
       const buttons = wrapper.find('button');
 
-      assert.equal(1, buttons.length);
+      assert.equal(2, buttons.length);
       assert.notEqual('Back', buttons.at(0).text());
+      assert.notEqual('Back', buttons.at(1).text());
     });
 
     it('hides continue button if no next level or script url', () => {
@@ -133,8 +136,9 @@ describe('BubbleChoice', () => {
       const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} level={level} />);
       const buttons = wrapper.find('button');
 
-      assert.equal(1, buttons.length);
+      assert.equal(2, buttons.length);
       assert(!['Finish', 'Continue'].includes(buttons.at(0).text()));
+      assert(!['Finish', 'Continue'].includes(buttons.at(1).text()));
     });
   });
 });

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -110,5 +110,31 @@ describe('BubbleChoice', () => {
         DEFAULT_PROPS.level.script_url + window.location.search
       );
     });
+
+    it('hides back button if no previous level or script url', () => {
+      const level = {
+        ...DEFAULT_PROPS.level,
+        previous_level_url: null,
+        script_url: null
+      };
+      const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} level={level} />);
+      const buttons = wrapper.find('button');
+
+      assert.equal(1, buttons.length);
+      assert.notEqual('Back', buttons.at(0).text());
+    });
+
+    it('hides continue button if no next level or script url', () => {
+      const level = {
+        ...DEFAULT_PROPS.level,
+        next_level_url: null,
+        script_url: null
+      };
+      const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} level={level} />);
+      const buttons = wrapper.find('button');
+
+      assert.equal(1, buttons.length);
+      assert(!['Finish', 'Continue'].includes(buttons.at(0).text()));
+    });
   });
 });

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -57,12 +57,14 @@ ruby
   # Summarizes the level.
   # @param [ScriptLevel] script_level. Optional. If provided, the URLs for sublevels,
   # previous/next levels, and script will be included in the summary.
+  # @param [Integer] user_id. Optional. If provided, the "perfect" field will be calculated
+  # in the sublevel summary.
   # @return [Hash]
-  def summarize(script_level: nil)
+  def summarize(script_level: nil, user_id: nil)
     summary = {
       title: title,
       description: description,
-      sublevels: summarize_sublevels(script_level: script_level)
+      sublevels: summarize_sublevels(script_level: script_level, user_id: user_id)
     }
 
     if script_level
@@ -84,8 +86,9 @@ ruby
   # Summarizes the level's sublevels.
   # @param [ScriptLevel] script_level. Optional. If provided, the URLs for sublevels
   # will be included in the summary.
+  # @param [Integer] user_id. Optional. If provided, "perfect" field will be calculated for sublevels.
   # @return [Hash[]]
-  def summarize_sublevels(script_level: nil)
+  def summarize_sublevels(script_level: nil, user_id: nil)
     summary = []
     sublevels.each_with_index do |level, index|
       level_info = {
@@ -94,11 +97,13 @@ ruby
         thumbnail_url: level.try(:thumbnail_url)
       }
 
-      level_info[:url] = if script_level
-                           build_script_level_url(script_level, {sublevel_position: index + 1})
-                         else
-                           level_url(level.id)
-                         end
+      level_info[:url] = script_level ?
+        build_script_level_url(script_level, {sublevel_position: index + 1}) :
+        level_url(level.id)
+
+      if user_id
+        level_info[:perfect] = UserLevel.find_by(level: level, user_id: user_id)&.perfect?
+      end
 
       summary << level_info
     end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -94,9 +94,11 @@ ruby
         thumbnail_url: level.try(:thumbnail_url)
       }
 
-      if script_level
-        level_info[:url] = build_script_level_url(script_level, {sublevel_position: index + 1})
-      end
+      level_info[:url] = if script_level
+                           build_script_level_url(script_level, {sublevel_position: index + 1})
+                         else
+                           level_url(level.id)
+                         end
 
       summary << level_info
     end

--- a/dashboard/app/views/levels/_bubble_choice.html.haml
+++ b/dashboard/app/views/levels/_bubble_choice.html.haml
@@ -1,3 +1,5 @@
+- @page_title = @script_level.level.title
+
 %div#bubble-choice
 
 - data = {}

--- a/dashboard/app/views/levels/_bubble_choice.html.haml
+++ b/dashboard/app/views/levels/_bubble_choice.html.haml
@@ -3,6 +3,7 @@
 %div#bubble-choice
 
 - data = {}
-- data[:level] = @level.summarize(script_level: @script_level)
+- user_id = request.params["user_id"] || current_user&.id
+- data[:level] = @level.summarize(script_level: @script_level, user_id: user_id)
 
 %script{src: minifiable_asset_path('js/levels/_bubble_choice.js'), data: {bubblechoice: data.to_json}}

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -150,6 +150,15 @@ DSL
     refute_nil sublevel_summary.last[:url]
   end
 
+  test 'summarize_sublevels with user_id' do
+    student = create :student
+    create :user_level, user: student, level: @sublevel1, best_result: ActivityConstants::BEST_PASS_RESULT
+    sublevel_summary = @bubble_choice.summarize_sublevels(user_id: student.id)
+    assert_equal 2, sublevel_summary.length
+    assert sublevel_summary.first[:perfect]
+    assert_nil sublevel_summary.last[:perfect]
+  end
+
   test 'best_result_sublevel_id returns sublevel with highest best_result for user' do
     student = create :student
     create :user_level, user: student, level: @sublevel2, best_result: 100

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class BubbleChoiceTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
   self.use_transactional_test_case = true
 
   setup_all do
@@ -88,8 +89,18 @@ DSL
       title: @bubble_choice.title,
       description: @bubble_choice.description,
       sublevels: [
-        {id: @sublevel1.id, title: @sublevel1.display_name, thumbnail_url: @sublevel1.thumbnail_url},
-        {id: @sublevel2.id, title: @sublevel2.name, thumbnail_url: nil}
+        {
+          id: @sublevel1.id,
+          title: @sublevel1.display_name,
+          thumbnail_url: @sublevel1.thumbnail_url,
+          url: level_url(@sublevel1.id)
+        },
+        {
+          id: @sublevel2.id,
+          title: @sublevel2.name,
+          thumbnail_url: nil,
+          url: level_url(@sublevel2.id)
+        }
       ]
     }
 
@@ -115,8 +126,18 @@ DSL
   test 'summarize_sublevels' do
     sublevel_summary = @bubble_choice.summarize_sublevels
     expected_summary = [
-      {id: @sublevel1.id, title: @sublevel1.display_name, thumbnail_url: @sublevel1.thumbnail_url},
-      {id: @sublevel2.id, title: @sublevel2.name, thumbnail_url: nil}
+      {
+        id: @sublevel1.id,
+        title: @sublevel1.display_name,
+        thumbnail_url: @sublevel1.thumbnail_url,
+        url: level_url(@sublevel1.id)
+      },
+      {
+        id: @sublevel2.id,
+        title: @sublevel2.name,
+        thumbnail_url: nil,
+        url: level_url(@sublevel2.id)
+      }
     ]
 
     assert_equal expected_summary, sublevel_summary


### PR DESCRIPTION
[LP-535](https://codedotorg.atlassian.net/browse/LP-535)

Making some tweaks to the BubbleChoice landing page. Most important ones to lay out:
- Add duplicate Back/Continue buttons beneath the level description for easier access
- Hide buttons when URLs are not available (i.e., there are no previous/next levels _and_ there is no script)
- Display green checkmark overlay if user has completed the sublevel
- Explicitly define the sublevel thumbnail images' height

### Before
(Notice that Back/Continue buttons are hidden behind the teacher panel)
![Screen Shot 2019-06-21 at 5 35 46 PM](https://user-images.githubusercontent.com/9812299/59957220-0f337780-944b-11e9-8592-257f9ee695be.png)

### After
![Screen Shot 2019-06-21 at 5 09 46 PM](https://user-images.githubusercontent.com/9812299/59957137-52d9b180-944a-11e9-9284-4a879ecd83e8.png)

### Follow-up Work
- Add a "bubble_choice_description" field to levels so that BubbleChoice sublevels can display an informational description about the level, in the context of BubbleChoice (e.g., "Complete this level to learn the 'Point' block!").