### PR TITLE
Projects: allow project validators to see private or profane assets

### DIFF
--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -61,7 +61,7 @@ class FilesApi < Sinatra::Base
   end
 
   def can_view_profane_or_pii_assets?(encrypted_channel_id)
-    owns_channel?(encrypted_channel_id) || admin?
+    owns_channel?(encrypted_channel_id) || admin? || has_permission?('project_validator')
   end
 
   def file_too_large(quota_type)


### PR DESCRIPTION
Fix for [LP-400](https://codedotorg.atlassian.net/browse/LP-400)

Previously only project owners and admin could view assets that had been flagged as pii or profanity.  However, those with project_validator permissions should also be able to see these assets to diagnose issues.  I updated  `can_view_profane_or_pii_assets?` to be more consistent with `can_view_abusive_assets?` and also allow project validators to view the contents of the flagged project. 