### PR TITLE
Privacy: some tweaks to the share partial

### DIFF
--- a/pegasus/sites.v3/code.org/views/share_privacy.haml
+++ b/pegasus/sites.v3/code.org/views/share_privacy.haml
@@ -1,4 +1,4 @@
-%div{style: 'position:absolute; top:5px; right:5px', id: 'share_privacy_policy'}
+%div{style: 'float: right; padding-top: 5px; padding-right: 5px', id: 'share_privacy_policy'}
   -# haml-lint:disable MultilinePipe
   - email_body = "Dear parents,\n\n" + |
                   "Software and technology are everywhere - in our computers, in our pockets, in our cars, " + |
@@ -25,45 +25,47 @@
   %a{class: 'print-button', href: "javascript:window.print()", id: 'print_button'}
     %i.fa.fa-print{"aria-hidden": "true"}
     Print
+%div{style: 'clear: both'}
 
 %script{src: minifiable_asset_path("js/code.org/views/share_privacy.js")}
 
-%body
-  :css
-    .share-on-remind {
-      display: inline-block;
-      width: 185px;
-      height: 40px;
-      background: url("/images/share-on-remind-button-with-text.png") no-repeat top;
-      background-position: center top;
-      text-decoration: none;
-      text-align: center;
-      position: relative;
-      vertical-align: middle;
-    }
-    .share-label {
-      margin-right: 5px;
-    }
-    .share-on-remind:active {
-      background-position: center bottom;
-    }
-    .email-button, .print-button {
-      background-color: #7665a0;
+:css
+  .share-on-remind {
+    display: inline-block;
+    width: 185px;
+    height: 40px;
+    background: url("/images/share-on-remind-button-with-text.png") no-repeat top;
+    background-position: center top;
+    text-decoration: none;
+    text-align: center;
+    position: relative;
+    vertical-align: middle;
+    margin-bottom: 5px;
+  }
+  .share-label {
+    margin-right: 5px;
+  }
+  .share-on-remind:active {
+    background-position: center bottom;
+  }
+  .email-button, .print-button {
+    background-color: #7665a0;
+    color: white;
+    text-decoration: none;
+    display: inline-block;
+    width: 90px;
+    height: 40px;
+    border-radius: 5px;
+    text-align: center;
+    line-height: 40px;
+    vertical-align: middle;
+    margin-bottom: 5px;
+  }
+  .email-button:visited, .print-button:visited, .email-button:link, .print-button:link {
       color: white;
-      text-decoration: none;
-      display: inline-block;
-      width: 90px;
-      height: 40px;
-      border-radius: 5px;
-      text-align: center;
-      line-height: 40px;
-      vertical-align: middle;
+  }
+  @media print {
+    #share_privacy_policy {
+      display: none
     }
-    .email-button:visited, .print-button:visited, .email-button:link, .print-button:link {
-        color: white;
-    }
-    @media print {
-      #share_privacy_policy {
-        display: none
-      }
-    }
+  }


### PR DESCRIPTION
Some tweaks to the `share_privacy` partial.  Now it sits inline with the page's regular content, rather than being pinned to an absolute position on the page.

This will allow it to be included on pages which include the regular header.

This also fixes it for narrow displays.

## before

### desktop

![Screenshot 2019-08-05 11 23 20](https://user-images.githubusercontent.com/2205926/62486403-0933f480-b774-11e9-8e72-281c74dc7096.png)

### mobile

![Screenshot 2019-08-05 11 23 40](https://user-images.githubusercontent.com/2205926/62486402-0933f480-b774-11e9-97d9-96545e6c47c7.png)



### after

### desktop

![Screenshot 2019-08-05 11 24 07](https://user-images.githubusercontent.com/2205926/62486411-0f29d580-b774-11e9-9112-2dc528643880.png)

### mobile

![Screenshot 2019-08-05 11 24 29](https://user-images.githubusercontent.com/2205926/62486410-0f29d580-b774-11e9-8a83-b17e1b29fa03.png)

