### PR TITLE
Feedback:  use created_at instead of updated_at

### DIFF
--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -62,7 +62,7 @@ export default class LevelFeedbackEntry extends Component {
       linkToLevel,
       unitName,
       linkToUnit,
-      updated_at,
+      created_at,
       comment
     } = this.props.feedback;
 
@@ -97,7 +97,7 @@ export default class LevelFeedbackEntry extends Component {
             </div>
           </a>
         </div>
-        <TimeAgo style={styles.time} dateString={updated_at} />
+        <TimeAgo style={styles.time} dateString={created_at} />
         <div style={styles.comment}>{comment}</div>
       </div>
     );

--- a/apps/src/templates/feedback/LevelFeedbackEntry.story.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.story.jsx
@@ -8,7 +8,7 @@ const defaultProps = {
     linkToLevel: '/',
     unitName: 'CSP Unit 3 - Intro to Programming',
     linkToUnit: '/',
-    updated_at: new Date(),
+    created_at: new Date(),
     comment: 'Excellent work! You followed the directions closely.'
   }
 };

--- a/apps/src/templates/feedback/shapes.js
+++ b/apps/src/templates/feedback/shapes.js
@@ -9,7 +9,7 @@ const shapes = {
     linkToLevel: PropTypes.string.isRequired,
     unitName: PropTypes.string,
     linkToUnit: PropTypes.string,
-    updated_at: PropTypes.oneOfType([
+    created_at: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.instanceOf(Date)
     ]).isRequired,


### PR DESCRIPTION
When feedbacks were marked as "seen" on the All Feedback page #29742, the timestamp switched to "a few seconds ago" for the newly viewed feedback .  This was a clue that there was a 🐛! We want the timestamp to reflect when the teacher left the feedback, which is based on the `created_at` field rather than the `updated_at` field. I made a little change so that the timestamps accurately show when the teacher left the feedback: 
<img width="652" alt="Screen Shot 2019-07-17 at 10 25 53 AM" src="https://user-images.githubusercontent.com/12300669/61396871-84913d00-a87d-11e9-8d6b-b58a86d1c4d6.png">
