### PR TITLE
[Workaround] Disabled ruby tests that are causing the DTT to fail due to incorrect test DB

### DIFF
--- a/dashboard/test/controllers/api/v1/census/census_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/census/census_controller_test.rb
@@ -9,6 +9,7 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
   end
 
   test 'census submission with bad school fails' do
+    skip 'workaround for Aug 8 DB issue'
     post :create,
       params: {
         form_version: 'anything',

--- a/dashboard/test/controllers/api/v1/school_districts_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/school_districts_controller_test.rb
@@ -18,18 +18,21 @@ class Api::V1::SchoolDistrictsControllerTest < ActionController::TestCase
   }.deep_stringify_keys.freeze
 
   test 'search by school name prefix' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'lowe', limit: 40}
     assert_response :success
     assert_equal [LOWER_KUSKOKWIM_SCHOOL_DISTRICT, LOWER_YUKON_SCHOOL_DISTRICT], JSON.parse(@response.body)
   end
 
   test 'search by word within' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'yukon', limit: 40}
     assert_response :success
     assert_equal [LOWER_YUKON_SCHOOL_DISTRICT], JSON.parse(@response.body)
   end
 
   test 'search by school city prefix' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'beth', limit: 40}
     assert_response :success
     assert_equal [LOWER_KUSKOKWIM_SCHOOL_DISTRICT], JSON.parse(@response.body)

--- a/dashboard/test/controllers/api/v1/schools_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/schools_controller_test.rb
@@ -57,48 +57,56 @@ class Api::V1::SchoolsControllerTest < ActionController::TestCase
   }.deep_stringify_keys.freeze
 
   test 'search by school name prefix' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'glad', limit: 40}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by short school name prefix' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'elementary ju', limit: 40}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by school name substring' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'jung', limit: 40}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by school city prefix' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'beth', limit: 40}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by school zip' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: '91355', limit: 40}
     assert_response :success
     assert_equal [ALBERT_EINSTEIN_ACADEMY_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by school zip with extended format' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: '91355-1234', limit: 40}
     assert_response :success
     assert_equal [ALBERT_EINSTEIN_ACADEMY_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search with limit of negative one' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'glad', limit: -1}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search with limit of zero' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'glad', limit: 0}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
@@ -111,24 +119,28 @@ class Api::V1::SchoolsControllerTest < ActionController::TestCase
   end
 
   test 'search with hyphen' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'winston-salem', limit: 40}
     assert_response :success
     assert_equal [QUALITY_EDUCATION_ACADEMY], JSON.parse(@response.body)
   end
 
   test 'search with apostrophe' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: "children's village", limit: 40}
     assert_response :success
     assert_equal [CHILDRENS_VILLAGE], JSON.parse(@response.body)
   end
 
   test 'new search with apostrophe' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: "children's village", limit: 40, use_new_search: true}
     assert_response :success
     assert_equal [CHILDRENS_VILLAGE], JSON.parse(@response.body)
   end
 
   test 'new search with hyphen' do
+    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'winston-salem', limit: 40, use_new_search: true}
     assert_response :success
     assert_equal [QUALITY_EDUCATION_ACADEMY], JSON.parse(@response.body)

--- a/dashboard/test/lib/api/v1/school_autocomplete_test.rb
+++ b/dashboard/test/lib/api/v1/school_autocomplete_test.rb
@@ -24,6 +24,7 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
   end
 
   test 'search by unique name matches only 1 school' do
+    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Chalkville', MAXIMUM_RESULTS, false)
     assert_equal 1, search_results.count
     assert search_results.detect {|school| school[:nces_id] == '10000200277'}
@@ -49,18 +50,21 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
   end
 
   test 'search by partial name matches school' do
+    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Albert', MAXIMUM_RESULTS, false)
     # ALBERT EINSTEIN ACADEMY ELEMENTARY
     assert search_results.detect {|school| school[:nces_id] == '60000113717'}
   end
 
   test 'search by partial word matches school' do
+    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Alb', MAXIMUM_RESULTS, false)
     # ALBERT EINSTEIN ACADEMY ELEMENTARY
     assert search_results.detect {|school| school[:nces_id] == '60000113717'}
   end
 
   test 'search by common abbreviation returns multiple matches' do
