### PR TITLE
add editor_experiment field to all level types

### DIFF
--- a/dashboard/app/dsl/base_dsl.rb
+++ b/dashboard/app/dsl/base_dsl.rb
@@ -3,6 +3,10 @@ class BaseDSL
     @hash = {}
   end
 
+  def name(text)
+    @name = text
+  end
+
   # returns 'xyz' from 'XyzDSL' subclasses
   def prefix
     self.class.to_s.tap {|s| s.slice!('DSL')}.underscore

--- a/dashboard/app/dsl/base_dsl.rb
+++ b/dashboard/app/dsl/base_dsl.rb
@@ -3,21 +3,6 @@ class BaseDSL
     @hash = {}
   end
 
-  def name(text)
-    @name = text
-  end
-
-  def encrypted(text)
-    @hash['encrypted'] = '1'
-
-    begin
-      instance_eval(Encryption.decrypt_object(text))
-    rescue OpenSSL::Cipher::CipherError, Encryption::KeyMissingError
-      puts "warning: unable to decrypt level #{@name}, skipping"
-      return
-    end
-  end
-
   # returns 'xyz' from 'XyzDSL' subclasses
   def prefix
     self.class.to_s.tap {|s| s.slice!('DSL')}.underscore

--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -1,4 +1,4 @@
-class BubbleChoiceDSL < BaseDSL
+class BubbleChoiceDSL < LevelDSL
   def initialize
     super
     @hash[:display_name] = nil

--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -7,10 +7,6 @@ class BubbleChoiceDSL < LevelDSL
     @i18n_strings = Hash.new({})
   end
 
-  def parse_output
-    {name: @name, properties: @hash}
-  end
-
   def display_name(text) @hash[:display_name] = text end
 
   def description(text) @hash[:description] = text end

--- a/dashboard/app/dsl/content_dsl.rb
+++ b/dashboard/app/dsl/content_dsl.rb
@@ -1,5 +1,5 @@
 # Abstract class for DSL types which provide a standard set of content-definition methods.
-class ContentDSL < BaseDSL
+class ContentDSL < LevelDSL
   def initialize
     super
     @hash.merge! options: {}

--- a/dashboard/app/dsl/content_dsl.rb
+++ b/dashboard/app/dsl/content_dsl.rb
@@ -33,10 +33,6 @@ class ContentDSL < LevelDSL
   # levels only)
   def pre_title(text) @hash[:pre_title] = text end
 
-  def parse_output
-    {name: @name, properties: @hash}
-  end
-
   def method_missing(key, *args)
     @hash[:options] ||= {}
     @hash[:options][key.to_sym] = args.first

--- a/dashboard/app/dsl/external_dsl.rb
+++ b/dashboard/app/dsl/external_dsl.rb
@@ -3,10 +3,6 @@ class ExternalDSL < ContentDSL
     @hash = {href: '', options: {skip_dialog: true}}
   end
 
-  def parse_output
-    {name: @name, properties: @hash}
-  end
-
   def i18n_strings
     strings = super
     strings['markdown'] = @hash[:markdown] unless @hash[:markdown].blank?

--- a/dashboard/app/dsl/level_dsl.rb
+++ b/dashboard/app/dsl/level_dsl.rb
@@ -15,4 +15,8 @@ class LevelDSL < BaseDSL
       return
     end
   end
+
+  def parse_output
+    {name: @name, properties: @hash}
+  end
 end

--- a/dashboard/app/dsl/level_dsl.rb
+++ b/dashboard/app/dsl/level_dsl.rb
@@ -1,0 +1,18 @@
+# Abstract base class for all level-specific DSLs, which provides some methods
+# which are available to all DSL-defined level types.
+class LevelDSL < BaseDSL
+  def name(text)
+    @name = text
+  end
+
+  def encrypted(text)
+    @hash['encrypted'] = '1'
+
+    begin
+      instance_eval(Encryption.decrypt_object(text))
+    rescue OpenSSL::Cipher::CipherError, Encryption::KeyMissingError
+      puts "warning: unable to decrypt level #{@name}, skipping"
+      return
+    end
+  end
+end

--- a/dashboard/app/dsl/level_dsl.rb
+++ b/dashboard/app/dsl/level_dsl.rb
@@ -1,6 +1,11 @@
 # Abstract base class for all level-specific DSLs, which provides some methods
 # which are available to all DSL-defined level types.
 class LevelDSL < BaseDSL
+  def initialize
+    super
+    @hash[:editor_experiment] = nil
+  end
+
   def name(text)
     @name = text
   end
@@ -14,6 +19,10 @@ class LevelDSL < BaseDSL
       puts "warning: unable to decrypt level #{@name}, skipping"
       return
     end
+  end
+
+  def editor_experiment(text)
+    @hash[:editor_experiment] = text
   end
 
   def parse_output

--- a/dashboard/app/dsl/level_dsl.rb
+++ b/dashboard/app/dsl/level_dsl.rb
@@ -6,10 +6,6 @@ class LevelDSL < BaseDSL
     @hash[:editor_experiment] = nil
   end
 
