### PR TITLE
Convert "Code.org - Markdown" files from ERB to partials

### DIFF
--- a/bin/i18n/codeorg_markdown_crowdin.yml
+++ b/bin/i18n/codeorg_markdown_crowdin.yml
@@ -6,6 +6,9 @@
 "api_key" : ""
 
 files: [{
-  "source": "/public/international/about.md",
+  "source": "/public/international/about.md.partial",
+  "translation": "/i18n/%original_path%/%file_name%.%locale%.%file_extension%",
+}, {
+  "source": "/public/educate/curriculum/csf-transition-guide.md",
   "translation": "/i18n/%original_path%/%file_name%.%locale%.%file_extension%",
 }]

--- a/pegasus/sites.v3/code.org/public/international/about.md.partial
+++ b/pegasus/sites.v3/code.org/public/international/about.md.partial
@@ -54,4 +54,4 @@ All curriculum resources and tutorials we create will forever be free to use and
 
 [Sign up to receive status updates](/about/hear-from-us) about progress in the K-12 computer science movement and about the work of Code.org. Or follow Code.org on social media:
 
-<%= view :social_media, facebook: "Code.org", twitter: "codeorg", instagram: "codeorg" %>
+{{ social_media_codeorg }}

--- a/pegasus/sites.v3/code.org/views/social_media_codeorg.haml
+++ b/pegasus/sites.v3/code.org/views/social_media_codeorg.haml
@@ -1,0 +1,1 @@
+= view :social_media, facebook: "Code.org", twitter: "codeorg", instagram: "codeorg"


### PR DESCRIPTION
So that we can begin syncing them regularly again.

Also add the CSF transition guide to the config, since it was apparently never added?