### PR TITLE
hide stage lock message from teachers when lockable stages are readonly

### DIFF
--- a/apps/src/code-studio/components/TeacherContentToggle.js
+++ b/apps/src/code-studio/components/TeacherContentToggle.js
@@ -85,16 +85,16 @@ class TeacherContentToggle extends React.Component {
       if (!hiddenStagesInitialized || !sectionsAreLoaded || hasOverlayFrame) {
         contentStyle.visibility = 'hidden';
       }
+    }
 
-      // In the case where isBlocklyOrDroplet is true, we don't want to actually set
-      // display none, as that causes the editor (be it blockly or droplet) to
-      // misrender. We can get away with just setting visibilityhidden because the editor
-      // is rendered to an absolute position and doesnt affect the layout of this
-      // component. For cases where we don't have an IDE (i.e. multi/match) we
-      // need to set display:none such that it doesnt affect our layout
-      if (hasOverlayFrame && !isBlocklyOrDroplet) {
-        contentStyle.display = 'none';
-      }
+    // In the case where isBlocklyOrDroplet is true, we don't want to actually set
+    // display none, as that causes the editor (be it blockly or droplet) to
+    // misrender. We can get away with just setting visibilityhidden because the editor
+    // is rendered to an absolute position and doesnt affect the layout of this
+    // component. For cases where we don't have an IDE (i.e. multi/match) we
+    // need to set display:none such that it doesnt affect our layout
+    if (hasOverlayFrame && !isBlocklyOrDroplet) {
+      contentStyle.display = 'none';
     }
 
     const showLockedStageMessage = isLockedStage && !isHiddenStage;

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -33,7 +33,7 @@ import {
   getLevelResult
 } from './progressRedux';
 import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
-import {renderTeacherPanel} from './teacherPanelHelpers';
+import {queryLockStatus, renderTeacherPanel} from './teacherPanelHelpers';
 import experiments from '../util/experiments';
 
 var progress = module.exports;
@@ -278,6 +278,7 @@ function queryUserProgress(store, scriptData, currentLevelId) {
       }
 
       store.dispatch(showTeacherInfo());
