### PR TITLE
Paginate Data Table in App Lab Data Tab

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -947,6 +947,7 @@
   "onetimeHintPromptTitle": "Feeling Stuck?",
   "other": "Other",
   "otherTeacher": "Other teacher",
+  "paginationLabel": "Page:",
   "pairingNavigatorWarning": "This puzzle was completed while pairing with {driver}.",
   "pairingNavigatorLink": "Click here to view the solution you created as a team.",
   "pairProgramming": "Pair Programming",

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -16,8 +16,11 @@ import * as dataStyles from './dataStyles';
 import color from '../../util/color';
 import {connect} from 'react-redux';
 import {getColumnNamesFromRecords} from '../firebaseMetadata';
+import PaginationWrapper from '../../templates/PaginationWrapper';
+import msg from '@cdo/locale';
 
 const MIN_TABLE_WIDTH = 600;
+const MAX_ROWS_PER_PAGE = 500;
 
 const styles = {
   addColumnHeader: [
@@ -39,6 +42,11 @@ const styles = {
     flexGrow: 1,
     overflow: 'scroll'
   },
+  pagination: {
+    float: 'right',
+    display: 'inline',
+    marginTop: 10
+  },
   plusIcon: {
     alignItems: 'center',
     borderRadius: 2,
@@ -57,7 +65,8 @@ const INITIAL_STATE = {
   pendingAdd: false,
   // The old name of the column currently being renamed or deleted.
   pendingColumn: null,
-  showDebugView: false
+  showDebugView: false,
+  currentPage: 0
 };
 
 class DataTable extends React.Component {
@@ -267,12 +276,31 @@ class DataTable extends React.Component {
     return JSON.stringify(records, null, 2);
   }
 
+  onChangePageNumber = number => {
+    this.setState({currentPage: number - 1});
+  };
+
+  getRowsForCurrentPage() {
+    if (this.props.tableRecords['slice']) {
+      return this.props.tableRecords.slice(
+        this.state.currentPage * MAX_ROWS_PER_PAGE,
+        (this.state.currentPage + 1) * MAX_ROWS_PER_PAGE
+      );
+    }
+    return this.props.tableRecords;
+  }
+
   render() {
     let columnNames = this.getColumnNames(
       this.props.tableRecords,
       this.props.tableColumns
     );
     let editingColumn = this.state.editingColumn;
+
+    let numPages = Math.ceil(
+      Object.keys(this.props.tableRecords).length / MAX_ROWS_PER_PAGE
+    );
+    let rows = this.getRowsForCurrentPage();
 
     // Always show at least one column.
     if (columnNames.length === 1) {
@@ -333,6 +361,15 @@ class DataTable extends React.Component {
 
         <div style={debugDataStyle}>{this.getTableJson()}</div>
 
+        <div style={styles.pagination}>
+          <PaginationWrapper
+            totalPages={numPages}
+            currentPage={this.state.currentPage + 1}
+            onChangePage={this.onChangePageNumber}
+            label={msg.paginationLabel()}
+          />
+        </div>
+
         <div style={styles.tableWrapper}>
           <table style={tableDataStyle}>
             <tbody>
@@ -379,11 +416,11 @@ class DataTable extends React.Component {
                 columnNames={columnNames}
               />
 
-              {Object.keys(this.props.tableRecords).map(id => (
+              {Object.keys(rows).map(id => (
                 <EditTableRow
                   columnNames={columnNames}
                   tableName={this.props.tableName}
-                  record={JSON.parse(this.props.tableRecords[id])}
+                  record={JSON.parse(rows[id])}
                   key={id}
                 />
               ))}

--- a/apps/src/templates/PaginationWrapper.jsx
+++ b/apps/src/templates/PaginationWrapper.jsx
@@ -6,6 +6,11 @@ import Radium, {Style} from 'radium';
 import color from '../util/color';
 import Pagination from 'react-bootstrap/lib/Pagination';
 
+const styles = {
+  label: {
+    float: 'left'
+  }
+};
 /**
  * Pagination control for navigating between pages of a list.
  */
@@ -13,7 +18,8 @@ class PaginationWrapper extends Component {
   static propTypes = {
     totalPages: PropTypes.number.isRequired,
     currentPage: PropTypes.number.isRequired,
-    onChangePage: PropTypes.func.isRequired
+    onChangePage: PropTypes.func.isRequired,
+    label: PropTypes.string
   };
 
   render() {
@@ -43,6 +49,9 @@ class PaginationWrapper extends Component {
             }
           }}
         />
+        {this.props.label && (
+          <span style={styles.label}>{this.props.label}</span>
+        )}
         <Pagination
           bsSize={'small'}
           items={this.props.totalPages}


### PR DESCRIPTION
This change is required in order to remove the 1000 row limit for app lab tables, because rendering the entire table gets quite slow. We still download the whole table, but only render 500 rows at a time.

![image](https://user-images.githubusercontent.com/8787187/60837680-9b4cdb00-a17d-11e9-83c4-4d797d39ffa2.png)
