### PR TITLE
 Update `user.managing_own_credentials?` to consider migrated users

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -821,7 +821,17 @@ class User < ActiveRecord::Base
   end
 
   def managing_own_credentials?
-    provider.blank? || (provider == User::PROVIDER_MANUAL)
+    if provider.blank?
+      true
+    elsif provider == User::PROVIDER_MANUAL
+      true
+    elsif provider == User::PROVIDER_MIGRATED
+      authentication_options.any? do |ao|
+        ao.credential_type == AuthenticationOption::EMAIL
+      end
+    else
+      false
+    end
   end
 
   def password_required?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -823,9 +823,9 @@ class User < ActiveRecord::Base
   def managing_own_credentials?
     if provider.blank?
       true
-    elsif provider == User::PROVIDER_MANUAL
+    elsif manual?
       true
-    elsif provider == User::PROVIDER_MIGRATED
+    elsif migrated?
       authentication_options.any? do |ao|
         ao.credential_type == AuthenticationOption::EMAIL
       end
@@ -848,7 +848,7 @@ class User < ActiveRecord::Base
 
   def email_required?
     return true if teacher?
-    return false if provider == User::PROVIDER_MANUAL
+    return false if manual?
     return false if sponsored?
     return false if oauth?
     return false if parent_managed_account?
@@ -856,7 +856,7 @@ class User < ActiveRecord::Base
   end
 
   def username_required?
-    provider == User::PROVIDER_MANUAL || username_changed?
+    manual? || username_changed?
   end
 
   def update_without_password(params, *options)
@@ -1883,6 +1883,10 @@ class User < ActiveRecord::Base
 
   def migrated?
     provider == PROVIDER_MIGRATED
+  end
+
+  def manual?
+    provider == PROVIDER_MANUAL
   end
 
   def sponsored?

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3281,14 +3281,34 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 'fake refresh token', google_auth_option.data_hash[:oauth_refresh_token]
   end
 
+  test 'managing_own_credentials? is true for users with email logins' do
+    user = create :user
+    assert user.managing_own_credentials?
+  end
+
+  test 'managing_own_credentials? is true for students with email logins' do
+    user = create :student
+    assert user.managing_own_credentials?
+  end
+
+  test 'managing_own_credentials? is false for users with oauth logins' do
+    user = create :user, :sso_provider
+    refute user.managing_own_credentials?
+  end
+
+  test 'managing_own_credentials? is false for students with sponsored logins' do
+    user = create :student_in_picture_section
+    refute user.managing_own_credentials?
+  end
+
   test 'password_required? is false if user is not creating their own account' do
-    user = build :user
+    user = create :user
     user.expects(:managing_own_credentials?).returns(false)
     refute user.password_required?
   end
 
   test 'password_required? is true for new users with no encrypted password' do
-    user = build :user, encrypted_password: nil
+    user = create :user, encrypted_password: nil
     user.expects(:managing_own_credentials?).returns(true)
     assert user.encrypted_password.nil?
     assert user.password_required?


### PR DESCRIPTION
And therefore also update `password_required?` and the password validation rules to do the same.

Fixes https://codedotorg.atlassian.net/browse/FND-366