### PR TITLE
Applab: fix dontMarshalApi functions for export

### DIFF
--- a/apps/src/applab/api.js
+++ b/apps/src/applab/api.js
@@ -499,22 +499,6 @@ export function penRGB(r, g, b, a) {
   return Applab.executeCmd(null, 'penRGB', {r: r, g: g, b: b, a: a});
 }
 
-export function insertItem(array, index, item) {
-  return Applab.executeCmd(null, 'insertItem', {
-    array: array,
-    index: index,
-    item: item
-  });
-}
-
-export function appendItem(array, item) {
-  return Applab.executeCmd(null, 'appendItem', {array: array, item: item});
-}
-
-export function removeItem(array, index) {
-  return Applab.executeCmd(null, 'removeItem', {array: array, index: index});
-}
-
 export function drawChart(chartId, chartType, chartData, options, callback) {
   return Applab.executeCmd(null, 'drawChart', {
     chartId: chartId,

--- a/apps/src/applab/dontMarshalApi.js
+++ b/apps/src/applab/dontMarshalApi.js
@@ -27,7 +27,7 @@ import {
  * import * as dontMarshalApi from './dontMarshalApi'
  */
 
-function dmapiValidateType(funcName, varName, varValue, expectedType, opt) {
+function dmapiValidateType(_, funcName, varName, varValue, expectedType, opt) {
   var properType;
   if (typeof varValue !== 'undefined') {
     if (expectedType === 'number') {
@@ -79,17 +79,18 @@ var getInt = function(obj, def, calledWithinInterpreter) {
 };
 
 function interpreterInsertItem(array, index, item) {
-  insertItem(array, index, item, true);
+  insertItem(array, index, item, dmapiValidateType, true);
 }
 
-export function insertItem(array, index, item, calledWithinInterpreter) {
-  if (calledWithinInterpreter) {
-    dmapiValidateType('insertItem', 'list', array, 'array');
-    dmapiValidateType('insertItem', 'index', index, 'number');
-  } else {
-    apiValidateType({}, 'insertItem', 'list', array, 'array');
-    apiValidateType({}, 'insertItem', 'index', index, 'number');
-  }
+export function insertItem(
+  array,
+  index,
+  item,
+  validateType = apiValidateType,
+  calledWithinInterpreter
+) {
+  validateType({}, 'insertItem', 'list', array, 'array');
+  validateType({}, 'insertItem', 'index', index, 'number');
 
   const arrayValues = calledWithinInterpreter ? array.properties : array;
 
@@ -111,17 +112,17 @@ export function insertItem(array, index, item, calledWithinInterpreter) {
 }
 
 function interpreterRemoveItem(array, index) {
-  removeItem(array, index, true);
+  removeItem(array, index, dmapiValidateType, true);
 }
 
-export function removeItem(array, index, calledWithinInterpreter) {
-  if (calledWithinInterpreter) {
-    dmapiValidateType('removeItem', 'list', array, 'array');
-    dmapiValidateType('removeItem', 'index', index, 'number');
-  } else {
-    apiValidateType({}, 'removeItem', 'list', array, 'array');
-    apiValidateType({}, 'removeItem', 'index', index, 'number');
-  }
+export function removeItem(
+  array,
+  index,
+  validateType = apiValidateType,
+  calledWithinInterpreter
+) {
+  validateType({}, 'removeItem', 'list', array, 'array');
+  validateType({}, 'removeItem', 'index', index, 'number');
 
   const arrayValues = calledWithinInterpreter ? array.properties : array;
 
@@ -155,15 +156,16 @@ export function removeItem(array, index, calledWithinInterpreter) {
 }
 
 function interpreterAppendItem(array, item) {
-  return appendItem(array, item, true);
+  return appendItem(array, item, dmapiValidateType, true);
 }
 
-export function appendItem(array, item, calledWithinInterpreter) {
-  if (calledWithinInterpreter) {
-    dmapiValidateType('appendItem', 'list', array, 'array');
-  } else {
-    apiValidateType({}, 'appendItem', 'list', array, 'array');
-  }
+export function appendItem(
+  array,
+  item,
+  validateType = apiValidateType,
+  calledWithinInterpreter
+) {
+  validateType('appendItem', 'list', array, 'array');
 
   const arrayValues = calledWithinInterpreter ? array.properties : array;
 
@@ -182,149 +184,66 @@ export function appendItem(array, item, calledWithinInterpreter) {
 
 // TODO: more parameter validation (data array type, length), error output
 
-function interpreterGetRed(imageData, x, y) {
-  return getRed(imageData, x, y, true);
-}
-
-export function getRed(imageData, x, y, calledWithinInterpreter) {
+function getImageDataValue(
+  calledWithinInterpreter,
+  colorOffset,
+  imageData,
+  x,
+  y
+) {
   const imageDataProperties = calledWithinInterpreter
     ? imageData.properties
     : imageData;
   if (imageDataProperties.data && imageDataProperties.width) {
     const pixelOffset = y * imageDataProperties.width * 4 + x * 4;
-    const redOffset = pixelOffset;
+    const totalOffset = pixelOffset + colorOffset;
     return calledWithinInterpreter
-      ? imageDataProperties.data.properties[redOffset].toNumber()
-      : imageDataProperties.data[redOffset];
+      ? imageDataProperties.data.properties[totalOffset].toNumber()
+      : imageDataProperties.data[totalOffset];
   }
 }
 
-function interpreterGetGreen(imageData, x, y) {
-  return getGreen(imageData, x, y, true);
-}
+const interpreterGetRed = getImageDataValue.bind(null, true, 0);
+const interpreterGetGreen = getImageDataValue.bind(null, true, 1);
+const interpreterGetBlue = getImageDataValue.bind(null, true, 2);
+const interpreterGetAlpha = getImageDataValue.bind(null, true, 3);
 
-export function getGreen(imageData, x, y, calledWithinInterpreter) {
+export const getRed = getImageDataValue.bind(null, false, 0);
+export const getGreen = getImageDataValue.bind(null, false, 1);
+export const getBlue = getImageDataValue.bind(null, false, 2);
+export const getAlpha = getImageDataValue.bind(null, false, 3);
+
+function setImageDataValue(
+  calledWithinInterpreter,
+  colorOffset,
+  imageData,
+  x,
+  y,
+  value
+) {
   const imageDataProperties = calledWithinInterpreter
     ? imageData.properties
     : imageData;
   if (imageDataProperties.data && imageDataProperties.width) {
     const pixelOffset = y * imageDataProperties.width * 4 + x * 4;
-    const greenOffset = pixelOffset + 1;
-    return calledWithinInterpreter
-      ? imageDataProperties.data.properties[greenOffset].toNumber()
-      : imageDataProperties.data[greenOffset];
-  }
-}
-
-function interpreterGetBlue(imageData, x, y) {
-  return getBlue(imageData, x, y, true);
-}
-
-export function getBlue(imageData, x, y, calledWithinInterpreter) {
-  const imageDataProperties = calledWithinInterpreter
-    ? imageData.properties
-    : imageData;
-  if (imageDataProperties.data && imageDataProperties.width) {
-    const pixelOffset = y * imageDataProperties.width * 4 + x * 4;
-    const blueOffset = pixelOffset + 2;
-    return calledWithinInterpreter
-      ? imageDataProperties.data.properties[blueOffset].toNumber()
-      : imageDataProperties.data[blueOffset];
-  }
-}
-
-function interpreterGetAlpha(imageData, x, y) {
-  return getAlpha(imageData, x, y, true);
-}
-
-export function getAlpha(imageData, x, y, calledWithinInterpreter) {
-  const imageDataProperties = calledWithinInterpreter
-    ? imageData.properties
-    : imageData;
-  if (imageDataProperties.data && imageDataProperties.width) {
-    const pixelOffset = y * imageDataProperties.width * 4 + x * 4;
-    const alphaOffset = pixelOffset + 3;
-    return calledWithinInterpreter
-      ? imageDataProperties.data.properties[alphaOffset].toNumber()
-      : imageDataProperties.data[alphaOffset];
-  }
-}
-
-function interpreterSetRed(imageData, x, y, value) {
-  setRed(imageData, x, y, value, true);
-}
-
-export function setRed(imageData, x, y, value, calledWithinInterpreter) {
-  const imageDataProperties = calledWithinInterpreter
-    ? imageData.properties
-    : imageData;
-  if (imageDataProperties.data && imageDataProperties.width) {
-    const pixelOffset = y * imageDataProperties.width * 4 + x * 4;
-    const redOffset = pixelOffset;
+    const totalOffset = pixelOffset + colorOffset;
     if (calledWithinInterpreter) {
-      imageDataProperties.data.properties[redOffset] = value;
+      imageDataProperties.data.properties[totalOffset] = value;
     } else {
-      imageDataProperties.data[redOffset] = value;
+      imageDataProperties.data[totalOffset] = value;
     }
   }
 }
 
-function interpreterSetGreen(imageData, x, y, value) {
-  setGreen(imageData, x, y, value, true);
-}
+const interpreterSetRed = setImageDataValue.bind(null, true, 0);
+const interpreterSetGreen = setImageDataValue.bind(null, true, 1);
+const interpreterSetBlue = setImageDataValue.bind(null, true, 2);
+const interpreterSetAlpha = setImageDataValue.bind(null, true, 3);
 
-export function setGreen(imageData, x, y, value, calledWithinInterpreter) {
-  const imageDataProperties = calledWithinInterpreter
-    ? imageData.properties
-    : imageData;
-  if (imageDataProperties.data && imageDataProperties.width) {
-    const pixelOffset = y * imageDataProperties.width * 4 + x * 4;
-    const greenOffset = pixelOffset + 1;
-    if (calledWithinInterpreter) {
-      imageDataProperties.data.properties[greenOffset] = value;
-    } else {
-      imageDataProperties.data[greenOffset] = value;
-    }
-  }
-}
-
-function interpreterSetBlue(imageData, x, y, value) {
-  setBlue(imageData, x, y, value, true);
-}
-
-export function setBlue(imageData, x, y, value, calledWithinInterpreter) {
-  const imageDataProperties = calledWithinInterpreter
-    ? imageData.properties
-    : imageData;
-  if (imageDataProperties.data && imageDataProperties.width) {
-    const pixelOffset = y * imageDataProperties.width * 4 + x * 4;
-    const blueOffset = pixelOffset + 2;
-    if (calledWithinInterpreter) {
-      imageDataProperties.data.properties[blueOffset] = value;
-    } else {
-      imageDataProperties.data[blueOffset] = value;
-    }
-  }
-}
-
-function interpreterSetAlpha(imageData, x, y, value) {
-  setAlpha(imageData, x, y, value, true);
-}
-
-export function setAlpha(imageData, x, y, value, calledWithinInterpreter) {
-  const imageDataProperties = calledWithinInterpreter
-    ? imageData.properties
-    : imageData;
-  if (imageDataProperties.data && imageDataProperties.width) {
-    const pixelOffset = y * imageDataProperties.width * 4 + x * 4;
-    const alphaOffset = pixelOffset + 3;
-    if (calledWithinInterpreter) {
-      imageDataProperties.data.properties[alphaOffset] = value;
-    } else {
-      imageDataProperties.data[alphaOffset] = value;
-    }
-  }
-}
+export const setRed = setImageDataValue.bind(null, false, 0);
+export const setGreen = setImageDataValue.bind(null, false, 1);
+export const setBlue = setImageDataValue.bind(null, false, 2);
+export const setAlpha = setImageDataValue.bind(null, false, 3);
 
 function interpreterSetRGB(imageData, x, y, r, g, b, a) {
   setRGB(imageData, x, y, r, g, b, a, true);

--- a/apps/src/applab/dontMarshalApi.js
+++ b/apps/src/applab/dontMarshalApi.js
@@ -165,7 +165,7 @@ export function appendItem(
   validateType = apiValidateType,
   calledWithinInterpreter
 ) {
-  validateType('appendItem', 'list', array, 'array');
+  validateType({}, 'appendItem', 'list', array, 'array');
 
   const arrayValues = calledWithinInterpreter ? array.properties : array;
 

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -1,7 +1,7 @@
 /* global dashboard */
 import $ from 'jquery';
 import * as api from './api';
-import * as dontMarshalApi from './dontMarshalApi';
+import dontMarshalApi from './dontMarshalApi';
 import consoleApi from '../consoleApi';
 import * as audioApi from '@cdo/apps/lib/util/audioApi';
 import audioApiDropletConfig from '@cdo/apps/lib/util/audioApiDropletConfig';

--- a/apps/test/integration/levelSolutions/applab/ec_simple.js
+++ b/apps/test/integration/levelSolutions/applab/ec_simple.js
@@ -94,6 +94,21 @@ module.exports = {
       expect: '"message"'
     }),
 
+    // These exercise some simple use cases for the list blocks:
+    // insertItem, appendItem, and removeItem
+    testApplabConsoleOutput({
+      testName: 'List blocks',
+      source: `
+        var list = ["a", "b", "d"];
+        var g = list.length;
+        insertItem(list, 2, "c");
+        appendItem(list, "f");
+        removeItem(list, 0);
+        console.log(g + ' ' + list.length + ' ' + list.join(','));
+      `,
+      expect: '"3 4 b,c,d,f"'
+    }),
+
     // These exercise all of the blocks in canvas category
     // It does not validate that they behave correctly, just that we don't end
     // up with any errors

--- a/apps/test/unit/applab/ExporterTest.js
+++ b/apps/test/unit/applab/ExporterTest.js
@@ -2,6 +2,7 @@ import {assert} from '../../util/configuredChai';
 import sinon from 'sinon';
 
 var testUtils = require('../../util/testUtils');
+import {expect} from '../../util/reconfiguredChai';
 import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
 import {setAppOptions} from '@cdo/apps/code-studio/initApp/loadApp';
 import Exporter, {getAppOptionsFile} from '@cdo/apps/applab/Exporter';
@@ -841,6 +842,30 @@ describe('Applab Exporter,', function() {
         `<div><div class="screen" id="screen1" tabindex="1"></div></div>`,
         done,
         'webRequestPromise'
+      );
+    });
+
+    it('should run custom marshall methods', done => {
+      sinon.spy(window, 'write');
+      runExportedApp(
+        `
+        var a = 'abcdef'.split('');
+        insertItem(a, 3, 'hi');
+        write(a);
+        `,
+        `<div><div class="screen" id="screen1" tabindex="1"></div></div>`,
+        () => {
+          expect(window.write).to.have.been.calledWith([
+            'a',
+            'b',
+            'c',
+            'hi',
+            'd',
+            'e',
+            'f'
+          ]);
+          done();
+        }
       );
     });
   });

--- a/apps/test/unit/applab/dontMarshalApiTest.js
+++ b/apps/test/unit/applab/dontMarshalApiTest.js
@@ -1,0 +1,131 @@
+import {expect} from '../../util/configuredChai';
+import sinon from 'sinon';
+import {injectErrorHandler} from '@cdo/apps/lib/util/javascriptMode';
+import * as dontMarshalApi from '@cdo/apps/applab/dontMarshalApi';
+
+/*
+ * These tests verify the behavior of dontMarshalApi.js list APIs when called
+ * from native JS (not from within the interpreter)
+ *
+ * These APIs are called in this fashion when accessed from exported
+ * applab projects.
+ *
+ * The ec_simple integration test has some basic verification for the
+ * list APIs when called from the interpreter
+ */
+
+describe('insertItem', () => {
+  it('inserts an item at the beginning of an empty array', () => {
+    const array = [];
+    dontMarshalApi.insertItem(array, 0, 'foo');
+    expect(array).to.eql(['foo']);
+  });
+
+  it('inserts an item at the beginning of an existing array', () => {
+    const array = ['bar'];
+    dontMarshalApi.insertItem(array, 0, 'foo');
+    expect(array).to.eql(['foo', 'bar']);
+  });
+
+  it('inserts an item at the end of an existing array', () => {
+    const array = ['bar'];
+    dontMarshalApi.insertItem(array, array.length, 'foo');
+    expect(array).to.eql(['bar', 'foo']);
+  });
+
+  it('inserts an item at the end of an existing array when passed a large index', () => {
+    const array = ['bar'];
+    dontMarshalApi.insertItem(array, 1000, 'foo');
+    expect(array).to.eql(['bar', 'foo']);
+  });
+
+  it('inserts an item in the middle of an existing array', () => {
+    const array = ['foo', 'bar'];
+    dontMarshalApi.insertItem(array, array.length - 1, 'and');
+    expect(array).to.eql(['foo', 'and', 'bar']);
+  });
+
+  it('inserts an item right before the last item of an existing array when passed -1', () => {
+    const array = ['foo', 'bar'];
+    dontMarshalApi.insertItem(array, -1, 'and');
+    expect(array).to.eql(['foo', 'and', 'bar']);
+  });
+
+  it('inserts an item at the beginning of an existing array when passed -array.length', () => {
+    const array = ['foo', 'bar'];
+    dontMarshalApi.insertItem(array, -array.length, 'and');
+    expect(array).to.eql(['and', 'foo', 'bar']);
+  });
+
+  it('inserts an item at the beginning of an existing array when passed a large negative index', () => {
+    const array = ['foo', 'bar'];
+    dontMarshalApi.insertItem(array, -1000, 'and');
+    expect(array).to.eql(['and', 'foo', 'bar']);
+  });
+});
+
+describe('appendItem', () => {
+  it('appends an item at the end of an empty array', () => {
+    const array = [];
+    dontMarshalApi.appendItem(array, 'foo');
+    expect(array).to.eql(['foo']);
+  });
+
+  it('appends an item at the end of an existing array', () => {
+    const array = ['bar'];
+    dontMarshalApi.appendItem(array, 'foo');
+    expect(array).to.eql(['bar', 'foo']);
+  });
+});
+
+describe('removeItem', () => {
+  it('removes an item at the end of an existing array', () => {
+    const array = ['foo', 'bar'];
+    dontMarshalApi.removeItem(array, array.length - 1);
+    expect(array).to.eql(['foo']);
+  });
+
+  it('warns and does nothing when passed a large index', () => {
+    const errorHandler = {
+      outputWarning: sinon.spy()
+    };
+    injectErrorHandler(errorHandler);
+
+    const array = ['foo', 'bar'];
+    dontMarshalApi.removeItem(array, 1000);
+    expect(array).to.eql(['foo', 'bar']);
+    expect(errorHandler.outputWarning).to.have.been.calledOnce.and.calledWith(
+      'removeItem() index parameter value (1000) is larger than the number of items in the list (2).'
+    );
+  });
+
+  it('removes an item at the beginning of an existing array', () => {
+    const array = ['foo', 'bar'];
+    dontMarshalApi.removeItem(array, 0);
+    expect(array).to.eql(['bar']);
+  });
+
+  it('removes an item at the beginning of an existing array when passed a large negative index', () => {
+    const array = ['foo', 'bar'];
+    dontMarshalApi.removeItem(array, -1000);
+    expect(array).to.eql(['bar']);
+  });
+
+  it('removes an item in the middle of an existing array', () => {
+    const array = ['foo', 'and', 'bar'];
+    dontMarshalApi.removeItem(array, 1);
+    expect(array).to.eql(['foo', 'bar']);
+  });
+
+  it('removes the last item of an existing array when passed -1', () => {
+    const array = ['foo', 'and', 'bar'];
+    dontMarshalApi.removeItem(array, -1);
+    expect(array).to.eql(['foo', 'and']);
+  });
+
+  it('removes an item at the beginning of an existing array when passed -array.length', () => {
+    const array = ['foo', 'bar'];
+    dontMarshalApi.removeItem(array, -array.length);
+    expect(array).to.eql(['bar']);
+  });
+});


### PR DESCRIPTION
Resolves an issue covered here: https://codedotorg.atlassian.net/browse/STAR-336

All of the APIs within `dontMarshalApi.js` have specific knowledge of interpreter data structures. In order to use these outside of the interpreter, we need to have equivalent versions that can run in a normal JavaScript environment.

This PR addresses that. Rather than introduce two versions of each function that will need to be maintained in parallel, I've decided to set things up so that a single implementation is available that can do some work conditionally when it is running within the interpreter (through a new `calledWithinInterpreter` argument)

Also, removed unused list functions from `api.js` - the real versions of these are in `dontMarshalApi.js` - we were exporting both versions and the first versions didn't do anything.

Added a basic correctness test for the list blocks (`insertItem`, `appendItem`, and `removeItem`) since I couldn't find any test coverage for these at all.