### PR TITLE
Revert "PL: Remove queue system from end workshop action"

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -180,6 +180,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
   # POST /api/v1/pd/workshops/1/end
   def end
     @workshop.end!
+    Pd::AsyncWorkshopHandler.process_ended_workshop @workshop.id
     head :no_content
   end
 

--- a/dashboard/app/models/pd/async_workshop_handler.rb
+++ b/dashboard/app/models/pd/async_workshop_handler.rb
@@ -1,0 +1,66 @@
+require 'aws-sdk-sqs'
+require 'sqs/sqs_queue'
+
+# An SQS messages handler for asynchronous workshop jobs,
+# notably wrapping up a workshop when it ends (sending emails, generating reports, etc.)
+class Pd::AsyncWorkshopHandler
+  ACTIONS = [
+    ACTION_END = 'end'.freeze
+  ].freeze
+
+  def self.process_workshop(workshop_id, action)
+    raise "Unexpected action #{action}" unless ACTIONS.include? action
+
+    op = {
+      workshop_id: workshop_id,
+      action: action
+    }
+
+    # Test and Production should always have a pd_workshop_queue_url,
+    # and enqueue the job in SQS
+    if Rails.env.production? || Rails.env.test?
+      raise "CDO.pd_workshop_queue_url is required on #{Rails.env}" unless CDO.pd_workshop_queue_url
+      workshop_queue.enqueue(op.to_json)
+    elsif CDO.pd_workshop_queue_url
+      # Other environments may have it specified (e.g. adhoc), but it's not required.
+      workshop_queue.enqueue(op.to_json)
+    else
+      # Otherwise perform the job immediately (e.g. on development)
+      handle_operation(op)
+    end
+  end
+
+  def self.process_ended_workshop(workshop_id)
+    process_workshop(workshop_id, ACTION_END)
+  end
+
+  # Returns a thread-local SQS queue for handling asynchronous workshop operations
+  # The queue is thread-local because the SQS client is not thread-safe.
+  def self.workshop_queue
+    Thread.current['pd_workshop_queue'] ||=
+      SQS::SQSQueue.new(Aws::SQS::Client.new, CDO.pd_workshop_queue_url)
+  end
+
+  def self.handle_operation(op)
+    case op[:action]
+      when ACTION_END
+        Pd::Workshop.process_ended_workshop_async(op[:workshop_id])
+      else
+        raise "Unexpected action #{op[:action]} in #{op}"
+    end
+  rescue Exception => exception
+    # Notify honeybadger when an error occurs.
+    Honeybadger.notify(exception,
+      error_message: "Error processing Pd workshop: #{exception.message}",
+      context: {op: op}
+    )
+    raise exception
+  end
+
+  def handle(messages)
+    messages.each do |message|
+      op = JSON.parse(message.body).symbolize_keys
+      self.class.handle_operation(op)
+    end
+  end
+end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -306,9 +306,6 @@ class Pd::Workshop < ActiveRecord::Base
     return unless ended_at.nil?
     self.ended_at = Time.zone.now
     save!
-
-    send_exit_surveys
-    update!(processed_at: Time.zone.now)
   end
 
   def state
@@ -413,6 +410,15 @@ class Pd::Workshop < ActiveRecord::Base
     send_reminder_for_upcoming_in_days(10)
     send_reminder_to_close
     send_follow_up_after_days(30)
+  end
+
+  def self.process_ended_workshop_async(id)
+    workshop = Pd::Workshop.find(id)
+    raise "Unexpected workshop state #{workshop.state}." unless workshop.state == STATE_ENDED
+
+    workshop.send_exit_surveys
+
+    workshop.update!(processed_at: Time.zone.now)
   end
 
   # Updates enrollments with resolved users.

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -804,6 +804,8 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   # Actions: Start, End
 
   test 'admins can start and end workshops' do
+    Pd::AsyncWorkshopHandler.expects(:process_ended_workshop).with(@workshop.id)
+
     sign_in @admin
     @workshop.sessions << create(:pd_session)
     assert_equal 'Not Started', @workshop.state
@@ -821,6 +823,8 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
 
   # TODO: remove this test when workshop_organizer is deprecated
   test 'organizers can start and stop their workshops' do
