### PR TITLE
Tests: Minimal setup in WorkshopDailySurveyControllerTest

### DIFF
--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -39,14 +39,8 @@ module Pd
 
     self.use_transactional_test_case = true
     setup do
-      @enrolled_two_day_academic_year_teacher = create :teacher
       @regional_partner = create :regional_partner
       @facilitators = create_list :facilitator, 2
-
-      @two_day_academic_year_workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_5,
-        num_sessions: 2, regional_partner: @regional_partner, facilitators: @facilitators
-      @two_day_academic_year_enrollment = create :pd_enrollment, :from_user,
-        user: @enrolled_two_day_academic_year_teacher, workshop: @two_day_academic_year_workshop
 
       @csf201_not_started_workshop = create :pd_workshop,
         course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
@@ -500,6 +494,7 @@ module Pd
     end
 
     test 'facilitator specific submit for 2-day academic redirects to thanks for day 1' do
+      setup_two_day_academic_year_workshop
       sign_in @enrolled_two_day_academic_year_teacher
 
       assert_creates Pd::WorkshopFacilitatorDailySurvey do
@@ -528,6 +523,7 @@ module Pd
     end
 
     test 'facilitator specific submit for 2-day academic redirects to post for day 2' do
+      setup_two_day_academic_year_workshop
       sign_in @enrolled_two_day_academic_year_teacher
 
       assert_creates Pd::WorkshopFacilitatorDailySurvey do
@@ -1095,6 +1091,16 @@ module Pd
       @academic_year_enrollment = create :pd_enrollment, :from_user, workshop: @academic_year_workshop
       @enrolled_academic_year_teacher = @academic_year_enrollment.user
       @facilitators = @academic_year_workshop.facilitators
+    end
+
+    def setup_two_day_academic_year_workshop
+      @regional_partner = create :regional_partner
+      @two_day_academic_year_workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_5,
+        num_sessions: 2, num_facilitators: 2, regional_partner: @regional_partner
+      @two_day_academic_year_enrollment = create :pd_enrollment, :from_user,
+        workshop: @two_day_academic_year_workshop
+      @enrolled_two_day_academic_year_teacher = @two_day_academic_year_enrollment.user
+      @facilitators = @two_day_academic_year_workshop.facilitators
     end
 
     def unenrolled_teacher

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -40,18 +40,6 @@ module Pd
     self.use_transactional_test_case = true
     setup do
       CDO.stubs(:jotform_forms).returns(FAKE_JOTFORM_FORMS)
-
-      @csf_pre201_params = {
-        environment: Rails.env,
-        day: CSF_SURVEY_INDEXES[PRE_DEEPDIVE_SURVEY],
-        formId: CDO.jotform_forms[CSF_CATEGORY][PRE_DEEPDIVE_SURVEY]
-      }
-
-      @csf_post201_params = {
-        environment: Rails.env,
-        day: CSF_SURVEY_INDEXES[POST_DEEPDIVE_SURVEY],
-        formId: CDO.jotform_forms[CSF_CATEGORY][POST_DEEPDIVE_SURVEY]
-      }
     end
 
     test 'daily summer workshop survey returns 404 for days outside of range 0-4' do
@@ -691,10 +679,10 @@ module Pd
       get '/pd/workshop_survey/csf/pre201'
 
       assert_response :success
-      assert_equal @csf_pre201_params[:formId], actual_form_id
+      assert_equal csf_pre201_params[:formId], actual_form_id
       assert_equal teacher.id, actual_form_params[:userId]
       assert_equal @csf201_not_started_workshop.id, actual_form_params[:workshopId]
-      assert_equal @csf_pre201_params[:day], actual_form_params[:day]
+      assert_equal csf_pre201_params[:day], actual_form_params[:day]
     end
 
     test 'csf pre201 survey: reports survey render to New Relic' do
