### PR TITLE
Census: support seeding state CS offering data for five more states

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -23,6 +23,7 @@ class Census::StateCsOffering < ApplicationRecord
   UNSPECIFIED_VALUE = 'unspecified'.freeze
 
   SUPPORTED_STATES = %w(
+    AK
     AL
     AR
     CA
@@ -35,6 +36,7 @@ class Census::StateCsOffering < ApplicationRecord
     HI
     IA
     ID
+    IL
     IN
     KS
     KY
@@ -43,6 +45,7 @@ class Census::StateCsOffering < ApplicationRecord
     ME
     MD
     MI
+    MN
     MO
     MS
     MT
@@ -50,6 +53,7 @@ class Census::StateCsOffering < ApplicationRecord
     ND
     NH
     NJ
+    NM
     NV
     NY
     OH
@@ -58,6 +62,7 @@ class Census::StateCsOffering < ApplicationRecord
     PA
     RI
     SC
+    SD
     TN
     TX
     UT


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/29710

It was necessary to add these new states to the master list of states for which we seed data.