### PR TITLE
[React 16] Upgrading react-motion to latest to be compatible with React 16

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -170,7 +170,7 @@
     "react-idle-timer": "~1.5.2",
     "react-inspector": "2.3.1",
     "react-lazy-load": "~3.0.10",
-    "react-motion": "0.4.5",
+    "react-motion": "^0.5.2",
     "react-onclickoutside": "^5.7.1",
     "react-paginate": "^6.3.0",
     "react-pointable": "^1.1.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -12701,11 +12701,13 @@ react-modal@^3.6.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-motion@0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.4.5.tgz#ecc42f692fec9b2de4c92f85e26375071f779b76"
+react-motion@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
+  integrity sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==
   dependencies:
     performance-now "^0.2.0"
+    prop-types "^15.5.8"
     raf "^3.1.0"
 
 react-onclickoutside@^5.7.1:


### PR DESCRIPTION
Only the latest version of react-motion is compatible with React 16. 

Note: Although not explicitly stated by the owners, react-motion is no longer being maintained. We should eventually migrate away from it.

Task for updating react-motion: https://codedotorg.atlassian.net/browse/XTEAM-207
Task for deprecating react-motioh: https://codedotorg.atlassian.net/browse/XTEAM-206