### PR TITLE
[Cleanup] Key sounds by url, not name

### DIFF
--- a/apps/src/code-studio/components/SoundList.jsx
+++ b/apps/src/code-studio/components/SoundList.jsx
@@ -43,7 +43,7 @@ export default class SoundList extends React.Component {
         this.props.selectedSound.name === sound.name ? true : false;
       return (
         <SoundListEntry
-          key={sound.name}
+          key={sound.sourceUrl}
           assetChosen={this.props.assetChosen}
           soundMetadata={sound}
           isSelected={isSelected}


### PR DESCRIPTION
There are two sounds (`jump_7` and `whoosh_2`) that appear in multiple categories. So if search results include these sounds, we get a React warning that the components do not have unique keys and only the first instance of the sound appears:
![image](https://user-images.githubusercontent.com/8787187/64275035-88465500-cef9-11e9-99ae-33afa335401f.png)
![image](https://user-images.githubusercontent.com/8787187/64275070-9b592500-cef9-11e9-92f7-28890371aba5.png)


This changes the sounds to be keyed by sourceUrl instead of name, which are unique. As a result, both sounds will show up in the search results. I don't think this is an issue because it's just two sounds that are in multiple categories, but let me know if you disagree!
After:
![image](https://user-images.githubusercontent.com/8787187/64274913-43222300-cef9-11e9-9f78-3c11139fcadc.png)
