### PR TITLE
Resolve secrets in ERB strings

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -450,11 +450,11 @@ db_reader: <%=db_writer%>
 reporting_db_reader: <%=reporting_db_writer%>
 
 # Default DB-specific endpoints to base endpoint plus db name.
-dashboard_db_reader:           <%="#{db_reader}#{dashboard_db_name}"%>
-dashboard_db_writer:           <%="#{db_writer}#{dashboard_db_name}"%>
-pegasus_db_reader:             <%="#{db_reader}#{pegasus_db_name}"%>
-pegasus_db_writer:             <%="#{db_writer}#{pegasus_db_name}"%>
-dashboard_reporting_db_reader: <%="#{reporting_db_reader}#{dashboard_db_name}"%>
-dashboard_reporting_db_writer: <%="#{reporting_db_writer}#{dashboard_db_name}"%>
-pegasus_reporting_db_reader:   <%="#{reporting_db_reader}#{pegasus_db_name}"%>
-pegasus_reporting_db_writer:   <%="#{reporting_db_writer}#{pegasus_db_name}"%>
+dashboard_db_reader:           '<%="#{db_reader}#{dashboard_db_name}"%>'
+dashboard_db_writer:           '<%="#{db_writer}#{dashboard_db_name}"%>'
+pegasus_db_reader:             '<%="#{db_reader}#{pegasus_db_name}"%>'
+pegasus_db_writer:             '<%="#{db_writer}#{pegasus_db_name}"%>'
+dashboard_reporting_db_reader: '<%="#{reporting_db_reader}#{dashboard_db_name}"%>'
+dashboard_reporting_db_writer: '<%="#{reporting_db_writer}#{dashboard_db_name}"%>'
+pegasus_reporting_db_reader:   '<%="#{reporting_db_reader}#{pegasus_db_name}"%>'
+pegasus_reporting_db_writer:   '<%="#{reporting_db_writer}#{pegasus_db_name}"%>'

--- a/lib/cdo/lazy.rb
+++ b/lib/cdo/lazy.rb
@@ -22,11 +22,19 @@ module Cdo
     end
 
     def __getobj__
-      __setobj__(@block.call) unless defined?(@delegate_sd_obj)
-      super
+      __setobj__(super(&@block))
     end
 
-    undef_method(:instance_of?, :kind_of?, :is_a?, :nil?, :class)
+    def is_a?(class1)
+      class1 == Lazy || __getobj__.is_a?(class1)
+    end
+    alias kind_of? is_a?
+
+    def instance_of?(class1)
+      class1 == Lazy || __getobj__.instance_of?(class1)
+    end
+
+    undef_method(:nil?, :class)
   end
 
   def self.lazy(&block)

--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -34,10 +34,10 @@ module Cdo
     end
 
     # Add keys to list of required secrets, and begin pre-fetching them.
-    def required(*keys)
+    def required(*keys, fetch: false)
       keys = keys.map(&:to_s)
       @required += keys
-      keys.map(&method(:get))
+      keys.map(&method(:get)) if fetch
     end
 
     # Ensure all required secrets are fully loaded.
@@ -94,8 +94,7 @@ module Cdo
     # @param raise_not_found[Boolean] Raise exception if secret is not found.
     def lazy(key, fetch: false, fallback: nil, raise_not_found: false)
       key = key.to_s
-      @required.add(key)
-      get(key) if fetch
+      required(key, fetch: fetch)
       Cdo.lazy do
         if raise_not_found
           get(key).value!

--- a/lib/test/cdo/test_lazy.rb
+++ b/lib/test/cdo/test_lazy.rb
@@ -18,6 +18,9 @@ class LazyTest < Minitest::Test
   def test_class
     lazy = Cdo.lazy {'test'}
     assert_instance_of String, lazy
+    assert_instance_of Cdo::Lazy, lazy
+    assert_kind_of String, lazy
+    assert_kind_of Cdo::Lazy, lazy
     assert_equal String, lazy.class
   end
 end

--- a/lib/test/cdo/test_secrets_config.rb
+++ b/lib/test/cdo/test_secrets_config.rb
@@ -2,36 +2,44 @@ require_relative '../test_helper'
 require 'cdo/secrets_config'
 
 class SecretsConfigTest < Minitest::Test
