### PR TITLE
Fixed CSD 2019 course name in section drop down

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -6,12 +6,14 @@ en:
       category:
         csd_category_name: CS Discoveries ('17-'18)
         csd_2018_category_name: CS Discoveries ('18-'19)
+        csd_2019_category_name: CS Discoveries ('19-'20)
         csf_category_name: CS Fundamentals
         csf_2018_category_name: CS Fundamentals (2018)
         csf_international_category_name: CS Fundamentals International
         csf2_draft_category_name: 'Under Development: Courses A - F'
         csp_category_name: "'15-'16 CS Principles"
         csp_2018_category_name: CS Principles ('18-'19)
+        csp_2019_category_name: CS Principles ('19-'20)
         cspexams_category_name: CS Principles Practice Test
         csp17_category_name: CS Principles ('17-'18)
         full_course_category_name: Full Courses


### PR DESCRIPTION
In viewing section progress, the drop down had a category name csd_2019 not consistent with the other categories names (like CS Discoveries ('18-'19)). While I was at it I added a category name for csp_2019 as well. (issue [LP-537](https://codedotorg.atlassian.net/browse/LP-537)

![before](https://user-images.githubusercontent.com/1072387/60628141-07f25f00-9da5-11e9-9a9f-1a11193ca576.png)

<img width="400" alt="after csd" src="https://user-images.githubusercontent.com/1072387/60628150-0cb71300-9da5-11e9-84ae-a8749fae3115.png">
<img width="400" alt="after csp" src="https://user-images.githubusercontent.com/1072387/60628151-0cb71300-9da5-11e9-8691-1e8dc4d0f977.png">


