### PR TITLE
clear progress in sessionStorage when signing in via secret pictures or secret words

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -520,6 +520,7 @@ describe('entry tests', () => {
     schoolInfoInterstitial:
       './src/sites/studio/pages/schoolInfoInterstitial.js',
     'scripts/stage_extras': './src/sites/studio/pages/scripts/stage_extras.js',
+    'sections/show': './src/sites/studio/pages/sections/show.js',
     'shared/_header_progress':
       './src/sites/studio/pages/shared/_header_progress.js',
     signup: './src/sites/studio/pages/signup.js',

--- a/apps/src/sites/studio/pages/sections/show.js
+++ b/apps/src/sites/studio/pages/sections/show.js
@@ -1,0 +1,61 @@
+const script = document.querySelector('script[data-section]');
+const sectionData = JSON.parse(script.dataset['section']);
+const {loginType, loginTypeWord, loginTypePicture, pairingAllowed} = sectionData;
+
+$(function() {
+  // Select name.
+  $('ul.students li').click(function() {
+    $('ul.students li').removeClass('selected');
+    $(this).addClass('selected');
+    $('input#user_id').val($(this).attr('id'));
+
+    if (loginType == loginTypeWord) {
+      // Clear the password.
+      $('#secret_words').val("");
+    } else if (loginType == loginTypePicture) {
+      // Deselect picture.
+      $('ul.pictures li').removeClass('selected');
+    }
+
+    // Disable the login button.
+    $('#login_button').prop('disabled', true);
+
+    // Hide the pairing checkbox
+    $('#pairing_checkbox').hide();
+
+
+    // Reveal the secret section...
+    $('#secret').hide().slideDown();
+
+    // ...and simultaneously fade in the login button.
+    $('#login_button').fadeIn();
+  });
+
+  // Select secret picture.
+  $('ul.pictures li').click(function() {
+    $('ul.pictures li').removeClass('selected');
+    $(this).addClass('selected');
+    $('input#secret_picture_id').val($(this).attr('id'));
+
+    // Show the pairing checkbox
+    if (pairingAllowed) {
+      $('#pairing_checkbox').show();
+    }
+
+    // Enable the login button.
+    $('#login_button').prop('disabled', false);
+  });
+
+  // Type something in password box.
+  $('#secret_words').keyup(function() {
+    // Show the pairing checkbox
+    if (pairingAllowed) {
+      $('#pairing_checkbox').show();
+    }
+
+    // Enable the login button.
+    $('#login_button').prop('disabled', false);
+  });
+
+  $(".section-user-sign-in").on("submit", dashboard.clientState.reset);
+});

--- a/apps/src/sites/studio/pages/sections/show.js
+++ b/apps/src/sites/studio/pages/sections/show.js
@@ -1,6 +1,13 @@
+import clientState from '@cdo/apps/code-studio/clientState.js';
+
 const script = document.querySelector('script[data-section]');
 const sectionData = JSON.parse(script.dataset['section']);
-const {loginType, loginTypeWord, loginTypePicture, pairingAllowed} = sectionData;
+const {
+  loginType,
+  loginTypeWord,
+  loginTypePicture,
+  pairingAllowed
+} = sectionData;
 
 $(function() {
   // Select name.
@@ -9,10 +16,10 @@ $(function() {
     $(this).addClass('selected');
     $('input#user_id').val($(this).attr('id'));
 
-    if (loginType == loginTypeWord) {
+    if (loginType === loginTypeWord) {
       // Clear the password.
-      $('#secret_words').val("");
-    } else if (loginType == loginTypePicture) {
+      $('#secret_words').val('');
+    } else if (loginType === loginTypePicture) {
       // Deselect picture.
       $('ul.pictures li').removeClass('selected');
     }
@@ -23,9 +30,10 @@ $(function() {
     // Hide the pairing checkbox
     $('#pairing_checkbox').hide();
 
-
     // Reveal the secret section...
-    $('#secret').hide().slideDown();
+    $('#secret')
+      .hide()
+      .slideDown();
 
     // ...and simultaneously fade in the login button.
     $('#login_button').fadeIn();
@@ -57,5 +65,5 @@ $(function() {
     $('#login_button').prop('disabled', false);
   });
 
-  $(".section-user-sign-in").on("submit", dashboard.clientState.reset);
+  $('.section-user-sign-in').on('submit', clientState.reset);
 });

--- a/dashboard/app/views/sections/show.html.haml
+++ b/dashboard/app/views/sections/show.html.haml
@@ -1,69 +1,14 @@
 - @page_title = @section.name
 
-:javascript
+:ruby
+  section_data = {
+    loginType: @section.login_type,
+    loginTypePicture: Section::LOGIN_TYPE_PICTURE,
+    loginTypeWord: Section::LOGIN_TYPE_WORD,
+    pairingAllowed: @section.pairing_allowed
+  }.to_json
 
-  var loginType = "#{escape_javascript @section.login_type}";
-  var loginTypePicture = "#{Section::LOGIN_TYPE_PICTURE}";
-  var loginTypeWord = "#{Section::LOGIN_TYPE_WORD}";
-  var pairingAllowed = #{@section.pairing_allowed};
-
-  $(function() {
-    // Select name.
-    $('ul.students li').click(function() {
-      $('ul.students li').removeClass('selected');
-      $(this).addClass('selected');
-      $('input#user_id').val($(this).attr('id'));
-
-      if (loginType == loginTypeWord) {
-        // Clear the password.
-        $('#secret_words').val("");
-      } else if (loginType == loginTypePicture) {
-        // Deselect picture.
-        $('ul.pictures li').removeClass('selected');
-      }
-
-      // Disable the login button.
-      $('#login_button').prop('disabled', true);
-
-      // Hide the pairing checkbox
-      $('#pairing_checkbox').hide();
-
-
-      // Reveal the secret section...
-      $('#secret').hide().slideDown();
-
-      // ...and simultaneously fade in the login button.
-      $('#login_button').fadeIn();
-    });
-
-    // Select secret picture.
-    $('ul.pictures li').click(function() {
-      $('ul.pictures li').removeClass('selected');
-      $(this).addClass('selected');
-      $('input#secret_picture_id').val($(this).attr('id'));
-
-      // Show the pairing checkbox
-      if (pairingAllowed) {
-        $('#pairing_checkbox').show();
-      }
-
-      // Enable the login button.
-      $('#login_button').prop('disabled', false);
-    });
-
-    // Type something in password box.
-    $('#secret_words').keyup(function() {
-      // Show the pairing checkbox
-      if (pairingAllowed) {
-        $('#pairing_checkbox').show();
-      }
-
-      // Enable the login button.
-      $('#login_button').prop('disabled', false);
-    });
-
-    $(".section-user-sign-in").on("submit", dashboard.clientState.reset);
-  });
+%script{src: minifiable_asset_path('js/sections/show.js'), data: {section: section_data}}
 
 #signinsection
   %h2

--- a/dashboard/app/views/sections/show.html.haml
+++ b/dashboard/app/views/sections/show.html.haml
@@ -61,6 +61,8 @@
       // Enable the login button.
       $('#login_button').prop('disabled', false);
     });
+
+    $(".section-user-sign-in").on("submit", dashboard.clientState.reset);
   });
 
 #signinsection
@@ -81,7 +83,7 @@
   = precede '*' do
     != t('signinsection.student_privacy', student_privacy_blog: 'http://teacherblog.code.org/post/156768797364/privacy-concern-with-using-student-full-names')
 
-  = form_tag log_in_section_path(id: @section.code) do
+  = form_tag(log_in_section_path(id: @section.code), class: 'section-user-sign-in') do
     = hidden_field_tag :secret_picture_id
     = hidden_field_tag :user_id
 


### PR DESCRIPTION
## Background

When a signed-out user makes progress, we storage that progress in [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). When a signed-in user makes progress, we persist that progress in the user_levels table, but we also store it in sessionStorage. We make a best-effort attempt to clear sessionStorage when a user signs in or out, but sometimes we fail to do this, causing progress to leak between users as described in [LP-502](https://codedotorg.atlassian.net/browse/LP-502).

It's not 100% clear why we store progress in sessionStorage. PRs https://github.com/code-dot-org/code-dot-org/pull/4256 and https://github.com/code-dot-org/code-dot-org/pull/4452 are poorly documented, but it probably had something to do with achieving scalability on HoC scripts.

### signing in

On sign-in, we sometimes clear sessionStorage by attaching event handlers to the UI elements used to submit login data:
* Email sign in / sign up: cleared at: https://github.com/code-dot-org/code-dot-org/blob/fd7a8279988fddf5f94b1345ca40b9b5b24f4086/dashboard/app/views/devise/sessions/new.html.haml#L64 https://github.com/code-dot-org/code-dot-org/blob/fd7a8279988fddf5f94b1345ca40b9b5b24f4086/dashboard/app/views/devise/sessions/new.html.haml#L70
* OAuth: cleared at: https://github.com/code-dot-org/code-dot-org/blob/4972686ef6470b429e4ee3560579d2ba84035441/dashboard/app/views/devise/shared/_oauth_links.haml#L28
* Secret picture / secret words: not cleared. (fixed in this PR)
* sign in via direct ajax request: not cleared. only done in ui tests, must also remember to hit /reset_session.

### signing out

On sign-out, we clear session storage when the sign-out menu item is selected. This succeeds when done from dashboard pages, but fails when done from pegasus because sessionStorage is domain-specific: https://github.com/code-dot-org/code-dot-org/blob/f30081ed14678c928962b55c7b1eab42fcdc23dd/shared/haml/user_header.haml#L124-L131

## Description

Fixes the specific problem described in [LP-502](https://codedotorg.atlassian.net/browse/LP-502), by making sure we clear sessionStorage when a user signs in via secret pictures or secret words (https://github.com/code-dot-org/code-dot-org/pull/29386/commits/fd7384ca516dc8504eaeffb9dced5fa7186c2e93). This ensures we always clear sessionStorage when signing in via the UI, preventing progress from being leaked between signed-in users, or from a signed-out user to a signed-in user. This does NOT prevent progress from being leaked from a signed-in user to a signed-out user in all cases (see Caveats).

## Caveats

1. this solution does not prevent leakage of progress when a user signs out in either of the following ways:
  a. by hitting https://studio.code.org/users/sign_out directly
  b. by using the drop-down menu to sign out from https://code.org/congrats

2. this solution is brittle because it relies on each sign in / sign out mechanism to remember to clear session storage

## Detours

* extracted sections/show.js from haml in https://github.com/code-dot-org/code-dot-org/pull/29386/commits/2270dbbe2c1b63e37bc9cf619b0ac9661f2c1742 without making any functional changes in that commit

## Future Work

A simple, robust solution would be to isolate progress belonging to different users by bucketing sessionStorage progress based on user id. This work item is tracked by [LP-576](https://codedotorg.atlassian.net/browse/LP-576). 