### PR TITLE
Remove race condition from selector click action

### DIFF
--- a/dashboard/test/ui/features/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_homepage.feature
@@ -109,8 +109,8 @@ Feature: Using the teacher homepage sections feature
 
     # Try to assign the unit
     Given I am on "http://studio.code.org/home"
-    And I click selector ".ui-test-section-dropdown"
-    And I click selector ".edit-section-details-link"
+    And I click selector ".ui-test-section-dropdown" once I see it
+    And I click selector ".edit-section-details-link" once I see it
     And I wait until element "#uitest-secondary-assignment" is visible
     And I select the "CSP Unit 2 - Digital Information ('17-'18)" option in dropdown "uitest-secondary-assignment"
     And I press the first ".uitest-saveButton" element


### PR DESCRIPTION
`teacher_homepage.feature` started failing pretty consistently on Friday, Aug. 23 ([Slack convo](https://codedotorg.slack.com/archives/C03CM903Y/p1566598998056900)), and it appears to be due to a race condition where the ".ui-test-section-dropdown" element was not visible when the UI test went to click it:

[S3 Cucumber log](https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_teacher_homepage_output.html?versionId=SaH8CCEpm25837d.Mir3hNtPx6JjwFGI)
[Saucelabs video](https://app.saucelabs.com/tests/c6707a63e91d4e56a812f5c4b2ee29c5#94)

![Screen Shot 2019-08-26 at 11 55 20 AM](https://user-images.githubusercontent.com/9812299/63715488-a7a5f980-c7f8-11e9-8a00-2d205d716652.png)
