### PR TITLE
Enable AYW to use new survey pipeline

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
@@ -31,8 +31,7 @@ const questionOrder = {
     'overall_success_1',
     'overall_success_2',
     'overall_success_3',
-    'overall_success_4',
-    'overall_success_5'
+    'overall_success_4'
   ]
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
@@ -31,7 +31,8 @@ const questionOrder = {
     'overall_success_1',
     'overall_success_2',
     'overall_success_3',
-    'overall_success_4'
+    'overall_success_4',
+    'overall_success_5'
   ]
 };
 

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_joiner.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_joiner.rb
@@ -69,8 +69,6 @@ module Pd::SurveyPipeline
 
             if question[:type] == TYPE_MATRIX && ans.is_a?(Array)
               ans.each do |sub_ans|
-                next if sub_ans[:answer].blank?
-
                 # Create a new question for each sub question and add it to question list.
                 # Its id and name are generated based on the parent's id and name.
                 new_qid = compute_descendant_key(qid, sub_ans[:text])
@@ -84,6 +82,7 @@ module Pd::SurveyPipeline
                 )
                 parsed_questions[form_id][new_qid] = new_question
 
+                next if sub_ans[:answer].blank?
                 # Create flatten question-answer record
                 results << shared_submission_info.
                   merge(new_question).

--- a/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
@@ -60,8 +60,7 @@ module Pd::SurveyPipeline::Helper
     context = {
       current_workshop_id: workshop.id,
       facilitator_id: facilitator_id,
-      question_categories: [FACILITATOR_EFFECTIVENESS_CATEGORY],
-      submission_type: 'Facilitator'
+      question_categories: [FACILITATOR_EFFECTIVENESS_CATEGORY]
     }
 
     # Retrieve data
@@ -71,19 +70,13 @@ module Pd::SurveyPipeline::Helper
 
     # Process data
     process_rollup_data context
-
-    # Decorate
-    Pd::SurveyPipeline::FacilitatorSurveyRollupDecorator.process_data context
-
-    context[:decorated_summaries]
   end
 
   def report_workshop_rollup(facilitator_id, workshop)
     context = {
       current_workshop_id: workshop.id,
       facilitator_id: facilitator_id,
-      question_categories: [WORKSHOP_OVERALL_SUCCESS_CATEGORY, WORKSHOP_TEACHER_ENGAGEMENT_CATEGORY],
-      submission_type: 'Workshop'
+      question_categories: [WORKSHOP_OVERALL_SUCCESS_CATEGORY, WORKSHOP_TEACHER_ENGAGEMENT_CATEGORY]
     }
 
     # Retrieve data
@@ -93,11 +86,6 @@ module Pd::SurveyPipeline::Helper
 
     # Process data
     process_rollup_data context
-
-    # Decorate
-    Pd::SurveyPipeline::WorkshopSurveyRollupDecorator.process_data context
-
-    context[:decorated_summaries]
   end
 
   def process_rollup_data(context)
@@ -151,6 +139,9 @@ module Pd::SurveyPipeline::Helper
     Pd::SurveyPipeline::GenericMapper.new(
       group_config: group_config_this_ws, map_config: map_config_this_ws
     ).process_data context
+
+    # Decorate
+    Pd::SurveyPipeline::SurveyRollupDecorator.decorate_facilitator_rollup context
   end
 
   # Summarize all survey results for a workshop.

--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
@@ -1,5 +1,21 @@
 module Pd::SurveyPipeline
   class SurveyRollupDecorator
+    # Create a roll up report to send to client view.
+    #
+    # @param [Hash] data a hash contains all important pieces of information from
+    #   previous steps in the pipeline.
+    #
+    # @return [Hash] a hash report contains following keys
+    #   :facilitators => {factilitator_id => facilitator_name}
+    #   :current_workshop => Integer
+    #   :related_workshops: {facilitator_id => Array<Integer>}
+    #   :facilitator_response_counts =>
+    #     {workshop_scope => {factilitator_id => {submission_type => count}}}
+    #   :facilitator_averages => a hash with following keys
+    #     :questions => {question_name => question_text}
+    #     facilitator_name => {question_name_or_category => {workshop_scope => score}}
+    #   :errors => Array
+    #
     def self.decorate_facilitator_rollup(data)
       report = {
         facilitators: {},
@@ -10,51 +26,36 @@ module Pd::SurveyPipeline
         errors: data[:errors]
       }
 
-      # facilitators: {factilitator_id => facilitator_name}
+      # Get values for :facilitators and :related_workshops keys
       facilitator_id = data[:facilitator_id]
       facilitator_name = get_user_name_by_id(facilitator_id)
       report[:facilitators][facilitator_id] = facilitator_name
+      report[:related_workshops][facilitator_id] = data[:related_workshop_ids]
 
-      # related_workshops: {facilitator_name => Array<Integer>}
-      report[:related_workshops][facilitator_name] = data[:related_workshop_ids]
-
-      # facilitator_response_counts:
-      #   {:this_workshop, :all_my_workshops => {factilitator_id => {submission_type => count}}}
+      # Get value for :facilitator_response_counts key
       # TODO: count only submissions that contribute to average scores
       submissions = data[:facilitator_submissions] || data[:workshop_submissions]
       report[:facilitator_response_counts] =
         get_submission_counts submissions, data[:facilitator_id], data[:current_workshop_id]
 
