### PR TITLE
New coat of paint for /levels

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -65,7 +65,7 @@ class LevelsController < ApplicationController
     levels = levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
     @levels = levels.page(params[:page]).per(LEVELS_PER_PAGE)
     @level_types = LEVEL_CLASSES.map(&:name)
-    @scripts = Script.pluck(:name, :id)
+    @scripts = Script.valid_scripts(current_user).pluck(:name, :id).sort_by {|a| a[0]}
   end
 
   # GET /levels/1

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -62,9 +62,7 @@ class LevelsController < ApplicationController
     levels = Level.order(updated_at: :desc)
     levels = levels.where('levels.name LIKE ?', "%#{params[:name]}%") if params[:name]
     levels = levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
-    if params[:script_id].present?
-      levels = levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id])
-    end
+    levels = levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
     @levels = levels.page(params[:page]).per(LEVELS_PER_PAGE)
     @level_types = LEVEL_CLASSES.map(&:name)
     @scripts = Script.pluck(:name, :id)

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -14,7 +14,7 @@ class LevelsController < ApplicationController
 
   before_action :set_level, only: [:show, :edit, :update, :destroy]
 
-  LEVELS_PER_PAGE = 100
+  LEVELS_PER_PAGE = 30
 
   # All level types that can be requested via /levels/new
   LEVEL_CLASSES = [

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -293,7 +293,7 @@ class LevelsController < ApplicationController
   def clone
     if params[:name]
       # Clone existing level and open edit page
-      old_level = Level.find(params[:level_id])
+      old_level = @level
 
       begin
         editor_experiment = Experiment.get_editor_experiment(current_user)

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -290,23 +290,16 @@ class LevelsController < ApplicationController
   end
 
   # POST /levels/1/clone?name=new_name
+  # Clone existing level and open edit page
   def clone
-    if params[:name]
-      # Clone existing level and open edit page
-      old_level = @level
-
-      begin
-        editor_experiment = Experiment.get_editor_experiment(current_user)
-        @level = old_level.clone_with_name(params[:name], editor_experiment: editor_experiment)
-      rescue ArgumentError => e
-        render(status: :not_acceptable, text: e.message) && return
-      rescue ActiveRecord::RecordInvalid => invalid
-        render(status: :not_acceptable, text: invalid) && return
-      end
-      render json: {redirect: edit_level_url(@level)}
-    else
-      render status: :not_acceptable, text: 'New name required to clone level'
-    end
+    new_name = params.require(:name)
+    editor_experiment = Experiment.get_editor_experiment(current_user)
+    @new_level = @level.clone_with_name(new_name, editor_experiment: editor_experiment)
+    render json: {redirect: edit_level_url(@new_level)}
+  rescue ArgumentError => e
+    render(status: :not_acceptable, text: e.message)
+  rescue ActiveRecord::RecordInvalid => invalid
+    render(status: :not_acceptable, text: invalid)
   end
 
   def embed_level

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -60,10 +60,14 @@ class LevelsController < ApplicationController
   # GET /levels.json
   def index
     levels = Level.order(updated_at: :desc)
-    levels = levels.where('name LIKE ?', "%#{params[:name]}%") if params[:name]
-    levels = levels.where('type = ?', params[:level_type]) if params[:level_type].present?
+    levels = levels.where('levels.name LIKE ?', "%#{params[:name]}%") if params[:name]
+    levels = levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
+    if params[:script_id].present?
+      levels = levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id])
+    end
     @levels = levels.page(params[:page]).per(LEVELS_PER_PAGE)
     @level_types = LEVEL_CLASSES.map(&:name)
+    @scripts = Script.pluck(:name, :id)
   end
 
   # GET /levels/1

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -59,11 +59,11 @@ class LevelsController < ApplicationController
   # GET /levels
   # GET /levels.json
   def index
