### PR TITLE
School Info Completeness:  submit sii form with only non-US country

### DIFF
--- a/apps/src/lib/ui/SchoolInfoInterstitial.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.jsx
@@ -217,8 +217,8 @@ export default class SchoolInfoInterstitial extends React.Component {
     if (this.isBlank(country)) {
       errors.country = true;
       isValid = false;
-    } else {
-      if (this.isBlank(schoolType) && country === 'United States') {
+    } else if (country === 'United States') {
+      if (this.isBlank(schoolType)) {
         errors.schoolType = true;
         isValid = false;
       } else {

--- a/apps/src/lib/ui/SchoolInfoInterstitial.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.jsx
@@ -222,27 +222,25 @@ export default class SchoolInfoInterstitial extends React.Component {
         errors.schoolType = true;
         isValid = false;
       } else {
-        if (country === 'United States') {
-          /**
-           * NCES (National center for education statistics) only stores information
-           * for private, public and charter schools in the United States.
-           * Teachers with NCES school IDs are unique becuase of the useful information
-           * that is provided by NCES that the data team can join onto/use such as the
-           * the number of students in a school, % of URM students.
-           */
-          const ncesSchoolType = ['public', 'private', 'charter'];
-          if (ncesSchoolType.includes(schoolType)) {
-            if (this.isBlank(ncesSchoolId)) {
-              errors.ncesSchoolId = true;
-              isValid = false;
-            }
+        /**
+         * NCES (National center for education statistics) only stores information
+         * for private, public and charter schools in the United States.
+         * Teachers with NCES school IDs are unique becuase of the useful information
+         * that is provided by NCES that the data team can join onto/use such as the
+         * the number of students in a school, % of URM students.
+         */
+        const ncesSchoolType = ['public', 'private', 'charter'];
+        if (ncesSchoolType.includes(schoolType)) {
+          if (this.isBlank(ncesSchoolId)) {
+            errors.ncesSchoolId = true;
+            isValid = false;
+          }
 
-            // ncesSchoolId is set to -1 when the checkbox for school not found is clicked
-            // For a US, NCES school type, No NCES school id, school name is required.
-            if (ncesSchoolId === '-1' && this.isBlank(schoolName)) {
-              errors.schoolName = true;
-              isValid = false;
-            }
+          // ncesSchoolId is set to -1 when the checkbox for school not found is clicked
+          // For a US, NCES school type, No NCES school id, school name is required.
+          if (ncesSchoolId === '-1' && this.isBlank(schoolName)) {
+            errors.schoolName = true;
+            isValid = false;
           }
         }
       }

--- a/apps/src/lib/ui/SchoolInfoInterstitial.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.jsx
@@ -218,7 +218,7 @@ export default class SchoolInfoInterstitial extends React.Component {
       errors.country = true;
       isValid = false;
     } else {
-      if (this.isBlank(schoolType)) {
+      if (this.isBlank(schoolType) && country === 'United States') {
         errors.schoolType = true;
         isValid = false;
       } else {

--- a/apps/test/unit/lib/ui/SchoolInfoInterstitialTest.jsx
+++ b/apps/test/unit/lib/ui/SchoolInfoInterstitialTest.jsx
@@ -556,6 +556,30 @@ describe('SchoolInfoInterstitial', () => {
       );
     });
 
+    it('submits with only non-US', () => {
+      const wrapper = shallow(
+        <SchoolInfoInterstitial
+          {...MINIMUM_PROPS}
+          scriptData={{
+            ...MINIMUM_PROPS.scriptData,
+            existingSchoolInfo: {
+              country: 'Algeria',
+              school_type: ''
+            }
+          }}
+        />
+      );
+      wrapper.find('Button[id="save-button"]').simulate('click');
+      expect(server.requests[0].requestBody).to.equal(
+        [
+          '_method=patch',
+          'auth_token=fake_auth_token',
+          'user%5Bschool_info_attributes%5D%5Bcountry%5D=Algeria',
+          'user%5Bschool_info_attributes%5D%5Bschool_type%5D='
+        ].join('&')
+      );
+    });
+
     it('submits with non-US, NCES school type', () => {
       const wrapper = shallow(
         <SchoolInfoInterstitial


### PR DESCRIPTION
[Bug bash](https://docs.google.com/document/d/1KxMHcnQlTCKWJxHi0mK2uh_dBSIcqvWCe_4vTd7OCYI/edit#bookmark=id.r3p047rsnb08)

Bug re-pro
Select non-US country
Click “Save”
Required messages show up for Type and City/Town
Once a type is selected, City/Town is no longer required and user can Save out of the interstitial

Fix:  School type and city are not required when a non-US country is selected
Remove error messages for school type and city/town


Before
![us_to_non_us_before](https://user-images.githubusercontent.com/30066710/62021399-e6a24a00-b17b-11e9-8d6a-7172c8ba3cb6.gif)


After
![us_to_non_us_after](https://user-images.githubusercontent.com/30066710/62021392-e2762c80-b17b-11e9-9210-979cf527fb21.gif)
