### PR TITLE
Pegasus: fix logo layout

### DIFF
--- a/pegasus/sites.v3/code.org/views/about_logos.haml
+++ b/pegasus/sites.v3/code.org/views/about_logos.haml
@@ -10,8 +10,7 @@
   - else
     .col-25.col-mobile-50{:style => 'text-align: center;'}
       %div{:style => 'width: 160px; height: 190px; line-height:190px; text-align: center;'}
-        %a
-          %img{:src=>avatar_url, :style => 'max-width: 140px; max-height: 140px;'}
-          %p= logo[:description_t]
+        %img{:src=>avatar_url, :style => 'max-width: 140px; max-height: 140px;'}
+        %p= logo[:description_t]
 
 %br{:style=>'clear: both;'}

--- a/pegasus/sites.v3/code.org/views/about_logos.haml
+++ b/pegasus/sites.v3/code.org/views/about_logos.haml
@@ -8,9 +8,10 @@
         %a{:href=>logo[:url_s], :style => 'vertical-align: middle;'}
           %img{:src=>avatar_url, :style => 'width: 140px; max-height: 140px;'}
   - else
-    .col-25.col-mobile-50
-      %a
-        %img{:src=>avatar_url, :style => 'max-width: 140px; max-height: 140px;'}
-        %p= logo[:description_t]
+    .col-25.col-mobile-50{:style => 'text-align: center;'}
+      %div{:style => 'width: 160px; height: 190px; line-height:190px; text-align: center;'}
+        %a
+          %img{:src=>avatar_url, :style => 'max-width: 140px; max-height: 140px;'}
+          %p= logo[:description_t]
 
 %br{:style=>'clear: both;'}


### PR DESCRIPTION
When showing a grid of logos, the presentation of a logo without a URL should be the same as one that has one.

## Before
![Screenshot 2019-07-03 08 56 50](https://user-images.githubusercontent.com/2205926/60607746-baf59500-9d72-11e9-99c2-31745fb5786c.png)

## After
![Screenshot 2019-07-03 08 59 54](https://user-images.githubusercontent.com/2205926/60607745-baf59500-9d72-11e9-8613-5c369b8b12b5.png)

