### PR TITLE
Peer reviews: Include first and last submission dates in CSV

### DIFF
--- a/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
@@ -129,6 +129,128 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     )
   end
 
+  test 'Peer Review report shows first submission date and latest submission date' do
+    sign_out @plc_reviewer
+
+    Timecop.freeze do
+      # Create a one-level peer review module
+      course_unit = create :plc_course_unit
+      level = create :free_response, peer_reviewable: true
+      script_level = create :script_level, script: course_unit.script, levels: [level]
+      learning_module = create :plc_learning_module, plc_course_unit: course_unit, stage: script_level.stage
+
+      # Create a PD'd teacher and an instructor
+      learner = create :teacher
+      instructor = create :plc_reviewer
+
+      # Assign the learner to the peer review module
+      # (Whoa let's simplify this in the future...)
+      create(
+        :plc_enrollment_module_assignment,
+        user: learner,
+        plc_learning_module: learning_module,
+        plc_enrollment_unit_assignment: create(
+          :plc_enrollment_unit_assignment,
+          user: learner,
+          plc_course_unit: course_unit,
+          plc_user_course_enrollment: create(
+            :plc_user_course_enrollment,
+            user: learner,
+            plc_course: course_unit.plc_course
+          )
+        )
+      )
+
+      # All set up - let's jump forward in time
+      Timecop.travel 1.day
+
+      # Learner submits an answer for the level
+      first_answer = create :level_source, level: level
+      user_level = create :user_level,
+        user: learner,
+        level: level,
+        level_source: first_answer,
+        script: course_unit.script,
+        submitted: true,
+        best_result: ActivityConstants::UNREVIEWED_SUBMISSION_RESULT
+      # Setup check: We created two peer reviews for this submission
+      assert_equal 2, PeerReview.where(level_source: first_answer).count
+
+      # Remember this date, we'll check it later
+      first_submission_date = PeerReview.where(level_source: first_answer).last.created_at
+
+      # The instructor reviews a day later, rejecting the submission
+      Timecop.travel 1.day
+      PeerReview.where(level_source: first_answer, status: :escalated).update(
+        reviewer: instructor,
+        from_instructor: true,
+        data: 'Please make some changes',
+        status: :rejected
+      )
+
+      # The learner updates their answer
+      Timecop.travel 1.day
+      second_answer = create :level_source, level: level
+      user_level.update level_source: second_answer
+      # Setup check: Two new peer reviews should exist for this submission
+      assert_equal 2, PeerReview.where(level_source: second_answer).count
+
+      # The instructor reviews again, rejecting the submission a second time
+      Timecop.travel 1.day
+      PeerReview.where(level_source: second_answer, status: :escalated).update(
+        reviewer: instructor,
+        from_instructor: true,
+        data: 'Still not good enough',
+        status: :rejected
+      )
+
+      # The learner updates their answer one more time
+      Timecop.travel 1.day
+      final_answer = create :level_source, level: level
+      user_level.update level_source: final_answer
+      # Setup check: Two new peer reviews should exist for this submission
+      assert_equal 2, PeerReview.where(level_source: final_answer).count
+
+      # Remember this date - we'll check it later
+      last_submission_date = PeerReview.where(level_source: final_answer).last.created_at
+
+      # The instructor reviews a third time, finally accepting the submission
+      Timecop.travel 1.day
+      PeerReview.where(level_source: final_answer, status: :escalated).update(
+        reviewer: instructor,
+        from_instructor: true,
+        data: 'Great work!',
+        status: :accepted
+      )
+
+      # Setup check: We should now see three completed peer reviews and one still
+      # open for a non-instructor.
+      assert_equal 3, PeerReview.where(level: level, submitter: learner, reviewer: instructor).count
+      assert_equal 1, PeerReview.where(level: level, submitter: learner, reviewer: nil).count
+
+      # Jump forward one more day for good measure
+      Timecop.travel 1.day
+
+      # Finally, the thing we wanted to test:
+      # Generate CSV as the instructor
+      sign_in instructor
+      get :report_csv, params: {plc_course_unit_id: course_unit.id}
+      assert_response :success
+      response = CSV.parse(@response.body)
+
+      # Check that the relevant columns are where we expect them to be
+      assert_equal "#{level.name.titleize} First Submit Date", response[0][3]
+      assert_equal "#{level.name.titleize} Latest Submit Date", response[0][4]
+
+      # Check that only our test data was included (a header row and one data row)
+      assert_equal 2, response.count
+
+      # Check columns for correct dates
+      assert_equal first_submission_date.strftime("%-m/%-d/%Y"), response[1][3]
+      assert_equal last_submission_date.strftime("%-m/%-d/%Y"), response[1][4]
+    end
+  end
+
   test 'Peer Review report returns expected columns' do
     create :peer_review, reviewer: @submitter, script: @course_unit.script
     create :peer_review, reviewer: @submitter
