### PR TITLE
School Info Completeness - make SchoolInfo read-only

### DIFF
--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -82,7 +82,12 @@ class SchoolInfo < ActiveRecord::Base
   # Only sync from school on create to avoid unintended updates to old data
   before_validation :sync_from_schools, on: :create
 
-  before_validation :update_school_info, on: :update
+  before_validation :readonly?, on: :update
+
+  # Set SchoolInfo to read-only.  Explicitly raise an error for any attempts to update school info
+  def readonly?
+    !new_record?
+  end
 
   def sync_from_schools
     # If a SchoolInfo is linked to a School then the SchoolInfo pulls its data from the School
@@ -318,11 +323,5 @@ class SchoolInfo < ActiveRecord::Base
 
     # Given we got past above cases, school name is sufficient
     !school_name.blank?
-  end
-
-  private
-
-  def update_school_info
-    throw :abort
   end
 end

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -82,7 +82,7 @@ class SchoolInfo < ActiveRecord::Base
   # Only sync from school on create to avoid unintended updates to old data
   before_validation :sync_from_schools, on: :create
 
-  # Set SchoolInfo to read-only.  Explicitly raise an error for any attempts to update school info
+  # Set SchoolInfo to read-only.  readonly method overrides the default ActiveRecord::Core#readonly?
   def readonly?
     !new_record?
   end

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -82,8 +82,6 @@ class SchoolInfo < ActiveRecord::Base
   # Only sync from school on create to avoid unintended updates to old data
   before_validation :sync_from_schools, on: :create
 
-  before_validation :readonly?, on: :update
-
   # Set SchoolInfo to read-only.  Explicitly raise an error for any attempts to update school info
   def readonly?
     !new_record?

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -82,6 +82,8 @@ class SchoolInfo < ActiveRecord::Base
   # Only sync from school on create to avoid unintended updates to old data
   before_validation :sync_from_schools, on: :create
 
+  before_validation :update_school_info, on: :update
+
   def sync_from_schools
     # If a SchoolInfo is linked to a School then the SchoolInfo pulls its data from the School
     # It seems like there is some code that is passing in mismatched data at times.
@@ -316,5 +318,11 @@ class SchoolInfo < ActiveRecord::Base
 
     # Given we got past above cases, school name is sufficient
     !school_name.blank?
+  end
+
+  private
+
+  def update_school_info
+    throw :abort
   end
 end

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -590,4 +590,17 @@ class SchoolInfoTest < ActiveSupport::TestCase
     school_info.school_name = '     '
     refute school_info.complete?
   end
+
+  test 'school info is readonly for an existing record' do
+    school_info = SchoolInfo.new
+    school_info.country = 'United States'
+    school_info.school_type = SchoolInfo::SCHOOL_TYPE_PUBLIC
+    school_info.school_name = 'Primary School'
+    school_info.validation_type = SchoolInfo::VALIDATION_COMPLETE
+    school_info.save!
+
+    assert_raises("ActiveRecord::ReadOnlyRecord") do
+      school_info.update(country: 'United States', school_type: SchoolInfo::SCHOOL_TYPE_PRIVATE)
+    end
+  end
 end


### PR DESCRIPTION
The goal of over-riding the SchoolInfo update method is to prevent school info objects from being updated incorrectly.  This is accomplished by making SchoolInfo read-only.


