### PR TITLE
 allow flex_category to be nil in script editor gui

### DIFF
--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -177,6 +177,8 @@ class Stage < ActiveRecord::Base
     summary = summarize.dup
     # Do not let script name override stage name when there is only one stage
     summary[:name] = I18n.t("data.script.name.#{script.name}.stages.#{name}.name")
+    # Do not use a default value if flex_category is nil
+    summary[:flex_category] = flex_category && I18n.t("flex_category.#{flex_category}")
     summary.freeze
   end
 


### PR DESCRIPTION
second attempt at fixing  https://codedotorg.atlassian.net/browse/LP-603

#30345 did not work because it broke a pegasus page. build off of #30382 instead.