### PR TITLE
Clean up FollowersController

### DIFF
--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -5,14 +5,7 @@
 
 class FollowersController < ApplicationController
   before_action :authenticate_user!, except: [:student_user_new, :student_register]
-  before_action :load_section, only: [:create, :create_sync, :student_user_new, :student_register]
-
-  # join a section as a logged in student
-  def create
-    @section.add_student current_user
-
-    redirect_to redirect_url, notice: I18n.t('follower.added_teacher', name: @section.teacher.name)
-  end
+  before_action :load_section, only: [:student_user_new, :student_register]
 
   # GET /join/XXXXXX
   def student_user_new

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -115,7 +115,6 @@ class FollowersController < ApplicationController
   end
 
   def load_section
-    p request.path
     if params[:section_code].blank?
       if request.path != student_user_new_path(section_code: params[:section_code])
         # if user submitted the section form without a code /join

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -73,6 +73,8 @@ class FollowersController < ApplicationController
   end
 
   def load_section
+    return if params[:section_code].blank?
+
     @section = Section.find_by_code(params[:section_code])
     # Note that we treat the section as not being found if the section user
     # (i.e., the teacher) does not exist (possibly soft-deleted) or is not a teacher

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -118,7 +118,7 @@ class FollowersController < ApplicationController
     @section = Section.find_by_code(params[:section_code])
     # Note that we treat the section as not being found if the section user
     # (i.e., the teacher) does not exist (possibly soft-deleted) or is not a teacher
-    unless @section && @section.user && @section.user.teacher?
+    unless @section && @section.user&.teacher?
       redirect_to redirect_url, alert: I18n.t('follower.error.section_not_found', section_code: params[:section_code])
       return
     end

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -8,27 +8,6 @@ class FollowersController < ApplicationController
 
   # GET /join/XXXXXX
   def student_user_new
-    # Though downstream validations would raise an exception, we redirect to the admin directory to
-    # improve user experience.
-    if current_user&.admin?
-      redirect_to admin_directory_path
-      return
-    end
-
-    # Redirect and provide an error for provider-managed sections.
-    if @section&.provider_managed?
-      provider = I18n.t(@section.login_type, scope: 'section.type')
-      redirect_to root_path, alert: I18n.t('follower.error.provider_managed_section', provider: provider)
-      return
-    end
-
-    # If this is a picture or word section, redirect to the section login page so that the student
-    # does not have to type in the full URL.
-    if [Section::LOGIN_TYPE_PICTURE, Section::LOGIN_TYPE_WORD].include?(@section&.login_type)
-      redirect_to controller: 'sections', action: 'show', id: @section.code
-    end
-
-    # render the default student_user_new view, which includes the section code form or sign up form
     @user = current_user || User.new
   end
 
@@ -74,6 +53,13 @@ class FollowersController < ApplicationController
   def load_section
     return if params[:section_code].blank?
 
+    # Though downstream validations would raise an exception, we redirect to the admin directory to
+    # improve user experience.
+    if current_user&.admin?
+      redirect_to admin_directory_path
+      return
+    end
+
     @section = Section.find_by_code(params[:section_code])
     # Note that we treat the section as not being found if the section user
     # (i.e., the teacher) does not exist (possibly soft-deleted) or is not a teacher
@@ -85,6 +71,19 @@ class FollowersController < ApplicationController
     if current_user && current_user == @section.user
       redirect_to redirect_url, alert: I18n.t('follower.error.cant_join_own_section')
       return
+    end
+
+    # Redirect and provide an error for provider-managed sections.
+    if @section&.provider_managed?
+      provider = I18n.t(@section.login_type, scope: 'section.type')
+      redirect_to root_path, alert: I18n.t('follower.error.provider_managed_section', provider: provider)
+      return
+    end
+
+    # If this is a picture or word section, redirect to the section login page so that the student
+    # does not have to type in the full URL.
+    if [Section::LOGIN_TYPE_PICTURE, Section::LOGIN_TYPE_WORD].include?(@section&.login_type)
+      redirect_to controller: 'sections', action: 'show', id: @section.code
     end
   end
 end

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -115,14 +115,6 @@ class FollowersController < ApplicationController
   end
 
   def load_section
