### PR TITLE
Increase max_table_rows for App Lab data tables

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -167,7 +167,7 @@ firebase_channel_id_suffix: ''
 firebase_max_channel_writes_per_15_sec: 300
 firebase_max_channel_writes_per_60_sec: 600
 firebase_max_table_count: 10
-firebase_max_table_rows: 1000
+firebase_max_table_rows: 20000
 firebase_max_record_size: 4096
 firebase_max_property_size: 4096
 


### PR DESCRIPTION
Now that the data tab view is paginated (#29533), we want to increase the number of rows students can have in a table.