### PR TITLE
Don't copy dsls.en.yml into i18n source dir

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -29,7 +29,6 @@ cp_in $orig_dir/en.yml $loc_dir/base.yml
 
 # Copy in needed files from dashboard
 cp_in $orig_dir/blocks.en.yml $loc_dir/blocks.yml
-cp_in $orig_dir/dsls.en.yml $loc_dir/dsls.yml
 cp_in $orig_dir/data.en.yml $loc_dir/data.yml
 cp_in $orig_dir/devise.en.yml $loc_dir/devise.yml
 cp_in $orig_dir/scripts.en.yml $loc_dir/scripts.yml


### PR DESCRIPTION
Since we now generate DSL content into course_content, and no longer
sync this file to crowdin