### PR TITLE
Mapbox cron job

### DIFF
--- a/bin/cron/update_census_mapbox
+++ b/bin/cron/update_census_mapbox
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# The map on code.org/yourschool is run off of Mapbox
+# The map on code.org/yourschool is run off of Mapbox.
 # This script updates the data on Mapbox by querying all rows from
 # census_summaries table for the appropriate school year,
 # creating maptiles with Mapbox's command line tool, Tippecanoe,
@@ -67,8 +67,24 @@ end
 file = Tempfile.new(['census', 'geojson'])
 tiles = Tempfile.new(['censustiles', 'mbtiles'])
 file.write(JSON.pretty_generate(geojson))
-stdout, _status = Open3.capture2(
+_stdout, stderr, tippecanoe_status = Open3.capture2(
+  # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
+  # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
+  # The layer is called "census". DO NOT change the layer name without changing the map
+  # in the Mapbox UI.
   "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"census\" --force #{file.path}"
 )
-upload_maptiles(tiles.path, 'censustiles')
-puts stdout
+upload_successful = false
+if tippecanoe_status.success?
+  upload_successful = upload_maptiles(tiles.path, 'censustiles')
+end
+unless tippecanoe_status.success? && upload_successful
+  Honeybadger.notify(
+    error_message: "Updating HOC map on Mapbox failed",
+    error_class: "HOC Map Update Failure",
+    context: {
+      tippecanoe_status: stderr,
+      upload_status: upload_successful
+    }
+  )
+end

--- a/bin/cron/update_census_mapbox
+++ b/bin/cron/update_census_mapbox
@@ -1,14 +1,13 @@
 #!/usr/bin/env ruby
 
-# The map on code.org/yourschool is run off of a Google Fusion Table
-# (documentation: https://developers.google.com/maps/documentation/javascript/fusiontableslayer).
-# This script updates the fusion table using the REST API
-# (documentation: https://developers.google.com/fusiontables/docs/v2/using),
-# populating it with all rows from the census_summaries table for the appropriate school year.
+# The map on code.org/yourschool is run off of Mapbox
+# This script updates the data on Mapbox by querying all rows from
+# census_summaries table for the appropriate school year,
+# creating maptiles with Mapbox's command line tool, Tippecanoe,
+# and uploading them to Mapbox's server.
 
 # After setting up authentication, provide the following CDO.* attributes:
-#   CDO.hoc_map_account: (JSON of a credential which can edit the FusionTables table)
-#   CDO.census_map_table_id: (the id of the fusion table)
+#   CDO.mapbox_upload_token: (the auth token for uploading tiles to Mapbox's servers)
 
 require_relative '../../dashboard/config/environment'
 require 'cdo/properties'

--- a/bin/cron/update_census_mapbox
+++ b/bin/cron/update_census_mapbox
@@ -10,6 +10,7 @@
 #   CDO.mapbox_upload_token: (the auth token for uploading tiles to Mapbox's servers)
 
 require_relative '../../dashboard/config/environment'
+require 'cdo/only_one'
 require 'cdo/properties'
 
 require_relative 'upload_to_mapbox'
@@ -20,71 +21,77 @@ def make_location(lat, long)
   "#{format('%.6f', lat)}, #{format('%.6f', long)}"
 end
 
-# Update summaries before updating the fusion table
-# If any single teaches_cs category in a given year changes by more than
-# 10% of the total number of schools then issue a Honeybadger notification.
-threshold = School.count * 0.1
-old_summary_counts = Census::CensusSummary.group(:school_year, :teaches_cs).count
-Census::CensusSummary.summarize_census_data
-new_summary_counts = Census::CensusSummary.group(:school_year, :teaches_cs).count
+def main
+  return unless only_one_running?(__FILE__)
 
-unless old_summary_counts.select {|k, c| (c - new_summary_counts[k]).abs > threshold}.empty?
-  Honeybadger.notify(
-    error_message: "High rate of change in census_summaries. This may be expected if summary logic was recently changed or if a new data source was just added.",
-    error_class: "Census Summary High Rate of Change",
-    context: {
-      old_counts: old_summary_counts,
-      new_counts: new_summary_counts
-    }
+  # Update summaries before updating the fusion table
+  # If any single teaches_cs category in a given year changes by more than
+  # 10% of the total number of schools then issue a Honeybadger notification.
+  threshold = School.count * 0.1
+  old_summary_counts = Census::CensusSummary.group(:school_year, :teaches_cs).count
+  Census::CensusSummary.summarize_census_data
+  new_summary_counts = Census::CensusSummary.group(:school_year, :teaches_cs).count
+
+  unless old_summary_counts.select {|k, c| (c - new_summary_counts[k]).abs > threshold}.empty?
+    Honeybadger.notify(
+      error_message: "High rate of change in census_summaries. This may be expected if summary logic was recently changed or if a new data source was just added.",
+      error_class: "Census Summary High Rate of Change",
+      context: {
+        old_counts: old_summary_counts,
+        new_counts: new_summary_counts
+      }
+    )
+  end
+
+  # The map should show the data from the school year that began
+  # in the previous calendar year. So, Aug-Dec we show the previous school
+  # year's data and then switch over to the current school year in Jan.
+  year = Date.today.year - 1
+  geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
+  Census::CensusSummary.where(school_year: year).find_each do |summary|
+    school = summary.school
+    geojson["features"] <<
+      {
+        geometry: {
+          coordinates: [school.longitude.to_f, school.latitude.to_f],
+          type: "Point"
+        },
+        properties: {
+          school_id: school.id,
+          year: year,
+          school_name: school.name.titleize,
+          school_city: school.city.titleize,
+          school_state: school.state,
+          teaches_cs: summary.teaches_cs
+        },
+        type: "Feature"
+      }
+  end
+
+  file = Tempfile.new(['census', 'geojson'])
+  tiles = Tempfile.new(['censustiles', 'mbtiles'])
+  file.write(JSON.pretty_generate(geojson))
+  _stdout, stderr, tippecanoe_status = Open3.capture2(
+    # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
+    # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
+    # The layer is called "census". DO NOT change the layer name without changing the map
+    # in the Mapbox UI.
+    "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"census\" --force #{file.path}"
   )
+  upload_successful = false
+  if tippecanoe_status.success?
+    upload_successful = upload_maptiles(tiles.path, 'censustiles')
+  end
+  unless tippecanoe_status.success? && upload_successful
+    Honeybadger.notify(
+      error_message: "Updating HOC map on Mapbox failed",
+      error_class: "HOC Map Update Failure",
+      context: {
+        tippecanoe_status: stderr,
+        upload_status: upload_successful
+      }
+    )
+  end
 end
 
-# The map should show the data from the school year that began
-# in the previous calendar year. So, Aug-Dec we show the previous school
-# year's data and then switch over to the current school year in Jan.
-year = Date.today.year - 1
-geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
-Census::CensusSummary.where(school_year: year).find_each do |summary|
-  school = summary.school
-  geojson["features"] <<
-    {
-      geometry: {
-        coordinates: [school.longitude.to_f, school.latitude.to_f],
-        type: "Point"
-      },
-      properties: {
-        school_id: school.id,
-        year: year,
-        school_name: school.name.titleize,
-        school_city: school.city.titleize,
-        school_state: school.state,
-        teaches_cs: summary.teaches_cs
-      },
-      type: "Feature"
-    }
-end
-
-file = Tempfile.new(['census', 'geojson'])
-tiles = Tempfile.new(['censustiles', 'mbtiles'])
-file.write(JSON.pretty_generate(geojson))
-_stdout, stderr, tippecanoe_status = Open3.capture2(
-  # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
-  # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
-  # The layer is called "census". DO NOT change the layer name without changing the map
-  # in the Mapbox UI.
-  "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"census\" --force #{file.path}"
-)
-upload_successful = false
-if tippecanoe_status.success?
-  upload_successful = upload_maptiles(tiles.path, 'censustiles')
-end
-unless tippecanoe_status.success? && upload_successful
-  Honeybadger.notify(
-    error_message: "Updating HOC map on Mapbox failed",
-    error_class: "HOC Map Update Failure",
-    context: {
-      tippecanoe_status: stderr,
-      upload_status: upload_successful
-    }
-  )
-end
+main

--- a/bin/cron/update_census_mapbox
+++ b/bin/cron/update_census_mapbox
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+
+# The map on code.org/yourschool is run off of a Google Fusion Table
+# (documentation: https://developers.google.com/maps/documentation/javascript/fusiontableslayer).
+# This script updates the fusion table using the REST API
+# (documentation: https://developers.google.com/fusiontables/docs/v2/using),
+# populating it with all rows from the census_summaries table for the appropriate school year.
+
+# After setting up authentication, provide the following CDO.* attributes:
+#   CDO.hoc_map_account: (JSON of a credential which can edit the FusionTables table)
+#   CDO.census_map_table_id: (the id of the fusion table)
+
+require_relative '../../dashboard/config/environment'
+require 'cdo/properties'
+
+require_relative 'upload_to_mapbox'
+
+def make_location(lat, long)
+  return nil if lat.nil? || long.nil?
+
+  "#{format('%.6f', lat)}, #{format('%.6f', long)}"
+end
+
+# Update summaries before updating the fusion table
+# If any single teaches_cs category in a given year changes by more than
+# 10% of the total number of schools then issue a Honeybadger notification.
+threshold = School.count * 0.1
+old_summary_counts = Census::CensusSummary.group(:school_year, :teaches_cs).count
+Census::CensusSummary.summarize_census_data
+new_summary_counts = Census::CensusSummary.group(:school_year, :teaches_cs).count
+
+unless old_summary_counts.select {|k, c| (c - new_summary_counts[k]).abs > threshold}.empty?
+  Honeybadger.notify(
+    error_message: "High rate of change in census_summaries. This may be expected if summary logic was recently changed or if a new data source was just added.",
+    error_class: "Census Summary High Rate of Change",
+    context: {
+      old_counts: old_summary_counts,
+      new_counts: new_summary_counts
+    }
+  )
+end
+
+# The map should show the data from the school year that began
+# in the previous calendar year. So, Aug-Dec we show the previous school
+# year's data and then switch over to the current school year in Jan.
+year = Date.today.year - 1
+geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
+Census::CensusSummary.where(school_year: year).find_each do |summary|
+  school = summary.school
+  geojson["features"] <<
+    {
+      geometry: {
+        coordinates: [school.longitude.to_f, school.latitude.to_f],
+        type: "Point"
+      },
+      properties: {
+        school_id: school.id,
+        year: year,
+        school_name: school.name.titleize,
+        school_city: school.city.titleize,
+        school_state: school.state,
+        teaches_cs: summary.teaches_cs
+      },
+      type: "Feature"
+    }
+end
+
+file = Tempfile.new(['census', 'geojson'])
+tiles = Tempfile.new(['censustiles', 'mbtiles'])
+file.write(JSON.pretty_generate(geojson))
+stdout, _status = Open3.capture2(
+  "./../tippecanoe-executable -zg -o #{tiles.path} -l \"census\" --force -r1 --cluster-distance=10 #{file.path}"
+)
+upload_maptiles(tiles.path, 'censustiles')
+puts stdout

--- a/bin/cron/update_census_mapbox
+++ b/bin/cron/update_census_mapbox
@@ -68,7 +68,7 @@ file = Tempfile.new(['census', 'geojson'])
 tiles = Tempfile.new(['censustiles', 'mbtiles'])
 file.write(JSON.pretty_generate(geojson))
 stdout, _status = Open3.capture2(
-  "./../tippecanoe-executable -zg -o #{tiles.path} -l \"census\" --force -r1 --cluster-distance=10 #{file.path}"
+  "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"census\" --force #{file.path}"
 )
 upload_maptiles(tiles.path, 'censustiles')
 puts stdout

--- a/bin/cron/update_hoc_mapbox
+++ b/bin/cron/update_hoc_mapbox
@@ -51,7 +51,8 @@ DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 1
         type: "Point"
       },
       properties: {
-        organization_name: organization_name
+        organization_name: organization_name,
+        special_event_details: data['special_event_details_s']
       },
       type: "Feature"
     }
