### PR TITLE
changing CGI.escape to URI.encode to replace '+' with '%20'

### DIFF
--- a/pegasus/sites.v3/code.org/views/share_privacy.haml
+++ b/pegasus/sites.v3/code.org/views/share_privacy.haml
@@ -19,7 +19,7 @@
     Share this notice with parents:
   %a{class:'share-on-remind', href:'https://www.remind.com/v1/share?url=code.org/privacy/student-privacy&referer=code.org&text=Code.org%20Student%20Privacy%20Policy', target:'_blank', id: 'share_on_remind'}
   %a{class: 'email-button',
-    href: "mailto:?to=&subject=" + CGI.escape(email_subject) + "&body=" + CGI.escape(email_body), target:'_blank', id: 'email_button'}
+    href: "mailto:?to=&subject=" + URI.encode(email_subject) + "&body=" + URI.encode(email_body), target:'_blank', id: 'email_button'}
     %i.fa.fa-envelope{"aria-hidden": "true"}
     Email
   %a{class: 'print-button', href: "javascript:window.print()", id: 'print_button'}


### PR DESCRIPTION
This is to enable Outlook email clients opening the email link to render spaces instead of the '+' literally, which is what happens when CGI uses '+' as the separator.

URI.encode is an alias for URI.escape, which was deprecated in 2009. However, we use URI.encode in several other places in our codebase. Since the marketing wants to send out the CSP privacy notice tomorrow, this is a quick fix to address the spaces issue.