### PR TITLE
Include all CSP 19-20 units in ScriptConstants

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -134,11 +134,16 @@ module ScriptConstants
       CSD5_NAME = 'csd5-2017'.freeze,
       CSD6_NAME = 'csd6-2017'.freeze,
     ],
-    # Currently only used for TTS.
     csp_2019: [
+      CSP1_2019_NAME = 'csp1-2019'.freeze,
+      CSP2_2019_NAME = 'csp2-2019'.freeze,
       CSP3_2019_NAME = 'csp3-2019'.freeze,
+      CSP4_2019_NAME = 'csp4-2019'.freeze,
       CSP5_2019_NAME = 'csp5-2019'.freeze,
+      CSP_CREATE_2019_NAME = 'csp-create-2019'.freeze,
       CSP_POSTAP_2019_NAME = 'csppostap-2019'.freeze,
+      CSP_POST_SURVEY_2019_NAME = 'csp-post-survey-2019'.freeze,
+      CSP_EXPLORE_2019_NAME = 'csp-explore-2019'.freeze,
     ],
     csp_2018: [
       CSP1_2018_NAME = 'csp1-2018'.freeze,


### PR DESCRIPTION
[LP-608](https://codedotorg.atlassian.net/browse/LP-608)

In the `ScriptSelector` on the teacher dashboard, some CSP units were erroneously categorized as "other". 
<img width="394" alt="Screen Shot 2019-07-29 at 3 31 22 PM" src="https://user-images.githubusercontent.com/12300669/62087602-2a965d00-b217-11e9-8d55-4d4fe1b1404a.png">

I added these scripts to the `csp_2019` category in `ScriptConstants` so they would appear in the correct category in the dropdown. 
<img width="377" alt="Screen Shot 2019-07-29 at 3 35 02 PM" src="https://user-images.githubusercontent.com/12300669/62087652-5c0f2880-b217-11e9-9966-cab4e5e99999.png">

