### PR TITLE
Re-enable pixelation.feature UI tests on CI

### DIFF
--- a/dashboard/test/ui/features/pixelation.feature
+++ b/dashboard/test/ui/features/pixelation.feature
@@ -2,7 +2,6 @@
 Feature: Pixelation levels
   # Brad (2018-11-14) Skip on IE due to blocked pop-ups
   @no_ie
-  @no_circle
   @as_student
   Scenario: Pixelation version 2 in black and white with no sliders
     Given I am on the 1st pixelation test level
@@ -21,7 +20,6 @@ Feature: Pixelation levels
 
   # Brad (2018-11-14) Skip on IE due to blocked pop-ups
   @no_ie
-  @no_circle
   @as_student
   Scenario: Pixelation version 3 in color with sliders
     Given I am on the 2nd pixelation test level
@@ -40,7 +38,6 @@ Feature: Pixelation levels
 
   # Brad (2018-11-14) Skip on IE due to blocked pop-ups
   @no_ie
-  @no_circle
   @as_student
   Scenario: Pixelation version 3 in color with sliders starting in hex mode
     Given I am on the 3rd pixelation test level


### PR DESCRIPTION
Revert https://github.com/code-dot-org/code-dot-org/pull/16149 from June 2017

(Yesterday, a change was merged in that was not detected by CI because these UI tests had `@no_circle` on them. After discussing with @islemaster , we've decided to re-enable them on CI to determine if the flakiness is really an issue. The tests are valuable and should be run if possible)
