### PR TITLE
Census: support CSV V2 format

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -73,8 +73,6 @@ class Census::StateCsOffering < ApplicationRecord
   # the new format as of 2019-20.
   STATES_USING_FORMAT_V2_IN_2018_19 = %w(
     ID
-    MN
-    AR
   ).freeze
 
   def self.state_uses_format_v2(state_code, school_year)
@@ -104,11 +102,14 @@ class Census::StateCsOffering < ApplicationRecord
   def self.construct_state_school_id(state_code, row_hash, school_year)
     # Using V2 format.
     if state_uses_format_v2(state_code, school_year)
-      # The V2 format requires either (district_id and school_id) OR nces_id.
-      if row_hash['nces_id'] && row_hash['nces_id'] != UNSPECIFIED_VALUE
-        return School.find_by(id: row_hash['nces_id'])&.state_school_id
-      elsif row_hash['state_school_id'] && row_hash['state_school_id'] != UNSPECIFIED_VALUE
-        return row_hash['state_school_id']
+      nces_id = row_hash['nces_id']
+      state_school_id = row_hash['state_school_id']
+
+      # The V2 format requires either nces_id or state_school_id.
+      if nces_id != UNSPECIFIED_VALUE
+        return School.find_by(id: nces_id)&.state_school_id
+      elsif state_school_id != UNSPECIFIED_VALUE
+        return state_school_id
       else
         raise ArgumentError.new("Entry for #{state_code} requires either (district_id and school_id) OR nces_id.")
       end

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -104,7 +104,7 @@ class Census::StateCsOffering < ApplicationRecord
     if state_uses_format_v2(state_code, school_year)
       # The V2 format requires either (district_id and school_id) OR nces_id.
       if row_hash['nces_id']
-        return School.find_by(id: row_hash['NCES'])&.state_school_id
+        return School.find_by(id: row_hash['nces_id'])&.state_school_id
       elsif row_hash['district_id'] && row_hash['school_id']
         return School.construct_state_school_id(state_code, row_hash['district_id'], row_hash['school_id'])
       else

--- a/dashboard/test/fixtures/census/state_cs_offerings_id_2018.csv
+++ b/dashboard/test/fixtures/census/state_cs_offerings_id_2018.csv
@@ -1,45 +1,45 @@
 school_name,district_id,school_id,nces_id,course_id,course_name,teacher_name_or_id,num_students_enrolled,num_students_female,num_students_black_or_african_american,num_students_hispanic_or_latino,num_students_american_indian_or_native_alaskan,num_students_native_hawaiian_or_pacific_islander,num_students_free_or_reduced_lunch,num_students_special_education_status,num_students_english_language_learner_status
