### PR TITLE
Feedback: log feedback expansions

### DIFF
--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -100,14 +100,16 @@ export default class LevelFeedbackEntry extends Component {
 
   expand = () => {
     this.setState({expanded: true});
-    firehoseClient.putRecord(
-      {
-        study: 'all-feedback',
-        event: 'expand-feedback',
-        data_json: {feedback_id: this.props.feedback.id}.to_json
-      },
-      {includeUserId: true}
-    );
+    if (this.longComment()) {
+      firehoseClient.putRecord(
+        {
+          study: 'all-feedback',
+          event: 'expand-feedback',
+          data_json: {feedback_id: this.props.feedback.id}
+        },
+        {includeUserId: true}
+      );
+    }
   };
 
   collapse = () => {

--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -5,6 +5,7 @@ import color from '@cdo/apps/util/color';
 import shapes from './shapes';
 import {UnlocalizedTimeAgo as TimeAgo} from '@cdo/apps/templates/TimeAgo';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   main: {
@@ -99,6 +100,14 @@ export default class LevelFeedbackEntry extends Component {
 
   expand = () => {
     this.setState({expanded: true});
+    firehoseClient.putRecord(
+      {
+        study: 'all-feedback',
+        event: 'expand-feedback',
+        data_string: this.props.feedback.id
+      },
+      {includeUserId: true}
+    );
   };
 
   collapse = () => {

--- a/apps/src/templates/feedback/LevelFeedbackEntry.jsx
+++ b/apps/src/templates/feedback/LevelFeedbackEntry.jsx
@@ -104,7 +104,7 @@ export default class LevelFeedbackEntry extends Component {
       {
         study: 'all-feedback',
         event: 'expand-feedback',
-        data_string: this.props.feedback.id
+        data_json: {feedback_id: this.props.feedback.id}.to_json
       },
       {includeUserId: true}
     );


### PR DESCRIPTION
[LP-525](https://codedotorg.atlassian.net/browse/LP-525) Metrics for feedback, partial 

Record an event when a feedback entry with a long comment is clicked on studio.code.org/feedback. One of the concerns of displaying the comments on the all feedback page was that it would be too cluttered; to alleviate this concern we collapse long comments. However, we want to gauge if students are actually expanding and reading the feedback.  This tracking will give us a better sense if that is happening. 