### PR TITLE
More realistic workshop factories

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -656,7 +656,6 @@ module Api::V1::Pd
 
       Timecop.freeze(time) do
         workshop = create :summer_workshop,
-          num_sessions: 3,
           sessions_from: Date.new(2017, 1, 1),
           processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
         create :pd_enrollment, workshop: workshop, user: @serializing_teacher
@@ -685,7 +684,7 @@ module Api::V1::Pd
             district_name: 'A School District',
             school_name: 'A Seattle Public School',
             email: 'minerva@hogwarts.edu',
-            assigned_workshop: 'January 1-3, 2017, Orchard Park NY',
+            assigned_workshop: 'January 1-5, 2017, Orchard Park NY',
             registered_workshop: 'Yes',
             status: 'accepted_not_notified',
             notes: nil,
@@ -791,7 +790,6 @@ module Api::V1::Pd
 
       Timecop.freeze(time) do
         workshop = create :summer_workshop,
-          num_sessions: 3,
           sessions_from: Date.new(2017, 1, 1),
           processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
         create :pd_enrollment, workshop: workshop, user: @serializing_teacher
@@ -822,7 +820,7 @@ module Api::V1::Pd
             district_name: 'A School District',
             school_name: 'A Seattle Public School',
             email: 'minerva@hogwarts.edu',
-            assigned_workshop: 'January 1-3, 2017, Orchard Park NY',
+            assigned_workshop: 'January 1-5, 2017, Orchard Park NY',
             registered_workshop: 'Yes',
             status: 'accepted_not_notified',
             notes: nil,

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -354,7 +354,9 @@ module Api::V1::Pd
     end
 
     test 'update appends to the timestamp log if summer workshop is changed' do
-      summer_workshop = create :workshop, :local_summer_workshop, num_sessions: 5, sessions_from: Date.new(2019, 6, 1), processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+      summer_workshop = create :summer_workshop,
+        sessions_from: Date.new(2019, 6, 1),
+        processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
 
       sign_in @program_manager
       @csp_facilitator_application.update(status_timestamp_change_log: '[]')
@@ -376,8 +378,13 @@ module Api::V1::Pd
     end
 
     test 'update does not append to the timestamp log if fit and summer workshop are not changed' do
-      summer_workshop = create :workshop, :local_summer_workshop, num_sessions: 5, sessions_from: Date.new(2019, 6, 1), processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
-      fit_workshop = create :workshop, :fit, num_sessions: 3, sessions_from: Date.new(2019, 6, 1), processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+      summer_workshop = create :summer_workshop,
+        sessions_from: Date.new(2019, 6, 1),
+        processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+      fit_workshop = create :workshop, :fit,
+        num_sessions: 3,
+        sessions_from: Date.new(2019, 6, 1),
+        processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
 
       sign_in @program_manager
       @csp_facilitator_application.update(status_timestamp_change_log: '[]')
@@ -648,7 +655,10 @@ module Api::V1::Pd
       time = Date.new(2017, 3, 15)
 
       Timecop.freeze(time) do
