### PR TITLE
Exported Apps: Reduce black/white flashing during load

### DIFF
--- a/apps/src/templates/export/expo/App.js.ejs
+++ b/apps/src/templates/export/expo/App.js.ejs
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Platform, StyleSheet, View, WebView } from 'react-native';
+import { AppLoading } from 'expo';
 
 import CustomAsset from './CustomAsset';
 import DataWarning from './DataWarning';
@@ -55,7 +56,7 @@ export default class App extends React.Component {
     });
   };
 
-  onLoadEnd = () => {
+  onLoad = () => {
     //
     // NOTE: wait for 2 frames after the WebView says it is loaded before we set our state to
     // loaded and remove the "cover" View (without this delay, we see a white flash from the WebView)
@@ -98,6 +99,12 @@ export default class App extends React.Component {
       );
     }
 
+    if (!indexUri) {
+      return (
+        <AppLoading />
+      );
+    }
+
     return (
       <View onLayout={this.onLayout} style={styles.container}>
         {!!height && indexUri && <View style={this.webViewContainerStyle()}>
@@ -112,10 +119,10 @@ export default class App extends React.Component {
             scrollEnabled={false}
             bounces={false}
             scalesPageToFit={Platform.OS === 'ios'}
-            onLoadEnd={this.onLoadEnd}
+            onLoad={this.onLoad}
           />
-          {!loaded && <View style={styles.cover} />}
         </View>}
+        {!loaded && <View style={styles.cover} />}
       </View>
     );
   }
@@ -129,7 +136,7 @@ const styles = StyleSheet.create({
   },
   cover: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'black',
+    backgroundColor: 'white',
   },
   webViewIOS: {
     backgroundColor: 'black',


### PR DESCRIPTION
A few changes to polish the Exported App experience as we prepare to launch a Beta for Android exported apps:

* Show the `AppLoading` component while the HTML content is being downloaded and installed on the device (this keeps the splash screen visible - see [here](https://docs.expo.io/versions/latest/sdk/app-loading/))
* Use the `onLoad` event instead of the `onLoadEnd` event from the `WebView`. Experimentally proved that this event fires after `onLoadEnd`, so we'd prefer to use it. See docs [here](https://facebook.github.io/react-native/docs/webview#onload)
* Changed the "cover" element to be white instead of black (which matches the splash screen) and made it cover the entire screen instead of just the `WebView`. This element appears over top of the `WebView` while it is loading the HTML content. Once the load completes, this element is removed and the app is ready for use.
