### PR TITLE
[React 16] Upgraded react-tether to React 16 compatible version

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -179,7 +179,7 @@
     "react-router": "~2.6.0",
     "react-select": "^1.2.1",
     "react-sticky": "~5.0.5",
-    "react-tether": "^0.5.2",
+    "react-tether": "^1.0.4",
     "react-tooltip": "^3.2.7",
     "react-virtualized": "^9.18.5",
     "react-virtualized-select": "^3.0.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -12836,12 +12836,13 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-tether@^0.5.2:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/react-tether/-/react-tether-0.5.7.tgz#418ea61041b65b958271478489b71a3572f01422"
+react-tether@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-tether/-/react-tether-1.0.4.tgz#a1f0973391ba4c3c2b5c38d5be16c42f0fd96759"
+  integrity sha512-WQ3Ulj9k6to8We/rUqkX4fB5L4jYGnUEXtAxyth9kcKqf0miVOR6MYS3hJodQbpNIBB5DvA+/ZH8nlUtMupSVA==
   dependencies:
-    prop-types "^15.5.8"
-    tether "^1.3.7"
+    prop-types "^15.6.2"
+    tether "^1.4.5"
 
 react-textarea-autosize@^7.0.4:
   version "7.1.0"
@@ -15138,9 +15139,10 @@ test262-parser@^2.0.7:
     js-yaml "^3.2.1"
     through "^2.3.4"
 
-tether@^1.3.7:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.5.tgz#8efd7b35572767ba502259ba9b1cc167fcf6f2c1"
+tether@^1.4.5:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.6.tgz#30c538eebc8ab72a7ac0840843efdd4542d57e5f"
+  integrity sha512-TyWPw9O0ExqH9/ZBnQ0P1/mNI6LX16YPx5XvixC/ZvAqMkhGeXmKTTsMbSBn3ViOrPuQi/Uef11bVp3sd5UcQQ==
 
 text-encoding@0.6.4:
   version "0.6.4"


### PR DESCRIPTION
Updating react-tether to unblock React 16 upgrade

https://codedotorg.atlassian.net/browse/XTEAM-199