@@ -140,7 +262,11 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
 
     expected_headers = ['Name', 'Email']
     expected_headers << [@level_1, @level_2, @level_3].map do |level|
-      [level.name.titleize, "#{level.name.titleize} Submit Date"]
+      [
+        level.name.titleize,
+        "#{level.name.titleize} First Submit Date",
+        "#{level.name.titleize} Latest Submit Date"
+      ]
     end
     expected_headers << 'Reviews Performed'
 
@@ -148,8 +274,34 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
 
     assert_equal [
       expected_headers.flatten,
-      [@submitter.name, @submitter.email, 'Pending Review', date, 'Accepted', date, 'Pending Review', date, '1'],
-      [@teacher_reviewer.name, @teacher_reviewer.email, 'Unsubmitted', '', 'Unsubmitted', '', 'Unsubmitted', '', '2']
+      [
+        @submitter.name,
+        @submitter.email,
+        'Pending Review',
+        date,
+        date,
+        'Accepted',
+        date,
+        date,
+        'Pending Review',
+        date,
+        date,
+        '1'
+      ],
+      [
+        @teacher_reviewer.name,
+        @teacher_reviewer.email,
+        'Unsubmitted',
+        '',
+        '',
+        'Unsubmitted',
+        '',
+        '',
+        'Unsubmitted',
+        '',
+        '',
+        '2'
+      ]
     ], response
   end
 

--- a/dashboard/test/factories/plc_factories.rb
+++ b/dashboard/test/factories/plc_factories.rb
@@ -39,7 +39,7 @@ FactoryGirl.define do
   end
 
   factory :plc_learning_module, class: 'Plc::LearningModule' do
-    name "MyString"
+    sequence(:name) {|n| "plc-learning-module-#{n}"}
     plc_course_unit {create(:plc_course_unit)}
     stage {create(:stage)}
     module_type Plc::LearningModule::CONTENT_MODULE
@@ -47,7 +47,7 @@ FactoryGirl.define do
 
   factory :plc_course, class: 'Plc::Course' do
     transient do
-      name 'plccourse'
+      sequence(:name) {|n| "plc-course-#{n}"}
     end
     after(:build) do |plc_course, evaluator|
       create(:course, name: evaluator.name, plc_course: plc_course)

--- a/dashboard/test/models/peer_review_test.rb
+++ b/dashboard/test/models/peer_review_test.rb
@@ -414,7 +414,7 @@ class PeerReviewTest < ActiveSupport::TestCase
     base_expected = {
       submitter: @user.name,
       course_name: @plc_course.name,
-      unit_name: @learning_module.name,
+      unit_name: @plc_course_unit.name,
     }
 
     level_1_pr_1 = PeerReview.find_by(level: level_1, status: nil)


### PR DESCRIPTION
[PLC-63](https://codedotorg.atlassian.net/browse/PLC-63) / [Spec]() / "Add timestamp of created submission to CSV"

Further spec details:
> In the current CSV, we show the date for the most recent submission. I’d like to keep that and add the original submission date. That’ll give us a better sense of how long it’s taken for facilitators to pass units.

# Context
We have a peer review dashboard (https://studio.code.org/peer_reviews/dashboard) accessible to a handful of users with the `PLC_REVIEWER` permission.  It looks like this:

![image](https://user-images.githubusercontent.com/1615761/62395904-7baf9500-b526-11e9-940f-b81f1aa08c7e.png)

That "CSV report" button in the corner downloads a CSV for the selected course unit, with one row for every enrolled teacher, and multiple columns for every peer-reviewable level in the unit:
- Status
- Submit Date

# What's changing
We're splitting that "Submit Date" column (per-level) in the CSV into "First Submit Date" and "Latest Submit Date."

# Testing
Tested manually on localhost with test data, and added a fairly robust test case to the controller that generates the CSV.