### PR TITLE
[Applab Datasets] Add applabDatasets experiment and show "current tables" in data tab

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -23,7 +23,7 @@ import {
   onColumnNames,
   addMissingColumns
 } from '../storage/firebaseMetadata';
-import {getProjectDatabase} from '../storage/firebaseUtils';
+import {getProjectDatabase, getSharedDatabase} from '../storage/firebaseUtils';
 import * as apiTimeoutList from '../lib/util/timeoutList';
 import designMode from './designMode';
 import applabTurtle from './applabTurtle';
@@ -47,6 +47,7 @@ const {ApplabInterfaceMode} = applabConstants;
 import {DataView} from '../storage/constants';
 import consoleApi from '../consoleApi';
 import {
+  tableType,
   addTableName,
   deleteTableName,
   updateTableColumns,
@@ -814,13 +815,26 @@ function setupReduxSubscribers(store) {
   });
 
   if (store.getState().pageConstants.hasDataMode) {
+    if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      const sharedTablesRef = getSharedDatabase().child('counters/tables');
+      sharedTablesRef.on('child_added', snapshot => {
+        store.dispatch(
+          addTableName(
+            typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key,
+            tableType.SHARED
+          )
+        );
+      });
+    }
+
     // Initialize redux's list of tables from firebase, and keep it up to date as
     // new tables are added and removed.
     const tablesRef = getProjectDatabase().child('counters/tables');
     tablesRef.on('child_added', snapshot => {
       store.dispatch(
         addTableName(
-          typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key
+          typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key,
+          tableType.PROJECT
         )
       );
     });
