### PR TITLE
Only translate active levels

### DIFF
--- a/bin/i18n/sync-codeorg-in.rb
+++ b/bin/i18n/sync-codeorg-in.rb
@@ -97,20 +97,7 @@ def localize_level_content
       next unless ScriptConstants.i18n? script.name
       script_strings = {}
       script.script_levels.each do |script_level|
-        level =
-          if script_level.levels.count > 1
-            levels = script_level.levels.to_a
-            levels.delete_if do |l|
-              script_level.variants[l.name] && !script_level.variants[l.name]['active']
-            end
-            if levels.count > 1
-              puts "Multiple active levels for script level #{script_level.id}"
-              next
-            end
-            levels.first
-          else
-            script_level.level
-          end
+        level = script_level.oldest_active_level
         url = get_level_url_key(script, level)
         script_strings[url] = get_i18n_strings(level)
 

--- a/bin/i18n/sync-codeorg-in.rb
+++ b/bin/i18n/sync-codeorg-in.rb
@@ -96,7 +96,21 @@ def localize_level_content
     Script.all.each do |script|
       next unless ScriptConstants.i18n? script.name
       script_strings = {}
-      script.levels.each do |level|
+      script.script_levels.each do |script_level|
+        level =
+          if script_level.levels.count > 1
+            levels = script_level.levels.to_a
+            levels.delete_if do |l|
+              script_level.variants[l.name] && !script_level.variants[l.name]['active']
+            end
+            if levels.count > 1
+              puts "Multiple active levels for script level #{script_level.id}"
+              next
+            end
+            levels.first
+          else
+            script_level.level
+          end
         url = get_level_url_key(script, level)
         script_strings[url] = get_i18n_strings(level)
 


### PR DESCRIPTION
Some script levels contain multiple levels. If we process the "inactive" level after the "active" level associated with the same script level, we'll overwrite the active level's strings with the inactive level's strings. This causes the translations to differ from the level content.

Example level: https://studio.code.org/s/express-2017/stage/2/puzzle/5 (switch to Latin American Spanish and notice that the instructions reference "TNT").

This appears to affect 46 levels, 55 URLs (most of the express course levels are reused from course d-f), and a total of 194 strings across URLs (not levels).