-      # Convert question names to the format that the view expects.
-      # There is a difference in how we name sub-questions in the controller and in the (legacy) view.
-      # In the controller, sub-question names have <original_question>_<hash_of_sub_question_text> format.
-      # While in the view, it expects question names in format <original_question>_<index_of_sub_question>.
-      # Conversion examples:
-      # overall_success_<hash_string> -> overall_success_<index_number>
-      # teacher_engagement_<hash_string> -> teacher_engagement_<index_number>
-      # facilitator_effectiveness_<hash_string> -> facilitator_effectiveness__<index_number>
+      # Get value for :questions key in :facilitator_averages key.
+      # The value contains all questions in selected categories, even if not all of them have responses.
+      # Also convert question names to the format that the UI expects.
+      # E.g. overall_success_<hash_string> -> overall_success_<index_number>.
+      category_questions =
+        get_category_questions data[:parsed_questions], data[:question_categories]
       q_name_replacements =
-        get_question_name_replacements data[:parsed_questions], data[:question_categories]
+        get_question_name_replacements category_questions, data[:question_categories]
+      report[:facilitator_averages][:questions] =
+        replace_question_name_keys category_questions, q_name_replacements
 
-      # Get list of questions to calculate averages.
+      # Get question averages for this facilitator in :facilitator_averages key
       # Replace question names if needed.
-      # facilitator_averages: {:questions => {question_name => question_text}}
-      q_names_to_texts = map_question_name_to_text data[:parsed_questions]
-      q_names_to_texts.transform_keys! {|q_name| q_name_replacements[q_name] || q_name}
-      # TODO: remove hidden questions and all questions that are not in summaries
-      report[:facilitator_averages][:questions] = q_names_to_texts
+      question_averages = get_question_averages data[:summaries], data[:current_workshop_id]
+      report[:facilitator_averages][facilitator_name] =
+        replace_question_name_keys question_averages, q_name_replacements
 
-      # Calculate question averages.
-      # Replace question names if needed.
-      # facilitator_averages:
-      #   {facilitator_name => {question_name => {:this_workshop, :all_my_workshops => score}}}
-      question_averages = get_question_averages(data[:summaries], data[:current_workshop_id])
-      question_averages.transform_keys! {|q_name| q_name_replacements[q_name] || q_name}
-      report[:facilitator_averages][facilitator_name] = question_averages
-
-      # Calculate category averages.
-      # facilitator_averages:
-      #   {facilitator_name => {question_category => {:this_workshop, :all_my_workshops => score}}}
+      # Get category averages for this facilitator in :facilitator_averages key
       category_averages = get_category_averages data[:question_categories], question_averages
       report[:facilitator_averages][facilitator_name].merge! category_averages
 
@@ -63,14 +64,124 @@ module Pd::SurveyPipeline
 
     private_class_method
 
-    def self.get_category_averages(question_categories, question_averages)
-      result = {}
-      question_categories.each do |category|
-        # qnames_in_cateogry = qname_replacements.values.select {|val| val.start_with? category}
-        # category_scores = avg_scores[facilitator_name].values_at(*qnames_in_cateogry).compact
-        # this_workshop_scores = category_scores.pluck(:this_workshop).compact
-        # all_workshop_scores = category_scores.pluck(:all_my_workshops).compact
+    def self.get_user_name_by_id(id)
+      User.find(id)&.name || "UserId_#{id}"
+    end
 