@@ -60,7 +61,7 @@ file = Tempfile.new(['hocevents', 'geojson'])
 tiles = Tempfile.new(['hoctiles', 'mbtiles'])
 file.write(JSON.pretty_generate(geojson))
 stdout, _status = Open3.capture2(
-  "./../tippecanoe-executable -zg -o #{tiles.path} -l \"hoc\" --force -r1 --cluster-distance=10 #{file.path}"
+  "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"hoc\" --force #{file.path}"
 )
 upload_maptiles(tiles.path, 'hoctiles')
 puts stdout

--- a/bin/cron/update_hoc_mapbox
+++ b/bin/cron/update_hoc_mapbox
@@ -20,8 +20,7 @@ require_relative 'upload_to_mapbox'
 
 DB_READONLY = Sequel.connect(CDO.pegasus_db_reader.sub('mysql:', 'mysql2:'))
 
-#CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
-CURRENT_HOC_SIGNUP = "VolunteerEngineerSubmission2015"
+CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
 
 geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
 

--- a/bin/cron/update_hoc_mapbox
+++ b/bin/cron/update_hoc_mapbox
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# The map on hourofcode.com is run off of Mapbox
+# The map on hourofcode.com is run off of Mapbox.
 # This script updates the data on Mapbox by querying all rows from
 # the pegasus forms table whose kind is the
 # most recent HocSignup (e.g., HocSignup2017 in Fall 2017),
