### PR TITLE
Tests: Deflake TeacherAttendanceReportControllerTest

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -229,9 +229,17 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
     assert_response :success
     response = CSV.parse(@response.body)
 
-    # 22 rows (header + 21 teacher rows)
-    assert_equal 22, response.count
+    # Check that we have the expected number of columns in the header row
     assert_equal EXPECTED_COMMON_FIELDS.count + EXPECTED_PAYMENT_FIELDS.count, response.first.count
+
+    # Check that column 11 in the header row is workshop id
+    assert_equal 'Workshop Id', response.first[11]
+
+    # Check expected row counts for our test workshops
+    # (We don't count all rows to insulate this test against existing state)
+    assert_equal 10, response.select {|row| row[11] == @pm_workshop.id.to_s}.count
+    assert_equal 10, response.select {|row| row[11] == @workshop.id.to_s}.count
+    assert_equal 1, response.select {|row| row[11] == @other_workshop.id.to_s}.count
   end
 
   private


### PR DESCRIPTION
Re-enables one of the tests disabled in https://github.com/code-dot-org/code-dot-org/pull/29765, with speculative modifications to make it less flaky.

My hypothesis is that assertions in this test that count total rows returned, on the broadest queries, are flaky because they assume no existing rows will be present in the relevant tables.

I've modified these tests to constrain their assertions to the test data that they should be aware of, hopefully without weakening any of the assertions (besides the assumption about a clean test database).