### PR TITLE
replace level selector with simple text input

### DIFF
--- a/apps/src/lib/script-editor/LevelNameInput.jsx
+++ b/apps/src/lib/script-editor/LevelNameInput.jsx
@@ -23,7 +23,7 @@ const styles = {
 export default class LevelNameInput extends Component {
   static propTypes = {
     onSelectLevel: PropTypes.func.isRequired,
-    levelKeyToIdMap: PropTypes.objectOf(PropTypes.number).isRequired,
+    levelNameToIdMap: PropTypes.objectOf(PropTypes.number).isRequired,
     initialLevelName: PropTypes.string
   };
 
@@ -37,7 +37,7 @@ export default class LevelNameInput extends Component {
 
   handleLevelNameChange = levelName => {
     this.setState({levelName});
-    const levelId = this.props.levelKeyToIdMap[levelName];
+    const levelId = this.props.levelNameToIdMap[levelName];
     if (levelId) {
       this.props.onSelectLevel(levelId);
     }
@@ -45,7 +45,7 @@ export default class LevelNameInput extends Component {
 
   render() {
     const {levelName} = this.state;
-    const isValid = !!this.props.levelKeyToIdMap[levelName];
+    const isValid = !!this.props.levelNameToIdMap[levelName];
     return (
       <span style={styles.levelSelect}>
         <input

--- a/apps/src/lib/script-editor/LevelNameInput.jsx
+++ b/apps/src/lib/script-editor/LevelNameInput.jsx
@@ -32,7 +32,6 @@ export default class LevelNameInput extends Component {
     super(props);
 
     this.state = {
-      isValid: props.levelId !== -1,
       levelName: props.initialLevelName
     };
   }
@@ -41,15 +40,13 @@ export default class LevelNameInput extends Component {
     this.setState({levelName});
     const levelId = this.props.levelKeyToIdMap[levelName];
     if (levelId) {
-      this.setState({isValid: true});
       this.props.onSelectLevel(levelId);
-    } else {
-      this.setState({isValid: false});
     }
   };
 
   render() {
-    const {isValid, levelName} = this.state;
+    const {levelName} = this.state;
+    const isValid = !!this.props.levelKeyToIdMap[levelName];
     return (
       <span style={styles.levelSelect}>
         <input

--- a/apps/src/lib/script-editor/LevelNameInput.jsx
+++ b/apps/src/lib/script-editor/LevelNameInput.jsx
@@ -23,7 +23,7 @@ const styles = {
 export default class LevelNameInput extends Component {
   static propTypes = {
     onSelectLevel: PropTypes.func.isRequired,
-    levelNameMap: PropTypes.objectOf(PropTypes.number).isRequired,
+    levelKeyToIdMap: PropTypes.objectOf(PropTypes.number).isRequired,
     levelId: PropTypes.number.isRequired,
     initialLevelName: PropTypes.string
   };
@@ -39,7 +39,7 @@ export default class LevelNameInput extends Component {
 
   handleLevelNameChange = levelName => {
     this.setState({levelName});
-    const levelId = this.props.levelNameMap[levelName];
+    const levelId = this.props.levelKeyToIdMap[levelName];
     if (levelId) {
       this.setState({isValid: true});
       this.props.onSelectLevel(levelId);

--- a/apps/src/lib/script-editor/LevelNameInput.jsx
+++ b/apps/src/lib/script-editor/LevelNameInput.jsx
@@ -24,7 +24,6 @@ export default class LevelNameInput extends Component {
   static propTypes = {
     onSelectLevel: PropTypes.func.isRequired,
     levelKeyToIdMap: PropTypes.objectOf(PropTypes.number).isRequired,
-    levelId: PropTypes.number.isRequired,
     initialLevelName: PropTypes.string
   };
 

--- a/apps/src/lib/script-editor/LevelNameInput.jsx
+++ b/apps/src/lib/script-editor/LevelNameInput.jsx
@@ -1,0 +1,69 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from '../../templates/FontAwesome';
+
+const styles = {
+  levelSelect: {
+    display: 'inline-block',
+    verticalAlign: 'middle',
+    width: 600
+  },
+  validIcon: {
+    color: 'green',
+    fontSize: 16,
+    marginLeft: 6
+  },
+  invalidIcon: {
+    color: 'red',
+    fontSize: 16,
+    marginLeft: 6
+  }
+};
+
+export default class LevelNameInput extends Component {
+  static propTypes = {
+    onSelectLevel: PropTypes.func.isRequired,
+    levelNameMap: PropTypes.objectOf(PropTypes.number).isRequired,
+    levelId: PropTypes.number.isRequired,
+    initialLevelName: PropTypes.string
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isValid: props.levelId !== -1,
+      levelName: props.initialLevelName
+    };
+  }
+
+  handleLevelNameChange = levelName => {
+    this.setState({levelName});
+    const levelId = this.props.levelNameMap[levelName];
+    if (levelId) {
+      this.setState({isValid: true});
+      this.props.onSelectLevel(levelId);
+    } else {
+      this.setState({isValid: false});
+    }
+  };
+
+  render() {
+    const {isValid, levelName} = this.state;
+    return (
+      <span style={styles.levelSelect}>
+        <input
+          type="text"
+          style={styles.textInput}
+          onChange={e => this.handleLevelNameChange(e.target.value)}
+          value={levelName}
+        />
+        {isValid ? (
+          <FontAwesome icon={'check-circle'} style={styles.validIcon} />
+        ) : (
+          <FontAwesome icon={'times-circle'} style={styles.invalidIcon} />
+        )}
+      </span>
+    );
+  }
+}

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -86,10 +86,17 @@ class LevelNameInput extends Component {
     levelId: PropTypes.number.isRequired
   };
 
+  state = {
+    isValid: true
+  };
+
   handleLevelNameChange = levelName => {
     const levelId = this.props.levelNameMap[levelName];
     if (levelId) {
+      this.setState({isValid: true});
       this.props.onSelectLevel(levelId);
+    } else {
+      this.setState({isValid: false});
     }
   };
 

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -78,6 +78,34 @@ const ArrowRenderer = ({onMouseDown}) => {
 };
 ArrowRenderer.propTypes = {onMouseDown: PropTypes.func.isRequried};
 
+class LevelNameInput extends Component {
+  static propTypes = {
+    onSelectLevel: PropTypes.func.isRequired,
+    levelKeyList: PropTypes.object.isRequired,
+    levelNameMap: PropTypes.objectOf(PropTypes.number).isRequired,
+    levelId: PropTypes.number.isRequired
+  };
+
+  handleLevelNameChange = levelName => {
+    const levelId = this.props.levelNameMap[levelName];
+    if (levelId) {
+      this.props.onSelectLevel(levelId);
+    }
+  };
+
+  render() {
+    return (
+      <span style={styles.levelSelect}>
+        <input
+          type="text"
+          onChange={e => this.handleLevelNameChange(e.target.value)}
+          defaultValue={this.props.levelKeyList[this.props.levelId]}
+        />
+      </span>
+    );
+  }
+}
+
 export class UnconnectedLevelTokenDetails extends Component {
   static propTypes = {
     levelKeyList: PropTypes.object.isRequired,
@@ -108,16 +136,13 @@ export class UnconnectedLevelTokenDetails extends Component {
     );
   }
 
-  handleLevelNameChange = (variant, levelName) => {
-    const levelId = this.levelNameMap[levelName];
-    if (levelId) {
-      this.props.chooseLevel(
-        this.props.stagePosition,
-        this.props.level.position,
-        variant,
-        levelId
-      );
-    }
+  handleLevelSelected = (variant, levelId) => {
+    this.props.chooseLevel(
+      this.props.stagePosition,
+      this.props.level.position,
+      variant,
+      levelId
+    );
   };
 
   handleAddVariant = () => {
@@ -256,15 +281,12 @@ export class UnconnectedLevelTokenDetails extends Component {
               </div>
             )}
             <span style={{...styles.levelFieldLabel}}>Level name:</span>
-            <span style={styles.levelSelect}>
-              <input
-                type="text"
-                onChange={e =>
-                  this.handleLevelNameChange(index, e.target.value)
-                }
-                defaultValue={this.props.levelKeyList[id]}
-              />
-            </span>
+            <LevelNameInput
+              onSelectLevel={id => this.handleLevelSelected(index, id)}
+              levelKeyList={this.props.levelKeyList}
+              levelNameMap={this.levelNameMap}
+              levelId={id}
+            />
           </div>
         ))}
         {/* We don't currently support editing progression names here, but do

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -77,7 +77,7 @@ ArrowRenderer.propTypes = {onMouseDown: PropTypes.func.isRequried};
 export class UnconnectedLevelTokenDetails extends Component {
   static propTypes = {
     levelKeyList: PropTypes.object.isRequired,
-    levelKeyToIdMap: PropTypes.objectOf(PropTypes.number).isRequired,
+    levelNameToIdMap: PropTypes.objectOf(PropTypes.number).isRequired,
     chooseLevel: PropTypes.func.isRequired,
     addVariant: PropTypes.func.isRequired,
     removeVariant: PropTypes.func.isRequired,
@@ -244,7 +244,7 @@ export class UnconnectedLevelTokenDetails extends Component {
             <span style={{...styles.levelFieldLabel}}>Level name:</span>
             <LevelNameInput
               onSelectLevel={id => this.handleLevelSelected(index, id)}
-              levelKeyToIdMap={this.props.levelKeyToIdMap}
+              levelNameToIdMap={this.props.levelNameToIdMap}
               initialLevelName={this.props.levelKeyList[id] || ''}
             />
           </div>
@@ -297,7 +297,7 @@ export class UnconnectedLevelTokenDetails extends Component {
 export default connect(
   state => ({
     levelKeyList: state.levelKeyList,
-    levelKeyToIdMap: state.levelKeyToIdMap
+    levelNameToIdMap: state.levelNameToIdMap
   }),
   dispatch => ({
     chooseLevel(stage, level, variant, value) {

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -1,7 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import _ from 'lodash';
 import {
   chooseLevel,
   addVariant,
@@ -97,7 +96,8 @@ export class UnconnectedLevelTokenDetails extends Component {
 
   componentWillMount() {
     this.levelNameMap = {};
-    _.toPairs(this.props.levelKeyList).forEach(([levelId, levelName]) => {
+    Object.keys(this.props.levelKeyList).forEach(levelId => {
+      const levelName = this.props.levelKeyList[levelId];
       this.levelNameMap[levelName] = +levelId;
     });
   }

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -245,7 +245,6 @@ export class UnconnectedLevelTokenDetails extends Component {
             <LevelNameInput
               onSelectLevel={id => this.handleLevelSelected(index, id)}
               levelKeyToIdMap={this.props.levelKeyToIdMap}
-              levelId={id}
               initialLevelName={this.props.levelKeyList[id] || ''}
             />
           </div>

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -81,16 +81,22 @@ ArrowRenderer.propTypes = {onMouseDown: PropTypes.func.isRequried};
 class LevelNameInput extends Component {
   static propTypes = {
     onSelectLevel: PropTypes.func.isRequired,
-    levelKeyList: PropTypes.object.isRequired,
     levelNameMap: PropTypes.objectOf(PropTypes.number).isRequired,
-    levelId: PropTypes.number.isRequired
+    levelId: PropTypes.number.isRequired,
+    initialLevelName: PropTypes.string
   };
 
-  state = {
-    isValid: true
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isValid: true,
+      levelName: props.initialLevelName
+    };
+  }
 
   handleLevelNameChange = levelName => {
+    this.setState({levelName});
     const levelId = this.props.levelNameMap[levelName];
     if (levelId) {
       this.setState({isValid: true});
@@ -107,7 +113,7 @@ class LevelNameInput extends Component {
           type="text"
           style={styles.textInput}
           onChange={e => this.handleLevelNameChange(e.target.value)}
-          defaultValue={this.props.levelKeyList[this.props.levelId]}
+          value={this.state.levelName}
         />
       </span>
     );
@@ -291,9 +297,9 @@ export class UnconnectedLevelTokenDetails extends Component {
             <span style={{...styles.levelFieldLabel}}>Level name:</span>
             <LevelNameInput
               onSelectLevel={id => this.handleLevelSelected(index, id)}
-              levelKeyList={this.props.levelKeyList}
               levelNameMap={this.levelNameMap}
               levelId={id}
+              initialLevelName={this.props.levelKeyList[id] || ''}
             />
           </div>
         ))}

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -1,10 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import VirtualizedSelect from 'react-virtualized-select';
-import 'react-virtualized/styles.css';
-import 'react-select/dist/react-select.css';
-import 'react-virtualized-select/styles.css';
 import _ from 'lodash';
 import {
   chooseLevel,
@@ -100,10 +96,10 @@ export class UnconnectedLevelTokenDetails extends Component {
   };
 
   componentWillMount() {
-    this.levelKeyOptions = _.map(this.props.levelKeyList, (label, value) => ({
-      label,
-      value: +value
-    }));
+    this.levelNameMap = {};
+    _.toPairs(this.props.levelKeyList).forEach(([levelId, levelName]) => {
+      this.levelNameMap[levelName] = +levelId;
+    });
   }
 
   containsLegacyLevel() {
@@ -112,13 +108,16 @@ export class UnconnectedLevelTokenDetails extends Component {
     );
   }
 
-  handleLevelSelected = (index, {value}) => {
-    this.props.chooseLevel(
-      this.props.stagePosition,
-      this.props.level.position,
-      index,
-      value
-    );
+  handleLevelNameChange = (variant, levelName) => {
+    const levelId = this.levelNameMap[levelName];
+    if (levelId) {
+      this.props.chooseLevel(
+        this.props.stagePosition,
+        this.props.level.position,
+        variant,
+        levelId
+      );
+    }
   };
 
   handleAddVariant = () => {
@@ -258,12 +257,12 @@ export class UnconnectedLevelTokenDetails extends Component {
             )}
             <span style={{...styles.levelFieldLabel}}>Level name:</span>
             <span style={styles.levelSelect}>
-              <VirtualizedSelect
-                options={this.levelKeyOptions}
-                value={id}
-                onChange={this.handleLevelSelected.bind(null, index)}
-                clearable={false}
-                arrowRenderer={ArrowRenderer}
+              <input
+                type="text"
+                onChange={e =>
+                  this.handleLevelNameChange(index, e.target.value)
+                }
+                defaultValue={this.props.levelKeyList[id]}
               />
             </span>
           </div>

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -77,6 +77,7 @@ ArrowRenderer.propTypes = {onMouseDown: PropTypes.func.isRequried};
 export class UnconnectedLevelTokenDetails extends Component {
   static propTypes = {
     levelKeyList: PropTypes.object.isRequired,
+    levelKeyToIdMap: PropTypes.objectOf(PropTypes.number).isRequired,
     chooseLevel: PropTypes.func.isRequired,
     addVariant: PropTypes.func.isRequired,
     removeVariant: PropTypes.func.isRequired,
@@ -89,14 +90,6 @@ export class UnconnectedLevelTokenDetails extends Component {
   state = {
     showBlankProgression: false
   };
-
-  componentWillMount() {
-    this.levelKeyToIdMap = {};
-    Object.keys(this.props.levelKeyList).forEach(levelId => {
-      const levelName = this.props.levelKeyList[levelId];
-      this.levelKeyToIdMap[levelName] = +levelId;
-    });
-  }
 
   containsLegacyLevel() {
     return this.props.level.ids.some(id =>
@@ -251,7 +244,7 @@ export class UnconnectedLevelTokenDetails extends Component {
             <span style={{...styles.levelFieldLabel}}>Level name:</span>
             <LevelNameInput
               onSelectLevel={id => this.handleLevelSelected(index, id)}
-              levelKeyToIdMap={this.levelKeyToIdMap}
+              levelKeyToIdMap={this.props.levelKeyToIdMap}
               levelId={id}
               initialLevelName={this.props.levelKeyList[id] || ''}
             />
@@ -304,7 +297,8 @@ export class UnconnectedLevelTokenDetails extends Component {
 
 export default connect(
   state => ({
-    levelKeyList: state.levelKeyList
+    levelKeyList: state.levelKeyList,
+    levelKeyToIdMap: state.levelKeyToIdMap
   }),
   dispatch => ({
     chooseLevel(stage, level, variant, value) {

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -91,10 +91,10 @@ export class UnconnectedLevelTokenDetails extends Component {
   };
 
   componentWillMount() {
-    this.levelNameMap = {};
+    this.levelKeyToIdMap = {};
     Object.keys(this.props.levelKeyList).forEach(levelId => {
       const levelName = this.props.levelKeyList[levelId];
-      this.levelNameMap[levelName] = +levelId;
+      this.levelKeyToIdMap[levelName] = +levelId;
     });
   }
 
@@ -251,7 +251,7 @@ export class UnconnectedLevelTokenDetails extends Component {
             <span style={{...styles.levelFieldLabel}}>Level name:</span>
             <LevelNameInput
               onSelectLevel={id => this.handleLevelSelected(index, id)}
-              levelNameMap={this.levelNameMap}
+              levelKeyToIdMap={this.levelKeyToIdMap}
               levelId={id}
               initialLevelName={this.props.levelKeyList[id] || ''}
             />

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -10,7 +10,7 @@ import {
   NEW_LEVEL_ID
 } from './editorRedux';
 import {levelShape} from './shapes';
-import FontAwesome from '../../templates/FontAwesome';
+import LevelNameInput from './LevelNameInput';
 
 const styles = {
   checkbox: {
@@ -27,11 +27,6 @@ const styles = {
     lineHeight: '36px',
     margin: '0 7px 0 5px',
     verticalAlign: 'middle'
-  },
-  levelSelect: {
-    display: 'inline-block',
-    verticalAlign: 'middle',
-    width: 600
   },
   textInput: {
     height: 34,
@@ -71,16 +66,6 @@ const styles = {
   },
   progression: {
     paddingTop: 5
-  },
-  validIcon: {
-    color: 'green',
-    fontSize: 16,
-    marginLeft: 6
-  },
-  invalidIcon: {
-    color: 'red',
-    fontSize: 16,
-    marginLeft: 6
   }
 };
 
@@ -88,54 +73,6 @@ const ArrowRenderer = ({onMouseDown}) => {
   return <i className="fa fa-chevron-down" onMouseDown={onMouseDown} />;
 };
 ArrowRenderer.propTypes = {onMouseDown: PropTypes.func.isRequried};
-
-class LevelNameInput extends Component {
-  static propTypes = {
-    onSelectLevel: PropTypes.func.isRequired,
-    levelNameMap: PropTypes.objectOf(PropTypes.number).isRequired,
-    levelId: PropTypes.number.isRequired,
-    initialLevelName: PropTypes.string
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      isValid: props.levelId !== -1,
-      levelName: props.initialLevelName
-    };
-  }
-
-  handleLevelNameChange = levelName => {
-    this.setState({levelName});
-    const levelId = this.props.levelNameMap[levelName];
-    if (levelId) {
-      this.setState({isValid: true});
-      this.props.onSelectLevel(levelId);
-    } else {
-      this.setState({isValid: false});
-    }
-  };
-
-  render() {
-    const {isValid, levelName} = this.state;
-    return (
-      <span style={styles.levelSelect}>
-        <input
-          type="text"
-          style={styles.textInput}
-          onChange={e => this.handleLevelNameChange(e.target.value)}
-          value={levelName}
-        />
-        {isValid ? (
-          <FontAwesome icon={'check-circle'} style={styles.validIcon} />
-        ) : (
-          <FontAwesome icon={'times-circle'} style={styles.invalidIcon} />
-        )}
-      </span>
-    );
-  }
-}
 
 export class UnconnectedLevelTokenDetails extends Component {
   static propTypes = {

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -10,6 +10,7 @@ import {
   NEW_LEVEL_ID
 } from './editorRedux';
 import {levelShape} from './shapes';
+import FontAwesome from '../../templates/FontAwesome';
 
 const styles = {
   checkbox: {
@@ -70,6 +71,16 @@ const styles = {
   },
   progression: {
     paddingTop: 5
+  },
+  validIcon: {
+    color: 'green',
+    fontSize: 16,
+    marginLeft: 6
+  },
+  invalidIcon: {
+    color: 'red',
+    fontSize: 16,
+    marginLeft: 6
   }
 };
 
@@ -90,7 +101,7 @@ class LevelNameInput extends Component {
     super(props);
 
     this.state = {
-      isValid: true,
+      isValid: props.levelId !== -1,
       levelName: props.initialLevelName
     };
   }
@@ -107,14 +118,20 @@ class LevelNameInput extends Component {
   };
 
   render() {
+    const {isValid, levelName} = this.state;
     return (
       <span style={styles.levelSelect}>
         <input
           type="text"
           style={styles.textInput}
           onChange={e => this.handleLevelNameChange(e.target.value)}
-          value={this.state.levelName}
+          value={levelName}
         />
+        {isValid ? (
+          <FontAwesome icon={'check-circle'} style={styles.validIcon} />
+        ) : (
+          <FontAwesome icon={'times-circle'} style={styles.invalidIcon} />
+        )}
       </span>
     );
   }

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -98,6 +98,7 @@ class LevelNameInput extends Component {
       <span style={styles.levelSelect}>
         <input
           type="text"
+          style={styles.textInput}
           onChange={e => this.handleLevelNameChange(e.target.value)}
           defaultValue={this.props.levelKeyList[this.props.levelId]}
         />

--- a/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
@@ -9,6 +9,13 @@ const levelKeyList = {
   4: 'blockly:Studio:playlab_1'
 };
 
+const levelKeyToIdMap = {
+  'Level One': 1,
+  'Level Two': 2,
+  'Level Three': 3,
+  'blockly:Studio:playlab_1': 4
+};
+
 const defaultLevel = {
   position: 1,
   ids: [2],
@@ -30,6 +37,7 @@ export default storybook => {
         <div style={{width: 800}}>
           <LevelTokenDetails
             levelKeyList={levelKeyList}
+            levelKeyToIdMap={levelKeyToIdMap}
             chooseLevel={action('chooseLevel')}
             addVariant={action('addVariant')}
             removeVariant={action('removeVariant')}
@@ -47,6 +55,7 @@ export default storybook => {
         <div style={{width: 800}}>
           <LevelTokenDetails
             levelKeyList={levelKeyList}
+            levelKeyToIdMap={levelKeyToIdMap}
             chooseLevel={action('chooseLevel')}
             addVariant={action('addVariant')}
             removeVariant={action('removeVariant')}

--- a/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
@@ -9,7 +9,7 @@ const levelKeyList = {
   4: 'blockly:Studio:playlab_1'
 };
 
-const levelKeyToIdMap = {
+const levelNameToIdMap = {
   'Level One': 1,
   'Level Two': 2,
   'Level Three': 3,
@@ -37,7 +37,7 @@ export default storybook => {
         <div style={{width: 800}}>
           <LevelTokenDetails
             levelKeyList={levelKeyList}
-            levelKeyToIdMap={levelKeyToIdMap}
+            levelNameToIdMap={levelNameToIdMap}
             chooseLevel={action('chooseLevel')}
             addVariant={action('addVariant')}
             removeVariant={action('removeVariant')}
@@ -55,7 +55,7 @@ export default storybook => {
         <div style={{width: 800}}>
           <LevelTokenDetails
             levelKeyList={levelKeyList}
-            levelKeyToIdMap={levelKeyToIdMap}
+            levelNameToIdMap={levelNameToIdMap}
             chooseLevel={action('chooseLevel')}
             addVariant={action('addVariant')}
             removeVariant={action('removeVariant')}

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -214,7 +214,6 @@ function stages(state = [], action) {
       break;
     }
     case CHOOSE_LEVEL: {
-      console.log(action);
       const level = newState[action.stage - 1].levels[action.level - 1];
       if (level.ids[action.variant] === level.activeId) {
         level.activeId = action.value;

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -274,7 +274,22 @@ function levelKeyList(state = {}, action) {
   return state;
 }
 
+function levelKeyToIdMap(state = {}, action) {
+  switch (action.type) {
+    case INIT: {
+      const levelKeyToIdMap = {};
+      Object.keys(action.levelKeyList).forEach(levelId => {
+        const levelKey = action.levelKeyList[levelId];
+        levelKeyToIdMap[levelKey] = +levelId;
+      });
+      return levelKeyToIdMap;
+    }
+  }
+  return state;
+}
+
 export default {
   stages,
-  levelKeyList
+  levelKeyList,
+  levelKeyToIdMap
 };

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -214,6 +214,7 @@ function stages(state = [], action) {
       break;
     }
     case CHOOSE_LEVEL: {
+      console.log(action);
       const level = newState[action.stage - 1].levels[action.level - 1];
       if (level.ids[action.variant] === level.activeId) {
         level.activeId = action.value;

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -274,15 +274,15 @@ function levelKeyList(state = {}, action) {
   return state;
 }
 
-function levelKeyToIdMap(state = {}, action) {
+function levelNameToIdMap(state = {}, action) {
   switch (action.type) {
     case INIT: {
-      const levelKeyToIdMap = {};
+      const levelNameToIdMap = {};
       Object.keys(action.levelKeyList).forEach(levelId => {
         const levelKey = action.levelKeyList[levelId];
-        levelKeyToIdMap[levelKey] = +levelId;
+        levelNameToIdMap[levelKey] = +levelId;
       });
-      return levelKeyToIdMap;
+      return levelNameToIdMap;
     }
   }
   return state;
@@ -291,5 +291,5 @@ function levelKeyToIdMap(state = {}, action) {
 export default {
   stages,
   levelKeyList,
-  levelKeyToIdMap
+  levelNameToIdMap
 };

--- a/apps/test/unit/lib/script-editor/LevelNameInputTest.js
+++ b/apps/test/unit/lib/script-editor/LevelNameInputTest.js
@@ -4,7 +4,7 @@ import {expect} from '../../../util/reconfiguredChai';
 import sinon from 'sinon';
 import LevelNameInput from '@cdo/apps/lib/script-editor/LevelNameInput';
 
-const levelKeyToIdMap = {
+const levelNameToIdMap = {
   'Level One': 1,
   'Level Two': 2,
   'Level Three': 3
@@ -16,7 +16,7 @@ describe('LevelNameInput', () => {
     onSelectLevel = sinon.spy();
     defaultProps = {
       onSelectLevel,
-      levelKeyToIdMap,
+      levelNameToIdMap,
       initialLevelName: 'Level One'
     };
   });

--- a/apps/test/unit/lib/script-editor/LevelNameInputTest.js
+++ b/apps/test/unit/lib/script-editor/LevelNameInputTest.js
@@ -17,7 +17,6 @@ describe('LevelNameInput', () => {
     defaultProps = {
       onSelectLevel,
       levelKeyToIdMap,
-      levelId: 1,
       initialLevelName: 'Level One'
     };
   });
@@ -47,7 +46,6 @@ describe('LevelNameInput', () => {
   it('renders a blank level', () => {
     const props = {
       ...defaultProps,
-      levelId: -1,
       initialLevelName: ''
     };
     const wrapper = shallow(<LevelNameInput {...props} />);

--- a/apps/test/unit/lib/script-editor/LevelNameInputTest.js
+++ b/apps/test/unit/lib/script-editor/LevelNameInputTest.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+import LevelNameInput from '@cdo/apps/lib/script-editor/LevelNameInput';
+
+const levelKeyToIdMap = {
+  'Level One': 1,
+  'Level Two': 2,
+  'Level Three': 3
+};
+
+describe('LevelNameInput', () => {
+  let onSelectLevel, defaultProps;
+  beforeEach(() => {
+    onSelectLevel = sinon.spy();
+    defaultProps = {
+      onSelectLevel,
+      levelKeyToIdMap,
+      levelId: 1,
+      initialLevelName: 'Level One'
+    };
+  });
+
+  it('renders a valid level', () => {
+    const wrapper = shallow(<LevelNameInput {...defaultProps} />);
+    const iconName = wrapper.find('FontAwesome').props().icon;
+    expect(iconName).to.equal('check-circle');
+  });
+
+  it('responds to input', () => {
+    const wrapper = shallow(<LevelNameInput {...defaultProps} />);
+    let iconName = wrapper.find('FontAwesome').props().icon;
+    expect(iconName).to.equal('check-circle');
+
+    wrapper.find('input').simulate('change', {target: {value: 'Level'}});
+    iconName = wrapper.find('FontAwesome').props().icon;
+    expect(iconName).to.equal('times-circle');
+    expect(onSelectLevel).not.to.have.been.called;
+
+    wrapper.find('input').simulate('change', {target: {value: 'Level Two'}});
+    iconName = wrapper.find('FontAwesome').props().icon;
+    expect(iconName).to.equal('check-circle');
+    expect(onSelectLevel).to.have.been.calledWith(2);
+  });
+
+  it('renders a blank level', () => {
+    const props = {
+      ...defaultProps,
+      levelId: -1,
+      initialLevelName: ''
+    };
+    const wrapper = shallow(<LevelNameInput {...props} />);
+    const iconName = wrapper.find('FontAwesome').props().icon;
+    expect(iconName).to.equal('times-circle');
+  });
+});

--- a/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
+++ b/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
@@ -11,6 +11,13 @@ const levelKeyList = {
   4: 'blockly:Studio:playlab_1'
 };
 
+const levelNameToIdMap = {
+  'Level One': 1,
+  'Level Two': 2,
+  'Level Three': 3,
+  'blockly:Studio:playlab_1': 4
+};
+
 const defaultLevel = {
   position: 1,
   ids: [2],
@@ -57,6 +64,7 @@ describe('LevelTokenDetails', () => {
 
     defaultProps = {
       levelKeyList,
+      levelNameToIdMap,
       chooseLevel,
       addVariant,
       removeVariant,

--- a/dashboard/config/scripts/valentine.script
+++ b/dashboard/config/scripts/valentine.script
@@ -1,5 +1,5 @@
 stage 'Valentine Puzzles'
 level 'Valentine_playlab_01'
-level 'Valentine_artist2_01'
+level 'Valentine_artist_01'
 level 'Valentine_artist2_01'
 level 'valentine_artist_03'

--- a/dashboard/config/scripts/valentine.script
+++ b/dashboard/config/scripts/valentine.script
@@ -1,5 +1,5 @@
 stage 'Valentine Puzzles'
 level 'Valentine_playlab_01'
-level 'Valentine_artist_01'
+level 'Valentine_artist2_01'
 level 'Valentine_artist2_01'
 level 'valentine_artist_03'


### PR DESCRIPTION
### background

the level selector dropdown in the stage editor gui is painfully slow to update after each keypress:

![level-name-selector](https://user-images.githubusercontent.com/8001765/63900592-d1f0e600-c9b5-11e9-95b9-0028c6b05bb8.gif)

curriculum team members report that they do not need a level dropdown, rather when they are adding levels to a script they usually just need a place to paste the level name in and see some confirmation that it is valid.

### description

replace the level selector dropdown with a simple text input which also shows whether the level name that's been entered is valid.

### screenshot

the following recording shows the process of partially typing, then pasting, a level name into the input:

![level-name-input](https://user-images.githubusercontent.com/8001765/63900454-6e66b880-c9b5-11e9-8787-32dc01ccc099.gif)
