### PR TITLE
Metrics: Update how we log user_id for curriculum tracking pixel

### DIFF
--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -10,7 +10,7 @@ class CurriculumTrackingPixelController < ApplicationController
     end
 
     if curriculum_page
-      FirehoseClient.putRecord(
+      FirehoseClient.instance.put_record(
         {
           study: STUDY_NAME,
           study_group: 'v1',

--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -8,17 +8,18 @@ class CurriculumTrackingPixelController < ApplicationController
     if params[:from]
       curriculum_page = URI.unescape(params[:from])
     end
-    user_id = current_user&.id
 
     if curriculum_page
-      FirehoseClient.instance.put_record(
-        study: STUDY_NAME,
-        study_group: 'v0',
-        event: EVENT_NAME,
-        data_json: {
-          curriculumBuilderUrl: curriculum_page,
-          userId: user_id
-        }.to_json
+      FirehoseClient.putRecord(
+        {
+          study: STUDY_NAME,
+          study_group: 'v1',
+          event: EVENT_NAME,
+          data_json: {
+            curriculumBuilderUrl: curriculum_page
+          }.to_json
+        },
+        {includeUserId: true}
       )
     end
 

--- a/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
+++ b/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
@@ -12,7 +12,6 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
     assert @firehose_record[:study], CurriculumTrackingPixelController::STUDY_NAME
     assert @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
     assert @firehose_record[:data_json]["curriculumBuilderUrl"], curriculum_url
-    assert @firehose_record[:data_json]["userId"], user_id
   end
 
   def refute_curriculum_page_view_logged


### PR DESCRIPTION
[LP-648](https://codedotorg.atlassian.net/browse/LP-648)

It's easier for PMs to analyze data related to the curriculum tracking pixel if the user_id is not appended to the JSON data blob.  With the `includeUserId` tag, we'll now log to the user_id field of the events table for easier querying. 