### PR TITLE
Metrics: log data about hidden units 

### DIFF
--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -156,7 +156,8 @@ class FirehoseClient {
    * project gallery, we can also directly pass user_id as a field on the data * object. In this case, includeUserId should be false to avoid overriding
    * the manually set user_id.
    * NOTE: In scenarios where the script_id we want to log is different than
-   * that inferred by progress (such as in tracking which scripts a teacher has * hidden), we can directly pass script_id as a field on the data object by
+   * that inferred by progress (such as in tracking which scripts a teacher has
+   * hidden), we can directly pass script_id as a field on the data object by
    * setting useProgressScriptId to false to avoid overriding the manually set
    * script_id.
    */

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -155,8 +155,12 @@ class FirehoseClient {
    * NOTE: In scenarios where userId is not in pageConstants, such as in the
    * project gallery, we can also directly pass user_id as a field on the data * object. In this case, includeUserId should be false to avoid overriding
    * the manually set user_id.
+   * NOTE: In scenarios where the script_id we want to log is different than
+   * that inferred by progress (such as in tracking which scripts a teacher has * hidden), we can directly pass script_id as a field on the data object by
+   * setting useProgressScriptId to false to avoid overriding the manually set
+   * script_id.
    */
-  addCommonValues(data, includeUserId) {
+  addCommonValues(data, includeUserId, useProgressScriptId) {
     data['created_at'] = new Date().toISOString();
     data['environment'] = this.getEnvironment();
     data['uuid'] = this.getAnalyticsUuid();
@@ -171,7 +175,7 @@ class FirehoseClient {
         }
       }
       const progress = state.progress;
-      if (progress) {
+      if (progress && useProgressScriptId) {
         data['script_id'] = progress.scriptId;
         data['level_id'] = parseInt(progress.currentLevelId);
       }
@@ -209,9 +213,18 @@ class FirehoseClient {
    */
   putRecord(
     data,
-    options = {alwaysPut: false, includeUserId: false, callback: null}
+    options = {
+      alwaysPut: false,
+      includeUserId: false,
+      callback: null,
+      useProgressScriptId: true
+    }
   ) {
-    data = this.addCommonValues(data, options.includeUserId);
+    data = this.addCommonValues(
+      data,
+      options.includeUserId,
+      options.useProgressScriptId
+    );
     const handleError = this.handleError.bind(this, data);
     if (!this.shouldPutRecord(options['alwaysPut'])) {
       console.groupCollapsed('Skipped sending record to ' + deliveryStreamName);
@@ -248,9 +261,20 @@ class FirehoseClient {
    * @option options [boolean] alwaysPut Forces the record to be sent.
    * @option options [boolean] includeUserId Include userId in records, if signed in
    */
-  putRecordBatch(data, options = {alwaysPut: false, includeUserId: false}) {
+  putRecordBatch(
+    data,
+    options = {
+      alwaysPut: false,
+      includeUserId: false,
+      useProgressScriptId: true
+    }
+  ) {
     data.map(function(record) {
-      return this.AddCommonValues(record, options.includeUserId);
+      return this.AddCommonValues(
+        record,
+        options.includeUserId,
+        options.useProgressScriptId
+      );
     });
 
     if (!this.shouldPutRecord(options['alwaysPut'])) {

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -70,8 +70,10 @@ class CourseScript extends Component {
         study_group: 'v0',
         event: value,
         script_id: id,
-        data_int: selectedSectionId,
-        data_string: name
+        data_json: JSON.stringify({
+          script_name: name,
+          section_id: selectedSectionId
+        })
       },
       {useProgressScriptId: false}
     );

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -10,6 +10,7 @@ import {
   isScriptHiddenForSection,
   toggleHiddenScript
 } from '@cdo/apps/code-studio/hiddenStageRedux';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   main: {
@@ -63,6 +64,17 @@ class CourseScript extends Component {
   onClickHiddenToggle = value => {
     const {name, selectedSectionId, id, toggleHiddenScript} = this.props;
     toggleHiddenScript(name, selectedSectionId, id, value === 'hidden');
+    firehoseClient.putRecord(
+      {
+        study: 'hidden-units',
+        study_group: 'v0',
+        event: value,
+        script_id: id,
+        data_int: selectedSectionId,
+        data_string: name
+      },
+      {useProgressScriptId: false}
+    );
   };
 
   render() {


### PR DESCRIPTION
[LP-564](https://codedotorg.atlassian.net/browse/LP-564):

"_How many teachers are hiding lessons | units?
Which lessons | units are they hiding?
How often (if ever) do they unhide lessons | units?
Do teachers maintain multiple active sections with some categories hidden and others unhidden? 
What pattern do teachers follow when hiding lessons | units for a section? Do they update for a single section multiple times? Do they set it and forget it?_"

As a start to gathering metrics to answer the above questions, I've added Firehose logging to `onClickHiddenToggle` to log which units are being hidden/shown for which sections. For example:

<img width="594" alt="Screen Shot 2019-08-08 at 3 49 55 PM" src="https://user-images.githubusercontent.com/12300669/62742886-2e836580-b9f5-11e9-8146-7b545739c385.png">

<img width="604" alt="Screen Shot 2019-08-08 at 3 50 03 PM" src="https://user-images.githubusercontent.com/12300669/62742888-2fb49280-b9f5-11e9-8a71-322969451d31.png">

**Note: The data_int field is being set to the current sectionId.** Because we're going to have to use sectionId to find the section owner to figure out the userId I thought it would be easier to query from this column even if it means the value is label-less in the table.  Is this a horrible idea?

Also, in order to log the script_id without it being overwritten I modified firehose utils loosely following the pattern of `includeUserId`.
