### PR TITLE
School Info Completeness:  Add Validation_Complete to SchoolInfo

### DIFF
--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -140,7 +140,7 @@ class SchoolInfo < ActiveRecord::Base
     ['US', 'USA', 'United States'].include? country
   end
 
-  def should_check_for_full_or_no_validation?
+  def should_check_for_full_validation?
     !(validation_type == VALIDATION_NONE || validation_type == VALIDATION_COMPLETE)
   end
 
@@ -165,7 +165,7 @@ class SchoolInfo < ActiveRecord::Base
   #
   # This method reports errors if the record has a country and is invalid.
   def validate_with_country
-    return unless country && should_check_for_full_or_no_validation?
+    return unless country && should_check_for_full_validation?
     usa? ? validate_us : validate_non_us
   end
 
@@ -241,7 +241,7 @@ class SchoolInfo < ActiveRecord::Base
   # validate records in the older data format (see school_info_test.rb for details).
   # This method reports errors if the record does NOT have a country and is invalid.
   def validate_without_country
-    return unless should_check_for_full_or_no_validation?
+    return unless should_check_for_full_validation?
     return if country
 
     # don't allow any new fields in the old data format.

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -141,7 +141,7 @@ class SchoolInfo < ActiveRecord::Base
   end
 
   def should_validate?
-    validation_type != VALIDATION_NONE
+    !(validation_type == VALIDATION_NONE || validation_type == VALIDATION_COMPLETE)
   end
 
   def validate_zip

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -277,7 +277,7 @@ class SchoolInfo < ActiveRecord::Base
     return if validation_type != VALIDATION_COMPLETE || complete?
 
     errors.add(:country, "is required") if country.nil?
-    errors.add(:school_name, "can not be blank") if school_name.blank?
+    errors.add(:school_name, "cannot be blank") if school_name.blank?
   end
 
   def effective_school_district_name

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -140,7 +140,7 @@ class SchoolInfo < ActiveRecord::Base
     ['US', 'USA', 'United States'].include? country
   end
 
-  def should_validate?
+  def should_check_for_full_or_no_validation?
     !(validation_type == VALIDATION_NONE || validation_type == VALIDATION_COMPLETE)
   end
 
@@ -165,7 +165,7 @@ class SchoolInfo < ActiveRecord::Base
   #
   # This method reports errors if the record has a country and is invalid.
   def validate_with_country
-    return unless country && should_validate?
+    return unless country && should_check_for_full_or_no_validation?
     usa? ? validate_us : validate_non_us
   end
 
@@ -241,7 +241,7 @@ class SchoolInfo < ActiveRecord::Base
   # validate records in the older data format (see school_info_test.rb for details).
   # This method reports errors if the record does NOT have a country and is invalid.
   def validate_without_country
-    return unless should_validate?
+    return unless should_check_for_full_or_no_validation?
     return if country
 
     # don't allow any new fields in the old data format.

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -39,7 +39,8 @@ class SchoolInfo < ActiveRecord::Base
 
   VALIDATION_TYPES = [
     VALIDATION_FULL = 'full'.freeze,
-    VALIDATION_NONE = 'none'.freeze
+    VALIDATION_NONE = 'none'.freeze,
+    VALIDATION_COMPLETE = 'complete'.freeze
   ].freeze
 
   belongs_to :school_district
@@ -133,6 +134,7 @@ class SchoolInfo < ActiveRecord::Base
   validate :validate_with_country
   validate :validate_without_country
   validate :validate_zip
+  validate :validate_complete
 
   def usa?
     ['US', 'USA', 'United States'].include? country
@@ -269,6 +271,13 @@ class SchoolInfo < ActiveRecord::Base
     end
 
     errors.add(:school_district, "is required")
+  end
+
+  def validate_complete
+    return if validation_type != VALIDATION_COMPLETE || complete?
+
+    errors.add(:country, "is required") if country.nil?
+    errors.add(:school_name, "can not be blank") if school_name.blank?
   end
 
   def effective_school_district_name

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -204,6 +204,40 @@ class SchoolInfoTest < ActiveSupport::TestCase
     assert_equal 'School name is required', school_info.errors.full_messages.first
   end
 
