### PR TITLE
Migrate level_source_id in user_levels to bigint in non-production environments

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -10,7 +10,7 @@
 #  updated_at       :datetime
 #  best_result      :integer
 #  script_id        :integer
-#  level_source_id  :integer
+#  level_source_id  :integer          unsigned
 #  submitted        :boolean
 #  readonly_answers :boolean
 #  unlocked_at      :datetime

--- a/dashboard/db/migrate/20190829175243_convert_level_source_id_to_bigint_user_levels.rb
+++ b/dashboard/db/migrate/20190829175243_convert_level_source_id_to_bigint_user_levels.rb
@@ -1,0 +1,9 @@
+class ConvertLevelSourceIdToBigintUserLevels < ActiveRecord::Migration[5.0]
+  def up
+    change_column :user_levels, :level_source_id, 'BIGINT(11) UNSIGNED'
+  end
+
+  def down
+    change_column :user_levels, :level_source_id, :int
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190828195110) do
+ActiveRecord::Schema.define(version: 20190829175243) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1433,7 +1433,7 @@ ActiveRecord::Schema.define(version: 20190828195110) do
     t.datetime "updated_at"
     t.integer  "best_result"
     t.integer  "script_id"
-    t.integer  "level_source_id"
+    t.bigint   "level_source_id",                           unsigned: true
     t.boolean  "submitted"
     t.boolean  "readonly_answers"
     t.datetime "unlocked_at"


### PR DESCRIPTION
Migrates level_source_id columns in `user_levels` table to bigint -- this migration has already been run on production per https://github.com/code-dot-org/code-dot-org/pull/30317.

This migration will update all other environments to match.