### PR TITLE
Courses: allow students to see teacher view

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -10,7 +10,7 @@ class CoursesController < ApplicationController
     view_options(full_width: true, responsive_content: true, has_i18n: true)
     respond_to do |format|
       format.html do
-        @is_teacher = (current_user && current_user.teacher?) || (!current_user && params[:view] == 'teacher')
+        @is_teacher = (current_user && current_user.teacher?) || params[:view] == 'teacher'
         @is_english = request.language == 'en'
         @is_signed_out = current_user.nil?
         @force_race_interstitial = params[:forceRaceInterstitial]


### PR DESCRIPTION
A student account viewing https://studio.code.org/courses?view=teacher will now see the teacher view, rather than being forced to see the student view.

That behaviour has been in place since https://github.com/code-dot-org/code-dot-org/pull/16868, but we have some cases where an information page links here but teachers signed into a student account aren't able to see the desired information.