### PR TITLE
Clean up I18n utils (including redaction and restoration utils)

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -12,131 +12,133 @@ HOUROFCODE_IDENTITY_FILE = File.join(File.dirname(__FILE__), "hourofcode_credent
 CODEORG_MARKDOWN_CONFIG_FILE = File.join(File.dirname(__FILE__), "codeorg_markdown_crowdin.yml")
 CODEORG_MARKDOWN_IDENTITY_FILE = File.join(File.dirname(__FILE__), "codeorg_markdown_credentials.yml")
 
-# Output the given data to YAML that will be consumed by Crowdin. Includes a
-# couple changes to the default `data.to_yaml` serialization:
-#
-#   1. Don't wrap lines. This is an optional feature provided by yaml, intended
-#      to make human editing of the serialized data easier. Because this data
-#      is only managed programmatically, we avoid wrapping to make the git
-#      diffs smaller and change detection easier.
-#
-#   2. Quote 'y' and 'n'. Psych intentionally departs from the YAML spec for
-#      these strings: https://github.com/ruby/psych/blob/8e880f7837db9ed66032a1dddc85444a1514a1e3/test/psych/test_boolean.rb#L21-L35
-#      But Crowdin sticks strictly to the YAML spec, so here we add special
-#      logic to ensure that we conform to the spec when outputting for Crowdin
-#      consumption.
-#      See https://github.com/gvvaughan/lyaml/issues/8#issuecomment-123132430
-def to_crowdin_yaml(data)
-  ast = Psych.parse_stream(Psych.dump(data))
+class I18nScriptUtils
+  # Output the given data to YAML that will be consumed by Crowdin. Includes a
+  # couple changes to the default `data.to_yaml` serialization:
+  #
+  #   1. Don't wrap lines. This is an optional feature provided by yaml, intended
+  #      to make human editing of the serialized data easier. Because this data
+  #      is only managed programmatically, we avoid wrapping to make the git
+  #      diffs smaller and change detection easier.
+  #
+  #   2. Quote 'y' and 'n'. Psych intentionally departs from the YAML spec for
+  #      these strings: https://github.com/ruby/psych/blob/8e880f7837db9ed66032a1dddc85444a1514a1e3/test/psych/test_boolean.rb#L21-L35
+  #      But Crowdin sticks strictly to the YAML spec, so here we add special
+  #      logic to ensure that we conform to the spec when outputting for Crowdin
+  #      consumption.
+  #      See https://github.com/gvvaughan/lyaml/issues/8#issuecomment-123132430
+  def self.to_crowdin_yaml(data)
+    ast = Psych.parse_stream(Psych.dump(data))
 
-  # Make sure we treat the strings 'y' and 'n' as strings, and not bools
-  yaml_bool = /^(?:y|Y|n|N)$/
-  ast.grep(Psych::Nodes::Scalar).each do |node|
-    if yaml_bool.match node.value
-      node.plain = false
-      node.quoted = true
+    # Make sure we treat the strings 'y' and 'n' as strings, and not bools
+    yaml_bool = /^(?:y|Y|n|N)$/
+    ast.grep(Psych::Nodes::Scalar).each do |node|
+      if yaml_bool.match node.value
+        node.plain = false
+        node.quoted = true
+      end
+    end
+
+    return ast.yaml(nil, {line_width: -1})
+  end
+
+  def self.should_i(question)
+    loop do
+      print "Should I #{question}? [Yes]/Skip/Quit: "
+      response = gets.strip.downcase
+      puts ''
+      if 'yes'.start_with?(response) # also catches blank/return ;)
+        return true
+      elsif 'skip'.start_with?(response) || 'no'.start_with?(response)
+        return false
+      elsif 'quit'.start_with?(response)
+        puts "quitting"
+        exit(-1)
+      else
+        puts "Sorry, I didn't understand that.\n\n"
+      end
     end
   end
 
-  return ast.yaml(nil, {line_width: -1})
-end
+  def self.git_add_and_commit(paths, commit_message)
+    paths.each do |path|
+      `git add -u #{path}`
+    end
+    `git commit -m "#{commit_message}"`
+  end
 
-def should_i(question)
-  loop do
-    print "Should I #{question}? [Yes]/Skip/Quit: "
-    response = gets.strip.downcase
-    puts ''
-    if 'yes'.start_with?(response) # also catches blank/return ;)
-      return true
-    elsif 'skip'.start_with?(response) || 'no'.start_with?(response)
-      return false
-    elsif 'quit'.start_with?(response)
-      puts "quitting"
-      exit(-1)
+  def self.run_standalone_script(location)
+    Open3.popen3(location) do |_stdin, stdout, stderr, _wait_thread|
+      while line = stdout.gets
+        puts(line)
+      end
+      while line = stderr.gets
+        puts(line)
+      end
+    end
+  end
+
+  def self.run_bash_script(location)
+    I18nScriptUtils.run_standalone_script("bash #{location}")
+  end
+
+  private_class_method def self.report_malformed_restoration(key, translation, file_name)
+    @malformed_restorations ||= [["Key", "File Name", "Translation"]]
+    @malformed_restorations << [key, file_name, translation]
+  end
+
+  def self.upload_malformed_restorations(locale)
+    return if @malformed_restorations.blank?
+    Google::Drive.new.add_sheet_to_spreadsheet(@malformed_restorations, "i18n_bad_translations", locale)
+    @malformed_restorations = nil
+  end
+
+  def self.recursively_find_malformed_links_images(hash, key_str, file_name)
+    hash.each do |key, val|
+      if val.is_a?(Hash)
+        I18nScriptUtils.recursively_find_malformed_links_images(val, "#{key_str}.#{key}", file_name)
+      else
+        I18nScriptUtils.report_malformed_restoration("#{key_str}.#{+key}", val, file_name) if I18nScriptUtils.contains_malformed_link_or_image(val)
+      end
+    end
+  end
+
+  # This function currently looks for
+  # 1. Translations with malformed redaction syntax, i.e. [] [0] (note the space)
+  # 2. Translations with similarly malformed markdown, i.e. [link] (example.com)
+  # If this function finds either of these cases in the string, it return true.
+  def self.contains_malformed_link_or_image(translation)
+    malformed_redaction_regex = /\[.*\]\s+\[[0-9]+\]/
+    malformed_markdown_regex = /\[.*\]\s+\(.+\)/
+    non_malformed_redaction = (translation =~ malformed_redaction_regex).nil?
+    non_malformed_translation = (translation =~ malformed_markdown_regex).nil?
+    return !(non_malformed_redaction && non_malformed_translation)
+  end
+
+  def self.get_level_url_key(script, level)
+    script_name = script.name
+    script_level = level.script_levels.find_by_script_id(script.id)
+    if script_level.bonus
+      escaped_level_name = CGI.escape(level.name)
+      "https://studio.code.org/s/#{script_name}/stage/#{script_level.stage.relative_position}/extras?level_name=#{escaped_level_name}"
     else
-      puts "Sorry, I didn't understand that.\n\n"
+      "https://studio.code.org/s/#{script_name}/stage/#{script_level.stage.relative_position}/puzzle/#{script_level.position}"
     end
   end
-end
 
-def git_add_and_commit(paths, commit_message)
-  paths.each do |path|
-    `git add -u #{path}`
-  end
-  `git commit -m "#{commit_message}"`
-end
-
-def run_standalone_script(location)
-  Open3.popen3(location) do |_stdin, stdout, stderr, _wait_thread|
-    while line = stdout.gets
-      puts(line)
-    end
-    while line = stderr.gets
-      puts(line)
-    end
-  end
-end
-
-def run_bash_script(location)
-  run_standalone_script("bash #{location}")
-end
-
-def report_malformed_restoration(key, translation, file_name)
-  @malformed_restorations ||= [["Key", "File Name", "Translation"]]
-  @malformed_restorations << [key, file_name, translation]
-end
-
-def upload_malformed_restorations(locale)
-  return if @malformed_restorations.blank?
-  Google::Drive.new.add_sheet_to_spreadsheet(@malformed_restorations, "i18n_bad_translations", locale)
-  @malformed_restorations = nil
-end
-
-def recursively_find_malformed_links_images(hash, key_str, file_name)
-  hash.each do |key, val|
-    if val.is_a?(Hash)
-      recursively_find_malformed_links_images(val, "#{key_str}.#{key}", file_name)
+  def self.get_level_from_url(url)
+    url_regex = %r{https://studio.code.org/s/(?<script_name>[A-Za-z0-9\s\-_]+)/stage/(?<stage_pos>[0-9]+)/(?<level_info>.+)}
+    matches = url.match(url_regex)
+    if matches[:level_info].starts_with?("extras")
+      level_info_regex = %r{extras\?level_name=(?<level_name>.+)}
+      level_name = matches[:level_info].match(level_info_regex)[:level_name]
+      Level.find_by_name(CGI.unescape(level_name))
     else
-      report_malformed_restoration("#{key_str}.#{+key}", val, file_name) if contains_malformed_link_or_image(val)
+      script = Script.find_by_name(matches[:script_name])
+      stage = script.stages.find_by_relative_position(matches[:stage_pos])
+      level_info_regex = %r{puzzle/(?<level_pos>[0-9]+)}
+      level_pos = matches[:level_info].match(level_info_regex)[:level_pos]
+      stage.script_levels.find_by_position(level_pos.to_i).oldest_active_level
     end
-  end
-end
-
-# This function currently looks for
-# 1. Translations with malformed redaction syntax, i.e. [] [0] (note the space)
-# 2. Translations with similarly malformed markdown, i.e. [link] (example.com)
-# If this function finds either of these cases in the string, it return true.
-def contains_malformed_link_or_image(translation)
-  malformed_redaction_regex = /\[.*\]\s+\[[0-9]+\]/
-  malformed_markdown_regex = /\[.*\]\s+\(.+\)/
-  non_malformed_redaction = (translation =~ malformed_redaction_regex).nil?
-  non_malformed_translation = (translation =~ malformed_markdown_regex).nil?
-  return !(non_malformed_redaction && non_malformed_translation)
-end
-
-def get_level_url_key(script, level)
-  script_name = script.name
-  script_level = level.script_levels.find_by_script_id(script.id)
-  if script_level.bonus
-    escaped_level_name = CGI.escape(level.name)
-    "https://studio.code.org/s/#{script_name}/stage/#{script_level.stage.relative_position}/extras?level_name=#{escaped_level_name}"
-  else
-    "https://studio.code.org/s/#{script_name}/stage/#{script_level.stage.relative_position}/puzzle/#{script_level.position}"
-  end
-end
-
-def get_level_from_url(url)
-  url_regex = %r{https://studio.code.org/s/(?<script_name>[A-Za-z0-9\s\-_]+)/stage/(?<stage_pos>[0-9]+)/(?<level_info>.+)}
-  matches = url.match(url_regex)
-  if matches[:level_info].starts_with?("extras")
-    level_info_regex = %r{extras\?level_name=(?<level_name>.+)}
-    level_name = matches[:level_info].match(level_info_regex)[:level_name]
-    Level.find_by_name(CGI.unescape(level_name))
-  else
-    script = Script.find_by_name(matches[:script_name])
-    stage = script.stages.find_by_relative_position(matches[:stage_pos])
-    level_info_regex = %r{puzzle/(?<level_pos>[0-9]+)}
-    level_pos = matches[:level_info].match(level_info_regex)[:level_pos]
-    stage.script_levels.find_by_position(level_pos.to_i).oldest_active_level
   end
 end

--- a/bin/i18n/redact_restore_utils.rb
+++ b/bin/i18n/redact_restore_utils.rb
@@ -1,0 +1,129 @@
+require 'json'
+require 'open3'
+require 'tempfile'
+require 'yaml'
+
+class RedactRestoreUtils
+  def self.redact_file(source_path, plugins=[], format='md')
+    args = ['bin/i18n/node_modules/.bin/redact']
+    args.push("-p #{plugins_to_arg(plugins)}") unless plugins.empty?
+    args.push("-f #{format}")
+    args.push("-s #{source_path.inspect}")
+    stdout, _status = Open3.capture2(args.join(" "))
+
+    return JSON.parse(stdout)
+  end
+
+  def self.restore_file(source_path, redacted_path, plugins=[], format='md')
+    args = ['bin/i18n/node_modules/.bin/restore']
+    args.push("-p #{plugins_to_arg(plugins)}") unless plugins.empty?
+    args.push("-f #{format}")
+    args.push("-s #{source_path.inspect}")
+    args.push("-r #{redacted_path.inspect}")
+
+    stdout, _status = Open3.capture2(args.join(" "))
+
+    return JSON.parse(stdout)
+  end
+
+  def self.redact_data(source_data, plugins=[], format='md')
+    args = ['bin/i18n/node_modules/.bin/redact']
+    args.push("-p #{plugins_to_arg(plugins)}") unless plugins.empty?
+    args.push("-f #{format}")
+
+    stdout, _status = Open3.capture2(
+      args.join(" "),
+      stdin_data: JSON.generate(source_data)
+    )
+
+    return JSON.parse(stdout)
+  end
+
+  def self.restore_data(source_data, redacted_data, plugins=[], format='md')
+    source_json = Tempfile.new(['source', '.json'])
+    redacted_json = Tempfile.new(['redacted', '.json'])
+
+    source_json.write(JSON.generate(source_data))
+    redacted_json.write(JSON.generate(redacted_data))
+
+    source_json.flush
+    redacted_json.flush
+
+    restored = RedactRestoreUtils.restore_file(source_json.path, redacted_json.path, plugins, format)
+
+    source_json.close
+    redacted_json.close
+
+    return restored
+  end
+
+  def self.restore(source, redacted, dest, plugins=[], format='md')
+    return unless File.exist?(source)
+    return unless File.exist?(redacted)
+    is_json = File.extname(source) == '.json'
+    source_data =
+      if is_json
+        JSON.load(File.open(source, 'r'))
+      else
+        YAML.load_file(source)
+      end
+    redacted_data =
+      if is_json
+        JSON.load(File.open(redacted, 'r'))
+      else
+        YAML.load_file(redacted)
+      end
+
+    return unless source_data&.values&.first&.length
+    return unless redacted_data&.values&.first&.length
+
+    restored =
+      if is_json
+        RedactRestoreUtils.restore_data(source_data, redacted_data, plugins, format)
+      else
+        RedactRestoreUtils.restore_data(source_data.values.first, redacted_data.values.first, plugins, format)
+      end
+
+    File.open(dest, "w+") do |file|
+      if File.extname(dest) == '.json'
+        file.write(JSON.pretty_generate(restored))
+      else
+        redacted_key = redacted_data.keys.first
+        file.write(
+          to_crowdin_yaml(
+            {
+              redacted_key => restored
+            }
+          )
+        )
+      end
+    end
+  end
+
+  def self.redact(source, dest, plugins=[], format='md')
+    return unless File.exist? source
+    FileUtils.mkdir_p File.dirname(dest)
+
+    source_data =
+      if File.extname(source) == '.json'
+        f = File.open(source, 'r')
+        JSON.load(f)
+      else
+        YAML.load_file(source)
+      end
+
+    redacted = RedactRestoreUtils.redact_data(source_data, plugins, format)
+
+    File.open(dest, "w+") do |file|
+      if File.extname(dest) == '.json'
+        file.write(JSON.pretty_generate(redacted))
+      else
+        file.write(to_crowdin_yaml(redacted))
+      end
+    end
+  end
+
+  private_class_method def self.plugins_to_arg(plugins)
+    plugins.map {|name| "bin/i18n/node_modules/@code-dot-org/remark-plugins/src/#{name}.js" if name}.join(',')
+  end
+end

--- a/bin/i18n/redact_restore_utils.rb
+++ b/bin/i18n/redact_restore_utils.rb
@@ -3,6 +3,8 @@ require 'open3'
 require 'tempfile'
 require 'yaml'
 
+require_relative 'i18n_script_utils'
+
 class RedactRestoreUtils
   def self.redact_file(source_path, plugins=[], format='md')
     args = ['bin/i18n/node_modules/.bin/redact']
@@ -74,6 +76,8 @@ class RedactRestoreUtils
         YAML.load_file(redacted)
       end
 
+    return unless source_data
+    return unless redacted_data
     return unless source_data&.values&.first&.length
     return unless redacted_data&.values&.first&.length
 
@@ -90,7 +94,7 @@ class RedactRestoreUtils
       else
         redacted_key = redacted_data.keys.first
         file.write(
-          to_crowdin_yaml(
+          I18nScriptUtils.to_crowdin_yaml(
             {
               redacted_key => restored
             }
@@ -118,7 +122,7 @@ class RedactRestoreUtils
       if File.extname(dest) == '.json'
         file.write(JSON.pretty_generate(redacted))
       else
-        file.write(to_crowdin_yaml(redacted))
+        file.write(I18nScriptUtils.to_crowdin_yaml(redacted))
       end
     end
   end

--- a/bin/i18n/sync-codeorg-all.rb
+++ b/bin/i18n/sync-codeorg-all.rb
@@ -75,10 +75,10 @@ def parse_options
 end
 
 def create_in_up_pr
-  return unless should_i "create the in & up PR"
+  return unless I18nScriptUtils.should_i "create the in & up PR"
   `git checkout -B #{IN_UP_BRANCH}`
 
-  git_add_and_commit(
+  I18nScriptUtils.git_add_and_commit(
     [
       "dashboard/config/locales/*.en.yml",
       "i18n/locales/source/dashboard"
@@ -86,21 +86,21 @@ def create_in_up_pr
     "dashboard i18n sync"
   )
 
-  git_add_and_commit(
+  I18nScriptUtils.git_add_and_commit(
     [
       "i18n/locales/source/course_content"
     ],
     "course content i18n sync"
   )
 
-  git_add_and_commit(
+  I18nScriptUtils.git_add_and_commit(
     [
       "i18n/locales/source/pegasus",
     ],
     "pegasus i18n sync"
   )
 
-  git_add_and_commit(
+  I18nScriptUtils.git_add_and_commit(
     [
       "i18n/locales/source/blockly-mooc",
     ],
@@ -118,10 +118,10 @@ def create_in_up_pr
 end
 
 def create_down_out_pr
-  return unless should_i "create the down & out PR"
+  return unless I18nScriptUtils.should_i "create the down & out PR"
   `git checkout -B #{DOWN_OUT_BRANCH}`
 
-  git_add_and_commit(
+  I18nScriptUtils.git_add_and_commit(
     [
       "pegasus/cache",
       "i18n/locales/*/pegasus",
@@ -129,7 +129,7 @@ def create_down_out_pr
     "pegasus i18n updates"
   )
 
-  git_add_and_commit(
+  I18nScriptUtils.git_add_and_commit(
     [
       "pegasus/sites.v3/code.org/i18n",
     ],
@@ -141,7 +141,7 @@ def create_down_out_pr
   Languages.get_crowdin_name_and_locale.each do |prop|
     locale = prop[:locale_s]
     next if locale == 'en-US'
-    git_add_and_commit(
+    I18nScriptUtils.git_add_and_commit(
       [
         "dashboard/config/locales/*#{locale}.yml",
         "i18n/locales/#{locale}/dashboard",
@@ -150,7 +150,7 @@ def create_down_out_pr
     )
   end
 
-  git_add_and_commit(
+  I18nScriptUtils.git_add_and_commit(
     [
       "apps/i18n/*/*.json",
       "i18n/locales/*/blockly-mooc",
@@ -158,7 +158,7 @@ def create_down_out_pr
     "apps i18n updates"
   )
 
-  git_add_and_commit(
+  I18nScriptUtils.git_add_and_commit(
     [
       "apps/lib/blockly/*.js",
       "i18n/locales/*/blockly-core",
@@ -182,7 +182,7 @@ end
 
 def checkout_staging
   return if GitUtils.current_branch == "staging"
-  `git checkout staging` if should_i "switch to staging branch"
+  `git checkout staging` if I18nScriptUtils.should_i "switch to staging branch"
 end
 
 def main
@@ -190,13 +190,13 @@ def main
 
   if options[:interactive]
     checkout_staging
-    sync_in if should_i "sync in"
-    sync_up if should_i "sync up"
+    sync_in if I18nScriptUtils.should_i "sync in"
+    sync_up if I18nScriptUtils.should_i "sync up"
     create_in_up_pr if options[:with_pull_request]
-    sync_down if should_i "sync down"
-    sync_out if should_i "sync out"
+    sync_down if I18nScriptUtils.should_i "sync down"
+    sync_out if I18nScriptUtils.should_i "sync out"
     create_down_out_pr if options[:with_pull_request]
-    upload_i18n_stats if should_i "upload translation stats"
+    upload_i18n_stats if I18nScriptUtils.should_i "upload translation stats"
     checkout_staging
   elsif options[:command]
     case options[:command]

--- a/bin/i18n/sync-codeorg-in.rb
+++ b/bin/i18n/sync-codeorg-in.rb
@@ -10,6 +10,7 @@ require 'fileutils'
 require 'json'
 
 require_relative 'i18n_script_utils'
+require_relative 'redact_restore_utils'
 
 I18N_SOURCE_DIR = "i18n/locales/source"
 
@@ -205,11 +206,8 @@ def redact_level_file(source_path)
     file.write(JSON.pretty_generate(redactable_data))
   end
 
-  stdout, _status = Open3.capture2(
-    'bin/i18n/node_modules/.bin/redact',
-    stdin_data: JSON.generate(redactable_data)
-  )
-  redacted_data = JSON.parse(stdout)
+  redacted_data = RedactRestoreUtils.redact_data(redactable_data)
+
   File.open(source_path, 'w') do |source_file|
     source_file.write(JSON.pretty_generate(source_data.deep_merge(redacted_data)))
   end
@@ -230,7 +228,7 @@ def redact_block_content
   backup = source.sub("source", "original")
   FileUtils.mkdir_p(File.dirname(backup))
   FileUtils.cp(source, backup)
-  redact(source, source, ['blockfield'], 'txt')
+  RedactRestoreUtils.redact(source, source, ['blockfield'], 'txt')
 end
 
 sync_in if __FILE__ == $0

--- a/bin/i18n/sync-codeorg-in.rb
+++ b/bin/i18n/sync-codeorg-in.rb
@@ -18,7 +18,7 @@ def sync_in
   localize_level_content
   localize_block_content
   puts "Copying source files"
-  run_bash_script "bin/i18n-codeorg/in.sh"
+  I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
   redact_level_content
   redact_block_content
 end
@@ -99,7 +99,7 @@ def localize_level_content
       script_strings = {}
       script.script_levels.each do |script_level|
         level = script_level.oldest_active_level
-        url = get_level_url_key(script, level)
+        url = I18nScriptUtils.get_level_url_key(script, level)
         script_strings[url] = get_i18n_strings(level)
 
         # extract block category strings; although these are defined for each
@@ -163,7 +163,7 @@ def localize_block_content
   end
 
   File.open("dashboard/config/locales/blocks.en.yml", "w+") do |f|
-    f.write(to_crowdin_yaml({"en" => {"data" => {"blocks" => blocks}}}))
+    f.write(I18nScriptUtils.to_crowdin_yaml({"en" => {"data" => {"blocks" => blocks}}}))
   end
 end
 

--- a/bin/i18n/sync-codeorg-out.rb
+++ b/bin/i18n/sync-codeorg-out.rb
@@ -23,7 +23,7 @@ def sync_out
   copy_untranslated_apps
   rebuild_blockly_js_files
   puts "updating TTS I18n (should usually take 2-3 minutes, may take up to 15 if there are a whole lot of translation updates)"
-  run_standalone_script "dashboard/scripts/update_tts_i18n.rb"
+  I18nScriptUtils.run_standalone_script "dashboard/scripts/update_tts_i18n.rb"
 end
 
 # Files downloaded from Crowdin are organized by language name,
@@ -48,8 +48,9 @@ def find_malformed_links_images(locale, file_path)
       YAML.load_file(file_path)
     end
 
+  return unless data
   return unless data&.values&.first&.length
-  recursively_find_malformed_links_images(data, locale, file_path)
+  I18nScriptUtils.recursively_find_malformed_links_images(data, locale, file_path)
 end
 
 def restore_redacted_files
@@ -80,7 +81,7 @@ def restore_redacted_files
       end
       find_malformed_links_images(locale, translated_path)
     end
-    upload_malformed_restorations(locale)
+    I18nScriptUtils.upload_malformed_restorations(locale)
   end
 end
 
@@ -166,7 +167,7 @@ def distribute_course_content(locale)
     next unless course_strings
 
     course_strings.each do |level_url, level_strings|
-      level = get_level_from_url(level_url)
+      level = I18nScriptUtils.get_level_from_url(level_url)
       locale_strings.deep_merge! serialize_i18n_strings(level, level_strings)
     end
   end
@@ -243,7 +244,7 @@ def copy_untranslated_apps
 end
 
 def rebuild_blockly_js_files
-  run_bash_script "apps/node_modules/@code-dot-org/blockly/i18n/codeorg-messages.sh"
+  I18nScriptUtils.run_bash_script "apps/node_modules/@code-dot-org/blockly/i18n/codeorg-messages.sh"
   Dir.chdir('apps') do
     puts `yarn build`
   end

--- a/bin/i18n/sync-codeorg-out.rb
+++ b/bin/i18n/sync-codeorg-out.rb
@@ -12,6 +12,7 @@ require 'tempfile'
 require 'yaml'
 
 require_relative 'i18n_script_utils'
+require_relative 'redact_restore_utils'
 
 CLEAR = "\r\033[K"
 
@@ -67,11 +68,15 @@ def restore_redacted_files
       $stdout.flush
 
       if original_path.include? "course_content"
-        restore_course_content(original_path, translated_path, translated_path)
+        restored_data = RedactRestoreUtils.restore_file(original_path, translated_path)
+        translated_data = JSON.parse(File.read(translated_path))
+        File.open(translated_path, "w") do |file|
+          file.write(JSON.pretty_generate(translated_data.deep_merge(restored_data)))
+        end
       elsif original_path == 'i18n/locales/original/dashboard/blocks.yml'
-        restore(original_path, translated_path, translated_path, ['blockfield'], 'txt')
+        RedactRestoreUtils.restore(original_path, translated_path, translated_path, ['blockfield'], 'txt')
       else
-        restore(original_path, translated_path, translated_path)
+        RedactRestoreUtils.restore(original_path, translated_path, translated_path)
       end
       find_malformed_links_images(locale, translated_path)
     end


### PR DESCRIPTION
Specifically, extract the redaction and restoration helpers to their own file and turn all formerly free-floating utility methods into class methods.

Will probably be easiest to review [with whitespace changes disabled](https://github.com/code-dot-org/code-dot-org/pull/29796/files)