### PR TITLE
allow platformization partners to create and edit levels

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -182,8 +182,13 @@ class LevelsController < ApplicationController
     params[:level][:maze_data] = params[:level][:maze_data].to_json if type_class <= Grid
     params[:user] = current_user
 
+    create_level_params = level_params
+
+    editor_experiment = Experiment.get_editor_experiment(current_user)
+    create_level_params[:editor_experiment] = editor_experiment if editor_experiment
+
     begin
-      @level = type_class.create_from_level_builder(params, level_params)
+      @level = type_class.create_from_level_builder(params, create_level_params)
     rescue ArgumentError => e
       render(status: :not_acceptable, text: e.message) && return
     rescue ActiveRecord::RecordInvalid => invalid

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -184,6 +184,7 @@ class LevelsController < ApplicationController
 
     create_level_params = level_params
 
+    # Give platformization partners permission to edit any levels they create.
     editor_experiment = Experiment.get_editor_experiment(current_user)
     create_level_params[:editor_experiment] = editor_experiment if editor_experiment
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -230,6 +230,11 @@ class Ability
       can [:upload, :destroy], :level_starter_asset
     end
 
+    if user.persisted?
+      editor_experiment = Experiment.get_editor_experiment(user)
+      can :manage, Level, editor_experiment: editor_experiment
+    end
+
     if user.persisted? && user.permission?(UserPermission::PROJECT_VALIDATOR)
       # let them change the hidden state
       can :manage, LevelSource

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -232,7 +232,9 @@ class Ability
 
     if user.persisted?
       editor_experiment = Experiment.get_editor_experiment(user)
-      can :manage, Level, editor_experiment: editor_experiment
+      if editor_experiment
+        can :manage, Level, editor_experiment: editor_experiment
+      end
     end
 
     if user.persisted? && user.permission?(UserPermission::PROJECT_VALIDATOR)

--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -42,7 +42,7 @@ class Experiment < ApplicationRecord
   # edit scripts and levels marked with the same editor_experiment.
   LEVEL_EDITOR_EXPERIMENTS = %w(
     broward
-    hogwarts
+    platformization-partners
   )
 
   def self.get_editor_experiment(user)

--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -45,6 +45,12 @@ class Experiment < ApplicationRecord
     hogwarts
   )
 
+  def self.get_editor_experiment(user)
+    LEVEL_EDITOR_EXPERIMENTS.find do |experiment|
+      Experiment.enabled?(user: user, experiment_name: experiment)
+    end
+  end
+
   def self.get_all_enabled(user: nil, section: nil, script: nil, experiment_name: nil)
     if @@experiments.nil? || @@experiments_loaded < DateTime.now - MAX_CACHE_AGE
       update_cache

--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -38,6 +38,13 @@ class Experiment < ApplicationRecord
   cattr_accessor :experiments
   @@experiments = nil
 
+  # users in these experiments can create levels on levelbuilder, as well as
+  # edit scripts and levels marked with the same editor_experiment.
+  LEVEL_EDITOR_EXPERIMENTS = %w(
+    broward
+    hogwarts
+  )
+
   def self.get_all_enabled(user: nil, section: nil, script: nil, experiment_name: nil)
     if @@experiments.nil? || @@experiments_loaded < DateTime.now - MAX_CACHE_AGE
       update_cache

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -825,6 +825,22 @@ DSL
     params: -> {{id: @partner_level.id}}
   )
 
+  test_user_gets_response_for(
+    :update,
+    method: :patch,
+    response: :forbidden,
+    user: :platformization_partner,
+    params: -> {{id: @level.id, level: {name: 'new partner name'}}}
+  )
+
+  test_user_gets_response_for(
+    :update,
+    method: :patch,
+    response: :success,
+    user: :platformization_partner,
+    params: -> {{id: @partner_level.id, level: {name: 'new partner name'}}}
+  )
+
   private
 
   # Assert that the url is a real S3 url, and not a placeholder.

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -10,6 +10,7 @@ class LevelsControllerTest < ActionController::TestCase
     @level = create(:level)
     @admin = create(:admin)
     @not_admin = create(:user)
