### PR TITLE
[Widget Mode] Create extra-width mode that levelbuilders can use to create widgets

### DIFF
--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -105,18 +105,20 @@ class ApplabVisualizationColumn extends React.Component {
       );
     }
     const chromelessShare = dom.isMobile() && !dom.isIPad();
-    const visualizationColumnClassNames = classNames({
-      with_padding: this.props.visualizationHasPadding,
-      responsive: this.props.isResponsive,
-      pin_bottom: !this.props.hideSource && this.props.pinWorkspaceToBottom,
+    const visualizationColumnClassNames = this.props.widgetMode
+      ? 'widgetWidth'
+      : classNames({
+          with_padding: this.props.visualizationHasPadding,
+          responsive: this.props.isResponsive,
+          pin_bottom: !this.props.hideSource && this.props.pinWorkspaceToBottom,
 
-      // the below replicates some logic in StudioApp.handleHideSource_ which
-      // imperatively changes the css classes depending on various share
-      // parameters. This logic really shouldn't live in StudioApp, so I don't
-      // feel too bad about copying it here, where it should really live...
-      chromelessShare: chromelessShare && this.props.isShareView,
-      wireframeShare: !chromelessShare && this.props.isShareView
-    });
+          // the below replicates some logic in StudioApp.handleHideSource_ which
+          // imperatively changes the css classes depending on various share
+          // parameters. This logic really shouldn't live in StudioApp, so I don't
+          // feel too bad about copying it here, where it should really live...
+          chromelessShare: chromelessShare && this.props.isShareView,
+          wireframeShare: !chromelessShare && this.props.isShareView
+        });
 
     return (
       <div

--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -65,6 +65,7 @@ class ApplabVisualizationColumn extends React.Component {
     pinWorkspaceToBottom: PropTypes.bool.isRequired,
     isPaused: PropTypes.bool,
     awaitingContainedResponse: PropTypes.bool.isRequired,
+    widgetMode: PropTypes.bool,
 
     // non redux backed
     isEditingProject: PropTypes.bool.isRequired,
@@ -73,12 +74,15 @@ class ApplabVisualizationColumn extends React.Component {
   };
 
   render() {
+    let appWidth = this.props.widgetMode
+      ? applabConstants.WIDGET_WIDTH
+      : applabConstants.APP_WIDTH;
     let visualization = [
       <Visualization key="1" />,
       this.props.isIframeEmbed && !this.props.isRunning && (
         <IFrameEmbedOverlay
           key="2"
-          appWidth={applabConstants.APP_WIDTH}
+          appWidth={appWidth}
           appHeight={applabConstants.APP_HEIGHT}
         />
       )
@@ -171,6 +175,7 @@ export default connect(function propsFromStore(state) {
     awaitingContainedResponse: state.runState.awaitingContainedResponse,
     isPaused: state.runState.isDebuggerPaused,
     playspacePhoneFrame: state.pageConstants.playspacePhoneFrame,
-    pinWorkspaceToBottom: state.pageConstants.pinWorkspaceToBottom
+    pinWorkspaceToBottom: state.pageConstants.pinWorkspaceToBottom,
+    widgetMode: state.pageConstants.widgetMode
   };
 })(Radium(ApplabVisualizationColumn));

--- a/apps/src/applab/ApplabVisualizationColumn.story.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.story.jsx
@@ -34,7 +34,8 @@ export default function(storybook) {
     isProjectLevel: false,
     isResponsive: false,
     isSubmittable: false,
-    isSubmitted: false
+    isSubmitted: false,
+    widgetMode: false
   };
   const runState = {
     isRunning: false,

--- a/apps/src/applab/PhoneFrame.jsx
+++ b/apps/src/applab/PhoneFrame.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '../util/color';
-import * as applabConstants from './constants';
 import ScreenSelector, {styles as ScreenSelectorStyles} from './ScreenSelector';
 import {RunButton, ResetButton} from '../templates/GameButtons';
 import {styles as CompletionButtonStyles} from '../templates/CompletionButton';
@@ -27,9 +26,6 @@ const styles = {
   phoneFrameBottom: {
     borderBottomLeftRadius: RADIUS,
     borderBottomRightRadius: RADIUS
-  },
-  nonResponsive: {
-    maxWidth: applabConstants.APP_WIDTH
   },
   screenSelector: {
     marginLeft: 'auto',

--- a/apps/src/applab/PhoneFrame.jsx
+++ b/apps/src/applab/PhoneFrame.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
 import Radium from 'radium';
 import color from '../util/color';
 import ScreenSelector, {styles as ScreenSelectorStyles} from './ScreenSelector';
@@ -52,6 +53,14 @@ const styles = {
   },
   buttonMinWidth: {
     minWidth: CompletionButtonStyles.phoneFrameButton.minWidth
+  },
+  widgetModeTop: {
+    visibility: 'hidden',
+    height: '0'
+  },
+  widgetModeBottom: {
+    display: 'block',
+    height: FRAME_HEIGHT
   }
 };
 
@@ -62,7 +71,8 @@ class PhoneFrame extends React.Component {
     showSelector: PropTypes.bool.isRequired,
     isPaused: PropTypes.bool.isRequired,
     onScreenCreate: PropTypes.func.isRequired,
-    children: PropTypes.node
+    children: PropTypes.node,
+    widgetMode: PropTypes.bool
   };
 
   render() {
@@ -71,17 +81,22 @@ class PhoneFrame extends React.Component {
       screenIds,
       showSelector,
       isPaused,
-      onScreenCreate
+      onScreenCreate,
+      widgetMode
     } = this.props;
     return (
       <span id="phoneFrame">
         <div id="phoneFrameWrapper">
           <div
-            style={[
-              styles.phoneFrame,
-              styles.phoneFrameTop,
-              isDark && styles.phoneFrameDark
-            ]}
+            style={
+              widgetMode
+                ? styles.widgetModeTop
+                : [
+                    styles.phoneFrame,
+                    styles.phoneFrameTop,
+                    isDark && styles.phoneFrameDark
+                  ]
+            }
           >
             {showSelector && (
               <div style={styles.screenSelector}>
@@ -100,11 +115,15 @@ class PhoneFrame extends React.Component {
           </div>
           {this.props.children}
           <div
-            style={[
-              styles.phoneFrame,
-              styles.phoneFrameBottom,
-              isDark && styles.phoneFrameDark
-            ]}
+            style={
+              widgetMode
+                ? styles.widgetModeBottom
+                : [
+                    styles.phoneFrame,
+                    styles.phoneFrameBottom,
+                    isDark && styles.phoneFrameDark
+                  ]
+            }
           >
             <div style={styles.centeredInFrame}>
               <RunButton hidden={false} style={styles.buttonMinWidth} />
@@ -117,4 +136,6 @@ class PhoneFrame extends React.Component {
   }
 }
 
-export default Radium(PhoneFrame);
+export default connect(state => ({
+  widgetMode: state.pageConstants.widgetMode
+}))(Radium(PhoneFrame));

--- a/apps/src/applab/Visualization.jsx
+++ b/apps/src/applab/Visualization.jsx
@@ -19,7 +19,6 @@ import MakerStatusOverlay from '../lib/kits/maker/ui/MakerStatusOverlay';
 
 const styles = {
   nonResponsive: {
-    width: applabConstants.APP_WIDTH,
     height: applabConstants.APP_HEIGHT - applabConstants.FOOTER_HEIGHT
   },
   share: {
@@ -35,7 +34,6 @@ const styles = {
   },
   screenBlock: {
     backgroundColor: 'rgba(255, 255, 255, 0.5)',
-    width: applabConstants.APP_WIDTH,
     height: applabConstants.APP_HEIGHT - applabConstants.FOOTER_HEIGHT,
     overflow: 'hidden',
     // layer 1 is design mode/div applab
@@ -56,7 +54,8 @@ class Visualization extends React.Component {
     isPaused: PropTypes.bool.isRequired,
     isRunning: PropTypes.bool.isRequired,
     playspacePhoneFrame: PropTypes.bool.isRequired,
-    isResponsive: PropTypes.bool.isRequired
+    isResponsive: PropTypes.bool.isRequired,
+    widgetMode: PropTypes.bool
   };
 
   handleDisableMaker = () => project.toggleMakerEnabled();
@@ -67,7 +66,9 @@ class Visualization extends React.Component {
   };
 
   render() {
-    const appWidth = applabConstants.APP_WIDTH;
+    const appWidth = this.props.widgetMode
+      ? applabConstants.WIDGET_WIDTH
+      : applabConstants.APP_WIDTH;
     const appHeight =
       applabConstants.APP_HEIGHT - applabConstants.FOOTER_HEIGHT;
 
@@ -79,7 +80,10 @@ class Visualization extends React.Component {
           with_padding: this.props.visualizationHasPadding
         })}
         style={[
-          !this.props.isResponsive && styles.nonResponsive,
+          !this.props.isResponsive && {
+            ...styles.nonResponsive,
+            ...{width: appWidth}
+          },
           this.props.isShareView && styles.share,
           this.props.playspacePhoneFrame && styles.phoneFrame,
           this.props.playspacePhoneFrame &&
@@ -106,7 +110,7 @@ class Visualization extends React.Component {
         />
         <div
           style={[
-            styles.screenBlock,
+            {...styles.screenBlock, ...{width: appWidth}},
             !(this.props.isPaused && this.props.playspacePhoneFrame) &&
               commonStyles.hidden
           ]}
@@ -122,5 +126,6 @@ export default connect(state => ({
   isRunning: state.runState.isRunning,
   isPaused: state.runState.isDebuggerPaused,
   playspacePhoneFrame: state.pageConstants.playspacePhoneFrame,
-  isResponsive: isResponsiveFromState(state)
+  isResponsive: isResponsiveFromState(state),
+  widgetMode: state.pageConstants.widgetMode
 }))(Radium(Visualization));

--- a/apps/src/applab/Visualization.jsx
+++ b/apps/src/applab/Visualization.jsx
@@ -75,10 +75,14 @@ class Visualization extends React.Component {
     return (
       <div
         id={VISUALIZATION_DIV_ID}
-        className={classNames({
-          responsive: this.props.isResponsive,
-          with_padding: this.props.visualizationHasPadding
-        })}
+        className={
+          this.props.widgetMode
+            ? 'widgetWidth widgetHeight'
+            : classNames({
+                responsive: this.props.isResponsive,
+                with_padding: this.props.visualizationHasPadding
+              })
+        }
         style={[
           !this.props.isResponsive && {
             ...styles.nonResponsive,

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -147,7 +147,10 @@ function loadLevel() {
   // This led to lots of hackery in the code to properly scale the visualization
   // area. Width/height are now constant, but much of the hackery still remains
   // since I don't understand it well enough.
-  Applab.appWidth = applabConstants.APP_WIDTH;
+  Applab.appWidth = level.widgetMode
+    ? applabConstants.WIDGET_WIDTH
+    : applabConstants.APP_WIDTH;
+
   Applab.appHeight = applabConstants.APP_HEIGHT;
 
   // In share mode we need to reserve some number of pixels for our in-app
@@ -567,7 +570,9 @@ Applab.init = function(config) {
 
   config.appMsg = applabMsg;
 
-  config.mobileNoPaddingShareWidth = applabConstants.APP_WIDTH;
+  config.mobileNoPaddingShareWidth = config.level.widgetMode
+    ? applabConstants.WIDGET_WIDTH
+    : applabConstants.APP_WIDTH;
 
   config.enableShowLinesCount = false;
 
@@ -663,7 +668,9 @@ Applab.init = function(config) {
       config.expoSession,
       Applab.setAndroidExportProps
     ),
-    nonResponsiveVisualizationColumnWidth: applabConstants.APP_WIDTH,
+    nonResponsiveVisualizationColumnWidth: config.level.widgetMode
+      ? applabConstants.WIDGET_WIDTH
+      : applabConstants.APP_WIDTH,
     visualizationHasPadding: !config.noPadding,
     hasDataMode: !config.level.hideViewDataButton,
     hasDesignMode: !config.level.hideDesignMode,

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -677,7 +677,8 @@ Applab.init = function(config) {
     showDebugWatch:
       !!config.level.isProjectLevel || config.level.showDebugWatch,
     showMakerToggle:
-      !!config.level.isProjectLevel || config.level.makerlabEnabled
+      !!config.level.isProjectLevel || config.level.makerlabEnabled,
+    widgetMode: config.level.widgetMode
   });
 
   config.dropletConfig = dropletConfig;

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -570,9 +570,7 @@ Applab.init = function(config) {
 
   config.appMsg = applabMsg;
 
-  config.mobileNoPaddingShareWidth = config.level.widgetMode
-    ? applabConstants.WIDGET_WIDTH
-    : applabConstants.APP_WIDTH;
+  config.mobileNoPaddingShareWidth = applabConstants.APP_WIDTH;
 
   config.enableShowLinesCount = false;
 
@@ -668,9 +666,7 @@ Applab.init = function(config) {
       config.expoSession,
       Applab.setAndroidExportProps
     ),
-    nonResponsiveVisualizationColumnWidth: config.level.widgetMode
-      ? applabConstants.WIDGET_WIDTH
-      : applabConstants.APP_WIDTH,
+    nonResponsiveVisualizationColumnWidth: applabConstants.APP_WIDTH,
     visualizationHasPadding: !config.noPadding,
     hasDataMode: !config.level.hideViewDataButton,
     hasDesignMode: !config.level.hideDesignMode,

--- a/apps/src/applab/constants.js
+++ b/apps/src/applab/constants.js
@@ -4,6 +4,7 @@ import {ICON_PREFIX, ICON_PREFIX_REGEX} from '../assetManagement/assetPrefix';
 export {ICON_PREFIX, ICON_PREFIX_REGEX};
 export const FOOTER_HEIGHT = 30;
 export const APP_WIDTH = 320;
+export const WIDGET_WIDTH = 600;
 export const APP_HEIGHT = 480;
 export const DESIGN_ELEMENT_ID_PREFIX = 'design_';
 export const NEW_SCREEN = 'New screen...';

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -12,6 +12,7 @@ import elementLibrary from './library';
 import * as applabConstants from '../constants';
 import * as elementUtils from './elementUtils';
 import themeValues from '../themeValues';
+import {getStore} from '../../redux';
 
 class ScreenProperties extends React.Component {
   static propTypes = {
@@ -153,13 +154,16 @@ export default {
   themeValues: themeValues.screen,
 
   create: function() {
+    let width = getStore().getState().pageConstants.widgetMode
+      ? applabConstants.WIDGET_WIDTH
+      : applabConstants.APP_WIDTH;
     const element = document.createElement('div');
     element.setAttribute('class', 'screen');
     element.setAttribute('tabIndex', '1');
     element.style.display = 'block';
     element.style.height =
       applabConstants.APP_HEIGHT - applabConstants.FOOTER_HEIGHT + 'px';
-    element.style.width = applabConstants.APP_WIDTH + 'px';
+    element.style.width = width + 'px';
     element.style.left = '0px';
     element.style.top = '0px';
     // We want our screen to be behind canvases. By setting any z-index on the

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -154,9 +154,11 @@ export default {
   themeValues: themeValues.screen,
 
   create: function() {
-    let width = getStore().getState().pageConstants.widgetMode
-      ? applabConstants.WIDGET_WIDTH
-      : applabConstants.APP_WIDTH;
+    let pageConstants = getStore().getState().pageConstants;
+    let width =
+      pageConstants && pageConstants.widgetMode
+        ? applabConstants.WIDGET_WIDTH
+        : applabConstants.APP_WIDTH;
     const element = document.createElement('div');
     element.setAttribute('class', 'screen');
     element.setAttribute('tabIndex', '1');

--- a/apps/src/lib/ui/VisualizationResizeBar.jsx
+++ b/apps/src/lib/ui/VisualizationResizeBar.jsx
@@ -138,6 +138,7 @@ class VisualizationResizeBar extends React.Component {
 export const UnconnectedVisualizationResizeBar = VisualizationResizeBar;
 export default connect(state => ({
   hidden:
+    state.pageConstants.widgetMode ||
     // e.g. jigsaw
     state.pageConstants.noVisualization ||
     // e.g. share pages

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -66,7 +66,8 @@ var ALLOWED_KEYS = new Set([
   'expoGenerateApk',
   'expoCheckApkBuild',
   'expoCancelApkBuild',
-  'allowExportExpo'
+  'allowExportExpo',
+  'widgetMode'
 ]);
 
 const initialState = {

--- a/apps/src/templates/VisualizationOverlay.jsx
+++ b/apps/src/templates/VisualizationOverlay.jsx
@@ -133,6 +133,7 @@ export default connect(state => ({
 
 export function shouldRunStateOverlaysBeVisible(state) {
   return (
+    !state.pageConstants.widgetMode &&
     !state.pageConstants.hideCoordinateOverlay &&
     !state.pageConstants.isShareView
   );
@@ -140,6 +141,7 @@ export function shouldRunStateOverlaysBeVisible(state) {
 
 export function shouldOverlaysBeVisible(state) {
   return (
+    !state.pageConstants.widgetMode &&
     !state.pageConstants.hideCoordinateOverlay &&
     !(state.runState.isRunning || state.pageConstants.isShareView)
   );

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -179,7 +179,7 @@ class TopInstructions extends Component {
     shortInstructions: PropTypes.string,
     isMinecraft: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
-    widgetMode: PropTypes.bool.isRequired
+    widgetMode: PropTypes.bool
   };
 
   constructor(props) {

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -28,6 +28,7 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import queryString from 'query-string';
 import InstructionsCSF from './InstructionsCSF';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
@@ -177,7 +178,8 @@ class TopInstructions extends Component {
     hidden: PropTypes.bool.isRequired,
     shortInstructions: PropTypes.string,
     isMinecraft: PropTypes.bool.isRequired,
-    isRtl: PropTypes.bool.isRequired
+    isRtl: PropTypes.bool.isRequired,
+    widgetMode: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -497,6 +499,7 @@ class TopInstructions extends Component {
 
     const isCSF = !this.props.noInstructionsWhenCollapsed;
     const isCSDorCSP = this.props.noInstructionsWhenCollapsed;
+    const widgetWidth = WIDGET_WIDTH + 'px';
 
     const mainStyle = [
       this.props.isRtl ? styles.mainRtl : styles.main,
@@ -504,7 +507,9 @@ class TopInstructions extends Component {
         height: this.props.height - RESIZER_HEIGHT
       },
       this.props.noVisualization && styles.noViz,
-      this.props.isEmbedView && styles.embedView
+      this.props.isEmbedView && styles.embedView,
+      this.props.widgetMode &&
+        (this.props.isRtl ? {right: widgetWidth} : {left: widgetWidth})
     ];
     const ttsUrl = this.props.ttsLongInstructionsUrl;
     const videoData = this.props.levelVideos ? this.props.levelVideos[0] : [];
@@ -764,7 +769,8 @@ export default connect(
     teacherMarkdown: state.instructions.teacherMarkdown,
     hidden: state.pageConstants.isShareView,
     shortInstructions: state.instructions.shortInstructions,
-    isRtl: state.isRtl
+    isRtl: state.isRtl,
+    widgetMode: state.pageConstants.widgetMode
   }),
   dispatch => ({
     toggleInstructionsCollapsed() {

--- a/apps/style/applab/style.scss
+++ b/apps/style/applab/style.scss
@@ -238,6 +238,16 @@ div#visualizationResizeBar {
   }
 }
 
+.widgetWidth {
+  width: 600px !important;
+  max-width: 600px !important;
+}
+
+.widgetHeight {
+  height: 450px !important;
+  max-height: 450px !important;
+}
+
 #visualizationColumn.wireframeShare {
   max-width: none !important;
   // If you change this width and height,

--- a/apps/test/integration/levelSolutions/applab/cspunit3.js
+++ b/apps/test/integration/levelSolutions/applab/cspunit3.js
@@ -57,7 +57,8 @@ var levelDefinition = {
   lastAttempt: '',
   levelHtml:
     '<div xmlns="http://www.w3.org/1999/xhtml" id="divApplab" class="appModern" tabindex="1" style="width: 200px; height: 200px;"><div class="screen" tabindex="1" id="screen1" style="display: block; height: 200px; width: 200px; left: 0px; top: 0px; position: absolute; z-index: 0;"></div></div>',
-  id: 'custom'
+  id: 'custom',
+  widgetMode: false
 };
 
 // Extract a list of those pixels that are actually filled

--- a/apps/test/unit/applab/ExporterTest.js
+++ b/apps/test/unit/applab/ExporterTest.js
@@ -162,7 +162,8 @@ describe('Applab Exporter,', function() {
         stage_total: 1,
         iframeEmbed: false,
         lastAttempt: null,
-        submittable: false
+        submittable: false,
+        widgetMode: false
       },
       showUnusedBlocks: true,
       fullWidth: true,

--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -50,6 +50,7 @@ class Applab < Blockly
     debugger_disabled
     makerlab_enabled
     helper_libraries
+    widget_mode
   )
 
   # List of possible skins, the first is used as a default.

--- a/dashboard/app/views/levels/editors/_applab.html.haml
+++ b/dashboard/app/views/levels/editors/_applab.html.haml
@@ -10,6 +10,8 @@
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :design_mode_at_start, description: "Start in Design Mode"}
 .field
+  = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :widget_mode, description: "Use Widget Mode"}
+.field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_design_mode, description: "Hide Design Mode"}
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :makerlab_enabled, description: "Enable Maker APIs"}


### PR DESCRIPTION
Widget mode is an option levelbuilders can use to create a non-resizable version of Applab with extra width. There is no coding or design workspace in widget mode.

**1024x768 screen resolution**
![image](https://user-images.githubusercontent.com/8324574/62329793-c6200b80-b46b-11e9-8f7f-df54bbf929b0.png)

**2256x1504 screen resolution, zoomed to 150% (default settings) on a large external monitor**
![image](https://user-images.githubusercontent.com/8324574/62329935-24e58500-b46c-11e9-82a2-1b11ce97965d.png)


Next steps: 
1. Adjust levelbuilder option to auto-disable code mode, sharing, and design mode.
2. Don't allow widget mode and embed mode to be set at the same time.

Task: https://codedotorg.atlassian.net/browse/STAR-2
Spec: https://docs.google.com/document/d/1laYGDKIgW405YrnrWcURJDAhaKXeQPHrJ7BhyUqJMQE/edit#