### PR TITLE
[React 16] Upgraded react-sticky to React 16 compatible version

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -178,7 +178,7 @@
     "react-redux": "~4.4.5",
     "react-router": "~2.6.0",
     "react-select": "^1.2.1",
-    "react-sticky": "~5.0.5",
+    "react-sticky": "~6.0.3",
     "react-tether": "^0.5.2",
     "react-tooltip": "^3.2.7",
     "react-virtualized": "^9.18.5",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -12351,7 +12351,7 @@ raf@^3.1.0:
   dependencies:
     performance-now "~0.2.0"
 
-raf@^3.4.0:
+raf@^3.3.0, raf@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   dependencies:
@@ -12824,11 +12824,13 @@ react-split-pane@^0.1.84:
     react-lifecycles-compat "^3.0.4"
     react-style-proptype "^3.0.0"
 
-react-sticky@~5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/react-sticky/-/react-sticky-5.0.8.tgz#d5f85f96977f410081d792ab81886c622c5d8b14"
+react-sticky@~6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/react-sticky/-/react-sticky-6.0.3.tgz#7a18b643e1863da113d7f7036118d2a75d9ecde4"
+  integrity sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==
   dependencies:
     prop-types "^15.5.8"
+    raf "^3.3.0"
 
 react-style-proptype@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Upgrade react-sticky to unblock React 16 upgrade

https://codedotorg.atlassian.net/browse/XTEAM-200