### PR TITLE
Add drone ssh key for each user on gateway [ci skip]

### DIFF
--- a/cookbooks/cdo-users/recipes/default.rb
+++ b/cookbooks/cdo-users/recipes/default.rb
@@ -81,6 +81,7 @@ node['cdo-users'].each_pair do |user_name, user_data|
     'authorized_keys' => user_data['ssh-key'],
     'server_access_key' => node['cdo-servers']['ssh-private-key'],
     'server_access_key.pub' => node['cdo-servers']['ssh-key'],
+    'drone_access_key' => node['cdo-servers']['drone-ssh-private-key'],
   }.each_pair do |file, text|
     template File.join(ssh_directory, file) do
       source 'text_file.erb'


### PR DESCRIPTION
Tried using `kitchen test` to test this but ran into errors similar to: https://github.com/someara/kitchen-dokken/issues/105

Let me know if I should try to get that working before merging; the change seems simple enough though. I'll add the key to chef before merging and verify on gateway.