### PR TITLE
Use MemAvailable when available for apps test parallelism

### DIFF
--- a/apps/test-low-memory.sh
+++ b/apps/test-low-memory.sh
@@ -5,16 +5,13 @@ MEM_PER_PROCESS=4096
 GRUNT_CMD="node --max_old_space_size=${MEM_PER_PROCESS} `npm bin`/grunt"
 
 if [ -n "$DRONE" ]; then
-  mkdir -p log
   CODECOV=/tmp/codecov.sh
   curl -s https://codecov.io/bash > ${CODECOV}
   chmod +x ${CODECOV}
   CODECOV="$CODECOV -C $DRONE_COMMIT_SHA"
-  LOG='&& :' # stub
 else
-  # For non-Circle runs, stub-out codecov and logging to files.
+  # For non-Drone runs, stub-out codecov.
   CODECOV=: # stub
-  LOG='&& :' # stub
 fi
 
 # Use MemAvailable when available, otherwise fall back to MemFree
@@ -48,19 +45,14 @@ fi
 
 ${PARALLEL} <<SCRIPT
 npm run lint
-(PORT=9876 ${GRUNT_CMD} unitTest && ${CODECOV} -cF unit) ${LOG} log/unitTest.log
-(PORT=9877 $GRUNT_CMD storybookTest && ${CODECOV} -cF storybook) ${LOG} log/storybookTest.log
+(PORT=9876 ${GRUNT_CMD} unitTest && ${CODECOV} -cF unit)
+(PORT=9877 $GRUNT_CMD storybookTest && ${CODECOV} -cF storybook)
 # Since scratch tests are disable this also needs to be disable. If enable scratch tests
 # then uncomment this
-# (PORT=9878 $GRUNT_CMD scratchTest && ${CODECOV} -cF scratch) ${LOG} log/scratchTest.log
-(PORT=9879 LEVEL_TYPE='turtle' $GRUNT_CMD karma:integration && \
-  ${CODECOV} -cF integration) ${LOG} log/turtleTest.log
-(PORT=9880 LEVEL_TYPE='maze|bounce|calc|eval|flappy|studio' $GRUNT_CMD karma:integration && \
-  ${CODECOV} -cF integration) ${LOG} log/integrationTest.log
-(PORT=9881 LEVEL_TYPE='applab' $GRUNT_CMD karma:integration && \
-  ${CODECOV} -cF integration) ${LOG} log/appLabTest.log
-(PORT=9882 LEVEL_TYPE='gamelab' $GRUNT_CMD karma:integration && \
-  ${CODECOV} -cF integration) ${LOG} log/gameLabTest.log
-(PORT=9883 LEVEL_TYPE='craft' $GRUNT_CMD karma:integration && \
-  ${CODECOV} -cF integration) ${LOG} log/craftTest.log
+# (PORT=9878 $GRUNT_CMD scratchTest && ${CODECOV} -cF scratch)
+(PORT=9879 LEVEL_TYPE='turtle' $GRUNT_CMD karma:integration && ${CODECOV} -cF integration)
+(PORT=9880 LEVEL_TYPE='maze|bounce|calc|eval|flappy|studio' $GRUNT_CMD karma:integration && ${CODECOV} -cF integration)
+(PORT=9881 LEVEL_TYPE='applab' $GRUNT_CMD karma:integration && ${CODECOV} -cF integration)
+(PORT=9882 LEVEL_TYPE='gamelab' $GRUNT_CMD karma:integration && ${CODECOV} -cF integration)
+(PORT=9883 LEVEL_TYPE='craft' $GRUNT_CMD karma:integration && ${CODECOV} -cF integration)
 SCRIPT

--- a/apps/test-low-memory.sh
+++ b/apps/test-low-memory.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+MEM_PER_PROCESS=4096
 GRUNT_CMD="node --max_old_space_size=${MEM_PER_PROCESS} `npm bin`/grunt"
 
 if [ -n "$DRONE" ]; then
@@ -16,9 +17,6 @@ else
   LOG='&& :' # stub
 fi
 
-MEM_PER_PROCESS=4096
-NPROC=$(nproc)
-
 # Use MemAvailable when available, otherwise fall back to MemFree
 if grep -q MemAvailable /proc/meminfo; then
   MEM_METRIC=MemAvailable
@@ -28,6 +26,7 @@ fi
 
 # Don't run more processes than can fit in free memory.
 MEM_PROCS=$(awk "/${MEM_METRIC}/ {printf \"%d\", \$2/1024/${MEM_PER_PROCESS}}" /proc/meminfo)
+NPROC=$(nproc)
 PROCS=$(( ${MEM_PROCS} < ${NPROC} ? ${MEM_PROCS} : ${NPROC} ))
 
 if [ $PROCS -eq 0 ]; then


### PR DESCRIPTION
It looks like drone runs with 3 parallel processes instead of 1 after this change.

With:
`[test] apps tests succeeded in 15:00 minutes`
https://drone.cdn-code.org/code-dot-org/code-dot-org/3659/1/4

Without:
`[test] apps tests succeeded in 23:09 minutes`
https://drone.cdn-code.org/code-dot-org/code-dot-org/3653/1/4