-BOISE SENIOR HIGH SCHOOL,Unspecified,0007,00044,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,117,42,1,9,1,0,6,9,**
-BORAH SENIOR HIGH SCHOOL,Unspecified,0008,00045,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,91,29,2,10,1,0,21,**,**
-CAPITAL SENIOR HIGH SCHOOL,Unspecified,0009,00047,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,23,7,0,3,0,0,**,**,**
-CAPITAL SENIOR HIGH SCHOOL,Unspecified,0009,00047,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,33,9,1,5,0,0,8,**,**
-TIMBERLINE HIGH SCHOOL,Unspecified,0243,00643,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,105,25,2,6,0,2,10,**,**
-TREASURE VALLEY MATH/SCIENCE,Unspecified,0573,00823,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,230,55,5,15,0,0,**,**,**
-CENTENNIAL HIGH SCHOOL,Unspecified,0015,00674,10157,AP Computer Science A ,Unspecified,72,12,0,2,1,1,**,**,**
-ST MARIES HIGH SCHOOL,Unspecified,0029,00532,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-SANDPOINT HIGH SCHOOL,Unspecified,0202,00087,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,52,20,0,4,0,0,7,**,**
-BONNERS FERRY HIGH SCHOOL,Unspecified,0057,00089,10157,AP Computer Science A ,Unspecified,1,0,0,0,0,0,**,**,**
-SKYVIEW HIGH SCHOOL,Unspecified,0994,00515,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,2,0,10,0,0,**,**,**
-NAMPA SENIOR HIGH SCHOOL,Unspecified,0998,00514,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,33,8,0,10,0,0,10,**,**
-CALDWELL SENIOR HIGH SCHOOL,Unspecified,0065,00104,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,175,45,0,80,5,0,CEP,5,10
-PARMA HIGH SCHOOL,Unspecified,0072,00451,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
-VALLIVUE HIGH SCHOOL,Unspecified,0074,00118,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,62,17,1,16,0,0,29,**,**
-RIDGEVUE HIGH SCHOOL,Unspecified,1380,01078,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-SODA SPRINGS HIGH SCHOOL,Unspecified,0079,00526,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,0,0,0,0,0,**,**,**
-OROFINO HIGH SCHOOL,Unspecified,0088,00440,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-CHALLIS JR/SR HIGH SCHOOL,Unspecified,0089,00140,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,0,0,0,0,0,**,**,**
-SALMON RIVER JR/SR HIGH SCHOOL,Unspecified,1281,00944,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,1,0,0,0,0,**,**,**
-COEUR D'ALENE HIGH SCHOOL,Unspecified,0122,00149,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,5,0,0,1,0,**,**,**
-LAKELAND SENIOR HIGH SCHOOL,Unspecified,0124,00311,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,2,0,0,0,0,**,**,**
-MOSCOW HIGH SCHOOL,Unspecified,0130,00394,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,22,5,0,1,0,0,**,**,**
-TROY JR/SR HIGH SCHOOL,Unspecified,0772,00582,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-SALMON JR/SR HIGH SCHOOL,Unspecified,0136,00504,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
-MADISON SENIOR HIGH SCHOOL,Unspecified,0146,00341,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,4,0,0,0,0,**,**,**
-MADISON SENIOR HIGH SCHOOL,Unspecified,0146,00341,10157,AP Computer Science A ,Unspecified,2,0,0,0,0,0,**,**,**
-LEWISTON HIGH SCHOOL,Unspecified,0153,00323,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,25,7,0,4,0,1,**,**,**
-CULDESAC SCHOOL,Unspecified,0795,00164,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,5,2,0,0,0,0,**,**,**
-NEW PLYMOUTH HIGH SCHOOL,Unspecified,0164,00736,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,9,3,0,2,0,0,**,**,**
-FRUITLAND HIGH SCHOOL,Unspecified,0166,00212,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,8,2,0,0,0,0,**,**,**
-KELLOGG HIGH SCHOOL,Unspecified,0171,00293,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,2,0,1,0,0,**,**,**
-BUHL HIGH SCHOOL,Unspecified,0180,00102,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
-FILER HIGH SCHOOL,Unspecified,0181,00194,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,0,0,0,0,0,**,**,**
-KIMBERLY HIGH SCHOOL,Unspecified,0182,00635,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-MCCALL-DONNELLY HIGH SCHOOL,Unspecified,0189,00354,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,15,2,0,0,0,0,**,**,**
-WEISER HIGH SCHOOL,Unspecified,0192,00568,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,4,0,11,0,0,10,**,**
-iSUCCEED VIRTUAL HIGH SCHOOL,Unspecified,0654,00967,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,7,3,0,0,1,0,**,**,**
-BINGHAM ACADEMY,Unspecified,1364,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,1,0,0,**,**,**
-IDAHO DISTANCE EDUCATION ACADEMY,Unspecified,1369,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-COEUR D'ALENE CHARTER ACADEMY SCHOOL,Unspecified,1370,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,7,3,0,1,0,0,**,**,**
-COEUR D'ALENE CHARTER ACADEMY SCHOOL,Unspecified,1370,NULL,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,1,0,0,0,0,0,**,**,**
-ARTE I RPTCS (Regional Professional Technical Charter School),Unspecified,1414,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
-IDLA School,Unspecified,1082,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,46,10,0,3,0,0,**,**,**
+BOISE SENIOR HIGH SCHOOL,,0007,00044,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,117,42,1,9,1,0,6,9,**
+BORAH SENIOR HIGH SCHOOL,,0008,00045,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,91,29,2,10,1,0,21,**,**
+CAPITAL SENIOR HIGH SCHOOL,,0009,00047,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,23,7,0,3,0,0,**,**,**
+CAPITAL SENIOR HIGH SCHOOL,,0009,00047,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,33,9,1,5,0,0,8,**,**
+TIMBERLINE HIGH SCHOOL,,0243,00643,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,105,25,2,6,0,2,10,**,**
+TREASURE VALLEY MATH/SCIENCE,,0573,00823,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,230,55,5,15,0,0,**,**,**
+CENTENNIAL HIGH SCHOOL,,0015,00674,10157,AP Computer Science A ,Unspecified,72,12,0,2,1,1,**,**,**
+ST MARIES HIGH SCHOOL,,0029,00532,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+SANDPOINT HIGH SCHOOL,,0202,00087,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,52,20,0,4,0,0,7,**,**
+BONNERS FERRY HIGH SCHOOL,,0057,00089,10157,AP Computer Science A ,Unspecified,1,0,0,0,0,0,**,**,**
+SKYVIEW HIGH SCHOOL,,0994,00515,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,2,0,10,0,0,**,**,**
+NAMPA SENIOR HIGH SCHOOL,,0998,00514,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,33,8,0,10,0,0,10,**,**
+CALDWELL SENIOR HIGH SCHOOL,,0065,00104,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,175,45,0,80,5,0,CEP,5,10
+PARMA HIGH SCHOOL,,0072,00451,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
+VALLIVUE HIGH SCHOOL,,0074,00118,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,62,17,1,16,0,0,29,**,**
+RIDGEVUE HIGH SCHOOL,,1380,01078,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+SODA SPRINGS HIGH SCHOOL,,0079,00526,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,0,0,0,0,0,**,**,**
+OROFINO HIGH SCHOOL,,0088,00440,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+CHALLIS JR/SR HIGH SCHOOL,,0089,00140,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,0,0,0,0,0,**,**,**
+SALMON RIVER JR/SR HIGH SCHOOL,,1281,00944,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,1,0,0,0,0,**,**,**
+COEUR D'ALENE HIGH SCHOOL,,0122,00149,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,5,0,0,1,0,**,**,**
+LAKELAND SENIOR HIGH SCHOOL,,0124,00311,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,2,0,0,0,0,**,**,**
+MOSCOW HIGH SCHOOL,,0130,00394,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,22,5,0,1,0,0,**,**,**
+TROY JR/SR HIGH SCHOOL,,0772,00582,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+SALMON JR/SR HIGH SCHOOL,,0136,00504,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
+MADISON SENIOR HIGH SCHOOL,,0146,00341,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,4,0,0,0,0,**,**,**
+MADISON SENIOR HIGH SCHOOL,,0146,00341,10157,AP Computer Science A ,Unspecified,2,0,0,0,0,0,**,**,**
+LEWISTON HIGH SCHOOL,,0153,00323,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,25,7,0,4,0,1,**,**,**
+CULDESAC SCHOOL,,0795,00164,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,5,2,0,0,0,0,**,**,**
+NEW PLYMOUTH HIGH SCHOOL,,0164,00736,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,9,3,0,2,0,0,**,**,**
+FRUITLAND HIGH SCHOOL,,0166,00212,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,8,2,0,0,0,0,**,**,**
+KELLOGG HIGH SCHOOL,,0171,00293,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,2,0,1,0,0,**,**,**
+BUHL HIGH SCHOOL,,0180,00102,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
+FILER HIGH SCHOOL,,0181,00194,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,0,0,0,0,0,**,**,**
+KIMBERLY HIGH SCHOOL,,0182,00635,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+MCCALL-DONNELLY HIGH SCHOOL,,0189,00354,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,15,2,0,0,0,0,**,**,**
+WEISER HIGH SCHOOL,,0192,00568,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,4,0,11,0,0,10,**,**
+iSUCCEED VIRTUAL HIGH SCHOOL,,0654,00967,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,7,3,0,0,1,0,**,**,**
+BINGHAM ACADEMY,,1364,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,1,0,0,**,**,**
+IDAHO DISTANCE EDUCATION ACADEMY,,1369,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+COEUR D'ALENE CHARTER ACADEMY SCHOOL,,1370,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,7,3,0,1,0,0,**,**,**
+COEUR D'ALENE CHARTER ACADEMY SCHOOL,,1370,NULL,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,1,0,0,0,0,0,**,**,**
+ARTE I RPTCS (Regional Professional Technical Charter School),,1414,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
+IDLA School,,1082,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,46,10,0,3,0,0,**,**,**