-    levels = Level.order(updated_at: :desc)
-    levels = levels.where('levels.name LIKE ?', "%#{params[:name]}%") if params[:name]
-    levels = levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
-    levels = levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
-    @levels = levels.page(params[:page]).per(LEVELS_PER_PAGE)
+    @levels = @levels.order(updated_at: :desc)
+    @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%") if params[:name]
+    @levels = @levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
+    @levels = @levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
+    @levels = @levels.page(params[:page]).per(LEVELS_PER_PAGE)
     @level_types = LEVEL_CLASSES.map(&:name)
     @scripts = Script.valid_scripts(current_user).pluck(:name, :id).sort_by {|a| a[0]}
   end

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -61,7 +61,9 @@ class LevelsController < ApplicationController
   def index
     levels = Level.order(updated_at: :desc)
     levels = levels.where('name LIKE ?', "%#{params[:name]}%") if params[:name]
+    levels = levels.where('type = ?', params[:level_type]) if params[:level_type].present?
     @levels = levels.page(params[:page]).per(LEVELS_PER_PAGE)
+    @level_types = LEVEL_CLASSES.map(&:name)
   end
 
   # GET /levels/1

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -48,6 +48,7 @@ class Ability
       Pd::InternationalOptIn,
       :maker_discount
     ]
+    cannot :index, Level
 
     if user.persisted?
       can :manage, user

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -234,7 +234,7 @@ class Ability
     if user.persisted?
       editor_experiment = Experiment.get_editor_experiment(user)
       if editor_experiment
-        can :clone, Level
+        can :clone, Level, &:custom?
         can :manage, Level, editor_experiment: editor_experiment
         can [:edit, :update], Script, editor_experiment: editor_experiment
       end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -234,6 +234,7 @@ class Ability
     if user.persisted?
       editor_experiment = Experiment.get_editor_experiment(user)
       if editor_experiment
+        can :index, Level
         can :clone, Level, &:custom?
         can :manage, Level, editor_experiment: editor_experiment
         can [:edit, :update], Script, editor_experiment: editor_experiment

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -221,7 +221,7 @@ class Ability
       ]
 
       # Only custom levels are editable.
-      cannot [:update, :destroy], Level do |level|
+      cannot [:clone, :update, :destroy], Level do |level|
         !level.custom?
       end
 

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -34,7 +34,7 @@
           %li
             = link_to 'clone', '', onclick: "$('#clone_#{@level.id}').toggle(); return false;"
             %div{class: 'clone_level', id: "clone_#{@level.id}", style: 'display: none;'}
-              = form_tag level_clone_path(@level), method: :post, remote: true do
+              = form_tag clone_level_path(@level), method: :post, remote: true do
                 = label_tag 'New name:'
                 = text_field_tag :name, @level.name
                 = hidden_field_tag :authenticity_token, form_authenticity_token

--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -1,15 +1,22 @@
 - content_for(:head) do
   %script{src: minifiable_asset_path('js/levelbuilder.js')}
   :scss
