### PR TITLE
Sprite Lab: Fix audio in video downloads

### DIFF
--- a/dashboard/config/videos.csv
+++ b/dashboard/config/videos.csv
@@ -352,7 +352,7 @@ loop_times,,,Jdhkf9R25Qk,https://videos.code.org/levelbuilder/curso-d-leccion-2-
 C2_zuck_repeat_loop,,,Jdhkf9R25Qk,https://videos.code.org/levelbuilder/curso-d-leccion-2-zuckernberg_es-mp4.mp4,es-MX
 csd_problem_solving_process,,,z7RaFPT3DTE,https://videos.code.org/levelbuilder/problemsolvingprocess-mp4.mp4,en-US
 CSF_Going_Places_Safely,,,oPHOsCnjMU4,https://videos.code.org/levelbuilder/my-online-neighborhood-mp4.mp4,en-US
-CSF_SpriteLab_Intro_v2,,,yd-9xZ275dM,https://videos.code.org/levelbuilder/01-introducingspritelab-sm-mp4.mp4,en-US
-CSF_Spritelab_MakeSprite_v2,,,wbTJpx3driA,https://videos.code.org/levelbuilder/02-howtomakeasprite-sm-mp4.mp4,en-US
-CSF_SpriteLab_SpritesInAction_v2,,,VUmZ2IsFAGo,https://videos.code.org/levelbuilder/03-spritesinaction-sm-mp4.mp4,en-US
+CSF_SpriteLab_Intro_v2,,,yd-9xZ275dM,https://videos.code.org/levelbuilder/01-IntroducingSpriteLab_sm.mp4,en-US
+CSF_Spritelab_MakeSprite_v2,,,wbTJpx3driA,https://videos.code.org/levelbuilder/02-HowToMakeASprite_sm.mp4,en-US
+CSF_SpriteLab_SpritesInAction_v2,,,VUmZ2IsFAGo,https://videos.code.org/levelbuilder/03-SpritesInAction_sm.mp4,en-US
 csd_debugging,,,YlopmN5757s,https://videos.code.org/levelbuilder/debugging-no-sfx-mp4.mp4,en-US


### PR DESCRIPTION
Updates three video download URLs to point to updated versions that include the audio track.

We discovered that our download videos for Sprite Lab (also used for the fallback player) were missing their audio track.  Jael got me updated versions of the video files that included audio, which I've already uploaded to S3 at the appropriate location.  This change to our video manifest is the last step.

I'm doing this instead of updating the video files in place to avoid any possibility of clients caching the old version.