### PR TITLE
PL: don't allow workshop_organizer to be assigned as a permission

### DIFF
--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -53,6 +53,8 @@ class UserPermission < ActiveRecord::Base
     AUTHORIZED_TEACHER,
   ].freeze
 
+  ASSIGNABLE_PERMISSIONS = (VALID_PERMISSIONS - [WORKSHOP_ORGANIZER]).freeze
+
   validates_inclusion_of :permission, in: VALID_PERMISSIONS
 
   after_save :log_permission_save

--- a/dashboard/app/views/admin_users/permissions_form.html.haml
+++ b/dashboard/app/views/admin_users/permissions_form.html.haml
@@ -46,7 +46,7 @@
           %td
             %input{:hidden => true, :name => "user_id", :value => @user.id}
             .field
-              = select_tag :permission, options_for_select(UserPermission::VALID_PERMISSIONS)
+              = select_tag :permission, options_for_select(UserPermission::ASSIGNABLE_PERMISSIONS)
           %td
 %br
 %p View Users with selected Permission
@@ -78,7 +78,7 @@
 %br
 %p Grant selected Permission to a set of Users in bulk
 = form_tag url_for(action: 'bulk_grant_permission'), method: 'post', class: 'form-inline', enforce_utf8: false do
-  = select_tag :bulk_permission, options_for_select(UserPermission::VALID_PERMISSIONS, params[:bulk_permission]), class: 'form-control'
+  = select_tag :bulk_permission, options_for_select(UserPermission::ASSIGNABLE_PERMISSIONS, params[:bulk_permission]), class: 'form-control'
   = submit_tag('Assign', id: 'submitBulkAssignPermission')
   %p
   %p Please enter each email on a new line


### PR DESCRIPTION
This removes `workshop_organizer` from the list of assignable permissions.  It can still be used to view existing permissions though.

### No longer assignable

![Screenshot 2019-09-06 12 20 17](https://user-images.githubusercontent.com/2205926/64397737-90db8e80-d0a5-11e9-9da0-c78cf4ea1fd7.png)

![Screenshot 2019-09-06 12 20 24](https://user-images.githubusercontent.com/2205926/64397756-9df87d80-d0a5-11e9-8bb6-8ce534008541.png)

### Still viewable

![Screenshot 2019-09-06 12 25 15](https://user-images.githubusercontent.com/2205926/64397766-a5b82200-d0a5-11e9-8f64-ac97e3ee7f3b.png)
