### PR TITLE
Spritelab Fix: toolbox displays on top of block layout when switching out of the costume tab

### DIFF
--- a/apps/src/p5lab/GameLabVisualizationHeader.jsx
+++ b/apps/src/p5lab/GameLabVisualizationHeader.jsx
@@ -8,6 +8,7 @@ import msg from '@cdo/locale';
 import ToggleGroup from '@cdo/apps/templates/ToggleGroup';
 import styleConstants from '@cdo/apps/styleConstants';
 import {allowAnimationMode} from './stateQueries';
+import * as utils from '../utils';
 
 const styles = {
   main: {
@@ -29,15 +30,27 @@ class GameLabVisualizationHeader extends React.Component {
     spriteLab: PropTypes.bool.isRequired
   };
 
+  changeInterfaceMode = mode => {
+    if (!this.props.spriteLab) {
+      // Add a resize event to Gamelab (i.e. droplet) to ensure code is rendered
+      // correctly if it was in the middle of a transition from code to block mode
+      // when the interface mode was changed. Blockly already fires resize events
+      // so this is not needed for spriteLab - too many resize events seem to
+      // conflict with each other.
+      setTimeout(() => utils.fireResizeEvent(), 0);
+    }
+
+    this.props.onInterfaceModeChange(mode);
+  };
+
   render() {
-    const {
-      interfaceMode,
-      allowAnimationMode,
-      onInterfaceModeChange
-    } = this.props;
+    const {interfaceMode, allowAnimationMode} = this.props;
     return (
       <div style={styles.main} id="playSpaceHeader">
-        <ToggleGroup selected={interfaceMode} onChange={onInterfaceModeChange}>
+        <ToggleGroup
+          selected={interfaceMode}
+          onChange={this.changeInterfaceMode}
+        >
           <button type="button" value={P5LabInterfaceMode.CODE} id="codeMode">
             {msg.codeMode()}
           </button>

--- a/apps/src/p5lab/actions.js
+++ b/apps/src/p5lab/actions.js
@@ -1,7 +1,6 @@
 /** @file Redux action-creators for Game Lab.
  *  @see http://redux.js.org/docs/basics/Actions.html */
 import $ from 'jquery';
-import * as utils from '@cdo/apps/utils';
 import {
   pickNewAnimation,
   show,
@@ -33,9 +32,6 @@ export const ADD_MESSAGE = 'spritelab/ADD_MESSAGE';
  * @returns {function}
  */
 export function changeInterfaceMode(interfaceMode, spritelabDraw) {
-  //Add a resize event on each call to changeInterfaceMode to ensure
-  //proper rendering of droplet and code mode. Similar solution in applab.
-  setTimeout(() => utils.fireResizeEvent(), 0);
   return function(dispatch) {
     $(window).trigger('appModeChanged');
     dispatch({


### PR DESCRIPTION
Reintroduces the change made here:
https://github.com/code-dot-org/code-dot-org/pull/28294

This time, we are not expecting any breaks due to the fix applied to the instruction space in this PR: https://github.com/code-dot-org/code-dot-org/pull/30196

Bug: https://codedotorg.atlassian.net/browse/STAR-587

Old: 
![image](https://user-images.githubusercontent.com/8324574/62813405-7373ce80-babf-11e9-968c-3c50594118b1.png)

New:
![image](https://user-images.githubusercontent.com/8324574/62813410-7c64a000-babf-11e9-8960-ca6782a689bd.png)

Couple more notes on the issue this PR fixes
1. Slack discussion capturing the full issue with explanation of fixes both to the instruction space and to the costume tab: https://codedotorg.slack.com/archives/C1B3PNDL7/p1565036149117300
2. Old PRs that attempted to fix this issue: (first) https://github.com/code-dot-org/code-dot-org/pull/28294, (first revert) https://github.com/code-dot-org/code-dot-org/pull/28361, (second) https://github.com/code-dot-org/code-dot-org/pull/28384, (second revert) https://github.com/code-dot-org/code-dot-org/pull/28485