### PR TITLE
Professional Learning: Facilitator workshops have no exit surveys

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -123,7 +123,8 @@ class Pd::Enrollment < ActiveRecord::Base
   scope :with_surveys, (lambda do
     for_ended_workshops.
       attended.
-      where('pd_workshops.subject != ? or pd_workshops.subject is null', SUBJECT_FIT)
+      where.not(pd_workshops: {course: COURSE_FACILITATOR}).
+      where('pd_workshops.subject != ? or pd_workshops.subject is null', [SUBJECT_FIT])
   end)
 
   def has_user?

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -433,7 +433,7 @@ class Pd::Workshop < ActiveRecord::Base
   # from other logic deciding whether a workshop should have exit surveys.
   def send_exit_surveys
     # FiT workshops should not send exit surveys
-    return if SUBJECT_FIT == subject
+    return if SUBJECT_FIT == subject || COURSE_FACILITATOR == course
 
     resolve_enrolled_users
 

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -99,6 +99,52 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
     assert_equal csf_workshop.course, response[:last_workshop_survey_course]
   end
 
+  test 'Facilitator workshops do not show up as pending exit surveys' do
+    # Fake FiT workshop, which should not produce an exit survey
+    facilitator_workshop = create :pd_ended_workshop,
+      course: Pd::Workshop::COURSE_FACILITATOR
+
+    # Given a teacher that attended the workshop, such that they would get
+    # a survey for any other workshop subject.
+    teacher = create :teacher
+    go_to_workshop facilitator_workshop, teacher
+
+    # When the teacher loads the PL landing page
+    load_pl_landing teacher
+
+    # Then they don't see a prompt for a pending exit survey
+    # (That is, we didn't pass down the parameters that would cause that prompt to appear.)
+    response = assigns(:landing_page_data)
+    assert_nil response[:last_workshop_survey_url]
+    assert_nil response[:last_workshop_survey_course]
+  end
+
+  test 'Facilitator workshops do not interfere with other pending exit surveys' do
+    # Fake CSF workshop (older than the Facilitator workshop) which should
+    # produce a pending exit survey
+    csf_workshop = create :pd_ended_workshop,
+      course: Pd::Workshop::COURSE_CSF,
+      ended_at: Date.today - 1.day
+
+    # Fake Facilitator workshop, which should not produce an exit survey
+    facilitator_workshop = create :pd_ended_workshop,
+      course: Pd::Workshop::COURSE_FACILITATOR
+
+    # Given a teacher that attended both workshops
+    teacher = create :teacher
+    go_to_workshop csf_workshop, teacher
+    go_to_workshop facilitator_workshop, teacher
+
+    # When the teacher loads the PL landing page
+    load_pl_landing teacher
+
+    # They see a prompt to take the CSF workshop exit survey (not the more recent FiT workshop)
+    response = assigns(:landing_page_data)
+    csf_enrollment = csf_workshop.enrollments.first
+    assert_equal csf_enrollment.exit_survey_url, response[:last_workshop_survey_url]
+    assert_equal csf_workshop.course, response[:last_workshop_survey_course]
+  end
+
   test_redirect_to_sign_in_for :index
 
   test 'teachers without enrollments are redirected' do

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -400,6 +400,12 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     fit_enrollment = create :pd_enrollment, workshop: fit_workshop
     create :pd_attendance, session: fit_workshop.sessions.first, enrollment: fit_enrollment
 
+    # Ended Facilitator workshop, with attendance
+    # (Checks a special case: Facilitator workshops don't have exit surveys)
+    facilitator_workshop = create :pd_ended_workshop, num_sessions: 1, course: COURSE_FACILITATOR
+    facilitator_enrollment = create :pd_enrollment, workshop: facilitator_workshop
+    create :pd_attendance, session: facilitator_workshop.sessions.first, enrollment: facilitator_enrollment
+
     # Non-ended workshop, no attendance
     # (No surveys because not ended)
     non_ended_workshop = create :pd_workshop, num_sessions: 1

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -351,7 +351,17 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     # Make a FiT workshop that's ended and has attendance;
     # these are the conditions under which we'd normally send a survey.
     workshop = create :pd_ended_workshop, subject: SUBJECT_FIT
-    create(:pd_workshop_participant, workshop: workshop, enrolled: true)
+    create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
+
+    # Ensure no exit surveys are sent
+    Pd::Enrollment.any_instance.expects(:send_exit_survey).never
+    workshop.send_exit_surveys
+  end
+
+  test 'send_exit_surveys sends no surveys for Facilitator workshops' do
+    # Make a Facilitator workshop that's ended and has attendance;
+    # these are the conditions under which we'd normally send a survey.
+    workshop = create :pd_ended_workshop, course: COURSE_FACILITATOR
     create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
 
     # Ensure no exit surveys are sent


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/29511, prerequisite to solving [PLC-350 "Manually close facilitator summit workshops."](https://codedotorg.atlassian.net/browse/PLC-350)

Specifically, workshops with `course: COURSE_FACILITATOR` will not send exit survey emails, nor will they remind about pending exit surveys on the professional learning landing page.

Doing this so we can close some workshops without sending emails to SarahF. We've only got 6 workshops on production using `COURSE_FACILITATOR`. Four of them are currently open (have been since May) so they keep reminding her to close them.  After this change ships, we'll manually close those workshops.