### PR TITLE
Dump translations with added spaces in redactions to a Google Sheet

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -170,6 +170,10 @@ def redact(source, dest, *plugins)
   end
 end
 
+# This function currently looks for
+# 1. Translations with malformed redaction syntax, i.e. [] [0] (note the space)
+# 2. Translations with similarly malformed markdown, i.e. [link] (example.com)
+# If this function finds either of these cases in the string, it return true.
 def contains_malformed_link_or_image(translation)
   malformed_redaction_regex = /\[.*\]\s+\[[0-9]+\]/
   malformed_markdown_regex = /\[.*\]\s+\(.+\)/

--- a/bin/i18n/sync-codeorg-out.rb
+++ b/bin/i18n/sync-codeorg-out.rb
@@ -48,10 +48,7 @@ def find_malformed_links_images(locale, file_path)
     end
 
   return unless data&.values&.first&.length
-  crowdin_file_path_match = file_path.match(/i18n\/locales\/[a-z]+\-[A-Z]+\/(.+)/)
-  if crowdin_file_path_match
-    recursively_find_malformed_links_images(data, locale, crowdin_file_path_match[1])
-  end
+  recursively_find_malformed_links_images(data, locale, file_path)
 end
 
 def restore_redacted_files

--- a/bin/i18n/sync-codeorg-out.rb
+++ b/bin/i18n/sync-codeorg-out.rb
@@ -48,7 +48,10 @@ def find_malformed_links_images(locale, file_path)
     end
 
   return unless data&.values&.first&.length
-  recursively_find_malformed_links_images(data, locale)
+  crowdin_file_path_match = file_path.match(/i18n\/locales\/[a-z]+\-[A-Z]+\/(.+)/)
+  if crowdin_file_path_match
+    recursively_find_malformed_links_images(data, locale, crowdin_file_path_match[1])
+  end
 end
 
 def restore_redacted_files

--- a/bin/i18n/sync-codeorg-out.rb
+++ b/bin/i18n/sync-codeorg-out.rb
@@ -36,6 +36,21 @@ def rename_from_crowdin_name_to_locale
   end
 end
 
+def find_malformed_links_images(locale, file_path)
+  return unless File.exist?(file_path)
+  is_json = File.extname(file_path) == '.json'
+  data =
+    if is_json
+      file = File.open(file_path, 'r')
+      JSON.load(file)
+    else
+      YAML.load_file(file_path)
+    end
+
+  return unless data&.values&.first&.length
+  recursively_find_malformed_links_images(data, locale)
+end
+
 def restore_redacted_files
   total_locales = Languages.get_locale.count
   Languages.get_locale.each_with_index do |prop, i|
@@ -56,7 +71,9 @@ def restore_redacted_files
       else
         restore(original_path, translated_path, translated_path, plugin)
       end
+      find_malformed_links_images(locale, translated_path)
     end
+    upload_malformed_restorations(locale)
   end
 end
 

--- a/lib/cdo/google_drive.rb
+++ b/lib/cdo/google_drive.rb
@@ -78,6 +78,22 @@ module Google
       file.title = target_name
     end
 
+    def add_sheet_to_spreadsheet(data, spreadsheet_path, sheet_name)
+      target_name = ::File.basename(spreadsheet_path)
+      target_folder = ::File.dirname(spreadsheet_path)
+      folder = self.folder(target_folder)
+      spreadsheet = @session.spreadsheet_by_title(spreadsheet_path)
+      unless spreadsheet
+        spreadsheet = @session.create_spreadsheet(target_name)
+        folder.add(spreadsheet)
+      end
+      worksheet = spreadsheet.worksheet_by_title(sheet_name)
+      worksheet ||= spreadsheet.add_worksheet(sheet_name, 500)
+      worksheet.delete_rows(1, worksheet.num_rows)
+      worksheet.update_cells(1, 1, data)
+      worksheet.save
+    end
+
     private
 
     def path_to_title_array(path)


### PR DESCRIPTION
This implements a very simple regex to identify spaces between parts of redaction (i.e. `[] [0]`). We hope to replace this simplistic method with something more robust and complete in the next couple of weeks. 

This PR also implements a way to dump all of these strings into a centralized location, which will be maintained for the medium term. Ideally, I would like to be able to dump these strings into a Slack channel but I suspect there will be too many strings to be able to do that right now (especially once we check for missing or extra redactions). The method in this PR identified 96 malformed redactions in es-MX alone, which would make for a very noisy Slack channel over 87 languages.