### PR TITLE
Rename title to display_name for BubbleChoice

### DIFF
--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -63,7 +63,7 @@ const styles = {
 export default class BubbleChoice extends React.Component {
   static propTypes = {
     level: PropTypes.shape({
-      title: PropTypes.string.isRequired,
+      display_name: PropTypes.string.isRequired,
       description: PropTypes.string.isRequired,
       previous_level_url: PropTypes.string,
       next_level_url: PropTypes.string,
@@ -71,7 +71,7 @@ export default class BubbleChoice extends React.Component {
       sublevels: PropTypes.arrayOf(
         PropTypes.shape({
           id: PropTypes.number.isRequired,
-          title: PropTypes.string.isRequired,
+          display_name: PropTypes.string.isRequired,
           description: PropTypes.string,
           thumbnail_url: PropTypes.string,
           url: PropTypes.string.isRequired,
@@ -119,7 +119,7 @@ export default class BubbleChoice extends React.Component {
 
     return (
       <div>
-        <h1>{level.title}</h1>
+        <h1>{level.display_name}</h1>
         <UnsafeRenderedMarkdown markdown={level.description} />
         {this.renderButtons()}
         <h2 style={styles.h2}>{i18n.chooseActivity()}</h2>
@@ -141,7 +141,7 @@ export default class BubbleChoice extends React.Component {
             )}
             <div style={styles.column}>
               <a href={sublevel.url + location.search} style={styles.title}>
-                {sublevel.title}
+                {sublevel.display_name}
               </a>
               {sublevel.description && (
                 <div style={styles.description}>{sublevel.description}</div>

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -8,13 +8,13 @@ import * as utils from '@cdo/apps/utils';
 const fakeSublevels = [
   {
     id: 1,
-    title: 'Choice 1',
+    display_name: 'Choice 1',
     thumbnail_url: 'some-fake.url/kittens.png',
     url: '/s/script/stage/1/puzzle/2/sublevel/1'
   },
   {
     id: 2,
-    title: 'Choice 2',
+    display_name: 'Choice 2',
     thumbnail_url: null,
     url: '/s/script/stage/1/puzzle/2/sublevel/2'
   }
@@ -22,7 +22,7 @@ const fakeSublevels = [
 
 const DEFAULT_PROPS = {
   level: {
-    title: 'Bubble Choice',
+    display_name: 'Bubble Choice',
     description: 'Choose one or more levels!',
     sublevels: fakeSublevels,
     previous_level_url: '/s/script/stage/1/puzzle/1',
@@ -34,7 +34,7 @@ const DEFAULT_PROPS = {
 describe('BubbleChoice', () => {
   it('renders level information', () => {
     const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} />);
-    assert.equal(DEFAULT_PROPS.level.title, wrapper.find('h1').text());
+    assert.equal(DEFAULT_PROPS.level.display_name, wrapper.find('h1').text());
     assert.equal(
       DEFAULT_PROPS.level.description,
       wrapper.find('UnsafeRenderedMarkdown').text()

--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -1,7 +1,7 @@
 class BubbleChoiceDSL < BaseDSL
   def initialize
     super
-    @hash[:title] = nil
+    @hash[:display_name] = nil
     @hash[:description] = nil
     @hash[:sublevels] = []
     @i18n_strings = Hash.new({})
@@ -11,7 +11,7 @@ class BubbleChoiceDSL < BaseDSL
     {name: @name, properties: @hash}
   end
 
-  def title(text) @hash[:title] = text end
+  def display_name(text) @hash[:display_name] = text end
 
   def description(text) @hash[:description] = text end
 
@@ -34,7 +34,7 @@ class BubbleChoiceDSL < BaseDSL
   end
 
   def i18n_strings
-    @i18n_strings['title'] = @hash[:title] if @hash[:title]
+    @i18n_strings['display_name'] = @hash[:display_name] if @hash[:display_name]
     @i18n_strings['description'] = @hash[:description] if @hash[:description]
     @i18n_strings
   end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -29,14 +29,14 @@ class BubbleChoice < DSLDefined
   include SerializedProperties
 
   serialized_attrs %w(
-    title
+    display_name
     description
   )
 
   def dsl_default
     <<ruby
 name 'unique level name here'
-title 'level title here'
+display_name 'level display_name here'
 description 'level description here'
 
 sublevels
@@ -62,7 +62,7 @@ ruby
   # @return [Hash]
   def summarize(script_level: nil, user_id: nil)
     summary = {
-      title: title,
+      display_name: display_name,
       description: description,
       sublevels: summarize_sublevels(script_level: script_level, user_id: user_id)
     }
@@ -93,7 +93,7 @@ ruby
     sublevels.each_with_index do |level, index|
       level_info = {
         id: level.id,
-        title: level.display_name || level.name,
+        display_name: level.display_name || level.name,
         description: level.try(:bubble_choice_description),
         thumbnail_url: level.try(:thumbnail_url)
       }

--- a/dashboard/config/scripts/csd_u3_drawing_challenges.bubble_choice
+++ b/dashboard/config/scripts/csd_u3_drawing_challenges.bubble_choice
@@ -1,5 +1,5 @@
 name 'CSD U3 drawing challenges'
-title 'Drawing Challenges'
+display_name 'Drawing Challenges'
 description 'Try out some challenges!'
 
 sublevels

--- a/dashboard/config/scripts/csd_u3_drawing_practice_choice.bubble_choice
+++ b/dashboard/config/scripts/csd_u3_drawing_practice_choice.bubble_choice
@@ -1,5 +1,5 @@
 name 'CSD U3 drawing practice choice'
-title 'Practice'
+display_name 'Practice'
 description 'Do lots of practice!'
 
 sublevels

--- a/dashboard/config/scripts/csd_web_headings_challenge.bubble_choice
+++ b/dashboard/config/scripts/csd_web_headings_challenge.bubble_choice
@@ -1,5 +1,5 @@
 name 'CSD Web Headings challenge'
-title 'HTML Headings'
+display_name 'HTML Headings'
 description 'Here are some extra HTML codes to try out, and a Free Play area to use them in.'
 
 sublevels

--- a/dashboard/config/scripts/csd_web_headings_practice.bubble_choice
+++ b/dashboard/config/scripts/csd_web_headings_practice.bubble_choice
@@ -1,5 +1,5 @@
 name 'CSD Web Headings practice'
-title 'HTML Headings'
+display_name 'HTML Headings'
 description 'Try out what you\'ve learned on one or more of the following activities.'
 
 sublevels

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -855,13 +855,13 @@ FactoryGirl.define do
   factory :bubble_choice_level, class: BubbleChoice do
     game {create(:game, app: "bubble_choice")}
     name 'name'
-    title 'title'
+    display_name 'display_name'
     transient do
       sublevels []
     end
     properties do
       {
-        title: title,
+        display_name: display_name,
         sublevels: sublevels.pluck(:name)
       }
     end

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -11,7 +11,7 @@ class BubbleChoiceTest < ActiveSupport::TestCase
     @sublevel1 = create :level, name: 'choice_1', display_name: 'Choice 1!', thumbnail_url: 'some-fake.url/kittens.png', bubble_choice_description: 'Choose me!'
     @sublevel2 = create :level, name: 'choice_2'
     sublevels = [@sublevel1, @sublevel2]
-    @bubble_choice = create :bubble_choice_level, name: 'bubble_choices', title: 'Bubble Choices', description: 'Choose one or more!', sublevels: sublevels
+    @bubble_choice = create :bubble_choice_level, name: 'bubble_choices', display_name: 'Bubble Choices', description: 'Choose one or more!', sublevels: sublevels
     @script_level = create :script_level, levels: [@bubble_choice]
   end
 
@@ -20,7 +20,7 @@ class BubbleChoiceTest < ActiveSupport::TestCase
 
     input_dsl = <<DSL
 name 'bubble choice 1'
-title 'Choose a Bubble'
+display_name 'Choose a Bubble'
 description 'Choose the level you want to complete.'
 
 sublevels
@@ -29,7 +29,7 @@ DSL
 
     level = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice 1', dsl_text: input_dsl})
     assert_equal 'bubble choice 1', level.name
-    assert_equal 'Choose a Bubble', level.title
+    assert_equal 'Choose a Bubble', level.display_name
     assert_equal 'Choose the level you want to complete.', level.description
     assert_equal [sublevel], level.sublevels
   end
@@ -86,7 +86,7 @@ DSL
   test 'summarize' do
     summary = @bubble_choice.summarize
     expected_summary = {
-      title: @bubble_choice.title,
+      display_name: @bubble_choice.display_name,
       description: @bubble_choice.description,
       sublevels: @bubble_choice.summarize_sublevels
     }
@@ -115,14 +115,14 @@ DSL
     expected_summary = [
       {
         id: @sublevel1.id,
-        title: @sublevel1.display_name,
+        display_name: @sublevel1.display_name,
         description: @sublevel1.bubble_choice_description,
         thumbnail_url: @sublevel1.thumbnail_url,
         url: level_url(@sublevel1.id)
       },
       {
         id: @sublevel2.id,
-        title: @sublevel2.name,
+        display_name: @sublevel2.name,
         description: @sublevel2.bubble_choice_description,
         thumbnail_url: nil,
         url: level_url(@sublevel2.id)


### PR DESCRIPTION
[LP-574](https://codedotorg.atlassian.net/browse/LP-574)

In most places, we refer to a level by its `display_name`, so this PR updates BubbleChoice levels to have a `display_name` instead of a `title` for consistency