### PR TITLE
Remove auto_run_setup and custom_setup_code from Gamelab

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -69,7 +69,6 @@ end
 def main
   shared_content = generate_multiple_constants %w(
     ARTIST_AUTORUN_OPTIONS
-    GAMELAB_AUTORUN_OPTIONS
     LEVEL_KIND
     LEVEL_STATUS
     SECTION_LOGIN_TYPE

--- a/apps/src/sites/studio/pages/levelbuilder_gamelab.js
+++ b/apps/src/sites/studio/pages/levelbuilder_gamelab.js
@@ -62,29 +62,4 @@ $(document).ready(function() {
   if (document.getElementById('level_validation_code')) {
     initializeCodeMirror('level_validation_code', 'javascript');
   }
-  const autoRunSetup = document.getElementById('level_auto_run_setup');
-  const customSetupCode = document.getElementById('level_custom_setup_code');
-  if (autoRunSetup && customSetupCode) {
-    const changeHandler = () => {
-      if (autoRunSetup.value === 'CUSTOM') {
-        customSetupCode.previousElementSibling.style.display = '';
-        if (customSetupCode.editor) {
-          customSetupCode.editor.getWrapperElement().style.display = '';
-        } else {
-          customSetupCode.editor = initializeCodeMirror(
-            'level_custom_setup_code',
-            'javascript'
-          );
-        }
-      } else {
-        customSetupCode.previousElementSibling.style.display = 'none';
-        customSetupCode.style.display = 'none';
-        if (customSetupCode.editor) {
-          customSetupCode.editor.getWrapperElement().style.display = 'none';
-        }
-      }
-    };
-    autoRunSetup.onchange = changeHandler;
-    changeHandler();
-  }
 });

--- a/dashboard/app/models/levels/gamelab.rb
+++ b/dashboard/app/models/levels/gamelab.rb
@@ -44,8 +44,6 @@ class Gamelab < Blockly
     debugger_disabled
     pause_animations_by_default
     start_animations
-    auto_run_setup
-    custom_setup_code
     validation_code
     helper_libraries
   )

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -60,15 +60,6 @@ module SharedConstants
     }
   ).freeze
 
-  # The set of gamelab autorun options
-  GAMELAB_AUTORUN_OPTIONS = OpenStruct.new(
-    {
-      draw_loop: 'DRAW_LOOP',
-      draw_sprites: 'DRAW_SPRITES',
-      custom: 'CUSTOM',
-    }
-  ).freeze
-
   # Valid milestone post modes
   POST_MILESTONE_MODE = OpenStruct.new(
     {


### PR DESCRIPTION
Follow up to #29366 and #29364 to fully remove these options from Gamelab now that they are not used anywhere