### PR TITLE
Migrate level_source_id in level_source_images to bigint on non-production environments

### DIFF
--- a/dashboard/app/models/level_source_image.rb
+++ b/dashboard/app/models/level_source_image.rb
@@ -3,7 +3,7 @@
 # Table name: level_source_images
 #
 #  id              :integer          not null, primary key
-#  level_source_id :integer
+#  level_source_id :integer          unsigned
 #  image           :binary(16777215)
 #  created_at      :datetime
 #  updated_at      :datetime

--- a/dashboard/db/migrate/20190814190546_convert_level_source_id_to_bigint_level_source_images.rb
+++ b/dashboard/db/migrate/20190814190546_convert_level_source_id_to_bigint_level_source_images.rb
@@ -1,0 +1,9 @@
+class ConvertLevelSourceIdToBigintLevelSourceImages < ActiveRecord::Migration[5.0]
+  def up
+    change_column :level_source_images, :level_source_id, 'BIGINT(11) UNSIGNED'
+  end
+
+  def down
+    change_column :level_source_images, :level_source_id, :int
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190812195807) do
+ActiveRecord::Schema.define(version: 20190814190546) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -441,7 +441,7 @@ ActiveRecord::Schema.define(version: 20190812195807) do
   end
 
   create_table "level_source_images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer  "level_source_id"
+    t.bigint   "level_source_id",                  unsigned: true
     t.binary   "image",           limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"


### PR DESCRIPTION
Migrates `level_source_id` column in `level_source_images` table to `bigint` -- this migration has already been run on production per https://github.com/code-dot-org/code-dot-org/pull/30201. 

This migration will update all other environments to match.