### PR TITLE
PL: Send count of active workshops to New Relic

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -296,6 +296,10 @@ class Pd::Workshop < ActiveRecord::Base
     sessions.each(&:assign_code)
     update!(started_at: Time.zone.now)
 
+    if CDO.newrelic_logging
+      NewRelic::Agent.record_metric "Custom/Workshops/InProgress", self.class.in_state(STATE_IN_PROGRESS).count
+    end
+
     # return nil in case any callers are still expecting a section
     nil
   end
@@ -306,6 +310,12 @@ class Pd::Workshop < ActiveRecord::Base
     return unless ended_at.nil?
     self.ended_at = Time.zone.now
     save!
+
+    if CDO.newrelic_logging
+      NewRelic::Agent.record_metric "Custom/Workshops/InProgress", self.class.in_state(STATE_IN_PROGRESS).count
+    end
+
+    nil
   end
 
   def state

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -205,6 +205,25 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal ended_at, @workshop.reload.ended_at
   end
 
+  test 'start and end log to New Relic' do
+    CDO.stubs(:newrelic_logging).returns(true)
+
+    metrics_logged = []
+    NewRelic::Agent.expects(:record_metric).twice.with do |key, value|
+      metrics_logged << {key: key, value: value}
+    end
+
+    @workshop.sessions << create(:pd_session)
+    @workshop.start!
+    @workshop.end!
+
+    # Both start! and end! record the same metric
+    metrics_logged.each {|metric| assert_equal('Custom/Workshops/InProgress', metric[:key])}
+    # The first call should _definitely_ be more than zero
+    # (Not making a stronger assertion here because it could interact with other tests)
+    assert metrics_logged[0][:value] > 0
+  end
+
   test 'sessions must start on separate days' do
     @workshop.sessions << create(:pd_session)
     @workshop.sessions << create(:pd_session)

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1,3 +1,4 @@
+require_relative '../../../../shared/test/spy_newrelic_agent'
 require 'test_helper'
 
 class Pd::WorkshopTest < ActiveSupport::TestCase


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#29875. Restores code-dot-org/code-dot-org#29848.

Original description:

> We spoke at standup about wanting more insight into how busy a particular week is with PD workshops.  We can use the workshop dashboard to browse and get insight into past and future workshops, but I thought it might be nice to record a point-in-time metric showing how many workshops are currently in progress, as a point of comparison on our dashboards.

The original PR failed on the test machine with error:
```
ERROR["test_start_and_end_log_to_New_Relic", "Pd::WorkshopTest", 84.89894836395979]
 test_start_and_end_log_to_New_Relic#Pd::WorkshopTest (84.90s)
NameError:         NameError: uninitialized constant Pd::WorkshopTest::NewRelic
            test/models/pd/workshop_test.rb:212:in `block in <class:WorkshopTest>'
            test/testing/setup_all_and_teardown_all.rb:22:in `run'
```
Turns out I forgot to include the `spy_newrelic_agent` - kind of surprised this didn't fail on Drone.