### PR TITLE
Revert "Bump Expo SDK version for exported projects (from v31 to v33)"

### DIFF
--- a/apps/src/templates/export/expo/App.js.ejs
+++ b/apps/src/templates/export/expo/App.js.ejs
@@ -100,7 +100,7 @@ export default class App extends React.Component {
 
     return (
       <View onLayout={this.onLayout} style={styles.container}>
-        {!!height && indexUri && <View style={this.webViewContainerStyle()}>
+        {height && indexUri && <View style={this.webViewContainerStyle()}>
           <WebView
             allowUniversalAccessFromFileURLs
             originWhitelist={['*']}

--- a/apps/src/templates/export/expo/package.exported_json
+++ b/apps/src/templates/export/expo/package.exported_json
@@ -8,9 +8,9 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^33.0.7",
-    "expo-cli": "^2.20.10",
-    "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz"
+    "expo": "^31.0.4",
+    "expo-cli": "^2.6.14",
+    "react": "16.5.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.1.tar.gz"
   }
 }

--- a/apps/src/util/exporter.js
+++ b/apps/src/util/exporter.js
@@ -12,7 +12,7 @@ import exportExpoAppJsonEjs from '../templates/export/expo/app.json.ejs';
 import exportExpoPackagedFilesEjs from '../templates/export/expo/packagedFiles.js.ejs';
 import exportExpoPackagedFilesEntryEjs from '../templates/export/expo/packagedFilesEntry.js.ejs';
 
-export const EXPO_SDK_VERSION = '33.0.0';
+export const EXPO_SDK_VERSION = '31.0.0';
 
 export function createPackageFilesFromZip(zip, appName) {
   const moduleList = [];


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#29580

SDK 33 is causing some problems with APK builds. I'd like to revert this change while I work the Expo team on this.