### PR TITLE
Don't merge from staging before unit tests on drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,10 +14,6 @@ steps:
   # Also fetch the target branch (which is staging for pull requests.) We need this for determining which tests to run based on changed files.
   - git remote set-branches --add origin $DRONE_TARGET_BRANCH
   - git fetch --depth 100 origin $DRONE_TARGET_BRANCH
-  # Merge so we're up-to-date with the target before running tests.
-  - git config user.name "Drone"
-  - git config user.email "drone-fake-user@code.org"
-  - git merge origin/$DRONE_TARGET_BRANCH
 
 - name: verify-pr
   image: joshlory/code-dot-org:0.10
@@ -114,7 +110,8 @@ steps:
   # Also fetch the target branch (which is staging for pull requests.) We need this for determining which tests to run based on changed files.
   - git remote set-branches --add origin $DRONE_TARGET_BRANCH
   - git fetch --depth 100 origin $DRONE_TARGET_BRANCH
-  # Merge so we're up-to-date with the target before running tests.
+  # Merge so we're up-to-date with the target before running tests. We only do this for UI tests, not unit tests,
+  # since it disrupts Codecov pull request reports.
   - git config user.name "Drone"
   - git config user.email "drone-fake-user@code.org"
   - git merge origin/$DRONE_TARGET_BRANCH
@@ -199,6 +196,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: 79d4be8e9397ef07b8896318ddfc617abda7f25e95a773604ddad6865c531d9e
+hmac: e1f0041c4f9eaf8cfb2bf8d7aad6935f832708735c1830480aa51c3fc89acdf7
 
 ...


### PR DESCRIPTION
We previously merged from staging before running unit tests to help ensure the PR branch is up-to-date with staging before testing. This causes codecov reports on pull requests to be inaccurate in a confusing way, as it then treats all of the changes from the merge as being part of the diff for the PR. Example:

https://github.com/code-dot-org/code-dot-org/pull/29911

With this change, there's an increased risk of merging changes that pass on Drone but fail on DTT, but it's hard to say how often it will come up in practice because we are still doing the merge for UI tests, and because developers can still manually merge from staging before running tests. From our discussion the sentiment seems to be that we're okay trying this out for now and then seeing if there's a noticeable increase in these issues.