### PR TITLE
PL: remove code after bad merge

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -326,12 +326,6 @@ class Pd::Workshop < ActiveRecord::Base
         workshop.update!(processed_at: Time.zone.now)
       end
     end
-
-    if CDO.newrelic_logging
-      NewRelic::Agent.record_metric "Custom/Workshops/InProgress", self.class.in_state(STATE_IN_PROGRESS).count
-    end
-
-    nil
   end
 
   def state


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/29984.  Remove a mention of New Relic that must have made it in during a bad merge.