### PR TITLE
split up applab and gamelab integration tests to avoid crashes

### DIFF
--- a/apps/test-low-memory.sh
+++ b/apps/test-low-memory.sh
@@ -55,8 +55,10 @@ npm run lint
   ${CODECOV} -cF integration) ${LOG} log/turtleTest.log
 (PORT=9880 LEVEL_TYPE='maze|bounce|calc|eval|flappy|studio' $GRUNT_CMD karma:integration && \
   ${CODECOV} -cF integration) ${LOG} log/integrationTest.log
-(PORT=9881 LEVEL_TYPE='applab|gamelab' $GRUNT_CMD karma:integration && \
-  ${CODECOV} -cF integration) ${LOG} log/appLabgameLabTest.log
-(PORT=9882 LEVEL_TYPE='craft' $GRUNT_CMD karma:integration && \
+(PORT=9881 LEVEL_TYPE='applab' $GRUNT_CMD karma:integration && \
+  ${CODECOV} -cF integration) ${LOG} log/appLabTest.log
+(PORT=9882 LEVEL_TYPE='gamelab' $GRUNT_CMD karma:integration && \
+  ${CODECOV} -cF integration) ${LOG} log/gameLabTest.log
+(PORT=9883 LEVEL_TYPE='craft' $GRUNT_CMD karma:integration && \
   ${CODECOV} -cF integration) ${LOG} log/craftTest.log
 SCRIPT


### PR DESCRIPTION
phantomjs has been crashing during DTTs during this step:
```
(PORT=9881 LEVEL_TYPE='applab|gamelab' node --max_old_space_size=4096 /home/ubuntu/test/apps/node_modules/.bin/grunt karma:integration &&   : -cF integration) && : log/appLabgameLabTest.log
```
This is a speculative fix to split this test run up further to hopefully avoid future crashes.

Caveat: this might make test runs take longer, depending on how many are being run in parallel.

The long term solution is probably to move to headless chrome, where this whole splitting approach shouldn't be necessary.

There is also some chance that webpack optimizations will lead to smaller test bundles, which could also help things.