### PR TITLE
Realistic workshop factories

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -208,8 +208,7 @@ module Api::V1::Pd
     end
 
     test 'facilitators cannot see results for other types of workshops' do
-      workshop = create :workshop, course: COURSE_CSF, subject: SUBJECT_CSF_101,
-        facilitators: [@facilitator]
+      workshop = create :csf_intro_workshop, facilitators: [@facilitator]
       sign_in @facilitator
 
       get :generic_survey_report, params: {workshop_id: workshop.id}
@@ -305,7 +304,7 @@ module Api::V1::Pd
     end
 
     test 'generic_survey_report: CSF101 workshop cannot invoke this action' do
-      csf_101_ws = create :workshop, course: COURSE_CSF, subject: SUBJECT_CSF_101
+      csf_101_ws = create :csf_intro_workshop
 
       WorkshopSurveyReportController.any_instance.expects(:create_csf_survey_report).never
       WorkshopSurveyReportController.any_instance.expects(:local_workshop_daily_survey_report).never

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -252,14 +252,50 @@ module Api::V1::Pd
     test 'experiment_survey_report: return empty result for workshop without responds' do
       csf_201_ws = create :csf_deep_dive_workshop
 
+      # This test assumes there's one facilitator in the workshop
+      assert_equal 1, csf_201_ws.facilitators.count
+      f_id = csf_201_ws.facilitators.first.id.to_s
+      f_name = csf_201_ws.facilitators.first.name
+
       expected_result = {
         "course_name" => nil,
         "questions" => {},
         "this_workshop" => {},
         "all_my_workshops" => {},
-        "facilitators" => {},
-        "facilitator_averages" => {},
-        "facilitator_response_counts" => {},
+        "facilitators" => {
+          f_id => f_name
+        },
+        "facilitator_averages" => {
+          f_name => {
+            "facilitator_effectiveness" => {
+              "this_workshop" => nil,
+              "all_my_workshops" => nil
+            },
+            "overall_success" => {
+              "this_workshop" => nil,
+              "all_my_workshops" => nil
+            },
+            "teacher_engagement" => {
+              "this_workshop" => nil,
+              "all_my_workshops" => nil
+            }
+          },
+          "questions" => {}
+        },
+        "facilitator_response_counts" => {
+          "this_workshop" => {
+            f_id => {
+              "Facilitator" => 0,
+              "Workshop" => 0
+            }
+          },
+          "all_my_workshops" => {
+            f_id => {
+              "Facilitator" => 0,
+              "Workshop" => 0
+            }
+          }
+        },
         "experiment" => true
       }
 

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -250,7 +250,7 @@ module Api::V1::Pd
     end
 
     test 'experiment_survey_report: return empty result for workshop without responds' do
