### PR TITLE
Bug fix:  Sign in button misaligned on pegasus home page

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/common.css
+++ b/pegasus/sites.v3/code.org/public/css/common.css
@@ -676,7 +676,7 @@ button {
   box-sizing: border-box;
   float: left;
   cursor: pointer;
-  margin-top: -5px;
+  margin-top: -6px;
   a:hover {
     text-decoration: none;
     background-color: #ffa400;


### PR DESCRIPTION
Sign-in button and create button are not aligned on the Pegasus homepage. 
[jira](https://codedotorg.atlassian.net/browse/FND-648)

Root-cause:  margin-top on create button was adjusted for when a user is signed-in as part of the change to make the header on Dashboard and Pegasus match.
[See PR](https://github.com/code-dot-org/code-dot-org/pull/29622)

Fix:  Adjust margin-top on the create button to match margin-top setting for sign-in button.

- Before screen-shot:
<img width="284" alt="Screen Shot 2019-08-22 at 12 02 12 PM" src="https://user-images.githubusercontent.com/30066710/63543439-b4b0a900-c4d7-11e9-93cd-31644ebcc7cd.png">


- After screen-shot:
<img width="288" alt="Screen Shot 2019-08-22 at 12 14 42 PM" src="https://user-images.githubusercontent.com/30066710/63543430-aebac800-c4d7-11e9-8dbd-e344e339f22f.png">