+  # Test VALIDATION_COMPLETE
+
+  test 'US public school with school_type and name succeeds' do
+    school_info = SchoolInfo.create(
+      {country: 'US',
+      school_type: 'public',
+      school_name: 'Philly High Harmony',
+      validation_type: SchoolInfo::VALIDATION_COMPLETE}
+    )
+    assert school_info.valid? school_info.errors.full_messages
+  end
+
+  test 'School info with only school type and name school does not succeed' do
+    school_info = SchoolInfo.create(
+      {country: nil,
+      school_type: 'private',
+      school_name: 'Grovers Academy',
+      validation_type: SchoolInfo::VALIDATION_COMPLETE}
+    )
+    refute school_info.valid?
+    assert_equal 'Country is required', school_info.errors.full_messages.first
+  end
+
+  test 'US private school with only school type does not succeed' do
+    school_info = SchoolInfo.create(
+      {country: 'US',
+      school_type: 'private',
+      school_name: '',
+      validation_type: SchoolInfo::VALIDATION_COMPLETE}
+    )
+    refute school_info.valid?
+    assert_equal 'School name cannot be blank', school_info.errors.full_messages.first
+  end
+
   # US, charter
 
   test 'US charter with school succeeds' do

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -294,14 +294,14 @@ class SchoolInfoTest < ActiveSupport::TestCase
   # Non-US homeschool
 
   test 'Non-US homeschool succeeds' do
-    school_info = build :school_info_non_us_homeschool, validation_type: SchoolInfo::VALIDATION_NONE
+    school_info = build :school_info_non_us_homeschool, validation_type: SchoolInfo::VALIDATION_COMPLETE
     assert school_info.valid?, school_info.errors.full_messages
   end
 
   # Non-US after school
 
   test 'Non-US after school succeeds' do
-    school_info = build :school_info_non_us_after_school, validation_type: SchoolInfo::VALIDATION_NONE
+    school_info = build :school_info_non_us_after_school, validation_type: SchoolInfo::VALIDATION_COMPLETE
     assert school_info.valid?, school_info.errors.full_messages
   end
 

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -137,7 +137,7 @@ class SchoolInfoTest < ActiveSupport::TestCase
 
   test 'auto upgrade validation type without other overwritting does not notify' do
     Honeybadger.expects(:notify).never
-    school_info = build :school_info_with_public_school_only, validation_type: SchoolInfo::VALIDATION_NONE
+    school_info = build :school_info_with_public_school_only, validation_type: SchoolInfo::VALIDATION_COMPLETE
     assert school_info.valid?, school_info.errors.full_messages
   end
 
@@ -280,14 +280,14 @@ class SchoolInfoTest < ActiveSupport::TestCase
   # US homeschool
 
   test 'US homeschool succeeds' do
-    school_info = build :school_info_us_homeschool, validation_type: SchoolInfo::VALIDATION_NONE
+    school_info = build :school_info_us_homeschool, validation_type: SchoolInfo::VALIDATION_COMPLETE
     assert school_info.valid?, school_info.errors.full_messages
   end
 
   # US after school
 
   test 'US after school succeeds' do
-    school_info = build :school_info_us_after_school, validation_type: SchoolInfo::VALIDATION_NONE
+    school_info = build :school_info_us_after_school, validation_type: SchoolInfo::VALIDATION_COMPLETE
     assert school_info.valid?, school_info.errors.full_messages
   end
 


### PR DESCRIPTION
A new validation type, VALIDATION_COMPLETE is added to the school info model to validate the required fields on the school info interstitial.  The goal is to replace most instances of VALIDATION_NONE with VALIDATION_COMPLETE with the exception being when a new user signs up.

Implementation
- Add new method that checks for completeness
- Add error handling
- Replace instances of VALIDATION_NONE with VALIDATION_COMPLETE 
- Update existing tests

[School Info](https://docs.google.com/document/d/1rDIvlERMUxYz49hXG0i3OaZsas75q_TQAja6999hRrY/edit#)