### PR TITLE
Upgrade react-sticky to prepare for React 16

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -175,7 +175,7 @@
     "react-redux": "~4.4.9",
     "react-router": "^3.2.3",
     "react-select": "^1.2.1",
-    "react-sticky": "~5.0.5",
+    "react-sticky": "^6.0.3",
     "react-tether": "^1.0.4",
     "react-tooltip": "^3.2.7",
     "react-virtualized": "^9.18.5",

--- a/apps/src/tutorialExplorer/filterHeader.jsx
+++ b/apps/src/tutorialExplorer/filterHeader.jsx
@@ -110,72 +110,80 @@ export default class FilterHeader extends React.Component {
       <div style={styles.header}>
         {this.props.backButton && <BackButton />}
 
-        <Sticky style={{zIndex: 1}}>
-          <div
-            style={getResponsiveValue({
-              xs: styles.barMobile,
-              md: styles.barDesktop
-            })}
-          >
-            {!this.props.mobileLayout && (
-              <div style={styles.full}>
-                {filterGroupGrade && (
-                  <FilterGroupHeaderSelection
-                    containerStyle={styles.filterGroupGradeContainer}
-                    filterGroup={filterGroupGrade}
-                    selection={this.props.selection['grade']}
-                    onUserInput={this.props.onUserInputFilter}
-                  />
-                )}
-                {filterGroupHeaderStudentExperience && (
-                  <FilterGroupHeaderSelection
-                    containerStyle={
-                      styles.filterGroupStudentExperienceContainer
-                    }
-                    filterGroup={filterGroupHeaderStudentExperience}
-                    selection={this.props.selection['student_experience']}
-                    onUserInput={this.props.onUserInputFilter}
-                  />
-                )}
-              </div>
-            )}
-
-            {this.props.mobileLayout && (
-              <div>
-                <div style={styles.left}>
-                  <span style={styles.mobileCount}>{tutorialCountString}</span>
-                </div>
-
-                <div style={styles.right}>
-                  {this.shouldShowOpenFiltersButton() && (
-                    <span>
-                      <button
-                        type="button"
-                        onClick={this.props.showModalFilters}
-                        style={styles.button}
-                        className="noFocusButton"
-                      >
-                        {i18n.filterHeaderShowFilters()}
-                      </button>
-                    </span>
+        <Sticky>
+          {({style}) => (
+            <div
+              style={{
+                ...style,
+                zIndex: 1,
+                ...getResponsiveValue({
+                  xs: styles.barMobile,
+                  md: styles.barDesktop
+                })
+              }}
+            >
+              {!this.props.mobileLayout && (
+                <div style={styles.full}>
+                  {filterGroupGrade && (
+                    <FilterGroupHeaderSelection
+                      containerStyle={styles.filterGroupGradeContainer}
+                      filterGroup={filterGroupGrade}
+                      selection={this.props.selection['grade']}
+                      onUserInput={this.props.onUserInputFilter}
+                    />
                   )}
-
-                  {this.shouldShowCloseFiltersButton() && (
-                    <span>
-                      <button
-                        type="button"
-                        onClick={this.props.hideModalFilters}
-                        style={styles.button}
-                        className="noFocusButton"
-                      >
-                        {i18n.filterHeaderHideFilters()}
-                      </button>
-                    </span>
+                  {filterGroupHeaderStudentExperience && (
+                    <FilterGroupHeaderSelection
+                      containerStyle={
+                        styles.filterGroupStudentExperienceContainer
+                      }
+                      filterGroup={filterGroupHeaderStudentExperience}
+                      selection={this.props.selection['student_experience']}
+                      onUserInput={this.props.onUserInputFilter}
+                    />
                   )}
                 </div>
-              </div>
-            )}
-          </div>
+              )}
+
+              {this.props.mobileLayout && (
+                <div>
+                  <div style={styles.left}>
+                    <span style={styles.mobileCount}>
+                      {tutorialCountString}
+                    </span>
+                  </div>
+
+                  <div style={styles.right}>
+                    {this.shouldShowOpenFiltersButton() && (
+                      <span>
+                        <button
+                          type="button"
+                          onClick={this.props.showModalFilters}
+                          style={styles.button}
+                          className="noFocusButton"
+                        >
+                          {i18n.filterHeaderShowFilters()}
+                        </button>
+                      </span>
+                    )}
+
+                    {this.shouldShowCloseFiltersButton() && (
+                      <span>
+                        <button
+                          type="button"
+                          onClick={this.props.hideModalFilters}
+                          style={styles.button}
+                          className="noFocusButton"
+                        >
+                          {i18n.filterHeaderHideFilters()}
+                        </button>
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </Sticky>
       </div>
     );

--- a/apps/test/unit/tutorialExplorer/filterHeaderTest.jsx
+++ b/apps/test/unit/tutorialExplorer/filterHeaderTest.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount} from 'enzyme';
+import {StickyContainer} from 'react-sticky';
 import {expect} from '../../util/configuredChai';
 import FilterHeader from '@cdo/apps/tutorialExplorer/filterHeader';
 import BackButton from '@cdo/apps/tutorialExplorer/backButton';
@@ -24,8 +25,10 @@ const DEFAULT_PROPS = {
 
 describe('FilterHeader', () => {
   it('renders simplest mobile view', () => {
-    const wrapper = shallow(
-      <FilterHeader {...DEFAULT_PROPS} mobileLayout={true} />
+    const wrapper = mount(
+      <StickyContainer>
+        <FilterHeader {...DEFAULT_PROPS} mobileLayout={true} />
+      </StickyContainer>
     );
     expect(wrapper).to.containMatchingElement(
       <span>{i18n.filterHeaderTutorialCountPlural({tutorial_count: 5})}</span>
@@ -38,12 +41,14 @@ describe('FilterHeader', () => {
   });
 
   it('renders open modal filters on mobile view', () => {
-    const wrapper = shallow(
-      <FilterHeader
-        {...DEFAULT_PROPS}
-        mobileLayout={true}
-        showingModalFilters={true}
-      />
+    const wrapper = mount(
+      <StickyContainer>
+        <FilterHeader
+          {...DEFAULT_PROPS}
+          mobileLayout={true}
+          showingModalFilters={true}
+        />
+      </StickyContainer>
     );
     expect(wrapper).to.containMatchingElement(
       <span>{i18n.filterHeaderTutorialCountPlural({tutorial_count: 5})}</span>
@@ -56,41 +61,49 @@ describe('FilterHeader', () => {
   });
 
   it('adds a back button if requested', () => {
-    const wrapper = shallow(
-      <FilterHeader {...DEFAULT_PROPS} backButton={true} />
+    const wrapper = mount(
+      <StickyContainer>
+        <FilterHeader {...DEFAULT_PROPS} backButton={true} />
+      </StickyContainer>
     );
     expect(wrapper).to.containMatchingElement(<BackButton />);
   });
 
   it('pluralizes result summary correctly', () => {
-    const noResults = shallow(
-      <FilterHeader
-        {...DEFAULT_PROPS}
-        mobileLayout={true}
-        filteredTutorialsCount={0}
-      />
+    const noResults = mount(
+      <StickyContainer>
+        <FilterHeader
+          {...DEFAULT_PROPS}
+          mobileLayout={true}
+          filteredTutorialsCount={0}
+        />
+      </StickyContainer>
     );
     expect(noResults).to.containMatchingElement(
       <span>{i18n.filterHeaderTutorialCountPlural({tutorial_count: 0})}</span>
     );
 
-    const oneResult = shallow(
-      <FilterHeader
-        {...DEFAULT_PROPS}
-        filteredTutorialsCount={1}
-        mobileLayout={true}
-      />
+    const oneResult = mount(
+      <StickyContainer>
+        <FilterHeader
+          {...DEFAULT_PROPS}
+          filteredTutorialsCount={1}
+          mobileLayout={true}
+        />
+      </StickyContainer>
     );
     expect(oneResult).to.containMatchingElement(
       <span>{i18n.filterHeaderTutorialCountSingle()}</span>
     );
 
-    const twoResults = shallow(
-      <FilterHeader
-        {...DEFAULT_PROPS}
-        filteredTutorialsCount={2}
-        mobileLayout={true}
-      />
+    const twoResults = mount(
+      <StickyContainer>
+        <FilterHeader
+          {...DEFAULT_PROPS}
+          filteredTutorialsCount={2}
+          mobileLayout={true}
+        />
+      </StickyContainer>
     );
     expect(twoResults).to.containMatchingElement(
       <span>{i18n.filterHeaderTutorialCountPlural({tutorial_count: 2})}</span>

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -12291,7 +12291,7 @@ raf@^3.1.0:
   dependencies:
     performance-now "~0.2.0"
 
-raf@^3.4.0:
+raf@^3.3.0, raf@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   dependencies:
@@ -12754,11 +12754,13 @@ react-split-pane@^0.1.84:
     react-lifecycles-compat "^3.0.4"
     react-style-proptype "^3.0.0"
 
-react-sticky@~5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/react-sticky/-/react-sticky-5.0.8.tgz#d5f85f96977f410081d792ab81886c622c5d8b14"
+react-sticky@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/react-sticky/-/react-sticky-6.0.3.tgz#7a18b643e1863da113d7f7036118d2a75d9ecde4"
+  integrity sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==
   dependencies:
     prop-types "^15.5.8"
+    raf "^3.3.0"
 
 react-style-proptype@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
[XTEAM-200](https://codedotorg.atlassian.net/browse/XTEAM-200): Upgrades [`react-sticky`](https://github.com/captivationsoftware/react-sticky) from 5.0.8 to 6.0.3 which is compatible with React 16, in preparation for our React 16 upgrade.

We only use this library for the sticky header on the tutorial explorer at https://code.org/learn.

`react-sticky` had a major breaking change in version 6: The interface for the `Sticky` component has changed.  Before, it rendered itself as a DOM element with appropriate sticky styles and took other components as children, like so:

```jsx
<StickyContainer>
  <Sticky>
    <h1>Sticky element</h1>
  </Sticky>
</StickyContainer>
```

As of version 6, `Sticky` itself does not render into the DOM. Instead it takes a function as a child and passes the appropriate sticky styles as a parameter, then renders the result of the function, giving consumers maximum control over the rendered output:

```jsx
<StickyContainer>
  <Sticky>
    {
      ({ style }) => <h1 style={style}>Sticky element</h1>
    }
  </Sticky>
</StickyContainer>
```

So I had to update `FilterHeader` to use this new style.  This also doesn't play nicely with enzyme shallow-rendering so I had to update all of the `FilterHeader` tests to use full rendering.

FilterHeader tests are passing now, and manually verified that the tutorial explorer is working as expected.