-    .controls-column > a {
-      &:hover {
-        text-decoration: none;
-      }
-      &:first-of-type {
-        margin-left: 1em;
-      }
-      &:last-of-type {
-        margin-right: 1em;
+    .main table {
+      width: 100%;
+    }
+    .controls-column {
+      width: 1%;
+      white-space: nowrap;
+      > a {
+        &:hover {
+          text-decoration: none;
+        }
+        &:first-of-type {
+          margin-left: 1em;
+        }
+        &:last-of-type {
+          margin-right: 1em;
+        }
       }
     }
 
@@ -32,7 +39,7 @@
 %table
   %thead
     %tr
-      %th
+      %th.controls-column
       %th Name
       %th Type
   %tbody

--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -5,6 +5,10 @@
 = form_tag levels_path, method: :get do
   = label_tag 'Filter by name:'
   = text_field_tag :name, params[:name], autofocus: true
+  = label_tag 'Filter by type:'
+  - level_type_options = [['All types', '']].concat @level_types.map {|x| [x, x]}
+  = select_tag :level_type, options_for_select(level_type_options, params[:level_type])
+  = submit_tag "Search"
 = paginate @levels
 %table
   %thead

--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -1,5 +1,17 @@
 - content_for(:head) do
   %script{src: minifiable_asset_path('js/levelbuilder.js')}
+  :scss
+    .controls-column > a {
+      &:hover {
+        text-decoration: none;
+      }
+      &:first-of-type {
+        margin-left: 1em;
+      }
+      &:last-of-type {
+        margin-right: 1em;
+      }
+    }
 
 %h1 Levels
 = form_tag levels_path, method: :get do
@@ -13,25 +25,27 @@
 %table
   %thead
     %tr
-      %th{ width:100 } Levels
-      %th{ width:100 } Type
-      %th{ width:300 }
+      %th
+      %th Name
+      %th Type
   %tbody
     - @levels.each do |level|
       %tr
-        %td= level.name
-        %td= level.class.name
-        %td
-          = link_to t('crud.show'), level
+        %td.controls-column
           - if level.custom?
-            = link_to t('crud.edit'), edit_level_path(level)
-            = link_to t('crud.destroy'), level, method: :delete, data: { confirm: t('crud.confirm') }
-            = link_to 'Clone', '', onclick: "$('#clone_#{level.id}').toggle(); return false;"
+            = link_to edit_level_path(level), title: t('crud.edit') do
+              %i.fa.fa-fw.fa-pencil
+            = link_to level, title: t('crud.destroy'), method: :delete, data: { confirm: t('crud.confirm') } do
+              %i.fa.fa-fw.fa-trash
+            = link_to '', title: 'Clone', onclick: "$('#clone_#{level.id}').toggle(); return false;" do
+              %i.fa.fa-fw.fa-copy
             %div{class: 'clone_level', id: "clone_#{level.id}", style: 'display: none;'}
               = form_tag level_clone_path(level), method: :post, remote: true do
                 = label_tag 'New name:'
                 = text_field_tag :name, level.name
                 = submit_tag 'Clone'
+        %td= link_to level.name, level, title: t('crud.show')
+        %td= level.class.name
 = paginate @levels
 %br/
 - if can? :create, Level

--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -79,7 +79,7 @@
             = link_to '', title: 'Clone', onclick: "$('#clone_#{level.id}').toggle(); return false;" do
               %i.fa.fa-fw.fa-copy
             %div{class: 'clone_level', id: "clone_#{level.id}", style: 'display: none;'}
-              = form_tag level_clone_path(level), method: :post, remote: true do
+              = form_tag clone_level_path(level), method: :post, remote: true do
                 = label_tag 'New name:'
                 = text_field_tag :name, level.name
                 = submit_tag 'Clone'

--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -15,12 +15,19 @@
 
 %h1 Levels
 = form_tag levels_path, method: :get do
-  = label_tag 'Filter by name:'
+  = label_tag :name, 'Filter by name:'
   = text_field_tag :name, params[:name], autofocus: true
-  = label_tag 'Filter by type:'
+
+  = label_tag :level_type, 'Filter by type:'
   - level_type_options = [['All types', '']].concat @level_types.map {|x| [x, x]}
   = select_tag :level_type, options_for_select(level_type_options, params[:level_type])
+
+  = label_tag :script_id, 'Filter by script'
+  - script_options = [['All scripts', '']].concat @scripts
+  = select_tag :script_id, options_for_select(script_options, params[:script_id])
+
   = submit_tag "Search"
+
 = paginate @levels
 %table
   %thead

--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -1,6 +1,15 @@
 - content_for(:head) do
   %script{src: minifiable_asset_path('js/levelbuilder.js')}
   :scss
+    .main .new-level {
+      font-size: 20px;
+      line-height: 40px;
+      margin: 10px 0;
+      float: right;
+    }
+    .pagination {
+      text-align: center;
+    }
     .main table {
       width: 100%;
     }
@@ -20,22 +29,30 @@
       }
     }
 
