### PR TITLE
Prune config.assets.precompile list

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -112,7 +112,6 @@ module Dashboard
     config.assets.precompile += %w(
       js/*
       css/*.css
-      assets/**/*
       levels/*
       jquery.handsontable.full.css
       jquery.handsontable.full.js

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -112,7 +112,7 @@ module Dashboard
     config.assets.precompile += %w(
       js/*
       css/*.css
-      levels/*
+      levels/*.css
       jquery.handsontable.full.css
       jquery.handsontable.full.js
       video-js/*.css

--- a/dashboard/config/environments/staging.rb
+++ b/dashboard/config/environments/staging.rb
@@ -58,10 +58,6 @@ Dashboard::Application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
-  # Precompile additional assets.
-  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-  # config.assets.precompile += %w( search.js )
-
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
This is a warm-up PR to clean up some useless and confusing config regarding rails assets. There should be no performance or behavior change, but I want to clean it up in a separate PR to keep the future PRs smaller.

 From the docs for precompiling assets: https://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets

> Compiled assets are written to the location specified in config.assets.prefix. By default, this is the /assets directory.

Note that we only need this ^ if we reference the asset by url, but not if we just `//= require` it into application.scss or application.js.erb.

> The default matcher for compiling files includes application.js, application.css and all non-JS/CSS files (this will include all image assets automatically) from app/assets folders including your gems

> The matcher (and other members of the precompile array; see below) is applied to final compiled file names. This means anything that compiles to JS/CSS is excluded, as well as raw JS/CSS files

### Description

Update `config.assets.precompile` as follows:
* remove `assets/**/*` which doesn't match anything -- it looks like it might be trying to match the subdirectories of `dashboard/app/assets`, but the syntax is wrong because it looks for `dashboard/app/assets/assets/**/*` which doesn't exist. the files in app/assets don't need to be on the list anyway because (1) images are already included, application.js (the only file in app/assets/javascripts/) is already included, and (3) `contract_match.scss` (the only css file we refer to by url) is already included by the `levels/*` entry on the next line.
* rename `levels/*` --> `levels/*.css` so as to still match app/assets/stylesheets/levels but not to accidentally match and javascripts
* remove commented-out, staging-specific config for nonexistent and unused `search.js`. This does not exist in any of the `config.assets.paths` and is not referenced to by any call to `stylesheet_link_tag` or `asset_path`

### Verification

The output of `rake assets:precompile` is unchanged.
