### PR TITLE
Feedback: include script_level_id when new teacher feedbacks are stored

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3221,7 +3221,8 @@ StudioApp.prototype.setPageConstants = function(config, appSpecificConstants) {
         !!config.level.projectTemplateLevelName &&
         !config.level.isK1 &&
         !config.readonlyWorkspace,
-      serverLevelId: config.serverLevelId
+      serverLevelId: config.serverLevelId,
+      serverScriptLevelId: config.serverScriptLevelId
     },
     appSpecificConstants
   );

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -38,6 +38,7 @@
  * @property {?} authoredHintsUsedIds
  * @property {number} serverLevelId
  * @property {number} serverProjectLevelId
+ * @property {number} serverScriptLevelId
  * @property {string} gameDisplayName
  * @property {boolean} publicCaching
  * @property {?boolean} is13Plus - Will be true if the user is 13 or older,

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -61,6 +61,7 @@ var ALLOWED_KEYS = new Set([
   'nextLevelUrl',
   'showProjectTemplateWorkspaceIcon',
   'serverLevelId',
+  'serverScriptLevelId',
   'exportApp',
   'expoGenerateApk',
   'expoCheckApkBuild',

--- a/apps/src/templates/instructions/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/TeacherFeedback.jsx
@@ -97,6 +97,7 @@ export class TeacherFeedback extends Component {
     //Provided by Redux
     viewAs: PropTypes.oneOf(['Teacher', 'Student']).isRequired,
     serverLevelId: PropTypes.number,
+    serverScriptLevelId: PropTypes.number,
     teacher: PropTypes.number,
     displayKeyConcept: PropTypes.bool,
     latestFeedback: PropTypes.array,
@@ -160,6 +161,7 @@ export class TeacherFeedback extends Component {
       comment: this.state.comment,
       student_id: this.state.studentId,
       level_id: this.props.serverLevelId,
+      script_level_id: this.props.serverScriptLevelId,
       teacher_id: this.props.teacher,
       performance: this.state.performance
     };
@@ -340,5 +342,6 @@ export const UnconnectedTeacherFeedback = TeacherFeedback;
 export default connect(state => ({
   viewAs: state.viewAs,
   serverLevelId: state.pageConstants.serverLevelId,
+  serverScriptLevelId: state.pageConstants.serverScriptLevelId,
   teacher: state.pageConstants.userId
 }))(TeacherFeedback);

--- a/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
@@ -74,6 +74,6 @@ class Api::V1::TeacherFeedbacksController < Api::V1::JsonApiController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def teacher_feedback_params
-    params.require(:teacher_feedback).permit(:student_id, :level_id, :comment, :teacher_id, :performance)
+    params.require(:teacher_feedback).permit(:student_id, :level_id, :script_level_id, :comment, :teacher_id, :performance)
   end
 end

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -248,6 +248,10 @@ module LevelsHelper
         view_options.camelize_keys
       end
 
+    if @script_level && @level.can_have_feedback?
+      @app_options[:serverScriptLevelId] = @script_level.id
+    end
+
     # Blockly caches level properties, whereas this field depends on the user
     @app_options['teacherMarkdown'] = @level.properties['teacher_markdown'] if I18n.en? && can_view_teacher_markdown?
 

--- a/dashboard/app/serializers/api/v1/teacher_feedback_serializer.rb
+++ b/dashboard/app/serializers/api/v1/teacher_feedback_serializer.rb
@@ -18,7 +18,7 @@
 #
 
 class Api::V1::TeacherFeedbackSerializer < ActiveModel::Serializer
-  attributes :id, :teacher_name, :student_id, :level_id, :comment, :performance, :created_at
+  attributes :id, :teacher_name, :student_id, :level_id, :script_level_id, :comment, :performance, :created_at
 
   private
 


### PR DESCRIPTION
Follow up to #29590
[LP-591](https://codedotorg.atlassian.net/browse/LP-591)

To retrieve accurate information to display on the All Feedback page, `script_level_id` needs to be stored for each TeacherFeedback. When a new TeacherFeedback is created we now populate that field with `serverScriptLevelId` passed in from `pageConstants` via `appOptions` to the `TeacherFeedback` component. 

<img width="1151" alt="scriptlevelid" src="https://user-images.githubusercontent.com/12300669/61153155-41ab2000-a49f-11e9-9151-f08b4c544f38.png">
