### PR TITLE
hoc: "pre-hoc" now shows "Try it" button

### DIFF
--- a/pegasus/sites.v3/csedweek.org/views/csedweek_action_buttons.haml
+++ b/pegasus/sites.v3/csedweek.org/views/csedweek_action_buttons.haml
@@ -2,11 +2,7 @@
   %a#try-button{:href=>'/learn'}
     %button.optionbutton{:style=>'min-width: 100px;'}
       =I18n.t :homepage_action_text_learn
--elsif ["pre-hoc"].include?(hoc_mode)
-  %a#try-button{:href=>'https://hourofcode.com/#join'}
-    %button.optionbutton{:style=>'min-width: 100px;'}
-      =I18n.t :homepage_action_text_join_us
--elsif ["soon-hoc"].include?(hoc_mode)
+-elsif ["pre-hoc", "soon-hoc"].include?(hoc_mode)
   %a#try-button{:href=>'https://hourofcode.com/#join', style: "text-decoration: none"}
     %button.optionbutton{:style=>'min-width: 100px;'}
       =I18n.t :homepage_action_text_join_us

--- a/pegasus/sites.v3/hourofcode.com/views/hoc_action_buttons.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/hoc_action_buttons.haml
@@ -6,11 +6,7 @@
   %a#videobutton.ctabuttontag{onclick: "adjustScroll('homepage-video');", style: "text-decoration: none;"}
     %button.ctabutton-white-inverse
       = hoc_s(:front_watch_regular_video)
--elsif ["pre-hoc"].include?(hoc_mode)
-  %a#signupbutton.ctabuttonatag{onclick: "adjustScroll('join');", style: "text-decoration: none;"}
-    %button.ctabutton-white
-      = hoc_s(:front_join_us_button)
--elsif ["soon-hoc"].include?(hoc_mode)
+-elsif ["pre-hoc", "soon-hoc"].include?(hoc_mode)
   %a#signupbutton.ctabuttonatag{onclick: "adjustScroll('join');", style: "text-decoration: none;"}
     %button.ctabutton-white
       = hoc_s(:front_join_us_button)


### PR DESCRIPTION
On [hourofcode.com](https://hourofcode.com), the `"pre-hoc"` behaviour now matches the `"soon-hoc"` behaviour by adding a "Try it" button, which links to /learn, joining the existing "Join us" button which scrolls down to the sign up form.

The same change has also been made to [csedweek.org](https://csedweek.org).

## hourofcode.com
### before
![Screenshot 2019-09-05 06 25 44](https://user-images.githubusercontent.com/2205926/64289478-96eb4580-cfa7-11e9-9b23-1de3b855cba2.png)

### after
![Screenshot 2019-09-05 06 34 01](https://user-images.githubusercontent.com/2205926/64289487-9baff980-cfa7-11e9-852b-75fc6aad20e3.png)

## csedweek.org
### before
![Screenshot 2019-09-05 07 11 22](https://user-images.githubusercontent.com/2205926/64292150-0a438600-cfad-11e9-8057-aa0da4d0e489.png)

### after
![Screenshot 2019-09-05 07 11 58](https://user-images.githubusercontent.com/2205926/64292158-10396700-cfad-11e9-89b1-0df459432a4b.png)


