### PR TITLE
Revert "Revert "Fix z-index for teacher panel & hamburger menu""

### DIFF
--- a/dashboard/app/assets/stylesheets/teacher-panel.scss
+++ b/dashboard/app/assets/stylesheets/teacher-panel.scss
@@ -17,7 +17,7 @@
   border-right: none;
   border-radius: 10px 0 0 10px;
 
-  /* must appear in front of <Overlay/>, whose z-index is 1020 */
+  /* Must appear in front of <Overlay/>, whose z-index is 1020. */
   z-index: 1021;
 
   .hide-handle,

--- a/dashboard/app/assets/stylesheets/teacher-panel.scss
+++ b/dashboard/app/assets/stylesheets/teacher-panel.scss
@@ -17,8 +17,8 @@
   border-right: none;
   border-radius: 10px 0 0 10px;
 
-  /* must appear in front of ProgressBubble */
-  z-index: 1000;
+  /* must appear in front of <Overlay/>, whose z-index is 1020 */
+  z-index: 1021;
 
   .hide-handle,
   .show-handle {

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -42,9 +42,6 @@
 
   display: inline-block;
   float: right;
-  // We want the z-index to be greater than the teacher panel, which is currently 1021.
-  // Teacher panel z-index is defined in teacher-panel.scss
-  z-index: 1050;
   position: relative;
   font-size: 14px;
 
@@ -65,7 +62,9 @@
     position: absolute;
     top: 55px;
     background-color: $teal;
-    z-index: 99;
+    // We want the z-index to be greater than the teacher panel, which is currently 1021.
+    // Teacher panel z-index is defined in teacher-panel.scss
+    z-index: 1022;
     max-height: 100vh;
     overflow-y: auto;
     padding-top: 10px;

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -42,7 +42,9 @@
 
   display: inline-block;
   float: right;
-  z-index: 99;
+  // We want the z-index to be greater than the teacher panel, which is currently 1021.
+  // Teacher panel z-index is defined in teacher-panel.scss
+  z-index: 1050;
   position: relative;
   font-size: 14px;
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#30624 and re-applies the original PR (#30599) with a fix

In the original PR, I was updating the z-index on the `#hamburger` element, but should have been updating `#hamburger-contents`. However, this required removing `z-index: 99;` from `#hamburger` because changing the z-index on the child element (`#hamburger-contents`) has no effect if the parent has already defined a z-index. TIL!