### PR TITLE
[React 16] Updated react-onclickoutside in package.json to match the react16-compatible version in the yarn.lock

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -171,7 +171,7 @@
     "react-inspector": "2.3.1",
     "react-lazy-load": "~3.0.10",
     "react-motion": "0.4.5",
-    "react-onclickoutside": "^5.7.1",
+    "react-onclickoutside": "~5.11.1",
     "react-paginate": "^6.3.0",
     "react-pointable": "^1.1.1",
     "react-portal": "^3.0.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -12708,15 +12708,16 @@ react-motion@0.4.5:
     performance-now "^0.2.0"
     raf "^3.1.0"
 
-react-onclickoutside@^5.7.1:
-  version "5.11.1"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-5.11.1.tgz#00314e52567cf55faba94cabbacd119619070623"
-  dependencies:
-    create-react-class "^15.5.x"
-
 react-onclickoutside@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
+
+react-onclickoutside@~5.11.1:
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-5.11.1.tgz#00314e52567cf55faba94cabbacd119619070623"
+  integrity sha1-ADFOUlZ89V+rqUyrus0RlhkHBiM=
+  dependencies:
+    create-react-class "^15.5.x"
 
 react-overlays@^0.6.6:
   version "0.6.10"


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/XTEAM-208

This changes no functionality - it simply makes our dependencies clearer.