-  def name(text)
-    @name = text
-  end
-
   def encrypted(text)
     @hash['encrypted'] = '1'
 

--- a/dashboard/app/dsl/level_group_dsl.rb
+++ b/dashboard/app/dsl/level_group_dsl.rb
@@ -18,10 +18,6 @@ class LevelGroupDSL < LevelDSL
   string :description_short
   string :description
 
-  def parse_output
-    {name: @name, properties: @hash}
-  end
-
   def title(text) @hash[:title] = text end
 
   def page

--- a/dashboard/app/dsl/level_group_dsl.rb
+++ b/dashboard/app/dsl/level_group_dsl.rb
@@ -1,4 +1,4 @@
-class LevelGroupDSL < BaseDSL
+class LevelGroupDSL < LevelDSL
   def initialize
     super
     @id = nil

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -70,6 +70,7 @@ class Level < ActiveRecord::Base
     rubric_performance_level_4
     mini_rubric
     encrypted
+    editor_experiment
     teacher_markdown
     bubble_choice_description
     starter_assets

--- a/dashboard/app/views/levels/editors/_all.html.haml
+++ b/dashboard/app/views/levels/editors/_all.html.haml
@@ -115,3 +115,8 @@
 - if @level.respond_to? :coordinate_grid_background
   .field
     = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :coordinate_grid_background, description: "Coordinate grid background"}
+
+.field
+  = f.label :editor_experiment, 'Editor Experiment'
+  %p If specified, users with this experiment on the levelbuilder machine will be able to edit this level.
+  = f.text_field :editor_experiment, placeholder: 'Editor Experiment'

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -206,6 +206,7 @@ SCRIPT
 name 'name1'
 title 'title1'
 description 'desc1'
+editor_experiment 'my-editors'
 question 'q1'
 wrong 'w1'
 wrong 'w2'
@@ -215,7 +216,7 @@ wrong 'w3'
     output, i18n = MultiDSL.parse(input_dsl, 'test')
     expected = {
       name: 'name1', properties: {
-        editor_experiment: nil,
+        editor_experiment: 'my-editors',
         options: {},
         questions: [{text: 'q1'}],
         answers: [

--- a/dashboard/test/dsl/dsl_test.rb
+++ b/dashboard/test/dsl/dsl_test.rb
@@ -215,6 +215,7 @@ wrong 'w3'
     output, i18n = MultiDSL.parse(input_dsl, 'test')
     expected = {
       name: 'name1', properties: {
+        editor_experiment: nil,
         options: {},
         questions: [{text: 'q1'}],
         answers: [
@@ -270,6 +271,7 @@ DSL
     expected = {
       name: 'Test question',
       properties: {
+        editor_experiment: nil,
         display_name: 'Test override question',
         options: {},
         questions: [{text: 'Question text'}],


### PR DESCRIPTION
### Background

finishes https://codedotorg.atlassian.net/browse/LP-691 

also see [tech spec](https://docs.google.com/document/d/1aigN_ziWIVQJ-mZgz0R1eh8xOrYUXQrJtx_Mza-HWgk/edit#heading=h.b967o41qr86g) describing this work

previously, https://github.com/code-dot-org/code-dot-org/pull/30442 added the editor_experiment field to the script model.

### Description

* 02fc6a6abd01b866b7b23434b862323ee67b6c30 adds the field to all .level file types
* c008fd24be62ced3ba147581140835467d09a923 fixes some pre-existing problems with our DSL setup. Our Script DSL format and various level DSL formats all inherited from BaseDSL, which contained some functionality that is specific to levels. This has been extracted into a new LevelDSL class which all DSL level types now inherit from. I did this now in order to have a good place to put new code in the following step.
* d078195ffdfe84ff366e733ca9f28d64679f1347 adds the `editor_experiment` field to all DSL level types via the new LevelDSL class

### Testing

In addition to updating automated test cases, I also manually tested the following with levelbuilder_mode enabled:

#### Valentine_playlab_01.level
* setting Editor Experiment in level edit GUI causes `editor_experiment` to be set in the DB and the .level file
  <img width="627" alt="Screen Shot 2019-08-27 at 4 35 33 PM" src="https://user-images.githubusercontent.com/8001765/63815284-e4e9b480-c8e8-11e9-9b4c-72525dbc3102.png">

* changing `editor_experiment` in the .level file and then running `rake seed` causes `editor_experiment` to be updated in the DB

#### submittable_multi.multi

DSL-defined levels are a bit weird in that (unlike Script DSL) the DSL file contents are never generated from the DB contents. Instead, when you edit a DSL-defined level, you see the raw level file in a text window and any changes you make to it are used to update the DB. So here is what I tested manually in this case:
* adding `editor_experiment 'foo'` in the level editor causes the DB and the .multi file to be updated
  <img width="995" alt="Screen Shot 2019-08-27 at 4 39 07 PM" src="https://user-images.githubusercontent.com/8001765/63815389-3f831080-c8e9-11e9-9886-e17aa3d8a00a.png">

* changing this to `editor_experiment 'bar'` in the .multi file and then running `rake seed` causes the DB to be updated