### PR TITLE
Configure multi-threaded replication for reporting DB cluster

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -191,6 +191,12 @@ Resources:
       Description: !Sub "Aurora DB Cluster Parameters for ${AWS::StackName}."
       Family: aurora-mysql5.7
       Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['AuroraCluster'].compact.to_json %>
+  AuroraReportingClusterDBParameters:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Properties:
+      Description: !Sub "Aurora Reporting DB Cluster Parameters for ${AWS::StackName}."
+      Family: aurora-mysql5.7
+      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['AuroraReportingCluster'].compact.to_json %>
   AuroraWriterDBParameters:
     Type: AWS::RDS::DBParameterGroup
     Properties:

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -142,7 +142,7 @@ Replica:
   slave_preserve_commit_order: 1
 
 # System variables for the Aurora DB cluster.
-AuroraCluster:
+AuroraCluster: &aurora
   # When using row-based logging, the master writes events to the binary log that indicate how individual table rows are changed.
   # Replication of the master to the slave works by copying the events representing the changes to the table rows to the slave.
   # ROW required for DMS Change Data Capture:
@@ -174,6 +174,13 @@ AuroraCluster:
   # IAM role ARN used to select data into AWS S3.
   aurora_select_into_s3_role: {'Fn::GetAtt': [AuroraS3Role, Arn]}
 
+# Aurora Reporting cluster parameters.
+AuroraReportingCluster:
+  <<: *aurora
+
+  # Apply transactions that are part of the same binary-log group-commit in parallel.
+  slave_parallel_type: LOGICAL_CLOCK
+
 # System variables for the Aurora DB writer.
 AuroraWriter:
   # Enable Performance Schema.
@@ -182,7 +189,9 @@ AuroraWriter:
   # Relax transaction isolation for improved concurrency under load.
   tx_isolation: READ-COMMITTED
 
-# System variables for the Aurora DB writer.
+# System variables for the Aurora DB reporting replica.
 AuroraReportingReplica:
   # No max execution time on reporting DB.
   max_execution_time: null
+  # Use 8 parallel worker threads for replication.
+  slave_parallel_workers: 8


### PR DESCRIPTION
Updates to data CloudFormation stack, adding a Reporting cluster DB parameter group and setting Aurora DB cluster/instance parameters for multi-threaded replication.