### PR TITLE
JS errors from malformed project html no longer disable the Start Over button.

### DIFF
--- a/apps/src/applab/designElements/library.js
+++ b/apps/src/applab/designElements/library.js
@@ -158,17 +158,18 @@ export default {
             return ElementType.TEXT_INPUT;
         }
     }
+    let errorMessage =
+      'Project contains an element with an unknown type' +
+      `\nType: ${element.tagName}` +
+      `\nId: ${element.id}` +
+      `\nClass: ${element.className}`;
     // Unknown elements are expected. Return null because we don't know type.
     if (allowUnknown) {
-      console.warn(
-        'Project contains an element with an unknown type' +
-          `\nType: ${element.tagName}` +
-          `\nId: ${element.id}` +
-          `\nClass: ${element.className}`
-      );
+      console.warn(errorMessage);
       return null;
     }
-    throw new Error('unknown element type');
+    // TODO: Gracefully handle errors from malformed design mode elements
+    throw new Error(errorMessage);
   },
 
   /**

--- a/apps/src/applab/designElements/library.js
+++ b/apps/src/applab/designElements/library.js
@@ -160,6 +160,12 @@ export default {
     }
     // Unknown elements are expected. Return null because we don't know type.
     if (allowUnknown) {
+      console.warn(
+        'Project contains an element with an unknown type' +
+          `\nType: ${element.tagName}` +
+          `\nId: ${element.id}` +
+          `\nClass: ${element.className}`
+      );
       return null;
     }
     throw new Error('unknown element type');
@@ -203,9 +209,13 @@ export default {
    * Code to be called after deserializing element, allowing us to attach any
    * necessary event handlers.
    */
-  onDeserialize: function(element, updateProperty) {
-    var elementType = this.getElementType(element);
-    if (elements[elementType] && elements[elementType].onDeserialize) {
+  onDeserialize: function(element, updateProperty, skipIfUnknown) {
+    var elementType = this.getElementType(element, skipIfUnknown);
+    if (
+      elementType &&
+      elements[elementType] &&
+      elements[elementType].onDeserialize
+    ) {
       elements[elementType].onDeserialize(element, updateProperty);
     }
   },

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1114,7 +1114,8 @@ function getUnsafeHtmlReporter(sanitizationTarget) {
 designMode.parseScreenFromLevelHtml = function(
   screenEl,
   allowDragging,
-  prefix
+  prefix,
+  skipUnknownElements
 ) {
   var screen = $(screenEl);
   elementUtils.addIdPrefix(screen[0], prefix);
@@ -1132,7 +1133,8 @@ designMode.parseScreenFromLevelHtml = function(
     var element = $(this).hasClass('ui-draggable') ? this.firstChild : this;
     elementLibrary.onDeserialize(
       element,
-      designMode.updateProperty.bind(element)
+      designMode.updateProperty.bind(element),
+      skipUnknownElements
     );
   });
   return screen[0];
@@ -1164,7 +1166,7 @@ designMode.parseFromLevelHtml = function(rootEl, allowDragging, prefix) {
   );
   var children = $(levelDom).children();
   children.each(function() {
-    designMode.parseScreenFromLevelHtml(this, allowDragging, prefix);
+    designMode.parseScreenFromLevelHtml(this, allowDragging, prefix, true);
   });
   children.appendTo(rootEl);
 };

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1166,7 +1166,12 @@ designMode.parseFromLevelHtml = function(rootEl, allowDragging, prefix) {
   );
   var children = $(levelDom).children();
   children.each(function() {
-    designMode.parseScreenFromLevelHtml(this, allowDragging, prefix, true);
+    designMode.parseScreenFromLevelHtml(
+      this,
+      allowDragging,
+      prefix,
+      true /* skipUnknownElements */
+    );
   });
   children.appendTo(rootEl);
 };


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/STAR-385

In the past, if a student had an error in their project html, this would throw an error when the project was loaded. The click handler for the 'start over'/'version history' gets setup after this error is thrown. Because of this, 'start over'/'version history' were broken. A student could never get out of this broken state. They couldn't manually fix their html nor could they restart the level. This fixes that issue by logging rather than throwing if a student's project is in a bad state.

In this case, the image on the screen is wrapped in a paragraph tag (which is invalid in AppLab). 
![badElementType](https://user-images.githubusercontent.com/8324574/60299497-b4ce6700-98e1-11e9-92d4-67818e6efa29.gif)
