### PR TITLE
Increase parallelism for drone apps tests [test apps][skip ui]

### DIFF
--- a/apps/test-low-memory.sh
+++ b/apps/test-low-memory.sh
@@ -10,6 +10,9 @@ if [ -n "$DRONE" ]; then
   curl -s https://codecov.io/bash > ${CODECOV}
   chmod +x ${CODECOV}
   CODECOV="$CODECOV -C $DRONE_COMMIT_SHA"
+
+  # Limit parallelism on Drone to reduce chances of PhantomJS crashes.
+  NPROC=2
 else
   # For non-Drone runs, stub-out codecov.
   CODECOV=: # stub

--- a/apps/test-low-memory.sh
+++ b/apps/test-low-memory.sh
@@ -10,9 +10,6 @@ if [ -n "$DRONE" ]; then
   curl -s https://codecov.io/bash > ${CODECOV}
   chmod +x ${CODECOV}
   CODECOV="$CODECOV -C $DRONE_COMMIT_SHA"
-
-  # As of 8/2/2019, PhantomJS seems to frequently crash on drone instances when using > 1 processes.
-  NPROC=1
 else
   # For non-Drone runs, stub-out codecov.
   CODECOV=: # stub


### PR DESCRIPTION
Re-ran this a few times to see if it greatly increased flakiness - at parallelism=2 it succeeded all 5 times.

We can go back down to 1 if we observe issues.