### PR TITLE
Feedback: add script_level_id to teacher_feedbacks

### DIFF
--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -14,6 +14,7 @@
 #  student_visit_count      :integer
 #  student_first_visited_at :datetime
 #  student_last_visited_at  :datetime
+#  script_level_id          :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20190710165640_add_script_leve_l_id_to_teacher_feedbacks.rb
+++ b/dashboard/db/migrate/20190710165640_add_script_leve_l_id_to_teacher_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddScriptLeveLIdToTeacherFeedbacks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :teacher_feedbacks, :script_level_id, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190618213451) do
+ActiveRecord::Schema.define(version: 20190710165640) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1406,6 +1406,7 @@ ActiveRecord::Schema.define(version: 20190618213451) do
     t.integer  "student_visit_count"
     t.datetime "student_first_visited_at"
     t.datetime "student_last_visited_at"
+    t.integer  "script_level_id"
     t.index ["student_id", "level_id", "teacher_id"], name: "index_feedback_on_student_and_level_and_teacher_id", using: :btree
     t.index ["student_id", "level_id"], name: "index_feedback_on_student_and_level", using: :btree
   end


### PR DESCRIPTION
`TeacherFeedback` is currently associated with `Level` instead of `ScriptLevel`.  When notifying students about teacher feedback ([spec](https://docs.google.com/document/d/1anY8vf8KKSGP_p88KAmUlTR3HVtMkoEQ9XGcUKynnmQ/edit?ts=5cc9c2de#)), I need to pull information about the level (lesson name, level number, course and unit name) to share with the student.  Most of that information actually lives on the `ScriptLevel` and can't be accurately inferred with just a level_id (See https://github.com/code-dot-org/code-dot-org/pull/29530#discussion_r301219498 for details). 

Here I'm adding a migration to include script_level_id as a field on the teacher_feedback model. In upcoming work, I'll start writing to this field for new teacher feedback and backfill this field based on level_id when we can (i.e. when we only have one script_level associated with the level_id, then using progress and assignment). Eventually, the plan is to remove level_id in favor of script_level_id. 