### PR TITLE
School Info Confirmation Dialog:  remove experiment flag

### DIFF
--- a/apps/src/sites/studio/pages/layouts/_school_info_confirmation_dialog.js
+++ b/apps/src/sites/studio/pages/layouts/_school_info_confirmation_dialog.js
@@ -8,7 +8,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import SchoolInfoConfirmationDialog from '@cdo/apps/lib/ui/SchoolInfoConfirmationDialog';
 import getScriptData from '@cdo/apps/util/getScriptData';
-import experiments from '@cdo/apps/util/experiments';
 
 document.addEventListener('DOMContentLoaded', () => {
   const scriptData = getScriptData('schoolinfoconfirmationdialog');
@@ -21,13 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.removeChild(mountPoint);
   }
 
-  if (experiments.isEnabled(experiments.SCHOOL_INFO_CONFIRMATION_DIALOG)) {
-    ReactDOM.render(
-      <SchoolInfoConfirmationDialog
-        scriptData={scriptData}
-        onClose={unmount}
-      />,
-      mountPoint
-    );
-  }
+  ReactDOM.render(
+    <SchoolInfoConfirmationDialog scriptData={scriptData} onClose={unmount} />,
+    mountPoint
+  );
 });

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -21,7 +21,6 @@ const EXPERIMENT_LIFESPAN_HOURS = 12;
 experiments.REDUX_LOGGING = 'reduxLogging';
 experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
   'schoolAutocompleteDropdownNewSearch';
-experiments.SCHOOL_INFO_CONFIRMATION_DIALOG = 'schoolInfoConfirmationDialog';
 experiments.FEEDBACK_NOTIFICATION = 'feedbackNotification';
 experiments.ROLLUP_SURVEY_REPORT = 'rollupSurveyReport';
 


### PR DESCRIPTION
This PR is to remove the SCHOOL_INFO_CONFIRMATION_DIALOG experiment flag so that the schoolInfoConfirmationDialog is shown when a teacher is prompted to update school info.

[Reference: Set Experiment Flag](https://github.com/code-dot-org/code-dot-org/pull/28653)