### PR TITLE
Re-merge "School Info Completeness - make SchoolInfo read-only"

### DIFF
--- a/dashboard/app/controllers/api/v1/census/census_controller.rb
+++ b/dashboard/app/controllers/api/v1/census/census_controller.rb
@@ -136,7 +136,7 @@ class Api::V1::Census::CensusController < ApplicationController
     # to allow update on existing records.
     if errors.empty?
       ActiveRecord::Base.transaction do
-        school_info.save! if school_info.new_record?
+        school_info.save! if school_info&.new_record?
         submission.save!
       end
       if template

--- a/dashboard/app/controllers/api/v1/census/census_controller.rb
+++ b/dashboard/app/controllers/api/v1/census/census_controller.rb
@@ -131,9 +131,12 @@ class Api::V1::Census::CensusController < ApplicationController
 
     errors.merge!(submission.errors) unless submission.nil? || submission.valid?
 
+    # Only new records can be saved.
+    # Note if desired behavior changes, remember to remove condition
+    # to allow update on existing records.Note: remove condition if exsit
     if errors.empty?
       ActiveRecord::Base.transaction do
-        school_info.save!
+        school_info.save! if school_info.new_record?
         submission.save!
       end
       if template

--- a/dashboard/app/controllers/api/v1/census/census_controller.rb
+++ b/dashboard/app/controllers/api/v1/census/census_controller.rb
@@ -132,8 +132,6 @@ class Api::V1::Census::CensusController < ApplicationController
     errors.merge!(submission.errors) unless submission.nil? || submission.valid?
 
     # Only new records can be saved.
-    # Note if desired behavior changes, remember to remove condition
-    # to allow update on existing records.
     if errors.empty?
       ActiveRecord::Base.transaction do
         school_info.save! if school_info&.new_record?

--- a/dashboard/app/controllers/api/v1/census/census_controller.rb
+++ b/dashboard/app/controllers/api/v1/census/census_controller.rb
@@ -133,7 +133,7 @@ class Api::V1::Census::CensusController < ApplicationController
 
     # Only new records can be saved.
     # Note if desired behavior changes, remember to remove condition
-    # to allow update on existing records.Note: remove condition if exsit
+    # to allow update on existing records.
     if errors.empty?
       ActiveRecord::Base.transaction do
         school_info.save! if school_info.new_record?

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -82,6 +82,11 @@ class SchoolInfo < ActiveRecord::Base
   # Only sync from school on create to avoid unintended updates to old data
   before_validation :sync_from_schools, on: :create
 
+  # Set SchoolInfo to read-only.  readonly method overrides the default ActiveRecord::Core#readonly?
+  def readonly?
+    !new_record?
+  end
+
   def sync_from_schools
     # If a SchoolInfo is linked to a School then the SchoolInfo pulls its data from the School
     # It seems like there is some code that is passing in mismatched data at times.

--- a/dashboard/test/controllers/api/v1/census/census_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/census/census_controller_test.rb
@@ -93,6 +93,45 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
     refute response['census_submission_id'].nil?, "census_submission_id expected in response: #{response}"
   end
 
+  test 'yourschool census submission with negative 1 school_name, existing school_id succeeds' do
+    post :create,
+      params: {
+        form_version: 'CensusYourSchool2017v4',
+        nces_school_s: '-1',
+        school_year: 2017,
+        country_s: "US",
+        school_name_s: "Rushmore",
+        submitter_email_address: "rushmore@email.address",
+        submitter_name: "Somebody",
+        submitter_role: 'OTHER',
+        how_many_do_hoc: 'NONE',
+        how_many_after_school: 'NONE',
+        how_many_10_hours: 'NONE',
+        how_many_20_hours: 'NONE',
+        opt_in: true
+      }
+
+    post :create,
+      params: {
+        form_version: 'CensusYourSchool2017v4',
+        nces_school_s: '-1',
+        school_year: 2017,
+        country_s: "US",
+        school_name_s: "Rushmore",
+        submitter_email_address: "rushmore@email.address",
+        submitter_name: "Somebody",
+        submitter_role: 'OTHER',
+        how_many_do_hoc: 'NONE',
+        how_many_after_school: 'NONE',
+        how_many_10_hours: 'NONE',
+        how_many_20_hours: 'NONE',
+        opt_in: true
+      }
+    assert_response 201, @response.body.to_s
+    response = JSON.parse(@response.body)
+    refute response['census_submission_id'].nil?, "census_submission_id expected in response: #{response}"
+  end
+
   test 'yourschool census submission with negative 1 school_id fails' do
     post :create,
       params: {

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -590,4 +590,17 @@ class SchoolInfoTest < ActiveSupport::TestCase
     school_info.school_name = '     '
     refute school_info.complete?
   end
+
+  test 'school info is readonly for an existing record' do
+    school_info = SchoolInfo.new
+    school_info.country = 'United States'
+    school_info.school_type = SchoolInfo::SCHOOL_TYPE_PUBLIC
+    school_info.school_name = 'Primary School'
+    school_info.validation_type = SchoolInfo::VALIDATION_COMPLETE
+    school_info.save!
+
+    assert_raises("ActiveRecord::ReadOnlyRecord") do
+      school_info.update(country: 'United States', school_type: SchoolInfo::SCHOOL_TYPE_PRIVATE)
+    end
+  end
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#29836, to re-merge the original PR https://github.com/code-dot-org/code-dot-org/pull/29751.

Fix:   Only new records are saved (existing school_infos are not updated).
Passing test included.



