### PR TITLE
Remove the "make sure we're on staging" check from the I18n sync

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -11,13 +11,6 @@ function cp_in() {
   cp $1 $2
 }
 
-# make sure we're on staging
-branch=$(git branch | sed -n '/\* /s///p')
-if [ "$branch" != "staging" ]; then
-  echo "Must run from staging branch"
-  exit
-fi
-
 ### Dashboard
 
 orig_dir=dashboard/config/locales


### PR DESCRIPTION
Before, it was annoying to keep around but at least made some sense
since the branch you were on was directly related to the content you
were going to sync.

Now that we treat the database as the source of truth for a lot of our
content, rather than just the files, this is no longer nearly as
relevant as it used to be while still being just as annoying. So let's
get rid of it.