@@ -20,7 +20,8 @@ require_relative 'upload_to_mapbox'
 
 DB_READONLY = Sequel.connect(CDO.pegasus_db_reader.sub('mysql:', 'mysql2:'))
 
-CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
+#CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
+CURRENT_HOC_SIGNUP = "VolunteerEngineerSubmission2015"
 
 geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
 
@@ -60,8 +61,24 @@ end
 file = Tempfile.new(['hocevents', 'geojson'])
 tiles = Tempfile.new(['hoctiles', 'mbtiles'])
 file.write(JSON.pretty_generate(geojson))
-stdout, _status = Open3.capture2(
+_stdout, stderr, tippecanoe_status = Open3.capture3(
+  # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
+  # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
+  # The layer is called "hoc". DO NOT change the layer name without changing the map
+  # in the Mapbox UI.
   "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"hoc\" --force #{file.path}"
 )
-upload_maptiles(tiles.path, 'hoctiles')
-puts stdout
+upload_successful = false
+if tippecanoe_status.success?
+  upload_successful = upload_maptiles(tiles.path, 'hoctiles')
+end
+unless tippecanoe_status.success? && upload_successful
+  Honeybadger.notify(
+    error_message: "Updating HOC map on Mapbox failed",
+    error_class: "HOC Map Update Failure",
+    context: {
+      tippecanoe_status: stderr,
+      upload_status: upload_successful
+    }
+  )
+end

--- a/bin/cron/update_hoc_mapbox
+++ b/bin/cron/update_hoc_mapbox
@@ -12,6 +12,7 @@
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require src_dir 'database'
+require 'cdo/only_one'
 require 'cdo/properties'
 require 'dynamic_config/dcdo'
 require 'tempfile'
@@ -21,63 +22,68 @@ require_relative 'upload_to_mapbox'
 DB_READONLY = Sequel.connect(CDO.pegasus_db_reader.sub('mysql:', 'mysql2:'))
 
 CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
+def main
+  return unless only_one_running?(__FILE__)
 
-geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
+  geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
 
-DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 10_000) do |form|
-  data = JSON.parse(form[:data])
-  processed_data = JSON.parse(form[:processed_data]) rescue {}
-  # In order to be placed on the map, all events require an organization name,
-  # processed location, and city. With the exception that approved special events
-  # don't need a city so we can show events like the Cocos Keeling Islands.
-  next if data['name_s'].nil? || processed_data['location_p'].nil?
+  DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 10_000) do |form|
+    data = JSON.parse(form[:data])
+    processed_data = JSON.parse(form[:processed_data]) rescue {}
+    # In order to be placed on the map, all events require an organization name,
+    # processed location, and city. With the exception that approved special events
+    # don't need a city so we can show events like the Cocos Keeling Islands.
+    next if data['name_s'].nil? || processed_data['location_p'].nil?
 
