### PR TITLE
Set element's scrollTop prop instead of calling scrollTo()

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -459,7 +459,7 @@ class TopInstructions extends Component {
 
   scrollToTopOfTab = () => {
     var myDiv = document.getElementById('scroll-container');
-    myDiv.scrollTo(0, 0);
+    myDiv.scrollTop = 0;
   };
 
   /**


### PR DESCRIPTION
Part of [LP-500](https://codedotorg.atlassian.net/browse/LP-500) - "Re-enable csp_instructions.feature for IE once debugged"

Found a little bug while I was diagnosing why csp_instructions.feature fails in IE --

We want to reset the instructions' scrollTop to 0 when a user switches tabs in the instructions. We were using [`Element.scrollTo()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo), but this doesn't work in IE (or on Safari iOS). This updates us to set the [`Element.scrollTop`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop) to 0 instead, which has the same effect but is supported in all browsers.