### PR TITLE
Fix pd-workshop-survey contact_id reference

### DIFF
--- a/pegasus/sites.v3/code.org/public/pd-workshop-survey/splat.haml
+++ b/pegasus/sites.v3/code.org/public/pd-workshop-survey/splat.haml
@@ -21,7 +21,7 @@ title: "Professional Development Workshop Survey"
   name = teacher.nil? ? "#{enrollment[:first_name]} #{enrollment[:last_name]}" : teacher[:name]
   email = teacher.try(:[], :email).presence || enrollment[:email]
 
-  plp = DASHBOARD_DB[:regional_partners].where(contact_id: workshop[:organizer_id]).first
+  plp = DASHBOARD_DB[:regional_partners].where(id: workshop[:regional_partner_id]).first
   # Have they ever taken any pd-workshop-survey?
   is_first_survey = teacher_id.nil? || DB[:forms].where(kind: 'PdWorkshopSurvey', user_id: teacher_id).count == 0
 


### PR DESCRIPTION
This survey partial still contained a reference to `regional_partners.contact_id`, which was removed in https://github.com/code-dot-org/code-dot-org/pull/30445. Instead, I'm using the workshop's regional_partner_id to do a regional partner lookup so we can populate a hidden field on the form.

This is intentionally a shallow fix, no cleanup or refactoring; I'm just trying to quickly correct what looks like a regression on production ([Honeybadger](https://app.honeybadger.io/projects/34365/faults/54042037)). We're hoping to deprecate this view soon anyway.