### PR TITLE
Add BubbleChoice levels/sublevels to contained_levels rollup table

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -76,6 +76,18 @@ def main
     end
   end
 
+  Level.where(type: 'BubbleChoice').find_each do |level|
+    level.properties['sublevels'].each_with_index do |sublevel_name, sublevel_index|
+      sublevel = Level.find_by_name(sublevel_name)
+      contained_levels << {
+        level_id: level.id,
+        contained_level_id: sublevel.id,
+        contained_level_type: sublevel.type,
+        contained_level_position: sublevel_index
+      }
+    end
+  end
+
   Level.find_each do |level|
     begin
       next unless level.script_levels.map(&:script).select(&:k5_draft_course?)


### PR DESCRIPTION
To make it easier to query Redshift for data about BubbleChoice sublevels (which are similar in structure to contained levels and LevelGroups), I'd like to add BubbleChoice levels to the `contained_levels` rollup table.

For each BubbleChoice sublevel, we will record the following information:
- `level_id` - ID of parent level
- `contained_level_id` - ID of sublevel
- `contained_level_type` - type of sublevel
- `contained_level_position` - position of sublevel under parent level