### PR TITLE
Update rubyzip gem in Chef

### DIFF
--- a/cookbooks/Gemfile.lock
+++ b/cookbooks/Gemfile.lock
@@ -242,7 +242,7 @@ GEM
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubyntlm (0.6.2)
-    rubyzip (1.2.1)
+    rubyzip (1.2.3)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)


### PR DESCRIPTION
Update Rubyzip to 1.2.3 in Chef execution environment.