### PR TITLE
Feedback: pass real data to the AllFeedback component and determine seenByStudent

### DIFF
--- a/apps/src/sites/studio/pages/teacher_feedbacks/index.js
+++ b/apps/src/sites/studio/pages/teacher_feedbacks/index.js
@@ -6,23 +6,11 @@ import AllFeedback from '@cdo/apps/templates/feedback/AllFeedback';
 $(document).ready(showFeedback);
 
 function showFeedback() {
-  // TODO: Erin B. delete in favor of real data
-  // once TeacherFeedbacks are associated with ScriptLevels rather than Levels.
-  const feedbacks = [
-    {
-      lessonName: 'Creating Functions',
-      levelNum: '8',
-      linkToLevel: '/',
-      unitName: 'CSP Unit 3 - Intro to Programming',
-      linkToUnit: '/',
-      lastUpdated: new Date().toLocaleString(),
-      comment: 'Good job!',
-      seenByStudent: false
-    }
-  ];
+  const script = document.querySelector('script[data-feedback]');
+  const feedbackData = JSON.parse(script.dataset.feedback);
 
   ReactDOM.render(
-    <AllFeedback feedbacks={feedbacks} />,
+    <AllFeedback feedbacks={feedbackData.all_feedback} />,
     document.getElementById('feedback-container')
   );
 }

--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -55,15 +55,18 @@ export default class LevelFeedbackEntry extends Component {
 
   render() {
     const {
-      seenByStudent,
+      seen_on_feedback_page_at,
+      student_first_visited_at,
       lessonName,
       levelNum,
       linkToLevel,
       unitName,
       linkToUnit,
-      lastUpdated,
+      updated_at,
       comment
     } = this.props.feedback;
+
+    const seenByStudent = seen_on_feedback_page_at || student_first_visited_at;
 
     const style = {
       backgroundColor: seenByStudent ? color.lightest_teal : color.white,
@@ -94,7 +97,7 @@ export default class LevelFeedbackEntry extends Component {
             </div>
           </a>
         </div>
-        <TimeAgo style={styles.time} dateString={lastUpdated} />
+        <TimeAgo style={styles.time} dateString={updated_at} />
         <div style={styles.comment}>{comment}</div>
       </div>
     );

--- a/apps/src/templates/feedback/LevelFeedbackEntry.story.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.story.jsx
@@ -4,26 +4,19 @@ import LevelFeedbackEntry from './LevelFeedbackEntry';
 const defaultProps = {
   feedback: {
     lessonName: 'Creating Functions',
-    levelNum: '8',
+    levelNum: 8,
     linkToLevel: '/',
     unitName: 'CSP Unit 3 - Intro to Programming',
     linkToUnit: '/',
-    lastUpdated: new Date(),
+    updated_at: new Date(),
     comment: 'Excellent work! You followed the directions closely.'
-  }
-};
-
-const unseenFeedback = {
-  feedback: {
-    ...defaultProps.feedback,
-    seenByStudent: false
   }
 };
 
 const seenFeedback = {
   feedback: {
     ...defaultProps.feedback,
-    seenByStudent: true
+    seen_on_feedback_page_at: new Date().toLocaleString()
   }
 };
 
@@ -34,7 +27,7 @@ export default storybook => {
     .addStoryTable([
       {
         name: 'LevelFeedbackEntry - not yet seen',
-        story: () => <LevelFeedbackEntry {...unseenFeedback} />
+        story: () => <LevelFeedbackEntry {...defaultProps} />
       },
       {
         name: 'LevelFeedbackEntry - seen by student',

--- a/apps/src/templates/feedback/shapes.js
+++ b/apps/src/templates/feedback/shapes.js
@@ -2,13 +2,14 @@ import PropTypes from 'prop-types';
 
 const shapes = {
   feedback: PropTypes.shape({
-    seenByStudent: PropTypes.bool.isRequired,
+    seen_on_feedback_page_at: PropTypes.string,
+    student_first_visited_at: PropTypes.string,
     lessonName: PropTypes.string.isRequired,
-    levelNum: PropTypes.string.isRequired,
+    levelNum: PropTypes.number.isRequired,
     linkToLevel: PropTypes.string.isRequired,
     unitName: PropTypes.string,
     linkToUnit: PropTypes.string,
-    lastUpdated: PropTypes.oneOfType([
+    updated_at: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.instanceOf(Date)
     ]).isRequired,

--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -5,5 +5,6 @@ class TeacherFeedbacksController < ApplicationController
   # Feedback from any teacher who has provided feedback to the current
   # student on any level
   def index
+    @teacher_feedbacks = @teacher_feedbacks.map {|feedback| feedback.attributes.merge(feedback&.script_level&.summary_for_feedback)}
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -447,6 +447,16 @@ class ScriptLevel < ActiveRecord::Base
     teacher_panel_summary
   end
 
+  def summary_for_feedback
+    {
+      lessonName: stage.name,
+      levelNum: position,
+      linkToLevel: path,
+      unitName: stage.script.localized_title,
+      linkToUnit: stage.script.link
+    }
+  end
+
   def self.cache_find(id)
     Script.cache_find_script_level(id)
   end

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -29,6 +29,7 @@ class TeacherFeedback < ApplicationRecord
   belongs_to :student, class_name: 'User'
   has_many :student_sections, class_name: 'Section', through: :student, source: 'sections_as_student'
   belongs_to :level
+  belongs_to :script_level
   belongs_to :teacher, class_name: 'User'
 
   def self.get_student_level_feedback(student_id, level_id, teacher_id)


### PR DESCRIPTION
Spec: [notifying students about teacher feedback](https://docs.google.com/document/d/1anY8vf8KKSGP_p88KAmUlTR3HVtMkoEQ9XGcUKynnmQ/edit?ts=5cc9c2de#)
Continuation of #29530

Now that `script_level_id` is being saved for new TeacherFeedbacks, I populated the All Feedback page with real data. 

![all-feedback-real-data](https://user-images.githubusercontent.com/12300669/61261517-f448e000-a736-11e9-9e10-88be3ce13fa6.png)

`seenByStudent` will be set to `true` if `student_first_visited_at` or `seen_on_feedback_page_at` is not null as outlined in #29623.

If the `script_level_id` is not yet set the `LevelFeedbackEntry` still renders with the comment text but the details about the lesson and unit are blank, for now. 