### PR TITLE
Ensure all level classes are loaded for level creation

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -16,6 +16,46 @@ class LevelsController < ApplicationController
 
   LEVELS_PER_PAGE = 100
 
+  # All level types that can be requested via /levels/new
+  LEVEL_CLASSES = [
+    Applab,
+    Artist,
+    Bounce,
+    BubbleChoice,
+    Calc,
+    ContractMatch,
+    Craft,
+    CurriculumReference,
+    Dancelab,
+    Eval,
+    EvaluationMulti,
+    External,
+    ExternalLink,
+    Flappy,
+    FreeResponse,
+    FrequencyAnalysis,
+    Gamelab,
+    GamelabJr,
+    Karel,
+    LevelGroup,
+    Map,
+    Match,
+    Maze,
+    Multi,
+    NetSim,
+    Odometer,
+    Pixelation,
+    PublicKeyCryptography,
+    StandaloneVideo,
+    StarWarsGrid,
+    Studio,
+    TextCompression,
+    TextMatch,
+    Unplugged,
+    Vigenere,
+    Weblab
+  ]
+
   # GET /levels
   # GET /levels.json
   def index
@@ -211,7 +251,7 @@ class LevelsController < ApplicationController
   def new
     authorize! :create, Level
     if params.key? :type
-      @type_class = Level.descendants.find {|klass| klass.name == params[:type]}
+      @type_class = LEVEL_CLASSES.find {|klass| klass.name == params[:type]}
       raise "Level type '#{params[:type]}' not permitted" unless @type_class
       if @type_class == Artist
         @game = Game.custom_artist

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -70,7 +70,7 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "should get new of all types" do
-    Level.descendants.each do |klass|
+    LevelsController::LEVEL_CLASSES.each do |klass|
       get :new, params: {type: klass.name}
 
       assert_response :success


### PR DESCRIPTION
[LP-665](https://codedotorg.atlassian.net/browse/LP-665) Return to an approach considered in https://github.com/code-dot-org/code-dot-org/pull/27783 (fixing [XTEAM-105](https://codedotorg.atlassian.net/browse/XTEAM-105)) to resolve an issue where `Level.descendants` doesn't reliably list all level classes since they may not have been autoloaded yet shortly after the server restarts.  This approach avoids that issue by explicitly listing them, which unfortunately is less DRY but is a lot less action-at-a-distancey.