### PR TITLE
Add primary key to AP school code model description

### DIFF
--- a/dashboard/app/models/census/ap_school_code.rb
+++ b/dashboard/app/models/census/ap_school_code.rb
@@ -2,7 +2,7 @@
 #
 # Table name: ap_school_codes
 #
-#  school_year :integer
+#  school_year :integer          primary key
 #  school_code :string(6)        not null, primary key
 #  school_id   :string(12)       not null
 #  created_at  :datetime         not null


### PR DESCRIPTION
Missed change to AP school code model description that appears after running migration locally. Should have been included in this [PR](https://github.com/code-dot-org/code-dot-org/pull/27866).