### PR TITLE
fix valueTypeTabShapeMap imports

### DIFF
--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -8,7 +8,7 @@ import jsonic from 'jsonic';
 import {parseElement} from '@cdo/apps/xml';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
 import {customInputTypes} from '@cdo/apps/p5lab/gamelab/blocks';
-import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/gamelab/GameLab';
+import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/P5Lab';
 import animationListModule, {
   setInitialAnimationList
 } from '@cdo/apps/p5lab/gamelab/animationListModule';

--- a/apps/src/sites/studio/pages/blocks/index.js
+++ b/apps/src/sites/studio/pages/blocks/index.js
@@ -4,7 +4,7 @@ import jsonic from 'jsonic';
 import {parseElement} from '@cdo/apps/xml';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
 import {customInputTypes} from '@cdo/apps/p5lab/gamelab/blocks';
-import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/gamelab/GameLab';
+import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/P5Lab';
 import {shrinkBlockSpaceContainer} from '@cdo/apps/templates/instructions/utils';
 import animationListModule, {
   setInitialAnimationList

--- a/apps/src/sites/studio/pages/shared_blockly_functions/edit.js
+++ b/apps/src/sites/studio/pages/shared_blockly_functions/edit.js
@@ -3,7 +3,7 @@ import unzip from 'lodash/unzip';
 import assetUrl from '@cdo/apps/code-studio/assetUrl';
 
 import {install, customInputTypes} from '@cdo/apps/p5lab/gamelab/blocks';
-import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/gamelab/GameLab';
+import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/P5Lab';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
 
 const customSimpleDialog = function({


### PR DESCRIPTION
Wrong import was causing block edit pages to break on levelbuilder 
Bug introduced by #29918