### PR TITLE
Move survey pipeline logic from controller to helper module

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -1,8 +1,4 @@
-require 'pd/survey_pipeline/daily_survey_retriever.rb'
-require 'pd/survey_pipeline/daily_survey_parser.rb'
-require 'pd/survey_pipeline/daily_survey_joiner.rb'
-require 'pd/survey_pipeline/mapper.rb'
-require 'pd/survey_pipeline/daily_survey_decorator.rb'
+require 'pd/survey_pipeline/survey_pipeline_helper.rb'
 require 'honeybadger/ruby'
 
 module Api::V1::Pd
@@ -10,6 +6,7 @@ module Api::V1::Pd
     include WorkshopScoreSummarizer
     include ::Pd::WorkshopSurveyReportCsvConverter
     include Pd::WorkshopSurveyResultsHelper
+    include Pd::SurveyPipeline::Helper
 
     load_and_authorize_resource :workshop, class: 'Pd::Workshop'
 
@@ -159,60 +156,7 @@ module Api::V1::Pd
     end
 
     def create_csf_survey_report
-      # Fields used to group survey answers
-      group_config = [:workshop_id, :form_id, :facilitator_id, :name, :type, :answer_type]
-
-      is_single_select_answer = lambda {|hash| hash.dig(:answer_type) == 'singleSelect'}
-      is_free_format_question = lambda {|hash| ['textbox', 'textarea'].include?(hash[:type])}
-      is_number_question = lambda {|hash| hash[:type] == 'number'}
-
-      # Rules to map groups of survey answers to reducers
-      map_config = [
-        {
-          condition: is_single_select_answer,
-          field: :answer,
-          reducers: [Pd::SurveyPipeline::HistogramReducer]
-        },
-        {
-          condition: is_free_format_question,
-          field: :answer,
-          reducers: [Pd::SurveyPipeline::NoOpReducer]
-        },
-        {
-          condition: is_number_question,
-          field: :answer,
-          reducers: [Pd::SurveyPipeline::AvgReducer]
-        },
-      ]
-
-      # Centralized context object shared by all workers in the pipeline.
-      # Workers read from and write to this object.
-      context = {
-        current_user: current_user,
-        filters: {workshop_ids: @workshop.id}
-      }
-
-      # Assembly line to summarize CSF surveys
-      workers = [
-        Pd::SurveyPipeline::DailySurveyRetriever,
-        Pd::SurveyPipeline::DailySurveyParser,
-        Pd::SurveyPipeline::DailySurveyJoiner,
-        Pd::SurveyPipeline::GenericMapper.new(
-          group_config: group_config, map_config: map_config
-        ),
-        Pd::SurveyPipeline::DailySurveyDecorator
-      ]
-
-      create_generic_survey_report context, workers
-
-      render json: context[:decorated_summaries]
-    end
-
-    # Create survey report by having a group of workers process data in the same context.
-    def create_generic_survey_report(context, workers)
-      workers&.each do |w|
-        w.process_data context
-      end
+      render json: report_single_workshop(@workshop, current_user)
     end
 
     # We want to filter facilitator-specific responses if the user is a facilitator and

--- a/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
@@ -1,0 +1,57 @@
+require 'pd/survey_pipeline/daily_survey_retriever.rb'
+require 'pd/survey_pipeline/daily_survey_parser.rb'
+require 'pd/survey_pipeline/daily_survey_joiner.rb'
+require 'pd/survey_pipeline/mapper.rb'
+require 'pd/survey_pipeline/daily_survey_decorator.rb'
+
+module Pd::SurveyPipeline::Helper
+  def report_single_workshop(workshop, current_user)
+    # Fields used to group survey answers
+    group_config = [:workshop_id, :form_id, :facilitator_id, :name, :type, :answer_type]
+
+    # Rules to map groups of survey answers to reducers
+    is_single_select_answer = lambda {|hash| hash.dig(:answer_type) == 'singleSelect'}
+    is_free_format_question = lambda {|hash| ['textbox', 'textarea'].include?(hash[:type])}
+
+    map_config = [
+      {
+        condition: is_single_select_answer,
+        field: :answer,
+        reducers: [Pd::SurveyPipeline::HistogramReducer]
+      },
+      {
+        condition: is_free_format_question,
+        field: :answer,
+        reducers: [Pd::SurveyPipeline::NoOpReducer]
+      }
+    ]
+
+    # Centralized context object shared by all workers in the pipeline.
+    # Workers read from and write to this object.
+    context = {
+      current_user: current_user,
+      filters: {workshop_ids: @workshop.id}
+    }
+
+    # Assembly line to summarize CSF surveys
+    workers = [
+      Pd::SurveyPipeline::DailySurveyRetriever,
+      Pd::SurveyPipeline::DailySurveyParser,
+      Pd::SurveyPipeline::DailySurveyJoiner,
+      Pd::SurveyPipeline::GenericMapper.new(
+        group_config: group_config, map_config: map_config
+      ),
+      Pd::SurveyPipeline::DailySurveyDecorator
+    ]
+
+    create_generic_survey_report context, workers
+    context[:decorated_summaries]
+  end
+
+  # Create survey report by having a group of workers process data in the same context.
+  def create_generic_survey_report(context, workers)
+    workers&.each do |w|
+      w.process_data context
+    end
+  end
+end


### PR DESCRIPTION
First PR in a series to support workshop survey roll-ups. 

### What
- Move survey pipeline logic from controller to helper module to make it easier adding more roll-up pipelines later.
- Also remove some unnecessary mapping configuration.

### How tested
- Unit Test
  - bundle exec rails test test/lib/pd/survey_pipeline/survey_pipeline_worker_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/mapper_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_joiner_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_parser_test.rb
  - bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_retriever_test.rb
  - bundle exec rails test test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
- Manual integration test
  - API check: http://localhost-studio.code.org:3000/api/v1/pd/workshops/6482/generic_survey_report
  - UI check: http://localhost-studio.code.org:3000/pd/workshop_dashboard/daily_survey_results/6482