### PR TITLE
Show links to let platformization partners edit scripts and clone levels

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -292,7 +292,8 @@ class LevelsController < ApplicationController
       old_level = Level.find(params[:level_id])
 
       begin
-        @level = old_level.clone_with_name(params[:name])
+        editor_experiment = Experiment.get_editor_experiment(current_user)
+        @level = old_level.clone_with_name(params[:name], editor_experiment: editor_experiment)
       rescue ArgumentError => e
         render(status: :not_acceptable, text: e.message) && return
       rescue ActiveRecord::RecordInvalid => invalid

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -233,6 +233,7 @@ class Ability
     if user.persisted?
       editor_experiment = Experiment.get_editor_experiment(user)
       if editor_experiment
+        can :clone, Level
         can :manage, Level, editor_experiment: editor_experiment
         can [:edit, :update], Script, editor_experiment: editor_experiment
       end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -559,7 +559,9 @@ class Level < ActiveRecord::Base
   def clone_with_name(new_name, editor_experiment: nil)
     level = dup
     # specify :published to make should_write_custom_level_file? return true
-    level.update!(name: new_name, parent_level_id: id, published: true)
+    level_params = {name: new_name, parent_level_id: id, published: true}
+    level_params[:editor_experiment] = editor_experiment if editor_experiment
+    level.update!(level_params)
     level
   end
 

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -8,8 +8,8 @@
       %li= link_to "see callouts (#{@level.available_callouts(@script_level).count})", show_callouts: '1'
       - if @level.is_a? Gamelab
         %li= link_to 'view animation JSON', '', onclick: 'window.viewExportableAnimationList(); return false'
-      - if can? :edit, @level
-        - if Rails.application.config.levelbuilder_mode
+      - if Rails.application.config.levelbuilder_mode
+        - if can? :edit, @level
           %li
             = link_to '[E]dit', edit_level_path(@level), { accesskey: 'e', title: "Edit this level. Can use the browser-dependent accesskey shortcut for quick access." }
             - if @level.is_a? Blockly
@@ -61,10 +61,10 @@
               = 'template: '
               = link_to project_template_level_name, level_path(project_template_level)
               = link_to '[E]', edit_level_path(project_template_level)
-        - elsif @script_level
-          %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level)).to_s
-      - else
-        %li (Cannot edit)
+        - else
+          %li (Cannot edit)
+      - elsif @script_level
+        %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level)).to_s
 
     -# Include any BubbleChoice parent script_levels in script_level list.
     - parent_levels = BubbleChoice.parent_levels(@level.name)

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -1,4 +1,4 @@
-- if current_user && (current_user.levelbuilder? || current_user.project_validator?)
+- if current_user && (current_user.levelbuilder? || current_user.project_validator? || Experiment.get_editor_experiment(current_user))
   = render layout: 'shared/extra_links' do
     %strong= @level.name
     %ul

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -26,7 +26,11 @@
               - unless @level.uses_droplet?
                 %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
                   Copy workspace to clipboard
+        - else
+          %li (Cannot edit)
+        - if can? :delete, @level
           %li= link_to 'delete', level_path(@level), method: :delete, data: { confirm: t('crud.confirm') }, style: 'color: red'
+        - if can? :clone, @level
           %li
             = link_to 'clone', '', onclick: "$('#clone_#{@level.id}').toggle(); return false;"
             %div{class: 'clone_level', id: "clone_#{@level.id}", style: 'display: none;'}
@@ -39,30 +43,29 @@
               %script{src: minifiable_asset_path('js/levelbuilder.js')}
             :javascript
               window.levelbuilder.ajaxSubmit('.clone_level');
