### PR TITLE
Update location before selecting on mobile devices in SpriteLab

### DIFF
--- a/apps/src/p5lab/GameLabVisualizationColumn.jsx
+++ b/apps/src/p5lab/GameLabVisualizationColumn.jsx
@@ -27,6 +27,7 @@ import {
   isPickingLocation
 } from './spritelab/locationPickerModule';
 import {calculateOffsetCoordinates} from '@cdo/apps/utils';
+import {isMobileDevice} from '@cdo/apps/util/browser-detector';
 
 const MODAL_Z_INDEX = 1050;
 
@@ -73,6 +74,11 @@ class GameLabVisualizationColumn extends React.Component {
 
   pickerPointerUp = e => {
     if (this.props.pickingLocation) {
+      if (isMobileDevice()) {
+        this.props.updatePicker(
+          calculateOffsetCoordinates(this.divGameLab, e.clientX, e.clientY)
+        );
+      }
       this.props.selectPicker(
         calculateOffsetCoordinates(this.divGameLab, e.clientX, e.clientY)
       );

--- a/apps/src/p5lab/GameLabVisualizationColumn.jsx
+++ b/apps/src/p5lab/GameLabVisualizationColumn.jsx
@@ -74,6 +74,8 @@ class GameLabVisualizationColumn extends React.Component {
 
   pickerPointerUp = e => {
     if (this.props.pickingLocation) {
+      // Workaround to make sure location picker works for iOS tablets. These devices are not triggering onPointerMove
+      // events, so the location was never getting updated.
       if (isMobileDevice()) {
         this.props.updatePicker(
           calculateOffsetCoordinates(this.divGameLab, e.clientX, e.clientY)


### PR DESCRIPTION
Fixes the live issue with the locationPicker not working on iPads
iPads are only sending `onPointerUp` events, not `onPointerMove` events. So we were never hitting the locationPickerModule `updateLocation` event, only the `selectLocation` event. 

This fix uses `isMobileDevice` as a proxy for checking whether it's a touch device, so it wouldn't fix this issue for touch-enabled laptops. However, from testing with a Microsoft Surface, it appears that at least for that device, it is sending the `onPointerMove` events, so this was never an issue.

If this becomes a problem for other non-mobile touch-enabled devices, we should investigate how to detect touch-capability and check for that instead.