@@ -707,7 +695,7 @@ module Pd
         'RenderJotFormView',
         {
           route: 'GET /pd/workshop_survey/csf/pre201',
-          form_id: @csf_pre201_params[:formId],
+          form_id: csf_pre201_params[:formId],
           workshop_course: COURSE_CSF,
           workshop_subject: SUBJECT_CSF_201,
           regional_partner_name: @regional_partner.name
@@ -728,12 +716,12 @@ module Pd
       search_params = {
         user_id: teacher.id,
         pd_workshop_id: @csf201_not_started_workshop.id,
-        day: @csf_pre201_params[:day],
-        form_id: @csf_pre201_params[:formId],
+        day: csf_pre201_params[:day],
+        form_id: csf_pre201_params[:formId],
         submission_id: FAKE_SUBMISSION_ID
       }
 
-      key_params = @csf_pre201_params.merge(
+      key_params = csf_pre201_params.merge(
         userId: teacher.id,
         workshopId: @csf201_not_started_workshop.id
       )
@@ -758,8 +746,8 @@ module Pd
       WorkshopDailySurvey.create_placeholder!(
         user_id: teacher.id,
         pd_workshop_id: @csf201_not_started_workshop.id,
-        day: @csf_pre201_params[:day],
-        form_id: @csf_pre201_params[:formId],
+        day: csf_pre201_params[:day],
+        form_id: csf_pre201_params[:formId],
         submission_id: FAKE_SUBMISSION_ID
       )
 
@@ -830,10 +818,10 @@ module Pd
       get "/pd/workshop_survey/csf/post201/#{enrollment.code}"
 
       assert_response :success
-      assert_equal @csf_post201_params[:formId], actual_form_id
+      assert_equal csf_post201_params[:formId], actual_form_id
       assert_equal teacher.id, actual_form_params[:userId]
       assert_equal @csf201_in_progress_workshop.id, actual_form_params[:workshopId]
-      assert_equal @csf_post201_params[:day], actual_form_params[:day]
+      assert_equal csf_post201_params[:day], actual_form_params[:day]
       assert_equal session.id, actual_form_params[:sessionId]
       refute nil, actual_form_params[:submitRedirect]
     end
@@ -858,10 +846,10 @@ module Pd
       get '/pd/workshop_survey/csf/post201'
 
       assert_response :success
-      assert_equal @csf_post201_params[:formId], actual_form_id
+      assert_equal csf_post201_params[:formId], actual_form_id
       assert_equal teacher.id, actual_form_params[:userId]
       assert_equal @csf201_in_progress_workshop.id, actual_form_params[:workshopId]
-      assert_equal @csf_post201_params[:day], actual_form_params[:day]
+      assert_equal csf_post201_params[:day], actual_form_params[:day]
       assert_equal session.id, actual_form_params[:sessionId]
       refute nil, actual_form_params[:submitRedirect]
     end
@@ -877,7 +865,7 @@ module Pd
         'RenderJotFormView',
         {
           route: 'GET /pd/workshop_survey/csf/post201',
-          form_id: @csf_post201_params[:formId],
+          form_id: csf_post201_params[:formId],
           workshop_course: COURSE_CSF,
           workshop_subject: SUBJECT_CSF_201,
           regional_partner_name: @regional_partner.name
@@ -902,11 +890,11 @@ module Pd
       search_params = {
         user_id: teacher.id,
         pd_workshop_id: @csf201_in_progress_workshop.id,
-        day: @csf_post201_params[:day],
-        form_id: @csf_post201_params[:formId]
+        day: csf_post201_params[:day],
+        form_id: csf_post201_params[:formId]
       }
 
-      key_params = @csf_post201_params.merge(
+      key_params = csf_post201_params.merge(
         userId: teacher.id,
         workshopId: @csf201_in_progress_workshop.id,
         sessionId: session.id
@@ -954,7 +942,7 @@ module Pd
       assert_equal FAKE_FACILITATOR_FORM_ID, actual_form_id
       assert_equal teacher.id, actual_form_params[:userId]
       assert_equal @csf201_in_progress_workshop.id, actual_form_params[:workshopId]
-      assert_equal @csf_post201_params[:day], actual_form_params[:day]
+      assert_equal csf_post201_params[:day], actual_form_params[:day]
       assert_equal session.id, actual_form_params[:sessionId]
       assert_equal first_facilitator.id, actual_form_params[:facilitatorId]
       assert_equal first_facilitator_index, actual_form_params[:facilitatorIndex]
@@ -983,7 +971,7 @@ module Pd
       key_params = {
         environment: Rails.env,
         userId: teacher.id,
-        day: @csf_post201_params[:day],
+        day: csf_post201_params[:day],
         sessionId: session.id,
         facilitatorId: first_facilitator.id,
         facilitatorIndex: first_facilitator_index,
@@ -1019,7 +1007,7 @@ module Pd
 
       WorkshopFacilitatorDailySurvey.create_placeholder!(
         user_id: teacher.id,
-        day: @csf_post201_params[:day],
+        day: csf_post201_params[:day],
         pd_session_id: session.id,
         facilitator_id: first_facilitator.id,
         form_id: FAKE_FACILITATOR_FORM_ID,
@@ -1047,7 +1035,7 @@ module Pd
       @csf201_in_progress_workshop.facilitators.each_with_index do |facilitator, index|
         WorkshopFacilitatorDailySurvey.create_placeholder!(
           user_id: teacher.id,
-          day: @csf_post201_params[:day],
+          day: csf_post201_params[:day],
           pd_session_id: session.id,
           facilitator_id: facilitator.id,
           form_id: FAKE_FACILITATOR_FORM_ID,
@@ -1187,6 +1175,22 @@ module Pd
           facilitatorIndex: facilitator_index,
           formId: FAKE_FACILITATOR_FORM_ID,
         }
+      }
+    end
+
+    def csf_pre201_params
+      {
+        environment: Rails.env,
+        day: CSF_SURVEY_INDEXES[PRE_DEEPDIVE_SURVEY],
+        formId: CDO.jotform_forms[CSF_CATEGORY][PRE_DEEPDIVE_SURVEY]
+      }
+    end
+
+    def csf_post201_params
+      {
+        environment: Rails.env,
+        day: CSF_SURVEY_INDEXES[POST_DEEPDIVE_SURVEY],
+        formId: CDO.jotform_forms[CSF_CATEGORY][POST_DEEPDIVE_SURVEY]
       }
     end
   end

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -39,7 +39,6 @@ module Pd
 
     self.use_transactional_test_case = true
     setup do
-      @unenrolled_teacher = create :teacher
       @enrolled_summer_teacher = create :teacher
       @enrolled_academic_year_teacher = create :teacher
       @enrolled_two_day_academic_year_teacher = create :teacher
@@ -106,7 +105,7 @@ module Pd
     end
 
     test 'pre-workshop survey displays not enrolled message when not enrolled' do
-      sign_in @unenrolled_teacher
+      sign_in unenrolled_teacher
       get '/pd/workshop_survey/day/0'
       assert_response :success
       assert_not_enrolled
@@ -185,7 +184,7 @@ module Pd
     end
 
     test 'daily workshop survey displays not enrolled message when not enrolled' do
-      sign_in @unenrolled_teacher
+      sign_in unenrolled_teacher
       get '/pd/workshop_survey/day/1'
       assert_response :success
       assert_not_enrolled
@@ -642,7 +641,7 @@ module Pd
     end
 
     test 'csf pre201 survey: unenrolled teacher gets not_enrolled msg' do
-      sign_in @unenrolled_teacher
+      sign_in unenrolled_teacher
       get '/pd/workshop_survey/csf/pre201'
 
       assert_response :success
@@ -761,7 +760,7 @@ module Pd
     end
 
     test 'csf post201 survey: show not-enrolled page if teacher did not enroll' do
-      sign_in @unenrolled_teacher
+      sign_in unenrolled_teacher
       get '/pd/workshop_survey/csf/post201'
 
       assert_response :success
@@ -1046,6 +1045,10 @@ module Pd
     end
 
     private
+
+    def unenrolled_teacher
+      create :teacher
+    end
 
     def assert_not_enrolled
       assert_select 'h1', text: 'Not Enrolled'

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -42,10 +42,6 @@ module Pd
       @regional_partner = create :regional_partner
       @facilitators = create_list :facilitator, 2
 
-      @csf201_ended_workshop = create :pd_ended_workshop,
-        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
-        num_sessions: 1, facilitators: (create_list :facilitator, 2)
-
       CDO.stubs(:jotform_forms).returns(FAKE_JOTFORM_FORMS)
 
       @csf_pre201_params = {
@@ -669,6 +665,7 @@ module Pd
     end
 
     test 'csf pre201 survey: enrolled teacher in ended workshop gets too-late msg' do
+      setup_csf201_ended_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_ended_workshop
 
@@ -1120,6 +1117,13 @@ module Pd
       @csf201_in_progress_workshop = create :pd_workshop,
         course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
         num_sessions: 1, num_facilitators: 2, started_at: DateTime.now
+    end
+
+    def setup_csf201_ended_workshop
+      @regional_partner = create :regional_partner
+      @csf201_ended_workshop = create :pd_ended_workshop,
+        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
+        num_sessions: 1, num_facilitators: 2
     end
 
     def unenrolled_teacher

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -6,8 +6,15 @@ module Pd
     include WorkshopConstants
     include WorkshopSurveyConstants
 
+    # Array of ids for days 0 (pre) and 1 - 5
+    FAKE_DAILY_FORM_IDS = (123450..123455).to_a.freeze
+    FAKE_FACILITATOR_FORM_ID = 123459
+    FAKE_SUBMISSION_ID = 987654
+    FAKE_ACADEMIC_YEAR_IDS = (54321...54324).to_a.freeze
+    FAKE_CSF_201_FORM_IDS = [201903, 201904].freeze
+
     self.use_transactional_test_case = true
-    setup_all do
+    setup do
       @unenrolled_teacher = create :teacher
       @enrolled_summer_teacher = create :teacher
       @enrolled_academic_year_teacher = create :teacher
@@ -39,16 +46,7 @@ module Pd
       @csf201_ended_workshop = create :pd_ended_workshop,
         course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
         num_sessions: 1, facilitators: (create_list :facilitator, 2)
-    end
 
-    # Array of ids for days 0 (pre) and 1 - 5
-    FAKE_DAILY_FORM_IDS = (123450..123455).to_a.freeze
-    FAKE_FACILITATOR_FORM_ID = 123459
-    FAKE_SUBMISSION_ID = 987654
-    FAKE_ACADEMIC_YEAR_IDS = (54321...54324).to_a.freeze
-    FAKE_CSF_201_FORM_IDS = [201903, 201904].freeze
-
-    setup do
       CDO.stubs(:jotform_forms).returns(
         {
           local_summer: {

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -39,9 +39,6 @@ module Pd
 
     self.use_transactional_test_case = true
     setup do
-      @regional_partner = create :regional_partner
-      @facilitators = create_list :facilitator, 2
-
       CDO.stubs(:jotform_forms).returns(FAKE_JOTFORM_FORMS)
 
       @csf_pre201_params = {

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -42,10 +42,6 @@ module Pd
       @regional_partner = create :regional_partner
       @facilitators = create_list :facilitator, 2
 
-      @csf201_not_started_workshop = create :pd_workshop,
-        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
-        num_sessions: 1, facilitators: (create_list :facilitator, 2)
-
       @csf201_in_progress_workshop = create :pd_workshop,
         course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
         num_sessions: 1, facilitators: (create_list :facilitator, 2), started_at: DateTime.now
@@ -688,6 +684,7 @@ module Pd
     end
 
     test 'csf pre201 survey: enrolled teacher in unended workshop gets survey' do
+      setup_csf201_not_started_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_not_started_workshop
 
@@ -711,6 +708,7 @@ module Pd
     end
 
     test 'csf pre201 survey: reports survey render to New Relic' do
+      setup_csf201_not_started_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_not_started_workshop
 
@@ -733,6 +731,7 @@ module Pd
     end
 
     test 'csf pre201 survey: submission creates a placeholder record and redirects teacher to thanks' do
+      setup_csf201_not_started_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_not_started_workshop
 
@@ -762,6 +761,7 @@ module Pd
     end
 
     test 'csf pre201 survey: teacher already submitted survey does not gets survey again' do
+      setup_csf201_not_started_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_not_started_workshop
 
@@ -796,6 +796,7 @@ module Pd
     end
 
     test 'csf post201 survey: show no-attendance page if teacher did not attend' do
+      setup_csf201_not_started_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_not_started_workshop
 
@@ -1101,6 +1102,13 @@ module Pd
         workshop: @two_day_academic_year_workshop
       @enrolled_two_day_academic_year_teacher = @two_day_academic_year_enrollment.user
       @facilitators = @two_day_academic_year_workshop.facilitators
+    end
+
+    def setup_csf201_not_started_workshop
+      @regional_partner = create :regional_partner
+      @csf201_not_started_workshop = create :pd_workshop,
+        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
+        num_sessions: 1, num_facilitators: 2
     end
 
     def unenrolled_teacher

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -12,6 +12,30 @@ module Pd
     FAKE_SUBMISSION_ID = 987654
     FAKE_ACADEMIC_YEAR_IDS = (54321...54324).to_a.freeze
     FAKE_CSF_201_FORM_IDS = [201903, 201904].freeze
+    FAKE_JOTFORM_FORMS = {
+      local_summer: {
+        day_0: FAKE_DAILY_FORM_IDS[0],
+        day_1: FAKE_DAILY_FORM_IDS[1],
+        day_5: FAKE_DAILY_FORM_IDS[5],
+        facilitator: FAKE_FACILITATOR_FORM_ID
+      },
+      academic_year_1: {
+        day_1: FAKE_ACADEMIC_YEAR_IDS[0],
+        post_workshop: FAKE_ACADEMIC_YEAR_IDS[4],
+        facilitator: FAKE_FACILITATOR_FORM_ID
+      },
+      academic_year_5: {
+        day_1: FAKE_ACADEMIC_YEAR_IDS[0],
+        day_2: FAKE_ACADEMIC_YEAR_IDS[1],
+        post_workshop: FAKE_ACADEMIC_YEAR_IDS[4],
+        facilitator: FAKE_FACILITATOR_FORM_ID
+      },
+      csf: {
+        pre201: FAKE_CSF_201_FORM_IDS[0],
+        post201: FAKE_CSF_201_FORM_IDS[1],
+        facilitator: FAKE_FACILITATOR_FORM_ID
+      }
+    }.deep_stringify_keys
 
     self.use_transactional_test_case = true
     setup do
@@ -47,32 +71,7 @@ module Pd
         course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
         num_sessions: 1, facilitators: (create_list :facilitator, 2)
 
-      CDO.stubs(:jotform_forms).returns(
-        {
-          local_summer: {
-            day_0: FAKE_DAILY_FORM_IDS[0],
-            day_1: FAKE_DAILY_FORM_IDS[1],
-            day_5: FAKE_DAILY_FORM_IDS[5],
-            facilitator: FAKE_FACILITATOR_FORM_ID
-          },
-          academic_year_1: {
-            day_1: FAKE_ACADEMIC_YEAR_IDS[0],
-            post_workshop: FAKE_ACADEMIC_YEAR_IDS[4],
-            facilitator: FAKE_FACILITATOR_FORM_ID
-          },
-          academic_year_5: {
-            day_1: FAKE_ACADEMIC_YEAR_IDS[0],
-            day_2: FAKE_ACADEMIC_YEAR_IDS[1],
-            post_workshop: FAKE_ACADEMIC_YEAR_IDS[4],
-            facilitator: FAKE_FACILITATOR_FORM_ID
-          },
-          csf: {
-            pre201: FAKE_CSF_201_FORM_IDS[0],
-            post201: FAKE_CSF_201_FORM_IDS[1],
-            facilitator: FAKE_FACILITATOR_FORM_ID
-          }
-        }.deep_stringify_keys
-      )
+      CDO.stubs(:jotform_forms).returns(FAKE_JOTFORM_FORMS)
 
       @csf_pre201_params = {
         environment: Rails.env,

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -42,10 +42,6 @@ module Pd
       @regional_partner = create :regional_partner
       @facilitators = create_list :facilitator, 2
 
-      @csf201_in_progress_workshop = create :pd_workshop,
-        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
-        num_sessions: 1, facilitators: (create_list :facilitator, 2), started_at: DateTime.now
-
       @csf201_ended_workshop = create :pd_ended_workshop,
         course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
         num_sessions: 1, facilitators: (create_list :facilitator, 2)
@@ -808,6 +804,7 @@ module Pd
     end
 
     test 'csf post201 survey: show 404 page if enrollment code is invalid' do
+      setup_csf201_in_progress_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
       create :pd_attendance, session: @csf201_in_progress_workshop.sessions.first, teacher: teacher
@@ -820,6 +817,7 @@ module Pd
     end
 
     test 'csf post201 survey: show survey if attended teacher has valid enrollment code' do
+      setup_csf201_in_progress_workshop
       teacher = create :teacher
       session = @csf201_in_progress_workshop.sessions.first
       enrollment = create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
@@ -847,6 +845,7 @@ module Pd
     end
 
     test 'csf post201 survey: show survey if attended teacher does not have enrollment code' do
+      setup_csf201_in_progress_workshop
       teacher = create :teacher
       session = @csf201_in_progress_workshop.sessions.first
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
@@ -874,6 +873,7 @@ module Pd
     end
 
     test 'csf post201 survey: report survey rendering to New Relic' do
+      setup_csf201_in_progress_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
       create :pd_attendance, session: @csf201_in_progress_workshop.sessions.first, teacher: teacher
@@ -897,6 +897,7 @@ module Pd
     end
 
     test 'csf post201 survey: create placeholder and redirect to 1st facilitator survey on submission' do
+      setup_csf201_in_progress_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
       session = @csf201_in_progress_workshop.sessions.first
@@ -934,6 +935,7 @@ module Pd
     test 'csf facilitator survey: show 1st facilitator survey to attended teacher' do
       skip 'Investigate flaky test failures'
 
+      setup_csf201_in_progress_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
       session = @csf201_in_progress_workshop.sessions.first
@@ -966,6 +968,7 @@ module Pd
     end
 
     test 'csf facilitator survey: creates placeholder and redirects to 2nd facilitator survey on submission' do
+      setup_csf201_in_progress_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
       session = @csf201_in_progress_workshop.sessions.first
@@ -1011,6 +1014,7 @@ module Pd
     test 'csf facilitator survey: redirect to 2nd facilitator survey if response exists for 1st one' do
       skip 'Investigate flaky test failures'
 
+      setup_csf201_in_progress_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
       session = @csf201_in_progress_workshop.sessions.first
@@ -1109,6 +1113,13 @@ module Pd
       @csf201_not_started_workshop = create :pd_workshop,
         course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
         num_sessions: 1, num_facilitators: 2
+    end
+
+    def setup_csf201_in_progress_workshop
+      @regional_partner = create :regional_partner
+      @csf201_in_progress_workshop = create :pd_workshop,
+        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
+        num_sessions: 1, num_facilitators: 2, started_at: DateTime.now
     end
 
     def unenrolled_teacher


### PR DESCRIPTION
While working on tests disabled in https://github.com/code-dot-org/code-dot-org/pull/29765 I discovered a bunch of test cleanup I'd like to do while I'm in here.  This is the first such PR. (I did some exploration [here](https://github.com/code-dot-org/code-dot-org/pull/29785) but that change got large and messy, so I'm taking it a bit slower.)

Here, I'm breaking up a large `setup_all` block in this test so that individual tests are better isolated from one another _and_ so they only set up what they actually need.  Note, I'm not actually re-enabling any disabled tests yet.

For now I've done this by creating a bunch of smaller setup helpers at the end of the file, that individual tests call.  This makes this test file run a bit slower (from 30s to 37s on my machine) but I believe it's necessary for correctness given the large number (6) of tests we've disabled for flakiness in this file, and that it may get faster with further cleanup.

Next steps include

- eliminate the use of instance variables in this test, starting with `@facilitators` and `@regional_partner` since those should be pulled from the workshop under test anyway.
- some serious factory cleanup (I've already experimented with this and it can get waaaay nicer)
- actually re-enabling the tests we've disabled in this file
- audit for tests we can remove or test against more realistic fakes (e.g. no more testing against teachercon workshops)
- find other tests that can benefit from factory cleanup done here