### PR TITLE
Import p5 directly, instead of expecting it to be present on the page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -220,19 +220,6 @@ describe('entry tests', () => {
           src: ['**/*.js'],
           dest: 'build/package/js/ace/'
         },
-        // Pull p5.js and p5.play.js into the package from our forks.
-        {
-          expand: true,
-          cwd: './node_modules/@code-dot-org/p5/lib',
-          src: ['p5.js'],
-          dest: 'build/package/js/p5play/'
-        },
-        {
-          expand: true,
-          cwd: './node_modules/@code-dot-org/p5.play/lib',
-          src: ['p5.play.js'],
-          dest: 'build/package/js/p5play/'
-        },
         {
           expand: true,
           // For some reason, if we provide piskel root as an absolute path here,

--- a/apps/src/p5lab/GameLabP5.js
+++ b/apps/src/p5lab/GameLabP5.js
@@ -1,5 +1,7 @@
 import {getStore} from '@cdo/apps/redux';
 import {allAnimationsSingleFrameSelector} from './animationListModule';
+window.p5 = require('@code-dot-org/p5');
+require('@code-dot-org/p5.play/lib/p5.play');
 var gameLabSprite = require('./GameLabSprite');
 var gameLabGroup = require('./GameLabGroup');
 import {backgrounds} from './spritelab/backgrounds.json';

--- a/apps/src/p5lab/GameLabP5.js
+++ b/apps/src/p5lab/GameLabP5.js
@@ -1,7 +1,10 @@
 import {getStore} from '@cdo/apps/redux';
 import {allAnimationsSingleFrameSelector} from './animationListModule';
-window.p5 = require('@code-dot-org/p5');
-require('@code-dot-org/p5.play/lib/p5.play');
+import p5 from '@code-dot-org/p5';
+// Needed while we transition to importing p5 everywhere, instead of depending
+// on it globally.
+window.p5 = p5;
+import '@code-dot-org/p5.play/lib/p5.play';
 var gameLabSprite = require('./GameLabSprite');
 var gameLabGroup = require('./GameLabGroup');
 import {backgrounds} from './spritelab/backgrounds.json';

--- a/dashboard/app/views/levels/_apps_dependencies.html.haml
+++ b/dashboard/app/views/levels/_apps_dependencies.html.haml
@@ -20,11 +20,6 @@
   %link{href: asset_path('css/droplet/droplet.min.css'), rel: 'stylesheet', type: 'text/css'}
   %link{href: asset_path('css/tooltipster/tooltipster.min.css'), rel: 'stylesheet', type: 'text/css'}
 
--# Gamelab script dependencies
-- if use_gamelab
-  %script{src: minifiable_asset_path('js/p5play/p5.js')}
-  %script{src: minifiable_asset_path('js/p5play/p5.play.js')}
-
 -# Droplet script dependencies (only when editor present)
 - if use_droplet && !hide_source
 


### PR DESCRIPTION
Next step towards letting webpack optimize the overlap in code between `dance-party` dependencies and Game Lab / Sprite Lab.

Follow up to PR https://github.com/code-dot-org/code-dot-org/pull/30389.