-        workshop = create :workshop, :local_summer_workshop, num_sessions: 3, sessions_from: Date.new(2017, 1, 1), processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+        workshop = create :summer_workshop,
+          num_sessions: 3,
+          sessions_from: Date.new(2017, 1, 1),
+          processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
         create :pd_enrollment, workshop: workshop, user: @serializing_teacher
 
         application = create(
@@ -780,7 +790,10 @@ module Api::V1::Pd
       time = Date.new(2017, 3, 15)
 
       Timecop.freeze(time) do
-        workshop = create :workshop, :local_summer_workshop, num_sessions: 3, sessions_from: Date.new(2017, 1, 1), processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
+        workshop = create :summer_workshop,
+          num_sessions: 3,
+          sessions_from: Date.new(2017, 1, 1),
+          processed_location: {city: 'Orchard Park', state: 'NY'}.to_json
         create :pd_enrollment, workshop: workshop, user: @serializing_teacher
 
         application = create(

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -313,7 +313,7 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ::ActionController::TestC
   end
 
   test 'admin can update scholarship info' do
-    workshop = create :workshop, :local_summer_workshop_upcoming, organizer: @program_manager, facilitators: [@facilitator]
+    workshop = create :summer_workshop
     enrollment = create :pd_enrollment, :from_user, workshop: workshop
     sign_in create(:admin)
 
@@ -325,7 +325,7 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ::ActionController::TestC
   end
 
   test 'program managers can update scholarship info' do
-    workshop = create :workshop, :local_summer_workshop_upcoming, organizer: @program_manager, facilitators: [@facilitator]
+    workshop = create :summer_workshop, organizer: @program_manager
     enrollment = create :pd_enrollment, :from_user, workshop: workshop
     sign_in @program_manager
 
@@ -337,9 +337,9 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ::ActionController::TestC
   end
 
   test 'facilitators cannot update scholarship info' do
-    workshop = create :workshop, :local_summer_workshop_upcoming, facilitators: [@facilitator]
+    workshop = create :summer_workshop
     enrollment = create :pd_enrollment, :from_user, workshop: workshop
-    sign_in @facilitator
+    sign_in workshop.facilitators.first
 
     assert_nil enrollment.scholarship_status
     post :update_scholarship_info, params: {enrollment_id: enrollment.id, scholarship_status: Pd::ScholarshipInfoConstants::YES_OTHER}

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -190,8 +190,8 @@ module Api::V1::Pd
     )
 
     test 'facilitators can see results for local summer workshops' do
-      workshop = create :workshop, :local_summer_workshop, facilitators: [@facilitator]
-      sign_in @facilitator
+      workshop = create :summer_workshop
+      sign_in workshop.facilitators.first
 
       @controller.expects(:generate_workshop_daily_session_summary)
       get :generic_survey_report, params: {workshop_id: workshop.id}
@@ -353,7 +353,7 @@ module Api::V1::Pd
     end
 
     test 'generic_survey_report: summer workshop uses old pipeline' do
-      local_summer_ws = create :workshop, course: COURSE_CSD, subject: SUBJECT_SUMMER_WORKSHOP
+      local_summer_ws = create :summer_workshop
 
       WorkshopSurveyReportController.any_instance.expects(:create_csf_survey_report).never
       WorkshopSurveyReportController.any_instance.expects(:local_workshop_daily_survey_report)
@@ -365,8 +365,7 @@ module Api::V1::Pd
     end
 
     test 'generic_survey_report: academic-year workshop uses old pipeline' do
-      new_academic_ws = create :workshop, course: COURSE_CSP, num_sessions: 1,
-        started_at: Date.new(2019, 8, 1)
+      new_academic_ws = create :academic_year_workshop, started_at: Date.new(2019, 8, 1)
 
       WorkshopSurveyReportController.any_instance.expects(:create_csf_survey_report).never
       WorkshopSurveyReportController.any_instance.expects(:local_workshop_daily_survey_report)
@@ -395,9 +394,9 @@ module Api::V1::Pd
       facilitators = [facilitator_1, facilitator_2]
       organizer = create :program_manager
       create :workshop_admin
-      workshop_1 = create(:workshop, :local_summer_workshop, num_sessions: 5, num_enrollments: 3, organizer: organizer, facilitators: facilitators)
-      workshop_2 = create(:workshop, :local_summer_workshop, num_sessions: 5, num_enrollments: 3, organizer: organizer, facilitators: facilitators)
-      create(:workshop, :local_summer_workshop, num_sessions: 5, num_enrollments: 3, organizer: organizer, facilitators: facilitators)
+      workshop_1 = create :summer_workshop, num_enrollments: 3, organizer: organizer, facilitators: facilitators
+      workshop_2 = create :summer_workshop, num_enrollments: 3, organizer: organizer, facilitators: facilitators
+      create :summer_workshop, num_enrollments: 3, organizer: organizer, facilitators: facilitators
 
       workshop_1.enrollments.each do |enrollment|
         hash = build :pd_local_summer_workshop_survey_hash

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -103,7 +103,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   test 'exclude local summer workshops if exclude_summer present' do
     sign_in @organizer
 
-    create :workshop, :local_summer_workshop, organizer: @organizer
+    create :summer_workshop, organizer: @organizer
 
     get :index, params: {exclude_summer: 1}
     assert_response :success
@@ -115,7 +115,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   test 'includes local summer workshop if exclude_summer not present' do
     sign_in @organizer
 
-    summer_workshop = create :workshop, :local_summer_workshop, organizer: @organizer
+    summer_workshop = create :summer_workshop, organizer: @organizer
 
     get :index, params: {}
     response = JSON.parse(@response.body)

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -96,8 +96,8 @@ module Pd
           sessionId: nil,
           userName: @enrolled_summer_teacher.name,
           userEmail: @enrolled_summer_teacher.email,
-          workshopCourse: COURSE_CSP,
-          workshopSubject: SUBJECT_TEACHER_CON,
+          workshopCourse: @summer_workshop.course,
+          workshopSubject: @summer_workshop.subject,
           regionalPartnerName: @regional_partner.name,
           submitRedirect: submit_redirect
         }
