### PR TITLE
Stage edit polish

### DIFF
--- a/apps/src/lib/script-editor/LevelNameInput.jsx
+++ b/apps/src/lib/script-editor/LevelNameInput.jsx
@@ -5,7 +5,7 @@ import FontAwesome from '../../templates/FontAwesome';
 const styles = {
   levelSelect: {
     display: 'inline-block',
-    verticalAlign: 'middle',
+    verticalAlign: 'baseline',
     width: 600
   },
   validIcon: {

--- a/apps/src/lib/script-editor/LevelNameInput.jsx
+++ b/apps/src/lib/script-editor/LevelNameInput.jsx
@@ -17,6 +17,11 @@ const styles = {
     color: 'red',
     fontSize: 16,
     marginLeft: 6
+  },
+  textInput: {
+    width: 550,
+    verticalAlign: 'baseline',
+    marginBottom: 0
   }
 };
 

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -146,7 +146,11 @@ class LevelToken extends Component {
               {this.props.level.challenge && (
                 <span style={styles.tags}>challenge</span>
               )}
-              {this.props.level.named && <span style={styles.tags}>named</span>}
+              {/* progression supercedes named, so only show the named tag
+                  when the level is behaving like a named level. */}
+              {this.props.level.named && !this.props.level.progression && (
+                <span style={styles.tags}>named</span>
+              )}
               {this.props.level.assessment && (
                 <span style={styles.tags}>assessment</span>
               )}

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -36,13 +36,26 @@ const styles = {
     borderBottom: '1px solid #ddd',
     cursor: 'pointer'
   },
-  variants: {
+  tags: {
     color: 'white',
     background: color.purple,
     padding: '3px 5px',
     lineHeight: '12px',
     borderRadius: 5,
-    float: 'right'
+    float: 'right',
+    marginLeft: 3
+  },
+  progression: {
+    color: color.purple,
+    background: 'white',
+    padding: '2px 5px',
+    lineHeight: '12px',
+    borderRadius: 5,
+    borderColor: color.purple,
+    borderWidth: 1,
+    borderStyle: 'solid',
+    float: 'right',
+    marginLeft: 3
   },
   remove: {
     fontSize: 14,
@@ -126,8 +139,20 @@ class LevelToken extends Component {
             <span style={styles.levelTokenName} onMouseDown={this.toggleExpand}>
               {this.props.levelKeyList[this.props.level.activeId]}
               {this.props.level.ids.length > 1 && (
-                <span style={styles.variants}>
+                <span style={styles.tags}>
                   {this.props.level.ids.length} variants
+                </span>
+              )}
+              {this.props.level.challenge && (
+                <span style={styles.tags}>challenge</span>
+              )}
+              {this.props.level.named && <span style={styles.tags}>named</span>}
+              {this.props.level.assessment && (
+                <span style={styles.tags}>assessment</span>
+              )}
+              {this.props.level.progression && (
+                <span style={styles.progression}>
+                  {this.props.level.progression}
                 </span>
               )}
             </span>

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -34,7 +34,7 @@ const styles = {
     width: '100%',
     borderTop: '1px solid #ddd',
     borderBottom: '1px solid #ddd',
-    cursor: 'text'
+    cursor: 'pointer'
   },
   variants: {
     color: 'white',

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -36,7 +36,7 @@ const styles = {
     borderBottom: '1px solid #ddd',
     cursor: 'pointer'
   },
-  tags: {
+  tag: {
     color: 'white',
     background: color.purple,
     padding: '3px 5px',
@@ -45,7 +45,7 @@ const styles = {
     float: 'right',
     marginLeft: 3
   },
-  progression: {
+  progressionTag: {
     color: color.purple,
     background: 'white',
     padding: '2px 5px',
@@ -139,23 +139,23 @@ class LevelToken extends Component {
             <span style={styles.levelTokenName} onMouseDown={this.toggleExpand}>
               {this.props.levelKeyList[this.props.level.activeId]}
               {this.props.level.ids.length > 1 && (
-                <span style={styles.tags}>
+                <span style={styles.tag}>
                   {this.props.level.ids.length} variants
                 </span>
               )}
               {this.props.level.challenge && (
-                <span style={styles.tags}>challenge</span>
+                <span style={styles.tag}>challenge</span>
               )}
               {/* progression supercedes named, so only show the named tag
                   when the level is behaving like a named level. */}
               {this.props.level.named && !this.props.level.progression && (
-                <span style={styles.tags}>named</span>
+                <span style={styles.tag}>named</span>
               )}
               {this.props.level.assessment && (
-                <span style={styles.tags}>assessment</span>
+                <span style={styles.tag}>assessment</span>
               )}
               {this.props.level.progression && (
-                <span style={styles.progression}>
+                <span style={styles.progressionTag}>
                   {this.props.level.progression}
                 </span>
               )}

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -6,7 +6,6 @@ import {
   addVariant,
   removeVariant,
   setActiveVariant,
-  hasVariants,
   setField,
   NEW_LEVEL_ID
 } from './editorRedux';
@@ -85,13 +84,19 @@ export class UnconnectedLevelTokenDetails extends Component {
     setActiveVariant: PropTypes.func.isRequired,
     setField: PropTypes.func.isRequired,
     level: levelShape.isRequired,
-    stagePosition: PropTypes.number.isRequired,
-    hasVariants: PropTypes.bool.isRequired
+    stagePosition: PropTypes.number.isRequired
   };
 
-  state = {
-    showBlankProgression: false
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      showBlankProgression: false,
+      // Variants are deprecated. Only show them if they are already in use.
+      // If the number of variants is reduced to 1, keep showing the Add
+      // Variants button for the rest of this editing session.
+      showAddVariants: props.level.ids.length > 1
+    };
+  }
 
   containsLegacyLevel() {
     return this.props.level.ids.some(id =>
@@ -151,6 +156,7 @@ export class UnconnectedLevelTokenDetails extends Component {
   };
 
   render() {
+    const {showBlankProgression, showAddVariants} = this.state;
     const scriptLevelOptions = ['assessment', 'named', 'challenge'];
     return (
       <div style={styles.levelTokenActive}>
@@ -253,7 +259,7 @@ export class UnconnectedLevelTokenDetails extends Component {
         ))}
         {/* We don't currently support editing progression names here, but do
          * show the current progression if we have one. */}
-        {(this.props.level.progression || this.state.showBlankProgression) && (
+        {(this.props.level.progression || showBlankProgression) && (
           <div style={styles.progression}>
             <hr style={styles.divider} />
             <span style={styles.levelFieldLabel}>Progression name:</span>
@@ -269,18 +275,17 @@ export class UnconnectedLevelTokenDetails extends Component {
           </div>
         )}
         <hr style={styles.divider} />
-        {this.props.hasVariants &&
-          !this.props.level.ids.includes(NEW_LEVEL_ID) && (
-            <button
-              onMouseDown={this.handleAddVariant}
-              className="btn"
-              style={styles.button}
-              type="button"
-            >
-              <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-              Add Variant
-            </button>
-          )}
+        {showAddVariants && !this.props.level.ids.includes(NEW_LEVEL_ID) && (
+          <button
+            onMouseDown={this.handleAddVariant}
+            className="btn"
+            style={styles.button}
+            type="button"
+          >
+            <i style={{marginRight: 7}} className="fa fa-plus-circle" />
+            Add Variant
+          </button>
+        )}
         {!this.props.level.progression && !this.state.showBlankProgression && (
           <button
             onMouseDown={this.handleAddProgression}
@@ -300,8 +305,7 @@ export class UnconnectedLevelTokenDetails extends Component {
 export default connect(
   state => ({
     levelKeyList: state.levelKeyList,
-    levelNameToIdMap: state.levelNameToIdMap,
-    hasVariants: hasVariants(state)
+    levelNameToIdMap: state.levelNameToIdMap
   }),
   dispatch => ({
     chooseLevel(stage, level, variant, value) {

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -38,6 +38,8 @@ const styles = {
     margin: '7px 0 10px 0'
   },
   progressionTextInput: {
+    width: 550,
+    verticalAlign: 'baseline',
     marginBottom: 0
   },
   checkboxLabel: {
@@ -296,7 +298,7 @@ export class UnconnectedLevelTokenDetails extends Component {
               data-for={tooltipIds.progression}
               data-tip
             >
-              Progression name:
+              Progression:
             </span>
             <ReactTooltip id={tooltipIds.progression} delayShow={500}>
               <div style={styles.tooltip}>{tooltipText.progression}</div>
@@ -307,7 +309,7 @@ export class UnconnectedLevelTokenDetails extends Component {
                 type="text"
                 onChange={event => this.handleFieldChange('progression', event)}
                 value={this.props.level.progression}
-                style={styles.textInput}
+                style={styles.progressionTextInput}
                 data-field-name="progression"
               />
             </span>

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -28,12 +28,12 @@ const styles = {
     display: 'inline-block',
     lineHeight: '36px',
     margin: '0 7px 0 5px',
-    verticalAlign: 'middle'
+    verticalAlign: 'middle',
+    textAlign: 'right',
+    width: 80
   },
-  textInput: {
-    height: 34,
-    width: 350,
-    boxSizing: 'border-box',
+  shortTextInput: {
+    width: 330,
     verticalAlign: 'baseline',
     margin: '7px 0 10px 0'
   },
@@ -208,41 +208,37 @@ export class UnconnectedLevelTokenDetails extends Component {
         <div style={{clear: 'both'}} />
         {this.containsLegacyLevel() && (
           <div>
-            <span style={styles.levelFieldLabel}>Skin</span>
+            <span style={styles.levelFieldLabel}>Skin:</span>
             <input
               defaultValue={this.props.level.skin}
               type="text"
-              style={styles.textInput}
+              style={styles.shortTextInput}
               onChange={event => this.handleFieldChange('skin', event)}
             />
-            <div style={{float: 'right'}}>
-              <span style={styles.levelFieldLabel}>Video key</span>
-              <input
-                defaultValue={this.props.level.videoKey}
-                type="text"
-                style={styles.textInput}
-                onChange={event => this.handleFieldChange('videoKey', event)}
-              />
-            </div>
+            <span style={styles.levelFieldLabel}>Video key:</span>
+            <input
+              defaultValue={this.props.level.videoKey}
+              type="text"
+              style={styles.shortTextInput}
+              onChange={event => this.handleFieldChange('videoKey', event)}
+            />
             <div style={{clear: 'both'}} />
-            <span style={styles.levelFieldLabel}>Difficulty</span>
+            <span style={styles.levelFieldLabel}>Difficulty:</span>
             <input
               defaultValue={this.props.level.conceptDifficulty}
               type="text"
-              style={styles.textInput}
+              style={styles.shortTextInput}
               onChange={event =>
                 this.handleFieldChange('conceptDifficulty', event)
               }
             />
-            <div style={{float: 'right'}}>
-              <span style={styles.levelFieldLabel}>Concepts</span>
-              <input
-                defaultValue={this.props.level.concepts}
-                type="text"
-                style={Object.assign({}, styles.textInput, {width: 320})}
-                onChange={this.handleFieldChange.bind(this, 'concepts')}
-              />
-            </div>
+            <span style={styles.levelFieldLabel}>Concepts:</span>
+            <input
+              defaultValue={this.props.level.concepts}
+              type="text"
+              style={styles.shortTextInput}
+              onChange={this.handleFieldChange.bind(this, 'concepts')}
+            />
           </div>
         )}
         {this.props.level.ids.map((id, index) => (

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -6,6 +6,7 @@ import {
   addVariant,
   removeVariant,
   setActiveVariant,
+  hasVariants,
   setField,
   NEW_LEVEL_ID
 } from './editorRedux';
@@ -84,7 +85,8 @@ export class UnconnectedLevelTokenDetails extends Component {
     setActiveVariant: PropTypes.func.isRequired,
     setField: PropTypes.func.isRequired,
     level: levelShape.isRequired,
-    stagePosition: PropTypes.number.isRequired
+    stagePosition: PropTypes.number.isRequired,
+    hasVariants: PropTypes.bool.isRequired
   };
 
   state = {
@@ -267,17 +269,18 @@ export class UnconnectedLevelTokenDetails extends Component {
           </div>
         )}
         <hr style={styles.divider} />
-        {!this.props.level.ids.includes(NEW_LEVEL_ID) && (
-          <button
-            onMouseDown={this.handleAddVariant}
-            className="btn"
-            style={styles.button}
-            type="button"
-          >
-            <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-            Add Variant
-          </button>
-        )}
+        {this.props.hasVariants &&
+          !this.props.level.ids.includes(NEW_LEVEL_ID) && (
+            <button
+              onMouseDown={this.handleAddVariant}
+              className="btn"
+              style={styles.button}
+              type="button"
+            >
+              <i style={{marginRight: 7}} className="fa fa-plus-circle" />
+              Add Variant
+            </button>
+          )}
         {!this.props.level.progression && !this.state.showBlankProgression && (
           <button
             onMouseDown={this.handleAddProgression}
@@ -297,7 +300,8 @@ export class UnconnectedLevelTokenDetails extends Component {
 export default connect(
   state => ({
     levelKeyList: state.levelKeyList,
-    levelNameToIdMap: state.levelNameToIdMap
+    levelNameToIdMap: state.levelNameToIdMap,
+    hasVariants: hasVariants(state)
   }),
   dispatch => ({
     chooseLevel(stage, level, variant, value) {

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -11,6 +11,8 @@ import {
 } from './editorRedux';
 import {levelShape} from './shapes';
 import LevelNameInput from './LevelNameInput';
+import ReactTooltip from 'react-tooltip';
+import _ from 'lodash';
 
 const styles = {
   checkbox: {
@@ -67,6 +69,16 @@ const styles = {
   progression: {
     paddingTop: 5
   }
+};
+
+const scriptLevelOptions = ['assessment', 'named', 'challenge'];
+
+const tooltipText = {
+  assessment:
+    'Visibly mark this level as an assessment, and show it in the Assessments tab in Teacher Dashboard.',
+  named:
+    'Show this level on a line by itself, with the Display Name of the level as the label.',
+  challenge: 'Show students the Challenge dialog when viewing this level.'
 };
 
 const ArrowRenderer = ({onMouseDown}) => {
@@ -157,19 +169,31 @@ export class UnconnectedLevelTokenDetails extends Component {
 
   render() {
     const {showBlankProgression, showAddVariants} = this.state;
-    const scriptLevelOptions = ['assessment', 'named', 'challenge'];
+    const tooltipIds = {};
+    scriptLevelOptions.forEach(option => {
+      tooltipIds[option] = _.uniqueId();
+    });
     return (
       <div style={styles.levelTokenActive}>
         <span className="level-token-checkboxes">
           {scriptLevelOptions.map(option => (
-            <label key={option} style={styles.checkboxLabel}>
+            <label
+              key={option}
+              style={styles.checkboxLabel}
+              data-for={tooltipIds[option]}
+              data-tip
+            >
               <input
                 type="checkbox"
                 style={styles.checkboxInput}
                 checked={!!this.props.level[option]}
                 onChange={this.handleCheckboxChange.bind(this, option)}
               />
-              &nbsp;<span style={styles.checkboxText}>{option}</span>
+              &nbsp;
+              <span style={styles.checkboxText}>{option}</span>
+              <ReactTooltip id={tooltipIds[option]} delayShow={500}>
+                {tooltipText[option]}
+              </ReactTooltip>
             </label>
           ))}
         </span>

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -68,6 +68,9 @@ const styles = {
   },
   progression: {
     paddingTop: 5
+  },
+  tooltip: {
+    maxWidth: 450
   }
 };
 
@@ -78,7 +81,9 @@ const tooltipText = {
     'Visibly mark this level as an assessment, and show it in the Assessments tab in Teacher Dashboard.',
   named:
     'Show this level on a line by itself, with the Display Name of the level as the label.',
-  challenge: 'Show students the Challenge dialog when viewing this level.'
+  challenge: 'Show students the Challenge dialog when viewing this level.',
+  progression:
+    'Group this level with other levels in the same progression, with this text as the label. This overrides the "named" checkbox.'
 };
 
 const ArrowRenderer = ({onMouseDown}) => {
@@ -173,6 +178,7 @@ export class UnconnectedLevelTokenDetails extends Component {
     scriptLevelOptions.forEach(option => {
       tooltipIds[option] = _.uniqueId();
     });
+    tooltipIds.progression = _.uniqueId();
     return (
       <div style={styles.levelTokenActive}>
         <span className="level-token-checkboxes">
@@ -192,7 +198,7 @@ export class UnconnectedLevelTokenDetails extends Component {
               &nbsp;
               <span style={styles.checkboxText}>{option}</span>
               <ReactTooltip id={tooltipIds[option]} delayShow={500}>
-                {tooltipText[option]}
+                <div style={styles.tooltip}>{tooltipText[option]}</div>
               </ReactTooltip>
             </label>
           ))}
@@ -286,7 +292,17 @@ export class UnconnectedLevelTokenDetails extends Component {
         {(this.props.level.progression || showBlankProgression) && (
           <div style={styles.progression}>
             <hr style={styles.divider} />
-            <span style={styles.levelFieldLabel}>Progression name:</span>
+            <span
+              style={styles.levelFieldLabel}
+              data-for={tooltipIds.progression}
+              data-tip
+            >
+              Progression name:
+            </span>
+            <ReactTooltip id={tooltipIds.progression} delayShow={500}>
+              <div style={styles.tooltip}>{tooltipText.progression}</div>
+            </ReactTooltip>
+
             <span style={styles.levelSelect}>
               <input
                 type="text"

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -175,10 +175,9 @@ export class UnconnectedLevelTokenDetails extends Component {
   render() {
     const {showBlankProgression, showAddVariants} = this.state;
     const tooltipIds = {};
-    scriptLevelOptions.forEach(option => {
+    Object.keys(tooltipText).forEach(option => {
       tooltipIds[option] = _.uniqueId();
     });
-    tooltipIds.progression = _.uniqueId();
     return (
       <div style={styles.levelTokenActive}>
         <span className="level-token-checkboxes">

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -230,7 +230,7 @@ export class UnconnectedLevelTokenDetails extends Component {
               defaultValue={this.props.level.concepts}
               type="text"
               style={styles.shortTextInput}
-              onChange={this.handleFieldChange.bind(this, 'concepts')}
+              onChange={event => this.handleFieldChange('concepts', event)}
             />
           </div>
         )}

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -28,14 +28,14 @@ const styles = {
     display: 'inline-block',
     lineHeight: '36px',
     margin: '0 7px 0 5px',
-    verticalAlign: 'middle',
+    verticalAlign: 'baseline',
     textAlign: 'right',
     width: 80
   },
   shortTextInput: {
     width: 330,
     verticalAlign: 'baseline',
-    margin: '7px 0 10px 0'
+    marginBottom: 0
   },
   progressionTextInput: {
     width: 550,
@@ -56,7 +56,8 @@ const styles = {
   },
   divider: {
     borderColor: '#ddd',
-    margin: '7px 0'
+    margin: '7px 0',
+    paddingBottom: 5
   },
   button: {
     fontSize: 14,
@@ -67,9 +68,6 @@ const styles = {
   },
   removeVariant: {
     float: 'right'
-  },
-  progression: {
-    paddingTop: 5
   },
   tooltip: {
     maxWidth: 450
@@ -109,7 +107,6 @@ export class UnconnectedLevelTokenDetails extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showBlankProgression: false,
       // Variants are deprecated. Only show them if they are already in use.
       // If the number of variants is reduced to 1, keep showing the Add
       // Variants button for the rest of this editing session.
@@ -144,10 +141,6 @@ export class UnconnectedLevelTokenDetails extends Component {
     );
   };
 
-  handleAddProgression = () => {
-    this.setState({showBlankProgression: true});
-  };
-
   handleActiveVariantChanged = id => {
     this.props.setActiveVariant(
       this.props.stagePosition,
@@ -175,7 +168,7 @@ export class UnconnectedLevelTokenDetails extends Component {
   };
 
   render() {
-    const {showBlankProgression, showAddVariants} = this.state;
+    const {showAddVariants} = this.state;
     const tooltipIds = {};
     Object.keys(tooltipText).forEach(option => {
       tooltipIds[option] = _.uniqueId();
@@ -284,55 +277,42 @@ export class UnconnectedLevelTokenDetails extends Component {
             />
           </div>
         ))}
-        {/* We don't currently support editing progression names here, but do
-         * show the current progression if we have one. */}
-        {(this.props.level.progression || showBlankProgression) && (
-          <div style={styles.progression}>
-            <hr style={styles.divider} />
-            <span
-              style={styles.levelFieldLabel}
-              data-for={tooltipIds.progression}
-              data-tip
-            >
-              Progression:
-            </span>
-            <ReactTooltip id={tooltipIds.progression} delayShow={500}>
-              <div style={styles.tooltip}>{tooltipText.progression}</div>
-            </ReactTooltip>
+        {showAddVariants && <hr style={styles.divider} />}
+        <div style={styles.progression}>
+          <span
+            style={styles.levelFieldLabel}
+            data-for={tooltipIds.progression}
+            data-tip
+          >
+            Progression:
+          </span>
+          <ReactTooltip id={tooltipIds.progression} delayShow={500}>
+            <div style={styles.tooltip}>{tooltipText.progression}</div>
+          </ReactTooltip>
 
-            <span style={styles.levelSelect}>
-              <input
-                type="text"
-                onChange={event => this.handleFieldChange('progression', event)}
-                value={this.props.level.progression}
-                style={styles.progressionTextInput}
-                data-field-name="progression"
-              />
-            </span>
-          </div>
-        )}
-        <hr style={styles.divider} />
+          <span style={styles.levelSelect}>
+            <input
+              type="text"
+              onChange={event => this.handleFieldChange('progression', event)}
+              value={this.props.level.progression}
+              style={styles.progressionTextInput}
+              data-field-name="progression"
+            />
+          </span>
+        </div>
         {showAddVariants && !this.props.level.ids.includes(NEW_LEVEL_ID) && (
-          <button
-            onMouseDown={this.handleAddVariant}
-            className="btn"
-            style={styles.button}
-            type="button"
-          >
-            <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-            Add Variant
-          </button>
-        )}
-        {!this.props.level.progression && !this.state.showBlankProgression && (
-          <button
-            onMouseDown={this.handleAddProgression}
-            className="btn"
-            style={styles.button}
-            type="button"
-          >
-            <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-            Add Progression
-          </button>
+          <div>
+            <hr style={styles.divider} />
+            <button
+              onMouseDown={this.handleAddVariant}
+              className="btn"
+              style={styles.button}
+              type="button"
+            >
+              <i style={{marginRight: 7}} className="fa fa-plus-circle" />
+              Add Variant
+            </button>
+          </div>
         )}
       </div>
     );

--- a/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
@@ -45,6 +45,7 @@ export default storybook => {
             setField={action('setField')}
             level={defaultLevel}
             stagePosition={1}
+            hasVariants={true}
           />
         </div>
       )
@@ -63,6 +64,7 @@ export default storybook => {
             setField={action('setField')}
             level={blocklyLevel}
             stagePosition={1}
+            hasVariants={true}
           />
         </div>
       )

--- a/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.story.jsx
@@ -45,7 +45,6 @@ export default storybook => {
             setField={action('setField')}
             level={defaultLevel}
             stagePosition={1}
-            hasVariants={true}
           />
         </div>
       )
@@ -64,7 +63,6 @@ export default storybook => {
             setField={action('setField')}
             level={blocklyLevel}
             stagePosition={1}
-            hasVariants={true}
           />
         </div>
       )

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -298,7 +298,3 @@ export default {
   levelKeyList,
   levelNameToIdMap
 };
-
-// Whether any level in the script has multiple variants.
-export const hasVariants = state =>
-  state.stages.some(stage => stage.levels.some(level => level.ids.length > 1));

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -298,3 +298,7 @@ export default {
   levelKeyList,
   levelNameToIdMap
 };
+
+// Whether any level in the script has multiple variants.
+export const hasVariants = state =>
+  state.stages.some(stage => stage.levels.some(level => level.ids.length > 1));

--- a/apps/src/lib/script-editor/shapes.jsx
+++ b/apps/src/lib/script-editor/shapes.jsx
@@ -21,5 +21,6 @@ export const levelShape = PropTypes.shape({
   // other script level options
   named: PropTypes.bool,
   assessment: PropTypes.bool,
-  challenge: PropTypes.bool
+  challenge: PropTypes.bool,
+  progression: PropTypes.string
 });

--- a/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
+++ b/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
@@ -69,7 +69,6 @@ describe('LevelTokenDetails', () => {
       addVariant,
       removeVariant,
       setActiveVariant,
-      hasVariants: true,
       setField,
       level: defaultLevel,
       stagePosition: 5

--- a/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
+++ b/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
@@ -82,7 +82,7 @@ describe('LevelTokenDetails', () => {
     assertChecked(wrapper, 'assessment', false);
     assertChecked(wrapper, 'challenge', false);
 
-    assertButtonVisible(wrapper, 'Add Variant', true);
+    assertButtonVisible(wrapper, 'Add Variant', false);
     assertButtonVisible(wrapper, 'Remove Variant', false);
     assertButtonVisible(wrapper, 'Add Progression', true);
 

--- a/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
+++ b/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
@@ -84,9 +84,8 @@ describe('LevelTokenDetails', () => {
 
     assertButtonVisible(wrapper, 'Add Variant', false);
     assertButtonVisible(wrapper, 'Remove Variant', false);
-    assertButtonVisible(wrapper, 'Add Progression', true);
 
-    assertInputVisible(wrapper, 'progression', false);
+    assertInputVisible(wrapper, 'progression', true);
   });
 
   it('renders with progression', () => {
@@ -96,19 +95,8 @@ describe('LevelTokenDetails', () => {
         level={{...defaultLevel, progression: 'intro'}}
       />
     );
-    assertButtonVisible(wrapper, 'Add Progression', false);
     assertInputVisible(wrapper, 'progression', true);
     assertInputValue(wrapper, 'progression', 'intro');
-  });
-
-  it('shows progression when clicked', () => {
-    const wrapper = shallow(<LevelTokenDetails {...defaultProps} />);
-    assertInputVisible(wrapper, 'progression', false);
-    const button = wrapper.findWhere(
-      n => n.name() === 'button' && n.text().includes('Add Progression')
-    );
-    button.simulate('mousedown');
-    assertInputVisible(wrapper, 'progression', true);
   });
 
   it('shows new blank variant', () => {

--- a/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
+++ b/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
@@ -69,6 +69,7 @@ describe('LevelTokenDetails', () => {
       addVariant,
       removeVariant,
       setActiveVariant,
+      hasVariants: true,
       setField,
       level: defaultLevel,
       stagePosition: 5

--- a/dashboard/config/scripts/csp1-2019.script
+++ b/dashboard/config/scripts/csp1-2019.script
@@ -3,7 +3,7 @@ login_required true
 hideable_stages true
 exclude_csf_column_in_legend true
 student_detail_progress_view true
-teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-19/unit1/"], ["teacherForum", "https://forum.code.org/c/csp1"], ["vocabulary", "https://curriculum.code.org/csp-19/unit1/vocab/"], ["standardMappings", "https://curriculum.code.org/csp-19/unit1/standards/"], ["professionalLearning", "https://studio.code.org/s/csp1-support"]]
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-19/unit1/"], ["teacherForum", "https://forum.code.org/c/csp1"], ["vocabulary", "https://curriculum.code.org/csp-19/unit1/vocab/"], ["standardMappings", "https://curriculum.code.org/csp-19/unit1/standards/"], ["professionalLearning", "https://code.org/educate/professional-learning/middle-high"]]
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-19/unit1/{LESSON}'
@@ -13,26 +13,26 @@ is_stable true
 project_sharing true
 curriculum_umbrella 'CSP'
 
-stage 'CS Principles Pre-survey', lockable: true, flex_category: 'Survey'
-level 'csp-pre-survey-2017-levelgroup_2018_2019', assessment: true
+stage 'CS Principles Pre-survey', lockable: true, flex_category: 'cspSurvey'
+level 'csp-pre-survey-levelgroup_2019', assessment: true
 
-stage 'Personal Innovations', flex_category: 'Chapter 1: Representing and Transmitting Information'
+stage 'Personal Innovations', flex_category: 'csp1_1'
 level 'CSP U1L01 SFLP_2019', named: true
 level 'Computer Science is Changing Everything_2019', progression: 'Computer Science is Changing Everything', named: true
 variants
   level 'csp_socialBelonging_control_2019', progression: 'Reflection: starting out in computer science', assessment: true
-  level 'csp_socialBelonging_intervention_2019', active: false, progression: 'Reflection: starting out in computer science', assessment: true
+  level 'csp_socialBelonging_intervention_2019', progression: 'Reflection: starting out in computer science', assessment: true
 endvariants
 
-stage 'Sending Binary Messages', flex_category: 'Chapter 1: Representing and Transmitting Information'
+stage 'Sending Binary Messages', flex_category: 'csp1_1'
 level 'CSP U1L02 SFLP_2019', named: true
 level 'U1L2 Multiple Choice Assessment Question_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L3 Free response reflection question_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L2 Free response assessment question_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L3 Free Response_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Sending Binary Messages with the Internet Simulator', flex_category: 'Chapter 1: Representing and Transmitting Information'
-level 'CSP U1L03 SFLP_2019', progression: 'Internet Simulator: Sending Binary Messages', named: true
+stage 'Sending Binary Messages with the Internet Simulator', flex_category: 'csp1_1'
+level 'CSP U1L03 SFLP_2019', named: true
 level 'Internet Simulator: Sending Binary Messages_2019', progression: 'Internet Simulator: Sending Binary Messages', named: true
 level 'The Internet: Wires, Cables, and Wifi_2019', progression: 'The Internet: Wires, Cables, and Wifi', named: true
 level 'U1L4 Multiple Choice_2018_2019', progression: 'Check Your Understanding', assessment: true
@@ -40,24 +40,24 @@ level 'U1L3 Multiple Choice_2018_2019', progression: 'Check Your Understanding',
 level 'U1L4 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L5 Matching Assessment_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Number Systems', flex_category: 'Chapter 1: Representing and Transmitting Information'
+stage 'Number Systems', flex_category: 'csp1_1'
 level 'CSP U1L04 SFLP_2019', named: true
 level 'U1L6 Assessment multiple choice_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L6 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Binary Numbers', flex_category: 'Chapter 1: Representing and Transmitting Information'
+stage 'Binary Numbers', flex_category: 'csp1_1'
 level 'CSP U1L05 SFLP_2019', named: true
 level 'Widget: Binary Odometer_2019', progression: 'Widget: Binary Odometer', named: true
 level 'U1L7 Free Response Assessment_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L7 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Sending Numbers', flex_category: 'Chapter 1: Representing and Transmitting Information'
+stage 'Sending Numbers', flex_category: 'csp1_1'
 level 'CSP U1L06 SFLP_2019', named: true
 level 'Internet Simulator: Sending Numbers_2019', progression: 'Internet Simulator: Sending Numbers', named: true
 level 'U1L8 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L8 Multiple Choice_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Sending Text', flex_category: 'Chapter 1: Representing and Transmitting Information'
+stage 'Sending Text', flex_category: 'csp1_1'
 level 'CSP U1L07 SFLP_2019', named: true
 level 'Internet Simulator: Sending Text_2019', progression: 'Internet Simulator: Sending Text', named: true
 level 'U1L10 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
@@ -66,10 +66,10 @@ level 'U1L11 Assessment 1_2018_2019', progression: 'Check Your Understanding', a
 level 'U1L11 Reflection Multiple Representations_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L11 Abstraction Reflection_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Unit 1 Chapter 1 Assessment', lockable: true, flex_category: 'Chapter 1: Representing and Transmitting Information'
+stage 'Unit 1 Chapter 1 Assessment', lockable: true, flex_category: 'csp1_1'
 level 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018_2019', assessment: true
 
-stage 'The Internet', flex_category: 'Chapter 2: Inventing the Internet'
+stage 'The Internet', flex_category: 'csp1_2'
 level 'CSP U1L08 SFLP_2019', named: true
 level 'What is the Internet?_2019', progression: 'What is the Internet?', named: true
 level 'U2L01 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
@@ -78,7 +78,7 @@ level 'U2L01 Assessment 3_2018_2019', progression: 'Check Your Understanding', a
 level 'U2L01 Assessment 4_2019', progression: 'Check Your Understanding', assessment: true
 level 'csp-pulse-check-survey-1-levelgroup-U1Ch2_2018_2019', progression: 'Quick Check-In', assessment: true
 
-stage 'The Need for Addressing', flex_category: 'Chapter 2: Inventing the Internet'
+stage 'The Need for Addressing', flex_category: 'csp1_2'
 level 'CSP U1L09 SFLP_2019', named: true
 level 'Internet Simulator: Broadcast_2019', progression: 'Internet Simulator: Broadcast', named: true
 level 'The Internet: IP Addresses & DNS_2019', progression: 'The Internet: IP Addresses & DNS', named: true
@@ -88,7 +88,7 @@ level 'U2L02 Assessment 4_2018_2019', progression: 'Check Your Understanding', a
 level 'U2L02 Assessment 5_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L3 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Routers and Redundancy', flex_category: 'Chapter 2: Inventing the Internet'
+stage 'Routers and Redundancy', flex_category: 'csp1_2'
 level 'CSP U1L10 SFLP_2019', named: true
 level 'Internet Simulator: Routers_2019', progression: 'Internet Simulator: Routers', named: true
 level 'U2L04 Assessment1_2018_2019', progression: 'Check Your Understanding', assessment: true
@@ -97,7 +97,7 @@ level 'U2L04 Assessment5_2018_2019', progression: 'Check Your Understanding', as
 level 'U2L04 Assessment2_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L04 Assessment3_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Packets and Making a Reliable Internet', flex_category: 'Chapter 2: Inventing the Internet'
+stage 'Packets and Making a Reliable Internet', flex_category: 'csp1_2'
 level 'CSP U1L11 SFLP_2019', named: true
 level 'Internet Simulator: Packets_2019', progression: 'Internet Simulator: Packets', named: true
 level 'The Internet: Packets, Routing, and Reliability_2019', progression: 'The Internet: Packets, Routing, and Reliability', named: true
@@ -106,7 +106,7 @@ level 'U2L05 Assessment 1_2018_2019', progression: 'Check Your Understanding', a
 level 'U2L05 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L3 Assessment_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'The Need for DNS', flex_category: 'Chapter 2: Inventing the Internet'
+stage 'The Need for DNS', flex_category: 'csp1_2'
 level 'CSP U1L12 SFLP_2019', named: true
 level 'Internet Simulator: DNS_2019', progression: 'Internet Simulator: DNS', named: true
 level 'The Internet: IP Addresses & DNS_2019', progression: 'The Internet: IP Addresses & DNS', named: true
@@ -115,15 +115,15 @@ level 'U2L09 Assessment2_2019', progression: 'Check Your Understanding', assessm
 level 'U2L09 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L10 Assessment1_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'HTTP and Abstraction', flex_category: 'Chapter 2: Inventing the Internet'
+stage 'HTTP and Abstraction', flex_category: 'csp1_2'
 level 'CSP U1L13 SFLP_2019', named: true
 level 'The Internet: HTTP and HTML_2019', progression: 'The Internet: HTTP and HTML', named: true
 level 'U2L11 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L11 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L11 Free Response_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Practice PT - The Internet and Society', flex_category: 'Chapter 2: Inventing the Internet'
+stage 'Practice PT - The Internet and Society', flex_category: 'csp1_2'
 level 'CSP U1L14 SFLP_2019', named: true
 
-stage 'Unit 1 Chapter 2 Assessment', lockable: true, flex_category: 'Chapter 2: Inventing the Internet'
+stage 'Unit 1 Chapter 2 Assessment', lockable: true, flex_category: 'csp1_2'
 level 'CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018_2019', assessment: true

--- a/dashboard/config/scripts/csp1-2019.script
+++ b/dashboard/config/scripts/csp1-2019.script
@@ -3,7 +3,7 @@ login_required true
 hideable_stages true
 exclude_csf_column_in_legend true
 student_detail_progress_view true
-teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-19/unit1/"], ["teacherForum", "https://forum.code.org/c/csp1"], ["vocabulary", "https://curriculum.code.org/csp-19/unit1/vocab/"], ["standardMappings", "https://curriculum.code.org/csp-19/unit1/standards/"], ["professionalLearning", "https://code.org/educate/professional-learning/middle-high"]]
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-19/unit1/"], ["teacherForum", "https://forum.code.org/c/csp1"], ["vocabulary", "https://curriculum.code.org/csp-19/unit1/vocab/"], ["standardMappings", "https://curriculum.code.org/csp-19/unit1/standards/"], ["professionalLearning", "https://studio.code.org/s/csp1-support"]]
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-19/unit1/{LESSON}'
@@ -13,26 +13,26 @@ is_stable true
 project_sharing true
 curriculum_umbrella 'CSP'
 
-stage 'CS Principles Pre-survey', lockable: true, flex_category: 'cspSurvey'
-level 'csp-pre-survey-levelgroup_2019', assessment: true
+stage 'CS Principles Pre-survey', lockable: true, flex_category: 'Survey'
+level 'csp-pre-survey-2017-levelgroup_2018_2019', assessment: true
 
-stage 'Personal Innovations', flex_category: 'csp1_1'
+stage 'Personal Innovations', flex_category: 'Chapter 1: Representing and Transmitting Information'
 level 'CSP U1L01 SFLP_2019', named: true
 level 'Computer Science is Changing Everything_2019', progression: 'Computer Science is Changing Everything', named: true
 variants
   level 'csp_socialBelonging_control_2019', progression: 'Reflection: starting out in computer science', assessment: true
-  level 'csp_socialBelonging_intervention_2019', progression: 'Reflection: starting out in computer science', assessment: true
+  level 'csp_socialBelonging_intervention_2019', active: false, progression: 'Reflection: starting out in computer science', assessment: true
 endvariants
 
-stage 'Sending Binary Messages', flex_category: 'csp1_1'
+stage 'Sending Binary Messages', flex_category: 'Chapter 1: Representing and Transmitting Information'
 level 'CSP U1L02 SFLP_2019', named: true
 level 'U1L2 Multiple Choice Assessment Question_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L3 Free response reflection question_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L2 Free response assessment question_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L3 Free Response_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Sending Binary Messages with the Internet Simulator', flex_category: 'csp1_1'
-level 'CSP U1L03 SFLP_2019', named: true
+stage 'Sending Binary Messages with the Internet Simulator', flex_category: 'Chapter 1: Representing and Transmitting Information'
+level 'CSP U1L03 SFLP_2019', progression: 'Internet Simulator: Sending Binary Messages', named: true
 level 'Internet Simulator: Sending Binary Messages_2019', progression: 'Internet Simulator: Sending Binary Messages', named: true
 level 'The Internet: Wires, Cables, and Wifi_2019', progression: 'The Internet: Wires, Cables, and Wifi', named: true
 level 'U1L4 Multiple Choice_2018_2019', progression: 'Check Your Understanding', assessment: true
@@ -40,24 +40,24 @@ level 'U1L3 Multiple Choice_2018_2019', progression: 'Check Your Understanding',
 level 'U1L4 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L5 Matching Assessment_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Number Systems', flex_category: 'csp1_1'
+stage 'Number Systems', flex_category: 'Chapter 1: Representing and Transmitting Information'
 level 'CSP U1L04 SFLP_2019', named: true
 level 'U1L6 Assessment multiple choice_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L6 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Binary Numbers', flex_category: 'csp1_1'
+stage 'Binary Numbers', flex_category: 'Chapter 1: Representing and Transmitting Information'
 level 'CSP U1L05 SFLP_2019', named: true
 level 'Widget: Binary Odometer_2019', progression: 'Widget: Binary Odometer', named: true
 level 'U1L7 Free Response Assessment_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L7 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Sending Numbers', flex_category: 'csp1_1'
+stage 'Sending Numbers', flex_category: 'Chapter 1: Representing and Transmitting Information'
 level 'CSP U1L06 SFLP_2019', named: true
 level 'Internet Simulator: Sending Numbers_2019', progression: 'Internet Simulator: Sending Numbers', named: true
 level 'U1L8 Free Response Reflection_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L8 Multiple Choice_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Sending Text', flex_category: 'csp1_1'
+stage 'Sending Text', flex_category: 'Chapter 1: Representing and Transmitting Information'
 level 'CSP U1L07 SFLP_2019', named: true
 level 'Internet Simulator: Sending Text_2019', progression: 'Internet Simulator: Sending Text', named: true
 level 'U1L10 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
@@ -66,10 +66,10 @@ level 'U1L11 Assessment 1_2018_2019', progression: 'Check Your Understanding', a
 level 'U1L11 Reflection Multiple Representations_2019', progression: 'Check Your Understanding', assessment: true
 level 'U1L11 Abstraction Reflection_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Unit 1 Chapter 1 Assessment', lockable: true, flex_category: 'csp1_1'
+stage 'Unit 1 Chapter 1 Assessment', lockable: true, flex_category: 'Chapter 1: Representing and Transmitting Information'
 level 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018_2019', assessment: true
 
-stage 'The Internet', flex_category: 'csp1_2'
+stage 'The Internet', flex_category: 'Chapter 2: Inventing the Internet'
 level 'CSP U1L08 SFLP_2019', named: true
 level 'What is the Internet?_2019', progression: 'What is the Internet?', named: true
 level 'U2L01 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
@@ -78,7 +78,7 @@ level 'U2L01 Assessment 3_2018_2019', progression: 'Check Your Understanding', a
 level 'U2L01 Assessment 4_2019', progression: 'Check Your Understanding', assessment: true
 level 'csp-pulse-check-survey-1-levelgroup-U1Ch2_2018_2019', progression: 'Quick Check-In', assessment: true
 
-stage 'The Need for Addressing', flex_category: 'csp1_2'
+stage 'The Need for Addressing', flex_category: 'Chapter 2: Inventing the Internet'
 level 'CSP U1L09 SFLP_2019', named: true
 level 'Internet Simulator: Broadcast_2019', progression: 'Internet Simulator: Broadcast', named: true
 level 'The Internet: IP Addresses & DNS_2019', progression: 'The Internet: IP Addresses & DNS', named: true
@@ -88,7 +88,7 @@ level 'U2L02 Assessment 4_2018_2019', progression: 'Check Your Understanding', a
 level 'U2L02 Assessment 5_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L3 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Routers and Redundancy', flex_category: 'csp1_2'
+stage 'Routers and Redundancy', flex_category: 'Chapter 2: Inventing the Internet'
 level 'CSP U1L10 SFLP_2019', named: true
 level 'Internet Simulator: Routers_2019', progression: 'Internet Simulator: Routers', named: true
 level 'U2L04 Assessment1_2018_2019', progression: 'Check Your Understanding', assessment: true
@@ -97,7 +97,7 @@ level 'U2L04 Assessment5_2018_2019', progression: 'Check Your Understanding', as
 level 'U2L04 Assessment2_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L04 Assessment3_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Packets and Making a Reliable Internet', flex_category: 'csp1_2'
+stage 'Packets and Making a Reliable Internet', flex_category: 'Chapter 2: Inventing the Internet'
 level 'CSP U1L11 SFLP_2019', named: true
 level 'Internet Simulator: Packets_2019', progression: 'Internet Simulator: Packets', named: true
 level 'The Internet: Packets, Routing, and Reliability_2019', progression: 'The Internet: Packets, Routing, and Reliability', named: true
@@ -106,7 +106,7 @@ level 'U2L05 Assessment 1_2018_2019', progression: 'Check Your Understanding', a
 level 'U2L05 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L3 Assessment_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'The Need for DNS', flex_category: 'csp1_2'
+stage 'The Need for DNS', flex_category: 'Chapter 2: Inventing the Internet'
 level 'CSP U1L12 SFLP_2019', named: true
 level 'Internet Simulator: DNS_2019', progression: 'Internet Simulator: DNS', named: true
 level 'The Internet: IP Addresses & DNS_2019', progression: 'The Internet: IP Addresses & DNS', named: true
@@ -115,15 +115,15 @@ level 'U2L09 Assessment2_2019', progression: 'Check Your Understanding', assessm
 level 'U2L09 Free Response Wrap Up_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L10 Assessment1_2018_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'HTTP and Abstraction', flex_category: 'csp1_2'
+stage 'HTTP and Abstraction', flex_category: 'Chapter 2: Inventing the Internet'
 level 'CSP U1L13 SFLP_2019', named: true
 level 'The Internet: HTTP and HTML_2019', progression: 'The Internet: HTTP and HTML', named: true
 level 'U2L11 Assessment 1_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L11 Assessment 2_2018_2019', progression: 'Check Your Understanding', assessment: true
 level 'U2L11 Free Response_2019', progression: 'Check Your Understanding', assessment: true
 
-stage 'Practice PT - The Internet and Society', flex_category: 'csp1_2'
+stage 'Practice PT - The Internet and Society', flex_category: 'Chapter 2: Inventing the Internet'
 level 'CSP U1L14 SFLP_2019', named: true
 
-stage 'Unit 1 Chapter 2 Assessment', lockable: true, flex_category: 'csp1_2'
+stage 'Unit 1 Chapter 2 Assessment', lockable: true, flex_category: 'Chapter 2: Inventing the Internet'
 level 'CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018_2019', assessment: true


### PR DESCRIPTION
### Description

fit-and-finish improvements to the stage edit gui in preparation for tomorrow's bug bash.

#### summary row tags

the most commonly-edited details are now visible in the summary row:

| before        | after         |
| ------------- |---------------|
| <img width="500" alt="Screen Shot 2019-09-04 at 9 35 40 AM" src="https://user-images.githubusercontent.com/8001765/64274190-b9be2100-cef7-11e9-9d62-7e13ac68f15f.png"> | <img width="500" alt="Screen Shot 2019-09-04 at 9 36 00 AM" src="https://user-images.githubusercontent.com/8001765/64274197-bcb91180-cef7-11e9-9392-3b821bfbf021.png"> |

#### level details

in the common case, when editing non-legacy levels without variants:
* uses less vertical space 
* level field long enough for longest level names
* Add Progression button is gone and the Progression field is always present
* the Add Variants button (deprecated) is hidden when no variants previously exist
* tooltips added on frequently-edited fields

| before        | after         |
| ------------- |---------------|
| <img width="500" alt="Screen Shot 2019-09-04 at 9 32 23 AM" src="https://user-images.githubusercontent.com/8001765/64274264-d8241c80-cef7-11e9-8d70-7e5ae8ac0827.png">      | <img width="500" alt="Screen Shot 2019-09-04 at 9 32 42 AM" src="https://user-images.githubusercontent.com/8001765/64274269-db1f0d00-cef7-11e9-82f7-7d671f9c84a6.png"> |
| <img width="500" alt="Screen Shot 2019-09-04 at 9 42 06 AM" src="https://user-images.githubusercontent.com/8001765/64274554-73b58d00-cef8-11e9-9fdf-d7bb65152b30.png"> | <img width="500" alt="Screen Shot 2019-09-04 at 9 42 06 AM" src="https://user-images.githubusercontent.com/8001765/64274852-1f5edd00-cef9-11e9-83dd-e4518f466f0a.gif">  |

#### compact legacy editing

hurts your eyes less when editing legacy levels

| before        | after         |
| ------------- |---------------|
| <img width="500" alt="Screen Shot 2019-09-04 at 9 51 31 AM" src="https://user-images.githubusercontent.com/8001765/64275094-a6ac5080-cef9-11e9-9874-cae2297d4ea6.png">      | <img width="500" alt="Screen Shot 2019-09-04 at 9 51 45 AM" src="https://user-images.githubusercontent.com/8001765/64275097-aad86e00-cef9-11e9-898f-5893aef91e93.png"> |

#### variants

can still use the Add Variants button when level already has variants. this view is still pretty ugly, but variants are deprecated so that's ok for now.

| before        | after         |
| ------------- |---------------|
|   <img width="895" alt="Screen Shot 2019-09-04 at 9 53 38 AM" src="https://user-images.githubusercontent.com/8001765/64275209-f12dcd00-cef9-11e9-9370-343278cce819.png">    | <img width="894" alt="Screen Shot 2019-09-04 at 9 53 50 AM" src="https://user-images.githubusercontent.com/8001765/64275219-f7bc4480-cef9-11e9-9d49-efaae65ea706.png">   |