+    # Count number of submissions for a specific workshop and for all workshops.
+    #
+    # @param [Array<Pd::WorkshopDailySurvey|Pd::WorkshopFacilitatorId>] submissions
+    # @param [Integer] facilitator_id
+    # @param [Integer] workshop_id
+    # @return [Hash] {workshop_scope => {facilitator_id => {submission_type => count}}
+    #
+    def self.get_submission_counts(submissions, facilitator_id, workshop_id)
+      result = {this_workshop: {facilitator_id => {}}, all_my_workshops: {facilitator_id => {}}}
+
+      if submissions.present?
+        submission_type =
+          submissions.first.is_a?(Pd::WorkshopDailySurvey) ? 'Workshop surveys' : 'Facilitator surveys'
+
+        result[:all_my_workshops][facilitator_id] = {submission_type => submissions.count}
+        result[:this_workshop][facilitator_id] =
+          {submission_type => submissions.where(pd_workshop_id: workshop_id).count}
+      end
+
+      result
+    end
+
+    # Get all questions in selected categories.
+    #
+    # @param [Hash{form_id => {question_id => question_content}}] parsed_questions
+    # @param [Array<String>] categories
+    # @return [Hash] {question_name => question_text}.
+    #
+    def self.get_category_questions(parsed_questions, categories)
+      result = {}
+      parsed_questions&.each_pair do |_, form_questions|
+        form_questions.each_pair do |_, q_content|
+          q_name = q_content[:name]
+          next if result.key? q_name
+          next if categories.none? {|category| q_name.start_with? category}
+
+          result[q_name] = q_content[:text]
+        end
+      end
+
+      result
+    end
+
+    # Create new names for questions in the selected categories.
+    # Old name: <category>_<hash string>. New name: <category>_<index number>.
+    #
+    # @param [Hash<question_name, question_text>] questions
+    # @param [Array<String>] categories
+    # @return [Hash] {old_question_name => new_question_name}
+    #
+    def self.get_question_name_replacements(questions, categories)
+      q_name_replacements = {}
+      categories.each do |category|
+        # Questions in a category could also mean sub-questions of a the same parent question.
+        # In that case, we ignore the parent question and also replace names of the sub-questions.
+        # Sort question names by question texts so order of questions is always in
+        # alphabetical order.
+        sorted_q_names = questions.
+          select {|q_name, _| q_name.start_with?(category) && q_name != category}.
+          sort_by {|_, value| value}.
+          pluck(0)
+
+        sorted_q_names.each_with_index do |q_name, index|
+          q_name_replacements[q_name] = "#{category}_#{index}"
+        end
+      end
+
+      q_name_replacements
+    end
+
+    # Replace keys for an input hash which uses question names as keys.
+    #
+    # @param [Hash<question_name, value>] question_hash
+    # @param [Hash<old_name, new_name>] q_name_replacements
+    # @return [Hash] a new hash with the same values as the original input hash
+    #   but with the keys replaced.
+    #
+    def self.replace_question_name_keys(question_hash, q_name_replacements)
+      question_hash.
+        select {|q_name, _| q_name_replacements.key? q_name}.
+        transform_keys {|q_name| q_name_replacements[q_name]}
+    end
+
+    # Get quetion average results for a specific workshop and for all workshops.
+    #
+    # @param [Array<Hash>] summaries
+    # @param [Integer] workshop_id
+    # @return [Hash] {question_name => {workshop_scope => avg_result}}]
+    #
+    def self.get_question_averages(summaries, workshop_id)
+      result = {}
+
+      summaries.each do |summary|
+        # Acceptable values for workshop_id is either nil or current_workshop_id
+        next if summary[:workshop_id] && summary[:workshop_id] != workshop_id
+
+        scope = summary[:workshop_id] ? :this_workshop : :all_my_workshops
+        q_name = summary[:name]
+        result[q_name] ||= {}
+        result[q_name][scope] = summary[:reducer_result]
+      end
+
+      result
+    end
+
+    # Get average results of all questions in the same category.
+    #
+    # @param [Array<String>] categories
+    # @param [Hash{question_name => {workshop_scope => avg_result}}] question_averages
+    # @return [Hash] {category_name => {workshop_scope => avg_result}}
+    #
+    def self.get_category_averages(categories, question_averages)
+      result = {}
+      categories.each do |category|
         category_scores = question_averages.select {|q_name, _| q_name.start_with? category}
         this_workshop_scores = category_scores.values.pluck(:this_workshop).compact
         all_workshop_scores = category_scores.values.pluck(:all_my_workshops).compact
@@ -83,85 +194,6 @@ module Pd::SurveyPipeline
       end
 
       result
-    end
-
-    def self.get_question_averages(summaries, current_workshop_id)
-      result = {}
-
-      summaries.each do |summary|
-        # Acceptable values for workshop_id is either nil or current_workshop_id
-        next if summary[:workshop_id] && summary[:workshop_id] != current_workshop_id
-        scope = summary[:workshop_id] ? :this_workshop : :all_my_workshops
-
-        q_name = summary[:name]
-        result[q_name] ||= {}
-        result[q_name][scope] = summary[:reducer_result]
-      end
-
-      result
-    end
-
-    def self.map_question_name_to_text(parsed_questions)
-      # Create mappings from question name to question text for all parsed questions
-      q_names_to_texts = {}
-      parsed_questions&.each_pair do |_, form_questions|
-        form_questions.each_pair do |_, q_content|
-          # If there are multiple questions with the same name, we assume they are all the same
-          # and keep the first one we find.
-          q_names_to_texts[q_content[:name]] = q_content[:text] unless
-            q_names_to_texts.key?(q_content[:name])
-        end
-      end
-
-      q_names_to_texts
-    end
-
-    def self.get_question_names(parsed_questions)
-      q_names = Set[]
-
-      parsed_questions&.each_pair do |_, form_questions|
-        form_questions.each_pair do |_, q_content|
-          q_names.add(q_content[:name])
-        end
-      end
-
-      q_names.to_a
-    end
-
-    def self.get_question_name_replacements(parsed_questions, question_categories)
-      q_names = get_question_names parsed_questions
-
-      # Create replacements for questions in selected categories
-      q_name_replacements = {}
-      question_categories.each do |category|
-        # Sort names so order of questions in a category is always consistent
-        sorted_q_names = q_names.select {|q_name| q_name.start_with?(category)}.sort
-
-        sorted_q_names.each_with_index do |q_name, index|
-          q_name_replacements[q_name] = "#{category}_#{index}"
-        end
-      end
-
-      q_name_replacements
-    end
-
-    def self.get_submission_counts(submissions, facilitator_id, current_workshop_id)
-      result = {this_workshop: {facilitator_id => {}}, all_my_workshops: {facilitator_id => {}}}
-
-      if submissions.present?
-        submission_type =
-          submissions.first.is_a?(Pd::WorkshopDailySurvey) ? 'Workshop surveys' : 'Facilitator surveys'
-
-        result[:all_my_workshops][facilitator_id] = {submission_type => submissions.count}
-        result[:this_workshop][facilitator_id] =
-          {submission_type => submissions.where(pd_workshop_id: current_workshop_id).count}
-      end
-
-      result
-    end
-
-    def self.get_user_name_by_id(id)
-      User.find(id)&.name || "UserId_#{id}"
     end
   end
 end

--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
@@ -54,19 +54,22 @@ module Pd::SurveyPipeline
       report[:facilitator_averages][facilitator_name].merge! category_averages
 
       # Count number of submissions contributed to category average scores.
