### PR TITLE
fix clear_secrets bug with empty hash

### DIFF
--- a/lib/cdo/secrets_config.rb
+++ b/lib/cdo/secrets_config.rb
@@ -81,7 +81,7 @@ module Cdo
     def clear_secrets
       @secrets ||= []
       @secrets |= table.select {|_, v| v.is_a?(Secret)}.keys.map(&:to_s)
-      @secrets.product([nil]).to_h.to_yaml.gsub("---\n", '')
+      @secrets.product([nil]).to_h.to_yaml.sub(/^---.*\n/, '')
     end
   end
 end


### PR DESCRIPTION
`SecretsConfig#clear_secrets` (used as `<%=clear_secrets%>` tag in erb-config files) returns a YAML-fragment that resets all secret tags to `nil`. In order for the fragment to be inserted inline within an existing YAML document, the document header (`---`) was removed via `yaml.gsub("---\n", '')`. 

However, for the edge case where there were no secrets to clear by this method call, the YAML document is output as `--- {}`, which the gsub regex did not match, causing the fragment to close the current YAML document early not picking up any values defined after that point in the document.

This PR contains a tweak to the regex which fixes the issue, as verified by the `test_clear_secrets_empty` test (fails without the fix in this PR, passes with it).

This edge case only occurred in the `test` environment with `UNIT_TEST=1` set, and only where all existing secrets were overwritten by values set in `globals.yml`, which is why it did not reproduce in any other environment.