### PR TITLE
improve error message when CDO.channels_api_secret is missing

### DIFF
--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -29,6 +29,7 @@ end
 
 def storage_decrypt(encrypted)
   $storage_id_decrypter ||= OpenSSL::Cipher.new('AES-128-CBC').tap do |decrypter|
+    raise 'please define CDO.channels_api_secret' unless CDO.channels_api_secret
     decrypter.decrypt
     decrypter.pkcs5_keyivgen(CDO.channels_api_secret, '8 octets')
   end
@@ -69,6 +70,7 @@ end
 
 def storage_encrypt(plain)
   $storage_id_encrypter ||= OpenSSL::Cipher.new('AES-128-CBC').tap do |encrypter|
+    raise 'please define CDO.channels_api_secret' unless CDO.channels_api_secret
     encrypter.encrypt
     encrypter.pkcs5_keyivgen(CDO.channels_api_secret, '8 octets')
   end


### PR DESCRIPTION
without this, I get the following cryptic error message on an adhoc when I try to load applab:
```
2019-09-04 19:03:40 - TypeError - no implicit conversion of nil into String:
        /home/ubuntu/adhoc/shared/middleware/helpers/storage_id.rb:73:in `pkcs5_keyivgen'
        /home/ubuntu/adhoc/shared/middleware/helpers/storage_id.rb:73:in `block in storage_encrypt'
        /home/ubuntu/adhoc/shared/middleware/helpers/storage_id.rb:71:in `tap'
        /home/ubuntu/adhoc/shared/middleware/helpers/storage_id.rb:71:in `storage_encrypt'
        /home/ubuntu/adhoc/shared/middleware/helpers/storage_id.rb:83:in `storage_encrypt_id'
        /home/ubuntu/adhoc/shared/middleware/helpers/storage_id.rb:10:in `create_storage_id_cookie'
        /home/ubuntu/adhoc/shared/middleware/helpers/storage_id.rb:95:in `get_storage_id'
        /home/ubuntu/adhoc/shared/middleware/channels_api.rb:49:in `block in <class:ChannelsApi>'
```