### PR TITLE
[Spritelab] Don't reset/preview when code is running

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -351,8 +351,10 @@ P5Lab.prototype.init = function(config) {
 
     if (this.isSpritelab) {
       this.studioApp_.addChangeHandler(() => {
-        this.reset();
-        this.preview.apply(this);
+        if (!getStore().getState().runState.isRunning) {
+          this.reset();
+          this.preview.apply(this);
+        }
       });
     }
   };


### PR DESCRIPTION
Current bug: If you interact with the blockspace while the code is running, everything resets to white.

This changes the changeHandler function to check if the code is running first so we only reset and preview when the program is not running.