### PR TITLE
Feedback: backfill script_level_id for teacher_feedbacks based on progress

### DIFF
--- a/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
+++ b/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
@@ -21,11 +21,14 @@ def update_script_level_ids
         level_id: feedback.level_id
       )
       if associated_user_levels.length == 1
-        script_level_id = ScriptLevel.where(
+        script_levels = ScriptLevel.where(
           level_id: associated_user_levels[0].level_id,
           script_id: associated_user_levels[0].script_id
-        ).id
-        feedback.update_attributes(script_level_id: script_level_id)
+        )
+        if script_levels.length == 1
+          script_level_id = script_levels[0].id
+          feedback.update_attributes(script_level_id: script_level_id)
+        end
       end
     end
   end

--- a/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
+++ b/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
@@ -14,6 +14,7 @@ end
 def update_script_level_ids
   puts "backfilling script_level_ids..."
   feedbacks_without_script_level_id.find_each do |feedback|
+    puts "*"
     associated_script_levels = feedback.level.script_levels
     if associated_script_levels.length > 1
       associated_user_levels = UserLevel.where(

--- a/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
+++ b/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# Backfill existing TeacherFeedbacks to set script_level_id based on user progress.
+
+require_relative '../../config/environment'
+
+def feedbacks_without_script_level_id
+  TeacherFeedback.where(script_level_id: nil)
+end
+
+def puts_count
+  puts "There are #{feedbacks_without_script_level_id.count} feedbacks without a script_level_id"
+end
+
+def update_script_level_ids
+  puts "backfilling script_level_ids..."
+  feedbacks_without_script_level_id.find_each do |feedback|
+    associated_script_levels = feedback.level.script_levels
+    if associated_script_levels.length > 1
+      associated_user_levels = UserLevel.where(
+        user_id: feedback.student_id,
+        level_id: feedback.level_id
+      )
+      if associated_user_levels.length == 1
+        script_level_id = ScriptLevel.where(
+          level_id: associated_user_levels[0].level_id,
+          script_id: associated_user_levels[0].script_id
+        ).id
+        feedback.update_attributes(script_level_id: script_level_id)
+      end
+    end
+  end
+end
+
+TeacherFeedback.transaction do
+  puts_count
+  update_script_level_ids
+  puts_count
+end


### PR DESCRIPTION
Partial fulfillment of [LP-590](https://codedotorg.atlassian.net/browse/LP-590) 
Continuation of #29676 

If the `Level` associated with the `TeacherFeedback` in question is associated with more than one `ScriptLevel` we will next look to progress to infer the correct `script_level_id`. If the student only has one `UserLevel` associated with the `Level` associated with the `TeacherFeedback`, then we will use the  `UserLevel`'s `level_id` and `script_id` to find the assumed `ScriptLevel` and set `script_level_id` for the `TeacherFeedback` to use that `ScriptLevel`'s id. 