### PR TITLE
Update user's primary_contact_info when taking over a windowslive acc…

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -388,7 +388,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     begin
       if lookup_user.migrated?
-        AuthenticationOption.create!(
+        ao = AuthenticationOption.create!(
           user: lookup_user,
           email: lookup_email,
           credential_type: provider,
@@ -405,6 +405,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         # deprecated in favor of microsoft_v2_auth.
         windowslive_auth_option = lookup_user.authentication_options.find {|auth_option| auth_option.credential_type == AuthenticationOption::WINDOWS_LIVE}
         if windowslive_auth_option.present? && provider == AuthenticationOption::MICROSOFT
+          lookup_user.update!(primary_contact_info: ao) if windowslive_auth_option.primary?
           windowslive_auth_option.destroy!
         end
       else

--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -66,6 +66,10 @@ class AuthenticationOption < ApplicationRecord
     OAUTH_CREDENTIAL_TYPES.include? credential_type
   end
 
+  def primary?
+    user.primary_contact_info == self
+  end
+
   def remove_student_cleartext_email
     self.email = '' if user&.student?
   end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1024,6 +1024,9 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       },
     )
 
+    windowslive_auth_option = user.authentication_options.find {|ao| ao.credential_type == 'windowslive'}
+    assert windowslive_auth_option.primary?
+
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
     get :microsoft_v2_auth
@@ -1033,6 +1036,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal 1, user.authentication_options.count
     microsoft_auth_option = user.authentication_options.first
     refute_nil microsoft_auth_option
+    assert microsoft_auth_option.primary?
     assert_equal 'microsoft_v2_auth', microsoft_auth_option.credential_type
     assert_equal uid, microsoft_auth_option.authentication_id
     assert_equal signed_in_user_id, user.id

--- a/dashboard/test/models/authentication_option_test.rb
+++ b/dashboard/test/models/authentication_option_test.rb
@@ -125,14 +125,17 @@ class AuthenticationOptionTest < ActiveSupport::TestCase
   test 'primary?' do
     user = create(:user)
 
-    assert_equal 0, user.authentication_options.count
-    assert_nil user.primary_contact_info
+    assert_equal 1, user.authentication_options.count
+    refute_nil user.primary_contact_info
+    old_primary_ao = user.primary_contact_info
+    assert old_primary_ao.primary?
 
     google_ao = create(:google_authentication_option, user: user)
-    facebook_ao = create(:facebook_authentication_option, user: user)
+    user.update!(primary_contact_info: google_ao)
+    old_primary_ao.reload
 
     assert google_ao.primary?
-    refute facebook_ao.primary?
+    refute old_primary_ao.primary?
   end
 
   test 'update_oauth_credential_tokens raises an error if auth option is not oauth' do

--- a/dashboard/test/models/authentication_option_test.rb
+++ b/dashboard/test/models/authentication_option_test.rb
@@ -122,6 +122,19 @@ class AuthenticationOptionTest < ActiveSupport::TestCase
     assert option.oauth?
   end
 
+  test 'primary?' do
+    user = create(:user)
+
+    assert_equal 0, user.authentication_options.count
+    assert_nil user.primary_contact_info
+
+    google_ao = create(:google_authentication_option, user: user)
+    facebook_ao = create(:facebook_authentication_option, user: user)
+
+    assert google_ao.primary?
+    refute facebook_ao.primary?
+  end
+
   test 'update_oauth_credential_tokens raises an error if auth option is not oauth' do
     not_oauth = build :authentication_option, credential_type: AuthenticationOption::EMAIL
     assert_raises(RuntimeError) do


### PR DESCRIPTION
…ount

Resolves [this Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/243990).

Repro steps:
1. User's `primary_contact_info` was their windowslive AuthenticationOption
2. The last time the user logged in, we created a microsoft_v2_auth AuthenticationOption and deleted the windowslive AuthenticationOption (since windowslive has been deprecated in favor of microsoft_v2_auth)
3. We did not update the user's `primary_contact_info`, so it was still pointing to the deleted windowslive AuthenticationOption