### PR TITLE
set blank family name to nil

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1188,7 +1188,7 @@ class Script < ActiveRecord::Base
             hidden: general_params[:hidden].nil? ? true : general_params[:hidden], # default true
             login_required: general_params[:login_required].nil? ? false : general_params[:login_required], # default false
             wrapup_video: general_params[:wrapup_video],
-            family_name: general_params[:family_name],
+            family_name: general_params[:family_name].presence ? general_params[:family_name] : nil, # default nil
             properties: Script.build_property_hash(general_params)
           },
           script_data[:stages],
@@ -1484,7 +1484,6 @@ class Script < ActiveRecord::Base
       has_lesson_plan: !!script_data[:has_lesson_plan],
       curriculum_path: script_data[:curriculum_path],
       script_announcements: script_data[:script_announcements] || false,
-      family_name: script_data[:family_name],
       version_year: script_data[:version_year],
       is_stable: script_data[:is_stable],
       supported_locales: script_data[:supported_locales],

--- a/dashboard/config/scripts/allthethings.script
+++ b/dashboard/config/scripts/allthethings.script
@@ -1,6 +1,5 @@
 hideable_stages true
 stage_extras_available true
-family_name ''
 
 stage 'Jigsaw'
 skin 'jigsaw'

--- a/dashboard/config/scripts/andrea-test.script
+++ b/dashboard/config/scripts/andrea-test.script
@@ -2,7 +2,6 @@ professional_learning_course 'Andrea Test'
 peer_reviews_to_complete 6
 login_required true
 student_detail_progress_view true
-family_name ''
 
 stage 'Deeper Learning Overview', flex_category: 'required'
 level 'andrea_test1', progression: 'What is Deeper Learning', named: true

--- a/dashboard/config/scripts/applab-intro-staging.script
+++ b/dashboard/config/scripts/applab-intro-staging.script
@@ -1,5 +1,4 @@
 student_detail_progress_view true
-family_name ''
 
 stage 'Intro to AppLab - Choose Your Own Adventure'
 level 'AppLab Intro 1 - Welcome', progression: 'Welcome to App Lab!'

--- a/dashboard/config/scripts/csd-bugs.script
+++ b/dashboard/config/scripts/csd-bugs.script
@@ -1,4 +1,3 @@
-family_name ''
 
 stage 'Game Lab Bugs'
 level 'gamelab bug declare sprite in loop'

--- a/dashboard/config/scripts/csd-pilot.script
+++ b/dashboard/config/scripts/csd-pilot.script
@@ -1,4 +1,3 @@
-family_name ''
 
 stage 'Pilot Information 1'
 level 'CSD Pilot Warning Page'

--- a/dashboard/config/scripts/csd1-pilot.script
+++ b/dashboard/config/scripts/csd1-pilot.script
@@ -6,7 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-19/unit1"], 
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-19/unit1/{LESSON}'
-family_name ''
 pilot_experiment 'csd-piloters'
 project_sharing true
 curriculum_umbrella 'CSD'

--- a/dashboard/config/scripts/csd2-pilot.script
+++ b/dashboard/config/scripts/csd2-pilot.script
@@ -6,7 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-19/unit2/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-20/unit2/{LESSON}'
-family_name ''
 pilot_experiment 'csd-piloters'
 project_sharing true
 curriculum_umbrella 'CSD'

--- a/dashboard/config/scripts/csd3-pilot.script
+++ b/dashboard/config/scripts/csd3-pilot.script
@@ -7,7 +7,6 @@ has_verified_resources true
 has_lesson_plan true
 project_widget_visible true
 project_widget_types ["gamelab", "weblab"]
-family_name ''
 pilot_experiment 'csd-piloters'
 project_sharing true
 curriculum_umbrella 'CSD'

--- a/dashboard/config/scripts/csd4-pilot.script
+++ b/dashboard/config/scripts/csd4-pilot.script
@@ -1,4 +1,3 @@
-family_name ''
 pilot_experiment 'csd-piloters'
 
 stage 'What is a Computer?', flex_category: 'csd1_2'

