### PR TITLE
Fixing spacing on CSD Unit 1 title in CSD course overview

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -10452,7 +10452,7 @@ en:
             Concept Practice with Minecraft:
               name: Concept Practice with Minecraft
         csd1-2019:
-          title: CSD Unit 1 - Problem Solving and Computing('19-'20)
+          title: CSD Unit 1 - Problem Solving and Computing ('19-'20)
           description: "Problem Solving and Computing is a highly interactive and collaborative introduction to the field of computer science, as framed within the broader pursuit of solving problems. You’ll practice using a problem solving process to address a series of puzzles, challenges, and real world scenarios. Next, you’ll learn how computers input, output, store, and process information to help humans solve problems.  The unit concludes with a project in which you design an application that helps solve a problem of your choosing.\r\n"
           description_short: "  Learn how humans work with computers to solve problems."
           description_audience: ''


### PR DESCRIPTION
Fixed the bug in the scripts.en.yml file - also found the text in the scripts.yml but that is apparently automatically generated. 

With help from @Erin007 ... We *think* this was added through level builder and hope this fix will "stick". 

(associated Jira ticket: LP-655)