### PR TITLE
fix i18n imports for Sprite/Game lab

### DIFF
--- a/apps/src/gamelab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/gamelab/AnimationPicker/AnimationPicker.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {createUuid} from '@cdo/apps/utils';
 import {connect} from 'react-redux';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
-import gamelabMsg from '@cdo/gamelab/locale';
+var msg = require('@cdo/gamelab/locale') || require('@cdo/spritelab/locale');
 import styles from './styles';
 import {
   hide,
@@ -59,14 +59,10 @@ class AnimationPicker extends React.Component {
   renderVisibleBody() {
     if (this.props.uploadError) {
       return (
-        <h1>
-          {gamelabMsg.animationPicker_error({message: this.props.uploadError})}
-        </h1>
+        <h1>{msg.animationPicker_error({message: this.props.uploadError})}</h1>
       );
     } else if (this.props.uploadInProgress) {
-      return (
-        <h1 style={styles.title}>{gamelabMsg.animationPicker_uploading()}</h1>
-      );
+      return <h1 style={styles.title}>{msg.animationPicker_uploading()}</h1>;
     }
     return (
       <AnimationPickerBody
@@ -131,9 +127,7 @@ export default connect(
     },
     onUploadStart(data) {
       if (data.files[0].size >= MAX_UPLOAD_SIZE) {
-        dispatch(
-          handleUploadError(gamelabMsg.animationPicker_unsupportedSize())
-        );
+        dispatch(handleUploadError(msg.animationPicker_unsupportedSize()));
       } else if (
         data.files[0].type === 'image/png' ||
         data.files[0].type === 'image/jpeg'
@@ -141,9 +135,7 @@ export default connect(
         dispatch(beginUpload(data.files[0].name));
         data.submit();
       } else {
-        dispatch(
-          handleUploadError(gamelabMsg.animationPicker_unsupportedType())
-        );
+        dispatch(handleUploadError(msg.animationPicker_unsupportedType()));
       }
     },
     onUploadDone(result) {

--- a/apps/src/gamelab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/gamelab/AnimationPicker/AnimationPickerBody.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import {AnimationCategories, CostumeCategories} from '../constants';
-import gamelabMsg from '@cdo/gamelab/locale';
+var msg = require('@cdo/gamelab/locale') || require('@cdo/spritelab/locale');
 import animationLibrary from '../animationLibrary.json';
 import spriteCostumeLibrary from '../spriteCostumeLibrary.json';
 import ScrollableList from '../AnimationTab/ScrollableList.jsx';
@@ -118,9 +118,9 @@ class AnimationPickerBody extends React.Component {
 
     return (
       <div>
-        <h1 style={styles.title}>{gamelabMsg.animationPicker_title()}</h1>
+        <h1 style={styles.title}>{msg.animationPicker_title()}</h1>
         {!this.props.is13Plus && !hideUploadOption && (
-          <WarningLabel>{gamelabMsg.animationPicker_warning()}</WarningLabel>
+          <WarningLabel>{msg.animationPicker_warning()}</WarningLabel>
         )}
         <AnimationPickerSearchBar
           value={this.state.searchQuery}
@@ -164,13 +164,13 @@ class AnimationPickerBody extends React.Component {
             pageCount === 0) && (
             <div>
               <AnimationPickerListItem
-                label={gamelabMsg.animationPicker_drawYourOwn()}
+                label={msg.animationPicker_drawYourOwn()}
                 icon="pencil"
                 onClick={this.props.onDrawYourOwnClick}
               />
               {!hideUploadOption && (
                 <AnimationPickerListItem
-                  label={gamelabMsg.animationPicker_uploadImage()}
+                  label={msg.animationPicker_uploadImage()}
                   icon="upload"
                   onClick={this.props.onUploadClick}
                 />

--- a/apps/src/gamelab/AnimationPicker/animationPickerModule.js
+++ b/apps/src/gamelab/AnimationPicker/animationPickerModule.js
@@ -10,7 +10,7 @@ import {
 } from '../animationListModule';
 import {makeEnum} from '@cdo/apps/utils';
 import {animations as animationsApi} from '@cdo/apps/clientApi';
-import gamelabMsg from '@cdo/gamelab/locale';
+var msg = require('@cdo/gamelab/locale') || require('@cdo/spritelab/locale');
 import {changeInterfaceMode} from '../actions';
 import {GameLabInterfaceMode} from '../constants';
 
@@ -131,9 +131,7 @@ export function handleUploadComplete(result) {
         dispatch(hide());
       },
       () => {
-        dispatch(
-          handleUploadError(gamelabMsg.animationPicker_failedToParseImage())
-        );
+        dispatch(handleUploadError(msg.animationPicker_failedToParseImage()));
       }
     );
   };

--- a/apps/src/gamelab/ErrorDialogStack.jsx
+++ b/apps/src/gamelab/ErrorDialogStack.jsx
@@ -5,7 +5,7 @@ import * as actions from './errorDialogStackModule';
 import {connect} from 'react-redux';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
-import gamelabMsg from '@cdo/gamelab/locale';
+var labMsg = require('@cdo/gamelab/locale') || require('@cdo/spritelab/locale');
 import msg from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
 import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
@@ -87,7 +87,7 @@ class ErrorDialogStack extends React.Component {
         {error.error_type === 'anim_load' && (
           <div>
             <p>
-              {gamelabMsg.errorLoadingAnimation({animationName: animationName})}
+              {labMsg.errorLoadingAnimation({animationName: animationName})}
             </p>
             <p>
               {msg.contactWithoutEmail()}{' '}


### PR DESCRIPTION
Apps can only import their own locale files. Now that spritelab has its own app entrypoint (see #29831), we need to conditionally import either spritelab or gamelab locale for the AnimationPicker. Without this change, the AnimationPicker tries to import the gamelab locale files (which are undefined for sprite lab), and the costume picker breaks.