### PR TITLE
Line breaks are removed from student answers in the Assessments tab

### DIFF
--- a/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.jsx
+++ b/apps/src/templates/sectionAssessments/FreeResponsesAssessmentsTable.jsx
@@ -27,6 +27,9 @@ const styles = {
   },
   noResponse: {
     color: color.lighter_gray
+  },
+  response: {
+    whiteSpace: 'pre-wrap'
   }
 };
 
@@ -68,7 +71,7 @@ class FreeResponsesAssessmentsTable extends Component {
   responseCellFormatter = (response, {rowData, rowIndex}) => {
     return (
       <div>
-        {response && <div>{response}</div>}
+        {response && <div style={styles.response}>{response}</div>}
         {!response && (
           <div style={styles.noResponse}>{i18n.emptyFreeResponse()}</div>
         )}

--- a/apps/src/templates/sectionAssessments/assessmentsTestHelpers.js
+++ b/apps/src/templates/sectionAssessments/assessmentsTestHelpers.js
@@ -522,6 +522,14 @@ export const questionOne = [
     name: 'BrendanBrendanBrendanBrendan',
     response: `We do not make mistakes we just have happy little accidents. Once you learn the technique,
         ohhh! Turn you loose on the world; you become a tiger.,`
+  },
+  {
+    id: 5,
+    studentId: '214',
+    name: 'Awesome Coder',
+    response: `for (let ii = 0; ii < stuff.length; ii++) {
+    console.log("I fixed a bug!!!");
+}`
   }
 ];
 

--- a/apps/test/unit/templates/sectionAssessments/FreeResponsesAssessmentsTableTest.js
+++ b/apps/test/unit/templates/sectionAssessments/FreeResponsesAssessmentsTableTest.js
@@ -22,6 +22,7 @@ describe('FreeResponsesAssessmentsTable', () => {
     expect(tableHeaders).to.have.length(2);
 
     const tableRows = wrapper.find('tr');
-    expect(tableRows).to.have.length(5);
+    // Depends on length of the fixture - one row per answer, plus a header row.
+    expect(tableRows).to.have.length(questionOne.length + 1);
   });
 });


### PR DESCRIPTION
Fixing https://codedotorg.atlassian.net/browse/LP-342 "Line breaks are removed from student answers in the Assessments tab"

Found that using the style white-space: pre-wrap solves the problem.  (found from https://stackoverflow.com/questions/2703601/how-to-line-break-from-css-without-using-br). Just pre or pre-line didn't quite work right. 

Also added a "code" test to show that this actually worked. 

<img width="740" alt="Screen Shot 2019-06-25 at 4 05 21 PM" src="https://user-images.githubusercontent.com/1072387/60139563-377ce800-9763-11e9-9939-49667465b3c5.png">

