### PR TITLE
Peer Reviews: Instructor feedback is visually differentiated

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2080,9 +2080,7 @@ a.download-video {
   border-radius: 5px;
   padding: 10px;
   margin-bottom: 1em;
-  &.outdated {
-    color: $light_gray;
-  }
+
   &:last-child {
     margin-bottom: 0;
   }
@@ -2091,8 +2089,22 @@ a.download-video {
   }
   .peer-review-status {
     font-size: 1em;
-    & > strong {
-      font-family: inherit;
+  }
+  &.from-instructor {
+    border: 2px solid $cyan;
+
+    .peer-review-title {
+      color: $cyan;
+    }
+  }
+  &.outdated {
+    color: $light_gray;
+    &.from-instructor {
+      border: 2px solid $lighter_cyan;
+
+      .peer-review-title {
+        color: $lighter_cyan;
+      }
     }
   }
 }

--- a/dashboard/app/models/peer_review.rb
+++ b/dashboard/app/models/peer_review.rb
@@ -289,6 +289,19 @@ class PeerReview < ActiveRecord::Base
     )
   end
 
+  # Whether this peer review is a review of the latest version of the submitter's answer
+  def current?
+    level_source == submitter.last_attempt(level, script).level_source
+  end
+
+  # Classes applied to the .peer-review-content div whenever this review is rendered
+  def css_classes
+    classes = []
+    classes << 'outdated' unless current?
+    classes << 'from-instructor' if from_instructor
+    classes.join(' ')
+  end
+
   private
 
   def append_audit_trail(message)

--- a/dashboard/app/views/peer_reviews/_viewer.html.haml
+++ b/dashboard/app/views/peer_reviews/_viewer.html.haml
@@ -1,12 +1,11 @@
 .peer-review
   %p Feedback:
   - @peer_reviews.each do |peer_review|
-    - current = (peer_review.level_source_id == @last_activity.level_source_id)
-    .peer-review-content{class: current ? nil : 'outdated'}
+    .peer-review-content{class: peer_review.css_classes}
       %p.peer-review-title
         %strong= peer_review.from_instructor ? t('peer_review.instructor_feedback') : t('peer_review.peer_feedback')
         = "\u2022 added #{time_ago_in_words(peer_review.updated_at)} ago"
       %p.peer-review-status= peer_review.localized_status_description
       %p= peer_review.data
-      - unless current
+      - unless peer_review.current?
         %em= t('peer_review.outdated')

--- a/dashboard/app/views/peer_reviews/show.html.haml
+++ b/dashboard/app/views/peer_reviews/show.html.haml
@@ -28,7 +28,7 @@
     #previous-reviews
       %p Previous reviews
       - @peer_review.related_reviews.where.not(reviewer: nil).each do |peer_review|
-        .peer-review-content
+        .peer-review-content{class: peer_review.css_classes}
           %p.peer-review-title
             %strong="#{peer_review.reviewer.name} added #{time_ago_in_words(peer_review.updated_at)} ago"
           %p.peer-review-status= peer_review.localized_status_description


### PR DESCRIPTION
[PLC-61](https://codedotorg.atlassian.net/browse/PLC-61) / [Spec](https://docs.google.com/document/d/1rtSHDfNh2E6sVpoF1kM2zIy0SQRHrfX3bfnkp5AHEW8/edit) / "Make the instructor feedback look more different - outline the box blue (for all instructor feedback boxes)"

We show peer reviews in two different places:
- To the PD'd teacher (the submitter) on the level where they submit the content being reviewed.
- To a PLC reviewer (or admin) on the peer review dashboard when reviewing submissions.

Reviews have four different statuses, as well:
- Reviews from instructors on the latest submission.
- Reviews from non-instructors on the latest submission.
- Reviews from instructions on outdated submissions.
- Reviews from non-instructors on outdated submissions.

I've made some changes to differentiate these four statuses on both pages.  Screenshots below (click to expand):

### Submitter view

| Before | After |
| --- | --- |
| ![before_submitter_view](https://user-images.githubusercontent.com/1615761/62333337-f8376a80-b477-11e9-90d3-ea96b8cb4af1.png) | ![Screenshot from 2019-08-01 16-03-45](https://user-images.githubusercontent.com/1615761/62333345-fec5e200-b477-11e9-9a40-56864b54b612.png) |

### Reviewer view

| Before | After |
| --- | --- |
| ![before_reviewer_view](https://user-images.githubusercontent.com/1615761/62333349-04232c80-b478-11e9-9f89-b3c5bd94c062.png) | ![Screenshot from 2019-08-01 16-03-31](https://user-images.githubusercontent.com/1615761/62333355-071e1d00-b478-11e9-8932-8f7a0fdad401.png) |

In case the changes weren't clear in the screenshots:

- Use a thicker blue outline on instructor reviews
- Change the heading to the same blue on instructor reviews
- Put the bold text back into the status summary line in instructor reviews
- Outdated versions of instructor reviews get the same changes, with a lighter blue to match the light gray normal outdated reviews use