-  organization_name =
-    if !processed_data['nces_school_name_s'].to_s.strip.empty?
-      processed_data['nces_school_name_s']
-    elsif !data['school_name_s'].to_s.strip.empty?
-      data['school_name_s']
-    else
-      data['name_s']
-    end
+    organization_name =
+      if !processed_data['nces_school_name_s'].to_s.strip.empty?
+        processed_data['nces_school_name_s']
+      elsif !data['school_name_s'].to_s.strip.empty?
+        data['school_name_s']
+      else
+        data['name_s']
+      end
 
-  coordinates = processed_data['location_p'].split(',')
-  long = coordinates[1].to_f
-  lat = coordinates[0].to_f
-  geojson["features"] <<
-    {
-      geometry: {
-        coordinates: [long, lat],
-        type: "Point"
-      },
-      properties: {
-        organization_name: organization_name,
-        special_event_details: data['special_event_details_s']
-      },
-      type: "Feature"
-    }
-end
-file = Tempfile.new(['hocevents', 'geojson'])
-tiles = Tempfile.new(['hoctiles', 'mbtiles'])
-file.write(JSON.pretty_generate(geojson))
-_stdout, stderr, tippecanoe_status = Open3.capture3(
-  # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
-  # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
-  # The layer is called "hoc". DO NOT change the layer name without changing the map
-  # in the Mapbox UI.
-  "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"hoc\" --force #{file.path}"
-)
-upload_successful = false
-if tippecanoe_status.success?
-  upload_successful = upload_maptiles(tiles.path, 'hoctiles')
-end
-unless tippecanoe_status.success? && upload_successful
-  Honeybadger.notify(
-    error_message: "Updating HOC map on Mapbox failed",
-    error_class: "HOC Map Update Failure",
-    context: {
-      tippecanoe_status: stderr,
-      upload_status: upload_successful
-    }
+    coordinates = processed_data['location_p'].split(',')
+    long = coordinates[1].to_f
+    lat = coordinates[0].to_f
+    geojson["features"] <<
+      {
+        geometry: {
+          coordinates: [long, lat],
+          type: "Point"
+        },
+        properties: {
+          organization_name: organization_name,
+          special_event_details: data['special_event_details_s']
+        },
+        type: "Feature"
+      }
+  end
+  file = Tempfile.new(['hocevents', 'geojson'])
+  tiles = Tempfile.new(['hoctiles', 'mbtiles'])
+  file.write(JSON.pretty_generate(geojson))
+  _stdout, stderr, tippecanoe_status = Open3.capture3(
+    # Tippecanoe will generate a map that has a min zoom of 1 (approx the whole world),
+    # clusters points that are approximately 2 pixels apart, and drops points to make them fit if they can't.
+    # The layer is called "hoc". DO NOT change the layer name without changing the map
+    # in the Mapbox UI.
+    "tippecanoe -Z 1 -rg --cluster-distance=2 -o #{tiles.path} -l \"hoc\" --force #{file.path}"
   )
+  upload_successful = false
+  if tippecanoe_status.success?
+    upload_successful = upload_maptiles(tiles.path, 'hoctiles')
+  end
+  unless tippecanoe_status.success? && upload_successful
+    Honeybadger.notify(
+      error_message: "Updating HOC map on Mapbox failed",
+      error_class: "HOC Map Update Failure",
+      context: {
+        tippecanoe_status: stderr,
+        upload_status: upload_successful
+      }
+    )
+  end
 end
+
+main

--- a/bin/cron/update_hoc_mapbox
+++ b/bin/cron/update_hoc_mapbox
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+
+# The map on hourofcode.com is run off of a Google Fusion Table
+# (documentation: https://developers.google.com/maps/documentation/javascript/fusiontableslayer).
+# This script updates the fusion table using the REST API
+# (documentation: https://developers.google.com/fusiontables/docs/v2/using),
+# populating it with all rows from the pegasus forms table whose kind is the
+# most recent HocSignup (e.g., HocSignup2017 in Fall 2017).
+
+# After setting up authentication, provide the following CDO.* attributes (example values below):
+#   CDO.hoc_map_account: JSON of a credential which can edit the FusionTables table
+#   CDO.hoc_map_table_id: ABCDEF123456 (the id of the fusion table)
+
+require File.expand_path('../../../pegasus/src/env', __FILE__)
+require src_dir 'database'
+require 'cdo/properties'
+require 'dynamic_config/dcdo'
+require 'tempfile'
+
+require_relative 'upload_to_mapbox'
+
+DB_READONLY = Sequel.connect(CDO.pegasus_db_reader.sub('mysql:', 'mysql2:'))
+
+CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
+
+geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
+
+DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 10_000) do |form|
+  data = JSON.parse(form[:data])
+  processed_data = JSON.parse(form[:processed_data]) rescue {}
+  # In order to be placed on the map, all events require an organization name,
+  # processed location, and city. With the exception that approved special events
+  # don't need a city so we can show events like the Cocos Keeling Islands.
+  next if data['name_s'].nil? || processed_data['location_p'].nil?
+
+  organization_name =
+    if !processed_data['nces_school_name_s'].to_s.strip.empty?
+      processed_data['nces_school_name_s']
+    elsif !data['school_name_s'].to_s.strip.empty?
+      data['school_name_s']
+    else
+      data['name_s']
+    end
+
+  coordinates = processed_data['location_p'].split(',')
+  long = coordinates[1].to_f
+  lat = coordinates[0].to_f
+  geojson["features"] <<
+    {
+      geometry: {
+        coordinates: [long, lat],
+        type: "Point"
+      },
+      properties: {
+        organization_name: organization_name
+      },
+      type: "Feature"
+    }
+end
+file = Tempfile.new(['hocevents', 'geojson'])
+tiles = Tempfile.new(['hoctiles', 'mbtiles'])
+file.write(JSON.pretty_generate(geojson))
+stdout, _status = Open3.capture2(
+  "./../tippecanoe-executable -zg -o #{tiles.path} -l \"hoc\" --force -r1 --cluster-distance=10 #{file.path}"
+)
+upload_maptiles(tiles.path, 'hoctiles')
+puts stdout