+  class CdoSecrets < Cdo::Config
+    prepend Cdo::SecretsConfig
+  end
+
+  attr_accessor :config
+
+  def setup
+    self.config = CdoSecrets.new
+  end
+
   def test_load
     secrets_file = CDO.dir('config/secrets.yml.template')
     secrets = Cdo::SecretsConfig.load(secrets_file)
     assert_equal 'bar', secrets['staging/cdo/foo']
   end
 
-  class CdoSecrets < Cdo::Config
-    prepend Cdo::SecretsConfig
-  end
-
-  def load_configuration(yml_erb, config = CdoSecrets.new)
+  def load_configuration(yml_erb)
     file = Tempfile.new(%w(config .yml.erb))
     file.write yml_erb
     file.close
     config.load_configuration(file.path)
     config.freeze
-    config
   end
 
-  def test_secret_tag
-    config = CdoSecrets.new
+  def stub_secret(str)
     client = Aws::SecretsManager::Client.new(
       stub_responses: {
         get_secret_value: ->(_) do
-          {secret_string: 'bar!'}
+          {secret_string: str}
         end
       }
     )
     config.cdo_secrets = Cdo::Secrets.new(client: client)
-    load_configuration(<<YAML, config)
+  end
+
+  def test_secret_tag
+    stub_secret 'bar!'
+    load_configuration <<YAML
 foo: foo!
 bar: !Secret
 YAML
@@ -40,7 +48,7 @@ YAML
   end
 
   def test_clear_secrets
-    config = load_configuration <<YAML
+    load_configuration <<YAML
 foo: !Secret
 <%=clear_secrets%>
 YAML
@@ -48,7 +56,7 @@ YAML
   end
 
   def test_clear_secrets_empty
-    config = load_configuration <<YAML
+    load_configuration <<YAML
 foo: false
 <%=clear_secrets%>
 foo: true
@@ -56,17 +64,18 @@ YAML
     assert_equal true, config.foo
   end
 
+  def test_erb_string_secret
+    stub_secret 'FOO'
+    load_configuration <<YAML
+foo: !Secret
+bar: <%=foo%>bar
+YAML
+    assert_equal 'FOObar', config.bar
+  end
+
   def test_json_secret
-    config = CdoSecrets.new
-    client = Aws::SecretsManager::Client.new(
-      stub_responses: {
-        get_secret_value: ->(_) do
-          {secret_string: {bar: 'baz'}.to_json}
-        end
-      }
-    )
-    config.cdo_secrets = Cdo::Secrets.new(client: client)
-    load_configuration(<<YAML, config)
+    stub_secret({bar: 'baz'}.to_json)
+    load_configuration <<YAML
 foo: !Secret
 YAML
     assert_equal({bar: 'baz'}, config.foo)

--- a/lib/test/cdo/test_secrets_config.rb
+++ b/lib/test/cdo/test_secrets_config.rb
@@ -55,4 +55,21 @@ foo: true
 YAML
     assert_equal true, config.foo
   end
+
+  def test_json_secret
+    config = CdoSecrets.new
+    client = Aws::SecretsManager::Client.new(
+      stub_responses: {
+        get_secret_value: ->(_) do
+          {secret_string: {bar: 'baz'}.to_json}
+        end
+      }
+    )
+    config.cdo_secrets = Cdo::Secrets.new(client: client)
+    load_configuration(<<YAML, config)
+foo: !Secret
+YAML
+    assert_equal({bar: 'baz'}, config.foo)
+    assert_equal 'baz', config.foo.bar
+  end
 end


### PR DESCRIPTION
Allow configuration values to depend on secrets within interpolated strings (such as `db_reader: !Secret` referenced within `dashboard_db_reader: '<%="#{db_reader}#{dashboard_db_name}"%>'`.

For the implementation, I've added an internal string representation of the secret as `${secretkey}`, which is matched in the `lazy_load_secrets!` method enhanced to regex-replace (`gsub`) all secrets found within string values.

Added a test (`test_erb_string_secret`) to verify the new functionality, and I also added some extra coverage around json secrets (`test_json_secret`) and fixed a related bug in how json secrets get passed through the system.