### PR TITLE
Add Developer role

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -144,7 +144,7 @@ Resources:
             - cloudformation:CreateStack
             - cloudformation:UpdateStack
             - cloudformation:DeleteStack
-            - cloudformation:CreateChangeSet
+            - cloudformation:ExecuteChangeSet
             Resource: '*'
             Condition:
               ForAnyValue:StringNotEquals:

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -3,6 +3,10 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   IAM layer including global/shared roles and access permissions for Code.org infrastructure.
   Note: Admin permissions are required to manage some admin-only resources in this stack.
+Parameters:
+  GoogleDeveloperIDs:
+    Type: AWS::SSM::Parameter::Value<List<String>>
+    Default: /IAM/GoogleDeveloperIDs
 Resources:
   # Admin Service Role for managing all resources in CloudFormation stacks.
   # Only admins can update stacks using this service role.
@@ -105,7 +109,49 @@ Resources:
             Condition:
               StringNotEquals:
                 cloudformation:RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/CloudFormationService"
-
+  Developer:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: Developer
+      Path: /admin/
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal: {Federated: !Sub "arn:aws:iam::${AWS::AccountId}:saml-provider/Google"}
+          Action: sts:AssumeRoleWithSAML
+          Condition:
+            StringEquals:
+              SAML:aud: https://signin.aws.amazon.com/saml
+        - Effect: Allow
+          Principal: {Federated: accounts.google.com}
+          Action: sts:AssumeRoleWithWebIdentity
+          Condition:
+            StringEquals:
+              accounts.google.com:aud: '{{resolve:secretsmanager:admin/google_client_id}}'
+            ForAnyValue:StringEquals:
+              accounts.google.com:sub: !Ref GoogleDeveloperIDs
+        - Effect: Allow
+          Principal: {Service: ec2.amazonaws.com}
+          Action: sts:AssumeRole
+      Policies:
+      # Only allow developers to create/update stacks in specific environments.
+      - PolicyName: ProtectedStacks
+        PolicyDocument:
+          Statement:
+          - Effect: Deny
+            Action:
+            - cloudformation:CreateStack
+            - cloudformation:UpdateStack
+            - cloudformation:DeleteStack
+            - cloudformation:CreateChangeSet
+            Resource: '*'
+            Condition:
+              ForAnyValue:StringNotEquals:
+                aws:ResourceTag/environment: [adhoc, development]
+              ForAnyValue:StringEquals:
+                aws:TagKeys: environment
+      ManagedPolicyArns: [!Ref DevPermissions]
   # Used by FirehoseMicroservice Lambda function.
   # TODO move to Data stack
   FirehoseLambdaRole:


### PR DESCRIPTION
This PR adds the `Developer` Role to the `IAM` stack, which will be the main entry-point moving forward for federated 'developers' access from multiple sources (Google SAML console access, Google OAuth API access through the [`aws/google`](https://github.com/code-dot-org/aws-google) gem, and EC2-instance-profile access for developer-workstations).

This Role is based on the `DevPermissions` policy (which is used as a permissions boundary by our application stacks). It also adds additional developer protections to CloudFormation stacks: stack update operations are denied on any stack with an `environment` tag set to anything other than `development` or `adhoc`. (Developer protections to Secrets operations are coming in a future PR as well.)

The stack update adds two configuration/secret references, that were manually added:
- `GoogleDeveloperIDs` - this is an SSM Parameter Store reference to a [`StringList`](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-about-examples.html), which was added to the `/IAM/GoogleDeveloperIDs` parameter. (Using SSM Parameter as a CFn Parameter, with the key as `Default` value is the only current way to include a parameter to populate a `List of String` value in a CFn template.)
- `admin/google_client_id` Secrets Manager secret, included as a dynamic reference in the template.