### PR TITLE
Display levelbuilder links to script_levels for BubbleChoice sublevels

### DIFF
--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -54,6 +54,14 @@ ruby
     sublevels[index]
   end
 
+  # Returns a sublevel's position in the parent level. Can be used for generating
+  # a sublevel URL (/s/:script_name/stage/:stage_pos/puzzle/:puzzle_pos/sublevel/:sublevel_pos).
+  # @param [Level] sublevel
+  # @return [Integer] The sublevel's position (i.e., its index + 1) under the parent level.
+  def sublevel_position(sublevel)
+    sublevels.index(sublevel) + 1
+  end
+
   # Summarizes the level.
   # @param [ScriptLevel] script_level. Optional. If provided, the URLs for sublevels,
   # previous/next levels, and script will be included in the summary.

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -119,4 +119,11 @@ ruby
     ul = user.user_levels.where(level: sublevels).max_by(&:best_result)
     ul&.level
   end
+
+  # Returns an array of BubbleChoice parent levels for any given sublevel name.
+  # @param [String] level_name. The name of the sublevel.
+  # @return [Array<BubbleChoice>] The BubbleChoice parent level(s) of the given sublevel.
+  def self.parent_levels(level_name)
+    where("properties -> '$.sublevels' LIKE ?", "%\"#{level_name}\"%")
+  end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -59,7 +59,8 @@ ruby
   # @param [Level] sublevel
   # @return [Integer] The sublevel's position (i.e., its index + 1) under the parent level.
   def sublevel_position(sublevel)
-    sublevels.index(sublevel) + 1
+    i = sublevels.index(sublevel)
+    i.present? ? i + 1 : nil
   end
 
   # Summarizes the level.

--- a/dashboard/app/views/levels/_form.html.haml
+++ b/dashboard/app/views/levels/_form.html.haml
@@ -57,6 +57,12 @@
       - @level.script_levels.each do |script_level|
         %li
           = f.submit build_script_level_path(script_level), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
+      - BubbleChoice.parent_levels(@level.name).each do |parent_level|
+        - parent_level.script_levels.each do |script_level|
+          %li
+            - position = parent_level.sublevel_position(@level)
+            = f.submit build_script_level_path(script_level, sublevel_position: position), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
+
 %pre#validation-error.validation-error{style: 'background-color: yellow; display: none'}
 :javascript
   window.levelbuilder.ajaxSubmit("#{@level.new_record? ? '#new_level' : '.edit_level'}");

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -155,4 +155,23 @@ DSL
 
     assert_equal @sublevel2, @bubble_choice.best_result_sublevel(student)
   end
+
+  test 'self.parent_levels returns BubbleChoice parent levels for given sublevel name' do
+    sublevel1 = create :level, name: 'sublevel_1'
+    sublevel2 = create :level, name: 'sublevel_2'
+    parent1 = create :bubble_choice_level, name: 'parent_1', sublevels: [sublevel1, sublevel2]
+    parent2 = create :bubble_choice_level, name: 'parent_2', sublevels: [sublevel1]
+
+    sublevel1_parents = BubbleChoice.parent_levels(sublevel1.name)
+    assert_equal 2, sublevel1_parents.length
+    assert sublevel1_parents.include?(parent1)
+    assert sublevel1_parents.include?(parent2)
+
+    assert_equal [parent1], BubbleChoice.parent_levels(sublevel2.name)
+
+    # Edge cases
+    assert_empty BubbleChoice.parent_levels("sublevel") # contained by sublevel names above
+    assert_empty BubbleChoice.parent_levels("sublevel_12") # contains sublevel name above
+    assert_empty BubbleChoice.parent_levels("nonexistent level name")
+  end
 end

--- a/dashboard/test/models/bubble_choice_test.rb
+++ b/dashboard/test/models/bubble_choice_test.rb
@@ -83,6 +83,15 @@ DSL
     assert_equal [sublevel1, sublevel2, sublevel3], level.sublevels
   end
 
+  test 'sublevel_position returns the position of a sublevel in a parent level' do
+    assert_equal 1, @bubble_choice.sublevel_position(@sublevel1)
+    assert_equal 2, @bubble_choice.sublevel_position(@sublevel2)
+  end
+
+  test 'sublevel_position returns nil for a level that is not a sublevel of the parent' do
+    assert_nil @bubble_choice.sublevel_position(create(:level))
+  end
+
   test 'summarize' do
     summary = @bubble_choice.summarize
     expected_summary = {


### PR DESCRIPTION
Partially satisfies [LP-580](https://codedotorg.atlassian.net/browse/LP-580)

Previously, when a levelbuilder edited a level that is a BubbleChoice sublevel, we were not displaying URLs to take the levelbuilder to after saving these levels. Now, we display those URLs:
<img width="419" alt="Screen Shot 2019-07-11 at 1 55 59 PM" src="https://user-images.githubusercontent.com/9812299/61085166-77d79980-a3e4-11e9-991b-9d0e719fa024.png">

In the example above, the level is the sublevel at position 1 in puzzle 9 of stage 3 of the csd3-pilot script. If the level is not a sublevel of any BubbleChoice levels, nothing will be displayed.

**Additional work:**
- Display the parent's scripts in the gray admin box when viewing a BubbleChoice sublevel