### PR TITLE
Add sub-question to Overall Success question

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,15 @@ npm-debug.log
 /rebuild-code-studio
 /shared/js/node_modules/
 /tools/scripts/brokenLinkChecker/node_modules/
+.solargraph.yml
+/bin/log/
+/bin/sc
+/bin/sc-4.5.4-osx/
+/dashboard/bin/log/
+/dashboard/node_modules/
+/dashboard/test/lib/pd/survey_pipeline/notes/
+/dashboard/yarn.lock
+/mytools/
+/node_modules/.bin/
+/node_modules/prettier/
+/package.json

--- a/.gitignore
+++ b/.gitignore
@@ -68,15 +68,3 @@ npm-debug.log
 /rebuild-code-studio
 /shared/js/node_modules/
 /tools/scripts/brokenLinkChecker/node_modules/
-.solargraph.yml
-/bin/log/
-/bin/sc
-/bin/sc-4.5.4-osx/
-/dashboard/bin/log/
-/dashboard/node_modules/
-/dashboard/test/lib/pd/survey_pipeline/notes/
-/dashboard/yarn.lock
-/mytools/
-/node_modules/.bin/
-/node_modules/prettier/
-/package.json

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
@@ -31,8 +31,7 @@ const questionOrder = {
     'overall_success_1',
     'overall_success_2',
     'overall_success_3',
-    'overall_success_4',
-    'overall_success_5'
+    'overall_success_4'
   ]
 };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/facilitator_averages_table.jsx
@@ -31,7 +31,8 @@ const questionOrder = {
     'overall_success_1',
     'overall_success_2',
     'overall_success_3',
-    'overall_success_4'
+    'overall_success_4',
+    'overall_success_5'
   ]
 };
 


### PR DESCRIPTION
According to this [discussion](https://codedotorg.slack.com/archives/C0T10H26N/p1567541604004000), we actually have 6 sub-questions under Overall Success question. This affects survey roll-up view because the average score uses scores from 6 sub-questions but we only show 5. The mismatch may causes confusion to users. The fix is to simply add 1 more sub-question to the list.

The side effect is for workshop that doesn't have the 6th question, users will see a blank line at the bottom of the roll-up table.