### PR TITLE
Prevent invalid urls from causing 500 errors in safe browsing API

### DIFF
--- a/lib/cdo/safe_browsing.rb
+++ b/lib/cdo/safe_browsing.rb
@@ -44,11 +44,12 @@ module SafeBrowsing
     # informed-redirect model and record the error value
     if response.nil?
       response_message = 'No response from API'
+    elsif response.code == '400' || response.code == '429'
+      # Note: with a 400 response, the body has no 'matches' field
+      response_message = "Error code: #{response.code}"
     elsif !JSON.parse(response.body).empty?
       response_message = JSON.parse(response.body)['matches'][0]['threatType']
       site_approved = false
-    elsif response.code == '400' || response.code == '429'
-      response_message = "Error code: #{response.code}"
     end
 
     # Record to Firehose the response time of request rounded to thousandths of a second,


### PR DESCRIPTION
We got a large number of 500 errors due to invalid urls being used in applab projects. See this error in Honeybadger https://app.honeybadger.io/projects/3240/faults/50873912?at=2019-08-09T08:00:00-07:00

A 400 response (bad url) from the safe browsing API has a response formatted like this:
`{`
`  "error": {`
`    "code": 400,`
`    "message": "API key not valid. Please pass a valid API key.",`
`    "status": "INVALID_ARGUMENT",`
`    "details": [`
`      {`
`        "@type": "type.googleapis.com/google.rpc.Help",`
`        "links": [`
`          {`
`            "description": "Google developers console",`
`            "url": "https://console.developers.google.com"`
`          }`
`        ]`
`      }`
`    ]`
`  }`
`}`

There is no 'matches' field in this response, and we threw a 500 error while trying to access it.


Follow up actions:
1. Correctly handle all HTTP status codes: https://developers.google.com/safe-browsing/v4/status-codes [https://codedotorg.atlassian.net/browse/STAR-621](STAR-621)
2. Add client side caching [https://codedotorg.atlassian.net/browse/STAR-446](STAR-446)