### PR TITLE
PL: CSF facilitator can delete their own workshop

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
@@ -165,6 +165,10 @@ export class WorkshopManagement extends React.Component {
   }
 
   render() {
+    const confirmationBodyText =
+      "Are you sure you want to delete this workshop? Once deleted it can't be recovered. " +
+      'Participants will not be notified. Please reach out to them directly before deleting.';
+
     return (
       <div>
         {this.renderViewButton()}
@@ -176,7 +180,7 @@ export class WorkshopManagement extends React.Component {
           onOk={this.handleDeleteConfirmed}
           onCancel={this.handleDeleteCanceled}
           headerText="Delete Workshop"
-          bodyText="Are you sure you want to delete this workshop? Once deleted it can't be recovered."
+          bodyText={confirmationBodyText}
         />
       </div>
     );

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -281,7 +281,7 @@ export default class WorkshopTable extends React.Component {
   };
 
   formatManagement = manageData => {
-    const {id, course, subject, state, date} = manageData;
+    const {id, course, subject, state, date, canDelete} = manageData;
 
     return (
       <WorkshopManagement
@@ -291,7 +291,7 @@ export default class WorkshopTable extends React.Component {
         viewUrl={`/workshops/${id}`}
         date={date}
         editUrl={state === 'Not Started' ? `/workshops/${id}/edit` : null}
-        onDelete={state !== 'Ended' ? this.props.onDelete : null}
+        onDelete={canDelete ? this.props.onDelete : null}
         showSurveyUrl={
           state === 'Ended' ||
           ([CSD, CSP].includes(course) &&
@@ -317,7 +317,8 @@ export default class WorkshopTable extends React.Component {
           course: row.course,
           subject: row.subject,
           state: row.state,
-          date: row.sessions[0].start
+          date: row.sessions[0].start,
+          canDelete: row.can_delete
         }
       })
     );

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
@@ -78,7 +78,8 @@ export class WorkshopIndex extends React.Component {
     const canDelete = this.props.permission.hasAny(
       WorkshopAdmin,
       Organizer,
-      ProgramManager
+      ProgramManager,
+      CsfFacilitator
     );
     const canCreate = this.props.permission.hasAny(
       WorkshopAdmin,

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -58,7 +58,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
           limit: limit,
           total_count: workshops.length,
           filters: filter_params,
-          workshops: limited_workshops.map {|w| Api::V1::Pd::WorkshopSerializer.new(w).attributes}
+          workshops: limited_workshops.map {|w| Api::V1::Pd::WorkshopSerializer.new(w, scope: {current_user: current_user}).attributes}
         }
       end
       format.csv do

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -103,7 +103,7 @@ class Ability
 
         if Pd::CourseFacilitator.exists?(facilitator: user, course: Pd::Workshop::COURSE_CSF)
           can :create, Pd::Workshop
-          can :update, Pd::Workshop, facilitators: {id: user.id}
+          can [:update, :destroy], Pd::Workshop, facilitators: {id: user.id}
         end
       end
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -102,8 +102,9 @@ class Ability
         can :read, Pd::CourseFacilitator, facilitator_id: user.id
 
         if Pd::CourseFacilitator.exists?(facilitator: user, course: Pd::Workshop::COURSE_CSF)
-          can :create, Pd::Workshop
-          can [:update, :destroy], Pd::Workshop, facilitators: {id: user.id}
+          can :create, Pd::Workshop, course: Pd::Workshop::COURSE_CSF
+          can :update, Pd::Workshop, facilitators: {id: user.id}
+          can :destroy, Pd::Workshop, organizer_id: user.id
         end
       end
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -720,4 +720,8 @@ class Pd::Workshop < ActiveRecord::Base
 
     potential_organizers
   end
+
+  def can_user_delete?(user)
+    state != STATE_ENDED && Ability.new(user).can?(:destroy, self)
+  end
 end

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -34,7 +34,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
     :enrollment_code, :on_map, :funded, :funding_type, :ready_to_close?,
     :date_and_location_name, :regional_partner_name, :regional_partner_id,
-    :scholarship_workshop?, :potential_organizers
+    :scholarship_workshop?, :potential_organizers, :can_delete
 
   def sessions
     object.sessions.map do |session|
@@ -62,5 +62,9 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
 
   def regional_partner_name
     object.regional_partner.try(:name)
+  end
+
+  def can_delete
+    @scope.try(:[], :current_user) && object.can_user_delete?(@scope[:current_user])
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -507,6 +507,15 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     assert_response :success
   end
 
+  test 'CSF facilitator can delete their own workshop' do
+    sign_in @csf_facilitator
+    workshop = create :pd_workshop, facilitators: [@csf_facilitator]
+    assert_destroys(Pd::Workshop) do
+      delete :destroy, params: {id: workshop.id}
+    end
+    assert_response :success
+  end
+
   # TODO: remove this test when workshop_organizer is deprecated
   test_user_gets_response_for(
     :destroy,

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -463,12 +463,25 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     params: -> {{pd_workshop: workshop_params}}
   )
 
-  test 'csf facilitators can create workshops' do
+  test 'csf facilitators can create csf workshops' do
     sign_in(@csf_facilitator)
 
     assert_creates(Pd::Workshop) do
       post :create, params: {pd_workshop: workshop_params}
       assert_response :success
+    end
+  end
+
+  test 'csf facilitators can not create non-csf workshops' do
+    sign_in(@csf_facilitator)
+
+    params = workshop_params.merge(
+      {course: Pd::Workshop::COURSE_CSD}
+    )
+
+    assert_does_not_create(Pd::Workshop) do
+      post :create, params: {pd_workshop: params}
+      assert_response :forbidden
     end
   end
 


### PR DESCRIPTION
A CSF Facilitator can now delete their own workshop:

![Screenshot 2019-08-04 18 47 10](https://user-images.githubusercontent.com/2205926/62433345-e6a8c980-b6e8-11e9-9743-ed9bdbd3d1d4.png)

The confirmation dialog has had some extra text added:

![Screenshot 2019-08-04 18 47 19](https://user-images.githubusercontent.com/2205926/62433344-e6a8c980-b6e8-11e9-8f56-736d4261d36a.png)

