### PR TITLE
chef_local_mode: true for adhoc environment

### DIFF
--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -1,2 +1,2 @@
-chef_local_mode: false
+chef_local_mode: true
 stub_school_data: true


### PR DESCRIPTION
#28877 introduced a bug which set [`chef_local_mode: false`](https://github.com/code-dot-org/code-dot-org/pull/28877/files#diff-b358760e9fc2794e5e94b9721592e852R1) in `adhoc` environment, when it should be `true` in order to adhoc deployments to work as expected (where they do not interact with the hosted Chef server, and instead use locally deployed cookbooks/configuration). This PR fixes the bug by setting `chef_local_mode: true` in the `adhoc` config.