### PR TITLE
Feedback: remove redundant index for teacher_feedbacks

### DIFF
--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -19,7 +19,6 @@
 #
 # Indexes
 #
-#  index_feedback_on_student_and_level                 (student_id,level_id)
 #  index_feedback_on_student_and_level_and_teacher_id  (student_id,level_id,teacher_id)
 #
 

--- a/dashboard/db/migrate/20190828195110_remove_redundant_index_from_teacher_feedback.rb
+++ b/dashboard/db/migrate/20190828195110_remove_redundant_index_from_teacher_feedback.rb
@@ -1,0 +1,5 @@
+class RemoveRedundantIndexFromTeacherFeedback < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :teacher_feedbacks, name: "index_feedback_on_student_and_level"
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190826184856) do
+ActiveRecord::Schema.define(version: 20190828195110) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1393,7 +1393,6 @@ ActiveRecord::Schema.define(version: 20190826184856) do
     t.integer  "script_level_id",                        null: false
     t.datetime "seen_on_feedback_page_at"
     t.index ["student_id", "level_id", "teacher_id"], name: "index_feedback_on_student_and_level_and_teacher_id", using: :btree
-    t.index ["student_id", "level_id"], name: "index_feedback_on_student_and_level", using: :btree
   end
 
   create_table "teacher_profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
[LP-700](https://codedotorg.atlassian.net/browse/LP-700)

While investigating performance on the all feedback page, [Dave realized that we have redundant indexing](https://codedotorg.slack.com/archives/C03CK49G9/p1567010125001700?thread_ts=1567009252.001500&cid=C03CK49G9) on the TeacherFeedback model.  To clean up I deleted ` index_feedback_on_student_and_level_and_teacher_id  (student_id,level_id,teacher_id)` because we have ` index_feedback_on_student_and_level_and_teacher_id  (student_id,level_id,teacher_id)`