### PR TITLE
Extract p5-dependencies.js chunk

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -854,6 +854,13 @@ describe('entry tests', () => {
                   )
                 );
               }
+            },
+            p5lab: {
+              name: 'p5-dependencies',
+              priority: 40,
+              chunks: chunk =>
+                ['spritelab', 'gamelab', 'dance'].includes(chunk.name),
+              test: module => /p5/.test(module.resource)
             }
           }
         }

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -857,7 +857,8 @@ describe('entry tests', () => {
             },
             p5lab: {
               name: 'p5-dependencies',
-              priority: 40,
+              priority: 10,
+              minChunks: 2,
               chunks: chunk =>
                 ['spritelab', 'gamelab', 'dance'].includes(chunk.name),
               test: module => /p5/.test(module.resource)

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -305,19 +305,18 @@ module LevelsHelper
     use_weblab = @level.game == Game.weblab
     use_phaser = @level.game == Game.craft
     use_blockly = !use_droplet && !use_netsim && !use_weblab
-    use_dance = @level.is_a?(Gamelab) && @level.helper_libraries.try(:include?, 'DanceLab')
+    use_p5 = @level.is_a?(Gamelab)
     hide_source = app_options[:hideSource]
     render partial: 'levels/apps_dependencies',
       locals: {
         app: app_options[:app],
         use_droplet: use_droplet,
-        use_netsim: use_netsim,
         use_blockly: use_blockly,
         use_applab: use_applab,
         use_gamelab: use_gamelab,
         use_weblab: use_weblab,
         use_phaser: use_phaser,
-        use_dance: use_dance,
+        use_p5: use_p5,
         hide_source: hide_source,
         preload_asset_list: @level.try(:preload_asset_list),
         static_asset_base_path: app_options[:baseUrl]

--- a/dashboard/app/views/levels/_apps_dependencies.html.haml
+++ b/dashboard/app/views/levels/_apps_dependencies.html.haml
@@ -1,9 +1,9 @@
 -#
-  Expected locals: app, use_blockly, use_droplet, use_netsim, use_applab, hide_source, static_asset_base_path
+  Expected locals: app, use_blockly, use_droplet, use_p5, use_applab, hide_source, static_asset_base_path
   Provide default values for some of these
 - use_blockly ||= false
 - use_droplet ||= false
-- use_netsim ||= false
+- use_p5 ||= false
 - use_applab ||= false
 - use_gamelab ||= false
 - use_weblab ||= false
@@ -14,6 +14,9 @@
 -# Common style dependencies
 %link{href: asset_path('css/common.css'), rel: 'stylesheet', type: 'text/css'}
 %link{href: asset_path("css/#{app}.css"), rel: 'stylesheet', type: 'text/css'}
+
+- if use_p5
+  %script{src: minifiable_asset_path('js/p5-dependencies.js')}
 
 -# Droplet style dependencies (only when editor present)
 - if use_droplet && !hide_source


### PR DESCRIPTION
<img width="465" alt="Screen Shot 2019-08-29 at 11 55 37 AM" src="https://user-images.githubusercontent.com/413693/63971387-31ed9800-ca5b-11e9-8af7-883d95f3137a.png">

With PR https://github.com/code-dot-org/code-dot-org/pull/30510, more p5-specific code will be pulled into the common.js chunk. Create a separate p5-dependencies.js chunk for gamelab, spritelab & dance.