### PR TITLE
Professional Learning: FiT workshops have no exit surveys

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -116,8 +116,10 @@ class Pd::Enrollment < ActiveRecord::Base
   scope :not_attended, -> {includes(:attendances).where(pd_attendances: {pd_enrollment_id: nil})}
   scope :for_ended_workshops, -> {joins(:workshop).where.not(pd_workshops: {ended_at: nil})}
 
-  # Any enrollment with attendance, for an ended workshop, has a survey
+  # Any enrollment with attendance, for an ended workshop, has a survey.
   # Except for FiT workshops - no exit surveys for them!
+  # This scope is used in ProfessionalLearningLandingController to direct the teacher
+  #   to their latest pending survey.
   scope :with_surveys, -> {for_ended_workshops.attended.where.not(pd_workshops: {subject: SUBJECT_FIT})}
 
   def has_user?

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -117,7 +117,8 @@ class Pd::Enrollment < ActiveRecord::Base
   scope :for_ended_workshops, -> {joins(:workshop).where.not(pd_workshops: {ended_at: nil})}
 
   # Any enrollment with attendance, for an ended workshop, has a survey
-  scope :with_surveys, -> {for_ended_workshops.attended}
+  # Except for FiT workshops - no exit surveys for them!
+  scope :with_surveys, -> {for_ended_workshops.attended.where.not(pd_workshops: {subject: SUBJECT_FIT})}
 
   def has_user?
     user_id

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -428,6 +428,9 @@ class Pd::Workshop < ActiveRecord::Base
     end
   end
 
+  # Called at the very end of the async close-workshop workflow, to actually send exit
+  # surveys to attended teachers.  Note that logic here is more-or-less independent
+  # from other logic deciding whether a workshop should have exit surveys.
   def send_exit_surveys
     # FiT workshops should not send exit surveys
     return if SUBJECT_FIT == subject

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -429,6 +429,9 @@ class Pd::Workshop < ActiveRecord::Base
   end
 
   def send_exit_surveys
+    # FiT workshops should not send exit surveys
+    return if SUBJECT_FIT == subject
+
     resolve_enrolled_users
 
     # Send the emails

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCase
-  setup do
+  def prepare_scenario
     @csf_workshop = create :pd_ended_workshop, num_sessions: 3, course: Pd::Workshop::COURSE_CSF, ended_at: Date.today - 1.day
     @csd_workshop = create :pd_ended_workshop, num_sessions: 3, course: Pd::Workshop::COURSE_CSD, ended_at: Date.today - 2.days
     @csp_workshop = create :pd_workshop, num_sessions: 3, course: Pd::Workshop::COURSE_CSP
@@ -22,6 +22,7 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
   end
 
   test 'index returns expected values' do
+    prepare_scenario
     sign_in @teacher
 
     get :index
@@ -53,6 +54,7 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
   end
 
   test 'courses are sorted as expected' do
+    prepare_scenario
     sign_in(@teacher)
 
     ['Bills Fandom 101', 'ECS Support', 'CSP Support'].each do |name|

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -33,6 +33,30 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
     assert_equal Pd::Workshop::COURSE_CSF, response[:last_workshop_survey_course]
   end
 
+  test 'FiT workshops do not show up as pending exit surveys' do
+    # Fake FiT workshop, which should not produce an exit survey
+    fit_workshop = create :pd_ended_workshop,
+      course: Pd::Workshop::COURSE_CSF,
+      subject: Pd::Workshop::SUBJECT_CSF_FIT
+
+    # Given a teacher that attended the workshop, such that they would get
+    # a survey for any other workshop subject.
+    teacher = create :teacher
+    enrollment = create :pd_enrollment, email: teacher.email, workshop: fit_workshop
+    create :pd_attendance, session: fit_workshop.sessions.first, enrollment: enrollment
+
+    # When the teacher loads the PL landing page
+    sign_in teacher
+    get :index
+    assert_response :success
+
+    # Then they don't see a prompt for a pending exit survey
+    # (That is, we didn't pass down the parameters that would cause that prompt to appear.)
+    response = assigns(:landing_page_data)
+    assert_nil response[:last_workshop_survey_url]
+    assert_nil response[:last_workshop_survey_course]
+  end
+
   test_redirect_to_sign_in_for :index
 
   test 'teachers without enrollments are redirected' do

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -392,6 +392,12 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     expected_enrollment = create :pd_enrollment, workshop: ended_workshop
     create :pd_attendance, session: ended_workshop.sessions.first, enrollment: expected_enrollment
 
