### PR TITLE
exclude associated models when script caching is disabled

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -412,6 +412,7 @@ class Script < ActiveRecord::Base
   end
 
   def cached
+    return self unless Script.should_cache?
     self.class.get_from_cache(id)
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -415,7 +415,7 @@ class Script < ActiveRecord::Base
     self.class.get_from_cache(id)
   end
 
-  def self.get_without_cache(id_or_name, version_year: nil)
+  def self.get_without_cache(id_or_name, version_year: nil, with_associated_models: true)
     # Also serve any script by its new_name, if it has one.
     script = id_or_name && Script.find_by(new_name: id_or_name)
     return script if script
@@ -424,7 +424,8 @@ class Script < ActiveRecord::Base
     # names which are strings that may contain numbers (eg. 2-3)
     is_id = id_or_name.to_i.to_s == id_or_name.to_s
     find_by = is_id ? :id : :name
-    script = Script.with_associated_models.find_by(find_by => id_or_name)
+    script_model = with_associated_models ? Script.with_associated_models : Script
+    script = script_model.find_by(find_by => id_or_name)
     return script if script
 
     raise ActiveRecord::RecordNotFound.new("Couldn't find Script with id|name=#{id_or_name}")
@@ -447,7 +448,7 @@ class Script < ActiveRecord::Base
       raise "Do not call Script.get_from_cache with a family_name. Call Script.get_script_family_redirect_for_user instead.  Family: #{id_or_name}"
     end
 
-    return get_without_cache(id_or_name, version_year: version_year) unless should_cache?
+    return get_without_cache(id_or_name, version_year: version_year, with_associated_models: false) unless should_cache?
     cache_key_suffix = version_year ? "/#{version_year}" : ''
     cache_key = "#{id_or_name}#{cache_key_suffix}"
     script_cache.fetch(cache_key) do


### PR DESCRIPTION
### Background

after rails server is restarted, takes almost 3 minutes to load the homepage at http://localhost-studio.code.org:3000/home . 

### Description

This PR reduces the time taken to load /home from 162 seconds to 72 seconds in development mode, as reported in `dashboard/log/development.log`. It will also probably improve all around performance on the levelbuilder machine as well.

All of this savings comes from eliminating calls to `Script.with_associated_models.find_by` in `Script.get_without_cache` when script caching is disabled. 95% of the benefit comes from eliminating the `with_associated_models` part of this call (https://github.com/code-dot-org/code-dot-org/pull/29878/commits/7552f92bc9eb87d18d20b2fe574d35d0219f0b2d), and the remaining benefit comes from avoiding calls to `Script.get_without_cache` entirely (https://github.com/code-dot-org/code-dot-org/pull/29878/commits/e4f5f8e3a8b49581960efd12d62cc19a5191e970).

The changes in this PR affect only environments where script caching is disabled, which include all developer machines and also the levelbuilder machine.

### Alternatives

#### avoid calling `Script.get_with_cache`

It is possible to achieve almost the same level of performance by instead trying harder to avoid calling `Script.get_with_cache` at all when not needed (see https://github.com/code-dot-org/code-dot-org/pull/29834), however this seems less future-proof because we generally encourage use of the script cache so it seems like just a matter of time until more uses of it are introduced which could reintroduce the performance problem.

#### cache scripts in development

It is also possible to re-enable caching in development mode, avoiding various issues by clearing the cache when code changes are detected. This actually made /home take even longer to load (222 seconds), because when caching is enabled `Script.script_cache_from_db` fetches _all_ scripts from the cache on the first call to `Script.get_from_cache`, including associated models. It might be possible to augment this approach to (1) not populate the entire cache when `config.skip_script_preload` is false, and (2) not use `with_associated_models`, but this takes us down the road of building a separate cache implementation for development environments and doesn't really promise substantial savings over the simpler option proposed in this PR.

### Future work

A whopping 60 seconds are spent in the first call to the rails/sprockets `asset_path` helper, which appears to trigger compiling of all assets. There are 7264 files in all of our `Rails.application.config.assets.paths`, 5781 of which are in our apps package. The time to resolve the first asset path seems to drop linearly as the number of assets present in these paths is reduced. There are a few approaches which might reduce the number of files (for example, removing non-english locales in the apps package saves 5 seconds) and further savings might come out of upcoming webpack optimizations. However, a more promising approach might be to find a more systemic way to work around sprockets slowness. 
