### PR TITLE
Always show preview in spritelab

### DIFF
--- a/apps/src/gamelab/GameLab.js
+++ b/apps/src/gamelab/GameLab.js
@@ -55,7 +55,6 @@ import Sounds from '../Sounds';
 import {TestResults, ResultType} from '../constants';
 import {showHideWorkspaceCallouts} from '../code-studio/callouts';
 import defaultSprites from './defaultSprites.json';
-import {GamelabAutorunOptions} from '@cdo/apps/util/sharedConstants';
 import wrap from './debugger/replay';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {
@@ -231,9 +230,6 @@ GameLab.prototype.init = function(config) {
   }
   this.level = config.level;
 
-  this.shouldAutoRunSetup =
-    config.level.autoRunSetup && !this.level.edit_blocks;
-
   this.level.helperLibraries = this.level.helperLibraries || [];
 
   this.level.softButtons = this.level.softButtons || [];
@@ -354,7 +350,7 @@ GameLab.prototype.init = function(config) {
 
     this.setCrosshairCursorForPlaySpace();
 
-    if (this.shouldAutoRunSetup) {
+    if (this.isSpritelab) {
       this.studioApp_.addChangeHandler(this.rerunSetupCode.bind(this));
     }
   };
@@ -697,7 +693,7 @@ GameLab.prototype.startTickTimer = function() {
  *     implementation.
  */
 GameLab.prototype.resetHandler = function(ignore) {
-  if (this.shouldAutoRunSetup) {
+  if (this.isSpritelab) {
     this.execute(false /* shouldLoop */);
   } else {
     this.reset();
@@ -1366,18 +1362,8 @@ GameLab.prototype.onP5Draw = function() {
         this.eventHandlers.draw.apply(null);
         this.runValidationCode();
       });
-    } else if (this.shouldAutoRunSetup) {
-      switch (this.level.autoRunSetup) {
-        case GamelabAutorunOptions.draw_loop:
-          this.eventHandlers.draw.apply(null);
-          break;
-        case GamelabAutorunOptions.draw_sprites:
-          this.JSInterpreter.evalInCurrentScope('drawSprites();');
-          break;
-        case GamelabAutorunOptions.custom:
-          this.JSInterpreter.evalInCurrentScope(this.level.customSetupCode);
-          break;
-      }
+    } else if (this.isSpritelab) {
+      this.eventHandlers.draw.apply(null);
     }
   }
   this.completeRedrawIfDrawComplete();


### PR DESCRIPTION
This is a no-op except for the couple of levels that have an option other than `GamelabAutorunOptions.draw_loop` set.

Levels with no setting:
```
GamelabJr.all.select{|l| l.auto_run_setup.nil?}.pluck(:name)
["Bunny Game", "CourseE_Project_SpriteLab", "CourseE_Project_SpriteLab_2019", "CourseE_Project_Template_SpriteLab", "CourseE_hoops - take2", "CourseE_hoops", "CourseE_hoops_2019", "CourseF_Project_Revise_SpriteLab", "CourseF_Project_Revise_SpriteLab_2019", "CourseF_Project_SpriteLab", "CourseF_Project_SpriteLab_2019", "CourseF_Project_Template_SpriteLab", "CourseF_Project_Template_SpriteLab_2019", "GLJ Bounce", "GLJ Drag and fall", "GLJ Dragity", "GLJ Draw Loop", "GLJ Flappy test", "GLJ Flappy", "GLJ Flappy2", "GLJ Forever", "GLJ Sprites Where", "GLJ_Crawl_Exemplar_1", "GLJ_test", "GLJr_Behavior_1", "GLJr_Behavior_2", "GLJr_Behavior_5", "GLJr_Behavior_6", "GLJr_Behavior_7", "GLJr_Behavior_8", "GLJr_Behavior_9", "GLJr_Forever_1", "GLJr_Forever_2", "GLJr_Forever_5", "GLJr_Forever_6", "GLJr_Forever_7", "GLJr_Forever_8", "GLJr_Forever_9", "Josh GLJr Test", "Josh SL test", "Josh Sprite Text", "Josh Test", "Josh test funky blocks", "JoshLSpriteLabTest", "KIKI GLJ Test 1", "KIKI GLJ Test 1a", "KIKI GLJ Test 2", "KIKI GLJ Test Static", "KIKI GLJ Test", "Mikelab Groups Blocks", "New SL Test", "Ram Having Fun", "Ram color mixing", "Ryan GLJr Test", "Ryan Lab Test", "Ryan's GL Jr", "Sprite Lab property mapping v2", "Sprite Lab property mapping vw", "Sprite Lab property mapping", "SpriteLabDebugger", "Toolbox test", "aalevel-mike", "aalevel", "aalevel3", "aalevel4", "aalevel5-mike", "aalevel5", "aalevel6", "aalevel7", "aalevel8", "aalevel8_2", "aalevel8_3", "aalevel9", "aalevelcopy", "aalevelthrowaway", "aatoolboxtest", "asteroids", "behaviors pet test 123 copy", "behaviors pet test 123", "behaviors pet test 2", "behaviors pet test 3", "behaviors pet test", "courseE_Buttons", "courseE_Dogger - take2", "courseE_Dogger", "courseE_Dogger_2", "courseE_Dogger_2_2019", "courseE_aboutme_7", "courseE_aboutme_again", "courseE_aboutme_freeplay", "courseE_aboutme_test", "courseE_aboutme_test2", "courseE_data_1", "courseF_data_1", "courseF_project_1", "courseF_project_1_2019", "coursef_EOC_2 Ram", "coursef_EOC_2", "data and behaviors 1", "elijah - animation poc", "gl jr clone me", "gljr_demo_pet", "josh_bonanza_test", "kiki_test_GLJ", "kiki_test_SL", "loop pet test 2", "loop pet test 3", "loop pet test 4", "loop pet test", "lumen", "pet game 1", "pet game 2", "pet game 3", "pet game 4", "pet game 5", "pet game 6", "pet game 7", "pet game 8", "pet game 9", "spritelab required blocks", "spritelab xml bug", "test block requirements", "test shared behaviors", "test-dani", "timeforcs_demo_spritelab_1"]

GamelabJr.all.select{|l| l.auto_run_setup.nil?}.count
125
```

Levels with `DRAW_SPRITES` set
```
GamelabJr.all.select{|l| !l.auto_run_setup.nil? and l.auto_run_setup == "DRAW_SPRITES"}.pluck(:name)
[]
```

Levels with `CUSTOM` set
```
GamelabJr.all.select{|l| !l.auto_run_setup.nil? and l.auto_run_setup == "CUSTOM"}.pluck(:name)
["BinLab", "BinaryMove", "EmojiKeyboard"]
```

Of these levels, the only ones used in any scripts are:
```
['CourseF_Project_SpriteLab_2019', 'CourseF_Project_Revise_SpriteLab', 'courseE_Dogger_2', 'CourseE_Project_SpriteLab_2019', 'CourseE_hoops', 'courseF_project_1', 'CourseE_Project_SpriteLab', 'CourseF_Project_SpriteLab']
```
I've confirmed with Ryan that it's okay and expected for these levels to start showing previews. 