### PR TITLE
Census: Skip seeding state CS offerings for unknown NCES IDs

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -171,7 +171,7 @@ class Census::StateCsOffering < ApplicationRecord
       end
 
       # At this point we have nothing left.
-      CDO.log.warn "Entry for #{state_code} requires either nces_id or state_school_id.  (nces_id: #{nces_id}, state_school_id: #{state_school_id})"
+      CDO.log.warn "Entry for #{state_code} requires either state_school_id or nces_id that matches a School in the db with state_school_id column populated.  (nces_id: #{nces_id}, state_school_id: #{state_school_id})"
       return nil
     end
 

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -171,7 +171,8 @@ class Census::StateCsOffering < ApplicationRecord
       end
 
       # At this point we have nothing left.
-      raise ArgumentError.new("Entry for #{state_code} requires either nces_id or state_school_id.")
+      CDO.log.warn "Entry for #{state_code} requires either nces_id or state_school_id."
+      return nil
     end
 
     # Special casing for V1 format.

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -171,7 +171,7 @@ class Census::StateCsOffering < ApplicationRecord
       end
 
       # At this point we have nothing left.
-      CDO.log.warn "Entry for #{state_code} requires either nces_id or state_school_id."
+      CDO.log.warn "Entry for #{state_code} requires either nces_id or state_school_id.  (nces_id: #{nces_id}, state_school_id: #{state_school_id})"
       return nil
     end
 


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/29710

We might have entries in our state CS offering CSVs that mention an `nces_id` but no `state_school_id`, but with an `nces_id` that we don't recognise and therefore can't find the `state_school_id` for.  Let's just warn in such cases rather than raise an exception.