### PR TITLE
Errors and warning circumvent react-inspector

### DIFF
--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -250,6 +250,8 @@ export default connect(
           }
           if (rowValue.input) {
             return <div key={i}>&gt; {rowValue.input}</div>;
+          } else if (rowValue.skipInspector) {
+            return rowValue.output;
           } else if (this.isValidOutput(rowValue)) {
             if (rowValue.fromConsoleLog) {
               return <Inspector key={i} data={rowValue.output} />;

--- a/apps/src/lib/tools/jsdebugger/redux.js
+++ b/apps/src/lib/tools/jsdebugger/redux.js
@@ -102,6 +102,9 @@ export function initialize({runApp}) {
  */
 export function appendLog(output, level) {
   return (dispatch, getState) => {
+    // Errors and warnings should circumvent the react-inspector because they have
+    // their own styling
+    output['skipInspector'] = level === 'ERROR' || level === 'WARNING';
     const logLevel = level && level.toLowerCase();
     dispatch({type: APPEND_LOG, output, logLevel});
     if (!isOpen(getState())) {

--- a/apps/test/unit/lib/tools/jsdebugger/reduxTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/reduxTest.js
@@ -140,6 +140,21 @@ describe('The JSDebugger redux duck', () => {
       store.dispatch(actions.appendLog({output: 'open sesame'}));
       expect(selectors.isOpen(store.getState())).to.be.true;
     });
+
+    it('will append errors and warnings with note to skip react-inspector', () => {
+      store.dispatch(actions.appendLog({output: 'Text'}, 'ERROR'));
+      store.dispatch(actions.appendLog({input: 'More text'}, 'WARNING'));
+      store.dispatch(actions.appendLog({output: 'Even more text'}));
+      expect(
+        selectors.getLogOutput(store.getState()).toJS()[0].skipInspector
+      ).to.equal(true);
+      expect(
+        selectors.getLogOutput(store.getState()).toJS()[1].skipInspector
+      ).to.equal(true);
+      expect(
+        selectors.getLogOutput(store.getState()).toJS()[2].skipInspector
+      ).to.equal(false);
+    });
   });
 
   describe('before being initialized', () => {


### PR DESCRIPTION
This PR branches off: https://github.com/code-dot-org/code-dot-org/pull/29375

This PR introduces the option to "skipInspector". At the moment, this is used only for errors and warnings because these types of messages have special formatting that the inspector doesn't handle.

This test will mean that some of the integration tests that were failing and fixed in PR 29375 will go fail again as they return to their un-inspector state. @epeach is on the hook to fix those tests.