### PR TITLE
Fix displaying scale question in survey result

### DIFF
--- a/dashboard/lib/pd/survey_pipeline/daily_survey_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_decorator.rb
@@ -16,6 +16,10 @@ module Pd::SurveyPipeline
       "82115646319154".to_i => {
         full_name: 'Academic Year 6-12 Workshop Post Survey',
         short_name: 'Post Workshop'
+      },
+      "92125916725157".to_i => {
+        full_name: 'Academic Year 6-12 Workshop Post Survey',
+        short_name: 'Post Workshop'
       }
     }
 

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_modifier.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_modifier.rb
@@ -19,10 +19,15 @@ module Pd::SurveyPipeline
 
     # Augment a scale question for the purpose of displaying in UI.
     #
-    # @param [Hash] question Contains all question attributes. Must have values and options keys
-    # @return [Hash] A copy of input question with augmented attributes
+    # @param [Hash] question Contains all question attributes. Must have values and options keys.
+    # @return [Hash] A copy of input question with augmented attributes or the question itself
+    #   if required input keys don't exist.
+    # @note This function follows best-effort approach and doesn't raise exception
+    #   if it cannot augment the input question.
     #
     def self.augment_scale_question_for_display(question)
+      return question unless question[:values] && question[:options]
+
       # JotForm format: values.first and values.last are the the lowest and highest rating points.
       # E.g. values = [1, 2, 3]
       min_value = question[:values].first

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_modifier.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_modifier.rb
@@ -1,0 +1,43 @@
+module Pd::SurveyPipeline
+  class DailySurveyModifier
+    include Pd::JotForm::Constants
+
+    # Augment a collection of questions for the purpose of displaying in UI.
+    #
+    # @param [Hash] parsed_questions {form_id => {question_id => question_content}}
+    # @return [Hash] The same input with modified question content
+    #
+    def self.augment_questions_for_display(parsed_questions = {})
+      parsed_questions.each do |_, form_questions|
+        form_questions.each do |q_id, q_content|
+          form_questions[q_id] = augment_scale_question_for_display(q_content) if
+            q_content[:type] == TYPE_SCALE
+        end
+      end
+    end
+
+    # Augment a scale question for the purpose of displaying in UI.
+    #
+    # @param [Hash] question Contains all question attributes. Must have values and options keys
+    # @return [Hash] A copy of input question with augmented attributes
+    #
+    def self.augment_scale_question_for_display(question)
+      # JotForm format: values.first and values.last are the the lowest and highest rating points.
+      # E.g. values = [1, 2, 3]
+      min_value = question[:values].first
+      max_value = question[:values].last
+
+      # JotForm format: options.first and options.last are the lowest and highest rating texts.
+      # E.g. options = ['Lowest', 'Highest']
+      augmented_options = question[:values].map(&:to_s)
+      augmented_options[0] = "#{augmented_options[0]} - #{question[:options].first}"
+      augmented_options[-1] = "#{augmented_options[-1]} - #{question[:options].last}"
+
+      question.merge(
+        min_value: min_value,
+        max_value: max_value,
+        options: augmented_options
+      )
+    end
+  end
+end

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_modifier.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_modifier.rb
@@ -6,6 +6,7 @@ module Pd::SurveyPipeline
     #
     # @param [Hash] parsed_questions {form_id => {question_id => question_content}}
     # @return [Hash] The same input with modified question content
+    # @note This function changes input param!
     #
     def self.augment_questions_for_display(parsed_questions = {})
       parsed_questions.each do |_, form_questions|

--- a/dashboard/lib/pd/survey_pipeline/daily_survey_parser.rb
+++ b/dashboard/lib/pd/survey_pipeline/daily_survey_parser.rb
@@ -102,9 +102,9 @@ module Pd::SurveyPipeline
     #
     # @param survey_questions [Array<Pd::SurveyQuestion>]
     #
