### PR TITLE
Peer Review Dashboard: Require instructors to select a status before submit

### DIFF
--- a/apps/src/sites/studio/pages/peer_reviews/show.js
+++ b/apps/src/sites/studio/pages/peer_reviews/show.js
@@ -1,3 +1,23 @@
 import PlcHeader from '@cdo/apps/code-studio/plc/header';
 
 window.dashboard.plcHeader = PlcHeader;
+
+// For PLC reviewers, the submit button is disabled by default.
+// Enable it once a radio button is selected.
+function enableSubmitOnRadioChange() {
+  const form = document.querySelector('form.edit_peer_review');
+  const radios = form.querySelectorAll('input[type=radio]');
+  const submitButton = form.querySelector('input[type=submit]');
+  if (submitButton.disabled) {
+    const onRadioChange = () => {
+      submitButton.disabled = false;
+      radios.forEach(el => el.removeEventListener('change', onRadioChange));
+    };
+    radios.forEach(el => el.addEventListener('change', onRadioChange));
+  }
+}
+
+window.addEventListener('DOMContentLoaded', function onDomContentLoaded() {
+  window.removeEventListener('DOMContentLoaded', onDomContentLoaded);
+  enableSubmitOnRadioChange();
+});

--- a/dashboard/app/controllers/peer_reviews_controller.rb
+++ b/dashboard/app/controllers/peer_reviews_controller.rb
@@ -47,13 +47,10 @@ class PeerReviewsController < ApplicationController
   end
 
   def update
-    begin
-      @peer_review.update!(peer_review_params.merge(reviewer: current_user, from_instructor: current_user.permission?('plc_reviewer')))
-    rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid => error
-      Honeybadger.notify(error, error_message: "Error updating peer review", context: {peer_review: @peer_review})
-      redirect_to peer_review_path(@peer_review)
-      return
-    end
+    @peer_review.update! peer_review_params.merge(
+      reviewer: current_user,
+      from_instructor: current_user.plc_reviewer?
+    )
 
     flash[:notice] = t('peer_review.review_submitted')
 

--- a/dashboard/app/models/peer_review.rb
+++ b/dashboard/app/models/peer_review.rb
@@ -37,6 +37,8 @@ class PeerReview < ActiveRecord::Base
   belongs_to :level
   belongs_to :level_source
 
+  validates :status, inclusion: {in: %w{accepted rejected}}, if: -> {from_instructor}
+
   after_update :mark_user_level, if: -> {status_changed? || data_changed?}
 
   SYSTEM_DELETED_DATA = ''.freeze

--- a/dashboard/app/views/peer_reviews/show.html.haml
+++ b/dashboard/app/views/peer_reviews/show.html.haml
@@ -57,4 +57,4 @@
       = f.text_area :data, rows: 7, placeholder: 'Type your peer review here', style: 'width: 100%; box-sizing: border-box;', disabled: reviewed
     - unless reviewed
       .actions
-        = f.submit 'Submit', class: 'btn btn-large btn-primary'
+        = f.submit 'Submit', class: 'btn btn-large btn-primary', disabled: current_user.plc_reviewer?


### PR DESCRIPTION
[PLC-62](https://codedotorg.atlassian.net/browse/PLC-62) / [Spec](https://docs.google.com/document/d/1rtSHDfNh2E6sVpoF1kM2zIy0SQRHrfX3bfnkp5AHEW8/edit) / "Add validation for lead reviewer so they cannot submit without selecting yes or no"

This change requires PD instructors to select "accepted" or "rejected" status before submitting a review in the peer review dashboard.  I'm enforcing this on the client and server: On the client by disabling the submit button until a status is selected, and on the server with a model validation.

Here's the new behavior:

![Peek 2019-07-31 17-59](https://user-images.githubusercontent.com/1615761/62258314-bd253080-b3be-11e9-8bc7-1fff538e1081.gif)

I've removed a Honeybadger notification and success message when a review fails to save because we actually _want_ to lean on our validations.

This may obsolete [PLC-65 "Remove escalation logic for reviews"](https://codedotorg.atlassian.net/browse/PLC-65), except in terms of removing unneeded code, because escalation logic is normally triggered by submitting a review with no status.
