### PR TITLE
disable flaky PLC tests

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -131,6 +131,8 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   end
 
   test 'Returns only workshops that have ended and have teachers' do
+    skip 'Investigate flaky test failures'
+
     # New workshop, not ended, with teachers that should not be returned.
     workshop_in_progress = create :pd_workshop, num_sessions: 1
     workshop_in_progress.start!

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -32,6 +32,8 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
   end
 
   test 'Admin workshops may show up as pending exit surveys' do
+    skip 'Investigate flaky test failures'
+
     # Fake Admin workshop, which should produce an exit survey
     admin_workshop = create :pd_ended_workshop,
       course: Pd::Workshop::COURSE_ADMIN,
@@ -73,6 +75,8 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
   end
 
   test 'FiT workshops do not interfere with other pending exit surveys' do
+    skip 'Investigate flaky test failures'
+
     # Fake CSF workshop (older than the FiT workshop) which should
     # produce a pending exit survey
     csf_workshop = create :pd_ended_workshop,

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -907,6 +907,8 @@ module Pd
     end
 
     test 'csf facilitator survey: show 1st facilitator survey to attended teacher' do
+      skip 'Investigate flaky test failures'
+
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
       session = @csf201_in_progress_workshop.sessions.first


### PR DESCRIPTION
These four tests have all intermittently failed unit test runs on `test` CI build recently (in the past couple of weeks), some multiple times. This PR disables these tests until the source of this flakiness can be investigated and fixed.

In addition, a large number of tests in `Api::V1::Pd::TeacherAttendanceReportControllerTest` and `Pd::SessionAttendanceControllerTest` intermittently failed once in a [recent test run](https://console.aws.amazon.com/s3/object/cdo-build-logs/test/20190708T233504%252B0000), the cause of which I believe has also not been figured out at this point that could also use similar investigation (the cause may overlap with these other test failures).