### PR TITLE
Reverse order of operations in migration

### DIFF
--- a/dashboard/db/migrate/20190826184856_remove_contact_id_from_regional_partners.rb
+++ b/dashboard/db/migrate/20190826184856_remove_contact_id_from_regional_partners.rb
@@ -1,6 +1,17 @@
 class RemoveContactIdFromRegionalPartners < ActiveRecord::Migration[5.0]
   def change
-    remove_column :regional_partners, :contact_id, :integer
+    # This migration was retroactively changed on August 28th.
+    # The original form had the statements in reverse order, and looked like this:
+    #
+    # remove_column :regional_partners, :contact_id, :integer
+    # remove_index :regional_partners, name: "index_regional_partners_on_name_and_contact_id"
+    #
+    # However if a duplicate name existed in regional_partners, removing the contact_id column
+    # would cause a violation of the unique index and prevent the migration from running.
+    # In its current form this should not be an issue, and the end result of running the
+    # migration should be identical.
+
     remove_index :regional_partners, name: "index_regional_partners_on_name_and_contact_id"
+    remove_column :regional_partners, :contact_id, :integer
   end
 end


### PR DESCRIPTION
Retroactively update a migration file to make it more resilient (without changing its overall effect).

[This migration](https://github.com/code-dot-org/code-dot-org/commit/d1adcea1507dcf01af8c5bbf15d4f5cdba101d9b) was created two days ago and hasn't shipped yet.

When I tried to run this migration on my local machine, I received this error:

```
Mysql2::Error: Duplicate entry 'Partner1' for key 'index_regional_partners_on_name_and_contact_id': ALTER TABLE `regional_partners` DROP `contact_id`
[CDO]/dashboard/db/migrate/20190826184856_remove_contact_id_from_regional_partners.rb:3:in `change'
```

It turns out having multiple partners with the same name but different contact ids in your database could break this migration, because removing the column caused a unique index on (name, contact_id) to become a unique index on (name).

Dropping the index first has no effect on the end result of this migration, but makes it work in this particular scenario as well.