### PR TITLE
Use pegasus unittest

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -443,7 +443,7 @@ db_writer: !Secret
 reporting_db_writer: <%=db_writer%>
 
 dashboard_db_name: dashboard_<%=env%>
-pegasus_db_name: <%= ENV['PEGASUS_UNIT_TEST'] ? 'pegasus_unittest' : "pegasus#{_env}" %>
+pegasus_db_name: <%= ENV['USE_PEGASUS_UNITTEST_DB'] ? 'pegasus_unittest' : "pegasus#{_env}" %>
 
 # Default reader endpoints to writer endpoint.
 db_reader: <%=db_writer%>

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -112,7 +112,7 @@ namespace :test do
       ChatClient.wrap('dashboard ruby unit tests') do
         ENV['DISABLE_SPRING'] = '1'
         ENV['UNIT_TEST'] = '1'
-        ENV['PEGASUS_UNIT_TEST'] = 1
+        ENV['USE_PEGASUS_UNITTEST_DB'] = 1
         ENV['CODECOV_FLAGS'] = 'dashboard'
         ENV['PARALLEL_TEST_FIRST_IS_1'] = '1'
         # Parallel tests don't seem to run more quickly over 16 processes.
@@ -198,7 +198,7 @@ namespace :test do
         TestRunUtils.run_dashboard_tests(parallel: true)
 
         ENV.delete 'UNIT_TEST'
-        ENV.delete 'PEGASUS_UNIT_TEST'
+        ENV.delete 'USE_PEGASUS_UNITTEST_DB'
         ENV.delete 'CODECOV_FLAGS'
       end
     end
@@ -206,16 +206,16 @@ namespace :test do
 
   task :shared_ci do
     # isolate unit tests from the pegasus_test DB
-    ENV['PEGASUS_UNIT_TEST'] = '1'
+    ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
     TestRunUtils.run_shared_tests
-    ENV.delete 'PEGASUS_UNIT_TEST'
+    ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
   task :pegasus_ci do
     # isolate unit tests from the pegasus_test DB
-    ENV['PEGASUS_UNIT_TEST'] = '1'
+    ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
     TestRunUtils.run_pegasus_tests
-    ENV.delete 'PEGASUS_UNIT_TEST'
+    ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
   task ci: [:shared_ci, :pegasus_ci, :dashboard_ci, :ui_live]

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -112,6 +112,7 @@ namespace :test do
       ChatClient.wrap('dashboard ruby unit tests') do
         ENV['DISABLE_SPRING'] = '1'
         ENV['UNIT_TEST'] = '1'
+        ENV['PEGASUS_UNIT_TEST'] = 1
         ENV['CODECOV_FLAGS'] = 'dashboard'
         ENV['PARALLEL_TEST_FIRST_IS_1'] = '1'
         # Parallel tests don't seem to run more quickly over 16 processes.
@@ -197,6 +198,7 @@ namespace :test do
         TestRunUtils.run_dashboard_tests(parallel: true)
 
         ENV.delete 'UNIT_TEST'
+        ENV.delete 'PEGASUS_UNIT_TEST'
         ENV.delete 'CODECOV_FLAGS'
       end
     end


### PR DESCRIPTION
follow-on to https://github.com/code-dot-org/code-dot-org/pull/30239 . Makes dashboard unit tests use the `pegasus_unittest` DB which shared and pegasus tests are now using, because it turns out dashboard unit tests are relying on the shared and pegasus tests to both migrate and truncate the pegasus DB.