### PR TITLE
School Info Completeness: close confirmation dialog when dismiss button is clicked

### DIFF
--- a/apps/src/lib/ui/SchoolInfoInterstitial.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.jsx
@@ -301,6 +301,7 @@ export default class SchoolInfoInterstitial extends React.Component {
 
   dismissSchoolInfoForm = () => {
     this.setState({isOpen: false});
+    this.props.onClose();
   };
 
   onCountryChange = (_, event) => {

--- a/apps/test/unit/lib/ui/SchoolInfoInterstitialTest.jsx
+++ b/apps/test/unit/lib/ui/SchoolInfoInterstitialTest.jsx
@@ -98,6 +98,27 @@ describe('SchoolInfoInterstitial', () => {
     expect(wrapper.state('isOpen')).to.be.false;
   });
 
+  it('closes the school info confirmation dialog when the dismiss button is clicked', () => {
+    const onClose = sinon.spy();
+    const wrapper = mount(
+      <SchoolInfoInterstitial
+        {...MINIMUM_PROPS}
+        scriptData={{
+          ...MINIMUM_PROPS.scriptData,
+          existingSchoolInfo: {}
+        }}
+        onClose={onClose}
+      />
+    );
+    const wrapperInstance = wrapper.instance();
+    sinon.spy(wrapperInstance, 'dismissSchoolInfoForm');
+    wrapper.instance().forceUpdate();
+    wrapper.find('Button[id="dismiss-button"]').simulate('click');
+    expect(wrapperInstance.dismissSchoolInfoForm).to.have.been.called;
+    expect(wrapper.state('isOpen')).to.be.false;
+    expect(onClose).to.have.been.calledOnce;
+  });
+
   it('passes empty school info if created with no existing school info', () => {
     const wrapper = shallow(
       <SchoolInfoInterstitial


### PR DESCRIPTION
[Bug bash](https://docs.google.com/document/d/1KxMHcnQlTCKWJxHi0mK2uh_dBSIcqvWCe_4vTd7OCYI/edit#bookmark=id.9ybue0qkgard)

Bug Repro:
On school info confirmation dialog, click “no, update my info”
On school info interstitial dialog, click “Dismiss”
Part of the school information dialog is still visible

Fix:  call onClose function after the dismiss button is clicked to close the school info confirmation dialog.

Before
![dismiss_button_before](https://user-images.githubusercontent.com/30066710/62018069-05014900-b16e-11e9-96c8-df1b1b711e06.gif)


After
![dismiss_button_after](https://user-images.githubusercontent.com/30066710/62018081-10ed0b00-b16e-11e9-9252-3d463df061fa.gif)

