### PR TITLE
Include @dashboard_db_access for feedback UI and eyes tests

### DIFF
--- a/dashboard/test/ui/features/instructions/feedback_tab.feature
+++ b/dashboard/test/ui/features/instructions/feedback_tab.feature
@@ -1,3 +1,4 @@
+@dashboard_db_access
 @no_mobile
 Feature: Feedback Tab Visibility
 

--- a/dashboard/test/ui/features/instructions/feedback_tab_eyes.feature
+++ b/dashboard/test/ui/features/instructions/feedback_tab_eyes.feature
@@ -1,3 +1,4 @@
+@dashboard_db_access
 @eyes
 Feature: Feedback Tab Visibility
 


### PR DESCRIPTION
In #30098 I prevent non-authorized teachers from leaving feedback for students. While doing so I updated the related UI and Eyes test by giving the teacher `AUTHORIZED_TEACHER` permissions. These tests passed locally and during Drone run.  However, they were failing consistently on the test machine ([example](https://codedotorg.slack.com/archives/C03CM903Y/p1565135154348700)). 

The [Saucelabs log for the test ](https://app.saucelabs.com/tests/4795b2ad4ae44289b4aa8169cbe9c8e9/metadata) showed that the test was timing out on the `And I give user .... authorized teacher permissions" step. 
<img width="988" alt="Screen Shot 2019-08-06 at 10 06 48 PM" src="https://user-images.githubusercontent.com/12300669/62596554-9c197f80-b897-11e9-9581-a260f3b0c615.png">

This happens because there isn't access to the dashboard database to update that permission for the user. I added `@dashboard_db_access` to the feedback_tab.feature on test and it [passed](https://codedotorg.slack.com/archives/C03CM903Y/p1565154003351300). (Then, I put the file back in its original) state.  Which gives me confidence that this is the right fix moving forward to unblock the failing tests. 