@@ -115,8 +115,8 @@ module Pd
         {
           route: 'GET /pd/workshop_survey/day/0',
           form_id: FAKE_DAILY_FORM_IDS[0],
-          workshop_course: COURSE_CSP,
-          workshop_subject: SUBJECT_TEACHER_CON,
+          workshop_course: @summer_workshop.course,
+          workshop_subject: @summer_workshop.subject,
           regional_partner_name: @regional_partner.name
         }
       )
@@ -204,8 +204,8 @@ module Pd
           sessionId: @summer_workshop.sessions[0].id,
           userName: @enrolled_summer_teacher.name,
           userEmail: @enrolled_summer_teacher.email,
-          workshopCourse: COURSE_CSP,
-          workshopSubject: SUBJECT_TEACHER_CON,
+          workshopCourse: @summer_workshop.course,
+          workshopSubject: @summer_workshop.subject,
           regionalPartnerName: @regional_partner.name,
           submitRedirect: submit_redirect
         }
@@ -385,8 +385,8 @@ module Pd
           workshopId: @summer_workshop.id,
           userName: @enrolled_summer_teacher.name,
           userEmail: @enrolled_summer_teacher.email,
-          workshopCourse: COURSE_CSP,
-          workshopSubject: SUBJECT_TEACHER_CON,
+          workshopCourse: @summer_workshop.course,
+          workshopSubject: @summer_workshop.subject,
           regionalPartnerName: @regional_partner.name,
           day: 1,
           facilitatorPosition: 1,
@@ -408,8 +408,8 @@ module Pd
         {
           route: "GET /pd/workshop_survey/facilitators/#{@summer_workshop.sessions[0].id}/0",
           form_id: FAKE_FACILITATOR_FORM_ID,
-          workshop_course: COURSE_CSP,
-          workshop_subject: SUBJECT_TEACHER_CON,
+          workshop_course: @summer_workshop.course,
+          workshop_subject: @summer_workshop.subject,
           regional_partner_name: @regional_partner.name
         }
       )
@@ -575,8 +575,8 @@ module Pd
           sessionId: @summer_workshop.sessions[4].id,
           userName: @enrolled_summer_teacher.name,
           userEmail: @enrolled_summer_teacher.email,
-          workshopCourse: COURSE_CSP,
-          workshopSubject: SUBJECT_TEACHER_CON,
+          workshopCourse: @summer_workshop.course,
+          workshopSubject: @summer_workshop.subject,
           regionalPartnerName: @regional_partner.name,
           submitRedirect: submit_redirect,
           enrollmentCode: @summer_enrollment.code
@@ -1056,8 +1056,7 @@ module Pd
 
     def setup_summer_workshop
       @regional_partner = create :regional_partner
-      @summer_workshop = create :workshop, course: COURSE_CSP, subject: SUBJECT_TEACHER_CON,
-        num_sessions: 5, num_facilitators: 2, regional_partner: @regional_partner
+      @summer_workshop = create :summer_workshop, regional_partner: @regional_partner
       @summer_enrollment = create :pd_enrollment, :from_user, workshop: @summer_workshop
       @enrolled_summer_teacher = @summer_enrollment.user
       @facilitators = @summer_workshop.facilitators.order(:name, :id)

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -252,7 +252,7 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
 
   test 'demographic questions added (for teachers, without application, for local summer workshop)' do
     sign_in @teacher
-    workshop = create :workshop, :local_summer_workshop
+    workshop = create :summer_workshop
 
     get :new, params: {workshop_id: workshop.id}
     assert_template :new

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1119,7 +1119,16 @@ FactoryGirl.define do
     csp_cost 12
     cost_scholarship_information "Additional scholarship information will be here."
     additional_program_information "Additional program information will be here."
