### PR TITLE
Surveys: Redirect to JotForm forms instead of embedding them (experiment)

### DIFF
--- a/dashboard/app/controllers/pd/misc_survey_controller.rb
+++ b/dashboard/app/controllers/pd/misc_survey_controller.rb
@@ -36,6 +36,8 @@ module Pd
         submitRedirect: url_for(action: 'submit', params: {key: key_params})
       )
 
+      return if experimental_redirect! @form_id, @form_params
+
       if CDO.newrelic_logging
         NewRelic::Agent.record_custom_event(
           "RenderJotFormView",

--- a/dashboard/app/controllers/pd/post_course_survey_controller.rb
+++ b/dashboard/app/controllers/pd/post_course_survey_controller.rb
@@ -30,6 +30,8 @@ module Pd
         submitRedirect: url_for(action: 'submit', params: {key: key_params})
       )
 
+      return if experimental_redirect! @form_id, @form_params
+
       if CDO.newrelic_logging
         NewRelic::Agent.record_custom_event(
           "RenderJotFormView",

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -70,6 +70,8 @@ module Pd
         submitRedirect: url_for(action: 'submit_general', params: {key: key_params})
       )
 
+      return if experimental_redirect! @form_id, @form_params
+
       if CDO.newrelic_logging
         NewRelic::Agent.record_custom_event(
           "RenderJotFormView",
@@ -153,6 +155,8 @@ module Pd
         submitRedirect: url_for(action: 'submit_facilitator', params: {key: key_params})
       )
 
+      return if experimental_redirect! @form_id, @form_params
+
       if CDO.newrelic_logging
         NewRelic::Agent.record_custom_event(
           "RenderJotFormView",
@@ -220,6 +224,8 @@ module Pd
         regionalPartnerName: workshop.regional_partner&.name,
         submitRedirect: url_for(action: 'submit_general', params: {key: key_params})
       )
+
+      return if experimental_redirect! @form_id, @form_params
 
       # Same view as the general daily survey
       render :new_general
@@ -351,6 +357,7 @@ module Pd
       )
 
       return redirect_general(key_params) if response_exists_general?(key_params)
