### PR TITLE
School Info Params - Fix country and full address bug

### DIFF
--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -25,9 +25,9 @@ class Api::V1::UserSchoolInfosController < ApplicationController
     end
 
     existing_school_info = current_user.last_complete_school_info
-    existing_school_info&.assign_attributes school_info_params
+    existing_school_info&.assign_attributes new_school_info_params
     if existing_school_info.nil? || existing_school_info.changed?
-      submitted_school_info = SchoolInfo.where(school_info_params).
+      submitted_school_info = SchoolInfo.where(new_school_info_params).
         first_or_create(validation_type: SchoolInfo::VALIDATION_NONE)
       current_user.update! school_info: submitted_school_info
       current_user.user_school_infos.where(school_info: submitted_school_info).

--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -10,46 +10,29 @@ class Api::V1::UserSchoolInfosController < ApplicationController
   end
 
   # PATCH /api/v1/users_school_infos
-  # def update
-  #   return unless school_info_params[:school_id].present? || school_info_params[:country].present?
-
-  #   existing_school_info = current_user.last_complete_school_info
-  #   existing_school_info&.assign_attributes school_info_params
-  #   if existing_school_info.nil? || existing_school_info.changed?
-  #     submitted_school_info = SchoolInfo.where(school_info_params).
-  #       first_or_create(validation_type: SchoolInfo::VALIDATION_NONE)
-  #     current_user.update! school_info: submitted_school_info
-  #     current_user.user_school_infos.where(school_info: submitted_school_info).
-  #       update(last_confirmation_date: DateTime.now)
-  #   else
-  #     current_user.user_school_infos.where(school_info: existing_school_info).
-  #       update(last_confirmation_date: DateTime.now)
-  #   end
-  # end
-
   def update
     return unless school_info_params[:school_id].present? || school_info_params[:country].present?
 
-    if school_info_params[:country]&.downcase&.eql? 'united states'
-      school_info_params[:country] = 'US'
-    end
+    new_school_info_params =
+      if school_info_params[:full_address]&.blank?
+        school_info_params.except(:full_address)
+      else
+        school_info_params
+      end
 
-    if school_info_params[:full_address]&.blank?
-      new_school_info_params = school_info_params.merge!(full_address: nil)
+    if new_school_info_params[:country]&.downcase&.eql? 'united states'
+      new_school_info_params[:country] = 'US'
     end
-
-    # new_school_info_params = school_info_params.reject{ |_, v| v.blank? }
 
     existing_school_info = current_user.last_complete_school_info
-    existing_school_info&.assign_attributes new_school_info_params
+    existing_school_info&.assign_attributes school_info_params
     if existing_school_info.nil? || existing_school_info.changed?
-      submitted_school_info = SchoolInfo.where(new_school_info_params).
+      submitted_school_info = SchoolInfo.where(school_info_params).
         first_or_create(validation_type: SchoolInfo::VALIDATION_NONE)
       current_user.update! school_info: submitted_school_info
       current_user.user_school_infos.where(school_info: submitted_school_info).
         update(last_confirmation_date: DateTime.now)
     else
-      puts "do I make it here?"
       current_user.user_school_infos.where(school_info: existing_school_info).
         update(last_confirmation_date: DateTime.now)
     end

--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -10,18 +10,46 @@ class Api::V1::UserSchoolInfosController < ApplicationController
   end
 
   # PATCH /api/v1/users_school_infos
+  # def update
+  #   return unless school_info_params[:school_id].present? || school_info_params[:country].present?
+
+  #   existing_school_info = current_user.last_complete_school_info
+  #   existing_school_info&.assign_attributes school_info_params
+  #   if existing_school_info.nil? || existing_school_info.changed?
+  #     submitted_school_info = SchoolInfo.where(school_info_params).
+  #       first_or_create(validation_type: SchoolInfo::VALIDATION_NONE)
+  #     current_user.update! school_info: submitted_school_info
+  #     current_user.user_school_infos.where(school_info: submitted_school_info).
+  #       update(last_confirmation_date: DateTime.now)
+  #   else
+  #     current_user.user_school_infos.where(school_info: existing_school_info).
+  #       update(last_confirmation_date: DateTime.now)
+  #   end
+  # end
+
   def update
     return unless school_info_params[:school_id].present? || school_info_params[:country].present?
 
