### PR TITLE
Add ECS task execution role to Aurora Verify Backups template [ci skip]

### DIFF
--- a/aws/offsite/aurora-snapshots-fargate/aurora-verify-backups-stack.yml
+++ b/aws/offsite/aurora-snapshots-fargate/aurora-verify-backups-stack.yml
@@ -33,6 +33,23 @@ Resources:
             Action: 
               - "sts:AssumeRole"
 
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AuroraVerifyBackupsEcsTaskExecutionRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        -
+          Effect: "Allow"
+          Principal:
+            Service:
+            - "ecs-tasks.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
+
   CWEInvokeECSRole:
     Type: AWS::IAM::Role
     Properties:
@@ -78,7 +95,7 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
       NetworkMode: awsvpc
-      ExecutionRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/ecsTaskExecutionRole"
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
       Cpu: 256
       Memory: 0.5GB
       TaskRoleArn: !GetAtt TaskRole.Arn


### PR DESCRIPTION
`ecsTaskExecutionRole` is created by the ECS console wizard, but isn't present in the offsite account. Creating the role explicitly in the template instead.