### PR TITLE
Differentiate Deep Dive workshops on map

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -12,7 +12,7 @@ import {ScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfo
 import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const CSF = 'CS Fundamentals';
-const DEEP_DIVE = 'Deep Dive';
+const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
 const NA = 'N/A';
 const LOCAL_SUMMER = SubjectNames.SUBJECT_SUMMER_WORKSHOP;
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
@@ -69,7 +69,7 @@ export class WorkshopManagement extends React.Component {
 
     let new_csf_201 =
       workshop_date >= new Date('2019-05-20') &&
-      this.props.subject === 'Deep Dive';
+      this.props.subject === SubjectNames.SUBJECT_CSF_201;
 
     return (
       new_local_summer_and_teachercon || new_facilitator_weekend || new_csf_201

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -296,7 +296,7 @@ export default class WorkshopTable extends React.Component {
           state === 'Ended' ||
           ([CSD, CSP].includes(course) &&
             subject !== SubjectNames.SUBJECT_FIT) ||
-          (course === CSF && subject === 'Deep Dive')
+          (course === CSF && subject === SubjectNames.SUBJECT_CSF_201)
         }
       />
     );

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -11,13 +11,14 @@ import FieldGroup from '../form_components/FieldGroup';
 import QuestionsTable from '../form_components/QuestionsTable';
 import {isEmail} from '@cdo/apps/util/formatValidation';
 import SchoolAutocompleteDropdownWithCustomFields from '../components/schoolAutocompleteDropdownWithCustomFields';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const OTHER = 'Other';
 const NOT_TEACHING = "I'm not teaching this year";
 const EXPLAIN = '(Please Explain):';
 
 const CSF = 'CS Fundamentals';
-const DEEP_DIVE = 'Deep Dive';
+const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
 
 const VALIDATION_STATE_ERROR = 'error';
 

--- a/apps/src/sites/code.org/pages/views/workshop_search.js
+++ b/apps/src/sites/code.org/pages/views/workshop_search.js
@@ -3,6 +3,7 @@
 import $ from 'jquery';
 import MarkerClusterer from 'node-js-marker-clusterer';
 import getScriptData from '@cdo/apps/util/getScriptData';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const markerCustererOptions = {
   imagePath: getScriptData('workshopSearch').imagePath,
@@ -68,7 +69,7 @@ function processPdWorkshops(workshops) {
       infoWindowContent = compileHtml(workshop, false);
       markersByLocation[hash].infoWindowContent += infoWindowContent;
       // Upgrade any marker containing a deep dive workshop to the deep dive icon
-      if (workshop.subject === 'Deep Dive') {
+      if (workshop.subject === SubjectNames.SUBJECT_CSF_201) {
         markersByLocation[hash].icon = {url: iconForSubject(workshop.subject)};
       }
     }
@@ -92,7 +93,7 @@ function createNewMarker(latLng, title, infoWindowContent, subject) {
 }
 
 function iconForSubject(subject) {
-  if (subject === 'Deep Dive') {
+  if (subject === SubjectNames.SUBJECT_CSF_201) {
     return 'https://maps.google.com/mapfiles/kml/paddle/red-stars.png';
   }
   return 'https://maps.google.com/mapfiles/kml/paddle/red-blank.png';

--- a/apps/src/sites/code.org/pages/views/workshop_search.js
+++ b/apps/src/sites/code.org/pages/views/workshop_search.js
@@ -60,22 +60,28 @@ function processPdWorkshops(workshops) {
       markersByLocation[hash] = createNewMarker(
         latLng,
         workshop.location_name,
-        infoWindowContent
+        infoWindowContent,
+        workshop.subject
       );
     } else {
       // Extend existing marker.
       infoWindowContent = compileHtml(workshop, false);
       markersByLocation[hash].infoWindowContent += infoWindowContent;
+      // Upgrade any marker containing a deep dive workshop to the deep dive icon
+      if (workshop.subject === 'Deep Dive') {
+        markersByLocation[hash].icon = {url: iconForSubject(workshop.subject)};
+      }
     }
   });
 }
 
-function createNewMarker(latLng, title, infoWindowContent) {
+function createNewMarker(latLng, title, infoWindowContent, subject) {
   var marker = new google.maps.Marker({
     position: latLng,
     map: gmap,
     title: title,
-    infoWindowContent: infoWindowContent
+    infoWindowContent: infoWindowContent,
+    icon: {url: iconForSubject(subject)}
   });
   google.maps.event.addListener(marker, 'click', function() {
     infoWindow.setContent(this.get('infoWindowContent'));
@@ -83,6 +89,13 @@ function createNewMarker(latLng, title, infoWindowContent) {
   });
   markerClusterer.addMarker(marker);
   return marker;
+}
+
+function iconForSubject(subject) {
+  if (subject === 'Deep Dive') {
+    return 'https://maps.google.com/mapfiles/kml/paddle/red-stars.png';
+  }
+  return 'https://maps.google.com/mapfiles/kml/paddle/red-blank.png';
 }
 
 function completeProcessingPdWorkshops() {
@@ -102,6 +115,10 @@ function compileHtml(workshop, first) {
     '<div class="workshop-location-name"><strong>' +
     workshop.location_name +
     '</strong></div>';
+
+  // Add the workshop subject
+  html +=
+    '<div class="workshop-subject">' + workshop.subject + ' Workshop</div>';
 
   // Add the date(s).
   html += '<div class="workshop-dates">';

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -114,10 +114,6 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
       on_map: true
     }
 
-    # Later in 2019 we will not set 'Intro' as a condition, so that the default
-    # will be to show workshops from all subjects when deep-dive isn't specified.
-    # But until then, when deep-dive isn't specified, we only show 'Intro'
-    # workshops.
     if params['deep_dive_only']
       conditions[:subject] = Pd::Workshop::SUBJECT_CSF_201
     end

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -119,7 +119,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
     # But until then, when deep-dive isn't specified, we only show 'Intro'
     # workshops.
     if params['deep_dive_only']
-      conditions[:subject] = 'Deep Dive'
+      conditions[:subject] = Pd::Workshop::SUBJECT_CSF_201
     end
 
     @workshops = Pd::Workshop.scheduled_start_on_or_after(Date.today.beginning_of_day).

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -118,7 +118,9 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
     # will be to show workshops from all subjects when deep-dive isn't specified.
     # But until then, when deep-dive isn't specified, we only show 'Intro'
     # workshops.
-    conditions[:subject] = params['deep_dive_only'] ? 'Deep Dive' : 'Intro'
+    if params['deep_dive_only']
+      conditions[:subject] = 'Deep Dive'
+    end
 
     @workshops = Pd::Workshop.scheduled_start_on_or_after(Date.today.beginning_of_day).
       where(conditions).where.not(processed_location: nil)

--- a/dashboard/app/serializers/api/v1/pd/workshop_k5_map_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_k5_map_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::Pd::WorkshopK5MapSerializer < ActiveModel::Serializer
-  attributes :id, :location_name, :location_address, :sessions, :processed_location
+  attributes :id, :subject, :location_name, :location_address, :sessions, :processed_location
 
   def processed_location
     return nil unless object.processed_location

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -20,6 +20,8 @@ module Pd
 
     SUBJECT_TEACHER_CON = 'Code.org TeacherCon'.freeze
     SUBJECT_NAMES = {
+      SUBJECT_CSF_101: SUBJECT_CSF_101 = 'Intro'.freeze,
+      SUBJECT_CSF_201: SUBJECT_CSF_201 = 'Deep Dive'.freeze,
       SUBJECT_FIT: SUBJECT_FIT = 'Code.org Facilitator Weekend'.freeze,
       SUBJECT_SUMMER_WORKSHOP: SUBJECT_SUMMER_WORKSHOP = '5-day Summer'.freeze,
       SUBJECT_VIRTUAL_1: SUBJECT_VIRTUAL_1 = 'Virtual Workshop 1'.freeze,
@@ -88,8 +90,8 @@ module Pd
         SUBJECT_CSD_VIRTUAL_8 = SUBJECT_VIRTUAL_8
       ],
       COURSE_CSF => [
-        SUBJECT_CSF_101 = 'Intro'.freeze,
-        SUBJECT_CSF_201 = 'Deep Dive'.freeze,
+        SUBJECT_CSF_101,
+        SUBJECT_CSF_201,
         SUBJECT_CSF_FIT = SUBJECT_FIT
       ]
     }.freeze


### PR DESCRIPTION
[PLC-417](https://codedotorg.atlassian.net/browse/PLC-417) Displays different map info and pin colors depending on whether a CSF workshop is Intro or Deep Dive on code.org/professional-development-workshops/update.

Adds Deep Dive workshops to the map on this page.

Deep Dive workshops get a star on their pin.  We collapse workshops at the same location into one pin - in these cases if any of the workshops is deep dive, the pin gets the star.  Also adds the workshop subject to the tooltip.

Before:
![image](https://user-images.githubusercontent.com/1615761/64048809-a42bae80-cb27-11e9-8d95-b85f1512f8d7.png)
![image](https://user-images.githubusercontent.com/1615761/64048835-c02f5000-cb27-11e9-8bc9-917366fc25e9.png)

After:
![image](https://user-images.githubusercontent.com/1615761/64048825-b279ca80-cb27-11e9-99c2-40a430d39975.png)
![image](https://user-images.githubusercontent.com/1615761/64048854-cfae9900-cb27-11e9-999b-463a891ecc31.png)