--- a/dashboard/config/scripts/csl-vn.script
+++ b/dashboard/config/scripts/csl-vn.script
@@ -1,5 +1,4 @@
 hidden false
-family_name ''
 
 stage 'Sequencing with Scrat', flex_category: 'csf_sequencing'
 level 'courseAB_video_NewIntro_2019'

--- a/dashboard/config/scripts/csp1-pilot-staging.script
+++ b/dashboard/config/scripts/csp1-pilot-staging.script
@@ -1,4 +1,3 @@
-family_name ''
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp1-pilot.script
+++ b/dashboard/config/scripts/csp1-pilot.script
@@ -3,7 +3,6 @@ hideable_stages true
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/cspilot/unit1/{LESSON}'
-family_name ''
 pilot_experiment 'csp-piloters'
 
 stage 'CS Principles Pre-survey', lockable: true, flex_category: 'cspSurvey'

--- a/dashboard/config/scripts/csp2-pilot.script
+++ b/dashboard/config/scripts/csp2-pilot.script
@@ -3,7 +3,6 @@ hideable_stages true
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/cspilot/unit-2/{LESSON}'
-family_name ''
 pilot_experiment 'csp-piloters'
 
 stage 'Building a Network'

--- a/dashboard/config/scripts/csp3-pilot-staging.script
+++ b/dashboard/config/scripts/csp3-pilot-staging.script
@@ -1,4 +1,3 @@
-family_name ''
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp3-pilot.script
+++ b/dashboard/config/scripts/csp3-pilot.script
@@ -1,7 +1,6 @@
 login_required true
 hideable_stages true
 has_verified_resources true
-family_name ''
 pilot_experiment 'csp-piloters'
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/denny-science.script
+++ b/dashboard/config/scripts/denny-science.script
@@ -1,4 +1,3 @@
-family_name ''
 
 stage 'Earthquake Detector: Designing Screens'
 level 'Design Mode Map'

--- a/dashboard/config/scripts/dlp19-csd-mod-fit.script
+++ b/dashboard/config/scripts/dlp19-csd-mod-fit.script
@@ -3,7 +3,6 @@ peer_reviews_to_complete 2
 login_required true
 exclude_csf_column_in_legend true
 student_detail_progress_view true
-family_name ''
 
 stage 'Deeper Learning Overview', flex_category: 'required'
 level 'dlp19_overview1', progression: 'Background'

--- a/dashboard/config/scripts/dlp19-csd-mod-w1.script
+++ b/dashboard/config/scripts/dlp19-csd-mod-w1.script
@@ -2,7 +2,6 @@ professional_learning_course 'CS Discoveries Deeper Learning 2019 - 2020'
 peer_reviews_to_complete 6
 login_required true
 student_detail_progress_view true
-family_name ''
 
 stage 'Deeper Learning Overview', flex_category: 'required'
 level 'dlp19_overview1', progression: 'Background'

--- a/dashboard/config/scripts/dlp19-csd-mod-w2.script
+++ b/dashboard/config/scripts/dlp19-csd-mod-w2.script
@@ -1,7 +1,6 @@
 professional_learning_course 'CS Discoveries Deeper Learning 2019 - 2020'
 login_required true
 student_detail_progress_view true
-family_name ''
 
 stage 'CS Discoveries Deeper Learning Module 2'
 level 'dlp19-hold-mod1'

--- a/dashboard/config/scripts/dlp19-csd-mod-w3.script
+++ b/dashboard/config/scripts/dlp19-csd-mod-w3.script
@@ -1,7 +1,6 @@
 professional_learning_course 'CS Discoveries Deeper Learning 2019 - 2020'
 login_required true
 student_detail_progress_view true
-family_name ''
 
 stage 'CS Discoveries Deeper Learning Module 3'
 level 'dlp19-hold-mod1'

