### PR TITLE
Revert "supply default value for flex_category string on the client"

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -669,7 +669,6 @@
   "findLocalClassDescription": "Find a local after-school program, summer camp, or school to learn in person.",
   "findLocalClassButton": "Find a class",
   "finish": "Finish",
-  "flexCategoryContent": "Content",
   "formErrorsBelow": "Please correct the errors below.",
   "formServerError": "Something went wrong on our end; please try again later.",
   "forTeachersOnly": "For Teachers Only",

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -11,7 +11,6 @@ import {ViewType, SET_VIEW_TYPE} from './viewAsRedux';
 import {processedLevel} from '@cdo/apps/templates/progress/progressHelpers';
 import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 import {authorizeLockable} from './stageLockRedux';
-import i18n from '@cdo/locale';
 
 // Action types
 export const INIT_PROGRESS = 'progress/INIT_PROGRESS';
@@ -677,7 +676,7 @@ export const categorizedLessons = (state, includeBonusLevels = false) => {
   const allLevels = levelsByLesson(state);
 
   state.stages.forEach((stage, index) => {
-    const category = stage.flex_category || i18n.flexCategoryContent();
+    const category = stage.flex_category;
     const lesson = lessonFromStageAtIndex(state, index);
     let stageLevels = allLevels[index];
     if (!includeBonusLevels) {


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#30344

This was causing the [regional partner playbook](https://code.org/educate/regional-partner/playbook) not to load, with the error `playbook.min-8aed1876da95b8a570d63683f75c94d3e1efbf13ad851d480c2d2fa6ccc5702d.js:12 Uncaught TypeError: Cannot read property 'common_locale' of undefined`