### PR TITLE
Tests: JsDebuggerTest passes in Chrome browser

### DIFF
--- a/apps/src/dom.js
+++ b/apps/src/dom.js
@@ -122,6 +122,7 @@ var TOUCH_MAP = {
     ie11: 'pointermove'
   }
 };
+exports.TOUCH_MAP = TOUCH_MAP;
 
 exports.isMobile = function() {
   var reg = /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/;


### PR DESCRIPTION
Tiny progress on [XTEAM-41](https://codedotorg.atlassian.net/browse/XTEAM-41): While trying to update sinon I ran across this test that wouldn't pass on my local machine (because I have to use Chrome instead of Phantom).  Narrowed the problem down to two things:

- An assumption about the browser height baked into the test
- An assumption about touch events being available in the browser being used

I fixed the first by making the assertion slightly more flexible, and the second by stubbing a bit of our code that decides which event names to use.

Depending on Drone to tell me if this still passes on Phantom.