### PR TITLE
Restore "use pegasus_unittest database for shared & pegasus unit tests during DTT"

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -443,7 +443,7 @@ db_writer: !Secret
 reporting_db_writer: <%=db_writer%>
 
 dashboard_db_name: dashboard_<%=env%>
-pegasus_db_name: pegasus<%=_env%>
+pegasus_db_name: <%= ENV['PEGASUS_UNIT_TEST'] ? 'pegasus_unittest' : "pegasus#{_env}" %>
 
 # Default reader endpoints to writer endpoint.
 db_reader: <%=db_writer%>

--- a/lib/cdo/test_run_utils.rb
+++ b/lib/cdo/test_run_utils.rb
@@ -49,6 +49,17 @@ module TestRunUtils
   def self.run_pegasus_tests
     Dir.chdir(pegasus_dir) do
       ChatClient.wrap('pegasus tests') do
+        # Make sure the pegasus database is created before running pegasus
+        # tests. This might be pegasus_test (on development machines) or
+        # pegasus_unittest (during ci on the test machine).
+        #
+        # This does not enforce that all migrations have been applied.
+        # Strangely, during our CI process, this is taken care of by the
+        # prepare_dbs step in shared/rake/test.rake which works because shared
+        # tests run before pegasus tests.
+        with_rack_env(:test) do
+          RakeUtils.rake_stream_output 'db:ensure_created'
+        end
         RakeUtils.rake_stream_output 'test'
       end
     end

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -202,7 +202,21 @@ namespace :test do
     end
   end
 
-  task ci: [:pegasus, :shared, :dashboard_ci, :ui_live]
+  task :shared_ci do
+    # isolate unit tests from the pegasus_test DB
+    ENV['PEGASUS_UNIT_TEST'] = '1'
+    TestRunUtils.run_shared_tests
+    ENV.delete 'PEGASUS_UNIT_TEST'
+  end
+
+  task :pegasus_ci do
+    # isolate unit tests from the pegasus_test DB
+    ENV['PEGASUS_UNIT_TEST'] = '1'
+    TestRunUtils.run_pegasus_tests
+    ENV.delete 'PEGASUS_UNIT_TEST'
+  end
+
+  task ci: [:pegasus_ci, :shared_ci, :dashboard_ci, :ui_live]
 
   desc 'Runs dashboard tests.'
   task :dashboard do

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -216,7 +216,7 @@ namespace :test do
     ENV.delete 'PEGASUS_UNIT_TEST'
   end
 
-  task ci: [:pegasus_ci, :shared_ci, :dashboard_ci, :ui_live]
+  task ci: [:shared_ci, :pegasus_ci, :dashboard_ci, :ui_live]
 
   desc 'Runs dashboard tests.'
   task :dashboard do

--- a/shared/rake/test.rake
+++ b/shared/rake/test.rake
@@ -4,7 +4,7 @@ require 'cdo/rake_utils'
 task :prepare_dbs do
   with_rack_env(:test) do
     Dir.chdir(pegasus_dir) do
-      puts 'Migrating pegasus test database...'
+      puts "Migrating #{CDO.pegasus_db_name} database..."
       RakeUtils.rake 'db:ensure_created', 'db:migrate', 'seed:migrate'
     end
   end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#30234, restoring https://github.com/code-dot-org/code-dot-org/pull/30181 with fixes for problems that occurred during DTT