--- a/bin/cron/update_hoc_mapbox
+++ b/bin/cron/update_hoc_mapbox
@@ -1,15 +1,14 @@
 #!/usr/bin/env ruby
 
-# The map on hourofcode.com is run off of a Google Fusion Table
-# (documentation: https://developers.google.com/maps/documentation/javascript/fusiontableslayer).
-# This script updates the fusion table using the REST API
-# (documentation: https://developers.google.com/fusiontables/docs/v2/using),
-# populating it with all rows from the pegasus forms table whose kind is the
-# most recent HocSignup (e.g., HocSignup2017 in Fall 2017).
+# The map on hourofcode.com is run off of Mapbox
+# This script updates the data on Mapbox by querying all rows from
+# the pegasus forms table whose kind is the
+# most recent HocSignup (e.g., HocSignup2017 in Fall 2017),
+# creating maptiles with Mapbox's command line tool, Tippecanoe,
+# and uploading them to Mapbox's server.
 
-# After setting up authentication, provide the following CDO.* attributes (example values below):
-#   CDO.hoc_map_account: JSON of a credential which can edit the FusionTables table
-#   CDO.hoc_map_table_id: ABCDEF123456 (the id of the fusion table)
+# After setting up authentication, provide the following CDO.* attributes:
+#   CDO.mapbox_upload_token: (the auth token for uploading tiles to Mapbox's servers)
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require src_dir 'database'

