### PR TITLE
Move marginBottom to containing div

### DIFF
--- a/apps/src/code-studio/components/IconLibrary.jsx
+++ b/apps/src/code-studio/components/IconLibrary.jsx
@@ -23,7 +23,7 @@ export default class IconLibrary extends React.Component {
   render() {
     return (
       <div>
-        <div style={{width: '300px', float: 'right'}}>
+        <div style={{width: '300px', float: 'right', marginBottom: 10}}>
           <SearchBar
             onChange={this.search}
             placeholderText={i18n.iconSearchPlaceholder()}

--- a/apps/src/code-studio/components/SoundLibrary.jsx
+++ b/apps/src/code-studio/components/SoundLibrary.jsx
@@ -74,7 +74,8 @@ const styles = {
   },
   searchBarContainer: {
     width: '300px',
-    float: 'right'
+    float: 'right',
+    marginBottom: 10
   }
 };
 

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -119,7 +119,7 @@ class AnimationPickerBody extends React.Component {
     let hideUploadOption = this.props.spriteLab;
 
     return (
-      <div>
+      <div style={{marginBottom: 10}}>
         <h1 style={styles.title}>{msg.animationPicker_title()}</h1>
         {!this.props.is13Plus && !hideUploadOption && (
           <WarningLabel>{msg.animationPicker_warning()}</WarningLabel>

--- a/apps/src/templates/SearchBar.jsx
+++ b/apps/src/templates/SearchBar.jsx
@@ -13,13 +13,11 @@ const styles = {
     width: '100%',
     boxSizing: 'border-box',
     padding: '3px 7px',
-    marginLeft: 0,
-    marginRight: 0,
+    margin: 0,
     borderStyle: 'solid',
     borderWidth: BORDER_WIDTH,
     borderColor: BORDER_COLOR,
     borderRadius: BORDER_RADIUS,
-    marginBottom: 10,
     textIndent: 22
   },
   icon: {

--- a/apps/src/templates/SearchBar.story.jsx
+++ b/apps/src/templates/SearchBar.story.jsx
@@ -6,11 +6,7 @@ export default storybook => {
     {
       name: 'Search Bar',
       story: () => (
-        <SearchBar
-          placeholderText={'Some Text'}
-          styles={{}}
-          onChange={() => {}}
-        />
+        <SearchBar placeholderText={'Some Text'} onChange={() => {}} />
       )
     }
   ]);


### PR DESCRIPTION
No visual change for Icon, Sound, or Animation library search bars.
Making this change so that the SearchBar fits better in the Data Library Pane, where we don't want that much space on the bottom.

Also quick cleanup to remove unused styles prop from storybook entry.