### PR TITLE
log errors to firehose when level save fails

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -1,5 +1,6 @@
 require "csv"
 require "naturally"
+require 'cdo/firehose'
 
 EMPTY_XML = '<xml></xml>'.freeze
 
@@ -140,6 +141,7 @@ class LevelsController < ApplicationController
         @level.name.downcase == level_params[:name].downcase
       # do not allow case-only changes in the level name because that confuses git on OSX
       @level.errors.add(:name, 'Cannot change only the capitalization of the level name (it confuses git on OSX)')
+      log_save_error(@level)
       render json: @level.errors, status: :unprocessable_entity
       return
     end
@@ -151,6 +153,7 @@ class LevelsController < ApplicationController
       redirect = params["redirect"] || level_url(@level, show_callouts: 1)
       render json: {redirect: redirect}
     else
+      log_save_error(@level)
       render json: @level.errors, status: :unprocessable_entity
     end
   end
@@ -349,5 +352,23 @@ class LevelsController < ApplicationController
       true
     )
     @level.properties['solution_image_url'] = level_source_image.s3_url if level_source_image
+  end
+
+  # Gathers data on top pain points for level builders by logging error details
+  # to Firehose / Redshift.
+  def log_save_error(level)
+    FirehoseClient.instance.put_record(
+      study: 'level-save-error',
+      # Make it easy to count most frequent field name in which errors occur.
+      event: level.errors.keys.first,
+      # Level ids are different on levelbuilder, so use the level name. This can
+      # be joined against to determine the level type or other level properties.
+      data_string: level.name,
+      data_json: {
+        errors: level.errors.to_h,
+        # User ids are different on levelbuilder, so use the email.
+        user_email: current_user.email,
+      }.to_json
+    )
   end
 end

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -361,8 +361,9 @@ class LevelsController < ApplicationController
       study: 'level-save-error',
       # Make it easy to count most frequent field name in which errors occur.
       event: level.errors.keys.first,
-      # Level ids are different on levelbuilder, so use the level name. This can
-      # be joined against to determine the level type or other level properties.
+      # Level ids are different on levelbuilder, so use the level name. The
+      # level name can be joined on, against the levels table, to determine the
+      # level type or other level properties.
       data_string: level.name,
       data_json: {
         errors: level.errors.to_h,


### PR DESCRIPTION
Fixes https://codedotorg.atlassian.net/browse/LP-494

sample output in development mode:
```
Skipped sending record to analysis-events: 
{:study=>"level-save-error", :event=>:name, :data_string=>"Valentine_artist_01", :data_json=>"{\"errors\":{\"name\":\"has already been taken\"},\"user_email\":\"dave@code.org\"}"}
```

