### PR TITLE
Revert "School Info Completeness - make SchoolInfo read-only"

### DIFF
--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -82,11 +82,6 @@ class SchoolInfo < ActiveRecord::Base
   # Only sync from school on create to avoid unintended updates to old data
   before_validation :sync_from_schools, on: :create
 
-  # Set SchoolInfo to read-only.  readonly method overrides the default ActiveRecord::Core#readonly?
-  def readonly?
-    !new_record?
-  end
-
   def sync_from_schools
     # If a SchoolInfo is linked to a School then the SchoolInfo pulls its data from the School
     # It seems like there is some code that is passing in mismatched data at times.

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -590,17 +590,4 @@ class SchoolInfoTest < ActiveSupport::TestCase
     school_info.school_name = '     '
     refute school_info.complete?
   end
-
-  test 'school info is readonly for an existing record' do
-    school_info = SchoolInfo.new
-    school_info.country = 'United States'
-    school_info.school_type = SchoolInfo::SCHOOL_TYPE_PUBLIC
-    school_info.school_name = 'Primary School'
-    school_info.validation_type = SchoolInfo::VALIDATION_COMPLETE
-    school_info.save!
-
-    assert_raises("ActiveRecord::ReadOnlyRecord") do
-      school_info.update(country: 'United States', school_type: SchoolInfo::SCHOOL_TYPE_PRIVATE)
-    end
-  end
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#29751 because this PR [broke](https://codedotorg.slack.com/archives/C03CM903Y/p1563826608041300) the yourschool dashboard UI tests on iPad/iPhone/Safari/Chrome/Firefox.