### PR TITLE
add option to seed a single .level file

### DIFF
--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -2,8 +2,9 @@ require 'set'
 
 class LevelLoader
   # Top-level entry point, called by rake seed:custom_levels
-  def self.load_custom_levels
-    import_levels 'config/scripts/**/*.level'
+  def self.load_custom_levels(level_name)
+    levels_glob = level_name ? "config/scripts/**/#{level_name}.level" : 'config/scripts/**/*.level'
+    import_levels levels_glob
   end
 
   #

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -201,9 +201,11 @@ namespace :seed do
     Library.load_records
   end
 
-  # Generate the database entry from the custom levels json file
+  # Generate the database entry from the custom levels json file.
+  # Optionally limit to a single level via LEVEL_NAME= env variable.
   task custom_levels: :environment do
-    LevelLoader.load_custom_levels
+    level_name = ENV['LEVEL_NAME']
+    LevelLoader.load_custom_levels(level_name)
   end
 
   # Seeds the data in callouts


### PR DESCRIPTION
similar to https://github.com/code-dot-org/code-dot-org/pull/30293 which added a similar option for scripts. This one doesn't need to be a separate rake task because it already doesn't depend on any other rake tasks besides `:environment`.