### PR TITLE
Tests: Add :in_progress and :ended traits to workshop factory

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -42,19 +42,19 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
     @program_manager = create :program_manager
 
     # CSF workshop from this program manager with 10 teachers.
-    @pm_workshop = create :pd_ended_workshop, organizer: @program_manager, course: Pd::Workshop::COURSE_CSF
+    @pm_workshop = create :workshop, :ended, organizer: @program_manager, course: Pd::Workshop::COURSE_CSF
     10.times do
       create :pd_workshop_participant, workshop: @pm_workshop, enrolled: true, attended: true
     end
 
     # CSF workshop from this organizer with 10 teachers.
-    @workshop = create :pd_ended_workshop, organizer: @organizer, course: Pd::Workshop::COURSE_CSF
+    @workshop = create :workshop, :ended, organizer: @organizer, course: Pd::Workshop::COURSE_CSF
     10.times do
       create :pd_workshop_participant, workshop: @workshop, enrolled: true, attended: true
     end
 
     # Non-CSF workshop from a different organizer, with 1 teacher.
-    @other_workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_ECS,
+    @other_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_ECS,
       subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
     create :pd_workshop_participant, workshop: @other_workshop, enrolled: true, attended: true
   end
@@ -141,7 +141,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
 
     # Workshop, ended, with no teachers
     # This workshop should not be returned
-    teacherless_workshop = create :pd_ended_workshop
+    teacherless_workshop = create :workshop, :ended
 
     sign_in @workshop_admin
     get :index
@@ -163,14 +163,14 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
     start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
-    workshop_in_range = create :pd_ended_workshop, sessions_from: start_date + 2.weeks
+    workshop_in_range = create :workshop, :ended, sessions_from: start_date + 2.weeks
     teacher_in_range = create :pd_workshop_participant, workshop: workshop_in_range, enrolled: true, attended: true
 
     # Noise
-    workshop_before = create :pd_ended_workshop, sessions_from: start_date - 1.day
+    workshop_before = create :workshop, :ended, sessions_from: start_date - 1.day
     create :pd_workshop_participant, workshop: workshop_before, enrolled: true, attended: true
 
-    workshop_after = create :pd_ended_workshop, sessions_from: end_date + 1.day
+    workshop_after = create :workshop, :ended, sessions_from: end_date + 1.day
     create :pd_workshop_participant, workshop: workshop_after, enrolled: true, attended: true
 
     sign_in @workshop_admin
@@ -187,14 +187,14 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
     start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
-    workshop_in_range = create :pd_ended_workshop, ended_at: start_date + 2.weeks
+    workshop_in_range = create :workshop, :ended, ended_at: start_date + 2.weeks
     teacher_in_range = create :pd_workshop_participant, workshop: workshop_in_range, enrolled: true, attended: true
 
     # Noise
-    workshop_before = create :pd_ended_workshop, ended_at: start_date - 1.day
+    workshop_before = create :workshop, :ended, ended_at: start_date - 1.day
     create :pd_workshop_participant, workshop: workshop_before, enrolled: true, attended: true
 
-    workshop_after = create :pd_ended_workshop, ended_at: end_date + 1.day
+    workshop_after = create :workshop, :ended, ended_at: end_date + 1.day
     create :pd_workshop_participant, workshop: workshop_after, enrolled: true, attended: true
 
     sign_in @workshop_admin

--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -133,7 +133,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   test 'Returns only workshops that have ended and have teachers' do
     # Workshop, not ended, with teachers
     # This workshop should not be returned
-    workshop_in_progress = create :workshop, num_sessions: 1
+    workshop_in_progress = create :workshop
     workshop_in_progress.start!
     5.times do
       create :pd_workshop_participant, workshop: workshop_in_progress, enrolled: true, attended: true

--- a/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
@@ -50,15 +50,15 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ::ActionController::Tes
     @program_manager = create :program_manager
 
     # CSF workshop for this regional partner
-    @workshop = create :pd_ended_workshop, organizer: @program_manager, course: Pd::Workshop::COURSE_CSF
+    @workshop = create :workshop, :ended, organizer: @program_manager, course: Pd::Workshop::COURSE_CSF
     create :pd_workshop_participant, workshop: @workshop, enrolled: true, attended: true
 
     # CSF workshop for this organizer.
-    @organizer_workshop = create :pd_ended_workshop, organizer: @organizer, course: Pd::Workshop::COURSE_CSF
+    @organizer_workshop = create :workshop, :ended, organizer: @organizer, course: Pd::Workshop::COURSE_CSF
     create :pd_workshop_participant, workshop: @organizer_workshop, enrolled: true, attended: true
 
     # Non-CSF workshop from a different organizer
-    @other_workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_ECS,
+    @other_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_ECS,
       subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
   end
 
@@ -151,11 +151,11 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ::ActionController::Tes
     start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
-    workshop_in_range = create :pd_ended_workshop, sessions_from: start_date + 2.weeks
+    workshop_in_range = create :workshop, :ended, sessions_from: start_date + 2.weeks
 
     # Noise
-    create :pd_ended_workshop, sessions_from: start_date - 1.day
-    create :pd_ended_workshop, sessions_from: end_date + 1.day
+    create :workshop, :ended, sessions_from: start_date - 1.day
+    create :workshop, :ended, sessions_from: end_date + 1.day
 
     sign_in @workshop_admin
     get :index, params: {start: start_date, end: end_date, query_by: 'schedule'}
@@ -170,11 +170,11 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ::ActionController::Tes
     start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
-    workshop_in_range = create :pd_ended_workshop, ended_at: start_date + 2.weeks
+    workshop_in_range = create :workshop, :ended, ended_at: start_date + 2.weeks
 
     # Noise
-    create :pd_ended_workshop, ended_at: start_date - 1.day
-    create :pd_ended_workshop, ended_at: end_date + 1.day
+    create :workshop, :ended, ended_at: start_date - 1.day
+    create :workshop, :ended, ended_at: end_date + 1.day
 
     sign_in @workshop_admin
     get :index, params: {start: start_date, end: end_date, query_by: 'end'}
@@ -212,7 +212,7 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ::ActionController::Tes
   end
 
   test 'includes unpaid workshops' do
-    unpaid_workshop = create :pd_ended_workshop, organizer: @program_manager, course: Pd::Workshop::COURSE_CSD
+    unpaid_workshop = create :workshop, :ended, organizer: @program_manager, course: Pd::Workshop::COURSE_CSD
     create :pd_workshop_participant, workshop: @workshop, enrolled: true, attended: true
 
     sign_in @workshop_admin

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -159,8 +159,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
       :funded,
       organizer: @organizer,
       facilitators: [@facilitator],
