### PR TITLE
Added donordrive.com to allowlist. Zendesk: 245208

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -53,6 +53,7 @@ class XhrProxyController < ApplicationController
     data.cityofchicago.org
     data.gv.at
     data.nasa.gov
+    donordrive.com
     dweet.io
     enclout.com
     githubusercontent.com


### PR DESCRIPTION
Zendesk: https://codeorg.zendesk.com/agent/tickets/245208
Api Doc: https://github.com/DonorDrive/PublicAPI

Note: This is a fundraising site for non-profits. Since their public api is readonly, returns JSON, and no donations/payments are accepted through the api, we will allow-list for startWebRequest.