+      return if experimental_redirect! @form_id, @form_params
 
       if CDO.newrelic_logging
         NewRelic::Agent.record_custom_event(

--- a/dashboard/app/helpers/pd/jot_form/embed_helper.rb
+++ b/dashboard/app/helpers/pd/jot_form/embed_helper.rb
@@ -5,7 +5,11 @@ module Pd
       # @param form_id [Integer]
       # @param params [Hash] parameters to pass to the form, shaped {question_name => initial value}
       def jotform_iframe(form_id, params)
-        content_tag :iframe, nil, id: "JotFormIFrame-#{form_id}", onload: "window.parent.scrollTo(0,0)", allowtransparency: "true", allowfullscreen: "true", allow: "geolocation; microphone; camera", src: "https://form.jotform.com/#{form_id}?#{format_url_params(params)}", frameborder: "0", style: "width: 1px; min-width: 100%; height:539px; border:none;", scrolling: "no"
+        content_tag :iframe, nil, id: "JotFormIFrame-#{form_id}", onload: "window.parent.scrollTo(0,0)", allowtransparency: "true", allowfullscreen: "true", allow: "geolocation; microphone; camera", src: jotform_form_url(form_id, params), frameborder: "0", style: "width: 1px; min-width: 100%; height:539px; border:none;", scrolling: "no"
+      end
+
+      def jotform_form_url(form_id, params)
+        "https://form.jotform.com/#{form_id}?#{format_url_params(params)}"
       end
 
       def format_url_params(hash)

--- a/dashboard/app/helpers/pd/jot_form/embed_helper.rb
+++ b/dashboard/app/helpers/pd/jot_form/embed_helper.rb
@@ -12,6 +12,12 @@ module Pd
         "https://form.jotform.com/#{form_id}?#{format_url_params(params)}"
       end
 
+      def experimental_redirect!(form_id, params)
+        DCDO.get('jotform_redirect', false).tap do |experiment_enabled|
+          redirect_to jotform_form_url form_id, params if experiment_enabled
+        end
+      end
+
       def format_url_params(hash)
         hash.map do |key, value|
           [

--- a/dashboard/app/helpers/pd/jot_form/embed_helper.rb
+++ b/dashboard/app/helpers/pd/jot_form/embed_helper.rb
@@ -12,6 +12,11 @@ module Pd
         "https://form.jotform.com/#{form_id}?#{format_url_params(params)}"
       end
 
+      # If the DCDO setting 'jotform_redirect' is enabled,
+      # this method causes the server to respond with a 302,
+      # redirecting the browser to the JotForm form URL (instead of following our usual flow,
+      # embedding the form within our own chrome).
+      # @return [Boolean] whether the experiment is enabled and a redirect occurred
       def experimental_redirect!(form_id, params)
         DCDO.get('jotform_redirect', false).tap do |experiment_enabled|
           redirect_to jotform_form_url form_id, params if experiment_enabled


### PR DESCRIPTION
[PLC-347](https://codedotorg.atlassian.net/browse/PLC-347) Introduces a DCDO setting `jotform_redirect` that causes our survey URLs to redirect the user's browser directly to JotForm to take their survey, instead of rendering the survey embedded on our own domain in our own chrome.

- Before: Teacher clicks a Code.org survey link, takes the survey(s) embedded on Code.org, ends up on a Code.org thank-you page.
- After: Teacher clicks a Code.org survey link, takes the survey(s) on jotform.com, ends up on a Code.org thank-you page.

I'm proposing this change as a quick stopgap measure while we evaluate other options for improving the reliability of our surveys.

Here's what the new experience looks like, using our `Pd::MiscSurvey` controller:

![Peek 2019-07-10 15-06](https://user-images.githubusercontent.com/1615761/61008785-6bd8d280-a325-11e9-9381-77c5bd5f04d5.gif)

I believe this will address some subset of the load and submit issues we've seen with our JotForm surveys, specifically anything caused by cross-origin content restrictions or bad interactions between scripts loaded on the two domains.

Notably, while working on this feature I repro'd one of the submission failure modes we've had reported in the wild, a cross-origin navigation error caused when the 302 our `submit` action returns is interpreted as the jotform.com frame trying to cause its parent (on studio.code.org) to navigate.

![image](https://user-images.githubusercontent.com/1615761/61009166-a1ca8680-a326-11e9-8144-19a703220f9b.png)

The experiment solves this case, as expected.

**Pros**

- Fixes at least one known issue.
- Likely to fix more; we suspect this approach is closer to how JotForm intended that their product be used, and therefore will be better supported.
- Minimal change to the user flow: Click a link, take one or more surveys as if they were one, end up back on Code.org.
- Low-cost: This was easy to write.  If we go with this approach permanently, we'll actually end up with _less_ code.
- Hot-swappable: As a DCDO setting, we can change from embed mode to redirect mode and back without a deploy.
- More debuggable:
  - When something does go wrong (say, a 404) we'll see useful URLs in screenshots.
  - Browsers have better default failure messages when it's the top-level page failing, not an iframe request.
  - This change helps isolate which problems are on our side and which are on JotForm's side.

**Cons**

- Won't solve all of our survey problems.
  - Districts that have JotForm blocked will still be blocked - though hopefully in a more obvious way.
  - Other JotForm reliability issues are not addressed by this change.
- Users leave Code.org.  This means they lose our chrome while taking the survey. They don't have access to any of our navigation if they decide to leave early or something goes wrong - they'll have to rely on their browser history for that.
- No monitoring of survey load failure rates; we're handing control of the actual survey page over to JotForm entirely, so we can't attach metrics to it that they don't provide.
- Makes an existing minor security issue easier to abuse.
  The autofill fields we pass to JotForm can be manipulated by the client and are not validated on submit.  With this change, these params appear in the browser's address bar, making it more obvious that they could be changed. We have a plan to fix this (ask for details).

## Technical details

Here's the sequence of requests under the experiment:

![image](https://user-images.githubusercontent.com/1615761/61009094-616b0880-a326-11e9-8bca-bc48e7eacdf1.png)

- The user visits a Code.org survey URL, either via navigation on our site, an email we sent them, typing it into the URL bar, etc.
- Code.org sends back a redirect to the correct JotForm page with appropriate parameters autofilled.
- The user takes the survey.
- The user clicks submit, which performs a POST to submit.jotform.us.
- After the last POST finishes, JotForm also POSTs to a Code.org-provided submit redirect URL, which happens to be our submit action (which saves a placeholder).
- Our submit action sends back a redirect to our thank-you page, or the next survey URL, as appropriate.
- User ends up on the thank-you page.

I'm intentionally _not_ sending New Relic logging for visits to survey URLs while the experiment is enabled.  We've been using these metrics to determine load failure rates for embedded forms, and sending render event metrics when we've done a redirect would mess up that failure rate calculation.