-          -if @level.is_a? LevelGroup
-            %li
-              sublevels
-              %ol
-                - @level.properties['pages'].each do |page|
-                  - page['levels'].each do |level_name|
-                    %li= link_to level_name, level_path(Level.find_by_name(level_name))
-          - if contained_level_names = @level.properties['contained_level_names']
-            %li
-              contained levels
-              %ol
-                - contained_level_names.each do |contained_level_name|
-                  - contained_level = Level.find_by_name(contained_level_name)
-                  %li
-                    = link_to contained_level_name, level_path(contained_level)
-                    = link_to '[E]', edit_level_path(contained_level)
-          - if project_template_level_name = @level.properties['project_template_level_name']
-            - project_template_level = Level.find_by_name(project_template_level_name)
-            %li
-              = 'template: '
-              = link_to project_template_level_name, level_path(project_template_level)
-              = link_to '[E]', edit_level_path(project_template_level)
-        - else
-          %li (Cannot edit)
+        -if @level.is_a? LevelGroup
+          %li
+            sublevels
+            %ol
+              - @level.properties['pages'].each do |page|
+                - page['levels'].each do |level_name|
+                  %li= link_to level_name, level_path(Level.find_by_name(level_name))
+        - if contained_level_names = @level.properties['contained_level_names']
+          %li
+            contained levels
+            %ol
+              - contained_level_names.each do |contained_level_name|
+                - contained_level = Level.find_by_name(contained_level_name)
+                %li
+                  = link_to contained_level_name, level_path(contained_level)
+                  = link_to '[E]', edit_level_path(contained_level)
+        - if project_template_level_name = @level.properties['project_template_level_name']
+          - project_template_level = Level.find_by_name(project_template_level_name)
+          %li
+            = 'template: '
+            = link_to project_template_level_name, level_path(project_template_level)
+            = link_to '[E]', edit_level_path(project_template_level)
+
       - elsif @script_level
         %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level)).to_s
 

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -51,7 +51,7 @@
         %br/
         %br/
 
-  - if current_user && current_user.permission?(UserPermission::LEVELBUILDER)
+  - if can? :edit, @script
     -# Show all the levels, their names, and instructions in the extra links box.
     = render layout: 'shared/extra_links' do
       %strong= @script.name

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -780,6 +780,7 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test 'external markdown levels will render <user_id/> as the actual user id' do
+    File.stubs(:write)
     dsl_text = <<DSL
 name 'user_id_replace'
 title 'title for user_id_replace'

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -705,6 +705,23 @@ class LevelsControllerTest < ActionController::TestCase
     assert_equal "/levels/#{new_level.id}/edit", URI(JSON.parse(@response.body)['redirect']).path
   end
 
+  test "platformization partner should own cloned level" do
+    sign_out @levelbuilder
+    sign_in @platformization_partner
+
+    game = Game.find_by_name("Custom")
+    old = create(:level, game_id: game.id, name: "Fun Level")
+    assert_creates(Level) do
+      post :clone, params: {level_id: old.id, name: "Fun Level (copy 1)"}
+    end
+
+    new_level = assigns(:level)
+    assert_equal new_level.game, old.game
+    assert_equal new_level.name, "Fun Level (copy 1)"
+    assert_equal "/levels/#{new_level.id}/edit", URI(JSON.parse(@response.body)['redirect']).path
+    assert_equal 'platformization-partners', new_level.editor_experiment
+  end
+
   test 'cannot update level name with just a case change' do
     level = create :level, name: 'original name'
 


### PR DESCRIPTION
### Background

Finishes [LP-694](https://codedotorg.atlassian.net/browse/LP-694)

Also see [tech spec](https://docs.google.com/document/d/1aigN_ziWIVQJ-mZgz0R1eh8xOrYUXQrJtx_Mza-HWgk/edit#heading=h.7kd0im68meug)

### Description

* shows script edit link on script overview pages which parter owns. these look identical to how they look for levelbuilders today:

  ![Screen Shot 2019-09-09 at 3 36 50 PM](https://user-images.githubusercontent.com/8001765/64571122-af48c080-d317-11e9-8081-4598c536ee45.png)

* show full level extra links to partners on levels they own:

  ![Screen Shot 2019-09-09 at 3 39 03 PM](https://user-images.githubusercontent.com/8001765/64571209-fb940080-d317-11e9-9e04-a1aa2aa878ed.png)

* show only the clone link to partners on levels they do not own:

  ![Screen Shot 2019-09-09 at 3 39 45 PM](https://user-images.githubusercontent.com/8001765/64571243-1ebeb000-d318-11e9-8fee-27ceb27fa36d.png)
