### PR TITLE
Zendesk 246444: Added developers.zomato.com to allowlist

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -53,6 +53,7 @@ class XhrProxyController < ApplicationController
     data.cityofchicago.org
     data.gv.at
     data.nasa.gov
+    developers.zomato.com
     donordrive.com
     dweet.io
     enclout.com


### PR DESCRIPTION
https://codeorg.zendesk.com/agent/tickets/246444

Defaults to json responses, but can respond with xml (this is ok. Attempts to use xml responses not work). Got offline approval from Ryan (PM). https://codedotorg.slack.com/archives/C0T0UQPLZ/p1566323915078800