### PR TITLE
Upgrade react-bootstrap for React 16

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -160,7 +160,7 @@
     "raw-loader": "^0.5.1",
     "react": "~15.4.0",
     "react-addons-test-utils": "~15.4.0",
-    "react-bootstrap": "0.30.1",
+    "react-bootstrap": "0.30.10",
     "react-color": "^2.17.3",
     "react-datepicker": "1.6.0",
     "react-dom": "~15.4.0",

--- a/apps/package.json
+++ b/apps/package.json
@@ -160,7 +160,7 @@
     "raw-loader": "^0.5.1",
     "react": "~15.4.0",
     "react-addons-test-utils": "~15.4.0",
-    "react-bootstrap": "0.31.5",
+    "react-bootstrap": "^0.32.4",
     "react-color": "^2.17.3",
     "react-datepicker": "1.6.0",
     "react-dom": "~15.4.0",

--- a/apps/package.json
+++ b/apps/package.json
@@ -160,7 +160,7 @@
     "raw-loader": "^0.5.1",
     "react": "~15.4.0",
     "react-addons-test-utils": "~15.4.0",
-    "react-bootstrap": "0.30.10",
+    "react-bootstrap": "0.31.5",
     "react-color": "^2.17.3",
     "react-datepicker": "1.6.0",
     "react-dom": "~15.4.0",

--- a/apps/package.json
+++ b/apps/package.json
@@ -51,6 +51,7 @@
     "@code-dot-org/p5.play": "^1.3.12-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",
+    "@react-bootstrap/pagination": "^1.0.0",
     "@storybook/addon-actions": "^4.1.16",
     "@storybook/addon-info": "^3.3.15",
     "@storybook/addon-options": "^4.1.16",

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_response.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_response.jsx
@@ -106,11 +106,16 @@ export default class DetailViewResponse extends React.Component {
         );
 
         return (
-          <Panel header={heading} style={styles.panel}>
-            <Row>
-              <Col xs={scoredQuestion ? 9 : 12}>{renderedValue}</Col>
-              {scoredQuestion && <Col xs={3}>{this.renderScore()}</Col>}
-            </Row>
+          <Panel style={styles.panel}>
+            <Panel.Heading>
+              <Panel.Title>{heading}</Panel.Title>
+            </Panel.Heading>
+            <Panel.Body>
+              <Row>
+                <Col xs={scoredQuestion ? 9 : 12}>{renderedValue}</Col>
+                {scoredQuestion && <Col xs={3}>{this.renderScore()}</Col>}
+              </Row>
+            </Panel.Body>
           </Panel>
         );
       }

