### PR TITLE
Fix "assetChosen is not a function" error

### DIFF
--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -258,11 +258,13 @@ export default class AssetManager extends React.Component {
         <AssetRow
           {...this.defaultAssetProps(asset)}
           api={boundApi}
-          onChoose={() =>
-            this.props.assetChosen(
-              STARTER_ASSET_PREFIX + asset.filename,
-              asset.timestamp
-            )
+          onChoose={
+            this.props.assetChosen &&
+            (() =>
+              this.props.assetChosen(
+                STARTER_ASSET_PREFIX + asset.filename,
+                asset.timestamp
+              ))
           }
           onDelete={() => this.deleteStarterAssetRow(asset.filename)}
           levelName={this.props.levelName}
@@ -278,8 +280,9 @@ export default class AssetManager extends React.Component {
         <AssetRow
           {...this.defaultAssetProps(asset)}
           useFilesApi={this.props.useFilesApi}
-          onChoose={() =>
-            this.props.assetChosen(asset.filename, asset.timestamp)
+          onChoose={
+            this.props.assetChosen &&
+            (() => this.props.assetChosen(asset.filename, asset.timestamp))
           }
           onDelete={() => this.deleteAssetRow(asset.filename)}
         />


### PR DESCRIPTION
The issue here is that we shouldn't be showing the Choose button when the asset manager is shown standalone (not part of the ImagePicker or SoundPicker)

The presence/absence of the `onChoose` prop in `AssetRow` determines whether the Choose button is visible. #30218 changed it so we provide `onChoose` unconditionally, causing the Choose button to always be visible. This fix just makes it so that we don't provide the `onChoose` prop if `assetChosen` isn't provided to `AssetManager`. I think this code is kind of confusing and would probably be worth a more general refactor, but I'm not sure the best approach so thought it would be worth just fixing this error case for now.

Before:
![image](https://user-images.githubusercontent.com/8787187/64298360-205c3280-cf2a-11e9-8a5b-c2ade04ad834.png)

After:
![image](https://user-images.githubusercontent.com/8787187/64298408-484b9600-cf2a-11e9-8799-0fb30dfd056e.png)
