### PR TITLE
Use VerifiedResourcesNotification in ScriptOverviewHeader

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -22,6 +22,7 @@ import AssignmentVersionSelector, {
   setRecommendedAndSelectedVersions
 } from '@cdo/apps/templates/teacherDashboard/AssignmentVersionSelector';
 import {assignmentVersionShape} from '@cdo/apps/templates/teacherDashboard/shapes';
+import VerifiedResourcesNotification from '@cdo/apps/templates/courseOverview/VerifiedResourcesNotification';
 
 const SCRIPT_OVERVIEW_WIDTH = 1100;
 
@@ -142,22 +143,6 @@ class ScriptOverviewHeader extends Component {
         currentAnnouncements.push(element);
       }
     });
-
-    // Checks if the non-verified teacher announcement should be shown
-    if (currentView === 'Teacher') {
-      if (
-        this.props.verificationCheckComplete &&
-        !this.props.isVerifiedTeacher &&
-        this.props.hasVerifiedResources
-      ) {
-        currentAnnouncements.push({
-          notice: i18n.verifiedResourcesNotice(),
-          details: i18n.verifiedResourcesDetails(),
-          link: 'https://support.code.org/hc/en-us/articles/115001550131',
-          type: NotificationType.information
-        });
-      }
-    }
     return currentAnnouncements;
   };
 
@@ -175,8 +160,17 @@ class ScriptOverviewHeader extends Component {
       showRedirectWarning,
       versions,
       showHiddenUnitWarning,
-      courseName
+      courseName,
+      verificationCheckComplete,
+      isVerifiedTeacher,
+      hasVerifiedResources
     } = this.props;
+
+    const displayVerifiedResources =
+      viewAs === ViewType.Teacher &&
+      verificationCheckComplete &&
+      !isVerifiedTeacher &&
+      hasVerifiedResources;
 
     const displayVersionWarning =
       showRedirectWarning &&
@@ -213,6 +207,9 @@ class ScriptOverviewHeader extends Component {
             announcements={this.filterAnnouncements(viewAs)}
             width={SCRIPT_OVERVIEW_WIDTH}
           />
+        )}
+        {displayVerifiedResources && (
+          <VerifiedResourcesNotification width={SCRIPT_OVERVIEW_WIDTH} />
         )}
         {displayVersionWarning && (
           <Notification

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewHeaderTest.js
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewHeaderTest.js
@@ -5,7 +5,6 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {NotificationType} from '@cdo/apps/templates/Notification';
 import {VisibilityType} from '../../../../../src/code-studio/scriptAnnouncementsRedux';
 import {UnconnectedScriptOverviewHeader as ScriptOverviewHeader} from '@cdo/apps/code-studio/components/progress/ScriptOverviewHeader';
-import i18n from '@cdo/locale';
 
 const defaultProps = {
   plcHeaderProps: undefined,
@@ -97,14 +96,7 @@ describe('ScriptOverviewHeader', () => {
       />,
       {disableLifecycleMethods: true}
     );
-    assert.equal(
-      wrapper.find('ScriptAnnouncements').props().announcements.length,
-      1
-    );
-    assert.equal(
-      wrapper.find('ScriptAnnouncements').props().announcements[0].notice,
-      i18n.verifiedResourcesNotice()
-    );
+    assert.equal(wrapper.find('VerifiedResourcesNotification').length, 1);
   });
 
   it('displays old teacher announcement for teacher', () => {
@@ -150,8 +142,9 @@ describe('ScriptOverviewHeader', () => {
     );
     assert.equal(
       wrapper.find('ScriptAnnouncements').props().announcements.length,
-      2
+      1
     );
+    assert.equal(wrapper.find('VerifiedResourcesNotification').length, 1);
   });
 
   it('has non-verified and provided teacher announcements if necessary', () => {
@@ -170,8 +163,9 @@ describe('ScriptOverviewHeader', () => {
     );
     assert.equal(
       wrapper.find('ScriptAnnouncements').props().announcements.length,
-      3
+      2
     );
+    assert.equal(wrapper.find('VerifiedResourcesNotification').length, 1);
   });
 
   it('has only teacher announcements', () => {


### PR DESCRIPTION
Turns out we already have a `VerifiedResourcesNotification` component which was in use on the Course Overview page.  I removed what was essentially a duplication of that component and used `VerifiedResourcesNotification` in `ScriptOverviewHeader`.  I also updated tests accordingly. There's no user effect, just a little tidier code. 