### PR TITLE
add missing "beta" translation

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
         error:
           future: can't be in the future
 
+  beta: "beta"
   hello: "Hello world"
   welcome_back: "Welcome back, %{name}"
   your_professional_learning_plan: "Your Professional Learning Plan"


### PR DESCRIPTION
today, certain script overview pages look like this:
![Screen Shot 2019-08-20 at 1 44 13 PM](https://user-images.githubusercontent.com/8001765/63383152-27434c80-c351-11e9-95cd-eb536f634107.png)

because this translation is missing: https://github.com/code-dot-org/code-dot-org/blob/e4f5f8e3a8b49581960efd12d62cc19a5191e970/dashboard/app/models/script.rb#L1324

This PR corrects the problem:
![Screen Shot 2019-08-20 at 1 44 41 PM](https://user-images.githubusercontent.com/8001765/63383196-34f8d200-c351-11e9-8e61-e95dfb33a5f2.png)

I don't see many top-level translations in the file where I'm adding this, so please correct my placement of this translation if there is a better spot for it.