### PR TITLE
Create edge sprites when needed

### DIFF
--- a/apps/src/gamelab/spritelab/actionCommands.js
+++ b/apps/src/gamelab/spritelab/actionCommands.js
@@ -26,10 +26,16 @@ export const commands = {
     });
   },
   edgesDisplace(spriteId) {
+    if (!this.edges) {
+      this.createEdgeSprites();
+    }
     let sprites = spriteUtils.getSpriteArray(spriteId);
     sprites.forEach(sprite => this.edges.displace(sprite));
   },
   isTouchingEdges(spriteId) {
+    if (!this.edges) {
+      this.createEdgeSprites();
+    }
     let sprites = spriteUtils.getSpriteArray(spriteId);
     let touching = false;
     sprites.forEach(sprite => {

--- a/apps/src/gamelab/spritelab/commands.js
+++ b/apps/src/gamelab/spritelab/commands.js
@@ -30,7 +30,6 @@ function updateTitle() {
 
 export const commands = {
   executeDrawLoopAndCallbacks() {
-    this.createEdgeSprites();
     drawBackground.apply(this);
     spriteUtils.runBehaviors();
     spriteUtils.runEvents(this);


### PR DESCRIPTION
Ensure that edge sprites exist when they are needed. Fixes a bug where isTouchingEdges and edgesDisplace blocks broke preview because edge sprites were not created in time for preview