### PR TITLE
Tests: Re-enable tests in professional_learning_landing_controller_test

### DIFF
--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -32,8 +32,6 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
   end
 
   test 'Admin workshops may show up as pending exit surveys' do
-    skip 'Investigate flaky test failures'
-
     # Fake Admin workshop, which should produce an exit survey
     admin_workshop = create :pd_ended_workshop,
       course: Pd::Workshop::COURSE_ADMIN,
@@ -75,8 +73,6 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
   end
 
   test 'FiT workshops do not interfere with other pending exit surveys' do
-    skip 'Investigate flaky test failures'
-
     # Fake CSF workshop (older than the FiT workshop) which should
     # produce a pending exit survey
     csf_workshop = create :pd_ended_workshop,
@@ -124,8 +120,6 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
   end
 
   test 'Facilitator workshops do not interfere with other pending exit surveys' do
-    skip 'Investigate flaky test failures'
-
     # Fake CSF workshop (older than the Facilitator workshop) which should
     # produce a pending exit survey
     csf_workshop = create :pd_ended_workshop,


### PR DESCRIPTION
Re-enables three tests which were disabled over the course of the last month (https://github.com/code-dot-org/code-dot-org/pull/29765, https://github.com/code-dot-org/code-dot-org/pull/29883) for flakiness.

Flakiness in these tests often had to do with state from other tests interfering - queries that would pick up any workshops in the database, or maybe cleanup not happening properly.

I believe the following recent improvements to the PLC tests and in particular this file will have addressed the flakiness we were experiencing before.

- https://github.com/code-dot-org/code-dot-org/pull/29511/commits/5bfeaa1f20a937b7093217a5f4215da7fae311c4
- https://github.com/code-dot-org/code-dot-org/pull/30106/
- https://github.com/code-dot-org/code-dot-org/pull/30217

We've removed a lot of the global setup from this file, and are making better use of factories than before, and I've changed a number of assertions that were vulnerable to global state.