### PR TITLE
Revert "PL: Send count of active workshops to New Relic"

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -296,10 +296,6 @@ class Pd::Workshop < ActiveRecord::Base
     sessions.each(&:assign_code)
     update!(started_at: Time.zone.now)
 
-    if CDO.newrelic_logging
-      NewRelic::Agent.record_metric "Custom/Workshops/InProgress", self.class.in_state(STATE_IN_PROGRESS).count
-    end
-
     # return nil in case any callers are still expecting a section
     nil
   end
@@ -310,12 +306,6 @@ class Pd::Workshop < ActiveRecord::Base
     return unless ended_at.nil?
     self.ended_at = Time.zone.now
     save!
-
-    if CDO.newrelic_logging
-      NewRelic::Agent.record_metric "Custom/Workshops/InProgress", self.class.in_state(STATE_IN_PROGRESS).count
-    end
-
-    nil
   end
 
   def state

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1,4 +1,3 @@
-require_relative '../../../../shared/test/spy_newrelic_agent'
 require 'test_helper'
 
 class Pd::WorkshopTest < ActiveSupport::TestCase
@@ -204,25 +203,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     ended_at = @workshop.reload.ended_at
     @workshop.end!
     assert_equal ended_at, @workshop.reload.ended_at
-  end
-
-  test 'start and end log to New Relic' do
-    CDO.stubs(:newrelic_logging).returns(true)
-
-    metrics_logged = []
-    NewRelic::Agent.expects(:record_metric).twice.with do |key, value|
-      metrics_logged << {key: key, value: value}
-    end
-
-    @workshop.sessions << create(:pd_session)
-    @workshop.start!
-    @workshop.end!
-
-    # Both start! and end! record the same metric
-    metrics_logged.each {|metric| assert_equal('Custom/Workshops/InProgress', metric[:key])}
-    # The first call should _definitely_ be more than zero
-    # (Not making a stronger assertion here because it could interact with other tests)
-    assert metrics_logged[0][:value] > 0
   end
 
   test 'sessions must start on separate days' do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#29876

```
======= FAIL["test_start_and_end_log_to_New_Relic", "Pd::WorkshopTest", 707.1443195249885]
test_start_and_end_log_to_New_Relic#Pd::WorkshopTest (707.14s)
not all expectations were satisfied
unsatisfied expectations:
- expected exactly twice, invoked once: NewRelic::Agent.record_metric()
satisfied expectations:
- allowed any number of times, not yet invoked: UserHelpers.random_donor(any_parameters)
- allowed any number of times, not yet invoked: AWS::S3.download_from_bucket(any_parameters)
- allowed any number of times, not yet invoked: AWS::S3.upload_to_bucket(any_parameters)
- allowed any number of times, invoked once: #<Cdo::Impl:0x55c139dde348>.newrelic_logging(any_parameters)
- allowed any number of times, invoked once: #<Cdo::Impl:0x55c139dde348>.rack_env(any_parameters)
- allowed any number of times, not yet invoked: #<Cdo::Impl:0x55c139dde348>.override_dashboard(any_parameters)
- allowed any number of times, not yet invoked: #<Cdo::Impl:0x55c139dde348>.override_pegasus(any_parameters)
- allowed any number of times, not yet invoked: #<Rails::Application::Configuration:0x55c143302fc8>.levelbuilder_mode(any_parameters)
test/models/pd/workshop_test.rb:213:in `block in <class:WorkshopTest>'
test/testing/setup_all_and_teardown_all.rb:22:in `run'
```
([Slack](https://codedotorg.slack.com/archives/C2ALWLRHN/p1564501340018400))

I don't understand yet why this test keeps failing on the test machine when it's passing on my local machine and on Drone.