### PR TITLE
Fix <user_id/> replacement in External Markdown levels

### DIFF
--- a/dashboard/app/models/levels/external.rb
+++ b/dashboard/app/models/levels/external.rb
@@ -52,10 +52,11 @@ class External < DSLDefined
     true
   end
 
-  # returns a properties hash in which USER_ID_REPLACE_STRING is replaced by the current user's id
-  # in markdown
-  def properties_with_replaced_markdown(user)
+  # returns a version of the markdown for this level in which
+  # USER_ID_REPLACE_STRING is replaced by the current user's id
+  def localized_replaced_markdown(user)
     user_id = user.try(:id).to_s
-    properties.merge({'markdown' => properties['markdown'].gsub(USER_ID_REPLACE_STRING, user_id)})
+    localized_markdown = localized_property('markdown')
+    return localized_markdown.gsub(USER_ID_REPLACE_STRING, user_id)
   end
 end

--- a/dashboard/app/views/levels/_content.html.haml
+++ b/dashboard/app/views/levels/_content.html.haml
@@ -17,6 +17,7 @@
   / Markdown support using the 'markdown' property.
   - if data['markdown'].present?
     #markdown
+      - level_markdown = level.try(:localized_replaced_markdown, current_user) || level.localized_property('markdown')
       / Render markdown text through the ActionView template engine.
-      = ActionView::Base.new.render(inline: level.localized_property('markdown'), type: :md)
+      = ActionView::Base.new.render(inline: level_markdown, type: :md)
   = postcontent

--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -1,7 +1,6 @@
 - level ||= @level
 - last_attempt = @last_attempt unless local_assigns.has_key? :last_attempt
 - in_level_group ||= false
-- level_props = level.properties_with_replaced_markdown(current_user)
 - video_key = @level.video_key
 - video =  video_key ? Video.current_locale.find_by_key(video_key) : nil
 - use_large_video_player = level.properties["use_large_video_player"]
@@ -12,7 +11,7 @@
 - content_for(:head) do
   %script{src: minifiable_asset_path('js/levels/_external.js'), data: {external: { in_level_group: in_level_group }.to_json}}
   :javascript
-    var options = #{level_props['options'].to_json}
+    var options = #{level.properties['options'].to_json}
 
 .external
   - postcontent = capture_haml do
@@ -22,8 +21,8 @@
       - elsif !(video && use_large_video_player)
         %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
 
-  = render partial: 'levels/content', locals: {app: 'external', data: level_props, content_class: level_props['options'].try(:[], 'css'), postcontent: postcontent, source_level: level}
-  = render partial: 'levels/teacher_markdown', locals: {data: level_props}
+  = render partial: 'levels/content', locals: {app: 'external', data: level.properties, content_class: level.properties['options'].try(:[], 'css'), postcontent: postcontent, source_level: level}
+  = render partial: 'levels/teacher_markdown', locals: {data: level.properties}
 
 - if in_level_group
   -# This partial will take care of milestone posts in the contexts of levelgroups,

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -771,6 +771,19 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'external markdown levels will render <user_id/> as the actual user id' do
+    dsl_text = <<DSL
+name 'user_id_replace'
+title 'title for user_id_replace'
+markdown 'this is the markdown for <user_id/>'
+DSL
+    level = External.create_from_level_builder({}, {name: 'my_user_id_replace', dsl_text: dsl_text})
+    sign_in @not_admin
+    get :show, params: {id: level}
+    assert_response :success
+    assert_select '#markdown', "this is the markdown for #{@not_admin.id}"
+  end
+
   private
 
   # Assert that the url is a real S3 url, and not a placeholder.

--- a/dashboard/test/models/external_test.rb
+++ b/dashboard/test/models/external_test.rb
@@ -13,18 +13,15 @@ DSL
   test "replaces <user_id/> with user's id" do
     user1 = create :user
     user2 = create :user
-    properties1 = @level.properties_with_replaced_markdown(user1)
-    properties2 = @level.properties_with_replaced_markdown(user2)
+    markdown1 = @level.localized_replaced_markdown(user1)
+    markdown2 = @level.localized_replaced_markdown(user2)
 
-    assert_equal("this is the markdown for #{user1.id}", properties1['markdown'])
-    assert_equal("this is the markdown for #{user2.id}", properties2['markdown'])
-
-    # make sure we didn't lose other properties
-    assert_equal('title for user_id_replace', properties1['title'])
+    assert_equal("this is the markdown for #{user1.id}", markdown1)
+    assert_equal("this is the markdown for #{user2.id}", markdown2)
   end
 
   test "replaces <user_id/> with empty string if no user" do
-    properties = @level.properties_with_replaced_markdown(nil)
-    assert_equal("this is the markdown for ", properties['markdown'])
+    markdown = @level.localized_replaced_markdown(nil)
+    assert_equal("this is the markdown for ", markdown)
   end
 end


### PR DESCRIPTION
The original logic (added in https://github.com/code-dot-org/code-dot-org/pull/14538) was bypassed by the update in https://github.com/code-dot-org/code-dot-org/pull/28987 to use localized values for markdown.

The new logic will support user_id replacement in both English and translated levels.

Also added a test to validate the rendered content itself.