### PR TITLE
lazy load aws-sdk package

### DIFF
--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -348,5 +348,20 @@ function createNewFirehose() {
   });
 }
 
-const firehoseClient = new FirehoseClient();
-export default firehoseClient;
+let singleton;
+function getSingleton() {
+  if (!singleton) {
+    singleton = new FirehoseClient();
+  }
+  return singleton;
+}
+
+function putRecord(data, options) {
+  getSingleton().putRecord(data, options);
+}
+
+function putRecordBatch(data, options) {
+  getSingleton().putRecordBatch(data, options);
+}
+
+export default {putRecord, putRecordBatch};

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -347,18 +347,17 @@ function createNewFirehose(AWS, Firehose) {
 
 let promise;
 function getSingleton() {
-  return Promise.all([
-    import('aws-sdk/lib/core'),
-    import('aws-sdk/clients/firehose'),
-    import('aws-sdk/lib/config')
-  ]).then(([{default: AWS}, {default: Firehose}]) => {
-    if (!promise) {
-      promise = new Promise(resolve =>
-        resolve(new FirehoseClient(AWS, Firehose))
-      );
-    }
-    return promise;
-  });
+  if (!promise) {
+    promise = Promise.all([
+      import('aws-sdk/lib/core'),
+      import('aws-sdk/clients/firehose'),
+      import('aws-sdk/lib/config')
+    ]).then(
+      ([{default: AWS}, {default: Firehose}]) =>
+        new Promise(resolve => resolve(new FirehoseClient(AWS, Firehose)))
+    );
+  }
+  return promise;
 }
 
 function putRecord(data, options) {

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -358,6 +358,9 @@ function getSingleton() {
           new Promise(resolve => resolve(new FirehoseClient(AWS, Firehose)))
       )
       .catch(() => {
+        // If the import() network request failed, make it look like we never
+        // requested the singleton object before so that the next call to
+        // firehose will try the import() call again.
         promise = null;
       });
   }

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -311,35 +311,39 @@ class FirehoseClient {
 // This code sets up an AWS config against a very restricted user, so this is
 // not a concern, we just don't want to make things super obvious. For the
 // plaintext, contact asher or eric.
-// eslint-disable-next-line
-const _0x12ed = [
-  '\x41\x4b\x49\x41\x4a\x41\x41\x4d\x42\x59\x4d\x36\x55\x53\x59\x54\x34\x35\x34\x51',
-  '\x78\x4e\x4e\x39\x4e\x79\x32\x61\x6d\x39\x78\x75\x4b\x79\x57\x39\x53\x2b\x4e\x76\x41\x77\x33\x67\x68\x68\x74\x68\x72\x6b\x37\x6b\x6e\x51\x59\x54\x77\x6d\x4d\x48',
-  '\x75\x73\x2d\x65\x61\x73\x74\x2d\x31',
-  '\x63\x6f\x6e\x66\x69\x67'
-];
-(function(_0xb54a92, _0x4e682a) {
-  var _0x44f3e8 = function(_0x35c55a) {
-    while (--_0x35c55a) {
-      _0xb54a92['\x70\x75\x73\x68'](_0xb54a92['\x73\x68\x69\x66\x74']());
-    }
+function createNewFirehose() {
+  // eslint-disable-next-line
+  const _0x12ed = [
+    '\x41\x4b\x49\x41\x4a\x41\x41\x4d\x42\x59\x4d\x36\x55\x53\x59\x54\x34\x35\x34\x51',
+    '\x78\x4e\x4e\x39\x4e\x79\x32\x61\x6d\x39\x78\x75\x4b\x79\x57\x39\x53\x2b\x4e\x76\x41\x77\x33\x67\x68\x68\x74\x68\x72\x6b\x37\x6b\x6e\x51\x59\x54\x77\x6d\x4d\x48',
+    '\x75\x73\x2d\x65\x61\x73\x74\x2d\x31',
+    '\x63\x6f\x6e\x66\x69\x67'
+  ];
+  (function(_0xb54a92, _0x4e682a) {
+    var _0x44f3e8 = function(_0x35c55a) {
+      while (--_0x35c55a) {
+        _0xb54a92['\x70\x75\x73\x68'](_0xb54a92['\x73\x68\x69\x66\x74']());
+      }
+    };
+    _0x44f3e8(++_0x4e682a);
+  })(_0x12ed, 0x127);
+  var _0xd12e = function(_0x2cedd5, _0x518781) {
+    _0x2cedd5 = _0x2cedd5 - 0x0;
+    var _0x4291ea = _0x12ed[_0x2cedd5];
+    return _0x4291ea;
   };
-  _0x44f3e8(++_0x4e682a);
-})(_0x12ed, 0x127);
-var _0xd12e = function(_0x2cedd5, _0x518781) {
-  _0x2cedd5 = _0x2cedd5 - 0x0;
-  var _0x4291ea = _0x12ed[_0x2cedd5];
-  return _0x4291ea;
-};
-AWS[_0xd12e('0x0')] = new AWS['\x43\x6f\x6e\x66\x69\x67']({
-  accessKeyId: _0xd12e('0x1'),
-  secretAccessKey: _0xd12e('0x2'),
-  region: _0xd12e('0x3')
-});
+  AWS[_0xd12e('0x0')] = new AWS['\x43\x6f\x6e\x66\x69\x67']({
+    accessKeyId: _0xd12e('0x1'),
+    secretAccessKey: _0xd12e('0x2'),
+    region: _0xd12e('0x3')
+  });
 
-const FIREHOSE = new Firehose({
-  apiVersion: '2015-08-04',
-  correctClockSkew: true
-});
+  return new Firehose({
+    apiVersion: '2015-08-04',
+    correctClockSkew: true
+  });
+}
+
+const FIREHOSE = createNewFirehose();
 const firehoseClient = new FirehoseClient();
 export default firehoseClient;

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -56,6 +56,10 @@ const deliveryStreamName = 'analysis-events';
 // TODO(asher): Determine whether any of the utility functions herein should be
 // moved elsewhere, e.g., to apps/src/util.js.
 class FirehoseClient {
+  constructor() {
+    this.firehose = createNewFirehose();
+  }
+
   /**
    * Returns the current environment.
    * @return {string} The current environment, e.g., "staging" or "production".
@@ -240,7 +244,7 @@ class FirehoseClient {
       return;
     }
 
-    FIREHOSE.putRecord(
+    this.firehose.putRecord(
       {
         DeliveryStreamName: deliveryStreamName,
         Record: {
@@ -298,7 +302,7 @@ class FirehoseClient {
       };
     });
 
-    FIREHOSE.putRecordBatch(
+    this.firehose.putRecordBatch(
       {
         DeliveryStreamName: deliveryStreamName,
         Records: batch
@@ -344,6 +348,5 @@ function createNewFirehose() {
   });
 }
 
-const FIREHOSE = createNewFirehose();
 const firehoseClient = new FirehoseClient();
 export default firehoseClient;

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -348,20 +348,24 @@ function createNewFirehose() {
   });
 }
 
-let singleton;
+let promise;
 function getSingleton() {
-  if (!singleton) {
-    singleton = new FirehoseClient();
+  if (!promise) {
+    promise = new Promise(resolve => resolve(new FirehoseClient()));
   }
-  return singleton;
+  return promise;
 }
 
 function putRecord(data, options) {
-  getSingleton().putRecord(data, options);
+  getSingleton().then(firehoseClient =>
+    firehoseClient.putRecord(data, options)
+  );
 }
 
 function putRecordBatch(data, options) {
-  getSingleton().putRecordBatch(data, options);
+  getSingleton().then(firehoseClient =>
+    firehoseClient.putRecordBatch(data, options)
+  );
 }
 
 export default {putRecord, putRecordBatch};

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -352,10 +352,14 @@ function getSingleton() {
       import('aws-sdk/lib/core'),
       import('aws-sdk/clients/firehose'),
       import('aws-sdk/lib/config')
-    ]).then(
-      ([{default: AWS}, {default: Firehose}]) =>
-        new Promise(resolve => resolve(new FirehoseClient(AWS, Firehose)))
-    );
+    ])
+      .then(
+        ([{default: AWS}, {default: Firehose}]) =>
+          new Promise(resolve => resolve(new FirehoseClient(AWS, Firehose)))
+      )
+      .catch(() => {
+        promise = null;
+      });
   }
   return promise;
 }


### PR DESCRIPTION
Removes 211KB of parsed JS from every code studio page load by lazy-loading the `aws-sdk`npm package (147KB) and its dependences.

This is a follow-on to #30937 , which introduced our very first usage of dynamic import() statements via the loadable-components package. See that PR for context.

The `aws-sdk` package is a great candidate for lazy-loading because its only caller (Firehose) uses it to record log messages to our servers, so there is no user-visible lag as a result of lazy-loading. Because it is not user-visible, there is also no need for loading UX or error UX.

Visually, this PR extracts the following code from code-studio-common.js which is present on every code studio page:

before:
![aws-sdk](https://user-images.githubusercontent.com/8001765/68443011-ab0a1980-0187-11ea-8cde-2672e15a7b50.png)

after:
![Screen Shot 2019-11-07 at 5 47 54 PM](https://user-images.githubusercontent.com/8001765/68442745-ce809480-0186-11ea-9ec0-22ac921727c8.png)