+    Pd::AsyncWorkshopHandler.expects(:process_ended_workshop).with(@organizer_workshop.id)
+
     sign_in @workshop_organizer
     @organizer_workshop.sessions << create(:pd_session)
     assert_equal 'Not Started', @organizer_workshop.state
@@ -837,6 +841,8 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'program manager organizers can start and stop their workshops' do
+    Pd::AsyncWorkshopHandler.expects(:process_ended_workshop).with(@workshop.id)
+
     sign_in @organizer
     @workshop.sessions << create(:pd_session)
     assert_equal 'Not Started', @workshop.state

--- a/dashboard/test/models/pd/async_workshop_handler_test.rb
+++ b/dashboard/test/models/pd/async_workshop_handler_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+require 'fake_sqs/test_integration'
+
+# Launch a fake SQS service running on Localhost
+Aws.config.update(region: 'us-east-1', access_key_id: 'fake id', secret_access_key: 'fake secret')
+$fake_sqs_service = FakeSQS::TestIntegration.new(
+  database: ':memory:',
+  sqs_endpoint: '127.0.0.1',
+  sqs_port: 4569
+)
+
+class Pd::AsyncWorkshopHandlerTest < ActiveSupport::TestCase
+  setup do
+    @sqs = Aws::SQS::Client.new
+
+    # Start the fake SQS service for testing.
+    $fake_sqs_service.start
+    @sqs.config.endpoint = $fake_sqs_service.uri
+
+    # Create the test queue.
+    queue_name = "test-pd-workshop-#{SecureRandom.hex}"
+    response = @sqs.create_queue(queue_name: queue_name, attributes: {"VisibilityTimeout" => "1"})
+    @queue_url = response.queue_url
+
+    @workshop = create :pd_ended_workshop
+  end
+
+  teardown do
+    @sqs.delete_queue(queue_url: @queue_url)
+    $fake_sqs_service.stop
+  end
+
+  test 'queue' do
+    CDO.expects(:pd_workshop_queue_url).returns(@queue_url).at_least_once
+    Pd::AsyncWorkshopHandler.process_ended_workshop @workshop.id
+
+    Pd::Workshop.expects(:process_ended_workshop_async).with(@workshop.id)
+    process_pending_queue_messages
+  end
+
+  test 'unexpected action' do
+    e = assert_raises RuntimeError do
+      Pd::AsyncWorkshopHandler.process_workshop(@workshop.id, 'nonsense')
+    end
+    assert e.message.include? 'Unexpected action'
+  end
+
+  test 'test and production raise error when no queue provided' do
+    CDO.expects(:pd_workshop_queue_url).returns(nil).at_least_once
+
+    [:test, :production].each do |env|
+      set_env env
+      e = assert_raises RuntimeError do
+        Pd::AsyncWorkshopHandler.process_ended_workshop(@workshop.id)
+      end
+      assert e.message.include? 'CDO.pd_workshop_queue_url is required'
+    end
+  end
+
+  test 'specified queue is used' do
+    CDO.expects(:pd_workshop_queue_url).returns(@queue_url).at_least_once
+
+    mock_queue = mock
+    mock_queue.expects(:enqueue).times(3)
+    Pd::AsyncWorkshopHandler.expects(:workshop_queue).returns(mock_queue).times(3)
+
+    # include an environment other than the required test & production
+    [:test, :production, :adhoc].each do |env|
+      set_env env
+      Pd::AsyncWorkshopHandler.process_ended_workshop(@workshop.id)
+    end
+  end
+
+  test 'no queue specified in development env processes immediately' do
+    CDO.expects(:pd_workshop_queue_url).returns(nil).at_least_once
+    set_env :development
+
+    Pd::AsyncWorkshopHandler.expects(:handle_operation)
+    Pd::AsyncWorkshopHandler.process_ended_workshop(@workshop.id)
+  end
+
+  private
+
+  # Helper function to synchronously process all of the currently pending messages at `queue_url`
+  # using handler. (In reality the handler would be called by an asynchronous QueueProcessor but
+  # this helps testing by allowing us to process messages only when we want to.)
+  def process_pending_queue_messages
+    response = @sqs.receive_message(queue_url: @queue_url, wait_time_seconds: 10)
+    Pd::AsyncWorkshopHandler.new.handle(response.messages.map {|msg| SQS::Message.new(msg.body)})
+  end
+end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#29903

> Emails with attachments can only be generated on a daemon server