### PR TITLE
make exemplar links use /projects/frozen when applicable

### DIFF
--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -25,7 +25,8 @@
       - elsif @level.is_a?(GamelabJr)
         - send("#{"spritelab"}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
       - elsif @level.is_a?(Artist)
-        - send("#{"artist"}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
+        - artist_type = ['elsa', 'anna'].include?(@level.skin) ? 'frozen' : 'artist'
+        - send("#{artist_type}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
       - elsif @level.is_a?(Studio) # playlab
         - send("#{"playlab"}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
       - else


### PR DESCRIPTION
follow-on to https://github.com/code-dot-org/code-dot-org/pull/29212 to fix a bug reported here: https://codedotorg.slack.com/archives/CA3KCSGTD/p1565293317149700

for the first exemplar link on /s/coursee-2019/stage/13/puzzle/3 :

before: https://studio.code.org/projects/artist/4K69LAsN8AUZ4rdwH7j8n2XvfKd6TewjYMOysMw29-w/view
after: https://studio.code.org/projects/frozen/4K69LAsN8AUZ4rdwH7j8n2XvfKd6TewjYMOysMw29-w/view