### PR TITLE
Added new allowed hostnames for startWebRequest

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -60,6 +60,7 @@ class XhrProxyController < ApplicationController
     hamlin.myschoolapp.com
     herokuapp.com
     hubblesite.org
+    images-api.nasa.gov
     isenseproject.org
     lakeside-cs.org
     qrng.anu.edu.au
@@ -73,6 +74,7 @@ class XhrProxyController < ApplicationController
     nuevaschool3.ngrok.io
     numbersapi.com
     random.org
+    restcountries.eu
     rhcloud.com
     runescape.com
     samples.openweathermap.org


### PR DESCRIPTION
Request: https://codeorg.zendesk.com/agent/filters/301129028

images-api.nasa.gov is documented here: https://images.nasa.gov/docs/images.nasa.gov_api_docs.pdf
restcountries returns information about different countries such as currency, language, capital city, etc.