+      queryLockStatus(store, scriptData.id);
 
       renderTeacherPanel(
         store,

--- a/apps/src/code-studio/teacherPanelHelpers.js
+++ b/apps/src/code-studio/teacherPanelHelpers.js
@@ -26,7 +26,6 @@ export function renderTeacherPanel(
 ) {
   const div = document.createElement('div');
   div.setAttribute('id', 'teacher-panel-container');
-  queryLockStatus(store, scriptId);
 
   if (section && section.students) {
     store.dispatch(setStudentsForCurrentSection(section.id, section.students));

--- a/apps/src/code-studio/verifiedTeacherRedux.js
+++ b/apps/src/code-studio/verifiedTeacherRedux.js
@@ -1,7 +1,7 @@
 const SET_VERIFIED = 'verifiedTeacher/SET_VERIFIED';
 const SET_VERIFIED_RESOURCES = 'verifiedTeacher/SET_VERIFIED_RESOURCES';
 
-export const setVerified = isVerified => ({type: SET_VERIFIED});
+export const setVerified = () => ({type: SET_VERIFIED});
 export const setVerifiedResources = hasVerifiedResources => ({
   type: SET_VERIFIED_RESOURCES
 });
@@ -16,6 +16,7 @@ const initialState = {
 
 export default function verifiedTeacher(state = initialState, action) {
   if (action.type === SET_VERIFIED) {
+    console.log('SET_VERIFIED');
     return {
       ...state,
       isVerified: true

--- a/apps/src/code-studio/verifiedTeacherRedux.js
+++ b/apps/src/code-studio/verifiedTeacherRedux.js
@@ -16,7 +16,6 @@ const initialState = {
 
 export default function verifiedTeacher(state = initialState, action) {
   if (action.type === SET_VERIFIED) {
-    console.log('SET_VERIFIED');
     return {
       ...state,
       isVerified: true

--- a/apps/src/sites/studio/pages/levels/_teacher_panel.js
+++ b/apps/src/sites/studio/pages/levels/_teacher_panel.js
@@ -13,6 +13,7 @@ import {
   renderTeacherPanel,
   queryLockStatus
 } from '@cdo/apps/code-studio/teacherPanelHelpers';
+import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 
 $(document).ready(initPage);
 
@@ -25,6 +26,9 @@ function initPage() {
   initViewAs(store);
   queryLockStatus(store, teacherPanelData.script_id);
   store.dispatch(getHiddenStages(teacherPanelData.script_name, false));
+  if (teacherPanelData.is_verified_teacher) {
+    store.dispatch(setVerified());
+  }
   // Stage Extras fail to load with this
   if (!teacherPanelData.stage_extra) {
     renderTeacherContentToggle(store);

--- a/apps/test/unit/code-studio/TeacherContentToggleTest.js
+++ b/apps/test/unit/code-studio/TeacherContentToggleTest.js
@@ -100,6 +100,58 @@ describe('TeacherContentToggle', () => {
     assert.equal(hiddenStageElement.style.display, 'none');
   });
 
+  it('shows content after async calls when Teacher is authorized', () => {
+    const component = mount(
+      <TeacherContentToggle
+        isBlocklyOrDroplet={false}
+        viewAs="Teacher"
+        hiddenStagesInitialized={true}
+        sectionsAreLoaded={true}
+        isHiddenStage={false}
+        isLockedStage={false}
+      />,
+      {attachTo: renderElement}
+    );
+
+    const root = $(component.html());
+    const [
+      contentElement,
+      lockedStageElement,
+      hiddenStageElement
+    ] = root.children().toArray();
+
+    assert.equal(contentElement.style.display, '');
+    assert.equal(contentElement.style.visibility, '');
+    assert.equal(lockedStageElement.style.display, 'none');
+    assert.equal(hiddenStageElement.style.display, 'none');
+  });
+
+  it('shows lock message after async calls when Teacher is unauthorized', () => {
+    const component = mount(
+      <TeacherContentToggle
+        isBlocklyOrDroplet={false}
+        viewAs="Teacher"
+        hiddenStagesInitialized={true}
+        sectionsAreLoaded={true}
+        isHiddenStage={false}
+        isLockedStage={true}
+      />,
+      {attachTo: renderElement}
+    );
+
+    const root = $(component.html());
+    const [
+      contentElement,
+      lockedStageElement,
+      hiddenStageElement
+    ] = root.children().toArray();
+
+    assert.equal(contentElement.style.display, 'none');
+    assert.equal(contentElement.style.visibility, '');
+    assert.equal(lockedStageElement.style.display, '');
+    assert.equal(hiddenStageElement.style.display, 'none');
+  });
+
   it('does not initially show anything when viewAs Student', () => {
     const component = mount(
       <TeacherContentToggle

--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -3,6 +3,7 @@
 - data[:script_id] = @script.id
 - data[:section] = @section&.summarize
 - data[:stage_extra] = @stage_extras
+- data[:is_verified_teacher] = @current_user.authorized_teacher?
 
 - if @stage_extras
   - data[:teacher_level] = ScriptLevel.summarize_as_bonus_for_teacher_panel(@stage.script, @bonus_level_ids, @current_user)


### PR DESCRIPTION
Fixes https://codedotorg.atlassian.net/browse/LP-546

also does a bit of incidental cleanup in 63ca89e and 1063ced

#### before

any teacher viewing a lockable stage would see both the level content and the stage lock message:

<img width="1543" alt="Screen Shot 2019-06-20 at 4 22 20 PM (1)" src="https://user-images.githubusercontent.com/8001765/61102445-a70cfb80-a422-11e9-9133-316915c17065.png">

#### after

verified teachers always see lockable stage level content. unverified teachers always see just the stage lock message.