### PR TITLE
Updated BorderProperties to use prop-types package

### DIFF
--- a/apps/src/applab/designElements/BorderProperties.jsx
+++ b/apps/src/applab/designElements/BorderProperties.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import PropertyRow from './PropertyRow';
 import ColorPickerPropertyRow from './ColorPickerPropertyRow';
 import * as elementUtils from './elementUtils';


### PR DESCRIPTION
Importing PropTypes from react is deprecated. This updates BorderProperties to the React 16 way of importing PropTypes from prop-types.