### PR TITLE
log I18n.t calls to firehose

### DIFF
--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -77,10 +77,14 @@ module Cdo
       def translate(locale, key, options = ::I18n::EMPTY_HASH)
         # Sample our data so we don't blow up firehose (or add a high overhead
         # to every Rails view request). Sample rate can be controlled with
-        # DCDO; defaulting to 1:1000 initially, to give us a safe starting
+        # DCDO; defaulting to disabled, both to give us a safe starting
         # place from which to configure actual desired sampling once we have
-        # some data.
-        sample_chance = DCDO.get('dashboard_translation_tracking_sample_chance', 0.001)
+        # some data and to prevent us from attempting to put records from the
+        # test environment. (The FirehoseClient internally suppresses requests
+        # when in the test environment, so we're not so much worried about data
+        # contamination here as we are about not messing up tests that try to
+        # look at firehose usage)
+        sample_chance = DCDO.get('dashboard_translation_tracking_sample_chance', 0.0)
         if rand < sample_chance
           # Generate the key sans locale, so we can track string usage across
           # locales

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -95,7 +95,7 @@ module Cdo
             }.to_json
           )
         end
-
+      ensure
         super(locale, key, options)
       end
     end


### PR DESCRIPTION
Based on the prototype in https://github.com/code-dot-org/code-dot-org/pull/29805

I decided to move away from `i18n-instrument`, at least initially; it works great, but adds a _significant_ overhead to I18n calls (as a result of all the information like stack traces and request urls that it gathers). We might want to explore reimplementing that eventually, but for the purposes of an initial proof-of concept, I prefer this minimal implementation.

Most significantly, this includes adjustable sampling logic; my plan is for us to deploy this, then adjust the sample rate while monitoring site performance and firebase traffic, to attempt to build a solid idea of what about of data we are reasonably capable of gathering.