### PR TITLE
remove mimeo_api property

### DIFF
--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -6,7 +6,6 @@ hoc_map_api_secret: !Secret
 hoc_map_service_account_email: !Secret
 hoc_map_table_id: !Secret
 level_sources_redis_url: !Secret
-mimeo_api: !Secret
 pardot_password: !Secret
 pardot_user_key: !Secret
 pardot_username: !Secret


### PR DESCRIPTION
Followup to #30036, resolve conflict with #29926 (where this property was originally removed).