### PR TITLE
create vendor bundle with hand-picked libraries

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -837,8 +837,7 @@ describe('entry tests', () => {
               },
               test(module) {
                 return [
-                  'canvg',
-                  'core-js',
+                  'babel-polyfill',
                   'immutable',
                   'lodash',
                   'moment',

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -819,6 +819,39 @@ describe('entry tests', () => {
                 return chunkNames.includes(chunk.name);
               },
               priority: 20
+            },
+            vendors: {
+              name: 'vendors',
+              priority: 30,
+              chunks: chunk => {
+                // all 'initial' chunks except otherEntries
+                const chunkNames = _.concat(
+                  _.keys(codeStudioEntries),
+                  _.keys(appsEntries),
+                  _.keys(pegasusEntries),
+                  _.keys(professionalDevelopmentEntries),
+                  _.keys(internalEntries)
+                );
+                return chunkNames.includes(chunk.name);
+              },
+              test(module) {
+                return [
+                  'canvg',
+                  'core-js',
+                  'immutable',
+                  'lodash',
+                  'moment',
+                  'pepjs',
+                  'radium',
+                  'react',
+                  'react-dom',
+                  'wgxpath'
+                ].some(libName =>
+                  new RegExp(`/apps/node_modules/${libName}/`).test(
+                    module.resource
+                  )
+                );
+              }
             }
           }
         }

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -783,7 +783,7 @@ describe('entry tests', () => {
               name: 'code-studio-common',
               minChunks: 2,
               chunks: chunk => {
-                const chunkNames = _.keys(codeStudioEntries);
+                const chunkNames = Object.keys(codeStudioEntries);
                 return chunkNames.includes(chunk.name);
               },
               priority: 10
@@ -812,10 +812,10 @@ describe('entry tests', () => {
             // For more information see: https://webpack.js.org/guides/code-splitting/
             'code-studio-multi': {
               name: 'code-studio-common',
-              minChunks: _.keys(appsEntries).length + 1,
+              minChunks: Object.keys(appsEntries).length + 1,
               chunks: chunk => {
-                const chunkNames = _.keys(codeStudioEntries).concat(
-                  _.keys(appsEntries)
+                const chunkNames = Object.keys(codeStudioEntries).concat(
+                  Object.keys(appsEntries)
                 );
                 return chunkNames.includes(chunk.name);
               },
@@ -827,11 +827,11 @@ describe('entry tests', () => {
               chunks: chunk => {
                 // all 'initial' chunks except otherEntries
                 const chunkNames = _.concat(
-                  _.keys(codeStudioEntries),
-                  _.keys(appsEntries),
-                  _.keys(pegasusEntries),
-                  _.keys(professionalDevelopmentEntries),
-                  _.keys(internalEntries)
+                  Object.keys(codeStudioEntries),
+                  Object.keys(appsEntries),
+                  Object.keys(pegasusEntries),
+                  Object.keys(professionalDevelopmentEntries),
+                  Object.keys(internalEntries)
                 );
                 return chunkNames.includes(chunk.name);
               },

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -767,6 +767,9 @@ describe('entry tests', () => {
           name: 'webpack-runtime'
         },
         splitChunks: {
+          // Override the default limit of 3 concurrent downloads on page load,
+          // which only makes sense for HTTP 1.1 servers. HTTP 2 performance has
+          // been observed to degrade only with > 200 simultaneous downloads.
           maxInitialRequests: 100,
           cacheGroups: {
             // Pull any module shared by 2+ appsEntries into the "common" chunk.

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -767,6 +767,7 @@ describe('entry tests', () => {
           name: 'webpack-runtime'
         },
         splitChunks: {
+          maxInitialRequests: 100,
           cacheGroups: {
             // Pull any module shared by 2+ appsEntries into the "common" chunk.
             common: {

--- a/dashboard/app/views/admin_styleguide/show.html.haml
+++ b/dashboard/app/views/admin_styleguide/show.html.haml
@@ -1,7 +1,0 @@
-#styleguide-app
-%script{src: minifiable_asset_path('js/marked/marked.js')}
-%script{src: minifiable_asset_path('js/essential.js')}
-%script{src: minifiable_asset_path('js/code-studio-common.js')}
-%script{src: minifiable_asset_path('js/common.js')}
-%script{src: asset_path("js/#{js_locale}/common_locale.js")}
-%script{src: minifiable_asset_path('js/styleguide.js')}

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -18,6 +18,7 @@
     %script{src: minifiable_asset_path('js/webpack-runtime.js')}
     // essential.js is ordered above application.js to filter new relic errors
     %script{src: minifiable_asset_path('js/essential.js')}
+    %script{src: minifiable_asset_path('js/vendors.js')}
     = render file: Rails.root.join('..', 'shared', 'haml', 'answerdash.haml') if view_options[:answerdash]
     = javascript_include_tag 'application'
     = javascript_include_tag "js/#{js_locale}/common_locale"

--- a/pegasus/sites.v3/code.org/views/theme_common_head_after.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_head_after.haml
@@ -10,6 +10,7 @@
 
 -# webpack-runtime.js must appear exactly once on any page containing webpack entries
 %script{src: minifiable_asset_path('js/webpack-runtime.js')}
+%script{src: minifiable_asset_path('js/vendors.js')}
 %script{:defer => "defer", src: minifiable_asset_path("js/code.org/views/theme_common_head_after.js")}
 
 - if header['chart']

--- a/pegasus/sites.v3/hourofcode.com/views/theme_common_head_after.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/theme_common_head_after.haml
@@ -6,4 +6,5 @@
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
 -# webpack-runtime.js must appear exactly once on any page containing webpack entries
 %script{src: minifiable_asset_path('js/webpack-runtime.js')}
+%script{src: minifiable_asset_path('js/vendors.js')}
 %script{src: minifiable_asset_path("js/hourofcode.com/views/theme_common_head_after.js")}


### PR DESCRIPTION
### Background

One problem with our current webpack config is that shared modules are not pulled out of plc entry points. Because using count-based approaches is [tricky](https://github.com/code-dot-org/code-dot-org/blob/e9995bd5fa3a470fa0cca6ec8c0094487dcad533/apps/Gruntfile.js#L790-L811), I am hand-picking the list of packages included here based on inspection of which packages are used by most entry points as well as which packages are aligned with our current best practices (e.g. react). 

According to many sources on the internet, the strategy of bundling npm packages separately from application code should improve our caching performance because vendors.js is likely to remain cached (by Cloudfront, firewalls, browsers, etc.) for days or weeks, compared with our application code which updates daily.

### Description

Extract a hand-picked list of npm packages from most dashboard and pegasus entry points. This does not include special entry points like applab-api.js and embedVideo.js which need to be entirely self-contained. 

### results

* overall bundle size reduced by **11MB** (from 49.4 to 38.4)
* many PLC entry points now include 700KB less JS
* code-studio-common.js decreased in size by 700KB (the size of vendors.js), therefore JS size does not increase for any dashboard page.
* theoretically improves cache performance, because the 700KB moved to vendors.js can be cached for days or weeks whereas code-studio-common.js is typically modified daily.

### before
<img width="1542" alt="Screen Shot 2019-08-22 at 1 27 50 PM" src="https://user-images.githubusercontent.com/8001765/63548293-d06d7c80-c4e2-11e9-8d1d-3117df5aa787.png">

### after
<img width="1542" alt="Screen Shot 2019-08-22 at 1 27 59 PM" src="https://user-images.githubusercontent.com/8001765/63548305-d5cac700-c4e2-11e9-9641-3142584232b1.png">

### future work

there is some code still shared across many PLC entry points (e.g. react-bootstrap) which could benefit from being extracted into some kind of `plc-common.js` bundle. I didn't include this in vendors.js because react-bootstrap is not used widely outside of PLC code. 

Ideally, we'd be able to do something like this:
* app-specific code extracted into common.js
* plc-common code extracted into plc-common.js
* any code common to common.js and plc-common.js further extracted into code-studio-common.js
currently we use this strategy to avoid duplication between common.js and code-studio-common.js, however it is not clear whether the [trick](https://github.com/code-dot-org/code-dot-org/blob/e9995bd5fa3a470fa0cca6ec8c0094487dcad533/apps/Gruntfile.js#L790-L811) mentioned earlier will scale as the number of shared bundles increases.

I have a future work item to explore a more dynamic approach to bundle splitting which does not require our configuration to have specific knowledge of our application code, which is part of why I'm choosing this as a stopping point for now.
