### PR TITLE
Remove experiments that are no longer in use

### DIFF
--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -19,16 +19,9 @@ const EXPERIMENT_LIFESPAN_HOURS = 12;
 
 // Specific experiment names
 experiments.REDUX_LOGGING = 'reduxLogging';
-experiments.COMMENT_BOX_TAB = 'commentBoxTab';
-experiments.DEV_COMMENT_BOX_TAB = 'devCommentBoxTab';
 experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
   'schoolAutocompleteDropdownNewSearch';
 experiments.SCHOOL_INFO_CONFIRMATION_DIALOG = 'schoolInfoConfirmationDialog';
-
-// This is a per user experiment and is defined in experiments.rb
-// On the front end we are treating it as an experiment group.
-experiments.TEACHER_EXP_2018 = '2018-teacher-experience';
-experiments.TEACHER_EXP_2018_LIST = [experiments.COMMENT_BOX_TAB];
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.
@@ -105,16 +98,6 @@ experiments.isEnabled = function(key) {
       window.appOptions.experiments &&
       window.appOptions.experiments.includes(key)
     );
-
-  // Check for parent experiment
-  if (
-    storedExperiments
-      .map(obj => obj.key)
-      .includes(experiments.TEACHER_EXP_2018) &&
-    experiments.TEACHER_EXP_2018_LIST.includes(key)
-  ) {
-    enabled = true;
-  }
 
   const query = queryString.parse(this.getQueryString_());
   const enableQuery = query['enableExperiments'];


### PR DESCRIPTION
We had references in experiments.js to experiments that are no longer running: `COMMENT_BOX_TAB`, `DEV_COMMENT_BOX_TAB` and `TEACHER_EXP_2018`. Doing some small clean up to delete them. 