-    if params[:section_code].blank?
-      if request.path != student_user_new_path(section_code: params[:section_code])
-        # if user submitted the section form without a code /join
-        redirect_to student_user_new_path(section_code: params[:section_code])
-      end
-      return
-    end
-
     @section = Section.find_by_code(params[:section_code])
     # Note that we treat the section as not being found if the section user
     # (i.e., the teacher) does not exist (possibly soft-deleted) or is not a teacher

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -14,41 +14,6 @@ class FollowersController < ApplicationController
     redirect_to redirect_url, notice: I18n.t('follower.added_teacher', name: @section.teacher.name)
   end
 
-  # Remove enrollment in a section (as a student in the section).
-  def remove
-    @section = Section.find_by_code params[:section_code]
-    if @section
-      f = Follower.where(section: @section.id, student_user_id: current_user.id).first
-    end
-
-    unless @section && f
-      # TODO(asher): Change the alert message to section.
-      redirect_to root_path, alert: t(
-        'follower.error.section_not_found',
-        section_code: params[:section_code]
-      )
-      return
-    end
-
-    @teacher = @section.user
-
-    authorize! :destroy, f
-    f.delete
-    # Though in theory required, we are missing an email address for many teachers.
-    if @teacher && @teacher.email.present?
-      FollowerMailer.student_disassociated_notify_teacher(@teacher, current_user).deliver_now
-    end
-    teacher_name = @teacher ? @teacher.name : I18n.t('user.deleted_user')
-    redirect_to(
-      root_path,
-      notice: t(
-        'teacher.student_teacher_disassociated',
-        teacher_name: teacher_name,
-        section_code: params[:section_code]
-      )
-    )
-  end
-
   # GET /join/XXXXXX
   def student_user_new
     # Though downstream validations would raise an exception, we redirect to the admin directory to

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -4,8 +4,7 @@
 # models).
 
 class FollowersController < ApplicationController
-  before_action :authenticate_user!, except: [:student_user_new, :student_register]
-  before_action :load_section, only: [:student_user_new, :student_register]
+  before_action :load_section
 
   # GET /join/XXXXXX
   def student_user_new

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -6,12 +6,12 @@
 class FollowersController < ApplicationController
   before_action :load_section
 
-  # GET /join/XXXXXX
+  # GET /join/:section_code (section_code is optional)
   def student_user_new
     @user = current_user || User.new
   end
 
-  # POST /join/XXXXXX
+  # POST /join/:section_code
   # join a section
   def student_register
     if current_user

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -53,26 +53,26 @@ class FollowersController < ApplicationController
   def student_user_new
     # Though downstream validations would raise an exception, we redirect to the admin directory to
     # improve user experience.
-    if current_user && current_user.admin?
+    if current_user&.admin?
       redirect_to admin_directory_path
       return
     end
 
-    if @section && @section.provider_managed?
+    # Redirect and provide an error for provider-managed sections.
+    if @section&.provider_managed?
       provider = I18n.t(@section.login_type, scope: 'section.type')
       redirect_to root_path, alert: I18n.t('follower.error.provider_managed_section', provider: provider)
       return
     end
 
-    @user = current_user || User.new
-
-    # if this is a picture or word section, redirect to the section login page so that the student
-    # does not have to type in the full URL
-    if @section && [Section::LOGIN_TYPE_PICTURE, Section::LOGIN_TYPE_WORD].include?(@section.login_type)
+    # If this is a picture or word section, redirect to the section login page so that the student
+    # does not have to type in the full URL.
+    if [Section::LOGIN_TYPE_PICTURE, Section::LOGIN_TYPE_WORD].include?(@section&.login_type)
       redirect_to controller: 'sections', action: 'show', id: @section.code
     end
 
     # render the default student_user_new view, which includes the section code form or sign up form
+    @user = current_user || User.new
   end
 
   # POST /join/XXXXXX

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -292,8 +292,6 @@ Dashboard::Application.routes.draw do
 
   get '/weblab/host', to: 'weblab_host#index'
 
