### PR TITLE
Revert "Create edge sprites when needed"

### DIFF
--- a/apps/src/gamelab/spritelab/actionCommands.js
+++ b/apps/src/gamelab/spritelab/actionCommands.js
@@ -26,16 +26,10 @@ export const commands = {
     });
   },
   edgesDisplace(spriteId) {
-    if (!this.edges) {
-      this.createEdgeSprites();
-    }
     let sprites = spriteUtils.getSpriteArray(spriteId);
     sprites.forEach(sprite => this.edges.displace(sprite));
   },
   isTouchingEdges(spriteId) {
-    if (!this.edges) {
-      this.createEdgeSprites();
-    }
     let sprites = spriteUtils.getSpriteArray(spriteId);
     let touching = false;
     sprites.forEach(sprite => {

--- a/apps/src/gamelab/spritelab/commands.js
+++ b/apps/src/gamelab/spritelab/commands.js
@@ -30,6 +30,7 @@ function updateTitle() {
 
 export const commands = {
   executeDrawLoopAndCallbacks() {
+    this.createEdgeSprites();
     drawBackground.apply(this);
     spriteUtils.runBehaviors();
     spriteUtils.runEvents(this);


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#29598. My fault for suggesting we skip Drone on this one.

Sample UI test failure:
https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_spritelab_spritelab_output.html?versionId=r4mYAXnLuP6UFVffoPJK95B159Ib.1HB
https://app.saucelabs.com/tests/2cc18b3da75440f9a16259dcb1825a82