### PR TITLE
Make peer review feedback colors WCAG2.0-compliant

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2098,13 +2098,9 @@ a.download-video {
     }
   }
   &.outdated {
-    color: $light_gray;
+    color: $charcoal;
     &.from-instructor {
       border: 2px solid $lighter_cyan;
-
-      .peer-review-title {
-        color: $lighter_cyan;
-      }
     }
   }
 }


### PR DESCRIPTION
At least in part, make the colors we're using to display peer review compliant with WCAG 2.0 guidelines for text contrast.

@breville pointed out in https://github.com/code-dot-org/code-dot-org/pull/30083 that the colors we chose were very low-contrast and may be hard to read.  This PR updates our colors to make the text significantly more readable, although we lose some of the visual distinction between outdated and current feedback.

Colors checked with https://contrastchecker.com

Possible follow-up work: Change the visual indicator for outdated entries, either by moving the "This feedback was added for a previously submitted version" text up to the header, or adding an `OUTDATED` tag like GitHub uses on comments for previous changes.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1615761/62480362-7770bb00-b764-11e9-9ef3-586d379f27fe.png) | ![image](https://user-images.githubusercontent.com/1615761/62480369-7e97c900-b764-11e9-9ba2-3ab27c6c1c6d.png) |
