### PR TITLE
Migrate level_source_id columns in authored_hint_view_requests to bigint on non-production environments

### DIFF
--- a/dashboard/app/models/authored_hint_view_request.rb
+++ b/dashboard/app/models/authored_hint_view_request.rb
@@ -12,15 +12,15 @@
 #  prev_time             :integer
 #  prev_attempt          :integer
 #  prev_test_result      :integer
-#  prev_level_source_id  :integer
+#  prev_level_source_id  :integer          unsigned
 #  next_time             :integer
 #  next_attempt          :integer
 #  next_test_result      :integer
-#  next_level_source_id  :integer
+#  next_level_source_id  :integer          unsigned
 #  final_time            :integer
 #  final_attempt         :integer
 #  final_test_result     :integer
-#  final_level_source_id :integer
+#  final_level_source_id :integer          unsigned
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #

--- a/dashboard/db/migrate/20190822172626_convert_level_source_id_to_bigint_authored_hint_view_requests.rb
+++ b/dashboard/db/migrate/20190822172626_convert_level_source_id_to_bigint_authored_hint_view_requests.rb
@@ -1,0 +1,13 @@
+class ConvertLevelSourceIdToBigintAuthoredHintViewRequests < ActiveRecord::Migration[5.0]
+  def up
+    change_column :authored_hint_view_requests, :prev_level_source_id, 'BIGINT(11) UNSIGNED'
+    change_column :authored_hint_view_requests, :next_level_source_id, 'BIGINT(11) UNSIGNED'
+    change_column :authored_hint_view_requests, :final_level_source_id, 'BIGINT(11) UNSIGNED'
+  end
+
+  def down
+    change_column :authored_hint_view_requests, :prev_level_source_id, :int
+    change_column :authored_hint_view_requests, :next_level_source_id, :int
+    change_column :authored_hint_view_requests, :final_level_source_id, :int
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190814190546) do
+ActiveRecord::Schema.define(version: 20190822172626) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -85,15 +85,15 @@ ActiveRecord::Schema.define(version: 20190814190546) do
     t.integer  "prev_time"
     t.integer  "prev_attempt"
     t.integer  "prev_test_result"
-    t.integer  "prev_level_source_id"
+    t.bigint   "prev_level_source_id",               unsigned: true
     t.integer  "next_time"
     t.integer  "next_attempt"
     t.integer  "next_test_result"
-    t.integer  "next_level_source_id"
+    t.bigint   "next_level_source_id",               unsigned: true
     t.integer  "final_time"
     t.integer  "final_attempt"
     t.integer  "final_test_result"
-    t.integer  "final_level_source_id"
+    t.bigint   "final_level_source_id",              unsigned: true
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
     t.index ["level_id"], name: "fk_rails_8f51960e09", using: :btree


### PR DESCRIPTION
Migrates level_source_id columns in authored_hint_view_requests table to bigint -- this migration has already been run on production per #30135.

This migration will update all other environments to match.