### PR TITLE
Handle case where params[:section_code] is empty

### DIFF
--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -90,8 +90,7 @@ class FollowersController < ApplicationController
     end
 
     Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do
-      if @user.save
-        @section.add_student @user
+      if @user.save && @section&.add_student(@user)
         sign_in(:user, @user)
         redirect_to root_path, notice: I18n.t('follower.registered', section_name: @section.name)
         return

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -237,6 +237,25 @@ class FollowersControllerTest < ActionController::TestCase
     assert_select '#signup'
   end
 
+  test "student_register with no section when signed in" do
+    sign_in @student
+    assert_does_not_create(User, Follower) do
+      post :student_register, params: {section_code: ''}
+    end
+
+    assert_template 'followers/student_user_new'
+    assert_select 'input#section_code'
+  end
+
+  test "student_register with no section when not signed in" do
+    assert_does_not_create(User, Follower) do
+      post :student_register, params: {section_code: ''}
+    end
+
+    assert_template 'followers/student_user_new'
+    assert_select 'input#section_code'
+  end
+
   test "create with section code" do
     sign_in @student
 


### PR DESCRIPTION
Follow-up to #30458, as it was causing [this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/54109507/bae183de-ce6f-11e9-976d-daf2fe1e26aa#notice-summary) for signed in users when submitting the "join section" form with an empty section code.

More detailed repro:
1. Sign in (as any user type)
2. Visit studio.code.org/join
3. Submit the form by clicking "Go". Do not enter a section code.

EXPECTED: "Join section" form is re-rendered
ACTUAL: A 500 error "sad bee" page was displayed.

Video of fixed/expected flow:
![out](https://user-images.githubusercontent.com/9812299/64212089-191b2300-ce5d-11e9-9dce-b09fd1115ee2.gif)
