### PR TITLE
IE now works with spritelab shared functions.

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -440,14 +440,14 @@ exports.appendNewFunctions = function(blocksXml, functionsXml) {
   const sharedFunctionsDom = xml.parseElement(functionsXml);
   const functions = [...sharedFunctionsDom.ownerDocument.firstChild.childNodes];
   for (let func of functions) {
-    const name = func.ownerDocument.evaluate(
+    const name = document.evaluate(
       'title[@name="NAME"]/text()',
       func,
       null,
       XPathResult.STRING_TYPE,
       null
     ).stringValue;
-    const type = func.ownerDocument.evaluate(
+    const type = document.evaluate(
       '@type',
       func,
       null,
@@ -455,7 +455,7 @@ exports.appendNewFunctions = function(blocksXml, functionsXml) {
       null
     ).stringValue;
     const alreadyPresent =
-      startBlocksDom.ownerDocument.evaluate(
+      document.evaluate(
         `//block[@type="${type}"]/title[@name="NAME"][text()="${name}"]`,
         startBlocksDom,
         null,


### PR DESCRIPTION
Any spritelab level (including standalone projects) that used shared functions would fail to load in IE due to a missing polyfill on ownerDocument.evaluate.

Our IE polyfill for document.evaluate cannot be applied to document objects that don't have a parent window (such as the ones in this change). Fortunately, we can use the default document object to get the same functionality.