+    # Special case: FiT workshops don't have exit surveys
+    # Ended FiT workshop, with attendance
+    fit_workshop = create :pd_ended_workshop, num_sessions: 1, subject: SUBJECT_FIT
+    fit_enrollment = create :pd_enrollment, workshop: fit_workshop
+    create :pd_attendance, session: fit_workshop.sessions.first, enrollment: fit_enrollment
+
     # Non-ended workshop, no attendance
     non_ended_workshop = create :pd_workshop, num_sessions: 1
     create :pd_enrollment, workshop: non_ended_workshop

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -388,25 +388,30 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'with_surveys scope' do
+    # Ended workshop with attendance
+    # (ONLY this one should show up in the scope at the end of the test)
     ended_workshop = create :pd_ended_workshop, num_sessions: 1
     expected_enrollment = create :pd_enrollment, workshop: ended_workshop
     create :pd_attendance, session: ended_workshop.sessions.first, enrollment: expected_enrollment
 
-    # Special case: FiT workshops don't have exit surveys
     # Ended FiT workshop, with attendance
+    # (Checks a special case: FiT workshops don't have exit surveys)
     fit_workshop = create :pd_ended_workshop, num_sessions: 1, subject: SUBJECT_FIT
     fit_enrollment = create :pd_enrollment, workshop: fit_workshop
     create :pd_attendance, session: fit_workshop.sessions.first, enrollment: fit_enrollment
 
     # Non-ended workshop, no attendance
+    # (No surveys because not ended)
     non_ended_workshop = create :pd_workshop, num_sessions: 1
     create :pd_enrollment, workshop: non_ended_workshop
 
     # Non-ended workshop, with attendance
+    # (No surveys because not ended)
     create :pd_enrollment, workshop: non_ended_workshop
     create :pd_attendance, session: non_ended_workshop.sessions.first
 
     # Ended workshop, no attendance
+    # (No surveys because no attendance)
     create :pd_enrollment, workshop: ended_workshop
 
     assert_equal [expected_enrollment], Pd::Enrollment.with_surveys

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -347,6 +347,17 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop.send_exit_surveys
   end
 
+  test 'send_exit_surveys sends no surveys for FiT workshops' do
+    workshop = create :pd_ended_workshop, subject: SUBJECT_FIT
+    create(:pd_workshop_participant, workshop: workshop, enrolled: true)
+    create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
+
+    assert workshop.account_required_for_attendance?
+    Pd::Enrollment.any_instance.expects(:send_exit_survey).never
+
+    workshop.send_exit_surveys
+  end
+
   test 'send_follow_up only teachers attended workshop get follow up emails' do
     workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSF,
       subject: Pd::Workshop::SUBJECT_CSF_101, num_sessions: 1, sessions_from: Date.today - 30.days

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -348,13 +348,14 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_exit_surveys sends no surveys for FiT workshops' do
+    # Make a FiT workshop that's ended and has attendance;
+    # these are the conditions under which we'd normally send a survey.
     workshop = create :pd_ended_workshop, subject: SUBJECT_FIT
     create(:pd_workshop_participant, workshop: workshop, enrolled: true)
     create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
 
-    assert workshop.account_required_for_attendance?
+    # Ensure no exit surveys are sent
     Pd::Enrollment.any_instance.expects(:send_exit_survey).never
-
     workshop.send_exit_surveys
   end
 


### PR DESCRIPTION
[PLC-350](https://codedotorg.atlassian.net/browse/PLC-350): Ensure FiT (Facilitator in Training) workshops do not email exit surveys to participants on close, and do not show a pending survey to participants on the workshop dashboard.

FiT workshops are relatively rare; we've only got twenty of them on production.  We have a couple open right now that our team has been avoiding closing because they don't want these surveys to go out, but then our system emails our team regularly to remind them to close the workshop.