### PR TITLE
clear rails cache after class reload

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -303,7 +303,6 @@ class Script < ActiveRecord::Base
   # Caching is disabled when editing scripts and levels or running unit tests.
   def self.should_cache?
     return false if Rails.application.config.levelbuilder_mode
-    return false unless Rails.application.config.cache_classes
     return false if ENV['UNIT_TEST'] || ENV['CI']
     true
   end

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -142,6 +142,17 @@ module Dashboard
     # See http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#autoloading-is-disabled-after-booting-in-the-production-environment
     config.enable_dependency_loading = true
 
+    # Make sure we never clear the Rails cache in production. This is just a
+    # precaution, because ActiveSupport::Reloader already promises never to run
+    # its callbacks if config.cache_classes is set.
+    unless Rails.env.production?
+      ActiveSupport::Reloader.after_class_unload do
+        # Make sure the script cache never contains stale class references.
+        CDO.log.info "clearing rails cache after class reload"
+        Rails.cache.clear
+      end
+    end
+
     if CDO.newrelic_logging
       require 'newrelic_rpm'
     end


### PR DESCRIPTION
2 years ago we stopped allowing script caching in development mode in https://github.com/code-dot-org/code-dot-org/pull/16820 due to problems described in that PR. This PR enables script caching in development mode (as long as levelbuilder_mode is disabled), and clears the script cache whenever code changes are detected. 