### PR TITLE
Revert "Fix z-index for teacher panel & hamburger menu"

### DIFF
--- a/dashboard/app/assets/stylesheets/teacher-panel.scss
+++ b/dashboard/app/assets/stylesheets/teacher-panel.scss
@@ -17,8 +17,8 @@
   border-right: none;
   border-radius: 10px 0 0 10px;
 
-  /* must appear in front of <Overlay/>, whose z-index is 1020 */
-  z-index: 1021;
+  /* must appear in front of ProgressBubble */
+  z-index: 1000;
 
   .hide-handle,
   .show-handle {

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -42,9 +42,7 @@
 
   display: inline-block;
   float: right;
-  // We want the z-index to be greater than the teacher panel, which is currently 1021.
-  // Teacher panel z-index is defined in teacher-panel.scss
-  z-index: 1050;
+  z-index: 99;
   position: relative;
   font-size: 14px;
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#30599

This had some unintended Eyes failures where the main dropdown navigation's z-index is higher than we'd like it to be. Example from @nkiruka:
<img width="78" alt="Screen Shot 2019-09-06 at 9 06 15 AM" src="https://user-images.githubusercontent.com/9812299/64444178-629b8600-d088-11e9-88c8-f3bfb1807779.png">

Going to revert for now to do a little more tweaking