### PR TITLE
Infrastructure: Remove Amazon SQS properties

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -207,11 +207,6 @@ freegeoip_host:
 geocoder_redis_url:
 solr_server:
 
-# Asynchronous queue-processor
-pd_workshop_queue_url:
-activity_queue_url:
-process_queues:
-
 # S3 bucket and (environment-specific) path-prefix configuration
 assets_bucket:             cdo-dist
 assets_bucket_prefix:      <%=env%>


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/29936.  Once these properties are removed from Chef, we'll remove them here.  This avoids errors during deployment to production, as discussed at https://github.com/code-dot-org/code-dot-org/pull/29936/files#r310300803.