--- a/bin/cron/upload_to_mapbox.rb
+++ b/bin/cron/upload_to_mapbox.rb
@@ -34,7 +34,7 @@ def put_file_on_s3(tileset_path, credentials)
   obj.upload_file(tileset_path)
 end
 
-# Return upload response code so that it can be logged
+# Return true if the upload completed without errors
 def upload_maptiles(tileset_path, tileset_name)
   credentials = create_upload_credentials
   return false unless put_file_on_s3(tileset_path, credentials)

--- a/bin/cron/upload_to_mapbox.rb
+++ b/bin/cron/upload_to_mapbox.rb
@@ -10,20 +10,20 @@ require 'aws-sdk-s3'
 require 'rest-client'
 
 def create_upload_credentials
-  puts "Creating credentials"
+  CDO.log "Creating credentials"
   response = RestClient.post("https://api.mapbox.com/uploads/v1/codeorg/credentials?access_token=#{CDO.mapbox_upload_token}", {})
   JSON.parse(response.body)
 end
 
 # Returns response code
 def create_upload(config)
-  puts "Creating upload"
+  CDO.log "Creating upload"
   RestClient.post("https://api.mapbox.com/uploads/v1/codeorg?access_token=#{CDO.mapbox_upload_token}", config.to_json, {content_type: :json, accept: :json}).code
 end
 
 # Return true if upload was successful
 def put_file_on_s3(tileset_path, credentials)
