### PR TITLE
Fix i18n for redirect confirmation

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1159,7 +1159,7 @@
   "record": "Record",
   "recording": "Recording",
   "recordAudio": "Record Audio",
-  "redirectConfirm": "Do you want to open this website?",
+  "redirectConfirmation": "Do you want to open this website?",
   "redirectCourseVersionWarningDetails": "It looks like you accidentally went to a different version of the course. You've been redirected to the recommended version or the version assigned by your teacher.",
   "redirectExplanation": "This is a link to an external website not operated or reviewed by Code.org and it does not follow the Code.org privacy policy. Please report this app if it is linking to content that is inappropriate or unsafe: ",
   "redirectRejectExplanation": "This app is trying to open a website that appears to be unsafe.",

--- a/apps/src/applab/ExternalRedirectDialog.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.jsx
@@ -48,7 +48,7 @@ class ExternalRedirectDialog extends React.Component {
       title = i18n.redirectTitle();
       body = (
         <div>
-          <h2 style={styles.title}>{i18n.redirectConfirm()}</h2>
+          <h2 style={styles.title}>{i18n.redirectConfirmation()}</h2>
           <p style={styles.url}>{url}</p>
           <p>
             {i18n.redirectExplanation()}


### PR DESCRIPTION
#30316 should have made a new string instead of removing the parameter from the `redirectConfirm` string

![image](https://user-images.githubusercontent.com/8787187/63715764-534f4980-c7f9-11e9-94a8-b6cc1c7207b9.png)
