### PR TITLE
Feedback: backfill script_level_id for teacher_feedback based on script stability

### DIFF
--- a/dashboard/scripts/archive/backfill_script_level_ids_teacher_feedbacks_4.rb
+++ b/dashboard/scripts/archive/backfill_script_level_ids_teacher_feedbacks_4.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+# Backfill existing TeacherFeedbacks to set script_level_id based on script
+# stability. Scripts have is_stable set to true when we launch curriculum.
+# Scripts that do not have is_stable set to true are used internally, usually
+# as drafts.
+
+require_relative '../../config/environment'
+
+def feedbacks_without_script_level_id
+  TeacherFeedback.where(script_level_id: nil)
+end
+
+def puts_count
+  puts "There are #{feedbacks_without_script_level_id.count} feedbacks without a script_level_id"
+end
+
+def update_script_level_ids_based_on_script_stability
+  puts "backfilling script_level_ids based on script stability"
+  feedbacks_without_script_level_id.find_each do |feedback|
+    puts "*"
+    associated_script_levels = feedback.level.script_levels
+    if associated_script_levels.length > 1
+      script_levels_with_stable_scripts = associated_script_levels.select {|sl| sl.script.is_stable}
+      if script_levels_with_stable_scripts.length == 1
+        feedback.update_attributes(script_level: script_levels_with_stable_scripts.first)
+      end
+    end
+  end
+  puts "finished backfilling script_level_ids based on script stability!"
+end
+
+TeacherFeedback.transaction do
+  puts_count
+  update_script_level_ids_based_on_script_stability
+  puts_count
+end

--- a/dashboard/scripts/archive/backfill_script_level_ids_teacher_feedbacks_4.rb
+++ b/dashboard/scripts/archive/backfill_script_level_ids_teacher_feedbacks_4.rb
@@ -22,7 +22,7 @@ def update_script_level_ids_based_on_script_stability
     if associated_script_levels.length > 1
       script_levels_with_stable_scripts = associated_script_levels.select {|sl| sl.script.is_stable}
       if script_levels_with_stable_scripts.length == 1
-        feedback.update_attributes(script_level: script_levels_with_stable_scripts.first)
+        feedback.update_attributes(script_level_id: script_levels_with_stable_scripts.first.id)
       end
     end
   end


### PR DESCRIPTION
*Background*

Partial fulfillment of [LP-590](https://codedotorg.atlassian.net/browse/LP-590) 

To retrieve accurate information to display on the All Feedback page, script_level_id needs to be stored for each TeacherFeedback. With #29671 when a new TeacherFeedback is created we will begin populating that field. However, we need to backfill script_level_id for previously created TeacherFeedbacks. I've been doing this process incrementally and so far have used the following to backfill script_level_id for a subset of TeacherFeedbacks: 

#29676 - Only one ScriptLevel associated with the feedback's level_id 
#29701 & #29753 - Infer via progress 
#29711 - Infer via assignment 

On production, there are still 5,897 TeacherFeedbacks where script_level_id is null.  

*Thought Process* 

I wanted to know how many and which Levels are involved in this problem and of those Levels, which have the most TeacherFeedbacks. By looking closely at those Levels and their associated ScriptLevels, could I find a way to infer script_level_id for another large chunk of the remaining 5,897? So, I gathered some data. 

` TeacherFeedback.where(script_level_id: nil).pluck(:level_id).uniq.count` => 176 unique Levels

Ok, which of those Levels will get me closest to determining the most ScriptLevels for TeacherFeedbacks?

`level_ids = TeacherFeedback.where(script_level_id: nil).pluck(:level_id)`
`level_ids.inject(Hash.new(0)) {|hash,level_id| hash[level_id] +=1; hash }.values.max.key` => 11458

If I figured out which ScriptLevel to use for Level 11458 I could backfill ScriptLevel for 561 TeacherFeedbacks. That seemed like a nice dent, so I took a look at Level 11458. 

Level 11458 is associated with 2 ScriptLevels (88987  and 89764). ScriptLevel 88987 has a script_id of 299, which is "csd3-2018", a stable script and ScriptLevel 89764 has a script_id of 295, which is "csd3-1819draft", not stable. 

The vast majority of the TeacherFeedback is from external users working in stable scripts. In this particular case that meant that more likely than not I should pick ScriptLevel 88987 to use for the backfill. The downside of doing this is that it's not 100% accurate - the internal cases where feedback may have been left  on a level in "csd3-1819draft". In this particular scenario, the worst that I can think would happen is that someone like Elizabeth would go to the All Feedback page and there would be entries that would be inaccurate because they would reference a stable script in the published curriculum rather than the actual draft/unstable script where the feedback was left. But for nearly all the cases and nearly all the users defaulting to inferring ScriptLevel via associated Script stability seemed reasonable. 
 
*Proposed Solution*

If only one of the potential ScriptLevels is associated with a stable Script, use that ScriptLevel to backfill TeacherFeedbacks. 