### PR TITLE
Import unbuilt ES6 dance-party classes directly, so we can optimize

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -10,7 +10,8 @@ import DanceVisualizationColumn from './DanceVisualizationColumn';
 import Sounds from '../Sounds';
 import {TestResults} from '../constants';
 import {DancelabReservedWords} from './constants';
-import {DanceParty, ResourceLoader} from '@code-dot-org/dance-party';
+import DanceParty from '@code-dot-org/dance-party/src/p5.dance';
+import ResourceLoader from '@code-dot-org/dance-party/src/ResourceLoader';
 import danceMsg from './locale';
 import {
   reducers,

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -16,6 +16,7 @@ var toTranspileWithinNodeModules = [
   path.resolve(__dirname, 'node_modules', 'chai-as-promised'),
   path.resolve(__dirname, 'node_modules', 'enzyme-wait'),
   path.resolve(__dirname, 'node_modules', 'json-parse-better-errors'),
+  path.resolve(__dirname, 'node_modules', '@code-dot-org', 'dance-party'),
   path.resolve(__dirname, 'node_modules', '@code-dot-org', 'snack-sdk'),
   // parse5 ships in ES6: https://github.com/inikulin/parse5/issues/263#issuecomment-410745073
   path.resolve(__dirname, 'node_modules', 'parse5')


### PR DESCRIPTION
We had been importing the pre-built `dist/main.js` from `@code-dot-org/dance-party`. That file wasn't very optimized, and includes 1.5mb of source maps. By importing the class directly we can re-optimize during our webpack build, and (in the future) share any common dependencies in a common chunk.

Paired with @davidsbailey.