### PR TITLE
[Cleanup] Remove unused parameter to getDatabase()

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -816,7 +816,7 @@ function setupReduxSubscribers(store) {
   if (store.getState().pageConstants.hasDataMode) {
     // Initialize redux's list of tables from firebase, and keep it up to date as
     // new tables are added and removed.
-    const tablesRef = getDatabase(Applab.channelId).child('counters/tables');
+    const tablesRef = getDatabase().child('counters/tables');
     tablesRef.on('child_added', snapshot => {
       store.dispatch(
         addTableName(
@@ -1274,7 +1274,7 @@ function onDataViewChange(view, oldTableName, newTableName) {
   if (!getStore().getState().pageConstants.hasDataMode) {
     throw new Error('onDataViewChange triggered without data mode enabled');
   }
-  const storageRef = getDatabase(Applab.channelId).child('storage');
+  const storageRef = getDatabase().child('storage');
 
   // Unlisten from previous data view. This should not interfere with events listened to
   // by onRecordEvent, which listens for added/updated/deleted events, whereas we are


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/11895/commits/0c78862e0ae9030113025681e56cf5dcc86a3f1e made it so that `getDatabase()` does not take any arguments, but we're still passing through the channel ID here.