-      regional_partner: @regional_partner,
-      num_sessions: 1
+      regional_partner: @regional_partner
     )
 
     fit_weekend = create(
@@ -261,7 +260,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
 
   test 'filter by state' do
     sign_in @admin
-    workshop_in_progress = create :workshop, num_sessions: 1
+    workshop_in_progress = create :workshop
     workshop_in_progress.start!
     assert_equal Pd::Workshop::STATE_IN_PROGRESS, workshop_in_progress.state
 
@@ -326,13 +325,13 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   test 'filters' do
     # 10 workshops from different organizers that will be filtered out
     10.times do
-      create :workshop, num_sessions: 1
+      create :workshop
     end
 
     # Same organizer
     organizer = create :workshop_organizer
-    earlier_workshop = create :workshop, organizer: organizer, num_sessions: 1, sessions_from: Time.now
-    later_workshop = create :workshop, organizer: organizer, num_sessions: 1, sessions_from: Time.now + 1.week
+    earlier_workshop = create :workshop, organizer: organizer, sessions_from: Time.now
+    later_workshop = create :workshop, organizer: organizer, sessions_from: Time.now + 1.week
 
     sign_in @workshop_admin
     filters = {organizer_id: organizer.id.to_s, order_by: 'date desc'}
@@ -1034,7 +1033,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     phoenix = create(
       :workshop,
       course: Pd::Workshop::COURSE_CSD,
-      num_sessions: 1,
       organizer: @organizer,
       subject: Pd::Workshop::SUBJECT_TEACHER_CON,
       location_address: "Phoenix"
@@ -1042,7 +1040,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     atlanta = create(
       :workshop,
       course: Pd::Workshop::COURSE_CSD,
-      num_sessions: 1,
       organizer: @organizer,
       subject: Pd::Workshop::SUBJECT_TEACHER_CON,
       location_address: "Atlanta"
@@ -1061,14 +1058,12 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     csd = create(
       :workshop,
       course: Pd::Workshop::COURSE_CSD,
-      num_sessions: 1,
       organizer: @organizer,
       subject: Pd::Workshop::SUBJECT_TEACHER_CON,
     )
     csp = create(
       :workshop,
       course: Pd::Workshop::COURSE_CSP,
-      num_sessions: 1,
       organizer: @organizer,
       subject: Pd::Workshop::SUBJECT_TEACHER_CON,
     )

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -189,7 +189,8 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     sign_in(teacher)
 
     teachercon = create(
-      :pd_ended_workshop,
+      :workshop,
+      :ended,
       :teachercon,
       :funded,
       organizer: @organizer,
@@ -198,7 +199,8 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     )
 
     fit_weekend = create(
-      :pd_ended_workshop,
+      :workshop,
+      :ended,
       :funded,
       subject: Pd::Workshop::SUBJECT_CSD_FIT,
       course: Pd::Workshop::COURSE_CSD,

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -710,19 +710,20 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'program manager organizers can add workshop sessions' do
-    sign_in @organizer
-    assert_equal 0, @workshop.sessions.count
+    program_manager = create :program_manager
+    workshop = create :workshop, organizer: program_manager, num_sessions: 0
+    sign_in program_manager
 
     session_start = tomorrow_at 9
     session_end = tomorrow_at 17
     params = {sessions_attributes: [{start: session_start, end: session_end}]}
 
-    put :update, params: {id: @workshop.id, pd_workshop: params}
+    put :update, params: {id: workshop.id, pd_workshop: params}
     assert_response :success
-    @workshop.reload
-    assert_equal 1, @workshop.sessions.count
-    assert_equal session_start, @workshop.sessions.first[:start]
-    assert_equal session_end, @workshop.sessions.first[:end]
+    workshop.reload
+    assert_equal 1, workshop.sessions.count
+    assert_equal session_start, workshop.sessions.first[:start]
+    assert_equal session_end, workshop.sessions.first[:end]
   end
 
   # TODO: remove this test when workshop_organizer is deprecated

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -873,19 +873,20 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'program manager organizers can start and stop their workshops' do
-    sign_in @organizer
-    @workshop.sessions << create(:pd_session)
-    assert_equal 'Not Started', @workshop.state
+    program_manager = create :program_manager
+    workshop = create :workshop, organizer: program_manager
+    assert_equal 'Not Started', workshop.state
 
-    post :start, params: {id: @workshop.id}
+    sign_in program_manager
+    post :start, params: {id: workshop.id}
     assert_response :success
-    @workshop.reload
-    assert_equal 'In Progress', @workshop.state
+    workshop.reload
+    assert_equal 'In Progress', workshop.state
 
-    post :end, params: {id: @workshop.id}
+    post :end, params: {id: workshop.id}
     assert_response :success
-    @workshop.reload
-    assert_equal 'Ended', @workshop.state
+    workshop.reload
+    assert_equal 'Ended', workshop.state
   end
 
   # TODO: remove this test when workshop_organizer is deprecated
@@ -905,16 +906,16 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
 
   test 'program manager organizers cannot start and stop workshops they are not organizing' do
     sign_in create(:workshop_organizer)
-    @workshop.sessions << create(:pd_session)
-    assert_equal 'Not Started', @workshop.state
+    workshop = create :workshop
+    assert_equal 'Not Started', workshop.state
 
-    post :start, params: {id: @workshop.id}
+    post :start, params: {id: workshop.id}
     assert_response :forbidden
 
-    post :end, params: {id: @workshop.id}
+    post :end, params: {id: workshop.id}
     assert_response :forbidden
-    @workshop.reload
-    assert_equal 'Not Started', @workshop.state
+    workshop.reload
+    assert_equal 'Not Started', workshop.state
   end
 
   # No access

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -6,8 +6,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
 
   self.use_transactional_test_case = true
   setup_all do
-    @workshop_admin = create(:workshop_admin)
-
     @regional_partner = create(:regional_partner)
     @program_manager = create(:program_manager, regional_partner: @regional_partner)
     @organizer = @program_manager
@@ -332,7 +330,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     earlier_workshop = create :workshop, organizer: organizer, sessions_from: Time.now
     later_workshop = create :workshop, organizer: organizer, sessions_from: Time.now + 1.week
 
-    sign_in @workshop_admin
+    sign_in create :workshop_admin
     filters = {organizer_id: organizer.id.to_s, order_by: 'date desc'}
     get :filter, params: filters
     response = JSON.parse(@response.body)
@@ -345,7 +343,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   # Action: Show
 
   test 'admins can view workshops' do
-    [create(:admin), @workshop_admin].each do |admin|
+    [create(:admin), create(:workshop_admin)].each do |admin|
       sign_in admin
       get :show, params: {id: @workshop.id}
       assert_response :success

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -751,26 +751,28 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'program manager organizers can update existing workshop sessions' do
-    sign_in @organizer
+    program_manager = create :program_manager
+    workshop = create :workshop, organizer: program_manager, num_sessions: 0
     session_initial_start = tomorrow_at 9
     session_initial_end = tomorrow_at 15
     session = create(:pd_session, start: session_initial_start, end: session_initial_end)
-    @workshop.sessions << session
-    @workshop.save!
-    assert_equal 1, @workshop.sessions.count
+    workshop.sessions << session
+    workshop.save!
+    assert_equal 1, workshop.sessions.count
 
+    sign_in program_manager
     session_updated_start = session_initial_start + 2.days
     session_updated_end = session_initial_end + 2.days + 2.hours
     params = {
       sessions_attributes: [{id: session.id, start: session_updated_start, end: session_updated_end}]
     }
-
-    put :update, params: {id: @workshop.id, pd_workshop: params}
+    put :update, params: {id: workshop.id, pd_workshop: params}
     assert_response :success
-    @workshop.reload
-    assert_equal 1, @workshop.sessions.count
-    assert_equal session_updated_start, @workshop.sessions.first[:start]
-    assert_equal session_updated_end, @workshop.sessions.first[:end]
+
+    workshop.reload
+    assert_equal 1, workshop.sessions.count
+    assert_equal session_updated_start, workshop.sessions.first[:start]
+    assert_equal session_updated_end, workshop.sessions.first[:end]
   end
 
   # TODO: remove this test when workshop_organizer is deprecated

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -1087,26 +1087,26 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'workshop admins can unstart' do
-    @workshop.sessions << create(:pd_session)
-    @workshop.start!
+    workshop = create :workshop
+    workshop.start!
 
-    sign_in @workshop_admin
-    post :unstart, params: {id: @workshop.id}
+    sign_in create :workshop_admin
+    post :unstart, params: {id: workshop.id}
     assert_response :success
-    @workshop.reload
-    assert_equal 'Not Started', @workshop.state
+    workshop.reload
+    assert_equal 'Not Started', workshop.state
   end
 
   test 'workshop admins can reopen' do
-    @workshop.sessions << create(:pd_session)
-    @workshop.start!
-    @workshop.end!
+    workshop = create :workshop
+    workshop.start!
+    workshop.end!
 
-    sign_in @workshop_admin
-    post :reopen, params: {id: @workshop.id}
+    sign_in create :workshop_admin
+    post :reopen, params: {id: workshop.id}
     assert_response :success
-    @workshop.reload
-    assert_equal 'In Progress', @workshop.state
+    workshop.reload
+    assert_equal 'In Progress', workshop.state
   end
 
   test 'program managers cannot unstart' do

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -838,19 +838,20 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   # Actions: Start, End
 
   test 'admins can start and end workshops' do
-    sign_in @admin
-    @workshop.sessions << create(:pd_session)
-    assert_equal 'Not Started', @workshop.state
+    workshop = create :workshop
 
-    post :start, params: {id: @workshop.id}
-    assert_response :success
-    @workshop.reload
-    assert_equal 'In Progress', @workshop.state
+    sign_in create :admin
+    assert_equal 'Not Started', workshop.state
 
-    post :end, params: {id: @workshop.id}
+    post :start, params: {id: workshop.id}
     assert_response :success
-    @workshop.reload
-    assert_equal 'Ended', @workshop.state
+    workshop.reload
+    assert_equal 'In Progress', workshop.state
+
+    post :end, params: {id: workshop.id}
+    assert_response :success
+    workshop.reload
+    assert_equal 'Ended', workshop.state
   end
 
   # TODO: remove this test when workshop_organizer is deprecated

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -6,7 +6,6 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
 
   self.use_transactional_test_case = true
   setup_all do
-    @admin = create(:admin)
     @workshop_admin = create(:workshop_admin)
 
     @regional_partner = create(:regional_partner)
@@ -46,7 +45,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   test_user_gets_response_for :index, user: nil, response: :forbidden
 
   test 'admins can list all workshops' do
-    sign_in @admin
+    sign_in create :admin
     assert_equal 3, Pd::Workshop.count
 
     get :index
@@ -259,7 +258,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'filter by state' do
-    sign_in @admin
+    sign_in create :admin
     workshop_in_progress = create :workshop
     workshop_in_progress.start!
     assert_equal Pd::Workshop::STATE_IN_PROGRESS, workshop_in_progress.state
@@ -273,7 +272,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
 
   # Action: filter
   test 'admins can filter' do
-    sign_in @admin
+    sign_in create :admin
     get :filter
     assert_response :success
   end
@@ -298,7 +297,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'filter defaults' do
-    sign_in @admin
+    sign_in create :admin
     get :filter
     response = JSON.parse(@response.body)
     assert_nil response['limit']
@@ -313,7 +312,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
       create :workshop
     end
 
-    sign_in @admin
+    sign_in create :admin
     get :filter, params: {limit: 5}
     response = JSON.parse(@response.body)
     assert_equal 5, response['limit']
@@ -346,7 +345,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   # Action: Show
 
   test 'admins can view workshops' do
-    [@admin, @workshop_admin].each do |admin|
+    [create(:admin), @workshop_admin].each do |admin|
       sign_in admin
       get :show, params: {id: @workshop.id}
       assert_response :success
@@ -423,7 +422,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   # Action: Create
 
   test 'admins can create workshops' do
-    sign_in @admin
+    sign_in create :admin
 
     assert_creates(Pd::Workshop) do
       post :create, params: {pd_workshop: workshop_params}
@@ -513,7 +512,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'admins can delete any workshop' do
-    sign_in @admin
+    sign_in create :admin
     assert_destroys(Pd::Workshop) do
       delete :destroy, params: {id: @workshop.id}
     end
@@ -572,7 +571,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   # Action: Update
 
   test 'admins can update any workshop' do
-    sign_in @admin
+    sign_in create :admin
     put :update, params: {id: @workshop.id, pd_workshop: workshop_params}
     assert_response :success
   end
@@ -655,7 +654,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   )
 
   test 'updating with notify true sends detail change notification emails' do
-    sign_in @admin
+    sign_in create :admin
 
     # create some enrollments
     5.times do
@@ -674,7 +673,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'updating with notify false does not send detail change notification emails' do
-    sign_in @admin
+    sign_in create :admin
 
     # create some enrollments
     5.times do
@@ -979,7 +978,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   )
 
   test 'summary' do
-    sign_in @admin
+    sign_in create :admin
     workshop = create :workshop, num_sessions: 3
     workshop.start!
 
@@ -1045,7 +1044,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
       location_address: "Atlanta"
     )
 
-    sign_in @admin
+    sign_in create :admin
 
     get :upcoming_teachercons
     assert_response :success
@@ -1068,7 +1067,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
       subject: Pd::Workshop::SUBJECT_TEACHER_CON,
     )
 
