### PR TITLE
Disable password reset button for teachers in sections

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1191,6 +1191,7 @@
   "reset": "Reset",
   "resetProgram": "Reset",
   "resetPassword": "Reset password",
+  "resetTeacherPasswordTooltip": "You cannot reset passwords for teacher accounts in your section.",
   "resources": "Resources",
   "response": "Response",
   "restoreSection": "Restore Section",

--- a/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
@@ -39,6 +39,8 @@ class ManageStudentActionsCell extends Component {
     studentName: PropTypes.string.isRequired,
     hasEverSignedIn: PropTypes.bool,
     dependsOnThisSectionForLogin: PropTypes.bool,
+    canEdit: PropTypes.bool,
+
     // Provided by redux
     startEditingStudent: PropTypes.func,
     cancelEditingStudent: PropTypes.func,
@@ -109,12 +111,17 @@ class ManageStudentActionsCell extends Component {
       SectionLoginType.picture,
       SectionLoginType.email
     ].includes(loginType);
+
     return (
       <div>
         {!isEditing && (
           <QuickActionsCell>
-            <PopUpMenu.Item onClick={this.onEdit}>{i18n.edit()}</PopUpMenu.Item>
-            {canDelete && <MenuBreak />}
+            {this.props.canEdit && (
+              <PopUpMenu.Item onClick={this.onEdit}>
+                {i18n.edit()}
+              </PopUpMenu.Item>
+            )}
+            {this.props.canEdit && canDelete && <MenuBreak />}
             {canDelete && (
               <PopUpMenu.Item onClick={this.onRequestDelete} color={color.red}>
                 <FontAwesome icon="times-circle" style={styles.xIcon} />

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -185,7 +185,9 @@ class ManageStudentsTable extends Component {
     );
   };
 
-  isPasswordResetDisabled = userType => {
+  // Editing is disabled if the "student" in the section is a teacher
+  // (e.g., their userType is 'teacher').
+  isEditingDisabled = userType => {
     return userType === 'teacher';
   };
 
@@ -193,7 +195,7 @@ class ManageStudentsTable extends Component {
 
   passwordFormatter = (loginType, {rowData}) => {
     const {sectionId} = this.props;
-    const resetDisabled = this.isPasswordResetDisabled(rowData.userType);
+    const resetDisabled = this.isEditingDisabled(rowData.userType);
     return (
       <div>
         {!rowData.isEditing && (
@@ -286,6 +288,7 @@ class ManageStudentsTable extends Component {
         studentName={rowData.name}
         hasEverSignedIn={rowData.hasEverSignedIn}
         dependsOnThisSectionForLogin={rowData.dependsOnThisSectionForLogin}
+        canEdit={!this.isEditingDisabled(rowData.userType)}
       />
     );
   };

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -81,7 +81,8 @@ export const studentSectionDataPropType = PropTypes.shape({
   loginType: PropTypes.string,
   hasEverSignedIn: PropTypes.bool,
   dependsOnThisSectionForLogin: PropTypes.bool,
-  rowType: PropTypes.oneOf(Object.values(RowType))
+  rowType: PropTypes.oneOf(Object.values(RowType)),
+  userType: PropTypes.string
 });
 
 /** @enum {number} */
@@ -208,6 +209,7 @@ class ManageStudentsTable extends Component {
                 loginType={rowData.loginType}
                 id={rowData.id}
                 sectionId={sectionId}
+                userType={rowData.userType}
               />
             )}
           </div>

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -203,6 +203,7 @@ class ManageStudentsTable extends Component {
                 initialIsResetting={false}
                 sectionId={sectionId}
                 studentId={rowData.id}
+                resetDisabled={resetDisabled}
               />
             )}
             {(rowData.loginType === SectionLoginType.word ||

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -185,10 +185,15 @@ class ManageStudentsTable extends Component {
     );
   };
 
+  isPasswordResetDisabled = userType => {
+    return userType === 'teacher';
+  };
+
   // Cell formatters.
 
   passwordFormatter = (loginType, {rowData}) => {
     const {sectionId} = this.props;
+    const resetDisabled = this.isPasswordResetDisabled(rowData.userType);
     return (
       <div>
         {!rowData.isEditing && (
@@ -209,7 +214,7 @@ class ManageStudentsTable extends Component {
                 loginType={rowData.loginType}
                 id={rowData.id}
                 sectionId={sectionId}
-                userType={rowData.userType}
+                resetDisabled={resetDisabled}
               />
             )}
           </div>

--- a/apps/src/templates/manageStudents/PasswordReset.jsx
+++ b/apps/src/templates/manageStudents/PasswordReset.jsx
@@ -86,7 +86,7 @@ class PasswordReset extends Component {
               onClick={this.reset}
               color={Button.ButtonColor.white}
               text={i18n.resetPassword()}
-              disabled={this.props.resetDisabled}
+              disabled={resetDisabled}
             />
             {resetDisabled && (
               <ReactTooltip id={tooltipId} role="tooltip" effect="solid">

--- a/apps/src/templates/manageStudents/PasswordReset.jsx
+++ b/apps/src/templates/manageStudents/PasswordReset.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
+import ReactTooltip from 'react-tooltip';
+import _ from 'lodash';
 import Button from '../Button';
 import i18n from '@cdo/locale';
 
@@ -16,7 +18,8 @@ class PasswordReset extends Component {
   static propTypes = {
     initialIsResetting: PropTypes.bool,
     sectionId: PropTypes.number,
-    studentId: PropTypes.number
+    studentId: PropTypes.number,
+    resetDisabled: PropTypes.bool
   };
 
   state = {
@@ -72,14 +75,25 @@ class PasswordReset extends Component {
   };
 
   render() {
+    const {resetDisabled} = this.props;
+    const tooltipId = resetDisabled && _.uniqueId();
+
     return (
       <div>
         {!this.state.isResetting && (
-          <Button
-            onClick={this.reset}
-            color={Button.ButtonColor.white}
-            text={i18n.resetPassword()}
-          />
+          <span data-for={tooltipId} data-tip>
+            <Button
+              onClick={this.reset}
+              color={Button.ButtonColor.white}
+              text={i18n.resetPassword()}
+              disabled={this.props.resetDisabled}
+            />
+            {resetDisabled && (
+              <ReactTooltip id={tooltipId} role="tooltip" effect="solid">
+                <div>{i18n.resetTeacherPasswordTooltip()}</div>
+              </ReactTooltip>
+            )}
+          </span>
         )}
         {this.state.isResetting && (
           <div>

--- a/apps/src/templates/manageStudents/ShowSecret.jsx
+++ b/apps/src/templates/manageStudents/ShowSecret.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
+import ReactTooltip from 'react-tooltip';
+import _ from 'lodash';
 import Button from '../Button';
 import i18n from '@cdo/locale';
 import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
@@ -77,6 +79,9 @@ class ShowSecret extends Component {
   };
 
   render() {
+    const resetDisabled = this.props.userType === 'teacher';
+    const tooltipId = resetDisabled && _.uniqueId();
+
     return (
       <div>
         {!this.state.isShowing && (
@@ -97,13 +102,20 @@ class ShowSecret extends Component {
                 style={styles.image}
               />
             )}
-            <Button
-              onClick={this.reset}
-              color={Button.ButtonColor.blue}
-              text={i18n.reset()}
-              style={styles.reset}
-              disabled={this.props.userType === 'teacher'}
-            />
+            <span data-for={tooltipId} data-tip>
+              <Button
+                onClick={this.reset}
+                color={Button.ButtonColor.blue}
+                text={i18n.reset()}
+                style={styles.reset}
+                disabled={resetDisabled}
+              />
+              {resetDisabled && (
+                <ReactTooltip id={tooltipId} role="tooltip" effect="solid">
+                  <div>{i18n.resetTeacherPasswordTooltip()}</div>
+                </ReactTooltip>
+              )}
+            </span>
             <Button
               onClick={this.hide}
               color={Button.ButtonColor.white}

--- a/apps/src/templates/manageStudents/ShowSecret.jsx
+++ b/apps/src/templates/manageStudents/ShowSecret.jsx
@@ -109,6 +109,7 @@ class ShowSecret extends Component {
                 text={i18n.reset()}
                 style={styles.reset}
                 disabled={resetDisabled}
+                className="uitest-reset-password"
               />
               {resetDisabled && (
                 <ReactTooltip id={tooltipId} role="tooltip" effect="solid">

--- a/apps/src/templates/manageStudents/ShowSecret.jsx
+++ b/apps/src/templates/manageStudents/ShowSecret.jsx
@@ -24,6 +24,8 @@ class ShowSecret extends Component {
     loginType: PropTypes.string.isRequired,
     id: PropTypes.number.isRequired,
     sectionId: PropTypes.number.isRequired,
+    userType: PropTypes.string,
+
     // Provided in redux
     setSecretImage: PropTypes.func.isRequired,
     setSecretWords: PropTypes.func.isRequired
@@ -100,6 +102,7 @@ class ShowSecret extends Component {
               color={Button.ButtonColor.blue}
               text={i18n.reset()}
               style={styles.reset}
+              disabled={this.props.userType === 'teacher'}
             />
             <Button
               onClick={this.hide}

--- a/apps/src/templates/manageStudents/ShowSecret.jsx
+++ b/apps/src/templates/manageStudents/ShowSecret.jsx
@@ -26,7 +26,7 @@ class ShowSecret extends Component {
     loginType: PropTypes.string.isRequired,
     id: PropTypes.number.isRequired,
     sectionId: PropTypes.number.isRequired,
-    userType: PropTypes.string,
+    resetDisabled: PropTypes.bool,
 
     // Provided in redux
     setSecretImage: PropTypes.func.isRequired,
@@ -79,7 +79,7 @@ class ShowSecret extends Component {
   };
 
   render() {
-    const resetDisabled = this.props.userType === 'teacher';
+    const {resetDisabled} = this.props;
     const tooltipId = resetDisabled && _.uniqueId();
 
     return (

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -735,7 +735,8 @@ export const convertStudentServerData = (studentData, loginType, sectionId) => {
       dependsOnThisSectionForLogin: student.depends_on_this_section_for_login,
       isEditing: false,
       isSaving: false,
-      rowType: RowType.STUDENT
+      rowType: RowType.STUDENT,
+      userType: student.user_type
     };
   }
   return studentLookup;

--- a/apps/test/unit/templates/manageStudents/ManageStudentsActionsCellTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsActionsCellTest.js
@@ -10,7 +10,8 @@ const DEFAULT_PROPS = {
   studentName: 'Clark Kent',
   startEditingStudent: () => {},
   cancelEditingStudent: () => {},
-  removeStudent: () => {}
+  removeStudent: () => {},
+  canEdit: true
 };
 
 describe('ManageStudentsActionsCell', () => {
@@ -50,5 +51,12 @@ describe('ManageStudentsActionsCell', () => {
       <ManageStudentsActionsCell {...DEFAULT_PROPS} loginType={'google'} />
     );
     expect(wrapper).to.contain('Edit');
+  });
+
+  it('does not render the edit option when canEdit is false', () => {
+    const wrapper = shallow(
+      <ManageStudentsActionsCell {...DEFAULT_PROPS} canEdit={false} />
+    );
+    expect(wrapper).not.to.contain('Edit');
   });
 });

--- a/apps/test/unit/templates/manageStudents/PasswordResetTest.js
+++ b/apps/test/unit/templates/manageStudents/PasswordResetTest.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import PasswordReset from '@cdo/apps/templates/manageStudents/PasswordReset';
+
+describe('PasswordReset', () => {
+  it('disables reset password button if resetDisabled prop is true', () => {
+    let wrapper = mount(<PasswordReset />);
+    expect(wrapper.find('Button').prop('disabled')).to.equal(undefined);
+
+    wrapper = mount(<PasswordReset resetDisabled={true} />);
+    expect(wrapper.find('Button').prop('disabled')).to.be.true;
+  });
+});

--- a/apps/test/unit/templates/manageStudents/ShowSecretTest.js
+++ b/apps/test/unit/templates/manageStudents/ShowSecretTest.js
@@ -8,18 +8,17 @@ const DEFAULT_PROPS = {
   id: 1,
   loginType: 'picture',
   sectionId: 2,
-  userType: 'student',
   setSecretImage: () => {},
   setSecretWords: () => {}
 };
 
 describe('ShowSecret', () => {
-  it('disables reset password button if userType is teacher', () => {
+  it('disables reset password button if resetDisabled prop is true', () => {
     let wrapper = mount(<ShowSecret {...DEFAULT_PROPS} />);
     let resetPasswordButton = wrapper.find('Button.uitest-reset-password');
-    expect(resetPasswordButton.prop('disabled')).to.be.false;
+    expect(resetPasswordButton.prop('disabled')).to.equal(undefined);
 
-    wrapper = mount(<ShowSecret {...DEFAULT_PROPS} userType="teacher" />);
+    wrapper = mount(<ShowSecret {...DEFAULT_PROPS} resetDisabled={true} />);
     resetPasswordButton = wrapper.find('Button.uitest-reset-password');
     expect(resetPasswordButton.prop('disabled')).to.be.true;
   });

--- a/apps/test/unit/templates/manageStudents/ShowSecretTest.js
+++ b/apps/test/unit/templates/manageStudents/ShowSecretTest.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import {UnconnectedShowSecret as ShowSecret} from '@cdo/apps/templates/manageStudents/ShowSecret';
+
+const DEFAULT_PROPS = {
+  initialIsShowing: true,
+  id: 1,
+  loginType: 'picture',
+  sectionId: 2,
+  userType: 'student',
+  setSecretImage: () => {},
+  setSecretWords: () => {}
+};
+
+describe('ShowSecret', () => {
+  it('disables reset password button if userType is teacher', () => {
+    let wrapper = mount(<ShowSecret {...DEFAULT_PROPS} />);
+    let resetPasswordButton = wrapper.find('Button.uitest-reset-password');
+    expect(resetPasswordButton.prop('disabled')).to.be.false;
+
+    wrapper = mount(<ShowSecret {...DEFAULT_PROPS} userType="teacher" />);
+    resetPasswordButton = wrapper.find('Button.uitest-reset-password');
+    expect(resetPasswordButton.prop('disabled')).to.be.true;
+  });
+});


### PR DESCRIPTION
Client changes for [LP-680](https://codedotorg.atlassian.net/browse/LP-680). (Server changes forthcoming.)

### Change 1
If a teacher (A) is in another teacher's (B) section, teacher B can reset teacher A's password via the "Manage Students" tab. This disables the reset password button and displays a tooltip on hover that says 'You cannot reset passwords for teacher accounts in your section.' 

**Examples:**
Picture/word section (treated the same) --
<img width="507" alt="Screen Shot 2019-08-23 at 4 55 04 PM" src="https://user-images.githubusercontent.com/9812299/63629435-0552ff80-c5c7-11e9-887c-683cb1b73608.png">

Email section --
<img width="507" alt="Screen Shot 2019-08-23 at 4 53 55 PM" src="https://user-images.githubusercontent.com/9812299/63629415-dc326f00-c5c6-11e9-9af2-a242c6f9b5d4.png">

### Change 2
Hides the "Edit" option from the dropdown menu on the "Manage Students" tab for teachers in the section:
<img width="207" alt="Screen Shot 2019-08-23 at 4 57 12 PM" src="https://user-images.githubusercontent.com/9812299/63629475-5236d600-c5c7-11e9-9ed0-28ebce1941a8.png">

