### PR TITLE
Update yarn to 1.16.0

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 		apt-get install -y \
 		  git \
 		  xvfb \
-		  yarn=0.27.5-1 \
+		  yarn=1.16.0-1 \
 		  sudo \
 		  openssh-client \
 		  ca-certificates \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
 
       - run:
           name: set yarn version
-          command: sudo apt-get install yarn=1.16.0
+          command: sudo apt-get install yarn=1.16.0-1
 
       - run:
           name: setup locals.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
 
       - run:
           name: set yarn version
-          command: sudo apt-get install yarn=1.6.0-1
+          command: sudo apt-get install yarn=1.16.0
 
       - run:
           name: setup locals.yml

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ steps:
   - git merge origin/$DRONE_TARGET_BRANCH
 
 - name: verify-pr
-  image: joshlory/code-dot-org:0.8
+  image: joshlory/code-dot-org:0.10
   pull: always
   commands:
     - |
@@ -44,7 +44,7 @@ steps:
     restore: true
 
 - name: unit-tests
-  image: joshlory/code-dot-org:0.8
+  image: joshlory/code-dot-org:0.10
   pull: always
   volumes:
   - name: rbenv
@@ -117,7 +117,7 @@ steps:
   - git merge origin/$DRONE_TARGET_BRANCH
 
 - name: verify-pr
-  image: joshlory/code-dot-org:0.8
+  image: joshlory/code-dot-org:0.10
   pull: always
   commands:
     - |
@@ -141,7 +141,7 @@ steps:
     restore: true
 
 - name: ui-tests
-  image: joshlory/code-dot-org:0.8
+  image: joshlory/code-dot-org:0.10
   volumes:
   - name: rbenv
     path: /home/circleci/.rbenv
@@ -196,6 +196,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: 9975920fee51286f7f774adcbfea7b8f5b4a539e13c4152a432093be3f8cb001
+hmac: 998790c43f43d05898f32bcbfea381bee5d2e40b36c2bb3332af626d01c4ee5a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ steps:
   - git merge origin/$DRONE_TARGET_BRANCH
 
 - name: verify-pr
-  image: wintercdo/code-dot-org:0.7
+  image: joshlory/code-dot-org:0.8
   pull: always
   commands:
     - |
@@ -44,7 +44,7 @@ steps:
     restore: true
 
 - name: unit-tests
-  image: wintercdo/code-dot-org:0.7
+  image: joshlory/code-dot-org:0.8
   pull: always
   volumes:
   - name: rbenv
@@ -117,7 +117,7 @@ steps:
   - git merge origin/$DRONE_TARGET_BRANCH
 
 - name: verify-pr
-  image: wintercdo/code-dot-org:0.7
+  image: joshlory/code-dot-org:0.8
   pull: always
   commands:
     - |
@@ -141,7 +141,7 @@ steps:
     restore: true
 
 - name: ui-tests
-  image: wintercdo/code-dot-org:0.7
+  image: joshlory/code-dot-org:0.8
   volumes:
   - name: rbenv
     path: /home/circleci/.rbenv

--- a/SETUP.md
+++ b/SETUP.md
@@ -92,7 +92,7 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
     1. Pick up those changes: `source ~/.bash_profile`
 1. Install Node and yarn
     1. `nvm install 8.15.0 && nvm alias default 8.15.0` this command should make this version the default version and print something like: `Creating default alias: default -> 8.15.0 (-> v8.15.0)`
-    1. `curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0`. Move the line
+    1. `npm install -g yarn@1.16.0`. Move the line
     `export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"`
     from your `~/.bashrc` to your `~/.bash_profile` to ensure it gets executed on terminal startup.
     1. (Note: You will have to come back to this step after you clone your repository) Reinstall node_modules `cd apps; yarn; cd ..`

--- a/SETUP.md
+++ b/SETUP.md
@@ -12,7 +12,7 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
      ```
      ruby --version  # --> ruby 2.5.0
      node --version  # --> v8.15.0
-     yarn --version  # --> 1.6.0
+     yarn --version  # --> 1.16.0
      ```
 1. If using HTTPS: `git clone https://github.com/code-dot-org/code-dot-org.git`, if using SSH: `git@github.com:code-dot-org/code-dot-org.git`
 1. `gem install bundler -v 1.17`
@@ -92,7 +92,7 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
     1. Pick up those changes: `source ~/.bash_profile`
 1. Install Node and yarn
     1. `nvm install 8.15.0 && nvm alias default 8.15.0` this command should make this version the default version and print something like: `Creating default alias: default -> 8.15.0 (-> v8.15.0)`
-    1. `curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0`. Move the line  
+    1. `curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0`. Move the line
     `export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"`
     from your `~/.bashrc` to your `~/.bash_profile` to ensure it gets executed on terminal startup.
     1. (Note: You will have to come back to this step after you clone your repository) Reinstall node_modules `cd apps; yarn; cd ..`
@@ -143,7 +143,7 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
 1. Install yarn
     1. `curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -`
     1. `echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list`