+- if can? :create, Level
+  = link_to new_level_path, class: 'new-level' do
+    %i.fa.fa-plus-circle
+    = t('crud.new_model', model: Level.model_name.human)
+
 %h1 Levels
 = form_tag levels_path, method: :get do
-  = label_tag :name, 'Filter by name:'
-  = text_field_tag :name, params[:name], autofocus: true
+  %table
+    %tr
+      %td= label_tag :name, 'Filter by name:'
+      %td= label_tag :level_type, 'By type:'
+      %td= label_tag :script_id, 'By script'
+      %td
+    %tr
+      %td= text_field_tag :name, params[:name], autofocus: true
 
-  = label_tag :level_type, 'Filter by type:'
-  - level_type_options = [['All types', '']].concat @level_types.map {|x| [x, x]}
-  = select_tag :level_type, options_for_select(level_type_options, params[:level_type])
+      - level_type_options = [['All types', '']].concat @level_types.map {|x| [x, x]}
+      %td= select_tag :level_type, options_for_select(level_type_options, params[:level_type])
 
-  = label_tag :script_id, 'Filter by script'
-  - script_options = [['All scripts', '']].concat @scripts
-  = select_tag :script_id, options_for_select(script_options, params[:script_id])
+      - script_options = [['All scripts', '']].concat @scripts
+      %td= select_tag :script_id, options_for_select(script_options, params[:script_id])
 
-  = submit_tag "Search"
+      %td= submit_tag "Search"
 
-= paginate @levels
 %table
   %thead
     %tr
@@ -69,12 +86,18 @@
           - else
             %i.fa.fa-fw
 
-        %td= link_to level.name, level, title: t('crud.show')
+        -# Level name column, linked to view action if permitted
+        %td
+          - if can? :view, level
+            = link_to level.name, level, title: t('crud.show')
+          - else
+            = level.name
+
+        -# Level type column
         %td= level.class.name
+
 = paginate @levels
 %br/
-- if can? :create, Level
-  = link_to t('crud.new_model', model: Level.model_name.human), new_level_path
 #validation-error.validation-error{style: 'background-color: yellow'}
 :javascript
   window.levelbuilder.ajaxSubmit('.clone_level');

--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -46,11 +46,19 @@
     - @levels.each do |level|
       %tr
         %td.controls-column
-          - if level.custom?
+          - if can? :edit, level
             = link_to edit_level_path(level), title: t('crud.edit') do
               %i.fa.fa-fw.fa-pencil
+          - else
+            %i.fa.fa-fw
+
+          - if can? :destroy, level
             = link_to level, title: t('crud.destroy'), method: :delete, data: { confirm: t('crud.confirm') } do
               %i.fa.fa-fw.fa-trash
+          - else
+            %i.fa.fa-fw
+
+          - if can? :clone, level
             = link_to '', title: 'Clone', onclick: "$('#clone_#{level.id}').toggle(); return false;" do
               %i.fa.fa-fw.fa-copy
             %div{class: 'clone_level', id: "clone_#{level.id}", style: 'display: none;'}
@@ -58,6 +66,9 @@
                 = label_tag 'New name:'
                 = text_field_tag :name, level.name
                 = submit_tag 'Clone'
+          - else
+            %i.fa.fa-fw
+
         %td= link_to level.name, level, title: t('crud.show')
         %td= level.class.name
 = paginate @levels

--- a/dashboard/app/views/levels/new.html.haml
+++ b/dashboard/app/views/levels/new.html.haml
@@ -69,7 +69,7 @@
     = link_to t('crud.show'), level_path(level)
     = link_to t('crud.edit'), edit_level_path(level)
     = link_to t('crud.delete'), level_path(level, redirect: new_level_path), method: :delete
