### PR TITLE
Applab export: remove extractCSSFromHTML

### DIFF
--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -8,7 +8,6 @@ import {SnackSession} from '@code-dot-org/snack-sdk';
 import * as applabConstants from './constants';
 import * as assetPrefix from '../assetManagement/assetPrefix';
 import download from '../assetManagement/download';
-import elementLibrary from './designElements/library';
 import exportProjectEjs from '../templates/export/project.html.ejs';
 import exportProjectReadmeEjs from '../templates/export/projectReadme.md.ejs';
 import exportFontAwesomeCssEjs from '../templates/export/fontAwesome.css.ejs';
@@ -187,88 +186,6 @@ export function getAppOptionsFile(expoMode, channelId) {
   return `window.APP_OPTIONS = ${JSON.stringify(options)};`;
 }
 
-/**
- * Extracts a CSS file from the given HTML dom node by traversing each node and
- * looking at the style attributes. We use the element library to determine
- * which styles are common among each element and split those out into more
- * generic selectors. This function also removes all the style attributes from
- * the elements. It gives each element where it removed styles an
- * 'appModernDesign' class.
- */
-function extractCSSFromHTML(el) {
-  var css = [];
-
-  // We need to prefix all of our selectors with divApplab to overcome the
-  // precendence of css defined in applab.css
-  var selectorPrefix = '#divApplab.appModern ';
-
-  var baseEls = {};
-  for (var elementType in elementLibrary.ElementType) {
-    var baseEl = elementLibrary.createElement(elementType, 0, 0, true);
-    baseEls[elementType] = baseEl;
-    var selector = selectorPrefix + baseEl.tagName.toLowerCase();
-    if (baseEl.classList.length > 0) {
-      selector += '.' + baseEl.classList[0];
-    }
-    if (baseEl.tagName.toLowerCase() === 'input') {
-      selector += '[type=' + (baseEl.getAttribute('type') || 'text') + ']';
-    }
-    selector += '.appModernDesign';
-    selector += ',\n' + selector + ':hover';
-    css.push(selector + ' {');
-    for (var k = 0; k < baseEl.style.length; k++) {
-      var key = baseEl.style[k];
-      css.push('  ' + key + ': ' + baseEl.style[key] + ';');
-    }
-    css.push('}');
-    css.push('');
-  }
-
-  function traverse(root) {
-    for (var i = 0; i < root.children.length; i++) {
-      var child = root.children[i];
-      var elementType = elementLibrary.getElementType(child, true);
-      if (elementType) {
-        var styleDiff = [];
-        for (var k = 0; k < child.style.length; k++) {
-          var key = child.style[k];
-          if (child.style[key] !== baseEls[elementType].style[key]) {
-            styleDiff.push('  ' + key + ': ' + child.style[key] + ';');
-          }
-        }
-        child.removeAttribute('style');
-        if (child.tagName.toLowerCase() === 'input') {
-          // make sure all input tags have a type attribute specified
-          if (!child.getAttribute('type')) {
-            child.setAttribute('type', 'text');
-          }
-        }
-        if (styleDiff.length > 0) {
-          let childId = child.id;
-          const firstIdChar = childId.charAt(0);
-          if (!isNaN(parseInt(firstIdChar, 10))) {
-            // First character of id is a number. Must transform this to create
-            // legal CSS:
-            childId = `\\3${firstIdChar} ${childId.substring(1)}`;
-          }
-          css.push(selectorPrefix + '#' + childId + ' {');
-          css = css.concat(styleDiff);
-          css.push('}');
-          css.push('');
-        }
-        const exitingClassName = child.className;
-        const exitingClassNamePrefix = exitingClassName
-          ? `${exitingClassName} `
-          : '';
-        child.className = `${exitingClassNamePrefix}appModernDesign`;
-      }
-      traverse(child);
-    }
-  }
-  traverse(el);
-  return css.join('\n');
-}
-
 const fontAwesomeWOFFRelativeSourcePath = '/fonts/fontawesome-webfont.woff2';
 const fontAwesomeWOFFPath = 'applab/fontawesome-webfont.woff2';
 