-    sign_in @admin
+    sign_in create :admin
 
     get :upcoming_teachercons, params: {course: Pd::Workshop::COURSE_CSD}
     assert_response :success

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -788,18 +788,17 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   end
 
   test 'program manager organizers can destroy workshop sessions' do
-    sign_in @organizer
-    session = create(:pd_session)
-    @workshop.sessions << session
-    @workshop.save!
-    assert_equal 1, @workshop.sessions.count
+    program_manager = create :program_manager
+    workshop = create :workshop, organizer: program_manager
+    session = workshop.sessions.first
 
+    sign_in program_manager
     params = {sessions_attributes: [{id: session.id, _destroy: true}]}
-
-    put :update, params: {id: @workshop.id, pd_workshop: params}
+    put :update, params: {id: workshop.id, pd_workshop: params}
     assert_response :success
-    @workshop.reload
-    assert_equal 0, @workshop.sessions.count
+
+    workshop.reload
+    assert_equal 0, workshop.sessions.count
   end
 
   # TODO: remove this test when workshop_organizer is deprecated

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -29,7 +29,8 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
       :funded,
       organizer: @workshop_organizer,
       facilitators: [@facilitator],
-      on_map: true
+      on_map: true,
+      num_sessions: 0
     )
 
     @standalone_workshop = create(:workshop)

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCase
   def prepare_scenario
-    @csf_workshop = create :pd_ended_workshop, num_sessions: 3, course: Pd::Workshop::COURSE_CSF, ended_at: Date.today - 1.day
-    @csd_workshop = create :pd_ended_workshop, num_sessions: 3, course: Pd::Workshop::COURSE_CSD, ended_at: Date.today - 2.days
+    @csf_workshop = create :workshop, :ended, num_sessions: 3, course: Pd::Workshop::COURSE_CSF, ended_at: Date.today - 1.day
+    @csd_workshop = create :workshop, :ended, num_sessions: 3, course: Pd::Workshop::COURSE_CSD, ended_at: Date.today - 2.days
     @csp_workshop = create :workshop, num_sessions: 3, course: Pd::Workshop::COURSE_CSP
 
     @teacher = create(:teacher, email: 'test_email@foo.com', user_type: 'teacher')
@@ -35,7 +35,8 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
     skip 'Investigate flaky test failures'
 
     # Fake Admin workshop, which should produce an exit survey
-    admin_workshop = create :pd_ended_workshop,
+    admin_workshop = create :workshop,
+      :ended,
       course: Pd::Workshop::COURSE_ADMIN,
       subject: nil
 
@@ -55,7 +56,8 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
 
   test 'FiT workshops do not show up as pending exit surveys' do
     # Fake FiT workshop, which should not produce an exit survey
-    fit_workshop = create :pd_ended_workshop,
+    fit_workshop = create :workshop,
+      :ended,
       course: Pd::Workshop::COURSE_CSF,
       subject: Pd::Workshop::SUBJECT_CSF_FIT
 
@@ -79,12 +81,14 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
 
     # Fake CSF workshop (older than the FiT workshop) which should
     # produce a pending exit survey
-    csf_workshop = create :pd_ended_workshop,
+    csf_workshop = create :workshop,
+      :ended,
       course: Pd::Workshop::COURSE_CSF,
       ended_at: Date.today - 1.day
 
     # Fake FiT workshop, which should not produce an exit survey
-    fit_workshop = create :pd_ended_workshop,
+    fit_workshop = create :workshop,
+      :ended,
       course: Pd::Workshop::COURSE_CSD,
       subject: Pd::Workshop::SUBJECT_CSD_FIT
 
@@ -105,7 +109,8 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
 
   test 'Facilitator workshops do not show up as pending exit surveys' do
     # Fake FiT workshop, which should not produce an exit survey
-    facilitator_workshop = create :pd_ended_workshop,
+    facilitator_workshop = create :workshop,
+      :ended,
       course: Pd::Workshop::COURSE_FACILITATOR
 
     # Given a teacher that attended the workshop, such that they would get
@@ -128,12 +133,14 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
 
     # Fake CSF workshop (older than the Facilitator workshop) which should
     # produce a pending exit survey
-    csf_workshop = create :pd_ended_workshop,
+    csf_workshop = create :workshop,
+      :ended,
       course: Pd::Workshop::COURSE_CSF,
       ended_at: Date.today - 1.day
 
     # Fake Facilitator workshop, which should not produce an exit survey
-    facilitator_workshop = create :pd_ended_workshop,
+    facilitator_workshop = create :workshop,
+      :ended,
       course: Pd::Workshop::COURSE_FACILITATOR
 
     # Given a teacher that attended both workshops

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -250,7 +250,7 @@ module Pd
     test 'enrollment code override is used when fetching the workshop for a user' do
       setup_academic_year_workshop
       other_academic_workshop = create :workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1,
-        num_sessions: 1, regional_partner: @regional_partner, facilitators: @facilitators, sessions_from: Date.today + 1.month
+        regional_partner: @regional_partner, facilitators: @facilitators, sessions_from: Date.today + 1.month
       other_enrollment = create :pd_enrollment, :from_user, workshop: other_academic_workshop, user: @enrolled_academic_year_teacher
       create :pd_attendance, session: other_academic_workshop.sessions[0], teacher: @enrolled_academic_year_teacher, enrollment: other_enrollment
 
@@ -1074,7 +1074,7 @@ module Pd
     def setup_academic_year_workshop
       @regional_partner = create :regional_partner
       @academic_year_workshop = create :workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1,
-        num_sessions: 1, num_facilitators: 2, regional_partner: @regional_partner
+        num_facilitators: 2, regional_partner: @regional_partner
       @academic_year_enrollment = create :pd_enrollment, :from_user, workshop: @academic_year_workshop
       @enrolled_academic_year_teacher = @academic_year_enrollment.user
       @facilitators = @academic_year_workshop.facilitators
@@ -1094,14 +1094,14 @@ module Pd
       @regional_partner = create :regional_partner
       @csf201_not_started_workshop = create :workshop,
         course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
-        num_sessions: 1, num_facilitators: 2
+        num_facilitators: 2
     end
 
     def setup_csf201_in_progress_workshop
       @regional_partner = create :regional_partner
       @csf201_in_progress_workshop = create :workshop,
         course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
-        num_sessions: 1, num_facilitators: 2, started_at: DateTime.now
+        num_facilitators: 2, started_at: DateTime.now
     end
 
     def setup_csf201_ended_workshop
@@ -1111,7 +1111,6 @@ module Pd
         course: COURSE_CSF,
         subject: SUBJECT_CSF_201,
         regional_partner: @regional_partner,
-        num_sessions: 1,
         num_facilitators: 2
     end
 

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -1100,8 +1100,11 @@ module Pd
     def setup_csf201_in_progress_workshop
       @regional_partner = create :regional_partner
       @csf201_in_progress_workshop = create :workshop,
-        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
-        num_facilitators: 2, started_at: DateTime.now
+        :in_progress,
+        course: COURSE_CSF,
+        subject: SUBJECT_CSF_201,
+        regional_partner: @regional_partner,
+        num_facilitators: 2
     end
 
     def setup_csf201_ended_workshop

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -1106,9 +1106,13 @@ module Pd
 
     def setup_csf201_ended_workshop
       @regional_partner = create :regional_partner
-      @csf201_ended_workshop = create :pd_ended_workshop,
-        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
-        num_sessions: 1, num_facilitators: 2
+      @csf201_ended_workshop = create :workshop,
+        :ended,
+        course: COURSE_CSF,
+        subject: SUBJECT_CSF_201,
+        regional_partner: @regional_partner,
+        num_sessions: 1,
+        num_facilitators: 2
     end
 
     def unenrolled_teacher

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -53,6 +53,11 @@ FactoryGirl.define do
       subject Pd::Workshop::SUBJECT_CSP_FIT
     end
 
+    trait :ended do
+      started_at {Time.zone.now}
+      ended_at {Time.zone.now}
+    end
+
     trait :with_codes_assigned do
       assign_session_code true
     end
@@ -120,8 +125,7 @@ FactoryGirl.define do
 
     # TODO: Change into a trait
     factory :pd_ended_workshop do
-      started_at {Time.zone.now}
-      ended_at {Time.zone.now}
+      ended
     end
   end
 end

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -67,15 +67,17 @@ FactoryGirl.define do
     #
 
     after(:build) do |workshop, evaluator|
-      # Sessions, one per day starting today
-      evaluator.num_sessions.times do |i|
-        params = [{
-          workshop: workshop,
-          start: evaluator.sessions_from + i.days,
-          duration_hours: evaluator.each_session_hours
-        }]
-        params.prepend :with_assigned_code if evaluator.assign_session_code
-        workshop.sessions << build(:pd_session, *params)
+      # Sessions, one per day starting today (unless they were manually provided)
+      if evaluator.sessions.empty?
+        evaluator.num_sessions.times do |i|
+          params = [{
+            workshop: workshop,
+            start: evaluator.sessions_from + i.days,
+            duration_hours: evaluator.each_session_hours
+          }]
+          params.prepend :with_assigned_code if evaluator.assign_session_code
+          workshop.sessions << build(:pd_session, *params)
+        end
       end
       evaluator.num_enrollments.times do
         workshop.enrollments << build(:pd_enrollment, workshop: workshop)

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -4,7 +4,7 @@
 FactoryGirl.define do
   factory :workshop, class: 'Pd::Workshop', aliases: [:pd_workshop] do
     transient do
-      num_sessions 0
+      num_sessions 1
       num_facilitators 0
       sessions_from {Date.current + 9.hours} # Start time of the first session, then one per day after that.
       each_session_hours 6
@@ -118,7 +118,6 @@ FactoryGirl.define do
 
     # TODO: Change into a trait
     factory :pd_ended_workshop do
