### PR TITLE
Sound dialog height

### DIFF
--- a/apps/src/code-studio/components/SoundLibrary.jsx
+++ b/apps/src/code-studio/components/SoundLibrary.jsx
@@ -72,7 +72,7 @@ const styles = {
     float: 'left',
     marginBottom: 20,
     overflowY: 'scroll',
-    height: 350
+    height: 320
   },
   allCategoriesText: {
     fontSize: 16,

--- a/apps/src/code-studio/components/SoundList.jsx
+++ b/apps/src/code-studio/components/SoundList.jsx
@@ -6,7 +6,7 @@ import soundLibrary from '../soundLibrary.json';
 
 const styles = {
   root: {
-    height: 330,
+    height: 315,
     overflowY: 'scroll',
     clear: 'both'
   }


### PR DESCRIPTION
Adjusts heights so that the last rows in the sound library list and song lists are cut in half, to encourage users to scroll down to see more items below the fold.

![Screen Shot 2019-06-28 at 2 47 06 PM](https://user-images.githubusercontent.com/11651276/60373586-87eb8400-99b5-11e9-94d1-f4d7c58d017f.png)
![Screen Shot 2019-06-28 at 2 47 42 PM](https://user-images.githubusercontent.com/11651276/60373589-8a4dde00-99b5-11e9-87c2-2d49c82601e0.png)
