### PR TITLE
hoc: More small fixes to make hoc_mode of "pre-hoc" work for 2019

### DIFF
--- a/pegasus/emails/hoc_signup_2019_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_pt.md
@@ -7,7 +7,7 @@ litmus_tracking_id: "5g5lyi1a"
   <% codedotorg = CDO.canonical_hostname('code.org') %>
 
 # Obrigado por se inscrever para organizar um evento da Hora do Código!
-Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, no período de 7 a 13 de outubro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
+Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, no período de 9 a 15 de dezembro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
 
 ## 1. Encontre um voluntário para ajudá-lo no evento.
 [Busque em nosso mapa de voluntários](https://<%= codedotorg %>/volunteer/local) voluntários que possam visitar sua sala de aula ou fazer um chat de vídeo remotamente para inspirar seus alunos, falando sobre a imensidão de possibilidades que a Ciência da Computação proporciona.

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -142,7 +142,7 @@ class Homepage
           url: "/hourofcode/overview"
         }
       ]
-    elsif hoc_mode == "post-hoc"
+    elsif ["post-hoc", "pre-hoc"].include? hoc_mode
       [
         {
           text: "homepage_action_text_learn",


### PR DESCRIPTION
- br email lists December 2019 dates, matching website dates
- adjust homepage buttons for pre-hoc (make same as post-hoc)

![Screenshot 2019-06-24 16 59 56](https://user-images.githubusercontent.com/2205926/60059615-0f798000-96a2-11e9-9817-d9f9e2ed6bc8.png)

Followup to https://github.com/code-dot-org/code-dot-org/pull/29322
