### PR TITLE
Set stage lockable via stage editor gui

### DIFF
--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -36,7 +36,7 @@ const styles = {
   }
 };
 
-class StageCard extends Component {
+export class UnconnectedStageCard extends Component {
   static propTypes = {
     reorderLevel: PropTypes.func.isRequired,
     addLevel: PropTypes.func.isRequired,
@@ -145,7 +145,7 @@ class StageCard extends Component {
             position={this.props.stage.position}
             total={this.props.stagesCount}
           />
-          <div style={styles.stageLockable}>
+          <label style={styles.stageLockable}>
             Require teachers to unlock this stage before students in their
             section can access it
             <input
@@ -154,7 +154,7 @@ class StageCard extends Component {
               type="checkbox"
               style={styles.checkbox}
             />
-          </div>
+          </label>
         </div>
         {this.props.stage.levels.map(level => (
           <LevelToken
@@ -202,4 +202,4 @@ export default connect(
       dispatch(setStageLockable(stage, lockable));
     }
   })
-)(StageCard);
+)(UnconnectedStageCard);

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -124,10 +124,10 @@ class StageCard extends Component {
     this.props.addLevel(this.props.stage.position);
   };
 
-  handleLockableChanged = () => {
+  toggleLockable = () => {
     this.props.setStageLockable(
       this.props.stage.position,
-      this.refs.lockable.checked
+      !this.props.stage.lockable
     );
   };
 
@@ -149,9 +149,8 @@ class StageCard extends Component {
             Require teachers to unlock this stage before students in their
             section can access it
             <input
-              ref="lockable"
-              defaultChecked={this.props.stage.lockable}
-              onChange={this.handleLockableChanged}
+              checked={this.props.stage.lockable}
+              onChange={this.toggleLockable}
               type="checkbox"
               style={styles.checkbox}
             />

--- a/apps/test/unit/lib/script-editor/StageCardTest.js
+++ b/apps/test/unit/lib/script-editor/StageCardTest.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+
+import {UnconnectedStageCard as StageCard} from '@cdo/apps/lib/script-editor/StageCard';
+
+describe('StageCard', () => {
+  let reorderLevel, addLevel, setStageLockable, defaultProps;
+
+  beforeEach(() => {
+    reorderLevel = sinon.spy();
+    addLevel = sinon.spy();
+    setStageLockable = sinon.spy();
+    defaultProps = {
+      reorderLevel,
+      addLevel,
+      setStageLockable,
+      stagesCount: 1,
+      stage: {
+        levels: [],
+        position: 1,
+        lockable: false
+      }
+    };
+  });
+
+  it('displays lockable property', () => {
+    let wrapper = shallow(<StageCard {...defaultProps} />);
+    let labelText = 'Require teachers to unlock this stage';
+    let label = wrapper.findWhere(
+      n => n.name() === 'label' && n.text().includes(labelText)
+    );
+    expect(label.find('input').props().checked).to.equal(false);
+
+    const props = {
+      ...defaultProps,
+      stage: {
+        ...defaultProps.stage,
+        lockable: true
+      }
+    };
+    wrapper = shallow(<StageCard {...props} />);
+    labelText = 'Require teachers to unlock this stage';
+    label = wrapper.findWhere(
+      n => n.name() === 'label' && n.text().includes(labelText)
+    );
+    expect(label.find('input').props().checked).to.equal(true);
+  });
+});


### PR DESCRIPTION
fixes https://codedotorg.atlassian.net/browse/LP-598

![lockable](https://user-images.githubusercontent.com/8001765/63722034-4174a300-c807-11e9-8a60-8543f9b54663.gif)

There was a pre-existing implementation that didn't work for some reason. The error message in the anigif about making the last level be an assessment comes from the server.