### PR TITLE
Remove unnecessary validation in Contact Rollups

### DIFF
--- a/lib/cdo/contact_rollups_validation.rb
+++ b/lib/cdo/contact_rollups_validation.rb
@@ -175,15 +175,6 @@ class ContactRollupsValidation
       max: 40_000
     },
     {
-      name: "Check that all contacts with courses facilitated are "\
-            "facilitators",
-      query: "SELECT COUNT(*) FROM contact_rollups_daily
-              WHERE courses_facilitated IS NOT NULL
-              AND Roles NOT LIKE '%Facilitator%'",
-      min: 0,
-      max: 0
-    },
-    {
       name: "Count of contacts with professional learning enrollment",
       query:  "SELECT COUNT(*) FROM contact_rollups_daily
               WHERE professional_learning_enrolled IS NOT NULL",


### PR DESCRIPTION
This is one of the validations that check internal relationship among fields of a record, e.g. if `course_facilitated` is not null then `Roles` has to contain "facilitator". They are too strict and don't offer much value. The downside is if 1 record out of million records doesn't satisfy this validation, the whole process is aborted. E.g. [Honeybadger error](https://app.honeybadger.io/projects/3240/faults/52396538), [Slack log](https://codedotorg.slack.com/archives/C3S8AJY9K/p1563955724003800).

Remove this particular validation now. Candidates to remove later if they hold up contact syncing are: 
* Check that all contacts with grades taught are teachers
* Check that all contacts with ages taught are teachers
* Check that all contacts with forms submitted are form submitters
* Check that all contacts with form roles are form submitters