### PR TITLE
Disabled test that acts differently dependent on environment.

### DIFF
--- a/dashboard/test/ui/features/manage_assets.feature
+++ b/dashboard/test/ui/features/manage_assets.feature
@@ -11,7 +11,8 @@ Feature: Manage Assets
     And I wait until element ".modal-content" contains text "Your computer is not set-up to record audio."
 
   # Safari thinks it can record audio on saucelabs, so this tests the success condition.
-  @no_chrome @no_firefox @no_ie
+  # Skipping for now because safari responds differently for localhost vs adhoc environments.
+  @skip #@no_chrome @no_firefox @no_ie
   Scenario: The manage assets dialog allows recording audio on Safari.
     Given I am a student
     And I start a new Game Lab project


### PR DESCRIPTION
This unblocks the DTT and allows the [record as MP3](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=26&projectKey=STAR&view=detail&selectedIssue=STAR-533) feature to be deployed

In live testing this feature works as expected. In Sauce Labs, however, safari seems to respond differently if localhost is in the domain name. With localhost, it is able to "find" a microphone even though none exist and it allows recording of audio. In test-studio.code.org, it is unable to find a microphone and does not allow recording.

I'm disabling this test until we can figure out why the two instances respond differently.

Task to re-enable the test: https://codedotorg.atlassian.net/browse/STAR-638