### PR TITLE
Metrics: pre-parse curriculum url to make querying easier

### DIFF
--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -11,13 +11,40 @@ class CurriculumTrackingPixelController < ApplicationController
     user_id = current_user&.id
 
     if curriculum_page
+      # For ease of querying we attempt to parse the url into meaningful chunks.
+      # EXAMPLE:
+      # /csf-18/pre-express/11/
+      split_url = curriculum_page.split('/')
+      # ["", "csf-18", "pre-express", "11"]
+
+      if split_url.length > 1
+        # csf, csd, csp including version year, algebra or hoc
+        csx = split_url[1]
+      end
+
+      if split_url.length > 2
+        # csf -> coursea, courseb, ..., pre-express, express
+        # csd/csp -> unit1, unit2, ...
+        # algebra -> courseA, courseB
+        # hoc -> plugged, unplugged
+        course_or_unit = split_url[2]
+      end
+
+      if split_url.length > 3
+        # lesson number, standards, vocab, resources
+        lesson = split_url[3]
+      end
+
       FirehoseClient.instance.put_record(
         study: STUDY_NAME,
-        study_group: 'v0',
+        study_group: 'v1',
         event: EVENT_NAME,
+        user_id: user_id,
+        data_string: curriculum_page,
         data_json: {
-          curriculumBuilderUrl: curriculum_page,
-          userId: user_id
+          csx: csx,
+          course_or_unit: course_or_unit,
+          lesson: lesson
         }.to_json
       )
     end

--- a/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
+++ b/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
@@ -11,8 +11,11 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
   def assert_curriculum_page_view_logged(curriculum_url, user_id)
     assert @firehose_record[:study], CurriculumTrackingPixelController::STUDY_NAME
     assert @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
-    assert @firehose_record[:data_json]["curriculumBuilderUrl"], curriculum_url
-    assert @firehose_record[:data_json]["userId"], user_id
+    assert @firehose_record[:data_string], curriculum_url
+    split_url = curriculum_url.try(:split, '/')
+    assert @firehose_record[:data_json]["csx"], split_url[1]
+    assert @firehose_record[:data_json]["course_or_unit"], split_url[2]
+    assert @firehose_record[:data_json]["lesson"], split_url[3]
   end
 
   def refute_curriculum_page_view_logged


### PR DESCRIPTION
[LP-653](https://codedotorg.atlassian.net/browse/LP-653)

In #28532 I introduced a tracking pixel for curriculum.code.org pages so we can gather metrics about which lesson plans are viewed most frequently. 

After attempting the query the data we've been logging, it was requested that `userId` be stored in the `user_id` field so that data could be joined across the User's table. I messed up that [change,  such that it generated HoneyBadger errors and was reverted](https://github.com/code-dot-org/code-dot-org/pull/30103).

After continued discussion, in addition to user_id, we'd like to try pre-parsing other key information for further ease of analysis. This PR fixes the problem with `user_id` and includes logic to store course, unit and lesson as part of the `data_json` field. Tests have been updated accordingly.  