### PR TITLE
Disallow mailto redirect

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1143,6 +1143,8 @@
   "redirectRejectExplanation": "This app is trying to open a website that appears to be unsafe.",
   "redirectRejectTitle": "Navigation to Unsafe Site Detected",
   "redirectTitle": "You are leaving this app",
+  "redirectUnsupportedTitle": "Navigation Type Unsupported",
+  "redirectUnsupportedExplanation": "Mailto: links are not supported in App Lab. Please try using a different URL",
   "reloadPage": "Reload Page",
   "relockStage": "Re-lock stage",
   "relockStageInstructions": "\"Re-lock stage\" to prevent sharing of answers with other classes/schools.",

--- a/apps/src/applab/ExternalRedirectDialog.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.jsx
@@ -5,7 +5,7 @@ import DialogFooter from '../templates/teacherDashboard/DialogFooter';
 import Button from '../templates/Button';
 import i18n from '@cdo/locale';
 import {connect} from 'react-redux';
-import {actions} from './redux/applab';
+import {actions, REDIRECT_RESPONSE} from './redux/applab';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
 
 const styles = {
@@ -27,9 +27,9 @@ class ExternalRedirectDialog extends React.Component {
       return null;
     }
 
-    let approved = this.props.redirects[0].approved;
+    let response = this.props.redirects[0].response;
     let url = this.props.redirects[0].url;
-    if (approved) {
+    if (response === REDIRECT_RESPONSE.APPROVED) {
       title = i18n.redirectTitle();
       body = (
         <div>
@@ -60,8 +60,13 @@ class ExternalRedirectDialog extends React.Component {
         </DialogFooter>
       );
     } else {
-      title = i18n.redirectRejectTitle();
-      body = <p>{i18n.redirectRejectExplanation()}</p>;
+      if (response === REDIRECT_RESPONSE.UNSUPPORTED) {
+        title = i18n.redirectUnsupportedTitle();
+        body = <p>{i18n.redirectUnsupportedExplanation()}</p>;
+      } else {
+        title = i18n.redirectRejectTitle();
+        body = <p>{i18n.redirectRejectExplanation()}</p>;
+      }
       footer = (
         <DialogFooter rightAlign>
           <Button

--- a/apps/src/applab/ExternalRedirectDialog.story.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {UnconnectedExternalRedirectDialog as ExternalRedirectDialog} from '@cdo/apps/applab/ExternalRedirectDialog';
+import {REDIRECT_RESPONSE} from './redux/applab';
 
 export default storybook => {
   storybook.storiesOf('ExternalRedirectDialog', module).addStoryTable([
@@ -12,7 +13,7 @@ export default storybook => {
             {
               url:
                 'www.google.com/super_duper/long_url/should_be_wrapped/to-the-next-line.html',
-              approved: true
+              approved: REDIRECT_RESPONSE.APPROVED
             }
           ]}
         />
@@ -23,7 +24,26 @@ export default storybook => {
       story: () => (
         <ExternalRedirectDialog
           handleClose={() => {}}
-          redirects={[{url: 'www.google.com', approved: false}]}
+          redirects={[
+            {
+              url: 'www.google.com',
+              approved: REDIRECT_RESPONSE.REJECTED
+            }
+          ]}
+        />
+      )
+    },
+    {
+      name: 'Unsupported Site',
+      story: () => (
+        <ExternalRedirectDialog
+          handleClose={() => {}}
+          redirects={[
+            {
+              url: 'www.google.com',
+              approved: REDIRECT_RESPONSE.UNSUPPORTED
+            }
+          ]}
         />
       )
     }

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -22,7 +22,7 @@ import {commands as timeoutCommands} from '@cdo/apps/lib/util/timeoutApi';
 import * as makerCommands from '@cdo/apps/lib/kits/maker/commands';
 import {getAppOptions} from '@cdo/apps/code-studio/initApp/loadApp';
 import {AllowedWebRequestHeaders} from '@cdo/apps/util/sharedConstants';
-import {actions} from './redux/applab';
+import {actions, REDIRECT_RESPONSE} from './redux/applab';
 import {getStore} from '../redux';
 import datasetLibrary from '@cdo/apps/code-studio/datasetLibrary.json';
 import $ from 'jquery';
@@ -1573,12 +1573,16 @@ function filterUrl(urlToCheck) {
     data: JSON.stringify({url: urlToCheck})
   })
     .success(data => {
-      let approved = data['approved'];
-      getStore().dispatch(actions.addRedirectNotice(approved, urlToCheck));
+      let response = data['approved']
+        ? REDIRECT_RESPONSE.APPROVED
+        : REDIRECT_RESPONSE.REJECTED;
+      getStore().dispatch(actions.addRedirectNotice(response, urlToCheck));
     })
     .fail((jqXhr, status) => {
       // When this query fails, default to the dialog that allows the user to choose
-      getStore().dispatch(actions.addRedirectNotice(true, urlToCheck));
+      getStore().dispatch(
+        actions.addRedirectNotice(REDIRECT_RESPONSE.APPROVED, urlToCheck)
+      );
     });
 }
 
@@ -1603,6 +1607,10 @@ applabCommands.openUrl = function(opts) {
         // If url doesn't have a protocol, add one
         window.open('https://' + opts.url);
       }
+    } else if (hostname.startsWith('mailto')) {
+      getStore().dispatch(
+        actions.addRedirectNotice(REDIRECT_RESPONSE.UNSUPPORTED, opts.url)
+      );
     } else {
       filterUrl(opts.url);
     }

--- a/apps/src/applab/redux/applab.js
+++ b/apps/src/applab/redux/applab.js
@@ -5,6 +5,12 @@ import screens from './screens';
 import {reducers as jsDebuggerReducers} from '../../lib/tools/jsdebugger/redux';
 import {reducer as maker} from '../../lib/kits/maker/redux';
 
+export const REDIRECT_RESPONSE = {
+  APPROVED: 'approved',
+  REJECTED: 'rejected',
+  UNSUPPORTED: 'unsupported'
+};
+
 // Selectors
 
 // Actions
@@ -31,14 +37,14 @@ function changeInterfaceMode(interfaceMode) {
 
 /**
  * Add a redirect notice to our stack
- * @param {bool} approved
+ * @param {string} response
  * @param {string} url
  * @returns {{type: string, approved: bool, url: string}}
  */
-function addRedirectNotice(approved, url) {
+function addRedirectNotice(response, url) {
   return {
     type: ADD_REDIRECT_NOTICE,
-    approved: approved,
+    response: response,
     url: url
   };
 }
@@ -80,7 +86,7 @@ function redirectDisplay(state, action) {
       // Add a redirect notice to our stack of notices
       return [
         {
-          approved: action.approved,
+          response: action.response,
           url: action.url
         }
       ].concat(state);

--- a/apps/test/unit/applab/redux/applabTest.js
+++ b/apps/test/unit/applab/redux/applabTest.js
@@ -8,6 +8,7 @@ import {
 } from '@cdo/apps/redux';
 import {ApplabInterfaceMode} from '@cdo/apps/applab/constants';
 import {reducers, actions} from '@cdo/apps/applab/redux/applab';
+import {REDIRECT_RESPONSE} from '../../../../src/applab/redux/applab';
 
 describe('App Lab redux module', () => {
   let store;
@@ -31,40 +32,52 @@ describe('App Lab redux module', () => {
 
     describe('the addRedirectNotice action', () => {
       it('adds a single redirect notice', () => {
-        store.dispatch(actions.addRedirectNotice(false, 'this-is.a.url'));
+        store.dispatch(
+          actions.addRedirectNotice(REDIRECT_RESPONSE.REJECTED, 'this-is.a.url')
+        );
 
         expect(store.getState().redirectDisplay.length).to.equal(1);
         const redirect = store.getState().redirectDisplay[0];
         expect(redirect.url).to.equal('this-is.a.url');
-        expect(redirect.approved).to.equal(false);
+        expect(redirect.response).to.equal(REDIRECT_RESPONSE.REJECTED);
       });
 
       it('adds a multiple redirect notices back to back', () => {
-        store.dispatch(actions.addRedirectNotice(false, 'this-is.a.url'));
-        store.dispatch(actions.addRedirectNotice(true, 'also-a.url'));
+        store.dispatch(
+          actions.addRedirectNotice(REDIRECT_RESPONSE.REJECTED, 'this-is.a.url')
+        );
+        store.dispatch(
+          actions.addRedirectNotice(REDIRECT_RESPONSE.APPROVED, 'also-a.url')
+        );
 
         expect(store.getState().redirectDisplay.length).to.equal(2);
         const redirect = store.getState().redirectDisplay[0];
         expect(redirect.url).to.equal('also-a.url');
-        expect(redirect.approved).to.equal(true);
+        expect(redirect.response).to.equal(REDIRECT_RESPONSE.APPROVED);
       });
     });
 
     describe('the dismissRedirectNotice action', () => {
       it('removes the first redirect notice of many', () => {
-        store.dispatch(actions.addRedirectNotice(false, 'this-is.a.url'));
-        store.dispatch(actions.addRedirectNotice(true, 'also-a.url'));
+        store.dispatch(
+          actions.addRedirectNotice(REDIRECT_RESPONSE.REJECTED, 'this-is.a.url')
+        );
+        store.dispatch(
+          actions.addRedirectNotice(REDIRECT_RESPONSE.APPROVED, 'also-a.url')
+        );
         expect(store.getState().redirectDisplay.length).to.equal(2);
         store.dispatch(actions.dismissRedirectNotice());
 
         expect(store.getState().redirectDisplay.length).to.equal(1);
         const redirect = store.getState().redirectDisplay[0];
         expect(redirect.url).to.equal('this-is.a.url');
-        expect(redirect.approved).to.equal(false);
+        expect(redirect.response).to.equal(REDIRECT_RESPONSE.REJECTED);
       });
 
       it('removes the only redirect notice', () => {
-        store.dispatch(actions.addRedirectNotice(false, 'this-is.a.url'));
+        store.dispatch(
+          actions.addRedirectNotice(REDIRECT_RESPONSE.REJECTED, 'this-is.a.url')
+        );
         expect(store.getState().redirectDisplay.length).to.equal(1);
 
         store.dispatch(actions.dismissRedirectNotice());


### PR DESCRIPTION
Students were using the openUrl block with 'mailto' link. We don't want to make it easy to facilitate students contacting each other this way, so we adding a third option to the redirect dialog that details that mailto uris are not supported.

<Screenshot>