### PR TITLE
Fixing the spacing in the student table in the teacher panel

### DIFF
--- a/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
+++ b/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
@@ -24,7 +24,7 @@ const styles = {
     flexDirection: 'column'
   },
   bubble: {
-    marginLeft: 56
+    marginLeft: 0
   },
   name: {
     fontFamily: '"Gotham 5r", sans-serif',

--- a/apps/src/code-studio/components/progress/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/StudentTable.jsx
@@ -31,16 +31,21 @@ const styles = {
   },
   studentTableRow: {
     display: 'flex',
-    alignItems: 'center'
+    alignItems: 'center',
+    width: '100%'
   },
   meRow: {
     padding: '1px 1px 1px 5px'
   },
   nameInScript: {
-    paddingLeft: 5
+    paddingLeft: 5,
+    margin: '1px 1px 1px 0',
+    flexGrow: 1
   },
   nameWithBubble: {
-    paddingLeft: 5
+    paddingLeft: 5,
+    margin: '1px 1px 1px 0',
+    flexGrow: 1
   },
   linkIcon: {
     marginLeft: 10
@@ -112,11 +117,11 @@ class StudentTable extends React.Component {
                       level={levels.find(level => student.id === level.user_id)}
                     />
                   )}
-                  <span
+                  <div
                     style={levels ? styles.nameWithBubble : styles.nameInScript}
                   >
                     {student.name}
-                  </span>
+                  </div>
                   <a
                     href={this.getRowLink(student.id)}
                     target="_blank"

--- a/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
+++ b/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
@@ -79,7 +79,7 @@ export class TeacherPanelProgressBubble extends React.Component {
       <div
         style={{
           // Two pixels on each side for border, 2 pixels on each side for margin.
-          width: DOT_SIZE + 8,
+          minWidth: DOT_SIZE + 8,
           display: 'flex',
           justifyContent: 'center'
         }}


### PR DESCRIPTION
Darn that CSS - this was tough. Part of the problem (I think) was that the name of each student in the student table was in a span (inline) not a block element like p or div. 

setting the minWidth on the bubbles, then using flexGrow seemed to do the trick but changing the margins made things look better. I tried to limit the changes because I wasn't sure what other impacts this was going to have. I did search for these items in other files, but I want to see what the auto run tests say as well. 

I have no idea why bubble in SelectedStudentInfo was 56 - but that had to change as well or the bubble with the selected students name was off. 

P.S. If we want to truncate the student name so it doesn't interfere with the right and left arrow buttons in the SelectedStudentInfo, we would just need to add to the name: style (line 29-34) in apps/src/code-studio/components/progress/SelectedStudentInfo.jsx

    overflowX: 'hidden'



<img width="201" alt="Screen Shot 2019-08-06 at 9 51 42 PM" src="https://user-images.githubusercontent.com/1072387/62595951-3e843380-b895-11e9-8b15-43657d2bb3cd.png">
<img width="201" alt="Screen Shot 2019-08-06 at 9 51 07 PM" src="https://user-images.githubusercontent.com/1072387/62595952-3e843380-b895-11e9-9549-5db6df3f21b2.png">