### PR TITLE
Feedback: add seen_on_feedback_page_at to teacher_feedbacks

### DIFF
--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -15,6 +15,8 @@
 #  student_first_visited_at :datetime
 #  student_last_visited_at  :datetime
 #  script_level_id          :integer
+#  seen                     :boolean          default(FALSE)
+#  seen_at                  :datetime
 #
 # Indexes
 #

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -15,8 +15,7 @@
 #  student_first_visited_at :datetime
 #  student_last_visited_at  :datetime
 #  script_level_id          :integer
-#  seen                     :boolean          default(FALSE)
-#  seen_at                  :datetime
+#  seen_on_feedback_page_at :datetime
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20190711180756_add_seen_to_teacher_feedbacks.rb
+++ b/dashboard/db/migrate/20190711180756_add_seen_to_teacher_feedbacks.rb
@@ -1,0 +1,6 @@
+class AddSeenToTeacherFeedbacks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :teacher_feedbacks, :seen, :boolean, default: false
+    add_column :teacher_feedbacks, :seen_at, :datetime
+  end
+end

--- a/dashboard/db/migrate/20190711180756_add_seen_to_teacher_feedbacks.rb
+++ b/dashboard/db/migrate/20190711180756_add_seen_to_teacher_feedbacks.rb
@@ -1,6 +1,0 @@
-class AddSeenToTeacherFeedbacks < ActiveRecord::Migration[5.0]
-  def change
-    add_column :teacher_feedbacks, :seen, :boolean, default: false
-    add_column :teacher_feedbacks, :seen_at, :datetime
-  end
-end

--- a/dashboard/db/migrate/20190711190421_add_seen_at_to_teacher_feedbacks.rb
+++ b/dashboard/db/migrate/20190711190421_add_seen_at_to_teacher_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddSeenAtToTeacherFeedbacks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :teacher_feedbacks, :seen_on_feedback_page_at, :datetime
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190711180756) do
+ActiveRecord::Schema.define(version: 20190711190421) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1399,16 +1399,15 @@ ActiveRecord::Schema.define(version: 20190711180756) do
     t.integer  "student_id"
     t.integer  "level_id"
     t.integer  "teacher_id"
-    t.datetime "created_at",                                             null: false
-    t.datetime "updated_at",                                             null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.datetime "deleted_at"
     t.string   "performance"
     t.integer  "student_visit_count"
     t.datetime "student_first_visited_at"
     t.datetime "student_last_visited_at"
     t.integer  "script_level_id"
-    t.boolean  "seen",                                   default: false
-    t.datetime "seen_at"
+    t.datetime "seen_on_feedback_page_at"
     t.index ["student_id", "level_id", "teacher_id"], name: "index_feedback_on_student_and_level_and_teacher_id", using: :btree
     t.index ["student_id", "level_id"], name: "index_feedback_on_student_and_level", using: :btree
   end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190710165640) do
+ActiveRecord::Schema.define(version: 20190711180756) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1399,14 +1399,16 @@ ActiveRecord::Schema.define(version: 20190710165640) do
     t.integer  "student_id"
     t.integer  "level_id"
     t.integer  "teacher_id"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.datetime "created_at",                                             null: false
+    t.datetime "updated_at",                                             null: false
     t.datetime "deleted_at"
     t.string   "performance"
     t.integer  "student_visit_count"
     t.datetime "student_first_visited_at"
     t.datetime "student_last_visited_at"
     t.integer  "script_level_id"
+    t.boolean  "seen",                                   default: false
+    t.datetime "seen_at"
     t.index ["student_id", "level_id", "teacher_id"], name: "index_feedback_on_student_and_level_and_teacher_id", using: :btree
     t.index ["student_id", "level_id"], name: "index_feedback_on_student_and_level", using: :btree
   end


### PR DESCRIPTION
More migrations! 

[LP-516](https://codedotorg.atlassian.net/browse/LP-516)

We'd like to track whether feedback has been seen by a student so that we can update the `LevelFeedbackEntry` on the feedback overview page to the "seen" styles and to update (or hide) the notification we show students alerting them to how many levels they have unread feedback on. 

Currently we track whether a student has seen feedback on the level with the `student_first_visited_at` field. Here, I'm adding a `seen_on_feedback_page_at` field to track if the student has viewed the feedback on the feedback overview page. We can use `student_first_visited_at` to essentially mean `seen_on_level_at`. 

The feedback will be considered "seen" for the purpose of updating the UI and the notification if either `student_first_visited_at` or `seen_on_feedback_page_at` is not null. 

This set up will also allow us to track metrics of whether students are: 
- not viewing their feedback 
`seen_on_feeback_page` and `student_first_visited_at` both null
- viewing their feedback only on the level 
`seen_on_feeback_page` is null and `student_first_visited_at` is set
- viewing their feedback only on the feedback page
 `seen_on_feeback_page` is set and `student_first_visited_at` is null
- viewing their feedback on both the feedback page and the level 
`seen_on_feeback_page` is set and `student_first_visited_at` is set