-  puts "Putting file on s3"
+  CDO.log "Putting file on s3"
   s3_client = Aws::S3::Resource.new(
     access_key_id: credentials['accessKeyId'],
     secret_access_key: credentials['secretAccessKey'],

--- a/bin/cron/upload_to_mapbox.rb
+++ b/bin/cron/upload_to_mapbox.rb
@@ -1,3 +1,11 @@
+# Util file for uploading tilesets to Mapbox
+# Tilesets should be generated using Tippecanoe.
+# Tilesets are uploaded to Mapbox's servers using the process documented at
+# https://docs.mapbox.com/api/maps/#uploads.
+#
+# Before using these functions, be sure to provide the following CDO attribute:
+#  CDO.mapbox_upload_token: (the auth token for uploading tiles to Mapbox's servers)
+
 require 'aws-sdk-s3'
 require 'rest-client'
 

--- a/bin/cron/upload_to_mapbox.rb
+++ b/bin/cron/upload_to_mapbox.rb
@@ -1,0 +1,37 @@
+require 'aws-sdk-s3'
+require 'rest-client'
+
+def create_upload_credentials
+  puts "Creating credentials"
+  response = RestClient.post("https://api.mapbox.com/uploads/v1/bethanycodeorg/credentials?access_token=#{CDO.mapbox_upload_token}", {})
+  JSON.parse(response.body)
+end
+
+def create_upload(config)
+  puts "Creating upload"
+  RestClient.post("https://api.mapbox.com/uploads/v1/bethanycodeorg?access_token=#{CDO.mapbox_upload_token}", config.to_json, {content_type: :json, accept: :json})
+end
+
+def put_file_on_s3(tileset_path, credentials)
+  puts "Putting file on s3"
+  s3_client = Aws::S3::Resource.new(
+    access_key_id: credentials['accessKeyId'],
+    secret_access_key: credentials['secretAccessKey'],
+    session_token: credentials['sessionToken'],
+    region: 'us-east-1'
+  )
+  obj = s3_client.bucket(credentials['bucket']).object(credentials['key'])
+  obj.upload_file(tileset_path)
+end
+
+def upload_maptiles(tileset_path, tileset_name)
+  credentials = create_upload_credentials
+  put_file_on_s3(tileset_path, credentials)
+  create_upload(
+    {
+      url: credentials['url'],
+      tileset: "bethanycodeorg.#{tileset_name}",
+      name: "bethanycodeorg.#{tileset_name}"
+    }
+  )
+end

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -133,6 +133,9 @@ ga_account:
 ga_profile_id:
 google_safe_browsing_key: fake_api_key
 
+# Mapbox
+mapbox_upload_token:
+
 # Crowdin
 crowdin_codeorg_api_key:
 


### PR DESCRIPTION
This PR depends on #29820.

This PR introduces two jobs, `update_census_mapbox` and `update_hoc_mapbox`, which will eventually replace `update_census_map` and `update_hoc_map`. The cron config change to turn them on will be done in a future PR. 

In order to process this data so that it can work with Mapbox, we will:
1. query the data the same way we already do
2. transform it into GeoJSON and store that in a temp files
3. process that GeoJSON into maptiles using Tippecanoe (see PR #29820)
4. Upload hose maptiles to Mapbox using [Mapbox's documented upload process](https://docs.mapbox.com/api/maps/#uploads). They don't currently have any Ruby libraries we can use so I ported the util functions from their [JS SDK](https://github.com/mapbox/mapbox-sdk-js).