+    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Sch', MAXIMUM_RESULTS, false)
     assert_equal 8, search_results.count
     # Alakanuk School
@@ -80,6 +84,7 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
   end
 
   test 'new search by unique name matches only 1 school' do
+    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Chalkville', MAXIMUM_RESULTS, true)
     assert_equal 1, search_results.count
     assert search_results.detect {|school| school[:nces_id] == '10000200277'}
@@ -114,6 +119,7 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
 
   # New search intentionally has fewer low relevance matches with common abbreviations.
   test 'new search by common abbreviation returns multiple matches' do
+    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Sch', MAXIMUM_RESULTS, true)
     assert_equal 4, search_results.count
     # Ala Avenue Middle Sch


### PR DESCRIPTION
This is a temporary workaround. Somehow, the test DB was seeded with the production DB's data. There are a set of 22 tests that rely on the test DB having only a small set of data. While we work on fixing the DB issue, this PR temporarily disables those tests to unblock the deploy pipeline.

Details here: https://codedotorg.slack.com/archives/C0T0PNTM3/p1565289064387200

Broken test run at this [link](https://cdo-build-logs.s3.amazonaws.com/test/20190808T180005%2B0000?versionId=m8XOZHd5QEaL3reAiwD7fuJ7uFkPAcb8&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAW5P5EEELK6AMSYVN%2F20190808%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190808T182539Z&X-Amz-Expires=259200&X-Amz-SignedHeaders=host&X-Amz-Security-Token=AgoJb3JpZ2luX2VjEPP%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIBQZLlhYwlz4RKyRsrEfFGhlOgKxE62mwRcibJ6KZyGYAiEAoMWX7IBYFMbQzGvV8FEEudLG6KKYSbOwobGTGfZHk4IqvwMIexAAGgw0NzU2NjE2MDcxOTAiDCCQMOpwvg8FaYguJSqcA5daFb2xSCu3tt7Nvh%2BxZV%2BO3enG2jNQV4Ue982LD3G%2FwWHDa6qrUX9tkLloXXN6iFRizLE0rzSncYmC0WmoRrsfQke9z7g%2FnsR11ABXPfG8CzBdyaryiWIkTfwuKTbL1oIJH7PPYKcfokDjQxn2SLTaWWIpMDoGQ%2F16kq9S0Y29%2B%2FI%2B%2BPeMbYIKJP5jS0Jzi%2BXmsHvkkyjz5D2lrctMyl1i%2F7LtME0DMyITxIsZp57qI%2FkXzS2iO1wsUWnoI5c5irTceWtYbs%2BsOUiF71H0%2BM%2BZ9O95WVbH0z5EVrIBh%2F6mr58KEhblQNy9oIrfX4xC7R6ANm%2FcWJR6ExXX5Kb00VusNOLUt2TfnW%2Fu8pcXS4chNjOisF%2FhDKoD%2FdIqaydJPmW82rGJ0yiDfVhLeR4E6OlLH8zFODMIH9lrXEg61zHE80i1MZfQ0LXgSrHNHfu1R6fEm7GUszmXeDq9nATrFKjiiHH80Vanu199HmiYi9xIuYyOXFmuL0v9obr9D41XBXND6uigZl3qA1Kj98ri5BeOaAEh%2Fu2ht%2Bloej0wlMux6gU6tAEKiRY8IbT9m1JzxTOPQmD%2BdO7HzPtJ%2BeJgQ5UjomWfANeuw7vUI5frcM2twf%2BuiCffR%2FRRe1DArgWOToUiXOxd%2BvXecaEhj6bz8vX9QBzVv93xoGiKJOZn0GRCUqtJG6%2B5G6hUKK05BQEtixP%2FViMf38qGlhnYjnrObJ7424M9z4sa6foE8gHStpRaRKjWTSncOHWsAkmz3Vz9mowKu7pAUaaBf3QzkNG0I3k%2BjscKSz2RhMg%3D&X-Amz-Signature=dc04ec6f909ebbf2a87a40802424e3e140de2148729548a6da7bf1222a4a0e73)