### PR TITLE
Fix JotForm redirect experiment A/B test

### DIFF
--- a/dashboard/app/helpers/pd/jot_form/embed_helper.rb
+++ b/dashboard/app/helpers/pd/jot_form/embed_helper.rb
@@ -24,6 +24,12 @@ module Pd
         '91372090131144'  # 2019 K-12 Facilitator {facilitatorPosition} of {numFacilitators}
       ]
 
+      # Return true if the given form id is eligible for the JotForm redirect experiment
+      # @param [String|Integer] form_id
+      def form_in_experiment?(form_id)
+        JOTFORM_EXPERIMENTAL_REDIRECT_FORMS.map(&:to_i).include? form_id.to_i
+      end
+
       # If the DCDO setting 'jotform_redirect' is enabled,
       # and other experimental conditions are met,
       # this method causes the server to respond with a 302,
@@ -35,7 +41,7 @@ module Pd
         return false unless DCDO.get('jotform_redirect', false)
 
         # Restrict the experiment to certain forms
-        return false unless JOTFORM_EXPERIMENTAL_REDIRECT_FORMS.include? form_id
+        return false unless form_in_experiment? form_id
 
         # A/B test by restricting the experiment to signed-in users with an even-numbered user id
         return false unless current_user

--- a/dashboard/test/helpers/pd/jot_form/embed_helper_test.rb
+++ b/dashboard/test/helpers/pd/jot_form/embed_helper_test.rb
@@ -21,6 +21,20 @@ module Pd
         assert_equal 'before {plusSign} after', sanitize_value('before + after')
         assert_equal 'dev{plusSign}tag@code.org', sanitize_value('dev+tag@code.org')
       end
+
+      test 'form_in_experiment? works for strings' do
+        assert form_in_experiment? '90986506471163'
+        refute form_in_experiment? '90986506471164'
+      end
+
+      test 'form_in_experiment? works for integers' do
+        assert form_in_experiment? 90_986_506_471_163
+        refute form_in_experiment? 90_986_506_471_164
+      end
+
+      test 'form_in_experiment? safely returns false for nil' do
+        refute form_in_experiment? nil
+      end
     end
   end
 end


### PR DESCRIPTION
Corrects an error in https://github.com/code-dot-org/code-dot-org/pull/29861 and specifically in the follow-up commit https://github.com/code-dot-org/code-dot-org/commit/c9967aed2f9c4b9637b237884813e92e70d536b3 that caused the experiment to not run today.  In effect, no form ids were eligible for the experiment.

The error is that I stored the list of eligible form ids as strings, and checked them as such.  This worked when I did a quick local test using `MiscSurvey` because

```
[production] dashboard > Pd::MiscSurvey.all_form_data.first[:form_id]
=> "90525022719150"
[production] dashboard > Pd::MiscSurvey.all_form_data.first[:form_id].class
=> String
```

Unfortunately, I didn't test with `WorkshopDailySurvey` or `WorkshopFacilitatorDailySurvey`, the models using the form ids we actually want to include in the experiment.  It turns out they behave differently:

```
[production] dashboard > Pd::WorkshopDailySurvey.get_form_id_for_subject_and_day '5-day Summer', 3
=> 90986477669179
[production] dashboard > Pd::WorkshopDailySurvey.get_form_id_for_subject_and_day('5-day Summer', 3).class
=> Integer

[production] dashboard > Pd::WorkshopFacilitatorDailySurvey.form_id '5-day Summer'
=> 91372090131144
[production] dashboard > Pd::WorkshopFacilitatorDailySurvey.form_id('5-day Summer').class
=> Integer
```

In my opinion, we should be storing these form ids as strings everywhere.  However, as a minimum-impact fix to get the experiment running for tomorrow, I'm modifying the experiment code to include forms correctly whether we're checking a string or an integer.