### PR TITLE
Remove nill scores before calculating average

### DIFF
--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
@@ -91,8 +91,8 @@ module Pd::SurveyPipeline
         qnames_in_cateogry = qname_replacements.values.select {|val| val.start_with? category_name}
 
         category_scores = avg_scores[facilitator_name].values_at(*qnames_in_cateogry).compact
-        this_workshop_scores = category_scores.pluck(:this_workshop)
-        all_workshop_scores = category_scores.pluck(:all_my_workshops)
+        this_workshop_scores = category_scores.pluck(:this_workshop).compact
+        all_workshop_scores = category_scores.pluck(:all_my_workshops).compact
 
         avg_scores[facilitator_name][category_name] ||= {}
         avg_scores[facilitator_name][category_name][:this_workshop] =


### PR DESCRIPTION
[PLC-395](https://codedotorg.atlassian.net/browse/PLC-395)

* Bug report: https://app.honeybadger.io/projects/3240/faults/52842038
* Repro: https://studio.code.org/api/v1/pd/workshops/5040/experiment_survey_report

* Cause:
The failure happened when rolling up facilitator scores from all related workshops ([5040, 5080, 5601, 5799]). 
The current workshop in context (5040) used an older survey form that doesn't have `facilitator_effectiveness_*` questions, thus making this line `this_workshop_scores = category_scores.pluck(:this_workshop)` return an array of `nil` values. It then causes `this_workshop_scores.sum` to raise exception because it trying to `+` two `nil` values.

* Fix:
Use `compact` to remove all `nil` values before trying to sum them up.
