### PR TITLE
Script Overview: fix flashing notification 

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -78,6 +78,7 @@ class ScriptOverviewHeader extends Component {
     isSignedIn: PropTypes.bool.isRequired,
     isVerifiedTeacher: PropTypes.bool.isRequired,
     hasVerifiedResources: PropTypes.bool.isRequired,
+    verificationCheckComplete: PropTypes.bool,
     showCourseUnitVersionWarning: PropTypes.bool,
     showScriptVersionWarning: PropTypes.bool,
     showRedirectWarning: PropTypes.bool,
@@ -144,7 +145,11 @@ class ScriptOverviewHeader extends Component {
 
     // Checks if the non-verified teacher announcement should be shown
     if (currentView === 'Teacher') {
-      if (!this.props.isVerifiedTeacher && this.props.hasVerifiedResources) {
+      if (
+        this.props.verificationCheckComplete &&
+        !this.props.isVerifiedTeacher &&
+        this.props.hasVerifiedResources
+      ) {
         currentAnnouncements.push({
           notice: i18n.verifiedResourcesNotice(),
           details: i18n.verifiedResourcesDetails(),
@@ -277,5 +282,6 @@ export default connect(state => ({
   isSignedIn: state.progress.signInState === SignInState.SignedIn,
   viewAs: state.viewAs,
   isVerifiedTeacher: state.verifiedTeacher.isVerified,
-  hasVerifiedResources: state.verifiedTeacher.hasVerifiedResources
+  hasVerifiedResources: state.verifiedTeacher.hasVerifiedResources,
+  verificationCheckComplete: state.verifiedTeacher.verificationCheckComplete
 }))(ScriptOverviewHeader);

--- a/apps/src/code-studio/verifiedTeacherRedux.js
+++ b/apps/src/code-studio/verifiedTeacherRedux.js
@@ -10,7 +10,8 @@ const initialState = {
   isVerified: false,
   // True if a page (course/script) has resources that are only available to
   // verified teachers
-  hasVerifiedResources: false
+  hasVerifiedResources: false,
+  verficationCheckComplete: false
 };
 
 export default function verifiedTeacher(state = initialState, action) {
@@ -28,5 +29,8 @@ export default function verifiedTeacher(state = initialState, action) {
     };
   }
 
-  return state;
+  return {
+    ...state,
+    verificationCheckComplete: true
+  };
 }

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewHeaderTest.js
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewHeaderTest.js
@@ -5,6 +5,7 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {NotificationType} from '@cdo/apps/templates/Notification';
 import {VisibilityType} from '../../../../../src/code-studio/scriptAnnouncementsRedux';
 import {UnconnectedScriptOverviewHeader as ScriptOverviewHeader} from '@cdo/apps/code-studio/components/progress/ScriptOverviewHeader';
+import i18n from '@cdo/locale';
 
 const defaultProps = {
   plcHeaderProps: undefined,
@@ -92,12 +93,17 @@ describe('ScriptOverviewHeader', () => {
         {...defaultProps}
         hasVerifiedResources={true}
         isVerifiedTeacher={false}
+        verificationCheckComplete={true}
       />,
       {disableLifecycleMethods: true}
     );
     assert.equal(
       wrapper.find('ScriptAnnouncements').props().announcements.length,
       1
+    );
+    assert.equal(
+      wrapper.find('ScriptAnnouncements').props().announcements[0].notice,
+      i18n.verifiedResourcesNotice()
     );
   });
 
@@ -137,6 +143,7 @@ describe('ScriptOverviewHeader', () => {
         S
         hasVerifiedResources={true}
         isVerifiedTeacher={false}
+        verificationCheckComplete={true}
         announcements={[fakeTeacherAnnouncement]}
       />,
       {disableLifecycleMethods: true}
@@ -153,6 +160,7 @@ describe('ScriptOverviewHeader', () => {
         {...defaultProps}
         hasVerifiedResources={true}
         isVerifiedTeacher={false}
+        verificationCheckComplete={true}
         announcements={[
           fakeTeacherAnnouncement,
           fakeTeacherAndStudentAnnouncement


### PR DESCRIPTION
[LP-145](https://codedotorg.atlassian.net/browse/LP-145)

**PROBLEM**:
There was a bug on the script overview page wherein the "Locked Lessons" notification would briefly flash then disappear for verified teachers who were viewing scripts with verified resources. 

**BEFORE**: 
(the gif takes forever, but if you watch long enough the blue notification appears, then disappears) 
![notification-appear-then-disappear](https://user-images.githubusercontent.com/12300669/60048400-e98fb380-9680-11e9-9d76-af3a75819f78.gif)

This was understandably, confusing for teachers. 

**WHY**:
The underlying issue is that before we know whether a teacher is verified or not we assume they are not, `isVerified == false`. When `isVerified == false` and `hasVerifiedResources == true` we show the "Locked Lessons" notification. But, then when the state changes to reflect that the teacher is verified, `isVerified == true` and the notification disappears. 
<img width="410" alt="Screen Shot 2019-06-24 at 12 07 45 PM" src="https://user-images.githubusercontent.com/12300669/60048579-47240000-9681-11e9-8f62-e7bd9e907e14.png">

**FIX**:
Since the initial false value for `isVerified` means "we don't know yet" not "they are known NOT verified", I added an additional `verificationCheckComplete` prop.  If `verificationCheckComplete == true` then we can trust `isVerified == false` to mean that the user really is a non-verified teacher. With this new prop, the notification does not appear when it shouldn't. 

**AFTER**: 
![notification-fixed](https://user-images.githubusercontent.com/12300669/60049246-bf3ef580-9682-11e9-9863-f99fed70631a.gif)

I also updated the relevant tests to ensure that the "Lessons Locked" notification _does_ continue to appear when it should (when the teacher is known not verified and there are verified resources associate with the script). 
