### PR TITLE
Enable TTS for CSD Pilot scripts 

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -793,7 +793,10 @@ class Script < ActiveRecord::Base
       Script::CSD2_2019_NAME,
       Script::CSD3_2019_NAME,
       Script::CSD4_2019_NAME,
-      Script::CSD6_2019_NAME
+      Script::CSD6_2019_NAME,
+      Script::CSD1_PILOT_NAME,
+      Script::CSD2_PILOT_NAME,
+      Script::CSD3_PILOT_NAME
     ].include?(name)
   end
 
@@ -824,6 +827,11 @@ class Script < ActiveRecord::Base
 
   def text_to_speech_enabled?
     csf_tts_level? || csd_tts_level? || csp_tts_level? || hoc_tts_level? || name == Script::TTS_NAME
+  end
+
+  # Generates TTS files for each level in a script.
+  def tts_update
+    levels.each(&:tts_update)
   end
 
   def hint_prompt_enabled?

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -109,6 +109,11 @@ module ScriptConstants
       COURSEE_DRAFT_NAME = 'coursee-draft'.freeze,
       COURSEF_DRAFT_NAME = 'coursef-draft'.freeze,
     ],
+    csd_pilot: [
+      CSD1_PILOT_NAME = 'csd1-pilot'.freeze,
+      CSD2_PILOT_NAME = 'csd2-pilot'.freeze,
+      CSD3_PILOT_NAME = 'csd3-pilot'.freeze,
+    ],
     csd_2019: [
       CSD1_2019_NAME = 'csd1-2019'.freeze,
       CSD2_2019_NAME = 'csd2-2019'.freeze,


### PR DESCRIPTION
[LP-696](https://codedotorg.atlassian.net/browse/LP-696) Request from Elizabeth to enable TTS for CSD Pilot scripts. 

Adds CSD pilot scripts ('csd1-pilot', 'csd2-pilot' and 'csd3-pilot') to `csd_tts_level?` and `script_constants.rb`. 

Additionally, I wrote a little shortcut method that can be used to generate TTS files for all of the levels in a given script, which I will use once this change is merged in. 