### PR TITLE
 skip precompiling of all assets on the first request for any asset

### DIFF
--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -55,6 +55,9 @@ Dashboard::Application.configure do
 
   config.assets.quiet = true
 
+  # skip precompiling of all assets on the first request for any asset.
+  config.assets.check_precompiled_asset = false
+
   # Whether or not to display pretty apps (formerly called blockly).
   config.pretty_apps = true
 


### PR DESCRIPTION
follow-on to https://github.com/code-dot-org/code-dot-org/pull/29878. via simple but hard-to-find configuration change, tell rails sprockets to just compile assets on demand rather then compiling every asset on the first request for any asset.

This further reduces the time to load the first request to http://localhost-studio.code.org:3000/home from 72 seconds to 13 seconds (!!) according to development.log.

super-unhelpful documentation for this setting:

>`config.assets.check_precompiled_asset`
>
>When enabled, an exception is raised for missing assets. This option is enabled by default.