-    # @return [Hash{form_id => {question_id => question_content}}]
-    #   question_content is Hash{:type, :name, :text, :order, :hidden}.
-    #   It could also have question-specific keys such as :options, :sub_questions etc.
+    # @return [Hash] {form_id => {question_id => question_content}}
+    #   In which, question_content is Hash{:type, :name, :text, :order, :hidden, :answer_type}.
+    #   It could also have question-specific keys such as :options, :option_map and :values.
     #
     def self.parse_questions(survey_questions)
       parsed_questions = {}

--- a/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
@@ -181,6 +181,8 @@ module Pd::SurveyPipeline::Helper
       new(group_config: group_config, map_config: map_config).
       process_data(context)
 
+    Pd::SurveyPipeline::DailySurveyModifier.augment_questions_for_display context[:parsed_questions]
+
     Pd::SurveyPipeline::DailySurveyDecorator.process_data context
 
     context[:decorated_summaries]

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_modifier_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_modifier_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+module Pd::SurveyPipeline
+  class DailySurveyModifierTest < ActiveSupport::TestCase
+    test 'augmenting multiple questions for display' do
+      # Question collection format: {form_id => {question_id => question_content}}
+      parsed_questions = {
+        111222 => {
+          '1' => {type: 'scale', options: %w(Lowest highest), values: [1, 2]},
+          '2' => {type: 'scale', options: %w(From To), values: [1, 2, 3, 4]}
+        }
+      }
+
+      DailySurveyModifier.expects(:augment_scale_question_for_display).twice
+
+      DailySurveyModifier.augment_questions_for_display parsed_questions
+    end
+
+    test 'augmenting scale question for display' do
+      test_cases = [
+        {
+          input: {
+            options: %w(Lowest Highest),
+            values: [1, 2]
+          },
+          output: {
+            options: ['1 - Lowest', '2 - Highest'],
+            values: [1, 2],
+            min_value: 1,
+            max_value: 2
+          }
+        },
+        {
+          input: {
+            options: %w(Disagree Agree),
+            values: [1, 2, 3, 4]
+          },
+          output: {
+            options: ['1 - Disagree', '2', '3', '4 - Agree'],
+            values: [1, 2, 3, 4],
+            min_value: 1,
+            max_value: 4
+          }
+        }
+      ]
+
+      test_cases.each do |test_case|
+        output = DailySurveyModifier.augment_scale_question_for_display test_case[:input]
+        assert_equal test_case[:output], output
+      end
+    end
+  end
+end


### PR DESCRIPTION
[PLC-430](https://codedotorg.atlassian.net/browse/PLC-430) 
Add extra fields to `scale` question (_min_value_, _max_value_ and (augmented) _options_) so they can be displayed correctly in the UI. These fields don't come directly from JotForm.

This PR does following things
1. Add functions to agument scale question in `daily_survey_modifier.rb` (with unit tests).
2. Refactor pipeline execution in `survey_pipeline_helper.rb` to not use template pattern. The benefit of template pattern in `run_pipeline` function is small but come with the cost of much more boilerplate code just to add a few functions in step 1. (I.e. implementing `SurveyPipelineWorker`-derived class and `process_data` function. See this [file](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/pd/survey_pipeline/daily_survey_decorator.rb) for example. This pattern will be refactored away later.)
3. Add new post-workshop survey id to `daily_survey_decorator.rb`. This is the only form in the new set of academic year workshop surveys that has scale question.

**Before:**
<img width="636" alt="Screen Shot 2019-09-04 at 6 30 19 PM" src="https://user-images.githubusercontent.com/46507039/64304790-121a1080-cf42-11e9-9e72-1b75e1f1d013.png">

**After:**
<img width="621" alt="Screen Shot 2019-09-04 at 6 09 08 PM" src="https://user-images.githubusercontent.com/46507039/64303911-27417000-cf3f-11e9-8c82-f079bd21822f.png">
