### PR TITLE
Migrate level_source_id in level_sources_multi_types to bigint

### DIFF
--- a/dashboard/db/migrate/20190718184223_convert_level_source_id_to_bigint.rb
+++ b/dashboard/db/migrate/20190718184223_convert_level_source_id_to_bigint.rb
@@ -1,6 +1,6 @@
 class ConvertLevelSourceIdToBigint < ActiveRecord::Migration[5.0]
   def up
-    change_column :level_sources_multi_types, :level_source_id, :bigint
+    change_column :level_sources_multi_types, :level_source_id, 'BIGINT(11) UNSIGNED'
   end
 
   def down

--- a/dashboard/db/migrate/20190718184223_convert_level_source_id_to_bigint.rb
+++ b/dashboard/db/migrate/20190718184223_convert_level_source_id_to_bigint.rb
@@ -1,0 +1,9 @@
+class ConvertLevelSourceIdToBigint < ActiveRecord::Migration[5.0]
+  def up
+    change_column :level_sources_multi_types, :level_source_id, :bigint
+  end
+
+  def down
+    change_column :level_sources_multi_types, :level_source_id, :int
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -447,7 +447,7 @@ ActiveRecord::Schema.define(version: 20190718184223) do
   end
 
   create_table "level_sources_multi_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.bigint  "level_source_id",               null: false
+    t.bigint  "level_source_id",               null: false, unsigned: true
     t.integer "level_id",                      null: false
     t.text    "data",            limit: 65535
     t.string  "md5",                           null: false

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190711190421) do
+ActiveRecord::Schema.define(version: 20190718184223) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -447,7 +447,7 @@ ActiveRecord::Schema.define(version: 20190711190421) do
   end
 
   create_table "level_sources_multi_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "level_source_id",               null: false
+    t.bigint  "level_source_id",               null: false
     t.integer "level_id",                      null: false
     t.text    "data",            limit: 65535
     t.string  "md5",                           null: false


### PR DESCRIPTION
First migration of several to change columns referencing the ID field in `level_sources` to be of type `bigint` instead of `int`, in order to avoid an ID overflow.

This table (`level_sources_multi_types`) is used exclusively for analysis, and has no associated model file. Thus this PR doesn't include any change to the table description at the top of the model file typically found in migrations.