### PR TITLE
Join section vulnerability

### DIFF
--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -65,35 +65,26 @@ class FollowersController < ApplicationController
       return
     end
 
-    if current_user && @section
-      @section.add_student current_user
+    @user = current_user || User.new
 
-      redirect_to root_path, notice: I18n.t('follower.registered', section_name: @section.name)
-    else
-      @user = User.new
-
-      # if this is a picture or word section, redirect to the section login page so that the student
-      # does not have to type in the full URL
-      if @section && [Section::LOGIN_TYPE_PICTURE, Section::LOGIN_TYPE_WORD].include?(@section.login_type)
-        redirect_to controller: 'sections', action: 'show', id: @section.code
-      end
-
-      # if there is no logged in user and no section or an e-mail section, render the default
-      # student_user_new view which includes the section code form or sign up form
+    # if this is a picture or word section, redirect to the section login page so that the student
+    # does not have to type in the full URL
+    if @section && [Section::LOGIN_TYPE_PICTURE, Section::LOGIN_TYPE_WORD].include?(@section.login_type)
+      redirect_to controller: 'sections', action: 'show', id: @section.code
     end
+
+    # render the default student_user_new view, which includes the section code form or sign up form
   end
 
   # POST /join/XXXXXX
   # join a section as a new student
   def student_register
-    user_type = params[:user][:user_type] == User::TYPE_TEACHER ? User::TYPE_TEACHER : User::TYPE_STUDENT
-    @user = User.new(followers_params(user_type))
-    @user.user_type = user_type
-
     if current_user
-      @user.errors.add(:username, "Please signout before proceeding")
-      render 'student_user_new', formats: [:html]
-      return
+      @user = current_user
+    else
+      user_type = params[:user][:user_type] == User::TYPE_TEACHER ? User::TYPE_TEACHER : User::TYPE_STUDENT
+      @user = User.new(followers_params(user_type))
+      @user.user_type = user_type
     end
 
     Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -50,7 +50,6 @@ class FollowersController < ApplicationController
   end
 
   # GET /join/XXXXXX
-  # if logged in, join the section, if not logged in, present a form to create a new user and log in
   def student_user_new
     # Though downstream validations would raise an exception, we redirect to the admin directory to
     # improve user experience.
@@ -77,7 +76,7 @@ class FollowersController < ApplicationController
   end
 
   # POST /join/XXXXXX
-  # join a section as a new student
+  # join a section
   def student_register
     if current_user
       @user = current_user

--- a/dashboard/app/views/followers/student_user_new.html.haml
+++ b/dashboard/app/views/followers/student_user_new.html.haml
@@ -1,12 +1,10 @@
-- if !@section
+- if current_user || !@section
   = t('add_teacher_form.code.instructions')
   %br/
-  = form_tag(student_user_new_path, method: 'GET') do
+  = form_tag(student_user_new_path) do
     = text_field_tag(:section_code, params[:section_code], placeholder: I18n.t('add_teacher_form.code.placeholder'))
     %br/
     = submit_tag 'Go', class: 'btn btn-primary'
-- elsif current_user
-  You are currently signed in. #{link_to 'Return home', root_path} or #{link_to('log out', destroy_user_session_path)} to proceed.
 - else
   %h2 Register to join the class #{@section.name} taught by #{@section.user.name}
   %p

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -51,46 +51,22 @@ class FollowersControllerTest < ActionController::TestCase
   test "student_user_new when signed in" do
     sign_in @student
 
-    assert_creates(Follower) do
+    assert_does_not_create(Follower) do
       get :student_user_new, params: {section_code: @chris_section.code}
     end
 
-    assert_redirected_to '/'
-    assert_equal "You've registered for #{@chris_section.name}.", flash[:notice]
-
-    follower = Follower.last
-    assert_equal @student, follower.student_user
-    assert_equal @chris, follower.user
-    assert_equal @chris_section, follower.section
+    assert_response :success
+    assert_template 'followers/student_user_new'
   end
 
   test "student_user_new when signed in without section code" do
     sign_in @student
-
-    get :student_user_new
-
-    assert_response :success
-    # form to type in section code
-    assert_select 'input#section_code'
-  end
-
-  test "student user new with existing user with messed up email" do
-    # use update_attribute to bypass validations
-    @student.update_attribute(:email, '')
-    @student.update_attribute(:hashed_email, '')
-
-    sign_in @student
-    assert_creates(Follower) do
-      get :student_user_new, params: {section_code: @chris_section.code}
+    assert_does_not_create(Follower) do
+      get :student_user_new
     end
 
