### PR TITLE
Re-enable tests in workshop_daily_survey_controller_test

### DIFF
--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -342,7 +342,6 @@ module Pd
     end
 
     test 'facilitator specific survey redirects to next facilitator when response exists' do
-      skip 'Investigate flaky test failures'
       setup_summer_workshop
       Session.any_instance.expects(:open_for_attendance?).returns(true)
       create :pd_attendance, session: @summer_workshop.sessions[0], teacher: @enrolled_summer_teacher, enrollment: @summer_enrollment
@@ -355,7 +354,6 @@ module Pd
     end
 
     test 'last facilitator specific survey redirects to thanks when response exists' do
-      skip 'Investigate flaky test failures'
       setup_summer_workshop
       Session.any_instance.expects(:open_for_attendance?).returns(true)
       create :pd_attendance, session: @summer_workshop.sessions[0], teacher: @enrolled_summer_teacher, enrollment: @summer_enrollment
@@ -368,7 +366,6 @@ module Pd
     end
 
     test 'facilitator specific survey with open session attendance displays embedded JotForm' do
-      skip 'Investigate flaky test failures'
       setup_summer_workshop
       Session.any_instance.expects(:open_for_attendance?).returns(true)
       create :pd_attendance, session: @summer_workshop.sessions[0], teacher: @enrolled_summer_teacher, enrollment: @summer_enrollment
@@ -915,8 +912,6 @@ module Pd
     end
 
     test 'csf facilitator survey: show 1st facilitator survey to attended teacher' do
-      skip 'Investigate flaky test failures'
-
       setup_csf201_in_progress_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
@@ -994,8 +989,6 @@ module Pd
     end
 
     test 'csf facilitator survey: redirect to 2nd facilitator survey if response exists for 1st one' do
-      skip 'Investigate flaky test failures'
-
       setup_csf201_in_progress_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
@@ -1024,8 +1017,7 @@ module Pd
     end
 
     test 'csf facilitator survey: show thanks page if response exists for all facilitators' do
-      skip 'Investigate flaky test failures'
-
+      setup_csf201_in_progress_workshop
       teacher = create :teacher
       create :pd_enrollment, user: teacher, workshop: @csf201_in_progress_workshop
       session = @csf201_in_progress_workshop.sessions.first

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -918,7 +918,7 @@ module Pd
       session = @csf201_in_progress_workshop.sessions.first
       create :pd_attendance, session: session, teacher: teacher
 
-      first_facilitator = @csf201_in_progress_workshop.facilitators.first
+      first_facilitator = @csf201_in_progress_workshop.facilitators.order(:name, :id).first
       first_facilitator_index = 0
 
       actual_form_id = nil
@@ -951,7 +951,7 @@ module Pd
       session = @csf201_in_progress_workshop.sessions.first
       create :pd_attendance, session: session, teacher: teacher
 
-      first_facilitator = @csf201_in_progress_workshop.facilitators.first
+      first_facilitator = @csf201_in_progress_workshop.facilitators.order(:name, :id).first
       first_facilitator_index = 0
 
       search_params = {
@@ -995,7 +995,7 @@ module Pd
       session = @csf201_in_progress_workshop.sessions.first
       create :pd_attendance, session: session, teacher: teacher
 
-      first_facilitator = @csf201_in_progress_workshop.facilitators.first
+      first_facilitator = @csf201_in_progress_workshop.facilitators.order(:name, :id).first
       first_facilitator_index = 0
 
       WorkshopFacilitatorDailySurvey.create_placeholder!(
@@ -1024,7 +1024,7 @@ module Pd
       create :pd_attendance, session: session, teacher: teacher
 
       first_facilitator_index = 0
-      @csf201_in_progress_workshop.facilitators.each_with_index do |facilitator, index|
+      @csf201_in_progress_workshop.facilitators.order(:name, :id).each_with_index do |facilitator, index|
         WorkshopFacilitatorDailySurvey.create_placeholder!(
           user_id: teacher.id,
           day: csf_post201_params[:day],
@@ -1060,7 +1060,7 @@ module Pd
         num_sessions: 5, num_facilitators: 2, regional_partner: @regional_partner
       @summer_enrollment = create :pd_enrollment, :from_user, workshop: @summer_workshop
       @enrolled_summer_teacher = @summer_enrollment.user
-      @facilitators = @summer_workshop.facilitators
+      @facilitators = @summer_workshop.facilitators.order(:name, :id)
     end
 
     def setup_academic_year_workshop
@@ -1069,7 +1069,7 @@ module Pd
         num_sessions: 1, num_facilitators: 2, regional_partner: @regional_partner
       @academic_year_enrollment = create :pd_enrollment, :from_user, workshop: @academic_year_workshop
       @enrolled_academic_year_teacher = @academic_year_enrollment.user
-      @facilitators = @academic_year_workshop.facilitators
+      @facilitators = @academic_year_workshop.facilitators.order(:name, :id)
     end
 
     def setup_two_day_academic_year_workshop
@@ -1079,7 +1079,7 @@ module Pd
       @two_day_academic_year_enrollment = create :pd_enrollment, :from_user,
         workshop: @two_day_academic_year_workshop
       @enrolled_two_day_academic_year_teacher = @two_day_academic_year_enrollment.user
-      @facilitators = @two_day_academic_year_workshop.facilitators
+      @facilitators = @two_day_academic_year_workshop.facilitators.order(:name, :id)
     end
 
     def setup_csf201_not_started_workshop
@@ -1163,7 +1163,7 @@ module Pd
           userId: user.id,
           sessionId: workshop.sessions[day - 1].id,
           day: day,
-          facilitatorId: workshop.facilitators[facilitator_index].id,
+          facilitatorId: workshop.facilitators.order(:name, :id)[facilitator_index].id,
           facilitatorIndex: facilitator_index,
           formId: FAKE_FACILITATOR_FORM_ID,
         }


### PR DESCRIPTION
Re-enables six tests we'd disabled for flakiness in the last several months (https://github.com/code-dot-org/code-dot-org/commit/8c590574310d90c63c975095d6fa42edda4574c7, https://github.com/code-dot-org/code-dot-org/commit/87c429ab8528922970112951ec395cabbd03d0e5, https://github.com/code-dot-org/code-dot-org/commit/9966f0f0504254cbf97bc7addec20e035fe2d916) and fixes what I believe is the main cause of that flakiness.  I also believe other recent test clean-up may help:

- https://github.com/code-dot-org/code-dot-org/pull/30106/
- https://github.com/code-dot-org/code-dot-org/pull/30217

One of the key issues here is that the `:facilitators` association on `Workshop` is not ordered, but we reference into it as if it is all the time.  In particular, our controller uses the following code to pull up a facilitator-specific survey by index:

https://github.com/code-dot-org/code-dot-org/blob/dffcdf8890445365d630af9729e919b6adc3fbe6/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb#L123-L125

However, lots of our test code was simply pulling `facilitator.first` or otherwise doing a naive indexed reference into the facilitators collection for test purposes.  This worked _most_ of the time, but every once in a while if our autogenerated test facilitator names don't order alphabetically into the same order they were created...

```
Facilitators:
0: 1322 Facilitator Person 10
1: 1321 Facilitator Person 9
```

...you'd get a (seemingly-random) test expecting one facilitator but getting the other, resulting in a flaky failure.

I've updated all of the tests in this file to explicitly order facilitators before trying to retrieve them by index. Interested in thoughts on whether it's worth the deeper/riskier fix of applying a default order to the `:facilitators` association on `Workshop` (maybe in a follow-up PR).