-      submission_type =
-        data[:facilitator_submissions] ? 'Facilitator-specific submissions' : 'Workshop submissions'
-
       report[:facilitator_response_counts] = {
         this_workshop: {facilitator_id => {}},
         all_my_workshops: {facilitator_id => {}}
       }
-      report[:facilitator_response_counts][:this_workshop][facilitator_id][submission_type] =
-        get_submission_counts(
-          data[:question_answer_joined], data[:question_categories], data[:current_workshop_id]
-        )
-      report[:facilitator_response_counts][:all_my_workshops][facilitator_id][submission_type] =
-        get_submission_counts data[:question_answer_joined], data[:question_categories]
+
+      if data[:facilitator_submissions].present? || data[:workshop_submissions].present?
+        submission_type = data[:facilitator_submissions].present? ?
+          'Facilitator-specific submissions' : 'Workshop submissions'
+
+        report[:facilitator_response_counts][:this_workshop][facilitator_id][submission_type] =
+          get_submission_counts(
+            data[:question_answer_joined], data[:question_categories], data[:current_workshop_id]
+          )
+        report[:facilitator_response_counts][:all_my_workshops][facilitator_id][submission_type] =
+          get_submission_counts data[:question_answer_joined], data[:question_categories]
+      end
 
       report
     end

--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
@@ -102,7 +102,7 @@ module Pd::SurveyPipeline
         form_questions.each_pair do |_, q_content|
           q_name = q_content[:name]
           next if result.key? q_name
-          next if categories.none? {|category| q_name.start_with? category}
+          next if categories.none? {|category| q_name.start_with? "#{category}_"}
 
           result[q_name] = q_content[:text]
         end
@@ -126,7 +126,7 @@ module Pd::SurveyPipeline
         # Sort question names by question texts so order of questions is always in
         # alphabetical order.
         sorted_q_names = questions.
-          select {|q_name, _| q_name.start_with?(category) && q_name != category}.
+          select {|q_name, _| q_name.start_with? "#{category}_"}.
           sort_by {|_, value| value}.
           pluck(0)
 
@@ -167,7 +167,7 @@ module Pd::SurveyPipeline
         scope = summary[:workshop_id] ? :this_workshop : :all_my_workshops
         q_name = summary[:name]
         result[q_name] ||= {}
-        result[q_name][scope] = summary[:reducer_result]
+        result[q_name][scope] = summary[:reducer_result].round(2)
       end
 
       result
@@ -182,7 +182,7 @@ module Pd::SurveyPipeline
     def self.get_category_averages(categories, question_averages)
       result = {}
       categories.each do |category|
-        category_scores = question_averages.select {|q_name, _| q_name.start_with? category}
+        category_scores = question_averages.select {|q_name, _| q_name.start_with? "#{category}_"}
         this_workshop_scores = category_scores.values.pluck(:this_workshop).compact
         all_workshop_scores = category_scores.values.pluck(:all_my_workshops).compact
 

--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
@@ -1,135 +1,167 @@
 module Pd::SurveyPipeline