+    @wizard = create :teacher, editor_experiment: 'hogwarts'
     @levelbuilder = create(:levelbuilder)
     sign_in(@levelbuilder)
     @program = '<hey/>'
@@ -782,6 +783,23 @@ DSL
     get :show, params: {id: level}
     assert_response :success
     assert_select '#markdown', "this is the markdown for #{@not_admin.id}"
+  end
+
+  test 'platformization partner can edit their levels' do
+    sign_out @levelbuilder
+    sign_in @wizard
+
+    get :edit, params: {id: @level.id}
+    assert_response :forbidden
+  end
+
+  test 'platformization partner cannot edit our levels' do
+    sign_out @levelbuilder
+    sign_in @wizard
+    hogwarts_level = create :level, editor_experiment: 'hogwarts'
+
+    get :edit, params: {id: hogwarts_level.id}
+    assert_response :success
   end
 
   private

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -8,6 +8,7 @@ class LevelsControllerTest < ActionController::TestCase
     Level.any_instance.stubs(:write_to_file?).returns(false) # don't write to level files
 
     @level = create(:level)
+    @partner_level = create :level, editor_experiment: 'platformization-partners'
     @admin = create(:admin)
     @not_admin = create(:user)
     @platformization_partner = create :platformization_partner
@@ -810,22 +811,19 @@ DSL
     assert_equal 'platformization-partners', level.editor_experiment
   end
 
-  test 'platformization partner can edit their levels' do
-    sign_out @levelbuilder
-    sign_in @platformization_partner
+  test_user_gets_response_for(
+    :edit,
+    response: :forbidden,
+    user: :platformization_partner,
+    params: -> {{id: @level.id}}
+  )
 
-    get :edit, params: {id: @level.id}
-    assert_response :forbidden
-  end
-
-  test 'platformization partner cannot edit our levels' do
-    sign_out @levelbuilder
-    sign_in @platformization_partner
-    partner_level = create :level, editor_experiment: 'platformization-partners'
-
-    get :edit, params: {id: partner_level.id}
-    assert_response :success
-  end
+  test_user_gets_response_for(
+    :edit,
+    response: :success,
+    user: :platformization_partner,
+    params: -> {{id: @partner_level.id}}
+  )
 
   private
 

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -785,6 +785,31 @@ DSL
     assert_select '#markdown', "this is the markdown for #{@not_admin.id}"
   end
 
+  # test_platformization_partner_calling_get_new_should_receive_success
+  test_user_gets_response_for(
+    :new,
+    response: :success,
+    user: :platformization_partner
+  )
+
+  test 'platformization partner creates and owns new artist level' do
+    sign_out @levelbuilder
+    sign_in @platformization_partner
+
+    game = Game.find_by_name('Custom')
+    assert_creates(Level) do
+      post :create, params: {
+        level: {name: 'partner artist level', type: 'Artist'},
+        game_id: game.id,
+        program: @program
+      }
+    end
+
+    level = Level.last
+    assert_equal 'partner artist level', level.name
+    assert_equal 'platformization-partners', level.editor_experiment
+  end
+
   test 'platformization partner can edit their levels' do
     sign_out @levelbuilder
     sign_in @platformization_partner

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -10,7 +10,7 @@ class LevelsControllerTest < ActionController::TestCase
     @level = create(:level)
     @admin = create(:admin)
     @not_admin = create(:user)
-    @wizard = create :teacher, editor_experiment: 'hogwarts'
+    @platformization_partner = create :platformization_partner
     @levelbuilder = create(:levelbuilder)
     sign_in(@levelbuilder)
     @program = '<hey/>'
@@ -787,7 +787,7 @@ DSL
 
   test 'platformization partner can edit their levels' do
     sign_out @levelbuilder
-    sign_in @wizard
+    sign_in @platformization_partner
 
     get :edit, params: {id: @level.id}
     assert_response :forbidden
