### PR TITLE
Return :forbidden if teacher tries to edit another teacher

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_students_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_students_controller.rb
@@ -29,6 +29,10 @@ class Api::V1::SectionsStudentsController < Api::V1::JsonApiController
 
   # PATCH /sections/<section_id>/students/<id>
   def update
+    # Teachers aren't allowed to update other teachers' information, even if the teacher is
+    # a student in a section.
+    return head :forbidden if @student.teacher?
+
     @student.reset_secrets if params[:secrets] == User::RESET_SECRETS
 
     if @student.update(student_params)

--- a/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_students_controller_test.rb
@@ -127,6 +127,16 @@ class Api::V1::SectionsStudentsControllerTest < ActionController::TestCase
     assert_equal expected_level_count, @response.body
   end
 
+  test 'teacher cannot update another teacher' do
+    other_teacher = create(:teacher)
+    @section.students << other_teacher
+
+    sign_in @teacher
+    put :update, params: {section_id: @section.id, id: other_teacher.id, student: {age: 10}}
+
+    assert_response :forbidden
+  end
+
   test 'teacher can update gender, name, age, and password info for their student' do
     sign_in @teacher
     put :update, params: {section_id: @section.id, id: @student.id, student: {gender: 'f', age: 9, name: 'testname', password: 'testpassword'}}


### PR DESCRIPTION
Finishes [LP-680](https://codedotorg.atlassian.net/browse/LP-680)
Follow-up for #30421

Enforces that a teacher cannot edit another teacher's account at `PATCH /sections/:section_id/students/:student_id`.