### PR TITLE
Optimize storage id encryption

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ group :development, :test do
   #gem 'debugger' unless ENV['RM_INFO']
 
   gem 'active_record_query_trace'
+  gem 'benchmark-ips'
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,7 @@ GEM
       aws-eventstream (~> 1.0, >= 1.0.2)
     backports (3.11.3)
     bcrypt (3.1.11)
+    benchmark-ips (2.7.2)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -896,6 +897,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1)
   aws-sdk-secretsmanager (~> 1)
   bcrypt
+  benchmark-ips
   better_errors
   binding_of_caller
   bootstrap-sass (~> 2.3.2.2)

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -28,9 +28,11 @@ def destroy_storage_id_cookie
 end
 
 def storage_decrypt(encrypted)
-  decrypter = OpenSSL::Cipher.new 'AES-128-CBC'
-  decrypter.decrypt
-  decrypter.pkcs5_keyivgen(CDO.channels_api_secret, '8 octets')
+  $storage_id_decrypter ||= OpenSSL::Cipher.new('AES-128-CBC').tap do |decrypter|
+    decrypter.decrypt
+    decrypter.pkcs5_keyivgen(CDO.channels_api_secret, '8 octets')
+  end
+  (decrypter = $storage_id_decrypter).reset
   plain = decrypter.update(encrypted)
   plain << decrypter.final
 end
@@ -66,9 +68,11 @@ def valid_encrypted_channel_id(encrypted)
 end
 
 def storage_encrypt(plain)
-  encrypter = OpenSSL::Cipher.new('AES-128-CBC')
-  encrypter.encrypt
-  encrypter.pkcs5_keyivgen(CDO.channels_api_secret, '8 octets')
+  $storage_id_encrypter ||= OpenSSL::Cipher.new('AES-128-CBC').tap do |encrypter|
+    encrypter.encrypt
+    encrypter.pkcs5_keyivgen(CDO.channels_api_secret, '8 octets')
+  end
+  (encrypter = $storage_id_encrypter).reset
   encrypted = encrypter.update(plain.to_s)
   encrypted << encrypter.final
 end

--- a/shared/test/middleware/helpers/test_storage_id.rb
+++ b/shared/test/middleware/helpers/test_storage_id.rb
@@ -112,4 +112,17 @@ class StorageIdTest < Minitest::Test
     @user_storage_ids_table.where(id: cookie_storage_id).update(user_id: 2)
     assert_nil storage_id_from_cookie
   end
+
+  # Ensures decrypt/encrypt performance exceeds a minimum iterations per second threshold.
+  def test_encrypt_performance
+    require 'benchmark/ips'
+    result = Benchmark.ips(time: 1, warmup: 0.5, quiet: true) do |x|
+      id_range = 1..10000
+      x.report do
+        id = rand(id_range)
+        assert_equal id, storage_decrypt_id(storage_encrypt_id(id))
+      end
+    end
+    assert_operator result.entries.first.ips, :>, 3000
+  end
 end


### PR DESCRIPTION
This PR optimizes the storage id encryption routines (`storage_decrypt` and `storage_encrypt`) used by storage apps throughout the application. These routines use the `OpenSSL::Cipher` library, and create a new cipher object for each operation, which uses a somewhat time-consuming PKCS5 key-derivation step. However, since the password/salt is identical for all decryption / encryption operations performed by the application (they only depend on `channels_api_secret` and a constant string), the cipher objects can be cached and reused across operations.

In order to measure and verify the performance impact, this PR includes a unit test leveraging [`benchmark-ips`](https://github.com/evanphx/benchmark-ips) to ensure the function meets a minimum 'iterations per second' threshold, which I've (somewhat arbitrarily) set to 3000.

Before the change in this PR, this test would fail at ~970 ips. After the change, the test passes at ~178000 ips, for an ~180x speedup.