### PR TITLE
Migrate level_source_id column in assessment_activities to bigint

### DIFF
--- a/dashboard/app/models/assessment_activity.rb
+++ b/dashboard/app/models/assessment_activity.rb
@@ -6,7 +6,7 @@
 #  user_id         :integer          not null
 #  level_id        :integer          not null
 #  script_id       :integer          not null
-#  level_source_id :integer
+#  level_source_id :integer          unsigned
 #  attempt         :integer
 #  test_result     :integer
 #  created_at      :datetime         not null

--- a/dashboard/db/migrate/20190729203515_convert_level_source_id_to_bigint_assessment_activities.rb
+++ b/dashboard/db/migrate/20190729203515_convert_level_source_id_to_bigint_assessment_activities.rb
@@ -1,0 +1,9 @@
+class ConvertLevelSourceIdToBigintAssessmentActivities < ActiveRecord::Migration[5.0]
+  def up
+    change_column :assessment_activities, :level_source_id, 'BIGINT(11) UNSIGNED'
+  end
+
+  def down
+    change_column :assessment_activities, :level_source_id, :int
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190726230209) do
+ActiveRecord::Schema.define(version: 20190729203515) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20190726230209) do
     t.integer  "user_id",         null: false
     t.integer  "level_id",        null: false
     t.integer  "script_id",       null: false
-    t.integer  "level_source_id"
+    t.bigint   "level_source_id",              unsigned: true
     t.integer  "attempt"
     t.integer  "test_result"
     t.datetime "created_at",      null: false


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/29908.

In addition to testing locally, tested the raw SQL version of this migration on a copy of the production DB, which took under a second to complete. 