### PR TITLE
Surveys: Run sync_jotforms every half-hour

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -85,7 +85,7 @@
       cronjob at:'0 16 * * *', do:dashboard_dir('bin','scheduled_pd_application_emails')
       cronjob at:'10 */12 * * *', do:dashboard_dir('bin','refresh_pd_workshop_material_orders')
       cronjob at:'*/1 * * * *', do:dashboard_dir('bin', 'fill_jotform_placeholders')
-      cronjob at:'0 * * * *', do:dashboard_dir('bin', 'sync_jotforms')
+      cronjob at:'*/30 * * * *', do:dashboard_dir('bin', 'sync_jotforms')
       cronjob at:'25 7 * * *', do:deploy_dir('bin', 'cron', 'update_hoc_map')
       cronjob at:'19 4 * * *', do:deploy_dir('bin', 'cron', 'update_census_map')
       cronjob at:'0 9 * * 1-5', do:deploy_dir('bin', 'cron', 'check_for_census_inaccuracy_reports')


### PR DESCRIPTION
Run the `sync_jotforms` task every half-hour instead of every hour.

`sync_jotforms` looks up JotForm submissions that we did _not_ have placeholders for and ingests them into our dashboard database. (The `fill_jotform_placeholders` job that runs every minute handles forms that we _do_ have placeholders for.)  This makes it a fallback case, but we still get bug reports from workshops when this happens and it takes up to an hour for survey responses to show up.  This usually runs very quick, so we're making it run every half-hour to reduce the customer impact when it's needed.

Impetus for this change: [Slack conversation](https://codedotorg.slack.com/archives/C0T10H26N/p1563226711047300)