### PR TITLE
Feedback: metrics

### DIFF
--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -84,11 +84,14 @@ export default class LevelFeedbackEntry extends Component {
 
   expand = () => {
     this.setState({expanded: true});
-    firehoseClient.putRecord({
-      study: 'all-feedback',
-      event: 'expand',
-      data_string: this.props.feedback.id
-    });
+    firehoseClient.putRecord(
+      {
+        study: 'all-feedback',
+        event: 'expand-feedback',
+        data_string: this.props.feedback.id
+      },
+      {includeUserId: true}
+    );
   };
 
   collapse = () => {
@@ -103,11 +106,14 @@ export default class LevelFeedbackEntry extends Component {
   longComment = () => {
     let long = this.state.commentHeight > initialCommentHeight;
     if (long) {
-      firehoseClient.putRecord({
-        study: 'all-feedback',
-        event: 'long-comment',
-        data_string: this.props.feedback.id
-      });
+      firehoseClient.putRecord(
+        {
+          study: 'all-feedback',
+          event: 'long-comment',
+          data_string: this.props.feedback.id
+        },
+        {includeUserId: true}
+      );
     }
     return long;
   };

--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -84,7 +84,11 @@ export default class LevelFeedbackEntry extends Component {
 
   expand = () => {
     this.setState({expanded: true});
-    firehoseClient.putRecord({study: 'all-feedback', event: 'expand'});
+    firehoseClient.putRecord({
+      study: 'all-feedback',
+      event: 'expand',
+      data_string: this.props.feedback.id
+    });
   };
 
   collapse = () => {
@@ -96,7 +100,17 @@ export default class LevelFeedbackEntry extends Component {
       this.setState({commentHeight: measureElement(this.comment).height});
   }
 
-  longComment = () => this.state.commentHeight > initialCommentHeight;
+  longComment = () => {
+    let long = this.state.commentHeight > initialCommentHeight;
+    if (long) {
+      firehoseClient.putRecord({
+        study: 'all-feedback',
+        event: 'long-comment',
+        data_string: this.props.feedback.id
+      });
+    }
+    return long;
+  };
 
   render() {
     const {
@@ -139,10 +153,6 @@ export default class LevelFeedbackEntry extends Component {
 
     const showRightCaret = this.longComment() && !this.state.expanded;
     const showDownCaret = this.longComment() && this.state.expanded;
-
-    if (showRightCaret) {
-      firehoseClient.putRecord({study: 'all-feedback', event: 'long-comment'});
-    }
 
     return (
       <div style={style}>

--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -5,6 +5,7 @@ import color from '@cdo/apps/util/color';
 import shapes from './shapes';
 import {UnlocalizedTimeAgo as TimeAgo} from '@cdo/apps/templates/TimeAgo';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   main: {
@@ -83,6 +84,7 @@ export default class LevelFeedbackEntry extends Component {
 
   expand = () => {
     this.setState({expanded: true});
+    firehoseClient.putRecord({study: 'all-feedback', event: 'expand'});
   };
 
   collapse = () => {
@@ -137,6 +139,10 @@ export default class LevelFeedbackEntry extends Component {
 
     const showRightCaret = this.longComment() && !this.state.expanded;
     const showDownCaret = this.longComment() && this.state.expanded;
+
+    if (showRightCaret) {
+      firehoseClient.putRecord({study: 'all-feedback', event: 'long-comment'});
+    }
 
     return (
       <div style={style}>

--- a/apps/src/templates/feedback/StudentFeedbackNotification.jsx
+++ b/apps/src/templates/feedback/StudentFeedbackNotification.jsx
@@ -45,6 +45,7 @@ export default class StudentFeedbackNotification extends Component {
             buttonText={i18n.feedbackNotificationButton()}
             buttonLink="/feedback"
             dismissible={false}
+            analyticId="student-feedback"
           />
         )}
       </div>


### PR DESCRIPTION
One of the main goals of the All Feedback page and the Student Feedback Notification is to drive up usage of the teacher feedback feature by giving students more insight into when they have feedback and encouraging them to actually read that feedback. An important part of this work is determining whether the All Feedback page and Student Feedback Notification are effective. This PR adds logging that will allow us to answer a few key questions: 

- When students are shown the `StudentFeedbackNotification` do they click the button to view feedback? 

This will be tracked as an event in Google Analytics by providing an `analyticId` to the `Notification` component. 
<img width="992" alt="Screen Shot 2019-07-24 at 11 48 17 AM" src="https://user-images.githubusercontent.com/12300669/61819970-f41ca480-ae08-11e9-89ea-b42e677dd0ac.png">
 
- On the All Feedback page, how many comments are longer than the 2 lines shown initially? 

This is based on whether the comment has a height of greater than 60px and tracked in Redshift via Firehose. 

- For long comments, do students read the full comment? 

This is based on whether students click the expand icon and is tracked in Redshift via Firehose. 

![collapse-feedback](https://user-images.githubusercontent.com/12300669/61820255-7efd9f00-ae09-11e9-9c92-4bbea8a0241a.gif)


