### PR TITLE
Stop overwriting custom submit buttons for PD external levels

### DIFF
--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -16,10 +16,10 @@
 
 .external
   - postcontent = capture_haml do
-    - unless in_level_group
+    - unless in_level_group || @level.has_submit_button?
       - if @script.try(:professional_learning_course?) && @script_level
         = link_to @script_level.end_of_stage? ? t('done_with_module') : t('next_resource'), @script_level.next_level_or_redirect_path_for_user(current_user), class: 'btn btn-large pull-right btn-primary submitButton'
-      - elsif !@level.has_submit_button? && !(video && use_large_video_player)
+      - elsif !(video && use_large_video_player)
         %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
 
   = render partial: 'levels/content', locals: {app: 'external', data: level_props, content_class: level_props['options'].try(:[], 'css'), postcontent: postcontent, source_level: level}


### PR DESCRIPTION
Emma reported a mis-match between the markdown on Levelbuilder and production for a professional development external level, https://studio.code.org/s/K5-OnlinePD/stage/1/puzzle/2

On production: 
<img width="1111" alt="Screen Shot 2019-07-15 at 12 55 37 PM" src="https://user-images.githubusercontent.com/12300669/61244843-052a2f00-a700-11e9-9555-82d0ab1c7403.png">

But in the levelbuilder editing: 
<img width="923" alt="Screen Shot 2019-07-15 at 12 53 23 PM" src="https://user-images.githubusercontent.com/12300669/61244860-0e1b0080-a700-11e9-96a8-c814b157fccf.png">

This is happening because the level wasn't recognizing the custom submit button so it was defaulting to rendering a "Next Resource" button and overwriting Emma's desired button text. I adjusted the logic to handle for professional development levels with custom buttons. 