@@ -305,7 +222,7 @@ async function getExportConfig(expoMode) {
 
 export default {
   async exportAppToZip(appName, code, levelHtml, expoMode) {
-    const {css, outerHTML} = transformLevelHtml(levelHtml);
+    const transformedHTML = transformLevelHtml(levelHtml);
 
     const exportConfig = await getExportConfig(expoMode);
     const jQueryBaseName = 'jquery-1.12.1.min';
@@ -314,7 +231,7 @@ export default {
       html = exportExpoIndexEjs({
         appName,
         exportConfigPath: exportConfig.path,
-        htmlBody: outerHTML,
+        htmlBody: transformedHTML,
         applabApiPath: 'applab-api.j',
         jQueryPath: jQueryBaseName + '.j',
         applabCssPath: 'applab/applab.css',
@@ -329,7 +246,7 @@ export default {
       html = exportProjectEjs({
         appName,
         exportConfigPath: exportConfig.path,
-        htmlBody: outerHTML,
+        htmlBody: transformedHTML,
         fontPath: fontAwesomeWOFFPath
       });
     }
@@ -425,10 +342,7 @@ export default {
     const fontAwesomeCSS = exportFontAwesomeCssEjs({
       fontPath: fontAwesomeWOFFPath
     });
-    zip.file(
-      mainProjectFilesPrefix + 'style.css',
-      fontAwesomeCSS + rewriteAssetUrls(appAssets, css)
-    );
+    zip.file(mainProjectFilesPrefix + 'style.css', fontAwesomeCSS);
     zip.file(
       mainProjectFilesPrefix + (expoMode ? 'code.j' : 'code.js'),
       rewriteAssetUrls(appAssets, code)
@@ -595,7 +509,7 @@ export default {
   },
 
   async publishToExpo(appName, code, levelHtml, iconFileUrl, config) {
-    const {css, outerHTML} = transformLevelHtml(levelHtml);
+    const transformedHTML = transformLevelHtml(levelHtml);
     const fontAwesomeCSS = exportFontAwesomeCssEjs({
       fontPath: fontAwesomeWOFFPath
     });
@@ -613,7 +527,7 @@ export default {
     const html = exportExpoIndexEjs({
       appName,
       exportConfigPath: exportConfig.path,
-      htmlBody: outerHTML,
+      htmlBody: transformedHTML,
       commonLocalePath: `${origin}/blockly/js/en_us/common_locale.js`,
       applabLocalePath: `${origin}/blockly/js/en_us/applab_locale.js`,
       appOptionsPath: 'appOptions.j',
@@ -655,7 +569,7 @@ export default {
       {filename: 'index.html', data: rewriteAssetUrls(appAssets, html)},
       {
         filename: 'style.css',
-        data: fontAwesomeCSS + rewriteAssetUrls(appAssets, css)
+        data: fontAwesomeCSS
       },
       {filename: 'code.j', data: rewriteAssetUrls(appAssets, code)},
       {filename: 'appOptions.j', data: appOptionsJs}
@@ -775,11 +689,5 @@ function transformLevelHtml(levelHtml) {
   appElement.classList.remove('withCrosshair');
   appElement.style.transform = '';
 
-  // NOTE: this also modifies appElement!
-  const css = extractCSSFromHTML(appElement);
-
-  return {
-    outerHTML: appElement.outerHTML,
-    css
-  };
+  return appElement.outerHTML;
 }

--- a/apps/test/unit/applab/ExporterTest.js
+++ b/apps/test/unit/applab/ExporterTest.js
@@ -43,6 +43,14 @@ a.third-rule {
 }
 `;
 
+const STYLE_CSS_CONTENT = `@font-face {
+  font-family: 'FontAwesome';
+  src: url("applab/fontawesome-webfont.woff2") format("woff2");
+  font-weight: normal;
+  font-style: normal;
+}
+`;
+
 const JQUERY_JS_CONTENT = 'jquery content';
 const PNG_ASSET_CONTENT = 'asset content';
 const FONTAWESOME_CONTENT = 'fontawesome content';
@@ -408,62 +416,14 @@ describe('Applab Exporter,', function() {
             '#divApplab inner text second line'
           );
         });
-
-        it('should have added the appModernDesign class to the elements', () => {
-          assert.equal(
-            el.querySelector('#clickMeButton').className,
-            'appModernDesign',
-            'appModernDesign className should be set on elements'
-          );
-        });
-
-        it('should have added the appModernDesign class to the screen', () => {
-          assert.equal(
-            el.querySelector('#screen1').className,
-            'screen appModernDesign',
-            'appModernDesign className should be set on screen'
-          );
-        });
-
-        it('should have removed all style attributes from the elements', () => {
-          assert.isNull(
-            el.querySelector('#clickMeButton').getAttribute('style'),
-            'style attributes should be removed'
-          );
-          assert.isNull(
-            el.querySelector('#\\31 Button').getAttribute('style'),
-            'style attributes should be removed'
-          );
-        });
-
-        it('should have added type attributes to all input elements', () => {
-          assert.equal(el.querySelector("input[type='text']").id, 'nameInput');
-        });
       });
 
       it('should contain a style.css file', function() {
         assert.property(zipFiles, 'my-app/style.css');
       });
 
-      it('style.css should contain appModernDesign classes for design mode elements', () => {
-        assert.include(
-          zipFiles['my-app/style.css'],
-          '#divApplab.appModern button.appModernDesign,\n' +
-            '#divApplab.appModern button.appModernDesign:hover {\n'
-        );
-      });
-
-      it('style.css should contain id specific styles for design mode elements', () => {
-        assert.include(
-          zipFiles['my-app/style.css'],
-          '#divApplab.appModern #clickMeButton {\n' +
-            '  background-color: red;\n' +
-            '}\n' +
-            '\n' +
-            '#divApplab.appModern #\\31 Button {\n' +
-            '  background-color: blue;\n' +
-            '}'
-        );
+      it('style.css should contain the fontawesome definition', () => {
+        assert.include(zipFiles['my-app/style.css'], STYLE_CSS_CONTENT);
       });
 
       it('should contain a code.js file', function() {
@@ -640,62 +600,14 @@ describe('Applab Exporter,', function() {
             '#divApplab inner text second line'
           );
         });
-
-        it('should have added the appModernDesign class to the elements', () => {
-          assert.equal(
-            el.querySelector('#clickMeButton').className,
-            'appModernDesign',
-            'appModernDesign className should be set on elements'
-          );
-        });
-
-        it('should have added the appModernDesign class to the screen', () => {
-          assert.equal(
-            el.querySelector('#screen1').className,
-            'screen appModernDesign',
-            'appModernDesign className should be set on screen'
-          );
-        });
-
-        it('should have removed all style attributes from the elements', () => {
-          assert.isNull(
-            el.querySelector('#clickMeButton').getAttribute('style'),
-            'style attributes should be removed'
-          );
-          assert.isNull(
-            el.querySelector('#\\31 Button').getAttribute('style'),
-            'style attributes should be removed'
-          );
-        });
-
-        it('should have added type attributes to all input elements', () => {
-          assert.equal(el.querySelector("input[type='text']").id, 'nameInput');
-        });
       });
 
       it('should contain a style.css file', function() {
         assert.property(zipFiles, 'my-app/assets/style.css');
       });
 
-      it('style.css should contain appModernDesign classes for design mode elements', () => {
-        assert.include(
-          zipFiles['my-app/assets/style.css'],
-          '#divApplab.appModern button.appModernDesign,\n' +
-            '#divApplab.appModern button.appModernDesign:hover {\n'
-        );
-      });
-
-      it('style.css should contain id specific styles for design mode elements', () => {
-        assert.include(
-          zipFiles['my-app/assets/style.css'],
-          '#divApplab.appModern #clickMeButton {\n' +
-            '  background-color: red;\n' +
-            '}\n' +
-            '\n' +
-            '#divApplab.appModern #\\31 Button {\n' +
-            '  background-color: blue;\n' +
-            '}'
-        );
+      it('style.css should contain the fontawesome definition', () => {
+        assert.include(zipFiles['my-app/assets/style.css'], STYLE_CSS_CONTENT);
       });
 
       it('should contain a code.j file', function() {


### PR DESCRIPTION
* Fixes https://codedotorg.atlassian.net/browse/STAR-604 and https://codedotorg.atlassian.net/browse/STAR-605
* Keep all of the inline styles in our `levelHTML` in the exported HTML - don't generate CSS classes on the fly. This simplifies export, ensures that the exported projects more closely resemble the project in development, and fixes the two bugs listed above.
