### PR TITLE
Bump snack-sdk to 2.2.1-apkurl-v4, fix Expo build issues with dependencies, icon, and splash

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -224,7 +224,7 @@
   },
   "dependencies": {
     "@code-dot-org/js-interpreter": "^1.3.9",
-    "@code-dot-org/snack-sdk": "2.2.0-apkurl-v3",
+    "@code-dot-org/snack-sdk": "2.2.1-apkurl-v4",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/src/util/exporter.js
+++ b/apps/src/util/exporter.js
@@ -82,6 +82,16 @@ async function expoBuildOrCheckApk(options, mode, sessionSecret) {
   } = appJson.expo;
   appJson.expo = onlineOnlyExpo;
 
+  // Expo requires that these additional keys (iconUrl, imageUrl)
+  // are passed when the files are not provided locally
+  appJson.expo.iconUrl = appJson.expo.icon;
+  appJson.expo.splash.imageUrl = appJson.expo.splash.image;
+
+  // Starting with SDK 33, the turtle build system requires that
+  // we specify our dependencies here (we currently depend only
+  // on the 'expo' module):
+  appJson.expo.dependencies = ['expo'];
+
   if (buildMode) {
     return buildApk(session, appJson.expo);
   } else {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -972,9 +972,10 @@
     remark-stringify "^6.0.0"
     unified "^7.0.0"
 
-"@code-dot-org/snack-sdk@2.2.0-apkurl-v3":
-  version "2.2.0-apkurl-v3"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/snack-sdk/-/snack-sdk-2.2.0-apkurl-v3.tgz#571ea2cb15b21a27e1b397c963e04cfce32e7122"
+"@code-dot-org/snack-sdk@2.2.1-apkurl-v4":
+  version "2.2.1-apkurl-v4"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/snack-sdk/-/snack-sdk-2.2.1-apkurl-v4.tgz#b90c03ba129aef14a629e1a876ae5f7c0786dda6"
+  integrity sha512-VGmcK+Bp5jC5psDeIkulA1uM3hN6kq56+i1LcR2vIS/geEujyJ995e9ay5CqFN6uj5543dlD9qy92mAvM89Sxw==
   dependencies:
     babel-runtime "^6.23.0"
     diff "^3.2.0"


### PR DESCRIPTION
* Resolved the Expo SDK 33 build issue (we need to add `dependencies: ['expo']` to our manifest)
* Fixed Expo build issues with app icon and splash image (we need to specify and additional `iconUrl` and `splash.imageUrl` since we're providing remote URLs)
* Upgrade our Expo snack-sdk to match the pending snack-sdk PR: https://github.com/expo/snack-sdk/pull/10 (this has the latest and greatest)