### PR TITLE
PL: Make attendance link more obvious

### DIFF
--- a/dashboard/app/views/pd/session_attendance/match_registration.html.haml
+++ b/dashboard/app/views/pd/session_attendance/match_registration.html.haml
@@ -19,4 +19,6 @@
   .row
     .col-lg-12
       - join_route_options = {controller: 'pd/workshop_enrollment', action: 'join_session', session_code: @session.code}
-      = link_to 'My name is not on this list.', join_route_options
+      = link_to join_route_options do
+        %button{class: "btn btn-primary", style: "font-size: 18px"}
+          My name is not on this list


### PR DESCRIPTION
The "My name is not on this list" link at the bottom of the session attendance page (at https://studio.code.org/pd/attend/[code]) was not being noticed, so now it's bigger and a
button.

### before

![Screenshot 2019-09-05 12 55 32](https://user-images.githubusercontent.com/2205926/64310023-e6e6fe00-cfe1-11e9-9b07-13565cd591a0.png)

### after

![Screenshot 2019-09-05 13 29 25](https://user-images.githubusercontent.com/2205926/64310032-eb131b80-cfe1-11e9-8ae1-1a28d7e0fd34.png)
