### PR TITLE
Remove 'advertised scripts' helper methods from User model

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1503,16 +1503,6 @@ class User < ActiveRecord::Base
     Experiment.get_all_enabled(user: self).pluck(:name)
   end
 
-  def advertised_scripts
-    [
-      Script.hoc_2014_script, Script.frozen_script, Script.infinity_script,
-      Script.flappy_script, Script.playlab_script, Script.artist_script,
-      Script.course1_script, Script.course2_script, Script.course3_script,
-      Script.course4_script, Script.twenty_hour_script, Script.starwars_script,
-      Script.starwars_blocks_script, Script.minecraft_script
-    ]
-  end
-
   def in_progress_and_completed_scripts
     user_scripts.compact.reject do |user_script|
       user_script.script.nil?
@@ -1674,10 +1664,6 @@ class User < ActiveRecord::Base
   # @return [Section|nil]
   def last_joined_section
     Follower.where(student_user: self).order(created_at: :desc).first.try(:section)
-  end
-
-  def all_advertised_scripts_completed?
-    advertised_scripts.all? {|script| completed?(script)}
   end
 
   def completed?(script)


### PR DESCRIPTION
Originally defined in https://github.com/code-dot-org/code-dot-org/pull/3165, this appears to no longer actually be used. Validated via:

```bash
[~/cdo (remove-advertised-scripts)]$ git grep advertised
[~/cdo (remove-advertised-scripts)]$
```