### PR TITLE
Chrome browser temp pinned to version 75

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -4,7 +4,7 @@
   {
     "name": "Chrome",
     "browserName": "chrome",
-    "version": "latest",
+    "version": "75",
     "platform": "Windows 7",
     "screenResolution": "1280x1024",
     "extendedDebugging": true


### PR DESCRIPTION
cc @islemaster 

Merged to staging to unblock pipeline. Manually tested a handful of tests and believe Chrome76 test failures are not user-affecting. @epeach will own figuring out how to un-pin this version.