### PR TITLE
Pull spritelab preview code out of gamelab.js

### DIFF
--- a/apps/src/gamelab/spritelab/Spritelab.js
+++ b/apps/src/gamelab/spritelab/Spritelab.js
@@ -8,13 +8,13 @@ var Spritelab = function() {
   this.reset = () => spriteUtils.reset();
 
   this.preview = function() {
-    if (!this.areAnimationsReady_()) {
-      return;
-    }
     spriteUtils.reset();
     getStore().dispatch(clearConsole());
     Sounds.getSingleton().muteURLs();
     if (this.gameLabP5.p5 && this.JSInterpreter) {
+      if (!this.areAnimationsReady_()) {
+        return;
+      }
       this.gameLabP5.p5.allSprites.removeSprites();
       this.JSInterpreter.deinitialize();
       this.initInterpreter(false /* attachDebugger */);

--- a/apps/src/gamelab/spritelab/Spritelab.js
+++ b/apps/src/gamelab/spritelab/Spritelab.js
@@ -1,8 +1,30 @@
 import {commands} from './commands';
 import * as spriteUtils from './spriteUtils';
+import Sounds from '../../Sounds';
+import {getStore} from '../../redux';
+import {clearConsole} from '../textConsoleModule';
 
 var Spritelab = function() {
   this.reset = () => spriteUtils.reset();
+
+  this.preview = function() {
+    if (!this.areAnimationsReady_()) {
+      return;
+    }
+    spriteUtils.reset();
+    getStore().dispatch(clearConsole());
+    Sounds.getSingleton().muteURLs();
+    if (this.gameLabP5.p5 && this.JSInterpreter) {
+      this.gameLabP5.p5.allSprites.removeSprites();
+      this.JSInterpreter.deinitialize();
+      this.initInterpreter(false /* attachDebugger */);
+      this.onP5Setup();
+      this.gameLabP5.p5.redraw();
+    } else {
+      this.gameLabP5.startExecution();
+      this.gameLabP5.setLoop(false);
+    }
+  };
 
   this.commands = commands;
 };

--- a/apps/test/unit/gamelab/GameLabTest.js
+++ b/apps/test/unit/gamelab/GameLabTest.js
@@ -68,10 +68,8 @@ describe('GameLab', () => {
       beforeEach(() => instance.injectStudioApp(studioApp));
 
       describe('Muting', () => {
-        let muteSpy;
         let unmuteSpy;
         beforeEach(() => {
-          muteSpy = sinon.stub(Sounds.getSingleton(), 'muteURLs');
           unmuteSpy = sinon.stub(Sounds.getSingleton(), 'unmuteURLs');
           instance.gameLabP5.p5 = sinon.spy();
           instance.gameLabP5.p5.allSprites = sinon.spy();
@@ -90,22 +88,11 @@ describe('GameLab', () => {
         });
 
         afterEach(() => {
-          muteSpy.restore();
           unmuteSpy.restore();
         });
 
-        it('Rerun mutes URLs', () => {
-          instance.rerunSetupCode();
-          expect(Sounds.getSingleton().muteURLs).to.have.been.calledOnce;
-        });
-
-        it('Execute mutes if not looping', () => {
-          instance.execute(false /* shouldLoop */);
-          expect(Sounds.getSingleton().muteURLs).to.have.been.calledOnce;
-        });
-
-        it('Execute unmutes if looping', () => {
-          instance.execute(true /* shouldLoop */);
+        it('Execute unmutes URLs', () => {
+          instance.execute();
           expect(Sounds.getSingleton().unmuteURLs).to.have.been.calledOnce;
         });
       });

--- a/apps/test/unit/gamelab/spritelab/SpritelabTest.js
+++ b/apps/test/unit/gamelab/spritelab/SpritelabTest.js
@@ -1,0 +1,33 @@
+import sinon from 'sinon';
+import {expect} from '../../../util/reconfiguredChai';
+import Spritelab from '@cdo/apps/gamelab/spritelab/Spritelab';
+import Sounds from '@cdo/apps/Sounds';
+
+describe('Spritelab Preview', () => {
+  let gamelab, muteSpy;
+  beforeEach(function() {
+    gamelab = sinon.spy();
+    gamelab.areAnimationsReady_ = sinon.stub().returns(true);
+    gamelab.gameLabP5 = sinon.spy();
+    gamelab.gameLabP5.p5 = sinon.spy();
+    gamelab.gameLabP5.p5.allSprites = sinon.spy();
+    gamelab.gameLabP5.p5.allSprites.removeSprites = sinon.spy();
+    gamelab.gameLabP5.p5.redraw = sinon.spy();
+    gamelab.JSInterpreter = sinon.spy();
+    gamelab.JSInterpreter.deinitialize = sinon.spy();
+    gamelab.initInterpreter = sinon.spy();
+    gamelab.onP5Setup = sinon.spy();
+
+    muteSpy = sinon.stub(Sounds.getSingleton(), 'muteURLs');
+  });
+
+  afterEach(function() {
+    muteSpy.restore();
+  });
+  it('Mutes sounds', () => {
+    let spritelab = new Spritelab();
+    spritelab.preview.apply(gamelab);
+
+    expect(muteSpy).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
Original PR #29404, reverted by #29439

The issue was that if animations took a while to load on initial page load, `this.areAnimationsReady_()` would be false, and no preview would show. This change moves the `this.areAnimationsReady_()` check into the case where we already have a p5 instance and an interpreter (this case is triggered when the blockspace changes), so if it's the initial page load, we don't return early. Calling `gameLabP5.startExecution` waits for the animations to load, so everything should work as expected.