### PR TITLE
Check condition before adding event

### DIFF
--- a/apps/src/gamelab/spritelab/eventCommands.js
+++ b/apps/src/gamelab/spritelab/eventCommands.js
@@ -2,18 +2,24 @@ import * as spriteUtils from './spriteUtils';
 
 export const commands = {
   checkTouching(condition, sprite1, sprite2, callback) {
-    spriteUtils.addEvent(
-      condition + 'touch',
-      {sprite1: sprite1, sprite2: sprite2},
-      callback
-    );
+    if (condition === 'when' || condition === 'while') {
+      spriteUtils.addEvent(
+        condition + 'touch',
+        {sprite1: sprite1, sprite2: sprite2},
+        callback
+      );
+    }
   },
 
   keyPressed(condition, key, callback) {
-    spriteUtils.addEvent(condition + 'press', {key: key}, callback);
+    if (condition === 'when' || condition === 'while') {
+      spriteUtils.addEvent(condition + 'press', {key: key}, callback);
+    }
   },
 
   spriteClicked(condition, spriteId, callback) {
-    spriteUtils.addEvent(condition + 'click', {sprite: spriteId}, callback);
+    if (condition === 'when' || condition === 'while') {
+      spriteUtils.addEvent(condition + 'click', {sprite: spriteId}, callback);
+    }
   }
 };


### PR DESCRIPTION
`keyPressed` is also the name of a p5 function, and that function is called whenever a key is pressed. However, this was causing *our* p5 function to also get called. However, it didn't have any of the right parameters, so we were ending up with a bunch of `"undefinedpress"` events in the inputEvents list. There was no user-visible problem yet, but I'm working on another change that expects everything in the inputEvents list to make sense, and that's how this bug came up.

Adding these checks makes sure we don't accidentally add any events to the inputEvents list that don't at least have a condition that makes sense for our usage.