-    pd_workshops {[create(:workshop, :local_summer_workshop_upcoming, location_name: "Training building", location_address: "3 Smith Street")]}
+    pd_workshops do
+      [
+        create(
+          :summer_workshop,
+          location_name: "Training building",
+          location_address: "3 Smith Street",
+          sessions_from: (Date.current + 3.months)
+        )
+      ]
+    end
 
     trait :with_apps_priority_deadline_date do
       apps_priority_deadline_date {(Date.current + 5.days).strftime("%Y-%m-%d")}

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -229,9 +229,34 @@ FactoryGirl.define do
       factory(:csd_academic_year_workshop) {csd}
     end
 
+    # 5-day local summer workshops
+    factory :summer_workshop do
+      # CSP local summer workshop by default
+      csp
+
+      location_name 'Greedale Community College'
+      on_map false         # Never on the map
+      funded false         # Less than half are funded
+      num_facilitators 2   # Most have 2 facilitators
+      num_sessions 5       # Most have 5 sessions
+      each_session_hours 8 # The most common session length
+
+      trait :csp do
+        course Pd::Workshop::COURSE_CSP
+        subject Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP
+        capacity 40          # Average capacity
+      end
+      factory(:csp_summer_workshop) {csp}
+
+      trait :csd do
+        course Pd::Workshop::COURSE_CSD
+        subject Pd::Workshop::SUBJECT_CSD_SUMMER_WORKSHOP
+        capacity 35          # Average capacity
+      end
+      factory(:csd_summer_workshop) {csd}
+    end
+
     # TODO
-    # - CSD 5-day Summer
-    # - CSP 5-day Summer
     # - Admin workshop
     # - Facilitator workshop
     # - Counselor workshop

--- a/dashboard/test/factories/workshops.rb
+++ b/dashboard/test/factories/workshops.rb
@@ -44,19 +44,6 @@ FactoryGirl.define do
     end
 
     # TODO: Change into a sub-factory
-    trait :local_summer_workshop do
-      course Pd::Workshop::COURSE_CSP
-      subject Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP
-    end
-
-    # TODO: Change into a sub-factory + trait
-    trait :local_summer_workshop_upcoming do
-      local_summer_workshop
-      num_sessions 5
-      sessions_from {Date.current + 3.months}
-    end
-
-    # TODO: Change into a sub-factory
     trait :fit do
       course Pd::Workshop::COURSE_CSP
       subject Pd::Workshop::SUBJECT_CSP_FIT

--- a/dashboard/test/helpers/pd/workshop_survey_results_helper_test.rb
+++ b/dashboard/test/helpers/pd/workshop_survey_results_helper_test.rb
@@ -25,9 +25,8 @@ class Pd::WorkshopSurveyResultsHelperTest < ActionView::TestCase
 
   self.use_transactional_test_case = true
   setup_all do
