### PR TITLE
PL: Regional partner search shows less for closed workshops

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -410,12 +410,12 @@ class RegionalPartnerSearch extends Component {
               )}
             </div>
 
-            {appState !== WorkshopApplicationStates.now_closed && (
-              <div
-                className="professional_learning_information"
-                id={`id-${partnerInfo.id}`}
-              >
-                {partnerInfo.cost_scholarship_information && (
+            <div
+              className="professional_learning_information"
+              id={`id-${partnerInfo.id}`}
+            >
+              {appState !== WorkshopApplicationStates.now_closed &&
+                partnerInfo.cost_scholarship_information && (
                   <div>
                     <h3>Scholarship, discounts, and cost information:</h3>
                     <div style={styles.scholarship}>
@@ -426,16 +426,15 @@ class RegionalPartnerSearch extends Component {
                   </div>
                 )}
 
-                {partnerInfo.additional_program_information && (
-                  <div>
-                    <h3>Additional program information:</h3>
-                    <SafeMarkdown
-                      markdown={partnerInfo.additional_program_information}
-                    />
-                  </div>
-                )}
-              </div>
-            )}
+              {partnerInfo.additional_program_information && (
+                <div>
+                  <h3>Additional program information:</h3>
+                  <SafeMarkdown
+                    markdown={partnerInfo.additional_program_information}
+                  />
+                </div>
+              )}
+            </div>
 
             <div style={styles.partnerContact}>
               <h3>Have more questions?</h3>

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -410,30 +410,32 @@ class RegionalPartnerSearch extends Component {
               )}
             </div>
 
-            <div
-              className="professional_learning_information"
-              id={`id-${partnerInfo.id}`}
-            >
-              {partnerInfo.cost_scholarship_information && (
-                <div>
-                  <h3>Scholarship, discounts, and cost information:</h3>
-                  <div style={styles.scholarship}>
+            {appState !== WorkshopApplicationStates.now_closed && (
+              <div
+                className="professional_learning_information"
+                id={`id-${partnerInfo.id}`}
+              >
+                {partnerInfo.cost_scholarship_information && (
+                  <div>
+                    <h3>Scholarship, discounts, and cost information:</h3>
+                    <div style={styles.scholarship}>
+                      <SafeMarkdown
+                        markdown={partnerInfo.cost_scholarship_information}
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {partnerInfo.additional_program_information && (
+                  <div>
+                    <h3>Additional program information:</h3>
                     <SafeMarkdown
-                      markdown={partnerInfo.cost_scholarship_information}
+                      markdown={partnerInfo.additional_program_information}
                     />
                   </div>
-                </div>
-              )}
-
-              {partnerInfo.additional_program_information && (
-                <div>
-                  <h3>Additional program information:</h3>
-                  <SafeMarkdown
-                    markdown={partnerInfo.additional_program_information}
-                  />
-                </div>
-              )}
-            </div>
+                )}
+              </div>
+            )}
 
             <div style={styles.partnerContact}>
               <h3>Have more questions?</h3>

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/program-information.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/program-information.md.erb
@@ -9,7 +9,7 @@ theme: responsive
 
 <h2>Find your local workshop and apply</h2>
 
-Look up details of the Professional Learning Program in your region by submitting your zip code below. Or [apply directly now!](<%= CDO.studio_url("/pd/application/teacher") %>)
+Look up details of the Professional Learning Program in your region by submitting your zip code below.
 
 <%= view :regional_partner_search, source_page_id: "program-information" %>
 


### PR DESCRIPTION
When a regional partner is closed for workshop applications, show less.  In particular, the "Scholarship, discounts, and cost information:" heading and its grey box of content is not shown.

Also, the "Or, apply directly now!" link that was permanently at the top of the page is permanently removed.

### before
![Screenshot 2019-07-18 00 45 35](https://user-images.githubusercontent.com/2205926/61439422-5b60c300-a8f6-11e9-81d3-16bff03ccb75.png)

### after
![Screenshot 2019-07-18 13 58 55](https://user-images.githubusercontent.com/2205926/61492079-761e5080-a965-11e9-890b-d24cb98f30da.png)
