### PR TITLE
Remove school info interstitial passthrough methods from User model

### DIFF
--- a/dashboard/app/helpers/school_info_interstitial_helper.rb
+++ b/dashboard/app/helpers/school_info_interstitial_helper.rb
@@ -1,5 +1,6 @@
 module SchoolInfoInterstitialHelper
-  def self.show_school_info_interstitial?(user)
+  def self.show?(user)
+    return false if user.nil?
     return false unless user.teacher?
 
     return false if user.account_age_days < 7
@@ -25,7 +26,8 @@ module SchoolInfoInterstitialHelper
   # Show the school info confirmation dialog when a teacher has either completely
   # filled out the school info interstitial for a US public, private, or charter school
   # or confirmed current school over a year ago.
-  def self.show_school_info_confirmation_dialog?(user)
+  def self.show_confirmation_dialog?(user)
+    return false if user.nil?
     return false unless user.teacher?
 
     return false if user.user_school_infos.empty?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2078,14 +2078,6 @@ class User < ActiveRecord::Base
     RaceInterstitialHelper.show_race_interstitial?(self, ip_to_check)
   end
 
-  def show_school_info_confirmation_dialog?
-    SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog?(self)
-  end
-
-  def show_school_info_interstitial?
-    SchoolInfoInterstitialHelper.show_school_info_interstitial?(self)
-  end
-
   # Removes PII and other information from the user and marks the user as having been purged.
   # WARNING: This (permanently) destroys data and cannot be undone.
   # WARNING: This does not purge the user, only marks them as such.

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -13,7 +13,7 @@
   = render partial: 'layouts/terms_interstitial'
 - elsif SchoolInfoInterstitialHelper.show_confirmation_dialog?(current_user) || @force_school_info_confirmation_dialog
   = render partial: 'layouts/school_info_confirmation_dialog'
-- elsif SchoolInfoInterstitial.show?(current_user) || @force_school_info_interstitial
+- elsif SchoolInfoInterstitialHelper.show?(current_user) || @force_school_info_interstitial
   = render partial: 'layouts/school_info_interstitial', locals: {show_header: false, user: current_user, form_name: "user[school_info_attributes]"}
 
 - if current_user

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -11,9 +11,9 @@
 -# Teacher modals
 - if current_user && current_user.teacher? && !current_user.accepted_latest_terms?
   = render partial: 'layouts/terms_interstitial'
-- elsif (current_user && current_user.show_school_info_confirmation_dialog?) || @force_school_info_confirmation_dialog
+- elsif SchoolInfoInterstitialHelper.show_confirmation_dialog?(current_user) || @force_school_info_confirmation_dialog
   = render partial: 'layouts/school_info_confirmation_dialog'
-- elsif (current_user && current_user.show_school_info_interstitial?) || @force_school_info_interstitial
+- elsif SchoolInfoInterstitial.show?(current_user) || @force_school_info_interstitial
   = render partial: 'layouts/school_info_interstitial', locals: {show_header: false, user: current_user, form_name: "user[school_info_attributes]"}
 
 - if current_user

--- a/dashboard/test/lib/school_info_interstitial_helper_test.rb
+++ b/dashboard/test/lib/school_info_interstitial_helper_test.rb
@@ -20,15 +20,15 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
 
     refute user.teacher?
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    refute SchoolInfoInterstitialHelper.show? user
   end
 
   test 'does not show a dialog if the account is less than 7 days old' do
     user = create :teacher, created_at: 6.days.ago
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    refute SchoolInfoInterstitialHelper.show? user
   end
 
   test 'shows school info interstitial if account has no school info' do
@@ -37,8 +37,8 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     assert_nil user.school_info
     assert_empty user.user_school_infos
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    assert SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    assert SchoolInfoInterstitialHelper.show? user
   end
 
   test 'shows school info interstitial if account has incomplete school info' do
@@ -53,8 +53,8 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     refute user.school_info.complete?
     assert_nil user.last_complete_school_info
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    assert SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    assert SchoolInfoInterstitialHelper.show? user
   end
 
   test 'does not show a dialog if the last complete school_info is not a US school' do