-    = link_to 'Clone', level_clone_path(level), method: :post
+    = link_to 'Clone', clone_level_path(level), method: :post
 
 %h2 All levels
 %ul

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -226,7 +226,9 @@ Dashboard::Application.routes.draw do
     get 'embed_level', to: 'levels#embed_level', as: 'embed_level'
     post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
     post 'update_properties'
-    post 'clone', to: 'levels#clone'
+    member do
+      post 'clone'
+    end
   end
 
   post 'level_assets/upload', to: 'level_assets#upload'

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -57,12 +57,12 @@ class LevelsControllerTest < ActionController::TestCase
     user: :platformization_partner
   )
 
-  test "non-levelbuilder can't index levels" do
-    sign_out @levelbuilder
-    sign_in create :teacher
-    get :index
-    assert_response :forbidden
-  end
+  # non-levelbuilder can't index levels
+  test_user_gets_response_for(
+    :index,
+    response: :forbidden,
+    user: :teacher
+  )
 
   test "should get new" do
     get :new, params: {game_id: @level.game}

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -706,9 +706,9 @@ class LevelsControllerTest < ActionController::TestCase
       post :clone, params: {id: old.id, name: "Fun Level (copy 1)"}
     end
 
-    new_level = assigns(:level)
-    assert_equal new_level.game, old.game
-    assert_equal new_level.name, "Fun Level (copy 1)"
+    new_level = assigns(:new_level)
+    assert_equal old.game, new_level.game
+    assert_equal "Fun Level (copy 1)", new_level.name
     assert_equal "/levels/#{new_level.id}/edit", URI(JSON.parse(@response.body)['redirect']).path
   end
 
@@ -718,6 +718,13 @@ class LevelsControllerTest < ActionController::TestCase
     refute_creates(Level) do
       post :clone, params: {id: old.id, name: "Fun Level (copy 1)"}
       assert_response :forbidden
+    end
+  end
+
+  test "cloning a level requires a name parameter" do
+    old = create(:level, game_id: Game.first.id, name: "Fun Level")
+    assert_raise ActionController::ParameterMissing do
+      post :clone, params: {id: old.id, name: ''}
     end
   end
 
@@ -731,7 +738,7 @@ class LevelsControllerTest < ActionController::TestCase
       post :clone, params: {id: old.id, name: "Fun Level (copy 1)"}
     end
 
-    new_level = assigns(:level)
+    new_level = assigns(:new_level)
     assert_equal new_level.game, old.game
     assert_equal new_level.name, "Fun Level (copy 1)"
     assert_equal "/levels/#{new_level.id}/edit", URI(JSON.parse(@response.body)['redirect']).path

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -57,6 +57,13 @@ class LevelsControllerTest < ActionController::TestCase
     user: :platformization_partner
   )
 
+  test "non-levelbuilder can't index levels" do
+    sign_out @levelbuilder
+    sign_in create :teacher
+    get :index
+    assert_response :forbidden
+  end
+
   test "should get new" do
     get :new, params: {game_id: @level.game}
     assert_response :success


### PR DESCRIPTION
[LP-669](https://codedotorg.atlassian.net/browse/LP-669): Adds new filters to the `/levels` view, restricts it to users with certain permissions, and restyles it.

- Adds a level type filter
- Adds a script filter
- Only users with levelbuilder permission or an editor experiment may use this view

Also overhauls the design of this page, in an effort to make it more usable:

| Before | After |
| --- | --- |
| ![Screenshot from 2019-09-09 17-11-06](https://user-images.githubusercontent.com/1615761/64574764-aeb72680-d325-11e9-8ada-d0c601eda967.png) | ![after](https://user-images.githubusercontent.com/1615761/64574767-b080ea00-d325-11e9-8bec-c3cc530fc710.png) |

With changes annotated: (feedback in [Slack](https://codedotorg.slack.com/archives/C0T10H2HY/p1568074787041800))
![after_annotated](https://user-images.githubusercontent.com/1615761/64574769-b24aad80-d325-11e9-9940-69246ff1828f.png)
