### PR TITLE
Fix: Workshops without subjects have exit surveys

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -120,7 +120,11 @@ class Pd::Enrollment < ActiveRecord::Base
   # Except for FiT workshops - no exit surveys for them!
   # This scope is used in ProfessionalLearningLandingController to direct the teacher
   #   to their latest pending survey.
-  scope :with_surveys, -> {for_ended_workshops.attended.where.not(pd_workshops: {subject: SUBJECT_FIT})}
+  scope :with_surveys, (lambda do
+    for_ended_workshops.
+      attended.
+      where('pd_workshops.subject != ? or pd_workshops.subject is null', SUBJECT_FIT)
+  end)
 
   def has_user?
     user_id

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -31,6 +31,26 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
     assert_equal Pd::Workshop::COURSE_CSF, response[:last_workshop_survey_course]
   end
 
+  test 'Admin workshops may show up as pending exit surveys' do
+    # Fake Admin workshop, which should produce an exit survey
+    admin_workshop = create :pd_ended_workshop,
+      course: Pd::Workshop::COURSE_ADMIN,
+      subject: nil
+
+    # Given a teacher that attended the workshop
+    teacher = create :teacher
+    go_to_workshop admin_workshop, teacher
+
+    # When the teacher loads the PL landing page
+    load_pl_landing teacher
+
+    # They see a prompt to take the Admin workshop exit survey
+    response = assigns(:landing_page_data)
+    enrollment = admin_workshop.enrollments.first
+    assert_equal enrollment.exit_survey_url, response[:last_workshop_survey_url]
+    assert_equal admin_workshop.course, response[:last_workshop_survey_course]
+  end
+
   test 'FiT workshops do not show up as pending exit surveys' do
     # Fake FiT workshop, which should not produce an exit survey
     fit_workshop = create :pd_ended_workshop,


### PR DESCRIPTION
In particular, workshops with a `NULL` subject will still be included in the `with_surveys` enrollment scope, and therefore will remind about pending exit surveys on the professional learning landing page.

Fixes a regression introduced in https://github.com/code-dot-org/code-dot-org/pull/29511 when I added a condition to the `with_surveys` scope, not realizing it would implicitly exclude null values as well.

Did some work to evaluate impact, and it looks like we've had no workshops with `NULL` subject end in the week or so since I introduced this regression, so overall impact is near-zero.  Still, I'd like to get it fixed before I move on to disabling exit surveys for Facilitator workshops (which also have a `NULL` subject).