### PR TITLE
Fix survey sync

### DIFF
--- a/dashboard/bin/sync_jotforms
+++ b/dashboard/bin/sync_jotforms
@@ -36,8 +36,8 @@ def sync_questions
 end
 
 def main
-  sync_submissions
   sync_questions
+  sync_submissions
 end
 
 main

--- a/dashboard/bin/sync_jotforms
+++ b/dashboard/bin/sync_jotforms
@@ -17,10 +17,12 @@ JOT_FORM_CLASSES = [
 
 def sync_submissions
   JOT_FORM_CLASSES.each do |survey_class|
-    survey_class.sync_from_jotform
-  rescue => e
-    # One survey class fails to sync doesn't stop other from syncing
-    Honeybadger.notify e
+    survey_class.all_form_ids.each do |form_id|
+      survey_class.sync_from_jotform form_id
+    rescue => e
+      # One form fails to sync doesn't stop other forms from syncing
+      Honeybadger.notify e
+    end
   end
 end
 

--- a/dashboard/bin/sync_jotforms
+++ b/dashboard/bin/sync_jotforms
@@ -15,27 +15,18 @@ JOT_FORM_CLASSES = [
   Pd::MiscSurvey
 ].freeze
 
-def sync_submissions
-  JOT_FORM_CLASSES.each do |survey_class|
-    survey_class.sync_from_jotform
-  rescue => e
-    # One survey class fails to sync doesn't stop other from syncing
-    Honeybadger.notify e
-  end
-end
-
-def sync_questions
+def sync_survey_questions
   Pd::SurveyQuestion.all.each do |survey|
     survey.sync_from_jotform
   rescue => e
-    # One form fails to sync doesn't stop other forms from syncing
+    # One form fails to sync doesn't stop syncing other forms
     Honeybadger.notify e
   end
 end
 
 def main
-  sync_submissions
-  sync_questions
+  JOT_FORM_CLASSES.each(&:sync_from_jotform)
+  sync_survey_questions
 end
 
 main

--- a/dashboard/bin/sync_jotforms
+++ b/dashboard/bin/sync_jotforms
@@ -15,18 +15,27 @@ JOT_FORM_CLASSES = [
   Pd::MiscSurvey
 ].freeze
 
-def sync_survey_questions
+def sync_submissions
+  JOT_FORM_CLASSES.each do |survey_class|
+    survey_class.sync_from_jotform
+  rescue => e
+    # One survey class fails to sync doesn't stop other from syncing
+    Honeybadger.notify e
+  end
+end
+
+def sync_questions
   Pd::SurveyQuestion.all.each do |survey|
     survey.sync_from_jotform
   rescue => e
-    # One form fails to sync doesn't stop syncing other forms
+    # One form fails to sync doesn't stop other forms from syncing
     Honeybadger.notify e
   end
 end
 
 def main
-  JOT_FORM_CLASSES.each(&:sync_from_jotform)
-  sync_survey_questions
+  sync_submissions
+  sync_questions
 end
 
 main

--- a/dashboard/bin/sync_jotforms
+++ b/dashboard/bin/sync_jotforms
@@ -7,6 +7,7 @@ require_relative '../../lib/cdo/only_one'
 exit unless only_one_running?(__FILE__)
 
 require_relative '../config/environment'
+require 'honeybadger/ruby'
 
 JOT_FORM_CLASSES = [
   Pd::WorkshopFacilitatorDailySurvey,
@@ -14,8 +15,18 @@ JOT_FORM_CLASSES = [
   Pd::MiscSurvey
 ].freeze
 
+def sync_survey_questions
+  Pd::SurveyQuestion.all.each do |survey|
+    survey.sync_from_jotform
+  rescue => e
+    # One form fails to sync doesn't stop syncing other forms
+    Honeybadger.notify e
+  end
+end
+
 def main
   JOT_FORM_CLASSES.each(&:sync_from_jotform)
+  sync_survey_questions
 end
 
 main

--- a/dashboard/lib/pd/jot_form/constants.rb
+++ b/dashboard/lib/pd/jot_form/constants.rb
@@ -21,6 +21,7 @@ module Pd
         TYPE_PAGEBREAK = 'pagebreak'.freeze,
         TYPE_HEAD = 'head'.freeze,
         TYPE_WIDGET = 'widget'.freeze,
+        TYPE_IMAGE = 'image'.freeze,
       ].freeze
 
       ANSWER_TYPES = [


### PR DESCRIPTION
2 images were added to AYW survey forms [92125650301142](https://jotform.com/build/92125650301142), and [92125614667157](https://jotform.com/build/92125614667157). Since image type is not supported, it broke out survey syncing logic, resulting in thousands of failures in 
https://app.honeybadger.io/projects/45435/faults/53995453
https://app.honeybadger.io/projects/45435/faults/51538435

This change fixes the issue by
1. Add _image_ to ignored type.
2. Refactor survey submissions syncing code to isolate syncing submissions of each form. This prevents failures from syncing one form or 1 survey class from stopping others to sync. 
3. Add syncing survey questions to keep submissions and questions in sync.
