### PR TITLE
Surveys: Turn experimental JotForm redirect into a form-specific A/B test

### DIFF
--- a/dashboard/app/helpers/pd/jot_form/embed_helper.rb
+++ b/dashboard/app/helpers/pd/jot_form/embed_helper.rb
@@ -12,15 +12,38 @@ module Pd
         "https://form.jotform.com/#{form_id}?#{format_url_params(params)}"
       end
 
+      # These forms have had the "Continue Forms Later" advanced setting disabled
+      # to work around a bug we've encountered when loading JotForm surveys directly
+      # on JotForm's site.
+      # https://www.jotform.com/answers/1894693-Fields-values-do-not-update-while-changing-the-values-on-URL-parameters-if-autofill-is-enabled-
+      JOTFORM_EXPERIMENTAL_REDIRECT_FORMS = [
+        '90986506471163'.to_i, # 2019 Five-Day Workshop Survey - Day 1
+        '90986458251165'.to_i, # 2019 Five-Day Workshop Survey - Day 2
+        '90986477669179'.to_i, # 2019 Five-Day Workshop Survey - Day 3
+        '90986953273169'.to_i, # 2019 Five-Day Workshop Survey - Day 4
+        '91372090131144'.to_i  # 2019 K-12 Facilitator {facilitatorPosition} of {numFacilitators}
+      ]
+
       # If the DCDO setting 'jotform_redirect' is enabled,
+      # and other experimental conditions are met,
       # this method causes the server to respond with a 302,
       # redirecting the browser to the JotForm form URL (instead of following our usual flow,
       # embedding the form within our own chrome).
       # @return [Boolean] whether the experiment is enabled and a redirect occurred
       def experimental_redirect!(form_id, params)
-        DCDO.get('jotform_redirect', false).tap do |experiment_enabled|
-          redirect_to jotform_form_url form_id, params if experiment_enabled
-        end
+        # Check if the experiment is enabled at all
+        return false unless DCDO.get('jotform_redirect', false)
+
+        # Restrict the experiment to certain forms
+        return false unless JOTFORM_EXPERIMENTAL_REDIRECT_FORMS.include? form_id
+
+        # A/B test by restricting the experiment to signed-in users with an even-numbered user id
+        return false unless current_user
+        return false unless current_user.id.even?
+
+        # All conditions passed - execute the experiment
+        redirect_to jotform_form_url form_id, params
+        true
       end
 
       def format_url_params(hash)


### PR DESCRIPTION
[PLC-347](https://codedotorg.atlassian.net/browse/PLC-347) Iterates on the `jotform_redirect` DCDO setting introduced in https://github.com/code-dot-org/code-dot-org/pull/29603, so we can run a second experiment.

## Outcome of experiment 1

We were a bit haphazard in our data gathering, but it looks like two big changes happened as a result of our experiment last week.

* **The good:** Survey completion rates improved by 20%, suggesting the redirect approach resolves many of the load/submit issues teachers have been reporting.  Anecdotally, the teacher experience was also better.
* **The bad:** The feature that conditionally shows and hides questions on certain forms broke.  At least 88% of teachers saw Likert questions on their facilitator surveys when they should not have been visible.

## Plan for experiment 2

After [some investigation with JotForm](https://www.jotform.com/answers/1894693-Fields-values-do-not-update-while-changing-the-values-on-URL-parameters-if-autofill-is-enabled-) into why the show/hide logic failed, we believe we found a workaround: Disable the "Continue Forms Later" feature on a per-form basis.  I've disabled this feature on five heavily-used forms (the general survey for days 1-4 and the facilitator survey) that are short enough that the continue later feature won't make much difference.

We plan to run the experiment again Wednesday and Thursday this week, with the following changes:

- We're restricting the experiment to five JotForm form ids (as described above).
- We're restricting the experiment to signed-in users with even-numbered user ids, so that we can do a better A/B comparison of experiment results this time.