### PR TITLE
Preload background images for Sprite Lab

### DIFF
--- a/apps/src/gamelab/GameLab.js
+++ b/apps/src/gamelab/GameLab.js
@@ -1080,6 +1080,7 @@ GameLab.prototype.onP5ExecutionStarting = function() {
 GameLab.prototype.onP5Preload = function() {
   Promise.all([
     this.preloadAnimations_(this.level.pauseAnimationsByDefault),
+    this.maybePreloadBackgrounds_(),
     this.runPreloadEventHandler_()
   ]).then(() => {
     this.gameLabP5.notifyPreloadPhaseComplete();
@@ -1094,6 +1095,14 @@ GameLab.prototype.loadValidationCodeIfNeeded_ = function() {
   ) {
     this.level.helperLibraries.unshift(validationLibraryName);
   }
+};
+
+// Preloads background images if this is Sprite Lab
+GameLab.prototype.maybePreloadBackgrounds_ = function() {
+  if (!this.isSpritelab) {
+    return Promise.resolve();
+  }
+  return this.gameLabP5.preloadBackgrounds();
 };
 
 /**

--- a/apps/src/gamelab/GameLabP5.js
+++ b/apps/src/gamelab/GameLabP5.js
@@ -3,6 +3,7 @@ import {allAnimationsSingleFrameSelector} from './animationListModule';
 var gameLabSprite = require('./GameLabSprite');
 var gameLabGroup = require('./GameLabGroup');
 var Spritelab = require('./spritelab/Spritelab');
+import {backgrounds} from './spritelab/backgrounds.json';
 import * as assetPrefix from '../assetManagement/assetPrefix';
 
 const defaultFrameRate = 30;
@@ -579,6 +580,33 @@ GameLabP5.prototype.afterSetupStarted = function() {
 GameLabP5.prototype.afterSetupComplete = function() {
   this.p5._setupEpiloguePhase1();
   this.p5._setupEpiloguePhase2();
+};
+
+GameLabP5.prototype.preloadBackgrounds = function() {
+  if (this.preloadedBackgrounds) {
+    this.p5._predefinedBackgrounds = this.preloadedBackgrounds;
+    return Promise.resolve();
+  }
+  this.preloadedBackgrounds = {};
+  this.p5._predefinedBackgrounds = {};
+  return Promise.all(
+    backgrounds.map(background => {
+      return new Promise(resolve => {
+        this.p5.loadImage(
+          background.sourceUrl,
+          image => {
+            this.preloadedBackgrounds[background.legacyParam] = image;
+            this.p5._predefinedBackgrounds[background.legacyParam] = image;
+            resolve();
+          },
+          err => {
+            console.log(err);
+            resolve();
+          }
+        );
+      });
+    })
+  );
 };
 
 /**

--- a/apps/src/gamelab/GameLabP5.js
+++ b/apps/src/gamelab/GameLabP5.js
@@ -603,12 +603,9 @@ GameLabP5.prototype.preloadBackgrounds = function() {
       })
     );
   }
-  return this.preloadBackgrounds_.then(() => {
-    return new Promise(resolve => {
-      this.p5._preloadedBackgrounds = this.preloadedBackgrounds;
-      resolve();
-    });
-  });
+  return this.preloadBackgrounds_.then(
+    () => (this.p5._preloadedBackgrounds = this.preloadedBackgrounds)
+  );
 };
 
 /**

--- a/apps/src/gamelab/GameLabP5.js
+++ b/apps/src/gamelab/GameLabP5.js
@@ -583,30 +583,34 @@ GameLabP5.prototype.afterSetupComplete = function() {
 };
 
 GameLabP5.prototype.preloadBackgrounds = function() {
-  if (this.preloadedBackgrounds) {
-    this.p5._predefinedBackgrounds = this.preloadedBackgrounds;
-    return Promise.resolve();
+  if (!this.preloadBackgrounds_) {
+    this.preloadedBackgrounds = {};
+    this.preloadBackgrounds_ = Promise.all(
+      backgrounds.map(background => {
+        return new Promise(resolve => {
+          console.log('loading.. ' + background.name);
+          this.p5.loadImage(
+            background.sourceUrl,
+            image => {
+              this.preloadedBackgrounds[background.legacyParam] = image;
+              resolve();
+            },
+            err => {
+              console.log(err);
+              resolve();
+            }
+          );
+        });
+      })
+    );
   }
-  this.preloadedBackgrounds = {};
-  this.p5._predefinedBackgrounds = {};
-  return Promise.all(
-    backgrounds.map(background => {
-      return new Promise(resolve => {
-        this.p5.loadImage(
-          background.sourceUrl,
-          image => {
-            this.preloadedBackgrounds[background.legacyParam] = image;
-            this.p5._predefinedBackgrounds[background.legacyParam] = image;
-            resolve();
-          },
-          err => {
-            console.log(err);
-            resolve();
-          }
-        );
-      });
-    })
-  );
+  return this.preloadBackgrounds_.then(() => {
+    return new Promise(resolve => {
+      console.log('then');
+      this.p5._predefinedBackgrounds = this.preloadedBackgrounds;
+      resolve();
+    });
+  });
 };
 
 /**

--- a/apps/src/gamelab/GameLabP5.js
+++ b/apps/src/gamelab/GameLabP5.js
@@ -588,7 +588,6 @@ GameLabP5.prototype.preloadBackgrounds = function() {
     this.preloadBackgrounds_ = Promise.all(
       backgrounds.map(background => {
         return new Promise(resolve => {
-          console.log('loading.. ' + background.name);
           this.p5.loadImage(
             background.sourceUrl,
             image => {
@@ -606,8 +605,7 @@ GameLabP5.prototype.preloadBackgrounds = function() {
   }
   return this.preloadBackgrounds_.then(() => {
     return new Promise(resolve => {
-      console.log('then');
-      this.p5._predefinedBackgrounds = this.preloadedBackgrounds;
+      this.p5._preloadedBackgrounds = this.preloadedBackgrounds;
       resolve();
     });
   });

--- a/apps/src/gamelab/spritelab/Spritelab.js
+++ b/apps/src/gamelab/spritelab/Spritelab.js
@@ -8,6 +8,13 @@ var Spritelab = function() {
   this.reset = () => spriteUtils.reset();
 
   this.preview = function() {
+    if (this.gameLabP5.p5decrementPreload) {
+      // preload is still in progress. This happens sometimes on initial page load because both the Gamelab reset
+      // handler and the Blockly change handler call preview. The first call goes to the else case below and calls
+      // gameLabP5.startExecution (which starts the p5 preload phase). The second call would go into the first case
+      // and, not knowing that preload is still in progress, would attempt to call p5.redraw(), and mess up the preview
+      return;
+    }
     spriteUtils.reset();
     getStore().dispatch(clearConsole());
     Sounds.getSingleton().muteURLs();

--- a/apps/src/gamelab/spritelab/backgrounds.json
+++ b/apps/src/gamelab/spritelab/backgrounds.json
@@ -1,0 +1,149 @@
+{
+  "backgrounds": [
+    {
+      "name": "cave",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background_cave.png",
+      "sourceUrl": "/api/v1/animation-library/xQipuvePUXSq06jZsTlobJR8.Q7ZvgTC/category_backgrounds/background_cave.png"
+    },
+    {
+      "name": "city",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/04L4sdTODkNZF1OHf4qO_I.Al3QP43wA/category_backgrounds/city.png",
+      "sourceUrl": "/api/v1/animation-library/04L4sdTODkNZF1OHf4qO_I.Al3QP43wA/category_backgrounds/city.png"
+    },
+    {
+      "name": "continuous_grass",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/UieRK0NBKD3xVHtSJxcUTAuhzLM1D_Hq/category_backgrounds/continuous_grass.png",
+      "sourceUrl": "/api/v1/animation-library/UieRK0NBKD3xVHtSJxcUTAuhzLM1D_Hq/category_backgrounds/continuous_grass.png"
+    },
+    {
+      "name": "court",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background.png",
+      "sourceUrl": "/api/v1/animation-library/ybx_l2OXs2ZrM2C8p9Texf7sEvpKvY0T/category_backgrounds/background_court.png"
+    },
+    {
+      "name": "desert",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background_desert.png",
+      "sourceUrl": "/api/v1/animation-library/lXCJiemM_ybjwK6SzMVp07qqEC.lumSD/category_backgrounds/background_desert.png"
+    },
+    {
+      "name": "desert_road",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/nfgysU3t3P8XnUBAf9LjIy2JTHtdXpTj/category_backgrounds/desert_road.png",
+      "sourceUrl": "/api/v1/animation-library/nfgysU3t3P8XnUBAf9LjIy2JTHtdXpTj/category_backgrounds/desert_road.png"
+    },
+    {
+      "name": "farm_land",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/4FnSIFL33P0PH_C_DnKOse2QbZCdtaJJ/category_backgrounds/farm_land.png",
+      "sourceUrl": "/api/v1/animation-library/4FnSIFL33P0PH_C_DnKOse2QbZCdtaJJ/category_backgrounds/farm_land.png"
+    },
+    {
+      "name": "floating_grass",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/vrlUwPslp0VK_KJcPQ9OPZNb.Ms5eBL5/category_backgrounds/floating_grass.png",
+      "sourceUrl": "/api/v1/animation-library/vrlUwPslp0VK_KJcPQ9OPZNb.Ms5eBL5/category_backgrounds/floating_grass.png"
+    },
+    {
+      "name": "front_of_house",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/ZjjFGjO0xNEZGEweTgANloehQrxwIXVM/category_backgrounds/front_of_house.png",
+      "sourceUrl": "/api/v1/animation-library/ZjjFGjO0xNEZGEweTgANloehQrxwIXVM/category_backgrounds/front_of_house.png"
+    },
+    {
+      "name": "galaxy",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background_space.png",
+      "sourceUrl": "/api/v1/animation-library/8O2IYyEUlJ8FNRemqZEf0FXfKmbUIxiF/category_backgrounds/background_space.png"
+    },
+    {
+      "name": "grid",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background_grid.png",
+      "sourceUrl": "/api/v1/animation-library/E.uBGDJX3M_UR0wJ0XSCT4rm43eHbVXL/category_backgrounds/background_grid.png"
+    },
+    {
+      "name": "kitchen",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/1K7z7Kc3EeXsLV693byb0xxoJSJ4Du7e/category_backgrounds/kitchen.png",
+      "sourceUrl": "/api/v1/animation-library/1K7z7Kc3EeXsLV693byb0xxoJSJ4Du7e/category_backgrounds/kitchen.png"
+    },
+    {
+      "name": "living_room",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/4bsf67OUrcX.t1wbIcE_xygGKxOkiQ6f/category_backgrounds/living_room.png",
+      "sourceUrl": "/api/v1/animation-library/4bsf67OUrcX.t1wbIcE_xygGKxOkiQ6f/category_backgrounds/living_room.png"
+    },
+    {
+      "name": "meadow",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/cJKusc1WPgWvCvgdwRX1gk8Zk0FggcVj/category_backgrounds/meadow.png",
+      "sourceUrl": "/api/v1/animation-library/cJKusc1WPgWvCvgdwRX1gk8Zk0FggcVj/category_backgrounds/meadow.png"
+    },
+    {
+      "name": "park_view",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/4gC7uWaaRI4aDyrncCFO_wY_67vYhr4C/category_backgrounds/park_view.png",
+      "sourceUrl": "/api/v1/animation-library/4gC7uWaaRI4aDyrncCFO_wY_67vYhr4C/category_backgrounds/park_view.png"
+    },
+    {
+      "name": "pine_trees",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/5K0h1rGe5ql4J9TdlqggIzGZYzbD38pF/category_backgrounds/pine_trees.png",
+      "sourceUrl": "/api/v1/animation-library/5K0h1rGe5ql4J9TdlqggIzGZYzbD38pF/category_backgrounds/pine_trees.png"
+    },
+    {
+      "name": "rainbow",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background_rainbow.png",
+      "sourceUrl": "/api/v1/animation-library/QhGjRWwM9QmHltn3tJojhlSD_Im9Ubsu/category_backgrounds/background_rainbow.png"
+    },
+    {
+      "name": "sci_fi",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background_scifi.png",
+      "sourceUrl": "/api/v1/animation-library/AkZ46QubAbBWZCmJO7D7hW3xCENr_80h/category_backgrounds/background_scifi.png"
+    },
+    {
+      "name": "soccer_field",
+      "legacyParam": "https://studio.code.org//api/v1/animation-library/WJjQlG1rFhbVmPfcuI_wy6tpwI6mHYnM/category_backgrounds/soccer_field.png",
+      "sourceUrl": "/api/v1/animation-library/WJjQlG1rFhbVmPfcuI_wy6tpwI6mHYnM/category_backgrounds/soccer_field.png"
+    },
+    {
+      "name": "stage",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/Thvd6E7yU59nfop.zZKGWKoR8VLZDTq./category_backgrounds/stage.png",
+      "sourceUrl": "/api/v1/animation-library/Thvd6E7yU59nfop.zZKGWKoR8VLZDTq./category_backgrounds/stage.png"
+    },
+    {
+      "name": "stars",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background_santa.png",
+      "sourceUrl": "/api/v1/animation-library/9HfWWIAEPsb37dxbPayqZeE1qKKsmG5S/category_backgrounds/background_santa.png"
+    },
+    {
+      "name": "subway",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/RblQqWAuW0EkLfYuRVK4LRc0uY_76fvi/category_backgrounds/subway.png",
+      "sourceUrl": "/api/v1/animation-library/RblQqWAuW0EkLfYuRVK4LRc0uY_76fvi/category_backgrounds/subway.png"
+    },
+    {
+      "name": "sun_and_rainbow",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/ZY0THG5IedwCgmWVIhiPdJH59OORnmgT/category_backgrounds/sun_and_rainbow.png",
+      "sourceUrl": "/api/v1/animation-library/ZY0THG5IedwCgmWVIhiPdJH59OORnmgT/category_backgrounds/sun_and_rainbow.png"
+    },
+    {
+      "name": "sunshine_showers",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/_aXeLwM1Ge.ZDVJoON.cAlR3iwhKJJvl/category_backgrounds/sunshine_showers.png",
+      "sourceUrl": "/api/v1/animation-library/_aXeLwM1Ge.ZDVJoON.cAlR3iwhKJJvl/category_backgrounds/sunshine_showers.png"
+    },
+    {
+      "name": "tennis_court",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/.51KpEhDOyXg4dbDaAnm0dEWLAj1GZwy/category_backgrounds/tennis_court.png",
+      "sourceUrl": "/api/v1/animation-library/.51KpEhDOyXg4dbDaAnm0dEWLAj1GZwy/category_backgrounds/tennis_court.png"
+    },
+    {
+      "name": "tree_island",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/yatDsUkvGtT_.fSv68qi1d4YJDMHdGnS/category_backgrounds/tree_island.png",
+      "sourceUrl": "/api/v1/animation-library/yatDsUkvGtT_.fSv68qi1d4YJDMHdGnS/category_backgrounds/tree_island.png"
+    },
+    {
+      "name": "underground",
+      "legacyParam": "https://studio.code.org/api/v1/animation-library/INSgmsgsLuIk1Aqp7g72h9nLFez.NX0p/category_backgrounds/underground.png",
+      "sourceUrl": "/api/v1/animation-library/INSgmsgsLuIk1Aqp7g72h9nLFez.NX0p/category_backgrounds/underground.png"
+    },
+    {
+      "name": "underwater",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background_underwater.png",
+      "sourceUrl": "/api/v1/animation-library/Uc3U0ENCf9gcYmAADOJ9wD9KMfxXbbic/category_backgrounds/background_underwater.png"
+    },
+    {
+      "name": "winter",
+      "legacyParam": "https://studio.code.org/blockly/media/skins/studio/background_winter.png",
+      "sourceUrl": "/api/v1/animation-library/eamej9mDjbAXDV1GcRKy2hadPAdeB5Og/category_backgrounds/background_winter.png"
+    }
+  ]
+}

--- a/apps/src/gamelab/spritelab/worldCommands.js
+++ b/apps/src/gamelab/spritelab/worldCommands.js
@@ -20,7 +20,7 @@ export const commands = {
   },
 
   setBackgroundImage(img) {
-    if (this._preloadedBackgrounds[img]) {
+    if (this._preloadedBackgrounds && this._preloadedBackgrounds[img]) {
       let backgroundImage = this._preloadedBackgrounds[img];
       spriteUtils.background = backgroundImage;
     }

--- a/apps/src/gamelab/spritelab/worldCommands.js
+++ b/apps/src/gamelab/spritelab/worldCommands.js
@@ -20,9 +20,10 @@ export const commands = {
   },
 
   setBackgroundImage(img) {
-    let backgroundImage = this.loadImage(img);
-    backgroundImage.name = img;
-    spriteUtils.background = backgroundImage;
+    if (this._predefinedBackgrounds[img]) {
+      let backgroundImage = this._predefinedBackgrounds[img];
+      spriteUtils.background = backgroundImage;
+    }
   },
 
   showTitleScreen(title, subtitle) {

--- a/apps/src/gamelab/spritelab/worldCommands.js
+++ b/apps/src/gamelab/spritelab/worldCommands.js
@@ -20,8 +20,8 @@ export const commands = {
   },
 
   setBackgroundImage(img) {
-    if (this._predefinedBackgrounds[img]) {
-      let backgroundImage = this._predefinedBackgrounds[img];
+    if (this._preloadedBackgrounds[img]) {
+      let backgroundImage = this._preloadedBackgrounds[img];
       spriteUtils.background = backgroundImage;
     }
   },


### PR DESCRIPTION
Load background assets onto the p5 object during the p5 preload phase. Persists the p5 images across runs on the gameLabP5 object. This way, the initial page load makes network requests for the background images and creates the p5 images, but subsequent preload phases are fast (and don't require additional network requests)