-      num_sessions 1
       started_at {Time.zone.now}
       ended_at {Time.zone.now}
     end

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -53,6 +53,10 @@ FactoryGirl.define do
       subject Pd::Workshop::SUBJECT_CSP_FIT
     end
 
+    trait :in_progress do
+      started_at {Time.zone.now}
+    end
+
     trait :ended do
       started_at {Time.zone.now}
       ended_at {Time.zone.now}

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -122,10 +122,5 @@ FactoryGirl.define do
     #
     # Sub-factories
     #
-
-    # TODO: Change into a trait
-    factory :pd_ended_workshop do
-      ended
-    end
   end
 end

--- a/dashboard/test/helpers/pd/find_related_workshops_helper_test.rb
+++ b/dashboard/test/helpers/pd/find_related_workshops_helper_test.rb
@@ -14,12 +14,10 @@ class FindRelatedWorkshopTests < ActiveSupport::TestCase
     default_props = {
       course: Pd::Workshop::COURSE_CSD,
       subject: Pd::Workshop::SUBJECT_CSD_UNITS_2_3,
-      num_sessions: 1,
       sessions_from: Date.new(2018, 7, 1),
-      started_at: Date.today
     }
 
-    @first_workshop = create :workshop, default_props.merge(
+    @first_workshop = create :workshop, :in_progress, default_props.merge(
       {
         facilitators: [@facilitator],
         regional_partner: @regional_partner,
@@ -27,32 +25,32 @@ class FindRelatedWorkshopTests < ActiveSupport::TestCase
       }
     )
 
-    @same_regional_partner = create :workshop, default_props.merge(
+    @same_regional_partner = create :workshop, :in_progress, default_props.merge(
       {
         regional_partner: @regional_partner
       }
     )
 
-    @same_organizer = create :workshop, default_props.merge(
+    @same_organizer = create :workshop, :in_progress, default_props.merge(
       {
         organizer: @organizer
       }
     )
 
-    @same_facilitator = create :workshop, default_props.merge(
+    @same_facilitator = create :workshop, :in_progress, default_props.merge(
       {
         facilitators: [@facilitator]
       }
     )
 
     # These two should never be included. Creating them to make sure of it
-    create :workshop, default_props.merge(
+    create :workshop, :in_progress, default_props.merge(
       {
         sessions_from: Date.new(2018, 5, 31)
       }
     )
 
-    create :workshop, default_props.merge(
+    create :workshop, :in_progress, default_props.merge(
       {
         course: Pd::Workshop::COURSE_CSP
       }

--- a/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 module Pd::Payment
   class PaymentCalculatorBaseTest < ActiveSupport::TestCase
     test 'public unqualified' do
-      empty_workshop = create :pd_ended_workshop,
+      empty_workshop = create :workshop, :ended,
         on_map: true, funded: true,
         course: Pd::Workshop::COURSE_CSP,
         subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
@@ -16,10 +16,10 @@ module Pd::Payment
     end
 
     test 'pay_period' do
-      workshop_1 = create :pd_ended_workshop, ended_at: Date.new(2016, 9, 1)
-      workshop_15 = create :pd_ended_workshop, ended_at: Date.new(2016, 9, 15)
-      workshop_16 = create :pd_ended_workshop, ended_at: Date.new(2016, 9, 16)
-      workshop_30 = create :pd_ended_workshop, ended_at: Date.new(2016, 9, 30)
+      workshop_1 = create :workshop, :ended, ended_at: Date.new(2016, 9, 1)
+      workshop_15 = create :workshop, :ended, ended_at: Date.new(2016, 9, 15)
+      workshop_16 = create :workshop, :ended, ended_at: Date.new(2016, 9, 16)
+      workshop_30 = create :workshop, :ended, ended_at: Date.new(2016, 9, 30)
 
       assert_equal '09/01/2016 - 09/15/2016', PaymentCalculatorBase.instance.get_pay_period(workshop_1)
       assert_equal '09/01/2016 - 09/15/2016', PaymentCalculatorBase.instance.get_pay_period(workshop_15)
@@ -28,22 +28,22 @@ module Pd::Payment
     end
 
     test 'workshop payment type and regional_partner' do
-      workshop_no_regional_partner = create :pd_ended_workshop
+      workshop_no_regional_partner = create :workshop, :ended
       create :pd_workshop_participant, workshop: workshop_no_regional_partner, enrolled: true, attended: true
 
       regional_partner_urban = create :regional_partner, urban: true
       program_manager_urban = (create :regional_partner_program_manager, regional_partner: regional_partner_urban).program_manager
-      workshop_regional_partner_urban = create :pd_ended_workshop, organizer: program_manager_urban
+      workshop_regional_partner_urban = create :workshop, :ended, organizer: program_manager_urban
       create :pd_workshop_participant, workshop: workshop_regional_partner_urban, enrolled: true, attended: true
 
       regional_partner_non_urban = create :regional_partner, urban: false
       program_manager_non_urban = (create :regional_partner_program_manager, regional_partner: regional_partner_non_urban).program_manager
-      workshop_regional_partner_non_urban = create :pd_ended_workshop, organizer: program_manager_non_urban
+      workshop_regional_partner_non_urban = create :workshop, :ended, organizer: program_manager_non_urban
       create :pd_workshop_participant, workshop: workshop_regional_partner_non_urban, enrolled: true, attended: true
 
       regional_partner_nil_urban = create :regional_partner, urban: nil
       program_manager_nil_urban = (create :regional_partner_program_manager, regional_partner: regional_partner_nil_urban).program_manager
-      workshop_regional_partner_nil_urban = create :pd_ended_workshop, organizer: program_manager_nil_urban
+      workshop_regional_partner_nil_urban = create :workshop, :ended, organizer: program_manager_nil_urban
       create :pd_workshop_participant, workshop: workshop_regional_partner_nil_urban, enrolled: true, attended: true
 
       summary_no_regional_partner = PaymentCalculatorBase.instance.calculate workshop_no_regional_partner
@@ -73,7 +73,7 @@ module Pd::Payment
     test 'attendance' do
       # Create a workshop with 4 sessions, which will be capped at 3
       # TIME_CONSTRAINTS: COURSE_ECS => {SUBJECT_ECS_PHASE_4 => {min_days: 2, max_days: 3, max_hours: 18}}
-      workshop = create :pd_ended_workshop,
+      workshop = create :workshop, :ended,
         on_map: true, funded: true,
         course: Pd::Workshop::COURSE_ECS,
         subject: Pd::Workshop::SUBJECT_ECS_PHASE_4,
@@ -147,7 +147,7 @@ module Pd::Payment
     end
 
     test 'teacher summaries' do
-      workshop = create :pd_ended_workshop, :local_summer_workshop, num_sessions: 2
+      workshop = create :workshop, :ended, :local_summer_workshop, num_sessions: 2
 
       teacher_unqualified = create :pd_workshop_participant,
         workshop: workshop, enrolled: true, attended: true
@@ -222,7 +222,7 @@ module Pd::Payment
     end
 
     test 'teacher summaries with deleted teacher account' do
-      workshop = create :pd_ended_workshop, num_sessions: 1
+      workshop = create :workshop, :ended, num_sessions: 1
 
       pd_workshop_participant = create :pd_workshop_participant,
         workshop: workshop,
@@ -248,7 +248,7 @@ module Pd::Payment
     end
 
     test 'unexpected payment term' do
-      workshop = create :pd_ended_workshop
+      workshop = create :workshop, :ended
       create :pd_workshop_participant,
         workshop: workshop, enrolled: true, attended: true
       Pd::Enrollment.last.school_info.school_district
@@ -263,7 +263,7 @@ module Pd::Payment
     end
 
     test 'late-deleted enrollments with attendance still show up' do
-      workshop = create :pd_ended_workshop, num_sessions: 1
+      workshop = create :workshop, :ended, num_sessions: 1
 
       pd_workshop_participant = create :pd_workshop_participant,
         workshop: workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
@@ -222,7 +222,7 @@ module Pd::Payment
     end
 
     test 'teacher summaries with deleted teacher account' do
-      workshop = create :workshop, :ended, num_sessions: 1
+      workshop = create :workshop, :ended
 
       pd_workshop_participant = create :pd_workshop_participant,
         workshop: workshop,
@@ -263,7 +263,7 @@ module Pd::Payment
     end
 
     test 'late-deleted enrollments with attendance still show up' do
-      workshop = create :workshop, :ended, num_sessions: 1
+      workshop = create :workshop, :ended
 
       pd_workshop_participant = create :pd_workshop_participant,
         workshop: workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_counselor_admin_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_counselor_admin_test.rb
@@ -6,12 +6,8 @@ module Pd::Payment
       @workshop = create :workshop, :ended,
         on_map: true, funded: true,
         course: Pd::Workshop::COURSE_COUNSELOR,
-        num_sessions: 3
-
-      # 2 facilitators
-      2.times do
-        @workshop.facilitators << create(:facilitator)
-      end
+        num_sessions: 3,
+        num_facilitators: 2
 
       # 10 qualified teachers: 1 at partial (2 days) attendance, and 9 more at full (3 days) attendance
       create :pd_workshop_participant, workshop: @workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_counselor_admin_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_counselor_admin_test.rb
@@ -94,8 +94,7 @@ module Pd::Payment
     test 'no user account' do
       workshop = create :workshop, :ended,
         on_map: true, funded: true,
-        course: Pd::Workshop::COURSE_COUNSELOR,
-        num_sessions: 1
+        course: Pd::Workshop::COURSE_COUNSELOR
 
       5.times do
         enrollment = create :pd_enrollment, workshop: workshop

--- a/dashboard/test/lib/pd/payment/payment_calculator_counselor_admin_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_counselor_admin_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module Pd::Payment
   class PaymentCalculatorCounselorAdminTest < ActiveSupport::TestCase
     setup do
-      @workshop = create :pd_ended_workshop,
+      @workshop = create :workshop, :ended,
         on_map: true, funded: true,
         course: Pd::Workshop::COURSE_COUNSELOR,
         num_sessions: 3
@@ -92,7 +92,7 @@ module Pd::Payment
     end
 
     test 'no user account' do
-      workshop = create :pd_ended_workshop,
+      workshop = create :workshop, :ended,
         on_map: true, funded: true,
         course: Pd::Workshop::COURSE_COUNSELOR,
         num_sessions: 1

--- a/dashboard/test/lib/pd/payment/payment_calculator_csf_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_csf_test.rb
@@ -5,8 +5,7 @@ module Pd::Payment
   class PaymentCalculatorCSFTest < ActiveSupport::TestCase
     self.use_transactional_test_case = true
     setup_all do
-      @workshop = create :pd_ended_workshop, :funded, course: Pd::Workshop::COURSE_CSF,
-        on_map: true, num_sessions: 1
+      @workshop = create :workshop, :ended, :funded, course: Pd::Workshop::COURSE_CSF, on_map: true
       session = @workshop.sessions.first
 
       # >= 10 passing levels: qualified

--- a/dashboard/test/lib/pd/payment/payment_calculator_district_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_district_test.rb
@@ -7,12 +7,8 @@ module Pd::Payment
         on_map: false, funded: false,
         course: Pd::Workshop::COURSE_CS_IN_A,
         subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2,
-        num_sessions: 3
-
-      # 2 facilitators
-      2.times do
-        @workshop.facilitators << create(:facilitator)
-      end
+        num_sessions: 3,
+        num_facilitators: 2
 
       # One unqualified teacher, below min attendance
       create :pd_workshop_participant, workshop: @workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_district_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_district_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module Pd::Payment
   class PaymentCalculatorDistrictTest < ActiveSupport::TestCase
     setup do
-      @workshop = create :pd_ended_workshop,
+      @workshop = create :workshop, :ended,
         on_map: false, funded: false,
         course: Pd::Workshop::COURSE_CS_IN_A,
         subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2,

--- a/dashboard/test/lib/pd/payment/payment_calculator_standard_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_standard_test.rb
@@ -6,7 +6,7 @@ module Pd::Payment
 
     setup do
       # TIME_CONSTRAINTS: COURSE_ECS => {SUBJECT_ECS_PHASE_4 => {min_days: 2, max_days: 3, max_hours: 18}}
-      @workshop = create :pd_ended_workshop,
+      @workshop = create :workshop, :ended,
         on_map: true, funded: true,
         course: Pd::Workshop::COURSE_ECS,
         subject: Pd::Workshop::SUBJECT_ECS_PHASE_4,

--- a/dashboard/test/lib/pd/payment/payment_calculator_standard_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_standard_test.rb
@@ -10,12 +10,8 @@ module Pd::Payment
         on_map: true, funded: true,
         course: Pd::Workshop::COURSE_ECS,
         subject: Pd::Workshop::SUBJECT_ECS_PHASE_4,
-        num_sessions: 3
-
-      # 2 facilitators
-      2.times do
-        @workshop.facilitators << create(:facilitator)
-      end
+        num_sessions: 3,
+        num_facilitators: 2
 
       # One unqualified teacher, below min attendance
       create :pd_workshop_participant, workshop: @workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_test.rb
@@ -9,7 +9,7 @@ module Pd::Payment
       @program_manager = create :workshop_organizer
       @regional_partner = create :regional_partner, program_managers: [@program_manager]
 
-      @csp_workshop = create(:pd_ended_workshop, organizer: @program_manager, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1, enrolled_and_attending_users: 20, num_sessions: 2)
+      @csp_workshop = create(:workshop, :ended, organizer: @program_manager, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1, enrolled_and_attending_users: 20, num_sessions: 2)
 
       2.times do
         @csp_workshop.facilitators << create(:facilitator)
@@ -26,14 +26,14 @@ module Pd::Payment
     end
 
     test 'Calculate CSF Workshop payment' do
-      workshop = create(:pd_ended_workshop, :funded, course: Pd::Workshop::COURSE_CSF, enrolled_and_attending_users: 20)
+      workshop = create(:workshop, :ended, :funded, course: Pd::Workshop::COURSE_CSF, enrolled_and_attending_users: 20)
       create_passed_levels(workshop.enrollments[0..9])
 
       assert_equal 500, PaymentCalculator.instance.calculate(workshop)
     end
 
     test 'Calculate CSF Workshop with only some teachers who did puzzles' do
-      insufficient_puzzles = create(:pd_ended_workshop, :funded, course: Pd::Workshop::COURSE_CSF, enrolled_and_attending_users: 20)
+      insufficient_puzzles = create(:workshop, :ended, :funded, course: Pd::Workshop::COURSE_CSF, enrolled_and_attending_users: 20)
       create_passed_levels(insufficient_puzzles.enrollments[0..5])
       assert_equal 300, PaymentCalculator.instance.calculate(insufficient_puzzles)
     end
@@ -47,7 +47,7 @@ module Pd::Payment
     end
 
     test 'Error raised if workshop has no regional partner' do
-      unpartnered_workshop = create(:pd_ended_workshop, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1)
+      unpartnered_workshop = create(:workshop, :ended, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1)
       error = assert_raises(RuntimeError) do
         PaymentCalculator.instance.calculate(unpartnered_workshop)
       end

--- a/dashboard/test/lib/pd/payment/payment_calculator_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_test.rb
@@ -9,11 +9,14 @@ module Pd::Payment
       @program_manager = create :workshop_organizer
       @regional_partner = create :regional_partner, program_managers: [@program_manager]
 
-      @csp_workshop = create(:workshop, :ended, organizer: @program_manager, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1, enrolled_and_attending_users: 20, num_sessions: 2)
-
-      2.times do
-        @csp_workshop.facilitators << create(:facilitator)
-      end
+      @csp_workshop = create :workshop,
+        :ended,
+        organizer: @program_manager,
+        course: Pd::Workshop::COURSE_CSP,
+        subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1,
+        enrolled_and_attending_users: 20,
+        num_sessions: 2,
+        num_facilitators: 2
     end
 
     test 'Raise error if workshop is not ended' do

--- a/dashboard/test/lib/pd/payment/payment_calculator_unpaid_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_unpaid_test.rb
@@ -7,10 +7,8 @@ module Pd::Payment
         funded: true,
         on_map: true,
         course: Pd::Workshop::COURSE_CSD,
-        num_sessions: 2
-
-      # 2 facilitators
-      @workshop.facilitators += create_list(:facilitator, 2)
+        num_sessions: 2,
+        num_facilitators: 2
 
       # 10 qualified teachers: 1 at partial (1 day) attendance, and 9 more at full (2 days) attendance
       create :pd_workshop_participant, workshop: @workshop,

--- a/dashboard/test/lib/pd/payment/payment_calculator_unpaid_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_unpaid_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 module Pd::Payment
   class PaymentCalculatorUnpaidTest < ActiveSupport::TestCase
     setup do
-      @workshop = create :pd_ended_workshop,
+      @workshop = create :workshop,
+        :ended,
         funded: true,
         on_map: true,
         course: Pd::Workshop::COURSE_CSD,

--- a/dashboard/test/lib/pd/payment/payment_factory_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_factory_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 module Pd::Payment
   class PaymentFactoryTest < ActiveSupport::TestCase
     test 'district calculator' do
-      workshop_cs_in_a = create :pd_ended_workshop, on_map: false, funded: false,
+      workshop_cs_in_a = create :workshop, :ended, on_map: false, funded: false,
         course: Pd::Workshop::COURSE_CS_IN_A, subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2
 
-      workshop_cs_in_s = create :pd_ended_workshop, on_map: false, funded: false,
+      workshop_cs_in_s = create :workshop, :ended, on_map: false, funded: false,
         course: Pd::Workshop::COURSE_CS_IN_S, subject: Pd::Workshop::SUBJECT_CS_IN_S_PHASE_2
 
       assert_equal PaymentCalculatorDistrict, PaymentFactory.get_calculator_class(workshop_cs_in_a)
@@ -14,8 +14,8 @@ module Pd::Payment
     end
 
     test 'CSF calculator' do
-      workshop_csf_public = create :pd_ended_workshop, :funded, course: Pd::Workshop::COURSE_CSF, on_map: true
-      workshop_csf_private = create :pd_ended_workshop, :funded, course: Pd::Workshop::COURSE_CSF, on_map: false
+      workshop_csf_public = create :workshop, :ended, :funded, course: Pd::Workshop::COURSE_CSF, on_map: true
+      workshop_csf_private = create :workshop, :ended, :funded, course: Pd::Workshop::COURSE_CSF, on_map: false
 
       assert_equal PaymentCalculatorCSF, PaymentFactory.get_calculator_class(workshop_csf_public)
       assert_equal PaymentCalculatorCSF, PaymentFactory.get_calculator_class(workshop_csf_private)
@@ -23,16 +23,16 @@ module Pd::Payment
 
     test 'standard calculator' do
       # Mix of public and private types
-      workshop_ecs = create :pd_ended_workshop, on_map: false, funded: true,
+      workshop_ecs = create :workshop, :ended, on_map: false, funded: true,
         course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
 
-      workshop_csp = create :pd_ended_workshop, on_map: true, funded: true,
+      workshop_csp = create :workshop, :ended, on_map: true, funded: true,
         course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
 
-      workshop_cs_in_a = create :pd_ended_workshop, on_map: false, funded: true,
+      workshop_cs_in_a = create :workshop, :ended, on_map: false, funded: true,
         course: Pd::Workshop::COURSE_CS_IN_A, subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2
 
-      workshop_cs_in_s = create :pd_ended_workshop, on_map: true, funded: true,
+      workshop_cs_in_s = create :workshop, :ended, on_map: true, funded: true,
         course: Pd::Workshop::COURSE_CS_IN_S, subject: Pd::Workshop::SUBJECT_CS_IN_S_PHASE_2
 
       assert_equal PaymentCalculatorStandard, PaymentFactory.get_calculator_class(workshop_ecs)
@@ -43,10 +43,10 @@ module Pd::Payment
 
     test 'counselor admin calculator' do
       # Mix of public and private types
-      workshop_counselor = create :pd_ended_workshop, on_map: false, funded: true,
+      workshop_counselor = create :workshop, :ended, on_map: false, funded: true,
         course: Pd::Workshop::COURSE_COUNSELOR
 
-      workshop_admin = create :pd_ended_workshop, on_map: true, funded: true,
+      workshop_admin = create :workshop, :ended, on_map: true, funded: true,
         course: Pd::Workshop::COURSE_ADMIN
 
       assert_equal PaymentCalculatorCounselorAdmin, PaymentFactory.get_calculator_class(workshop_counselor)
@@ -54,10 +54,10 @@ module Pd::Payment
     end
 
     test 'unpaid' do
-      workshop_district_wrong_type = create :pd_ended_workshop, on_map: false, funded: false,
+      workshop_district_wrong_type = create :workshop, :ended, on_map: false, funded: false,
         course: Pd::Workshop::COURSE_CSF
 
-      workshop_csd = create :pd_ended_workshop, on_map: true, funded: true,
+      workshop_csd = create :workshop, :ended, on_map: true, funded: true,
         course: Pd::Workshop::COURSE_CSD
 
       assert_equal PaymentCalculatorUnpaid, PaymentFactory.get_calculator_class(workshop_district_wrong_type)
@@ -66,14 +66,14 @@ module Pd::Payment
 
     test 'workshops that do not match a known payment type fall through to unpaid' do
       # Build instead of create since this course is invalid and can't be saved
-      workshop = build :pd_ended_workshop, course: 'unexpected course'
+      workshop = build :workshop, :ended, course: 'unexpected course'
 
       assert_equal PaymentCalculatorUnpaid, PaymentFactory.get_calculator_class(workshop)
     end
 
     test 'calculate payment' do
       # Use a standard payment for example:
-      workshop_standard = create :pd_ended_workshop, on_map: true, funded: true,
+      workshop_standard = create :workshop, :ended, on_map: true, funded: true,
         course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
 
       standard_summary = PaymentFactory.get_payment(workshop_standard)

--- a/dashboard/test/lib/pd/payment/workshop_summary_test.rb
+++ b/dashboard/test/lib/pd/payment/workshop_summary_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module Pd::Payment
   class WorkshopSummaryTest < ActiveSupport::TestCase
     setup do
-      @ended_workshop = create :pd_ended_workshop, num_sessions: 1
+      @ended_workshop = create :workshop, :ended
       @workshop_summary = WorkshopSummary.new(
         workshop: @ended_workshop,
         pay_period: 'a pay period',

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -48,7 +48,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
   end
 
   test 'exit survey emails are sent for workshops with exit surveys' do
-    workshop = create :pd_ended_workshop
+    workshop = create :workshop, :ended
     enrollment = create :pd_enrollment, workshop: workshop
     Pd::Enrollment.any_instance.expects(:exit_survey_url).returns('a url')
 
@@ -58,7 +58,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
   end
 
   test 'exit survey emails are skipped for workshops without exit surveys' do
-    workshop = create :pd_ended_workshop
+    workshop = create :workshop, :ended
     enrollment = create :pd_enrollment, workshop: workshop
     Pd::Enrollment.any_instance.expects(:exit_survey_url).returns(nil)
 
@@ -74,7 +74,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
     ]
 
     courses.each do |course|
-      workshop = create :workshop, num_sessions: 1, course: course
+      workshop = create :workshop, course: course
       enrollment = create :pd_enrollment, workshop: workshop
       mail = Pd::WorkshopMailer.detail_change_notification(enrollment)
 
@@ -92,7 +92,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
     ]
 
     test_cases.each do |test_case|
-      workshop = create :pd_ended_workshop, course: test_case[:course], subject: test_case[:subject]
+      workshop = create :workshop, :ended, course: test_case[:course], subject: test_case[:subject]
       enrollment = create :pd_enrollment, workshop: workshop
       mail = Pd::WorkshopMailer.exit_survey(enrollment)
 
@@ -102,9 +102,9 @@ class WorkshopMailerTest < ActionMailer::TestCase
 
   test 'facilitator and organizer email links are complete urls' do
     facilitator = create :facilitator
-    csf_workshop = create :workshop, num_sessions: 1, facilitators: [facilitator], course: Pd::Workshop::COURSE_CSF, subject: Pd::Workshop::SUBJECT_CSF_101
+    csf_workshop = create :workshop, facilitators: [facilitator], course: Pd::Workshop::COURSE_CSF, subject: Pd::Workshop::SUBJECT_CSF_101
     csf_enrollment = create :pd_enrollment, workshop: csf_workshop
-    ecs_workshop = create :pd_ended_workshop, facilitators: [facilitator], course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
+    ecs_workshop = create :workshop, :ended, facilitators: [facilitator], course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
     ecs_enrollment = create :pd_enrollment, workshop: ecs_workshop
     mails = []
 
@@ -128,7 +128,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
     ]
 
     test_cases.each do |test_case|
-      workshop = create :workshop, num_sessions: 1, course: test_case[:course], subject: test_case[:subject]
+      workshop = create :workshop, course: test_case[:course], subject: test_case[:subject]
       enrollment = create :pd_enrollment, workshop: workshop
       mail = Pd::WorkshopMailer.teacher_cancel_receipt(enrollment)
 
@@ -155,7 +155,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
     ]
 
     test_cases.each do |test_case|
-      workshop = create :workshop, num_sessions: 1, course: test_case[:course], subject: test_case[:subject]
+      workshop = create :workshop, course: test_case[:course], subject: test_case[:subject]
       enrollment = create :pd_enrollment, workshop: workshop
       mail = Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment)
 
@@ -176,7 +176,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
     ]
 
     test_cases.each do |test_case|
-      workshop = create :workshop, num_sessions: 1, course: test_case[:course], subject: test_case[:subject]
+      workshop = create :workshop, course: test_case[:course], subject: test_case[:subject]
       enrollment = create :pd_enrollment, workshop: workshop
       mail = Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, days_before: test_case[:days_before])
 

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -257,9 +257,9 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'filter_for_survey_completion' do
-    teachercon1 = create :workshop, :teachercon, num_enrollments: 1, num_sessions: 1
-    teachercon2 = create :workshop, :ended, :teachercon, enrolled_and_attending_users: 1, num_sessions: 1
-    teachercon3 = create :workshop, :ended, :teachercon, enrolled_and_attending_users: 1, num_sessions: 1
+    teachercon1 = create :workshop, :teachercon, num_enrollments: 1
+    teachercon2 = create :workshop, :ended, :teachercon, enrolled_and_attending_users: 1
+    teachercon3 = create :workshop, :ended, :teachercon, enrolled_and_attending_users: 1
 
     create :pd_teachercon_survey, pd_enrollment: teachercon3.enrollments.first
 
@@ -300,7 +300,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'academic year survey filter' do
-    workshop = create :workshop, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1, num_sessions: 1
+    workshop = create :workshop, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
     teacher = create :teacher
     enrollment = create :pd_enrollment, :from_user, user: teacher, workshop: workshop
 
@@ -390,25 +390,25 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   test 'with_surveys scope' do
     # Ended workshop with attendance
     # (ONLY this one should show up in the scope at the end of the test)
-    ended_workshop = create :workshop, :ended, num_sessions: 1
+    ended_workshop = create :workshop, :ended
     expected_enrollment = create :pd_enrollment, workshop: ended_workshop
     create :pd_attendance, session: ended_workshop.sessions.first, enrollment: expected_enrollment
 
     # Ended FiT workshop, with attendance
     # (Checks a special case: FiT workshops don't have exit surveys)
-    fit_workshop = create :workshop, :ended, num_sessions: 1, subject: SUBJECT_FIT
+    fit_workshop = create :workshop, :ended, subject: SUBJECT_FIT
     fit_enrollment = create :pd_enrollment, workshop: fit_workshop
     create :pd_attendance, session: fit_workshop.sessions.first, enrollment: fit_enrollment
 
     # Ended Facilitator workshop, with attendance
     # (Checks a special case: Facilitator workshops don't have exit surveys)
-    facilitator_workshop = create :workshop, :ended, num_sessions: 1, course: COURSE_FACILITATOR
+    facilitator_workshop = create :workshop, :ended, course: COURSE_FACILITATOR
     facilitator_enrollment = create :pd_enrollment, workshop: facilitator_workshop
     create :pd_attendance, session: facilitator_workshop.sessions.first, enrollment: facilitator_enrollment
 
     # Non-ended workshop, no attendance
     # (No surveys because not ended)
-    non_ended_workshop = create :workshop, num_sessions: 1
+    non_ended_workshop = create :workshop
     create :pd_enrollment, workshop: non_ended_workshop
 
     # Non-ended workshop, with attendance
@@ -430,7 +430,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     # Root cause: WHERE subject != 'xyz' implicitly excludes rows where subject IS NULL too.
 
     # Ended Admin workshop with attendance; Admin workshops have no subject.
-    admin_workshop = create :workshop, :ended, num_sessions: 1, course: COURSE_ADMIN, subject: nil
+    admin_workshop = create :workshop, :ended, course: COURSE_ADMIN, subject: nil
     expected_enrollment = create :pd_enrollment, workshop: admin_workshop
     create :pd_attendance, session: admin_workshop.sessions.first, enrollment: expected_enrollment
 
@@ -555,7 +555,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'Updating existing enrollment sets permission' do
-    workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD, num_sessions: 1
+    workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
     enrollment = create :pd_enrollment, workshop: workshop, user: nil
 
     teacher = create :teacher
@@ -587,7 +587,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'update scholarship status for csf workshop' do
-    workshop = create :workshop, num_sessions: 1, sessions_from: Date.current + 3.months, course: Pd::SharedWorkshopConstants::COURSE_CSF
+    workshop = create :workshop, sessions_from: Date.current + 3.months, course: Pd::SharedWorkshopConstants::COURSE_CSF
     enrollment = create :pd_enrollment, :from_user, workshop: workshop
     # initially creates scholarship info with YES_CDO status
     assert_equal enrollment.scholarship_status, Pd::ScholarshipInfoConstants::YES_CDO
@@ -602,7 +602,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'scholarship info automatically created when enrolling in csf workshop' do
-    workshop = create :workshop, num_sessions: 1, sessions_from: Date.current + 3.months, course: Pd::SharedWorkshopConstants::COURSE_CSF
+    workshop = create :workshop, sessions_from: Date.current + 3.months, course: Pd::SharedWorkshopConstants::COURSE_CSF
     enrollment = create :pd_enrollment, :from_user, workshop: workshop
 
     # initially creates scholarship info with YES_CDO status

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -90,22 +90,22 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'exit_survey_url' do
-    csf_workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSF
+    csf_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSF
     csf_enrollment = create :pd_enrollment, workshop: csf_workshop
 
-    csp_workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSP
+    csp_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSP
     csp_enrollment = create :pd_enrollment, workshop: csp_workshop
 
-    counselor_workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_COUNSELOR
+    counselor_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_COUNSELOR
     counselor_enrollment = create :pd_enrollment, workshop: counselor_workshop
 
-    admin_workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_ADMIN
+    admin_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_ADMIN
     admin_enrollment = create :pd_enrollment, workshop: admin_workshop
 
-    local_summer_workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
+    local_summer_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
     local_summer_enrollment = create :pd_enrollment, workshop: local_summer_workshop
 
-    teachercon_workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_TEACHER_CON
+    teachercon_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_TEACHER_CON
     teachercon_enrollment = create :pd_enrollment, workshop: teachercon_workshop
 
     code_org_url = ->(path) {CDO.code_org_url(path, CDO.default_scheme)}
@@ -120,12 +120,12 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'should_send_exit_survey' do
-    normal_workshop = create :pd_ended_workshop
+    normal_workshop = create :workshop, :ended
     normal_enrollment = create :pd_enrollment, workshop: normal_workshop
 
     assert normal_enrollment.should_send_exit_survey?
 
-    fit_workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_FIT
+    fit_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_FIT
     fit_enrollment = create :pd_enrollment, user: create(:teacher), workshop: fit_workshop
 
     refute fit_enrollment.should_send_exit_survey?
@@ -139,7 +139,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'send_exit_survey does not send mail for FIT Weekend workshops' do
-    workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_FIT
+    workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_FIT
     enrollment = create :pd_enrollment, user: create(:teacher), workshop: workshop
     Pd::WorkshopMailer.expects(:exit_survey).never
 
@@ -258,8 +258,8 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
 
   test 'filter_for_survey_completion' do
     teachercon1 = create :workshop, :teachercon, num_enrollments: 1, num_sessions: 1
-    teachercon2 = create :pd_ended_workshop, :teachercon, enrolled_and_attending_users: 1, num_sessions: 1
-    teachercon3 = create :pd_ended_workshop, :teachercon, enrolled_and_attending_users: 1, num_sessions: 1
+    teachercon2 = create :workshop, :ended, :teachercon, enrolled_and_attending_users: 1, num_sessions: 1
+    teachercon3 = create :workshop, :ended, :teachercon, enrolled_and_attending_users: 1, num_sessions: 1
 
     create :pd_teachercon_survey, pd_enrollment: teachercon3.enrollments.first
 
@@ -382,7 +382,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   test 'ended workshop scope' do
     # not ended
     create :pd_enrollment
-    enrollment_ended = create :pd_enrollment, workshop: create(:pd_ended_workshop)
+    enrollment_ended = create :pd_enrollment, workshop: create(:workshop, :ended)
 
     assert_equal [enrollment_ended], Pd::Enrollment.for_ended_workshops
   end
@@ -390,19 +390,19 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   test 'with_surveys scope' do
     # Ended workshop with attendance
     # (ONLY this one should show up in the scope at the end of the test)
-    ended_workshop = create :pd_ended_workshop, num_sessions: 1
+    ended_workshop = create :workshop, :ended, num_sessions: 1
     expected_enrollment = create :pd_enrollment, workshop: ended_workshop
     create :pd_attendance, session: ended_workshop.sessions.first, enrollment: expected_enrollment
 
     # Ended FiT workshop, with attendance
     # (Checks a special case: FiT workshops don't have exit surveys)
-    fit_workshop = create :pd_ended_workshop, num_sessions: 1, subject: SUBJECT_FIT
+    fit_workshop = create :workshop, :ended, num_sessions: 1, subject: SUBJECT_FIT
     fit_enrollment = create :pd_enrollment, workshop: fit_workshop
     create :pd_attendance, session: fit_workshop.sessions.first, enrollment: fit_enrollment
 
     # Ended Facilitator workshop, with attendance
     # (Checks a special case: Facilitator workshops don't have exit surveys)
-    facilitator_workshop = create :pd_ended_workshop, num_sessions: 1, course: COURSE_FACILITATOR
+    facilitator_workshop = create :workshop, :ended, num_sessions: 1, course: COURSE_FACILITATOR
     facilitator_enrollment = create :pd_enrollment, workshop: facilitator_workshop
     create :pd_attendance, session: facilitator_workshop.sessions.first, enrollment: facilitator_enrollment
 
@@ -430,7 +430,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     # Root cause: WHERE subject != 'xyz' implicitly excludes rows where subject IS NULL too.
 
     # Ended Admin workshop with attendance; Admin workshops have no subject.
-    admin_workshop = create :pd_ended_workshop, num_sessions: 1, course: COURSE_ADMIN, subject: nil
+    admin_workshop = create :workshop, :ended, num_sessions: 1, course: COURSE_ADMIN, subject: nil
     expected_enrollment = create :pd_enrollment, workshop: admin_workshop
     create :pd_attendance, session: admin_workshop.sessions.first, enrollment: expected_enrollment
 

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -74,7 +74,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
   end
 
   test 'open for attendance' do
-    workshop_started = create :workshop, started_at: Time.now - 1.hour
+    workshop_started = create :workshop, :in_progress
     workshop_not_started = create :workshop
     workshop_ended = create :workshop, :ended
 
@@ -107,7 +107,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
   end
 
   test 'workshop with first session in three days does not show links and is not open for attendance' do
-    workshop = create :workshop, :with_codes_assigned, started_at: Time.now, num_sessions: 1, sessions_from: Time.now + 3.days
+    workshop = create :workshop, :in_progress, :with_codes_assigned, sessions_from: Time.now + 3.days
 
     refute workshop.sessions[0].open_for_attendance?
     refute workshop.sessions[0].show_link?
@@ -116,7 +116,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
   end
 
   test 'three day workshop with first session tomorrow shows two links but is not open for attendance' do
-    workshop = create :workshop, :with_codes_assigned, started_at: Time.now, num_sessions: 3, sessions_from: Time.now + 1.day - 1.minute
+    workshop = create :workshop, :in_progress, :with_codes_assigned, num_sessions: 3, sessions_from: Time.now + 1.day - 1.minute
 
     refute workshop.sessions[0].open_for_attendance?
     assert workshop.sessions[0].show_link?
@@ -127,7 +127,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
   end
 
   test 'three day workshop started on second day shows two links and has one session open for attendance' do
-    workshop = create :workshop, :with_codes_assigned, started_at: Time.now, num_sessions: 3, sessions_from: Time.now - 1.day - 1.minute
+    workshop = create :workshop, :in_progress, :with_codes_assigned, num_sessions: 3, sessions_from: Time.now - 1.day - 1.minute
 
     refute workshop.sessions[0].open_for_attendance?
     refute workshop.sessions[0].show_link?

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -76,7 +76,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
   test 'open for attendance' do
     workshop_started = create :workshop, started_at: Time.now - 1.hour
     workshop_not_started = create :workshop
-    workshop_ended = create :pd_ended_workshop
+    workshop_ended = create :workshop, :ended
 
     session_open = create :pd_session, :with_assigned_code, workshop: workshop_started
     assert session_open.open_for_attendance?

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -345,7 +345,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_exit_surveys with attendance but no account gets email for counselor admin' do
-    workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_COUNSELOR, num_sessions: 1
+    workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_COUNSELOR
 
     enrollment = create :pd_enrollment, workshop: workshop
     create :pd_attendance_no_account, session: workshop.sessions.first, enrollment: enrollment
@@ -390,7 +390,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'send_follow_up only teachers attended workshop get follow up emails' do
     workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, num_sessions: 1, sessions_from: Date.today - 30.days
+      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 30.days
 
     teacher_attended = create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
     create(:pd_workshop_participant, workshop: workshop, enrolled: true)
@@ -403,7 +403,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'send_follow_up all teachers attended workshop get follow up emails' do
     workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, num_sessions: 1, sessions_from: Date.today - 30.days
+      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 30.days
 
     teacher_count = 3
     create_list :pd_workshop_participant, teacher_count, workshop: workshop, enrolled: true, attended: true
@@ -415,7 +415,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'send_follow_up exception in email delivery raises honeybadger but does not stop batch' do
     workshop = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, num_sessions: 1, sessions_from: Date.today - 30.days
+      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 30.days
 
     teacher_count = 3
     create_list :pd_workshop_participant, teacher_count, workshop: workshop, enrolled: true, attended: true
@@ -435,11 +435,11 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'send_follow_up only workshop ended exactly 30 days ago get follow up emails' do
     workshop_31d = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, num_sessions: 1, sessions_from: Date.today - 31.days
+      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 31.days
     workshop_30d = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, num_sessions: 1, sessions_from: Date.today - 30.days
+      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 30.days
     workshop_29d = create :pd_ended_workshop, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, num_sessions: 1, sessions_from: Date.today - 29.days
+      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 29.days
 
     create(:pd_workshop_participant, workshop: workshop_31d, enrolled: true, attended: true)
     teacher_30d = create(:pd_workshop_participant, workshop: workshop_30d, enrolled: true, attended: true)
@@ -517,15 +517,15 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'in_year' do
     # before
-    create :workshop, num_sessions: 1, sessions_from: Date.new(2016, 12, 31)
+    create :workshop, sessions_from: Date.new(2016, 12, 31)
 
     workshops_this_year = [
-      create(:workshop, num_sessions: 1, sessions_from: Date.new(2017, 1, 1)),
-      create(:workshop, num_sessions: 1, sessions_from: Date.new(2017, 12, 31))
+      create(:workshop, sessions_from: Date.new(2017, 1, 1)),
+      create(:workshop, sessions_from: Date.new(2017, 12, 31))
     ]
 
     # after
-    create :workshop, num_sessions: 1, sessions_from: Date.new(2018, 12, 31)
+    create :workshop, sessions_from: Date.new(2018, 12, 31)
 
     assert_equal workshops_this_year.map(&:id), Pd::Workshop.in_year(2017).pluck(:id)
   end
@@ -533,19 +533,19 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   test 'future scope' do
     future_workshops = [
       # Today
-      a = create(:workshop, num_sessions: 1, sessions_from: Date.today),
+      a = create(:workshop, sessions_from: Date.today),
 
       # Next week
-      b = create(:workshop, num_sessions: 1, sessions_from: Date.today + 1.week)
+      b = create(:workshop, sessions_from: Date.today + 1.week)
     ]
 
     # Excluded (not future) workshops:
     # Last week
-    c = create :workshop, num_sessions: 1, sessions_from: Date.today - 1.week
+    c = create :workshop, sessions_from: Date.today - 1.week
     # Today, but ended
-    d = create :pd_ended_workshop, num_sessions: 1, sessions_from: Date.today
+    d = create :pd_ended_workshop, sessions_from: Date.today
     # Next week, but ended
-    e = create :pd_ended_workshop, num_sessions: 1, sessions_from: Date.today + 1.week
+    e = create :pd_ended_workshop, sessions_from: Date.today + 1.week
 
     workshop_ids = [a, b, c, d, e].map(&:id)
     assert_equal future_workshops, Pd::Workshop.where(id: workshop_ids).future
@@ -727,7 +727,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop_csf_101 = create :workshop,
       course: Pd::Workshop::COURSE_CSF,
       subject: Pd::Workshop::SUBJECT_CSF_101,
-      num_sessions: 1,
       each_session_hours: 8
 
     assert_equal 7, workshop_csf_101.effective_num_hours
@@ -737,7 +736,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop_csf_201 = create :workshop,
       course: Pd::Workshop::COURSE_CSF,
       subject: Pd::Workshop::SUBJECT_CSF_201,
-      num_sessions: 1,
       each_session_hours: 7
 
     assert_equal 6, workshop_csf_201.effective_num_hours
@@ -1179,10 +1177,10 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'nearest' do
-    target = create :workshop, num_sessions: 1, sessions_from: Date.today + 1.week
+    target = create :workshop, sessions_from: Date.today + 1.week
 
-    x = create :workshop, num_sessions: 1, sessions_from: Date.today + 2.weeks
-    y = create :workshop, num_sessions: 1, sessions_from: Date.today - 2.weeks
+    x = create :workshop, sessions_from: Date.today + 2.weeks
+    y = create :workshop, sessions_from: Date.today - 2.weeks
 
     ids = [target, x, y].map(&:id)
 
@@ -1190,9 +1188,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'nearest is independent of creation order' do
-    x = create :workshop, num_sessions: 1, sessions_from: Date.today - 2.weeks
-    target = create :workshop, num_sessions: 1, sessions_from: Date.today + 1.week
-    y = create :workshop, num_sessions: 1, sessions_from: Date.today + 2.weeks
+    x = create :workshop, sessions_from: Date.today - 2.weeks
+    target = create :workshop, sessions_from: Date.today + 1.week
+    y = create :workshop, sessions_from: Date.today + 2.weeks
 
     ids = [x, target, y].map(&:id)
 
@@ -1210,21 +1208,21 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'nearest combined with subject and enrollment' do
     user = create :teacher
-    target = create :workshop, num_sessions: 1, sessions_from: Date.today + 1.day,
+    target = create :workshop, sessions_from: Date.today + 1.day,
       course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
 
     create :pd_enrollment, :from_user, user: user, workshop: target
 
-    same_subject_farther = create :workshop, num_sessions: 1, sessions_from: Date.today + 1.week,
+    same_subject_farther = create :workshop, sessions_from: Date.today + 1.week,
       course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
     create :pd_enrollment, :from_user, user: user, workshop: same_subject_farther
 
-    different_subject_closer = create :workshop, num_sessions: 1, sessions_from: Date.today,
+    different_subject_closer = create :workshop, sessions_from: Date.today,
       course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_TEACHER_CON
     create :pd_enrollment, :from_user, user: user, workshop: different_subject_closer
 
     # closer, not enrolled
-    create :workshop, num_sessions: 1, sessions_from: Date.today,
+    create :workshop, sessions_from: Date.today,
       course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
 
     found = Pd::Workshop.where(subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP).enrolled_in_by(user).nearest

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -140,7 +140,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'query by state' do
     workshops_not_started = [@workshop, @organizer_workshop]
-    workshop_in_progress = create :workshop, started_at: Time.now
+    workshop_in_progress = create :workshop, :in_progress
     workshop_ended = create :workshop, :ended
 
     not_started = Pd::Workshop.in_state(Pd::Workshop::STATE_NOT_STARTED)
@@ -621,19 +621,18 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'order_by_state' do
-    @workshop.started_at = Time.now
     workshops = [
       build(:workshop, :ended), # Ended
-      # build(:workshop, started_at: Time.now), # In Progress
-      @workshop, # Not Started
-      @organizer_workshop # Not Started
+      build(:workshop, :in_progress), # In Progress
+      build(:workshop) # Not Started
     ]
     # save out of order
     workshops.shuffle.each(&:save!)
 
-    assert_equal workshops.pluck(:id), Pd::Workshop.order_by_state.pluck(:id)
-    assert_equal workshops.pluck(:id), Pd::Workshop.order_by_state(desc: false).pluck(:id)
-    assert_equal workshops.reverse.pluck(:id), Pd::Workshop.order_by_state(desc: true).pluck(:id)
+    ids = workshops.pluck(:id)
+    assert_equal ids, Pd::Workshop.where(id: ids).order_by_state.pluck(:id)
+    assert_equal ids, Pd::Workshop.where(id: ids).order_by_state(desc: false).pluck(:id)
+    assert_equal ids.reverse, Pd::Workshop.where(id: ids).order_by_state(desc: true).pluck(:id)
   end
 
   test 'min_attendance_days with no min_days constraint returns 1' do

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -176,7 +176,7 @@ class RegionalPartnerTest < ActiveSupport::TestCase
 
     # excluded (past or ended) partner workshops
     create :workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.yesterday
-    create :pd_ended_workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.today
+    create :workshop, :ended, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.today
 
     assert_equal future_partner_workshops, regional_partner.future_pd_workshops_organized
   end
@@ -193,7 +193,7 @@ class RegionalPartnerTest < ActiveSupport::TestCase
 
     # excluded (past or ended) partner workshops
     create :workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.yesterday
-    create :pd_ended_workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.today
+    create :workshop, :ended, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.today
 
     assert_equal future_partner_workshops, regional_partner.future_pd_workshops_organized
   end

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -170,13 +170,13 @@ class RegionalPartnerTest < ActiveSupport::TestCase
     create :regional_partner_program_manager, regional_partner: regional_partner, program_manager: partner_organizer
 
     future_partner_workshops = [
-      create(:workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.today),
-      create(:workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.tomorrow)
+      create(:workshop, organizer: partner_organizer, sessions_from: Date.today),
+      create(:workshop, organizer: partner_organizer, sessions_from: Date.tomorrow)
     ]
 
     # excluded (past or ended) partner workshops
-    create :workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.yesterday
-    create :workshop, :ended, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.today
+    create :workshop, organizer: partner_organizer, sessions_from: Date.yesterday
+    create :workshop, :ended, organizer: partner_organizer, sessions_from: Date.today
 
     assert_equal future_partner_workshops, regional_partner.future_pd_workshops_organized
   end
@@ -187,13 +187,13 @@ class RegionalPartnerTest < ActiveSupport::TestCase
     create :regional_partner_program_manager, regional_partner: regional_partner, program_manager: partner_organizer
 
     future_partner_workshops = [
-      create(:workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.today),
-      create(:workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.tomorrow)
+      create(:workshop, organizer: partner_organizer, sessions_from: Date.today),
+      create(:workshop, organizer: partner_organizer, sessions_from: Date.tomorrow)
     ]
 
     # excluded (past or ended) partner workshops
-    create :workshop, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.yesterday
-    create :workshop, :ended, organizer: partner_organizer, num_sessions: 1, sessions_from: Date.today
+    create :workshop, organizer: partner_organizer, sessions_from: Date.yesterday
+    create :workshop, :ended, organizer: partner_organizer, sessions_from: Date.today
 
     assert_equal future_partner_workshops, regional_partner.future_pd_workshops_organized
   end

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -196,7 +196,7 @@ end
 And(/^I am viewing a workshop with fake survey results$/) do
   require_rails_env
 
-  workshop = FactoryGirl.create :pd_ended_workshop, :local_summer_workshop,
+  workshop = FactoryGirl.create :workshop, :local_summer_workshop, :ended,
     organizer: FactoryGirl.create(:workshop_organizer, email: "test_organizer#{SecureRandom.hex}@code.org"),
     num_sessions: 5, enrolled_and_attending_users: 10,
     facilitators: [


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/30106: Replaces the `:pd_ended_workshop` factory with an `:ended` trait, and adds an `:in_progress` trait as well.

On the path to this change, also makes factory-generated workshops have one session by default instead of zero sessions. (For most test cases, this is more realistic.)

Updated a whole lot of test code to take advantage of these small changes.

Next steps: Convert the workshop type traits to subfactories, converting to a complete set that better represents our workshop types.