### PR TITLE
Stop logging an error message if an empty string is passed to the safe browsing api

### DIFF
--- a/dashboard/app/controllers/safe_browsing_controller.rb
+++ b/dashboard/app/controllers/safe_browsing_controller.rb
@@ -2,8 +2,7 @@ require 'cdo/safe_browsing'
 
 class SafeBrowsingController < ApplicationController
   def safe_to_open
-    result = SafeBrowsing.determine_safe_to_open(params[:url])
-
+    result = params[:url].blank? ? true : SafeBrowsing.determine_safe_to_open(params[:url])
     render json: {approved: result}
   end
 end

--- a/dashboard/app/controllers/safe_browsing_controller.rb
+++ b/dashboard/app/controllers/safe_browsing_controller.rb
@@ -2,7 +2,7 @@ require 'cdo/safe_browsing'
 
 class SafeBrowsingController < ApplicationController
   def safe_to_open
-    result = params[:url].blank? ? true : SafeBrowsing.determine_safe_to_open(params[:url])
+    result = params[:url].blank? || SafeBrowsing.determine_safe_to_open(params[:url])
     render json: {approved: result}
   end
 end


### PR DESCRIPTION
There are no changes from the user experience perspective. This simply handles an error condition gracefully rather than logging. In the past, when using the applab `open(url)` block with an empty string, a honeybadger error would be logged. An empty url is valid since it opens a new tab. Now, we manually mark an empty string as "safe"

Related HoneyBadger: https://app.honeybadger.io/projects/3240/faults/50873912
Jira ticket: https://codedotorg.atlassian.net/browse/STAR-588
