### PR TITLE
Add Database S3 export permissions (DMS, Aurora)

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -120,6 +120,28 @@ Resources:
       TableMappings: !Sub |
         <%= table_mappings.to_json %>
 <% end -%>
+  DMSS3Role:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: DMSS3Role
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal: {Service: [dms.amazonaws.com]}
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: DMSRolePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 's3:PutObject'
+                  - 's3:DeleteObject'
+                  - 's3:PutObjectTagging'
+                  - 's3:ListBucket'
+                Resource: 'arn:aws:s3:::cdo-activities-archive*'
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
   PrimaryDBParameters:
     Type: AWS::RDS::DBParameterGroup
     Properties:

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -142,6 +142,35 @@ Resources:
                   - 's3:ListBucket'
                 Resource: 'arn:aws:s3:::cdo-activities-archive*'
       PermissionsBoundary: !ImportValue IAM-DevPermissions
+  AuroraS3Role:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AuroraS3Role
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal: {Service: [rds.amazonaws.com]}
+            Action: 'sts:AssumeRole'
+      Policies:
+        # SELECT INTO OUTFILE S3 permissions:
+        # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.Authorizing.IAM.S3CreatePolicy.html
+        - PolicyName: SelectIntoOutfileS3
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 's3:AbortMultipartUpload'
+                  - 's3:DeleteObject'
+                  - 's3:GetObject'
+                  - 's3:ListMultipartUploadParts'
+                  - 's3:PutObject'
+                Resource: 'arn:aws:s3:::cdo-activities-archive/*'
+              - Effect: Allow
+                Action:
+                  - 's3:ListBucket'
+                Resource: 'arn:aws:s3:::cdo-activities-archive'
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
   PrimaryDBParameters:
     Type: AWS::RDS::DBParameterGroup
     Properties:

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -171,6 +171,9 @@ AuroraCluster:
   # Reduces durability for better performance.
   innodb_flush_log_at_trx_commit: 0
 
+  # IAM role ARN used to select data into AWS S3.
+  aurora_select_into_s3_role: {'Fn::GetAtt': [AuroraS3Role, Arn]}
+
 # System variables for the Aurora DB writer.
 AuroraWriter:
   # Enable Performance Schema.

--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -204,6 +204,11 @@ Resources:
           FromPort: 3306
           ToPort: 3306
           DestinationSecurityGroupId: {Ref: FrontendSecurityGroup}
+        - Description: S3 outbound access (us-east-1 Prefix List)
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          DestinationPrefixListId: pl-63a5400a
   DBSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:


### PR DESCRIPTION
Adds permissions to export from RDS database to S3, through two different mechanisms:

1. Using DMS replication task [S3 target](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html)
2. Using Aurora [`SELECT INTO OUTFILE S3`](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Integrating.SaveIntoS3.html)

This PR hard-codes the export to a single bucket, `cdo-activities-archive`, created for archive purposes; this can be relaxed/changed in the future as needed.