### PR TITLE
Fix slow query on organizer survey results

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
@@ -12,11 +12,37 @@ const styles = {
 
 export default class OrganizerFormPart extends React.Component {
   static propTypes = {
-    potential_organizers: PropTypes.array,
-    organizer_id: PropTypes.number,
+    workshopId: PropTypes.number,
+    organizerId: PropTypes.number,
     onChange: PropTypes.func,
     readOnly: PropTypes.bool
   };
+
+  state = {
+    loading: true,
+    potentialOrganizers: null
+  };
+
+  componentWillMount() {
+    this.load(this.props.workshopId);
+  }
+
+  load() {
+    let url = `/api/v1/pd/workshops/${
+      this.props.workshopId
+    }/potential_organizers`;
+
+    $.ajax({
+      method: 'GET',
+      url: url,
+      dataType: 'json'
+    }).done(data => {
+      this.setState({
+        loading: false,
+        potentialOrganizers: data
+      });
+    });
+  }
 
   renderOrganizerOption(organizer) {
     return (
@@ -27,9 +53,14 @@ export default class OrganizerFormPart extends React.Component {
   }
 
   render() {
-    const organizerOptions = this.props.potential_organizers.map(o =>
-      this.renderOrganizerOption(o)
-    );
+    let organizerOptions;
+    if (this.state.potentialOrganizers) {
+      organizerOptions = this.state.potentialOrganizers.map(o =>
+        this.renderOrganizerOption(o)
+      );
+    } else {
+      organizerOptions = [];
+    }
     return (
       <div>
         <h3>Organizer (admin)</h3>
@@ -37,7 +68,7 @@ export default class OrganizerFormPart extends React.Component {
           <Col sm={8}>
             <select
               className="form-control"
-              value={this.props.organizer_id}
+              value={this.props.organizerId}
               onChange={this.props.onChange}
               disabled={this.props.readOnly}
               style={this.props.readOnly && styles.readOnlyInput}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
@@ -14,6 +14,7 @@ export default class OrganizerFormPart extends React.Component {
   static propTypes = {
     workshopId: PropTypes.number,
     organizerId: PropTypes.number,
+    organizerName: PropTypes.string,
     onChange: PropTypes.func,
     readOnly: PropTypes.bool
   };
@@ -66,15 +67,20 @@ export default class OrganizerFormPart extends React.Component {
         <h3>Organizer (admin)</h3>
         <Row>
           <Col sm={8}>
-            <select
-              className="form-control"
-              value={this.props.organizerId}
-              onChange={this.props.onChange}
-              disabled={this.props.readOnly}
-              style={this.props.readOnly && styles.readOnlyInput}
-            >
-              {organizerOptions}
-            </select>
+            {this.state.potentialOrganizers && (
+              <select
+                className="form-control"
+                value={this.props.organizerId}
+                onChange={this.props.onChange}
+                disabled={this.props.readOnly}
+                style={this.props.readOnly && styles.readOnlyInput}
+              >
+                {organizerOptions}
+              </select>
+            )}
+            {!this.state.potentialOrganizers && (
+              <h4>{this.props.organizerName}</h4>
+            )}
           </Col>
         </Row>
       </div>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
@@ -7,6 +7,9 @@ const styles = {
     backgroundColor: 'inherit',
     cursor: 'default',
     border: 'none'
+  },
+  error: {
+    color: 'red'
   }
 };
 
@@ -21,7 +24,8 @@ export default class OrganizerFormPart extends React.Component {
 
   state = {
     loading: true,
-    potentialOrganizers: null
+    potentialOrganizers: null,
+    error: false
   };
 
   componentWillMount() {
@@ -37,12 +41,16 @@ export default class OrganizerFormPart extends React.Component {
       method: 'GET',
       url: url,
       dataType: 'json'
-    }).done(data => {
-      this.setState({
-        loading: false,
-        potentialOrganizers: data
+    })
+      .done(data => {
+        this.setState({
+          loading: false,
+          potentialOrganizers: data
+        });
+      })
+      .error(() => {
+        this.setState({error: true});
       });
-    });
   }
 
   renderOrganizerOption(organizer) {
@@ -80,6 +88,12 @@ export default class OrganizerFormPart extends React.Component {
             )}
             {!this.state.potentialOrganizers && (
               <h4>{this.props.organizerName}</h4>
+            )}
+            {this.state.error && (
+              <p style={styles.error}>
+                An error occurred loading the organizer dropdown. Try reloading
+                the page.
+              </p>
             )}
           </Col>
         </Row>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -84,7 +84,8 @@ export class WorkshopForm extends React.Component {
       regional_partner_name: PropTypes.string,
       regional_partner_id: PropTypes.number,
       organizer: PropTypes.shape({
-        id: PropTypes.number
+        id: PropTypes.number,
+        name: PropTypes.string
       })
     }),
     onSaved: PropTypes.func,
@@ -981,6 +982,7 @@ export class WorkshopForm extends React.Component {
             <OrganizerFormPart
               workshopId={this.props.workshop.id}
               organizerId={this.state.organizer.id}
+              organizerName={this.state.organizer.name}
               onChange={this.handleOrganizerChange}
               readOnly={this.props.readOnly}
             />

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -83,7 +83,6 @@ export class WorkshopForm extends React.Component {
       enrolled_teacher_count: PropTypes.number.isRequired,
       regional_partner_name: PropTypes.string,
       regional_partner_id: PropTypes.number,
-      potential_organizers: PropTypes.array,
       organizer: PropTypes.shape({
         id: PropTypes.number
       })
@@ -980,8 +979,8 @@ export class WorkshopForm extends React.Component {
           )}
           {this.props.permission.has(WorkshopAdmin) && this.props.workshop && (
             <OrganizerFormPart
-              potential_organizers={this.props.workshop.potential_organizers}
-              organizer_id={this.state.organizer.id}
+              workshopId={this.props.workshop.id}
+              organizerId={this.state.organizer.id}
               onChange={this.handleOrganizerChange}
               readOnly={this.props.readOnly}
             />

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -196,38 +196,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
 
   # Users who could be re-assigned to be the organizer of this workshop
   def potential_organizers
-    potential_organizer_ids = []
-    potential_organizers = []
-
-    # if there is a regional partner, only that partner's PMs can become the organizer
-    # otherwise, any PM can become the organizer
-    if @workshop.regional_partner
-      @workshop.regional_partner.program_managers.each do |pm|
-        potential_organizers << {label: pm.name, value: pm.id}
-      end
-    else
-      UserPermission.where(permission: UserPermission::PROGRAM_MANAGER).pluck(:user_id)&.map do |user_id|
-        potential_organizer_ids << user_id
-      end
-    end
-
-    # any CSF facilitator can become the organizer of a CSF workshhop
-    if @workshop.course == Pd::Workshop::COURSE_CSF
-      Pd::CourseFacilitator.where(course: Pd::Workshop::COURSE_CSF).pluck(:facilitator_id)&.map do |user_id|
-        potential_organizer_ids << user_id
-      end
-    end
-
-    # workshop admins can become the organizer of any workshop
-    UserPermission.where(permission: UserPermission::WORKSHOP_ADMIN).pluck(:user_id)&.map do |user_id|
-      potential_organizer_ids << user_id
-    end
-
-    User.where(id: potential_organizer_ids).pluck(:name, :id)&.map do |name, id|
-      potential_organizers << {label: name, value: id}
-    end
-
-    render json: potential_organizers
+    render json: @workshop.potential_organizers
   end
 
   private

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -699,7 +699,7 @@ class Pd::Workshop < ActiveRecord::Base
       end
     else
       UserPermission.where(permission: UserPermission::PROGRAM_MANAGER).pluck(:user_id)&.map do |user_id|
-        pm = User.find(user_id)
+        pm = User.where(id: user_id).select(:name, :id).first
         potential_organizers << {label: pm.name, value: pm.id}
       end
     end
@@ -707,14 +707,14 @@ class Pd::Workshop < ActiveRecord::Base
     # any CSF facilitator can become the organizer of a CSF workshhop
     if course == Pd::Workshop::COURSE_CSF
       Pd::CourseFacilitator.where(course: Pd::Workshop::COURSE_CSF).pluck(:facilitator_id)&.map do |user_id|
-        facilitator = User.find(user_id)
+        facilitator = User.where(id: user_id).select(:name, :id).first
         potential_organizers << {label: facilitator.name, value: facilitator.id}
       end
     end
 
     # workshop admins can become the organizer of any workshop
     UserPermission.where(permission: UserPermission::WORKSHOP_ADMIN).pluck(:user_id)&.map do |user_id|
-      admin = User.find(user_id)
+      admin = User.where(id: user_id).select(:name, :id).first
       potential_organizers << {label: admin.name, value: admin.id}
     end
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -687,42 +687,6 @@ class Pd::Workshop < ActiveRecord::Base
     end
   end
 
-  # Users who could be re-assigned to be the organizer of this workshop
-  def potential_organizers
-    potential_organizer_ids = []
-    potential_organizers = []
-
-    # if there is a regional partner, only that partner's PMs can become the organizer
-    # otherwise, any PM can become the organizer
-    if regional_partner
-      regional_partner.program_managers.each do |pm|
-        potential_organizers << {label: pm.name, value: pm.id}
-      end
-    else
-      UserPermission.where(permission: UserPermission::PROGRAM_MANAGER).pluck(:user_id)&.map do |user_id|
-        potential_organizer_ids << user_id
-      end
-    end
-
-    # any CSF facilitator can become the organizer of a CSF workshhop
-    if course == Pd::Workshop::COURSE_CSF
-      Pd::CourseFacilitator.where(course: Pd::Workshop::COURSE_CSF).pluck(:facilitator_id)&.map do |user_id|
-        potential_organizer_ids << user_id
-      end
-    end
-
-    # workshop admins can become the organizer of any workshop
-    UserPermission.where(permission: UserPermission::WORKSHOP_ADMIN).pluck(:user_id)&.map do |user_id|
-      potential_organizer_ids << user_id
-    end
-
-    User.where(id: potential_organizer_ids).pluck(:name, :id)&.map do |name, id|
-      potential_organizers << {label: name, value: id}
-    end
-
-    potential_organizers
-  end
-
   def can_user_delete?(user)
     state != STATE_ENDED && Ability.new(user).can?(:destroy, self)
   end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -689,6 +689,7 @@ class Pd::Workshop < ActiveRecord::Base
 
   # Users who could be re-assigned to be the organizer of this workshop
   def potential_organizers
+    potential_organizer_ids = []
     potential_organizers = []
 
     # if there is a regional partner, only that partner's PMs can become the organizer
@@ -699,23 +700,24 @@ class Pd::Workshop < ActiveRecord::Base
       end
     else
       UserPermission.where(permission: UserPermission::PROGRAM_MANAGER).pluck(:user_id)&.map do |user_id|
-        pm = User.where(id: user_id).select(:name, :id).first
-        potential_organizers << {label: pm.name, value: pm.id}
+        potential_organizer_ids << user_id
       end
     end
 
     # any CSF facilitator can become the organizer of a CSF workshhop
     if course == Pd::Workshop::COURSE_CSF
       Pd::CourseFacilitator.where(course: Pd::Workshop::COURSE_CSF).pluck(:facilitator_id)&.map do |user_id|
-        facilitator = User.where(id: user_id).select(:name, :id).first
-        potential_organizers << {label: facilitator.name, value: facilitator.id}
+        potential_organizer_ids << user_id
       end
     end
 
     # workshop admins can become the organizer of any workshop
     UserPermission.where(permission: UserPermission::WORKSHOP_ADMIN).pluck(:user_id)&.map do |user_id|
-      admin = User.where(id: user_id).select(:name, :id).first
-      potential_organizers << {label: admin.name, value: admin.id}
+      potential_organizer_ids << user_id
+    end
+
+    User.where(id: potential_organizer_ids).pluck(:name, :id)&.map do |name, id|
+      potential_organizers << {label: name, value: id}
     end
 
     potential_organizers

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -34,7 +34,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
     :enrollment_code, :on_map, :funded, :funding_type, :ready_to_close?,
     :date_and_location_name, :regional_partner_name, :regional_partner_id,
-    :scholarship_workshop?, :potential_organizers, :can_delete
+    :scholarship_workshop?, :can_delete
 
   def sessions
     object.sessions.map do |session|

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -395,6 +395,7 @@ Dashboard::Application.routes.draw do
           post :end
           post :reopen
           get  :summary
+          get  :potential_organizers
         end
         resources :enrollments, controller: 'workshop_enrollments', only: [:index, :destroy, :create]
 


### PR DESCRIPTION
[PLC-414](https://codedotorg.atlassian.net/browse/PLC-414?atlOrigin=eyJpIjoiM2EzNjA3MzQ4N2I0NDMxZjhhZjVhZTM5MTBiNjQ5MmEiLCJwIjoiaiJ9)

We've been seeing timeouts when loading organizer survey results because `potential_organizers` was generating hundreds of calls to the database. I restructured this method to improve the SQL, but also moved it into a separate api call that is only used when we need the potential organizers for a specific workshop - we don't need them for the survey results. The organizer survey results page didn't have a specific workshop id, so it was running these queries for all the user's workshops, which also contributed to the timeout.

Error message if loading the organizer dropdown fails:
<img width="485" alt="Screen Shot 2019-09-06 at 2 04 03 PM" src="https://user-images.githubusercontent.com/224089/64460470-4d861d80-d0af-11e9-97d4-a0e1712aa0ba.png">
