### PR TITLE
optimize Section#summarize_without_students

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -229,7 +229,13 @@ class Section < ActiveRecord::Base
       link_to_assigned = script_path(script)
     end
 
-    unique_students = students.uniq(&:id)
+    # Remove ordering from scope when not including full
+    # list of students, in order to improve query performance.
+    unique_students = include_students ?
+      students.distinct(&:id) :
+      students.unscope(:order).distinct(&:id)
+    num_students = unique_students.size
+
     {
       id: id,
       name: name,
@@ -239,7 +245,7 @@ class Section < ActiveRecord::Base
       linkToAssigned: link_to_assigned,
       currentUnitTitle: title_of_current_unit,
       linkToCurrentUnit: link_to_current_unit,
-      numberOfStudents: unique_students.length,
+      numberOfStudents: num_students,
       linkToStudents: "#{base_url}#{id}/manage",
       code: code,
       stage_extras: stage_extras,
@@ -252,7 +258,7 @@ class Section < ActiveRecord::Base
         name: script.try(:name),
         project_sharing: script.try(:project_sharing)
       },
-      studentCount: unique_students.size,
+      studentCount: num_students,
       grade: grade,
       providerManaged: provider_managed?,
       hidden: hidden,


### PR DESCRIPTION
This PR improves the performance of `section#summarize_without_students`, used by the home page for signed-in users within a section:

- Remove unnecessary 'ORDER BY' relation from scope to improve query.
- Use `#size` instead of `#length` to use `COUNT` instead of fetching full association.

I've also replaced `uniq` with `distinct`, the `uniq` alias is deprecated and will be removed in Rails 5.1.

Students within large sections (10k+ students) were seeing ~20 second load times for the home page due to this unoptimized query. Benchmarking `#summarize_without_students` against a single section of 10,000 students, this PR provides a ~70x improvement, which should make this page once again usable for students in large sections.