### PR TITLE
stop providing default value for flex_category on the server

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -668,6 +668,7 @@
   "findLocalClassDescription": "Find a local after-school program, summer camp, or school to learn in person.",
   "findLocalClassButton": "Find a class",
   "finish": "Finish",
+  "flexCategoryContent": "Content",
   "formErrorsBelow": "Please correct the errors below.",
   "formServerError": "Something went wrong on our end; please try again later.",
   "forTeachersOnly": "For Teachers Only",

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -11,6 +11,7 @@ import {ViewType, SET_VIEW_TYPE} from './viewAsRedux';
 import {processedLevel} from '@cdo/apps/templates/progress/progressHelpers';
 import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 import {authorizeLockable} from './stageLockRedux';
+import i18n from '@cdo/locale';
 
 // Action types
 export const INIT_PROGRESS = 'progress/INIT_PROGRESS';
@@ -676,7 +677,7 @@ export const categorizedLessons = (state, includeBonusLevels = false) => {
   const allLevels = levelsByLesson(state);
 
   state.stages.forEach((stage, index) => {
-    const category = stage.flex_category;
+    const category = stage.flex_category || i18n.flexCategoryContent();
     const lesson = lessonFromStageAtIndex(state, index);
     let stageLevels = allLevels[index];
     if (!includeBonusLevels) {

--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -87,11 +87,7 @@ class Stage < ActiveRecord::Base
   end
 
   def localized_category
-    if flex_category
-      I18n.t "flex_category.#{flex_category}"
-    else
-      I18n.t "flex_category.content"
-    end
+    flex_category && I18n.t("flex_category.#{flex_category}")
   end
 
   def localized_lesson_plan


### PR DESCRIPTION
fixes https://codedotorg.atlassian.net/browse/LP-603

### Background

Today, we supply a default value of "Content" for `flex_category` in the script summary which looks like this in the UI:
![Screen Shot 2019-08-20 at 2 15 33 PM](https://user-images.githubusercontent.com/8001765/63385078-18f72f80-c355-11e9-82f2-00a3d7f72c7e.png)

However, this breaks the gui script editor, because it receives a summary from the server with `flex_category: "Content"`, causing it to add a flex category to stages which did not previously have one.

### Description

The solution proposed here is to stop specifying a default value for `flex_category` on the server, and start specifying it on the client instead. The script editor GUI code already correctly handles the case where this field is blank: https://github.com/code-dot-org/code-dot-org/blob/09bdfb4c74fa057a8f6c2759e01407402c68adac/apps/src/lib/script-editor/FlexGroup.jsx#L79-L80

### Testing

Manually verified that /s/express-2017 still looks the same.

### Deployment plan

Because users do not immediately reload their web pages when we deploy, we should expect there to be some users not to pick up the javascript part of this fix immediately after we deploy, whereas any server requests they make will immediately hit our latest server code. Therefore, to avoid a blank space where we should see "Content", the deployment steps will be:

- [x] merge & ship the client changes in https://github.com/code-dot-org/code-dot-org/pull/30344
- [ ] wait 1-2 deploys
- [ ] merge & ship the server changes in this PR