### PR TITLE
Feedback: fix sort by recency of all feedbacks

### DIFF
--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -6,7 +6,7 @@ class TeacherFeedbacksController < ApplicationController
   # Feedback from any verified teacher who has provided feedback to the current
   # student on any level
   def index
-    @feedbacks_as_student = @teacher_feedbacks.includes(script_level: {stage: :script}).select do |feedback|
+    @feedbacks_as_student = @teacher_feedbacks.order(created_at: :desc).includes(script_level: {stage: :script}).select do |feedback|
       UserPermission.where(
         user_id: feedback.teacher_id,
         permission: 'authorized_teacher'

--- a/dashboard/app/views/teacher_feedbacks/index.html.haml
+++ b/dashboard/app/views/teacher_feedbacks/index.html.haml
@@ -1,5 +1,5 @@
 - feedback_data = {}
-- feedback_data[:all_feedback] = @feedbacks_as_student_with_level_info.reverse
+- feedback_data[:all_feedback] = @feedbacks_as_student_with_level_info
 
 #feedback-container
 


### PR DESCRIPTION
The last bug fix before launch! Amanda noticed that her feedbacks weren't sorted by recency on the all feedback page.  I modified the query to return the feedbacks ordered by `created_at` and now feedbacks are sorted correctly.