### PR TITLE
Loading starter assets in Applab

### DIFF
--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -462,6 +462,7 @@ class StarterAssetsApi {
 
   deleteFile(filename, success, error) {
     throw new Error('not yet implemented');
+    // TODO (madelynkasula): implement this endpoint and method
     // return ajaxInternal('DELETE', this.basePath(filename), success, error);
   }
 }

--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -435,29 +435,29 @@ class FilesApi extends CollectionsApi {
 }
 
 class StarterAssetsApi {
-  getStarterAssets(levelChannelId, onSuccess, onFailure) {
+  getStarterAssets(levelName, onSuccess, onFailure) {
     return ajaxInternal(
       'GET',
-      this.withLevelChannelId(levelChannelId).basePath(''),
+      this.withLevelName(levelName).basePath(''),
       onSuccess,
       onFailure
     );
   }
 
-  withLevelChannelId(channelId) {
+  withLevelName(levelName) {
     var boundApi = new this.constructor();
-    boundApi.channelId = channelId;
+    boundApi.levelName = levelName;
     return boundApi;
   }
 
   basePath(path) {
-    if (!this || !this.channelId) {
+    if (!this || !this.levelName) {
       const error =
-        'You must bind the API and set channelId before creating a base path.';
+        'You must bind the API and set levelName before creating a base path.';
       throw new Error(error);
     }
 
-    return `/level_starter_assets/${this.channelId}/${path}`;
+    return `/level_starter_assets/${this.levelName}/${path}`;
   }
 
   deleteFile(filename, success, error) {

--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -442,9 +442,22 @@ class FilesApi extends CollectionsApi {
     );
   }
 }
+
+class StarterAssetsApi {
+  getStarterAssets(channelId, onSuccess, onFailure) {
+    return ajaxInternal(
+      'GET',
+      `/level_starter_assets/${channelId}`,
+      onSuccess,
+      onFailure
+    );
+  }
+}
+
 module.exports = {
   animations: new CollectionsApi('animations'),
   assets: new AssetsApi('assets'),
+  starterAssets: new StarterAssetsApi(),
   files: new FilesApi('files'),
   sources: new CollectionsApi('sources'),
   channels: new CollectionsApi('channels')

--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -58,7 +58,7 @@ class CollectionsApi {
 
   ajax(method, file, success, error, data) {
     error = error || function() {};
-    if (!window.dashboard && !this.projectId) {
+    if (!window.dashboard && !this.getProjectId()) {
       error({status: 'No dashboard'});
       return;
     }
@@ -67,7 +67,7 @@ class CollectionsApi {
 
   getFile(file, version, success, error, data) {
     error = error || function() {};
-    if (!window.dashboard && !this.projectId) {
+    if (!window.dashboard && !this.getProjectId()) {
       error({status: 'No dashboard'});
       return;
     }

--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -452,6 +452,10 @@ class StarterAssetsApi {
       onFailure
     );
   }
+
+  basePath(path) {
+    throw new Error('not yet implemented');
+  }
 }
 
 module.exports = {

--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -451,6 +451,12 @@ class StarterAssetsApi {
   }
 
   basePath(path) {
+    if (!this || !this.channelId) {
+      const error =
+        'You must bind the API and set channelId before creating a base path.';
+      throw new Error(error);
+    }
+
     return `/level_starter_assets/${this.channelId}/${path}`;
   }
 

--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -453,8 +453,14 @@ class StarterAssetsApi {
     );
   }
 
+  withLevelChannelId(channelId) {
+    var boundApi = new this.constructor();
+    boundApi.channelId = channelId;
+    return boundApi;
+  }
+
   basePath(path) {
-    throw new Error('not yet implemented');
+    return `/level_starter_assets/${this.channelId}/${path}`;
   }
 }
 

--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -447,7 +447,7 @@ class StarterAssetsApi {
   getStarterAssets(levelChannelId, onSuccess, onFailure) {
     return ajaxInternal(
       'GET',
-      `/level_starter_assets/${levelChannelId}`,
+      this.withLevelChannelId(levelChannelId).basePath(''),
       onSuccess,
       onFailure
     );
@@ -461,6 +461,11 @@ class StarterAssetsApi {
 
   basePath(path) {
     return `/level_starter_assets/${this.channelId}/${path}`;
+  }
+
+  deleteFile(filename, success, error) {
+    throw new Error('not yet implemented');
+    // return ajaxInternal('DELETE', this.basePath(filename), success, error);
   }
 }
 

--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -444,10 +444,10 @@ class FilesApi extends CollectionsApi {
 }
 
 class StarterAssetsApi {
-  getStarterAssets(channelId, onSuccess, onFailure) {
+  getStarterAssets(levelChannelId, onSuccess, onFailure) {
     return ajaxInternal(
       'GET',
-      `/level_starter_assets/${channelId}`,
+      `/level_starter_assets/${levelChannelId}`,
       onSuccess,
       onFailure
     );

--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -41,6 +41,10 @@ class CollectionsApi {
     return boundApi;
   }
 
+  getProjectId() {
+    return this.projectId || project().getCurrentId();
+  }
+
   // NOTE: path parameter as supplied should not be URI encoded, as it will be
   // URI encoded in this function...
   basePath(path) {
@@ -49,11 +53,7 @@ class CollectionsApi {
       // encode all characters except forward slashes
       encodedPath = encodeURIComponent(path).replace(/%2F/g, '/');
     }
-    return apiPath(
-      this.collectionType,
-      this.projectId || project().getCurrentId(),
-      encodedPath
-    );
+    return apiPath(this.collectionType, this.getProjectId(), encodedPath);
   }
 
   ajax(method, file, success, error, data) {
@@ -120,10 +120,7 @@ class CollectionsApi {
 
 class AssetsApi extends CollectionsApi {
   copyAssets(sourceProjectId, assetFilenames, success, error) {
-    var path = apiPath(
-      'copy-assets',
-      this.projectId || project().getCurrentId()
-    );
+    var path = apiPath('copy-assets', this.getProjectId());
     path +=
       '?' +
       queryString.stringify({
@@ -222,10 +219,7 @@ class FilesApi extends CollectionsApi {
    * @param error {Function} callback when failed (includes xhr parameter)
    */
   getVersionHistory(success, error) {
-    var path = apiPath(
-      'files-version',
-      this.projectId || project().getCurrentId()
-    );
+    var path = apiPath('files-version', this.getProjectId());
     return ajaxInternal('GET', path, success, error);
   }
 
@@ -236,10 +230,7 @@ class FilesApi extends CollectionsApi {
    * @param error {Function} callback when failed (includes xhr parameter)
    */
   restorePreviousVersion(versionId, success, error) {
-    var path = apiPath(
-      'files-version',
-      this.projectId || project().getCurrentId()
-    );
+    var path = apiPath('files-version', this.getProjectId());
     path +=
       '?' +
       queryString.stringify({

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -213,10 +213,8 @@ export default class AssetManager extends React.Component {
           type={asset.category}
           size={asset.size}
           useFilesApi={this.props.useFilesApi}
-          onChoose={() =>
-            this.props.assetChosen(asset.filename, asset.timestamp)
-          }
-          onDelete={() => this.deleteAssetRow(asset.filename)}
+          onChoose={() => console.log('choose!')}
+          onDelete={() => console.log('delete!')}
           soundPlayer={this.props.soundPlayer}
           imagePicker={this.props.imagePicker}
           projectId={this.props.projectId}
@@ -236,8 +234,10 @@ export default class AssetManager extends React.Component {
           type={asset.category}
           size={asset.size}
           useFilesApi={this.props.useFilesApi}
-          onChoose={() => console.log('choose!')}
-          onDelete={() => console.log('delete!')}
+          onChoose={() =>
+            this.props.assetChosen(asset.filename, asset.timestamp)
+          }
+          onDelete={() => this.deleteAssetRow(asset.filename)}
           soundPlayer={this.props.soundPlayer}
           imagePicker={this.props.imagePicker}
           projectId={this.props.projectId}

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -78,6 +78,8 @@ export default class AssetManager extends React.Component {
   }
 
   componentWillMount() {
+    // TODO: replace with this.props.levelChannelId
+    // TODO: set starterAssets to [] if no levelChannelId
     starterAssetsApi.getStarterAssets(
       LEVEL_CHANNEL_ID,
       this.onStarterAssetsReceived,

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -238,16 +238,19 @@ export default class AssetManager extends React.Component {
     );
 
     let assetList;
-    // If `this.state.assets` is null, the asset list is still loading. If it's
-    // empty, the asset list has loaded and there are no assets in the current
+    // If this.state.assets or this.state.starterAssets are null, assets are still loading.
+    // If empty, the asset list has loaded and there are no assets in the current
     // channel (matching the `allowedExtensions`, if any were provided).
-    if (this.state.assets === null) {
+    if (this.state.assets === null || this.state.starterAssets === null) {
       assetList = (
         <div style={{margin: '1em 0', textAlign: 'center'}}>
           <i className="fa fa-spinner fa-spin" style={{fontSize: '32px'}} />
         </div>
       );
-    } else if (this.state.assets.length === 0) {
+    } else if (
+      this.state.assets.length === 0 &&
+      this.state.starterAssets.length === 0
+    ) {
       const emptyText =
         this.props.allowedExtensions === '.mp3' ? (
           <div>

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -106,7 +106,9 @@ export default class AssetManager extends React.Component {
 
   onStarterAssetsReceived = result => {
     const response = JSON.parse(result.response);
-    this.setState({starterAssets: response.starter_assets});
+    if (this._isMounted) {
+      this.setState({starterAssets: response.starter_assets});
+    }
   };
 
   onStarterAssetsFailure = xhr => {

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -203,8 +203,8 @@ export default class AssetManager extends React.Component {
     this.setState({recordingAudio: false, audioErrorType: err});
   };
 
-  getAssetRows = () => {
-    return this.state.assets.map(asset => {
+  getStarterAssetRows = () => {
+    return this.state.starterAssets.map(asset => {
       return (
         <AssetRow
           key={asset.filename}
@@ -217,6 +217,27 @@ export default class AssetManager extends React.Component {
             this.props.assetChosen(asset.filename, asset.timestamp)
           }
           onDelete={() => this.deleteAssetRow(asset.filename)}
+          soundPlayer={this.props.soundPlayer}
+          imagePicker={this.props.imagePicker}
+          projectId={this.props.projectId}
+          elementId={this.props.elementId}
+        />
+      );
+    });
+  };
+
+  getAssetRows = () => {
+    return this.state.assets.map(asset => {
+      return (
+        <AssetRow
+          key={asset.filename}
+          name={asset.filename}
+          timestamp={asset.timestamp}
+          type={asset.category}
+          size={asset.size}
+          useFilesApi={this.props.useFilesApi}
+          onChoose={() => console.log('choose!')}
+          onDelete={() => console.log('delete!')}
           soundPlayer={this.props.soundPlayer}
           imagePicker={this.props.imagePicker}
           projectId={this.props.projectId}
@@ -295,7 +316,7 @@ export default class AssetManager extends React.Component {
         </div>
       );
     } else {
-      const rows = this.getAssetRows();
+      const rows = [...this.getStarterAssetRows(), ...this.getAssetRows()];
       assetList = (
         <div>
           <div

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -44,6 +44,9 @@ const styles = {
   }
 };
 
+// TODO: move to redux
+const LEVEL_CHANNEL_ID = 1;
+
 /**
  * A component for managing hosted assets.
  */
@@ -76,7 +79,7 @@ export default class AssetManager extends React.Component {
 
   componentWillMount() {
     starterAssetsApi.getStarterAssets(
-      1, // TODO: GET VALUE FROM REDUX
+      LEVEL_CHANNEL_ID,
       this.onStarterAssetsReceived,
       this.onStarterAssetsFailure
     );
@@ -225,6 +228,7 @@ export default class AssetManager extends React.Component {
           api={starterAssetsApi}
           onChoose={() => console.log('choose!')}
           onDelete={() => console.log('delete!')}
+          levelChannelId={LEVEL_CHANNEL_ID}
         />
       );
     });

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -205,10 +205,6 @@ export default class AssetManager extends React.Component {
 
   getAssetRows = () => {
     return this.state.assets.map(asset => {
-      const choose =
-        this.props.assetChosen &&
-        this.props.assetChosen.bind(this, asset.filename, asset.timestamp);
-
       return (
         <AssetRow
           key={asset.filename}
@@ -217,8 +213,10 @@ export default class AssetManager extends React.Component {
           type={asset.category}
           size={asset.size}
           useFilesApi={this.props.useFilesApi}
-          onChoose={choose}
-          onDelete={this.deleteAssetRow.bind(this, asset.filename)}
+          onChoose={() =>
+            this.props.assetChosen(asset.filename, asset.timestamp)
+          }
+          onDelete={() => this.deleteAssetRow(asset.filename)}
           soundPlayer={this.props.soundPlayer}
           imagePicker={this.props.imagePicker}
           projectId={this.props.projectId}

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -81,7 +81,7 @@ export default class AssetManager extends React.Component {
       this.onStarterAssetsFailure
     );
 
-    // Request to files/assets API if no projectId is present, so only
+    // Request to files/assets API will fail if no projectId is present, so only
     // request files if we have a projectId.
     if (this.props.projectId) {
       let api = this.props.useFilesApi ? filesApi : assetsApi;

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -57,11 +57,16 @@ export default class AssetManager extends React.Component {
     soundPlayer: PropTypes.object,
     disableAudioRecording: PropTypes.bool,
     projectId: PropTypes.string,
-    levelChannelId: PropTypes.string,
+    levelName: PropTypes.string,
 
     // For logging purposes
     imagePicker: PropTypes.bool, // identifies if displayed by 'Manage Assets' flow
     elementId: PropTypes.string
+  };
+
+  // TODO: REMOVE DEFAULT PROPS
+  static defaultProps = {
+    levelName: 'U5 Lists Investigate Outfitly Code'
   };
 
   constructor(props) {
@@ -76,9 +81,9 @@ export default class AssetManager extends React.Component {
   }
 
   componentWillMount() {
-    if (this.props.levelChannelId) {
+    if (this.props.levelName) {
       starterAssetsApi.getStarterAssets(
-        this.props.levelChannelId,
+        this.props.levelName,
         this.onStarterAssetsReceived,
         this.onStarterAssetsFailure
       );
@@ -229,13 +234,11 @@ export default class AssetManager extends React.Component {
   };
 
   getStarterAssetRows = () => {
-    if (!this.props.levelChannelId || this.state.starterAssets.length === 0) {
+    if (!this.props.levelName || this.state.starterAssets.length === 0) {
       return [];
     }
 
-    const boundApi = starterAssetsApi.withLevelChannelId(
-      this.props.levelChannelId
-    );
+    const boundApi = starterAssetsApi.withLevelName(this.props.levelName);
     return this.state.starterAssets.map(asset => {
       return (
         <AssetRow
@@ -243,7 +246,7 @@ export default class AssetManager extends React.Component {
           api={boundApi}
           onChoose={() => console.log('choose!')}
           onDelete={() => console.log('delete!')}
-          levelChannelId={this.props.levelChannelId}
+          levelName={this.props.levelName}
         />
       );
     });

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -203,6 +203,31 @@ export default class AssetManager extends React.Component {
     this.setState({recordingAudio: false, audioErrorType: err});
   };
 
+  getAssetRows = () => {
+    return this.state.assets.map(asset => {
+      const choose =
+        this.props.assetChosen &&
+        this.props.assetChosen.bind(this, asset.filename, asset.timestamp);
+
+      return (
+        <AssetRow
+          key={asset.filename}
+          name={asset.filename}
+          timestamp={asset.timestamp}
+          type={asset.category}
+          size={asset.size}
+          useFilesApi={this.props.useFilesApi}
+          onChoose={choose}
+          onDelete={this.deleteAssetRow.bind(this, asset.filename)}
+          soundPlayer={this.props.soundPlayer}
+          imagePicker={this.props.imagePicker}
+          projectId={this.props.projectId}
+          elementId={this.props.elementId}
+        />
+      );
+    });
+  };
+
   render() {
     const displayAudioRecorder =
       this.state.audioErrorType !== AudioErrorType.INITIALIZE &&
@@ -272,31 +297,7 @@ export default class AssetManager extends React.Component {
         </div>
       );
     } else {
-      const rows = this.state.assets.map(
-        function(asset) {
-          const choose =
-            this.props.assetChosen &&
-            this.props.assetChosen.bind(this, asset.filename, asset.timestamp);
-
-          return (
-            <AssetRow
-              key={asset.filename}
-              name={asset.filename}
-              timestamp={asset.timestamp}
-              type={asset.category}
-              size={asset.size}
-              useFilesApi={this.props.useFilesApi}
-              onChoose={choose}
-              onDelete={this.deleteAssetRow.bind(this, asset.filename)}
-              soundPlayer={this.props.soundPlayer}
-              imagePicker={this.props.imagePicker}
-              projectId={this.props.projectId}
-              elementId={this.props.elementId}
-            />
-          );
-        }.bind(this)
-      );
-
+      const rows = this.getAssetRows();
       assetList = (
         <div>
           <div

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -88,8 +88,8 @@ export default class AssetManager extends React.Component {
 
     // Request to files/assets API will fail if no projectId is present, so only
     // request files if we have a projectId.
-    if (this.props.projectId) {
-      let api = this.props.useFilesApi ? filesApi : assetsApi;
+    let api = this.props.useFilesApi ? filesApi : assetsApi;
+    if (api.getProjectId()) {
       api.getFiles(this.onAssetListReceived, this.onAssetListFailure);
     } else {
       this.setState({assets: []});

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -56,10 +56,10 @@ export default class AssetManager extends React.Component {
     useFilesApi: PropTypes.bool,
     soundPlayer: PropTypes.object,
     disableAudioRecording: PropTypes.bool,
+    projectId: PropTypes.string,
 
     // For logging purposes
     imagePicker: PropTypes.bool, // identifies if displayed by 'Manage Assets' flow
-    projectId: PropTypes.string,
     elementId: PropTypes.string
   };
 
@@ -80,8 +80,15 @@ export default class AssetManager extends React.Component {
       this.onStarterAssetsReceived,
       this.onStarterAssetsFailure
     );
-    let api = this.props.useFilesApi ? filesApi : assetsApi;
-    api.getFiles(this.onAssetListReceived, this.onAssetListFailure);
+
+    // Request to files/assets API if no projectId is present, so only
+    // request files if we have a projectId.
+    if (this.props.projectId) {
+      let api = this.props.useFilesApi ? filesApi : assetsApi;
+      api.getFiles(this.onAssetListReceived, this.onAssetListFailure);
+    } else {
+      this.setState({assets: []});
+    }
   }
 
   componentDidMount() {

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -101,7 +101,7 @@ export default class AssetManager extends React.Component {
 
   onStarterAssetsReceived = result => {
     const response = JSON.parse(result.response);
-    this.setState({starterAssets: response.starter_asset_urls});
+    this.setState({starterAssets: response.starter_assets});
   };
 
   onStarterAssetsFailure = xhr => {

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -86,9 +86,13 @@ export default class AssetManager extends React.Component {
       this.setState({starterAssets: []});
     }
 
+    let api = this.props.useFilesApi ? filesApi : assetsApi;
+    if (!api.getProjectId()) {
+      api = api.withProjectId(this.props.projectId);
+    }
+
     // Request to files/assets API will fail if no projectId is present, so only
     // request files if we have a projectId.
-    let api = this.props.useFilesApi ? filesApi : assetsApi;
     if (api.getProjectId()) {
       api.getFiles(this.onAssetListReceived, this.onAssetListFailure);
     } else {

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -57,7 +57,7 @@ export default class AssetManager extends React.Component {
     soundPlayer: PropTypes.object,
     disableAudioRecording: PropTypes.bool,
     projectId: PropTypes.string,
-    levelChannelId: PropTypes.number,
+    levelChannelId: PropTypes.string,
 
     // For logging purposes
     imagePicker: PropTypes.bool, // identifies if displayed by 'Manage Assets' flow

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -44,9 +44,6 @@ const styles = {
   }
 };
 
-// TODO: move to redux
-const LEVEL_CHANNEL_ID = 1;
-
 /**
  * A component for managing hosted assets.
  */
@@ -60,6 +57,7 @@ export default class AssetManager extends React.Component {
     soundPlayer: PropTypes.object,
     disableAudioRecording: PropTypes.bool,
     projectId: PropTypes.string,
+    levelChannelId: PropTypes.number,
 
     // For logging purposes
     imagePicker: PropTypes.bool, // identifies if displayed by 'Manage Assets' flow
@@ -78,13 +76,15 @@ export default class AssetManager extends React.Component {
   }
 
   componentWillMount() {
-    // TODO: replace with this.props.levelChannelId
-    // TODO: set starterAssets to [] if no levelChannelId
-    starterAssetsApi.getStarterAssets(
-      LEVEL_CHANNEL_ID,
-      this.onStarterAssetsReceived,
-      this.onStarterAssetsFailure
-    );
+    if (this.props.levelChannelId) {
+      starterAssetsApi.getStarterAssets(
+        this.props.levelChannelId,
+        this.onStarterAssetsReceived,
+        this.onStarterAssetsFailure
+      );
+    } else {
+      this.setState({starterAssets: []});
+    }
 
     // Request to files/assets API will fail if no projectId is present, so only
     // request files if we have a projectId.
@@ -223,7 +223,13 @@ export default class AssetManager extends React.Component {
   };
 
   getStarterAssetRows = () => {
-    const boundApi = starterAssetsApi.withLevelChannelId(LEVEL_CHANNEL_ID);
+    if (!this.props.levelChannelId) {
+      return null;
+    }
+
+    const boundApi = starterAssetsApi.withLevelChannelId(
+      this.props.levelChannelId
+    );
     return this.state.starterAssets.map(asset => {
       return (
         <AssetRow
@@ -231,7 +237,7 @@ export default class AssetManager extends React.Component {
           api={boundApi}
           onChoose={() => console.log('choose!')}
           onDelete={() => console.log('delete!')}
-          levelChannelId={LEVEL_CHANNEL_ID}
+          levelChannelId={this.props.levelChannelId}
         />
       );
     });

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -203,22 +203,28 @@ export default class AssetManager extends React.Component {
     this.setState({recordingAudio: false, audioErrorType: err});
   };
 
+  defaultAssetProps = asset => {
+    return {
+      key: asset.filename,
+      name: asset.filename,
+      timestamp: asset.timestamp,
+      type: asset.category,
+      size: asset.size,
+      soundPlayer: this.props.soundPlayer,
+      imagePicker: this.props.imagePicker,
+      projectId: this.props.projectId,
+      elementId: this.props.elementId
+    };
+  };
+
   getStarterAssetRows = () => {
     return this.state.starterAssets.map(asset => {
       return (
         <AssetRow
-          key={asset.filename}
-          name={asset.filename}
-          timestamp={asset.timestamp}
-          type={asset.category}
-          size={asset.size}
+          {...this.defaultAssetProps(asset)}
           api={starterAssetsApi}
           onChoose={() => console.log('choose!')}
           onDelete={() => console.log('delete!')}
-          soundPlayer={this.props.soundPlayer}
-          imagePicker={this.props.imagePicker}
-          projectId={this.props.projectId}
-          elementId={this.props.elementId}
         />
       );
     });
@@ -228,20 +234,12 @@ export default class AssetManager extends React.Component {
     return this.state.assets.map(asset => {
       return (
         <AssetRow
-          key={asset.filename}
-          name={asset.filename}
-          timestamp={asset.timestamp}
-          type={asset.category}
-          size={asset.size}
+          {...this.defaultAssetProps(asset)}
           useFilesApi={this.props.useFilesApi}
           onChoose={() =>
             this.props.assetChosen(asset.filename, asset.timestamp)
           }
           onDelete={() => this.deleteAssetRow(asset.filename)}
-          soundPlayer={this.props.soundPlayer}
-          imagePicker={this.props.imagePicker}
-          projectId={this.props.projectId}
-          elementId={this.props.elementId}
         />
       );
     });

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -1,7 +1,11 @@
 /* eslint-disable react/no-is-mounted */
 import PropTypes from 'prop-types';
 import React from 'react';
-import {assets as assetsApi, files as filesApi} from '@cdo/apps/clientApi';
+import {
+  assets as assetsApi,
+  starterAssets as starterAssetsApi,
+  files as filesApi
+} from '@cdo/apps/clientApi';
 
 import AssetRow from './AssetRow';
 import assetListStore from '../assets/assetListStore';
@@ -63,6 +67,7 @@ export default class AssetManager extends React.Component {
     super(props);
     this.state = {
       assets: null,
+      starterAssets: null,
       statusMessage: props.uploadsEnabled ? '' : errorUploadDisabled,
       recordingAudio: false,
       audioErrorType: AudioErrorType.NONE
@@ -70,6 +75,11 @@ export default class AssetManager extends React.Component {
   }
 
   componentWillMount() {
+    starterAssetsApi.getStarterAssets(
+      1, // TODO: GET VALUE FROM REDUX
+      this.onStarterAssetsReceived,
+      this.onStarterAssetsFailure
+    );
     let api = this.props.useFilesApi ? filesApi : assetsApi;
     api.getFiles(this.onAssetListReceived, this.onAssetListFailure);
   }
@@ -81,6 +91,20 @@ export default class AssetManager extends React.Component {
   componentWillUnmount() {
     this._isMounted = false;
   }
+
+  onStarterAssetsReceived = result => {
+    const response = JSON.parse(result.response);
+    this.setState({starterAssets: response.starter_asset_urls});
+  };
+
+  onStarterAssetsFailure = xhr => {
+    if (this._isMounted) {
+      this.setState({
+        statusMessage:
+          'Error loading starter assets: ' + getErrorMessage(xhr.status)
+      });
+    }
+  };
 
   /**
    * Called after the component mounts, when the server responds with the

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -221,11 +221,12 @@ export default class AssetManager extends React.Component {
   };
 
   getStarterAssetRows = () => {
+    const boundApi = starterAssetsApi.withLevelChannelId(LEVEL_CHANNEL_ID);
     return this.state.starterAssets.map(asset => {
       return (
         <AssetRow
           {...this.defaultAssetProps(asset)}
-          api={starterAssetsApi}
+          api={boundApi}
           onChoose={() => console.log('choose!')}
           onDelete={() => console.log('delete!')}
           levelChannelId={LEVEL_CHANNEL_ID}

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -212,7 +212,7 @@ export default class AssetManager extends React.Component {
           timestamp={asset.timestamp}
           type={asset.category}
           size={asset.size}
-          useFilesApi={this.props.useFilesApi}
+          api={starterAssetsApi}
           onChoose={() => console.log('choose!')}
           onDelete={() => console.log('delete!')}
           soundPlayer={this.props.soundPlayer}

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -223,8 +223,8 @@ export default class AssetManager extends React.Component {
   };
 
   getStarterAssetRows = () => {
-    if (!this.props.levelChannelId) {
-      return null;
+    if (!this.props.levelChannelId || this.state.starterAssets.length === 0) {
+      return [];
     }
 
     const boundApi = starterAssetsApi.withLevelChannelId(

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -64,11 +64,6 @@ export default class AssetManager extends React.Component {
     elementId: PropTypes.string
   };
 
-  // TODO: REMOVE DEFAULT PROPS
-  static defaultProps = {
-    levelName: 'U5 Lists Investigate Outfitly Code'
-  };
-
   constructor(props) {
     super(props);
     this.state = {

--- a/apps/src/code-studio/components/AssetRow.jsx
+++ b/apps/src/code-studio/components/AssetRow.jsx
@@ -24,7 +24,10 @@ export default class AssetRow extends React.Component {
     timestamp: PropTypes.string,
     type: PropTypes.oneOf(['image', 'audio', 'video', 'pdf', 'doc']).isRequired,
     size: PropTypes.number,
-    useFilesApi: PropTypes.bool.isRequired,
+    // Declare a specific API to use. If undefined, useFilesApi prop will decide the API.
+    api: PropTypes.object,
+    // Uses files API if true; uses assets API if false.
+    useFilesApi: PropTypes.bool,
     onChoose: PropTypes.func,
     onDelete: PropTypes.func.isRequired,
     soundPlayer: PropTypes.object,
@@ -39,6 +42,15 @@ export default class AssetRow extends React.Component {
     action: 'normal',
     actionText: '',
     attemptedUsedDelete: false
+  };
+
+  api = () => {
+    const {api, useFilesApi} = this.props;
+    if (api) {
+      return api;
+    } else {
+      return useFilesApi ? filesApi : assetsApi;
+    }
   };
 
   /**
@@ -75,8 +87,7 @@ export default class AssetRow extends React.Component {
   handleDelete = () => {
     this.setState({action: 'deleting', actionText: ''});
 
-    let api = this.props.useFilesApi ? filesApi : assetsApi;
-    api.deleteFile(this.props.name, this.props.onDelete, () => {
+    this.api().deleteFile(this.props.name, this.props.onDelete, () => {
       this.setState({
         action: 'confirming delete',
         actionText: i18n.errorDeleting()
@@ -184,7 +195,7 @@ export default class AssetRow extends React.Component {
             type={this.props.type}
             name={this.props.name}
             timestamp={this.props.timestamp}
-            useFilesApi={this.props.useFilesApi}
+            api={this.api()}
             soundPlayer={this.props.soundPlayer}
           />
         </td>

--- a/apps/src/code-studio/components/AssetRow.jsx
+++ b/apps/src/code-studio/components/AssetRow.jsx
@@ -32,7 +32,7 @@ export default class AssetRow extends React.Component {
     onDelete: PropTypes.func.isRequired,
     soundPlayer: PropTypes.object,
     projectId: PropTypes.string,
-    levelChannelId: PropTypes.number,
+    levelChannelId: PropTypes.string,
 
     // For logging purposes
     imagePicker: PropTypes.bool, // identifies if displayed by 'Manage Assets' flow

--- a/apps/src/code-studio/components/AssetRow.jsx
+++ b/apps/src/code-studio/components/AssetRow.jsx
@@ -32,7 +32,7 @@ export default class AssetRow extends React.Component {
     onDelete: PropTypes.func.isRequired,
     soundPlayer: PropTypes.object,
     projectId: PropTypes.string,
-    levelChannelId: PropTypes.string,
+    levelName: PropTypes.string,
 
     // For logging purposes
     imagePicker: PropTypes.bool, // identifies if displayed by 'Manage Assets' flow
@@ -198,7 +198,7 @@ export default class AssetRow extends React.Component {
             timestamp={this.props.timestamp}
             api={this.api()}
             soundPlayer={this.props.soundPlayer}
-            levelChannelId={this.props.levelChannelId}
+            levelName={this.props.levelName}
           />
         </td>
         <td>{this.props.name}</td>

--- a/apps/src/code-studio/components/AssetRow.jsx
+++ b/apps/src/code-studio/components/AssetRow.jsx
@@ -32,6 +32,7 @@ export default class AssetRow extends React.Component {
     onDelete: PropTypes.func.isRequired,
     soundPlayer: PropTypes.object,
     projectId: PropTypes.string,
+    levelChannelId: PropTypes.number,
 
     // For logging purposes
     imagePicker: PropTypes.bool, // identifies if displayed by 'Manage Assets' flow
@@ -197,6 +198,7 @@ export default class AssetRow extends React.Component {
             timestamp={this.props.timestamp}
             api={this.api()}
             soundPlayer={this.props.soundPlayer}
+            levelChannelId={this.props.levelChannelId}
           />
         </td>
         <td>{this.props.name}</td>

--- a/apps/src/code-studio/components/AssetThumbnail.jsx
+++ b/apps/src/code-studio/components/AssetThumbnail.jsx
@@ -59,7 +59,7 @@ class AssetThumbnail extends React.Component {
     iconStyle: PropTypes.object,
     api: PropTypes.object,
     projectId: PropTypes.string,
-    levelChannelId: PropTypes.string,
+    levelChannelId: PropTypes.number,
     soundPlayer: PropTypes.object
   };
 

--- a/apps/src/code-studio/components/AssetThumbnail.jsx
+++ b/apps/src/code-studio/components/AssetThumbnail.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
-import {assets as assetsApi, files as filesApi} from '@cdo/apps/clientApi';
 import color from '@cdo/apps/util/color';
 
 const defaultIcons = {
@@ -58,14 +57,14 @@ class AssetThumbnail extends React.Component {
     type: PropTypes.oneOf(['image', 'audio', 'video', 'pdf', 'doc']).isRequired,
     style: PropTypes.object,
     iconStyle: PropTypes.object,
-    useFilesApi: PropTypes.bool,
+    api: PropTypes.object,
     projectId: PropTypes.string,
     soundPlayer: PropTypes.object
   };
 
   constructor(props) {
     super(props);
-    let api = this.props.useFilesApi ? filesApi : assetsApi;
+    let api = this.props.api;
     if (this.props.projectId) {
       api = api.withProjectId(this.props.projectId);
     }

--- a/apps/src/code-studio/components/AssetThumbnail.jsx
+++ b/apps/src/code-studio/components/AssetThumbnail.jsx
@@ -59,13 +59,16 @@ class AssetThumbnail extends React.Component {
     iconStyle: PropTypes.object,
     api: PropTypes.object,
     projectId: PropTypes.string,
+    levelChannelId: PropTypes.string,
     soundPlayer: PropTypes.object
   };
 
   constructor(props) {
     super(props);
     let api = this.props.api;
-    if (this.props.projectId) {
+    if (this.props.levelChannelId) {
+      api = api.withLevelChannelId(this.props.levelChannelId);
+    } else if (this.props.projectId) {
       api = api.withProjectId(this.props.projectId);
     }
     const basePath = api.basePath(this.props.name);

--- a/apps/src/code-studio/components/AssetThumbnail.jsx
+++ b/apps/src/code-studio/components/AssetThumbnail.jsx
@@ -59,7 +59,7 @@ class AssetThumbnail extends React.Component {
     iconStyle: PropTypes.object,
     api: PropTypes.object,
     projectId: PropTypes.string,
-    levelChannelId: PropTypes.number,
+    levelChannelId: PropTypes.string,
     soundPlayer: PropTypes.object
   };
 

--- a/apps/src/code-studio/components/AssetThumbnail.jsx
+++ b/apps/src/code-studio/components/AssetThumbnail.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
+import {assets as assetsApi} from '@cdo/apps/clientApi';
 
 const defaultIcons = {
   image: 'fa fa-picture-o',
@@ -65,7 +66,7 @@ class AssetThumbnail extends React.Component {
 
   constructor(props) {
     super(props);
-    let api = this.props.api;
+    let api = this.props.api || assetsApi; // Fallback to assetsApi.
     if (this.props.levelChannelId) {
       api = api.withLevelChannelId(this.props.levelChannelId);
     } else if (this.props.projectId) {

--- a/apps/src/code-studio/components/AssetThumbnail.jsx
+++ b/apps/src/code-studio/components/AssetThumbnail.jsx
@@ -60,15 +60,15 @@ class AssetThumbnail extends React.Component {
     iconStyle: PropTypes.object,
     api: PropTypes.object,
     projectId: PropTypes.string,
-    levelChannelId: PropTypes.string,
+    levelName: PropTypes.string,
     soundPlayer: PropTypes.object
   };
 
   constructor(props) {
     super(props);
     let api = this.props.api || assetsApi; // Fallback to assetsApi.
-    if (this.props.levelChannelId) {
-      api = api.withLevelChannelId(this.props.levelChannelId);
+    if (this.props.levelName) {
+      api = api.withLevelName(this.props.levelName);
     } else if (this.props.projectId) {
       api = api.withProjectId(this.props.projectId);
     }

--- a/apps/test/unit/clientApiTest.js
+++ b/apps/test/unit/clientApiTest.js
@@ -94,4 +94,63 @@ describe('clientApi module', () => {
       );
     });
   });
+
+  describe('starter assets api', () => {
+    const levelChannelId = 1;
+
+    describe('getStarterAssets', () => {
+      it('makes an ajax request to the correct url', () => {
+        clientApi.starterAssets.getStarterAssets(
+          levelChannelId,
+          () => {},
+          () => {}
+        );
+
+        expect(requests).to.have.length(1);
+        expect(requests[0].method).to.equal('GET');
+        expect(requests[0].url).to.equal(
+          `/level_starter_assets/${levelChannelId}/`
+        );
+      });
+    });
+
+    describe('withLevelChannelId', () => {
+      it('binds channelId to the api and returns the bound api', () => {
+        const boundApi = clientApi.starterAssets.withLevelChannelId(
+          levelChannelId
+        );
+
+        assert.equal(levelChannelId, boundApi.channelId);
+      });
+    });
+
+    describe('basePath', () => {
+      it('returns the correct base path', () => {
+        const path = 'some-path';
+        const boundApi = clientApi.starterAssets.withLevelChannelId(
+          levelChannelId
+        );
+
+        assert.equal(
+          `/level_starter_assets/${levelChannelId}/${path}`,
+          boundApi.basePath(path)
+        );
+      });
+
+      it('throws an error if StarterAssetsApi is not bound', () => {
+        assert.throws(
+          clientApi.starterAssets.basePath,
+          'You must bind the API and set channelId before creating a base path.'
+        );
+      });
+
+      it('throws an error if channelId is not set', () => {
+        const boundApi = clientApi.starterAssets.withLevelChannelId(undefined);
+        assert.throws(
+          boundApi.basePath,
+          'You must bind the API and set channelId before creating a base path.'
+        );
+      });
+    });
+  });
 });

--- a/apps/test/unit/clientApiTest.js
+++ b/apps/test/unit/clientApiTest.js
@@ -96,43 +96,33 @@ describe('clientApi module', () => {
   });
 
   describe('starter assets api', () => {
-    const levelChannelId = 1;
+    const levelName = 1;
 
     describe('getStarterAssets', () => {
       it('makes an ajax request to the correct url', () => {
-        clientApi.starterAssets.getStarterAssets(
-          levelChannelId,
-          () => {},
-          () => {}
-        );
+        clientApi.starterAssets.getStarterAssets(levelName, () => {}, () => {});
 
         expect(requests).to.have.length(1);
         expect(requests[0].method).to.equal('GET');
-        expect(requests[0].url).to.equal(
-          `/level_starter_assets/${levelChannelId}/`
-        );
+        expect(requests[0].url).to.equal(`/level_starter_assets/${levelName}/`);
       });
     });
 
-    describe('withLevelChannelId', () => {
-      it('binds channelId to the api and returns the bound api', () => {
-        const boundApi = clientApi.starterAssets.withLevelChannelId(
-          levelChannelId
-        );
+    describe('withLevelName', () => {
+      it('binds levelName to the api and returns the bound api', () => {
+        const boundApi = clientApi.starterAssets.withLevelName(levelName);
 
-        assert.equal(levelChannelId, boundApi.channelId);
+        assert.equal(levelName, boundApi.levelName);
       });
     });
 
     describe('basePath', () => {
       it('returns the correct base path', () => {
         const path = 'some-path';
-        const boundApi = clientApi.starterAssets.withLevelChannelId(
-          levelChannelId
-        );
+        const boundApi = clientApi.starterAssets.withLevelName(levelName);
 
         assert.equal(
-          `/level_starter_assets/${levelChannelId}/${path}`,
+          `/level_starter_assets/${levelName}/${path}`,
           boundApi.basePath(path)
         );
       });
@@ -140,15 +130,15 @@ describe('clientApi module', () => {
       it('throws an error if StarterAssetsApi is not bound', () => {
         assert.throws(
           clientApi.starterAssets.basePath,
-          'You must bind the API and set channelId before creating a base path.'
+          'You must bind the API and set levelName before creating a base path.'
         );
       });
 
-      it('throws an error if channelId is not set', () => {
-        const boundApi = clientApi.starterAssets.withLevelChannelId(undefined);
+      it('throws an error if levelName is not set', () => {
+        const boundApi = clientApi.starterAssets.withLevelName(undefined);
         assert.throws(
           boundApi.basePath,
-          'You must bind the API and set channelId before creating a base path.'
+          'You must bind the API and set levelName before creating a base path.'
         );
       });
     });

--- a/apps/test/unit/code-studio/components/AssetManagerTest.js
+++ b/apps/test/unit/code-studio/components/AssetManagerTest.js
@@ -24,16 +24,17 @@ describe('AssetManager', () => {
   });
 
   describe('componentWillMount', () => {
-    it('gets starter assets if levelChannelId is present', () => {
-      shallow(<AssetManager {...DEFAULT_PROPS} levelChannelId={'1'} />);
+    it('gets starter assets if levelName is present', () => {
+      const levelName = 'my level name';
+      shallow(<AssetManager {...DEFAULT_PROPS} levelName={levelName} />);
 
       expect(requests).to.have.length(1);
       expect(requests[0].method).to.equal('GET');
-      expect(requests[0].url).to.equal('/level_starter_assets/1/');
+      expect(requests[0].url).to.equal(`/level_starter_assets/${levelName}/`);
     });
 
-    it('does not get starter assets if no levelChannelId', () => {
-      shallow(<AssetManager {...DEFAULT_PROPS} levelChannelId={undefined} />);
+    it('does not get starter assets if no levelName', () => {
+      shallow(<AssetManager {...DEFAULT_PROPS} levelName={undefined} />);
 
       expect(requests).to.have.length(0);
     });

--- a/apps/test/unit/code-studio/components/AssetManagerTest.js
+++ b/apps/test/unit/code-studio/components/AssetManagerTest.js
@@ -25,7 +25,7 @@ describe('AssetManager', () => {
 
   describe('componentWillMount', () => {
     it('gets starter assets if levelChannelId is present', () => {
-      shallow(<AssetManager {...DEFAULT_PROPS} levelChannelId={1} />);
+      shallow(<AssetManager {...DEFAULT_PROPS} levelChannelId={'1'} />);
 
       expect(requests).to.have.length(1);
       expect(requests[0].method).to.equal('GET');

--- a/apps/test/unit/code-studio/components/AssetManagerTest.js
+++ b/apps/test/unit/code-studio/components/AssetManagerTest.js
@@ -1,0 +1,55 @@
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+import React from 'react';
+import {shallow} from 'enzyme';
+import AssetManager from '@cdo/apps/code-studio/components/AssetManager';
+
+const DEFAULT_PROPS = {
+  uploadsEnabled: true
+};
+
+describe('AssetManager', () => {
+  var xhr, requests;
+
+  beforeEach(() => {
+    xhr = sinon.useFakeXMLHttpRequest();
+    requests = [];
+    xhr.onCreate = function(xhr) {
+      requests.push(xhr);
+    };
+  });
+
+  afterEach(() => {
+    xhr.restore();
+  });
+
+  describe('componentWillMount', () => {
+    it('gets starter assets if levelChannelId is present', () => {
+      shallow(<AssetManager {...DEFAULT_PROPS} levelChannelId={1} />);
+
+      expect(requests).to.have.length(1);
+      expect(requests[0].method).to.equal('GET');
+      expect(requests[0].url).to.equal('/level_starter_assets/1/');
+    });
+
+    it('does not get starter assets if no levelChannelId', () => {
+      shallow(<AssetManager {...DEFAULT_PROPS} levelChannelId={undefined} />);
+
+      expect(requests).to.have.length(0);
+    });
+
+    it('gets files if projectId is present', () => {
+      shallow(<AssetManager {...DEFAULT_PROPS} projectId={'1'} />);
+
+      expect(requests).to.have.length(1);
+      expect(requests[0].method).to.equal('GET');
+      expect(requests[0].url).to.equal('/v3/assets/1');
+    });
+
+    it('does not get files if no projectId', () => {
+      shallow(<AssetManager {...DEFAULT_PROPS} projectId={undefined} />);
+
+      expect(requests).to.have.length(0);
+    });
+  });
+});

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -32,6 +32,10 @@ class LevelStarterAssetsController < ApplicationController
     send_data file_obj.get.body.read, type: content_type, disposition: 'inline'
   end
 
+  def get_file_objects(key)
+    bucket.objects(prefix: prefix(key))
+  end
+
   private
 
   def filename(key, file_obj)
@@ -49,10 +53,6 @@ class LevelStarterAssetsController < ApplicationController
 
   def prefix(key)
     S3_PREFIX + key
-  end
-
-  def get_file_objects(key)
-    bucket.objects(prefix: prefix(key))
   end
 
   def bucket

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -12,7 +12,7 @@ class LevelStarterAssetsController < ApplicationController
         filename = filename(level_channel_id, file_obj)
         {
           filename: filename,
-          category: File.extname(filename),
+          category: file_mime_type(File.extname(filename)),
           size: file_obj.size,
           timestamp: file_obj.last_modified
         }
@@ -26,6 +26,10 @@ class LevelStarterAssetsController < ApplicationController
 
   def filename(id, file_obj)
     file_obj.key.sub(prefix(id) + '/', '')
+  end
+
+  def file_mime_type(extension)
+    MIME::Types.type_for(extension)&.first&.raw_media_type
   end
 
   def prefix(id)

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -1,0 +1,20 @@
+class LevelStarterAssetsController < ApplicationController
+  S3_BUCKET = 'cdo-v3-assets'.freeze
+  S3_PREFIX = 'starter_assets/'.freeze
+
+  # GET /level_starter_assets/:id
+  def show
+    starter_asset_urls = get_object_summaries(params[:id]).map {|obj| obj.size.zero? ? nil : obj.public_url}.compact
+    render json: {starter_asset_urls: starter_asset_urls}
+  end
+
+  private
+
+  def get_object_summaries(id)
+    bucket.objects(prefix: S3_PREFIX + id)
+  end
+
+  def bucket
+    Aws::S3::Bucket.new(S3_BUCKET)
+  end
+end

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -42,19 +42,10 @@ class LevelStarterAssetsController < ApplicationController
     bucket.object(path)
   end
 
-  def get_file_objects(key)
-    bucket.objects(prefix: prefix(key))
-  end
-
   private
 
   def set_level
     @level = Level.cache_find(params[:level_name])
-  end
-
-  def filename(key, file_obj)
-    prefix = prefix("#{key}/")
-    file_obj.key.sub(prefix, '')
   end
 
   def file_mime_type(extension)

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -10,6 +10,7 @@ class LevelStarterAssetsController < ApplicationController
 
   private
 
+  # Returns S3_BUCKET objects in the S3_PREFIX/id directory.
   def get_object_summaries(id)
     bucket.objects(prefix: S3_PREFIX + id)
   end

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -1,18 +1,20 @@
 class LevelStarterAssetsController < ApplicationController
+  before_action :set_level
+
   S3_BUCKET = 'cdo-v3-assets'.freeze
   S3_PREFIX = 'starter_assets/'.freeze
 
   # GET /level_starter_assets/:level_name
   def show
-    level_channel_id = params[:level_name]
-    starter_assets = get_file_objects(level_channel_id).map do |file_obj|
+    starter_assets = @level.starter_assets.map do |friendly_name, guid_name|
+      file_obj = get_file_object(prefix(guid_name))
+
       if file_obj.size.zero?
         nil
       else
-        filename = filename(level_channel_id, file_obj)
         {
-          filename: filename,
-          category: file_mime_type(File.extname(filename)),
+          filename: friendly_name,
+          category: file_mime_type(File.extname(guid_name)),
           size: file_obj.size,
           timestamp: file_obj.last_modified
         }
@@ -25,11 +27,10 @@ class LevelStarterAssetsController < ApplicationController
   # GET /level_starter_assets/:level_name/:filename
   # Returns requested file body as an IO stream.
   def file
-    level_channel_id = params[:level_name]
-    path = prefix("#{level_channel_id}/#{params[:filename]}.#{params[:format]}")
-    file_obj = get_file_object(path)
-    filename = filename(level_channel_id, file_obj)
-    content_type = file_content_type(File.extname(filename))
+    friendly_name = "#{params[:filename]}.#{params[:format]}"
+    guid_name = @level.starter_assets[friendly_name]
+    file_obj = get_file_object(prefix(guid_name))
+    content_type = file_content_type(File.extname(guid_name))
     send_data read_file(file_obj), type: content_type, disposition: 'inline'
   end
 
@@ -46,6 +47,10 @@ class LevelStarterAssetsController < ApplicationController
   end
 
   private
+
+  def set_level
+    @level = Level.cache_find(params[:level_name])
+  end
 
   def filename(key, file_obj)
     prefix = prefix("#{key}/")

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -26,10 +26,18 @@ class LevelStarterAssetsController < ApplicationController
   # Returns requested file body as an IO stream.
   def file
     path = prefix("#{params[:id]}/#{params[:filename]}.#{params[:format]}")
-    file_obj = bucket.object(path)
+    file_obj = get_file_object(path)
     filename = filename(params[:id], file_obj)
     content_type = file_content_type(File.extname(filename))
-    send_data file_obj.get.body.read, type: content_type, disposition: 'inline'
+    send_data read_file(file_obj), type: content_type, disposition: 'inline'
+  end
+
+  def read_file(file_obj)
+    file_obj.get.body.read
+  end
+
+  def get_file_object(path)
+    bucket.object(path)
   end
 
   def get_file_objects(key)

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -2,9 +2,9 @@ class LevelStarterAssetsController < ApplicationController
   S3_BUCKET = 'cdo-v3-assets'.freeze
   S3_PREFIX = 'starter_assets/'.freeze
 
-  # GET /level_starter_assets/:id
+  # GET /level_starter_assets/:level_name
   def show
-    level_channel_id = params[:id]
+    level_channel_id = params[:level_name]
     starter_assets = get_file_objects(level_channel_id).map do |file_obj|
       if file_obj.size.zero?
         nil
@@ -22,12 +22,13 @@ class LevelStarterAssetsController < ApplicationController
     render json: {starter_assets: starter_assets}
   end
 
-  # GET /level_starter_assets/:id/:filename
+  # GET /level_starter_assets/:level_name/:filename
   # Returns requested file body as an IO stream.
   def file
-    path = prefix("#{params[:id]}/#{params[:filename]}.#{params[:format]}")
+    level_channel_id = params[:level_name]
+    path = prefix("#{level_channel_id}/#{params[:filename]}.#{params[:format]}")
     file_obj = get_file_object(path)
-    filename = filename(params[:id], file_obj)
+    filename = filename(level_channel_id, file_obj)
     content_type = file_content_type(File.extname(filename))
     send_data read_file(file_obj), type: content_type, disposition: 'inline'
   end

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -34,8 +34,9 @@ class LevelStarterAssetsController < ApplicationController
 
   private
 
-  def filename(id, file_obj)
-    file_obj.key.sub(prefix(id) + '/', '')
+  def filename(key, file_obj)
+    prefix = prefix("#{key}/")
+    file_obj.key.sub(prefix, '')
   end
 
   def file_mime_type(extension)
@@ -46,13 +47,12 @@ class LevelStarterAssetsController < ApplicationController
     MIME::Types.type_for(extension)&.first&.content_type
   end
 
-  def prefix(id)
-    S3_PREFIX + id
+  def prefix(key)
+    S3_PREFIX + key
   end
 
-  # Returns S3_BUCKET objects in the S3_PREFIX/id directory.
-  def get_file_objects(id)
-    bucket.objects(prefix: prefix(id))
+  def get_file_objects(key)
+    bucket.objects(prefix: prefix(key))
   end
 
   def bucket

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -31,6 +31,8 @@ class LevelStarterAssetsController < ApplicationController
     guid_name = @level.starter_assets[friendly_name]
     file_obj = get_file_object(prefix(guid_name))
     content_type = file_content_type(File.extname(guid_name))
+
+    expires_in 1.hour, public: true
     send_data read_file(file_obj), type: content_type, disposition: 'inline'
   end
 

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -22,6 +22,16 @@ class LevelStarterAssetsController < ApplicationController
     render json: {starter_assets: starter_assets}
   end
 
+  # GET /level_starter_assets/:id/:filename
+  # Returns requested file body as an IO stream.
+  def file
+    path = prefix("#{params[:id]}/#{params[:filename]}.#{params[:format]}")
+    file_obj = bucket.object(path)
+    filename = filename(params[:id], file_obj)
+    content_type = file_content_type(File.extname(filename))
+    send_data file_obj.get.body.read, type: content_type, disposition: 'inline'
+  end
+
   private
 
   def filename(id, file_obj)
@@ -30,6 +40,10 @@ class LevelStarterAssetsController < ApplicationController
 
   def file_mime_type(extension)
     MIME::Types.type_for(extension)&.first&.raw_media_type
+  end
+
+  def file_content_type(extension)
+    MIME::Types.type_for(extension)&.first&.content_type
   end
 
   def prefix(id)

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -72,6 +72,7 @@ class Level < ActiveRecord::Base
     encrypted
     teacher_markdown
     bubble_choice_description
+    starter_assets
   )
 
   # Fix STI routing http://stackoverflow.com/a/9463495

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -231,7 +231,11 @@ Dashboard::Application.routes.draw do
 
   post 'level_assets/upload', to: 'level_assets#upload'
 
-  resources :level_starter_assets, only: [:show]
+  resources :level_starter_assets, only: [:show] do
+    member do
+      get '/:filename', to: 'level_starter_assets#file'
+    end
+  end
 
   resources :scripts, path: '/s/' do
     # /s/xxx/reset

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -231,7 +231,7 @@ Dashboard::Application.routes.draw do
 
   post 'level_assets/upload', to: 'level_assets#upload'
 
-  resources :level_starter_assets, only: [:show] do
+  resources :level_starter_assets, only: [:show], param: 'level_name' do
     member do
       get '/:filename', to: 'level_starter_assets#file'
     end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -231,6 +231,8 @@ Dashboard::Application.routes.draw do
 
   post 'level_assets/upload', to: 'level_assets#upload'
 
+  resources :level_starter_assets, only: [:show]
+
   resources :scripts, path: '/s/' do
     # /s/xxx/reset
     get 'reset', to: 'script_levels#reset'

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 class LevelStarterAssetsControllerTest < ActionController::TestCase
   test 'show: returns summary of assets' do
     file_objs = [
-      FakeS3ObjectSummary.new('starter_assets/1/ty.png', 123, 1.day.ago),
-      FakeS3ObjectSummary.new('starter_assets/1/empty.png', 0, DateTime.now),
-      FakeS3ObjectSummary.new('starter_assets/1/welcome.jpg', 321, 2.days.ago)
+      MockS3ObjectSummary.new('starter_assets/1/ty.png', 123, 1.day.ago),
+      MockS3ObjectSummary.new('starter_assets/1/empty.png', 0, DateTime.now),
+      MockS3ObjectSummary.new('starter_assets/1/welcome.jpg', 321, 2.days.ago)
     ]
-    LevelStarterAssetsController.any_instance.stubs(:get_file_objects).returns(file_objs)
+    LevelStarterAssetsController.any_instance.expects(:get_file_objects).returns(file_objs)
 
     get :show, params: {id: 1}
     starter_assets = JSON.parse(response.body)['starter_assets']
@@ -20,11 +20,29 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     assert_equal 'image', starter_assets[1]['category']
     assert_equal file_objs[2].size, starter_assets[1]['size']
   end
+
+  test 'file: returns requested file' do
+    file_obj = MockS3ObjectSummary.new('starter_assets/1/ty.png', 123, 1.day.ago)
+    LevelStarterAssetsController.any_instance.
+      expects(:get_file_object).
+      with('starter_assets/1/ty.png').
+      returns(file_obj)
+    LevelStarterAssetsController.any_instance.
+      expects(:read_file).
+      with(file_obj).
+      returns('hello, world!')
+
+    get :file, params: {id: 1, filename: 'ty', format: 'png'}
+
+    assert_equal 'hello, world!', response.body
+    assert_equal 'image/png', response.headers['Content-Type']
+    assert_equal 'inline', response.headers['Content-Disposition']
+  end
 end
 
-# Mock the Aws::S3::ObjectSummary class since we can't request the objects from S3 in tests:
+# Mock Aws::S3::ObjectSummary class since we can't request the objects from S3 in tests:
 # https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/ObjectSummary.html
-class FakeS3ObjectSummary
+class MockS3ObjectSummary
   attr_reader :key, :size, :last_modified
 
   def initialize(key, size, last_modified)

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -13,12 +13,11 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     LevelStarterAssetsController.any_instance.
       expects(:get_file_object).twice.
       returns(file_objs[0], file_objs[1])
-    level = create(:level)
     level_starter_assets = {
       'ty.png' => guid_name_1,
       'welcome.jpg' => guid_name_2
     }
-    level.update!(starter_assets: level_starter_assets)
+    level = create(:level, starter_assets: level_starter_assets)
 
     get :show, params: {level_name: level.name}
     starter_assets = JSON.parse(response.body)['starter_assets']
@@ -44,11 +43,10 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
       expects(:read_file).
       with(file_obj).
       returns('hello, world!')
-    level = create(:level)
     level_starter_assets = {
       'ty.png' => guid_name
     }
-    level.update!(starter_assets: level_starter_assets)
+    level = create(:level, starter_assets: level_starter_assets)
 
     get :file, params: {level_name: level.name, filename: 'ty', format: 'png'}
 

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -2,14 +2,25 @@ require 'test_helper'
 
 class LevelStarterAssetsControllerTest < ActionController::TestCase
   test 'show: returns summary of assets' do
+    guid_name_1 = "#{SecureRandom.uuid}.png"
+    key_1 = "starter_assets/#{guid_name_1}"
+    guid_name_2 = "#{SecureRandom.uuid}.jpg"
+    key_2 = "starter_assets/#{guid_name_2}"
     file_objs = [
-      MockS3ObjectSummary.new('starter_assets/1/ty.png', 123, 1.day.ago),
-      MockS3ObjectSummary.new('starter_assets/1/empty.png', 0, DateTime.now),
-      MockS3ObjectSummary.new('starter_assets/1/welcome.jpg', 321, 2.days.ago)
+      MockS3ObjectSummary.new(key_1, 123, 1.day.ago),
+      MockS3ObjectSummary.new(key_2, 321, 2.days.ago)
     ]
-    LevelStarterAssetsController.any_instance.expects(:get_file_objects).returns(file_objs)
+    LevelStarterAssetsController.any_instance.
+      expects(:get_file_object).twice.
+      returns(file_objs[0], file_objs[1])
+    level = create(:level)
+    level_starter_assets = {
+      'ty.png' => guid_name_1,
+      'welcome.jpg' => guid_name_2
+    }
+    level.update!(starter_assets: level_starter_assets)
 
-    get :show, params: {id: 1}
+    get :show, params: {level_name: level.name}
     starter_assets = JSON.parse(response.body)['starter_assets']
 
     assert_equal 2, starter_assets.count
@@ -18,21 +29,28 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     assert_equal file_objs[0].size, starter_assets[0]['size']
     assert_equal 'welcome.jpg', starter_assets[1]['filename']
     assert_equal 'image', starter_assets[1]['category']
-    assert_equal file_objs[2].size, starter_assets[1]['size']
+    assert_equal file_objs[1].size, starter_assets[1]['size']
   end
 
   test 'file: returns requested file' do
-    file_obj = MockS3ObjectSummary.new('starter_assets/1/ty.png', 123, 1.day.ago)
+    guid_name = "#{SecureRandom.uuid}.png"
+    key = "starter_assets/#{guid_name}"
+    file_obj = MockS3ObjectSummary.new(key, 123, 1.day.ago)
     LevelStarterAssetsController.any_instance.
       expects(:get_file_object).
-      with('starter_assets/1/ty.png').
+      with(key).
       returns(file_obj)
     LevelStarterAssetsController.any_instance.
       expects(:read_file).
       with(file_obj).
       returns('hello, world!')
+    level = create(:level)
+    level_starter_assets = {
+      'ty.png' => guid_name
+    }
+    level.update!(starter_assets: level_starter_assets)
 
-    get :file, params: {id: 1, filename: 'ty', format: 'png'}
+    get :file, params: {level_name: level.name, filename: 'ty', format: 'png'}
 
     assert_equal 'hello, world!', response.body
     assert_equal 'image/png', response.headers['Content-Type']

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class LevelStarterAssetsControllerTest < ActionController::TestCase
+  test 'show: returns summary of assets' do
+    file_objs = [
+      FakeS3ObjectSummary.new('starter_assets/1/ty.png', 123, 1.day.ago),
+      FakeS3ObjectSummary.new('starter_assets/1/empty.png', 0, DateTime.now),
+      FakeS3ObjectSummary.new('starter_assets/1/welcome.jpg', 321, 2.days.ago)
+    ]
+    LevelStarterAssetsController.any_instance.stubs(:get_file_objects).returns(file_objs)
+
+    get :show, params: {id: 1}
+    starter_assets = JSON.parse(response.body)['starter_assets']
+
+    assert_equal 2, starter_assets.count
+    assert_equal 'ty.png', starter_assets[0]['filename']
+    assert_equal 'image', starter_assets[0]['category']
+    assert_equal file_objs[0].size, starter_assets[0]['size']
+    assert_equal 'welcome.jpg', starter_assets[1]['filename']
+    assert_equal 'image', starter_assets[1]['category']
+    assert_equal file_objs[2].size, starter_assets[1]['size']
+  end
+end
+
+# Mock the Aws::S3::ObjectSummary class since we can't request the objects from S3 in tests:
+# https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/ObjectSummary.html
+class FakeS3ObjectSummary
+  attr_reader :key, :size, :last_modified
+
+  def initialize(key, size, last_modified)
+    @key = key
+    @size = size
+    @last_modified = last_modified
+  end
+end


### PR DESCRIPTION
Initial PR for [LP-609](https://codedotorg.atlassian.net/browse/LP-609).
[Technical design](https://docs.google.com/document/d/1KrAAv4klJhLL_siQo-t6F-2zJrCOOub6Z7W2b9IqDto/edit#heading=h.gbynda1ya0gp)

### What it does
- If the `<AssetManager/>` is provided with the `levelName` prop, we will request the starter assets associated with that level from `/level_starter_assets/:level_name`. **This prop is currently always undefined, so this PR should have no impact on users.**
- `/level_starter_assets/:level_name` returns an array of summarized file objects present in S3's `cdo-v3-assets/starter_assets` directory ([view starter_assets dir here](https://s3.console.aws.amazon.com/s3/buckets/cdo-v3-assets/starter_assets/?region=us-east-1&tab=overview)) via the level's `starter_assets` property, which will be structured as follows:
```ruby
starter_assets: {
  # key - friendly file name
  # value - UUID file name stored in S3 (to avoid name collisions)
  "welcome.png" => "134354543.png"
}
```
- `/level_starter_assets/:level_name/:filename` will stream the image data from S3 for the requested file present at `cdo-v3-assets/starter_assets/:filename`. This is used when we display the starter asset in `<AssetThumbnail/>`.

Basically, this PR will allow us to request and display starter assets from S3 in Applab.

### Important note
In order to have starter assets consistent across all environments, they are served from the same bucket/directory (e.g., there isn't a "starter_assets_staging" or "_production" directory). **For this reason, levelbuilders will only be allowed to upload and delete starter assets on levelbuilder while in start mode.** There may be better ways to achieve this same outcome, but I couldn't think of any that weren't much more complicated, so let me know your thoughts!

### Examples
As a levelbuilder, when I visit a level and enter start mode, I can see the starter assets associated with that level:
![Screen Shot 2019-08-09 at 9 56 30 AM](https://user-images.githubusercontent.com/9812299/62795781-5b368c00-ba8c-11e9-9750-bf06b5658f4c.png)

As a student, when I visit a level, I can see the starter assets and my own uploaded assets associated with that level. (Note that students will be blocked from deleting these assets in a future PR, so ignore the "delete" button.)
![Screen Shot 2019-08-09 at 9 56 41 AM](https://user-images.githubusercontent.com/9812299/62795826-71444c80-ba8c-11e9-989c-09456107cd87.png)

### Next steps
- As a levelbuilder in levelbuilder_mode, I can:
  - Upload new starter assets in start mode
  - Delete starter assets in start mode