### PR TITLE
[Applab Datasets] Library tree-view

### DIFF
--- a/apps/src/storage/dataBrowser/DataCategory.jsx
+++ b/apps/src/storage/dataBrowser/DataCategory.jsx
@@ -1,25 +1,26 @@
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import React from 'react';
+import color from '../../util/color';
 import FontAwesome from '../../templates/FontAwesome';
 
 const styles = {
   categoryName: {
     fontFamily: '"Gotham 7r", sans-serif',
-    color: '#4D575F'
+    color: color.dark_charcoal
   },
   tableNumber: {
     float: 'right',
     fontFamily: '"Gotham 4r", sans-serif',
-    color: '#949CA2'
+    color: color.light_gray
   },
   categoryDescription: {
     fontFamily: '"Gotham 4r", sans-serif',
-    color: '#4D575F'
+    color: color.dark_charcoal
   },
   tableName: {
     fontFamily: '"Gotham 5r", sans-serif',
-    color: '#0094CA'
+    color: color.cyan
   }
 };
 

--- a/apps/src/storage/dataBrowser/DataCategory.jsx
+++ b/apps/src/storage/dataBrowser/DataCategory.jsx
@@ -58,9 +58,9 @@ class DataCategory extends React.Component {
               {this.props.description}
             </span>
             <ul>
-              {this.props.datasets.map(d => (
-                <li style={styles.tableName} key={d}>
-                  {d}
+              {this.props.datasets.map(dataset => (
+                <li style={styles.tableName} key={dataset}>
+                  {dataset}
                 </li>
               ))}
             </ul>

--- a/apps/src/storage/dataBrowser/DataCategory.jsx
+++ b/apps/src/storage/dataBrowser/DataCategory.jsx
@@ -1,0 +1,73 @@
+import PropTypes from 'prop-types';
+import Radium from 'radium';
+import React from 'react';
+import FontAwesome from '../../templates/FontAwesome';
+
+const styles = {
+  categoryName: {
+    fontFamily: '"Gotham 7r", sans-serif',
+    color: '#4D575F'
+  },
+  tableNumber: {
+    float: 'right',
+    fontFamily: '"Gotham 4r", sans-serif',
+    color: '#949CA2'
+  },
+  categoryDescription: {
+    fontFamily: '"Gotham 4r", sans-serif',
+    color: '#4D575F'
+  },
+  tableName: {
+    fontFamily: '"Gotham 5r", sans-serif',
+    color: '#0094CA'
+  }
+};
+
+class DataCategory extends React.Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    datasets: PropTypes.arrayOf(PropTypes.string).isRequired,
+    description: PropTypes.string.isRequired
+  };
+
+  state = {
+    collapsed: true
+  };
+
+  toggleCollapsed = () =>
+    this.setState({
+      collapsed: !this.state.collapsed
+    });
+
+  render() {
+    const icon = this.state.collapsed ? 'caret-right' : 'caret-down';
+    return (
+      <div>
+        <div onClick={this.toggleCollapsed}>
+          <FontAwesome icon={icon} />
+          <span style={styles.categoryName}>{this.props.name}</span>
+          <span style={styles.tableNumber}>
+            {this.props.datasets.length}{' '}
+            {this.props.datasets.length === 1 ? 'table' : 'tables'}
+          </span>
+        </div>
+        {!this.state.collapsed && (
+          <div>
+            <span style={styles.categoryDescription}>
+              {this.props.description}
+            </span>
+            <ul>
+              {this.props.datasets.map(d => (
+                <li style={styles.tableName} key={d}>
+                  {d}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default Radium(DataCategory);

--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -1,5 +1,6 @@
 import Radium from 'radium';
 import React from 'react';
+import DataCategory from './DataCategory';
 
 const styles = {
   container: {
@@ -13,9 +14,32 @@ const styles = {
     padding: 10
   }
 };
+
+// TODO: real data
+const categories = {
+  Animals: {description: 'description', datasets: ['one', 'two']},
+  'Arts & Entertainment': {
+    description: 'description',
+    datasets: ['three', 'four']
+  },
+  'Business & Money': {description: 'description', datasets: ['five', 'six']},
+  Education: {description: 'description', datasets: ['seven', 'eight', 'nine']},
+  'Health & Medicine': {description: 'description', datasets: ['ten']}
+};
 class DataLibraryPane extends React.Component {
   render() {
-    return <div style={styles.container} />;
+    return (
+      <div style={styles.container}>
+        {Object.keys(categories).map(category => (
+          <DataCategory
+            key={category}
+            name={category}
+            datasets={categories[category].datasets}
+            description={categories[category].description}
+          />
+        ))}
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
Spec: https://docs.google.com/document/d/1dCgzRfZTcss2SzAwzBQYSNnblsrTTHAp9cyTRpikpaM/edit

No real data yet, but this PR shows the structure. Next step: implement the table info view (when you click on one of the table names)

With experiment on:
![image](https://user-images.githubusercontent.com/8787187/63730473-45f98580-c820-11e9-9d13-9927e5f1c469.png)
![image](https://user-images.githubusercontent.com/8787187/63730482-50b41a80-c820-11e9-84af-8fe8a557fc54.png)

With experiment off:
![image](https://user-images.githubusercontent.com/8787187/63730511-6aedf880-c820-11e9-9c5e-09a9c59bc7f7.png)
