### PR TITLE
add default db_writer for adhoc environment

### DIFF
--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -2,3 +2,4 @@
 
 chef_local_mode: true
 stub_school_data: true
+db_writer: 'mysql://root@localhost/'


### PR DESCRIPTION
Adds a default `db_writer` value for adhoc environment, fixing a bug where `rake adhoc:` commands fail on startup.