### PR TITLE
Feedback: fix styles for long timestamps

### DIFF
--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -19,7 +19,7 @@ const styles = {
     boxSizing: 'border-box'
   },
   lessonDetails: {
-    width: '88%',
+    width: '75%',
     marginLeft: 20,
     marginTop: 8,
     marginBottom: 4
@@ -42,7 +42,10 @@ const styles = {
     fontSize: 14,
     lineHeight: '17px',
     color: color.light_gray,
-    float: 'left'
+    float: 'right',
+    textAlign: 'right',
+    marginRight: 20,
+    width: 200
   },
   comment: {
     color: color.dark_charcoal,


### PR DESCRIPTION
[LP-697](https://codedotorg.atlassian.net/browse/LP-697)

**BEFORE**: long timestamps would jump to the next line and disrupt the flow of the component 
<img width="1018" alt="Screen Shot 2019-08-27 at 10 39 07 AM" src="https://user-images.githubusercontent.com/12300669/63882823-ab1bbb00-c987-11e9-80d7-d564ccce7050.png">

**AFTER**: timestamps have more room to expand
<img width="987" alt="Screen Shot 2019-08-28 at 10 33 13 AM" src="https://user-images.githubusercontent.com/12300669/63882814-a35c1680-c987-11e9-9ff5-35fb9739ec1a.png">

