### PR TITLE
Revert "Support TTS for non-English contained levels"

### DIFF
--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -154,48 +154,42 @@ module TextToSpeech
   end
 
   def tts_long_instructions_text
-    # Instructions content priority:
-    #
-    # 1. manual override if it exists (English only)
-    # 2. contained level content if it exists
-    # 3. instructions content
-    if tts_long_instructions_override && I18n.locale == I18n.default_locale
-      tts_long_instructions_override
-    elsif contained_level_text = tts_for_contained_level
-      TextToSpeech.sanitize(contained_level_text)
+    if I18n.locale == I18n.default_locale
+      # Instructions in contained levels are used as TTS instead of the
+      # instructions of the containing level
+      return tts_long_instructions_override ||
+        TextToSpeech.sanitize(tts_for_contained_level || long_instructions || "")
     else
-      TextToSpeech.sanitize(try(:localized_long_instructions) || long_instructions || "")
+      TextToSpeech.sanitize(try(:localized_long_instructions) || "")
     end
   end
 
   def tts_for_contained_level
-    all_instructions = contained_levels.map do |contained|
-      contained_level_text(contained)
-    end
-    all_instructions.empty? ? nil : all_instructions.join("\n")
+    all_instructions = []
+
+    contained_levels.each {|contained| all_instructions.push(contained_level_text(contained))}
+    all_instructions.empty? ? nil : all_instructions * "\n"
   end
 
   def contained_level_text(contained)
     # For multi questions, create a string for TTS of the markdown, question, and answers
     if contained.long_instructions.nil?
-      combined_text = []
-      if contained.properties["markdown"]
-        combined_text << contained.localized_text(contained.properties["markdown"])
-      end
+      combined_text = contained.properties["markdown"].nil? ? "" : contained.properties["markdown"] + "\n"
       if contained.properties["questions"]
         contained.properties["questions"].each do |question|
-          combined_text << contained.localized_text(question["text"])
+          combined_text += question["text"] + "\n"
         end
       end
       if contained.properties["answers"]
         contained.properties["answers"].each do |answer|
-          combined_text << contained.localized_text(answer["text"])
+          combined_text += answer["text"] + "\n"
         end
       end
-      combined_text.join("\n")
+      combined_text
     else
-      # For free response, create a string for TTS of the instructions
-      contained.try(:localized_long_instructions) || contained.long_instructions
+      #For free response, create a string for TTS of the instructions
+      contained.long_instructions
+
     end
   end
 

--- a/dashboard/test/models/concerns/text_to_speech_test.rb
+++ b/dashboard/test/models/concerns/text_to_speech_test.rb
@@ -139,38 +139,6 @@ class TextToSpeechTest < ActiveSupport::TestCase
     assert_equal "long instructions in another language\n", translatable_level.tts_long_instructions_text
   end
 
-  test 'tts works for non-english contained levels' do
-    contained_level = create :level, name: 'contained level multi', type: 'Multi', properties: {
-      'markdown': 'Contained',
-      'questions': [{'text': 'Question text'}],
-      'answers': [
-        {"text" => "answer 1", "correct" => false},
-        {"text" => "answer 2", "correct" => true},
-        {"text" => "answer 3", "correct" => true},
-      ]
-    }
-    outer_level = create :level, name: 'level 4', type: 'Blockly'
-    outer_level.contained_level_names = [contained_level.name]
-
-    test_locale = :"te-ST"
-    I18n.locale = test_locale
-    custom_i18n = {
-      "data" => {
-        "multi" => {
-          contained_level.name => {
-            'Question text': 'texte de la question',
-            'answer 1': 'réponse un',
-            'answer 2': 'réponse deux',
-            'answer 3': 'réponse troi'
-          }
-        }
-      }
-    }
-
-    I18n.backend.store_translations test_locale, custom_i18n
-    assert_equal "Contained\ntexte de la question\nréponse un\nréponse deux\nréponse troi\n", outer_level.tts_long_instructions_text
-  end
-
   test 'tts ignores overrides for non-english' do
     translatable_level = create :level, name: 'TTS test Short Instructions',
       type: 'Blockly', short_instructions: "regular instructions in English",


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#29340

It was written before https://github.com/code-dot-org/code-dot-org/pull/29193 and uses some logic that was changed in that PR