### PR TITLE
/s/level/oldest_active_level

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -237,7 +237,7 @@ class ScriptLevel < ActiveRecord::Base
   end
 
   def bubble_choice?
-    level.is_a? BubbleChoice
+    oldest_active_level.is_a? BubbleChoice
   end
 
   def name


### PR DESCRIPTION
Use `oldest_active_level` instead of `level` helper to determine if a script_level is BubbleChoice -- following advice from [this comment](https://github.com/code-dot-org/code-dot-org/blob/92d2b7687c1d60334357f9acf4679b7d18acc8d2/dashboard/app/models/script_level.rb#L61-L66).