### PR TITLE
always use https for optimizely include tag

### DIFF
--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -21,7 +21,7 @@
     = render file: Rails.root.join('..', 'shared', 'haml', 'answerdash.haml') if view_options[:answerdash]
     = javascript_include_tag 'application'
     = javascript_include_tag "js/#{js_locale}/common_locale"
-    = javascript_include_tag '//cdn.optimizely.com/js/12977480133.js' if Rails.env.production?
+    = javascript_include_tag 'https://cdn.optimizely.com/js/12977480133.js' if Rails.env.production?
     %script{src: minifiable_asset_path('js/code-studio-common.js')}
     = csrf_meta_tags
     = yield :head

--- a/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
@@ -9,7 +9,7 @@
 %link{rel:'shortcut icon', href:'/images/favicon.ico'}
 %link{rel:'apple-touch-icon', href:'/images/apple-touch-icon-precomposed.png'}
 
-%script{src:'//cdn.optimizely.com/js/12977480133.js'}
+%script{src:'https://cdn.optimizely.com/js/12977480133.js'}
 
 =view :fonts
 -if @header['style_min'] && request.site == 'code.org'

--- a/pegasus/sites/all/views/page.haml
+++ b/pegasus/sites/all/views/page.haml
@@ -2,7 +2,7 @@
 %html
   %head
     -if request.site == 'code.org'
-      %script{src: "//cdn.optimizely.com/js/12977480133.js"}
+      %script{src: "https://cdn.optimizely.com/js/12977480133.js"}
 
     -# Add social networking meta properties.
     - header['social'].each_pair do |property, content|


### PR DESCRIPTION
The tide has apparently turned on [protocol-relative urls](https://www.paulirish.com/2010/the-protocol-relative-url/), while they were useful during the HTTPS-everywhere transition phase they are now widely considered to be an anti-pattern that should be replaced with the `https:` scheme for external assets for performance and (more importantly) security reasons. Standard [web best practices](https://webhint.io/docs/user-guide/hints/hint-no-protocol-relative-urls) and automated web-security scanners/linters are following suit, so we should update our codebase to keep in compliance.

This PR starts small by updating our Optimizely link tags to use HTTPS.