### PR TITLE
Generalize "google_classroom_takeover" logic to work for any oauth section

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -447,10 +447,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def allows_silent_takeover(oauth_user, auth_hash)
-    allow_takeover = auth_hash.provider.present?
-    allow_takeover &= AuthenticationOption::SILENT_TAKEOVER_CREDENTIAL_TYPES.include?(auth_hash.provider.to_s)
+    return false unless auth_hash.provider.present?
+    return false unless AuthenticationOption::SILENT_TAKEOVER_CREDENTIAL_TYPES.include?(auth_hash.provider.to_s)
+    return false if oauth_user.persisted?
+
     lookup_user = User.find_by_email_or_hashed_email(oauth_user.email)
-    allow_takeover && lookup_user && !oauth_user.persisted?
+    return !!lookup_user
   end
 
   def should_connect_provider?

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -164,7 +164,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     SignUpTracking.log_oauth_callback AuthenticationOption::GOOGLE, session
     prepare_locale_cookie user
 
-    if allows_google_classroom_takeover user
+    if allows_section_takeover user
       user = silent_takeover user, auth_hash
     end
     sign_in_user user
@@ -339,11 +339,11 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     scopes.include?(scope_name)
   end
 
-  def allows_google_classroom_takeover(user)
-    # Google Classroom does not provide student email addresses, so we want to perform
-    # silent takeover on these accounts, but *only if* the student hasn't made progress
-    # with the account created during the Google Classroom import.
-    user.persisted? && user.google_classroom_student? &&
+  def allows_section_takeover(user)
+    # OAuth providers do not necessarily provide student email addresses, so we
+    # want to perform silent takeover on these accounts, but *only if* the
+    # student hasn't made progress with the initial account
+    user.persisted? && user.oauth_student? &&
       user.email.blank? && user.hashed_email.blank? &&
       !user.has_activity?
   end
@@ -364,9 +364,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     provider = auth_hash.provider.to_s
 
     unless lookup_user.present?
-      # Even if silent takeover is not available for student imported from Google Classroom, we still want
-      # to attach the email received from Google login to the student's account since GC imports do not provide emails.
-      if allows_google_classroom_takeover(oauth_user)
+      # Even if silent takeover is not available for imported student, we still
+      # want to attach the email received from the provider to the student's
+      # account since many imports do not provide emails.
+      if allows_section_takeover(oauth_user)
         oauth_user.update_email_for(
           provider: provider,
           uid: auth_hash.uid,
@@ -376,8 +377,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       return oauth_user
     end
 
-    # Transfer sections and destroy Google Classroom user if takeover is possible
-    if allows_google_classroom_takeover(oauth_user)
+    # Transfer sections and destroy new user if takeover is possible
+    if allows_section_takeover(oauth_user)
       return unless move_sections_and_destroy_source_user(
         source_user: oauth_user,
         destination_user: lookup_user,

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -73,6 +73,11 @@ class Section < ActiveRecord::Base
     LOGIN_TYPE_CLEVER = 'clever'.freeze
   ]
 
+  LOGIN_TYPES_OAUTH = [
+    LOGIN_TYPE_GOOGLE_CLASSROOM,
+    LOGIN_TYPE_CLEVER
+  ]
+
   TYPES = [
     # Insert non-workshop section types here.
   ].concat(Pd::Workshop::SECTION_TYPES).freeze

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1017,6 +1017,11 @@ class User < ActiveRecord::Base
     sections_as_student.find_by_login_type(Section::LOGIN_TYPE_CLEVER).present?
   end
 
+  # True if user is a student in a section that uses any oauth login type
+  def oauth_student?
+    sections_as_student.find_by_login_type(Section::LOGIN_TYPES_OAUTH).present?
+  end
+
   # overrides Devise::Authenticatable#find_first_by_auth_conditions
   # see https://github.com/plataformatec/devise/blob/master/lib/devise/models/authenticatable.rb#L245
   def self.find_for_authentication(tainted_conditions)

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2128,6 +2128,21 @@ class UserTest < ActiveSupport::TestCase
     refute user.clever_student?
   end
 
+  test 'oauth_student? is true if the user belongs to any oauth section as a student' do
+    clever_section = create(:section, login_type: Section::LOGIN_TYPE_CLEVER)
+    clever_user = create(:follower, section: clever_section).student_user
+    assert clever_user.oauth_student?
+
+    google_section = create(:section, login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM)
+    google_user = create(:follower, section: google_section).student_user
+    assert google_user.oauth_student?
+  end
+
+  test 'oauth_student? is false if the user does not belong to any oauth section as a student' do
+    user = create(:user)
+    refute user.oauth_student?
+  end
+
   test 'track_proficiency adds proficiency if necessary and no hint used' do
     level_concept_difficulty = create :level_concept_difficulty
     # Defaults with repeat_loops_{d1,d2,d3,d4,d5}_count = {0,2,0,3,0}.


### PR DESCRIPTION
This logic was originally written to support the fact that google classroom accounts can be created without an identifying email, under the belief that that was true only of google classroom imports. Turns out, that's increasingly true for other logic providers so we want this to be a little more generalizable.

Also rewrite `allows_silent_takeover` for readability.