### PR TITLE
Fixed checkbox clone issue.

### DIFF
--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -601,7 +601,7 @@ designMode.onDuplicate = function(element, prevThemeName, event) {
       elementClass: element.className
     })
   });
-  var duplicateElement = $(element).clone(true)[0];
+  var duplicateElement = $(element).clone()[0];
   var dupLeft = parseInt(element.style.left, 10) + 10;
   var dupTop = parseInt(element.style.top, 10) + 10;
   var dupWidth = parseInt(element.style.width, 10);
@@ -844,7 +844,7 @@ function duplicateScreen(element) {
 
   // Clone each child of the source screen into the new screen (with new ids):
   sourceScreen.children().each(function() {
-    const clonedChild = $(this).clone(true)[0];
+    const clonedChild = $(this).clone()[0];
     const elementType = elementLibrary.getElementType(clonedChild);
     elementUtils.setId(
       clonedChild,
@@ -893,7 +893,7 @@ designMode.onCopyElementToScreen = function(element, destScreen) {
   // Unwrap the draggable wrappers around the elements in the source screen:
   const madeUndraggable = makeUndraggable(sourceElement.children());
 
-  const duplicateElement = sourceElement.clone(true)[0];
+  const duplicateElement = sourceElement.clone()[0];
   const elementType = elementLibrary.getElementType(duplicateElement);
   elementUtils.setId(
     duplicateElement,
@@ -1731,7 +1731,7 @@ designMode.setAsClipboardElement = function(element) {
   }
 
   // Remember the current element on the clipboard
-  clipboardElement = jqueryElement.clone(true)[0];
+  clipboardElement = jqueryElement.clone()[0];
 
   // Remember the current theme on the clipboard
   clipboardElementTheme = elementLibrary.getCurrentTheme(


### PR DESCRIPTION
Duplicating a checkbox caused the new checkbox's event handlers to check and uncheck the original checkbox. (This was also true for radio buttons).
![checkboxes_old](https://user-images.githubusercontent.com/8324574/63880019-be2b8c80-c981-11e9-8917-1825d6e01333.gif)

This happened because we used jquery's clone with data and events any time we copied a design element. After the clone happened, we changed the element's ID to a unique ID. That meant, however, that the new checkbox's event handlers still referenced the original checkbox. Removing `withDataAndEvents` fixes that issue.
![checkbox_new](https://user-images.githubusercontent.com/8324574/63880133-faf78380-c981-11e9-8647-e9a1acbb5665.gif)

Historical context: In the past, we used `Node.cloneNode(true /*deep*/)`. We migrated to jquery `.clone(true /*withDataAndEvents*/)`. withDataAndEvents was likely set to true due to a mistaken assumption that this would cause a deep copy. Removing this fixes the checkbox issue. This is the PR where we migrated from Node.cloneNode to jquery .clone: 
https://github.com/code-dot-org/code-dot-org/commit/3e61c7e4ae48e05ba5bd922d47d957f892e02d23 