### PR TITLE
Allow teachers to move students from archived sections

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -32,7 +32,7 @@ import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashbo
 const script = document.querySelector('script[data-dashboard]');
 const scriptData = JSON.parse(script.dataset.dashboard);
 const section = scriptData.section;
-const visibleSections = scriptData.visibleSections;
+const sections = scriptData.sections;
 const baseUrl = `/teacher_dashboard/sections/${section.id}`;
 
 $(document).ready(function() {
@@ -49,7 +49,7 @@ $(document).ready(function() {
   const store = getStore();
   // TODO: (madelynkasula) remove duplication in sectionData.setSection and teacherSections.setSections
   store.dispatch(setSection(section));
-  store.dispatch(setSections(visibleSections));
+  store.dispatch(setSections(sections));
 
   store.dispatch(selectSection(section.id));
   store.dispatch(setRosterProvider(section.login_type));

--- a/apps/src/templates/manageStudents/MoveStudents.jsx
+++ b/apps/src/templates/manageStudents/MoveStudents.jsx
@@ -8,6 +8,7 @@ import wrappedSortable from '../tables/wrapped_sortable';
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
 import Immutable from 'immutable';
 import {orderBy, compact} from 'lodash';
+import {getVisibleSections} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import Button from '../Button';
 import BaseDialog from '../BaseDialog';
 import DialogFooter from '../teacherDashboard/DialogFooter';
@@ -107,7 +108,7 @@ class MoveStudents extends Component {
     }),
 
     // redux provided
-    sections: PropTypes.objectOf(
+    sections: PropTypes.arrayOf(
       PropTypes.shape({
         name: PropTypes.string.isRequired,
         id: PropTypes.number.isRequired,
@@ -469,7 +470,7 @@ export const UnconnectedMoveStudents = MoveStudents;
 
 export default connect(
   state => ({
-    sections: state.teacherSections.sections,
+    sections: getVisibleSections(state),
     currentSectionId: state.sectionData.section.id
   }),
   dispatch => ({

--- a/apps/src/templates/manageStudents/MoveStudents.story.jsx
+++ b/apps/src/templates/manageStudents/MoveStudents.story.jsx
@@ -13,11 +13,11 @@ const studentData = [
   {id: 2, name: 'Student B'}
 ];
 
-const sections = {
-  1: {id: 1, name: 'Section A', loginType: 'email'},
-  2: {id: 2, name: 'Section B', loginType: 'word'},
-  3: {id: 3, name: 'Section C', loginType: 'picture'}
-};
+const sections = [
+  {id: 1, name: 'Section A', loginType: 'email'},
+  {id: 2, name: 'Section B', loginType: 'word'},
+  {id: 3, name: 'Section C', loginType: 'picture'}
+];
 
 const transferToOtherTeacher = {
   ...blankStudentTransfer,

--- a/apps/src/templates/teacherDashboard/SelectSectionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SelectSectionDropdown.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {navigateToHref} from '@cdo/apps/utils';
+import {getVisibleSections} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 const styles = {
   container: {
@@ -18,7 +19,7 @@ const styles = {
 class SelectSectionDropdown extends React.Component {
   static propTypes = {
     // Provided by redux.
-    sections: PropTypes.object,
+    sections: PropTypes.array,
     selectedSectionId: PropTypes.number
   };
 
@@ -38,9 +39,9 @@ class SelectSectionDropdown extends React.Component {
           value={selectedSectionId}
           style={styles.dropdown}
         >
-          {Object.keys(sections).map(id => (
-            <option key={id} value={id}>
-              {sections[id].name}
+          {(sections || []).map(section => (
+            <option key={section.id} value={section.id}>
+              {section.name}
             </option>
           ))}
         </select>
@@ -52,6 +53,6 @@ class SelectSectionDropdown extends React.Component {
 export const UnconnectedSelectSectionDropdown = SelectSectionDropdown;
 
 export default connect(state => ({
-  sections: state.teacherSections.sections,
+  sections: getVisibleSections(state),
   selectedSectionId: state.teacherSections.selectedSectionId
 }))(SelectSectionDropdown);

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -879,6 +879,11 @@ export function assignedScriptName(state) {
   return assignment ? assignment.name : '';
 }
 
+export function getVisibleSections(state) {
+  const allSections = Object.values(getRoot(state).sections);
+  return allSections.filter(s => !s.hidden);
+}
+
 /**
  * Gets the data needed by Reacttabular to show a sortable table
  * @param {object} state - Full store state

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -881,7 +881,7 @@ export function assignedScriptName(state) {
 
 export function getVisibleSections(state) {
   const allSections = Object.values(getRoot(state).sections);
-  return allSections.filter(s => !s.hidden);
+  return (allSections || []).filter(s => !s.hidden);
 }
 
 /**

--- a/apps/test/unit/templates/manageStudents/MoveStudentsTest.js
+++ b/apps/test/unit/templates/manageStudents/MoveStudentsTest.js
@@ -15,12 +15,12 @@ const studentData = [
   {id: 3, name: 'studentc'},
   {id: 0, name: 'studenta'}
 ];
-const sections = {
-  0: {id: 0, name: 'sectiona', loginType: SectionLoginType.google_classroom},
-  1: {id: 1, name: 'sectionb', loginType: SectionLoginType.email},
-  2: {id: 2, name: 'sectionc', loginType: SectionLoginType.clever},
-  3: {id: 3, name: 'sectiond', loginType: SectionLoginType.word}
-};
+const sections = [
+  {id: 0, name: 'sectiona', loginType: SectionLoginType.google_classroom},
+  {id: 1, name: 'sectionb', loginType: SectionLoginType.email},
+  {id: 2, name: 'sectionc', loginType: SectionLoginType.clever},
+  {id: 3, name: 'sectiond', loginType: SectionLoginType.word}
+];
 
 describe('MoveStudents', () => {
   let updateStudentTransfer;

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -36,6 +36,7 @@ import reducer, {
   sectionName,
   sectionProvider,
   isSectionProviderManaged,
+  getVisibleSections,
   isSaveInProgress,
   sectionsNameAndId,
   getSectionRows,
@@ -1698,6 +1699,54 @@ describe('teacherSectionsRedux', () => {
         ])
       );
       expect(isSectionProviderManaged(getState(), 11)).to.be.true;
+    });
+  });
+
+  describe('getVisibleSections', () => {
+    it('filters out hidden sections', () => {
+      const expectedVisibleSections = {
+        11: {id: 11, hidden: false},
+        1: {id: 1, hidden: null}
+      };
+      const state = {
+        teacherSections: {
+          sections: {
+            2: {id: 2, hidden: true},
+            ...expectedVisibleSections
+          }
+        }
+      };
+      const actualVisibleSections = getVisibleSections(state);
+
+      assert.deepEqual(
+        Object.values(expectedVisibleSections),
+        actualVisibleSections
+      );
+    });
+
+    it('returns an empty array if there are no visible sections', () => {
+      const state = {
+        teacherSections: {
+          sections: {
+            2: {id: 2, hidden: true},
+            1: {id: 1, hidden: true}
+          }
+        }
+      };
+      const visibleSections = getVisibleSections(state);
+
+      expect(visibleSections.length).to.equal(0);
+    });
+
+    it('does not error if there are no sections', () => {
+      const state = {
+        teacherSections: {
+          sections: {}
+        }
+      };
+      const visibleSections = getVisibleSections(state);
+
+      expect(visibleSections.length).to.equal(0);
     });
   });
 

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -3,6 +3,6 @@ class TeacherDashboardController < ApplicationController
 
   def show
     @section = @section.summarize
-    @visible_sections = current_user.sections.where(hidden: false).map(&:summarize)
+    @sections = current_user.sections.map(&:summarize)
   end
 end

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -3,6 +3,7 @@ class TeacherDashboardController < ApplicationController
 
   def show
     @section = @section.summarize
+    @visible_sections = current_user.sections.where(hidden: false).map(&:summarize)
     @sections = current_user.sections.map(&:summarize)
   end
 end

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -2,7 +2,7 @@
   teacher_dashboard_data = {}
   teacher_dashboard_data[:studioUrlPrefix] = CDO.studio_url('', CDO.default_scheme)
   teacher_dashboard_data[:pegasusUrlPrefix] = CDO.code_org_url('', CDO.default_scheme)
-  teacher_dashboard_data[:visibleSections] = @visible_sections
+  teacher_dashboard_data[:sections] = @sections
   teacher_dashboard_data[:section] = @section
 
 %script{src: minifiable_asset_path('js/teacher_dashboard/show.js'), data: {dashboard: teacher_dashboard_data.to_json}}

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -2,6 +2,7 @@
   teacher_dashboard_data = {}
   teacher_dashboard_data[:studioUrlPrefix] = CDO.studio_url('', CDO.default_scheme)
   teacher_dashboard_data[:pegasusUrlPrefix] = CDO.code_org_url('', CDO.default_scheme)
+  teacher_dashboard_data[:visibleSections] = @visible_sections
   teacher_dashboard_data[:sections] = @sections
   teacher_dashboard_data[:section] = @section
 


### PR DESCRIPTION
Previously, we were only returning "visible" sections (i.e., sections where `section.hidden == false`) from the `teacher_dashboard#show` endpoint into teacher dashboard. This meant that we weren't storing archived/hidden sections in our teacherSectionsRedux store (in `state.teacherSections.sections`).

This was only an issue when a teacher would try to move students _from_ an archived section to another section, which resulted in a 400 response from our POST request to `/sections/transfers` (due to [this check](https://github.com/code-dot-org/code-dot-org/blob/9115b15c5446d33aef611698b65f481d0da72e97/dashboard/app/controllers/transfers_controller.rb#L9-L11) where `current_section_code` was always empty for archived sections).

Now, we will store all sections (including archived/hidden ones) in teacherSectionsRedux, and filter out archived sections when we don't want to display them:
1. `<SelectSectionDropdown/>`
![Screen Shot 2019-09-05 at 4 13 25 PM](https://user-images.githubusercontent.com/9812299/64389636-47813580-cff8-11e9-99cb-4ad55fe833e2.png)

2. `<MoveStudents/>`
![Screen Shot 2019-09-05 at 4 14 29 PM](https://user-images.githubusercontent.com/9812299/64389637-47813580-cff8-11e9-99b3-7b716d8be956.png)

Video of moving a student from an archived section to a non-archived section:
![out](https://user-images.githubusercontent.com/9812299/64389793-f3c31c00-cff8-11e9-89be-c1daa999767d.gif)