--- a/apps/src/code-studio/pd/application_dashboard/form_data_edit.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/form_data_edit.jsx
@@ -128,22 +128,26 @@ export default class FormDataEdit extends React.Component {
         </ButtonToolbar>
 
         {(this.state.parseError || this.state.saveErrors) && (
-          <Panel
-            style={styles.error}
-            header={<div style={styles.error}>Error</div>}
-          >
-            {this.state.parseError}
+          <Panel style={styles.error}>
+            <Panel.Heading>
+              <Panel.Title>
+                <div style={styles.error}>Error</div>
+              </Panel.Title>
+            </Panel.Heading>
+            <Panel.Body>
+              {this.state.parseError}
 
-            {this.state.saveErrors && (
-              <div>
-                Missing or invalid fields:
-                <ul>
-                  {this.state.saveErrors.map(e => (
-                    <li key={e}>{e}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
+              {this.state.saveErrors && (
+                <div>
+                  Missing or invalid fields:
+                  <ul>
+                    {this.state.saveErrors.map(e => (
+                      <li key={e}>{e}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </Panel.Body>
           </Panel>
         )}
 

--- a/apps/src/code-studio/pd/form_components/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components/FormController.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
-import {Button, Alert, FormGroup, Pagination} from 'react-bootstrap';
+import {Button, Alert, FormGroup} from 'react-bootstrap';
+import {Pagination} from '@react-bootstrap/pagination';
 import i18n from '@cdo/locale';
 
 const styles = {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.jsx
@@ -173,36 +173,38 @@ export default class ChoiceResponses extends React.Component {
 
     return (
       <Panel>
-        {this.props.question}
-        <table style={{marginTop: '1em'}}>
-          <tbody>
-            {this.props.perFacilitator
-              ? this.renderPerFacilitatorAnswerCounts()
-              : this.renderSingleAnswerCounts()}
-            {this.props.otherText && (
-              <tr>
-                <td>
-                  {this.formatPercentage(
-                    otherAnswers.length / this.getTotalRespondents()
-                  )}
-                </td>
-                <td style={{paddingLeft: '20px'}}>{otherAnswers.length}</td>
-                <td style={{paddingLeft: '20px'}}>{this.props.otherText}</td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-        {this.props.otherText && otherAnswers.length > 0 && (
-          <div>
-            <br />
-            {this.props.otherText}
-            <ul>
-              {_.compact(otherAnswers).map((answer, i) => (
-                <li key={i}>{answer}</li>
-              ))}
-            </ul>
-          </div>
-        )}
+        <Panel.Body>
+          {this.props.question}
+          <table style={{marginTop: '1em'}}>
+            <tbody>
+              {this.props.perFacilitator
+                ? this.renderPerFacilitatorAnswerCounts()
+                : this.renderSingleAnswerCounts()}
+              {this.props.otherText && (
+                <tr>
+                  <td>
+                    {this.formatPercentage(
+                      otherAnswers.length / this.getTotalRespondents()
+                    )}
+                  </td>
+                  <td style={{paddingLeft: '20px'}}>{otherAnswers.length}</td>
+                  <td style={{paddingLeft: '20px'}}>{this.props.otherText}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+          {this.props.otherText && otherAnswers.length > 0 && (
+            <div>
+              <br />
+              {this.props.otherText}
+              <ul>
+                {_.compact(otherAnswers).map((answer, i) => (
+                  <li key={i}>{answer}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </Panel.Body>
       </Panel>
     );
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
@@ -877,7 +877,12 @@ export class Workshop extends React.Component {
     return (
       <Row>
         <Col sm={12}>
-          <Panel header={header}>{content}</Panel>
+          <Panel>
+            <Panel.Heading>
+              <Panel.Title>{header}</Panel.Title>
+            </Panel.Heading>
+            <Panel.Body>{content}</Panel.Body>
+          </Panel>
         </Col>
       </Row>
     );

--- a/apps/src/templates/PaginationWrapper.jsx
+++ b/apps/src/templates/PaginationWrapper.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import Radium, {Style} from 'radium';
 import color from '../util/color';
-import Pagination from 'react-bootstrap/lib/Pagination';
+import {Pagination} from '@react-bootstrap/pagination';
 
 const styles = {
   label: {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1090,6 +1090,14 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
+"@react-bootstrap/pagination@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@react-bootstrap/pagination/-/pagination-1.0.0.tgz#7ebab5b23519e030e0f9f98f1d73c8178d58356b"
+  integrity sha1-frq1sjUZ4DDg+fmPHXPIF41YNWs=
+  dependencies:
+    prop-types "^15.5.8"
+    react-prop-types "^0.4.0"
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -793,6 +793,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.1.0"
 
+"@babel/runtime-corejs2@^7.0.0":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz#c3214c08ef20341af4187f1c9fbdc357fbec96b2"
+  integrity sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
@@ -4748,6 +4756,11 @@ core-js@^2.5.7:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
 
+core-js@^2.6.5:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -8628,7 +8641,7 @@ invariant@^2.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-invariant@^2.1.0, invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -9393,10 +9406,6 @@ karma@^1.7.0:
 kew@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
-
-keycode@^2.1.2:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.7.tgz#7b9255919f6cff562b09a064d222dca70b020f5c"
 
 keycode@^2.2.0:
   version "2.2.0"
@@ -12418,20 +12427,22 @@ react-addons-test-utils@~15.4.0:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-bootstrap@0.31.5:
-  version "0.31.5"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.31.5.tgz#57040fa8b1274e1e074803c21a1b895fdabea05a"
-  integrity sha512-xgDihgX4QvYHmHzL87faDBMDnGfYyqcrqV0TEbWY+JizePOG1vfb8M3xJN+6MJ3kUYqDtQSZ7v/Q6Y5YDrkMdA==
+react-bootstrap@^0.32.4:
+  version "0.32.4"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.32.4.tgz#8efc4cbfc4807215d75b7639bee0d324c8d740d1"
+  integrity sha512-xj+JfaPOvnvr3ow0aHC7Y3HaBKZNR1mm361hVxVzVX3fcdJNIrfiodbQ0m9nLBpNxiKG6FTU2lq/SbTDYT2vew==
   dependencies:
-    babel-runtime "^6.11.6"
+    "@babel/runtime-corejs2" "^7.0.0"
     classnames "^2.2.5"
     dom-helpers "^3.2.0"
-    invariant "^2.2.1"
-    keycode "^2.1.2"
-    prop-types "^15.5.10"
+    invariant "^2.2.4"
+    keycode "^2.2.0"
+    prop-types "^15.6.1"
     prop-types-extra "^1.0.1"
-    react-overlays "^0.7.4"
-    uncontrollable "^4.1.0"
+    react-overlays "^0.8.0"
+    react-prop-types "^0.4.0"
+    react-transition-group "^2.0.0"
+    uncontrollable "^5.0.0"
     warning "^3.0.0"
 
 react-color@^2.17.3:
@@ -12636,15 +12647,16 @@ react-onclickoutside@~5.11.1:
   dependencies:
     create-react-class "^15.5.x"
 
-react-overlays@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.4.tgz#ef2ec652c3444ab8aa014262b18f662068e56d5c"
-  integrity sha512-7vsooMx3siLAuEfTs8FYeP/lAORWWFXTO8PON3KgX0Htq1Oa+po6ioSjGyO0/GO5CVSMNhpWt6V2opeexHgBuQ==
+react-overlays@^0.8.0:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
+  integrity sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.2.1"
     prop-types "^15.5.10"
     prop-types-extra "^1.0.1"
+    react-transition-group "^2.2.0"
     warning "^3.0.0"
 
 react-paginate@^6.3.0:
@@ -12670,6 +12682,13 @@ react-portal@^3.2.0:
   integrity sha512-avb1FreAZAVCvNNyS2dCpxZiPYPJnAasHYPxdVBTROgNFeI+KSb+OoMHNsC1GbDawESCriPwCX+qKua6WSPIFw==
   dependencies:
     prop-types "^15.5.8"
+
+react-prop-types@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/react-prop-types/-/react-prop-types-0.4.0.tgz#f99b0bfb4006929c9af2051e7c1414a5c75b93d0"
+  integrity sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=
+  dependencies:
+    warning "^3.0.0"
 
 react-redux@~4.4.9:
   version "4.4.10"
@@ -12778,7 +12797,7 @@ react-tooltip@^3.2.7:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-transition-group@2.9.0:
+react-transition-group@2.9.0, react-transition-group@^2.2.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   dependencies:
@@ -15319,12 +15338,12 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
-uncontrollable@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
-  integrity sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=
+uncontrollable@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-5.1.0.tgz#7e9a1c50ea24e3c78b625e52d21ff3f758c7bd59"
+  integrity sha512-5FXYaFANKaafg4IVZXUNtGyzsnYEvqlr9wQ3WpZxFpEUxl29A3H6Q4G1Dnnorvq9TGOGATBApWR4YpLAh+F5hw==
   dependencies:
-    invariant "^2.1.0"
+    invariant "^2.2.4"
 
 underscore.string@^2.3.3, underscore.string@~2.3.3:
   version "2.3.3"

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3253,12 +3253,6 @@ babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-runtime@^5.8.38:
-  version "5.8.38"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
-  dependencies:
-    core-js "^1.0.0"
-
 babel-runtime@^6.0.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.5.0, babel-runtime@^6.9.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
@@ -5467,11 +5461,7 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-2.4.0.tgz#9bb4b245f637367b1fa670274272aa28fe06c367"
-
-"dom-helpers@^2.4.0 || ^3.0.0", dom-helpers@^3.3.1, dom-helpers@^3.4.0:
+"dom-helpers@^2.4.0 || ^3.0.0", dom-helpers@^3.2.0, dom-helpers@^3.3.1, dom-helpers@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   dependencies:
@@ -12051,7 +12041,7 @@ prop-types@^15.5.4, prop-types@^15.5.9:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.7.2:
+prop-types@^15.5.6, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   dependencies:
@@ -12420,16 +12410,18 @@ react-addons-test-utils@~15.4.0:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-bootstrap@0.30.1:
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.30.1.tgz#b264310e6f4ceb52d99dfd1fe26b05720b7673a5"
+react-bootstrap@0.30.10:
+  version "0.30.10"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.30.10.tgz#dbba6909595f2af4d91937db0f96ec8c2df2d1a8"
+  integrity sha1-27ppCVlfKvTZGTfbD5bsjC3y0ag=
   dependencies:
-    babel-runtime "^5.8.38"
+    babel-runtime "^6.11.6"
     classnames "^2.2.5"
-    dom-helpers "^2.4.0"
+    dom-helpers "^3.2.0"
     invariant "^2.2.1"
     keycode "^2.1.2"
-    react-overlays "^0.6.6"
+    prop-types "^15.5.6"
+    react-overlays "^0.6.12"
     react-prop-types "^0.4.0"
     uncontrollable "^4.0.1"
     warning "^3.0.0"
@@ -12631,12 +12623,13 @@ react-onclickoutside@~5.11.1:
   dependencies:
     create-react-class "^15.5.x"
 
-react-overlays@^0.6.6:
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.6.10.tgz#e7e52dad47f00a0fc784eb044428c3a9e874bfa3"
+react-overlays@^0.6.12:
+  version "0.6.12"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.6.12.tgz#a079c750cc429d7db4c7474a95b4b54033e255c3"
+  integrity sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM=
   dependencies:
     classnames "^2.2.5"
-    dom-helpers "^2.4.0"
+    dom-helpers "^3.2.0"
     react-prop-types "^0.4.0"
     warning "^3.0.0"
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -5461,7 +5461,7 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-"dom-helpers@^2.4.0 || ^3.0.0", dom-helpers@^3.2.0, dom-helpers@^3.3.1, dom-helpers@^3.4.0:
+"dom-helpers@^2.4.0 || ^3.0.0", dom-helpers@^3.2.0, dom-helpers@^3.2.1, dom-helpers@^3.3.1, dom-helpers@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   dependencies:
@@ -12026,6 +12026,14 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
+prop-types-extra@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.0.tgz#32609910ea2dcf190366bacd3490d5a6412a605f"
+  integrity sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==
+  dependencies:
+    react-is "^16.3.2"
+    warning "^3.0.0"
+
 prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -12041,7 +12049,7 @@ prop-types@^15.5.4, prop-types@^15.5.9:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.6, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   dependencies:
@@ -12410,20 +12418,20 @@ react-addons-test-utils@~15.4.0:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-bootstrap@0.30.10:
-  version "0.30.10"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.30.10.tgz#dbba6909595f2af4d91937db0f96ec8c2df2d1a8"
-  integrity sha1-27ppCVlfKvTZGTfbD5bsjC3y0ag=
+react-bootstrap@0.31.5:
+  version "0.31.5"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.31.5.tgz#57040fa8b1274e1e074803c21a1b895fdabea05a"
+  integrity sha512-xgDihgX4QvYHmHzL87faDBMDnGfYyqcrqV0TEbWY+JizePOG1vfb8M3xJN+6MJ3kUYqDtQSZ7v/Q6Y5YDrkMdA==
   dependencies:
     babel-runtime "^6.11.6"
     classnames "^2.2.5"
     dom-helpers "^3.2.0"
     invariant "^2.2.1"
     keycode "^2.1.2"
-    prop-types "^15.5.6"
-    react-overlays "^0.6.12"
-    react-prop-types "^0.4.0"
-    uncontrollable "^4.0.1"
+    prop-types "^15.5.10"
+    prop-types-extra "^1.0.1"
+    react-overlays "^0.7.4"
+    uncontrollable "^4.1.0"
     warning "^3.0.0"
 
 react-color@^2.17.3:
@@ -12571,6 +12579,11 @@ react-inspector@2.3.1, react-inspector@^2.3.0:
     is-dom "^1.0.9"
     prop-types "^15.6.1"
 
+react-is@^16.3.2:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+
 react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
@@ -12623,14 +12636,15 @@ react-onclickoutside@~5.11.1:
   dependencies:
     create-react-class "^15.5.x"
 
-react-overlays@^0.6.12:
-  version "0.6.12"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.6.12.tgz#a079c750cc429d7db4c7474a95b4b54033e255c3"
-  integrity sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM=
+react-overlays@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.7.4.tgz#ef2ec652c3444ab8aa014262b18f662068e56d5c"
+  integrity sha512-7vsooMx3siLAuEfTs8FYeP/lAORWWFXTO8PON3KgX0Htq1Oa+po6ioSjGyO0/GO5CVSMNhpWt6V2opeexHgBuQ==
   dependencies:
     classnames "^2.2.5"
-    dom-helpers "^3.2.0"
-    react-prop-types "^0.4.0"
+    dom-helpers "^3.2.1"
+    prop-types "^15.5.10"
+    prop-types-extra "^1.0.1"
     warning "^3.0.0"
 
 react-paginate@^6.3.0:
@@ -12656,12 +12670,6 @@ react-portal@^3.2.0:
   integrity sha512-avb1FreAZAVCvNNyS2dCpxZiPYPJnAasHYPxdVBTROgNFeI+KSb+OoMHNsC1GbDawESCriPwCX+qKua6WSPIFw==
   dependencies:
     prop-types "^15.5.8"
-
-react-prop-types@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/react-prop-types/-/react-prop-types-0.4.0.tgz#f99b0bfb4006929c9af2051e7c1414a5c75b93d0"
-  dependencies:
-    warning "^3.0.0"
 
 react-redux@~4.4.9:
   version "4.4.10"
@@ -15311,9 +15319,10 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
-uncontrollable@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.0.3.tgz#06ec76cb9e02914756085d9cea0354fc746b09b4"
+uncontrollable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
+  integrity sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=
   dependencies:
     invariant "^2.1.0"
 


### PR DESCRIPTION
[XTEAM-214](https://codedotorg.atlassian.net/browse/XTEAM-214): Upgrade [`react-bootstrap`](https://github.com/react-bootstrap/react-bootstrap) to the latest 0.x version (supporting Bootstrap 3) to be compatible with React 16.

There was a [breaking change to `Panel`](https://github.com/react-bootstrap/react-bootstrap/pull/1769) in 0.32.0 that required changes in all the places we use it.  Manually verified that panels on the workshop dashboard still render correctly:

![image](https://user-images.githubusercontent.com/1615761/64463053-78746f80-d0b7-11e9-8fa6-fbcfa6476bb1.png)

0.32.0 also includes a significant breaking change to [`Pagination`](https://github.com/react-bootstrap/react-bootstrap/pull/2587) which we use in several places.  They've provided [`@react-bootstrap/pagination`](https://github.com/react-bootstrap/pagination) as a replacement.  It's unsupported, but should be sufficient to unblock our upgrade and is something we'd replace when we switched to a 1.x release of `react-bootstrap` anyway.

Pagination still working in the animation library:

![Peek 2019-09-06 12-32](https://user-images.githubusercontent.com/1615761/64455399-6e944180-d0a2-11e9-935a-2b989e7c3f54.gif)
