### PR TITLE
Modify Content-Security-Policy for Mapbox maps

### DIFF
--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -44,6 +44,7 @@ module Rack
           policies += [
             "default-src 'self' https:",
             "frame-src 'self' https: blob:",
+            "worker-src 'self' blob: ",
             "script-src 'self' https: 'unsafe-inline' https://vaas.acapela-group.com 'unsafe-eval'",
             "style-src 'self' https: 'unsafe-inline'",
             "img-src 'self' https: data: blob:",


### PR DESCRIPTION
Based off of [Mapbox documentation](https://docs.mapbox.com/mapbox-gl-js/overview/#csp-directives).

I tried to lock down this directive a bit more but couldn't figure out a way.