### PR TITLE
Sanitize the 'unsupported browser' error message

### DIFF
--- a/pegasus/sites.v3/code.org/views/unsupported_browser.haml
+++ b/pegasus/sites.v3/code.org/views/unsupported_browser.haml
@@ -1,4 +1,4 @@
 #warning-banner{style: 'display: none;'}
   %i.fa.fa-warning.warning-sign
   &nbsp;
-  != I18n.t("compatibility_unsupported_browser", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743')
+  = TextRender.safe_markdown I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743')

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -4,7 +4,6 @@
   language: 'English'
   front_title: 'Join the largest learning event in history, %{campaign_date}'
   coming_soon: 'Coming Soon'
-  compatibility_unsupported_browser: "Your browser is not supported. Please upgrade your browser to <a href='%{supported_browsers_url}', target='_blank'>one of our supported browsers</a>. You can try viewing the page, but expect functionality to be broken."
 
   campaign_date_start_short: "Dec. 4"
   campaign_date_start_long: "December 4"

--- a/pegasus/sites.v3/hourofcode.com/views/unsupported_browser.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/unsupported_browser.haml
@@ -1,4 +1,4 @@
 #warning-banner{style: 'display: none;'}
   %i.fa.fa-warning.warning-sign
   &nbsp;
-  != hoc_s("compatibility_unsupported_browser").gsub(/%{supported_browsers_url}/, 'https://support.code.org/hc/en-us/articles/202591743')
+  = TextRender.safe_markdown I18n.t("compatibility_unsupported_browser_markdown").gsub(/%{supported_browsers_url}/, 'https://support.code.org/hc/en-us/articles/202591743')


### PR DESCRIPTION
Was formerly vulnerable to script injection via translations. Will now
only support pure markdown with no added HTML.

Note that this depends on a newly-added string, and so should not be
merged until after the next staging scoop.