### PR TITLE
add named, assessment, and challenge checkboxes to stage editor gui

### DIFF
--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -7,7 +7,6 @@ import {borderRadius, ControlTypes} from './constants';
 import OrderControls from './OrderControls';
 import StageCard from './StageCard';
 import {NEW_LEVEL_ID, addStage, addGroup} from './editorRedux';
-import {LevelKind} from '@cdo/apps/util/sharedConstants';
 
 const styles = {
   groupHeader: {
@@ -115,30 +114,21 @@ class FlexGroup extends Component {
         s.push(`level_concept_difficulty '${level.conceptDifficulty}'`);
       }
     }
-    let l = `${this.normalizeLevelKind(level.kind)} '${key.replace(
-      /'/,
-      "\\'"
-    )}'`;
+    let l = `level '${key.replace(/'/, "\\'")}'`;
     if (active === false) {
       l += ', active: false';
+    }
+    if (level.named) {
+      l += `, named: true`;
+    }
+    if (level.assessment) {
+      l += `, assessment: true`;
     }
     if (level.progression) {
       l += `, progression: '${level.progression}'`;
     }
     s.push(l);
     return s;
-  }
-
-  /**
-   * Levels with kind "puzzle" and "unplugged" are special cases of "level", for
-   * the purpose of the ScriptDSL.
-   * @param kind
-   * @return {string}
-   */
-  normalizeLevelKind(kind) {
-    return !kind || kind === LevelKind.puzzle || kind === LevelKind.unplugged
-      ? LevelKind.level
-      : kind;
   }
 
   render() {

--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -124,6 +124,9 @@ class FlexGroup extends Component {
     if (level.assessment) {
       l += `, assessment: true`;
     }
+    if (level.challenge) {
+      l += `, challenge: true`;
+    }
     if (level.progression) {
       l += `, progression: '${level.progression}'`;
     }

--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -118,6 +118,9 @@ class FlexGroup extends Component {
     if (active === false) {
       l += ', active: false';
     }
+    if (level.progression) {
+      l += `, progression: '${level.progression}'`;
+    }
     if (level.named) {
       l += `, named: true`;
     }
@@ -126,9 +129,6 @@ class FlexGroup extends Component {
     }
     if (level.challenge) {
       l += `, challenge: true`;
-    }
-    if (level.progression) {
-      l += `, progression: '${level.progression}'`;
     }
     s.push(l);
     return s;

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -6,6 +6,7 @@ import color from '../../util/color';
 import {borderRadius, levelTokenMargin} from './constants';
 import LevelTokenDetails from './LevelTokenDetails';
 import {toggleExpand, removeLevel} from './editorRedux';
+import {levelShape} from './shapes';
 
 const styles = {
   levelToken: {
@@ -65,7 +66,7 @@ class LevelToken extends Component {
     levelKeyList: PropTypes.object.isRequired,
     toggleExpand: PropTypes.func.isRequired,
     removeLevel: PropTypes.func.isRequired,
-    level: PropTypes.object.isRequired,
+    level: levelShape.isRequired,
     stagePosition: PropTypes.number.isRequired,
     dragging: PropTypes.bool.isRequired,
     drag: PropTypes.bool.isRequired,

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -61,7 +61,7 @@ const ArrowRenderer = ({onMouseDown}) => {
 };
 ArrowRenderer.propTypes = {onMouseDown: PropTypes.func.isRequried};
 
-class LevelTokenDetails extends Component {
+export class UnconnectedLevelTokenDetails extends Component {
   static propTypes = {
     levelKeyList: PropTypes.object.isRequired,
     chooseLevelType: PropTypes.func.isRequired,
@@ -257,4 +257,4 @@ export default connect(
       dispatch(setField(stage, level, modifier));
     }
   })
-)(LevelTokenDetails);
+)(UnconnectedLevelTokenDetails);

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -41,6 +41,18 @@ const styles = {
     verticalAlign: 'baseline',
     margin: '7px 0 10px 0'
   },
+  checkboxLabel: {
+    display: 'inline-block',
+    marginRight: 10,
+    marginBottom: 0
+  },
+  checkboxInput: {
+    marginTop: 0,
+    verticalAlign: 'middle'
+  },
+  checkboxText: {
+    verticalAlign: 'middle'
+  },
   divider: {
     borderColor: '#ddd',
     margin: '7px 0'
@@ -132,9 +144,37 @@ export class UnconnectedLevelTokenDetails extends Component {
     }
   };
 
+  handleCheckboxChange = field => {
+    this.props.setField(this.props.stagePosition, this.props.level.position, {
+      [field]: !this.props.level[field]
+    });
+  };
+
   render() {
     return (
       <div style={styles.levelTokenActive}>
+        <span>
+          <label style={styles.checkboxLabel}>
+            <input
+              type="checkbox"
+              style={styles.checkboxInput}
+              checked={!!this.props.level.named}
+              onChange={this.handleCheckboxChange.bind(this, 'named')}
+            />
+            &nbsp;<span style={styles.checkboxText}>named</span>
+          </label>
+          <label style={styles.checkboxLabel}>
+            <input
+              type="checkbox"
+              style={styles.checkboxInput}
+              checked={!!this.props.level.assessment}
+              onChange={this.handleCheckboxChange.bind(this, 'assessment')}
+            />
+            &nbsp;<span style={styles.checkboxText}>assessment</span>
+          </label>
+        </span>
+        <hr style={styles.divider} />
+        <div style={{clear: 'both'}} />
         <span style={Object.assign({float: 'left'}, styles.levelFieldLabel)}>
           Level type
         </span>

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -7,7 +7,6 @@ import 'react-select/dist/react-select.css';
 import 'react-virtualized-select/styles.css';
 import _ from 'lodash';
 import {
-  chooseLevelType,
   chooseLevel,
   addVariant,
   setActiveVariant,
@@ -29,10 +28,6 @@ const styles = {
     display: 'inline-block',
     lineHeight: '36px',
     margin: '0 7px 0 5px'
-  },
-  levelTypeSelect: {
-    width: 'calc(100% - 80px)',
-    margin: '0 0 5px 80px'
   },
   textInput: {
     height: 34,
@@ -77,7 +72,6 @@ ArrowRenderer.propTypes = {onMouseDown: PropTypes.func.isRequried};
 export class UnconnectedLevelTokenDetails extends Component {
   static propTypes = {
     levelKeyList: PropTypes.object.isRequired,
-    chooseLevelType: PropTypes.func.isRequired,
     chooseLevel: PropTypes.func.isRequired,
     addVariant: PropTypes.func.isRequired,
     setActiveVariant: PropTypes.func.isRequired,
@@ -85,13 +79,6 @@ export class UnconnectedLevelTokenDetails extends Component {
     level: levelShape.isRequired,
     stagePosition: PropTypes.number.isRequired
   };
-
-  levelKindOptions = [
-    {label: 'Puzzle', value: 'puzzle'},
-    {label: 'Assessment', value: 'assessment'},
-    {label: 'Named Level', value: 'named_level'},
-    {label: 'Unplugged', value: 'unplugged'}
-  ];
 
   componentWillMount() {
     this.levelKeyOptions = _.map(this.props.levelKeyList, (label, value) => ({
@@ -105,14 +92,6 @@ export class UnconnectedLevelTokenDetails extends Component {
       /^blockly:/.test(this.props.levelKeyList[id])
     );
   }
-
-  handleLevelTypeSelected = ({value}) => {
-    this.props.chooseLevelType(
-      this.props.stagePosition,
-      this.props.level.position,
-      value
-    );
-  };
 
   handleLevelSelected = (index, {value}) => {
     this.props.chooseLevel(
@@ -169,17 +148,6 @@ export class UnconnectedLevelTokenDetails extends Component {
         </span>
         <hr style={styles.divider} />
         <div style={{clear: 'both'}} />
-        <span style={Object.assign({float: 'left'}, styles.levelFieldLabel)}>
-          Level type
-        </span>
-        <VirtualizedSelect
-          value={this.props.level.kind}
-          options={this.levelKindOptions}
-          onChange={this.handleLevelTypeSelected}
-          clearable={false}
-          arrowRenderer={ArrowRenderer}
-          style={styles.levelTypeSelect}
-        />
         {this.containsLegacyLevel() && (
           <div>
             <span style={styles.levelFieldLabel}>Skin</span>
@@ -276,9 +244,6 @@ export default connect(
     levelKeyList: state.levelKeyList
   }),
   dispatch => ({
-    chooseLevelType(stage, level, value) {
-      dispatch(chooseLevelType(stage, level, value));
-    },
     chooseLevel(stage, level, variant, value) {
       dispatch(chooseLevel(stage, level, variant, value));
     },

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -13,6 +13,7 @@ import {
   setActiveVariant,
   setField
 } from './editorRedux';
+import {levelShape} from './shapes';
 
 const styles = {
   checkbox: {
@@ -69,7 +70,7 @@ export class UnconnectedLevelTokenDetails extends Component {
     addVariant: PropTypes.func.isRequired,
     setActiveVariant: PropTypes.func.isRequired,
     setField: PropTypes.func.isRequired,
-    level: PropTypes.object.isRequired,
+    level: levelShape.isRequired,
     stagePosition: PropTypes.number.isRequired
   };
 

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -27,7 +27,13 @@ const styles = {
   levelFieldLabel: {
     display: 'inline-block',
     lineHeight: '36px',
-    margin: '0 7px 0 5px'
+    margin: '0 7px 0 5px',
+    verticalAlign: 'middle'
+  },
+  levelSelect: {
+    display: 'inline-block',
+    verticalAlign: 'middle',
+    width: 600
   },
   textInput: {
     height: 34,
@@ -208,13 +214,16 @@ export class UnconnectedLevelTokenDetails extends Component {
                 />
               </div>
             )}
-            <VirtualizedSelect
-              options={this.levelKeyOptions}
-              value={id}
-              onChange={this.handleLevelSelected.bind(null, index)}
-              clearable={false}
-              arrowRenderer={ArrowRenderer}
-            />
+            <span style={{...styles.levelFieldLabel}}>Level name:</span>
+            <span style={styles.levelSelect}>
+              <VirtualizedSelect
+                options={this.levelKeyOptions}
+                value={id}
+                onChange={this.handleLevelSelected.bind(null, index)}
+                clearable={false}
+                arrowRenderer={ArrowRenderer}
+              />
+            </span>
           </div>
         ))}
         {/* We don't currently support editing progression names here, but do

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -151,27 +151,21 @@ export class UnconnectedLevelTokenDetails extends Component {
   };
 
   render() {
+    const scriptLevelOptions = ['assessment', 'named', 'challenge'];
     return (
       <div style={styles.levelTokenActive}>
         <span>
-          <label style={styles.checkboxLabel}>
-            <input
-              type="checkbox"
-              style={styles.checkboxInput}
-              checked={!!this.props.level.named}
-              onChange={this.handleCheckboxChange.bind(this, 'named')}
-            />
-            &nbsp;<span style={styles.checkboxText}>named</span>
-          </label>
-          <label style={styles.checkboxLabel}>
-            <input
-              type="checkbox"
-              style={styles.checkboxInput}
-              checked={!!this.props.level.assessment}
-              onChange={this.handleCheckboxChange.bind(this, 'assessment')}
-            />
-            &nbsp;<span style={styles.checkboxText}>assessment</span>
-          </label>
+          {scriptLevelOptions.map(option => (
+            <label key={option} style={styles.checkboxLabel}>
+              <input
+                type="checkbox"
+                style={styles.checkboxInput}
+                checked={!!this.props.level[option]}
+                onChange={this.handleCheckboxChange.bind(this, option)}
+              />
+              &nbsp;<span style={styles.checkboxText}>{option}</span>
+            </label>
+          ))}
         </span>
         <hr style={styles.divider} />
         <div style={{clear: 'both'}} />

--- a/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
@@ -12,7 +12,8 @@ const defaultLevel = {
   position: 1,
   kind: 'puzzle',
   ids: [2],
-  activeId: 2
+  activeId: 2,
+  named: true
 };
 
 export default storybook => {

--- a/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {UnconnectedLevelTokenDetails as LevelTokenDetails} from './LevelTokenDetails';
+import {action} from '@storybook/addon-actions';
+
+const levelKeyList = {
+  1: 'Level One',
+  2: 'Level Two',
+  3: 'Level Three'
+};
+
+const defaultLevel = {
+  kind: 'puzzle',
+  ids: [2],
+  activeId: 2
+};
+
+export default storybook => {
+  storybook.storiesOf('LevelTokenDetails', module).addStoryTable([
+    {
+      name: 'level token details',
+      story: () => (
+        <div style={{width: 800}}>
+          <LevelTokenDetails
+            levelKeyList={levelKeyList}
+            chooseLevelType={action('chooseLevelType')}
+            chooseLevel={action('chooseLevel')}
+            addVariant={action('addVariant')}
+            setActiveVariant={action('setActiveVariant')}
+            setField={action('setField')}
+            level={defaultLevel}
+            stagePosition={1}
+          />
+        </div>
+      )
+    }
+  ]);
+};

--- a/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
@@ -10,7 +10,6 @@ const levelKeyList = {
 
 const defaultLevel = {
   position: 1,
-  kind: 'puzzle',
   ids: [2],
   activeId: 2,
   named: true

--- a/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
@@ -9,6 +9,7 @@ const levelKeyList = {
 };
 
 const defaultLevel = {
+  position: 1,
   kind: 'puzzle',
   ids: [2],
   activeId: 2

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -5,7 +5,6 @@ const ADD_GROUP = 'scriptEditor/ADD_GROUP';
 const ADD_STAGE = 'scriptEditor/ADD_STAGE';
 const TOGGLE_EXPAND = 'scriptEditor/TOGGLE_EXPAND';
 const REMOVE_LEVEL = 'scriptEditor/REMOVE_LEVEL';
-const CHOOSE_LEVEL_TYPE = 'scriptEditor/CHOOSE_LEVEL_TYPE';
 const CHOOSE_LEVEL = 'scriptEditor/CHOOSE_LEVEL';
 const ADD_VARIANT = 'scriptEditor/ADD_VARIANT';
 const SET_ACTIVE_VARIANT = 'scriptEditor/SET_ACTIVE_VARIANT';
@@ -46,13 +45,6 @@ export const removeLevel = (stage, level) => ({
   type: REMOVE_LEVEL,
   stage,
   level
-});
-
-export const chooseLevelType = (stage, level, value) => ({
-  type: CHOOSE_LEVEL_TYPE,
-  stage,
-  level,
-  value
 });
 
 export const chooseLevel = (stage, level, variant, value) => ({
@@ -213,10 +205,6 @@ function stages(state = [], action) {
         level.activeId = action.value;
       }
       level.ids[action.variant] = action.value;
-      break;
-    }
-    case CHOOSE_LEVEL_TYPE: {
-      newState[action.stage - 1].levels[action.level - 1].kind = action.value;
       break;
     }
     case TOGGLE_EXPAND: {

--- a/apps/src/lib/script-editor/shapes.jsx
+++ b/apps/src/lib/script-editor/shapes.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+
+export const levelShape = PropTypes.shape({
+  // The position of this level within the stage in the UI.
+  position: PropTypes.number.isRequired,
+
+  // level id, or -1 if no level is selected.
+  activeId: PropTypes.number.isRequired,
+  // level ids for all variants of this level
+  ids: PropTypes.arrayOf(PropTypes.number).isRequired,
+
+  // whether this LevelToken is expanded in the UI.
+  expand: PropTypes.bool,
+
+  // blockly script level options
+  conceptDifficulty: PropTypes.string,
+  concepts: PropTypes.string,
+  skin: PropTypes.string,
+  videoKey: PropTypes.string,
+
+  // to be removed
+  kind: PropTypes.string
+});

--- a/apps/src/lib/script-editor/shapes.jsx
+++ b/apps/src/lib/script-editor/shapes.jsx
@@ -21,6 +21,7 @@ export const levelShape = PropTypes.shape({
   // other script level options
   named: PropTypes.bool,
   assessment: PropTypes.bool,
+  challenge: PropTypes.bool,
 
   // to be removed
   kind: PropTypes.string

--- a/apps/src/lib/script-editor/shapes.jsx
+++ b/apps/src/lib/script-editor/shapes.jsx
@@ -21,8 +21,5 @@ export const levelShape = PropTypes.shape({
   // other script level options
   named: PropTypes.bool,
   assessment: PropTypes.bool,
-  challenge: PropTypes.bool,
-
-  // to be removed
-  kind: PropTypes.string
+  challenge: PropTypes.bool
 });

--- a/apps/src/lib/script-editor/shapes.jsx
+++ b/apps/src/lib/script-editor/shapes.jsx
@@ -18,6 +18,10 @@ export const levelShape = PropTypes.shape({
   skin: PropTypes.string,
   videoKey: PropTypes.string,
 
+  // other script level options
+  named: PropTypes.bool,
+  assessment: PropTypes.bool,
+
   // to be removed
   kind: PropTypes.string
 });

--- a/apps/src/sites/studio/pages/scripts/_form.js
+++ b/apps/src/sites/studio/pages/scripts/_form.js
@@ -32,7 +32,10 @@ export default function initPage(scriptEditorData) {
           videoKey: level.videoKey,
           concepts: level.concepts,
           conceptDifficulty: level.conceptDifficulty,
-          progression: level.progression
+          progression: level.progression,
+          named: !!level.name,
+          assessment: level.assessment,
+          challenge: level.challenge
         }))
     }));
   const locales = scriptEditorData.locales;

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -314,6 +314,8 @@ class ScriptLevel < ActiveRecord::Base
       summary[:videoKey] = level.video_key
       summary[:concepts] = level.summarize_concepts
       summary[:conceptDifficulty] = level.summarize_concept_difficulty
+      summary[:assessment] = !!assessment
+      summary[:challenge] = !!challenge
     end
 
     if include_prev_next


### PR DESCRIPTION
### Background

The goal is to eliminate DSL from the editing experience at `/s/.../edit`. The first step was to restore the partially-implemented stage editor gui in #29408 . Josh L left lots of good feedback there which has been captured in this [dev doc](https://docs.google.com/document/d/1bYGwyMS-8Kg8B4nda12hYbORHMhhQbXOloA3zItd_ls/edit#). The work items are tracked in [LP-586](https://codedotorg.atlassian.net/browse/LP-586) and [LP-601](https://codedotorg.atlassian.net/browse/LP-601)

### Description
Fixes subtask [LP-597](https://codedotorg.atlassian.net/browse/LP-597), specifically:

* adds checkboxes for `named`, `assessment` and `challenge` to the UI
  * populates these checkboxes on page load
  * persists any changes to these checkboxes to the DB
* refactoring / cleanup
  * eliminates now-obsolete "level type" dropdown
  * adds level shape
  * adds LevelTokenDetails storybook entry

What this does not have yet but probably should have:

* unit test (omitted since this PR is getting pretty big... though perhaps I should still include them here. either way this is the very next thing I'm working on regardless of whether we hold this PR for them)
* UI test (these will be [hard to write](https://docs.google.com/document/d/1DHti8TXvhdvQ7_ezB0L1w7-35xizJqo1dXRRsoRuIaU/edit))