### PR TITLE
School Info Completeness - change validation_type to VALIDATION_COMPLETE in user_school_infos 

### DIFF
--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -11,11 +11,8 @@ class Api::V1::UserSchoolInfosController < ApplicationController
 
   # PATCH /api/v1/users_school_infos
   def update
-    # return unless school_info_params[:school_id].present? || school_info_params[:country].present?
-
     unless school_info_params[:school_id].present? || school_info_params[:country].present?
       render json: {error: "school id or country is not present"}, status: 422
-      # head 422
       return
     end
 

--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -30,8 +30,14 @@ class Api::V1::UserSchoolInfosController < ApplicationController
     existing_school_info = current_user.last_complete_school_info
     existing_school_info&.assign_attributes new_school_info_params
     if existing_school_info.nil? || existing_school_info.changed?
-      submitted_school_info = SchoolInfo.where(new_school_info_params).
-        first_or_create(validation_type: SchoolInfo::VALIDATION_COMPLETE)
+      submitted_school_info =
+        if new_school_info_params[:school_id]
+          SchoolInfo.where(new_school_info_params).
+          first_or_create
+        else
+          SchoolInfo.where(new_school_info_params, validation_type: SchoolInfo::VALIDATION_NONE).
+          first_or_create(validation_type: SchoolInfo::VALIDATION_COMPLETE)
+        end
       unless current_user.update(school_info: submitted_school_info)
         render json: current_user.errors, status: 422
         return

--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -11,7 +11,13 @@ class Api::V1::UserSchoolInfosController < ApplicationController
 
   # PATCH /api/v1/users_school_infos
   def update
-    return unless school_info_params[:school_id].present? || school_info_params[:country].present?
+    # return unless school_info_params[:school_id].present? || school_info_params[:country].present?
+
+    unless school_info_params[:school_id].present? || school_info_params[:country].present?
+      render json: {error: "school id or country is not present"}, status: 422
+      # head 422
+      return
+    end
 
     new_school_info_params =
       if school_info_params[:full_address]&.blank?

--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -35,6 +35,10 @@ class Api::V1::UserSchoolInfosController < ApplicationController
           SchoolInfo.where(new_school_info_params).
           first_or_create
         else
+          # VALIDATION_COMPLETE is passed when the school_id does not exist to check
+          # for form completeness, specifically, school name is required.
+          # If school_id does not exist, ncesSchoolId  is set to -1 when the checkbox
+          # for school not found is clicked.
           SchoolInfo.where(new_school_info_params).
           first_or_create(validation_type: SchoolInfo::VALIDATION_COMPLETE)
         end

--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -35,7 +35,7 @@ class Api::V1::UserSchoolInfosController < ApplicationController
           SchoolInfo.where(new_school_info_params).
           first_or_create
         else
-          SchoolInfo.where(new_school_info_params, validation_type: SchoolInfo::VALIDATION_NONE).
+          SchoolInfo.where(new_school_info_params).
           first_or_create(validation_type: SchoolInfo::VALIDATION_COMPLETE)
         end
       unless current_user.update(school_info: submitted_school_info)

--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -28,8 +28,11 @@ class Api::V1::UserSchoolInfosController < ApplicationController
     existing_school_info&.assign_attributes new_school_info_params
     if existing_school_info.nil? || existing_school_info.changed?
       submitted_school_info = SchoolInfo.where(new_school_info_params).
-        first_or_create(validation_type: SchoolInfo::VALIDATION_NONE)
-      current_user.update! school_info: submitted_school_info
+        first_or_create(validation_type: SchoolInfo::VALIDATION_COMPLETE)
+      unless current_user.update(school_info: submitted_school_info)
+        render json: current_user.errors, status: 422
+        return
+      end
       current_user.user_school_infos.where(school_info: submitted_school_info).
         update(last_confirmation_date: DateTime.now)
     else

--- a/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
@@ -105,7 +105,7 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     sign_in @teacher
 
     submit_blank_school_info
-    assert_response :success, response.body
+    assert_response 422
 
     @teacher.reload
     assert_nil @teacher.school_info
@@ -174,7 +174,7 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
 
     @teacher.reload
 
-    assert_response :success, response.body
+    assert_response 422, response.body
     assert_equal @teacher.school_info.id, school_info.id
     assert_equal @teacher.school_info, school_info
     refute_nil @teacher.school_info.country
@@ -372,7 +372,7 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     sign_in @teacher
     submit_blank_school_info
 
-    assert_response :success, response.body
+    assert_response 422
     refute_nil @teacher.user_school_infos.last.school_info.school_name
     assert_equal 1, @teacher.user_school_infos.count
   end

--- a/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
@@ -306,14 +306,20 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     Timecop.travel 1.year
     submit_partial_school_info
 
+    # @teacher.reload
+    puts response.body
+    # refute_respond_to :success, response.body
+    # assert_raises(ActiveRecord::RecordInvalid) {submit_partial_school_info}
+    assert_response 422
+
     @teacher.reload
 
-    assert_response :success, response.body
+
     refute_nil @teacher.school_info
-    assert_equal @teacher.user_school_infos.count, 2
+    assert_equal @teacher.user_school_infos.count, 1
     assert_nil @teacher.user_school_infos.last.end_date
-    assert_equal Time.now.utc.to_date, @teacher.user_school_infos.last.start_date.to_date
-    assert_equal Time.now.utc.to_date, @teacher.user_school_infos.first.end_date.to_date
+    # assert_equal Time.now.utc.to_date, @teacher.user_school_infos.last.start_date.to_date
+    # assert_equal Time.now.utc.to_date, @teacher.user_school_infos.first.end_date.to_date
   end
 
   test 'confirmation, complete previous, complete, dropdown' do
@@ -420,9 +426,9 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
 
     new_tenure = @teacher.user_school_infos.last
     assert_nil @teacher.user_school_infos.last.school_info.school_name
-    assert_equal 3, @teacher.user_school_infos.count
-    assert_same_date Time.now, new_tenure.last_confirmation_date
-    refute_equal @teacher.user_school_infos.last.school_info.full_address, 'Seattle, Washington'
+    assert_equal 2, @teacher.user_school_infos.count
+    refute_equal Time.now, new_tenure.last_confirmation_date
+    assert_equal @teacher.user_school_infos.last.school_info.full_address, 'Seattle, Washington'
   end
 
   test 'confirmation, partial previous, complete, dropdown' do

--- a/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
@@ -171,6 +171,7 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
 
     Timecop.travel 1.hour
     submit_blank_school_info
+    assert_response 422
 
     @teacher.reload
 


### PR DESCRIPTION
Modified the update method in the user school infos controller to replace Validation_None with Validation_Complete.  Added logic to handle validation failures.

Relevant tests were updated to include Validation complete and assertions were modified.

[Validation Complete Implementation](https://github.com/code-dot-org/code-dot-org/pull/29399)