--- a/dashboard/test/fixtures/census/state_cs_offerings_id_2018.csv
+++ b/dashboard/test/fixtures/census/state_cs_offerings_id_2018.csv
@@ -1,0 +1,45 @@
+school_name,district_id,school_id,nces_id,course_id,course_name,teacher_name_or_id,num_students_enrolled,num_students_female,num_students_black_or_african_american,num_students_hispanic_or_latino,num_students_american_indian_or_native_alaskan,num_students_native_hawaiian_or_pacific_islander,num_students_free_or_reduced_lunch,num_students_special_education_status,num_students_english_language_learner_status
+BOISE SENIOR HIGH SCHOOL,Unspecified,0007,00044,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,117,42,1,9,1,0,6,9,**
+BORAH SENIOR HIGH SCHOOL,Unspecified,0008,00045,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,91,29,2,10,1,0,21,**,**
+CAPITAL SENIOR HIGH SCHOOL,Unspecified,0009,00047,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,23,7,0,3,0,0,**,**,**
+CAPITAL SENIOR HIGH SCHOOL,Unspecified,0009,00047,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,33,9,1,5,0,0,8,**,**
+TIMBERLINE HIGH SCHOOL,Unspecified,0243,00643,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,105,25,2,6,0,2,10,**,**
+TREASURE VALLEY MATH/SCIENCE,Unspecified,0573,00823,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,230,55,5,15,0,0,**,**,**
+CENTENNIAL HIGH SCHOOL,Unspecified,0015,00674,10157,AP Computer Science A ,Unspecified,72,12,0,2,1,1,**,**,**
+ST MARIES HIGH SCHOOL,Unspecified,0029,00532,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+SANDPOINT HIGH SCHOOL,Unspecified,0202,00087,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,52,20,0,4,0,0,7,**,**
+BONNERS FERRY HIGH SCHOOL,Unspecified,0057,00089,10157,AP Computer Science A ,Unspecified,1,0,0,0,0,0,**,**,**
+SKYVIEW HIGH SCHOOL,Unspecified,0994,00515,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,2,0,10,0,0,**,**,**
+NAMPA SENIOR HIGH SCHOOL,Unspecified,0998,00514,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,33,8,0,10,0,0,10,**,**
+CALDWELL SENIOR HIGH SCHOOL,Unspecified,0065,00104,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,175,45,0,80,5,0,CEP,5,10
+PARMA HIGH SCHOOL,Unspecified,0072,00451,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
+VALLIVUE HIGH SCHOOL,Unspecified,0074,00118,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,62,17,1,16,0,0,29,**,**
+RIDGEVUE HIGH SCHOOL,Unspecified,1380,01078,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+SODA SPRINGS HIGH SCHOOL,Unspecified,0079,00526,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,0,0,0,0,0,**,**,**
+OROFINO HIGH SCHOOL,Unspecified,0088,00440,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+CHALLIS JR/SR HIGH SCHOOL,Unspecified,0089,00140,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,0,0,0,0,0,**,**,**
+SALMON RIVER JR/SR HIGH SCHOOL,Unspecified,1281,00944,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,1,0,0,0,0,**,**,**
+COEUR D'ALENE HIGH SCHOOL,Unspecified,0122,00149,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,5,0,0,1,0,**,**,**
+LAKELAND SENIOR HIGH SCHOOL,Unspecified,0124,00311,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,2,0,0,0,0,**,**,**
+MOSCOW HIGH SCHOOL,Unspecified,0130,00394,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,22,5,0,1,0,0,**,**,**
+TROY JR/SR HIGH SCHOOL,Unspecified,0772,00582,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+SALMON JR/SR HIGH SCHOOL,Unspecified,0136,00504,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
+MADISON SENIOR HIGH SCHOOL,Unspecified,0146,00341,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,4,0,0,0,0,**,**,**
+MADISON SENIOR HIGH SCHOOL,Unspecified,0146,00341,10157,AP Computer Science A ,Unspecified,2,0,0,0,0,0,**,**,**
+LEWISTON HIGH SCHOOL,Unspecified,0153,00323,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,25,7,0,4,0,1,**,**,**
+CULDESAC SCHOOL,Unspecified,0795,00164,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,5,2,0,0,0,0,**,**,**
+NEW PLYMOUTH HIGH SCHOOL,Unspecified,0164,00736,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,9,3,0,2,0,0,**,**,**
+FRUITLAND HIGH SCHOOL,Unspecified,0166,00212,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,8,2,0,0,0,0,**,**,**
+KELLOGG HIGH SCHOOL,Unspecified,0171,00293,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,2,0,1,0,0,**,**,**
+BUHL HIGH SCHOOL,Unspecified,0180,00102,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
+FILER HIGH SCHOOL,Unspecified,0181,00194,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,0,0,0,0,0,**,**,**
+KIMBERLY HIGH SCHOOL,Unspecified,0182,00635,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+MCCALL-DONNELLY HIGH SCHOOL,Unspecified,0189,00354,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,15,2,0,0,0,0,**,**,**
+WEISER HIGH SCHOOL,Unspecified,0192,00568,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,4,0,11,0,0,10,**,**
+iSUCCEED VIRTUAL HIGH SCHOOL,Unspecified,0654,00967,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,7,3,0,0,1,0,**,**,**
+BINGHAM ACADEMY,Unspecified,1364,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,1,0,0,**,**,**
+IDAHO DISTANCE EDUCATION ACADEMY,Unspecified,1369,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+COEUR D'ALENE CHARTER ACADEMY SCHOOL,Unspecified,1370,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,7,3,0,1,0,0,**,**,**
+COEUR D'ALENE CHARTER ACADEMY SCHOOL,Unspecified,1370,NULL,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,1,0,0,0,0,0,**,**,**
+ARTE I RPTCS (Regional Professional Technical Charter School),Unspecified,1414,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
+IDLA School,Unspecified,1082,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,46,10,0,3,0,0,**,**,**

