### PR TITLE
PL: Remove the workshop material order table

### DIFF
--- a/dashboard/db/migrate/20190726230209_drop_pd_workshop_material_orders.rb
+++ b/dashboard/db/migrate/20190726230209_drop_pd_workshop_material_orders.rb
@@ -1,0 +1,5 @@
+class DropPdWorkshopMaterialOrders < ActiveRecord::Migration[5.0]
+  def change
+    drop_table :pd_workshop_material_orders
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190718184223) do
+ActiveRecord::Schema.define(version: 20190726230209) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -909,32 +909,6 @@ ActiveRecord::Schema.define(version: 20190718184223) do
     t.index ["pd_workshop_id"], name: "index_pd_workshop_facilitator_daily_surveys_on_pd_workshop_id", using: :btree
     t.index ["submission_id"], name: "index_pd_workshop_facilitator_daily_surveys_on_submission_id", unique: true, using: :btree
     t.index ["user_id"], name: "index_pd_workshop_facilitator_daily_surveys_on_user_id", using: :btree
-  end
-
-  create_table "pd_workshop_material_orders", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
-    t.integer  "pd_enrollment_id",                           null: false
-    t.integer  "user_id",                                    null: false
-    t.string   "school_or_company"
-    t.string   "street",                                     null: false
-    t.string   "apartment_or_suite"
-    t.string   "city",                                       null: false
-    t.string   "state",                                      null: false
-    t.string   "zip_code",                                   null: false
-    t.string   "phone_number",                               null: false
-    t.datetime "order_attempted_at"
-    t.datetime "ordered_at"
-    t.text     "order_response",               limit: 65535
-    t.text     "order_error",                  limit: 65535
-    t.string   "order_id"
-    t.string   "order_status"
-    t.datetime "order_status_last_checked_at"
-    t.datetime "order_status_changed_at"
-    t.string   "tracking_id"
-    t.string   "tracking_url"
-    t.index ["pd_enrollment_id"], name: "index_pd_workshop_material_orders_on_pd_enrollment_id", unique: true, using: :btree
-    t.index ["user_id"], name: "index_pd_workshop_material_orders_on_user_id", unique: true, using: :btree
   end
 
   create_table "pd_workshop_surveys", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/29926.  Removes the database table.  We have archived the data for the team.