### PR TITLE
Revert "use pegasus_unittest database for shared & pegasus unit tests during DTT"

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -443,7 +443,7 @@ db_writer: !Secret
 reporting_db_writer: <%=db_writer%>
 
 dashboard_db_name: dashboard_<%=env%>
-pegasus_db_name: <%= ENV['PEGASUS_UNIT_TEST'] ? 'pegasus_unittest' : "pegasus#{_env}" %>
+pegasus_db_name: pegasus<%=_env%>
 
 # Default reader endpoints to writer endpoint.
 db_reader: <%=db_writer%>

--- a/lib/cdo/test_run_utils.rb
+++ b/lib/cdo/test_run_utils.rb
@@ -49,17 +49,6 @@ module TestRunUtils
   def self.run_pegasus_tests
     Dir.chdir(pegasus_dir) do
       ChatClient.wrap('pegasus tests') do
-        # Make sure the pegasus database is created before running pegasus
-        # tests. This might be pegasus_test (on development machines) or
-        # pegasus_unittest (during ci on the test machine).
-        #
-        # This does not enforce that all migrations have been applied.
-        # Strangely, during our CI process, this is taken care of by the
-        # prepare_dbs step in shared/rake/test.rake which works because shared
-        # tests run before pegasus tests.
-        with_rack_env(:test) do
-          RakeUtils.rake_stream_output 'db:ensure_created'
-        end
         RakeUtils.rake_stream_output 'test'
       end
     end

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -202,21 +202,7 @@ namespace :test do
     end
   end
 
-  task :shared_ci do
-    # isolate unit tests from the pegasus_test DB
-    ENV['PEGASUS_UNIT_TEST'] = '1'
-    TestRunUtils.run_shared_tests
-    ENV.delete 'PEGASUS_UNIT_TEST'
-  end
-
-  task :pegasus_ci do
-    # isolate unit tests from the pegasus_test DB
-    ENV['PEGASUS_UNIT_TEST'] = '1'
-    TestRunUtils.run_pegasus_tests
-    ENV.delete 'PEGASUS_UNIT_TEST'
-  end
-
-  task ci: [:pegasus_ci, :shared_ci, :dashboard_ci, :ui_live]
+  task ci: [:pegasus, :shared, :dashboard_ci, :ui_live]
 
   desc 'Runs dashboard tests.'
   task :dashboard do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#30181 because `test:pegasus_ci` broke during DTT:

```
sudo service dashboard upgrade
sudo bundle --without development production adhoc staging levelbuilder integration --quiet --jobs 40
RAILS_ENV=test RACK_ENV=test bundle exec rake pegasus:setup_db --trace
sudo service pegasus upgrade
QUIET=1 bundle exec rake stack:start
[stack update] update stack: test...
[stack update] No updates are to be performed.
bin/flush_cache
RAILS_ENV=test RACK_ENV=test bundle exec rake db:ensure_created
mysql: [Warning] Using a password on the command line interface can be insecure.
RAILS_ENV=test RACK_ENV=test bundle exec rake test
/var/lib/gems/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:131:in `_query': Mysql2::Error: Table 'pegasus_unittest.storage_apps' doesn't exist (Sequel::DatabaseError)
	from /var/lib/gems/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:131:in `block in query'
	from /var/lib/gems/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:130:in `handle_interrupt'
	from /var/lib/gems/2.5.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:130:in `query'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/adapters/mysql2.rb:137:in `block in _execute'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/database/logging.rb:38:in `log_connection_yield'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/adapters/mysql2.rb:132:in `_execute'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/adapters/utils/mysql_mysql2.rb:38:in `block in execute'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/connection_pool/threaded.rb:91:in `hold'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/database/connecting.rb:270:in `synchronize'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/adapters/utils/mysql_mysql2.rb:38:in `execute'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/adapters/mysql2.rb:68:in `execute_dui'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/database/query.rb:43:in `execute_ddl'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/dataset/actions.rb:1087:in `execute_ddl'
	from /var/lib/gems/2.5.0/gems/sequel-5.9.0/lib/sequel/dataset/actions.rb:850:in `truncate'
	from /home/ubuntu/test/shared/test/common_test_helper.rb:45:in `block in <top (required)>'
	from /home/ubuntu/test/shared/test/common_test_helper.rb:44:in `each'
	from /home/ubuntu/test/shared/test/common_test_helper.rb:44:in `<top (required)>'
	from /home/ubuntu/test/pegasus/test/test_helper.rb:2:in `require_relative'
	from /home/ubuntu/test/pegasus/test/test_helper.rb:2:in `<top (required)>'
	from /home/ubuntu/test/pegasus/test/test_asset_helpers.rb:1:in `require_relative'
	from /home/ubuntu/test/pegasus/test/test_asset_helpers.rb:1:in `<top (required)>'
	from /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:10:in `require'
	from /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
	from /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:9:in `each'
	from /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:9:in `block in <main>'
	from /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:4:in `select'
	from /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -I"lib" -I"/var/lib/gems/2.5.0/gems/rake-11.3.0/lib" "/var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/rake_test_loader.rb" "test/test*.rb" ]
/var/lib/gems/2.5.0/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => test
(See full trace by running task with --trace)
rake aborted!
'RAILS_ENV=test RACK_ENV=test bundle exec rake test' returned 1
/home/ubuntu/test/lib/cdo/rake_utils.rb:115:in `system_stream_output'
/home/ubuntu/test/lib/cdo/rake_utils.rb:100:in `rake_stream_output'
/home/ubuntu/test/lib/cdo/test_run_utils.rb:63:in `block (2 levels) in run_pegasus_tests'
/home/ubuntu/test/lib/cdo/chat_client.rb:62:in `wrap'
/home/ubuntu/test/lib/cdo/test_run_utils.rb:51:in `block in run_pegasus_tests'
/home/ubuntu/test/lib/cdo/test_run_utils.rb:50:in `chdir'
/home/ubuntu/test/lib/cdo/test_run_utils.rb:50:in `run_pegasus_tests'
/home/ubuntu/test/lib/rake/test.rake:215:in `block (2 levels) in <top (required)>'
/home/ubuntu/test/lib/rake/ci.rake:99:in `block (2 levels) in <top (required)>'
/home/ubuntu/test/lib/cdo/chat_client.rb:62:in `wrap'
/home/ubuntu/test/lib/rake/ci.rake:99:in `block in <top (required)>'
/var/lib/gems/2.5.0/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => ci:test => test:ci => test:pegasus_ci
(See full trace by running task with --trace)
```