### PR TITLE
Add 2019 courses to contact rollups

### DIFF
--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -105,11 +105,19 @@ class ContactRollups
     coursed-2018
     coursee-2018
     coursef-2018
+    coursea-2019
+    courseb-2019
+    coursec-2019
+    coursed-2019
+    coursee-2019
+    coursef-2019
     20-hour
-    express-2018
-    pre-express-2018
     express-2017
     pre-express-2017
+    express-2018
+    pre-express-2018
+    express-2019
+    pre-express-2019
   ).freeze
 
   CSF_SCRIPT_LIST = CSF_SCRIPT_ARRAY.map {|x| "'#{x}'"}.join(',')
@@ -510,6 +518,8 @@ class ContactRollups
     add_role_from_course_sections_taught("CSP Teacher", "csp-2017")
     add_role_from_course_sections_taught("CSD Teacher", "csd-2018")
     add_role_from_course_sections_taught("CSP Teacher", "csp-2018")
+    add_role_from_course_sections_taught("CSD Teacher", "csd-2019")
+    add_role_from_course_sections_taught("CSP Teacher", "csp-2019")
     log_completion(start)
   end
 


### PR DESCRIPTION
[PLC-380](https://codedotorg.atlassian.net/browse/PLC-380?atlOrigin=eyJpIjoiNDM0MjUwNTk0NzlkNDgzNWJiZDE3MDRmNmQ1M2FiNWQiLCJwIjoiaiJ9)
Make sure teachers teaching the 2019 version of our courses are added to contact rollups

This is a quick fix because our next CSF teacher newsletter is going out soon, but I will follow up with a dynamic solution so we don't have to keep updating this list.