### PR TITLE
Email: Send Poste activity metrics to New Relic

### DIFF
--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -288,7 +288,7 @@ def create_threads(count)
 end
 
 def main
-  # started_at = Time.now
+  started_at = Time.now
 
   queue = Queue.new.tap do |results|
     POSTE_DB[:poste_deliveries].where(sent_at: nil).limit(BATCH_SIZE).reverse_order(:id).each {|i| results << i}
@@ -342,19 +342,19 @@ def main
   end
   workers.each(&:join)
 
-  # if CDO.newrelic_logging
-  #   # How many emails we sent on _this run_ of the cronjob
-  #   sent_count = POSTE_DB[:poste_deliveries].where(Sequel.lit('sent_at >= ?', started_at)).count
-  #   NewRelic::Agent.record_metric("Custom/Poste/Sent", sent_count)
-  #
-  #   # How many total abandoned emails we have
-  #   abandon_count = POSTE_DB[:poste_deliveries].where(sent_at: 0).count
-  #   NewRelic::Agent.record_metric("Custom/Poste/Abandoned", abandon_count)
-  #
-  #   # How many emails are still queued for send on subsequent runs
-  #   remaining_count = POSTE_DB[:poste_deliveries].where(sent_at: nil).count
-  #   NewRelic::Agent.record_metric("Custom/Poste/Queued", remaining_count)
-  # end
+  if CDO.newrelic_logging
+    # How many emails we sent on _this run_ of the cronjob
+    sent_count = POSTE_DB[:poste_deliveries].where(Sequel.lit('sent_at >= ?', started_at)).count
+    NewRelic::Agent.record_metric("Custom/Poste/Sent", sent_count)
+
+    # How many total abandoned emails we have
+    abandon_count = POSTE_DB[:poste_deliveries].where(sent_at: 0).count
+    NewRelic::Agent.record_metric("Custom/Poste/Abandoned", abandon_count)
+
+    # How many emails are still queued for send on subsequent runs
+    remaining_count = POSTE_DB[:poste_deliveries].where(sent_at: nil).count
+    NewRelic::Agent.record_metric("Custom/Poste/Queued", remaining_count)
+  end
 end
 
 main if only_one_running?(__FILE__)

--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -10,6 +10,10 @@ require 'nokogiri'
 require src_dir 'forms'
 require src_dir 'abort_email_error'
 
+if CDO.newrelic_logging
+  require 'newrelic_rpm'
+end
+
 BATCH_SIZE = 500_000
 MAX_THREAD_COUNT = 50
 MIN_MESSAGES_PER_THREAD = 50


### PR DESCRIPTION
Second attempt at https://github.com/code-dot-org/code-dot-org/pull/29308 after the first attempt [failed because New Relic wasn't loaded](https://github.com/code-dot-org/code-dot-org/commit/3f24a18efe8fc0e4c0356cc5bdd65444e66f1670).

Here I've added a conditional require for the New Relic agent that should solve that error.  We don't normally do this when we log to New Relic because it happens [on dashboard in application.rb](https://github.com/code-dot-org/code-dot-org/blob/d16fc9addb88600299d92889c29a019e722f5089/dashboard/config/application.rb#L145-L147) and [on pegasus in router.rb](https://github.com/code-dot-org/code-dot-org/blob/82792e36f388674d49c8ecf477ae4d614c377030/pegasus/router.rb#L27), probably because we don't want to do this more than once... but these don't reach our cronjobs!  So it's a one-off here.