### PR TITLE
Peer Review: Search by submitter name

### DIFF
--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
@@ -30,7 +30,7 @@ class PeerReviewSubmissions extends React.Component {
     // Autobind and debounce getFilteredResults
     this.getFilteredResults = _.debounce(
       this.getFilteredResults.bind(this),
-      1000
+      500
     );
   }
 

--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
@@ -101,7 +101,7 @@ class PeerReviewSubmissions extends React.Component {
 
     this.loadRequest = $.ajax({
       method: 'GET',
-      url: `/api/v1/peer_review_submissions/index?email=${emailFilter ||
+      url: `/api/v1/peer_review_submissions/index?user_q=${emailFilter ||
         ''}&plc_course_id=${plcCourseId ||
         ''}&plc_course_unit_id=${plcCourseUnitId || ''}&page=${pageNumber ||
         1}&per=30`,

--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
@@ -130,7 +130,7 @@ class PeerReviewSubmissions extends React.Component {
       <div>
         <FormControl
           style={{margin: '0px', verticalAlign: 'middle'}}
-          id="EmailFilter"
+          id="UserFilter"
           type="text"
           placeholder="Filter by submitter email"
           onChange={this.handleUserFilterChange}

--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
@@ -13,20 +13,29 @@ class PeerReviewSubmissions extends React.Component {
     courseUnitMap: PropTypes.object.isRequired
   };
 
-  state = {
-    loading: true,
-    emailFilter: '',
-    plcCourseId: '',
-    plcCourseUnitId: '',
-    pagination: {
-      current_page: 1,
-      total_pages: 1
-    }
-  };
+  constructor(props) {
+    super(props);
 
-  componentWillMount() {
-    this.getFilteredResults = _.debounce(this.getFilteredResults, 1000);
+    this.state = {
+      loading: true,
+      emailFilter: '',
+      plcCourseId: '',
+      plcCourseUnitId: '',
+      pagination: {
+        current_page: 1,
+        total_pages: 1
+      }
+    };
 
+    // Autobind and debounce getFilteredResults
+    this.getFilteredResults = _.debounce(
+      this.getFilteredResults.bind(this),
+      1000
+    );
+  }
+
+  componentDidMount() {
+    // Fetch initial results immediately
     this.getFilteredResults();
   }
 
@@ -87,12 +96,7 @@ class PeerReviewSubmissions extends React.Component {
     );
   };
 
-  getFilteredResults = (
-    emailFilter,
-    plcCourseId,
-    plcCourseUnitId,
-    pageNumber
-  ) => {
+  getFilteredResults(emailFilter, plcCourseId, plcCourseUnitId, pageNumber) {
     this.setState({loading: true});
 
     this.loadRequest = $.ajax({
@@ -119,7 +123,7 @@ class PeerReviewSubmissions extends React.Component {
         ref.forcePage(data.pagination.current_page)
       );
     });
-  };
+  }
 
   renderFilterOptions() {
     return (

--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
@@ -69,7 +69,7 @@ class PeerReviewSubmissions extends React.Component {
     }
   };
 
-  handleEmailFilterChange = event => {
+  handleUserFilterChange = event => {
     this.setState({userFilter: event.target.value});
     this.getFilteredResults(
       event.target.value,
@@ -133,7 +133,7 @@ class PeerReviewSubmissions extends React.Component {
           id="EmailFilter"
           type="text"
           placeholder="Filter by submitter email"
-          onChange={this.handleEmailFilterChange}
+          onChange={this.handleUserFilterChange}
           value={this.state.userFilter}
         />
         <FormControl

--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
@@ -18,7 +18,7 @@ class PeerReviewSubmissions extends React.Component {
 
     this.state = {
       loading: true,
-      emailFilter: '',
+      userFilter: '',
       plcCourseId: '',
       plcCourseUnitId: '',
       pagination: {
@@ -42,7 +42,7 @@ class PeerReviewSubmissions extends React.Component {
   handleCourseUnitFilterChange = event => {
     this.setState({plcCourseUnitId: event.target.value});
     this.getFilteredResults(
-      this.state.emailFilter,
+      this.state.userFilter,
       this.state.plcCourseId,
       event.target.value,
       this.state.pagination.current_page
@@ -53,7 +53,7 @@ class PeerReviewSubmissions extends React.Component {
     if (event.target.value === '') {
       this.setState({plcCourseId: '', plcCourseUnitId: ''});
       this.getFilteredResults(
-        this.state.emailFilter,
+        this.state.userFilter,
         '',
         '',
         this.state.pagination.current_page
@@ -61,7 +61,7 @@ class PeerReviewSubmissions extends React.Component {
     } else {
       this.setState({plcCourseId: event.target.value});
       this.getFilteredResults(
-        this.state.emailFilter,
+        this.state.userFilter,
         event.target.value,
         this.state.plcCourseUnitId,
         this.state.pagination.current_page
@@ -70,7 +70,7 @@ class PeerReviewSubmissions extends React.Component {
   };
 
   handleEmailFilterChange = event => {
-    this.setState({emailFilter: event.target.value});
+    this.setState({userFilter: event.target.value});
     this.getFilteredResults(
       event.target.value,
       this.state.plcCourseId,
@@ -81,7 +81,7 @@ class PeerReviewSubmissions extends React.Component {
 
   handlePageChange = newPageNumber => {
     this.getFilteredResults(
-      this.state.emailFilter,
+      this.state.userFilter,
       this.state.plcCourseId,
       this.state.plcCourseUnitId,
       newPageNumber
@@ -96,12 +96,12 @@ class PeerReviewSubmissions extends React.Component {
     );
   };
 
-  getFilteredResults(emailFilter, plcCourseId, plcCourseUnitId, pageNumber) {
+  getFilteredResults(userFilter, plcCourseId, plcCourseUnitId, pageNumber) {
     this.setState({loading: true});
 
     this.loadRequest = $.ajax({
       method: 'GET',
-      url: `/api/v1/peer_review_submissions/index?user_q=${emailFilter ||
+      url: `/api/v1/peer_review_submissions/index?user_q=${userFilter ||
         ''}&plc_course_id=${plcCourseId ||
         ''}&plc_course_unit_id=${plcCourseUnitId || ''}&page=${pageNumber ||
         1}&per=30`,
@@ -134,7 +134,7 @@ class PeerReviewSubmissions extends React.Component {
           type="text"
           placeholder="Filter by submitter email"
           onChange={this.handleEmailFilterChange}
-          value={this.state.emailFilter}
+          value={this.state.userFilter}
         />
         <FormControl
           id="PlcCourseSelect"

--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
@@ -130,9 +130,9 @@ class PeerReviewSubmissions extends React.Component {
       <div>
         <FormControl
           style={{margin: '0px', verticalAlign: 'middle'}}
-          id="UserFilter"
+          id="NameEmailFilter"
           type="text"
-          placeholder="Filter by submitter email"
+          placeholder="Submitter name/email filter"
           onChange={this.handleUserFilterChange}
           value={this.state.userFilter}
         />

--- a/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
+++ b/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
@@ -45,7 +45,7 @@ describe('PeerReviewSubmissions', () => {
     server = sinon.fakeServer.create();
     server.respondWith(
       'GET',
-      '/api/v1/peer_review_submissions/index?email=&plc_course_id=&plc_course_unit_id=&page=1&per=30',
+      '/api/v1/peer_review_submissions/index?user_q=&plc_course_id=&plc_course_unit_id=&page=1&per=30',
       [
         200,
         {'Content-Type': 'application/json'},
@@ -72,7 +72,7 @@ describe('PeerReviewSubmissions', () => {
   it('Initially renders course options and calls API for submissions', () => {
     expect(server.requests.length).to.equal(1);
     expect(server.requests[0].url).to.equal(
-      '/api/v1/peer_review_submissions/index?email=&plc_course_id=&plc_course_unit_id=&page=1&per=30'
+      '/api/v1/peer_review_submissions/index?user_q=&plc_course_id=&plc_course_unit_id=&page=1&per=30'
     );
 
     server.respond();
@@ -112,7 +112,7 @@ describe('PeerReviewSubmissions', () => {
       .find('select#PlcCourseSelect')
       .simulate('change', {target: {value: '1'}});
     expect(server.requests[0].url).to.equal(
-      '/api/v1/peer_review_submissions/index?email=&plc_course_id=1&plc_course_unit_id=&page=1&per=30'
+      '/api/v1/peer_review_submissions/index?user_q=&plc_course_id=1&plc_course_unit_id=&page=1&per=30'
     );
     expect(peerReviewSubmissions.state().plcCourseId).to.equal('1');
     expect(peerReviewSubmissions.state().plcCourseUnitId).to.equal('');
@@ -137,7 +137,7 @@ describe('PeerReviewSubmissions', () => {
       .find('select#PlcCourseUnitSelect')
       .simulate('change', {target: {value: '10'}});
     expect(server.requests[1].url).to.equal(
-      '/api/v1/peer_review_submissions/index?email=&plc_course_id=1&plc_course_unit_id=10&page=1&per=30'
+      '/api/v1/peer_review_submissions/index?user_q=&plc_course_id=1&plc_course_unit_id=10&page=1&per=30'
     );
     expect(peerReviewSubmissions.state().plcCourseId).to.equal('1');
     expect(peerReviewSubmissions.state().plcCourseUnitId).to.equal('10');
@@ -149,7 +149,7 @@ describe('PeerReviewSubmissions', () => {
       .find('select#PlcCourseSelect')
       .simulate('change', {target: {value: ''}});
     expect(server.requests[2].url).to.equal(
-      '/api/v1/peer_review_submissions/index?email=&plc_course_id=&plc_course_unit_id=&page=1&per=30'
+      '/api/v1/peer_review_submissions/index?user_q=&plc_course_id=&plc_course_unit_id=&page=1&per=30'
     );
     expect(peerReviewSubmissions.state().plcCourseId).to.equal('');
     expect(peerReviewSubmissions.state().plcCourseUnitId).to.equal('');
@@ -168,7 +168,7 @@ describe('PeerReviewSubmissions', () => {
       .find('input#EmailFilter')
       .simulate('change', {target: {value: 'someone@example.com'}});
     expect(server.requests[0].url).to.equal(
-      '/api/v1/peer_review_submissions/index?email=someone@example.com&plc_course_id=&plc_course_unit_id=&page=1&per=30'
+      '/api/v1/peer_review_submissions/index?user_q=someone@example.com&plc_course_id=&plc_course_unit_id=&page=1&per=30'
     );
     expect(
       peerReviewSubmissions.find('button#DownloadCsvReport').prop('disabled')

--- a/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
+++ b/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
@@ -79,7 +79,7 @@ describe('PeerReviewSubmissions', () => {
 
     expect(peerReviewSubmissions.state()).to.deep.equal({
       loading: false,
-      emailFilter: '',
+      userFilter: '',
       plcCourseId: '',
       plcCourseUnitId: '',
       submissions: fakePeerReviewData.submissions,

--- a/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
+++ b/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
@@ -165,7 +165,7 @@ describe('PeerReviewSubmissions', () => {
     server = sinon.fakeServer.create();
 
     peerReviewSubmissions
-      .find('input#EmailFilter')
+      .find('input#UserFilter')
       .simulate('change', {target: {value: 'someone@example.com'}});
     expect(server.requests[0].url).to.equal(
       '/api/v1/peer_review_submissions/index?user_q=someone@example.com&plc_course_id=&plc_course_unit_id=&page=1&per=30'

--- a/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
+++ b/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
@@ -165,7 +165,7 @@ describe('PeerReviewSubmissions', () => {
     server = sinon.fakeServer.create();
 
     peerReviewSubmissions
-      .find('input#UserFilter')
+      .find('input#NameEmailFilter')
       .simulate('change', {target: {value: 'someone@example.com'}});
     expect(server.requests[0].url).to.equal(
       '/api/v1/peer_review_submissions/index?user_q=someone@example.com&plc_course_id=&plc_course_unit_id=&page=1&per=30'

--- a/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
@@ -49,7 +49,7 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     create_peer_reviews_for_user_and_level(other_submitter, @level_3)
     submissions = PeerReview.where(level: @level_3, submitter: other_submitter)
 
-    get :index, params: {email: other_submitter.email}
+    get :index, params: {user_q: other_submitter.email}
     assert_response :success
     response = JSON.parse(@response.body)
     assert_equal [
@@ -79,7 +79,7 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     create_peer_reviews_for_user_and_level gerbil, @level_3
 
     # Try to find "Daneel" and "Danielle" but not "Toothy"
-    get :index, params: {email: 'Dan'}
+    get :index, params: {user_q: 'Dan'}
     assert_response :success
     response = JSON.parse(@response.body)
 


### PR DESCRIPTION
[PLC-66](https://codedotorg.atlassian.net/browse/PLC-66) Search by submitter name on the peer review dashboard.

![Peek 2019-08-12 14-32](https://user-images.githubusercontent.com/1615761/62900098-16218c80-bd0e-11e9-9710-db09ec4e0c55.gif)

Updates the "Submitter email" filter to also support fuzzy search for submitter name.

Includes some other cleanup that seemed necessary to do while I was in here:

- Remove deprecated `componentWillMount` lifecycle method.
- Faster debounce on this search, which felt sluggish before.
- Use a proper join for the email search instead of a second query.