### PR TITLE
Export: allow student to upload icon image for exported app

### DIFF
--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -574,7 +574,13 @@ export default {
   exportApp(appName, code, levelHtml, suppliedExpoOpts, config) {
     const expoOpts = suppliedExpoOpts || {};
     if (expoOpts.mode === 'expoPublish') {
-      return this.publishToExpo(appName, code, levelHtml, config);
+      return this.publishToExpo(
+        appName,
+        code,
+        levelHtml,
+        expoOpts.iconFileUrl,
+        config
+      );
     }
     return this.exportAppToZip(
       appName,
@@ -588,7 +594,7 @@ export default {
     });
   },
 
-  async publishToExpo(appName, code, levelHtml, config) {
+  async publishToExpo(appName, code, levelHtml, iconFileUrl, config) {
     const {css, outerHTML} = transformLevelHtml(levelHtml);
     const fontAwesomeCSS = exportFontAwesomeCssEjs({
       fontPath: fontAwesomeWOFFPath
@@ -680,13 +686,13 @@ export default {
       assetLocation: 'appassets/'
     });
     appAssets.push({
-      url: exportExpoIconPng,
+      url: iconFileUrl || exportExpoIconPng,
       dataType: 'binary',
       filename: 'icon.png',
       assetLocation: 'appassets/'
     });
     appAssets.push({
-      url: exportExpoSplashPng,
+      url: iconFileUrl || exportExpoSplashPng,
       dataType: 'binary',
       filename: 'splash.png',
       assetLocation: 'appassets/'

--- a/apps/src/code-studio/components/ExportDialog/Dialog.jsx
+++ b/apps/src/code-studio/components/ExportDialog/Dialog.jsx
@@ -12,7 +12,7 @@ import project from '../../initApp/project';
 import commonStyles from './styles';
 import IntroPage from './IntroPage';
 import PlatformPage from './PlatformPage';
-// import IconPage from './IconPage';
+import IconPage from './IconPage';
 import PublishPage from './PublishPage';
 import GeneratingPage from './GeneratingPage';
 
@@ -214,6 +214,7 @@ class ExportDialog extends React.Component {
       exportError: null,
       expoUri: undefined,
       expoSnackId: undefined,
+      iconFileUrl: undefined,
       iconUri: undefined,
       md5PublishSavedSources: undefined,
       splashImageUri: undefined,
@@ -228,22 +229,20 @@ class ExportDialog extends React.Component {
     this.props.onClose();
   };
 
-  onInstallExpoIOS = () => {
-    window.open(
-      'https://itunes.apple.com/app/apple-store/id982107779',
-      '_blank'
-    );
-  };
-
-  onInstallExpoAndroid = () => {
-    window.open(
-      'https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=www',
-      '_blank'
-    );
+  onIconSelected = url => {
+    this.setState({
+      iconFileUrl: url
+    });
   };
 
   async publishExpoExport() {
-    const {expoUri, expoSnackId, iconUri, splashImageUri} = this.state;
+    const {
+      expoUri,
+      expoSnackId,
+      iconFileUrl,
+      iconUri,
+      splashImageUri
+    } = this.state;
     if (expoUri) {
       // We have already have exported to Expo
       return {
@@ -260,7 +259,8 @@ class ExportDialog extends React.Component {
     });
     try {
       const exportResult = await exportApp({
-        mode: 'expoPublish'
+        mode: 'expoPublish',
+        iconFileUrl
       });
       const {exporting} = this.state;
       if (!exporting) {
@@ -443,13 +443,11 @@ class ExportDialog extends React.Component {
         this.setState({screen: 'platform'});
         break;
       case 'platform':
+        this.setState({screen: 'icon'});
+        break;
+      case 'icon':
         this.setState({screen: 'publish'});
         break;
-      // this.setState({screen: 'icon'});
-      // break;
-      // case 'icon':
-      //   this.setState({screen: 'publish'});
-      //   break;
       case 'publish':
         this.generateApkAsNeeded();
         this.setState({screen: 'generating'});
@@ -471,9 +469,11 @@ class ExportDialog extends React.Component {
       case 'platform':
         this.setState({screen: 'intro'});
         break;
-      // case 'icon':
-      case 'publish':
+      case 'icon':
         this.setState({screen: 'platform'});
+        break;
+      case 'publish':
+        this.setState({screen: 'icon'});
         break;
       case 'generating':
         this.setState({screen: 'publish'});
@@ -495,17 +495,20 @@ class ExportDialog extends React.Component {
   };
 
   renderMainContent() {
-    const {screen} = this.state;
+    const {screen, iconFileUrl} = this.state;
 
     switch (screen) {
       case 'intro':
         return <IntroPage />;
       case 'platform':
         return <PlatformPage />;
-      // case 'icon':
-      //   return (
-      //     <IconPage />
-      //   );
+      case 'icon':
+        return (
+          <IconPage
+            iconFileUrl={iconFileUrl}
+            onIconSelected={this.onIconSelected}
+          />
+        );
       case 'publish':
         return <PublishPage />;
       case 'generating': {

--- a/apps/src/code-studio/components/ExportDialog/IconPage.jsx
+++ b/apps/src/code-studio/components/ExportDialog/IconPage.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import color from '../../../util/color';
 import exportExpoIconPng from '../../../templates/export/expo/icon.png';
@@ -15,20 +16,13 @@ const styles = {
     position: 'relative',
     display: 'inline-block'
   },
-  iconImage: {
-    position: 'absolute',
-    left: '50%',
-    top: '50%',
-    width: '100%',
-    height: 'auto',
-    transform: 'translate(-50%,-50%)',
-    msTransform: 'translate(-50%,-50%)',
-    WebkitTransform: 'translate(-50%,-50%)'
-  },
   uploadIconButton: {
     ...commonStyles.button,
     backgroundColor: color.default_blue,
     color: color.white
+  },
+  hiddenFileInput: {
+    display: 'none'
   }
 };
 
@@ -36,7 +30,14 @@ const styles = {
  * Icon Page in Export Dialog
  */
 export default class IconPage extends React.Component {
+  static propTypes = {
+    iconFileUrl: PropTypes.string,
+    onIconSelected: PropTypes.func.isRequired
+  };
+
   render() {
+    const {iconFileUrl} = this.props;
+    const imgSrc = iconFileUrl || exportExpoIconPng;
     return (
       <div>
         <div style={commonStyles.section}>
@@ -44,7 +45,7 @@ export default class IconPage extends React.Component {
         </div>
         <div style={commonStyles.section}>
           <div style={styles.icon}>
-            <img style={styles.iconImage} src={exportExpoIconPng} />
+            <img src={imgSrc} />
           </div>
           <button
             type="button"
@@ -54,11 +55,26 @@ export default class IconPage extends React.Component {
             Upload another image
           </button>
         </div>
+        <input
+          ref={input => (this.uploadFileInput = input)}
+          type="file"
+          style={styles.hiddenFileInput}
+          accept="image/png"
+          onChange={this.handleSelectUploadFile}
+        />
       </div>
     );
   }
 
-  uploadIcon = () => {
-    // TODO: implement icon upload
+  handleSelectUploadFile = () => {
+    if (!this.uploadFileInput.value) {
+      return;
+    }
+    const {onIconSelected} = this.props;
+    onIconSelected(URL.createObjectURL(this.uploadFileInput.files[0]));
+  };
+
+  onUploadIcon = () => {
+    this.uploadFileInput.click();
   };
 }

--- a/apps/src/code-studio/components/ExportDialog/IconPage.jsx
+++ b/apps/src/code-studio/components/ExportDialog/IconPage.jsx
@@ -60,13 +60,13 @@ export default class IconPage extends React.Component {
           type="file"
           style={styles.hiddenFileInput}
           accept="image/png"
-          onChange={this.handleSelectUploadFile}
+          onChange={this.onUploadFileInputChange}
         />
       </div>
     );
   }
 
-  handleSelectUploadFile = () => {
+  onUploadFileInputChange = () => {
     if (!this.uploadFileInput.value) {
       return;
     }

--- a/apps/src/gamelab/Exporter.js
+++ b/apps/src/gamelab/Exporter.js
@@ -273,7 +273,13 @@ export default {
   exportApp(appName, code, animationOpts, suppliedExpoOpts, config) {
     const expoOpts = suppliedExpoOpts || {};
     if (expoOpts.mode === 'expoPublish') {
-      return this.publishToExpo(appName, code, animationOpts, config);
+      return this.publishToExpo(
+        appName,
+        code,
+        animationOpts,
+        expoOpts.iconFileUrl,
+        config
+      );
     }
     return this.exportAppToZip(
       appName,
@@ -287,7 +293,7 @@ export default {
     });
   },
 
-  async publishToExpo(appName, code, animationOpts, config) {
+  async publishToExpo(appName, code, animationOpts, iconFileUrl, config) {
     const {origin} = window.location;
     const webpackRuntimePath =
       getEnvironmentPrefix() === 'cdo-development'
@@ -373,13 +379,13 @@ export default {
       assetLocation: 'appassets/'
     });
     appAssets.push({
-      url: exportExpoIconPng,
+      url: iconFileUrl || exportExpoIconPng,
       dataType: 'binary',
       filename: 'icon.png',
       assetLocation: 'appassets/'
     });
     appAssets.push({
-      url: exportExpoSplashPng,
+      url: iconFileUrl || exportExpoSplashPng,
       dataType: 'binary',
       filename: 'splash.png',
       assetLocation: 'appassets/'

--- a/apps/test/unit/code-studio/components/ExportDialogTest.js
+++ b/apps/test/unit/code-studio/components/ExportDialogTest.js
@@ -169,7 +169,8 @@ describe('ExportDialog', () => {
     );
     wrapper.instance().publishExpoExport();
     expect(exportApp).to.have.been.calledOnce.and.calledWith({
-      mode: 'expoPublish'
+      mode: 'expoPublish',
+      iconFileUrl: undefined
     });
   });
 
@@ -181,7 +182,7 @@ describe('ExportDialog', () => {
       iconUri: 'iconUri',
       splashImageUri: 'splashUri'
     });
-    exportApp.withArgs({mode: 'expoPublish'}).returns(publishResult);
+    exportApp.returns(publishResult);
     const expoGenerateApk = sinon.stub();
     expoGenerateApk.returns(Promise.resolve('fakeBuildId'));
     const expoCheckApkBuild = sinon.stub();
@@ -206,7 +207,8 @@ describe('ExportDialog', () => {
     );
     await wrapper.instance().generateApkAsNeeded();
     expect(exportApp).to.have.been.calledOnce.and.calledWith({
-      mode: 'expoPublish'
+      mode: 'expoPublish',
+      iconFileUrl: undefined
     });
     expect(expoGenerateApk).to.have.been.calledOnce.and.calledWith({
       md5SavedSources: 'fakeHash',


### PR DESCRIPTION
* Completed the "Upload your App icon" screen in the Export flow - as described in this [spec](https://docs.google.com/document/d/1o-C8GOi45FCzUKPRnsyrNS8k10jUYOlrP2zIBPeO1X4/edit)
* Per discussion with @ryansloan, when the student uploads an icon, we will use it as both the icon and the splash screen. Verified by installing an APK on Android that this works.

<img width="742" alt="Screen Shot 2019-07-19 at 6 42 26 PM" src="https://user-images.githubusercontent.com/5429146/61572612-52d2ce80-aa55-11e9-98bb-5d1f93aef2c3.png">

Launching the Android app:

![ezgif-4-a629a531ab8c](https://user-images.githubusercontent.com/5429146/61572709-a42f8d80-aa56-11e9-8a15-ea7b4b8d76d3.gif)
