### PR TITLE
Add BubbleChoice levels to contained_levels after level_sources_multi…

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -76,19 +76,6 @@ def main
     end
   end
 
-  Level.where(type: 'BubbleChoice').find_each do |level|
-    level.properties['sublevels']&.each_with_index do |sublevel_name, sublevel_index|
-      sublevel = Level.find_by_name(sublevel_name)
-      contained_levels << {
-        level_id: level.id,
-        contained_level_id: sublevel.id,
-        contained_level_type: sublevel.type,
-        contained_level_page: 1,
-        contained_level_position: sublevel_index
-      }
-    end
-  end
-
   Level.find_each do |level|
     begin
       next unless level.script_levels.map(&:script).select(&:k5_draft_course?)
@@ -134,6 +121,19 @@ def main
         data: level_source.data,
         md5: level_source.md5,
         hidden: level_source.hidden
+      }
+    end
+  end
+
+  Level.where(type: 'BubbleChoice').find_each do |level|
+    level.properties['sublevels']&.each_with_index do |sublevel_name, sublevel_index|
+      sublevel = Level.find_by_name(sublevel_name)
+      contained_levels << {
+        level_id: level.id,
+        contained_level_id: sublevel.id,
+        contained_level_type: sublevel.type,
+        contained_level_page: 1,
+        contained_level_position: sublevel_index
       }
     end
   end


### PR DESCRIPTION
…_types is calculated

Fixes [this Honeybadger error](https://app.honeybadger.io/projects/45435/faults/51801323#comment_9378283) (hopefully for the last time).

This error occurred because after adding BubbleChoice levels, `contained_levels` is mapped to LevelSources ([here](https://github.com/code-dot-org/code-dot-org/blob/798bb7f9e614e19b7f4959b7fe1943498d41efc6/bin/cron/create_rollup_tables#L127-L139)), and a BubbleChoice level's `data` ([added here](https://github.com/code-dot-org/code-dot-org/blob/798bb7f9e614e19b7f4959b7fe1943498d41efc6/bin/cron/create_rollup_tables#L134)) broke our insert operation [here](https://github.com/code-dot-org/code-dot-org/blob/798bb7f9e614e19b7f4959b7fe1943498d41efc6/bin/cron/create_rollup_tables#L224) because the data had unescaped quotes:

![Screen Shot 2019-08-22 at 3 20 44 PM](https://user-images.githubusercontent.com/9812299/63553900-b9358b80-c4f0-11e9-85e2-987e884bddac.png)

This PR fixes that error by adding BubbleChoice levels to `contained_levels` after LevelSources are calculated, because we don't want to record LevelSources for BubbleChoice levels.