### PR TITLE
[Prototype] Embed-in-docs view for projects

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -465,9 +465,12 @@ Applab.init = function(config) {
     config.level.sliderSpeed = 1.0;
   }
 
-  var showDebugButtons = !config.hideSource && !config.level.debuggerDisabled;
+  var showDebugButtons =
+    !config.hideSource &&
+    !config.level.debuggerDisabled &&
+    !config.level.docsEmbed;
   var breakpointsEnabled = !config.level.debuggerDisabled;
-  var showDebugConsole = !config.hideSource;
+  var showDebugConsole = !config.hideSource && !config.level.docsEmbed;
 
   // Construct a logging observer for interpreter events
   if (!config.hideSource) {

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -113,6 +113,7 @@
  * @property {number} puzzle_number
  * @property {number} stage_total
  * @property {boolean} iframeEmbed
+ * @property {boolean} docsEmbed
  * @property {?} lastAttempt
  * @property {boolean} submittable
  * @property {boolean} final_level

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -365,8 +365,11 @@ P5Lab.prototype.init = function(config) {
 
   var showDebugButtons =
     config.level.editCode &&
-    (!config.hideSource && !config.level.debuggerDisabled);
-  var showDebugConsole = config.level.editCode && !config.hideSource;
+    (!config.hideSource &&
+      !config.level.debuggerDisabled &&
+      !config.level.docsEmbed);
+  var showDebugConsole =
+    config.level.editCode && !config.hideSource && !config.level.docsEmbed;
   this.debuggerEnabled = showDebugButtons || showDebugConsole;
 
   if (this.debuggerEnabled) {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -686,6 +686,40 @@ body.embedded_iframe {
     padding-left: 0;
   }
 }
+body.docs-embed {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+
+  .full_container {
+    padding: 0;
+  }
+
+  #codeApp {
+    height: 100%;
+  }
+}
+
+//#codeApp.pin_bottom {
+//  position: absolute;
+//  top: 60px;
+//  left: $codeApp-left-margin;
+//  right: 25px;
+//  bottom: 10px;
+//  @media screen and (max-device-height: 900px) and (max-device-width: 500px) {
+//    top: 10px;
+//  }
+//
+//  &.centered_embed {
+//    position: relative;
+//    top: 0;
+//    left: auto;
+//    right: auto;
+//    margin-top: 10px;
+//  }
+//}
 
 .responsive_full_container {
   padding: 0 10px 10px 10px;

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -280,9 +280,10 @@ class ProjectsController < ApplicationController
     end
 
     iframe_embed = params[:iframe_embed] == true
+    docs_embed = params[:docs_embed] == true
     sharing = iframe_embed || params[:share] == true
-    readonly = params[:readonly] == true
-    if iframe_embed
+    readonly = docs_embed || params[:readonly] == true
+    if iframe_embed || docs_embed
       # explicitly set security related headers so that this page can actually
       # be embedded.
       response.headers['X-Frame-Options'] = 'ALLOWALL'
@@ -293,6 +294,7 @@ class ProjectsController < ApplicationController
       hide_source: sharing,
       share: sharing,
       iframe_embed: iframe_embed,
+      docs_embed: docs_embed,
       project_type: params[:key]
     )
     # for sharing pages, the app will display the footer inside the playspace instead

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -517,7 +517,7 @@ module LevelsHelper
       level_overrides[:hide_source] = true
       level_overrides[:show_finish] = true
     end
-    if level_overrides[:embed]
+    if level_overrides[:embed] || level_overrides[:docs_embed]
       view_options(no_header: true, no_footer: true, white_background: true)
     end
 

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -62,6 +62,7 @@ module ViewOptionsHelper
     :submitted,
     :unsubmit_url,
     :iframe_embed,
+    :docs_embed,
     :pairing_driver,
     :pairing_attempt,
     :pairing_channel_id,

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -78,7 +78,7 @@
         - unless view_options[:no_footer] || view_options[:small_footer]
           .push
 
-      - if view_options[:small_footer]
+      - if view_options[:small_footer] && !view_options[:no_footer]
         = render partial: 'layouts/small_footer', locals: {channel: view_options[:channel]}
 
       - if view_options[:responsive_content]

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -195,6 +195,7 @@ Dashboard::Application.routes.draw do
         get "/#{key}/:channel_id/edit", to: 'projects#edit', key: key.to_s, as: "#{key}_project_edit"
         get "/#{key}/:channel_id/view", to: 'projects#show', key: key.to_s, as: "#{key}_project_view", readonly: true
         get "/#{key}/:channel_id/embed", to: 'projects#show', key: key.to_s, as: "#{key}_project_iframe_embed", iframe_embed: true
+        get "/#{key}/:channel_id/docs", to: 'projects#show', key: key.to_s, as: "#{key}_project_docs_embed", docs_embed: true
         get "/#{key}/:channel_id/remix", to: 'projects#remix', key: key.to_s, as: "#{key}_project_remix"
         get "/#{key}/:channel_id/export_create_channel", to: 'projects#export_create_channel', key: key.to_s, as: "#{key}_project_export_create_channel"
         get "/#{key}/:channel_id/export_config", to: 'projects#export_config', key: key.to_s, as: "#{key}_project_export_config"


### PR DESCRIPTION
So far: Put `/docs` on the end of a project URL and get a readonly view with cross-origin headers that drops most of our chrome and the debugger.  This is pretty hacked-together, but it's really just a proof-of-concept to evaluate how much work would be needed to productize it.

![image](https://user-images.githubusercontent.com/1615761/64360481-6e6f4580-cfbf-11e9-9b10-d95aa7ce8890.png)

![image](https://user-images.githubusercontent.com/1615761/64374731-45f44500-cfd9-11e9-9e16-6b1cd4ea3313.png)


Next steps:
- Try embedding in a curriculum builder page
- Remove toolbox, version history, other unneeded UI
- Hunt for a cleaner way to implement this.