### PR TITLE
Preserve stage name when editing scripts with only one stage

### DIFF
--- a/apps/src/templates/progress/ProgressDetailToggle.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.jsx
@@ -96,6 +96,7 @@ class ProgressDetailToggle extends React.Component {
           type="button"
           value="detail"
           style={whiteBorder ? styles.whiteBorder : undefined}
+          className="uitest-toggle-detail"
         >
           <img
             src={isSummaryView ? images.detailInactive : images.detailActive}

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1362,6 +1362,13 @@ class Script < ActiveRecord::Base
     summary
   end
 
+  def summarize_for_edit
+    include_stages = false
+    summary = summarize(include_stages)
+    summary[:stages] = stages.map(&:summarize_for_edit)
+    summary
+  end
+
   # @return {Hash<string,number[]>}
   #   For teachers, this will be a hash mapping from section id to a list of hidden
   #   script ids for that section, filtered so that the only script id which appears

--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -173,6 +173,13 @@ class Stage < ActiveRecord::Base
     stage_summary.freeze
   end
 
+  def summarize_for_edit
+    summary = summarize.dup
+    # Do not let script name override stage name when there is only one stage
+    summary[:name] = I18n.t("data.script.name.#{script.name}.stages.#{name}.name")
+    summary.freeze
+  end
+
   # Provides a JSON summary of a particular stage, that is consumed by tools used to
   # build lesson plans
   def summary_for_lesson_plans

--- a/dashboard/app/views/scripts/_form.html.haml
+++ b/dashboard/app/views/scripts/_form.html.haml
@@ -15,7 +15,7 @@
     = f.hidden_field :name
   .edit_container
   - include_stages = params[:beta].present?
-  - scriptData = {script: @script ? @script.summarize(include_stages) : {},
+  - scriptData = {script: @script ? @script.summarize_for_edit : {},
                   i18n: @script ? @script.summarize_i18n : {},
                   beta: params[:beta].present?,
                   levelKeyList: params[:beta] && Level.key_list,

--- a/dashboard/test/ui/features/script_overview.feature
+++ b/dashboard/test/ui/features/script_overview.feature
@@ -29,3 +29,22 @@ Feature: Script overview page
 
     # Make sure we only see student progress, not teacher progress.
     Then I verify progress for stage 29 level 4 is "not_tried"
+
+  Scenario: Script overview contents
+    Given I create a student named "Jean"
+    And I am on "http://studio.code.org/s/allthethings"
+    # make sure we are in summary view and the page has finished loading
+    And I wait until element "td:contains(Maze)" is visible
+    # verify name format in summary view
+    And element "td:contains(2. Maze)" is visible
+
+    And I click selector ".uitest-toggle-detail"
+    And I wait until element "td:contains(Maze)" is not visible
+    And I wait until element "span:contains(Maze)" is visible
+    # verify name format in detail view
+    And element "span:contains(Lesson 2: Maze)" is visible
+
+    And I am on "http://studio.code.org/s/mc"
+    And I wait until element "td:contains(Minecraft)" is visible
+    # verify script name overrides stage name when there is only one stage
+    And element "td:contains(1. Minecraft Hour of Code)" is visible


### PR DESCRIPTION
fixes https://codedotorg.atlassian.net/browse/LP-605

### Background

When editing a script with only one stage, Script#summarize provides the script name in place of the stage name for that stage so that the script name can be displayed instead of the stage name on the script overview page. This breaks the new script editor, which relies on the same Script#summarize method.

This is a similar problem to the one fixed in https://github.com/code-dot-org/code-dot-org/pull/30345, except that Stage#localized_title and Stage#localized_name are a bit more intwined.

### Description

create new `summarize_for_edit` methods on the Script and Stage objects so that we can provide different data to the new script editor than we do to the script overview page. 

I went with a different solution than #30345 here because (1) this code is harder to untangle and (2) we actually want to move in this direction anyway (see Future Work). 

### Future work

 we want to arrive at a situation where we supply only the data needed to allow editing of the stage, and also change the format of the data posted to the server to match that format. splitting off summarize_for_edit like we do in this PR helps get us closer to that situation.