### PR TITLE
Feedback: count only includes unseen, update seen_on_feedback_page_at

### DIFF
--- a/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
@@ -35,17 +35,19 @@ class Api::V1::TeacherFeedbacksController < Api::V1::JsonApiController
     render json: @level_feedbacks, each_serializer: Api::V1::TeacherFeedbackSerializer
   end
 
-  # Determine how many feedback entries from any teacher
+  # Determine how many not yet seen feedback entries from any teacher
   # for any level are associated with the current user
   def count
     # Setting CSRF token header allows us to access the token manually in subsequent POST requests.
     headers['csrf-token'] = form_authenticity_token
 
-    @all_feedbacks_count = TeacherFeedback.where(
-      student_id: current_user.id
+    @all_unseen_feedbacks_count = TeacherFeedback.where(
+      student_id: current_user.id,
+      seen_on_feedback_page_at: nil,
+      student_first_visited_at: nil
     ).length
 
-    render json: @all_feedbacks_count, each_serializer: Api::V1::TeacherFeedbackSerializer
+    render json: @all_unseen_feedbacks_count, each_serializer: Api::V1::TeacherFeedbackSerializer
   end
 
   # POST /teacher_feedbacks

--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -1,10 +1,15 @@
 class TeacherFeedbacksController < ApplicationController
   before_action :authenticate_user!
   load_and_authorize_resource
+  after_action :set_seen_on_feedback_page_at, only: :index
 
   # Feedback from any teacher who has provided feedback to the current
   # student on any level
   def index
     @teacher_feedbacks = @teacher_feedbacks.map {|feedback| feedback.attributes.merge(feedback&.script_level&.summary_for_feedback)}
+  end
+
+  def set_seen_on_feedback_page_at
+    TeacherFeedback.where(student_id: current_user.id).update_all(seen_on_feedback_page_at: DateTime.now)
   end
 end

--- a/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
@@ -155,6 +155,25 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     assert_equal "2", formatted_response
   end
 
+  test 'count does not include already seen feedback' do
+    sign_in @student
+    teacher_sign_in_and_give_feedback(@teacher, @student, @level, COMMENT1, PERFORMANCE1)
+    sign_out @teacher
+
+    sign_in @student
+    get "#{API}/count"
+
+    assert_equal "1", formatted_response
+
+    TeacherFeedback.last.update_attribute(
+      :seen_on_feedback_page_at,
+      DateTime.now
+    )
+
+    get "#{API}/count"
+    assert_equal "0", formatted_response
+  end
+
   test 'bad request when student_id not provided - get_feedbacks' do
     teacher_sign_in_and_give_feedback(@teacher, @student, @level, COMMENT1, PERFORMANCE1)
     get "#{API}/get_feedbacks", params: {level_id: @level.id}


### PR DESCRIPTION
There are 2 main changes here related to seen/unseen status for teacher feedbacks.

1.) The API endpoint that returns the count of the current student's feedbacks now filters out any seen feedback. Tests were updated accordingly. 

Before I was notified about 7 feedbacks: 
<img width="1089" alt="Screen Shot 2019-07-16 at 1 25 32 PM" src="https://user-images.githubusercontent.com/12300669/61333236-2b70cd00-a7db-11e9-879c-ebf2d4b08cdc.png">

After the change to the count endpoint, I was notified about only the 3 not yet seen feedbacks. 
<img width="1045" alt="Screen Shot 2019-07-16 at 1 29 21 PM" src="https://user-images.githubusercontent.com/12300669/61333239-2f045400-a7db-11e9-8242-6d720adb3d3b.png">


2.) [LP-519](https://codedotorg.atlassian.net/browse/LP-519) Mark feedback "seen" if viewed on the all feedback page was accomplished by adding an `after_action` to the index for /feedback that updates the `seen_on_feedback_page_at` field to the current time for all of the student's current feedbacks. In the gif you see that there are initially a mix of seen (teal) and unseen (white) feedbacks and on page re-load, the feedbacks are now all seen. 
![update-all](https://user-images.githubusercontent.com/12300669/61333067-b00f1b80-a7da-11e9-85ee-1b4624d1c727.gif)

