### PR TITLE
Remove sinon-chai-in-order

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -206,7 +206,6 @@
     "seedrandom": "2.4.2",
     "sinon": "^3.0.0",
     "sinon-chai": "^2.13.0",
-    "sinon-chai-in-order": "^0.1.0",
     "sprintf-js": "^1.0.3",
     "style-loader": "^0.13.1",
     "uglifyjs-webpack-plugin": "^2.1.1",

--- a/apps/test/unit/code-studio/pd/form_components/UsPhoneNumberInputTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/UsPhoneNumberInputTest.js
@@ -53,9 +53,9 @@ describe('UsPhoneNumberInput', () => {
       usPhoneNumberInput.setProps({onChange});
 
       sendText('xxx(123');
-      expect(onChange).inOrder.to.be.calledWith({phone: '1'});
-      expect(onChange).subsequently.to.be.calledWith({phone: '12'});
-      expect(onChange).subsequently.to.be.calledWith({phone: '123'});
+      expect(onChange.calledWith({phone: '1'})).to.be.true;
+      expect(onChange.calledWith({phone: '12'})).to.be.true;
+      expect(onChange.calledWith({phone: '123'})).to.be.true;
     });
   });
 

--- a/apps/test/util/configuredChai.js
+++ b/apps/test/util/configuredChai.js
@@ -3,12 +3,10 @@ import chai from 'chai';
 import chaiSubset from 'chai-subset';
 import chaiEnzyme from 'chai-enzyme';
 import sinonChai from 'sinon-chai';
-import sinonChaiInOrder from 'sinon-chai-in-order';
 import chaiAsPromised from 'chai-as-promised';
 import chaiXml from 'chai-xml';
 
 chai.use(sinonChai);
-chai.use(sinonChaiInOrder);
 chai.use(chaiEnzyme());
 chai.use(chaiSubset);
 chai.use(chaiAsPromised);

--- a/apps/test/util/reconfiguredChai.js
+++ b/apps/test/util/reconfiguredChai.js
@@ -2,12 +2,10 @@
 import chai from 'chai';
 import chaiSubset from 'chai-subset';
 import sinonChai from 'sinon-chai';
-import sinonChaiInOrder from 'sinon-chai-in-order';
 import chaiAsPromised from 'chai-as-promised';
 import chaiXml from 'chai-xml';
 
 chai.use(sinonChai);
-chai.use(sinonChaiInOrder);
 chai.use(chaiSubset);
 chai.use(chaiAsPromised);
 chai.use(chaiXml);

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -14281,13 +14281,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-sinon-chai-in-order@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/sinon-chai-in-order/-/sinon-chai-in-order-0.1.0.tgz#6c4a95189713ff3349f99f83b24dcac69ad32ab2"
-  dependencies:
-    sinon-chai "^2.8.0"
-
-sinon-chai@^2.13.0, sinon-chai@^2.8.0:
+sinon-chai@^2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.13.0.tgz#b9a42e801c20234bfc2f43b29e6f4f61b60990c4"
 


### PR DESCRIPTION
While working on the [Sinon upgrade](https://github.com/code-dot-org/code-dot-org/pull/29640) I found this outdated package that we're only using in one place, which is also messing with our dependency chain.  Removing it!