### PR TITLE
add editor_experiment field to script model

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -60,6 +60,7 @@ export default class ScriptEditor extends React.Component {
     hasLessonPlan: PropTypes.bool,
     curriculumPath: PropTypes.string,
     pilotExperiment: PropTypes.string,
+    editorExperiment: PropTypes.string,
     announcements: PropTypes.arrayOf(announcementShape),
     supportedLocales: PropTypes.arrayOf(PropTypes.string),
     locales: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
@@ -311,6 +312,13 @@ export default class ScriptEditor extends React.Component {
           <input
             name="pilot_experiment"
             defaultValue={this.props.pilotExperiment}
+            style={styles.input}
+          />
+          Editor Experiment. If specified, users with this experiment on the
+          levelbuilder machine will be able to edit this script.
+          <input
+            name="editor_experiment"
+            defaultValue={this.props.editorExperiment}
             style={styles.input}
           />
         </label>

--- a/apps/src/sites/studio/pages/scripts/_form.js
+++ b/apps/src/sites/studio/pages/scripts/_form.js
@@ -73,6 +73,7 @@ export default function initPage(scriptEditorData) {
         hasLessonPlan={scriptData.has_lesson_plan}
         curriculumPath={scriptData.curriculum_path}
         pilotExperiment={scriptData.pilot_experiment}
+        editorExperiment={scriptData.editor_experiment}
         announcements={announcements}
         supportedLocales={scriptData.supported_locales}
         locales={locales}

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -155,6 +155,7 @@ class ScriptsController < ApplicationController
       :has_lesson_plan,
       :script_announcements,
       :pilot_experiment,
+      :editor_experiment,
       resourceTypes: [],
       resourceLinks: [],
       project_widget_types: [],

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -31,6 +31,7 @@ class ScriptDSL < BaseDSL
     @is_stable = nil
     @supported_locales = []
     @pilot_experiment = nil
+    @editor_experiment = nil
     @project_sharing = nil
     @curriculum_umbrella = nil
   end
@@ -58,6 +59,7 @@ class ScriptDSL < BaseDSL
   string :version_year
   string :curriculum_path
   string :pilot_experiment
+  string :editor_experiment
   string :curriculum_umbrella
 
   def teacher_resources(resources)
@@ -120,6 +122,7 @@ class ScriptDSL < BaseDSL
       is_stable: @is_stable,
       supported_locales: @supported_locales,
       pilot_experiment: @pilot_experiment,
+      editor_experiment: @editor_experiment,
       project_sharing: @project_sharing,
       curriculum_umbrella: @curriculum_umbrella
     }
@@ -295,6 +298,7 @@ class ScriptDSL < BaseDSL
     s << 'is_stable true' if script.is_stable
     s << "supported_locales #{script.supported_locales}" if script.supported_locales
     s << "pilot_experiment '#{script.pilot_experiment}'" if script.pilot_experiment
+    s << "editor_experiment '#{script.editor_experiment}'" if script.editor_experiment
     s << 'project_sharing true' if script.project_sharing
     s << "curriculum_umbrella '#{script.curriculum_umbrella}'" if script.curriculum_umbrella
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -147,6 +147,7 @@ class Script < ActiveRecord::Base
     is_stable
     supported_locales
     pilot_experiment
+    editor_experiment
     project_sharing
     curriculum_umbrella
   )
@@ -1348,6 +1349,7 @@ class Script < ActiveRecord::Base
       supported_locales: supported_locales,
       section_hidden_unit_info: section_hidden_unit_info(user),
       pilot_experiment: pilot_experiment,
+      editor_experiment: editor_experiment,
       show_assign_button: assignable?(user),
       project_sharing: project_sharing,
       curriculum_umbrella: curriculum_umbrella,
@@ -1495,6 +1497,7 @@ class Script < ActiveRecord::Base
       is_stable: script_data[:is_stable],
       supported_locales: script_data[:supported_locales],
       pilot_experiment: script_data[:pilot_experiment],
+      editor_experiment: script_data[:editor_experiment],
       project_sharing: !!script_data[:project_sharing],
       curriculum_umbrella: script_data[:curriculum_umbrella]
     }.compact

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -453,6 +453,17 @@ DSL
     assert_equal 'science-experiment', output[:pilot_experiment]
   end
 
+  test 'can set editor_experiment' do
+    input_dsl = <<DSL
+editor_experiment 'script-editors'
+
+stage 'Stage1'
+level 'Level 1'
+DSL
+    output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    assert_equal 'script-editors', output[:editor_experiment]
+  end
+
   test 'Script DSL with level progressions' do
     input_dsl = <<DSL
 stage 'Stage1'

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -464,6 +464,17 @@ DSL
     assert_equal 'script-editors', output[:editor_experiment]
   end
 
+  test 'serialize editor_experiment' do
+    script = create :script, editor_experiment: 'editors'
+    script_text = ScriptDSL.serialize_to_string(script)
+    expected = <<-SCRIPT
+hidden false
+editor_experiment 'editors'
+
+    SCRIPT
+    assert_equal expected, script_text
+  end
+
   test 'Script DSL with level progressions' do
     input_dsl = <<DSL
 stage 'Stage1'

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -32,6 +32,7 @@ class DslTest < ActiveSupport::TestCase
     is_stable: nil,
     supported_locales: [],
     pilot_experiment: nil,
+    editor_experiment: nil,
     project_sharing: nil,
     curriculum_umbrella: nil
   }


### PR DESCRIPTION
### Background

partially implements https://codedotorg.atlassian.net/browse/LP-691

See tech spec at https://docs.google.com/document/d/1aigN_ziWIVQJ-mZgz0R1eh8xOrYUXQrJtx_Mza-HWgk/edit#heading=h.b967o41qr86g for details

### Screenshot

<img width="981" alt="Screen Shot 2019-08-26 at 2 42 36 PM" src="https://user-images.githubusercontent.com/8001765/63725632-c82d7e00-c80f-11e9-8017-5b3a181f3868.png">

### Testing

manually verified:

1. adding editor_experiment via levelbuilder UI persists to the .script file
2. adding `editor_experiment 'foo'` to the .script file and then seeding successfully updates the Script object in the dashboard console