+    if school_info_params[:country]&.downcase&.eql? 'united states'
+      school_info_params[:country] = 'US'
+    end
+
+    if school_info_params[:full_address]&.blank?
+      new_school_info_params = school_info_params.merge!(full_address: nil)
+    end
+
+    # new_school_info_params = school_info_params.reject{ |_, v| v.blank? }
+
     existing_school_info = current_user.last_complete_school_info
-    existing_school_info&.assign_attributes school_info_params
+    existing_school_info&.assign_attributes new_school_info_params
     if existing_school_info.nil? || existing_school_info.changed?
-      submitted_school_info = SchoolInfo.where(school_info_params).
+      submitted_school_info = SchoolInfo.where(new_school_info_params).
         first_or_create(validation_type: SchoolInfo::VALIDATION_NONE)
       current_user.update! school_info: submitted_school_info
       current_user.user_school_infos.where(school_info: submitted_school_info).
         update(last_confirmation_date: DateTime.now)
     else
+      puts "do I make it here?"
       current_user.user_school_infos.where(school_info: existing_school_info).
         update(last_confirmation_date: DateTime.now)
     end

--- a/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
@@ -561,8 +561,9 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
 
     # Then, only update the last confirmation date
     @teacher.reload
-    assert_equal 2, @teacher.user_school_infos.count
+    assert_equal 1, @teacher.user_school_infos.count
     assert tenure_c.school_info.complete?
+    assert_equal @teacher.school_info.id, school_info.id
   end
 
   test 'confirmation, complete, submit unchanged complete info' do

--- a/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
@@ -383,12 +383,12 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'confirmation, partial previous, unchanged, manual' do
-    complete_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: 'Philly High Harmony', full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_NONE})
+    complete_school_info = SchoolInfo.create({country: 'US', school_type: 'public', school_name: 'Philly High Harmony', full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_NONE})
     @teacher.update(school_info: complete_school_info)
 
     Timecop.travel 1.year
 
-    partial_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: nil, full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_NONE})
+    partial_school_info = SchoolInfo.create({country: 'US', school_type: 'public', school_name: nil, full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_NONE})
     @teacher.update(school_info: partial_school_info)
 
     Timecop.travel 7.days
@@ -401,7 +401,7 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     assert_equal @teacher.user_school_infos.count, 2
     new_tenure = @teacher.user_school_infos.last
     assert_nil new_tenure.school_info.school_name
-    assert_same_date Time.now, new_tenure.last_confirmation_date
+    # assert_same_date Time.now, new_tenure.last_confirmation_date
   end
 
   test 'confirmation, partial previous, partial, manual' do
@@ -548,10 +548,10 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     # Edge case involving complete school info
 
     # Given a user with a complete (dropdown OR manual) school info `A`
-    school_info = SchoolInfo.create({country: 'US', school_type: 'public', school_name: 'Acme Inc', full_address: 'Seattle, WA', validation_type: SchoolInfo::VALIDATION_NONE})
+    school_info = SchoolInfo.create({country: 'US', school_type: 'public', school_name: 'Acme Inc', full_address: nil, validation_type: SchoolInfo::VALIDATION_NONE})
     @teacher.update school_info: school_info
     tenure_c = @teacher.user_school_infos.first
-    assert tenure_a.school_info.complete?
+    assert tenure_c.school_info.complete?
 
     # When a year later they click "No" and "Save" without changing anything
     Timecop.travel 1.year
@@ -561,10 +561,8 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
 
     # Then, only update the last confirmation date
     @teacher.reload
-    assert_equal 1, @teacher.user_school_infos.count
+    assert_equal 2, @teacher.user_school_infos.count
     assert tenure_c.school_info.complete?
-    # assert_in_delta Time.now.to_i, tenure_a.last_confirmation_date.to_i, 10
-    # assert_same_date Time.now, tenure_a.last_confirmation_date
     assert_equal @teacher.school_info.id, school_info.id
   end
 
@@ -575,7 +573,7 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     school_info = create :school_info
     @teacher.update school_info: school_info
     tenure_d = @teacher.user_school_infos.first
-    assert tenure_a.school_info.complete?
+    assert tenure_d.school_info.complete?
 
     # When a year later they click "No" and "Save" without changing anything
     Timecop.travel 1.year
@@ -587,8 +585,6 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     @teacher.reload
     assert_equal 1, @teacher.user_school_infos.count
     assert tenure_d.school_info.complete?
-    assert_in_delta Time.now.to_i, tenure_a.last_confirmation_date.to_i, 10
-    # assert_same_date Time.now, tenure_a.last_confirmation_date
     assert_equal @teacher.school_info.id, school_info.id
   end
 

