### PR TITLE
Add queryUserProgress to progressRedux

### DIFF
--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -228,7 +228,7 @@ function initViewAs(store, scriptData) {
  */
 function queryUserProgress(store, scriptData, currentLevelId) {
   const userId = clientState.queryParams('user_id');
-  const onComplete = data => {
+  store.dispatch(reduxQueryUserProgress(userId)).then(data => {
     const onOverviewPage = !currentLevelId;
     if (!onOverviewPage) {
       return;
@@ -259,8 +259,7 @@ function queryUserProgress(store, scriptData, currentLevelId) {
         pageType
       );
     }
-  };
-  store.dispatch(reduxQueryUserProgress(userId, onComplete));
+  });
 }
 
 /**

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -34,7 +34,6 @@ import {
 } from './progressRedux';
 import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 import {queryLockStatus, renderTeacherPanel} from './teacherPanelHelpers';
-import experiments from '../util/experiments';
 
 var progress = module.exports;
 
@@ -51,9 +50,7 @@ function showDisabledBubblesModal() {
 progress.showDisabledBubblesAlert = function() {
   const store = getStore();
   const {postMilestoneDisabled} = store.getState().progress;
-  const showAlert =
-    postMilestoneDisabled || experiments.isEnabled('postMilestoneDisabledUI');
-  if (!showAlert) {
+  if (!postMilestoneDisabled) {
     return;
   }
 
@@ -247,9 +244,8 @@ function queryUserProgress(store, scriptData, currentLevelId) {
   }).done(data => {
     data = data || {};
 
-    const postMilestoneDisabled =
-      store.getState().progress.postMilestoneDisabled ||
-      experiments.isEnabled('postMilestoneDisabledUI');
+    const postMilestoneDisabled = store.getState().progress
+      .postMilestoneDisabled;
     // Depend on the fact that even if we have no levelProgress, our progress
     // data will have other keys
     const signedInUser = Object.keys(data).length > 0;
@@ -356,10 +352,7 @@ function initializeStoreWithProgress(
     })
   );
 
-  const postMilestoneDisabled =
-    scriptData.disablePostMilestone ||
-    experiments.isEnabled('postMilestoneDisabledUI');
-  if (postMilestoneDisabled) {
+  if (scriptData.disablePostMilestone) {
     store.dispatch(disablePostMilestone());
   }
 

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -227,30 +227,29 @@ function initViewAs(store, scriptData) {
  * as appropriate
  */
 function queryUserProgress(store, scriptData, currentLevelId) {
-  const onOverviewPage = !currentLevelId;
-  const pageType = currentLevelId ? 'level' : 'script_overview';
   const userId = clientState.queryParams('user_id');
-  const postMilestoneDisabled = store.getState().progress.postMilestoneDisabled;
-
   const onComplete = data => {
+    const onOverviewPage = !currentLevelId;
+    if (!onOverviewPage) {
+      return;
+    }
+
     // Depend on the fact that even if we have no levelProgress, our progress
     // data will have other keys
     const signedInUser = Object.keys(data).length > 0;
-    if (
-      onOverviewPage &&
-      signedInUser &&
-      postMilestoneDisabled &&
-      !scriptData.isHocScript
-    ) {
+    const postMilestoneDisabled = store.getState().progress
+      .postMilestoneDisabled;
+    if (signedInUser && postMilestoneDisabled && !scriptData.isHocScript) {
       showDisabledBubblesModal();
     }
 
     if (
       (data.isTeacher || data.teacherViewingStudent) &&
-      !data.professionalLearningCourse &&
-      onOverviewPage
+      !data.professionalLearningCourse
     ) {
       queryLockStatus(store, scriptData.id);
+
+      const pageType = currentLevelId ? 'level' : 'script_overview';
       renderTeacherPanel(
         store,
         scriptData.id,

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -661,18 +661,28 @@ export const progressionsFromLevels = levels => {
   return progressions;
 };
 
-export const queryUserProgress = (userId, onComplete = data => {}) => (
+export const queryUserProgress = (userId, onComplete) => (
   dispatch,
   getState
 ) => {
   const state = getState().progress;
+  userProgressFromServer(state, dispatch, userId, onComplete);
+};
 
+export const userProgressFromServer = (
+  state,
+  dispatch,
+  userId,
+  onComplete = data => {}
+) => {
   if (!state.scriptName) {
     return;
   }
 
-  $.ajax(`/api/user_progress/${state.scriptName}`, {
-    data: {user_id: userId}
+  $.ajax({
+    url: `/api/user_progress/${state.scriptName}`,
+    method: 'GET',
+    data: JSON.stringify({user_id: userId})
   }).done(data => {
     data = data || {};
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -304,6 +304,72 @@ export function processedStages(stages, isPlc) {
   });
 }
 
+/**
+ * Requests user progress from the server and dispatches other redux actions
+ * based on the server's response data.
+ */
+export const userProgressFromServer = (state, dispatch, userId) => {
+  if (!state.scriptName) {
+    return;
+  }
+
+  return $.ajax({
+    url: `/api/user_progress/${state.scriptName}`,
+    method: 'GET',
+    data: {user_id: userId}
+  }).done(data => {
+    data = data || {};
+
+    if (data.isVerifiedTeacher) {
+      dispatch(setVerified());
+    }
+
+    // We are on an overview page if currentLevelId is undefined.
+    const onOverviewPage = !state.currentLevelId;
+    // Show lesson plan links and other teacher info if teacher and on unit overview page.
+    if (
+      (data.isTeacher || data.teacherViewingStudent) &&
+      !data.professionalLearningCourse &&
+      onOverviewPage
+    ) {
+      // Default to progress summary view if teacher is viewing their student's progress.
+      if (data.teacherViewingStudent) {
+        dispatch(setIsSummaryView(true));
+      }
+
+      dispatch(showTeacherInfo());
+    }
+
+    if (data.focusAreaStageIds) {
+      dispatch(
+        updateFocusArea(data.changeFocusAreaPath, data.focusAreaStageIds)
+      );
+    }
+
+    if (data.lockableAuthorized) {
+      dispatch(authorizeLockable());
+    }
+
+    if (data.completed) {
+      dispatch(setScriptCompleted());
+    }
+
+    // Merge progress from server
+    if (data.levels) {
+      const levelProgress = _.mapValues(data.levels, getLevelResult);
+      dispatch(mergeProgress(levelProgress));
+
+      if (data.peerReviewsPerformed) {
+        dispatch(mergePeerReviewProgress(data.peerReviewsPerformed));
+      }
+
+      if (data.current_stage) {
+        dispatch(setCurrentStageId(data.current_stage));
+      }
+    }
+  });
+};
+
 // Action creators
 export const initProgress = ({
   currentLevelId,
@@ -383,6 +449,11 @@ export const setStageExtrasEnabled = stageExtrasEnabled => ({
   type: SET_STAGE_EXTRAS_ENABLED,
   stageExtrasEnabled
 });
+
+export const queryUserProgress = userId => (dispatch, getState) => {
+  const state = getState().progress;
+  return userProgressFromServer(state, dispatch, userId);
+};
 
 // Selectors
 
@@ -659,73 +730,6 @@ export const progressionsFromLevels = levels => {
   });
   progressions.push(currentProgression);
   return progressions;
-};
-
-export const queryUserProgress = userId => (dispatch, getState) => {
-  const state = getState().progress;
-  return userProgressFromServer(state, dispatch, userId);
-};
-
-export const userProgressFromServer = (state, dispatch, userId) => {
-  if (!state.scriptName) {
-    return;
-  }
-
-  return $.ajax({
-    url: `/api/user_progress/${state.scriptName}`,
-    method: 'GET',
-    data: {user_id: userId}
-  }).done(data => {
-    data = data || {};
-
-    if (data.isVerifiedTeacher) {
-      dispatch(setVerified());
-    }
-
-    // We are on an overview page if currentLevelId is undefined.
-    const onOverviewPage = !state.currentLevelId;
-    // Show lesson plan links and other teacher info if teacher and on unit overview page.
-    if (
-      (data.isTeacher || data.teacherViewingStudent) &&
-      !data.professionalLearningCourse &&
-      onOverviewPage
-    ) {
-      // Default to progress summary view if teacher is viewing their student's progress.
-      if (data.teacherViewingStudent) {
-        dispatch(setIsSummaryView(true));
-      }
-
-      dispatch(showTeacherInfo());
-    }
-
-    if (data.focusAreaStageIds) {
-      dispatch(
-        updateFocusArea(data.changeFocusAreaPath, data.focusAreaStageIds)
-      );
-    }
-
-    if (data.lockableAuthorized) {
-      dispatch(authorizeLockable());
-    }
-
-    if (data.completed) {
-      dispatch(setScriptCompleted());
-    }
-
-    // Merge progress from server
-    if (data.levels) {
-      const levelProgress = _.mapValues(data.levels, getLevelResult);
-      dispatch(mergeProgress(levelProgress));
-
-      if (data.peerReviewsPerformed) {
-        dispatch(mergePeerReviewProgress(data.peerReviewsPerformed));
-      }
-
-      if (data.current_stage) {
-        dispatch(setCurrentStageId(data.current_stage));
-      }
-    }
-  });
 };
 
 // export private function(s) to expose to unit testing

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -682,7 +682,7 @@ export const userProgressFromServer = (
   $.ajax({
     url: `/api/user_progress/${state.scriptName}`,
     method: 'GET',
-    data: JSON.stringify({user_id: userId})
+    data: {user_id: userId}
   }).done(data => {
     data = data || {};
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -310,7 +310,8 @@ export function processedStages(stages, isPlc) {
  */
 export const userProgressFromServer = (state, dispatch, userId) => {
   if (!state.scriptName) {
-    return;
+    const message = `Could not request progress for user ID ${userId} from server: scriptName must be present in progress redux.`;
+    throw new Error(message);
   }
 
   return $.ajax({

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -661,25 +661,17 @@ export const progressionsFromLevels = levels => {
   return progressions;
 };
 
-export const queryUserProgress = (userId, onComplete) => (
-  dispatch,
-  getState
-) => {
+export const queryUserProgress = userId => (dispatch, getState) => {
   const state = getState().progress;
-  userProgressFromServer(state, dispatch, userId, onComplete);
+  return userProgressFromServer(state, dispatch, userId);
 };
 
-export const userProgressFromServer = (
-  state,
-  dispatch,
-  userId,
-  onComplete = data => {}
-) => {
+export const userProgressFromServer = (state, dispatch, userId) => {
   if (!state.scriptName) {
     return;
   }
 
-  $.ajax({
+  return $.ajax({
     url: `/api/user_progress/${state.scriptName}`,
     method: 'GET',
     data: {user_id: userId}
@@ -733,8 +725,6 @@ export const userProgressFromServer = (
         dispatch(setCurrentStageId(data.current_stage));
       }
     }
-
-    onComplete(data);
   });
 };
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -666,8 +666,6 @@ export const queryUserProgress = (userId, onComplete = data => {}) => (
   getState
 ) => {
   const state = getState().progress;
-  // We are on an overview page if currentLevelId is undefined.
-  const onOverviewPage = !state.currentLevelId;
 
   if (!state.scriptName) {
     return;
@@ -677,12 +675,13 @@ export const queryUserProgress = (userId, onComplete = data => {}) => (
     data: {user_id: userId}
   }).done(data => {
     data = data || {};
-    console.log(data); // TODO: REMOVE THIS
 
     if (data.isVerifiedTeacher) {
       dispatch(setVerified());
     }
 
+    // We are on an overview page if currentLevelId is undefined.
+    const onOverviewPage = !state.currentLevelId;
     // Show lesson plan links and other teacher info if teacher and on unit overview page.
     if (
       (data.isTeacher || data.teacherViewingStudent) &&

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -308,7 +308,7 @@ export function processedStages(stages, isPlc) {
  * Requests user progress from the server and dispatches other redux actions
  * based on the server's response data.
  */
-export const userProgressFromServer = (state, dispatch, userId) => {
+const userProgressFromServer = (state, dispatch, userId) => {
   if (!state.scriptName) {
     const message = `Could not request progress for user ID ${userId} from server: scriptName must be present in progress redux.`;
     throw new Error(message);
@@ -739,6 +739,7 @@ export const __testonly__ = IN_UNIT_TEST
       bestResultLevelId,
       peerReviewLesson,
       peerReviewLevels,
-      PEER_REVIEW_ID
+      PEER_REVIEW_ID,
+      userProgressFromServer
     }
   : {};

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -1,4 +1,5 @@
 import {assert} from 'chai';
+import sinon from 'sinon';
 import {TestResults} from '@cdo/apps/constants';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import {ViewType, setViewType} from '@cdo/apps/code-studio/viewAsRedux';
@@ -25,6 +26,7 @@ import reducer, {
   stageExtrasUrl,
   setStageExtrasEnabled,
   getLevelResult,
+  userProgressFromServer,
   __testonly__
 } from '@cdo/apps/code-studio/progressRedux';
 
@@ -1361,6 +1363,73 @@ describe('progressReduxTest', () => {
         pages_completed: [-50, null, null, null, null]
       });
       assert.strictEqual(result, TestResults.READONLY_SUBMISSION_RESULT);
+    });
+  });
+
+  describe('userProgressFromServer', () => {
+    let server, state, dispatch, onComplete;
+
+    beforeEach(() => {
+      server = sinon.fakeServer.create();
+      state = {scriptName: 'my-script'};
+      dispatch = sinon.spy();
+      onComplete = sinon.spy();
+    });
+
+    afterEach(() => server.restore());
+
+    const serverResponse = data => {
+      server.respondWith([
+        200,
+        {'Content-Type': 'application/json'},
+        JSON.stringify(data)
+      ]);
+    };
+
+    it('requests user progress and does not dispatch actions with no data', () => {
+      serverResponse({});
+      userProgressFromServer(state, dispatch, 1, onComplete);
+      server.respond();
+
+      assert(dispatch.notCalled);
+      assert(onComplete.calledOnce);
+      assert.deepEqual({}, onComplete.getCall(0).args[0]);
+    });
+
+    it('requests user progress and dispatches appropriate actions', () => {
+      const responseData = {
+        isVerifiedTeacher: true,
+        teacherViewingStudent: true,
+        professionalLearningCourse: false,
+        focusAreaStageIds: [1, 2],
+        lockableAuthorized: true,
+        completed: true,
+        levels: {},
+        peerReviewsPerformed: true,
+        current_stage: 1
+      };
+      serverResponse(responseData);
+      userProgressFromServer(state, dispatch, 1, onComplete);
+      server.respond();
+
+      assert.equal(9, dispatch.callCount);
+      const dispatchActions = dispatch
+        .getCalls()
+        .map(call => call.args[0].type);
+      const expectedDispatchActions = [
+        'verifiedTeacher/SET_VERIFIED',
+        'progress/SET_IS_SUMMARY_VIEW',
+        'progress/SHOW_TEACHER_INFO',
+        'progress/UPDATE_FOCUS_AREAS',
+        'stageLock/AUTHORIZE_LOCKABLE',
+        'progress/SET_SCRIPT_COMPLETED',
+        'progress/MERGE_PROGRESS',
+        'progress/MERGE_PEER_REVIEW_PROGRESS',
+        'progress/SET_CURRENT_STAGE_ID'
+      ];
+      assert.deepEqual(expectedDispatchActions, dispatchActions);
+      assert(onComplete.calledOnce);
+      assert.deepEqual(responseData, onComplete.getCall(0).args[0]);
     });
   });
 });

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -26,7 +26,6 @@ import reducer, {
   stageExtrasUrl,
   setStageExtrasEnabled,
   getLevelResult,
-  userProgressFromServer,
   __testonly__
 } from '@cdo/apps/code-studio/progressRedux';
 
@@ -1368,6 +1367,7 @@ describe('progressReduxTest', () => {
 
   describe('userProgressFromServer', () => {
     let server, state, dispatch;
+    const {userProgressFromServer} = __testonly__;
 
     beforeEach(() => {
       server = sinon.fakeServer.create();

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -1367,13 +1367,12 @@ describe('progressReduxTest', () => {
   });
 
   describe('userProgressFromServer', () => {
-    let server, state, dispatch, onComplete;
+    let server, state, dispatch;
 
     beforeEach(() => {
       server = sinon.fakeServer.create();
       state = {scriptName: 'my-script'};
       dispatch = sinon.spy();
-      onComplete = sinon.spy();
     });
 
     afterEach(() => server.restore());
@@ -1388,12 +1387,12 @@ describe('progressReduxTest', () => {
 
     it('requests user progress and does not dispatch actions with no data', () => {
       serverResponse({});
-      userProgressFromServer(state, dispatch, 1, onComplete);
+      const promise = userProgressFromServer(state, dispatch, 1);
       server.respond();
-
-      assert(dispatch.notCalled);
-      assert(onComplete.calledOnce);
-      assert.deepEqual({}, onComplete.getCall(0).args[0]);
+      return promise.then(responseData => {
+        assert(dispatch.notCalled);
+        assert.deepEqual({}, responseData);
+      });
     });
 
     it('requests user progress and dispatches appropriate actions', () => {
@@ -1409,7 +1408,7 @@ describe('progressReduxTest', () => {
         current_stage: 1
       };
       serverResponse(responseData);
-      userProgressFromServer(state, dispatch, 1, onComplete);
+      const promise = userProgressFromServer(state, dispatch, 1);
       server.respond();
 
       assert.equal(9, dispatch.callCount);
@@ -1427,9 +1426,10 @@ describe('progressReduxTest', () => {
         'progress/MERGE_PEER_REVIEW_PROGRESS',
         'progress/SET_CURRENT_STAGE_ID'
       ];
-      assert.deepEqual(expectedDispatchActions, dispatchActions);
-      assert(onComplete.calledOnce);
-      assert.deepEqual(responseData, onComplete.getCall(0).args[0]);
+      return promise.then(serverResponseData => {
+        assert.deepEqual(expectedDispatchActions, dispatchActions);
+        assert.deepEqual(responseData, serverResponseData);
+      });
     });
   });
 });


### PR DESCRIPTION
Initial PR for [LP-587](https://codedotorg.atlassian.net/browse/LP-587)

No functionality change here. This PR is preparatory work to enable a consumer to call `progressRedux#queryUserProgress` to asynchronously load a new user's progress.

**What it does:**
- Detour: [a3aca25](https://github.com/code-dot-org/code-dot-org/pull/29746/commits/a3aca25ce3703e8e2def3e67552e50fc137721dd) - Delete checks for non-existent `postMilestoneDisabledUI` experiment
- Move all redux-related user progress actions into `progressRedux#queryUserProgress` (previously in [`queryUserProgress()`](https://github.com/code-dot-org/code-dot-org/blob/bb16abf3662016da5acf27d712485c70f72811e5/apps/src/code-studio/progress.js#L235-L319) in progress.js)