--- a/dashboard/test/fixtures/census/state_cs_offerings_id_2018.csv
+++ b/dashboard/test/fixtures/census/state_cs_offerings_id_2018.csv
@@ -1,45 +1,45 @@
-school_name,district_id,school_id,nces_id,course_id,course_name,teacher_name_or_id,num_students_enrolled,num_students_female,num_students_black_or_african_american,num_students_hispanic_or_latino,num_students_american_indian_or_native_alaskan,num_students_native_hawaiian_or_pacific_islander,num_students_free_or_reduced_lunch,num_students_special_education_status,num_students_english_language_learner_status
-BOISE SENIOR HIGH SCHOOL,,0007,00044,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,117,42,1,9,1,0,6,9,**
-BORAH SENIOR HIGH SCHOOL,,0008,00045,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,91,29,2,10,1,0,21,**,**
-CAPITAL SENIOR HIGH SCHOOL,,0009,00047,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,23,7,0,3,0,0,**,**,**
-CAPITAL SENIOR HIGH SCHOOL,,0009,00047,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,33,9,1,5,0,0,8,**,**
-TIMBERLINE HIGH SCHOOL,,0243,00643,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,105,25,2,6,0,2,10,**,**
-TREASURE VALLEY MATH/SCIENCE,,0573,00823,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,230,55,5,15,0,0,**,**,**
-CENTENNIAL HIGH SCHOOL,,0015,00674,10157,AP Computer Science A ,Unspecified,72,12,0,2,1,1,**,**,**
-ST MARIES HIGH SCHOOL,,0029,00532,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-SANDPOINT HIGH SCHOOL,,0202,00087,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,52,20,0,4,0,0,7,**,**
-BONNERS FERRY HIGH SCHOOL,,0057,00089,10157,AP Computer Science A ,Unspecified,1,0,0,0,0,0,**,**,**
-SKYVIEW HIGH SCHOOL,,0994,00515,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,2,0,10,0,0,**,**,**
-NAMPA SENIOR HIGH SCHOOL,,0998,00514,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,33,8,0,10,0,0,10,**,**
-CALDWELL SENIOR HIGH SCHOOL,,0065,00104,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,175,45,0,80,5,0,CEP,5,10
-PARMA HIGH SCHOOL,,0072,00451,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
-VALLIVUE HIGH SCHOOL,,0074,00118,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,62,17,1,16,0,0,29,**,**
-RIDGEVUE HIGH SCHOOL,,1380,01078,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-SODA SPRINGS HIGH SCHOOL,,0079,00526,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,0,0,0,0,0,**,**,**
-OROFINO HIGH SCHOOL,,0088,00440,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-CHALLIS JR/SR HIGH SCHOOL,,0089,00140,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,0,0,0,0,0,**,**,**
-SALMON RIVER JR/SR HIGH SCHOOL,,1281,00944,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,1,0,0,0,0,**,**,**
-COEUR D'ALENE HIGH SCHOOL,,0122,00149,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,5,0,0,1,0,**,**,**
-LAKELAND SENIOR HIGH SCHOOL,,0124,00311,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,2,0,0,0,0,**,**,**
-MOSCOW HIGH SCHOOL,,0130,00394,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,22,5,0,1,0,0,**,**,**
-TROY JR/SR HIGH SCHOOL,,0772,00582,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-SALMON JR/SR HIGH SCHOOL,,0136,00504,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
-MADISON SENIOR HIGH SCHOOL,,0146,00341,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,4,0,0,0,0,**,**,**
-MADISON SENIOR HIGH SCHOOL,,0146,00341,10157,AP Computer Science A ,Unspecified,2,0,0,0,0,0,**,**,**
-LEWISTON HIGH SCHOOL,,0153,00323,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,25,7,0,4,0,1,**,**,**
-CULDESAC SCHOOL,,0795,00164,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,5,2,0,0,0,0,**,**,**
-NEW PLYMOUTH HIGH SCHOOL,,0164,00736,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,9,3,0,2,0,0,**,**,**
-FRUITLAND HIGH SCHOOL,,0166,00212,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,8,2,0,0,0,0,**,**,**
-KELLOGG HIGH SCHOOL,,0171,00293,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,2,0,1,0,0,**,**,**
-BUHL HIGH SCHOOL,,0180,00102,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
-FILER HIGH SCHOOL,,0181,00194,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,0,0,0,0,0,**,**,**
-KIMBERLY HIGH SCHOOL,,0182,00635,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-MCCALL-DONNELLY HIGH SCHOOL,,0189,00354,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,15,2,0,0,0,0,**,**,**
-WEISER HIGH SCHOOL,,0192,00568,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,4,0,11,0,0,10,**,**
-iSUCCEED VIRTUAL HIGH SCHOOL,,0654,00967,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,7,3,0,0,1,0,**,**,**
-BINGHAM ACADEMY,,1364,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,1,0,0,**,**,**
-IDAHO DISTANCE EDUCATION ACADEMY,,1369,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-COEUR D'ALENE CHARTER ACADEMY SCHOOL,,1370,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,7,3,0,1,0,0,**,**,**
-COEUR D'ALENE CHARTER ACADEMY SCHOOL,,1370,NULL,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,1,0,0,0,0,0,**,**,**
-ARTE I RPTCS (Regional Professional Technical Charter School),,1414,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
-IDLA School,,1082,NULL,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,46,10,0,3,0,0,**,**,**
+school_name,state_school_id,nces_id,course_id,course_name,teacher_name_or_id,num_students_enrolled,num_students_female,num_students_black_or_african_american,num_students_hispanic_or_latino,num_students_american_indian_or_native_alaskan,num_students_native_hawaiian_or_pacific_islander,num_students_free_or_reduced_lunch,num_students_special_education_status,num_students_english_language_learner_status
+BOISE SENIOR HIGH SCHOOL,ID-001-0007,160036000044,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,117,42,1,9,1,0,6,9,**
+BORAH SENIOR HIGH SCHOOL,ID-001-0008,160036000045,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,91,29,2,10,1,0,21,**,**
+CAPITAL SENIOR HIGH SCHOOL,ID-001-0009,160036000047,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,23,7,0,3,0,0,**,**,**
+CAPITAL SENIOR HIGH SCHOOL,ID-001-0009,160036000047,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,33,9,1,5,0,0,8,**,**
+TIMBERLINE HIGH SCHOOL,ID-001-0243,160252000445,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,105,25,2,6,0,2,10,**,**
+TREASURE VALLEY MATH/SCIENCE,ID-001-0573,160036000823,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,230,55,5,15,0,0,**,**,**
+CENTENNIAL HIGH SCHOOL,ID-002-0015,160210000674,10157,AP Computer Science A ,Unspecified,72,12,0,2,1,1,**,**,**
+ST MARIES HIGH SCHOOL,ID-041-0029,160306000532,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+SANDPOINT HIGH SCHOOL,ID-084-0202,160000200087,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,52,20,0,4,0,0,7,**,**
+BONNERS FERRY HIGH SCHOOL,ID-101-0057,160042000089,10157,AP Computer Science A ,Unspecified,1,0,0,0,0,0,**,**,**
+SKYVIEW HIGH SCHOOL,ID-131-0994,160234000515,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,2,0,10,0,0,**,**,**
+NAMPA SENIOR HIGH SCHOOL,ID-131-0998,160234000514,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,33,8,0,10,0,0,10,**,**
+CALDWELL SENIOR HIGH SCHOOL,ID-132-0065,160051000104,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,175,45,0,80,5,0,CEP,5,10
+PARMA HIGH SCHOOL,ID-137-0072,160255000451,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
+VALLIVUE HIGH SCHOOL,ID-139-0074,160060000118,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,62,17,1,16,0,0,29,**,**
+RIDGEVUE HIGH SCHOOL,ID-139-1380,160060001078,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+SODA SPRINGS HIGH SCHOOL,ID-150-0079,160300000526,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,0,0,0,0,0,**,**,**
+OROFINO HIGH SCHOOL,ID-171-0088,160252000440,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+CHALLIS JR/SR HIGH SCHOOL,ID-181-0089,160072000140,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,0,0,0,0,0,**,**,**
+SALMON RIVER JR/SR HIGH SCHOOL,ID-243-1281,160013800944,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,1,0,0,0,0,**,**,**
+COEUR D'ALENE HIGH SCHOOL,ID-271-0122,160078000149,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,5,0,0,1,0,**,**,**
+LAKELAND SENIOR HIGH SCHOOL,ID-272-0124,160180000311,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,2,0,0,0,0,**,**,**
+MOSCOW HIGH SCHOOL,ID-281-0130,160222000394,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,22,5,0,1,0,0,**,**,**
+TROY JR/SR HIGH SCHOOL,ID-287-0772,160000900582,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+SALMON JR/SR HIGH SCHOOL,ID-291-0136,160285000504,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
+MADISON SENIOR HIGH SCHOOL,ID-321-0146,160192000341,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,4,0,0,0,0,**,**,**
+MADISON SENIOR HIGH SCHOOL,ID-321-0146,160192000341,10157,AP Computer Science A ,Unspecified,2,0,0,0,0,0,**,**,**
+LEWISTON HIGH SCHOOL,ID-340-0153,160186000323,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,25,7,0,4,0,1,**,**,**
+CULDESAC SCHOOL,ID-342-0795,160087000164,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,5,2,0,0,0,0,**,**,**
+NEW PLYMOUTH HIGH SCHOOL,ID-372-0164,160237000736,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,9,3,0,2,0,0,**,**,**
+FRUITLAND HIGH SCHOOL,ID-373-0166,160114000212,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,8,2,0,0,0,0,**,**,**
+KELLOGG HIGH SCHOOL,ID-391-0171,160165000293,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,2,0,1,0,0,**,**,**
+BUHL HIGH SCHOOL,ID-412-0180,160048000102,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
+FILER HIGH SCHOOL,ID-413-0181,160105000194,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,0,0,0,0,0,**,**,**
+KIMBERLY HIGH SCHOOL,ID-414-0182,160171000635,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+MCCALL-DONNELLY HIGH SCHOOL,ID-421-0189,160203000354,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,15,2,0,0,0,0,**,**,**
+WEISER HIGH SCHOOL,ID-431-0192,160333000568,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,4,0,11,0,0,10,**,**
+iSUCCEED VIRTUAL HIGH SCHOOL,ID-466-0654,unspecified,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,7,3,0,0,1,0,**,**,**
+BINGHAM ACADEMY,ID-485-1364,160016901067,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,1,0,0,**,**,**
+IDAHO DISTANCE EDUCATION ACADEMY,ID-490-1369,160017200846,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
+COEUR D'ALENE CHARTER ACADEMY SCHOOL,ID-491-1370,160017300765,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,7,3,0,1,0,0,**,**,**
+COEUR D'ALENE CHARTER ACADEMY SCHOOL,ID-491-1370,160017300765,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,1,0,0,0,0,0,**,**,**
+ARTE I RPTCS (Regional Professional Technical Charter School),ID-518-1414,160219000883,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
+IDLA School,ID-771-1082,unspecified,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,46,10,0,3,0,0,**,**,**

