### PR TITLE
Flex category polish

### DIFF
--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -148,10 +148,10 @@ class FlexGroup extends Component {
 
     return (
       <div>
-        {_.keys(groups).map((group, groupIndex) => (
+        {_.keys(groups).map(group => (
           <div key={group}>
             <div style={styles.groupHeader}>
-              Group {groupIndex + 1}: {group}
+              Flex Category: {group}
               <OrderControls
                 type={ControlTypes.Group}
                 position={afterStage}
@@ -188,7 +188,7 @@ class FlexGroup extends Component {
           type="button"
         >
           <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-          Add Group
+          Add Flex Category
         </button>
         <input
           type="hidden"

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -139,7 +139,10 @@ export class UnconnectedStageCard extends Component {
     return (
       <div style={styles.stageCard}>
         <div style={styles.stageCardHeader}>
-          Stage {this.props.stage.position}: {this.props.stage.name}
+          {!this.props.stage.lockable && (
+            <span>Stage {this.props.stage.relativePosition}:&nbsp;</span>
+          )}
+          {this.props.stage.name}
           <OrderControls
             type={ControlTypes.Stage}
             position={this.props.stage.position}

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -252,10 +252,16 @@ function stages(state = [], action) {
     case MOVE_STAGE: {
       const index = action.position - 1;
       const swap = action.direction === 'up' ? index - 1 : index + 1;
-      const temp = newState[index];
-      newState[index] = newState[swap];
-      newState[swap] = temp;
-      updatePositions(newState);
+      if (newState[index].flex_category === newState[swap].flex_category) {
+        const temp = newState[index];
+        newState[index] = newState[swap];
+        newState[swap] = temp;
+        updatePositions(newState);
+      } else {
+        // Move the stage into the adjacent group, without changing its
+        // position relative to other stages.
+        newState[index].flex_category = newState[swap].flex_category;
+      }
       break;
     }
     case SET_STAGE_LOCKABLE: {

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -123,9 +123,22 @@ export const setStageLockable = (stage, lockable) => ({
   lockable
 });
 
-function updatePositions(node) {
-  for (let i = 0; i < node.length; i++) {
-    node[i].position = i + 1;
+function updateStagePositions(stages) {
+  let relativePosition = 1;
+  for (let i = 0; i < stages.length; i++) {
+    stages[i].position = i + 1;
+    if (stages[i].lockable) {
+      stages[i].relativePosition = undefined;
+    } else {
+      stages[i].relativePosition = relativePosition;
+      relativePosition++;
+    }
+  }
+}
+
+function updateLevelPositions(levels) {
+  for (let i = 0; i < levels.length; i++) {
+    levels[i].position = i + 1;
   }
 }
 
@@ -141,7 +154,7 @@ function stages(state = [], action) {
       const levels = newState[action.stage - 1].levels;
       const temp = levels.splice(action.originalPosition - 1, 1);
       levels.splice(action.newPosition - 1, 0, temp[0]);
-      updatePositions(levels);
+      updateLevelPositions(levels);
       break;
     }
     case ADD_GROUP: {
@@ -150,7 +163,7 @@ function stages(state = [], action) {
         name: action.stageName,
         levels: []
       });
-      updatePositions(newState);
+      updateStagePositions(newState);
       break;
     }
     case ADD_STAGE: {
@@ -161,7 +174,7 @@ function stages(state = [], action) {
         flex_category: groupName,
         levels: []
       });
-      updatePositions(newState);
+      updateStagePositions(newState);
       break;
     }
     case ADD_LEVEL: {
@@ -171,7 +184,7 @@ function stages(state = [], action) {
         activeId: NEW_LEVEL_ID,
         expand: true
       });
-      updatePositions(levels);
+      updateLevelPositions(levels);
       break;
     }
     case ADD_VARIANT: {
@@ -199,18 +212,18 @@ function stages(state = [], action) {
     case REMOVE_GROUP: {
       const groupName = newState[action.position - 1].flex_category;
       newState = newState.filter(stage => stage.flex_category !== groupName);
-      updatePositions(newState);
+      updateStagePositions(newState);
       break;
     }
     case REMOVE_STAGE: {
       newState.splice(action.position - 1, 1);
-      updatePositions(newState);
+      updateStagePositions(newState);
       break;
     }
     case REMOVE_LEVEL: {
       const levels = newState[action.stage - 1].levels;
       levels.splice(action.level - 1, 1);
-      updatePositions(levels);
+      updateLevelPositions(levels);
       break;
     }
     case CHOOSE_LEVEL: {
@@ -246,7 +259,7 @@ function stages(state = [], action) {
         0,
         ...swap
       );
-      updatePositions(newState);
+      updateStagePositions(newState);
       break;
     }
     case MOVE_STAGE: {
@@ -256,7 +269,7 @@ function stages(state = [], action) {
         const temp = newState[index];
         newState[index] = newState[swap];
         newState[swap] = temp;
-        updatePositions(newState);
+        updateStagePositions(newState);
       } else {
         // Move the stage into the adjacent group, without changing its
         // position relative to other stages.

--- a/apps/src/sites/studio/pages/scripts/_form.js
+++ b/apps/src/sites/studio/pages/scripts/_form.js
@@ -17,6 +17,7 @@ export default function initPage(scriptEditorData) {
     .filter(stage => stage.id)
     .map(stage => ({
       position: stage.position,
+      relativePosition: stage.relative_position,
       flex_category: stage.flex_category,
       lockable: stage.lockable,
       name: stage.name,

--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -177,8 +177,7 @@ class Stage < ActiveRecord::Base
     summary = summarize.dup
     # Do not let script name override stage name when there is only one stage
     summary[:name] = I18n.t("data.script.name.#{script.name}.stages.#{name}.name")
-    # Do not use a default value if flex_category is nil
-    summary[:flex_category] = flex_category && I18n.t("flex_category.#{flex_category}")
+    summary[:flex_category] = flex_category
     summary.freeze
   end
 


### PR DESCRIPTION
### Description

A couple touch up steps which precede making some bigger changes to flex categories, all of which were seen in the demo / bug bash today.

* https://github.com/code-dot-org/code-dot-org/commit/ab6a0c41bca673bacd972c8ce204e61f335341ac prevents mangling flex category by supplying the flex category key rather than the translated value. a future change will bring back the display name, but this fixes the data loss bug. the following are both screenshots after opening the stage editor gui and immediately saving on /s/csp1-2019:

| before | after |
| --- | --- |
| ![Screen Shot 2019-09-05 at 4 29 07 PM](https://user-images.githubusercontent.com/8001765/64390099-523cca00-cffa-11e9-9db9-2b1e36ac2ee9.png) | ![Screen Shot 2019-09-05 at 4 23 42 PM](https://user-images.githubusercontent.com/8001765/64390030-fffba900-cff9-11e9-8c06-7faf7d729de1.png) |

* https://github.com/code-dot-org/code-dot-org/commit/5d520d0158fec0039915d1390fb8d18c94c9a2a9 fix up/down controls for moving stages between groups. previously, we let you move one stage to a position after another stage that was in a different flex group, causing the script to stay where it was and mess up the numbering. now when you do this we move the stage into the next flex group.

| before | after |
| --- | --- |
| ![up-down-broken](https://user-images.githubusercontent.com/8001765/64390963-ba3fe000-cffb-11e9-8654-8785e39de9c6.gif) | ![up-down-buttons](https://user-images.githubusercontent.com/8001765/64390962-b744ef80-cffb-11e9-895f-5b902b171fc5.gif) | 

* https://github.com/code-dot-org/code-dot-org/pull/30619/commits/fa9ec2ee14302a3ef9b2d5a39381982617da0d5b make stage numberings use relative position, not absolute position, so that lockable stages are excluded from the numbering and so that the numberings here match what you see on the script overview page.

| before | after |
| --- | --- |
| ![Screen Shot 2019-09-05 at 4 33 40 PM](https://user-images.githubusercontent.com/8001765/64390777-ffafdd80-cffa-11e9-95e2-8ffc66c3deb9.png) |  ![Screen Shot 2019-09-05 at 4 33 24 PM](https://user-images.githubusercontent.com/8001765/64390769-f9216600-cffa-11e9-8a1b-6b19bef164d8.png) | 