@@ -69,36 +69,36 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
 
     refute user.last_complete_school_info.usa?
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    refute SchoolInfoInterstitialHelper.show? user
   end
 
   test 'does not show a dialog when the last complete school_info school type is not private, public or charter' do
     homeschool_teacher = create :teacher
     homeschool_teacher.update! school_info: create(:school_info_us_homeschool)
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? homeschool_teacher
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? homeschool_teacher
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? homeschool_teacher
+    refute SchoolInfoInterstitialHelper.show? homeschool_teacher
 
     afterschool_teacher = create :teacher
     afterschool_teacher.update! school_info: create(:school_info_us_after_school)
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? afterschool_teacher
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? afterschool_teacher
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? afterschool_teacher
+    refute SchoolInfoInterstitialHelper.show? afterschool_teacher
 
     organization_teacher = create :teacher
     organization_teacher.update! school_info: create(
       :school_info_us_homeschool,
       school_type: SchoolInfo::SCHOOL_TYPE_ORGANIZATION
     )
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? organization_teacher
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? organization_teacher
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? organization_teacher
+    refute SchoolInfoInterstitialHelper.show? organization_teacher
 
     other_teacher = create :teacher
     other_teacher.update! school_info: create(
       :school_info_us_homeschool,
       school_type: SchoolInfo::SCHOOL_TYPE_ORGANIZATION
     )
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? other_teacher
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? other_teacher
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? other_teacher
+    refute SchoolInfoInterstitialHelper.show? other_teacher
   end
 
   test 'does not show a dialog when last complete school_info was confirmed less than a year ago' do
@@ -109,8 +109,8 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     assert user.user_school_infos.last.school_info.complete?
     assert user.user_school_infos.last.last_confirmation_date > 1.year.ago
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    refute SchoolInfoInterstitialHelper.show? user
   end
 
   test 'does not show a dialog if it has been less than 7 days since we asked' do
@@ -122,8 +122,8 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
 
     assert user.last_seen_school_info_interstitial > 7.days.ago
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    refute SchoolInfoInterstitialHelper.show? user
   end
 
   test 'shows the confirmation dialog if all above conditions are met' do
@@ -131,7 +131,7 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     user.update! school_info: create(:school_info)
 
     Timecop.travel 1.year
-    assert SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
+    assert SchoolInfoInterstitialHelper.show_confirmation_dialog? user
     # We never reach the call for the school_info_interstitial
   end
 
@@ -141,13 +141,13 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     assert_nil user.school_info
     assert_empty user.user_school_infos
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    refute SchoolInfoInterstitialHelper.show? user
 
     Timecop.travel 7.days
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    assert SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    assert SchoolInfoInterstitialHelper.show? user
 
     user.update! school_info: create(:school_info)
     user.reload
@@ -155,12 +155,12 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     assert_equal 1, user.user_school_infos.count
     assert_equal user.school_info, user.last_complete_school_info
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    refute SchoolInfoInterstitialHelper.show? user
 
     Timecop.travel 1.year
 
-    assert SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
+    assert SchoolInfoInterstitialHelper.show_confirmation_dialog? user
 
     user.update! school_info: create(:school_info)
     user.reload
@@ -168,7 +168,7 @@ class SchoolInfoInterstitialHelperTest < ActiveSupport::TestCase
     assert_equal 2, user.user_school_infos.count
     assert_equal user.school_info, user.last_complete_school_info
 
-    refute SchoolInfoInterstitialHelper.show_school_info_confirmation_dialog? user
-    refute SchoolInfoInterstitialHelper.show_school_info_interstitial? user
+    refute SchoolInfoInterstitialHelper.show_confirmation_dialog? user
+    refute SchoolInfoInterstitialHelper.show? user
   end
 end


### PR DESCRIPTION
These methods are already defined on the SchoolInfoInterstitialHelper, we can just use them directly there.

Also move the helper from `lib` into the helpers directory.

Part of an ongoing effort to slim down user.rb