### PR TITLE
Feedback: load performance, check UserPermissions rather than Users

### DIFF
--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -7,7 +7,10 @@ class TeacherFeedbacksController < ApplicationController
   # student on any level
   def index
     @feedbacks_as_student = @teacher_feedbacks.select do |feedback|
-      feedback.student_id == current_user.id && User.find(feedback.teacher_id).authorized_teacher?
+      feedback.student_id == current_user.id && UserPermission.where(
+        user_id: feedback.teacher_id,
+        permission: 'authorized_teacher'
+      )
     end
 
     @feedbacks_as_student_with_level_info = @feedbacks_as_student.map {|feedback| feedback.attributes.merge(feedback&.script_level&.summary_for_feedback)}


### PR DESCRIPTION
[LP-645](https://codedotorg.atlassian.net/browse/LP-645) - performance issue when loading the teacher feedback page

To prevent displaying feedback from non-authorized teachers, I was using the teacher_id associated with the feedback to query the Users table then using a helper method to determine if that user was an authorized teacher.  The Users table is huge so that query was slow. 

BEFORE: 
<img width="600" alt="Screen Shot 2019-08-08 at 1 27 09 PM" src="https://user-images.githubusercontent.com/12300669/62735895-10136f00-b9e1-11e9-9a21-b3f5ac932e2c.png">

Instead I check the UserPermissions table to see if there is an entry for the teacher_id with the permission authorized_teacher.  The UserPermissions table is much smaller, so the query is much quicker. 

AFTER:
<img width="658" alt="Screen Shot 2019-08-08 at 1 27 00 PM" src="https://user-images.githubusercontent.com/12300669/62735898-11dd3280-b9e1-11e9-88fa-6fb1ba52cf58.png">
