### PR TITLE
Feedback Notification: experiment & example use on student homepage 

### DIFF
--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -5,6 +5,8 @@ import HeaderBanner from '../HeaderBanner';
 import RecentCourses from './RecentCourses';
 import StudentSections from './StudentSections';
 import ProjectWidgetWithData from '@cdo/apps/templates/projects/ProjectWidgetWithData';
+import StudentFeedbackNotification from '@cdo/apps/templates/feedback/StudentFeedbackNotification';
+import experiments from '@cdo/apps/util/experiments';
 import shapes from './shapes';
 import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
 import i18n from '@cdo/locale';
@@ -33,6 +35,12 @@ export default class StudentHomepage extends Component {
       <div>
         <HeaderBanner headingText={i18n.homepageHeading()} short={true} />
         <ProtectedStatefulDiv ref="flashes" />
+        {experiments.isEnabled(experiments.FEEDBACK_NOTIFICATION) && (
+          <StudentFeedbackNotification
+            numFeedbackLevels="2"
+            linkToFeedbackOverview="/"
+          />
+        )}
         <RecentCourses
           courses={courses}
           topCourse={topCourse}

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -24,6 +24,7 @@ experiments.DEV_COMMENT_BOX_TAB = 'devCommentBoxTab';
 experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
   'schoolAutocompleteDropdownNewSearch';
 experiments.SCHOOL_INFO_CONFIRMATION_DIALOG = 'schoolInfoConfirmationDialog';
+experiments.FEEDBACK_NOTIFICATION = 'feedbackNotification';
 
 // This is a per user experiment and is defined in experiments.rb
 // On the front end we are treating it as an experiment group.


### PR DESCRIPTION
[LP-521](https://codedotorg.atlassian.net/browse/LP-521)

This PR sets up an experiment flag, `feedbackNotification`, which will be used for showing the `StudentFeedbackNotifcation`. As an example, I used the experiment flag to show the notification (with hardcoded props for now) on the student homepage. To turn on the experiment you can visit: http://localhost-studio.code.org:3000/home?enableExperiments=feedbackNotification

Experiment on: notification 
<img width="1235" alt="Screen Shot 2019-06-25 at 10 01 58 AM" src="https://user-images.githubusercontent.com/12300669/60118476-4ea2e200-9731-11e9-939f-7084b01c68e9.png">

Experiment off:  no notification 
<img width="1240" alt="Screen Shot 2019-06-25 at 10 02 41 AM" src="https://user-images.githubusercontent.com/12300669/60118480-519dd280-9731-11e9-9a4d-e33769f37dde.png">

