### PR TITLE
Add CloudWatch Alarm on reporting cluster binlog replica lag.

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -21,6 +21,8 @@ Parameters:
     NoEcho: true
   RDSHost:
     Type: String
+  ReportingCluster:
+    Type: String
   RedshiftDatabase:
     Type: String
     Default: dashboard
@@ -230,7 +232,25 @@ Resources:
     Properties:
       AliasName: !Sub "alias/snapshot-${AWS::StackName}"
       TargetKeyId: !Ref DBSnapshotKey
-
+  # The production reporting Aurora cluster replicates via MySQL binlog from the production Aurora cluster.
+  ReportingBinLogReplicaLagAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-ReportingBinLogReplicaLag"
+      AlarmDescription: Alarms when the Aurora Reporting Cluster binlog replica lag exceeds 900 seconds for 12 datapoints.
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-LowPriority"
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref ReportingCluster
+      MetricName: AuroraBinlogReplicaLag
+      Namespace: AWS/RDS
+      Statistic: Average
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: 600
+      Period: 3600 # 1 hour
+      EvaluationPeriods: 12
+      TreatMissingData: breaching
 # ELB Access Logs tables defined in Glue Data Catalog.
   ELBLogsDatabase:
     Type: AWS::Glue::Database


### PR DESCRIPTION
For various technical reasons, we do not use the Aurora replica / readonly endpoint on our production Aurora cluster and we have provisioned a separate Reporting Aurora cluster which uses MySQL binlog to replicate from the production cluster.  Add a CloudWatch Alarm to send a low priority notification if replica lag exceeds 600 seconds for 12 hours or if the metric stops being reported.