### PR TITLE
explain why we don't use digested ace assets

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -208,6 +208,11 @@ describe('entry tests', () => {
             return path.join(dest, outputPath);
           }
         },
+        // minifying ace code requires some advanced configuration:
+        // https://github.com/ajaxorg/ace/blob/b808ac14ec6d6afa74b36ff5c03452a2832b32a4/Makefile.dryice.js#L620-L638
+        // instead of replicating that configuration here, we keep minified
+        // and unminified js in our repo and provide the correct one
+        // based on whether we are in development or production mode.
         {
           expand: true,
           cwd: 'lib/ace/src' + ace_suffix + '-noconflict/',

--- a/dashboard/app/views/levels/_apps_dependencies.html.haml
+++ b/dashboard/app/views/levels/_apps_dependencies.html.haml
@@ -27,9 +27,18 @@
 
 -# Droplet script dependencies (only when editor present)
 - if use_droplet && !hide_source
-  %script{src: asset_path('js/ace/ace.js')}
-  %script{src: asset_path('js/ace/mode-javascript.js')}
-  %script{src: asset_path('js/ace/ext-language_tools.js')}
+
+  -# ace lazy-loads some of its files via relative url path, which doesn't play
+  -# nicely with asset paths containing digests. rather than having initial
+  -# assets use digests and lazy-loaded assets not use digests, just load all
+  -# ace assets without digests to avoid subtle bugs where failing to lazy-load.
+  -#
+  -# Although we do not use the .min.js filename, ace js contents is minified
+  -# whenever our js is built in production mode. See Gruntfile.js for details.
+
+  %script{src: "#{static_asset_base_path}js/ace/ace.js"}
+  %script{src: "#{static_asset_base_path}js/ace/mode-javascript.js"}
+  %script{src: "#{static_asset_base_path}js/ace/ext-language_tools.js"}
   %script{src: minifiable_asset_path('js/droplet/droplet-full.js')}
   %script{src: minifiable_asset_path('js/tooltipster/jquery.tooltipster.js')}
 -# Asset uploader script dependencies (not in share mode)

--- a/dashboard/app/views/levels/_apps_dependencies.html.haml
+++ b/dashboard/app/views/levels/_apps_dependencies.html.haml
@@ -27,9 +27,9 @@
 
 -# Droplet script dependencies (only when editor present)
 - if use_droplet && !hide_source
-  %script{src: "#{static_asset_base_path}js/ace/ace.js"}
-  %script{src: "#{static_asset_base_path}js/ace/mode-javascript.js"}
-  %script{src: "#{static_asset_base_path}js/ace/ext-language_tools.js"}
+  %script{src: asset_path('js/ace/ace.js')}
+  %script{src: asset_path('js/ace/mode-javascript.js')}
+  %script{src: asset_path('js/ace/ext-language_tools.js')}
   %script{src: minifiable_asset_path('js/droplet/droplet-full.js')}
   %script{src: minifiable_asset_path('js/tooltipster/jquery.tooltipster.js')}
 -# Asset uploader script dependencies (not in share mode)


### PR DESCRIPTION
confirmed locally that applab works in text mode (which uses ace.js), and that the js is being loaded via unminified, digested url: http://localhost-studio.code.org:3000/assets/js/ace/ace-32ae556db13ac085093052aae6ba9d6c39f66d0877c88d72b079bf70a726ed6e.js