### PR TITLE
Donors: create dashboard Donor model

### DIFF
--- a/dashboard/app/models/donor.rb
+++ b/dashboard/app/models/donor.rb
@@ -20,7 +20,7 @@ class Donor < ActiveRecord::Base
   include Seeded
 
   def self.setup
-    donors = CSV.read('../pegasus/data/cdo-donors.csv', headers: true).map.with_index(1) do |row, id|
+    donors = CSV.read(pegasus_dir('data/cdo-donors.csv'), headers: true).map.with_index(1) do |row, id|
       {
         id: id,
         name: row['name_s'],

--- a/dashboard/app/models/donor.rb
+++ b/dashboard/app/models/donor.rb
@@ -1,0 +1,40 @@
+# == Schema Information
+#
+# Table name: donors
+#
+#  id             :integer          not null, primary key
+#  name           :string(255)
+#  url            :string(255)
+#  show           :string(255)
+#  twitter        :string(255)
+#  level          :string(255)
+#  weight         :float(24)
+#  twitter_weight :float(24)
+#  created_at     :datetime
+#  updated_at     :datetime
+#  download       :string(255)
+#
+
+# A donor record sourced from the Pegasus CSV.
+class Donor < ActiveRecord::Base
+  include Seeded
+
+  def self.setup
+    donors = CSV.read('../pegasus/data/cdo-donors.csv', headers: true).map.with_index(1) do |row, id|
+      {
+        id: id,
+        name: row['name_s'],
+        url: row['url_s'],
+        show: row['show_s'],
+        twitter: row['twitter_s'],
+        level: row['level_s'],
+        weight: row['weight_f'],
+        twitter_weight: row['twitter_weight_f']
+      }
+    end
+    transaction do
+      reset_db
+      Donor.import! donors
+    end
+  end
+end

--- a/dashboard/db/migrate/20190812195807_create_donors.rb
+++ b/dashboard/db/migrate/20190812195807_create_donors.rb
@@ -1,0 +1,15 @@
+class CreateDonors < ActiveRecord::Migration[5.0]
+  def change
+    create_table :donors do |t|
+      t.string :name
+      t.string :url
+      t.string :show
+      t.string :twitter
+      t.string :level
+      t.float :weight
+      t.float :twitter_weight
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190805220126) do
+ActiveRecord::Schema.define(version: 20190812195807) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -308,6 +308,18 @@ ActiveRecord::Schema.define(version: 20190805220126) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.index ["name"], name: "index_courses_on_name", using: :btree
+  end
+
+  create_table "donors", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string   "name"
+    t.string   "url"
+    t.string   "show"
+    t.string   "twitter"
+    t.string   "level"
+    t.float    "weight",         limit: 24
+    t.float    "twitter_weight", limit: 24
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
   end
 
   create_table "email_preferences", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -18,6 +18,10 @@ namespace :seed do
     Game.setup
   end
 
+  task donors: :environment do
+    Donor.setup
+  end
+
   SCRIPTS_GLOB = Dir.glob('config/scripts/**/*.script').sort.flatten.freeze
   UI_TEST_SCRIPTS = [
     '20-hour',


### PR DESCRIPTION
Create a dashboard `Donor` model, seeded from the CSV file that Pegasus generates from its gsheet source, and which is committed as part of the daily content scoop.  

It is slightly unusual to have a Pegasus file be the source of data for a model in the Dashboard, but this lets us use the data with minimal code changes, and without introducing a runtime dependency on the Pegasus database.
