### PR TITLE
Regional partner table and details pages show correct contact info

### DIFF
--- a/dashboard/app/views/regional_partners/index.html.haml
+++ b/dashboard/app/views/regional_partners/index.html.haml
@@ -31,6 +31,6 @@
           %td= regional_partner.name
           %td= regional_partner.group
           %td= regional_partner.urban ? 'Yes' : 'No'
-          %td= regional_partner.contact.try(:email)
+          %td= regional_partner.contact_email_with_backup
           - if can? :update, regional_partner
             %td= link_to t('crud.edit'), edit_regional_partner_path(regional_partner)

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -50,10 +50,10 @@
   = @regional_partner.link_to_partner_application
 %p
   %strong Contact Email:
-  = @regional_partner.contact.try(:email)
+  = @regional_partner.contact_email
 %p
   %strong Contact Name:
-  = @regional_partner.contact.try(:name)
+  = @regional_partner.contact_name
 %p
   %strong Ship Attention:
   = @regional_partner.attention


### PR DESCRIPTION
[PLC-363](https://codedotorg.atlassian.net/browse/PLC-363?atlOrigin=eyJpIjoiNzMzZTc5OWVkOThhNDc1NGJkZGE4MmM1MzE0MDY4YTkiLCJwIjoiaiJ9)

The regional partner editing UI lets you edit the `contact_name` and `contact_email` fields, but we weren't showing these in the table view or the detail view. Now these pages all display the correct contact fields.

I'll do a followup PR to remove the `contact_id` field that we aren't using anymore.