### PR TITLE
Allow editing of flex category and fix how it displays

### DIFF
--- a/apps/src/lib/script-editor/FlexCategorySelector.jsx
+++ b/apps/src/lib/script-editor/FlexCategorySelector.jsx
@@ -1,0 +1,101 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {addGroup} from './editorRedux';
+
+const styles = {
+  flexCategoryLabel: {
+    fontSize: 14,
+    verticalAlign: 'baseline',
+    marginRight: 5
+  },
+  flexCategorySelect: {
+    verticalAlign: 'baseline',
+    width: 550,
+    margin: '0 5px 0 0'
+  },
+  flexCategoryButton: {
+    verticalAlign: 'baseline',
+    margin: '0 5px 0 0'
+  }
+};
+
+class FlexCategorySelector extends Component {
+  static propTypes = {
+    labelText: PropTypes.string.isRequired,
+    confirmButtonText: PropTypes.string.isRequired,
+    onConfirm: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+
+    // from redux
+    flexCategoryMap: PropTypes.object.isRequired
+  };
+
+  state = {
+    newFlexCategory: ''
+  };
+
+  handleCancel = () => {
+    this.setState({newFlexCategory: ''});
+    this.props.onCancel();
+  };
+
+  flexCategorySelected = newFlexCategory => {
+    this.setState({newFlexCategory});
+  };
+
+  handleConfirm = () => {
+    const {newFlexCategory} = this.state;
+    this.setState({newFlexCategory: ''});
+    this.props.onConfirm(newFlexCategory);
+  };
+
+  render() {
+    const {flexCategoryMap} = this.props;
+    return (
+      <div>
+        <span style={styles.flexCategoryLabel}>{this.props.labelText}:</span>
+        &nbsp;
+        <select
+          style={styles.flexCategorySelect}
+          onChange={e => this.flexCategorySelected(e.target.value)}
+          value={this.state.newFlexCategory}
+        >
+          <option value="">(none): "Content"</option>
+          {Object.keys(flexCategoryMap).map(flexCategory => (
+            <option key={flexCategory} value={flexCategory}>
+              {flexCategory}: "{flexCategoryMap[flexCategory]}"
+            </option>
+          ))}
+        </select>
+        <button
+          onMouseDown={this.handleConfirm}
+          className="btn btn-primary"
+          style={styles.flexCategoryButton}
+          type="button"
+        >
+          {this.props.confirmButtonText}
+        </button>
+        <button
+          onMouseDown={this.handleCancel}
+          className="btn"
+          style={styles.flexCategoryButton}
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    flexCategoryMap: state.flexCategoryMap
+  }),
+  dispatch => ({
+    addGroup(stageName, groupName) {
+      dispatch(addGroup(stageName, groupName));
+    }
+  })
+)(FlexCategorySelector);

--- a/apps/src/lib/script-editor/FlexCategorySelector.jsx
+++ b/apps/src/lib/script-editor/FlexCategorySelector.jsx
@@ -1,7 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {addGroup} from './editorRedux';
 
 const styles = {
   flexCategoryLabel: {
@@ -89,13 +88,6 @@ class FlexCategorySelector extends Component {
   }
 }
 
-export default connect(
-  state => ({
-    flexCategoryMap: state.flexCategoryMap
-  }),
-  dispatch => ({
-    addGroup(stageName, groupName) {
-      dispatch(addGroup(stageName, groupName));
-    }
-  })
-)(FlexCategorySelector);
+export default connect(state => ({
+  flexCategoryMap: state.flexCategoryMap
+}))(FlexCategorySelector);

--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -39,6 +39,24 @@ const styles = {
     border: '1px solid #ccc',
     boxShadow: 'none',
     margin: '0 10px 10px 10px'
+  },
+  bottomControls: {
+    height: 30,
+    marginBottom: 30
+  },
+  flexCategoryLabel: {
+    fontSize: 14,
+    verticalAlign: 'baseline',
+    marginRight: 5
+  },
+  flexCategorySelect: {
+    verticalAlign: 'baseline',
+    width: 550,
+    margin: '0 5px 0 0'
+  },
+  saveFlexCategoryButton: {
+    verticalAlign: 'baseline',
+    margin: '0 5px 0 0'
   }
 };
 
@@ -54,11 +72,37 @@ class FlexGroup extends Component {
     flexCategoryMap: PropTypes.object.isRequired
   };
 