-  class SurveyRollupDecorator < SurveyPipelineWorker
-    def self.process_data(context)
-      check_required_input_keys self::INPUT_KEYS, context
-
-      results = decorate(*context.values_at(*self::INPUT_KEYS))
-
-      self::OUTPUT_KEYS.each do |key|
-        context[key] ||= {}
-        context[key].deep_merge! results[key]
-      end
-
-      context
-    end
-
-    def self.decorate(summaries, facilitator_id, current_workshop_id, related_workshop_ids,
-      submissions, submission_type, parsed_questions, question_categories, errors = [])
-      result = {
+  class SurveyRollupDecorator
+    def self.decorate_facilitator_rollup(data)
+      report = {
         facilitators: {},
-        current_workshop: current_workshop_id,
+        current_workshop: data[:current_workshop_id],
         related_workshops: {},
-        facilitator_response_counts: {this_workshop: {}, all_my_workshops: {}},
+        facilitator_response_counts: {},
         facilitator_averages: {},
-        errors: errors
+        errors: data[:errors]
       }
 
-      # Populate result[:facilitators] = {factilitator_id => facilitator_name}
-      facilitator_name = User.find(facilitator_id)&.name || "UserId_#{facilitator_id}"
-      result[:facilitators][facilitator_id] = facilitator_name
+      # facilitators: {factilitator_id => facilitator_name}
+      facilitator_id = data[:facilitator_id]
+      facilitator_name = get_user_name_by_id(facilitator_id)
+      report[:facilitators][facilitator_id] = facilitator_name
 
-      # Populate related workshops
-      result[:related_workshops][facilitator_name] = related_workshop_ids
+      # related_workshops: {facilitator_name => Array<Integer>}
+      report[:related_workshops][facilitator_name] = data[:related_workshop_ids]
 
-      # Populate result[:facilitator_response_counts] =
-      # {this_workshop, all_my_workshops => {factilitator_id => {submission_type => count}}}
-      result[:facilitator_response_counts][:all_my_workshops][facilitator_id] =
-        {submission_type => submissions.count}
-      result[:facilitator_response_counts][:this_workshop][facilitator_id] =
-        {submission_type => submissions.where(pd_workshop_id: current_workshop_id).count}
+      # facilitator_response_counts:
+      #   {:this_workshop, :all_my_workshops => {factilitator_id => {submission_type => count}}}
+      # TODO: count only submissions that contribute to average scores
+      submissions = data[:facilitator_submissions] || data[:workshop_submissions]
+      report[:facilitator_response_counts] =
+        get_submission_counts submissions, data[:facilitator_id], data[:current_workshop_id]
 
-      # Populate result[:facilitator_averages]
-      # result[:facilitator_averages][facilitator_name][qname] = {this_workshop, all_my_workshops => score}
-      # result[:facilitator_averages][:questions] = {qname => qtext}
-      avg_scores = result[:facilitator_averages]
-      avg_scores[facilitator_name] = {}
-
-      qtexts = {}   # {qname => text}
-      summaries.each do |summary|
-        scope =
-          if summary[:workshop_id] == current_workshop_id
-            :this_workshop
-          elsif !summary[:workshop_id]
-            :all_my_workshops
-          else
-            :wrong_scope  # TODO: add non-fatal error
-          end
-        next if scope == :wrong_scope
-
-        qname = summary[:name]
-        avg_scores[facilitator_name][qname] ||= {}
-        avg_scores[facilitator_name][qname][scope] = summary[:reducer_result]
-
-        qtexts[qname] = find_first_question_text(parsed_questions, qname) unless
-          qtexts.key?(qname)
-      end
-
-      # Map current question name to new names which follow a format that the client expects.
-      # Examples:
+      # Convert question names to the format that the view expects.
+      # There is a difference in how we name sub-questions in the controller and in the (legacy) view.
+      # In the controller, sub-question names have <original_question>_<hash_of_sub_question_text> format.
+      # While in the view, it expects question names in format <original_question>_<index_of_sub_question>.
+      # Conversion examples:
       # overall_success_<hash_string> -> overall_success_<index_number>
       # teacher_engagement_<hash_string> -> teacher_engagement_<index_number>
-      qname_replacements = {}   # qname => q_new_name
-      qcategory_counts = {}     # qcategory => count
-      question_categories.each do |qcategory|
-        qtexts.each_pair do |qname, _|
-          next unless qname.start_with?(qcategory) && !qname_replacements.key?(qname)
+      # facilitator_effectiveness_<hash_string> -> facilitator_effectiveness__<index_number>
+      q_name_replacements =
+        get_question_name_replacements data[:parsed_questions], data[:question_categories]
 
-          qcategory_counts[qcategory] ||= 0
-          qname_replacements[qname] = "#{qcategory}_#{qcategory_counts[qcategory]}"
+      # Get list of questions to calculate averages.
+      # Replace question names if needed.
+      # facilitator_averages: {:questions => {question_name => question_text}}
+      q_names_to_texts = map_question_name_to_text data[:parsed_questions]
+      q_names_to_texts.transform_keys! {|q_name| q_name_replacements[q_name] || q_name}
+      # TODO: remove hidden questions and all questions that are not in summaries
+      report[:facilitator_averages][:questions] = q_names_to_texts
 
-          qcategory_counts[qcategory] += 1
-        end
-      end
+      # Calculate question averages.
+      # Replace question names if needed.
+      # facilitator_averages:
+      #   {facilitator_name => {question_name => {:this_workshop, :all_my_workshops => score}}}
+      question_averages = get_question_averages(data[:summaries], data[:current_workshop_id])
+      question_averages.transform_keys! {|q_name| q_name_replacements[q_name] || q_name}
+      report[:facilitator_averages][facilitator_name] = question_averages
 
-      # Replace question names in question list and score list
-      qtexts.transform_keys! {|k| qname_replacements[k] || k}
-      avg_scores[facilitator_name].transform_keys! {|k| qname_replacements[k] || k}
+      # Calculate category averages.
+      # facilitator_averages:
+      #   {facilitator_name => {question_category => {:this_workshop, :all_my_workshops => score}}}
+      category_averages = get_category_averages data[:question_categories], question_averages
+      report[:facilitator_averages][facilitator_name].merge! category_averages
 
-      # Calculate category averages
-      # result[:facilitator_averages][facilitator_name][qcategory] = {this_workshop, all_my_workshops => score}
-      question_categories.each do |category_name|
-        qnames_in_cateogry = qname_replacements.values.select {|val| val.start_with? category_name}
+      report
+    end
 
-        category_scores = avg_scores[facilitator_name].values_at(*qnames_in_cateogry).compact
-        this_workshop_scores = category_scores.pluck(:this_workshop).compact
-        all_workshop_scores = category_scores.pluck(:all_my_workshops).compact
+    private_class_method
 
-        avg_scores[facilitator_name][category_name] ||= {}
-        avg_scores[facilitator_name][category_name][:this_workshop] =
+    def self.get_category_averages(question_categories, question_averages)
+      result = {}
+      question_categories.each do |category|
+        # qnames_in_cateogry = qname_replacements.values.select {|val| val.start_with? category}
+        # category_scores = avg_scores[facilitator_name].values_at(*qnames_in_cateogry).compact
+        # this_workshop_scores = category_scores.pluck(:this_workshop).compact
+        # all_workshop_scores = category_scores.pluck(:all_my_workshops).compact
+
+        category_scores = question_averages.select {|q_name, _| q_name.start_with? category}
+        this_workshop_scores = category_scores.values.pluck(:this_workshop).compact
+        all_workshop_scores = category_scores.values.pluck(:all_my_workshops).compact
+
+        result[category] = {}
+        result[category][:this_workshop] =
           (this_workshop_scores.sum * 1.0 / this_workshop_scores.length).round(2)
-        avg_scores[facilitator_name][category_name][:all_my_workshops] =
+        result[category][:all_my_workshops] =
           (all_workshop_scores.sum * 1.0 / all_workshop_scores.length).round(2)
       end
 
-      avg_scores[:questions] = qtexts
-
-      {decorated_summaries: result}
+      result
     end
 
-    def self.find_first_question_text(parsed_questions, qname)
+    def self.get_question_averages(summaries, current_workshop_id)
+      result = {}
+
+      summaries.each do |summary|
+        # Acceptable values for workshop_id is either nil or current_workshop_id
+        next if summary[:workshop_id] && summary[:workshop_id] != current_workshop_id
+        scope = summary[:workshop_id] ? :this_workshop : :all_my_workshops
+
+        q_name = summary[:name]
+        result[q_name] ||= {}
+        result[q_name][scope] = summary[:reducer_result]
+      end
+
+      result
+    end
+
+    def self.map_question_name_to_text(parsed_questions)
+      # Create mappings from question name to question text for all parsed questions
+      q_names_to_texts = {}
       parsed_questions&.each_pair do |_, form_questions|
-        form_questions.each_pair do |_, qcontent|
-          if qcontent[:name] == qname
-            return qcontent[:text]
-          end
+        form_questions.each_pair do |_, q_content|
+          # If there are multiple questions with the same name, we assume they are all the same
+          # and keep the first one we find.
+          q_names_to_texts[q_content[:name]] = q_content[:text] unless
+            q_names_to_texts.key?(q_content[:name])
         end
       end
+
+      q_names_to_texts
     end
-  end
 
-  class FacilitatorSurveyRollupDecorator < SurveyRollupDecorator
-    INPUT_KEYS = [
-      :summaries, :facilitator_id, :current_workshop_id, :related_workshop_ids,
-      :facilitator_submissions, :submission_type, :parsed_questions, :question_categories, :errors
-    ]
-    OUTPUT_KEYS = [:decorated_summaries]
-  end
+    def self.get_question_names(parsed_questions)
+      q_names = Set[]
 
-  class WorkshopSurveyRollupDecorator < SurveyRollupDecorator
-    INPUT_KEYS = [
-      :summaries, :facilitator_id, :current_workshop_id, :related_workshop_ids,
-      :workshop_submissions, :submission_type, :parsed_questions, :question_categories, :errors
-    ]
-    OUTPUT_KEYS = [:decorated_summaries]
+      parsed_questions&.each_pair do |_, form_questions|
+        form_questions.each_pair do |_, q_content|
+          q_names.add(q_content[:name])
+        end
+      end
+
+      q_names.to_a
+    end
+
+    def self.get_question_name_replacements(parsed_questions, question_categories)
+      q_names = get_question_names parsed_questions
+
+      # Create replacements for questions in selected categories
+      q_name_replacements = {}
+      question_categories.each do |category|
+        # Sort names so order of questions in a category is always consistent
+        sorted_q_names = q_names.select {|q_name| q_name.start_with?(category)}.sort
+
+        sorted_q_names.each_with_index do |q_name, index|
+          q_name_replacements[q_name] = "#{category}_#{index}"
+        end
+      end
+
+      q_name_replacements
+    end
+
+    def self.get_submission_counts(submissions, facilitator_id, current_workshop_id)
+      result = {this_workshop: {facilitator_id => {}}, all_my_workshops: {facilitator_id => {}}}
+
+      if submissions.present?
+        submission_type =
+          submissions.first.is_a?(Pd::WorkshopDailySurvey) ? 'Workshop surveys' : 'Facilitator surveys'
+
+        result[:all_my_workshops][facilitator_id] = {submission_type => submissions.count}
+        result[:this_workshop][facilitator_id] =
+          {submission_type => submissions.where(pd_workshop_id: current_workshop_id).count}
+      end
+
+      result
+    end
+
+    def self.get_user_name_by_id(id)
+      User.find(id)&.name || "UserId_#{id}"
+    end
   end
 end

--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
@@ -1,19 +1,21 @@
+# This decorator combines pieces of survey roll-up data from previous steps of the survey pipeline
+# and organize them in a format that the client view can consume.
+
 module Pd::SurveyPipeline
   class SurveyRollupDecorator
-    # Create a roll up report to send to client view.
+    # Create roll-up report to send to client view.
     #
-    # @param [Hash] data a hash contains all important pieces of information from
-    #   previous steps in the pipeline.
+    # @param [Hash] data a hash contains pieces of information from previous steps in the pipeline.
     #
     # @return [Hash] a hash report contains following keys
     #   :facilitators => {factilitator_id => facilitator_name}
     #   :current_workshop => Integer
     #   :related_workshops: {facilitator_id => Array<Integer>}
-    #   :facilitator_response_counts =>
-    #     {workshop_scope => {factilitator_id => {submission_type => count}}}
     #   :facilitator_averages => a hash with following keys
     #     :questions => {question_name => question_text}
     #     facilitator_name => {question_name_or_category => {workshop_scope => score}}
+    #   :facilitator_response_counts =>
+    #     {workshop_scope => {factilitator_id => {submission_type => count}}}
     #   :errors => Array
     #
     def self.decorate_facilitator_rollup(data)
@@ -21,26 +23,19 @@ module Pd::SurveyPipeline
         facilitators: {},
         current_workshop: data[:current_workshop_id],
         related_workshops: {},
-        facilitator_response_counts: {},
         facilitator_averages: {},
+        facilitator_response_counts: {},
         errors: data[:errors]
       }
 
