### PR TITLE
createEdgeSprites as needed, fix validation

### DIFF
--- a/apps/src/gamelab/spritelab/actionCommands.js
+++ b/apps/src/gamelab/spritelab/actionCommands.js
@@ -26,10 +26,16 @@ export const commands = {
     });
   },
   edgesDisplace(spriteId) {
+    if (!this.edges) {
+      this.createEdgeSprites();
+    }
     let sprites = spriteUtils.getSpriteArray(spriteId);
     sprites.forEach(sprite => this.edges.displace(sprite));
   },
   isTouchingEdges(spriteId) {
+    if (!this.edges) {
+      this.createEdgeSprites();
+    }
     let sprites = spriteUtils.getSpriteArray(spriteId);
     let touching = false;
     sprites.forEach(sprite => {

--- a/apps/src/gamelab/spritelab/commands.js
+++ b/apps/src/gamelab/spritelab/commands.js
@@ -30,7 +30,6 @@ function updateTitle() {
 
 export const commands = {
   executeDrawLoopAndCallbacks() {
-    this.createEdgeSprites();
     drawBackground.apply(this);
     spriteUtils.runBehaviors();
     spriteUtils.runEvents(this);

--- a/dashboard/config/scripts/levels/allthethings_fish_tank.level
+++ b/dashboard/config/scripts/levels/allthethings_fish_tank.level
@@ -46,7 +46,7 @@
     "parent_level_id": 12950,
     "auto_run_setup": "DRAW_LOOP",
     "show_type_hints": "true",
-    "validation_code": "if (World.frameCount > 50) {\r\n  var status = 0;\r\n  \r\n  // Check through all sprites in case student changed the sprite name\r\n  for (var i=0; i<World.allSprites.length; i++) {\r\n    var sprite = World.allSprites[i];\r\n    // ignore edge sprites\r\n    if (!edges.contains(sprite)) {\r\n      if (sprite.getAnimationLabel() == \"tumbleweed\") {\r\n        status = 3;\r\n      }\r\n    }\r\n  }\r\n  levelSuccess(status);\r\n}",
+    "validation_code": "if (World.frameCount > 50) {\r\n  var status = 0;\r\n  var animations = getAnimationsInUse();\r\n  for (var i = 0; i < animations.length; i++) {\r\n    if (animations[i] == \"tumbleweed\") {\r\n      status = 3;\r\n    }\r\n  }\r\n  levelSuccess(status);\r\n}",
     "include_shared_functions": "false",
     "long_instructions": "All-the-things test level.",
     "block_pool": "gamelab",


### PR DESCRIPTION
Restores #29598 which was reverted by #29604 
Ensure that edge sprites exist when they are needed. Fixes a bug where isTouchingEdges and edgesDisplace blocks broke preview because edge sprites were not created in time for preview
UI test failure was caused by validation code for the allthethings not being updated when sprite lab moved to native, so it was accessing sprites directly from `World.allSprites` and inspecting `edges` directly, not using the validation commands.