### PR TITLE
Feedback: view feedback button goes to /feedback

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -213,10 +213,7 @@ class ScriptOverviewHeader extends Component {
           />
         )}
         {experiments.isEnabled(experiments.FEEDBACK_NOTIFICATION) && userId && (
-          <StudentFeedbackNotification
-            studentId={userId}
-            linkToFeedbackOverview="/"
-          />
+          <StudentFeedbackNotification studentId={userId} />
         )}
         {displayVerifiedResources && (
           <VerifiedResourcesNotification width={SCRIPT_OVERVIEW_WIDTH} />

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -188,10 +188,7 @@ export default class CourseOverview extends Component {
           />
         )}
         {experiments.isEnabled(experiments.FEEDBACK_NOTIFICATION) && userId && (
-          <StudentFeedbackNotification
-            studentId={userId}
-            linkToFeedbackOverview="/"
-          />
+          <StudentFeedbackNotification studentId={userId} />
         )}
         {showRedirectWarning && !dismissedRedirectWarning(name) && (
           <Notification

--- a/apps/src/templates/feedback/StudentFeedbackNotification.jsx
+++ b/apps/src/templates/feedback/StudentFeedbackNotification.jsx
@@ -6,8 +6,7 @@ import $ from 'jquery';
 
 export default class StudentFeedbackNotification extends Component {
   static propTypes = {
-    studentId: PropTypes.number.isRequired,
-    linkToFeedbackOverview: PropTypes.string.isRequired
+    studentId: PropTypes.number.isRequired
   };
 
   constructor(props) {
@@ -44,7 +43,7 @@ export default class StudentFeedbackNotification extends Component {
             notice={i18n.feedbackNotification()}
             details={notificationDetails}
             buttonText={i18n.feedbackNotificationButton()}
-            buttonLink={this.props.linkToFeedbackOverview}
+            buttonLink="/feedback"
             dismissible={false}
           />
         )}

--- a/apps/src/templates/feedback/StudentFeedbackNotification.story.jsx
+++ b/apps/src/templates/feedback/StudentFeedbackNotification.story.jsx
@@ -11,12 +11,7 @@ export default storybook => {
         name: 'StudentFeedbackNotification',
         story: () => {
           withFakeServer();
-          return (
-            <StudentFeedbackNotification
-              linkToFeedbackOverview="/"
-              studentId={123}
-            />
-          );
+          return <StudentFeedbackNotification studentId={123} />;
         }
       }
     ]);

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -37,10 +37,7 @@ export default class StudentHomepage extends Component {
         <HeaderBanner headingText={i18n.homepageHeading()} short={true} />
         <ProtectedStatefulDiv ref="flashes" />
         {experiments.isEnabled(experiments.FEEDBACK_NOTIFICATION) && (
-          <StudentFeedbackNotification
-            studentId={studentId}
-            linkToFeedbackOverview="/"
-          />
+          <StudentFeedbackNotification studentId={studentId} />
         )}
         <RecentCourses
           courses={courses}


### PR DESCRIPTION
Now that comments are visible on the All Feedback page, the "View Feedback" button should link directly to the overview page.  I removed the ` linkToFeedbackOverview` prop in the `StudentFeedbackNotification` component and set the button link to studio.code.org/feedback. 

![view-feedback](https://user-images.githubusercontent.com/12300669/61336846-ca032b00-a7e7-11e9-83c6-a87193bda043.gif)
