### PR TITLE
hoc: Some small fixes to make hoc_mode of "pre-hoc" work for 2019

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -379,7 +379,7 @@ proxy: false # If true, generated URLs will not include explicit port numbers in
 # Run dashboard-server with the level editing interface enabled (for admins)
 levelbuilder_mode:
 
-default_hoc_mode:   post-hoc # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode:   pre-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''       # overridden by 'hoc_launch' DCDO param, except in :test
 
 localize_apps: false

--- a/pegasus/emails/hoc_signup_2019_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_en.md
@@ -1,0 +1,47 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Get ready for the Hour of Code"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+  <% storedotcodedotorg = CDO.canonical_hostname('store.code.org') %>
+
+### Thanks for signing up to host an Hour of Code!
+Thank you for helping make it possible for students to start learning computer science! Computer Science Education Week and the Hour of Code run from December 9-15, and we couldn't be more excited.
+
+As a special thank you to Hour of Code organizers, we have a poster set featuring Malala, Stephen Curry, Shakira and more available to order at a [50% discount from Amazon](https://www.amazon.com/promocode/A3QAYNZUZTSSNQ). This year, each set comes with 6 posters and 126 "I did the Hour of Code" stickers. With the discount you'll get them for less than our cost to make them. Supplies are limited, so order your posters soon. If you're not in the United States, you can [download and print all posters](https://hourofcode.com/promote/resources#posters).
+
+In the meantime, what can you do now?
+
+### 1. Find a local volunteer to help you with your event.
+[Search our volunteer map](https://<%= codedotorg %>/volunteer/local) to find volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.
+
+### 2. Spread the word & recruit your whole school
+We need your help to reach organizers worldwide. Tell your friends about the #HourOfCode. [Use these helpful resources](https://<%= hourofcode %>/promote/resources) to promote your event.
+
+Help recruit more people from your school and community by [sending our sample emails](https://<%= hourofcode %>/promote/resources#sample-emails) to your principal, a local group, or even some friends.
+
+### 3. Start planning your event
+Choose an [Hour of Code activity](https://<%= hourofcode %>/learn) for your classroom and [review this how-to guide](https://<%= hourofcode %>/how-to) for more information on getting started.
+
+### 4. Stock up on swag
+Order materials to help get students excited about your event by heading to the Code.org [Amazon store](https://www.amazon.com/stores/page/8557B2A6-EBF2-4C9F-95C5-C3256FBA0220). [Order posters](https://www.amazon.com/promocode/A3QAYNZUZTSSNQ) (and get an extra 50% off), Hour of Code kits, stickers, and more! But hurry, supplies are limited.
+
+### From an Hour of Code to years of computer science
+<% if form.data["hoc_event_country_s"] == 'US' %> An Hour of Code is just the beginning. Whether you’re an administrator, teacher, or advocate, we have [professional learning, curriculum, and resources to help you bring computer science classes to your school or expand your offerings.](https://<%= codedotorg %>/yourschool) If you already teach computer science, use these resources during CS Education Week to rally support!
+
+If you find an Hour of Code activity you like, ask about going further. Most of the organizations offering activities have curriculum and professional learning available as well. To help you get started, we've highlighted [curriculum providers that can help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond) <% else %> An Hour of Code is just the beginning. Most of the organizations offering Hour of Code lessons also have curriculum available to go further. To help you get started, we've highlighted a number of [curriculum providers that will help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond)
+
+Code.org also offers full [introductory computer science courses](https://<%= codedotorg %>/educate/curriculum/cs-fundamentals-international) translated into over 25 languages at no cost to you or your school. <% end %>
+Thank you for leading the movement to give every student the chance to learn foundational computer science skills.
+
+Hadi Partovi<br />
+Founder, Code.org<br />
+
+<hr/>
+<small>
+You're receiving this email because you signed up for the Hour of Code, supported by more than 200 partners and organized by Code.org. Code.org is a 501c3 non-profit. Our address is [1501 4th Avenue, Suite 900, Seattle, WA 98101](https://maps.google.com/?q=1501+4th+Avenue,+Suite+900,+Seattle,+WA+98101&entry=gmail&source=g). Don't want these emails? [Unsubscribe](<%= unsubscribe_link %>).
+</small>
+
+![](<%= tracking_pixel %>)

--- a/pegasus/emails/hoc_signup_2019_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_es.md
@@ -1,0 +1,37 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hostname = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+
+# ¡Gracias por inscribirte para ser anfitrión de una Hora de Código!
+Usted está haciendo posible para que los estudiantes de todo el mundo aprendan una Hora de Código que puede cambiar el resto de sus vidas, durante los días del 7 al 13 de octubre. Estaremos en contacto sobre nuevos tutoriales y otras noticias interesantes. ¿Qué puede usted hacer ahora?
+
+## 1. Encuentre a un voluntario local para ayudarle con su evento.
+[Buscar en nuestro mapa del voluntariado](https://<%= codedotorg %>/volunteer/local) para que los voluntarios puedan visitar tu aula o hagan un videochat remotamente para inspirar a tus estudiantes acerca de la amplitud de posibilidades con las Ciencias de la Computación.
+
+## 2. Corre la voz
+Necesitamos su ayuda para llegar a los organizadores en todo el mundo. ¡Habla a tus amigos de la #HoraDeCódigo! [Use estos recursos útiles](https://<%= hostname %>/promote/resources) para promocionar tu evento.
+
+## 3. Pídele a tu escuela que ofrezca una Hora de Código
+[Envíe este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails) o [comparte estos folletos](https://<%= hostname %>/promote/resources) a su director y desafíe a cada clase de su escuela para que se inscriba.
+
+## 4. Pídele a tu compañía que se involucre
+[Envia este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails) a tu gerente o director general.
+
+## 5. Promociona la Hora de Código en tu comunidad
+Recluta a un grupo local o incluso algunos amigos. [Enviar este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails).
+
+Gracias por dirigir el movimiento para dar a cada estudiante la oportunidad de aprender habilidades informáticas fundacionales.
+
+Hadi Partovi<br />
+Fundador, Code.org
+
+<hr/>
+<small>
+Estás recibiendo este correo electrónico porque usted se registro para la Hora de Código, apoyado por más de 200 socios y organizado por Code.org. Code.org es una 501c3 sin fines de lucro. Nuestra dirección es 1501 4th Avenue, Suite 900, Seattle, WA 98101. ¿No quieres estos correos? [Darse de baja](<%= unsubscribe_link %>).
+</small>
+
+![](<%= tracking_pixel %>)

--- a/pegasus/emails/hoc_signup_2019_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_pt.md
@@ -1,0 +1,37 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Obrigado por se inscrever para sediar a Hora do Código!"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hostname = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+
+# Obrigado por se inscrever para organizar um evento da Hora do Código!
+Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, no período de 7 a 13 de outubro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
+
+## 1. Encontre um voluntário para ajudá-lo no evento.
+[Busque em nosso mapa de voluntários](https://<%= codedotorg %>/volunteer/local) voluntários que possam visitar sua sala de aula ou fazer um chat de vídeo remotamente para inspirar seus alunos, falando sobre a imensidão de possibilidades que a Ciência da Computação proporciona.
+
+## 2. Divulgue
+Precisamos da sua ajuda para alcançar organizadores do mundo todo. Fale para os seus amigos sobre a #HoraDoCodigo. [Use estes recursos](https://<%= hostname %>/promote/resources) para promover seu evento.
+
+## 3. Convide sua escola inteira para participar da Hora do Código
+[Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails) para o diretor ou [compartilhe estes materiais](https://<%= hostname %>/promote/resources).
+
+## 4. Peça para que sua empresa participe
+[Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails) para seu gerente ou CEO.
+
+## 5. Promova a Hora do Código na sua comunidade
+Reúna um grupo da sua região ou mesmo alguns amigos. [Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails).
+
+Obrigado por participar deste movimento e por dar aos alunos a chance de aprender as habilidades básicas da Ciência da Computação.
+
+Hadi Partovi<br />
+Fundador da Code.org
+
+<hr/>
+<small>
+Você está recebendo este e-mail porque você se cadastrou na Hora do Código, apoiada por mais de 200 parceiros e organizada pela Code.org. A Code.org é uma organização sem fins lucrativos. Nosso endereço é: 1501 4th Avenue, Suite 900, Seattle, WA 98101. Não quer receber esses e-mails? [Cancele sua assinatura](<%= unsubscribe_link %>).
+</small>
+
+![](<%= tracking_pixel %>)

--- a/pegasus/forms/hoc_signup_2019.rb
+++ b/pegasus/forms/hoc_signup_2019.rb
@@ -1,0 +1,14 @@
+require pegasus_dir 'forms/hoc_signup_2018'
+
+class HocSignup2019 < HocSignup2018
+  def self.receipt(data)
+    country = data["hoc_event_country_s"].downcase unless data["hoc_event_country_s"].nil_or_empty?
+    if %w(ar bo cl co cr cu do ec gq gt hn mx ni pa pe pr py sv uy ve).include? country
+      'hoc_signup_2019_receipt_es'
+    elsif country == "br"
+      'hoc_signup_2019_receipt_pt'
+    else
+      'hoc_signup_2019_receipt_en'
+    end
+  end
+end


### PR DESCRIPTION
- Updated hoc signup emails
- Test env gets `hoc_mode` of `"pre-hoc"`

Similar to what we did in 2018 in https://github.com/code-dot-org/code-dot-org/pull/24470