### PR TITLE
Feedback: don't show feedback from non-verified teachers on /feedback

### DIFF
--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -3,11 +3,11 @@ class TeacherFeedbacksController < ApplicationController
   load_and_authorize_resource
   after_action :set_seen_on_feedback_page_at, only: :index
 
-  # Feedback from any teacher who has provided feedback to the current
+  # Feedback from any verified teacher who has provided feedback to the current
   # student on any level
   def index
     @feedbacks_as_student = @teacher_feedbacks.select do |feedback|
-      feedback.student_id == current_user.id
+      feedback.student_id == current_user.id && User.find(feedback.teacher_id).authorized_teacher?
     end
 
     @feedbacks_as_student_with_level_info = @feedbacks_as_student.map {|feedback| feedback.attributes.merge(feedback&.script_level&.summary_for_feedback)}

--- a/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
@@ -12,7 +12,8 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
   self.use_transactional_test_case = true
   setup_all do
     #create student, teacher, and level and register student in teacher's section
-    @teacher = create :teacher
+    @teacher = create :authorized_teacher
+    @not_authorized_teacher = create :teacher
     @student = create :student
     @section = create :section, user: @teacher
     @section.add_student(@student)
@@ -171,6 +172,16 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     )
 
     get "#{API}/count"
+    assert_equal "0", formatted_response
+  end
+
+  test 'count does not include feedback from a not authorized teacher' do
+    teacher_sign_in_and_give_feedback(@not_authorized_teacher, @student, @level, COMMENT1, PERFORMANCE1)
+    sign_out @not_authorized_teacher
+
+    sign_in @student
+    get "#{API}/count"
+
     assert_equal "0", formatted_response
   end
 


### PR DESCRIPTION
Partial work related to [LP-637](https://codedotorg.atlassian.net/browse/LP-637)

While assuming identity for a student as part of the investigation to backfill `script_level_id` (see #29676 for context if needed) I found abusive feedback from one student (with a teacher account) to another. To safe guard against inappropriate use of the feedback feature, we want to restrict use to only verified teachers. 

I plan to do that work in 3 steps: 

1.) Hide feedback from non-verified teachers on the all feedback page (this PR)
 
2.) Hide feedback from non-verified teachers in the context of the level. (upcoming)

3.) Block non-verified teachers from leaving feedback. (upcoming)