-    facilitator_1 = create :facilitator, name: 'Facilitator Person 1'
-    facilitator_2 = create :facilitator, name: 'Facilitator Person 2'
-    @workshop = create :workshop, :local_summer_workshop, course: COURSE_CSP, facilitators: [facilitator_1, facilitator_2], num_sessions: 5
+    @workshop = create :csp_summer_workshop
+    @workshop.facilitators.each_with_index {|f, i| f.update(name: "Facilitator Person #{i + 1}")}
     @academic_year_workshop = create :csp_academic_year_workshop, :two_day
 
     @pre_workshop_questions = [
@@ -352,8 +351,8 @@ class Pd::WorkshopSurveyResultsHelperTest < ActionView::TestCase
   end
 
   test 'averaging across multiple surveys' do
-    workshop_1 = create(:workshop, :local_summer_workshop, num_sessions: 1, num_facilitators: 2, num_completed_surveys: 5)
-    workshop_2 = create(:workshop, :local_summer_workshop, num_sessions: 1, num_facilitators: 3, num_completed_surveys: 10)
+    workshop_1 = create :summer_workshop, num_sessions: 1, num_facilitators: 2, num_completed_surveys: 5
+    workshop_2 = create :summer_workshop, num_sessions: 1, num_facilitators: 3, num_completed_surveys: 10
 
     workshop_2.survey_responses.each do |response|
       response.update_form_data_hash(

--- a/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
+++ b/dashboard/test/lib/pd/payment/payment_calculator_base_test.rb
@@ -144,7 +144,7 @@ module Pd::Payment
     end
 
     test 'teacher summaries' do
-      workshop = create :workshop, :ended, :local_summer_workshop, num_sessions: 2
+      workshop = create :summer_workshop, :ended, num_sessions: 2, each_session_hours: 6
 
       teacher_unqualified = create :pd_workshop_participant,
         workshop: workshop, enrolled: true, attended: true

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -242,9 +242,8 @@ module Pd::SurveyPipeline
     end
 
     test 'get context of summer workshop survey submissions' do
-      facilitator = create :facilitator
-      workshop = create :workshop, course: COURSE_CSD, subject: SUBJECT_SUMMER_WORKSHOP,
-        num_sessions: 1, facilitators: [facilitator]
+      workshop = create :csd_summer_workshop, num_sessions: 1
+      facilitator = workshop.facilitators.first
       form_id = '1122334455'.to_i
 
       survey_metadata_to_context = {

--- a/dashboard/test/models/circuit_playground_discount_application_test.rb
+++ b/dashboard/test/models/circuit_playground_discount_application_test.rb
@@ -59,11 +59,7 @@ class CircuitPlaygroundDiscountApplicationTest < ActiveSupport::TestCase
     teacher = create :teacher
     create :pd_attendance,
       teacher: teacher,
-      workshop: create(:workshop,
-        course: Pd::Workshop::COURSE_CSD,
-        subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP,
-        started_at: DateTime.parse('2018-05-02')
-      )
+      workshop: create(:csd_summer_workshop, started_at: DateTime.parse('2018-05-02'))
 
     assert CircuitPlaygroundDiscountApplication.studio_person_pd_eligible? teacher
   end

--- a/dashboard/test/models/pd/application/teacher1920_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher1920_application_test.rb
@@ -231,7 +231,7 @@ module Pd::Application
     test 'get_first_selected_workshop ignores single deleted workshops' do
       Pd::Workshop.any_instance.stubs(:process_location)
 
-      workshop = create :workshop, :local_summer_workshop, num_sessions: 5, location_address: 'Buffalo, NY', sessions_from: Date.new(2019, 1, 1)
+      workshop = create :summer_workshop, location_address: 'Buffalo, NY', sessions_from: Date.new(2019, 1, 1)
       application = create :pd_teacher1920_application, form_data_hash: (
         build(:pd_teacher1920_application_hash,
           regional_partner_workshop_ids: [workshop.id],

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -90,7 +90,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'exit_survey_url' do
-    csf_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSF
+    csf_workshop = create :csf_workshop, :ended
     csf_enrollment = create :pd_enrollment, workshop: csf_workshop
 
     csp_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSP
@@ -102,7 +102,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     admin_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_ADMIN
     admin_enrollment = create :pd_enrollment, workshop: admin_workshop
 
-    local_summer_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
+    local_summer_workshop = create :csp_summer_workshop, :ended
     local_summer_enrollment = create :pd_enrollment, workshop: local_summer_workshop
 
     teachercon_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_TEACHER_CON
@@ -288,7 +288,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'local summer survey filter' do
-    workshop = create :workshop, :local_summer_workshop, num_sessions: 5
+    workshop = create :summer_workshop
     teacher = create :teacher
     enrollment = create :pd_enrollment, :from_user, user: teacher, workshop: workshop
 
@@ -572,7 +572,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'update scholarship status for local summer workshop' do
-    workshop = create :workshop, :local_summer_workshop_upcoming
+    workshop = create :summer_workshop
     enrollment = create :pd_enrollment, :from_user, workshop: workshop
     # no scholarship info initially
     assert_nil enrollment.scholarship_status

--- a/dashboard/test/models/pd/workshop_daily_survey_test.rb
+++ b/dashboard/test/models/pd/workshop_daily_survey_test.rb
@@ -10,7 +10,7 @@ module Pd
     self.use_transactional_test_case = true
     setup_all do
       @user = create :user
-      @pd_summer_workshop = create :workshop, num_sessions: 5, course: COURSE_CSP, subject: SUBJECT_CSP_TEACHER_CON
+      @pd_summer_workshop = create :csp_summer_workshop
       @pd_academic_year_workshop = create :csp_academic_year_workshop
     end
 

--- a/dashboard/test/models/pd/workshop_facilitator_daily_survey_test.rb
+++ b/dashboard/test/models/pd/workshop_facilitator_daily_survey_test.rb
@@ -10,12 +10,9 @@ module Pd
     self.use_transactional_test_case = true
     setup_all do
       @user = create :user
-      @pd_workshop = create :workshop, num_sessions: 5
       @facilitator = create :facilitator
-      @pd_summer_workshop = create :workshop, num_sessions: 5, course: COURSE_CSP, subject: SUBJECT_CSP_TEACHER_CON
-      @pd_academic_year_workshop = create :csp_academic_year_workshop
-      @pd_summer_workshop.facilitators << @facilitator
-      @pd_academic_year_workshop.facilitators << @facilitator
+      @pd_summer_workshop = create :csp_summer_workshop, facilitators: [@facilitator]
+      @pd_academic_year_workshop = create :csp_academic_year_workshop, facilitators: [@facilitator]
     end
 
     test 'response_exists? and create_placeholder!' do

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -85,7 +85,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'exclude_summer scope' do
-    summer_workshop = create :workshop, :local_summer_workshop
+    summer_workshop = create :summer_workshop
     teachercon = create :workshop, :teachercon
 
     assert Pd::Workshop.exclude_summer.exclude? summer_workshop
@@ -709,13 +709,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'csp summer workshops are capped at 33.5 hours' do
-    workshop_csp_summer = create :workshop,
-      course: Pd::Workshop::COURSE_CSP,
-      subject: Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP,
-      num_sessions: 5,
-      each_session_hours: 8
-
-    assert_equal 33.5, workshop_csp_summer.effective_num_hours
+    workshop = create :csp_summer_workshop, num_sessions: 5, each_session_hours: 8
+    assert_equal 33.5, workshop.effective_num_hours
   end
 
   test 'CSF 101 workshops are capped at 7 hours' do
@@ -1195,13 +1190,10 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'nearest combined with subject and enrollment' do
     user = create :teacher
-    target = create :workshop, sessions_from: Date.today + 1.day,
-      course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
-
+    target = create :csp_summer_workshop, sessions_from: Date.today + 1.day
     create :pd_enrollment, :from_user, user: user, workshop: target
 
-    same_subject_farther = create :workshop, sessions_from: Date.today + 1.week,
-      course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
+    same_subject_farther = create :csp_summer_workshop, sessions_from: Date.today + 1.week
     create :pd_enrollment, :from_user, user: user, workshop: same_subject_farther
 
     different_subject_closer = create :workshop, sessions_from: Date.today,
@@ -1209,8 +1201,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     create :pd_enrollment, :from_user, user: user, workshop: different_subject_closer
 
     # closer, not enrolled
-    create :workshop, sessions_from: Date.today,
-      course: Pd::Workshop::COURSE_CSP, subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
+    create :csp_summer_workshop, sessions_from: Date.today
 
     found = Pd::Workshop.where(subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP).enrolled_in_by(user).nearest
     assert_equal target, found

--- a/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
@@ -28,16 +28,15 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCa
   end
 
   test 'scholarship_ineligible_reason' do
-    summer_workshop = create :workshop, :local_summer_workshop_upcoming
-    enrollment = create :pd_enrollment, :from_user, workshop: summer_workshop
+    enrollment = create :pd_enrollment, :from_user, workshop: create(:summer_workshop)
 
-    serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(summer_workshop.enrollments.first).attributes
+    serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(enrollment).attributes
     assert_nil serialized[:scholarship_ineligible_reason]
 
     fac_app = create FACILITATOR_APPLICATION_FACTORY, user: enrollment.user
     fac_app.update(status: 'accepted')
 
-    serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(summer_workshop.enrollments.first).attributes
+    serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(enrollment).attributes
     assert_equal SCHOLARSHIP_INELIGIBLE_NEW_FACILITATOR, serialized[:scholarship_ineligible_reason]
   end
 end

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -196,7 +196,7 @@ end
 And(/^I am viewing a workshop with fake survey results$/) do
   require_rails_env
 
-  workshop = FactoryGirl.create :workshop, :local_summer_workshop, :ended,
+  workshop = FactoryGirl.create :summer_workshop, :ended,
     organizer: FactoryGirl.create(:workshop_organizer, email: "test_organizer#{SecureRandom.hex}@code.org"),
     num_sessions: 5, enrolled_and_attending_users: 10,
     facilitators: [


### PR DESCRIPTION
Continuing work started in https://github.com/code-dot-org/code-dot-org/pull/30281 to clean up our workshop factories and make them more realistic - specifically reflecting the workshop types that we're actively supporting.

This particular change adds support for CSD and CSP summer workshops, and removes the old summer workshop traits.