### PR TITLE
Fix permissions for verify backups CWE role [ci skip]

### DIFF
--- a/aws/offsite/aurora-snapshots-fargate/aurora-verify-backups-stack.yml
+++ b/aws/offsite/aurora-snapshots-fargate/aurora-verify-backups-stack.yml
@@ -88,7 +88,7 @@ Resources:
                 Action:
                   - ecs:RunTask
                 # Manually construct the Task Definition Family ARN, since !Ref returns the Task Definition Revision ARN
-                Resource: !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/${AWS::StackName}-aurora-verify-backups"
+                Resource: !Ref TaskDefinition
                 Condition:
                   ArnLike:
                     ecs:cluster: !GetAtt ECSCluster.Arn


### PR DESCRIPTION
I think this fixes it, but worth checking that the created role matches what we had manually changed it to.