### PR TITLE
Increase wait for instance restore timeout to 2 hours [ci skip]

### DIFF
--- a/aws/offsite/aurora-snapshots-fargate/restore-and-verify-backup.js
+++ b/aws/offsite/aurora-snapshots-fargate/restore-and-verify-backup.js
@@ -78,7 +78,11 @@ const restoreLatestSnapshot = async (rds, clusterId, instanceId) => {
 
   await rds
     .waitFor("dBInstanceAvailable", {
-      DBInstanceIdentifier: instanceId
+      DBInstanceIdentifier: instanceId,
+      $waiter: {
+        maxAttempts: 120,
+        delay: 60 // seconds
+      }
     })
     .promise();
 };


### PR DESCRIPTION
Ran unit tests and tested on dev account.