-    assert_redirected_to '/'
-    assert_equal "You've registered for #{@chris_section.name}.", flash[:notice]
-
-    follower = Follower.last
-    assert_equal @student, follower.student_user
-    assert_equal @chris, follower.user
-    assert_equal @chris_section, follower.section
+    assert_response :success
+    assert_template 'followers/student_user_new'
   end
 
   test 'student_user_new errors when joining a section with deleted teacher' do
@@ -239,16 +215,15 @@ class FollowersControllerTest < ActionController::TestCase
     end
   end
 
-  test "student_register gives error if already signed in" do
+  test "student_register adds existing student to section if already signed in" do
     sign_in @student
-    assert_does_not_create(User, Follower) do
-      post :student_register, params: {
-        section_code: @chris_section.code,
-        user: @student.attributes
-      }
+    assert_does_not_create(User) do
+      post :student_register, params: {section_code: @chris_section.code}
     end
-    assert_response :success
-    assert response.body.include? 'You are currently signed in.'
+
+    assert_redirected_to '/'
+    @student.reload
+    assert @chris_section.students.include? @student
   end
 
   test "create with section code" do
@@ -337,19 +312,6 @@ class FollowersControllerTest < ActionController::TestCase
     end
 
     refute Follower.exists?(follower.id)
-  end
-
-  test "student_user_new when signed in in section with script" do
-    sign_in @student
-
-    assert_creates(Follower, UserScript) do
-      get :student_user_new, params: {section_code: @laurel_section_script.code}
-    end
-
-    user_script = UserScript.where(user: @student, script: @laurel_section_script.script).first
-    assert user_script
-    assert user_script.assigned_at
-    assert_equal @laurel_section_script.script, @student.primary_script
   end
 
   test "student_register in section with script" do

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -216,6 +216,8 @@ class FollowersControllerTest < ActionController::TestCase
   end
 
   test "student_register adds existing student to section if already signed in" do
+    refute @chris_section.students.include? @student
+
     sign_in @student
     assert_does_not_create(User) do
       post :student_register, params: {section_code: @chris_section.code}

--- a/dashboard/test/ui/features/create_dropdown.feature
+++ b/dashboard/test/ui/features/create_dropdown.feature
@@ -62,7 +62,7 @@ Scenario: Young Student, In Section - Correct Create Links
   Given I create a teacher named "Ms_Frizzle"
   And I create a new section
   Given I create a young student named "Young Student - In Section"
-  And I navigate to the section url
+  And I join the section
   And I wait until element ".create_menu" is visible
   And I click selector ".create_menu"
   And I wait until element "#create_dropdown_spritelab" is visible

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1215,9 +1215,10 @@ And(/^I save the section url$/) do
   @section_url = "http://studio.code.org/join/#{section_code}"
 end
 
-And(/^I navigate to the section url$/) do
+And(/^I join the section$/) do
   steps %Q{
     Given I am on "#{@section_url}"
+    And I click selector ".btn.btn-primary" once I see it
   }
 end
 

--- a/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard_assessments2.feature
+++ b/dashboard/test/ui/features/teacher_dashboard/teacher_dashboard_assessments2.feature
@@ -6,19 +6,19 @@ Feature: Using the assessments tab in the teacher dashboard
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
 
     And I create a student named "Student2"
-    And I navigate to the section url
+    And I join the section
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
 
     And I create a student named "Student3"
-    And I navigate to the section url
+    And I join the section
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
 
     And I create a student named "Student4"
-    And I navigate to the section url
+    And I join the section
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
 
     And I create a student named "Student5"
-    And I navigate to the section url
+    And I join the section
     And I submit the assessment on "http://studio.code.org/s/csp-post-survey/stage/1/puzzle/1/page/6"
 
     # Assign a script with an unlocked survey

--- a/dashboard/test/ui/features/user_menu.feature
+++ b/dashboard/test/ui/features/user_menu.feature
@@ -56,9 +56,9 @@ Scenario: Pair Programming
   Given I create a teacher named "Dr_Seuss"
   And I create a new section
   Given I create a student named "Thing_One"
-  And I navigate to the section url
+  And I join the section
   Given I create a student named "Thing_Two"
-  And I navigate to the section url
+  And I join the section
   Given I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/7?noautoplay=true"
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Thing_Two"


### PR DESCRIPTION
[LP-683](https://codedotorg.atlassian.net/browse/LP-683)

Previously, a logged in student could join an email section via a single GET request to `/join/:section_code`. 

This PR refactors the user flow to:
1. Student visits `GET /join/:section_code`
2. The section code is pre-populated and the student is prompted to join the section
3. Student clicks "Go" to join the section, which triggers a POST request to `/join/:section_code`

Video of the above flow:
![out](https://user-images.githubusercontent.com/9812299/63558520-184fcc00-c502-11e9-8217-a8f1a4c80cee.gif)
