### PR TITLE
Don't update preview if code is running

### DIFF
--- a/apps/src/gamelab/spritelab/Spritelab.js
+++ b/apps/src/gamelab/spritelab/Spritelab.js
@@ -8,6 +8,9 @@ var Spritelab = function() {
   this.reset = () => spriteUtils.reset();
 
   this.preview = function() {
+    if (getStore().getState().runState.isRunning) {
+      return;
+    }
     if (this.gameLabP5.p5decrementPreload) {
       // preload is still in progress. This happens sometimes on initial page load because both the Gamelab reset
       // handler and the Blockly change handler call preview. The first call goes to the else case below and calls

--- a/apps/test/unit/gamelab/spritelab/SpritelabTest.js
+++ b/apps/test/unit/gamelab/spritelab/SpritelabTest.js
@@ -1,11 +1,23 @@
 import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux
+} from '@cdo/apps/redux';
+import commonReducers from '@cdo/apps/redux/commonReducers';
+import reducers from '@cdo/apps/gamelab/reducers';
+import {setIsRunning} from '@cdo/apps/redux/runState';
 import Spritelab from '@cdo/apps/gamelab/spritelab/Spritelab';
 import Sounds from '@cdo/apps/Sounds';
 
 describe('Spritelab Preview', () => {
+  beforeEach(stubRedux);
+  afterEach(restoreRedux);
   let gamelab, muteSpy;
   beforeEach(function() {
+    registerReducers({...commonReducers, ...reducers});
     gamelab = sinon.spy();
     gamelab.areAnimationsReady_ = sinon.stub().returns(true);
     gamelab.gameLabP5 = sinon.spy();
@@ -29,5 +41,12 @@ describe('Spritelab Preview', () => {
     spritelab.preview.apply(gamelab);
 
     expect(muteSpy).to.have.been.calledOnce;
+  });
+  it('Preview does not run if code is running', () => {
+    let spritelab = new Spritelab();
+    getStore().dispatch(setIsRunning(true));
+    spritelab.preview.apply(gamelab);
+
+    expect(muteSpy).to.not.have.been.called;
   });
 });


### PR DESCRIPTION
We shouldn't be updating live-preview if the blockspace changes while code is running.
This regression was introduced with #29445 with [this line](https://github.com/code-dot-org/code-dot-org/pull/29445/files#diff-17f6f980ad057a6db9a3b1f7de1dcd41L753)