### PR TITLE
Remove remaining references to regional partner contact_id

### DIFF
--- a/pegasus/sites.v3/code.org/public/pd-workshop-survey/counselor-admin/splat.haml
+++ b/pegasus/sites.v3/code.org/public/pd-workshop-survey/counselor-admin/splat.haml
@@ -15,7 +15,7 @@ title: "Workshop Survey for Counselors and Administrators"
   name = teacher.nil? ? "#{enrollment[:first_name]} #{enrollment[:last_name]}" : teacher[:name]
   email = teacher.nil? ? enrollment[:email] : teacher[:email]
 
-  plp = DASHBOARD_DB[:regional_partners].where(contact_id: workshop[:organizer_id]).first
+  plp = DASHBOARD_DB[:regional_partners].where(id: workshop[:regional_partner_id]).first
 
   # Have they taken this particular survey?
   previous_response = DB[:forms].where(kind: 'PdWorkshopSurveyCounselorAdmin', source_id: enrollment[:id]).first

--- a/pegasus/sites.v3/code.org/public/pd-workshop-survey/splat.haml
+++ b/pegasus/sites.v3/code.org/public/pd-workshop-survey/splat.haml
@@ -21,7 +21,7 @@ title: "Professional Development Workshop Survey"
   name = teacher.nil? ? "#{enrollment[:first_name]} #{enrollment[:last_name]}" : teacher[:name]
   email = teacher.try(:[], :email).presence || enrollment[:email]
 
-  plp = DASHBOARD_DB[:regional_partners].where(contact_id: workshop[:organizer_id]).first
+  plp = DASHBOARD_DB[:regional_partners].where(id: workshop[:regional_partner_id]).first
   # Have they ever taken any pd-workshop-survey?
   is_first_survey = teacher_id.nil? || DB[:forms].where(kind: 'PdWorkshopSurvey', user_id: teacher_id).count == 0
 


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/30445

I removed the `contact_id` from regional partners but forgot to check if it was referenced in any views. Removing those references now.