### PR TITLE
add editor_experiment option to Script#clone_with_suffix

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -539,8 +539,8 @@ class Blockly < Level
   end
 
   # Clear 'is_project_level' from cloned levels
-  def clone_with_name(name)
-    level = super(name)
+  def clone_with_name(name, editor_experiment: nil)
+    level = super(name, editor_experiment: editor_experiment)
     level.update!(is_project_level: false)
     level
   end

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -156,7 +156,7 @@ class DSLDefined < Level
     return dsl_text
   end
 
-  def clone_with_name(new_name)
+  def clone_with_name(new_name, editor_experiment: nil)
     raise "A level named '#{new_name}' already exists" if Level.find_by_name(new_name)
     old_dsl = dsl_text
     new_dsl = old_dsl.try(:sub, "name '#{name}'", "name '#{new_name}'")
@@ -164,6 +164,12 @@ class DSLDefined < Level
     # raises unless the name is formatted with single, non-curly quotes, e.g.:
     # name 'level-name', or the dsl_text is entirely blank as during unit tests
     raise "name not formatted correctly in dsl text for level: '#{name}'" if old_dsl && old_dsl == new_dsl
+
+    if new_dsl && editor_experiment
+      # define editor_experiment on the second line of the dsl file.
+      index = new_dsl.index("\n")
+      new_dsl = new_dsl.insert(index, "\neditor_experiment '#{editor_experiment}'") if index
+    end
 
     level_params = {}
     level_params[:encrypted] = level_encrypted? if level_encrypted?

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -554,6 +554,7 @@ class Level < ActiveRecord::Base
   # Create a copy of this level named new_name, and store the id of the original
   # level in parent_level_id.
   # @param [String] new_name
+  # @param [String] editor_experiment
   # @raise [ActiveRecord::RecordInvalid] if the new name already is taken.
   def clone_with_name(new_name, editor_experiment: nil)
     level = dup
@@ -574,6 +575,8 @@ class Level < ActiveRecord::Base
   # @param [String] new_suffix The suffix to append to the name of the original
   #   level when choosing a name for the new level, replacing any existing
   #   name_suffix if one exists.
+  # @param [String] editor_experiment Optional value to set the
+  #   editor_experiment property to on the newly-created level.
   def clone_with_suffix(new_suffix, editor_experiment: nil)
     # Make sure we don't go over the 70 character limit.
     new_name = "#{base_name[0..64]}#{new_suffix}"

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -103,11 +103,11 @@ ruby
 
   # Perform a deep copy of this level by cloning all of its sublevels
   # using the same suffix, and write them to the new level definition file.
-  def clone_with_suffix(new_suffix)
+  def clone_with_suffix(new_suffix, editor_experiment: nil)
     new_name = "#{base_name}#{new_suffix}"
     return Level.find_by_name(new_name) if Level.find_by_name(new_name)
 
-    level = super(new_suffix)
+    level = super(new_suffix, editor_experiment: editor_experiment)
     level.clone_sublevels_with_suffix(new_suffix)
     level.rewrite_dsl_file(LevelGroupDSL.serialize(level))
     level

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -888,6 +888,46 @@ EOS
     assert_equal contained_level_2_copy, level_2_copy.contained_levels.last
   end
 
+  test 'clone with suffix sets editor experiment' do
+    old_level = create :level, name: 'old level'
+    new_level = old_level.clone_with_suffix(' copy', editor_experiment: 'level-editors')
+    assert_equal 'old level copy', new_level.name
+    assert_equal 'level-editors', new_level.editor_experiment, 'clone_with_suffix adds editor experiment'
+  end
+
+  test 'cloning multi level sets editor experiment' do
+    old_dsl_text = <<EOS
+name 'old multi level'
+title 'Multiple Choice'
+question 'What is your favorite color?'
+wrong 'Red'
+wrong 'Green'
+right 'Blue'
+EOS
+
+    expected_new_dsl_text = <<EOS
+name 'old multi level copy'
+editor_experiment 'level-editors'
+title 'Multiple Choice'
+question 'What is your favorite color?'
+wrong 'Red'
+wrong 'Green'
+right 'Blue'
+EOS
+
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    File.expects(:write).once.with do |_pathname, new_dsl_text|
+      new_dsl_text == expected_new_dsl_text
+    end
+
+    old_level = create :multi, name: 'old multi level'
+    old_level.stubs(:dsl_text).returns(old_dsl_text)
+
+    new_level = old_level.clone_with_suffix(' copy', editor_experiment: 'level-editors')
+    assert_equal 'old multi level copy', new_level.name
+    assert_equal 'level-editors', new_level.editor_experiment
+  end
+
   test 'contained_level_names filters blank names before validation' do
     level = build :level
     level.contained_level_names = ['', 'real_name']

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1466,6 +1466,25 @@ endvariants
     assert_match Regexp.new(new_dsl_regex), ScriptDSL.serialize_to_string(script_copy)
   end
 
+  test 'clone with suffix and add editor experiment' do
+    scripts, _ = Script.setup([@script_file])
+    script = scripts[0]
+    assert_equal 1, script.script_announcements.count
+
+    Script.stubs(:script_directory).returns(self.class.fixture_path)
+    script_copy = script.clone_with_suffix('copy', editor_experiment: 'script-editors')
+    assert_equal 'test-fixture-copy', script_copy.name
+    assert_equal 'script-editors', script_copy.editor_experiment
+
+    # Validate levels.
+    assert_equal 5, script_copy.levels.count
+    script_copy.levels.each_with_index do |level, i|
+      level_num = i + 1
+      assert_equal "Level #{level_num}_copy", level.name
+      assert_equal 'script-editors', level.editor_experiment
+    end
+  end
+
   test "assignable_info: returns assignable info for a script" do
     script = create(:script, name: 'fake-script', hidden: true, stage_extras_available: true)
     assignable_info = script.assignable_info


### PR DESCRIPTION
### Background

Finishes https://codedotorg.atlassian.net/browse/LP-692

the list of requirements and work items is documented in the [tech spec](https://docs.google.com/document/d/1aigN_ziWIVQJ-mZgz0R1eh8xOrYUXQrJtx_Mza-HWgk/edit#heading=h.b967o41qr86g)

### Description

This PR makes it so that an engineer can create a copy of a script and assign it ownership to a particular group of curriculum writers by running `Script.find_by_name('coursea-2019').clone_with_suffix('copy', editor_experiment: 'script-editors')`. This will produce to a script named `coursea-copy` which users in the `script-editors` experiment can someday edit.

### Testing

In addition to unit tests, I also verified locally that cloning a script containing both DSL and non-DSL levels properly sets the editor experiment in the level DB objects as well as in the level files.