### PR TITLE
moving the link stuff into the div so it will look the way it did before

### DIFF
--- a/apps/src/code-studio/components/progress/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/StudentTable.jsx
@@ -121,14 +121,14 @@ class StudentTable extends React.Component {
                     style={levels ? styles.nameWithBubble : styles.nameInScript}
                   >
                     {student.name}
+                    <a
+                      href={this.getRowLink(student.id)}
+                      target="_blank"
+                      style={styles.linkIcon}
+                    >
+                      <FontAwesome icon="external-link" />
+                    </a>
                   </div>
-                  <a
-                    href={this.getRowLink(student.id)}
-                    target="_blank"
-                    style={styles.linkIcon}
-                  >
-                    <FontAwesome icon="external-link" />
-                  </a>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
Terrible commit message, sorry. This is to fix a problem with where the link is after [fixing the spacing ](https://github.com/code-dot-org/code-dot-org/commit/a8d22e44e7f26e95ca18a99c55ecbaf8a15853fd#diff-30bd06c14a02f179d286054a66203a69)

I didn't realize the link needed to be in the div I created. I put it in there now and the link should be right up against the user name again. 

Now it looks like this: 

<img width="198" alt="Screen Shot 2019-08-13 at 2 38 54 PM" src="https://user-images.githubusercontent.com/1072387/62979224-1b4b0e00-bdd8-11e9-8783-11616ca1e155.png">


