### PR TITLE
Feedback: controller tests for all feedback page 

### DIFF
--- a/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
@@ -17,6 +17,7 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
 
   test 'index: returns success if signed in user - feedback' do
     feedback = create :teacher_feedback
+    assert_equal TeacherFeedback.all.count, 1
     sign_in feedback.student
     get :index
     assert_response :success

--- a/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class TeacherFeedbacksControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
+  test 'index: returns forbidden if no logged in user' do
+    get :index
+    assert_redirected_to_sign_in
+  end
+
+  test 'index: returns success if signed in user - no feedback' do
+    student = create :student
+    sign_in student
+    get :index
+    assert_response :success
+  end
+
+  test 'index: returns success if signed in user - feedback' do
+    feedback = create :teacher_feedback
+    sign_in feedback.student
+    get :index
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Working on fixing the performance issues on studio.code.org/feedback on production and I thought it would be handy to add some test coverage for the page.  

- no signed in user gets redirected 
- signed in user without feedback can access 
- signed in user with feedback can access 