### PR TITLE
Metrics: log data about hidden lessons

### DIFF
--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -16,6 +16,7 @@ import {
 } from '@cdo/apps/code-studio/hiddenStageRedux';
 import Button from '../Button';
 import TeacherInfoBox from './TeacherInfoBox';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   buttonContainer: {
@@ -46,6 +47,17 @@ class ProgressLessonTeacherInfo extends React.Component {
   onClickHiddenToggle = value => {
     const {scriptName, sectionId, lesson, toggleHiddenStage} = this.props;
     toggleHiddenStage(scriptName, sectionId, lesson.id, value === 'hidden');
+    firehoseClient.putRecord({
+      study: 'hidden-lessons',
+      study_group: 'v0',
+      event: value,
+      data_json: JSON.stringify({
+        script_name: scriptName,
+        section_id: sectionId,
+        lesson_id: lesson.id,
+        lesson_name: lesson.name
+      })
+    });
   };
 
   render() {


### PR DESCRIPTION
[LP-564](https://codedotorg.atlassian.net/browse/LP-564), continuation of #30213, Logging metrics about which lessons are hidden/shown for which sections. 

<img width="622" alt="Screen Shot 2019-08-15 at 11 06 43 AM" src="https://user-images.githubusercontent.com/12300669/63116363-4d7e7c00-bf4e-11e9-920b-3e93931b7b56.png">
