### PR TITLE
Use path alias for gamelab imports

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -10,7 +10,7 @@ import AbuseError from './AbuseError';
 import SendToPhone from './SendToPhone';
 import color from '../../util/color';
 import * as applabConstants from '../../applab/constants';
-import * as gamelabConstants from '../../gamelab/constants';
+import * as gamelabConstants from '@cdo/apps/gamelab/constants';
 import {SongTitlesToArtistTwitterHandle} from '../dancePartySongArtistTags';
 import {hideShareDialog, unpublishProject} from './shareDialogRedux';
 import DownloadReplayVideoButton from './DownloadReplayVideoButton';

--- a/apps/src/gamelab/AnimationJsonViewer.jsx
+++ b/apps/src/gamelab/AnimationJsonViewer.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import Dialog, {Body} from '../templates/Dialog';
+import Dialog, {Body} from '@cdo/apps/templates/Dialog';
 import {hideAnimationJson} from './actions';
 
 const style = {

--- a/apps/src/gamelab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/gamelab/AnimationPicker/AnimationPicker.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {createUuid} from '../../utils';
+import {createUuid} from '@cdo/apps/utils';
 import {connect} from 'react-redux';
-import BaseDialog from '../../templates/BaseDialog.jsx';
+import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import gamelabMsg from '@cdo/gamelab/locale';
 import styles from './styles';
 import {
@@ -14,7 +14,7 @@ import {
   handleUploadError
 } from './animationPickerModule';
 import AnimationPickerBody from './AnimationPickerBody.jsx';
-import HiddenUploader from '../../code-studio/components/HiddenUploader';
+import HiddenUploader from '@cdo/apps/code-studio/components/HiddenUploader';
 
 // Some operating systems round their file sizes, so max size is 101KB even
 // though our error message says 100KB, to help users avoid confusion.

--- a/apps/src/gamelab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/gamelab/AnimationPicker/AnimationPickerBody.jsx
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Radium from 'radium';
-import color from '../../util/color';
+import color from '@cdo/apps/util/color';
 import {AnimationCategories, CostumeCategories} from '../constants';
 import gamelabMsg from '@cdo/gamelab/locale';
 import animationLibrary from '../animationLibrary.json';
@@ -11,8 +11,8 @@ import ScrollableList from '../AnimationTab/ScrollableList.jsx';
 import styles from './styles';
 import AnimationPickerListItem from './AnimationPickerListItem.jsx';
 import AnimationPickerSearchBar from './AnimationPickerSearchBar.jsx';
-import PaginationWrapper from '../../templates/PaginationWrapper';
-import {searchAssets} from '../../code-studio/assets/searchAssets';
+import PaginationWrapper from '@cdo/apps/templates/PaginationWrapper';
+import {searchAssets} from '@cdo/apps/code-studio/assets/searchAssets';
 import {connect} from 'react-redux';
 
 const MAX_SEARCH_RESULTS = 27;

--- a/apps/src/gamelab/AnimationPicker/AnimationPickerListItem.jsx
+++ b/apps/src/gamelab/AnimationPicker/AnimationPickerListItem.jsx
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Radium from 'radium';
-import color from '../../util/color';
+import color from '@cdo/apps/util/color';
 import {PlayBehavior} from '../constants';
 import * as shapes from '../shapes';
 import AnimationPreview from './AnimationPreview';

--- a/apps/src/gamelab/AnimationPicker/AnimationPickerSearchBar.jsx
+++ b/apps/src/gamelab/AnimationPicker/AnimationPickerSearchBar.jsx
@@ -1,7 +1,7 @@
 /** Animation picker dialog search bar */
 import PropTypes from 'prop-types';
 import React from 'react';
-import color from '../../util/color';
+import color from '@cdo/apps/util/color';
 
 const BORDER_WIDTH = 1;
 const BORDER_COLOR = color.light_gray;

--- a/apps/src/gamelab/AnimationPicker/animationPickerModule.js
+++ b/apps/src/gamelab/AnimationPicker/animationPickerModule.js
@@ -8,8 +8,8 @@ import {
   appendCustomFrames,
   appendLibraryFrames
 } from '../animationListModule';
-import {makeEnum} from '../../utils';
-import {animations as animationsApi} from '../../clientApi';
+import {makeEnum} from '@cdo/apps/utils';
+import {animations as animationsApi} from '@cdo/apps/clientApi';
 import gamelabMsg from '@cdo/gamelab/locale';
 import {changeInterfaceMode} from '../actions';
 import {GameLabInterfaceMode} from '../constants';

--- a/apps/src/gamelab/AnimationPicker/styles.js
+++ b/apps/src/gamelab/AnimationPicker/styles.js
@@ -1,5 +1,5 @@
 /** @file Shared styles for the animation picker dialog. */
-var color = require('../../util/color');
+var color = require('@cdo/apps/util/color');
 
 module.exports = {
   title: {

--- a/apps/src/gamelab/AnimationTab/AnimationList.jsx
+++ b/apps/src/gamelab/AnimationTab/AnimationList.jsx
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import color from '../../util/color';
+import color from '@cdo/apps/util/color';
 import * as shapes from '../shapes';
 import {show, Goal} from '../AnimationPicker/animationPickerModule';
 import AnimationListItem from './AnimationListItem';

--- a/apps/src/gamelab/AnimationTab/AnimationListItem.jsx
+++ b/apps/src/gamelab/AnimationTab/AnimationListItem.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Radium from 'radium';
 import {connect} from 'react-redux';
-import color from '../../util/color';
+import color from '@cdo/apps/util/color';
 import * as shapes from '../shapes';
 import {
   setAnimationName,

--- a/apps/src/gamelab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/gamelab/AnimationTab/AnimationTab.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Radium from 'radium';
 import {connect} from 'react-redux';
-import color from '../../util/color';
+import color from '@cdo/apps/util/color';
 import AnimationPicker from '../AnimationPicker/AnimationPicker';
 import GameLabVisualizationHeader from '../GameLabVisualizationHeader';
 import {setColumnSizes} from './animationTabModule';

--- a/apps/src/gamelab/AnimationTab/DeleteAnimationDialog.jsx
+++ b/apps/src/gamelab/AnimationTab/DeleteAnimationDialog.jsx
@@ -1,7 +1,12 @@
 /** @file controls below a dialog to delete animations */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Dialog, {Body, Buttons, Cancel, Confirm} from '../../templates/Dialog';
+import Dialog, {
+  Body,
+  Buttons,
+  Cancel,
+  Confirm
+} from '@cdo/apps/templates/Dialog';
 
 export default class DeleteAnimationDialog extends React.Component {
   static propTypes = {

--- a/apps/src/gamelab/AnimationTab/ListItemButtons.jsx
+++ b/apps/src/gamelab/AnimationTab/ListItemButtons.jsx
@@ -1,10 +1,10 @@
 /** @file controls below an animation thumbnail */
 import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
-import color from '../../util/color';
+import color from '@cdo/apps/util/color';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
-import SpeedSlider from '../../templates/SpeedSlider';
+import SpeedSlider from '@cdo/apps/templates/SpeedSlider';
 import ItemLoopToggle from './ItemLoopToggle';
 import DeleteAnimationDialog from './DeleteAnimationDialog';
 

--- a/apps/src/gamelab/AnimationTab/ListItemThumbnail.jsx
+++ b/apps/src/gamelab/AnimationTab/ListItemThumbnail.jsx
@@ -2,7 +2,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import color from '../../util/color';
+import color from '@cdo/apps/util/color';
 import {PlayBehavior} from '../constants';
 import * as shapes from '../shapes';
 import AnimationPreview from '../AnimationPicker/AnimationPreview';

--- a/apps/src/gamelab/AnimationTab/NewListItem.jsx
+++ b/apps/src/gamelab/AnimationTab/NewListItem.jsx
@@ -1,6 +1,6 @@
 /** List item placeholder for adding a new item */
 import React from 'react';
-import color from '../../util/color';
+import color from '@cdo/apps/util/color';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 

--- a/apps/src/gamelab/ErrorDialogStack.jsx
+++ b/apps/src/gamelab/ErrorDialogStack.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import * as actions from './errorDialogStackModule';
 import {connect} from 'react-redux';
-import BaseDialog from '../templates/BaseDialog.jsx';
+import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import gamelabMsg from '@cdo/gamelab/locale';
 import msg from '@cdo/locale';
@@ -11,7 +11,7 @@ import Button from '@cdo/apps/templates/Button';
 import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import * as animationActions from './animationListModule';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import {getCurrentId} from '../code-studio/initApp/project';
+import {getCurrentId} from '@cdo/apps/code-studio/initApp/project';
 
 /**
  * Renders error dialogs in sequence, given a stack of errors.

--- a/apps/src/gamelab/Exporter.js
+++ b/apps/src/gamelab/Exporter.js
@@ -5,23 +5,23 @@ import JSZip from 'jszip';
 import {saveAs} from 'filesaver.js';
 import {SnackSession} from '@code-dot-org/snack-sdk';
 
-import * as assetPrefix from '../assetManagement/assetPrefix';
-import download from '../assetManagement/download';
-import exportGamelabCodeEjs from '../templates/export/gamelabCode.js.ejs';
-import exportGamelabIndexEjs from '../templates/export/gamelabIndex.html.ejs';
-import exportExpoPackageJson from '../templates/export/expo/package.exported_json';
-import exportExpoAppJsonEjs from '../templates/export/expo/app.json.ejs';
-import exportExpoAppEjs from '../templates/export/expo/App.js.ejs';
-import exportExpoCustomAssetJs from '../templates/export/expo/CustomAsset.exported_js';
-import exportExpoDataWarningJs from '../templates/export/expo/DataWarning.exported_js';
-import exportExpoMetroConfigJs from '../templates/export/expo/metro.config.exported_js';
-import exportExpoWarningPng from '../templates/export/expo/warning.png';
-import exportExpoIconPng from '../templates/export/expo/icon.png';
-import exportExpoSplashPng from '../templates/export/expo/splash.png';
-import logToCloud from '../logToCloud';
+import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
+import download from '@cdo/apps/assetManagement/download';
+import exportGamelabCodeEjs from '@cdo/apps/templates/export/gamelabCode.js.ejs';
+import exportGamelabIndexEjs from '@cdo/apps/templates/export/gamelabIndex.html.ejs';
+import exportExpoPackageJson from '@cdo/apps/templates/export/expo/package.exported_json';
+import exportExpoAppJsonEjs from '@cdo/apps/templates/export/expo/app.json.ejs';
+import exportExpoAppEjs from '@cdo/apps/templates/export/expo/App.js.ejs';
+import exportExpoCustomAssetJs from '@cdo/apps/templates/export/expo/CustomAsset.exported_js';
+import exportExpoDataWarningJs from '@cdo/apps/templates/export/expo/DataWarning.exported_js';
+import exportExpoMetroConfigJs from '@cdo/apps/templates/export/expo/metro.config.exported_js';
+import exportExpoWarningPng from '@cdo/apps/templates/export/expo/warning.png';
+import exportExpoIconPng from '@cdo/apps/templates/export/expo/icon.png';
+import exportExpoSplashPng from '@cdo/apps/templates/export/expo/splash.png';
+import logToCloud from '@cdo/apps/logToCloud';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {GAME_WIDTH, GAME_HEIGHT} from './constants';
-import {EXPO_SESSION_SECRET} from '../constants';
+import {EXPO_SESSION_SECRET} from '@cdo/apps/constants';
 import {
   EXPO_SDK_VERSION,
   extractSoundAssets,
@@ -30,7 +30,7 @@ import {
   rewriteAssetUrls,
   getEnvironmentPrefix,
   fetchWebpackRuntime
-} from '../util/exporter';
+} from '@cdo/apps/util/exporter';
 
 const CONTROLS_HEIGHT = 165;
 

--- a/apps/src/gamelab/GameLab.js
+++ b/apps/src/gamelab/GameLab.js
@@ -9,27 +9,30 @@ import {
   GAME_WIDTH,
   SpritelabReservedWords
 } from './constants';
-import experiments from '../util/experiments';
-import {outputError, injectErrorHandler} from '../lib/util/javascriptMode';
-import JavaScriptModeErrorHandler from '../JavaScriptModeErrorHandler';
-import BlocklyModeErrorHandler from '../BlocklyModeErrorHandler';
+import experiments from '@cdo/apps/util/experiments';
+import {
+  outputError,
+  injectErrorHandler
+} from '@cdo/apps/lib/util/javascriptMode';
+import JavaScriptModeErrorHandler from '@cdo/apps/JavaScriptModeErrorHandler';
+import BlocklyModeErrorHandler from '@cdo/apps/BlocklyModeErrorHandler';
 var msg = require('@cdo/gamelab/locale');
-import CustomMarshalingInterpreter from '../lib/tools/jsinterpreter/CustomMarshalingInterpreter';
+import CustomMarshalingInterpreter from '@cdo/apps/lib/tools/jsinterpreter/CustomMarshalingInterpreter';
 var apiJavascript = require('./apiJavascript');
-var consoleApi = require('../consoleApi');
-var utils = require('../utils');
+var consoleApi = require('@cdo/apps/consoleApi');
+var utils = require('@cdo/apps/utils');
 var dropletConfig = require('./dropletConfig');
-var JSInterpreter = require('../lib/tools/jsinterpreter/JSInterpreter');
-import * as apiTimeoutList from '../lib/util/timeoutList';
-var JsInterpreterLogger = require('../JsInterpreterLogger');
+var JSInterpreter = require('@cdo/apps/lib/tools/jsinterpreter/JSInterpreter');
+import * as apiTimeoutList from '@cdo/apps/lib/util/timeoutList';
+var JsInterpreterLogger = require('@cdo/apps/JsInterpreterLogger');
 var GameLabP5 = require('./GameLabP5');
 var gameLabSprite = require('./GameLabSprite');
 var gameLabGroup = require('./GameLabGroup');
 var gamelabCommands = require('./commands');
-import {initializeSubmitHelper, onSubmitComplete} from '../submitHelper';
-var dom = require('../dom');
-import {initFirebaseStorage} from '../storage/firebaseStorage';
-import {getStore} from '../redux';
+import {initializeSubmitHelper, onSubmitComplete} from '@cdo/apps/submitHelper';
+var dom = require('@cdo/apps/dom');
+import {initFirebaseStorage} from '@cdo/apps/storage/firebaseStorage';
+import {getStore} from '@cdo/apps/redux';
 import {
   allAnimationsSingleFrameSelector,
   setInitialAnimationList,
@@ -37,23 +40,23 @@ import {
   withAbsoluteSourceUrls
 } from './animationListModule';
 import {getSerializedAnimationList} from './shapes';
-import {add as addWatcher} from '../redux/watchedExpressions';
+import {add as addWatcher} from '@cdo/apps/redux/watchedExpressions';
 var reducers = require('./reducers');
 var GameLabView = require('./GameLabView');
 var Provider = require('react-redux').Provider;
-import {shouldOverlaysBeVisible} from '../templates/VisualizationOverlay';
+import {shouldOverlaysBeVisible} from '@cdo/apps/templates/VisualizationOverlay';
 import {
   getContainedLevelResultInfo,
   postContainedLevelAttempt,
   runAfterPostContainedLevel
-} from '../containedLevels';
-import {hasValidContainedLevelResult} from '../code-studio/levels/codeStudioLevels';
-import {actions as jsDebugger} from '../lib/tools/jsdebugger/redux';
+} from '@cdo/apps/containedLevels';
+import {hasValidContainedLevelResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
+import {actions as jsDebugger} from '@cdo/apps/lib/tools/jsdebugger/redux';
 import {addConsoleMessage, clearConsole} from './textConsoleModule';
-import {captureThumbnailFromCanvas} from '../util/thumbnail';
-import Sounds from '../Sounds';
-import {TestResults, ResultType} from '../constants';
-import {showHideWorkspaceCallouts} from '../code-studio/callouts';
+import {captureThumbnailFromCanvas} from '@cdo/apps/util/thumbnail';
+import Sounds from '@cdo/apps/Sounds';
+import {TestResults, ResultType} from '@cdo/apps/constants';
+import {showHideWorkspaceCallouts} from '@cdo/apps/code-studio/callouts';
 import defaultSprites from './defaultSprites.json';
 import wrap from './debugger/replay';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
@@ -70,9 +73,9 @@ import {
   expoGenerateApk,
   expoCheckApkBuild,
   expoCancelApkBuild
-} from '../util/exporter';
-import project from '../code-studio/initApp/project';
-import {setExportGeneratedProperties} from '../code-studio/components/exportDialogRedux';
+} from '@cdo/apps/util/exporter';
+import project from '@cdo/apps/code-studio/initApp/project';
+import {setExportGeneratedProperties} from '@cdo/apps/code-studio/components/exportDialogRedux';
 
 const defaultMobileControlsConfig = {
   spaceButtonVisible: true,

--- a/apps/src/gamelab/GameLabP5.js
+++ b/apps/src/gamelab/GameLabP5.js
@@ -1,10 +1,10 @@
-import {getStore} from '../redux';
+import {getStore} from '@cdo/apps/redux';
 import {allAnimationsSingleFrameSelector} from './animationListModule';
 var gameLabSprite = require('./GameLabSprite');
 var gameLabGroup = require('./GameLabGroup');
 var Spritelab = require('./spritelab/Spritelab');
 import {backgrounds} from './spritelab/backgrounds.json';
-import * as assetPrefix from '../assetManagement/assetPrefix';
+import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
 
 const defaultFrameRate = 30;
 

--- a/apps/src/gamelab/GameLabView.jsx
+++ b/apps/src/gamelab/GameLabView.jsx
@@ -5,18 +5,18 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import AnimationTab from './AnimationTab/AnimationTab';
-import StudioAppWrapper from '../templates/StudioAppWrapper';
+import StudioAppWrapper from '@cdo/apps/templates/StudioAppWrapper';
 import ErrorDialogStack from './ErrorDialogStack';
 import AnimationJsonViewer from './AnimationJsonViewer';
 import {GameLabInterfaceMode, GAME_WIDTH, GAME_HEIGHT} from './constants';
 import GameLabVisualizationHeader from './GameLabVisualizationHeader';
 import GameLabVisualizationColumn from './GameLabVisualizationColumn';
-import InstructionsWithWorkspace from '../templates/instructions/InstructionsWithWorkspace';
-import {isResponsiveFromState} from '../templates/ProtectedVisualizationDiv';
-import CodeWorkspace from '../templates/CodeWorkspace';
+import InstructionsWithWorkspace from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
+import {isResponsiveFromState} from '@cdo/apps/templates/ProtectedVisualizationDiv';
+import CodeWorkspace from '@cdo/apps/templates/CodeWorkspace';
 import {allowAnimationMode, showVisualizationHeader} from './stateQueries';
-import IFrameEmbedOverlay from '../templates/IFrameEmbedOverlay';
-import VisualizationResizeBar from '../lib/ui/VisualizationResizeBar';
+import IFrameEmbedOverlay from '@cdo/apps/templates/IFrameEmbedOverlay';
+import VisualizationResizeBar from '@cdo/apps/lib/ui/VisualizationResizeBar';
 import AnimationPicker from './AnimationPicker/AnimationPicker';
 
 /**

--- a/apps/src/gamelab/GameLabVisualizationColumn.jsx
+++ b/apps/src/gamelab/GameLabVisualizationColumn.jsx
@@ -3,16 +3,18 @@ import React from 'react';
 import Pointable from 'react-pointable';
 import {connect} from 'react-redux';
 import classNames from 'classnames';
-import GameButtons from '../templates/GameButtons';
-import ArrowButtons from '../templates/ArrowButtons';
-import BelowVisualization from '../templates/BelowVisualization';
+import GameButtons from '@cdo/apps/templates/GameButtons';
+import ArrowButtons from '@cdo/apps/templates/ArrowButtons';
+import BelowVisualization from '@cdo/apps/templates/BelowVisualization';
 import {GAME_HEIGHT, GAME_WIDTH, GAMELAB_DPAD_CONTAINER_ID} from './constants';
-import CompletionButton from '../templates/CompletionButton';
-import ProtectedStatefulDiv from '../templates/ProtectedStatefulDiv';
-import ProtectedVisualizationDiv from '../templates/ProtectedVisualizationDiv';
-import VisualizationOverlay from '../templates/VisualizationOverlay';
-import CrosshairOverlay from '../templates/CrosshairOverlay';
-import TooltipOverlay, {coordinatesProvider} from '../templates/TooltipOverlay';
+import CompletionButton from '@cdo/apps/templates/CompletionButton';
+import ProtectedStatefulDiv from '@cdo/apps/templates/ProtectedStatefulDiv';
+import ProtectedVisualizationDiv from '@cdo/apps/templates/ProtectedVisualizationDiv';
+import VisualizationOverlay from '@cdo/apps/templates/VisualizationOverlay';
+import CrosshairOverlay from '@cdo/apps/templates/CrosshairOverlay';
+import TooltipOverlay, {
+  coordinatesProvider
+} from '@cdo/apps/templates/TooltipOverlay';
 import i18n from '@cdo/locale';
 import {toggleGridOverlay} from './actions';
 import GridOverlay from './GridOverlay';
@@ -23,7 +25,7 @@ import {
   updateLocation,
   isPickingLocation
 } from './locationPickerModule';
-import {calculateOffsetCoordinates} from '../utils';
+import {calculateOffsetCoordinates} from '@cdo/apps/utils';
 
 const MODAL_Z_INDEX = 1050;
 

--- a/apps/src/gamelab/GameLabVisualizationHeader.jsx
+++ b/apps/src/gamelab/GameLabVisualizationHeader.jsx
@@ -5,8 +5,8 @@ import {changeInterfaceMode} from './actions';
 import {connect} from 'react-redux';
 import {GameLabInterfaceMode} from './constants';
 import msg from '@cdo/locale';
-import ToggleGroup from '../templates/ToggleGroup';
-import styleConstants from '../styleConstants';
+import ToggleGroup from '@cdo/apps/templates/ToggleGroup';
+import styleConstants from '@cdo/apps/styleConstants';
 import {allowAnimationMode} from './stateQueries';
 
 const styles = {

--- a/apps/src/gamelab/MobileControls.js
+++ b/apps/src/gamelab/MobileControls.js
@@ -1,5 +1,5 @@
-import dom from '../dom';
-import gameLabDPadHtmlEjs from '../templates/gameLabDPad.html.ejs';
+import dom from '@cdo/apps/dom';
+import gameLabDPadHtmlEjs from '@cdo/apps/templates/gameLabDPad.html.ejs';
 import {GAMELAB_DPAD_CONTAINER_ID} from './constants';
 
 const DPAD_DEAD_ZONE = 3;

--- a/apps/src/gamelab/actions.js
+++ b/apps/src/gamelab/actions.js
@@ -1,7 +1,7 @@
 /** @file Redux action-creators for Game Lab.
  *  @see http://redux.js.org/docs/basics/Actions.html */
 import $ from 'jquery';
-import * as utils from '../utils';
+import * as utils from '@cdo/apps/utils';
 import {
   pickNewAnimation,
   show,

--- a/apps/src/gamelab/animationListModule.js
+++ b/apps/src/gamelab/animationListModule.js
@@ -3,14 +3,14 @@
  */
 import _ from 'lodash';
 import {combineReducers} from 'redux';
-import {createUuid} from '../utils';
+import {createUuid} from '@cdo/apps/utils';
 import {
   fetchURLAsBlob,
   blobToDataURI,
   dataURIToSourceSize
-} from '../imageUtils';
-import {animations as animationsApi} from '../clientApi';
-import * as assetPrefix from '../assetManagement/assetPrefix';
+} from '@cdo/apps/imageUtils';
+import {animations as animationsApi} from '@cdo/apps/clientApi';
+import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
 import {selectAnimation} from './AnimationTab/animationTabModule';
 import {reportError} from './errorDialogStackModule';
 import {throwIfSerializedAnimationListIsInvalid} from './shapes';
@@ -18,7 +18,7 @@ import {
   projectChanged,
   isOwner,
   getCurrentId
-} from '../code-studio/initApp/project';
+} from '@cdo/apps/code-studio/initApp/project';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 // TODO: Overwrite version ID within session

--- a/apps/src/gamelab/api-entry.js
+++ b/apps/src/gamelab/api-entry.js
@@ -1,5 +1,5 @@
 // entry point for api that gets exposed.
-import {globalFunctions as utilFunctions} from '../dropletUtilsGlobalFunctions';
+import {globalFunctions as utilFunctions} from '@cdo/apps/dropletUtilsGlobalFunctions';
 import {
   commands as audioCommands,
   executors as audioExecutors,

--- a/apps/src/gamelab/blocks.js
+++ b/apps/src/gamelab/blocks.js
@@ -1,7 +1,7 @@
 /* global dashboard */
 
-import {SVG_NS} from '../constants';
-import {getStore} from '../redux';
+import {SVG_NS} from '@cdo/apps/constants';
+import {getStore} from '@cdo/apps/redux';
 import {getLocation} from './locationPickerModule';
 import {GAME_HEIGHT, GameLabInterfaceMode} from './constants';
 import {animationSourceUrl} from './animationListModule';

--- a/apps/src/gamelab/commands.js
+++ b/apps/src/gamelab/commands.js
@@ -1,5 +1,5 @@
 /** @file Non-p5 GameLab commands */
-import {singleton as studioApp} from '../StudioApp';
+import {singleton as studioApp} from '@cdo/apps/StudioApp';
 import {commands as audioCommands} from '@cdo/apps/lib/util/audioApi';
 import {commands as timeoutCommands} from '@cdo/apps/lib/util/timeoutApi';
 

--- a/apps/src/gamelab/constants.js
+++ b/apps/src/gamelab/constants.js
@@ -1,5 +1,5 @@
 /** @file Game Lab constants */
-var utils = require('../utils');
+var utils = require('@cdo/apps/utils');
 
 /** @enum {string} */
 module.exports.GameLabInterfaceMode = utils.makeEnum('CODE', 'ANIMATION');

--- a/apps/src/gamelab/dropletConfig.js
+++ b/apps/src/gamelab/dropletConfig.js
@@ -1,13 +1,13 @@
 /* global dashboard */
 
 var api = require('./apiJavascript.js');
-import color from '../util/color';
-var consoleApi = require('../consoleApi');
+import color from '@cdo/apps/util/color';
+var consoleApi = require('@cdo/apps/consoleApi');
 import * as audioApi from '@cdo/apps/lib/util/audioApi';
 import audioApiDropletConfig from '@cdo/apps/lib/util/audioApiDropletConfig';
 import * as timeoutApi from '@cdo/apps/lib/util/timeoutApi';
-var getAssetDropdown = require('../assetManagement/getAssetDropdown');
-import {getStore} from '../redux';
+var getAssetDropdown = require('@cdo/apps/assetManagement/getAssetDropdown');
+import {getStore} from '@cdo/apps/redux';
 
 var spriteMethodPrefix = '[Sprite].';
 var groupMethodPrefix = '[Group].';

--- a/apps/src/gamelab/levels.js
+++ b/apps/src/gamelab/levels.js
@@ -1,5 +1,5 @@
-var utils = require('../utils');
-var blockUtils = require('../block_utils');
+var utils = require('@cdo/apps/utils');
+var blockUtils = require('@cdo/apps/block_utils');
 var tb = blockUtils.createToolbox;
 import {GamelabBlocks} from '@cdo/apps/gamelab/sharedGamelabBlocks';
 

--- a/apps/src/gamelab/locationPickerModule.js
+++ b/apps/src/gamelab/locationPickerModule.js
@@ -5,7 +5,7 @@ import {
   UPDATE_LOCATION
 } from './actions';
 import {LocationPickerMode} from './constants';
-import {getStore} from '../redux';
+import {getStore} from '@cdo/apps/redux';
 
 export default function locationPicker(state, action) {
   state = state || {

--- a/apps/src/gamelab/reducers.js
+++ b/apps/src/gamelab/reducers.js
@@ -6,7 +6,7 @@ import {
   HIDE_ANIMATION_JSON,
   TOGGLE_GRID_OVERLAY
 } from './actions';
-import {reducers as jsDebuggerReducers} from '../lib/tools/jsdebugger/redux';
+import {reducers as jsDebuggerReducers} from '@cdo/apps/lib/tools/jsdebugger/redux';
 import animationList from './animationListModule';
 import animationPicker from './AnimationPicker/animationPickerModule';
 import animationTab from './AnimationTab/animationTabModule';

--- a/apps/src/gamelab/spritelab/Spritelab.js
+++ b/apps/src/gamelab/spritelab/Spritelab.js
@@ -1,7 +1,7 @@
 import {commands} from './commands';
 import * as spriteUtils from './spriteUtils';
-import Sounds from '../../Sounds';
-import {getStore} from '../../redux';
+import Sounds from '@cdo/apps/Sounds';
+import {getStore} from '@cdo/apps/redux';
 import {clearConsole} from '../textConsoleModule';
 
 var Spritelab = function() {

--- a/apps/src/gamelab/spritelab/worldCommands.js
+++ b/apps/src/gamelab/spritelab/worldCommands.js
@@ -1,5 +1,5 @@
 import * as spriteUtils from './spriteUtils';
-import {getStore} from '../../redux';
+import {getStore} from '@cdo/apps/redux';
 import {addConsoleMessage} from '../textConsoleModule';
 
 export const commands = {


### PR DESCRIPTION
I'm planning to move SpriteLab and GameLab to both be nested under `P5Lab`, which will contain everything that's shared between SpriteLab and GameLab.

This PR will reduce the diff for that work by using the absolute path alias for imports rather than relative paths (since the directory level will change when GameLab moves under P5Lab).