### PR TITLE
Feedback: performance improvements 

### DIFF
--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -7,7 +7,7 @@ class TeacherFeedbacksController < ApplicationController
   # student on any level
   def index
     @feedbacks_as_student = @teacher_feedbacks.includes(script_level: {stage: :script}).select do |feedback|
-      feedback.student_id == current_user.id && UserPermission.where(
+      UserPermission.where(
         user_id: feedback.teacher_id,
         permission: 'authorized_teacher'
       )
@@ -17,6 +17,6 @@ class TeacherFeedbacksController < ApplicationController
   end
 
   def set_seen_on_feedback_page_at
-    TeacherFeedback.where(student_id: current_user.id).update_all(seen_on_feedback_page_at: DateTime.now)
+    @teacher_feedbacks.where(student_id: current_user.id).update_all(seen_on_feedback_page_at: DateTime.now)
   end
 end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -9,6 +9,7 @@ class Ability
     # Abilities for all users, signed in or not signed in.
     can :read, :all
     cannot :read, [
+      TeacherFeedback,
       Script, # see override below
       ScriptLevel, # see override below
       :reports,


### PR DESCRIPTION
[LP-645](https://codedotorg.atlassian.net/browse/LP-645)

Previously, I wrote the query for the teacher feedbacks to display on studio.code.org/feedback such that I was fetching ALL of the teacher feedbacks then relying on Ruby code to filter to the ones to display. Which resulted in the inefficient SQL query: 

`SELECT 'teacher_feedbacks' .* FROM 'teacher_feedbacks' WHERE 'teacher_feedbacks'.'deleted_at' IS NULL`

Which caused intermittent 504 timeout errors on production. 

Instead, here, I added `TeacherFeedback` to the cannot read section of ability.rb so that `@teacher_feedbacks` would automatically be limited to only feedback for the current student. This results in a more efficient SQL query: 

`SELECT 'teacher_feedbacks' .* FROM 'teacher_feedbacks' WHERE 'teacher_feedbacks'.'deleted_at' IS NULL AND ('teacher_feedbacks'.'student_id' = 214)`