### PR TITLE
Switch AnimationPicker to use common i18n files

### DIFF
--- a/apps/i18n/gamelab/en_us.json
+++ b/apps/i18n/gamelab/en_us.json
@@ -1,13 +1,4 @@
 {
-  "animationPicker_drawYourOwn": "Draw your own",
-  "animationPicker_error": "Error: {message}",
-  "animationPicker_failedToParseImage": "The image could not be parsed",
-  "animationPicker_title": "Animation Library",
-  "animationPicker_unsupportedType": "Sorry, this file type is not supported.",
-  "animationPicker_unsupportedSize": "Please make sure the image you are trying to upload is smaller than 100 KB.",
-  "animationPicker_uploadImage": "Upload image",
-  "animationPicker_uploading": "Uploading...",
-  "animationPicker_warning": "Warning: Do not upload anything that contains personal information.",
   "dropletBlock_Game.width_description": "The width of the drawing canvas.",
   "dropletBlock_Game.height_description": "The height of the drawing canvas.",
   "dropletBlock_createSprite_description": "Creates a sprite at the initial specified position.",

--- a/apps/i18n/spritelab/en_us.json
+++ b/apps/i18n/spritelab/en_us.json
@@ -1,13 +1,4 @@
 {
-  "animationPicker_drawYourOwn": "Draw your own",
-  "animationPicker_error": "Error: {message}",
-  "animationPicker_failedToParseImage": "The image could not be parsed",
-  "animationPicker_title": "Animation Library",
-  "animationPicker_unsupportedType": "Sorry, this file type is not supported.",
-  "animationPicker_unsupportedSize": "Please make sure the image you are trying to upload is smaller than 100 KB.",
-  "animationPicker_uploadImage": "Upload image",
-  "animationPicker_uploading": "Uploading...",
-  "animationPicker_warning": "Warning: Do not upload anything that contains personal information.",
   "errorLoadingAnimation": "It looks like we are having trouble loading your animation \"{animationName}\". Make sure you have a good internet connection and try reloading the page. If this problem persists, it is possible that this animation is broken. In this case, you may need to continue by removing the animation.",
   "reinfFeedbackMsg": "You're finished! Click \"Continue\" to move on to the next level.",
   "shareGame": "Share your game:",

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {createUuid} from '@cdo/apps/utils';
 import {connect} from 'react-redux';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
-var msg = require('@cdo/gamelab/locale') || require('@cdo/spritelab/locale');
+var msg = require('@cdo/locale');
 import styles from './styles';
 import {
   hide,

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import {AnimationCategories, CostumeCategories} from '../constants';
-var msg = require('@cdo/gamelab/locale') || require('@cdo/spritelab/locale');
+var msg = require('@cdo/locale');
 import animationLibrary from '../gamelab/animationLibrary.json';
 import spriteCostumeLibrary from '../spritelab/spriteCostumeLibrary.json';
 import ScrollableList from '../AnimationTab/ScrollableList.jsx';

--- a/apps/src/p5lab/AnimationPicker/animationPickerModule.js
+++ b/apps/src/p5lab/AnimationPicker/animationPickerModule.js
@@ -10,7 +10,7 @@ import {
 } from '../animationListModule';
 import {makeEnum} from '@cdo/apps/utils';
 import {animations as animationsApi} from '@cdo/apps/clientApi';
-var msg = require('@cdo/gamelab/locale') || require('@cdo/spritelab/locale');
+var msg = require('@cdo/locale');
 import {changeInterfaceMode} from '../actions';
 import {GameLabInterfaceMode} from '../constants';
 

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/configuredChai';
-const gamelabMsg = require('@cdo/gamelab/locale');
+const msg = require('@cdo/locale');
 import {
   WarningLabel,
   UnconnectedAnimationPickerBody as AnimationPickerBody
@@ -25,7 +25,7 @@ describe('AnimationPickerBody', function() {
       const warnings = body.find(WarningLabel);
       expect(warnings).to.have.length(1);
       expect(warnings.children().text()).to.equal(
-        gamelabMsg.animationPicker_warning()
+        msg.animationPicker_warning()
       );
     });
 
@@ -36,7 +36,7 @@ describe('AnimationPickerBody', function() {
       const warnings = body.find(WarningLabel);
       expect(warnings).to.have.length(1);
       expect(warnings.children().text()).to.equal(
-        gamelabMsg.animationPicker_warning()
+        msg.animationPicker_warning()
       );
     });
 


### PR DESCRIPTION
Follow up to #29884 

Now that these strings are in the common i18n files, delete them out of the spritelab/ and gamelab/ files and switch the imports to use the common files