-      # Get values for :facilitators and :related_workshops keys
+      # Get facilitator name and related workshops
       facilitator_id = data[:facilitator_id]
       facilitator_name = get_user_name_by_id(facilitator_id)
       report[:facilitators][facilitator_id] = facilitator_name
       report[:related_workshops][facilitator_id] = data[:related_workshop_ids]
 
-      # Get value for :facilitator_response_counts key
-      # TODO: count only submissions that contribute to average scores
-      submissions = data[:facilitator_submissions] || data[:workshop_submissions]
-      report[:facilitator_response_counts] =
-        get_submission_counts submissions, data[:facilitator_id], data[:current_workshop_id]
-
-      # Get value for :questions key in :facilitator_averages key.
-      # The value contains all questions in selected categories, even if not all of them have responses.
-      # Also convert question names to the format that the UI expects.
+      # Get all questions in the selected categories, even if not all of them have responses.
+      # Then convert question names to the format that the UI expects.
       # E.g. overall_success_<hash_string> -> overall_success_<index_number>.
       category_questions =
         get_category_questions data[:parsed_questions], data[:question_categories]
@@ -49,15 +44,29 @@ module Pd::SurveyPipeline
       report[:facilitator_averages][:questions] =
         replace_question_name_keys category_questions, q_name_replacements
 