-      csf_201_ws = create :workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201, num_sessions: 1
+      csf_201_ws = create :csf_deep_dive_workshop
 
       expected_result = {
         "course_name" => nil,
@@ -272,7 +272,7 @@ module Api::V1::Pd
     end
 
     test 'generic_survey_report: CSF201 workshop uses new pipeline' do
-      csf_201_ws = create :workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201
+      csf_201_ws = create :csf_deep_dive_workshop
 
       WorkshopSurveyReportController.any_instance.expects(:create_csf_survey_report)
 
@@ -283,7 +283,7 @@ module Api::V1::Pd
     end
 
     test 'generic_survey_report: return empty result for CSF201 workshop without responds' do
-      csf_201_ws = create :workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201, num_sessions: 2
+      csf_201_ws = create :csf_deep_dive_workshop, num_sessions: 2
 
       expected_result = {
         "course_name" => nil,

--- a/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
@@ -34,10 +34,7 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
   # rubocop:disable Lint/UnderscorePrefixedVariableName
 
   test 'Generates certificate for CSF 101 workshop' do
-    workshop = create :workshop,
-      num_sessions: 1,
-      course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101
+    workshop = create :csf_intro_workshop
     enrollment = create :pd_enrollment, workshop: workshop
 
     _ = anything

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -279,7 +279,7 @@ module Pd
 
       sign_in @enrolled_academic_year_teacher
       get "/pd/workshop_survey/day/1?enrollmentCode=#{other_enrollment.code}"
-      assert_response :success, response.body
+      assert_response :success
     end
 
     test 'daily workshop submit redirect creates placeholder and redirects to first facilitator form' do

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -1065,9 +1065,7 @@ module Pd
 
     def setup_academic_year_workshop
       @regional_partner = create :regional_partner
-      @academic_year_workshop = create :csp_academic_year_workshop,
-        num_facilitators: 2,
-        regional_partner: @regional_partner
+      @academic_year_workshop = create :csp_academic_year_workshop, regional_partner: @regional_partner
       @academic_year_enrollment = create :pd_enrollment, :from_user, workshop: @academic_year_workshop
       @enrolled_academic_year_teacher = @academic_year_enrollment.user
       @facilitators = @academic_year_workshop.facilitators.order(:name, :id)

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -249,7 +249,7 @@ module Pd
 
     test 'enrollment code override is used when fetching the workshop for a user' do
       setup_academic_year_workshop
-      other_academic_workshop = create :workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1,
+      other_academic_workshop = create :csp_academic_year_workshop, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1,
         regional_partner: @regional_partner, facilitators: @facilitators, sessions_from: Date.today + 1.month
       other_enrollment = create :pd_enrollment, :from_user, workshop: other_academic_workshop, user: @enrolled_academic_year_teacher
       create :pd_attendance, session: other_academic_workshop.sessions[0], teacher: @enrolled_academic_year_teacher, enrollment: other_enrollment
@@ -279,7 +279,7 @@ module Pd
 
       sign_in @enrolled_academic_year_teacher
       get "/pd/workshop_survey/day/1?enrollmentCode=#{other_enrollment.code}"
-      assert_response :success
+      assert_response :success, response.body
     end
 
     test 'daily workshop submit redirect creates placeholder and redirects to first facilitator form' do
@@ -1065,8 +1065,10 @@ module Pd
 
     def setup_academic_year_workshop
       @regional_partner = create :regional_partner
-      @academic_year_workshop = create :workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1,
-        num_facilitators: 2, regional_partner: @regional_partner
+      @academic_year_workshop = create :csp_academic_year_workshop,
+        subject: SUBJECT_CSP_WORKSHOP_1,
+        num_facilitators: 2,
+        regional_partner: @regional_partner
       @academic_year_enrollment = create :pd_enrollment, :from_user, workshop: @academic_year_workshop
       @enrolled_academic_year_teacher = @academic_year_enrollment.user
       @facilitators = @academic_year_workshop.facilitators.order(:name, :id)

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -249,7 +249,7 @@ module Pd
 
     test 'enrollment code override is used when fetching the workshop for a user' do
       setup_academic_year_workshop
-      other_academic_workshop = create :csp_academic_year_workshop, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1,
+      other_academic_workshop = create :csp_academic_year_workshop,
         regional_partner: @regional_partner, facilitators: @facilitators, sessions_from: Date.today + 1.month
       other_enrollment = create :pd_enrollment, :from_user, workshop: other_academic_workshop, user: @enrolled_academic_year_teacher
       create :pd_attendance, session: other_academic_workshop.sessions[0], teacher: @enrolled_academic_year_teacher, enrollment: other_enrollment
@@ -1066,7 +1066,6 @@ module Pd
     def setup_academic_year_workshop
       @regional_partner = create :regional_partner
       @academic_year_workshop = create :csp_academic_year_workshop,
-        subject: SUBJECT_CSP_WORKSHOP_1,
         num_facilitators: 2,
         regional_partner: @regional_partner
       @academic_year_enrollment = create :pd_enrollment, :from_user, workshop: @academic_year_workshop

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -1073,8 +1073,7 @@ module Pd
 
     def setup_two_day_academic_year_workshop
       @regional_partner = create :regional_partner
-      @two_day_academic_year_workshop = create :csp_academic_year_workshop,
-        subject: SUBJECT_CSP_WORKSHOP_5,
+      @two_day_academic_year_workshop = create :csp_academic_year_workshop, :two_day,
         regional_partner: @regional_partner
       @two_day_academic_year_enrollment = create :pd_enrollment, :from_user,
         workshop: @two_day_academic_year_workshop

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -1075,8 +1075,9 @@ module Pd
 
     def setup_two_day_academic_year_workshop
       @regional_partner = create :regional_partner
-      @two_day_academic_year_workshop = create :workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_5,
-        num_sessions: 2, num_facilitators: 2, regional_partner: @regional_partner
+      @two_day_academic_year_workshop = create :csp_academic_year_workshop,
+        subject: SUBJECT_CSP_WORKSHOP_5,
+        regional_partner: @regional_partner
       @two_day_academic_year_enrollment = create :pd_enrollment, :from_user,
         workshop: @two_day_academic_year_workshop
       @enrolled_two_day_academic_year_teacher = @two_day_academic_year_enrollment.user

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -1084,27 +1084,23 @@ module Pd
 
     def setup_csf201_not_started_workshop
       @regional_partner = create :regional_partner
-      @csf201_not_started_workshop = create :workshop,
-        course: COURSE_CSF, subject: SUBJECT_CSF_201, regional_partner: @regional_partner,
+      @csf201_not_started_workshop = create :csf_deep_dive_workshop,
+        regional_partner: @regional_partner,
         num_facilitators: 2
     end
 
     def setup_csf201_in_progress_workshop
       @regional_partner = create :regional_partner
-      @csf201_in_progress_workshop = create :workshop,
+      @csf201_in_progress_workshop = create :csf_deep_dive_workshop,
         :in_progress,
-        course: COURSE_CSF,
-        subject: SUBJECT_CSF_201,
         regional_partner: @regional_partner,
         num_facilitators: 2
     end
 
     def setup_csf201_ended_workshop
       @regional_partner = create :regional_partner
-      @csf201_ended_workshop = create :workshop,
+      @csf201_ended_workshop = create :csf_deep_dive_workshop,
         :ended,
-        course: COURSE_CSF,
-        subject: SUBJECT_CSF_201,
         regional_partner: @regional_partner,
         num_facilitators: 2
     end

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -158,14 +158,12 @@ FactoryGirl.define do
 
     # CSD Academic Year Workshops
     factory :csd_academic_year_workshop do
-      subject do
-        [
-          Pd::Workshop::SUBJECT_CSD_WORKSHOP_1,
-          Pd::Workshop::SUBJECT_CSD_WORKSHOP_2,
-          Pd::Workshop::SUBJECT_CSD_WORKSHOP_3,
-          Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
-        ].sample
-      end
+      # Possible subjects:
+      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
+      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_2
+      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_3
+      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
+      subject Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
       course Pd::Workshop::COURSE_CSD
       location_name 'Sunrise Middle School'
 
@@ -179,14 +177,12 @@ FactoryGirl.define do
 
     # CSP Academic Year Workshops
     factory :csp_academic_year_workshop do
-      subject do
-        [
-          Pd::Workshop::SUBJECT_CSP_WORKSHOP_1,
-          Pd::Workshop::SUBJECT_CSP_WORKSHOP_2,
-          Pd::Workshop::SUBJECT_CSP_WORKSHOP_3,
-          Pd::Workshop::SUBJECT_CSP_WORKSHOP_4
-        ].sample
-      end
+      # Possible subjects:
+      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
+      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_2
+      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_3
+      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_4
+      subject Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
       course Pd::Workshop::COURSE_CSP
       location_name 'Bayside High School'
 

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -126,5 +126,20 @@ FactoryGirl.define do
     #
     # Sub-factories
     #
+
+    # CSF Intro, also known as CSF 101
+    # Our most common workshop type as of August 2019.
+    #
+    factory :csf_intro_workshop do
+      subject Pd::Workshop::SUBJECT_CSF_101
+      course Pd::Workshop::COURSE_CSF
+      location_name 'Walkerville Elementary School'
+      capacity 30          # Average capacity
+      on_map true          # About 60% are on the map
+      funded               # About 90% are funded
+      num_sessions 1       # Most have 1 session
+      num_facilitators 1   # Most have 1 facilitator
+      each_session_hours 7 # The most common session length
+    end
   end
 end

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -176,5 +176,36 @@ FactoryGirl.define do
       num_facilitators 2   # Most have 2 facilitators
       each_session_hours 8 # The most common session length
     end
+
+    # CSP Academic Year Workshops
+    factory :csp_academic_year_workshop do
+      subject do
+        [
+          Pd::Workshop::SUBJECT_CSP_WORKSHOP_1,
+          Pd::Workshop::SUBJECT_CSP_WORKSHOP_2,
+          Pd::Workshop::SUBJECT_CSP_WORKSHOP_3,
+          Pd::Workshop::SUBJECT_CSP_WORKSHOP_4
+        ].sample
+      end
+      course Pd::Workshop::COURSE_CSP
+      location_name 'Bayside High School'
+
+      capacity 29          # Average capacity
+      on_map false         # Never on the map
+      funded               # About 57% are funded
+      num_sessions 1       # Most have 1 session
+      num_facilitators 2   # Most have 2 facilitators
+      each_session_hours 8 # The most common session length
+    end
+
+    # TODO
+    # - CSD 2-day Workshops
+    # - CSP 2-day Workshops
+    # - CSD 5-day Summer
+    # - CSP 5-day Summer
+    # - Admin workshop
+    # - Facilitator workshop
+    # - Counselor workshop
+    # - Facilitator Weekend
   end
 end

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -129,14 +129,28 @@ FactoryGirl.define do
 
     # CSF Intro, also known as CSF 101
     # Our most common workshop type as of August 2019.
-    #
     factory :csf_intro_workshop do
       subject Pd::Workshop::SUBJECT_CSF_101
       course Pd::Workshop::COURSE_CSF
       location_name 'Walkerville Elementary School'
+
       capacity 30          # Average capacity
       on_map true          # About 60% are on the map
       funded               # About 90% are funded
+      num_sessions 1       # Most have 1 session
+      num_facilitators 1   # Most have 1 facilitator
+      each_session_hours 7 # The most common session length
+    end
+
+    # CSF Deep Dive, also known as CSF 201
+    factory :csf_deep_dive_workshop do
+      subject Pd::Workshop::SUBJECT_CSF_201
+      course Pd::Workshop::COURSE_CSF
+      location_name 'Third Street Elementary School'
+
+      capacity 28          # Average capacity
+      on_map true          # About 63% are on the map
+      funded               # About 87% are funded
       num_sessions 1       # Most have 1 session
       num_facilitators 1   # Most have 1 facilitator
       each_session_hours 7 # The most common session length

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -155,5 +155,26 @@ FactoryGirl.define do
       num_facilitators 1   # Most have 1 facilitator
       each_session_hours 7 # The most common session length
     end
+
+    # CSD Academic Year Workshops
+    factory :csd_academic_year_workshop do
+      subject do
+        [
+          Pd::Workshop::SUBJECT_CSD_WORKSHOP_1,
+          Pd::Workshop::SUBJECT_CSD_WORKSHOP_2,
+          Pd::Workshop::SUBJECT_CSD_WORKSHOP_3,
+          Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
+        ].sample
+      end
+      course Pd::Workshop::COURSE_CSD
+      location_name 'Sunrise Middle School'
+
+      capacity 30          # Average capacity
+      on_map false         # Never on the map
+      funded               # About 58% are funded
+      num_sessions 1       # Most have 1 session
+      num_facilitators 2   # Most have 2 facilitators
+      each_session_hours 8 # The most common session length
+    end
   end
 end

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -136,85 +136,87 @@ FactoryGirl.define do
     # Sub-factories
     #
 
-    # CSF Intro, also known as CSF 101
-    # Our most common workshop type as of August 2019.
-    factory :csf_intro_workshop do
-      subject Pd::Workshop::SUBJECT_CSF_101
-      course Pd::Workshop::COURSE_CSF
-      location_name 'Walkerville Elementary School'
+    # CSF Workshops, which are usually one-day workshops
+    # that happen year-round.
+    factory :csf_workshop do
+      # Make a CSF 101 "Intro" workshop by default
+      intro
 
+      course Pd::Workshop::COURSE_CSF
       capacity 30          # Average capacity
       on_map true          # About 60% are on the map
       funded               # About 90% are funded
       num_sessions 1       # Most have 1 session
       num_facilitators 1   # Most have 1 facilitator
       each_session_hours 7 # The most common session length
+
+      # CSF Intro, also known as CSF 101
+      # Our most common workshop type as of August 2019.
+      trait :intro do
+        subject Pd::Workshop::SUBJECT_CSF_101
+        location_name 'Walkerville Elementary School'
+      end
+      factory(:csf_intro_workshop, aliases: [:csf_101_workshop]) {intro}
+
+      # CSF Deep Dive, also known as CSF 201
+      trait :deep_dive do
+        subject Pd::Workshop::SUBJECT_CSF_201
+        location_name 'Third Street Elementary School'
+      end
+      factory(:csf_deep_dive_workshop, aliases: [:csf_201_workshop]) {deep_dive}
     end
 
-    # CSF Deep Dive, also known as CSF 201
-    factory :csf_deep_dive_workshop do
-      subject Pd::Workshop::SUBJECT_CSF_201
-      course Pd::Workshop::COURSE_CSF
-      location_name 'Third Street Elementary School'
+    # CSD and CSP Academic Year Workshops
+    # These are one- or two-day workshops on specific parts of our curriculum that happen
+    # throughout the school year.  They have a lot in common.
+    factory :academic_year_workshop do
+      # Make a CSP workshop by default
+      csp
 
-      capacity 28          # Average capacity
-      on_map true          # About 63% are on the map
-      funded               # About 87% are funded
-      num_sessions 1       # Most have 1 session
-      num_facilitators 1   # Most have 1 facilitator
-      each_session_hours 7 # The most common session length
-    end
-
-    # CSD Academic Year Workshops
-    factory :csd_academic_year_workshop do
-      course Pd::Workshop::COURSE_CSD
-      location_name 'Sunrise Middle School'
-
-      # Possible subjects:
-      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
-      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_2
-      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_3
-      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
-      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_5 (2-day)
-      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_6 (2-day)
-      subject Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
-
-      capacity 30          # Typical capacity
+      capacity 30          # Average capacity
       on_map false         # Never on the map
       funded               # More than half are funded
       num_facilitators 2   # Most have 2 facilitators
+
+      # Course can be derived from the chosen subject
 
       # Workshops 5 and 6 are two-day workshops, others are one-day.
       num_sessions {TWO_DAY_AYW_SUBJECTS.include?(subject) ? 2 : 1}
 
       # The most common session length
       each_session_hours {TWO_DAY_AYW_SUBJECTS.include?(subject) ? 7 : 8}
-    end
 
-    # CSP Academic Year Workshops
-    factory :csp_academic_year_workshop do
-      course Pd::Workshop::COURSE_CSP
-      location_name 'Bayside High School'
+      # CSP Academic Year Workshops
+      trait :csp do
+        course Pd::Workshop::COURSE_CSP
+        location_name 'Bayside High School'
 
-      # Possible subjects:
-      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
-      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_2
-      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_3
-      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_4
-      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_5 (2-day)
-      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_6 (2-day)
-      subject Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
+        # Possible subjects:
+        # Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
+        # Pd::Workshop::SUBJECT_CSP_WORKSHOP_2
+        # Pd::Workshop::SUBJECT_CSP_WORKSHOP_3
+        # Pd::Workshop::SUBJECT_CSP_WORKSHOP_4
+        # Pd::Workshop::SUBJECT_CSP_WORKSHOP_5 (2-day)
+        # Pd::Workshop::SUBJECT_CSP_WORKSHOP_6 (2-day)
+        subject Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
+      end
+      factory(:csp_academic_year_workshop) {csp}
 
-      capacity 29          # Average capacity
-      on_map false         # Never on the map
-      funded               # More than half are funded
-      num_facilitators 2   # Most have 2 facilitators
+      # CSD Academic Year Workshops
+      trait :csd do
+        course Pd::Workshop::COURSE_CSD
+        location_name 'Sunrise Middle School'
 
-      # Workshops 5 and 6 are two-day workshops, others are one-day.
-      num_sessions {TWO_DAY_AYW_SUBJECTS.include?(subject) ? 2 : 1}
-
-      # The most common session length
-      each_session_hours {TWO_DAY_AYW_SUBJECTS.include?(subject) ? 7 : 8}
+        # Possible subjects:
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_2
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_3
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_5 (2-day)
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_6 (2-day)
+        subject Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
+      end
+      factory(:csd_academic_year_workshop) {csd}
     end
 
     # TODO

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -1,3 +1,12 @@
+# Most academic year workshops are one day workshops.
+# These specific workshop types are two day workshops.
+TWO_DAY_AYW_SUBJECTS = [
+  Pd::Workshop::SUBJECT_CSD_WORKSHOP_5,
+  Pd::Workshop::SUBJECT_CSD_WORKSHOP_6,
+  Pd::Workshop::SUBJECT_CSP_WORKSHOP_5,
+  Pd::Workshop::SUBJECT_CSP_WORKSHOP_6
+]
+
 #
 # Factories for different types of PD workshops
 #
@@ -158,45 +167,57 @@ FactoryGirl.define do
 
     # CSD Academic Year Workshops
     factory :csd_academic_year_workshop do
+      course Pd::Workshop::COURSE_CSD
+      location_name 'Sunrise Middle School'
+
       # Possible subjects:
       # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
       # Pd::Workshop::SUBJECT_CSD_WORKSHOP_2
       # Pd::Workshop::SUBJECT_CSD_WORKSHOP_3
       # Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
+      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_5 (2-day)
+      # Pd::Workshop::SUBJECT_CSD_WORKSHOP_6 (2-day)
       subject Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
-      course Pd::Workshop::COURSE_CSD
-      location_name 'Sunrise Middle School'
 
-      capacity 30          # Average capacity
+      capacity 30          # Typical capacity
       on_map false         # Never on the map
-      funded               # About 58% are funded
-      num_sessions 1       # Most have 1 session
+      funded               # More than half are funded
       num_facilitators 2   # Most have 2 facilitators
-      each_session_hours 8 # The most common session length
+
+      # Workshops 5 and 6 are two-day workshops, others are one-day.
+      num_sessions {TWO_DAY_AYW_SUBJECTS.include?(subject) ? 2 : 1}
+
+      # The most common session length
+      each_session_hours {TWO_DAY_AYW_SUBJECTS.include?(subject) ? 7 : 8}
     end
 
     # CSP Academic Year Workshops
     factory :csp_academic_year_workshop do
+      course Pd::Workshop::COURSE_CSP
+      location_name 'Bayside High School'
+
       # Possible subjects:
       # Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
       # Pd::Workshop::SUBJECT_CSP_WORKSHOP_2
       # Pd::Workshop::SUBJECT_CSP_WORKSHOP_3
       # Pd::Workshop::SUBJECT_CSP_WORKSHOP_4
+      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_5 (2-day)
+      # Pd::Workshop::SUBJECT_CSP_WORKSHOP_6 (2-day)
       subject Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
-      course Pd::Workshop::COURSE_CSP
-      location_name 'Bayside High School'
 
       capacity 29          # Average capacity
       on_map false         # Never on the map
-      funded               # About 57% are funded
-      num_sessions 1       # Most have 1 session
+      funded               # More than half are funded
       num_facilitators 2   # Most have 2 facilitators
-      each_session_hours 8 # The most common session length
+
+      # Workshops 5 and 6 are two-day workshops, others are one-day.
+      num_sessions {TWO_DAY_AYW_SUBJECTS.include?(subject) ? 2 : 1}
+
+      # The most common session length
+      each_session_hours {TWO_DAY_AYW_SUBJECTS.include?(subject) ? 7 : 8}
     end
 
     # TODO
-    # - CSD 2-day Workshops
-    # - CSP 2-day Workshops
     # - CSD 5-day Summer
     # - CSP 5-day Summer
     # - Admin workshop

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -178,7 +178,17 @@ FactoryGirl.define do
       funded               # More than half are funded
       num_facilitators 2   # Most have 2 facilitators
 
-      # Course can be derived from the chosen subject
+      # Some specific academic year workshops are usually two days instead of one.
+      # Add a trait making it easy to specify that we're testing a two-day workshop.
+      trait :two_day do
+        subject do
+          if course == Pd::Workshop::COURSE_CSP
+            Pd::Workshop::SUBJECT_CSP_WORKSHOP_5
+          else
+            Pd::Workshop::SUBJECT_CSD_WORKSHOP_5
+          end
+        end
+      end
 
       # Workshops 5 and 6 are two-day workshops, others are one-day.
       num_sessions {TWO_DAY_AYW_SUBJECTS.include?(subject) ? 2 : 1}

--- a/dashboard/test/helpers/pd/workshop_survey_results_helper_test.rb
+++ b/dashboard/test/helpers/pd/workshop_survey_results_helper_test.rb
@@ -28,7 +28,7 @@ class Pd::WorkshopSurveyResultsHelperTest < ActionView::TestCase
     facilitator_1 = create :facilitator, name: 'Facilitator Person 1'
     facilitator_2 = create :facilitator, name: 'Facilitator Person 2'
     @workshop = create :workshop, :local_summer_workshop, course: COURSE_CSP, facilitators: [facilitator_1, facilitator_2], num_sessions: 5
-    @academic_year_workshop = create :workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_5, num_facilitators: 2, num_sessions: 2
+    @academic_year_workshop = create :csp_academic_year_workshop, :two_day
 
     @pre_workshop_questions = [
       Pd::JotForm::MatrixQuestion.new(

--- a/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
@@ -5,10 +5,7 @@ require 'test_helper'
 module Pd::Payment
   class PaymentCalculatorBaseTest < ActiveSupport::TestCase
     test 'public unqualified' do
-      empty_workshop = create :workshop, :ended,
-        on_map: true, funded: true,
-        course: Pd::Workshop::COURSE_CSP,
-        subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
+      empty_workshop = create :csp_academic_year_workshop, :ended, on_map: true, funded: true
 
       workshop_summary = PaymentCalculatorBase.instance.calculate empty_workshop
       assert_equal 0, workshop_summary.num_teachers

--- a/dashboard/test/lib/pd/payment/payment_calculator_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_test.rb
@@ -9,11 +9,9 @@ module Pd::Payment
       @program_manager = create :workshop_organizer
       @regional_partner = create :regional_partner, program_managers: [@program_manager]
 
-      @csp_workshop = create :workshop,
+      @csp_workshop = create :csp_academic_year_workshop,
         :ended,
         organizer: @program_manager,
-        course: Pd::Workshop::COURSE_CSP,
-        subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1,
         enrolled_and_attending_users: 20,
         num_sessions: 2,
         num_facilitators: 2
@@ -50,7 +48,7 @@ module Pd::Payment
     end
 
     test 'Error raised if workshop has no regional partner' do
-      unpartnered_workshop = create(:workshop, :ended, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1)
+      unpartnered_workshop = create :csp_academic_year_workshop, :ended, regional_partner: nil
       error = assert_raises(RuntimeError) do
         PaymentCalculator.instance.calculate(unpartnered_workshop)
       end

--- a/dashboard/test/lib/pd/payment/payment_calculator_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_test.rb
@@ -13,8 +13,7 @@ module Pd::Payment
         :ended,
         organizer: @program_manager,
         enrolled_and_attending_users: 20,
-        num_sessions: 2,
-        num_facilitators: 2
+        num_sessions: 2
     end
 
     test 'Raise error if workshop is not ended' do

--- a/dashboard/test/lib/pd/payment/payment_factory_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_factory_test.rb
@@ -26,8 +26,7 @@ module Pd::Payment
       workshop_ecs = create :workshop, :ended, on_map: false, funded: true,
         course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
 
-      workshop_csp = create :workshop, :ended, on_map: true, funded: true,
-        course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
+      workshop_csp = create :csp_academic_year_workshop, :ended, on_map: true, funded: true
 
       workshop_cs_in_a = create :workshop, :ended, on_map: false, funded: true,
         course: Pd::Workshop::COURSE_CS_IN_A, subject: Pd::Workshop::SUBJECT_CS_IN_A_PHASE_2
@@ -73,8 +72,7 @@ module Pd::Payment
 
     test 'calculate payment' do
       # Use a standard payment for example:
-      workshop_standard = create :workshop, :ended, on_map: true, funded: true,
-        course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
+      workshop_standard = create :csp_academic_year_workshop, :ended, on_map: true, funded: true
 
       standard_summary = PaymentFactory.get_payment(workshop_standard)
       assert_not_nil standard_summary

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -260,9 +260,8 @@ module Pd::SurveyPipeline
     end
 
     test 'get context of academic year workshop survey submissions' do
-      facilitator = create :facilitator
-      workshop = create :workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1,
-        num_sessions: 1, facilitators: [facilitator]
+      workshop = create :csp_academic_year_workshop
+      facilitator = workshop.facilitators.first
       daily_form_id = '1122334455'.to_i
       post_ws_form_id = '82115646319154'.to_i
 

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -8,8 +8,7 @@ module Pd::SurveyPipeline
     self.use_transactional_test_case = true
     setup_all do
       @facilitators = create_list :facilitator, 2
-      @workshop = create :workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201,
-        num_sessions: 1, facilitators: @facilitators
+      @workshop = create :csf_deep_dive_workshop, facilitators: @facilitators
 
       @program_manager = create :program_manager
       @workshop_admin = create :workshop_admin
@@ -225,8 +224,7 @@ module Pd::SurveyPipeline
 
     test 'get context of CSF survey submissions' do
       facilitator = create :facilitator
-      workshop = create :workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201,
-        num_sessions: 1, facilitators: [facilitator]
+      workshop = create :csf_deep_dive_workshop, facilitators: [facilitator]
       form_id = '1122334455'.to_i
 
       survey_metadata_to_context = {

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_parser_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_parser_test.rb
@@ -11,7 +11,7 @@ module Pd::SurveyPipeline
     setup_all do
       @ws_form_id = "11000000000000".to_i
 
-      ws = create :workshop, course: COURSE_CSF, subject: SUBJECT_CSF_201, num_sessions: 1
+      ws = create :csf_deep_dive_workshop
       teacher = create :teacher
       day = 0
 

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_retriever_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_retriever_test.rb
@@ -10,8 +10,7 @@ module Pd::SurveyPipeline
     setup_all do
       @workshop_form_ids = [11_000_000_000_000, 11_000_000_000_001]
       @facilitator_form_ids = [22_000_000_000_000, 22_000_000_000_001]
-      @workshops = create_list :workshop, 2,
-        course: COURSE_CSF, subject: SUBJECT_CSF_201, num_sessions: 2
+      @workshops = create_list :csf_deep_dive_workshop, 2, num_sessions: 2
 
       teachers = create_list :teacher, 2
       facilitators = create_list :facilitator, 2

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -110,21 +110,20 @@ class WorkshopMailerTest < ActionMailer::TestCase
   end
 
   test 'facilitator and organizer email links are complete urls' do
-    facilitator = create :facilitator
-    csf_workshop = create :csf_intro_workshop, facilitators: [facilitator]
+    csf_workshop = create :csf_intro_workshop
     csf_enrollment = create :pd_enrollment, workshop: csf_workshop
-    ecs_workshop = create :workshop, :ended, facilitators: [facilitator], course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
+    ecs_workshop = create :workshop, :ended, num_facilitators: 1, course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
     ecs_enrollment = create :pd_enrollment, workshop: ecs_workshop
     mails = []
 
-    mails << Pd::WorkshopMailer.facilitator_enrollment_reminder(facilitator, ecs_workshop)
+    mails << Pd::WorkshopMailer.facilitator_enrollment_reminder(ecs_workshop.facilitators.first, ecs_workshop)
     mails << Pd::WorkshopMailer.organizer_enrollment_reminder(ecs_workshop)
     mails << Pd::WorkshopMailer.organizer_cancel_receipt(ecs_enrollment)
     mails << Pd::WorkshopMailer.organizer_cancel_receipt(csf_enrollment)
     mails << Pd::WorkshopMailer.organizer_enrollment_receipt(ecs_enrollment)
     mails << Pd::WorkshopMailer.organizer_should_close_reminder(ecs_workshop)
     mails << Pd::WorkshopMailer.organizer_should_close_reminder(csf_workshop)
-    mails << Pd::WorkshopMailer.facilitator_detail_change_notification(facilitator, csf_workshop)
+    mails << Pd::WorkshopMailer.facilitator_detail_change_notification(csf_workshop.facilitators.first, csf_workshop)
     mails << Pd::WorkshopMailer.organizer_detail_change_notification(csf_workshop)
 
     mails.each {|mail| assert links_are_complete_urls?(mail, allowed_urls: ['#'])}

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -111,7 +111,7 @@ class WorkshopMailerTest < ActionMailer::TestCase
 
   test 'facilitator and organizer email links are complete urls' do
     facilitator = create :facilitator
-    csf_workshop = create :workshop, facilitators: [facilitator], course: Pd::Workshop::COURSE_CSF, subject: Pd::Workshop::SUBJECT_CSF_101
+    csf_workshop = create :csf_intro_workshop, facilitators: [facilitator]
     csf_enrollment = create :pd_enrollment, workshop: csf_workshop
     ecs_workshop = create :workshop, :ended, facilitators: [facilitator], course: Pd::Workshop::COURSE_ECS, subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
     ecs_enrollment = create :pd_enrollment, workshop: ecs_workshop

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -300,14 +300,18 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'academic year survey filter' do
-    workshop = create :workshop, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
+    workshop = create :csp_academic_year_workshop
     teacher = create :teacher
     enrollment = create :pd_enrollment, :from_user, user: teacher, workshop: workshop
 
     assert_equal [enrollment], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
 
     # complete survey
-    create :pd_workshop_daily_survey, pd_workshop: workshop, user: enrollment.user, form_id: Pd::WorkshopDailySurvey.get_form_id_for_subject_and_day(workshop.subject, 'post_workshop'), day: 1
+    create :pd_workshop_daily_survey,
+      pd_workshop: workshop,
+      user: enrollment.user,
+      form_id: Pd::WorkshopDailySurvey.get_form_id_for_subject_and_day(workshop.subject, 'post_workshop'),
+      day: 1
     assert_equal [], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
   end
 

--- a/dashboard/test/models/pd/workshop_daily_survey_test.rb
+++ b/dashboard/test/models/pd/workshop_daily_survey_test.rb
@@ -11,7 +11,7 @@ module Pd
     setup_all do
       @user = create :user
       @pd_summer_workshop = create :workshop, num_sessions: 5, course: COURSE_CSP, subject: SUBJECT_CSP_TEACHER_CON
-      @pd_academic_year_workshop = create :workshop, num_sessions: 5, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1
+      @pd_academic_year_workshop = create :csp_academic_year_workshop
     end
 
     test 'response_exists? and create_placeholder!' do

--- a/dashboard/test/models/pd/workshop_facilitator_daily_survey_test.rb
+++ b/dashboard/test/models/pd/workshop_facilitator_daily_survey_test.rb
@@ -13,7 +13,7 @@ module Pd
       @pd_workshop = create :workshop, num_sessions: 5
       @facilitator = create :facilitator
       @pd_summer_workshop = create :workshop, num_sessions: 5, course: COURSE_CSP, subject: SUBJECT_CSP_TEACHER_CON
-      @pd_academic_year_workshop = create :workshop, num_sessions: 5, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1
+      @pd_academic_year_workshop = create :csp_academic_year_workshop
       @pd_summer_workshop.facilitators << @facilitator
       @pd_academic_year_workshop.facilitators << @facilitator
     end

--- a/dashboard/test/models/pd/workshop_survey_test.rb
+++ b/dashboard/test/models/pd/workshop_survey_test.rb
@@ -182,7 +182,7 @@ class Pd::WorkshopSurveyTest < ActiveSupport::TestCase
 
   test 'empty implementation required fields cause errors when present' do
     user = create :user
-    workshop = create :workshop, course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
+    workshop = create :csd_academic_year_workshop, subject: Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
 
     survey = Pd::WorkshopSurvey.new
     survey.pd_enrollment = create :pd_enrollment, user: user, workshop: workshop

--- a/dashboard/test/models/pd/workshop_survey_test.rb
+++ b/dashboard/test/models/pd/workshop_survey_test.rb
@@ -182,7 +182,7 @@ class Pd::WorkshopSurveyTest < ActiveSupport::TestCase
 
   test 'empty implementation required fields cause errors when present' do
     user = create :user
-    workshop = create :csd_academic_year_workshop, subject: Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
+    workshop = create :csd_academic_year_workshop
 
     survey = Pd::WorkshopSurvey.new
     survey.pd_enrollment = create :pd_enrollment, user: user, workshop: workshop

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -389,8 +389,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_follow_up only teachers attended workshop get follow up emails' do
-    workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 30.days
+    workshop = create :csf_intro_workshop, :ended, sessions_from: Date.today - 30.days
 
     teacher_attended = create(:pd_workshop_participant, workshop: workshop, enrolled: true, attended: true)
     create(:pd_workshop_participant, workshop: workshop, enrolled: true)
@@ -403,8 +402,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_follow_up all teachers attended workshop get follow up emails' do
-    workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 30.days
+    workshop = create :csf_intro_workshop, :ended, sessions_from: Date.today - 30.days
 
     teacher_count = 3
     create_list :pd_workshop_participant, teacher_count, workshop: workshop, enrolled: true, attended: true
@@ -415,8 +413,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_follow_up exception in email delivery raises honeybadger but does not stop batch' do
-    workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 30.days
+    workshop = create :csf_intro_workshop, :ended, sessions_from: Date.today - 30.days
 
     teacher_count = 3
     create_list :pd_workshop_participant, teacher_count, workshop: workshop, enrolled: true, attended: true
@@ -435,12 +432,9 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'send_follow_up only workshop ended exactly 30 days ago get follow up emails' do
-    workshop_31d = create :workshop, :ended, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 31.days
-    workshop_30d = create :workshop, :ended, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 30.days
-    workshop_29d = create :workshop, :ended, course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101, sessions_from: Date.today - 29.days
+    workshop_31d = create :csf_intro_workshop, :ended, sessions_from: Date.today - 31.days
+    workshop_30d = create :csf_intro_workshop, :ended, sessions_from: Date.today - 30.days
+    workshop_29d = create :csf_intro_workshop, :ended, sessions_from: Date.today - 29.days
 
     create(:pd_workshop_participant, workshop: workshop_31d, enrolled: true, attended: true)
     teacher_30d = create(:pd_workshop_participant, workshop: workshop_30d, enrolled: true, attended: true)
@@ -725,12 +719,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'CSF 101 workshops are capped at 7 hours' do
-    workshop_csf_101 = create :workshop,
-      course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_101,
-      each_session_hours: 8
-
-    assert_equal 7, workshop_csf_101.effective_num_hours
+    workshop = create :csf_intro_workshop, each_session_hours: 8
+    assert_equal 7, workshop.effective_num_hours
   end
 
   test 'CSF 201 workshops are capped at 6 hours' do

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -724,11 +724,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'CSF 201 workshops are capped at 6 hours' do
-    workshop_csf_201 = create :workshop,
-      course: Pd::Workshop::COURSE_CSF,
-      subject: Pd::Workshop::SUBJECT_CSF_201,
-      each_session_hours: 7
-
+    workshop_csf_201 = create :csf_deep_dive_workshop, each_session_hours: 7
     assert_equal 6, workshop_csf_201.effective_num_hours
   end
 


### PR DESCRIPTION
While doing some test cleanup recently (in particular, trying to clean up some flaky tests) I identified that we do an awful lot of manual setup of fake workshops in our tests.  We're using factories, but it's very common to use the generic workshop factory and then pass in a whole lot of additional properties to create a valid, realistic workshop for our test.  For example:

https://github.com/code-dot-org/code-dot-org/blob/4becbf256189c44f3e112787984c66fb26e5481a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb#L1066-L1073

Or worse, we _won't_ set up a realistic fake and our tests do a poor job of reflecting the kind of data our code will encounter on production.

Workshops can be configured in a large number of ways (and this may grow over time) but in practice we have a fairly small number of workshop _types_ that we currently support.  I did some digging in our production data and looked at all the workshops created in 2019 to identify common workshop types and the most typical properties of each type.  Then I made new factories for some of those types and started using them wherever possible in our test code.

I believe this results in cleaner test code that hews closer to our domain language, and powerful tools that will make writing robust tests with realistic fakes easier in the future.

# What's changed

I've added four new factories covering our four most common workshop types, and am planning to do six more in a follow-up PR.  I've also provided some generics and aliases that may be useful.

* `:csf_workshop` (CSF Intro by default)
  * `:csf_intro_workshop` (alias: `:csf_101_workshop`)
  * `:csf_deep_dive_workshop` (alias: `:csf_201_workshop`)
* `:academic_year_workshop` (CSP by default)
  * `:csp_academic_year_workshop`
  * `:csd_academic_year_workshop`

I've used these four factories to simplify test code in 36 places already.  Some of these places still include overrides; in some cases those overrides still mean we're testing an atypical or unrealistic workshop, like this two-session CSF deep dive workshop:

https://github.com/code-dot-org/code-dot-org/blob/f6f4635a6af286821b14cfe03d0ab5633a453d8a/dashboard/test/lib/pd/survey_pipeline/daily_survey_retriever_test.rb#L13

But in general I've simplified setup and gently nudged things toward more typical cases.