### PR TITLE
Clear text display for preview

### DIFF
--- a/apps/src/gamelab/GameLab.js
+++ b/apps/src/gamelab/GameLab.js
@@ -758,6 +758,7 @@ GameLab.prototype.rerunSetupCode = function() {
   ) {
     return;
   }
+  getStore().dispatch(clearConsole());
   Sounds.getSingleton().muteURLs();
   this.gameLabP5.p5.allSprites.removeSprites();
   if (this.gameLabP5.spritelab) {


### PR DESCRIPTION
Clears the console queue at the beginning of running preview code, so that duplicate lines aren't shown as the code changes

Old:
![text-display-old](https://user-images.githubusercontent.com/8787187/60033102-c7843a00-965c-11e9-8890-a3a2cf40b97a.gif)

New:
![text-display-new](https://user-images.githubusercontent.com/8787187/60033109-cb17c100-965c-11e9-8e46-62669668bf55.gif)
