### PR TITLE
Disable Secrets in non-Chef-managed test environments

### DIFF
--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -5,8 +5,9 @@ azure_content_moderation_key: !Secret
 saucelabs_authkey: !Secret
 saucelabs_username: !Secret
 
-# Disable Secrets in CI-test environments.
-<% if ci_test -%>
+# Disable Secrets for CI, unit-test runs,
+# and other non-chef_managed environments (e.g., preloading Spring for Rails tests).
+<% if ci_test || !chef_managed -%>
 <%= clear_secrets %>
 
 dashboard_honeybadger_api_key: '00000000'


### PR DESCRIPTION
This PR fixes preloading Spring for running Rails tests in local development.

It adds the assumption that any `test` environment on a non-`chef_managed` instance is primarily intended for running unit tests, and won't load any secrets.

----

### Background

Our system ambiguously uses the `test` environment symbol for two somewhat different purposes:
1. `test` infrastructure-environment where we perform pre-production UI and other manual testing before final deployment;
2. A local environment for various isolated unit and integration tests, invoking various system-isolating logic to make tests consistent and reliable, load fixtures instead of complete seed data, manipulate an isolated test-database instead of a live system database, etc.

When the `RAILS_ENV` / `RACK_ENV` environment variable is `test`, we further distinguish between these two sub-environments by setting the `CI` and / or the `UNIT_TEST` variables to indicate when unit/integration tests are being started (2), rather than the pre-production test server (1). In our configuration, we want to load `test`-environment secrets _only_ for the server (1) sub-environment, since our isolated tests shouldn't use any secrets to run correctly (and we also want to restrict access to these secrets from local workstations, to prevent accidental disclosure/modification of test-server resources). We accomplish this by setting `ENV["UNIT_TEST"] = "true"` in test helpers before configuration is loaded.

However, Rails unit-test commands invoked with `spring` (a utility used to speed up local Rails testing by forking a pre-initialized Rails process) load the Rails application (and CDO configuration) _before_ running the test helper code, so the non-unit test configuration is incorrectly loaded.