### PR TITLE
Remove preview options from level edit page

### DIFF
--- a/dashboard/app/views/levels/editors/_gamelab.html.haml
+++ b/dashboard/app/views/levels/editors/_gamelab.html.haml
@@ -64,19 +64,6 @@
   = boolean_check_box f, :hide_view_data_button
   = f.label 'Hide View Data Button'
 
-.field
-  = f.label 'Immediately show the results of setup code changes in the playspace?'
-  :ruby
-    selector = f.select :auto_run_setup, options_for_select([
-      ['No', nil],
-      ['Yes, run the draw loop once', SharedConstants::GAMELAB_AUTORUN_OPTIONS.draw_loop],
-      ['Yes, call drawSprites()', SharedConstants::GAMELAB_AUTORUN_OPTIONS.draw_sprites],
-      ['Yes, run some other JavaScript', SharedConstants::GAMELAB_AUTORUN_OPTIONS.custom],
-    ], selected: @level.auto_run_setup)
-  = selector
-  = f.label 'Custom setup code'
-  = f.text_field :custom_setup_code
-
 - if @level.is_a?(GamelabJr)
   .field
     = f.label :block_pools


### PR DESCRIPTION
Part 1 of Jira STAR-475.
We want all sprite lab levels to always have live preview, and for that to always mean the same thing.
As a first step, this removes the field to change preview options on levelbuilder.
I'll link future PRs when they're ready.
Part 2: #29366 Always show preview in Spritelab

New:
![image](https://user-images.githubusercontent.com/8787187/60195084-5a54de00-97ef-11e9-80a0-ec4cec1152a0.png)

Old:
![Screen Shot 2019-06-26 at 8 48 47 AM](https://user-images.githubusercontent.com/8787187/60195064-532dd000-97ef-11e9-9e50-71e605e17a37.png)
