### PR TITLE
Add alarm on failed/missing invocations of offsite backup workflow [ci skip]

### DIFF
--- a/aws/offsite/aurora-snapshots-fargate/aurora-verify-backups-stack.yml
+++ b/aws/offsite/aurora-snapshots-fargate/aurora-verify-backups-stack.yml
@@ -11,6 +11,9 @@
 #         Security Groups: default security group for VPC
 #         Auto-assign Public IP: DISABLED
 # - Enable Cloudwatch Event Rule
+#
+# Requires specifying the "CAPABILITY_NAMED_IAM" cloudformation capability, and specifying parameters via environment variables
+# or locals.yml
 
 AWSTemplateFormatVersion: 2010-09-09
 Description: AWS CloudFormation template to create an Fargate cluster and task definition for running Aurora backup verification.
@@ -20,6 +23,11 @@ Parameters:
     Type: String
     Default: ""
     Description: Honeybadger API key used for reporting errors during execution of the ECS task
+    NoEcho: True
+  HoneybadgerSnsTopicArn:
+    Type: String
+    Description: SNS topic ARN created by alerting CloudFormation stack
+    NoEcho: True
 
 Resources:
   TaskRole:
@@ -139,7 +147,6 @@ Resources:
             Name: HONEYBADGER_API_KEY
             Value: !Ref HoneybadgerApiKey
 
-
   CloudwatchLogsGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -164,3 +171,41 @@ Resources:
           EcsParameters:
             TaskCount: 1
             TaskDefinitionArn: !Ref TaskDefinition
+
+  FailedInvocationsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FailedInvocations"
+      AlarmDescription: Alarms when the "once per day" cloudwatch rule fails to start a Verify Backups fargate task.
+      AlarmActions:
+        - !Ref HoneybadgerSnsTopicArn
+      Dimensions:
+        - Name: RuleName
+          Value: !Ref OncePerDayRule
+      MetricName: FailedInvocations
+      Namespace: AWS/Events
+      Statistic: Sum
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 0.0
+      Period: 300 # 5 minutes
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+
+  NoInvocationsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-NoInvocations"
+      AlarmDescription: Alarms when the "once per day" cloudwatch rule doesn't attempt to start a Verify Backups fargate task at least once per day.
+      AlarmActions:
+      - !Ref HoneybadgerSnsTopicArn
+      Dimensions:
+      - Name: RuleName
+        Value: !Ref OncePerDayRule
+      MetricName: Invocations
+      Namespace: AWS/Events
+      Statistic: Sum
+      ComparisonOperator: LessThanThreshold
+      Threshold: 1.0
+      Period: 86400 # One day
+      EvaluationPeriods: 1
+      TreatMissingData: breaching


### PR DESCRIPTION
Depends on https://github.com/code-dot-org/code-dot-org/pull/29612

This will (hopefully) alert us via honeybadger if the scheduled offsite backup verification fargate task fails to start, or doesn't even try to start (e.g. if it's disabled or misconfigured). (If the task does start successfully, then error handling code inside the task will report failures from then on to Honeybadger.)