--- a/dashboard/test/fixtures/census/state_cs_offerings_id_2018.csv
+++ b/dashboard/test/fixtures/census/state_cs_offerings_id_2018.csv
@@ -1,45 +1,45 @@
 school_name,state_school_id,nces_id,course_id,course_name,teacher_name_or_id,num_students_enrolled,num_students_female,num_students_black_or_african_american,num_students_hispanic_or_latino,num_students_american_indian_or_native_alaskan,num_students_native_hawaiian_or_pacific_islander,num_students_free_or_reduced_lunch,num_students_special_education_status,num_students_english_language_learner_status
-BOISE SENIOR HIGH SCHOOL,ID-001-0007,160036000044,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,117,42,1,9,1,0,6,9,**
-BORAH SENIOR HIGH SCHOOL,ID-001-0008,160036000045,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,91,29,2,10,1,0,21,**,**
-CAPITAL SENIOR HIGH SCHOOL,ID-001-0009,160036000047,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,23,7,0,3,0,0,**,**,**
-CAPITAL SENIOR HIGH SCHOOL,ID-001-0009,160036000047,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,33,9,1,5,0,0,8,**,**
-TIMBERLINE HIGH SCHOOL,ID-001-0243,160252000445,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,105,25,2,6,0,2,10,**,**
-TREASURE VALLEY MATH/SCIENCE,ID-001-0573,160036000823,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,230,55,5,15,0,0,**,**,**
-CENTENNIAL HIGH SCHOOL,ID-002-0015,160210000674,10157,AP Computer Science A ,Unspecified,72,12,0,2,1,1,**,**,**
-ST MARIES HIGH SCHOOL,ID-041-0029,160306000532,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-SANDPOINT HIGH SCHOOL,ID-084-0202,160000200087,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,52,20,0,4,0,0,7,**,**
-BONNERS FERRY HIGH SCHOOL,ID-101-0057,160042000089,10157,AP Computer Science A ,Unspecified,1,0,0,0,0,0,**,**,**
-SKYVIEW HIGH SCHOOL,ID-131-0994,160234000515,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,2,0,10,0,0,**,**,**
-NAMPA SENIOR HIGH SCHOOL,ID-131-0998,160234000514,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,33,8,0,10,0,0,10,**,**
-CALDWELL SENIOR HIGH SCHOOL,ID-132-0065,160051000104,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,175,45,0,80,5,0,CEP,5,10
-PARMA HIGH SCHOOL,ID-137-0072,160255000451,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
-VALLIVUE HIGH SCHOOL,ID-139-0074,160060000118,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,62,17,1,16,0,0,29,**,**
-RIDGEVUE HIGH SCHOOL,ID-139-1380,160060001078,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-SODA SPRINGS HIGH SCHOOL,ID-150-0079,160300000526,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,0,0,0,0,0,**,**,**
-OROFINO HIGH SCHOOL,ID-171-0088,160252000440,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-CHALLIS JR/SR HIGH SCHOOL,ID-181-0089,160072000140,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,0,0,0,0,0,**,**,**
-SALMON RIVER JR/SR HIGH SCHOOL,ID-243-1281,160013800944,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,1,0,0,0,0,**,**,**
-COEUR D'ALENE HIGH SCHOOL,ID-271-0122,160078000149,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,5,0,0,1,0,**,**,**
-LAKELAND SENIOR HIGH SCHOOL,ID-272-0124,160180000311,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,4,2,0,0,0,0,**,**,**
-MOSCOW HIGH SCHOOL,ID-281-0130,160222000394,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,22,5,0,1,0,0,**,**,**
-TROY JR/SR HIGH SCHOOL,ID-287-0772,160000900582,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-SALMON JR/SR HIGH SCHOOL,ID-291-0136,160285000504,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,1,0,0,0,0,**,**,**
-MADISON SENIOR HIGH SCHOOL,ID-321-0146,160192000341,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,15,4,0,0,0,0,**,**,**
-MADISON SENIOR HIGH SCHOOL,ID-321-0146,160192000341,10157,AP Computer Science A ,Unspecified,2,0,0,0,0,0,**,**,**
-LEWISTON HIGH SCHOOL,ID-340-0153,160186000323,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,25,7,0,4,0,1,**,**,**
-CULDESAC SCHOOL,ID-342-0795,160087000164,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,5,2,0,0,0,0,**,**,**
-NEW PLYMOUTH HIGH SCHOOL,ID-372-0164,160237000736,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,9,3,0,2,0,0,**,**,**
-FRUITLAND HIGH SCHOOL,ID-373-0166,160114000212,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,8,2,0,0,0,0,**,**,**
-KELLOGG HIGH SCHOOL,ID-391-0171,160165000293,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,5,2,0,1,0,0,**,**,**
-BUHL HIGH SCHOOL,ID-412-0180,160048000102,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
-FILER HIGH SCHOOL,ID-413-0181,160105000194,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,2,0,0,0,0,0,**,**,**
-KIMBERLY HIGH SCHOOL,ID-414-0182,160171000635,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-MCCALL-DONNELLY HIGH SCHOOL,ID-421-0189,160203000354,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,15,2,0,0,0,0,**,**,**
-WEISER HIGH SCHOOL,ID-431-0192,160333000568,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,28,4,0,11,0,0,10,**,**
-iSUCCEED VIRTUAL HIGH SCHOOL,ID-466-0654,unspecified,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,7,3,0,0,1,0,**,**,**
-BINGHAM ACADEMY,ID-485-1364,160016901067,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,1,0,0,**,**,**
-IDAHO DISTANCE EDUCATION ACADEMY,ID-490-1369,160017200846,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,1,0,0,0,0,0,**,**,**
-COEUR D'ALENE CHARTER ACADEMY SCHOOL,ID-491-1370,160017300765,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,7,3,0,1,0,0,**,**,**
-COEUR D'ALENE CHARTER ACADEMY SCHOOL,ID-491-1370,160017300765,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),Unspecified,1,0,0,0,0,0,**,**,**
-ARTE I RPTCS (Regional Professional Technical Charter School),ID-518-1414,160219000883,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,6,1,0,1,0,0,**,**,**
-IDLA School,ID-771-1082,unspecified,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),Unspecified,46,10,0,3,0,0,**,**,**
+BOISE SENIOR HIGH SCHOOL,ID-001-0007,160036000044,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,117,42,1,9,1,0,6,9,**
+BORAH SENIOR HIGH SCHOOL,ID-001-0008,160036000045,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,91,29,2,10,1,0,21,**,**
+CAPITAL SENIOR HIGH SCHOOL,ID-001-0009,160036000047,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,23,7,0,3,0,0,**,**,**
+CAPITAL SENIOR HIGH SCHOOL,ID-001-0009,160036000047,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),unspecified,33,9,1,5,0,0,8,**,**
+TIMBERLINE HIGH SCHOOL,ID-001-0243,160252000445,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),unspecified,105,25,2,6,0,2,10,**,**
+TREASURE VALLEY MATH/SCIENCE,ID-001-0573,160036000823,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,230,55,5,15,0,0,**,**,**
+CENTENNIAL HIGH SCHOOL,ID-002-0015,160210000674,10157,AP Computer Science A ,unspecified,72,12,0,2,1,1,**,**,**
+ST MARIES HIGH SCHOOL,ID-041-0029,160306000532,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,1,0,0,0,0,0,**,**,**
+SANDPOINT HIGH SCHOOL,ID-084-0202,160000200087,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,52,20,0,4,0,0,7,**,**
+BONNERS FERRY HIGH SCHOOL,ID-101-0057,160042000089,10157,AP Computer Science A ,unspecified,1,0,0,0,0,0,**,**,**
+SKYVIEW HIGH SCHOOL,ID-131-0994,160234000515,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,28,2,0,10,0,0,**,**,**
+NAMPA SENIOR HIGH SCHOOL,ID-131-0998,160234000514,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,33,8,0,10,0,0,10,**,**
+CALDWELL SENIOR HIGH SCHOOL,ID-132-0065,160051000104,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,175,45,0,80,5,0,CEP,5,10
+PARMA HIGH SCHOOL,ID-137-0072,160255000451,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,1,1,0,0,0,0,**,**,**
+VALLIVUE HIGH SCHOOL,ID-139-0074,160060000118,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,62,17,1,16,0,0,29,**,**
+RIDGEVUE HIGH SCHOOL,ID-139-1380,160060001078,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,1,0,0,0,0,0,**,**,**
+SODA SPRINGS HIGH SCHOOL,ID-150-0079,160300000526,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,5,0,0,0,0,0,**,**,**
+OROFINO HIGH SCHOOL,ID-171-0088,160252000440,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,1,0,0,0,0,0,**,**,**
+CHALLIS JR/SR HIGH SCHOOL,ID-181-0089,160072000140,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,4,0,0,0,0,0,**,**,**
+SALMON RIVER JR/SR HIGH SCHOOL,ID-243-1281,160013800944,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,2,1,0,0,0,0,**,**,**
+COEUR D'ALENE HIGH SCHOOL,ID-271-0122,160078000149,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,15,5,0,0,1,0,**,**,**
+LAKELAND SENIOR HIGH SCHOOL,ID-272-0124,160180000311,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,4,2,0,0,0,0,**,**,**
+MOSCOW HIGH SCHOOL,ID-281-0130,160222000394,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,22,5,0,1,0,0,**,**,**
+TROY JR/SR HIGH SCHOOL,ID-287-0772,160000900582,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,1,0,0,0,0,0,**,**,**
+SALMON JR/SR HIGH SCHOOL,ID-291-0136,160285000504,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,1,1,0,0,0,0,**,**,**
+MADISON SENIOR HIGH SCHOOL,ID-321-0146,160192000341,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,15,4,0,0,0,0,**,**,**
+MADISON SENIOR HIGH SCHOOL,ID-321-0146,160192000341,10157,AP Computer Science A ,unspecified,2,0,0,0,0,0,**,**,**
+LEWISTON HIGH SCHOOL,ID-340-0153,160186000323,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,25,7,0,4,0,1,**,**,**
+CULDESAC SCHOOL,ID-342-0795,160087000164,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),unspecified,5,2,0,0,0,0,**,**,**
+NEW PLYMOUTH HIGH SCHOOL,ID-372-0164,160237000736,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,9,3,0,2,0,0,**,**,**
+FRUITLAND HIGH SCHOOL,ID-373-0166,160114000212,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,8,2,0,0,0,0,**,**,**
+KELLOGG HIGH SCHOOL,ID-391-0171,160165000293,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,5,2,0,1,0,0,**,**,**
+BUHL HIGH SCHOOL,ID-412-0180,160048000102,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,6,1,0,1,0,0,**,**,**
+FILER HIGH SCHOOL,ID-413-0181,160105000194,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,2,0,0,0,0,0,**,**,**
+KIMBERLY HIGH SCHOOL,ID-414-0182,160171000635,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,1,0,0,0,0,0,**,**,**
+MCCALL-DONNELLY HIGH SCHOOL,ID-421-0189,160203000354,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),unspecified,15,2,0,0,0,0,**,**,**
+WEISER HIGH SCHOOL,ID-431-0192,160333000568,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,28,4,0,11,0,0,10,**,**
+iSUCCEED VIRTUAL HIGH SCHOOL,ID-466-0654,160014400967,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),unspecified,7,3,0,0,1,0,**,**,**
+BINGHAM ACADEMY,ID-485-1364,160016901067,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,1,0,0,1,0,0,**,**,**
+IDAHO DISTANCE EDUCATION ACADEMY,ID-490-1369,160017200846,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,1,0,0,0,0,0,**,**,**
+COEUR D'ALENE CHARTER ACADEMY SCHOOL,ID-491-1370,160017300765,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,7,3,0,1,0,0,**,**,**
+COEUR D'ALENE CHARTER ACADEMY SCHOOL,ID-491-1370,160017300765,03208,AP/Dual Credit Computer Science – Science (11th-12th grade content),unspecified,1,0,0,0,0,0,**,**,**
+ARTE I RPTCS (Regional Professional Technical Charter School),ID-518-1414,160219000883,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,6,1,0,1,0,0,**,**,**
+IDLA School,ID-771-1082,unspecified,02204,AP/Dual Credit Computer Science - Mathematics (11-12 grade content),unspecified,46,10,0,3,0,0,**,**,**


### PR DESCRIPTION
Going forward, all CSVs should use this one "V2" format, with no more variants per state (which we support in the existing "V1" format).  For the 2018-19 school year, we already have some CSVs using the V1 format, and so we will only attempt to use the V2 format for some states.  The assumption is that all states will use the V2 format from 2019-20 onwards.

The V2 format has two columns of note for identifying a school: `state_school_id` and  `nces_id`.  If `nces_id` is provided, then we use it to look up a state school ID.  If `nces_is` is not provided or is `"unspecified"`, then we fall back to the `state_school_id` column.

The course is specified by `course_id` and must be a valid course; we no longer will compare against a list of valid course codes for a state.

Once this code is live, any subsequent seed step will be able to pick up a newly-added V2 CSV file on S3, and should successfully ingest it.  We will start this process by just doing one state - ID - and making sure that ingests successfully.