@@ -1274,37 +1288,57 @@ function onDataViewChange(view, oldTableName, newTableName) {
   if (!getStore().getState().pageConstants.hasDataMode) {
     throw new Error('onDataViewChange triggered without data mode enabled');
   }
-  const storageRef = getProjectDatabase().child('storage');
+
+  const projectStorageRef = getProjectDatabase().child('storage');
+  const sharedStorageRef = getSharedDatabase().child('storage');
 
   // Unlisten from previous data view. This should not interfere with events listened to
   // by onRecordEvent, which listens for added/updated/deleted events, whereas we are
   // only unlistening from 'value' events here.
-  storageRef.child('keys').off('value');
-  storageRef.child(`tables/${oldTableName}/records`).off('value');
+  projectStorageRef.child('keys').off('value');
+  projectStorageRef.child(`tables/${oldTableName}/records`).off('value');
+  sharedStorageRef.child(`tables/${oldTableName}/records`).off('value');
   getColumnsRef(oldTableName).off();
 
   switch (view) {
     case DataView.PROPERTIES:
-      storageRef.child('keys').on('value', snapshot => {
+      projectStorageRef.child('keys').on('value', snapshot => {
         getStore().dispatch(updateKeyValueData(snapshot.val()));
       });
       return;
-    case DataView.TABLE:
-      // Add any columns which appear in records in Firebase to the list of columns in
-      // Firebase. Do NOT do this every time the records change, to avoid adding back
-      // a column shortly after it was explicitly renamed or deleted.
-      addMissingColumns(newTableName);
+    case DataView.TABLE: {
+      if (
+        experiments.isEnabled(experiments.APPLAB_DATASETS) &&
+        getStore().getState().data.tableListMap[newTableName] ===
+          tableType.SHARED
+      ) {
+        sharedStorageRef
+          .child(`tables/${newTableName}/records`)
+          .on('value', snapshot => {
+            getStore().dispatch(
+              updateTableRecords(newTableName, snapshot.val())
+            );
+          });
+      } else {
+        // Add any columns which appear in records in Firebase to the list of columns in
+        // Firebase. Do NOT do this every time the records change, to avoid adding back
+        // a column shortly after it was explicitly renamed or deleted.
+        addMissingColumns(newTableName);
 
-      onColumnNames(newTableName, columnNames => {
-        getStore().dispatch(updateTableColumns(newTableName, columnNames));
-      });
-
-      storageRef
-        .child(`tables/${newTableName}/records`)
-        .on('value', snapshot => {
-          getStore().dispatch(updateTableRecords(newTableName, snapshot.val()));
+        onColumnNames(newTableName, columnNames => {
+          getStore().dispatch(updateTableColumns(newTableName, columnNames));
         });
+
+        projectStorageRef
+          .child(`tables/${newTableName}/records`)
+          .on('value', snapshot => {
+            getStore().dispatch(
+              updateTableRecords(newTableName, snapshot.val())
+            );
+          });
+      }
       return;
+    }
     default:
       return;
   }

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -23,7 +23,7 @@ import {
   onColumnNames,
   addMissingColumns
 } from '../storage/firebaseMetadata';
-import {getDatabase} from '../storage/firebaseUtils';
+import {getProjectDatabase} from '../storage/firebaseUtils';
 import * as apiTimeoutList from '../lib/util/timeoutList';
 import designMode from './designMode';
 import applabTurtle from './applabTurtle';
@@ -816,7 +816,7 @@ function setupReduxSubscribers(store) {
   if (store.getState().pageConstants.hasDataMode) {
     // Initialize redux's list of tables from firebase, and keep it up to date as
     // new tables are added and removed.
-    const tablesRef = getDatabase().child('counters/tables');
+    const tablesRef = getProjectDatabase().child('counters/tables');
     tablesRef.on('child_added', snapshot => {
       store.dispatch(
         addTableName(
@@ -1274,7 +1274,7 @@ function onDataViewChange(view, oldTableName, newTableName) {
   if (!getStore().getState().pageConstants.hasDataMode) {
     throw new Error('onDataViewChange triggered without data mode enabled');
   }
-  const storageRef = getDatabase().child('storage');
+  const storageRef = getProjectDatabase().child('storage');
 
   // Unlisten from previous data view. This should not interfere with events listened to
   // by onRecordEvent, which listens for added/updated/deleted events, whereas we are

--- a/apps/src/storage/firebaseCounters.js
+++ b/apps/src/storage/firebaseCounters.js
@@ -1,5 +1,9 @@
 import Firebase from 'firebase';
-import {loadConfig, getDatabase, showRateLimitAlert} from './firebaseUtils';
+import {
+  loadConfig,
+  getProjectDatabase,
+  showRateLimitAlert
+} from './firebaseUtils';
 
 /**
  * @fileoverview
@@ -21,7 +25,7 @@ import {loadConfig, getDatabase, showRateLimitAlert} from './firebaseUtils';
  * @returns {Promise}
  */
 export function enforceTableCount(config, tableName) {
-  const tablesRef = getDatabase().child(`counters/tables`);
+  const tablesRef = getProjectDatabase().child(`counters/tables`);
   return tablesRef.once('value').then(snapshot => {
     if (
       snapshot.numChildren() >= config.maxTableCount &&
@@ -56,7 +60,9 @@ export function updateTableCounters(tableName, rowCountChange, updateNextId) {
       return Promise.resolve(config);
     })
     .then(config => {
-      const tableRef = getDatabase().child(`counters/tables/${tableName}`);
+      const tableRef = getProjectDatabase().child(
+        `counters/tables/${tableName}`
+      );
       return updateTableCountersHelper(
         tableRef,
         updateNextId,
@@ -141,7 +147,7 @@ function updateTableCountersHelper(
  * @returns {Promise}
  */
 function incrementIntervalCounters(maxWriteCount, interval, currentTimeMs) {
-  const limitRef = getDatabase().child(`counters/limits/${interval}`);
+  const limitRef = getProjectDatabase().child(`counters/limits/${interval}`);
   const intervalMs = Number(interval) * 1000;
   return limitRef
     .transaction(limitData => {
@@ -269,7 +275,7 @@ export function incrementRateLimitCounters() {
  * @returns {Promise<number>} The current server time in milliseconds.
  */
 function getCurrentTime() {
-  const serverTimeRef = getDatabase().child('serverTime');
+  const serverTimeRef = getProjectDatabase().child('serverTime');
   return serverTimeRef.set(Firebase.ServerValue.TIMESTAMP).then(() => {
     return serverTimeRef.once('value').then(snapshot => snapshot.val());
   });
@@ -281,7 +287,9 @@ function getCurrentTime() {
  * current table, or 0 if no rows exist in the table or the table does not exist.
  */
 export function getLastRecordId(tableName) {
-  const lastIdRef = getDatabase().child(`counters/tables/${tableName}/lastId`);
+  const lastIdRef = getProjectDatabase().child(
+    `counters/tables/${tableName}/lastId`
+  );
   return lastIdRef.once('value').then(snapshot => {
     return snapshot.val() || 0;
   });

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -1,8 +1,8 @@
-import {getDatabase} from './firebaseUtils';
+import {getProjectDatabase} from './firebaseUtils';
 import _ from 'lodash';
 
 export function getColumnsRef(tableName) {
-  return getDatabase().child(`metadata/tables/${tableName}/columns`);
+  return getProjectDatabase().child(`metadata/tables/${tableName}/columns`);
 }
 
 /**
@@ -100,7 +100,7 @@ export function onColumnNames(tableName, callback) {
  */
 export function addMissingColumns(tableName) {
   return getColumnNames(tableName).then(existingColumnNames => {
-    const recordsRef = getDatabase().child(
+    const recordsRef = getProjectDatabase().child(
       `storage/tables/${tableName}/records`
     );
     return recordsRef.once('value').then(snapshot => {

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -1,8 +1,8 @@
 import {getProjectDatabase} from './firebaseUtils';
 import _ from 'lodash';
 
-export function getColumnsRef(tableName) {
-  return getProjectDatabase().child(`metadata/tables/${tableName}/columns`);
+export function getColumnsRef(database, tableName) {
+  return database.child(`metadata/tables/${tableName}/columns`);
 }
 
 /**
@@ -12,7 +12,7 @@ export function getColumnsRef(tableName) {
  * none exists.
  */
 export function getColumnRefByName(tableName, columnName) {
-  return getColumnsRef(tableName)
+  return getColumnsRef(getProjectDatabase(), tableName)
     .once('value')
     .then(columnsSnapshot => {
       const columns = columnsSnapshot.val();
@@ -21,7 +21,7 @@ export function getColumnRefByName(tableName, columnName) {
         column => column.columnName === columnName
       );
       if (key) {
-        return getColumnsRef(tableName).child(key);
+        return getColumnsRef(getProjectDatabase(), tableName).child(key);
       }
       return Promise.resolve();
     });
@@ -45,7 +45,7 @@ export function getColumnNamesFromRecords(records) {
  * @returns {Promise} Promise containing an array of column names.
  */
 export function getColumnNames(tableName) {
-  const columnsRef = getColumnsRef(tableName);
+  const columnsRef = getColumnsRef(getProjectDatabase(), tableName);
   return columnsRef.once('value').then(snapshot => {
     const columnsData = snapshot.val() || {};
     return _.values(columnsData).map(column => column.columnName);
@@ -55,7 +55,7 @@ export function getColumnNames(tableName) {
 export function addColumnName(tableName, columnName) {
   return getColumnRefByName(tableName, columnName).then(columnRef => {
     if (!columnRef) {
-      return getColumnsRef(tableName)
+      return getColumnsRef(getProjectDatabase(), tableName)
         .push()
         .set({columnName});
     }
@@ -77,15 +77,15 @@ export function renameColumnName(tableName, oldName, newName) {
     if (columnRef) {
       return columnRef.set({columnName: newName});
     } else {
-      return getColumnsRef(tableName)
+      return getColumnsRef(getProjectDatabase(), tableName)
         .push()
         .set({columnName: newName});
     }
   });
 }
 
-export function onColumnNames(tableName, callback) {
-  getColumnsRef(tableName).on('value', snapshot => {
+export function onColumnNames(database, tableName, callback) {
+  getColumnsRef(database, tableName).on('value', snapshot => {
     const columnsData = snapshot.val() || {};
     const columnNames = _.values(columnsData).map(column => column.columnName);
     callback(columnNames);
@@ -107,7 +107,7 @@ export function addMissingColumns(tableName) {
       const recordsData = snapshot.val() || {};
       getColumnNamesFromRecords(recordsData).forEach(columnName => {
         if (!existingColumnNames.includes(columnName)) {
-          getColumnsRef(tableName)
+          getColumnsRef(getProjectDatabase(), tableName)
             .push()
             .set({columnName});
         }

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -507,7 +507,7 @@ FirebaseStorage.deleteTable = function(tableName, onSuccess, onError) {
   tableRef
     .set(null)
     .then(() => countersRef.set(null))
-    .then(() => getColumnsRef(tableName).set(null))
+    .then(() => getColumnsRef(getProjectDatabase(), tableName).set(null))
     .then(onSuccess, onError);
 };
 
@@ -895,7 +895,7 @@ function overwriteTableData(tableName, recordsData) {
   const countersRef = getProjectDatabase().child(
     `counters/tables/${tableName}`
   );
-  return getColumnsRef(tableName)
+  return getColumnsRef(getProjectDatabase(), tableName)
     .set(null)
     .then(() => recordsRef.set(recordsData))
     .then(() => {

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -11,7 +11,7 @@ import {
   loadConfig,
   fixFirebaseKey,
   getRecordsRef,
-  getDatabase,
+  getProjectDatabase,
   resetConfigForTesting,
   isInitialized,
   validateFirebaseKey
@@ -40,7 +40,7 @@ const FirebaseStorage = {};
 const RECORD_ID_PADDING = 16;
 
 function getKeysRef() {
-  let kv = getDatabase().child('storage/keys');
+  let kv = getProjectDatabase().child('storage/keys');
   return kv;
 }
 
@@ -155,7 +155,7 @@ FirebaseStorage.deleteKeyValue = function(key, onSuccess, onError) {
  * @returns {Promise<boolean>} whether the record exists
  */
 function getRecordExistsPromise(tableName, recordId) {
-  let recordRef = getDatabase().child(
+  let recordRef = getProjectDatabase().child(
     `storage/tables/${tableName}/records/${recordId}`
   );
   return recordRef.once('value').then(snapshot => snapshot.val() !== null);
@@ -184,7 +184,7 @@ FirebaseStorage.createRecord = function(tableName, record, onSuccess, onError) {
     .then(() => updateTableCounters(tableName, 1, updateNextId))
     .then(nextId => {
       record.id = nextId;
-      const recordRef = getDatabase().child(
+      const recordRef = getProjectDatabase().child(
         `storage/tables/${tableName}/records/${record.id}`
       );
       return recordRef.set(JSON.stringify(record));
@@ -260,7 +260,7 @@ FirebaseStorage.readRecords = function(
 ) {
   tableName = fixTableName(tableName, onError);
 
-  const countersRef = getDatabase().child('counters/tables/');
+  const countersRef = getProjectDatabase().child('counters/tables/');
   // First, check if table exists using counters/tables/ as source of truth
   countersRef.once('value', countersSnapshot => {
     if (!countersSnapshot.val() || !countersSnapshot.val()[tableName]) {
@@ -310,7 +310,7 @@ FirebaseStorage.updateRecord = function(
   tableName = fixTableName(tableName, onError);
 
   const recordJson = JSON.stringify(record);
-  const recordRef = getDatabase().child(
+  const recordRef = getProjectDatabase().child(
     `storage/tables/${tableName}/records/${record.id}`
   );
   const hasId = true;
@@ -350,7 +350,7 @@ FirebaseStorage.deleteRecord = function(
 ) {
   tableName = fixTableName(tableName, onError);
 
-  const recordRef = getDatabase().child(
+  const recordRef = getProjectDatabase().child(
     `storage/tables/${tableName}/records/${record.id}`
   );
 
@@ -450,7 +450,7 @@ FirebaseStorage.resetForTesting = function() {
   }
 
   FirebaseStorage.resetRecordListener();
-  getDatabase().set(null);
+  getProjectDatabase().set(null);
 
   resetConfigForTesting();
 };
@@ -470,7 +470,9 @@ FirebaseStorage.createTable = function(tableName, onSuccess, onError) {
       return enforceTableCount(config, tableName);
     })
     .then(() => {
-      const countersRef = getDatabase().child(`counters/tables/${tableName}`);
+      const countersRef = getProjectDatabase().child(
+        `counters/tables/${tableName}`
+      );
       countersRef
         .transaction(countersData => {
           if (countersData === null) {
@@ -498,8 +500,10 @@ FirebaseStorage.createTable = function(tableName, onSuccess, onError) {
  * @param {function (string)} onError
  */
 FirebaseStorage.deleteTable = function(tableName, onSuccess, onError) {
-  const tableRef = getDatabase().child(`storage/tables/${tableName}`);
-  const countersRef = getDatabase().child(`counters/tables/${tableName}`);
+  const tableRef = getProjectDatabase().child(`storage/tables/${tableName}`);
+  const countersRef = getProjectDatabase().child(
+    `counters/tables/${tableName}`
+  );
   tableRef
     .set(null)
     .then(() => countersRef.set(null))
@@ -514,11 +518,11 @@ FirebaseStorage.deleteTable = function(tableName, onSuccess, onError) {
  * @param {function (string)} onError
  */
 FirebaseStorage.clearTable = function(tableName, onSuccess, onError) {
-  const tableRef = getDatabase().child(`storage/tables/${tableName}`);
+  const tableRef = getProjectDatabase().child(`storage/tables/${tableName}`);
   tableRef
     .set(null)
     .then(() => {
-      const rowCountRef = getDatabase().child(
+      const rowCountRef = getProjectDatabase().child(
         `counters/tables/${tableName}/rowCount`
       );
       return rowCountRef.set(0);
@@ -537,7 +541,7 @@ function getExistingTables(overwrite) {
   if (overwrite) {
     return Promise.resolve({});
   }
-  const tablesRef = getDatabase().child('counters/tables');
+  const tablesRef = getProjectDatabase().child('counters/tables');
   return tablesRef.once('value').then(snapshot => snapshot.val() || {});
 }
 
@@ -683,7 +687,9 @@ FirebaseStorage.deleteColumn = function(
   onSuccess,
   onError
 ) {
-  const recordsRef = getDatabase().child(`storage/tables/${tableName}/records`);
+  const recordsRef = getProjectDatabase().child(
+    `storage/tables/${tableName}/records`
+  );
   recordsRef
     .once('value')
     .then(snapshot => {
@@ -722,7 +728,9 @@ FirebaseStorage.renameColumn = function(
     );
     return;
   }
-  const recordsRef = getDatabase().child(`storage/tables/${tableName}/records`);
+  const recordsRef = getProjectDatabase().child(
+    `storage/tables/${tableName}/records`
+  );
   recordsRef
     .once('value')
     .then(snapshot => {
@@ -794,7 +802,9 @@ FirebaseStorage.coerceColumn = function(
   onSuccess,
   onError
 ) {
-  const recordsRef = getDatabase().child(`storage/tables/${tableName}/records`);
+  const recordsRef = getProjectDatabase().child(
+    `storage/tables/${tableName}/records`
+  );
   recordsRef
     .once('value')
     .then(snapshot => {
@@ -879,8 +889,12 @@ function validateRecordsData(recordsData) {
  * @returns {Promise} A promise which is successful if all writes were successful.
  */
 function overwriteTableData(tableName, recordsData) {
-  const recordsRef = getDatabase().child(`storage/tables/${tableName}/records`);
-  const countersRef = getDatabase().child(`counters/tables/${tableName}`);
+  const recordsRef = getProjectDatabase().child(
+    `storage/tables/${tableName}/records`
+  );
+  const countersRef = getProjectDatabase().child(
+    `counters/tables/${tableName}`
+  );
   return getColumnsRef(tableName)
     .set(null)
     .then(() => recordsRef.set(recordsData))

--- a/apps/src/storage/firebaseUtils.js
+++ b/apps/src/storage/firebaseUtils.js
@@ -76,10 +76,14 @@ export function getConfigRef() {
 }
 
 export function getRecordsRef(tableName) {
-  return getDatabase().child(`storage/tables/${tableName}/records`);
+  return getProjectDatabase().child(`storage/tables/${tableName}/records`);
 }
 
-export function getDatabase() {
+export function getSharedDatabase() {
+  return getFirebase().child('v3/channels/shared');
+}
+
+export function getProjectDatabase() {
   const path = `v3/channels/${config.channelId}${
     config.firebaseChannelIdSuffix
   }`;

--- a/apps/src/storage/redux/data.js
+++ b/apps/src/storage/redux/data.js
@@ -15,6 +15,15 @@ const UPDATE_KEY_VALUE_DATA = 'data/UPDATE_KEY_VALUE_DATA';
 const SHOW_WARNING = 'data/SHOW_WARNING';
 const CLEAR_WARNING = 'data/CLEAR_WARNING';
 
+/**
+ * Types which a column can be coerced to.
+ * @enum {string}
+ */
+export const tableType = {
+  SHARED: 'shared',
+  PROJECT: 'project'
+};
+
 const DataState = Record({
   view: DataView.OVERVIEW,
   tableListMap: {},
@@ -35,7 +44,7 @@ export default function(state = initialState, action) {
       return state.set(
         'tableListMap',
         Object.assign({}, state.tableListMap, {
-          [action.tableName]: true
+          [action.tableName]: action.tableType
         })
       );
     case CHANGE_VIEW:
@@ -81,9 +90,10 @@ export default function(state = initialState, action) {
  * Action which adds a table name to the table list map, if it doesn't exist already.
  * @param {string} tableName
  */
-export const addTableName = tableName => ({
+export const addTableName = (tableName, tableType) => ({
   type: ADD_TABLE_NAME,
-  tableName
+  tableName,
+  tableType
 });
 
 export const changeView = (view, tableName) => ({

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -23,6 +23,7 @@ experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
   'schoolAutocompleteDropdownNewSearch';
 experiments.FEEDBACK_NOTIFICATION = 'feedbackNotification';
 experiments.ROLLUP_SURVEY_REPORT = 'rollupSurveyReport';
+experiments.APPLAB_DATASETS = 'applabDatasets';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.

--- a/apps/test/integration/util/runLevelTest.js
+++ b/apps/test/integration/util/runLevelTest.js
@@ -2,7 +2,10 @@ import $ from 'jquery';
 import _ from 'lodash';
 import LegacyDialog from '@cdo/apps/code-studio/LegacyDialog';
 import {assert} from '../../util/configuredChai';
-import {getConfigRef, getDatabase} from '@cdo/apps/storage/firebaseUtils';
+import {
+  getConfigRef,
+  getProjectDatabase
+} from '@cdo/apps/storage/firebaseUtils';
 import Firebase from 'firebase';
 import MockFirebase from '../../util/MockFirebase';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
@@ -165,7 +168,7 @@ function runLevel(app, skinId, level, onAttempt, finished, testData) {
           'Expected to be using apps/test/util/MockFirebase in level tests.'
         );
 
-        getDatabase().autoFlush();
+        getProjectDatabase().autoFlush();
         getConfigRef().autoFlush();
         getConfigRef().set({
           limits: {
@@ -179,7 +182,7 @@ function runLevel(app, skinId, level, onAttempt, finished, testData) {
         });
         timeout = 500;
 
-        getDatabase().set(null);
+        getProjectDatabase().set(null);
       }
 
       setTimeout(function() {

--- a/apps/test/unit/storage/FirebaseStorageTest.js
+++ b/apps/test/unit/storage/FirebaseStorageTest.js
@@ -1,6 +1,9 @@
 import {expect} from '../../util/configuredChai';
 import {initFirebaseStorage} from '@cdo/apps/storage/firebaseStorage';
-import {getDatabase, getConfigRef} from '@cdo/apps/storage/firebaseUtils';
+import {
+  getProjectDatabase,
+  getConfigRef
+} from '@cdo/apps/storage/firebaseUtils';
 
 describe('FirebaseStorage', () => {
   let FirebaseStorage;
@@ -12,7 +15,7 @@ describe('FirebaseStorage', () => {
       firebaseAuthToken: 'test-firebase-auth-token',
       showRateLimitAlert: () => {}
     });
-    getDatabase().autoFlush();
+    getProjectDatabase().autoFlush();
     return getConfigRef()
       .set({
         limits: {
@@ -25,7 +28,7 @@ describe('FirebaseStorage', () => {
         maxTableCount: 3
       })
       .then(() => {
-        getDatabase().set(null);
+        getProjectDatabase().set(null);
       });
   });
 
@@ -36,7 +39,7 @@ describe('FirebaseStorage', () => {
       );
 
       function verifyStringValue() {
-        getDatabase()
+        getProjectDatabase()
           .child(`storage/keys`)
           .once('value')
           .then(snapshot => {
@@ -52,7 +55,7 @@ describe('FirebaseStorage', () => {
       );
 
       function verifyNumberValue() {
-        getDatabase()
+        getProjectDatabase()
           .child(`storage/keys`)
           .once('value')
           .then(snapshot => {
@@ -68,7 +71,7 @@ describe('FirebaseStorage', () => {
       );
 
       function verifySetKeyValue() {
-        getDatabase()
+        getProjectDatabase()
           .child(`storage/keys`)
           .once('value')
           .then(snapshot => {
@@ -99,7 +102,7 @@ describe('FirebaseStorage', () => {
       );
 
       function verifyNoKeys() {
-        getDatabase()
+        getProjectDatabase()
           .child(`storage/keys`)
           .once('value')
           .then(snapshot => {
@@ -123,7 +126,7 @@ describe('FirebaseStorage', () => {
 
       function verifyValueAndWarning() {
         expect(didWarn).to.be.true;
-        getDatabase()
+        getProjectDatabase()
           .child(`storage/keys`)
           .once('value')
           .then(snapshot => {
@@ -160,7 +163,7 @@ describe('FirebaseStorage', () => {
         'mytable',
         {name: 'bob', age: 8},
         () => {
-          getDatabase()
+          getProjectDatabase()
             .child(`storage/tables/${'mytable'}/records`)
             .once('value')
             .then(snapshot => {
@@ -244,7 +247,7 @@ describe('FirebaseStorage', () => {
 
       function handleDelete(status) {
         expect(status).to.equal(true);
-        getDatabase()
+        getProjectDatabase()
           .child(`storage/tables/${'mytable'}/records`)
           .once('value')
           .then(snapshot => {
@@ -264,7 +267,7 @@ describe('FirebaseStorage', () => {
         }
       );
 
-      const rowCountRef = getDatabase().child(
+      const rowCountRef = getProjectDatabase().child(
         `counters/tables/${'mytable'}/rowCount`
       );
 
@@ -294,7 +297,7 @@ describe('FirebaseStorage', () => {
 
       function handleDelete(status) {
         expect(status).to.equal(true);
-        getDatabase()
+        getProjectDatabase()
           .child(`storage/tables/${'mytable'}/records`)
           .once('value')
           .then(snapshot => {
@@ -320,12 +323,14 @@ describe('FirebaseStorage', () => {
    * @param {function} callback
    */
   function verifyEmptyTable(callback) {
-    const rowCountRef = getDatabase().child('counters/tables/mytable/rowCount');
+    const rowCountRef = getProjectDatabase().child(
+      'counters/tables/mytable/rowCount'
+    );
     rowCountRef
       .once('value')
       .then(snapshot => {
         expect(snapshot.val()).to.equal(0);
-        const recordsRef = getDatabase().child(
+        const recordsRef = getProjectDatabase().child(
           'storage/tables/mytable/records'
         );
         return recordsRef.once('value');
@@ -420,12 +425,14 @@ describe('FirebaseStorage', () => {
       }
 
       function verifyNoTable() {
-        const countersRef = getDatabase().child('counters/tables/mytable');
+        const countersRef = getProjectDatabase().child(
+          'counters/tables/mytable'
+        );
         countersRef
           .once('value')
           .then(snapshot => {
             expect(snapshot.val()).to.equal(null);
-            const recordsRef = getDatabase().child(
+            const recordsRef = getProjectDatabase().child(
               'storage/tables/mytable/records'
             );
             return recordsRef.once('value');
@@ -509,7 +516,7 @@ describe('FirebaseStorage', () => {
       }
 
       function validate() {
-        const recordsRef = getDatabase().child(
+        const recordsRef = getProjectDatabase().child(
           `storage/tables/mytable/records`
         );
         recordsRef.once('value').then(snapshot => {
@@ -580,7 +587,7 @@ describe('FirebaseStorage', () => {
       }
 
       function validate() {
-        const recordsRef = getDatabase().child(
+        const recordsRef = getProjectDatabase().child(
           `storage/tables/mytable/records`
         );
         recordsRef.once('value').then(snapshot => {
@@ -647,7 +654,7 @@ describe('FirebaseStorage', () => {
       }
 
       function validate() {
-        const recordsRef = getDatabase().child(
+        const recordsRef = getProjectDatabase().child(
           `storage/tables/mytable/records`
         );
         recordsRef.once('value').then(snapshot => {
@@ -702,7 +709,7 @@ describe('FirebaseStorage', () => {
       }
 
       function validate() {
-        const recordsRef = getDatabase().child(
+        const recordsRef = getProjectDatabase().child(
           `storage/tables/mytable/records`
         );
         recordsRef.once('value').then(snapshot => {
@@ -756,7 +763,7 @@ describe('FirebaseStorage', () => {
       }
 
       function validate() {
-        const recordsRef = getDatabase().child(
+        const recordsRef = getProjectDatabase().child(
           `storage/tables/mytable/records`
         );
         recordsRef.once('value').then(snapshot => {
@@ -802,7 +809,7 @@ describe('FirebaseStorage', () => {
     const BAD_JSON = '{';
 
     function verifyTable(expectedTablesData) {
-      return getDatabase()
+      return getProjectDatabase()
         .child(`storage/tables`)
         .once('value')
         .then(
@@ -829,11 +836,11 @@ describe('FirebaseStorage', () => {
 
     it('does not overwrite existing data when overwrite is false', done => {
       const overwrite = false;
-      getDatabase()
+      getProjectDatabase()
         .child(`storage/tables`)
         .set(EXISTING_TABLE_DATA)
         .then(() =>
-          getDatabase()
+          getProjectDatabase()
             .child('counters/tables')
             .set(EXISTING_COUNTER_DATA)
         )
@@ -854,7 +861,7 @@ describe('FirebaseStorage', () => {
     // sure we overwrite tables for users in that state.
     it('does overwrite existing data when counters/tables node is empty', done => {
       const overwrite = false;
-      getDatabase()
+      getProjectDatabase()
         .child(`storage/tables`)
         .set(EXISTING_TABLE_DATA)
         .then(() => {
@@ -871,11 +878,11 @@ describe('FirebaseStorage', () => {
 
     it('does overwrite existing data when overwrite is true', done => {
       const overwrite = true;
-      getDatabase()
+      getProjectDatabase()
         .child(`storage/tables`)
         .set(EXISTING_TABLE_DATA)
         .then(() =>
-          getDatabase()
+          getProjectDatabase()
             .child('counters/tables')
             .set(EXISTING_COUNTER_DATA)
         )
@@ -924,7 +931,7 @@ describe('FirebaseStorage', () => {
     const BAD_JSON = '{';
 
     function verifyKeyValue(expectedData) {
-      return getDatabase()
+      return getProjectDatabase()
         .child(`storage/keys`)
         .once('value')
         .then(
@@ -951,7 +958,7 @@ describe('FirebaseStorage', () => {
 
     it('does not overwrite existing data when overwrite is false', done => {
       const overwrite = false;
-      getDatabase()
+      getProjectDatabase()
         .child(`storage/keys`)
         .set(EXISTING_KEY_VALUE_DATA)
         .then(() => {
@@ -968,7 +975,7 @@ describe('FirebaseStorage', () => {
 
     it('does overwrite existing data when overwrite is true', done => {
       const overwrite = true;
-      getDatabase()
+      getProjectDatabase()
         .child(`storage/keys`)
         .set(EXISTING_KEY_VALUE_DATA)
         .then(() => {
@@ -1087,14 +1094,14 @@ describe('FirebaseStorage', () => {
       );
 
       function validateTableData() {
-        const rowCountRef = getDatabase().child(
+        const rowCountRef = getProjectDatabase().child(
           'counters/tables/mytable/rowCount'
         );
         rowCountRef
           .once('value')
           .then(snapshot => {
             expect(snapshot.val()).to.equal(3);
-            const recordsRef = getDatabase().child(
+            const recordsRef = getProjectDatabase().child(
               'storage/tables/mytable/records'
             );
             return recordsRef.once('value');
@@ -1128,14 +1135,14 @@ describe('FirebaseStorage', () => {
       }
 
       function validateTableData() {
-        const rowCountRef = getDatabase().child(
+        const rowCountRef = getProjectDatabase().child(
           'counters/tables/mytable/rowCount'
         );
         rowCountRef
           .once('value')
           .then(snapshot => {
             expect(snapshot.val()).to.equal(3);
-            const recordsRef = getDatabase().child(
+            const recordsRef = getProjectDatabase().child(
               'storage/tables/mytable/records'
             );
             return recordsRef.once('value');

--- a/apps/test/unit/storage/MockFirebaseTest.js
+++ b/apps/test/unit/storage/MockFirebaseTest.js
@@ -1,6 +1,6 @@
 import {expect} from '../../util/configuredChai';
 import MockFirebase from '../../util/MockFirebase';
-import {init, getDatabase} from '@cdo/apps/storage/firebaseUtils';
+import {init, getProjectDatabase} from '@cdo/apps/storage/firebaseUtils';
 
 describe('MockFirebase', () => {
   describe('initialization', () => {
@@ -165,7 +165,7 @@ describe('MockFirebase', () => {
         firebaseAuthToken: 'test-firebase-auth-token',
         showRateLimitAlert: () => {}
       });
-      channelRef = getDatabase();
+      channelRef = getProjectDatabase();
       channelRef.autoFlush();
     });
 

--- a/apps/test/unit/storage/firebaseMetadataTest.js
+++ b/apps/test/unit/storage/firebaseMetadataTest.js
@@ -6,7 +6,11 @@ import {
   getColumnNames,
   onColumnNames
 } from '@cdo/apps/storage/firebaseMetadata';
-import {init, getDatabase, getConfigRef} from '@cdo/apps/storage/firebaseUtils';
+import {
+  init,
+  getProjectDatabase,
+  getConfigRef
+} from '@cdo/apps/storage/firebaseUtils';
 
 describe('firebaseMetadata', () => {
   beforeEach(() => {
@@ -16,7 +20,7 @@ describe('firebaseMetadata', () => {
       firebaseAuthToken: 'test-firebase-auth-token',
       showRateLimitAlert: () => {}
     });
-    getDatabase().autoFlush();
+    getProjectDatabase().autoFlush();
     return getConfigRef()
       .set({
         limits: {
@@ -29,7 +33,7 @@ describe('firebaseMetadata', () => {
         maxTableCount: 3
       })
       .then(() => {
-        getDatabase().set(null);
+        getProjectDatabase().set(null);
       });
   });
 

--- a/apps/test/unit/storage/firebaseMetadataTest.js
+++ b/apps/test/unit/storage/firebaseMetadataTest.js
@@ -86,7 +86,7 @@ describe('firebaseMetadata', () => {
       ['foo', 'baz'],
       ['baz']
     ];
-    onColumnNames('mytable', columnNames => {
+    onColumnNames(getProjectDatabase(), 'mytable', columnNames => {
       expect(columnNames).to.deep.equal(expectedNames[count]);
       count++;
       if (count === expectedNames.length) {


### PR DESCRIPTION
Not shown in PR: Added a sample dataset to cdo-v3-dev on Firebase
![image](https://user-images.githubusercontent.com/8787187/63192124-2d6abd80-c01f-11e9-89af-bd2d95cbe6dd.png)

Main things here:
- add experiment flag
- rename a couple variables/functions to be project-specific, so that we can add shared equivalents (rename `getDatabase` to `getProjectDatabase` so that we can add `getSharedDatabase` and corresponding ref variables)
- add all tables in the shared DB channel to the data overview list (eventually we will want only datasets that the user has explicitly selected to show up here, but for now (before we have the dataset picker spec/UI set) I just wanted to get something working)
![image](https://user-images.githubusercontent.com/8787187/63192554-30b27900-c020-11e9-9082-aa391f1f4856.png)
![image](https://user-images.githubusercontent.com/8787187/63192564-3740f080-c020-11e9-8771-ed07c5ff26c7.png)
