### PR TITLE
Feedback: backfill by progress revised

### DIFF
--- a/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
+++ b/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
@@ -15,18 +15,17 @@ def update_script_level_ids
   puts "backfilling script_level_ids..."
   feedbacks_without_script_level_id.find_each do |feedback|
     puts "*"
-    associated_script_levels = feedback.level.script_levels
-    if associated_script_levels.length > 1
+    feedback_script_levels = feedback.level.script_levels
+    if feedback_script_levels.length > 1
       associated_user_levels = UserLevel.where(
         user_id: feedback.student_id,
         level_id: feedback.level_id
       )
       if associated_user_levels.length == 1
-        script_levels = ScriptLevel.where(
-          script_id: associated_user_levels.first.script_id
-        )
-        if script_levels.length == 1
-          script_level_id = script_levels[0].id
+        progress_script_levels = associated_user_levels.first.script_levels
+        candidate_script_levels = feedback_script_levels & progress_script_levels
+        if candidate_script_levels.length == 1
+          script_level_id = candidate_script_levels.first.id
           feedback.update_attributes(script_level_id: script_level_id)
         end
       end

--- a/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
+++ b/dashboard/scripts/archive/backfill_script_level_ids_for_teacher_feedbacks_2.rb
@@ -23,8 +23,7 @@ def update_script_level_ids
       )
       if associated_user_levels.length == 1
         script_levels = ScriptLevel.where(
-          level_id: associated_user_levels[0].level_id,
-          script_id: associated_user_levels[0].script_id
+          script_id: associated_user_levels.first.script_id
         )
         if script_levels.length == 1
           script_level_id = script_levels[0].id


### PR DESCRIPTION
Follow up to #29701 

ScriptLevels don't have a level_id because they have a  has_and_belongs_to_many relationship with Levels.  Therefore, when running this script, you get a `Unknown column 'script_levels.level_id' (ActiveRecord::StatementInvalid)` error.

Instead I updated the script get all of the ScriptLevels associated with the level there is feedback on and all of the ScriptLevels associated with the level there is feedback and progress for and see if there's an overlap. If there is only one ScriptLevel with progress for that feedback, we assume that ScriptLevel's id should be used. 