### PR TITLE
Feedback Notification: display real data on student homepage 

### DIFF
--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -79,6 +79,7 @@ function showHomepage() {
             topCourse={homepageData.topCourse}
             sections={homepageData.sections}
             canViewAdvancedTools={homepageData.canViewAdvancedTools}
+            studentId={homepageData.studentId}
           />
         )}
       </div>

--- a/apps/src/templates/feedback/StudentFeedbackNotification.jsx
+++ b/apps/src/templates/feedback/StudentFeedbackNotification.jsx
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 import i18n from '@cdo/locale';
+import $ from 'jquery';
 
 export default class StudentFeedbackNotification extends Component {
   static propTypes = {

--- a/apps/src/templates/feedback/StudentFeedbackNotification.jsx
+++ b/apps/src/templates/feedback/StudentFeedbackNotification.jsx
@@ -20,12 +20,12 @@ export default class StudentFeedbackNotification extends Component {
     const {studentId} = this.props;
 
     $.ajax({
-      url: `/api/v1/teacher_feedbacks/get_feedbacks_all?student_id=${studentId}`,
+      url: `/api/v1/teacher_feedbacks/count?student_id=${studentId}`,
       method: 'GET',
       dataType: 'json'
     }).done(data => {
       this.setState({
-        numFeedbackLevels: data.length
+        numFeedbackLevels: data
       });
     });
   }

--- a/apps/src/templates/feedback/StudentFeedbackNotification.jsx
+++ b/apps/src/templates/feedback/StudentFeedbackNotification.jsx
@@ -5,24 +5,49 @@ import i18n from '@cdo/locale';
 
 export default class StudentFeedbackNotification extends Component {
   static propTypes = {
-    numFeedbackLevels: PropTypes.string.isRequired,
+    studentId: PropTypes.number.isRequired,
     linkToFeedbackOverview: PropTypes.string.isRequired
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      numFeedbackLevels: 0
+    };
+  }
+
+  componentWillMount() {
+    const {studentId} = this.props;
+
+    $.ajax({
+      url: `/api/v1/teacher_feedbacks/get_feedbacks_all?student_id=${studentId}`,
+      method: 'GET',
+      dataType: 'json'
+    }).done(data => {
+      this.setState({
+        numFeedbackLevels: data.length
+      });
+    });
+  }
+
   render() {
     const notificationDetails = i18n.feedbackNotificationDetails({
-      numFeedbackLevels: this.props.numFeedbackLevels
+      numFeedbackLevels: this.state.numFeedbackLevels
     });
 
     return (
-      <Notification
-        type={NotificationType.feedback}
-        notice={i18n.feedbackNotification()}
-        details={notificationDetails}
-        buttonText={i18n.feedbackNotificationButton()}
-        buttonLink={this.props.linkToFeedbackOverview}
-        dismissible={false}
-      />
+      <div>
+        {this.state.numFeedbackLevels > 0 && (
+          <Notification
+            type={NotificationType.feedback}
+            notice={i18n.feedbackNotification()}
+            details={notificationDetails}
+            buttonText={i18n.feedbackNotificationButton()}
+            buttonLink={this.props.linkToFeedbackOverview}
+            dismissible={false}
+          />
+        )}
+      </div>
     );
   }
 }

--- a/apps/src/templates/feedback/StudentFeedbackNotification.story.jsx
+++ b/apps/src/templates/feedback/StudentFeedbackNotification.story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import StudentFeedbackNotification from './StudentFeedbackNotification';
+import sinon from 'sinon';
 
 export default storybook => {
   return storybook
@@ -8,13 +9,31 @@ export default storybook => {
     .addStoryTable([
       {
         name: 'StudentFeedbackNotification',
-        story: () => (
-          <StudentFeedbackNotification
-            numFeedbackLevels="2"
-            linkToFeedbackOverview="/"
-            studentId={123}
-          />
-        )
+        story: () => {
+          withFakeServer();
+          return (
+            <StudentFeedbackNotification
+              linkToFeedbackOverview="/"
+              studentId={123}
+            />
+          );
+        }
       }
     ]);
 };
+
+function withFakeServer() {
+  const server = sinon.fakeServer.create({
+    autoRespond: true
+  });
+  const successResponse = body => [
+    200,
+    {'Content-Type': 'application/json'},
+    JSON.stringify(body)
+  ];
+  server.respondWith(
+    'GET',
+    '/api/v1/teacher_feedbacks/count?student_id=123',
+    successResponse('2')
+  );
+}

--- a/apps/src/templates/feedback/StudentFeedbackNotification.story.jsx
+++ b/apps/src/templates/feedback/StudentFeedbackNotification.story.jsx
@@ -12,6 +12,7 @@ export default storybook => {
           <StudentFeedbackNotification
             numFeedbackLevels="2"
             linkToFeedbackOverview="/"
+            studentId={123}
           />
         )
       }

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -17,7 +17,8 @@ export default class StudentHomepage extends Component {
     courses: shapes.courses,
     topCourse: shapes.topCourse,
     sections: shapes.sections,
-    canViewAdvancedTools: PropTypes.bool
+    canViewAdvancedTools: PropTypes.bool,
+    studentId: PropTypes.number.isRequired
   };
 
   componentDidMount() {
@@ -29,7 +30,7 @@ export default class StudentHomepage extends Component {
 
   render() {
     const {courses, sections, topCourse} = this.props;
-    const {canViewAdvancedTools} = this.props;
+    const {canViewAdvancedTools, studentId} = this.props;
 
     return (
       <div>
@@ -37,7 +38,7 @@ export default class StudentHomepage extends Component {
         <ProtectedStatefulDiv ref="flashes" />
         {experiments.isEnabled(experiments.FEEDBACK_NOTIFICATION) && (
           <StudentFeedbackNotification
-            numFeedbackLevels="2"
+            studentId={studentId}
             linkToFeedbackOverview="/"
           />
         )}

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -14,6 +14,7 @@ describe('StudentHomepage', () => {
         topCourse={topCourse}
         sections={[]}
         codeOrgUrlPrefix="http://localhost:3000/"
+        studentId={123}
       />
     );
     const headerBanner = wrapper.find(HeaderBanner);
@@ -30,6 +31,7 @@ describe('StudentHomepage', () => {
         topCourse={topCourse}
         sections={[]}
         codeOrgUrlPrefix="http://localhost:3000/"
+        studentId={123}
       />
     );
     expect(wrapper.find('ProtectedStatefulDiv').exists()).to.be.true;
@@ -42,6 +44,7 @@ describe('StudentHomepage', () => {
         topCourse={topCourse}
         sections={[]}
         codeOrgUrlPrefix="http://localhost:3000/"
+        studentId={123}
       />
     );
     const recentCourses = wrapper.find('RecentCourses');
@@ -59,6 +62,7 @@ describe('StudentHomepage', () => {
         topCourse={topCourse}
         sections={joinedSections}
         codeOrgUrlPrefix="http://localhost:3000/"
+        studentId={123}
       />
     );
     expect(wrapper.find('ProjectWidgetWithData').exists()).to.be.true;
@@ -71,6 +75,7 @@ describe('StudentHomepage', () => {
         topCourse={topCourse}
         sections={joinedSections}
         codeOrgUrlPrefix="http://localhost:3000/"
+        studentId={123}
       />
     );
     const studentSections = wrapper.find(StudentSections);

--- a/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::TeacherFeedbacksController < Api::V1::JsonApiController
 
   # Use student_id to lookup feedback from any teacher who has provided feedback to that
   # student on any level
-  def get_feedbacks_all
+  def index
     # Setting CSRF token header allows us to access the token manually in subsequent POST requests.
     headers['csrf-token'] = form_authenticity_token
 
@@ -48,14 +48,17 @@ class Api::V1::TeacherFeedbacksController < Api::V1::JsonApiController
     render json: @all_feedbacks, each_serializer: Api::V1::TeacherFeedbackSerializer
   end
 
-  # POST /teacher_feedbacks
-  def create
-    @teacher_feedback.teacher_id = current_user.id
-    if @teacher_feedback.save
-      render json: @teacher_feedback, serializer: Api::V1::TeacherFeedbackSerializer, status: :created
-    else
-      head :bad_request
-    end
+  # Use student_id to determine how many feedback entries from any teacher
+  # for any level are associated with the given student
+  def count
+    # Setting CSRF token header allows us to access the token manually in subsequent POST requests.
+    headers['csrf-token'] = form_authenticity_token
+
+    @all_feedbacks_count = TeacherFeedback.where(
+      student_id: params.require(:student_id)
+    ).length
+
+    render json: @all_feedbacks_count, each_serializer: Api::V1::TeacherFeedbackSerializer
   end
 
   # POST /teacher_feedbacks

--- a/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
@@ -45,6 +45,16 @@ class Api::V1::TeacherFeedbacksController < Api::V1::JsonApiController
     end
   end
 
+  # POST /teacher_feedbacks
+  def create
+    @teacher_feedback.teacher_id = current_user.id
+    if @teacher_feedback.save
+      render json: @teacher_feedback, serializer: Api::V1::TeacherFeedbackSerializer, status: :created
+    else
+      head :bad_request
+    end
+  end
+
   # POST /teacher_feedbacks/:id/increment_visit_count
   #
   # Records metrics for student viewing teacher feedback.

--- a/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
@@ -35,6 +35,19 @@ class Api::V1::TeacherFeedbacksController < Api::V1::JsonApiController
     render json: @level_feedbacks, each_serializer: Api::V1::TeacherFeedbackSerializer
   end
 
+  # Use student_id to lookup feedback from any teacher who has provided feedback to that
+  # student on any level
+  def get_feedbacks_all
+    # Setting CSRF token header allows us to access the token manually in subsequent POST requests.
+    headers['csrf-token'] = form_authenticity_token
+
+    @all_feedbacks = TeacherFeedback.where(
+      student_id: params.require(:student_id)
+    )
+
+    render json: @all_feedbacks, each_serializer: Api::V1::TeacherFeedbackSerializer
+  end
+
   # POST /teacher_feedbacks
   def create
     @teacher_feedback.teacher_id = current_user.id

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -68,7 +68,7 @@ class Ability
       can :manage, Pd::Enrollment, user_id: user.id
       can :workshops_user_enrolled_in, Pd::Workshop
       can :index, Section, user_id: user.id
-      can [:get_feedbacks, :get_feedbacks_all, :increment_visit_count], TeacherFeedback, student_id: user.id
+      can [:get_feedbacks, :count, :increment_visit_count], TeacherFeedback, student_id: user.id
 
       if user.teacher?
         can :manage, Section, user_id: user.id

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -68,7 +68,7 @@ class Ability
       can :manage, Pd::Enrollment, user_id: user.id
       can :workshops_user_enrolled_in, Pd::Workshop
       can :index, Section, user_id: user.id
-      can [:get_feedbacks, :increment_visit_count], TeacherFeedback, student_id: user.id
+      can [:get_feedbacks, :get_feedbacks_all, :increment_visit_count], TeacherFeedback, student_id: user.id
 
       if user.teacher?
         can :manage, Section, user_id: user.id

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -47,6 +47,14 @@ class TeacherFeedback < ApplicationRecord
     )
   end
 
+  def self.get_all_feedback_for_student(student_id)
+    find(
+      where(
+        student_id: student_id
+      )
+    )
+  end
+
   def self.latest_per_teacher
     #Only select feedback from teachers who lead sections in which the student is still enrolled
     find(

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -47,14 +47,6 @@ class TeacherFeedback < ApplicationRecord
     )
   end
 
-  def self.get_all_feedback_for_student(student_id)
-    find(
-      where(
-        student_id: student_id
-      )
-    )
-  end
-
   def self.latest_per_teacher
     #Only select feedback from teachers who lead sections in which the student is still enrolled
     find(

--- a/dashboard/app/views/home/_homepage.html.haml
+++ b/dashboard/app/views/home/_homepage.html.haml
@@ -29,7 +29,7 @@
   - else
     - homepage_data[:sections] = @student_sections
     - homepage_data[:isTeacher] = false
-    - homepage_data[:feedback] = TeacherFeedback.get_all_feedback_for_student(current_user.id)
+    - homepage_data[:studentId] = current_user.id
   - homepage_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)
 
 - content_for(:head) do

--- a/dashboard/app/views/home/_homepage.html.haml
+++ b/dashboard/app/views/home/_homepage.html.haml
@@ -29,6 +29,7 @@
   - else
     - homepage_data[:sections] = @student_sections
     - homepage_data[:isTeacher] = false
+    - homepage_data[:feedback] = TeacherFeedback.get_all_feedback_for_student(current_user.id)
   - homepage_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)
 
 - content_for(:head) do

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -631,11 +631,11 @@ Dashboard::Application.routes.draw do
       get 'peer_review_submissions/index', to: 'peer_review_submissions#index'
       get 'peer_review_submissions/report_csv', to: 'peer_review_submissions#report_csv'
 
-      resources :teacher_feedbacks, only: [:create] do
+      resources :teacher_feedbacks, only: [:index, :create] do
         collection do
           get 'get_feedback_from_teacher'
           get 'get_feedbacks'
-          get 'get_feedbacks_all'
+          get 'count'
         end
         member do
           post 'increment_visit_count'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -635,6 +635,7 @@ Dashboard::Application.routes.draw do
         collection do
           get 'get_feedback_from_teacher'
           get 'get_feedbacks'
+          get 'get_feedbacks_all'
         end
         member do
           post 'increment_visit_count'

--- a/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
@@ -129,6 +129,26 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     assert_equal [], parsed_response
   end
 
+  test 'count is 0 when no feedback available' do
+    sign_in @student
+    get "#{API}/count", params: {student_id: @student.id}
+
+    assert_equal "0", formatted_response
+  end
+
+  test 'count is accurate when feedback is available' do
+    sign_in @student
+    teacher_sign_in_and_give_feedback(@teacher, @student, @level, COMMENT1, PERFORMANCE1)
+    get "#{API}/count", params: {student_id: @student.id}
+
+    assert_equal "1", formatted_response
+
+    teacher_sign_in_and_give_feedback(@teacher, @student, @level, COMMENT2, PERFORMANCE2)
+    get "#{API}/count", params: {student_id: @student.id}
+
+    assert_equal "2", formatted_response
+  end
+
   test 'bad request when student_id not provided - get_feedbacks' do
     teacher_sign_in_and_give_feedback(@teacher, @student, @level, COMMENT1, PERFORMANCE1)
     get "#{API}/get_feedbacks", params: {level_id: @level.id}
@@ -234,6 +254,10 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
 
   def parsed_response
     JSON.parse(@response.body)
+  end
+
+  def formatted_response
+    @response.body.delete!('\\"')
   end
 
   # Sign in as teacher and leave feedback for student on level.


### PR DESCRIPTION
Partial work for [LP-523](https://codedotorg.atlassian.net/browse/LP-523) Adding the feedback notification to the student home page. 

I added a new `count` method to teacher_feedbacks that gets a count of all of the feedback for a student. Which I call from the `StudentFeedbackNotification` using the `studentId` prop passed in from the `StudentHomepage` to render the notification with the # of levels. 
<img width="1071" alt="Screen Shot 2019-06-26 at 11 15 33 AM" src="https://user-images.githubusercontent.com/12300669/60204993-ffc67c80-9804-11e9-8599-c6c17a9a91c4.png">
