### PR TITLE
Bc sublevel orphans next

### DIFF
--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -265,7 +265,7 @@ module UsersHelper
       sl.level_ids.each do |level_id|
         # if we have a contained level or BubbleChoice level, use that to represent progress
         level = Level.cache_find(level_id)
-        sublevel_id = sl.bubble_choice? ? level.best_result_sublevel(user)&.id : nil
+        sublevel_id = level.is_a?(BubbleChoice) ? level.best_result_sublevel(user)&.id : nil
         contained_level_id = level.contained_levels.try(:first).try(:id)
 
         ul = user_levels_by_level.try(:[], sublevel_id || contained_level_id || level_id)

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -65,7 +65,11 @@
           %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level)).to_s
       - else
         %li (Cannot edit)
-    This level is in #{@level.script_levels.count} scripts:
+
+    -# Include any BubbleChoice parent script_levels in script_level list.
+    - parent_levels = BubbleChoice.parent_levels(@level.name)
+    - parent_script_level_count = parent_levels.flat_map(&:script_levels).count
+    This level is in #{@level.script_levels.count + parent_script_level_count} scripts:
     %ul
       - @level.script_levels.each do |script_level|
         %li
@@ -73,6 +77,15 @@
           = "(stage ID: #{script_level.stage_id})"
           as
           = link_to build_script_level_path(script_level), build_script_level_path(script_level)
+      - parent_levels.each do |parent_level|
+        - parent_level.script_levels.each do |script_level|
+          %li
+            = link_to script_level.script.name, script_level.script
+            = "(stage ID: #{script_level.stage_id})"
+            as
+            - sl_path = build_script_level_path(script_level, sublevel_position: parent_level.sublevel_position(@level))
+            = link_to sl_path, sl_path
+
     .project_admin
     - if current_user.project_validator? && params[:channel_id]
       %br/


### PR DESCRIPTION
Completes [LP-580](https://codedotorg.atlassian.net/browse/LP-580). Follow-up to #29634.

Script links will now be displayed in the admin panel when viewing a BubbleChoice sublevel:
<img width="514" alt="Screen Shot 2019-07-11 at 10 28 56 PM" src="https://user-images.githubusercontent.com/9812299/61104714-310d9200-a42c-11e9-9f8e-7aeb963dc422.png">
