### PR TITLE
Use workshop subject constants on the client

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -88,7 +88,15 @@ def main
 
   generate_shared_js_file(
     generate_multiple_constants(
-      %w(COURSES SUBJECTS STATES WORKSHOP_APPLICATION_STATES WORKSHOP_SEARCH_ERRORS WORKSHOP_TYPES),
+      %w(
+        COURSES
+        SUBJECT_NAMES
+        SUBJECTS
+        STATES
+        WORKSHOP_APPLICATION_STATES
+        WORKSHOP_SEARCH_ERRORS
+        WORKSHOP_TYPES
+      ),
       source_module: Pd::SharedWorkshopConstants,
       transform_keys: false
     ),

--- a/apps/src/code-studio/pd/application/facilitator1920/Section3ExperienceAndCommitments.jsx
+++ b/apps/src/code-studio/pd/application/facilitator1920/Section3ExperienceAndCommitments.jsx
@@ -84,7 +84,7 @@ export default class Section3ExperienceAndCommitments extends LabeledFormCompone
 
     const queryParams = {
       course: this.props.data.program,
-      subject: '5-day Summer',
+      subject: SubjectNames.SUBJECT_SUMMER_WORKSHOP,
       zip_code: this.props.data.zipCode,
       state: this.props.data.state
     };

--- a/apps/src/code-studio/pd/application/facilitator1920/Section3ExperienceAndCommitments.jsx
+++ b/apps/src/code-studio/pd/application/facilitator1920/Section3ExperienceAndCommitments.jsx
@@ -6,6 +6,7 @@ import {
   SectionHeaders,
   TextFields
 } from '@cdo/apps/generated/pd/facilitator1920ApplicationConstants';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import {CSF, CSD, CSP} from '../ApplicationConstants';
 
 const PARTNER_WORKSHOPS_API_ENDPOINT =
@@ -46,7 +47,7 @@ export default class Section3ExperienceAndCommitments extends LabeledFormCompone
   loadFitWorkshops() {
     const queryParams = {
       course: this.props.data.program,
-      subject: 'Code.org Facilitator Weekend',
+      subject: SubjectNames.fit,
       zip_code: this.props.data.zipCode,
       state: this.props.data.state
     };

--- a/apps/src/code-studio/pd/application/facilitator1920/Section3ExperienceAndCommitments.jsx
+++ b/apps/src/code-studio/pd/application/facilitator1920/Section3ExperienceAndCommitments.jsx
@@ -47,7 +47,7 @@ export default class Section3ExperienceAndCommitments extends LabeledFormCompone
   loadFitWorkshops() {
     const queryParams = {
       course: this.props.data.program,
-      subject: SubjectNames.fit,
+      subject: SubjectNames.SUBJECT_FIT,
       zip_code: this.props.data.zipCode,
       state: this.props.data.state
     };

--- a/apps/src/code-studio/pd/application/teacher1920/Section4ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section4ProfessionalLearningProgramRequirements.jsx
@@ -16,6 +16,7 @@ import Spinner from '../../components/spinner';
 import color from '@cdo/apps/util/color';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import _ from 'lodash';
+import SubjectNames from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const styles = {
   ...defaultStyles,
@@ -109,7 +110,7 @@ export default class Section4SummerWorkshop extends LabeledFormComponent {
 
     return {
       course,
-      subject: '5-day Summer'
+      subject: SubjectNames.SUBJECT_SUMMER_WORKSHOP
     };
   }
 

--- a/apps/src/code-studio/pd/application/teacher1920/Section4ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher1920/Section4ProfessionalLearningProgramRequirements.jsx
@@ -16,7 +16,7 @@ import Spinner from '../../components/spinner';
 import color from '@cdo/apps/util/color';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import _ from 'lodash';
-import SubjectNames from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const styles = {
   ...defaultStyles,

--- a/apps/src/code-studio/pd/application_dashboard/workshop_assignment_loader.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/workshop_assignment_loader.jsx
@@ -9,7 +9,7 @@ import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const SUBJECT_NAME_MAP = {
   summer: '5-day Summer',
-  fit: SubjectNames.fit
+  fit: SubjectNames.SUBJECT_FIT
 };
 const SUBJECT_TYPES = Object.keys(SUBJECT_NAME_MAP);
 export {SUBJECT_TYPES};

--- a/apps/src/code-studio/pd/application_dashboard/workshop_assignment_loader.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/workshop_assignment_loader.jsx
@@ -5,10 +5,11 @@ import $ from 'jquery';
 import _ from 'lodash';
 import Spinner from '../components/spinner';
 import WorkshopAssignmentSelect from './workshop_assignment_select';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const SUBJECT_NAME_MAP = {
   summer: '5-day Summer',
-  fit: 'Code.org Facilitator Weekend'
+  fit: SubjectNames.fit
 };
 const SUBJECT_TYPES = Object.keys(SUBJECT_NAME_MAP);
 export {SUBJECT_TYPES};

--- a/apps/src/code-studio/pd/application_dashboard/workshop_assignment_loader.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/workshop_assignment_loader.jsx
@@ -8,7 +8,7 @@ import WorkshopAssignmentSelect from './workshop_assignment_select';
 import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const SUBJECT_NAME_MAP = {
-  summer: '5-day Summer',
+  summer: SubjectNames.SUBJECT_SUMMER_WORKSHOP,
   fit: SubjectNames.SUBJECT_FIT
 };
 const SUBJECT_TYPES = Object.keys(SUBJECT_NAME_MAP);

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -9,7 +9,7 @@ import {ScholarshipDropdown} from '../../components/scholarshipDropdown';
 import Spinner from '../../components/spinner';
 import {WorkshopAdmin, ProgramManager} from '../permission';
 import {ScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
-import SubjectNames from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const CSF = 'CS Fundamentals';
 const DEEP_DIVE = 'Deep Dive';

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -9,11 +9,12 @@ import {ScholarshipDropdown} from '../../components/scholarshipDropdown';
 import Spinner from '../../components/spinner';
 import {WorkshopAdmin, ProgramManager} from '../permission';
 import {ScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
+import SubjectNames from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const CSF = 'CS Fundamentals';
 const DEEP_DIVE = 'Deep Dive';
 const NA = 'N/A';
-const LOCAL_SUMMER = '5-day Summer';
+const LOCAL_SUMMER = SubjectNames.SUBJECT_SUMMER_WORKSHOP;
 
 export class WorkshopEnrollmentSchoolInfo extends React.Component {
   constructor(props) {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
@@ -5,7 +5,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import {Button} from 'react-bootstrap';
-import {WorkshopTypes} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {
+  WorkshopTypes,
+  SubjectNames
+} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import ConfirmationDialog from '../../components/confirmation_dialog';
 import {PermissionPropType, Organizer, ProgramManager} from '../permission';
 
@@ -62,7 +65,7 @@ export class WorkshopManagement extends React.Component {
     let new_facilitator_weekend =
       workshop_date >= new Date('2018-08-01') &&
       ['CS Discoveries', 'CS Principles'].includes(this.props.course) &&
-      this.props.subject !== 'Code.org Facilitator Weekend';
+      this.props.subject !== SubjectNames.fit;
 
     let new_csf_201 =
       workshop_date >= new Date('2019-05-20') &&

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
@@ -65,7 +65,7 @@ export class WorkshopManagement extends React.Component {
     let new_facilitator_weekend =
       workshop_date >= new Date('2018-08-01') &&
       ['CS Discoveries', 'CS Principles'].includes(this.props.course) &&
-      this.props.subject !== SubjectNames.fit;
+      this.props.subject !== SubjectNames.SUBJECT_FIT;
 
     let new_csf_201 =
       workshop_date >= new Date('2019-05-20') &&

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -13,6 +13,7 @@ import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
 import {workshopShape} from '../types.js';
 import {Button} from 'react-bootstrap';
 import {CSF, CSD, CSP} from '../../application/ApplicationConstants';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const styles = {
   container: {
@@ -293,8 +294,7 @@ export default class WorkshopTable extends React.Component {
         onDelete={state !== 'Ended' ? this.props.onDelete : null}
         showSurveyUrl={
           state === 'Ended' ||
-          ([CSD, CSP].includes(course) &&
-            subject !== 'Code.org Facilitator Weekend') ||
+          ([CSD, CSP].includes(course) && subject !== SubjectNames.fit) ||
           (course === CSF && subject === 'Deep Dive')
         }
       />

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -294,7 +294,8 @@ export default class WorkshopTable extends React.Component {
         onDelete={state !== 'Ended' ? this.props.onDelete : null}
         showSurveyUrl={
           state === 'Ended' ||
-          ([CSD, CSP].includes(course) && subject !== SubjectNames.fit) ||
+          ([CSD, CSP].includes(course) &&
+            subject !== SubjectNames.SUBJECT_FIT) ||
           (course === CSF && subject === 'Deep Dive')
         }
       />

--- a/apps/src/code-studio/pd/workshop_survey/WorkshopSurvey.jsx
+++ b/apps/src/code-studio/pd/workshop_survey/WorkshopSurvey.jsx
@@ -7,7 +7,7 @@ import PersonalInvolvement from './PersonalInvolvement';
 import WorkshopResults from './WorkshopResults';
 import Demographics from './Demographics';
 import Implementation from './Implementation';
-import SubjectNames from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 export default class WorkshopSurvey extends FormController {
   /**

--- a/apps/src/code-studio/pd/workshop_survey/WorkshopSurvey.jsx
+++ b/apps/src/code-studio/pd/workshop_survey/WorkshopSurvey.jsx
@@ -7,6 +7,7 @@ import PersonalInvolvement from './PersonalInvolvement';
 import WorkshopResults from './WorkshopResults';
 import Demographics from './Demographics';
 import Implementation from './Implementation';
+import SubjectNames from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 export default class WorkshopSurvey extends FormController {
   /**
@@ -34,7 +35,7 @@ export default class WorkshopSurvey extends FormController {
   isLocalSummer() {
     return (
       this.props.course === 'CS Principles' &&
-      this.props.subject === '5-day Summer'
+      this.props.subject === SubjectNames.SUBJECT_SUMMER_WORKSHOP
     );
   }
 

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -18,8 +18,8 @@ module Pd
       STATE_ENDED = 'Ended'.freeze
     ].freeze
 
+    SUBJECT_TEACHER_CON = 'Code.org TeacherCon'.freeze
     SUBJECT_NAMES = {
-      SUBJECT_TEACHER_CON: SUBJECT_TEACHER_CON = 'Code.org TeacherCon'.freeze,
       SUBJECT_FIT: SUBJECT_FIT = 'Code.org Facilitator Weekend'.freeze,
       SUBJECT_SUMMER_WORKSHOP: SUBJECT_SUMMER_WORKSHOP = '5-day Summer'.freeze
     }

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -19,9 +19,9 @@ module Pd
     ].freeze
 
     SUBJECT_NAMES = {
-      teacher_con: SUBJECT_TEACHER_CON = 'Code.org TeacherCon'.freeze,
-      fit: SUBJECT_FIT = 'Code.org Facilitator Weekend'.freeze,
-      summer_workshop: SUBJECT_SUMMER_WORKSHOP = '5-day Summer'.freeze
+      SUBJECT_TEACHER_CON: SUBJECT_TEACHER_CON = 'Code.org TeacherCon'.freeze,
+      SUBJECT_FIT: SUBJECT_FIT = 'Code.org Facilitator Weekend'.freeze,
+      SUBJECT_SUMMER_WORKSHOP: SUBJECT_SUMMER_WORKSHOP = '5-day Summer'.freeze
     }
     SUBJECTS = {
       COURSE_ECS => [

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -18,9 +18,11 @@ module Pd
       STATE_ENDED = 'Ended'.freeze
     ].freeze
 
-    SUBJECT_TEACHER_CON = 'Code.org TeacherCon'.freeze
-    SUBJECT_FIT = 'Code.org Facilitator Weekend'.freeze
-    SUBJECT_SUMMER_WORKSHOP = '5-day Summer'.freeze
+    SUBJECT_NAMES = {
+      teacher_con: SUBJECT_TEACHER_CON = 'Code.org TeacherCon'.freeze,
+      fit: SUBJECT_FIT = 'Code.org Facilitator Weekend'.freeze,
+      summer_workshop: SUBJECT_SUMMER_WORKSHOP = '5-day Summer'.freeze
+    }
     SUBJECTS = {
       COURSE_ECS => [
         SUBJECT_ECS_PHASE_2 = 'Phase 2 in-person'.freeze,


### PR DESCRIPTION
While working on [PLC-350](https://codedotorg.atlassian.net/browse/PLC-350) and trying to add special logic for FiT workshops, I realized that we'd hard-coded this workshop subject name in our client code several times.

I'm now sharing the constant with the client and using it everywhere I could find it.