### PR TITLE
[Applab Datasets] Hook up the data table view and table add button

### DIFF
--- a/apps/src/storage/dataBrowser/DataBrowser.jsx
+++ b/apps/src/storage/dataBrowser/DataBrowser.jsx
@@ -114,7 +114,7 @@ class DataBrowser extends React.Component {
   handleTabClick = newTab => {
     this.setState({selectedTab: newTab});
     if (newTab === TabType.DATA_TABLES) {
-      this.props.onViewChange(DataView.TABLE);
+      this.props.onViewChange(DataView.OVERVIEW);
     }
     if (newTab === TabType.KEY_VALUE_PAIRS) {
       this.props.onViewChange(DataView.PROPERTIES);
@@ -188,7 +188,9 @@ class DataBrowser extends React.Component {
                   <EditTableListRow
                     key={tableName}
                     tableName={tableName}
-                    onViewChange={this.emptyHandler}
+                    onViewChange={() =>
+                      this.props.onViewChange(DataView.TABLE, tableName)
+                    }
                   />
                 ))}
               </tbody>
@@ -248,8 +250,8 @@ export default connect(
     onShowWarning(warningMsg, warningTitle) {
       dispatch(showWarning(warningMsg, warningTitle));
     },
-    onViewChange(view) {
-      dispatch(changeView(view));
+    onViewChange(view, tableName) {
+      dispatch(changeView(view, tableName));
     }
   })
 )(Radium(DataBrowser));

--- a/apps/src/storage/dataBrowser/DataBrowser.jsx
+++ b/apps/src/storage/dataBrowser/DataBrowser.jsx
@@ -98,6 +98,7 @@ const styles = {
 
 class DataBrowser extends React.Component {
   static propTypes = {
+    onTableAdd: PropTypes.func.isRequired,
     // from redux state
     tableListMap: PropTypes.object.isRequired,
     view: PropTypes.oneOf(Object.keys(DataView)),
@@ -120,9 +121,6 @@ class DataBrowser extends React.Component {
       this.props.onViewChange(DataView.PROPERTIES);
     }
   };
-
-  // TODO: implement the functionality of this tab
-  emptyHandler = () => {};
 
   render() {
     return (
@@ -168,7 +166,7 @@ class DataBrowser extends React.Component {
                 <col width={buttonColumnWidth} />
               </colgroup>
               <tbody>
-                <AddTableListRow onTableAdd={this.emptyHandler} />
+                <AddTableListRow onTableAdd={this.props.onTableAdd} />
               </tbody>
             </table>
             <br />

--- a/apps/src/storage/dataBrowser/DataOverview.jsx
+++ b/apps/src/storage/dataBrowser/DataOverview.jsx
@@ -80,6 +80,11 @@ class DataOverview extends React.Component {
     const visible = DataView.OVERVIEW === this.props.view;
 
     if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      styles.container.display =
+        this.props.view === DataView.OVERVIEW ||
+        this.props.view === DataView.PROPERTIES
+          ? 'block'
+          : 'none';
       return (
         <div id="data-library-container" style={styles.container}>
           <DataLibraryPane />

--- a/apps/src/storage/dataBrowser/DataOverview.jsx
+++ b/apps/src/storage/dataBrowser/DataOverview.jsx
@@ -89,7 +89,7 @@ class DataOverview extends React.Component {
         <div id="data-library-container" style={styles.container}>
           <DataLibraryPane />
           <div id="data-browser" style={styles.dataBrowser}>
-            <DataBrowser />
+            <DataBrowser onTableAdd={this.onTableAdd} />
           </div>
         </div>
       );

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -18,6 +18,7 @@ import {connect} from 'react-redux';
 import {getColumnNamesFromRecords} from '../firebaseMetadata';
 import PaginationWrapper from '../../templates/PaginationWrapper';
 import msg from '@cdo/locale';
+import experiments from '../../util/experiments';
 
 const MIN_TABLE_WIDTH = 600;
 const MAX_ROWS_PER_PAGE = 500;
@@ -33,7 +34,10 @@ const styles = {
     flexDirection: 'column',
     height: '100%',
     minWidth: MIN_TABLE_WIDTH,
-    maxWidth: '100%'
+    maxWidth: '100%',
+    paddingLeft: experiments.isEnabled(experiments.APPLAB_DATASETS)
+      ? '8px'
+      : '0px'
   },
   table: {
     minWidth: MIN_TABLE_WIDTH

--- a/apps/src/storage/dataBrowser/DataWorkspace.jsx
+++ b/apps/src/storage/dataBrowser/DataWorkspace.jsx
@@ -1,4 +1,5 @@
 import {ApplabInterfaceMode} from '../../applab/constants';
+import {DataView} from '../constants';
 import DataOverview from './DataOverview';
 import DataProperties from './DataProperties';
 import DataTable from './DataTable';
@@ -45,6 +46,7 @@ class DataWorkspace extends React.Component {
     warningMsg: PropTypes.string.isRequired,
     warningTitle: PropTypes.string.isRequired,
     isWarningDialogOpen: PropTypes.bool.isRequired,
+    view: PropTypes.oneOf(Object.keys(DataView)),
 
     // from redux dispatch
     onClearWarning: PropTypes.func.isRequired
@@ -62,11 +64,13 @@ class DataWorkspace extends React.Component {
           hasFocus={!this.props.isRunning}
           className={this.props.isRunning ? 'is-running' : ''}
         >
-          {experiments.isEnabled(experiments.APPLAB_DATASETS) && (
-            <PaneSection id="library-header" style={styles.libraryHeader}>
-              <span id="library-header-span">{msg.dataLibraryHeader()}</span>
-            </PaneSection>
-          )}
+          {experiments.isEnabled(experiments.APPLAB_DATASETS) &&
+            (this.props.view === DataView.OVERVIEW ||
+              this.props.view === DataView.PROPERTIES) && (
+              <PaneSection id="library-header" style={styles.libraryHeader}>
+                <span id="library-header-span">{msg.dataLibraryHeader()}</span>
+              </PaneSection>
+            )}
           <div id="dataModeHeaders">
             <PaneButton
               id="data-mode-versions-header"
@@ -109,7 +113,8 @@ export default connect(
     isVisible: ApplabInterfaceMode.DATA === state.interfaceMode,
     warningMsg: state.data.warningMsg,
     warningTitle: state.data.warningTitle || '',
-    isWarningDialogOpen: state.data.isWarningDialogOpen
+    isWarningDialogOpen: state.data.isWarningDialogOpen,
+    view: state.data.view
   }),
   dispatch => ({
     onClearWarning() {


### PR DESCRIPTION
Mostly just hooks the new UI to the existing functionality.
Starting from this view:
![image](https://user-images.githubusercontent.com/8787187/63624416-198c0200-c5b1-11e9-8275-099875a46c62.png)

- Clicking on a table name brings you to the table view:
![image](https://user-images.githubusercontent.com/8787187/63625301-0af31a00-c5b4-11e9-85d0-3b5c6ce617b7.png)

- Entering a table name and clicking add creates a new table in the user's firebase channel and brings you to the table view:
![image](https://user-images.githubusercontent.com/8787187/63625339-2cec9c80-c5b4-11e9-95e9-10fdf272922e.png)


With experiment disabled everything still works/looks as before:
![image](https://user-images.githubusercontent.com/8787187/63624496-64a61500-c5b1-11e9-8fb0-004645cbf7a0.png)
