### PR TITLE
Show different survey tab names for different workshops

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -157,7 +157,7 @@ module Api::V1::Pd
 
     def notify_error(exception, error_status_code = :internal_server_error)
       Honeybadger.notify(
-        error_message: exception.message,
+        exception,
         context: {
           workshop_id: @workshop.id,
           course: @workshop.course,

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_decorator.rb
@@ -12,6 +12,10 @@ module Pd::SurveyPipeline
       "91405279991164".to_i => {
         full_name: 'Facilitator Feedback Survey',
         short_name: 'Facilitator'
+      },
+      "82115646319154".to_i => {
+        full_name: 'Academic Year 6-12 Workshop Post Survey',
+        short_name: 'Post Workshop'
       }
     }
 
@@ -66,56 +70,55 @@ module Pd::SurveyPipeline
       # Populate entries for result[:this_workshop] and result[:questions]
       summaries.each do |summary|
         # Only process summarization for specific workshops and forms.
-        form_id = summary[:form_id]
-        workshop_id = summary[:workshop_id]
+        workshop_id, form_id, = summary.values_at(:workshop_id, :form_id)
         next unless workshop_id && form_id
 
         # Check if the current user can see specific data
         next unless data_visible_to_user?(current_user, summary)
 
-        form_name = get_form_short_name(form_id)
+        day, facilitator_id = summary.values_at(:day, :facilitator_id)
+        context_name = get_context_name(workshop_id, day, facilitator_id, form_id)
         q_name = summary[:name]
 
         # Create top structures if not already created
         result[:course_name] ||= Pd::Workshop.find_by_id(workshop_id)&.course
-        result[:this_workshop][form_name] ||= {
+        result[:this_workshop][context_name] ||= {
           response_count: parsed_submissions[form_id].size,
           general: {},
           facilitator: {}
         }
-        result[:questions][form_name] ||= {general: {}, facilitator: {}}
+        result[:questions][context_name] ||= {general: {}, facilitator: {}}
 
         # Create an entry in result[:this_workshop].
         # General format:
-        # Hash{form_name => {response_count => number, general => {question_name => summary_result}}}
+        # Hash{context_name => {response_count => number, general => {question_name => summary_result}}}
         #
         # Format for facilicator-specific result:
-        # Hash{form_name => {response_count => number,
+        # Hash{context_name => {response_count => number,
         #   facilitator => {question_name => {factilitator_name => summary_result}}}}
         #
-        if summary[:facilitator_id]
-          facilitator_name = User.find_by_id(summary[:facilitator_id])&.name ||
-            summary[:facilitator_id].to_s
+        if facilitator_id
+          facilitator_name = User.find_by_id(facilitator_id)&.name || facilitator_id.to_s
 
-          result[:this_workshop][form_name][:facilitator][q_name] ||= {}
-          result[:this_workshop][form_name][:facilitator][q_name][facilitator_name] =
+          result[:this_workshop][context_name][:facilitator][q_name] ||= {}
+          result[:this_workshop][context_name][:facilitator][q_name][facilitator_name] =
             summary[:reducer_result]
         else
-          result[:this_workshop][form_name][:general][q_name] = summary[:reducer_result]
+          result[:this_workshop][context_name][:general][q_name] = summary[:reducer_result]
         end
 
         # Create an entry in result[:questions].
         # General question format:
-        # Hash{form_name => {general => {question_name => question_content}}}
+        # Hash{context_name => {general => {question_name => question_content}}}
         #
         # Facilitator question format:
-        # Hash{form_name => {facilitator => {question_name => question_content}}}
+        # Hash{context_name => {facilitator => {question_name => question_content}}}
         #
         q_content = question_by_names.dig(form_id, q_name)
-        if summary[:facilitator_id]
-          result[:questions][form_name][:facilitator][q_name] ||= q_content
+        if facilitator_id
+          result[:questions][context_name][:facilitator][q_name] ||= q_content
         else
-          result[:questions][form_name][:general][q_name] ||= q_content
+          result[:questions][context_name][:general][q_name] ||= q_content
         end
       end
 
@@ -134,6 +137,37 @@ module Pd::SurveyPipeline
       end
 
       true
+    end
+
+    # Given metadata of a survey submission, returns context name for that submission.
+    # Example return values: Pre Workshop, Post Workshop, Day <number>, and Facilitator.
+    #
+    # @param workshop_id [Number] must be valid workshop id
+    # @param day [Number]
+    # @param facilitator_id [Number]
+    # @param form_id [Number]
+    #
+    # @return [String] context name
+    #
+    def self.get_context_name(workshop_id, day, facilitator_id, form_id)
+      workshop = Pd::Workshop.find(workshop_id)
+      return 'Invalid Metadata' unless workshop
+
+      if workshop.csf?
+        return 'Facilitator' if facilitator_id
+        # CSF is a 1-day workshop and doesn't have daily survey.
+        return day == 0 ? 'Pre Workshop' : 'Post Workshop'
+      elsif workshop.summer?
+        # Summer workshop doesn't have post-workshop survey.
+        return day == 0 ? 'Pre Workshop' : "Day #{day}"
+      else
+        # Academic year workshop doesn't have pre-workshop survey.
+        # Post workshop survey has the same "day" value as the last daily survey.
+        # Use form name to distinguish them.
+        session_count = workshop.sessions.size
+        form_name = get_form_short_name(form_id)
+        return day == session_count && form_name == 'Post Workshop' ? 'Post Workshop' : "Day #{day}"
+      end
     end
 
     def self.get_form_short_name(form_id)

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_decorator.rb
@@ -49,7 +49,7 @@ module Pd::SurveyPipeline
     # @param parsed_questions [Hash] question data get from DailySurveyParser.
     # @param parsed_submissions [Hash] submission data get from DailySurveyParser.
     # @param current_user [User] user making survey report request.
-    # @param errors [Array] non-fatal errors encounterd when calculating survey summaries.
+    # @param errors [Array] non-fatal errors encountered when calculating survey summaries.
     #
     # @return [Hash] data returned to client.
     #
@@ -93,9 +93,9 @@ module Pd::SurveyPipeline
         # General format:
         # Hash{context_name => {response_count => number, general => {question_name => summary_result}}}
         #
-        # Format for facilicator-specific result:
+        # Format for facilitator-specific result:
         # Hash{context_name => {response_count => number,
-        #   facilitator => {question_name => {factilitator_name => summary_result}}}}
+        #   facilitator => {question_name => {facilitator_name => summary_result}}}}
         #
         if facilitator_id
           facilitator_name = User.find_by_id(facilitator_id)&.name || facilitator_id.to_s
@@ -154,7 +154,7 @@ module Pd::SurveyPipeline
       return 'Invalid' unless workshop && day >= 0
 
       if workshop.csf?
-        return 'Facilitator' if facilitator_id
+        return 'Facilitators' if facilitator_id
 
         # CSF is a 1-day workshop and doesn't have daily survey.
         return day == 0 ? 'Pre Workshop' : 'Post Workshop'

--- a/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
@@ -160,11 +160,11 @@ module Pd::SurveyPipeline::Helper
   #
   def report_single_workshop(workshop, current_user)
     # Fields used to group survey answers
-    group_config = [:workshop_id, :form_id, :facilitator_id, :name, :type, :answer_type]
+    group_config = [:workshop_id, :day, :facilitator_id, :form_id, :name, :type, :answer_type]
 
     # Rules to map groups of survey answers to reducers
     is_single_select_answer = lambda {|hash| hash.dig(:answer_type) == 'singleSelect'}
-    is_free_format_question = lambda {|hash| ['textbox', 'textarea'].include?(hash[:type])}
+    not_single_select_answer = lambda {|hash| hash.dig(:answer_type) != 'singleSelect'}
 
     map_config = [
       {
@@ -173,7 +173,7 @@ module Pd::SurveyPipeline::Helper
         reducers: [Pd::SurveyPipeline::HistogramReducer]
       },
       {
-        condition: is_free_format_question,
+        condition: not_single_select_answer,
         field: :answer,
         reducers: [Pd::SurveyPipeline::NoOpReducer]
       }
@@ -183,7 +183,7 @@ module Pd::SurveyPipeline::Helper
     # Workers read from and write to this object.
     context = {
       current_user: current_user,
-      filters: {workshop_ids: @workshop.id}
+      filters: {workshop_ids: workshop.id}
     }
 
     # Assembly line to summarize CSF surveys

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -222,5 +222,64 @@ module Pd::SurveyPipeline
         assert_equal true, DailySurveyDecorator.data_visible_to_user?(user, data_row)
       end
     end
+
+    test 'get context of CSF survey submissions' do
+      facilitator = create :facilitator
+      workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201,
+        num_sessions: 1, facilitators: [facilitator]
+      form_id = '1122334455'.to_i
+
+      survey_metadata_to_context = {
+        [workshop.id, 0, facilitator.id, form_id] => 'Facilitator',
+        [workshop.id, 0, nil, form_id] => 'Pre Workshop',
+        [workshop.id, 1, nil, form_id] => 'Post Workshop',
+        [workshop.id, -1, nil, form_id] => 'Invalid',
+        [0, 0, facilitator.id, form_id] => 'Invalid'
+      }
+
+      survey_metadata_to_context.each do |input, expected_output|
+        assert_equal expected_output, DailySurveyDecorator.get_survey_context(*input),
+          "Wrong output for input #{input}"
+      end
+    end
+
+    test 'get context of summer workshop survey submissions' do
+      facilitator = create :facilitator
+      workshop = create :pd_workshop, course: COURSE_CSD, subject: SUBJECT_SUMMER_WORKSHOP,
+        num_sessions: 1, facilitators: [facilitator]
+      form_id = '1122334455'.to_i
+
+      survey_metadata_to_context = {
+        [workshop.id, 0, nil, form_id] => 'Pre Workshop',
+        [workshop.id, 1, nil, form_id] => 'Day 1',
+        [workshop.id, 1, facilitator.id, form_id] => 'Day 1'
+      }
+
+      survey_metadata_to_context.each do |input, expected_output|
+        assert_equal expected_output, DailySurveyDecorator.get_survey_context(*input),
+          "Wrong output for input #{input}"
+      end
+    end
+
+    test 'get context of academic year workshop survey submissions' do
+      facilitator = create :facilitator
+      workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1,
+        num_sessions: 1, facilitators: [facilitator]
+      daily_form_id = '1122334455'.to_i
+      post_ws_form_id = '82115646319154'.to_i
+
+      survey_metadata_to_context = {
+        [workshop.id, 0, nil, daily_form_id] => 'Invalid',
+        [workshop.id, 1, nil, daily_form_id] => 'Day 1',
+        [workshop.id, 1, facilitator.id, daily_form_id] => 'Day 1',
+        [workshop.id, 1, nil, post_ws_form_id] => 'Post Workshop',
+        [workshop.id, 1, facilitator.id, post_ws_form_id] => 'Post Workshop',
+      }
+
+      survey_metadata_to_context.each do |input, expected_output|
+        assert_equal expected_output, DailySurveyDecorator.get_survey_context(*input),
+          "Wrong output for input #{input}"
+      end
+    end
   end
 end

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -23,7 +23,7 @@ module Pd::SurveyPipeline
 
     test 'decorate facilitator survey results' do
       form_id = "91405279991164".to_i
-      form_name = 'Facilitator'
+      context_name = 'Facilitators'
 
       parsed_questions = {
         form_id => {
@@ -62,7 +62,7 @@ module Pd::SurveyPipeline
       expected_result = {
         course_name: COURSE_CSF,
         questions: {
-          form_name => {
+          context_name => {
             general: {},
             facilitator: {
               'importance' => parsed_questions[form_id]['1'].except(:name),
@@ -71,7 +71,7 @@ module Pd::SurveyPipeline
           }
         },
         this_workshop: {
-          form_name => {
+          context_name => {
             response_count: 4,
             general: {},
             facilitator: {
@@ -107,7 +107,7 @@ module Pd::SurveyPipeline
 
     test 'decorate general survey results' do
       form_id = "90066184161150".to_i
-      form_name = 'Pre Workshop'
+      context_name = 'Pre Workshop'
 
       parsed_questions = {
         form_id => {
@@ -138,7 +138,7 @@ module Pd::SurveyPipeline
       expected_result = {
         course_name: COURSE_CSF,
         questions: {
-          form_name => {
+          context_name => {
             general: {
               'importance' => parsed_questions[form_id]['1'].except(:name),
               'feedback' => parsed_questions[form_id]['2'].except(:name),
@@ -147,7 +147,7 @@ module Pd::SurveyPipeline
           }
         },
         this_workshop: {
-          form_name => {
+          context_name => {
             response_count: 4,
             general: {
               'importance' => {'Agree': 2, 'Neutral': 1, 'Disagree': 1},
@@ -230,7 +230,7 @@ module Pd::SurveyPipeline
       form_id = '1122334455'.to_i
 
       survey_metadata_to_context = {
-        [workshop.id, 0, facilitator.id, form_id] => 'Facilitator',
+        [workshop.id, 0, facilitator.id, form_id] => 'Facilitators',
         [workshop.id, 0, nil, form_id] => 'Pre Workshop',
         [workshop.id, 1, nil, form_id] => 'Post Workshop',
         [workshop.id, -1, nil, form_id] => 'Invalid',

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -49,13 +49,13 @@ module Pd::SurveyPipeline
       }
 
       summary_data = [
-        {workshop_id: @workshop.id, form_id: form_id, facilitator_id: @facilitators.first.id,
+        {workshop_id: @workshop.id, day: 0, form_id: form_id, facilitator_id: @facilitators.first.id,
           name: 'importance', reducer: 'histogram', reducer_result: {'Agree': 2}},
-        {workshop_id: @workshop.id, form_id: form_id, facilitator_id: @facilitators.first.id,
+        {workshop_id: @workshop.id, day: 0, form_id: form_id, facilitator_id: @facilitators.first.id,
           name: 'feedback', reducer: 'no_op', reducer_result: ['Feedback 1', 'Feedback 2']},
-        {workshop_id: @workshop.id, form_id: form_id, facilitator_id: @facilitators.last.id,
+        {workshop_id: @workshop.id, day: 0, form_id: form_id, facilitator_id: @facilitators.last.id,
           name: 'importance', reducer: 'histogram', reducer_result: {'Neutral': 1, 'Disagree': 1}},
-        {workshop_id: @workshop.id, form_id: form_id, facilitator_id: @facilitators.last.id,
+        {workshop_id: @workshop.id, day: 0, form_id: form_id, facilitator_id: @facilitators.last.id,
           name: 'feedback', reducer: 'no_op', reducer_result: ['Feedback 3']}
       ]
 
@@ -129,9 +129,9 @@ module Pd::SurveyPipeline
       }
 
       summary_data = [
-        {workshop_id: @workshop.id, form_id: form_id, name: 'importance',
+        {workshop_id: @workshop.id, day: 0, form_id: form_id, name: 'importance',
           reducer: 'histogram', reducer_result: {'Agree': 2, 'Neutral': 1, 'Disagree': 1}},
-        {workshop_id: @workshop.id, form_id: form_id, name: 'feedback',
+        {workshop_id: @workshop.id, day: 0, form_id: form_id, name: 'feedback',
           reducer: 'no_op', reducer_result: ['Feedback 1', 'Feedback 2', 'Feedback 3']}
       ]
 


### PR DESCRIPTION
### What
Use different tab names when displaying survey results depending on workshop types (CSF, summer or academic year workshop). Tab name examples: _Pre Workshop_, _Post Workshop_, _Day {x}_, _Facilitators_.

**Before**: Tabs are form ids and form names. (This example is from production environment.)
<img width="1323" alt="Screen Shot 2019-07-30 at 12 56 46 PM" src="https://user-images.githubusercontent.com/46507039/62162658-92a77a80-b2cd-11e9-9b4c-868f8bfaa4da.png">

**After** (Examples from development environment.)
CSF possible tab names: Pre Workshop, Post Workshop, Facilitators 
<img width="730" alt="Screen Shot 2019-07-30 at 12 56 56 PM" src="https://user-images.githubusercontent.com/46507039/62162704-ab179500-b2cd-11e9-859c-571460cb359a.png">

Summer workshop tab names: Pre Workshop, Day 1 ... Day 5
<img width="385" alt="Screen Shot 2019-07-30 at 12 57 01 PM" src="https://user-images.githubusercontent.com/46507039/62162716-b10d7600-b2cd-11e9-8e9c-64a2083006ba.png">

Academic-year workshop: Day 1, Day 2, Post Workshop
<img width="307" alt="Screen Shot 2019-07-30 at 12 57 06 PM" src="https://user-images.githubusercontent.com/46507039/62162735-b8348400-b2cd-11e9-9add-c6fb9f25b240.png">

### Why
We use `day` value in `Pd::WorkshopDailySurvey` and `Pd::WorkshopFacilitatorDailySurvey` to determine context of a survey submission. The context depends on type of workshop and the survey form. For example:
- day 0 means _Pre Workshop_ for summer workshop, but is an invalid value for academic year workshop.
- day 1 means _Day 1_ for summer workshop, but means _Post Workshop_ for CSF,  and could be both _Day 1_ and _Post Workshop_ for academic year workshop (the difference is in the survey form used).

Previously the new pipeline just uses name of survey form as tab name. It now determines tab name (survey context) using the type of workshop, `day` value and `form_id` value in the survey submission.

### How tested
- `bundle exec rails test test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb`
- `bundle exec rails test test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb`