@@ -795,10 +795,10 @@ DSL
 
   test 'platformization partner cannot edit our levels' do
     sign_out @levelbuilder
-    sign_in @wizard
-    hogwarts_level = create :level, editor_experiment: 'hogwarts'
+    sign_in @platformization_partner
+    partner_level = create :level, editor_experiment: 'platformization-partners'
 
-    get :edit, params: {id: hogwarts_level.id}
+    get :edit, params: {id: partner_level.id}
     assert_response :success
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -182,6 +182,9 @@ FactoryGirl.define do
           create :single_user_experiment, min_user_id: teacher.id, name: evaluator.editor_experiment
         end
       end
+      factory :platformization_partner do
+        editor_experiment 'platformization-partners'
+      end
 
       # We have some teacher records in our system that do not pass validation because they have
       # no email address.  Sometimes we want to test against this case because we still want features

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -176,6 +176,12 @@ FactoryGirl.define do
           create :single_user_experiment, min_user_id: teacher.id, name: evaluator.pilot_experiment
         end
       end
+      transient {editor_experiment nil}
+      after(:create) do |teacher, evaluator|
+        if evaluator.editor_experiment
+          create :single_user_experiment, min_user_id: teacher.id, name: evaluator.editor_experiment
+        end
+      end
 
       # We have some teacher records in our system that do not pass validation because they have
       # no email address.  Sometimes we want to test against this case because we still want features

--- a/dashboard/test/models/experiment_test.rb
+++ b/dashboard/test/models/experiment_test.rb
@@ -173,8 +173,7 @@ class ExperimentTest < ActiveSupport::TestCase
 
   test 'editor experiments' do
     teacher = create :teacher
-    wizard = create :teacher
-    SingleUserExperiment.find_or_create_by!(min_user_id: wizard.id, name: 'hogwarts')
+    wizard = create :teacher, editor_experiment: 'hogwarts'
     levelbuilder = create :levelbuilder
 
     assert_nil Experiment.get_editor_experiment(teacher)

--- a/dashboard/test/models/experiment_test.rb
+++ b/dashboard/test/models/experiment_test.rb
@@ -170,4 +170,15 @@ class ExperimentTest < ActiveSupport::TestCase
 
     assert_equal active_experiments, Experiment.experiments
   end
+
+  test 'editor experiments' do
+    teacher = create :teacher
+    wizard = create :teacher
+    SingleUserExperiment.find_or_create_by!(min_user_id: wizard.id, name: 'hogwarts')
+    levelbuilder = create :levelbuilder
+
+    assert_nil Experiment.get_editor_experiment(teacher)
+    assert_equal 'hogwarts', Experiment.get_editor_experiment(wizard)
+    assert_nil Experiment.get_editor_experiment(levelbuilder)
+  end
 end

--- a/dashboard/test/models/experiment_test.rb
+++ b/dashboard/test/models/experiment_test.rb
@@ -173,11 +173,11 @@ class ExperimentTest < ActiveSupport::TestCase
 
   test 'editor experiments' do
     teacher = create :teacher
-    wizard = create :teacher, editor_experiment: 'hogwarts'
+    platformization_partner = create :platformization_partner
     levelbuilder = create :levelbuilder
 
     assert_nil Experiment.get_editor_experiment(teacher)
-    assert_equal 'hogwarts', Experiment.get_editor_experiment(wizard)
+    assert_equal 'platformization-partners', Experiment.get_editor_experiment(platformization_partner)
     assert_nil Experiment.get_editor_experiment(levelbuilder)
   end
 end


### PR DESCRIPTION
### Background

continuation of https://github.com/code-dot-org/code-dot-org/pull/30457. finishes https://codedotorg.atlassian.net/browse/LP-693. click through to its parent to see the tech spec.

### Description
* creates a list of experiments designating groups of platformization partners who will share ownership of certain scripts and levels
* allows platformization partners to create new levels
* allows platformization partners to edit levels which they created or own

### Testing
Manually verified that a platformization partner can create and edit a new level, but cannot edit existing levels