### PR TITLE
add google_maps_api_key to unit test config

### DIFF
--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -19,6 +19,7 @@ pusher_application_secret: fake_application_secret
 poste_secret: not a real secret
 dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
+google_maps_api_key: boguskey
 db_writer: 'mysql://root@localhost/'
 <% end -%>
 


### PR DESCRIPTION
Workaround for running unit test in non-secret environments.
[ci skip]