### PR TITLE
Remove `school_info_optional?` check from users

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -229,7 +229,6 @@ class User < ActiveRecord::Base
 
   belongs_to :school_info
   accepts_nested_attributes_for :school_info, reject_if: :preprocess_school_info
-  validates_presence_of :school_info, unless: :school_info_optional?
 
   has_many :user_school_infos
   after_save :update_and_add_users_school_infos, if: :school_info_id_changed?
@@ -318,11 +317,6 @@ class User < ActiveRecord::Base
     if user_school_infos.count > 0 && !school_info&.complete?
       errors.add(:school_info_id, "cannot add new school id")
     end
-  end
-
-  # Not deployed to everyone, so we don't require this for anybody, yet
-  def school_info_optional?
-    true # update if/when A/B test is done and accepted
   end
 
   # Most recently created user_school_info referring to a complete school_info entry


### PR DESCRIPTION
Originally added in https://github.com/code-dot-org/code-dot-org/pull/13107, this piece of code seems to be intended to provide for a graceful release of a feature, but that was never followed up on. It's currently nonfunctional and is adding code to our already-overlarge User model, so I'd like to remove it.

Any objections?