### PR TITLE
Remove unused top level dependencies

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -182,7 +182,6 @@
     "react-virtualized-select": "^3.0.1",
     "react-with-context": "^2.0.0",
     "reactabular": "^2.0.5",
-    "reactabular-table": "^8.14",
     "redux": "^3.3.1",
     "redux-logger": "^2.6.1",
     "redux-mock-store": "^1.2.3",

--- a/apps/package.json
+++ b/apps/package.json
@@ -91,7 +91,6 @@
     "ejs-webpack-loader": "^2.2.2",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-15.4": "^1.3.1",
-    "es6-promise": "3.0.2",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^3.6.0",
     "eslint-plugin-babel": "^4.1.2",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -13050,13 +13050,6 @@ reactabular-table@^2.0.5:
   dependencies:
     reactabular-utils "^2.0.1"
 
-reactabular-table@^8.14:
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/reactabular-table/-/reactabular-table-8.14.0.tgz#2ce05de47d499db91678fa9518505ea509bf3d7f"
-  integrity sha512-F3qOa7yJCi1hnxsESmo2QBWVl1RQfUfZhMhpG81zOxDQKsk/nsXlq/5aBtQ17NadYI6PDdMNourNs+255GpmFQ==
-  dependencies:
-    classnames "^2.2.5"
-
 reactabular-utils@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/reactabular-utils/-/reactabular-utils-2.0.1.tgz#677586a410c5151058dec94f33053b02a657d110"

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -5952,10 +5952,6 @@ es6-iterator@^2.0.3, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-promise@3.0.2, es6-promise@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.0.2.tgz#010d5858423a5f118979665f46486a95c6ee2bb6"
-
 es6-promise@^3.2.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
@@ -5963,6 +5959,10 @@ es6-promise@^3.2.1:
 es6-promise@^4.0.3, es6-promise@~4.0.3:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.0.5.tgz#7882f30adde5b240ccfa7f7d78c548330951ae42"
+
+es6-promise@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.0.2.tgz#010d5858423a5f118979665f46486a95c6ee2bb6"
 
 es6-promisify@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
`es6-promise` was originally added [here](https://github.com/code-dot-org/code-dot-org/commit/d945dd02430bb817d64c77fb11742cd60e4e7699#diff-c76cbfffc4b66f004e8e73017ca2cadaR39), verified it's no longer used. Not sure why the `reactabular-table` dependency was originally added.

Removing these won't affect bundle size (since both are indirect dependencies of other modules we use) but should make our lives easier when trying to update versions.