### PR TITLE
use fullWidth for small screens

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1156,7 +1156,7 @@
   "recordedSoundsBrowserWarning": "Warning: Recorded sounds may not play correctly on mobile phones or other browsers. If you want to use your app on your phone, try uploading a sound from your computer instead.",
   "recording": "Recording",
   "recordAudio": "Record Audio",
-  "redirectConfirm": "Do you want to open this website? {url}",
+  "redirectConfirm": "Do you want to open this website?",
   "redirectCourseVersionWarningDetails": "It looks like you accidentally went to a different version of the course. You've been redirected to the recommended version or the version assigned by your teacher.",
   "redirectExplanation": "This is a link to an external website not operated or reviewed by Code.org and it does not follow the Code.org privacy policy. Please report this app if it is linking to content that is inappropriate or unsafe: ",
   "redirectRejectExplanation": "This app is trying to open a website that appears to be unsafe.",

--- a/apps/src/applab/ExternalRedirectDialog.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.jsx
@@ -36,11 +36,14 @@ class ExternalRedirectDialog extends React.Component {
 
     let response = this.props.redirects[0].response;
     let url = this.props.redirects[0].url;
+    let trimmedUrl = url.length > 100 ? url.substring(0, 100) + '...' : url;
     if (response === REDIRECT_RESPONSE.APPROVED) {
       title = i18n.redirectTitle();
       body = (
         <div>
-          <h2 style={styles.title}>{i18n.redirectConfirm({url: url})}</h2>
+          <h2 style={styles.title}>
+            {i18n.redirectConfirm({url: trimmedUrl})}
+          </h2>
           <p>
             {i18n.redirectExplanation()}
             <span>

--- a/apps/src/applab/ExternalRedirectDialog.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.jsx
@@ -20,7 +20,8 @@ const styles = {
     WebkitBoxOrient: 'vertical',
     overflow: 'hidden',
     maxWidth: '100%',
-    wordWrap: 'break-word'
+    wordWrap: 'break-word',
+    maxHeight: '140px'
   }
 };
 

--- a/apps/src/applab/ExternalRedirectDialog.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.jsx
@@ -15,6 +15,8 @@ const styles = {
   }
 };
 
+const DIALOG_WIDTH = 700;
+
 class ExternalRedirectDialog extends React.Component {
   static propTypes = {
     handleClose: PropTypes.func,
@@ -83,7 +85,12 @@ class ExternalRedirectDialog extends React.Component {
     }
 
     return (
-      <Dialog title={title} isOpen handleClose={this.props.handleClose}>
+      <Dialog
+        title={title}
+        fullWidth={window.innerWidth < DIALOG_WIDTH}
+        isOpen
+        handleClose={this.props.handleClose}
+      >
         <Body>
           {body}
           {footer}

--- a/apps/src/applab/ExternalRedirectDialog.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.jsx
@@ -7,6 +7,7 @@ import i18n from '@cdo/locale';
 import {connect} from 'react-redux';
 import {actions, REDIRECT_RESPONSE} from './redux/applab';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
+import {BASE_DIALOG_WIDTH} from '@cdo/apps/constants';
 
 const styles = {
   title: {
@@ -14,8 +15,6 @@ const styles = {
     wordWrap: 'break-word'
   }
 };
-
-const DIALOG_WIDTH = 700;
 
 class ExternalRedirectDialog extends React.Component {
   static propTypes = {
@@ -90,7 +89,7 @@ class ExternalRedirectDialog extends React.Component {
     return (
       <Dialog
         title={title}
-        fullWidth={window.innerWidth < DIALOG_WIDTH}
+        fullWidth={window.innerWidth < BASE_DIALOG_WIDTH}
         isOpen
         handleClose={this.props.handleClose}
       >

--- a/apps/src/applab/ExternalRedirectDialog.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.jsx
@@ -13,6 +13,14 @@ const styles = {
   title: {
     display: 'inline',
     wordWrap: 'break-word'
+  },
+  url: {
+    display: '-webkit-box',
+    WebkitLineClamp: 3,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+    maxWidth: '100%',
+    wordWrap: 'break-word'
   }
 };
 
@@ -35,14 +43,12 @@ class ExternalRedirectDialog extends React.Component {
 
     let response = this.props.redirects[0].response;
     let url = this.props.redirects[0].url;
-    let trimmedUrl = url.length > 100 ? url.substring(0, 100) + '...' : url;
     if (response === REDIRECT_RESPONSE.APPROVED) {
       title = i18n.redirectTitle();
       body = (
         <div>
-          <h2 style={styles.title}>
-            {i18n.redirectConfirm({url: trimmedUrl})}
-          </h2>
+          <h2 style={styles.title}>{i18n.redirectConfirm()}</h2>
+          <p style={styles.url}>{url}</p>
           <p>
             {i18n.redirectExplanation()}
             <span>

--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -179,3 +179,5 @@ export const CIPHER =
 
 export const EXPO_SESSION_SECRET =
   '{"id":"fakefake-67ec-4314-a438-60589b9c0fa2","version":1,"expires_at":2000000000000}';
+
+export const BASE_DIALOG_WIDTH = 700;

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {BASE_DIALOG_WIDTH} from '../constants';
 
 /**
  * BaseDialog
@@ -106,7 +107,7 @@ export default class BaseDialog extends React.Component {
       };
       bodyStyle = {
         ...bodyStyle,
-        width: this.props.fixedWidth || 700,
+        width: this.props.fixedWidth || BASE_DIALOG_WIDTH,
         marginLeft: -this.props.fixedWidth / 2 || -350
       };
       xCloseStyle = {


### PR DESCRIPTION
If window is smaller than the modal dialog, use `fullWidth = true` to fit the modal to the screen size.
Note that this goes by the window size at the time the dialog opens, so if you make the window smaller while the dialog is open, it won't resize.

Before:
![image](https://user-images.githubusercontent.com/8787187/63294033-34dbd200-c27e-11e9-97f6-15b8453c6d7b.png)
After:
![image](https://user-images.githubusercontent.com/8787187/63554569-c3f12000-c4f2-11e9-84f6-f75f0460ac89.png)