--- a/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
@@ -563,7 +563,6 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     @teacher.reload
     assert_equal 2, @teacher.user_school_infos.count
     assert tenure_c.school_info.complete?
-    assert_equal @teacher.school_info.id, school_info.id
   end
 
   test 'confirmation, complete, submit unchanged complete info' do

--- a/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
@@ -401,7 +401,7 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     assert_equal @teacher.user_school_infos.count, 2
     new_tenure = @teacher.user_school_infos.last
     assert_nil new_tenure.school_info.school_name
-    # assert_same_date Time.now, new_tenure.last_confirmation_date
+    assert_same_date Time.now, new_tenure.last_confirmation_date
   end
 
   test 'confirmation, partial previous, partial, manual' do

--- a/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
@@ -544,6 +544,54 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     assert_same_date 7.days.ago, tenure_b.last_confirmation_date
   end
 
+  test 'confirmation complete submit unchanged manual info' do
+    # Edge case involving complete school info
+
+    # Given a user with a complete (dropdown OR manual) school info `A`
+    school_info = SchoolInfo.create({country: 'US', school_type: 'public', school_name: 'Acme Inc', full_address: 'Seattle, WA', validation_type: SchoolInfo::VALIDATION_NONE})
+    @teacher.update school_info: school_info
+    tenure_c = @teacher.user_school_infos.first
+    assert tenure_a.school_info.complete?
+
+    # When a year later they click "No" and "Save" without changing anything
+    Timecop.travel 1.year
+    sign_in @teacher
+    submit_complete_school_info_manual_no_school_params
+    assert_response :success, response.body
+
+    # Then, only update the last confirmation date
+    @teacher.reload
+    assert_equal 1, @teacher.user_school_infos.count
+    assert tenure_c.school_info.complete?
+    # assert_in_delta Time.now.to_i, tenure_a.last_confirmation_date.to_i, 10
+    # assert_same_date Time.now, tenure_a.last_confirmation_date
+    assert_equal @teacher.school_info.id, school_info.id
+  end
+
+  test 'confirmation, complete, submit unchanged complete info' do
+    # Edge case involving complete school info
+
+    # Given a user with a complete (dropdown OR manual) school info `A`
+    school_info = create :school_info
+    @teacher.update school_info: school_info
+    tenure_d = @teacher.user_school_infos.first
+    assert tenure_a.school_info.complete?
+
+    # When a year later they click "No" and "Save" without changing anything
+    Timecop.travel 1.year
+    sign_in @teacher
+    submit_complete_school_info_from_dropdown school_info.school
+    assert_response :success, response.body
+
+    # Then, only update the last confirmation date
+    @teacher.reload
+    assert_equal 1, @teacher.user_school_infos.count
+    assert tenure_d.school_info.complete?
+    assert_in_delta Time.now.to_i, tenure_a.last_confirmation_date.to_i, 10
+    # assert_same_date Time.now, tenure_a.last_confirmation_date
+    assert_equal @teacher.school_info.id, school_info.id
+  end
+
   private def partial_manual_school_info
     SchoolInfo.create(
       country: 'United States',
@@ -594,6 +642,19 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
           school_type: 'public',
           school_name: 'Acme Inc',
           full_address: 'Seattle, Washington'
+        }
+      }
+    }
+  end
+
+  private def submit_complete_school_info_manual_no_school_params
+    patch "/api/v1/user_school_infos", params: {
+      user: {
+        school_info_attributes: {
+          country: 'United States',
+          school_type: 'public',
+          school_name: 'Acme Inc',
+          full_address: ''
         }
       }
     }


### PR DESCRIPTION
Bug
A new school info id is created when the school info interstitial form is submitted without changes (specifically, manual complete unchanged school info is saved).

When a user signs up for a new account, the country code ('US') is used but in the school info interstitial the country name ('United States') is used. This means that the School Infos are technically different, so a new one is created.  During our investigation, Bethany and I found https://github.com/code-dot-org/code-dot-org/pull/24993 which forces sign up to use the country code instead of country. 

Similar behavior is also observed when the full address is blank (empty).  If a user does not enter a city and state (full_address) during signup, nil is returned but in the school info interstitial, an empty string is used.  This results in the creation of a new school info id.

Fix
After discussion with Maddie, we got confirmation that we should use the 2 digit country code.
If full_address is blank, it is removed from the school_info_parms.  If country is 'united states', the 2 country digit code 'US' is reassigned to school_info_params[:country]

Updated tests