-    1. `sudo apt-get update && sudo apt-get install yarn=1.6.0-1`
+    1. `sudo apt-get update && sudo apt-get install yarn=1.16.0-1`
 1. Finally, configure your mysql to allow for a proper installation. You may run into errors if you did not leave mysql passwords blank
    1. `echo "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';" | sudo mysql`
 1. **IMPORTANT:** Read the following notes, then go back up to the [overview](#overview) and run the commands there.

--- a/SETUP.md
+++ b/SETUP.md
@@ -92,9 +92,7 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
     1. Pick up those changes: `source ~/.bash_profile`
 1. Install Node and yarn
     1. `nvm install 8.15.0 && nvm alias default 8.15.0` this command should make this version the default version and print something like: `Creating default alias: default -> 8.15.0 (-> v8.15.0)`
-    1. `npm install -g yarn@1.16.0`. Move the line
-    `export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"`
-    from your `~/.bashrc` to your `~/.bash_profile` to ensure it gets executed on terminal startup.
+    1. `npm install -g yarn@1.16.0`.
     1. (Note: You will have to come back to this step after you clone your repository) Reinstall node_modules `cd apps; yarn; cd ..`
 1. (El Capitan only) Ensure that openssl is linked: `brew link --force openssl`
 1. Prevent future problems related to the `Too many open files` error:

--- a/apps/README.md
+++ b/apps/README.md
@@ -17,12 +17,11 @@ cd apps
 
 # Machine setup (OSX with Homebrew)
 brew install node
-npm install -g grunt-cli yarn@1.6.0
+npm install -g grunt-cli yarn@1.16.0
 
 # Perform first full build
 yarn
 npm run build
-npm rebuild node-sass
 
 # automatically rebuild every time you make changes to source files
 yarn start

--- a/cookbooks/cdo-nodejs/attributes/default.rb
+++ b/cookbooks/cdo-nodejs/attributes/default.rb
@@ -1,2 +1,2 @@
 default['cdo-nodejs']['version'] = '8.x'
-default['cdo-nodejs']['yarn_version'] = '1.6.0-1'
+default['cdo-nodejs']['yarn_version'] = '1.16.0'

--- a/cookbooks/cdo-nodejs/attributes/default.rb
+++ b/cookbooks/cdo-nodejs/attributes/default.rb
@@ -1,2 +1,2 @@
 default['cdo-nodejs']['version'] = '8.x'
-default['cdo-nodejs']['yarn_version'] = '1.16.0'
+default['cdo-nodejs']['yarn_version'] = '1.16.0-1'

--- a/cookbooks/cdo-nodejs/test/integration/default/serverspec/node_spec.rb
+++ b/cookbooks/cdo-nodejs/test/integration/default/serverspec/node_spec.rb
@@ -4,4 +4,4 @@ file_exist '/usr/bin/node'
 cmd 'node -v', 'v8.'
 
 cmd 'which yarn', '/usr/bin/yarn'
-cmd 'yarn --version', '1.6.0'
+cmd 'yarn --version', '1.16.0'

--- a/cookbooks/cdo-nodejs/test/integration/upgrade_step_2/serverspec/node_spec.rb
+++ b/cookbooks/cdo-nodejs/test/integration/upgrade_step_2/serverspec/node_spec.rb
@@ -4,4 +4,4 @@ file_exist '/usr/bin/node'
 cmd 'node -v', 'v8.'
 
 cmd 'which yarn', '/usr/bin/yarn'
-cmd 'yarn --version', '1.6.0'
+cmd 'yarn --version', '1.16.0'

--- a/docker/dockerfiles/Dockerfile
+++ b/docker/dockerfiles/Dockerfile
@@ -83,16 +83,18 @@ RUN export CHROMEDRIVER_RELEASE=$(curl http://chromedriver.storage.googleapis.co
       && sudo chmod +x /usr/local/bin/chromedriver
 
 # install mysql
-RUN curl -sSL -o /tmp/mysql-apt-config_0.8.9-1_all.deb https://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb \
+RUN curl -sSL -o /tmp/mysql-apt-config_0.8.12-1_all.deb https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb \
   && echo "mysql-apt-config mysql-apt-config/select-server select mysql-5.7" | /usr/bin/debconf-set-selections \
-  && DEBIAN_FRONTEND=noninteractive dpkg -i /tmp/mysql-apt-config_0.8.9-1_all.deb || apt-get -fy install \
-  && rm -rf /tmp/mysql-apt-config_0.8.9-1_all.deb \
+  && DEBIAN_FRONTEND=noninteractive dpkg -i /tmp/mysql-apt-config_0.8.12-1_all.deb || apt-get -fy install \
+  && rm -rf /tmp/mysql-apt-config_0.8.12-1_all.deb \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     mysql-server \
     libmysqlclient-dev
-RUN service mysql start \
+RUN chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+  && service mysql start \
   && echo "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';" | mysql \
+  && chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
   && service mysql stop
 
 # install a couple more things from config.yml

--- a/docker/dockerfiles/Dockerfile
+++ b/docker/dockerfiles/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 		apt-get install -y \
 		  git \
 		  xvfb \
-		  yarn=1.16.0 \
+		  yarn=1.16.0-1 \
 		  sudo \
 		  openssh-client \
 		  ca-certificates \

--- a/docker/dockerfiles/Dockerfile
+++ b/docker/dockerfiles/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 		apt-get install -y \
 		  git \
 		  xvfb \
-		  yarn=1.6.0-1 \
+		  yarn=1.16.0 \
 		  sudo \
 		  openssh-client \
 		  ca-certificates \


### PR DESCRIPTION
Patterned after PR https://github.com/code-dot-org/code-dot-org/pull/22093. Replaces PR https://github.com/code-dot-org/code-dot-org/pull/29495.

I will send mail separately asking folks to upgrade their local install of yarn.