### PR TITLE
De-flaked eyes test by moving functionality to UI test

### DIFF
--- a/dashboard/test/ui/features/applab/eyes1.feature
+++ b/dashboard/test/ui/features/applab/eyes1.feature
@@ -13,10 +13,6 @@ Scenario: Button shows up on top of canvas
   Then I see no difference for "button should be visible"
   And I click selector ".project_share"
   And I wait to see a dialog titled "Share your project"
-  Then I close the dialog
-  And I see no difference for "closed share dialog"
-  Then I click selector ".project_share"
-  And I wait to see a dialog titled "Share your project"
   And I navigate to the share URL
   And I wait until element "#divApplab" is visible
   Then I see no difference for "app lab share"

--- a/dashboard/test/ui/features/applab/eyes1.feature
+++ b/dashboard/test/ui/features/applab/eyes1.feature
@@ -2,7 +2,7 @@
 @as_student
 Feature: App Lab Eyes -  Part 1
 
-Scenario: Button shows up on top of canvas
+Scenario: Design elements are visible in local and shared projects
   When I open my eyes to test "applab eyes"
   Given I start a new Applab project
   And I wait for the page to fully load

--- a/dashboard/test/ui/features/applab/eyes1.feature
+++ b/dashboard/test/ui/features/applab/eyes1.feature
@@ -13,6 +13,7 @@ Scenario: Button shows up on top of canvas
   Then I see no difference for "button should be visible"
   And I click selector ".project_share"
   And I wait to see a dialog titled "Share your project"
+  Then I see no difference for "project share dialog"
   And I navigate to the share URL
   And I wait until element "#divApplab" is visible
   Then I see no difference for "app lab share"

--- a/dashboard/test/ui/features/projects/project_sharing.feature
+++ b/dashboard/test/ui/features/projects/project_sharing.feature
@@ -2,16 +2,22 @@
 @as_young_student
 
 Feature: Project Sharing - Young Students
+  Scenario: Share dialog can be opened and closed
+    Then I make a "spritelab" project named "Spritelab Project"
+    And I open the project share dialog
+    Then I wait until element "#project-share" is visible
+    And I close the dialog
+    Then I wait until element "#project-share" is gone
 
-Scenario: Young Students Can Always Share Play Lab Projects
-  Then I make a "playlab" project named "Playlab Project!"
-  And I open the project share dialog
-  Then the project can be published
-  Then I publish the project from the share dialog
-  Given I open the project share dialog
-  And the project is published
+  Scenario: Young Students Can Always Share Play Lab Projects
+    Then I make a "playlab" project named "Playlab Project!"
+    And I open the project share dialog
+    Then the project can be published
+    Then I publish the project from the share dialog
+    Given I open the project share dialog
+    And the project is published
 
-Scenario: Young Students Can Not By Default Make App Lab Projects
-  Then I am on "http://studio.code.org/projects/applab/new"
-  And I get redirected to "/home" via "dashboard"
-  And element ".alert" is visible
+  Scenario: Young Students Can Not By Default Make App Lab Projects
+    Then I am on "http://studio.code.org/projects/applab/new"
+    And I get redirected to "/home" via "dashboard"
+    And element ".alert" is visible


### PR DESCRIPTION
Task: https://codedotorg.atlassian.net/browse/STAR-603

applab/eyes1.feature was causing eyes tests to intermittently fail due to the following sequence:
1. The share dialog would open. The x-button displayed over top of the "Show Blocks" button
2. The x-button would be clicked on the share dialog to close it
3. The cursor would now be hovering over the "Show Blocks" button
4. Occasionally, the button would detect the cursor as hovering and would change its background color to blue - the hover-over color. Since the mouse has to move over the button to cause the hover-over color to change, this difference in color was intermittent.

Why was the eyes test added in the first place?
In 2016, the share dialog failed to close due to a JS error. This caused a livesite issue (details here: https://codedotorg.slack.com/archives/C0T0PNTM3/p1464735319004999). To prevent a similar regression, an eyes test was added to close the dialog and ensure it closed. This would have been more appropriate as a UI test than as an eyes test. 

This PR. Replaces the eyes test with two different tests.
1. a UI test that ensures the share dialog can be closed.
2. an eyes test that checks whether the project share dialog has been changed.

Flaky eyes test that has been removed:
![image](https://user-images.githubusercontent.com/8324574/62639474-6eaeef00-b8f4-11e9-9c93-e20cf99b73b7.png)

New eyes test that has been added:
![image](https://user-images.githubusercontent.com/8324574/62639410-4b843f80-b8f4-11e9-81af-b6feb7d02c28.png)
