### PR TITLE
Feedback: remove rubric performance details from all feedback page

### DIFF
--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -102,8 +102,7 @@ export default class LevelFeedbackEntry extends Component {
       unitName,
       created_at,
       comment,
-      performance,
-      performance_details
+      performance
     } = this.props.feedback;
 
     const seenByStudent = seen_on_feedback_page_at || student_first_visited_at;
@@ -132,7 +131,7 @@ export default class LevelFeedbackEntry extends Component {
     };
 
     let rubricText = `${i18n.feedbackRubricEvaluation()}:
-    ${rubricPerformance[performance]} - ${performance_details}`;
+    ${rubricPerformance[performance]}`;
 
     const showRightCaret = this.longComment() && !this.state.expanded;
     const showDownCaret = this.longComment() && this.state.expanded;

--- a/apps/src/templates/feedback/shapes.js
+++ b/apps/src/templates/feedback/shapes.js
@@ -14,8 +14,7 @@ const shapes = {
       PropTypes.instanceOf(Date)
     ]).isRequired,
     comment: PropTypes.string,
-    performance: PropTypes.string,
-    performance_details: PropTypes.string
+    performance: PropTypes.string
   })
 };
 

--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -10,18 +10,7 @@ class TeacherFeedbacksController < ApplicationController
       feedback.student_id == current_user.id && User.find(feedback.teacher_id).authorized_teacher?
     end
 
-    performance_to_details = {
-      "performanceLevel1" => "rubric_performance_level_1",
-      "performanceLevel2" => "rubric_performance_level_2",
-      "performanceLevel3" => "rubric_performance_level_3",
-      "performanceLevel4" => "rubric_performance_level_4"
-    }
-
-    @feedbacks_as_student_with_level_info = @feedbacks_as_student.
-      map do |feedback|
-      feedback.attributes.merge(feedback&.script_level&.summary_for_feedback).
-        merge({performance_details: feedback.level.properties[performance_to_details[feedback.performance]]})
-    end
+    @feedbacks_as_student_with_level_info = @feedbacks_as_student.map {|feedback| feedback.attributes.merge(feedback&.script_level&.summary_for_feedback)}
   end
 
   def set_seen_on_feedback_page_at


### PR DESCRIPTION
Almost the opposite of #30085, but there were a couple of formatting changes  I wanted to keep. Product/Design team had a change of heart and decided we don't need to display the details of the performance rubric on the all feedback page. 