--- a/dashboard/config/scripts/dlp19-csd-mod-w4.script
+++ b/dashboard/config/scripts/dlp19-csd-mod-w4.script
@@ -1,7 +1,6 @@
 professional_learning_course 'CS Discoveries Deeper Learning 2019 - 2020'
 login_required true
 student_detail_progress_view true
-family_name ''
 
 stage 'CS Discoveries Deeper Learning Module 4'
 level 'dlp19-hold-mod1'

--- a/dashboard/config/scripts/dlp19-csp-mod-fit.script
+++ b/dashboard/config/scripts/dlp19-csp-mod-fit.script
@@ -3,7 +3,6 @@ peer_reviews_to_complete 2
 login_required true
 exclude_csf_column_in_legend true
 student_detail_progress_view true
-family_name ''
 
 stage 'Deeper Learning Overview', flex_category: 'required'
 level 'dlp19_overview1', progression: 'Background'

--- a/dashboard/config/scripts/dlp19-csp-mod-w1.script
+++ b/dashboard/config/scripts/dlp19-csp-mod-w1.script
@@ -2,7 +2,6 @@ professional_learning_course 'CS Principles Deeper Learning 2019 - 2020'
 peer_reviews_to_complete 6
 login_required true
 student_detail_progress_view true
-family_name ''
 
 stage 'Deeper Learning Overview', flex_category: 'required'
 level 'dlp19_overview1', progression: 'Background'

--- a/dashboard/config/scripts/dlp19-csp-mod-w2.script
+++ b/dashboard/config/scripts/dlp19-csp-mod-w2.script
@@ -1,7 +1,6 @@
 professional_learning_course 'CS Principles Deeper Learning 2019 - 2020'
 login_required true
 student_detail_progress_view true
-family_name ''
 
 stage 'CS Principles Deeper Learning Module 2'
 level 'dlp19-hold-mod1'

--- a/dashboard/config/scripts/dlp19-csp-mod-w3.script
+++ b/dashboard/config/scripts/dlp19-csp-mod-w3.script
@@ -1,7 +1,6 @@
 professional_learning_course 'CS Principles Deeper Learning 2019 - 2020'
 login_required true
 student_detail_progress_view true
-family_name ''
 
 stage 'CS Principles Deeper Learning Module 3'
 level 'dlp19-hold-mod1'

--- a/dashboard/config/scripts/dlp19-csp-mod-w4.script
+++ b/dashboard/config/scripts/dlp19-csp-mod-w4.script
@@ -1,7 +1,6 @@
 professional_learning_course 'CS Principles Deeper Learning 2019 - 2020'
 login_required true
 student_detail_progress_view true
-family_name ''
 
 stage 'CS Principles Deeper Learning Module 4'
 level 'dlp19-hold-mod1'

--- a/dashboard/config/scripts/peru-2019.script
+++ b/dashboard/config/scripts/peru-2019.script
@@ -1,4 +1,3 @@
-family_name ''
 version_year '2019'
 
 stage 'Introduction'

--- a/dashboard/config/scripts/pl-csd-bugs.script
+++ b/dashboard/config/scripts/pl-csd-bugs.script
@@ -1,5 +1,4 @@
 login_required true
-family_name ''
 
 stage 'CSD Workshop 1 Bugs'
 level 'CSD-PL AYWS1 Debugging Intro', named: true


### PR DESCRIPTION
### Background

Yesterday we ran into a problem where some scripts on levelbuilder couldn't be viewed. The root cause is that scripts with family name `''` were getting past our many `nil` checks, specifically this one: https://github.com/code-dot-org/code-dot-org/blob/b30124db92485b6af0ff11adbecd3a8fb19180b5/dashboard/app/models/script.rb#L1428-L1429

`family_name` is different from other fields because it is a column on the scripts table, not just an entry in the properties hash.

### Description
* set blank family name to nil when script is edited
* set blank family name to nil on existing scripts
* bonus: remove errant `family_name` from properties hash