### PR TITLE
remove unused "target" script level property

### DIFF
--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -160,7 +160,6 @@ class ScriptDSL < BaseDSL
   def level(name, properties = {})
     active = properties.delete(:active)
     progression = properties.delete(:progression)
-    target = properties.delete(:target)
     challenge = properties.delete(:challenge)
     experiments = properties.delete(:experiments)
     named = properties.delete(:named)
@@ -220,10 +219,9 @@ class ScriptDSL < BaseDSL
         levels: [level]
       }
 
-      if progression || target || challenge
+      if progression || challenge
         script_level[:properties] = {}
         script_level[:properties][:progression] = progression if progression
-        script_level[:properties][:target] = true if target
         script_level[:properties][:challenge] = true if challenge
       end
 
@@ -326,7 +324,6 @@ class ScriptDSL < BaseDSL
                 sl.active?(level),
                 sl.progression,
                 sl.named_level?,
-                sl.target,
                 sl.challenge,
                 sl.assessment,
                 sl.experiments(level)
@@ -335,7 +332,7 @@ class ScriptDSL < BaseDSL
           end
           s << 'endvariants'
         else
-          s.concat(serialize_level(sl.level, type, nil, sl.progression, sl.named_level?, sl.target, sl.challenge, sl.assessment))
+          s.concat(serialize_level(sl.level, type, nil, sl.progression, sl.named_level?, sl.challenge, sl.assessment))
         end
       end
       s << 'no_extras' if stage.stage_extras_disabled
@@ -350,7 +347,6 @@ class ScriptDSL < BaseDSL
     active = nil,
     progression = nil,
     named = nil,
-    target = nil,
     challenge = nil,
     assessment = nil,
     experiments = []
@@ -373,7 +369,6 @@ class ScriptDSL < BaseDSL
     l += ", progression: '#{progression}'" if progression
     l += ', named: true' if named
     l += ', assessment: true' if assessment
-    l += ', target: true' if target
     l += ', challenge: true' if challenge
     s << l
     s

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -49,7 +49,6 @@ class ScriptLevel < ActiveRecord::Base
   serialized_attrs %w(
     variants
     progression
-    target
     challenge
   )
 

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -529,13 +529,13 @@ level 'Level 3'
     end
   end
 
-  test 'Script DSL with level target and challenge' do
+  test 'Script DSL with level challenge' do
     input_dsl = <<DSL
 stage 'Stage1'
 level 'Level 1'
 level 'Level 2'
 level 'Level 3', challenge: true
-level 'Level 4', target: true
+level 'Level 4'
 variants
   level 'Level 5', challenge: true
   level 'Level 5.1', active: false
@@ -550,7 +550,7 @@ DSL
               {stage: "Stage1", levels: [{name: "Level 1"}]},
               {stage: "Stage1", levels: [{name: "Level 2"}]},
               {stage: "Stage1", levels: [{name: "Level 3"}], properties: {challenge: true}},
-              {stage: "Stage1", levels: [{name: "Level 4"}], properties: {target: true}},
+              {stage: "Stage1", levels: [{name: "Level 4"}]},
               {
                 stage: "Stage1",
                 levels: [


### PR DESCRIPTION
In preparation for [LP-586](https://codedotorg.atlassian.net/browse/LP-586), I'm removing some unused code from the existing script dsl so that I don't have to replicate that logic in the new script editing gui.


The following shows that this property is unused:
```
[production] dashboard > ScriptLevel.all.select{|sl| sl.challenge}.count
=> 304
[production] dashboard > ScriptLevel.all.select{|sl| sl.target}.count
=> 0
```

```
Dave-MBP:~/src/cdo/dashboard/config/scripts (level-edit-gui)$ grep -R challenge: * | wc -l
     306
Dave-MBP:~/src/cdo/dashboard/config/scripts (level-edit-gui)$ grep -R target: * | wc -l
       0
```