-      # Get question averages for this facilitator in :facilitator_averages key
-      # Replace question names if needed.
+      # Get question average scores
       question_averages = get_question_averages data[:summaries], data[:current_workshop_id]
       report[:facilitator_averages][facilitator_name] =
         replace_question_name_keys question_averages, q_name_replacements
 
-      # Get category averages for this facilitator in :facilitator_averages key
+      # Get category average scores
       category_averages = get_category_averages data[:question_categories], question_averages
       report[:facilitator_averages][facilitator_name].merge! category_averages
+
+      # Count number of submissions contributed to category average scores.
+      submission_type =
+        data[:facilitator_submissions] ? 'Facilitator-specific submissions' : 'Workshop submissions'
+
+      report[:facilitator_response_counts] = {
+        this_workshop: {facilitator_id => {}},
+        all_my_workshops: {facilitator_id => {}}
+      }
+      report[:facilitator_response_counts][:this_workshop][facilitator_id][submission_type] =
+        get_submission_counts(
+          data[:question_answer_joined], data[:question_categories], data[:current_workshop_id]
+        )
+      report[:facilitator_response_counts][:all_my_workshops][facilitator_id][submission_type] =
+        get_submission_counts data[:question_answer_joined], data[:question_categories]
 
       report
     end
@@ -68,35 +77,13 @@ module Pd::SurveyPipeline
       User.find(id)&.name || "UserId_#{id}"
     end
 
-    # Count number of submissions for a specific workshop and for all workshops.
+    # Get all questions in the selected categories.
     #
-    # @param [Array<Pd::WorkshopDailySurvey|Pd::WorkshopFacilitatorId>] submissions
-    # @param [Integer] facilitator_id
-    # @param [Integer] workshop_id
-    # @return [Hash] {workshop_scope => {facilitator_id => {submission_type => count}}
-    #
-    def self.get_submission_counts(submissions, facilitator_id, workshop_id)
-      result = {this_workshop: {facilitator_id => {}}, all_my_workshops: {facilitator_id => {}}}
-
-      if submissions.present?
-        submission_type =
-          submissions.first.is_a?(Pd::WorkshopDailySurvey) ? 'Workshop surveys' : 'Facilitator surveys'
-
-        result[:all_my_workshops][facilitator_id] = {submission_type => submissions.count}
-        result[:this_workshop][facilitator_id] =
-          {submission_type => submissions.where(pd_workshop_id: workshop_id).count}
-      end
-
-      result
-    end
-
-    # Get all questions in selected categories.
-    #
-    # @param [Hash{form_id => {question_id => question_content}}] parsed_questions
+    # @param [Hash] parsed_questions {form_id => {question_id => question_content}}
     # @param [Array<String>] categories
     # @return [Hash] {question_name => question_text}.
     #
-    def self.get_category_questions(parsed_questions, categories)
+    def self.get_category_questions(parsed_questions = {}, categories = [])
       result = {}
       parsed_questions&.each_pair do |_, form_questions|
         form_questions.each_pair do |_, q_content|
@@ -118,16 +105,13 @@ module Pd::SurveyPipeline
     # @param [Array<String>] categories
     # @return [Hash] {old_question_name => new_question_name}
     #
-    def self.get_question_name_replacements(questions, categories)
+    def self.get_question_name_replacements(questions = {}, categories = [])
       q_name_replacements = {}
       categories.each do |category|
-        # Questions in a category could also mean sub-questions of a the same parent question.
-        # In that case, we ignore the parent question and also replace names of the sub-questions.
-        # Sort question names by question texts so order of questions is always in
-        # alphabetical order.
+        # Sort question names by question texts so order of questions is always in alphabetical order.
         sorted_q_names = questions.
           select {|q_name, _| q_name.start_with? "#{category}_"}.