-  handleAddGroup = () => {
-    this.props.addGroup(
-      prompt('Enter new stage name'),
-      prompt('Enter new group name')
-    );
+  state = {
+    addingFlexCategory: false,
+    newFlexCategory: ''
+  };
+
+  handleAddFlexCategory = () => {
+    this.setState({
+      addingFlexCategory: true,
+      newFlexCategory: ''
+    });
+  };
+
+  cancelAddFlexCategory = () => {
+    this.setState({
+      addingFlexCategory: false,
+      newFlexCategory: ''
+    });
+  };
+
+  flexCategorySelected = newFlexCategory => {
+    this.setState({newFlexCategory});
+  };
+
+  handleCreateFlexCategory = () => {
+    const {newFlexCategory} = this.state;
+    const newStageName = prompt('Enter new stage name');
+    this.setState({
+      addingFlexCategory: false,
+      newFlexCategory: ''
+    });
+    this.props.addGroup(newStageName, newFlexCategory);
   };
 
   handleAddStage = position => {
@@ -184,15 +228,51 @@ class FlexGroup extends Component {
             </div>
           </div>
         ))}
-        <button
-          onMouseDown={this.handleAddGroup}
-          className="btn"
-          style={styles.addGroup}
-          type="button"
-        >
-          <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-          Add Flex Category
-        </button>
+        {!this.state.addingFlexCategory && (
+          <button
+            onMouseDown={this.handleAddFlexCategory}
+            className="btn"
+            style={styles.addGroup}
+            type="button"
+          >
+            <i style={{marginRight: 7}} className="fa fa-plus-circle" />
+            Add Flex Category
+          </button>
+        )}
+        {this.state.addingFlexCategory && (
+          <div style={styles.bottomControls}>
+            <span style={styles.flexCategoryLabel}>New Flex Category:</span>
+            &nbsp;
+            <select
+              style={styles.flexCategorySelect}
+              onChange={e => this.flexCategorySelected(e.target.value)}
+              value={this.state.newFlexCategory}
+            >
+              <option value="">(none): "Content"</option>
+              {Object.keys(flexCategoryMap).map(flexCategory => (
+                <option key={flexCategory} value={flexCategory}>
+                  {flexCategory}: "{flexCategoryMap[flexCategory]}"
+                </option>
+              ))}
+            </select>
+            <button
+              onMouseDown={this.handleCreateFlexCategory}
+              className="btn btn-primary"
+              style={styles.saveFlexCategoryButton}
+              type="button"
+            >
+              Create
+            </button>
+            <button
+              onMouseDown={this.cancelAddFlexCategory}
+              className="btn"
+              style={styles.saveFlexCategoryButton}
+              type="button"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
         <input
           type="hidden"
           name="script_text"

--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -7,6 +7,7 @@ import {borderRadius, ControlTypes} from './constants';
 import OrderControls from './OrderControls';
 import StageCard from './StageCard';
 import {NEW_LEVEL_ID, addStage, addGroup} from './editorRedux';
+import FlexCategorySelector from './FlexCategorySelector';
 
 const styles = {
   groupHeader: {
@@ -40,23 +41,9 @@ const styles = {
     boxShadow: 'none',
     margin: '0 10px 10px 10px'
   },
-  bottomControls: {
+  flexCategorySelector: {
     height: 30,
     marginBottom: 30
-  },
-  flexCategoryLabel: {
-    fontSize: 14,
-    verticalAlign: 'baseline',
-    marginRight: 5
-  },
-  flexCategorySelect: {
-    verticalAlign: 'baseline',
-    width: 550,
-    margin: '0 5px 0 0'
-  },
-  saveFlexCategoryButton: {
-    verticalAlign: 'baseline',
-    margin: '0 5px 0 0'
   }
 };
 
@@ -73,36 +60,25 @@ class FlexGroup extends Component {
   };
 
   state = {
-    addingFlexCategory: false,
-    newFlexCategory: ''
+    addingFlexCategory: false
   };
 
   handleAddFlexCategory = () => {
     this.setState({
-      addingFlexCategory: true,
-      newFlexCategory: ''
+      addingFlexCategory: true
     });
   };
 
-  cancelAddFlexCategory = () => {
-    this.setState({
-      addingFlexCategory: false,
-      newFlexCategory: ''
-    });
-  };
-
-  flexCategorySelected = newFlexCategory => {
-    this.setState({newFlexCategory});
-  };
-
-  handleCreateFlexCategory = () => {
-    const {newFlexCategory} = this.state;
+  createFlexCategory = newFlexCategory => {
+    this.hideFlexCategorySelector();
     const newStageName = prompt('Enter new stage name');
-    this.setState({
-      addingFlexCategory: false,
-      newFlexCategory: ''
-    });
-    this.props.addGroup(newStageName, newFlexCategory);
+    if (newStageName) {
+      this.props.addGroup(newStageName, newFlexCategory);
+    }
+  };
+
+  hideFlexCategorySelector = () => {
+    this.setState({addingFlexCategory: false});
   };
 
   handleAddStage = position => {
@@ -240,37 +216,13 @@ class FlexGroup extends Component {
           </button>
         )}
         {this.state.addingFlexCategory && (
-          <div style={styles.bottomControls}>
-            <span style={styles.flexCategoryLabel}>New Flex Category:</span>
-            &nbsp;
-            <select
-              style={styles.flexCategorySelect}
-              onChange={e => this.flexCategorySelected(e.target.value)}
-              value={this.state.newFlexCategory}
-            >
-              <option value="">(none): "Content"</option>
-              {Object.keys(flexCategoryMap).map(flexCategory => (
-                <option key={flexCategory} value={flexCategory}>
-                  {flexCategory}: "{flexCategoryMap[flexCategory]}"
-                </option>
-              ))}
-            </select>
-            <button
-              onMouseDown={this.handleCreateFlexCategory}
-              className="btn btn-primary"
-              style={styles.saveFlexCategoryButton}
-              type="button"
-            >
-              Create
-            </button>
-            <button
-              onMouseDown={this.cancelAddFlexCategory}
-              className="btn"
-              style={styles.saveFlexCategoryButton}
-              type="button"
-            >
-              Cancel
-            </button>
+          <div style={styles.flexCategorySelector}>
+            <FlexCategorySelector
+              labelText="New Flex Category"
+              confirmButtonText="Create"
+              onConfirm={this.createFlexCategory}
+              onCancel={this.hideFlexCategorySelector}
+            />
           </div>
         )}
         <input

--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -50,7 +50,8 @@ class FlexGroup extends Component {
     addGroup: PropTypes.func.isRequired,
     addStage: PropTypes.func.isRequired,
     stages: PropTypes.array.isRequired,
-    levelKeyList: PropTypes.object.isRequired
+    levelKeyList: PropTypes.object.isRequired,
+    flexCategoryMap: PropTypes.object.isRequired
   };
 
   handleAddGroup = () => {
@@ -145,13 +146,14 @@ class FlexGroup extends Component {
       stage => stage.flex_category || 'Default'
     );
     let afterStage = 1;
+    const {flexCategoryMap} = this.props;
 
     return (
       <div>
         {_.keys(groups).map(group => (
           <div key={group}>
             <div style={styles.groupHeader}>
-              Flex Category: {group}
+              Flex Category: {group}: "{flexCategoryMap[group]}"
               <OrderControls
                 type={ControlTypes.Group}
                 position={afterStage}
@@ -203,7 +205,8 @@ class FlexGroup extends Component {
 export default connect(
   state => ({
     levelKeyList: state.levelKeyList,
-    stages: state.stages
+    stages: state.stages,
+    flexCategoryMap: state.flexCategoryMap
   }),
   dispatch => ({
     addGroup(stageName, groupName) {

--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -143,7 +143,7 @@ class FlexGroup extends Component {
   render() {
     const groups = _.groupBy(
       this.props.stages,
-      stage => stage.flex_category || 'Default'
+      stage => stage.flex_category || ''
     );
     let afterStage = 1;
     const {flexCategoryMap} = this.props;
@@ -153,7 +153,8 @@ class FlexGroup extends Component {
         {_.keys(groups).map(group => (
           <div key={group}>
             <div style={styles.groupHeader}>
-              Flex Category: {group}: "{flexCategoryMap[group]}"
+              Flex Category: {group || '(none)'}: "
+              {flexCategoryMap[group] || 'Content'}"
               <OrderControls
                 type={ControlTypes.Group}
                 position={afterStage}

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -11,6 +11,7 @@ import {
   setStageLockable,
   setFlexCategory
 } from './editorRedux';
+import FlexCategorySelector from './FlexCategorySelector';
 
 const styles = {
   checkbox: {
@@ -41,19 +42,6 @@ const styles = {
     border: '1px solid #ddd',
     boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.8)',
     margin: '0 5px 0 0'
-  },
-  flexCategoryLabel: {
-    fontSize: 14,
-    verticalAlign: 'baseline'
-  },
-  flexCategorySelect: {
-    verticalAlign: 'baseline',
-    width: 550,
-    margin: '0 5px 0 0'
-  },
-  saveFlexCategoryButton: {
-    verticalAlign: 'baseline',
-    margin: '0 5px 0 0'
   }
 };
 
@@ -64,7 +52,6 @@ export class UnconnectedStageCard extends Component {
     setStageLockable: PropTypes.func.isRequired,
     stagesCount: PropTypes.number.isRequired,
     stage: PropTypes.object.isRequired,
-    flexCategoryMap: PropTypes.object.isRequired,
     setFlexCategory: PropTypes.func.isRequired
   };
 
@@ -81,8 +68,7 @@ export class UnconnectedStageCard extends Component {
     initialScroll: null,
     newPosition: null,
     startingPositions: null,
-    editingFlexCategory: false,
-    newFlexCategory: ''
+    editingFlexCategory: false
   };
 
   handleDragStart = (position, {pageY}) => {
@@ -151,31 +137,19 @@ export class UnconnectedStageCard extends Component {
 
   handleEditFlexCategory = () => {
     this.setState({
-      editingFlexCategory: true,
-      newFlexCategory: this.props.stage.flex_category || ''
+      editingFlexCategory: true
     });
   };
 
-  cancelEditFlexCategory = () => {
-    this.setState({
-      editingFlexCategory: false,
-      newFlexCategory: ''
-    });
-  };
-
-  flexCategorySelected = newFlexCategory => {
-    this.setState({newFlexCategory});
-  };
-
-  handleSaveFlexCategory = () => {
-    const {newFlexCategory} = this.state;
-    this.setState({
-      editingFlexCategory: false,
-      newFlexCategory: ''
-    });
+  handleSetFlexCategory = newFlexCategory => {
+    this.setState({editingFlexCategory: false});
     if (this.props.stage.flex_category !== newFlexCategory) {
       this.props.setFlexCategory(this.props.stage.position, newFlexCategory);
     }
+  };
+
+  hideFlexCategorySelector = () => {
+    this.setState({editingFlexCategory: false});
   };
 
   toggleLockable = () => {
@@ -190,7 +164,6 @@ export class UnconnectedStageCard extends Component {
   }
 
   render() {
-    const {flexCategoryMap} = this.props;
     return (
       <div style={styles.stageCard}>
         <div style={styles.stageCardHeader}>
@@ -257,38 +230,12 @@ export class UnconnectedStageCard extends Component {
             </span>
           )}
           {this.state.editingFlexCategory && (
-            <div>
-              <span style={styles.flexCategoryLabel}>Flex Category:</span>
-              &nbsp;
-              <select
-                style={styles.flexCategorySelect}
-                onChange={e => this.flexCategorySelected(e.target.value)}
-                value={this.state.newFlexCategory}
-              >
-                <option value="">(none): "Content"</option>
-                {Object.keys(flexCategoryMap).map(flexCategory => (
-                  <option key={flexCategory} value={flexCategory}>
-                    {flexCategory}: "{flexCategoryMap[flexCategory]}"
-                  </option>
-                ))}
-              </select>
-              <button
-                onMouseDown={this.handleSaveFlexCategory}
-                className="btn btn-primary"
-                style={styles.saveFlexCategoryButton}
-                type="button"
-              >
-                Save
-              </button>
-              <button
-                onMouseDown={this.cancelEditFlexCategory}
-                className="btn"
-                style={styles.saveFlexCategoryButton}
-                type="button"
-              >
-                Cancel
-              </button>
-            </div>
+            <FlexCategorySelector
+              labelText="Flex Category"
+              confirmButtonText="Save"
+              onConfirm={this.handleSetFlexCategory}
+              onCancel={this.hideFlexCategorySelector}
+            />
           )}
         </div>
       </div>
@@ -297,9 +244,7 @@ export class UnconnectedStageCard extends Component {
 }
 
 export default connect(
-  state => ({
-    flexCategoryMap: state.flexCategoryMap
-  }),
+  state => ({}),
   dispatch => ({
     reorderLevel(stage, originalPosition, newPosition) {
       dispatch(reorderLevel(stage, originalPosition, newPosition));

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -37,14 +37,15 @@ const styles = {
     background: '#eee',
     border: '1px solid #ddd',
     boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.8)',
-    margin: '5px 0 5px 5px'
+    margin: '0 5px 0 0'
   },
   flexCategoryLabel: {
-    fontSize: 13,
+    fontSize: 14,
     verticalAlign: 'baseline'
   },
-  flexCategoryInput: {
-    verticalAlign: 'baseline'
+  flexCategorySelect: {
+    verticalAlign: 'baseline',
+    width: 550
   },
   saveFlexCategoryButton: {
     verticalAlign: 'baseline'
@@ -175,6 +176,7 @@ export class UnconnectedStageCard extends Component {
   }
 
   render() {
+    const {flexCategoryMap} = this.props;
     return (
       <div style={styles.stageCard}>
         <div style={styles.stageCardHeader}>
@@ -239,13 +241,20 @@ export class UnconnectedStageCard extends Component {
         )}
         {this.state.editingFlexCategory && (
           <div>
-            <span style={styles.flexCategoryLabel}>Flex Category:</span>&nbsp;
-            <input
-              type="text"
-              value={this.state.newFlexCategory}
+            <span style={styles.flexCategoryLabel}>New Flex Category:</span>
+            &nbsp;
+            <select
+              style={styles.flexCategorySelect}
               onChange={e => this.flexCategorySelected(e.target.value)}
-              style={styles.flexCategoryInput}
-            />
+              value={this.state.newFlexCategory}
+            >
+              <option value="">(None)</option>
+              {Object.keys(flexCategoryMap).map(flexCategory => (
+                <option key={flexCategory} value={flexCategory}>
+                  {flexCategory}: "{flexCategoryMap[flexCategory]}"
+                </option>
+              ))}
+            </select>
             <button
               onMouseDown={this.handleSaveFlexCategory}
               className="btn"

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -32,6 +32,9 @@ const styles = {
     fontSize: 13,
     marginTop: 3
   },
+  bottomControls: {
+    height: 30
+  },
   addLevel: {
     fontSize: 14,
     background: '#eee',
@@ -45,10 +48,12 @@ const styles = {
   },
   flexCategorySelect: {
     verticalAlign: 'baseline',
-    width: 550
+    width: 550,
+    margin: '0 5px 0 0'
   },
   saveFlexCategoryButton: {
-    verticalAlign: 'baseline'
+    verticalAlign: 'baseline',
+    margin: '0 5px 0 0'
   }
 };
 
@@ -151,6 +156,13 @@ export class UnconnectedStageCard extends Component {
     });
   };
 
+  cancelEditFlexCategory = () => {
+    this.setState({
+      editingFlexCategory: false,
+      newFlexCategory: ''
+    });
+  };
+
   flexCategorySelected = newFlexCategory => {
     this.setState({newFlexCategory});
   };
@@ -219,52 +231,64 @@ export class UnconnectedStageCard extends Component {
             handleDragStart={this.handleDragStart}
           />
         ))}
-        <button
-          onMouseDown={this.handleAddLevel}
-          className="btn"
-          style={styles.addLevel}
-          type="button"
-        >
-          <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-          Add Level
-        </button>
-        {!this.state.editingFlexCategory && (
-          <button
-            onMouseDown={this.handleEditFlexCategory}
-            className="btn"
-            style={styles.addLevel}
-            type="button"
-          >
-            <i style={{marginRight: 7}} className="fa fa-pencil" />
-            Edit Flex Category
-          </button>
-        )}
-        {this.state.editingFlexCategory && (
-          <div>
-            <span style={styles.flexCategoryLabel}>New Flex Category:</span>
-            &nbsp;
-            <select
-              style={styles.flexCategorySelect}
-              onChange={e => this.flexCategorySelected(e.target.value)}
-              value={this.state.newFlexCategory}
-            >
-              <option value="">(None)</option>
-              {Object.keys(flexCategoryMap).map(flexCategory => (
-                <option key={flexCategory} value={flexCategory}>
-                  {flexCategory}: "{flexCategoryMap[flexCategory]}"
-                </option>
-              ))}
-            </select>
-            <button
-              onMouseDown={this.handleSaveFlexCategory}
-              className="btn"
-              style={styles.saveFlexCategoryButton}
-              type="button"
-            >
-              Save
-            </button>
-          </div>
-        )}
+        <div style={styles.bottomControls}>
+          {!this.state.editingFlexCategory && (
+            <span>
+              <button
+                onMouseDown={this.handleAddLevel}
+                className="btn"
+                style={styles.addLevel}
+                type="button"
+              >
+                <i style={{marginRight: 7}} className="fa fa-plus-circle" />
+                Add Level
+              </button>
+              <button
+                onMouseDown={this.handleEditFlexCategory}
+                className="btn"
+                style={styles.addLevel}
+                type="button"
+              >
+                <i style={{marginRight: 7}} className="fa fa-pencil" />
+                Edit Flex Category
+              </button>
+            </span>
+          )}
+          {this.state.editingFlexCategory && (
+            <div>
+              <span style={styles.flexCategoryLabel}>Flex Category:</span>
+              &nbsp;
+              <select
+                style={styles.flexCategorySelect}
+                onChange={e => this.flexCategorySelected(e.target.value)}
+                value={this.state.newFlexCategory}
+              >
+                <option value="">(None)</option>
+                {Object.keys(flexCategoryMap).map(flexCategory => (
+                  <option key={flexCategory} value={flexCategory}>
+                    {flexCategory}: "{flexCategoryMap[flexCategory]}"
+                  </option>
+                ))}
+              </select>
+              <button
+                onMouseDown={this.handleSaveFlexCategory}
+                className="btn btn-primary"
+                style={styles.saveFlexCategoryButton}
+                type="button"
+              >
+                Save
+              </button>
+              <button
+                onMouseDown={this.cancelEditFlexCategory}
+                className="btn"
+                style={styles.saveFlexCategoryButton}
+                type="button"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     );
   }

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -5,7 +5,12 @@ import {connect} from 'react-redux';
 import {borderRadius, levelTokenMargin, ControlTypes} from './constants';
 import OrderControls from './OrderControls';
 import LevelToken from './LevelToken';
-import {reorderLevel, addLevel, setStageLockable} from './editorRedux';
+import {
+  reorderLevel,
+  addLevel,
+  setStageLockable,
+  setFlexCategory
+} from './editorRedux';
 
 const styles = {
   checkbox: {
@@ -32,7 +37,17 @@ const styles = {
     background: '#eee',
     border: '1px solid #ddd',
     boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.8)',
-    margin: '5px 0'
+    margin: '5px 0 5px 5px'
+  },
+  flexCategoryLabel: {
+    fontSize: 13,
+    verticalAlign: 'baseline'
+  },
+  flexCategoryInput: {
+    verticalAlign: 'baseline'
+  },
+  saveFlexCategoryButton: {
+    verticalAlign: 'baseline'
   }
 };
 
@@ -43,7 +58,8 @@ export class UnconnectedStageCard extends Component {
     setStageLockable: PropTypes.func.isRequired,
     stagesCount: PropTypes.number.isRequired,
     stage: PropTypes.object.isRequired,
-    flexCategoryMap: PropTypes.object.isRequired
+    flexCategoryMap: PropTypes.object.isRequired,
+    setFlexCategory: PropTypes.func.isRequired
   };
 
   /**
@@ -58,7 +74,9 @@ export class UnconnectedStageCard extends Component {
     initialPageY: null,
     initialScroll: null,
     newPosition: null,
-    startingPositions: null
+    startingPositions: null,
+    editingFlexCategory: false,
+    newFlexCategory: ''
   };
 
   handleDragStart = (position, {pageY}) => {
@@ -125,6 +143,26 @@ export class UnconnectedStageCard extends Component {
     this.props.addLevel(this.props.stage.position);
   };
 
+  handleEditFlexCategory = () => {
+    this.setState({
+      editingFlexCategory: true,
+      newFlexCategory: this.props.stage.flex_category
+    });
+  };
+
+  flexCategorySelected = newFlexCategory => {
+    this.setState({newFlexCategory});
+  };
+
+  handleSaveFlexCategory = () => {
+    const {newFlexCategory} = this.state;
+    this.setState({
+      editingFlexCategory: false,
+      newFlexCategory: ''
+    });
+    this.props.setFlexCategory(this.props.stage.position, newFlexCategory);
+  };
+
   toggleLockable = () => {
     this.props.setStageLockable(
       this.props.stage.position,
@@ -188,6 +226,36 @@ export class UnconnectedStageCard extends Component {
           <i style={{marginRight: 7}} className="fa fa-plus-circle" />
           Add Level
         </button>
+        {!this.state.editingFlexCategory && (
+          <button
+            onMouseDown={this.handleEditFlexCategory}
+            className="btn"
+            style={styles.addLevel}
+            type="button"
+          >
+            <i style={{marginRight: 7}} className="fa fa-pencil" />
+            Edit Flex Category
+          </button>
+        )}
+        {this.state.editingFlexCategory && (
+          <div>
+            <span style={styles.flexCategoryLabel}>Flex Category:</span>&nbsp;
+            <input
+              type="text"
+              value={this.state.newFlexCategory}
+              onChange={e => this.flexCategorySelected(e.target.value)}
+              style={styles.flexCategoryInput}
+            />
+            <button
+              onMouseDown={this.handleSaveFlexCategory}
+              className="btn"
+              style={styles.saveFlexCategoryButton}
+              type="button"
+            >
+              Save
+            </button>
+          </div>
+        )}
       </div>
     );
   }
@@ -206,6 +274,9 @@ export default connect(
     },
     setStageLockable(stage, lockable) {
       dispatch(setStageLockable(stage, lockable));
+    },
+    setFlexCategory(stage, flexCategory) {
+      dispatch(setFlexCategory(stage, flexCategory));
     }
   })
 )(UnconnectedStageCard);

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -173,7 +173,9 @@ export class UnconnectedStageCard extends Component {
       editingFlexCategory: false,
       newFlexCategory: ''
     });
-    this.props.setFlexCategory(this.props.stage.position, newFlexCategory);
+    if (this.props.stage.flex_category !== newFlexCategory) {
+      this.props.setFlexCategory(this.props.stage.position, newFlexCategory);
+    }
   };
 
   toggleLockable = () => {

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -152,7 +152,7 @@ export class UnconnectedStageCard extends Component {
   handleEditFlexCategory = () => {
     this.setState({
       editingFlexCategory: true,
-      newFlexCategory: this.props.stage.flex_category
+      newFlexCategory: this.props.stage.flex_category || ''
     });
   };
 
@@ -265,7 +265,7 @@ export class UnconnectedStageCard extends Component {
                 onChange={e => this.flexCategorySelected(e.target.value)}
                 value={this.state.newFlexCategory}
               >
-                <option value="">(None)</option>
+                <option value="">(none): "Content"</option>
                 {Object.keys(flexCategoryMap).map(flexCategory => (
                   <option key={flexCategory} value={flexCategory}>
                     {flexCategory}: "{flexCategoryMap[flexCategory]}"

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -42,7 +42,8 @@ export class UnconnectedStageCard extends Component {
     addLevel: PropTypes.func.isRequired,
     setStageLockable: PropTypes.func.isRequired,
     stagesCount: PropTypes.number.isRequired,
-    stage: PropTypes.object.isRequired
+    stage: PropTypes.object.isRequired,
+    flexCategoryMap: PropTypes.object.isRequired
   };
 
   /**
@@ -193,7 +194,9 @@ export class UnconnectedStageCard extends Component {
 }
 
 export default connect(
-  state => ({}),
+  state => ({
+    flexCategoryMap: state.flexCategoryMap
+  }),
   dispatch => ({
     reorderLevel(stage, originalPosition, newPosition) {
       dispatch(reorderLevel(stage, originalPosition, newPosition));

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -18,10 +18,11 @@ const REMOVE_GROUP = 'scriptEditor/REMOVE_GROUP';
 const REMOVE_STAGE = 'scriptEditor/REMOVE_STAGE';
 const SET_STAGE_LOCKABLE = 'scriptEditor/SET_STAGE_LOCKABLE';
 
-export const init = (stages, levelKeyList) => ({
+export const init = (stages, levelKeyList, flexCategoryMap) => ({
   type: INIT,
   stages,
-  levelKeyList
+  levelKeyList,
+  flexCategoryMap
 });
 
 export const addGroup = (stageName, groupName) => ({
@@ -312,8 +313,17 @@ function levelNameToIdMap(state = {}, action) {
   return state;
 }
 
+function flexCategoryMap(state = {}, action) {
+  switch (action.type) {
+    case INIT:
+      return action.flexCategoryMap;
+  }
+  return state;
+}
+
 export default {
   stages,
   levelKeyList,
-  levelNameToIdMap
+  levelNameToIdMap,
+  flexCategoryMap
 };

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -290,7 +290,20 @@ function stages(state = [], action) {
       break;
     }
     case SET_FLEX_CATEGORY: {
-      newState[action.stage - 1].flex_category = action.flexCategory;
+      // Remove the stage from the array and update its flex category.
+      const index = action.stage - 1;
+      const [curStage] = newState.splice(index, 1);
+      curStage.flex_category = action.flexCategory;
+
+      // Insert the stage after the last stage with the same flex_category,
+      // or at the end of the list if none matches.
+      const categories = newState.map(stage => stage.flex_category);
+      const lastIndex = categories.lastIndexOf(action.flexCategory);
+      const targetIndex = lastIndex > 0 ? lastIndex + 1 : newState.length;
+      newState.splice(targetIndex, 0, curStage);
+
+      updateStagePositions(newState);
+
       break;
     }
   }

--- a/apps/src/lib/script-editor/editorRedux.js
+++ b/apps/src/lib/script-editor/editorRedux.js
@@ -17,6 +17,7 @@ const MOVE_STAGE = 'scriptEditor/MOVE_STAGE';
 const REMOVE_GROUP = 'scriptEditor/REMOVE_GROUP';
 const REMOVE_STAGE = 'scriptEditor/REMOVE_STAGE';
 const SET_STAGE_LOCKABLE = 'scriptEditor/SET_STAGE_LOCKABLE';
+const SET_FLEX_CATEGORY = 'scriptEditor/SET_FLEX_CATEGORY';
 
 export const init = (stages, levelKeyList, flexCategoryMap) => ({
   type: INIT,
@@ -122,6 +123,12 @@ export const setStageLockable = (stage, lockable) => ({
   type: SET_STAGE_LOCKABLE,
   stage,
   lockable
+});
+
+export const setFlexCategory = (stage, flexCategory) => ({
+  type: SET_FLEX_CATEGORY,
+  stage,
+  flexCategory
 });
 
 function updateStagePositions(stages) {
@@ -280,6 +287,11 @@ function stages(state = [], action) {
     }
     case SET_STAGE_LOCKABLE: {
       newState[action.stage - 1].lockable = action.lockable;
+      break;
+    }
+    case SET_FLEX_CATEGORY: {
+      newState[action.stage - 1].flex_category = action.flexCategory;
+      break;
     }
   }
 

--- a/apps/src/sites/studio/pages/scripts/_form.js
+++ b/apps/src/sites/studio/pages/scripts/_form.js
@@ -40,11 +40,11 @@ export default function initPage(scriptEditorData) {
         }))
     }));
   const locales = scriptEditorData.locales;
-  const flexCategories = scriptEditorData.flex_categories;
+  const flexCategoryMap = scriptEditorData.flex_category_map;
 
   registerReducers({...reducers, isRtl});
   const store = getStore();
-  store.dispatch(init(stages, scriptEditorData.levelKeyList, flexCategories));
+  store.dispatch(init(stages, scriptEditorData.levelKeyList, flexCategoryMap));
 
   const teacherResources = (scriptData.teacher_resources || []).map(
     ([type, link]) => ({type, link})

--- a/apps/src/sites/studio/pages/scripts/_form.js
+++ b/apps/src/sites/studio/pages/scripts/_form.js
@@ -40,10 +40,11 @@ export default function initPage(scriptEditorData) {
         }))
     }));
   const locales = scriptEditorData.locales;
+  const flexCategories = scriptEditorData.flex_categories;
 
   registerReducers({...reducers, isRtl});
   const store = getStore();
-  store.dispatch(init(stages, scriptEditorData.levelKeyList));
+  store.dispatch(init(stages, scriptEditorData.levelKeyList, flexCategories));
 
   const teacherResources = (scriptData.teacher_resources || []).map(
     ([type, link]) => ({type, link})

--- a/apps/test/unit/code-studio/editorReduxTest.js
+++ b/apps/test/unit/code-studio/editorReduxTest.js
@@ -6,7 +6,8 @@ import reducers, {
   addStage,
   moveStage,
   setActiveVariant,
-  setField
+  setField,
+  setFlexCategory
 } from '@cdo/apps/lib/script-editor/editorRedux';
 
 const getInitialState = () => ({
@@ -136,6 +137,34 @@ describe('editorRedux reducer tests', () => {
         state.stages,
         'third move changes group but not position'
       );
+    });
+
+    describe('set flex category', () => {
+      it('moves unique flex category to the end of the script', () => {
+        let state = reducer(initialState, setFlexCategory(2, 'Z'));
+        assert.deepEqual(
+          [
+            {flex_category: 'X', id: 101, position: 1, relativePosition: 1},
+            {flex_category: 'Y', id: 103, position: 2, relativePosition: 2},
+            {flex_category: 'Y', id: 104, position: 3, relativePosition: 3},
+            {flex_category: 'Z', id: 102, position: 4, relativePosition: 4}
+          ],
+          state.stages
+        );
+      });
+
+      it('groups with others in same flex category', () => {
+        const newState = reducer(initialState, setFlexCategory(4, 'X'));
+        assert.deepEqual(
+          [
+            {flex_category: 'X', id: 101, position: 1, relativePosition: 1},
+            {flex_category: 'X', id: 102, position: 2, relativePosition: 2},
+            {flex_category: 'X', id: 104, position: 3, relativePosition: 3},
+            {flex_category: 'Y', id: 103, position: 4, relativePosition: 4}
+          ],
+          newState.stages
+        );
+      });
     });
   });
 });

--- a/apps/test/unit/lib/script-editor/StageCardTest.js
+++ b/apps/test/unit/lib/script-editor/StageCardTest.js
@@ -6,16 +6,18 @@ import sinon from 'sinon';
 import {UnconnectedStageCard as StageCard} from '@cdo/apps/lib/script-editor/StageCard';
 
 describe('StageCard', () => {
-  let reorderLevel, addLevel, setStageLockable, defaultProps;
+  let reorderLevel, addLevel, setStageLockable, setFlexCategory, defaultProps;
 
   beforeEach(() => {
     reorderLevel = sinon.spy();
     addLevel = sinon.spy();
     setStageLockable = sinon.spy();
+    setFlexCategory = sinon.spy();
     defaultProps = {
       reorderLevel,
       addLevel,
       setStageLockable,
+      setFlexCategory,
       stagesCount: 1,
       stage: {
         levels: [],

--- a/apps/test/unit/sites/studio/pages/levelbuilder_edit_script.js
+++ b/apps/test/unit/sites/studio/pages/levelbuilder_edit_script.js
@@ -23,7 +23,8 @@ describe('the level builder page init script', () => {
       levelKeyList: [],
       locales: [['English', 'en-US'], ['French', 'fr-FR']],
       script_families: ['coursea', 'csd1'],
-      version_year_options: ['2017', '2018']
+      version_year_options: ['2017', '2018'],
+      flex_category_map: {}
     });
   });
 

--- a/dashboard/app/views/scripts/_form.html.haml
+++ b/dashboard/app/views/scripts/_form.html.haml
@@ -23,7 +23,7 @@
                   locales: options_for_locale_select,
                   script_families: ScriptConstants::FAMILY_NAMES,
                   version_year_options: Script.get_version_year_options,
-                  flex_categories: I18n.t('flex_category')}
+                  flex_category_map: I18n.t('flex_category')}
   %script{src: minifiable_asset_path('js/scripts/_form.js'),
           data: {levelBuilderEditScript: scriptData.to_json}}
 

--- a/dashboard/app/views/scripts/_form.html.haml
+++ b/dashboard/app/views/scripts/_form.html.haml
@@ -22,7 +22,8 @@
                   stageLevelData: @script_file,
                   locales: options_for_locale_select,
                   script_families: ScriptConstants::FAMILY_NAMES,
-                  version_year_options: Script.get_version_year_options}
+                  version_year_options: Script.get_version_year_options,
+                  flex_categories: I18n.t('flex_category')}
   %script{src: minifiable_asset_path('js/scripts/_form.js'),
           data: {levelBuilderEditScript: scriptData.to_json}}
 


### PR DESCRIPTION
continuation of https://github.com/code-dot-org/code-dot-org/pull/30619.

this PR makes the following improvements to the stage editor gui:
* allow adding a new flex category to the script via dropdown
* allow editing a stage's flex category, making sure it stays grouped with other stages in its new flex category.
* shows flex category key and translated name in flex category heading

### screenshots

![edit-flex-category](https://user-images.githubusercontent.com/8001765/64392092-17d62b80-d000-11e9-9fb9-bd05001dcadf.gif)
