### PR TITLE
Fix z-index for teacher panel & hamburger menu

### DIFF
--- a/dashboard/app/assets/stylesheets/teacher-panel.scss
+++ b/dashboard/app/assets/stylesheets/teacher-panel.scss
@@ -17,8 +17,8 @@
   border-right: none;
   border-radius: 10px 0 0 10px;
 
-  /* must appear in front of ProgressBubble */
-  z-index: 1000;
+  /* must appear in front of <Overlay/>, whose z-index is 1020 */
+  z-index: 1021;
 
   .hide-handle,
   .show-handle {

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -42,7 +42,7 @@
 
   display: inline-block;
   float: right;
-  z-index: 99;
+  z-index: 1050;
   position: relative;
   font-size: 14px;
 

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -42,6 +42,8 @@
 
   display: inline-block;
   float: right;
+  // We want the z-index to be greater than the teacher panel, which is currently 1021.
+  // Teacher panel z-index is defined in teacher-panel.scss
   z-index: 1050;
   position: relative;
   font-size: 14px;


### PR DESCRIPTION
[LP-578](https://codedotorg.atlassian.net/browse/LP-578)

Fixes z ordering for the teacher panel and main hamburger menu so that the ordering goes (from highest z-index to lowest): hamburger menu, teacher panel, instructions overlay.

### Before
<img width="1010" alt="Screen Shot 2019-09-04 at 3 32 29 PM" src="https://user-images.githubusercontent.com/9812299/64298154-79779680-cf29-11e9-936a-7b5b49ec2a9b.png">

### After
<img width="1010" alt="Screen Shot 2019-09-04 at 3 28 24 PM" src="https://user-images.githubusercontent.com/9812299/64298155-79779680-cf29-11e9-84d8-f48b49695f74.png">