-  resources :followers, only: [:create]
-
   get '/join(/:section_code)', to: 'followers#student_user_new', as: 'student_user_new'
   post '/join(/:section_code)', to: 'followers#student_register', as: 'student_register'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -293,7 +293,6 @@ Dashboard::Application.routes.draw do
   get '/weblab/host', to: 'weblab_host#index'
 
   resources :followers, only: [:create]
-  post '/followers/remove', to: 'followers#remove', as: 'remove_follower'
 
   get '/join(/:section_code)', to: 'followers#student_user_new', as: 'student_user_new'
   post '/join(/:section_code)', to: 'followers#student_register', as: 'student_register'

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -256,94 +256,6 @@ class FollowersControllerTest < ActionController::TestCase
     assert_select 'input#section_code'
   end
 
-  test "create with section code" do
-    sign_in @student
-
-    assert_creates(Follower) do
-      post :create, params: {
-        section_code: @laurel_section_1.code,
-        redirect: '/'
-      }
-    end
-
-    follower = Follower.last
-
-    assert_equal @laurel_section_1, follower.section
-    assert_equal @laurel, follower.user
-    assert_equal @student, follower.student_user
-
-    assert_redirected_to '/'
-    assert_equal "#{@laurel.name} added as your teacher", flash[:notice]
-  end
-
-  test "create does not allow joining your own section" do
-    sign_in @chris
-
-    assert_does_not_create(Follower) do
-      post :create, params: {section_code: @chris_section.code, redirect: '/'}
-    end
-
-    assert_redirected_to '/'
-    assert_equal "Sorry, you can't join your own section.", flash[:alert]
-  end
-
-  test "create with invalid section code gives error message" do
-    sign_in @student
-
-    assert_does_not_create(Follower) do
-      post :create, params: {section_code: '2323232', redirect: '/'}
-    end
-
-    assert_redirected_to '/'
-    assert_equal "Could not find a section with code '2323232'.", flash[:alert]
-  end
-
-  test "create without section code redirects to join" do
-    sign_in @student
-
-    assert_does_not_create(Follower) do
-      post :create, params: {redirect: '/'}
-    end
-
-    assert_response :redirect
-    assert_redirected_to '/join'
-  end
-
-  test "remove has nice error when student does not actually have teacher" do
-    sign_in @laurel
-
-    assert_does_not_destroy(Follower) do
-      post :remove, params: {section_code: @chris_section.code}
-    end
-    assert_redirected_to '/'
-    assert_equal "Could not find a section with code '#{@chris_section.code}'.", flash[:alert]
-  end
-
-  test "student can remove teacher" do
-    follower = @laurel_student_1
-
-    sign_in follower.student_user
-
-    assert_destroys(Follower) do
-      post :remove, params: {section_code: follower.section.code}
-    end
-
-    refute Follower.exists?(follower.id)
-  end
-
-  test "student can remove teacher if teacher does not have email" do
-    follower = @laurel_student_1
-    @laurel.update_attribute(:email, "")
-
-    sign_in follower.student_user
-
-    assert_destroys(Follower) do
-      post :remove, params: {section_code: follower.section.code}
-    end
-
-    refute Follower.exists?(follower.id)
-  end
-
   test "student_register in section with script" do
     student_params = {email: 'student1@school.edu',
                       name: "A name",
@@ -362,21 +274,5 @@ class FollowersControllerTest < ActionController::TestCase
     assert user_script
     assert user_script.assigned_at
     assert_equal @laurel_section_script.script, assigns(:user).primary_script
-  end
-
-  test "create with section with script" do
-    sign_in @student
-
-    assert_creates(Follower, UserScript) do
-      post :create, params: {
-        section_code: @laurel_section_script.code,
-        redirect: '/'
-      }
-    end
-
-    user_script = UserScript.where(user: @student, script: @laurel_section_script.script).first
-    assert user_script
-    assert user_script.assigned_at
-    assert_equal @laurel_section_script.script, @student.primary_script
   end
 end


### PR DESCRIPTION
While working on [LP-682](https://codedotorg.atlassian.net/browse/LP-682), I did some easy clean-up and removed two unused endpoints from the FollowersController.

Endpoints removed:
- `POST /followers/remove`
- `POST /followers`