### PR TITLE
Improve HOC map design

### DIFF
--- a/apps/src/sites/hourofcode.com/pages/views/hoc_events_map_replacement.js
+++ b/apps/src/sites/hourofcode.com/pages/views/hoc_events_map_replacement.js
@@ -8,6 +8,9 @@ $(document).ready(function() {
     minZoom: 1,
     center: [-98, 39]
   });
+
+  var popup = null;
+
   map.dragRotate.disable();
 
   map.on('load', function() {
@@ -21,7 +24,10 @@ $(document).ready(function() {
       while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
         coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
       }
-      new mapboxgl.Popup()
+      if (popup) {
+        popup.remove();
+      }
+      popup = new mapboxgl.Popup()
         .setLngLat(coordinates)
         .setText(organization_name)
         .addTo(map);
@@ -38,9 +44,12 @@ $(document).ready(function() {
       while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
         coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
       }
-      new mapboxgl.Popup()
+      if (popup) {
+        popup.remove();
+      }
+      popup = new mapboxgl.Popup({closeButton: false})
         .setLngLat(coordinates)
-        .setText(organization_name + '\n' + event_description)
+        .setHTML(organization_name + '<br>' + event_description)
         .addTo(map);
     });
 

--- a/apps/src/sites/hourofcode.com/pages/views/hoc_events_map_replacement.js
+++ b/apps/src/sites/hourofcode.com/pages/views/hoc_events_map_replacement.js
@@ -2,10 +2,10 @@
 
 $(document).ready(function() {
   // We keep some style elements as a Mapbox style for simplicity.
-  const style_path = 'mapbox://styles/codeorg/cjz36duae88ds1cp7ll7smx6s';
+  const stylePath = 'mapbox://styles/codeorg/cjz36duae88ds1cp7ll7smx6s';
   var map = new mapboxgl.Map({
     container: 'mapbox-map',
-    style: style_path,
+    style: stylePath,
     zoom: 1,
     minZoom: 1,
     center: [-98, 39]
@@ -30,14 +30,14 @@ $(document).ready(function() {
   map.on('load', function() {
     map.on('click', 'hoc-events', function(e) {
       var coordinates = e.features[0].geometry.coordinates.slice();
-      var organization_name = e.features[0].properties.organization_name;
+      var organizationName = e.features[0].properties.organization_name;
       var city = e.features[0].properties.city;
 
       if (popup) {
         popup.remove();
       }
       const popupText =
-        organization_name + (city.length > 0 ? ' (' + city + ')' : '');
+        organizationName + (city.length > 0 ? ' (' + city + ')' : '');
       popup = new mapboxgl.Popup({closeButton: false})
         .setLngLat(getPopupCoordinates(e.lngLat, coordinates))
         .setText(popupText)
@@ -46,7 +46,7 @@ $(document).ready(function() {
 
     map.on('click', 'hoc-special-events', function(e) {
       var coordinates = e.features[0].geometry.coordinates.slice();
-      var organization_name = e.features[0].properties.organization_name;
+      var organizationName = e.features[0].properties.organization_name;
       var city = e.features[0].properties.city;
       var event_description = e.features[0].properties.description;
 
@@ -54,7 +54,7 @@ $(document).ready(function() {
         popup.remove();
       }
       const popupText =
-        organization_name +
+        organizationName +
         (city.length > 0 ? ' (' + city + ')' : '') +
         '<br>' +
         event_description;

--- a/apps/src/sites/hourofcode.com/pages/views/hoc_events_map_replacement.js
+++ b/apps/src/sites/hourofcode.com/pages/views/hoc_events_map_replacement.js
@@ -28,6 +28,42 @@ $(document).ready(function() {
   }
 
   map.on('load', function() {
+    map.addSource('hoctiles', {
+      type: 'vector',
+      url: 'mapbox://codeorg.hoctiles'
+    });
+
+    // The order we add layers matters here as layers are added on top of each
+    // other. We want special events to be on top of the other events, so we
+    // add the special events layer second.
+    map.addLayer({
+      id: 'hoc-events',
+      type: 'symbol',
+      source: 'hoctiles',
+      'source-layer': 'hoc',
+      layout: {
+        visibility: 'visible',
+        'icon-allow-overlap': true,
+        'icon-size': 1,
+        'icon-image': 'circle-11-orange'
+      },
+      filter: ['!=', 'review', 'approved']
+    });
+
+    map.addLayer({
+      id: 'hoc-special-events',
+      type: 'symbol',
+      source: 'hoctiles',
+      'source-layer': 'hoc',
+      layout: {
+        visibility: 'visible',
+        'icon-allow-overlap': true,
+        'icon-size': 1.1,
+        'icon-image': 'marker-15-red'
+      },
+      filter: ['==', 'review', 'approved']
+    });
+
     map.on('click', 'hoc-events', function(e) {
       var coordinates = e.features[0].geometry.coordinates.slice();
       var organizationName = e.features[0].properties.organization_name;

--- a/apps/src/sites/hourofcode.com/pages/views/hoc_events_map_replacement.js
+++ b/apps/src/sites/hourofcode.com/pages/views/hoc_events_map_replacement.js
@@ -3,7 +3,7 @@
 $(document).ready(function() {
   var map = new mapboxgl.Map({
     container: 'mapbox-map',
-    style: 'mapbox://styles/mapbox/streets-v11',
+    style: 'mapbox://styles/codeorg/cjz36duae88ds1cp7ll7smx6s',
     zoom: 1,
     minZoom: 1,
     center: [-98, 39]
@@ -11,32 +11,7 @@ $(document).ready(function() {
   map.dragRotate.disable();
 
   map.on('load', function() {
-    map.addLayer({
-      id: 'hoc-points',
-      type: 'circle',
-      source: {
-        type: 'vector',
-        url: 'mapbox://codeorg.hoctiles'
-      },
-      'source-layer': 'hoc',
-      layout: {
-        visibility: 'visible'
-      },
-      paint: {
-        'circle-radius': 5,
-        'circle-color': [
-          'match',
-          ['get', 'review'],
-          'approved',
-          '#55D5D5',
-          /* other */ '#CC9966'
-        ],
-        'circle-stroke-width': 1,
-        'circle-stroke-color': '#000000'
-      }
-    });
-
-    map.on('click', 'hoc-points', function(e) {
+    map.on('click', 'hoc-events', function(e) {
       var coordinates = e.features[0].geometry.coordinates.slice();
       var organization_name = e.features[0].properties.organization_name;
 
@@ -52,12 +27,37 @@ $(document).ready(function() {
         .addTo(map);
     });
 
-    map.on('mouseenter', 'hoc-points', function() {
+    map.on('click', 'hoc-special-events', function(e) {
+      var coordinates = e.features[0].geometry.coordinates.slice();
+      var organization_name = e.features[0].properties.organization_name;
+      var event_description = e.features[0].properties.description;
+
+      // Ensure that if the map is zoomed out such that multiple
+      // copies of the feature are visible, the popup appears
+      // over the copy being pointed to.
+      while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+        coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+      }
+      new mapboxgl.Popup()
+        .setLngLat(coordinates)
+        .setText(organization_name + '\n' + event_description)
+        .addTo(map);
+    });
+
+    map.on('mouseenter', 'hoc-events', function() {
+      map.getCanvas().style.cursor = 'pointer';
+    });
+
+    map.on('mouseenter', 'hoc-special-events', function() {
       map.getCanvas().style.cursor = 'pointer';
     });
 
     // Change it back to a pointer when it leaves.
-    map.on('mouseleave', 'hoc-points', function() {
+    map.on('mouseleave', 'hoc-events', function() {
+      map.getCanvas().style.cursor = '';
+    });
+
+    map.on('mouseleave', 'hoc-special-events', function() {
       map.getCanvas().style.cursor = '';
     });
   });

--- a/pegasus/sites.v3/hourofcode.com/public/css/map.css
+++ b/pegasus/sites.v3/hourofcode.com/public/css/map.css
@@ -75,3 +75,11 @@
 .teal {
   background: #55D5D5;
 }
+
+.red {
+  background: #ff0000;
+}
+
+.orange {
+  background: #ffa500
+}

--- a/pegasus/sites.v3/hourofcode.com/views/hoc_events_map_replacement.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/hoc_events_map_replacement.haml
@@ -6,9 +6,9 @@
 %div{id: 'mapbox-map'}
   %div{id: 'events-legend', class: 'mapbox-legend'}
     .legend-title= hoc_s(:map_legend_title)
-    .color.brown
+    .color.orange
     %div= hoc_s(:map_legend_hoc_events)
-    .color.teal
+    .color.red
     %div= hoc_s(:map_legend_cs_tech_jam)
 
 :javascript


### PR DESCRIPTION
Update HOC map to use design Mark created. It will need to use a style created by us and hosted on Mapbox to have access to the background and icons.

![Screenshot 2019-09-04 at 3 23 23 PM](https://user-images.githubusercontent.com/46464143/64296092-f99cfc80-cf27-11e9-82fd-ef70d6db6884.png)

This PR includes a couple of other small changes to get it ready for launch.


##OLD Description
Mapbox allows you to style a map, including the data, on their site and just use that "style". I've been using that feature to prototype designs and think we should use this in the HOC map in production (tbd on the census map).

Reasons for this change:
 1. Because we're going to start using custom icons, we'd need to import a style anyway (easiest way to expose these custom icons)
 2. We don't need to wait for a deploy for style changes
 3. It allows us to [download an image of the map](ttps://docs.mapbox.com/api/maps/#static-images) to be served statically during hour of code

Downsides to this change:
 1. The legend is still defined using HTML/CSS and therefore will be _impossible_ to keep in sync if we change color schemes.
 2. Anyone with access to the style can change the look of the map in production without review.

The biggest driver for this change is reason number 3 for me. Notably, I don't know of any way of displaying a static image instead of the map during Hour of Code without this change, other than duplicating the JS defined style in a Mapbox style and using that.

This PR also contains a change to how popups are shown for special events to be more consistent with the current map.  I can separate that out if that's problematic.
