### PR TITLE
Script editor bug when new editor is not being used

### DIFF
--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -277,6 +277,11 @@ function levelKeyList(state = {}, action) {
 function levelNameToIdMap(state = {}, action) {
   switch (action.type) {
     case INIT: {
+      if (!action.levelKeyList) {
+        // This can be falsy if the new editor experiment is not enabled
+        return state;
+      }
+
       const levelNameToIdMap = {};
       Object.keys(action.levelKeyList).forEach(levelId => {
         const levelKey = action.levelKeyList[levelId];


### PR DESCRIPTION
[Slack thread](https://codedotorg.slack.com/archives/C0T10H2HY/p1567529277014000): Editor redux can process init action even if editor experiment is disabled and this required parameter is not passed down from the server.

