### PR TITLE
get rid of expandable images in DSL-defined levels

### DIFF
--- a/dashboard/config/scripts/csd_u2_test.multi
+++ b/dashboard/config/scripts/csd_u2_test.multi
@@ -7,7 +7,7 @@ right 'right answer'
 markdown <<MARKDOWN
 Questions 5 and 6 deal with the following web page:
 
-![expandable](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
+![](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
 
-![expandable](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
+![](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
 MARKDOWN

--- a/dashboard/config/scripts/csd_u2_test_code_styles.multi
+++ b/dashboard/config/scripts/csd_u2_test_code_styles.multi
@@ -12,7 +12,7 @@ wrong 'Put the code `style=“larger”` inside the h3 tag.'
 markdown <<MARKDOWN
 Questions 5 and 6 deal with the following web page:
 
-![expandable](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
+![](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
 
-![expandable](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
+![](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
 MARKDOWN

--- a/dashboard/config/scripts/csd_u2_test_code_styles_pilot.multi
+++ b/dashboard/config/scripts/csd_u2_test_code_styles_pilot.multi
@@ -12,7 +12,7 @@ wrong 'Put the code `style=“larger”` inside the h3 tag.'
 markdown <<MARKDOWN
 Questions 5 and 6 deal with the following web page:
 
-![expandable](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
+![](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
 
-![expandable](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
+![](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
 MARKDOWN

--- a/dashboard/config/scripts/csd_u2_test_code_stylesheet.multi
+++ b/dashboard/config/scripts/csd_u2_test_code_stylesheet.multi
@@ -23,7 +23,7 @@ wrong '1, 2, 3, and 4'
 markdown <<MARKDOWN
 Questions 5 and 6 deal with the following web page:
 
-![expandable](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
+![](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
 
-![expandable](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
+![](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
 MARKDOWN

--- a/dashboard/config/scripts/csd_u2_test_code_stylesheet_pilot.multi
+++ b/dashboard/config/scripts/csd_u2_test_code_stylesheet_pilot.multi
@@ -23,7 +23,7 @@ wrong '1, 2, 3, and 4'
 markdown <<MARKDOWN
 Questions 5 and 6 deal with the following web page:
 
-![expandable](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
+![](https://images.code.org/6a8e713405756aec4992cb5c406dcc2d-image-1552346175963.15.59 PM.png)
 
-![expandable](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
+![](https://images.code.org/d3ba5db1bffc7deb0f22a74836b338c9-image-1552346189165.16.05 PM.png)
 MARKDOWN

--- a/dashboard/config/scripts/csd_u6_array_multi.multi
+++ b/dashboard/config/scripts/csd_u6_array_multi.multi
@@ -9,5 +9,5 @@ wrong '<img src="https://images.code.org/ae34c1d87e697c789303c5c1b602b7c6-image-
 right '<img src="https://images.code.org/d220337a4cd1ec31b0a5bb70eaf6bffe-image-1512686800364.42.00 PM.png" width="200px"'
 
 markdown <<MARKDOWN
-![expandable](https://images.code.org/134a993836c148f64a7045d489ec58dc-image-1512686800350.45.08 PM.png)
+![](https://images.code.org/134a993836c148f64a7045d489ec58dc-image-1512686800350.45.08 PM.png)
 MARKDOWN

--- a/dashboard/config/scripts/csd_u6_array_multi_2018.multi
+++ b/dashboard/config/scripts/csd_u6_array_multi_2018.multi
@@ -9,5 +9,5 @@ wrong '<img src="https://images.code.org/ae34c1d87e697c789303c5c1b602b7c6-image-
 right '<img src="https://images.code.org/d220337a4cd1ec31b0a5bb70eaf6bffe-image-1512686800364.42.00 PM.png" width="200px"'
 
 markdown <<MARKDOWN
-![expandable](https://images.code.org/134a993836c148f64a7045d489ec58dc-image-1512686800350.45.08 PM.png)
+![](https://images.code.org/134a993836c148f64a7045d489ec58dc-image-1512686800350.45.08 PM.png)
 MARKDOWN

--- a/dashboard/config/scripts/csd_u6_array_multi_2018_2019.multi
+++ b/dashboard/config/scripts/csd_u6_array_multi_2018_2019.multi
@@ -9,5 +9,5 @@ wrong '<img src="https://images.code.org/ae34c1d87e697c789303c5c1b602b7c6-image-
 right '<img src="https://images.code.org/d220337a4cd1ec31b0a5bb70eaf6bffe-image-1512686800364.42.00 PM.png" width="200px"'
 
 markdown <<MARKDOWN
-![expandable](https://images.code.org/134a993836c148f64a7045d489ec58dc-image-1512686800350.45.08 PM.png)
+![](https://images.code.org/134a993836c148f64a7045d489ec58dc-image-1512686800350.45.08 PM.png)
 MARKDOWN


### PR DESCRIPTION
we don't currently support expandable images in DSL, so right now these are a no-op, but having them around is confusing.