### PR TITLE
Revert "[Workaround] Disabled ruby tests that are causing the DTT to fail due to incorrect test DB"

### DIFF
--- a/dashboard/test/controllers/api/v1/census/census_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/census/census_controller_test.rb
@@ -9,7 +9,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
   end
 
   test 'census submission with bad school fails' do
-    skip 'workaround for Aug 8 DB issue'
     post :create,
       params: {
         form_version: 'anything',

--- a/dashboard/test/controllers/api/v1/school_districts_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/school_districts_controller_test.rb
@@ -18,21 +18,18 @@ class Api::V1::SchoolDistrictsControllerTest < ActionController::TestCase
   }.deep_stringify_keys.freeze
 
   test 'search by school name prefix' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'lowe', limit: 40}
     assert_response :success
     assert_equal [LOWER_KUSKOKWIM_SCHOOL_DISTRICT, LOWER_YUKON_SCHOOL_DISTRICT], JSON.parse(@response.body)
   end
 
   test 'search by word within' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'yukon', limit: 40}
     assert_response :success
     assert_equal [LOWER_YUKON_SCHOOL_DISTRICT], JSON.parse(@response.body)
   end
 
   test 'search by school city prefix' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'beth', limit: 40}
     assert_response :success
     assert_equal [LOWER_KUSKOKWIM_SCHOOL_DISTRICT], JSON.parse(@response.body)

--- a/dashboard/test/controllers/api/v1/schools_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/schools_controller_test.rb
@@ -57,56 +57,48 @@ class Api::V1::SchoolsControllerTest < ActionController::TestCase
   }.deep_stringify_keys.freeze
 
   test 'search by school name prefix' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'glad', limit: 40}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by short school name prefix' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'elementary ju', limit: 40}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by school name substring' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'jung', limit: 40}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by school city prefix' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'beth', limit: 40}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by school zip' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: '91355', limit: 40}
     assert_response :success
     assert_equal [ALBERT_EINSTEIN_ACADEMY_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search by school zip with extended format' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: '91355-1234', limit: 40}
     assert_response :success
     assert_equal [ALBERT_EINSTEIN_ACADEMY_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search with limit of negative one' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'glad', limit: -1}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
   end
 
   test 'search with limit of zero' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'glad', limit: 0}
     assert_response :success
     assert_equal [GLADYS_JUNG_ELEMENTARY], JSON.parse(@response.body)
@@ -119,28 +111,24 @@ class Api::V1::SchoolsControllerTest < ActionController::TestCase
   end
 
   test 'search with hyphen' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'winston-salem', limit: 40}
     assert_response :success
     assert_equal [QUALITY_EDUCATION_ACADEMY], JSON.parse(@response.body)
   end
 
   test 'search with apostrophe' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: "children's village", limit: 40}
     assert_response :success
     assert_equal [CHILDRENS_VILLAGE], JSON.parse(@response.body)
   end
 
   test 'new search with apostrophe' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: "children's village", limit: 40, use_new_search: true}
     assert_response :success
     assert_equal [CHILDRENS_VILLAGE], JSON.parse(@response.body)
   end
 
   test 'new search with hyphen' do
-    skip 'workaround for Aug 8 DB issue'
     get :search, params: {q: 'winston-salem', limit: 40, use_new_search: true}
     assert_response :success
     assert_equal [QUALITY_EDUCATION_ACADEMY], JSON.parse(@response.body)

--- a/dashboard/test/lib/api/v1/school_autocomplete_test.rb
+++ b/dashboard/test/lib/api/v1/school_autocomplete_test.rb
@@ -24,7 +24,6 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
   end
 
   test 'search by unique name matches only 1 school' do
-    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Chalkville', MAXIMUM_RESULTS, false)
     assert_equal 1, search_results.count
     assert search_results.detect {|school| school[:nces_id] == '10000200277'}
@@ -50,21 +49,18 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
   end
 
   test 'search by partial name matches school' do
-    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Albert', MAXIMUM_RESULTS, false)
     # ALBERT EINSTEIN ACADEMY ELEMENTARY
     assert search_results.detect {|school| school[:nces_id] == '60000113717'}
   end
 
   test 'search by partial word matches school' do
-    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Alb', MAXIMUM_RESULTS, false)
     # ALBERT EINSTEIN ACADEMY ELEMENTARY
     assert search_results.detect {|school| school[:nces_id] == '60000113717'}
   end
 
   test 'search by common abbreviation returns multiple matches' do
-    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Sch', MAXIMUM_RESULTS, false)
     assert_equal 8, search_results.count
     # Alakanuk School
@@ -84,7 +80,6 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
   end
 
   test 'new search by unique name matches only 1 school' do
-    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Chalkville', MAXIMUM_RESULTS, true)
     assert_equal 1, search_results.count
     assert search_results.detect {|school| school[:nces_id] == '10000200277'}
@@ -119,7 +114,6 @@ class Api::V1::SchoolAutocompleteTest < ActiveSupport::TestCase
 
   # New search intentionally has fewer low relevance matches with common abbreviations.
   test 'new search by common abbreviation returns multiple matches' do
-    skip 'workaround for Aug 8 DB issue'
     search_results = Api::V1::SchoolAutocomplete.get_matches('Sch', MAXIMUM_RESULTS, true)
     assert_equal 4, search_results.count
     # Ala Avenue Middle Sch


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#30208

Seeding issue should be fixed by: https://github.com/code-dot-org/code-dot-org/pull/30219