### PR TITLE
School Info Completeness: Change from nces school type to non-nces school type

### DIFF
--- a/apps/src/lib/ui/SchoolInfoInterstitial.jsx
+++ b/apps/src/lib/ui/SchoolInfoInterstitial.jsx
@@ -309,7 +309,7 @@ export default class SchoolInfoInterstitial extends React.Component {
 
   onSchoolTypeChange = event => {
     const newType = event ? event.target.value : '';
-    this.setState({schoolType: newType, errors: {}});
+    this.setState({schoolType: newType, ncesSchoolId: '', errors: {}});
   };
 
   onSchoolChange = (_, event) => {

--- a/apps/test/unit/lib/ui/SchoolInfoInterstitialTest.jsx
+++ b/apps/test/unit/lib/ui/SchoolInfoInterstitialTest.jsx
@@ -216,10 +216,10 @@ describe('SchoolInfoInterstitial', () => {
         }}
       />
     );
-    expect(wrapper.state('school_type')).to.equal('public');
+    expect(wrapper.state('schoolType')).to.equal('public');
     expect(wrapper.state('ncesSchoolId')).to.equal('123');
     wrapper.instance().onSchoolTypeChange({target: {value: 'after school'}});
-    expect(wrapper.state('school_type')).to.equal('after school');
+    expect(wrapper.state('schoolType')).to.equal('after school');
     expect(wrapper.state('ncesSchoolId')).to.equal('');
   });
 

--- a/apps/test/unit/lib/ui/SchoolInfoInterstitialTest.jsx
+++ b/apps/test/unit/lib/ui/SchoolInfoInterstitialTest.jsx
@@ -200,6 +200,29 @@ describe('SchoolInfoInterstitial', () => {
     expect(wrapper.state('ncesSchoolId')).to.equal('');
   });
 
+  it('clears the school ID when school_type is changed', () => {
+    const wrapper = shallow(
+      <SchoolInfoInterstitial
+        {...MINIMUM_PROPS}
+        scriptData={{
+          ...MINIMUM_PROPS.scriptData,
+          existingSchoolInfo: {
+            school_id: '123',
+            country: 'United States',
+            school_type: 'public',
+            school_name: 'Test School',
+            full_address: 'Seattle'
+          }
+        }}
+      />
+    );
+    expect(wrapper.state('school_type')).to.equal('public');
+    expect(wrapper.state('ncesSchoolId')).to.equal('123');
+    wrapper.instance().onSchoolTypeChange({target: {value: 'after school'}});
+    expect(wrapper.state('school_type')).to.equal('after school');
+    expect(wrapper.state('ncesSchoolId')).to.equal('');
+  });
+
   it('interprets initial country "US" as "United States"', () => {
     const wrapper = shallow(
       <SchoolInfoInterstitial


### PR DESCRIPTION
[Bug](https://docs.google.com/document/d/1KxMHcnQlTCKWJxHi0mK2uh_dBSIcqvWCe_4vTd7OCYI/edit?pli=1#bookmark=id.fs1jtxqnom2u)

Context:  nces school type:  public, private or charter

Fix:  Clear ncesId on school type change.
Result: SchoolId changes from ncesSchoolId to null. Since the schoolId changes, the update_and_add_users_school_infos is called and the database is updated with the new entry.