-          sort_by {|_, value| value}.
+          sort_by {|_, q_text| q_text}.
           pluck(0)
 
         sorted_q_names.each_with_index do |q_name, index|
@@ -138,30 +122,30 @@ module Pd::SurveyPipeline
       q_name_replacements
     end
 
-    # Replace keys for an input hash which uses question names as keys.
+    # Replace keys of an input hash which uses question names as keys.
     #
-    # @param [Hash<question_name, value>] question_hash
+    # @param [Hash<question_name, some_value>] question_hash
     # @param [Hash<old_name, new_name>] q_name_replacements
     # @return [Hash] a new hash with the same values as the original input hash
     #   but with the keys replaced.
     #
-    def self.replace_question_name_keys(question_hash, q_name_replacements)
+    def self.replace_question_name_keys(question_hash = {}, q_name_replacements = {})
       question_hash.
         select {|q_name, _| q_name_replacements.key? q_name}.
         transform_keys {|q_name| q_name_replacements[q_name]}
     end
 
-    # Get quetion average results for a specific workshop and for all workshops.
+    # Get question average scores for a specific workshop and for all workshops.
     #
     # @param [Array<Hash>] summaries
     # @param [Integer] workshop_id
-    # @return [Hash] {question_name => {workshop_scope => avg_result}}]
+    # @return [Hash] {question_name => {workshop_scope => avg_score}}]
     #
-    def self.get_question_averages(summaries, workshop_id)
+    def self.get_question_averages(summaries = [], workshop_id)
       result = {}
 
       summaries.each do |summary|
-        # Acceptable values for workshop_id is either nil or current_workshop_id
+        # Acceptable workshop id value is either nil or the specified workshop_id
         next if summary[:workshop_id] && summary[:workshop_id] != workshop_id
 
         scope = summary[:workshop_id] ? :this_workshop : :all_my_workshops
@@ -175,11 +159,11 @@ module Pd::SurveyPipeline
 
     # Get average results of all questions in the same category.
     #
-    # @param [Array<String>] categories
-    # @param [Hash{question_name => {workshop_scope => avg_result}}] question_averages
-    # @return [Hash] {category_name => {workshop_scope => avg_result}}
+    # @param [Array<String>] categories category names
+    # @param [Hash] question_averages {question_name => {workshop_scope => avg_score}}
+    # @return [Hash] {category_name => {workshop_scope => avg_score}}
     #
-    def self.get_category_averages(categories, question_averages)
+    def self.get_category_averages(categories = [], question_averages = {})
       result = {}
       categories.each do |category|
         category_scores = question_averages.select {|q_name, _| q_name.start_with? "#{category}_"}
@@ -194,6 +178,27 @@ module Pd::SurveyPipeline
       end
 
       result
+    end
+
+    # Count number of unique submissions that have answers for any question in
+    # the selected categories.
+    #
+    # @param [Hash] question_with_answers combination of questions and answers
+    # @param [Array<String>] categories category names
+    # @param [Integer] workshop_id limit counting to a specific workshop
+    # @return [Integer] submission count
+    #
+    def self.get_submission_counts(question_with_answers = [], categories = [], workshop_id = nil)
+      submissions_ids = Set[]
+      question_with_answers.each do |qa|
+        next if workshop_id && qa[:workshop_id] != workshop_id
+        next if qa[:answer].blank?
+        next unless categories.any? {|category| qa[:name].start_with? "#{category}_"}
+
+        submissions_ids.add qa[:submission_id]
+      end
+
+      submissions_ids.length
     end
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -364,18 +364,6 @@ module Api::V1::Pd
       assert_response :success
     end
 
-    test 'generic_survey_report: academic-year workshop uses old pipeline' do
-      new_academic_ws = create :academic_year_workshop, started_at: Date.new(2019, 8, 1)
-
-      WorkshopSurveyReportController.any_instance.expects(:create_csf_survey_report).never
-      WorkshopSurveyReportController.any_instance.expects(:local_workshop_daily_survey_report)
-
-      sign_in @admin
-      get :generic_survey_report, params: {workshop_id: new_academic_ws.id}
-
-      assert_response :success
-    end
-
     private
 
     def assert_workshop_survey_report_facilitator_query(user:, expected_facilitator_name_filter:)

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -284,16 +284,10 @@ module Api::V1::Pd
         },
         "facilitator_response_counts" => {
           "this_workshop" => {
-            f_id => {
-              "Facilitator" => 0,
-              "Workshop" => 0
-            }
+            f_id => {}
           },
           "all_my_workshops" => {
-            f_id => {
-              "Facilitator" => 0,
-              "Workshop" => 0
-            }
+            f_id => {}
           }
         },
         "experiment" => true


### PR DESCRIPTION
[PLC-399](https://codedotorg.atlassian.net/browse/PLC-399). 

This changes enable academic year workshop survey report to use the new survey pipeline. The change itself is only 3 lines [here](https://github.com/code-dot-org/code-dot-org/blob/d5c2d3c48e277a59ad2e2215eeba8086bf8b8a02/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb#L113-L118).

The rest of the PR refactors roll-up result reporting code to into smaller, shorter and clearer functions. This will help debugging and make it easier for other people to work on this code later.

Will have a separate PR to add new unit tests.

Example of an academic-year workshop roll-up view
![Screen Shot 2019-09-03 at 4 29 42 PM](https://user-images.githubusercontent.com/46507039/64215113-15d96480-ce68-11e9-96e0-b7ad53c05454.png)
