### PR TITLE
Restore export work with pixelation fix

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -227,7 +227,7 @@
   },
   "dependencies": {
     "@code-dot-org/js-interpreter": "^1.3.9",
-    "@code-dot-org/snack-sdk": "2.2.0-apkurl-v1",
+    "@code-dot-org/snack-sdk": "2.2.0-apkurl-v3",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -27,6 +27,7 @@ import {getAppOptions} from '@cdo/apps/code-studio/initApp/loadApp';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {EXPO_SESSION_SECRET} from '../constants';
 import {
+  EXPO_SDK_VERSION,
   extractSoundAssets,
   createPackageFilesFromZip,
   createPackageFilesFromExpoFiles,
@@ -395,6 +396,7 @@ export default {
     if (expoMode) {
       const appJson = exportExpoAppJsonEjs({
         appName: appName,
+        sdkVersion: EXPO_SDK_VERSION,
         projectId: project.getCurrentId(),
         iconPath: '.' + iconPath,
         splashImagePath: '.' + splashImagePath
@@ -569,10 +571,10 @@ export default {
     });
   },
 
-  async exportApp(appName, code, levelHtml, suppliedExpoOpts, config) {
+  exportApp(appName, code, levelHtml, suppliedExpoOpts, config) {
     const expoOpts = suppliedExpoOpts || {};
     if (expoOpts.mode === 'expoPublish') {
-      return await this.publishToExpo(appName, code, levelHtml, config);
+      return this.publishToExpo(appName, code, levelHtml, config);
     }
     return this.exportAppToZip(
       appName,
@@ -636,7 +638,7 @@ export default {
       sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
       files,
       name: `project-${project.getCurrentId()}`,
-      sdkVersion: '31.0.0',
+      sdkVersion: EXPO_SDK_VERSION,
       user: {
         sessionSecret: config.expoSession || EXPO_SESSION_SECRET
       }
@@ -715,6 +717,10 @@ export default {
     };
 
     await session.sendCodeAsync(files);
+    // NOTE: We are waiting on a snack-sdk change that will make sendCodeAsync() actually
+    // send the code right away (currently, the method is debounced). Until then, we must
+    // call an internal method to ensure the code is saved:
+    await session._publishNotDebouncedAsync();
     const saveResult = await session.saveAsync();
     const expoUri = `exp://expo.io/${saveResult.id}`;
     const expoSnackId = saveResult.id;

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1132,7 +1132,11 @@ Applab.onReportComplete = function(response) {
 };
 
 function getGeneratedProperties() {
-  return Applab.generatedProperties;
+  // Must return a new object instance each time so the project
+  // system can properly compare currentSources vs newSources
+  return {
+    ...Applab.generatedProperties
+  };
 }
 
 /**

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -75,7 +75,12 @@ import experiments from '../util/experiments';
 import header from '../code-studio/header';
 import {TestResults, ResultType} from '../constants';
 import i18n from '../code-studio/i18n';
-import {generateExpoApk} from '../util/exporter';
+import {
+  expoGenerateApk,
+  expoCheckApkBuild,
+  expoCancelApkBuild
+} from '../util/exporter';
+import {setExportGeneratedProperties} from '../code-studio/components/exportDialogRedux';
 
 /**
  * Create a namespace for the application.
@@ -388,6 +393,14 @@ Applab.init = function(config) {
   // Necessary for tests.
   thumbnailUtils.init();
 
+  Applab.generatedProperties = {
+    ...config.initialGeneratedProperties
+  };
+  getStore().dispatch(
+    setExportGeneratedProperties(Applab.generatedProperties.export)
+  );
+  config.getGeneratedProperties = getGeneratedProperties;
+
   // replace studioApp methods with our own
   studioApp().reset = this.reset.bind(this);
   studioApp().runButtonClick = this.runButtonClick.bind(this);
@@ -635,6 +648,21 @@ Applab.init = function(config) {
     channelId: config.channel,
     allowExportExpo: experiments.isEnabled('exportExpo'),
     exportApp: Applab.exportApp,
+    expoGenerateApk: expoGenerateApk.bind(
+      null,
+      config.expoSession,
+      Applab.setAndroidExportProps
+    ),
+    expoCheckApkBuild: expoCheckApkBuild.bind(
+      null,
+      config.expoSession,
+      Applab.setAndroidExportProps
+    ),
+    expoCancelApkBuild: expoCancelApkBuild.bind(
+      null,
+      config.expoSession,
+      Applab.setAndroidExportProps
+    ),
     nonResponsiveVisualizationColumnWidth: applabConstants.APP_WIDTH,
     visualizationHasPadding: !config.noPadding,
     hasDataMode: !config.level.hideViewDataButton,
@@ -845,33 +873,36 @@ Applab.render = function() {
   );
 };
 
+/**
+ * Export the project for web or use within Expo.
+ * @param {Object} expoOpts
+ */
 Applab.exportApp = function(expoOpts) {
+  // Run, grab the html from divApplab, then reset:
   Applab.runButtonClick();
   var html = document.getElementById('divApplab').outerHTML;
   studioApp().resetButtonClick();
 
-  // TODO: find another way to get this info that doesn't rely on globals.
-  const appName = project.getCurrentName() || 'my-app';
-
-  const {mode, expoSnackId, iconUri, splashImageUri} = expoOpts || {};
-  if (mode === 'expoGenerateApk') {
-    return generateExpoApk(
-      {
-        appName,
-        expoSnackId,
-        iconUri,
-        splashImageUri
-      },
-      studioApp().config
-    );
-  }
-
   return Exporter.exportApp(
-    appName,
+    project.getCurrentName() || 'my-app',
     studioApp().editor.getValue(),
     html,
     expoOpts,
     studioApp().config
+  );
+};
+
+Applab.setAndroidExportProps = function(props) {
+  // Spread the previous object so changes here will always fail shallow
+  // compare and trigger react prop changes
+  Applab.generatedProperties.export = {
+    ...Applab.generatedProperties.export,
+    android: props
+  };
+  project.projectChanged();
+  project.saveIfSourcesChanged();
+  getStore().dispatch(
+    setExportGeneratedProperties(Applab.generatedProperties.export)
   );
 };
 
@@ -1099,6 +1130,10 @@ Applab.onReportComplete = function(response) {
   studioApp().onReportComplete(response);
   displayFeedback();
 };
+
+function getGeneratedProperties() {
+  return Applab.generatedProperties;
+}
 
 /**
  * Execute the app

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -10,6 +10,7 @@
  * @property {string} levelPosition
  * @property {AutoplayVideo} autoplayVideo
  * @property {SerializedAnimationList} initialAnimationList
+ * @property {Object} initialGeneratedProperties
  * @property {string} levelGameName
  * @property {string} skinId
  * @property {string} baseUrl

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -62,10 +62,6 @@ const style = {
   expoButtonLast: {
     marginRight: 0
   },
-  expoButtonApk: {
-    marginBottom: 10,
-    maxWidth: 280
-  },
   expoContainer: {
     display: 'flex',
     flexDirection: 'column'
@@ -186,35 +182,6 @@ class AdvancedShareOptions extends React.Component {
     }
   };
 
-  generateExpoApk = async () => {
-    const {expoSnackId, iconUri, splashImageUri} = this.state;
-    this.setState({generatingExpoApk: true});
-    try {
-      const expoApkUri = await this.props.exportApp({
-        mode: 'expoGenerateApk',
-        expoSnackId,
-        iconUri,
-        splashImageUri
-      });
-      this.setState({
-        generatingExpoApk: false,
-        generatingExpoApkError: null,
-        expoApkUri
-      });
-    } catch (e) {
-      this.setState({
-        generatingExpoApk: false,
-        generatingExpoApkError:
-          'Failed to create Android app. Please try again later.'
-      });
-    }
-  };
-
-  visitExpoSite = () => {
-    const {expoSnackId} = this.state;
-    window.open(`https://snack.expo.io/${expoSnackId}`, '_blank');
-  };
-
   renderEmbedTab() {
     let url = `${this.props.shareUrl}/embed`;
     if (this.state.embedWithoutCode) {
@@ -292,12 +259,7 @@ class AdvancedShareOptions extends React.Component {
   };
 
   renderExportExpoTab() {
-    const {
-      expoUri,
-      exportedExpoZip,
-      expoApkUri,
-      generatingExpoApk
-    } = this.state;
+    const {expoUri, exportedExpoZip} = this.state;
     const exportSpinner =
       this.state.exportingExpo === 'zip' ? (
         <i className="fa fa-spinner fa-spin" />
@@ -306,21 +268,10 @@ class AdvancedShareOptions extends React.Component {
       this.state.exportingExpo === 'publish' ? (
         <i className="fa fa-spinner fa-spin" />
       ) : null;
-    const generateApkSpinner = generatingExpoApk ? (
-      <i className="fa fa-spinner fa-spin" />
-    ) : null;
     // TODO: Make this use a nice UI component from somewhere.
     const alert = this.state.exportExpoError ? (
       <div className="alert fade in">{this.state.exportExpoError}</div>
     ) : null;
-    const apkAlert = this.state.generatingExpoApkError ? (
-      <div className="alert fade in">{this.state.generatingExpoApkError}</div>
-    ) : null;
-    const apkStatusString = expoApkUri
-      ? 'App created successfully'
-      : generatingExpoApk
-      ? 'Creating app...'
-      : '(This will take 5-10 minutes)';
 
     return (
       <div>
@@ -379,39 +330,6 @@ class AdvancedShareOptions extends React.Component {
                     value={expoUri}
                     style={style.expoInput}
                   />
-                  <button
-                    type="button"
-                    onClick={this.generateExpoApk}
-                    style={[style.expoButton, style.expoButtonApk]}
-                  >
-                    {generateApkSpinner}
-                    Create Android App
-                  </button>
-                  <button
-                    type="button"
-                    onClick={this.visitExpoSite}
-                    style={[style.expoButton, style.expoButtonApk]}
-                  >
-                    Visit Expo Site
-                  </button>
-                  <p style={style.p}>{apkStatusString}</p>
-                  {!!expoApkUri && (
-                    <div>
-                      <p style={[style.p, style.bold]}>
-                        Send this URL to an Android phone:
-                      </p>
-                    </div>
-                  )}
-                  {!!expoApkUri && (
-                    <input
-                      type="text"
-                      onClick={this.onInputSelect}
-                      readOnly="true"
-                      value={expoApkUri}
-                      style={style.expoInput}
-                    />
-                  )}
-                  {apkAlert}
                 </div>
               </div>
             </div>

--- a/apps/src/code-studio/components/ExportDialog.jsx
+++ b/apps/src/code-studio/components/ExportDialog.jsx
@@ -471,7 +471,7 @@ class ExportDialog extends React.Component {
       } else {
         // Check status again...
         // NOTE: we don't timeout automatically
-        this.waitTimerId = setTimeout(async () => {
+        this.waitTimerId = setTimeout(() => {
           this.waitTimerId = null;
           this.waitForApkBuild(apkBuildId, expoSnackId);
         }, APK_BUILD_STATUS_CHECK_PERIOD);

--- a/apps/src/code-studio/components/ExportDialog.jsx
+++ b/apps/src/code-studio/components/ExportDialog.jsx
@@ -511,17 +511,26 @@ class ExportDialog extends React.Component {
       apkBuildId,
       snackId: expoSnackId
     } = this.getValidPreviousApkInfo();
+    const {md5SavedSources} = this.props;
     if (apkUri) {
-      // The previous build completed, no need to generate a new one:
-      this.setState({apkUri, apkBuildId, expoSnackId});
+      // The previous build completed, no need to generate a new one.
+      // Set up state to match a completed export:
+      this.setState({
+        apkUri,
+        apkBuildId,
+        expoSnackId,
+        md5PublishSavedSources: md5SavedSources
+      });
       return Promise.resolve();
     } else if (apkBuildId) {
-      // The previous build was in progress, resume monitoring that build:
+      // The previous build was in progress, resume monitoring that build.
+      // Set up state to match an export in progress:
       this.setState({
         generatingApk: true,
         apkUri: null,
         apkBuildId,
-        expoSnackId
+        expoSnackId,
+        md5PublishSavedSources: md5SavedSources
       });
       return this.waitForApkBuild(apkBuildId, expoSnackId);
     } else {

--- a/apps/src/code-studio/components/ExportDialog.jsx
+++ b/apps/src/code-studio/components/ExportDialog.jsx
@@ -12,6 +12,8 @@ import exportExpoIconPng from '../../templates/export/expo/icon.png';
 import SendToPhone from './SendToPhone';
 import project from '../initApp/project';
 
+const APK_BUILD_STATUS_CHECK_PERIOD = 60000;
+
 function recordExport(type) {
   firehoseClient.putRecord(
     {
@@ -30,6 +32,7 @@ const baseStyles = {
     borderWidth: 1,
     borderColor: color.border_gray,
     fontSize: 'larger',
+    outline: 'none',
     padding: 10,
     marginTop: 0,
     marginBottom: 0,
@@ -96,6 +99,16 @@ const styles = {
     color: color.white
   },
   actionButtonDisabled: {
+    ...baseStyles.button,
+    backgroundColor: color.gray,
+    color: color.white
+  },
+  backButton: {
+    ...baseStyles.button,
+    backgroundColor: color.gray,
+    color: color.black
+  },
+  backButtonDisabled: {
     ...baseStyles.button,
     backgroundColor: color.gray,
     color: color.white
@@ -188,10 +201,13 @@ class ExportDialog extends React.Component {
       t: PropTypes.func.isRequired
     }).isRequired,
     exportApp: PropTypes.func.isRequired,
-    projectUpdatedAt: PropTypes.string,
+    expoGenerateApk: PropTypes.func.isRequired,
+    expoCheckApkBuild: PropTypes.func.isRequired,
+    expoCancelApkBuild: PropTypes.func.isRequired,
+    exportGeneratedProperties: PropTypes.object,
+    md5SavedSources: PropTypes.string.isRequired,
     isAbusive: PropTypes.bool.isRequired,
     isOpen: PropTypes.bool.isRequired,
-    channelId: PropTypes.string.isRequired,
     appType: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
     hideBackdrop: BaseDialog.propTypes.hideBackdrop,
@@ -206,25 +222,94 @@ class ExportDialog extends React.Component {
   };
 
   componentDidUpdate(prevProps) {
-    const {isOpen, projectUpdatedAt} = this.props;
-    const {exportProjectUpdatedAt} = this.state;
+    const {isOpen, md5SavedSources} = this.props;
+    const {md5PublishSavedSources} = this.state;
     if (isOpen && !prevProps.isOpen) {
       recordExport('open');
-      if (projectUpdatedAt !== exportProjectUpdatedAt) {
-        // The project has changed since we last opened the dialog,
-        // reset our export state, so we will need to export again:
-        this.resetExportState();
+      const md5ApkSavedSources = this.getMd5ApkSavedSources();
+      const sourcesChangedSinceExport =
+        md5ApkSavedSources && md5SavedSources !== md5ApkSavedSources;
+      const sourcesChangedThisInstance =
+        md5PublishSavedSources && md5SavedSources !== md5PublishSavedSources;
+      if (sourcesChangedSinceExport) {
+        // Cancel any build that may have started with an older version of this
+        // project before this page was reloaded:
+        this.cancelIfPreexistingApkBuild();
       }
+      if (sourcesChangedThisInstance) {
+        // The project has changed since we last published within this dialog,
+        // cancel any builds in progress and reset our export state, so we will
+        // start all over again:
+        this.cancelIfGeneratingAndResetState();
+      }
+    }
+  }
+
+  clearWaitTimer() {
+    if (this.waitTimerId) {
+      clearTimeout(this.waitTimerId);
+      this.waitTimerId = null;
+    }
+  }
+
+  cancelIfGeneratingAndResetState() {
+    const {screen, generatingApk} = this.state;
+    if (screen === 'generating' && generatingApk) {
+      this.clearWaitTimer();
+
+      const {expoCancelApkBuild, md5SavedSources} = this.props;
+      const {expoSnackId, apkBuildId} = this.state;
+
+      expoCancelApkBuild({
+        md5SavedSources,
+        expoSnackId,
+        apkBuildId
+      });
+    }
+    // If we are publishing to expo (state.exporting is true), we don't need
+    // to cancel, just resetting our state is good enough.
+    this.resetExportState();
+  }
+
+  getMd5ApkSavedSources() {
+    const {exportGeneratedProperties = {}} = this.props;
+    const {android = {}} = exportGeneratedProperties;
+    const {md5ApkSavedSources} = android;
+
+    return md5ApkSavedSources;
+  }
+
+  //
+  // Cancel preexisting builds for this project (the page may have been
+  // refreshed while a build was in progress)
+  //
+  cancelIfPreexistingApkBuild() {
+    const {exportGeneratedProperties = {}} = this.props;
+    const {android = {}} = exportGeneratedProperties;
+    const {md5ApkSavedSources, snackId, apkBuildId, apkUri} = android;
+
+    // If we have an apkBuildId, but not apkUri, there was a build
+    // in process that needs to be canceled because Expo will only
+    // allow one build to take place at a time
+    if (apkBuildId && !apkUri) {
+      const {expoCancelApkBuild} = this.props;
+      expoCancelApkBuild({
+        md5SavedSources: md5ApkSavedSources,
+        expoSnackId: snackId,
+        apkBuildId
+      });
     }
   }
 
   resetExportState() {
     this.setState({
+      screen: 'intro',
       exporting: false,
       exportError: null,
       expoUri: undefined,
       expoSnackId: undefined,
       iconUri: undefined,
+      md5PublishSavedSources: undefined,
       splashImageUri: undefined,
       showSendToPhone: false,
       apkUri: undefined,
@@ -234,15 +319,6 @@ class ExportDialog extends React.Component {
   }
 
   close = () => {
-    const {expoUri} = this.state;
-    if (expoUri) {
-      // If we are re-opened, start at the platform page:
-      this.setState({screen: 'platform'});
-    } else {
-      // If we don't haven't succesfully exported, then clear all export
-      // state so we will start again fresh the next time:
-      this.resetExportState();
-    }
     recordExport('close');
     this.props.onClose();
   };
@@ -282,15 +358,22 @@ class ExportDialog extends React.Component {
         splashImageUri
       };
     }
-    const {exportApp, projectUpdatedAt} = this.props;
+    const {exportApp, md5SavedSources} = this.props;
     this.setState({
       exporting: true,
-      exportProjectUpdatedAt: projectUpdatedAt
+      md5PublishSavedSources: md5SavedSources
     });
     try {
       const exportResult = await exportApp({
         mode: 'expoPublish'
       });
+      const {exporting} = this.state;
+      if (!exporting) {
+        // The user has canceled (resetExportState() was called)
+        // Simply return an empty object and don't modify state
+        // or return the exportResult:
+        return {};
+      }
       this.setState({
         exporting: false,
         exportError: null,
@@ -300,7 +383,7 @@ class ExportDialog extends React.Component {
     } catch (e) {
       this.setState({
         exporting: false,
-        exportProjectUpdatedAt: null,
+        md5PublishSavedSources: null,
         expoUri: null,
         expoSnackId: null,
         exportError: 'Failed to create app. Please try again later.'
@@ -319,9 +402,10 @@ class ExportDialog extends React.Component {
   }
 
   async publishAndGenerateApk() {
-    const {exportApp} = this.props;
+    const {expoGenerateApk, md5SavedSources} = this.props;
+    const {apkUri} = this.state;
 
-    if (this.state.apkUri) {
+    if (apkUri) {
       // We have already have generated an APK
       return;
     }
@@ -333,28 +417,117 @@ class ExportDialog extends React.Component {
     } = await this.publishExpoExport();
 
     if (!expoSnackId) {
-      // We failed to generate a snackId
+      // We failed to generate a snackId, simply return
+      // (publishExpoExport() will have set exportError in state as needed)
       return;
     }
 
     this.setState({generatingApk: true});
     try {
-      const apkUri = await exportApp({
-        mode: 'expoGenerateApk',
+      const apkBuildId = await expoGenerateApk({
+        md5SavedSources,
         expoSnackId,
         iconUri,
         splashImageUri
       });
-      this.setState({
-        generatingApk: false,
-        apkError: null,
-        apkUri
-      });
+      this.setState({apkBuildId});
+      return this.waitForApkBuild(apkBuildId, expoSnackId);
     } catch (e) {
       this.setState({
         generatingApk: false,
-        apkError: 'Failed to create Android app. Please try again later.'
+        apkError: 'Failed to create Android app. Please try again later.',
+        apkUri: null,
+        apkBuildId: null
       });
+    }
+  }
+
+  checkForApkBuild(apkBuildId, expoSnackId) {
+    const {expoCheckApkBuild, md5SavedSources} = this.props;
+
+    return expoCheckApkBuild({
+      md5SavedSources,
+      expoSnackId,
+      apkBuildId
+    });
+  }
+
+  async waitForApkBuild(apkBuildId, expoSnackId) {
+    this.clearWaitTimer();
+
+    try {
+      const apkUri = await this.checkForApkBuild(apkBuildId, expoSnackId);
+      const {generatingApk} = this.state;
+      if (!generatingApk) {
+        // Build was canceled while we were checking on the status
+        return;
+      }
+      if (apkUri) {
+        this.setState({
+          generatingApk: false,
+          apkError: null,
+          apkUri
+        });
+      } else {
+        // Check status again...
+        // NOTE: we don't timeout automatically
+        this.waitTimerId = setTimeout(async () => {
+          this.waitTimerId = null;
+          this.waitForApkBuild(apkBuildId, expoSnackId);
+        }, APK_BUILD_STATUS_CHECK_PERIOD);
+      }
+    } catch (e) {
+      this.setState({
+        generatingApk: false,
+        apkError: 'Failed to create Android app. Please try again later.',
+        apkUri: null,
+        apkBuildId: null
+      });
+    }
+  }
+
+  //
+  // Return properties related to the last saved APK build as long as the
+  // project's md5SavedSources hash matches
+  //
+  getValidPreviousApkInfo() {
+    const {exportGeneratedProperties = {}, md5SavedSources} = this.props;
+    const {android = {}} = exportGeneratedProperties;
+    const {md5ApkSavedSources, ...apkInfo} = android;
+
+    if (md5ApkSavedSources && md5SavedSources === md5ApkSavedSources) {
+      return apkInfo;
+    }
+    return {};
+  }
+
+  //
+  // Generates an APK - or monitors an existing APK build in progress
+  // Returns: Promise
+  //
+  generateApkAsNeeded() {
+    const {
+      apkUri,
+      apkBuildId,
+      snackId: expoSnackId
+    } = this.getValidPreviousApkInfo();
+    if (apkUri) {
+      // The previous build completed, no need to generate a new one:
+      this.setState({apkUri, apkBuildId, expoSnackId});
+      return Promise.resolve();
+    } else if (apkBuildId) {
+      // The previous build was in progress, resume monitoring that build:
+      this.setState({
+        generatingApk: true,
+        apkUri: null,
+        apkBuildId,
+        expoSnackId
+      });
+      return this.waitForApkBuild(apkBuildId, expoSnackId);
+    } else {
+      // There is no previous build that matches the current sources,
+      // so publish and generate a new build:
+      return this.publishAndGenerateApk();
     }
   }
 
@@ -363,22 +536,58 @@ class ExportDialog extends React.Component {
 
     switch (screen) {
       case 'intro':
-        return this.setState({screen: 'platform'});
-      // case 'export':
-      //   return this.setState({screen: 'platform'});
+        this.setState({screen: 'platform'});
+        break;
       case 'platform':
-        return this.setState({screen: 'publish'});
-      // return this.setState({screen: 'icon'});
+        this.setState({screen: 'publish'});
+        break;
+      // this.setState({screen: 'icon'});
+      // break;
       // case 'icon':
-      //   return this.setState({screen: 'publish'});
+      //   this.setState({screen: 'publish'});
+      //   break;
       case 'publish':
-        this.publishAndGenerateApk();
-        return this.setState({screen: 'generating'});
+        this.generateApkAsNeeded();
+        this.setState({screen: 'generating'});
+        break;
       case 'generating':
-        return this.close();
+        this.close();
+        break;
       default:
         throw new Error(`ExportDialog: Unexpected screen: ${screen}`);
     }
+  };
+
+  onBackButton = () => {
+    const {screen} = this.state;
+
+    switch (screen) {
+      case 'intro':
+        break;
+      case 'platform':
+        this.setState({screen: 'intro'});
+        break;
+      // case 'icon':
+      case 'publish':
+        this.setState({screen: 'platform'});
+        break;
+      case 'generating':
+        this.setState({screen: 'publish'});
+        break;
+      default:
+        throw new Error(`ExportDialog: Unexpected screen: ${screen}`);
+    }
+  };
+
+  onCancelButton = () => {
+    // If an operation is in progress, cancel and reset back the
+    // beginning as part of the close operation:
+    const {exporting} = this.state;
+    if (exporting) {
+      this.resetExportState();
+    }
+    this.cancelIfGeneratingAndResetState();
+    this.close();
   };
 
   renderMainContent() {
@@ -387,8 +596,6 @@ class ExportDialog extends React.Component {
     switch (screen) {
       case 'intro':
         return this.renderIntroPage();
-      // case 'export':
-      //   return this.renderExportPage();
       case 'platform':
         return this.renderPlatformPage();
       // case 'icon':
@@ -418,53 +625,6 @@ class ExportDialog extends React.Component {
             opening the Code.org website. If you make changes to your app after
             you export, you will need to export it again.
           </p>
-          {/*<p style={styles.p}>
-            The first step is to install the Expo app on your mobile device so
-            you can test your project within the Expo app.
-          </p>
-          <button
-            type="button"
-            style={styles.iosAppStoreButton}
-            onClick={this.onInstallExpoIOS}
-          >
-            iOS Expo App
-          </button>
-          <button
-            type="button"
-            style={styles.androidGooglePlayButton}
-            onClick={this.onInstallExpoAndroid}
-          >
-            Android Expo App
-          </button>*/}
-        </div>
-      </div>
-    );
-  }
-
-  renderExportPage() {
-    const {
-      exporting,
-      exportError,
-      expoUri,
-      expoSnackId,
-      iconUri,
-      splashImageUri
-    } = this.state;
-    // TODO: This page should be updated as a transition page to snack.expo.io
-    // when iOS IPA export is ready to go
-    return (
-      <div>
-        <div style={styles.section}>
-          <p style={styles.title}>Preview your project in the Expo app</p>
-        </div>
-        <div style={styles.section}>
-          <p style={styles.p}>TBD.</p>
-          <p style={styles.p}>{`exporting: ${exporting}`}</p>
-          <p style={styles.p}>{`exportError: ${exportError}`}</p>
-          <p style={styles.p}>{`expoUri: ${expoUri}`}</p>
-          <p style={styles.p}>{`expoSnackId: ${expoSnackId}`}</p>
-          <p style={styles.p}>{`iconUri: ${iconUri}`}</p>
-          <p style={styles.p}>{`splashImageUri: ${splashImageUri}`}</p>
         </div>
       </div>
     );
@@ -553,18 +713,16 @@ class ExportDialog extends React.Component {
     );
   }
 
+  isGenerating() {
+    const {screen, exporting, generatingApk} = this.state;
+    return screen === 'generating' && (exporting || generatingApk);
+  }
+
   renderGeneratingPage() {
-    const {
-      exporting,
-      generatingApk,
-      showSendToPhone,
-      exportError,
-      apkError,
-      apkUri = ''
-    } = this.state;
-    const waiting = exporting || generatingApk;
+    const {showSendToPhone, exportError, apkError, apkUri = ''} = this.state;
+    const waiting = this.isGenerating();
     const error = exportError || apkError;
-    const {appType, channelId} = this.props;
+    const {appType} = this.props;
     const titleText = waiting
       ? 'Creating Android Package...'
       : error
@@ -611,7 +769,6 @@ class ExportDialog extends React.Component {
               </button>
               {showSendToPhone && (
                 <SendToPhone
-                  channelId={channelId}
                   appType={appType}
                   downloadUrl={apkUri}
                   isLegacyShare={false}
@@ -636,14 +793,23 @@ class ExportDialog extends React.Component {
         info.text = 'Finish';
         info.enabled = !exporting && !generatingApk;
         break;
-      case 'export':
-        info.enabled = !exporting;
-        break;
       case 'publish':
         info.text = 'Create';
         break;
     }
     return info;
+  }
+
+  backButtonEnabled() {
+    const {screen, exporting, generatingApk} = this.state;
+    switch (screen) {
+      case 'intro':
+        return false;
+      case 'generating':
+        return !exporting && !generatingApk;
+      default:
+        return true;
+    }
   }
 
   render() {
@@ -657,6 +823,7 @@ class ExportDialog extends React.Component {
       signInState,
       userSharingDisabled
     } = this.props;
+    const {screen} = this.state;
 
     const needToSignIn =
       !isProjectLevel && signInState !== SignInState.SignedIn;
@@ -669,6 +836,9 @@ class ExportDialog extends React.Component {
       text: actionText,
       enabled: actionEnabled
     } = this.getActionButtonInfo();
+    const backVisible = screen !== 'intro';
+    const cancelVisible = this.isGenerating();
+    const backEnabled = this.backButtonEnabled();
     const showShareWarning = !canShareSocial;
     return (
       <div>
@@ -721,13 +891,29 @@ class ExportDialog extends React.Component {
                 )}
                 {this.renderMainContent()}
                 <div style={styles.buttonRow}>
-                  <button
-                    type="button"
-                    style={styles.cancelButton}
-                    onClick={this.close}
-                  >
-                    Cancel
-                  </button>
+                  {cancelVisible && (
+                    <button
+                      type="button"
+                      style={styles.cancelButton}
+                      onClick={this.onCancelButton}
+                    >
+                      Cancel Package Creation
+                    </button>
+                  )}
+                  {backVisible && (
+                    <button
+                      type="button"
+                      style={
+                        backEnabled
+                          ? styles.backButton
+                          : styles.backButtonDisabled
+                      }
+                      onClick={this.onBackButton}
+                      disabled={!backEnabled}
+                    >
+                      Back
+                    </button>
+                  )}
                   <button
                     type="button"
                     style={
@@ -755,8 +941,11 @@ export const UnconnectedExportDialog = ExportDialog;
 export default connect(
   state => ({
     exportApp: state.pageConstants.exportApp,
+    expoGenerateApk: state.pageConstants.expoGenerateApk,
+    expoCheckApkBuild: state.pageConstants.expoCheckApkBuild,
+    expoCancelApkBuild: state.pageConstants.expoCancelApkBuild,
     isOpen: state.exportDialog.isOpen,
-    projectUpdatedAt: state.header.projectUpdatedAt,
+    exportGeneratedProperties: state.exportDialog.exportGeneratedProperties,
     signInState: state.progress.signInState
   }),
   dispatch => ({

--- a/apps/src/code-studio/components/exportDialogRedux.js
+++ b/apps/src/code-studio/components/exportDialogRedux.js
@@ -2,11 +2,14 @@
 
 const SHOW_EXPORT_DIALOG = 'exportDialog/SHOW_EXPORT_DIALOG';
 const HIDE_EXPORT_DIALOG = 'exportDialog/HIDE_EXPORT_DIALOG';
+const SET_EXPORT_GENERATED_PROPERTIES =
+  'exportDialog/SET_EXPORT_GENERATED_PROPERTIES';
 
 // Reducer
 
 const initialState = {
-  isOpen: false
+  isOpen: false,
+  exportGeneratedProperties: {}
 };
 
 export default function reducer(state = initialState, action) {
@@ -14,13 +17,17 @@ export default function reducer(state = initialState, action) {
     case SHOW_EXPORT_DIALOG:
       return {
         ...state,
-        ...initialState,
         isOpen: true
       };
     case HIDE_EXPORT_DIALOG:
       return {
         ...state,
-        ...initialState
+        isOpen: false
+      };
+    case SET_EXPORT_GENERATED_PROPERTIES:
+      return {
+        ...state,
+        exportGeneratedProperties: action.exportGeneratedProperties
       };
     default:
       return state;
@@ -35,4 +42,16 @@ export function showExportDialog() {
 
 export function hideExportDialog() {
   return {type: HIDE_EXPORT_DIALOG};
+}
+
+/**
+ * Set the generated properties
+ * @param {object} exportGeneratedProperties
+ * @returns {{type: string, exportGeneratedProperties: object}}
+ */
+export function setExportGeneratedProperties(exportGeneratedProperties) {
+  return {
+    type: SET_EXPORT_GENERATED_PROPERTIES,
+    exportGeneratedProperties
+  };
 }

--- a/apps/src/code-studio/components/header/ProjectExport.jsx
+++ b/apps/src/code-studio/components/header/ProjectExport.jsx
@@ -1,19 +1,13 @@
-/* globals dashboard */
-
 import React from 'react';
 import i18n from '@cdo/locale';
 import {exportProject} from '../../headerExport';
 
 export default class ProjectExport extends React.Component {
-  exportProject = () => {
-    exportProject(dashboard.project.getShareUrl());
-  };
-
   render() {
     return (
       <div
         className="project_share header_button header_button_light"
-        onClick={this.exportProject}
+        onClick={exportProject}
       >
         {i18n.export()}
       </div>

--- a/apps/src/code-studio/headerExport.js
+++ b/apps/src/code-studio/headerExport.js
@@ -9,7 +9,7 @@ import {showExportDialog} from './components/exportDialogRedux';
 import project from './initApp/project';
 import i18n from './i18n';
 
-export function exportProject(shareUrl) {
+export function exportProject() {
   project.saveIfSourcesChanged().then(() => {
     let dialogDom = document.getElementById('project-export-dialog');
     if (!dialogDom) {
@@ -27,8 +27,7 @@ export function exportProject(shareUrl) {
         <ExportDialog
           isProjectLevel={!!project.isProjectLevel()}
           i18n={i18n}
-          shareUrl={shareUrl}
-          thumbnailUrl={project.getThumbnailUrl()}
+          md5SavedSources={project.md5CurrentSources()}
           isAbusive={project.exceedsAbuseThreshold()}
           channelId={project.getCurrentId()}
           appType={appType}

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -510,6 +510,13 @@ const sourceHandler = {
       callback({});
     }
   },
+  setInitialGeneratedProperties(generatedProperties) {
+    getAppOptions().initialGeneratedProperties = generatedProperties;
+  },
+  getGeneratedProperties() {
+    const {getGeneratedProperties} = getAppOptions();
+    return getGeneratedProperties && getGeneratedProperties();
+  },
   prepareForRemix() {
     const {prepareForRemix} = getAppOptions();
     if (prepareForRemix) {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1,5 +1,6 @@
 /* global appOptions */
 import $ from 'jquery';
+import MD5 from 'crypto-js/md5';
 import msg from '@cdo/locale';
 import * as utils from '../../utils';
 import {CIPHER, ALPHABET} from '../../constants';
@@ -127,6 +128,7 @@ function unpackSources(data) {
     html: data.html,
     animations: data.animations,
     makerAPIsEnabled: data.makerAPIsEnabled,
+    generatedProperties: data.generatedProperties,
     selectedSong: data.selectedSong
   };
 }
@@ -263,6 +265,19 @@ var projects = (module.exports = {
    */
   useMakerAPIs() {
     return currentSources.makerAPIsEnabled;
+  },
+
+  /**
+   * Calculates a md5 hash for everything within sources except the
+   * generatedProperties.
+   * @return {string} md5 hash string.
+   */
+  md5CurrentSources() {
+    const {
+      generatedProperties, // eslint-disable-line no-unused-vars
+      ...sourcesWithoutProperties
+    } = currentSources;
+    return MD5(JSON.stringify(sourcesWithoutProperties)).toString();
   },
 
   getCurrentSourceVersionId() {
@@ -504,7 +519,7 @@ var projects = (module.exports = {
     const {hideShareAndRemix} = level;
     return (
       !hideShareAndRemix &&
-      app === 'applab' &&
+      (app === 'applab' || app === 'gamelab') &&
       experiments.isEnabled('exportExpo')
     );
   },
@@ -543,6 +558,8 @@ var projects = (module.exports = {
    * @param {function(): string} sourceHandler.getLevelSource
    * @param {function(SerializedAnimationList)} sourceHandler.setInitialAnimationList
    * @param {function(function(): SerializedAnimationList)} sourceHandler.getAnimationList
+   * @param {function(Object)} sourceHandler.setInitialGeneratedProperties
+   * @param {function(): Object} sourceHandler.getGeneratedProperties
    * @param {function(boolean)} sourceHandler.setMakerAPIsEnabled
    * @param {function(): boolean} sourceHandler.getMakerAPIsEnabled
    * @param {function(): boolean} sourceHandler.setSelectedSong
@@ -570,6 +587,12 @@ var projects = (module.exports = {
 
       if (currentSources.animations) {
         sourceHandler.setInitialAnimationList(currentSources.animations);
+      }
+
+      if (currentSources.generatedProperties) {
+        sourceHandler.setInitialGeneratedProperties(
+          currentSources.generatedProperties
+        );
       }
 
       if (isEditing) {
@@ -1071,18 +1094,29 @@ var projects = (module.exports = {
    */
   getUpdatedSourceAndHtml_(callback) {
     this.sourceHandler.getAnimationList(animations =>
-      this.sourceHandler.getLevelSource().then(response => {
-        const source = response;
+      this.sourceHandler.getLevelSource().then(source => {
         const html = this.sourceHandler.getLevelHtml();
         const makerAPIsEnabled = this.sourceHandler.getMakerAPIsEnabled();
         const selectedSong = this.sourceHandler.getSelectedSong();
-        callback({source, html, animations, makerAPIsEnabled, selectedSong});
+        const generatedProperties = this.sourceHandler.getGeneratedProperties();
+        callback({
+          source,
+          html,
+          animations,
+          makerAPIsEnabled,
+          selectedSong,
+          generatedProperties
+        });
       })
     );
   },
 
   getSelectedSong() {
     return currentSources.selectedSong;
+  },
+
+  getGeneratedProperties() {
+    return currentSources.generatedProperties;
   },
 
   /**

--- a/apps/src/gamelab/Exporter.js
+++ b/apps/src/gamelab/Exporter.js
@@ -23,6 +23,7 @@ import project from '@cdo/apps/code-studio/initApp/project';
 import {GAME_WIDTH, GAME_HEIGHT} from './constants';
 import {EXPO_SESSION_SECRET} from '../constants';
 import {
+  EXPO_SDK_VERSION,
   extractSoundAssets,
   createPackageFilesFromZip,
   createPackageFilesFromExpoFiles,
@@ -98,6 +99,7 @@ export default {
     if (expoMode) {
       const appJson = exportExpoAppJsonEjs({
         appName,
+        sdkVersion: EXPO_SDK_VERSION,
         projectId: project.getCurrentId(),
         iconPath: '.' + iconPath,
         splashImagePath: '.' + splashImagePath
@@ -268,10 +270,10 @@ export default {
     return rewrittenAnimationList;
   },
 
-  async exportApp(appName, code, animationOpts, suppliedExpoOpts, config) {
+  exportApp(appName, code, animationOpts, suppliedExpoOpts, config) {
     const expoOpts = suppliedExpoOpts || {};
     if (expoOpts.mode === 'expoPublish') {
-      return await this.publishToExpo(appName, code, animationOpts, config);
+      return this.publishToExpo(appName, code, animationOpts, config);
     }
     return this.exportAppToZip(
       appName,
@@ -340,7 +342,7 @@ export default {
       sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
       files,
       name: `project-${project.getCurrentId()}`,
-      sdkVersion: '31.0.0',
+      sdkVersion: EXPO_SDK_VERSION,
       user: {
         sessionSecret: config.expoSession || EXPO_SESSION_SECRET
       }
@@ -412,6 +414,10 @@ export default {
     };
 
     await session.sendCodeAsync(files);
+    // NOTE: We are waiting on a snack-sdk change that will make sendCodeAsync() actually
+    // send the code right away (currently, the method is debounced). Until then, we must
+    // call an internal method to ensure the code is saved:
+    await session._publishNotDebouncedAsync();
     const saveResult = await session.saveAsync();
     const expoUri = `exp://expo.io/${saveResult.id}`;
     const expoSnackId = saveResult.id;

--- a/apps/src/gamelab/GameLab.js
+++ b/apps/src/gamelab/GameLab.js
@@ -1483,7 +1483,11 @@ GameLab.prototype.getSerializedAnimationList = function(callback) {
  * Bound to appOptions in gamelab/main.js, used in project.js for autosave.
  */
 GameLab.prototype.getGeneratedProperties = function() {
-  return this.generatedProperties;
+  // Must return a new object instance each time so the project
+  // system can properly compare currentSources vs newSources
+  return {
+    ...this.generatedProperties
+  };
 };
 
 /**

--- a/apps/src/gamelab/GameLab.js
+++ b/apps/src/gamelab/GameLab.js
@@ -66,7 +66,13 @@ import {
 } from '@cdo/apps/util/performance';
 import MobileControls from './MobileControls';
 import Exporter from './Exporter';
-import {generateExpoApk} from '../util/exporter';
+import {
+  expoGenerateApk,
+  expoCheckApkBuild,
+  expoCancelApkBuild
+} from '../util/exporter';
+import project from '../code-studio/initApp/project';
+import {setExportGeneratedProperties} from '../code-studio/components/exportDialogRedux';
 
 const defaultMobileControlsConfig = {
   spaceButtonVisible: true,
@@ -107,6 +113,7 @@ var GameLab = function() {
   /** @private {JsInterpreterLogger} */
   this.consoleLogger_ = new JsInterpreterLogger(window.console);
 
+  this.generatedProperties = {};
   this.eventHandlers = {};
   this.Globals = {};
   this.currentCmdQueue = null;
@@ -369,9 +376,26 @@ GameLab.prototype.init = function(config) {
     }
   }
 
+  const setAndroidExportProps = this.setAndroidExportProps.bind(this);
+
   this.studioApp_.setPageConstants(config, {
     allowExportExpo: experiments.isEnabled('exportExpo'),
     exportApp: this.exportApp.bind(this),
+    expoGenerateApk: expoGenerateApk.bind(
+      null,
+      config.expoSession,
+      setAndroidExportProps
+    ),
+    expoCheckApkBuild: expoCheckApkBuild.bind(
+      null,
+      config.expoSession,
+      setAndroidExportProps
+    ),
+    expoCancelApkBuild: expoCancelApkBuild.bind(
+      null,
+      config.expoSession,
+      setAndroidExportProps
+    ),
     channelId: config.channel,
     nonResponsiveVisualizationColumnWidth: GAME_WIDTH,
     showDebugButtons: showDebugButtons,
@@ -401,6 +425,13 @@ GameLab.prototype.init = function(config) {
       ? config.initialAnimationList
       : this.startAnimations;
   getStore().dispatch(setInitialAnimationList(initialAnimationList));
+
+  this.generatedProperties = {
+    ...config.initialGeneratedProperties
+  };
+  getStore().dispatch(
+    setExportGeneratedProperties(this.generatedProperties.export)
+  );
 
   // Pre-register all audio preloads with our Sounds API, which will load
   // them into memory so they can play immediately:
@@ -436,26 +467,25 @@ GameLab.prototype.init = function(config) {
  * @param {Object} expoOpts
  */
 GameLab.prototype.exportApp = async function(expoOpts) {
-  // TODO: find another way to get this info that doesn't rely on globals.
-  const appName =
-    (window.dashboard && window.dashboard.project.getCurrentName()) || 'my-app';
-  const {mode, expoSnackId, iconUri, splashImageUri} = expoOpts || {};
-  if (mode === 'expoGenerateApk') {
-    return generateExpoApk(
-      {
-        appName,
-        expoSnackId,
-        iconUri,
-        splashImageUri
-      },
-      this.studioApp_.config
-    );
-  }
   await this.whenAnimationsAreReady();
   return this.exportAppWithAnimations(
-    appName,
+    project.getCurrentName() || 'my-app',
     getStore().getState().animationList,
     expoOpts
+  );
+};
+
+GameLab.prototype.setAndroidExportProps = function(props) {
+  // Spread the previous object so changes here will always fail shallow
+  // compare and trigger react prop changes
+  this.generatedProperties.export = {
+    ...this.generatedProperties.export,
+    android: props
+  };
+  project.projectChanged();
+  project.saveIfSourcesChanged();
+  getStore().dispatch(
+    setExportGeneratedProperties(this.generatedProperties.export)
   );
 };
 
@@ -1446,6 +1476,14 @@ GameLab.prototype.getSerializedAnimationList = function(callback) {
       callback(getSerializedAnimationList(getStore().getState().animationList));
     })
   );
+};
+
+/**
+ * Get the project properties for upload to the sources API.
+ * Bound to appOptions in gamelab/main.js, used in project.js for autosave.
+ */
+GameLab.prototype.getGeneratedProperties = function() {
+  return this.generatedProperties;
 };
 
 /**

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -62,6 +62,9 @@ var ALLOWED_KEYS = new Set([
   'showProjectTemplateWorkspaceIcon',
   'serverLevelId',
   'exportApp',
+  'expoGenerateApk',
+  'expoCheckApkBuild',
+  'expoCancelApkBuild',
   'allowExportExpo'
 ]);
 

--- a/apps/src/sites/studio/pages/init/loadGamelab.js
+++ b/apps/src/sites/studio/pages/init/loadGamelab.js
@@ -12,6 +12,7 @@ export default function loadGamelab(options) {
 
   // Bind helper that provides project metadata for gamelab autosave
   options.getAnimationList = gamelab.getSerializedAnimationList.bind(gamelab);
+  options.getGeneratedProperties = gamelab.getGeneratedProperties.bind(gamelab);
 
   gamelab.injectStudioApp(studioApp());
   appMain(gamelab, levels, options);

--- a/apps/src/templates/export/expo/app.json.ejs
+++ b/apps/src/templates/export/expo/app.json.ejs
@@ -4,7 +4,7 @@
     "description": "<%- appName %> from Code.org Code Studio.",
     "slug": "project-<%- projectId.toLowerCase().replace(/[^\w-]+/g, '-') %>",
     "privacy": "public",
-    "sdkVersion": "31.0.0",
+    "sdkVersion": "<%- sdkVersion %>",
     "platforms": ["ios", "android"],
     "version": "1.0.0",
     "orientation": "portrait",

--- a/apps/src/util/exporter.js
+++ b/apps/src/util/exporter.js
@@ -12,6 +12,8 @@ import exportExpoAppJsonEjs from '../templates/export/expo/app.json.ejs';
 import exportExpoPackagedFilesEjs from '../templates/export/expo/packagedFiles.js.ejs';
 import exportExpoPackagedFilesEntryEjs from '../templates/export/expo/packagedFilesEntry.js.ejs';
 
+export const EXPO_SDK_VERSION = '31.0.0';
+
 export function createPackageFilesFromZip(zip, appName) {
   const moduleList = [];
   zip.folder(appName + '/assets').forEach((fileName, file) => {
@@ -42,21 +44,28 @@ export function createPackageFilesFromExpoFiles(files) {
   return exportExpoPackagedFilesEjs({entries});
 }
 
-export async function generateExpoApk(options, config) {
-  const {appName, expoSnackId, iconUri, splashImageUri} = options;
-  const session = new SnackSession({
+function createSnackSession(snackId, sessionSecret) {
+  return new SnackSession({
     sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
     name: `project-${project.getCurrentId()}`,
-    sdkVersion: '31.0.0',
-    snackId: expoSnackId,
+    sdkVersion: EXPO_SDK_VERSION,
+    snackId,
     user: {
-      sessionSecret: config.expoSession || EXPO_SESSION_SECRET
+      sessionSecret: sessionSecret || EXPO_SESSION_SECRET
     }
   });
+}
+
+async function expoBuildOrCheckApk(options, mode, sessionSecret) {
+  const {expoSnackId, iconUri, splashImageUri, apkBuildId} = options;
+  const buildMode = mode === 'generate';
+
+  const session = createSnackSession(expoSnackId, sessionSecret);
 
   const appJson = JSON.parse(
     exportExpoAppJsonEjs({
-      appName,
+      appName: project.getCurrentName() || 'my-app',
+      sdkVersion: EXPO_SDK_VERSION,
       projectId: project.getCurrentId(),
       iconPath: iconUri,
       splashImagePath: splashImageUri
@@ -73,9 +82,123 @@ export async function generateExpoApk(options, config) {
   } = appJson.expo;
   appJson.expo = onlineOnlyExpo;
 
-  const artifactUrl = await session.getApkUrlAsync(appJson);
+  if (buildMode) {
+    return buildApk(session, appJson.expo);
+  } else {
+    return checkApk(session, appJson.expo, apkBuildId);
+  }
+}
 
-  return artifactUrl;
+async function buildApk(session, manifest) {
+  const result = await session.buildAsync(manifest, {
+    platform: 'android',
+    mode: 'create',
+    isSnack: true,
+    sdkVersion: EXPO_SDK_VERSION
+  });
+  const {id} = result;
+  return id;
+}
+
+async function checkApk(session, manifest, apkBuildId) {
+  const result = await session.buildAsync(manifest, {
+    platform: 'android',
+    mode: 'status',
+    current: false
+  });
+  const {jobs = []} = result;
+  const job = jobs.find(job => apkBuildId && job.id === apkBuildId);
+  if (!job) {
+    throw new Error(`Expo build not found: ${apkBuildId}`);
+  }
+  if (job.status === 'finished') {
+    return job.artifactId
+      ? `https://expo.io/artifacts/${job.artifactId}`
+      : job.artifacts.url;
+  } else if (job.status === 'errored') {
+    throw new Error(`Expo build failed: Job status: ${job.status}`);
+  } else {
+    // In-progress, return undefined
+    return;
+  }
+}
+
+/**
+ * Generate Android APK using Expo
+ * @param {string} sessionSecret Expo session secret for snack APIs
+ * @param {function} setAndroidPropsCallback called when ready to update generated Android export props
+ * @param {Object} options
+ * @return {Promise.<string>} APK build id
+ */
+export async function expoGenerateApk(
+  sessionSecret,
+  setAndroidPropsCallback,
+  options
+) {
+  const {md5SavedSources: md5ApkSavedSources, expoSnackId: snackId} = options;
+  const apkBuildId = await expoBuildOrCheckApk(
+    options,
+    'generate',
+    sessionSecret
+  );
+  setAndroidPropsCallback({
+    md5ApkSavedSources,
+    snackId,
+    apkBuildId
+  });
+  return apkBuildId;
+}
+
+/**
+ * Check on Android APK build status using Expo
+ * @param {string} sessionSecret Expo session secret for snack APIs
+ * @param {function} setAndroidPropsCallback called when ready to update generated Android export props
+ * @param {Object} options
+ * @return {Promise.<string>} APK URI (if build has completed)
+ */
+export async function expoCheckApkBuild(
+  sessionSecret,
+  setAndroidPropsCallback,
+  options
+) {
+  const {md5SavedSources: md5ApkSavedSources, expoSnackId: snackId} = options;
+  try {
+    const apkUri = await expoBuildOrCheckApk(options, 'check', sessionSecret);
+    if (apkUri) {
+      const {apkBuildId} = options;
+      setAndroidPropsCallback({
+        md5ApkSavedSources,
+        snackId,
+        apkBuildId,
+        apkUri
+      });
+    }
+    return apkUri;
+  } catch (err) {
+    // Clear any android export props since the build failed:
+    setAndroidPropsCallback({});
+    throw err;
+  }
+}
+
+/**
+ * Cancel Android APK build using Expo
+ * @param {string} sessionSecret Expo session secret for snack APIs
+ * @param {function} setAndroidPropsCallback called when ready to update generated Android export props
+ * @param {Object} options
+ * @return {Promise} GraphQL Request
+ */
+export async function expoCancelApkBuild(
+  sessionSecret,
+  setAndroidPropsCallback,
+  options
+) {
+  // Clear any android export props since we are canceling the build:
+  setAndroidPropsCallback({});
+
+  const {expoSnackId, apkBuildId} = options;
+  const session = createSnackSession(expoSnackId, sessionSecret);
+  return session.cancelBuild(apkBuildId);
 }
 
 const soundRegex = /(\bsound:\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi;

--- a/apps/test/unit/code-studio/components/ExportDialogTest.js
+++ b/apps/test/unit/code-studio/components/ExportDialogTest.js
@@ -1,28 +1,9 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedExportDialog as ExportDialog} from '@cdo/apps/code-studio/components/ExportDialog';
 import {SignInState} from '@cdo/apps/code-studio/progressRedux';
-
-/*
-    i18n: PropTypes.shape({
-      t: PropTypes.func.isRequired
-    }).isRequired,
-    exportApp: PropTypes.func,
-    projectUpdatedAt: PropTypes.string,
-    isAbusive: PropTypes.bool.isRequired,
-    isOpen: PropTypes.bool.isRequired,
-    channelId: PropTypes.string.isRequired,
-    appType: PropTypes.string.isRequired,
-    onClose: PropTypes.func.isRequired,
-    hideBackdrop: BaseDialog.propTypes.hideBackdrop,
-    canShareSocial: PropTypes.bool.isRequired,
-    userSharingDisabled: PropTypes.bool,
-    signInState: PropTypes.oneOf(Object.values(SignInState)),
-    isProjectLevel: PropTypes.bool.isRequired
-
-*/
 
 describe('ExportDialog', () => {
   it('renders our signed in version when signed in', () => {
@@ -30,9 +11,13 @@ describe('ExportDialog', () => {
       <ExportDialog
         i18n={{t: id => id}}
         exportApp={async () => ({})}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{}}
+        md5SavedSources="fakeHash"
         isAbusive={false}
         isOpen={true}
-        channelId="fakeChannelId"
         appType="applab"
         onClose={() => {}}
         canShareSocial={true}
@@ -48,9 +33,13 @@ describe('ExportDialog', () => {
       <ExportDialog
         i18n={{t: id => id}}
         exportApp={async () => ({})}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{}}
+        md5SavedSources="fakeHash"
         isAbusive={false}
         isOpen={true}
-        channelId="fakeChannelId"
         appType="applab"
         onClose={() => {}}
         canShareSocial={true}
@@ -66,9 +55,13 @@ describe('ExportDialog', () => {
       <ExportDialog
         i18n={{t: id => id}}
         exportApp={async () => ({})}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{}}
+        md5SavedSources="fakeHash"
         isAbusive={false}
         isOpen={true}
-        channelId="fakeChannelId"
         appType="applab"
         onClose={() => {}}
         canShareSocial={true}
@@ -87,9 +80,13 @@ describe('ExportDialog', () => {
       <ExportDialog
         i18n={{t: id => id}}
         exportApp={async () => ({})}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{}}
+        md5SavedSources="fakeHash"
         isAbusive={false}
         isOpen={true}
-        channelId="fakeChannelId"
         appType="applab"
         onClose={() => {}}
         canShareSocial={true}
@@ -107,9 +104,13 @@ describe('ExportDialog', () => {
       <ExportDialog
         i18n={{t: id => id}}
         exportApp={async () => ({})}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{}}
+        md5SavedSources="fakeHash"
         isAbusive={true}
         isOpen={true}
-        channelId="fakeChannelId"
         appType="applab"
         onClose={() => {}}
         canShareSocial={true}
@@ -125,9 +126,13 @@ describe('ExportDialog', () => {
       <ExportDialog
         i18n={{t: id => id}}
         exportApp={async () => ({})}
-        isAbusive={true}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{}}
+        md5SavedSources="fakeHash"
+        isAbusive={false}
         isOpen={true}
-        channelId="fakeChannelId"
         appType="applab"
         onClose={() => {}}
         canShareSocial={false}
@@ -148,9 +153,13 @@ describe('ExportDialog', () => {
       <ExportDialog
         i18n={{t: id => id}}
         exportApp={exportApp}
-        isAbusive={true}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{}}
+        md5SavedSources="fakeHash"
+        isAbusive={false}
         isOpen={true}
-        channelId="fakeChannelId"
         appType="applab"
         onClose={() => {}}
         canShareSocial={true}
@@ -164,21 +173,30 @@ describe('ExportDialog', () => {
     });
   });
 
-  it('publishAndGenerateApk() method calls exportApp() twice with modes expoPublish and expoGenerateApk', async () => {
+  it('generateApkAsNeeded() method calls exportApp(), expoGenerateApk(), and expoCheckApkBuild()', async () => {
+    const exportApp = sinon.stub();
     const publishResult = Promise.resolve({
       expoUri: 'uri',
       expoSnackId: 'id',
       iconUri: 'iconUri',
       splashImageUri: 'splashUri'
     });
-    const exportApp = sinon.stub().returns(publishResult);
+    exportApp.withArgs({mode: 'expoPublish'}).returns(publishResult);
+    const expoGenerateApk = sinon.stub();
+    expoGenerateApk.returns(Promise.resolve('fakeBuildId'));
+    const expoCheckApkBuild = sinon.stub();
+
     const wrapper = shallow(
       <ExportDialog
         i18n={{t: id => id}}
         exportApp={exportApp}
-        isAbusive={true}
+        expoGenerateApk={expoGenerateApk}
+        expoCheckApkBuild={expoCheckApkBuild}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{}}
+        md5SavedSources="fakeHash"
+        isAbusive={false}
         isOpen={true}
-        channelId="fakeChannelId"
         appType="applab"
         onClose={() => {}}
         canShareSocial={true}
@@ -186,14 +204,223 @@ describe('ExportDialog', () => {
         isProjectLevel={false}
       />
     );
-    await wrapper.instance().publishAndGenerateApk();
-    expect(exportApp)
-      .to.have.been.calledTwice.and.calledWith({mode: 'expoPublish'})
-      .and.calledWith({
-        mode: 'expoGenerateApk',
-        expoSnackId: 'id',
-        iconUri: 'iconUri',
-        splashImageUri: 'splashUri'
-      });
+    await wrapper.instance().generateApkAsNeeded();
+    expect(exportApp).to.have.been.calledOnce.and.calledWith({
+      mode: 'expoPublish'
+    });
+    expect(expoGenerateApk).to.have.been.calledOnce.and.calledWith({
+      md5SavedSources: 'fakeHash',
+      expoSnackId: 'id',
+      iconUri: 'iconUri',
+      splashImageUri: 'splashUri'
+    });
+    expect(expoCheckApkBuild).to.have.been.calledOnce.and.calledWith({
+      md5SavedSources: 'fakeHash',
+      expoSnackId: 'id',
+      apkBuildId: 'fakeBuildId'
+    });
+  });
+
+  it('exportApp() not called by generateApkAsNeeded() if the sources have not changed since the last build', () => {
+    const exportApp = sinon.spy();
+    const wrapper = shallow(
+      <ExportDialog
+        i18n={{t: id => id}}
+        exportApp={exportApp}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{
+          android: {
+            md5ApkSavedSources: 'fakeHash',
+            snackId: 'fakeSnackId',
+            apkBuildId: 'fakeBuildId',
+            apkUri: 'fakeApkUri'
+          }
+        }}
+        md5SavedSources="fakeHash"
+        isAbusive={false}
+        isOpen={true}
+        appType="applab"
+        onClose={() => {}}
+        canShareSocial={true}
+        signInState={SignInState.SignedIn}
+        isProjectLevel={false}
+      />
+    );
+    wrapper.instance().generateApkAsNeeded();
+    expect(exportApp).to.not.have.been.called;
+  });
+
+  it('exportApp() will be called by generateApkAsNeeded() if the sources have changed since the last build', async () => {
+    const exportApp = sinon.stub();
+    exportApp.returns(Promise.resolve('fakeBuildId'));
+    const publishResult = Promise.resolve({
+      expoUri: 'uri',
+      expoSnackId: 'id',
+      iconUri: 'iconUri',
+      splashImageUri: 'splashUri'
+    });
+    exportApp.withArgs({mode: 'expoPublish'}).returns(publishResult);
+    const wrapper = shallow(
+      <ExportDialog
+        i18n={{t: id => id}}
+        exportApp={exportApp}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{
+          android: {
+            md5ApkSavedSources: 'differentHash',
+            snackId: 'fakeSnackId',
+            apkBuildId: 'fakeBuildId',
+            apkUri: 'fakeApkUri'
+          }
+        }}
+        md5SavedSources="fakeHash"
+        isAbusive={false}
+        isOpen={true}
+        appType="applab"
+        onClose={() => {}}
+        canShareSocial={true}
+        signInState={SignInState.SignedIn}
+        isProjectLevel={false}
+      />
+    );
+    await wrapper.instance().generateApkAsNeeded();
+    expect(exportApp).to.have.been.called;
+  });
+
+  it('An incomplete preexisting build will not be canceled when the dialog is opened if the sources are unchanged', () => {
+    const expoCancelApkBuild = sinon.stub();
+    const wrapper = mount(
+      <ExportDialog
+        i18n={{t: id => id}}
+        exportApp={async () => ({})}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={expoCancelApkBuild}
+        exportGeneratedProperties={{
+          android: {
+            md5ApkSavedSources: 'fakeHash',
+            snackId: 'fakeSnackId',
+            apkBuildId: 'fakeBuildId'
+          }
+        }}
+        md5SavedSources="fakeHash"
+        isAbusive={false}
+        isOpen={false}
+        appType="applab"
+        onClose={() => {}}
+        canShareSocial={true}
+        signInState={SignInState.SignedIn}
+        isProjectLevel={false}
+      />
+    );
+    wrapper.setProps({isOpen: true});
+
+    expect(expoCancelApkBuild).to.not.have.been.called;
+  });
+
+  it('An incomplete preexisting build will be resumed within generateApkAsNeeded when the sources are unchanged', () => {
+    const expoCheckApkBuild = sinon.stub();
+    const wrapper = shallow(
+      <ExportDialog
+        i18n={{t: id => id}}
+        exportApp={async () => ({})}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={expoCheckApkBuild}
+        expoCancelApkBuild={async () => ({})}
+        exportGeneratedProperties={{
+          android: {
+            md5ApkSavedSources: 'fakeHash',
+            snackId: 'fakeSnackId',
+            apkBuildId: 'fakeBuildId'
+          }
+        }}
+        md5SavedSources="fakeHash"
+        isAbusive={false}
+        isOpen={true}
+        appType="applab"
+        onClose={() => {}}
+        canShareSocial={true}
+        signInState={SignInState.SignedIn}
+        isProjectLevel={false}
+      />
+    );
+    wrapper.instance().generateApkAsNeeded();
+
+    expect(expoCheckApkBuild).to.have.been.calledWith({
+      md5SavedSources: 'fakeHash',
+      expoSnackId: 'fakeSnackId',
+      apkBuildId: 'fakeBuildId'
+    });
+  });
+
+  it('An incomplete preexisting build will be canceled when the dialog is opened if the sources hash has changed', () => {
+    const expoCancelApkBuild = sinon.stub();
+    const wrapper = mount(
+      <ExportDialog
+        i18n={{t: id => id}}
+        exportApp={async () => ({})}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={expoCancelApkBuild}
+        exportGeneratedProperties={{
+          android: {
+            md5ApkSavedSources: 'differentHash',
+            snackId: 'fakeSnackId',
+            apkBuildId: 'fakeBuildId'
+          }
+        }}
+        md5SavedSources="fakeHash"
+        isAbusive={false}
+        isOpen={false}
+        appType="applab"
+        onClose={() => {}}
+        canShareSocial={true}
+        signInState={SignInState.SignedIn}
+        isProjectLevel={false}
+      />
+    );
+    wrapper.setProps({isOpen: true});
+
+    expect(expoCancelApkBuild).to.have.been.calledWith({
+      md5SavedSources: 'differentHash',
+      expoSnackId: 'fakeSnackId',
+      apkBuildId: 'fakeBuildId'
+    });
+  });
+
+  it('A complete preexisting build will not be canceled when the dialog is opened if the sources hash has changed', () => {
+    const expoCancelApkBuild = sinon.stub();
+    const wrapper = mount(
+      <ExportDialog
+        i18n={{t: id => id}}
+        exportApp={async () => ({})}
+        expoGenerateApk={async () => ({})}
+        expoCheckApkBuild={async () => ({})}
+        expoCancelApkBuild={expoCancelApkBuild}
+        exportGeneratedProperties={{
+          android: {
+            md5ApkSavedSources: 'differentHash',
+            snackId: 'fakeSnackId',
+            apkBuildId: 'fakeBuildId',
+            apkUri: 'fakeApkUri'
+          }
+        }}
+        md5SavedSources="fakeHash"
+        isAbusive={false}
+        isOpen={false}
+        appType="applab"
+        onClose={() => {}}
+        canShareSocial={true}
+        signInState={SignInState.SignedIn}
+        isProjectLevel={false}
+      />
+    );
+    wrapper.setProps({isOpen: true});
+
+    expect(expoCancelApkBuild).to.not.have.been.called;
   });
 });

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -773,6 +773,8 @@ function createStubSourceHandler() {
     getLevelSource: sinon.stub().resolves(),
     setInitialAnimationList: sinon.stub(),
     getAnimationList: sinon.stub().callsFake(cb => cb({})),
+    setInitialGeneratedProperties: sinon.stub(),
+    getGeneratedProperties: sinon.stub(),
     setMakerAPIsEnabled: sinon.stub(),
     getMakerAPIsEnabled: sinon.stub(),
     setSelectedSong: sinon.stub(),

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -972,12 +972,13 @@
     remark-stringify "^6.0.0"
     unified "^7.0.0"
 
-"@code-dot-org/snack-sdk@2.2.0-apkurl-v1":
-  version "2.2.0-apkurl-v1"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/snack-sdk/-/snack-sdk-2.2.0-apkurl-v1.tgz#51afb887f4e528f42411eb1761add0d6db4ce86e"
+"@code-dot-org/snack-sdk@2.2.0-apkurl-v3":
+  version "2.2.0-apkurl-v3"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/snack-sdk/-/snack-sdk-2.2.0-apkurl-v3.tgz#571ea2cb15b21a27e1b397c963e04cfce32e7122"
   dependencies:
     babel-runtime "^6.23.0"
     diff "^3.2.0"
+    graphql-request "^1.8.2"
     lodash "^4.17.4"
     platform "^1.3.4"
     pubnub "^4.3.3"
@@ -4617,6 +4618,13 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cross-fetch@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
+  dependencies:
+    node-fetch "2.1.2"
+    whatwg-fetch "2.0.4"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -7187,6 +7195,12 @@ graceful-fs@~1.2.0:
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+graphql-request@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
+  dependencies:
+    cross-fetch "2.2.2"
 
 growl@1.9.2:
   version "1.9.2"
@@ -10343,6 +10357,10 @@ node-emoji@^1.4.1:
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.4.1.tgz#c9fa0cf91094335bcb967a6f42b2305c15af2ebc"
   dependencies:
     string.prototype.codepointat "^0.2.0"
+
+node-fetch@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -15891,6 +15909,10 @@ wgxpath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/wgxpath/-/wgxpath-1.2.0.tgz#a33e4e0f86e68e074d95d50a6e533d64938f432a"
 
+whatwg-fetch@2.0.4, whatwg-fetch@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+
 whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
@@ -15898,10 +15920,6 @@ whatwg-fetch@>=0.10.0:
 whatwg-fetch@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-
-whatwg-fetch@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
 whet.extend@~0.9.9:
   version "0.9.9"

--- a/dashboard/public/pixelation/pixelation.js
+++ b/dashboard/public/pixelation/pixelation.js
@@ -10,10 +10,22 @@
 
 var MAX_SIZE = 400;
 
-var pixel_format, pixel_data, canvas, main_ctx, widthText, widthRange, heightText, heightRange, bitsPerPixelText, bitsPerPixelRange, image_w, image_h, sqSize;
+var pixel_format,
+  pixel_data,
+  canvas,
+  main_ctx,
+  widthText,
+  widthRange,
+  heightText,
+  heightRange,
+  bitsPerPixelText,
+  bitsPerPixelRange,
+  image_w,
+  image_h,
+  sqSize;
 
 function pixelationInit() {
-  pixel_format = document.querySelector('#pixel_format');
+  pixel_format = document.querySelector("#pixel_format");
   pixel_data = document.querySelector("#pixel_data");
   canvas = document.querySelector("#canvas");
   main_ctx = canvas.getContext("2d");
@@ -48,47 +60,57 @@ function customizeStyles() {
   if (!window.options) {
     // Default is version 3 (all features enabled).
     window.options = {
-      version: '3',
+      version: "3",
       hideEncodingControls: false,
-      v1HideSliders: false,
+      v1HideSliders: false
     };
   }
-  if (options.version === '1') {
-    $('.hide_on_v1').hide();
+  if (options.version === "1") {
+    $(".hide_on_v1").hide();
 
     // Default initial width and height (only available to widget v1)
     const initialWidth = parseInt(options.v1InitialWidth, 10);
     const initialHeight = parseInt(options.v1InitialHeight, 10);
     if (!isNaN(initialWidth)) {
-      $('#width').val(initialWidth);
+      $("#width").val(initialWidth);
     }
     if (!isNaN(initialHeight)) {
-      $('#height').val(initialHeight);
+      $("#height").val(initialHeight);
     }
 
     // Hide sliders option (only available to widget v1)
     if (isHideSlidersLevel()) {
-      $('#heightRange, #widthRange').hide();
-      $('#height, #width').prop('readonly', true);
+      $("#heightRange, #widthRange").hide();
+      $("#height, #width").prop("readonly", true);
     }
 
     // The layout is fundamentally different in version 1 than it is in other versions.
     // Rearrange the DOM so that the visualization column sits at the top left.
-    var visualizationColumn = document.getElementById('visualizationColumn');
-    var visualizationEditorHeader = document.getElementById('visualizationEditorHeader');
-    visualizationColumn.parentNode.insertBefore(visualizationColumn, visualizationEditorHeader);
-  } else if (options.version === '2') {
-    $('.hide_on_v2').hide();
-    $('#height, #width').prop('readonly', true);
+    var visualizationColumn = document.getElementById("visualizationColumn");
+    var visualizationEditorHeader = document.getElementById(
+      "visualizationEditorHeader"
+    );
+    visualizationColumn.parentNode.insertBefore(
+      visualizationColumn,
+      visualizationEditorHeader
+    );
+  } else if (options.version === "2") {
+    $(".hide_on_v2").hide();
+    $("#height, #width").prop("readonly", true);
   }
   if (isHexLevel()) {
-    $('input[name="binHex"][value="hex"]').prop('checked', true);
+    $('input[name="binHex"][value="hex"]').prop("checked", true);
   }
-  if (options.hideEncodingControls === true || options.hideEncodingControls === 'true') {
-    $('.encoding_controls').hide();
+  if (
+    options.hideEncodingControls === true ||
+    options.hideEncodingControls === "true"
+  ) {
+    $(".encoding_controls").hide();
   }
   if (options.shortInstructions) {
-    $('#below_viz_instructions').text(options.shortInstructions).show();
+    $("#below_viz_instructions")
+      .text(options.shortInstructions)
+      .show();
   }
 }
 
@@ -96,30 +118,34 @@ function initProjects() {
   // Initialize projects for save/load functionality if channel id is present.
   if (appOptions.channel) {
     if (!window.dashboard) {
-      throw new Error('Assume existence of window.dashboard');
+      throw new Error("Assume existence of window.dashboard");
     }
 
     var sourceHandler = {
-      setMakerAPIsEnabled: function (_) {},
-      getMakerAPIsEnabled: function () {
+      setMakerAPIsEnabled: function(_) {},
+      getMakerAPIsEnabled: function() {
         return false;
       },
-      setSelectedSong: function () {},
-      getSelectedSong: function () {
+      setSelectedSong: function() {},
+      getSelectedSong: function() {
         return false;
       },
-      setInitialLevelHtml: function (levelHtml) {},
-      getLevelHtml: function () {
-        return '';
+      setInitialLevelHtml: function(levelHtml) {},
+      getLevelHtml: function() {
+        return "";
       },
-      setInitialAnimationList: function () {},
-      getAnimationList: function (callback) {
+      setInitialAnimationList: function() {},
+      getAnimationList: function(callback) {
         callback({});
       },
-      setInitialLevelSource: function (levelSource) {
+      setInitialGeneratedProperties: function(_) {},
+      getGeneratedProperties() {
+        return undefined;
+      },
+      setInitialLevelSource: function(levelSource) {
         options.projectData = levelSource;
       },
-      getLevelSource: function () {
+      getLevelSource: function() {
         return {
           // this method is expected to return a Promise. Since this file does not go through our
           // pipeline and can't be ES6, return a "then" method with a Promise-like interface
@@ -133,31 +159,34 @@ function initProjects() {
               callback(isHexLevel() ? binToHexPvt(binCode) : binCode);
             }
           }
-        }
+        };
       },
-      prepareForRemix: function () {
+      prepareForRemix: function() {
         return {
           // this method is expected to return a Promise. Since this file does not go through our
           // pipeline and can't be ES6, return a "then" method with a Promise-like interface
           then: function(callback) {
             callback();
           }
-        }
+        };
       }
     };
-    dashboard.project.load().then(function() {
-      // Only enable saving if the initial load succeeds. This means new work
-      // will not be saved, but old work will not be erased and may become
-      // available by refreshing the page.
-      options.saveProject = dashboard.project.save.bind(dashboard.project);
-      options.projectChanged = dashboard.project.projectChanged;
-      window.dashboard.project.init(sourceHandler);
+    dashboard.project
+      .load()
+      .then(function() {
+        // Only enable saving if the initial load succeeds. This means new work
+        // will not be saved, but old work will not be erased and may become
+        // available by refreshing the page.
+        options.saveProject = dashboard.project.save.bind(dashboard.project);
+        options.projectChanged = dashboard.project.projectChanged;
+        window.dashboard.project.init(sourceHandler);
 
-      // Complete project initialization sequence.
-      $(document).trigger('appInitialized');
-    }).always(function() {
-      pixelationDisplay();
-    });
+        // Complete project initialization sequence.
+        $(document).trigger("appInitialized");
+      })
+      .always(function() {
+        pixelationDisplay();
+      });
   } else {
     pixelationDisplay();
   }
@@ -174,12 +203,12 @@ function isHexSelected() {
 }
 
 function isHexLevel() {
-  return options.hex === true || options.hex === 'true';
+  return options.hex === true || options.hex === "true";
 }
 
 function isHideSlidersLevel() {
   if (parseInt(options.version, 10) === 1) {
-    return options.v1HideSliders === true || options.v1HideSliders === 'true';
+    return options.v1HideSliders === true || options.v1HideSliders === "true";
   } else if (parseInt(options.version, 10) === 2) {
     return true;
   }
@@ -218,12 +247,12 @@ function drawGraph(ctx, exportImage, updateControls) {
   // Restore cursor position. This may steal the focus from other controls,
   // so only do it if we know they should be updated.
   if (updateControls) {
-    cursorPosition += (pixel_data.value.length - characterCount);
+    cursorPosition += pixel_data.value.length - characterCount;
     pixel_data.setSelectionRange(cursorPosition, cursorPosition);
   }
 
   var bitsPerPix = 1;
-  if (options.version == '1') {
+  if (options.version == "1") {
     image_w = getPositiveValue(widthText);
     image_h = getPositiveValue(heightText);
   } else {
@@ -236,7 +265,7 @@ function drawGraph(ctx, exportImage, updateControls) {
     }
     binCode = binCode.substring(16, binCode.length);
 
-    if (options.version != '2') {
+    if (options.version != "2") {
       bitsPerPix = binToInt(readByte(binCode, 0));
       if (updateControls) {
         bitsPerPixelText.value = bitsPerPix;
@@ -247,24 +276,33 @@ function drawGraph(ctx, exportImage, updateControls) {
       // Update pixel format indicator.
       var bitsPerPixel = getPositiveValue(bitsPerPixelText);
       if (hexMode && bitsPerPixel % 4 !== 0) {
-        pixel_format.innerHTML = '<span class="unknown">' + pad('', Math.ceil(bitsPerPixel / 4), '-') + '</span>';
+        pixel_format.innerHTML =
+          '<span class="unknown">' +
+          pad("", Math.ceil(bitsPerPixel / 4), "-") +
+          "</span>";
       } else {
         if (bitsPerPixel % 3 === 0) {
           var str;
           if (hexMode) {
-            str = pad('', bitsPerPixel / 12, 'F');
+            str = pad("", bitsPerPixel / 12, "F");
           } else {
-            str = pad('', bitsPerPixel / 3, '1');
+            str = pad("", bitsPerPixel / 3, "1");
           }
           pixel_format.innerHTML =
-              '<span class="r">' + str + '</span>'
-              + '<span class="g">' + str + '</span>'
-              + '<span class="b">' + str + '</span>';
+            '<span class="r">' +
+            str +
+            "</span>" +
+            '<span class="g">' +
+            str +
+            "</span>" +
+            '<span class="b">' +
+            str +
+            "</span>";
         } else {
           if (hexMode) {
-            pixel_format.innerHTML = pad('', bitsPerPixel / 4, 'F');
+            pixel_format.innerHTML = pad("", bitsPerPixel / 4, "F");
           } else {
-            pixel_format.innerHTML = pad('', bitsPerPixel, '1');
+            pixel_format.innerHTML = pad("", bitsPerPixel, "1");
           }
         }
       }
@@ -278,8 +316,8 @@ function drawGraph(ctx, exportImage, updateControls) {
 
   var colorNums = bitsToColors(binCode, bitsPerPix);
 
-  sqSize = 1, fillSize = 1, offset = 0;
-  if (!document.querySelector('input#actual_size:checked')) {
+  (sqSize = 1), (fillSize = 1), (offset = 0);
+  if (!document.querySelector("input#actual_size:checked")) {
     // Auto-size pixel borders and edge offsets.
     sqSize = MAX_SIZE / Math.max(image_w, image_h);
     fillSize = sqSize * 0.95;
@@ -298,14 +336,18 @@ function drawGraph(ctx, exportImage, updateControls) {
   }
   for (var y = 0; y < image_h; y++) {
     for (var x = 0; x < image_w; x++) {
-      ctx.fillStyle = colorNums[(y * image_w) + x] || "#fdd";
-      ctx.fillRect(left + x * sqSize + offset, top + y * sqSize + offset, fillSize, fillSize);
+      ctx.fillStyle = colorNums[y * image_w + x] || "#fdd";
+      ctx.fillRect(
+        left + x * sqSize + offset,
+        top + y * sqSize + offset,
+        fillSize,
+        fillSize
+      );
     }
   }
 }
 
 function formatBitDisplay() {
-
   var theData = pixel_data.value;
   var chunksPerLine = getPositiveValue(widthText);
   var chunkSize = getPositiveValue(bitsPerPixelText);
@@ -325,16 +367,15 @@ function unformatBits() {
  * Take an unformatted string of bits, place spaces at "chunkSize" offsets (except for the first 3 bytes).
  */
 function formatBits(bitString, chunkSize, chunksPerLine) {
-
   var justBits = bitString.replace(/[ \n]/g, "");
   var formattedBits = "";
 
-  if (options.version != '1') {
+  if (options.version != "1") {
     // First break out first 2 bytes (width, height).
     if (isHexSelected()) {
       formattedBits += justBits.substr(0, 2) + "\n";
       formattedBits += justBits.substr(2, 2) + "\n";
-      if (options.version == '3') {
+      if (options.version == "3") {
         // Break out the next byte (bits per pixel)
         formattedBits += justBits.substr(4, 2) + "\n";
         justBits = justBits.substr(6);
@@ -343,10 +384,13 @@ function formatBits(bitString, chunkSize, chunksPerLine) {
       }
     } else {
       // Binary.
-      formattedBits += justBits.substr(0, 4) + " " + justBits.substr(4, 4) + "\n";
-      formattedBits += justBits.substr(8, 4) + " " + justBits.substr(12, 4) + "\n";
-      if (options.version == '3') {
-        formattedBits += justBits.substr(16, 4) + " " + justBits.substr(20, 4) + "\n";
+      formattedBits +=
+        justBits.substr(0, 4) + " " + justBits.substr(4, 4) + "\n";
+      formattedBits +=
+        justBits.substr(8, 4) + " " + justBits.substr(12, 4) + "\n";
+      if (options.version == "3") {
+        formattedBits +=
+          justBits.substr(16, 4) + " " + justBits.substr(20, 4) + "\n";
         justBits = justBits.substr(24);
       } else {
         justBits = justBits.substr(16);
@@ -365,10 +409,14 @@ function formatBits(bitString, chunkSize, chunksPerLine) {
   }
 
   // Add spaces to main pixel data section.
-  for (var i = 0, lineChunkCount = 1; i < justBits.length; i += chunkSize, lineChunkCount++) {
+  for (
+    var i = 0, lineChunkCount = 1;
+    i < justBits.length;
+    i += chunkSize, lineChunkCount++
+  ) {
     formattedBits += justBits.substr(i, chunkSize) + " ";
     if (lineChunkCount === chunksPerLine) {
-      formattedBits += '\n';
+      formattedBits += "\n";
       lineChunkCount = 0;
     }
   }
@@ -386,7 +434,6 @@ function hexToBin() {
  * Add `prefix` to the beginning of the given string until it reaches the given length.
  */
 function pad(str, len, prefix) {
-
   while (str.length < len) {
     str = prefix + str;
   }
@@ -394,31 +441,33 @@ function pad(str, len, prefix) {
 }
 
 function hexToBinPvt(allHexDigits) {
-
   var binString = "";
   for (var i = 0; i < allHexDigits.length; i++) {
-    binString += pad(parseInt(allHexDigits.substring(i, i + 1), 16).toString(2), 4, "0");
+    binString += pad(
+      parseInt(allHexDigits.substring(i, i + 1), 16).toString(2),
+      4,
+      "0"
+    );
   }
   return binString;
-
 }
 
 function binToHexPvt(allBits) {
-
   // Ensure bit string is half-byte aligned
   while (allBits.length % 4 !== 0) {
-    allBits += '0';
+    allBits += "0";
   }
   var hexString = "";
   // Work in chunks of 8.
   for (var i = 0; i < allBits.length; i += 4) {
-    hexString += parseInt(allBits.substring(i, i + 4), 2).toString(16).toUpperCase();
+    hexString += parseInt(allBits.substring(i, i + 4), 2)
+      .toString(16)
+      .toUpperCase();
   }
   return hexString;
 }
 
 function binToHex() {
-
   var allBits = pixel_data.value.replace(/[^01]/gi, "");
 
   pixel_data.value = binToHexPvt(allBits);
@@ -431,7 +480,6 @@ function binToHex() {
  * with jagged ends of bit strings.
  */
 function getColorVal(binVal, bitsPerPixel) {
-
   // Assume binVal is size of bits per pixel.
   var numColors = Math.pow(2, bitsPerPixel);
   var bitsPerColor = parseInt(bitsPerPixel / 3);
@@ -448,9 +496,9 @@ function getColorVal(binVal, bitsPerPixel) {
     var G = binVal.substring(bitsPerColor, bitsPerColor * 2);
     var B = binVal.substring(bitsPerColor * 2, bitsPerColor * 3);
 
-    var Rval = parseInt((binToInt(R) / (maxRGBVal)) * 255);
-    var Gval = parseInt((binToInt(G) / (maxRGBVal)) * 255);
-    var Bval = parseInt((binToInt(B) / (maxRGBVal)) * 255);
+    var Rval = parseInt((binToInt(R) / maxRGBVal) * 255);
+    var Gval = parseInt((binToInt(G) / maxRGBVal) * 255);
+    var Bval = parseInt((binToInt(B) / maxRGBVal) * 255);
 
     return "rgb(" + Rval + "," + Gval + "," + Bval + ")";
   }
@@ -478,10 +526,11 @@ function bitsToColors(bitString, bitsPerPixel) {
   }
 
   for (var i = 0; i < bitString.length; i += bitsPerPixel) {
-    colorList.push(getColorVal(bitString.substring(i, i + bitsPerPixel), bitsPerPixel));
-
+    colorList.push(
+      getColorVal(bitString.substring(i, i + bitsPerPixel), bitsPerPixel)
+    );
   }
-  if ((bitString.length / bitsPerPixel) != colorList.length) {
+  if (bitString.length / bitsPerPixel != colorList.length) {
     colorList.pop();
   }
 
@@ -506,7 +555,7 @@ function changeVal(elementID) {
   // Make textbox value match slider value.
   document.getElementById(elementID).value = val;
 
-  if (options.version != '1') {
+  if (options.version != "1") {
     updateBinaryDataToMatchSliders();
     formatBitDisplay();
   }
@@ -520,7 +569,7 @@ function setSliders() {
   widthRange.value = getPositiveValue(widthText);
   bitsPerPixelRange.value = getPositiveValue(bitsPerPixelText);
 
-  if (options.version != '1') {
+  if (options.version != "1") {
     updateBinaryDataToMatchSliders();
     formatBitDisplay();
   }
@@ -544,7 +593,6 @@ function getPositiveValue(element) {
 }
 
 function updateBinaryDataToMatchSliders() {
-
   var heightByte = pad(getPositiveValue(heightRange).toString(2), 8, "0");
   var widthByte = pad(getPositiveValue(widthRange).toString(2), 8, "0");
   var bppByte = pad(getPositiveValue(bitsPerPixelRange).toString(2), 8, "0");
@@ -556,7 +604,7 @@ function updateBinaryDataToMatchSliders() {
   }
 
   var newBits = widthByte + heightByte;
-  if (options.version == '3') {
+  if (options.version == "3") {
     newBits += bppByte;
     if (justBits.length > 24) {
       newBits += justBits.substring(24);
@@ -581,9 +629,8 @@ function updateBinaryDataToMatchSliders() {
  * @param canvasId the id of the canvas you want to make a PNG of.
  */
 function showPNG() {
-
-  var tempCanvas = document.createElement('canvas');
-  if (document.querySelector('input#actual_size:checked')) {
+  var tempCanvas = document.createElement("canvas");
+  if (document.querySelector("input#actual_size:checked")) {
     tempCanvas.width = image_w;
     tempCanvas.height = image_h;
   } else {
@@ -591,10 +638,17 @@ function showPNG() {
     tempCanvas.height = image_h * sqSize;
   }
   drawGraph(tempCanvas.getContext("2d"), true);
-  var w = window.open('', 'ShowImageWindow',
-      "width=" + canvas.width + ", height=" + canvas.height + ", left=100, menubar=0, titlebar=0, scrollbars=0");
+  var w = window.open(
+    "",
+    "ShowImageWindow",
+    "width=" +
+      canvas.width +
+      ", height=" +
+      canvas.height +
+      ", left=100, menubar=0, titlebar=0, scrollbars=0"
+  );
   w.focus();
-  w.document.write('<style>* { margin: 0; })</style>');
+  w.document.write("<style>* { margin: 0; })</style>");
   w.document.write('<img src="' + tempCanvas.toDataURL() + '">');
   w.document.close();
 
@@ -605,11 +659,11 @@ function showPNG() {
 
 var finishedButton;
 function onFinishedButtonClick() {
-  finishedButton = $('#finished');
-  if (finishedButton.attr('disabled')) {
+  finishedButton = $("#finished");
+  if (finishedButton.attr("disabled")) {
     return;
   }
-  finishedButton.attr('disabled', true);
+  finishedButton.attr("disabled", true);
 
   if (!appOptions.readonlyWorkspace && options.saveProject) {
     options.saveProject().then(onSaveProjectComplete);
@@ -629,7 +683,7 @@ function onSaveProjectComplete() {
  */
 function onComplete(willRedirect) {
   if (!willRedirect) {
-    finishedButton.attr('disabled', false);
+    finishedButton.attr("disabled", false);
   }
 }
 


### PR DESCRIPTION
* Revert https://github.com/code-dot-org/code-dot-org/pull/29537 (restoring https://github.com/code-dot-org/code-dot-org/pull/29029)
* Add fix to `pixelation.js` (source handler contract has changed)
  * (this file was processed by our `prettier` rules for the first time, so the diffs look larger than they really are)
* Add PR feedback modification to remove `async` from a function that didn't need it
* Fix 2 bugs based on an issue reported by @joshlory , introduced as a result of previous PR changes:
  * Ensure that `getGeneratedProperties()` always returns a new object instance. The project system relies on comparing `currentSources` with `newSources` to determine if a project should be saved. If `currentSources.generatedProperties` is a reference to an object that can change over time, the project system doesn't properly detect that the project should be saved.
  * When `ExportDialog` detects that a previous APK build is identical and skips to the end of the export process, it needs to set the `md5PublishSavedSources` value in its state, just as it would have had it exported it from scratch. This ensures that subsequent changes to the project will reset the export process to the beginning.
