### PR TITLE
Enable experiment survey pipeline

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
@@ -4,6 +4,7 @@ import $ from 'jquery';
 import Spinner from '../../../components/spinner';
 import Results from './results';
 import color from '@cdo/apps/util/color';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   errorContainer: {
@@ -32,9 +33,13 @@ export class ResultsLoader extends React.Component {
   }
 
   load() {
-    const url = `/api/v1/pd/workshops/${
-      this.props.params['workshopId']
-    }/generic_survey_report`;
+    const url = experiments.isEnabled(experiments.ROLLUP_SURVEY_REPORT)
+      ? `/api/v1/pd/workshops/${
+          this.props.params['workshopId']
+        }/experiment_survey_report`
+      : `/api/v1/pd/workshops/${
+          this.props.params['workshopId']
+        }/generic_survey_report`;
 
     this.loadRequest = $.ajax({
       method: 'GET',

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -23,6 +23,7 @@ experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
   'schoolAutocompleteDropdownNewSearch';
 experiments.SCHOOL_INFO_CONFIRMATION_DIALOG = 'schoolInfoConfirmationDialog';
 experiments.FEEDBACK_NOTIFICATION = 'feedbackNotification';
+experiments.ROLLUP_SURVEY_REPORT = 'rollupSurveyReport';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -123,7 +123,7 @@ module Api::V1::Pd
       error_status_code = :bad_request
       raise 'Action generic_survey_report should not be used for this workshop'
     rescue => e
-      notify_error error_status_code, e
+      notify_error e, error_status_code
     end
 
     # GET /api/v1/pd/workshops/experiment_survey_report/:id/
@@ -153,7 +153,7 @@ module Api::V1::Pd
       render json: report_single_workshop(@workshop, current_user)
     end
 
-    def notify_error(error_status_code, exception)
+    def notify_error(exception, error_status_code = :internal_server_error)
       Honeybadger.notify(
         error_message: exception.message,
         context: {

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -401,6 +401,7 @@ Dashboard::Application.routes.draw do
         get :workshop_survey_report, action: :workshop_survey_report, controller: 'workshop_survey_report'
         get :local_workshop_survey_report, action: :local_workshop_survey_report, controller: 'workshop_survey_report'
         get :generic_survey_report, action: :generic_survey_report, controller: 'workshop_survey_report'
+        get :experiment_survey_report, action: :experiment_survey_report, controller: 'workshop_survey_report'
         get :teachercon_survey_report, action: :teachercon_survey_report, controller: 'workshop_survey_report'
         get :workshop_organizer_survey_report, action: :workshop_organizer_survey_report, controller: 'workshop_organizer_survey_report'
       end

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -250,6 +250,29 @@ module Api::V1::Pd
       )
     end
 
+    test 'experiment_survey_report: return empty result for workshop without responds' do
+      csf_201_ws = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201, num_sessions: 1,
+        facilitators: create_list(:facilitator, 2)
+
+      expected_result = {
+        "course_name" => nil,
+        "questions" => {},
+        "this_workshop" => {},
+        "all_my_workshops" => {},
+        "facilitators" => {},
+        "facilitator_averages" => {},
+        "facilitator_response_counts" => {},
+        "experiment" => true
+      }
+
+      sign_in @admin
+      get :experiment_survey_report, params: {workshop_id: csf_201_ws.id}
+      result = JSON.parse(@response.body).slice(*expected_result.keys)
+
+      assert_equal expected_result, result
+      assert_response :success
+    end
+
     test 'generic_survey_report: CSF201 workshop uses new pipeline' do
       csf_201_ws = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201
 


### PR DESCRIPTION
2nd PR in a series to support workshop surveys rollup. ([1st PR](https://github.com/code-dot-org/code-dot-org/pull/29489))

### What
- Open new survey pipeline for all requests (currently it is limited to CSF Deep Dive) by using experiment action in controller and experiment flag in UI. It also enables testing rollup pipeline in the experiment action.

### How tested
- Unit test: `bundle exec rails test test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb`
- Manual integration test:
  - Experiment API check: http://localhost-studio.code.org:3000/api/v1/pd/workshops/6482/experiment_survey_report
  - Experiment UI check: http://localhost-studio.code.org:3000/pd/workshop_dashboard/daily_survey_results/6482?enableExperiments=rollupSurveyReport