### PR TITLE
Census: fix seeding for some states

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -129,7 +129,7 @@ class Census::StateCsOffering < ApplicationRecord
   def self.state_uses_format_v2(state_code, school_year, update)
     state_uses_format_v2_in_2018 =
       STATES_USING_FORMAT_V2_IN_2018_19.include?(state_code) ||
-      update >= UPDATES_FOR_STATES_USING_FORMAT_V2_IN_MID_2018_19[state_code]
+      update >= UPDATES_FOR_STATES_USING_FORMAT_V2_IN_MID_2018_19[state_code.to_sym]
     (school_year == 2018 && state_uses_format_v2_in_2018) || school_year >= 2019
   end
 

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1501,7 +1501,7 @@ class Census::StateCsOffering < ApplicationRecord
       UPDATES_FOR_STATES_USING_FORMAT_V2_IN_MID_2018_19.each do |state_code, update|
         school_year = 2018
         filename = construct_object_key(state_code, school_year, update)
-        seed_from_csv(state_code, school_year, update, "test/fixtures/census/actual_2018_2019/" + filename)
+        seed_from_csv(state_code.to_s, school_year, update, "test/fixtures/census/actual_2018_2019/" + filename)
       end
     else
       seed_from_s3


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/29710

A mistake was preventing seeding for those states which switched to the V2 format part way through ingesting their 2018-2019 data.

The stub code didn't catch this because it was calling `seed_from_csv` with a string rather than a symbol, so it didn't quite match the S3 code behaviour.  In retrospect, it would have been good to set up a new S3 folder with the new data ahead of time to rehearse the S3-based ingestion locally, rather than discovering this in a test-run on the staging environment.
