### PR TITLE
Add non-nullable contained_level_page column

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -83,6 +83,7 @@ def main
         level_id: level.id,
         contained_level_id: sublevel.id,
         contained_level_type: sublevel.type,
+        contained_level_page: 1,
         contained_level_position: sublevel_index
       }
     end


### PR DESCRIPTION
Follow-up to #29443. Fixes [this Honeybadger error](https://app.honeybadger.io/projects/45435/faults/51801323).

The `contained_level_page` column on the `contained_levels` table is non-nullable, but was null for BubbleChoice levels, so inserting new rows was failing. This fixes that failure by hardcoding the `contained_level_page` value to 1 for BubbleChoice levels.