### PR TITLE
Feedback: include mini rubric performance on the all feedback page

### DIFF
--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -63,7 +63,8 @@ export default class LevelFeedbackEntry extends Component {
       unitName,
       linkToUnit,
       created_at,
-      comment
+      comment,
+      performance
     } = this.props.feedback;
 
     const seenByStudent = seen_on_feedback_page_at || student_first_visited_at;
@@ -71,6 +72,13 @@ export default class LevelFeedbackEntry extends Component {
     const style = {
       backgroundColor: seenByStudent ? color.lightest_teal : color.white,
       ...styles.main
+    };
+
+    const rubricPerformance = {
+      performanceLevel1: i18n.rubricLevelOneHeader(),
+      performanceLevel2: i18n.rubricLevelTwoHeader(),
+      performanceLevel3: i18n.rubricLevelThreeHeader(),
+      performanceLevel4: i18n.rubricLevelFourHeader()
     };
 
     return (
@@ -98,6 +106,7 @@ export default class LevelFeedbackEntry extends Component {
           </a>
         </div>
         <TimeAgo style={styles.time} dateString={created_at} />
+        <div style={styles.comment}>{rubricPerformance[performance]}</div>
         <div style={styles.comment}>{comment}</div>
       </div>
     );

--- a/apps/src/templates/feedback/shapes.js
+++ b/apps/src/templates/feedback/shapes.js
@@ -13,7 +13,8 @@ const shapes = {
       PropTypes.string,
       PropTypes.instanceOf(Date)
     ]).isRequired,
-    comment: PropTypes.string
+    comment: PropTypes.string,
+    performance: PropTypes.string
   })
 };
 


### PR DESCRIPTION
For levels with a mini rubric option, we now display the "grade" in the comments section of the corresponding `LevelFeedbackEntry` on the All Feedback page. 

<img width="984" alt="Screen Shot 2019-07-19 at 12 18 59 PM" src="https://user-images.githubusercontent.com/12300669/61560441-23a26a00-aa21-11e9-9099-082d2db54bde.png">
