### PR TITLE
Continue button on unit overview should skip hidden lessons

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -282,7 +282,7 @@ class ScriptLevelsController < ApplicationController
 
   def user_or_session_level
     if current_user
-      current_user.next_unpassed_visible_progression_level(@script).try(:or_next_progression_level)
+      current_user.next_unpassed_visible_progression_level(@script)
     else
       find_next_level_for_session(@script)
     end

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -282,7 +282,7 @@ class ScriptLevelsController < ApplicationController
 
   def user_or_session_level
     if current_user
-      current_user.next_unpassed_progression_level(@script).try(:or_next_progression_level)
+      current_user.next_unpassed_visible_progression_level(@script).try(:or_next_progression_level)
     else
       find_next_level_for_session(@script)
     end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -137,7 +137,7 @@ class ScriptLevel < ActiveRecord::Base
       # next stage)
       level_to_follow = next_progression_level(user)
     else
-      # don't ever continue continue to a locked/hidden level
+      # don't ever continue to a locked/hidden level
       level_to_follow = next_level
       level_to_follow = level_to_follow.next_level while level_to_follow.try(:locked_or_hidden?, user)
     end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1138,18 +1138,19 @@ class User < ActiveRecord::Base
     user_levels.attempted.exists?
   end
 
-  # Returns the next visible script_level for the next progression level in the given
-  # script that hasn't yet been passed, starting its search at the last level we submitted
+  # Returns the next visible script_level for the next progression level in the # given script that hasn't yet been passed, starting at the last level the
+  # the user most recently submitted
   def next_unpassed_visible_progression_level(script)
-    # visible script levels
-    sl_level_ids = visible_script_levels(script).map(&:level_ids).flatten
+    visible_sls = visible_script_levels(script)
 
-    # levels the user made progress in
+    sl_level_ids = visible_sls.map(&:level_ids).flatten
+
+    # Levels the user made progress in
     ul_level_ids = user_levels_by_level(script).keys
 
-    # The user has not made any progress, return the first script_level
+    # The user has not made any progress, return the first visible script_level
     if ul_level_ids.empty?
-      return script.get_script_level_by_chapter(1)
+      visible_sls.min_by(&:chapter)
     end
 
     visible_completed_level_ids = sl_level_ids & ul_level_ids
@@ -1161,15 +1162,13 @@ class User < ActiveRecord::Base
     most_recent_ul = visible_user_levels.max_by(&:created_at)
 
     # Find the script_level that goes with the most recent user_level
-    most_recent_sl = visible_script_levels(script).detect do |sl|
-      sl.level_id == most_recent_ul.level_id
-    end
+    most_recent_sl = visible_sls.find_by(level_id: most_recent_ul.level_id)
 
     # Find the chapter for the script_level that goes with the most recent user_level
     most_recent_completed_chapter = most_recent_sl.chapter
 
     # Find the script_level that has the next highest chapter level from the one above
-    later_visible_sls = visible_script_levels(script).select do |sl|
+    later_visible_sls = visible_sls.select do |sl|
       sl.chapter > most_recent_completed_chapter
     end
 
@@ -1274,13 +1273,9 @@ class User < ActiveRecord::Base
   end
 
   def visible_script_levels(script)
-    visible_sls = []
-    script.script_levels.each do |sl|
-      unless script_level_hidden?(sl)
-        visible_sls << sl
-      end
+    script.script_levels.select do |sl|
+      !script_level_hidden?(sl)
     end
-    visible_sls
   end
 
   # Is the given script hidden for this user (based on the sections that they are in)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1150,7 +1150,7 @@ class User < ActiveRecord::Base
 
     # The user has not made any progress, return the first visible script_level
     if ul_level_ids.empty?
-      visible_sls.min_by(&:chapter)
+      return visible_sls.min_by(&:chapter)
     end
 
     visible_completed_level_ids = sl_level_ids & ul_level_ids
@@ -1162,17 +1162,17 @@ class User < ActiveRecord::Base
     most_recent_ul = visible_user_levels.max_by(&:created_at)
 
     # Find the script_level that goes with the most recent user_level
-    most_recent_sl = visible_sls.find_by(level_id: most_recent_ul.level_id)
+    most_recent_sl = visible_sls.find {|sl| sl.level_id == most_recent_ul.level_id}
 
     # Find the chapter for the script_level that goes with the most recent user_level
     most_recent_completed_chapter = most_recent_sl.chapter
 
-    # Find the script_level that has the next highest chapter level from the one above
-    later_visible_sls = visible_sls.select do |sl|
-      sl.chapter > most_recent_completed_chapter
+    # Find the script_level that has the next highest chapter level from the one above and is not complete
+    later_unpassed_visible_sls = visible_sls.select do |sl|
+      sl.chapter > most_recent_completed_chapter && !ul_level_ids.include?(sl.level_id)
     end
 
-    next_unpassed_visible_progression_sl = later_visible_sls.min_by(&:chapter)
+    next_unpassed_visible_progression_sl = later_unpassed_visible_sls.min_by(&:chapter)
 
     next_unpassed_visible_progression_sl
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1141,58 +1141,62 @@ class User < ActiveRecord::Base
   # Returns the next visible script_level for the next progression level in the # given script that hasn't yet been passed, starting at the last level the
   # the user most recently submitted
   def next_unpassed_visible_progression_level(script)
-    visible_sls = visible_script_levels(script).reject(&:bonus)
+    # If all levels in the script are complete, no need to find the next level,
+    # will be redirected to /congrats.
+    unless completed?(script)
+      visible_sls = visible_script_levels(script).reject {|sl| sl.bonus || sl.level.unplugged? || sl.locked?(self)}
 
-    sl_level_ids = visible_sls.map(&:level_ids).flatten
+      sl_level_ids = visible_sls.map(&:level_ids).flatten
 
-    # Levels the user made progress in
-    ul_level_ids = user_levels_by_level(script).keys
+      # Levels the user made progress in
+      ul_level_ids = user_levels_by_level(script).keys
 
-    visible_completed_level_ids = sl_level_ids & ul_level_ids
-    visible_incomplete_level_ids = sl_level_ids - ul_level_ids
+      visible_completed_level_ids = sl_level_ids & ul_level_ids
+      visible_incomplete_level_ids = sl_level_ids - ul_level_ids
 
-    first_visible_level = visible_sls.min_by(&:chapter)
+      first_visible_level = visible_sls.min_by(&:chapter)
 
-    completed_all_visible_levels = visible_incomplete_level_ids.empty? && !completed?(script)
+      completed_all_visible_levels = visible_incomplete_level_ids.empty?
 
-    visible_incomplete_sls = visible_sls.find_all {|sl| visible_incomplete_level_ids.include?(sl.level_id)}
+      # The user has not made any progress or has completed all visible levels
+      # but not the entire script, return the first visible script_level
+      if ul_level_ids.empty? || completed_all_visible_levels
+        return first_visible_level
+      end
 
-    first_visible_incomplete_level = visible_incomplete_sls.min_by(&:chapter)
+      # Find the user_levels associated with visible script_levels
+      visible_user_levels = user_levels.where(level_id: visible_completed_level_ids)
 
-    # The user has not made any progress or has completed all visible levels
-    # but not the entire script, return the first visible script_level
-    if ul_level_ids.empty? || completed_all_visible_levels
-      return first_visible_level
+      # Most recently completed user_level of the visible subset
+      most_recent_ul = visible_user_levels.max_by(&:created_at)
+
+      # Find the script_level that goes with the most recent user_level
+      most_recent_sl = visible_sls.find {|sl| sl.level_id == most_recent_ul.level_id}
+
+      last_visible_level = visible_sls.max_by(&:chapter)
+
+      visible_incomplete_sls = visible_sls.find_all {|sl| visible_incomplete_level_ids.include?(sl.level_id)}
+
+      first_visible_incomplete_level = visible_incomplete_sls.min_by(&:chapter)
+
+      # The user has completed the last level in the progress, but not all
+      # previous levels, return the first visible incomplete script_level
+      if most_recent_sl == last_visible_level
+        return first_visible_incomplete_level ? first_visible_incomplete_level : first_visible_level
+      end
+
+      # Find the chapter for the script_level that goes with the most recent user_level
+      most_recent_completed_chapter = most_recent_sl.chapter
+
+      # Find the script_level that has the next highest chapter level from the one above and is not complete
+      later_unpassed_visible_sls = visible_incomplete_sls.select do |sl|
+        sl.chapter > most_recent_completed_chapter
+      end
+
+      next_unpassed_visible_progression_sl = later_unpassed_visible_sls.min_by(&:chapter)
+
+      next_unpassed_visible_progression_sl
     end
-
-    # Find the user_levels associated with visible script_levels
-    visible_user_levels = user_levels.where(level_id: visible_completed_level_ids)
-
-    # Most recently completed user_level of the visible subset
-    most_recent_ul = visible_user_levels.max_by(&:created_at)
-
-    # Find the script_level that goes with the most recent user_level
-    most_recent_sl = visible_sls.find {|sl| sl.level_id == most_recent_ul.level_id}
-
-    last_visible_level = visible_sls.max_by(&:chapter)
-
-    # The user has completed the last level in the progress, but not all
-    # previous levels, return the first visible incomplete script_level
-    if most_recent_sl == last_visible_level && !completed?(script)
-      return first_visible_incomplete_level ? first_visible_incomplete_level : first_visible_level
-    end
-
-    # Find the chapter for the script_level that goes with the most recent user_level
-    most_recent_completed_chapter = most_recent_sl.chapter
-
-    # Find the script_level that has the next highest chapter level from the one above and is not complete
-    later_unpassed_visible_sls = visible_incomplete_sls.select do |sl|
-      sl.chapter > most_recent_completed_chapter
-    end
-
-    next_unpassed_visible_progression_sl = later_unpassed_visible_sls.min_by(&:chapter)
-
-    next_unpassed_visible_progression_sl
   end
 
   # Returns the next script_level for the next progression level in the given

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -821,6 +821,63 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(2, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
   end
 
+  test 'can get next_unpassed_visible_progression_level, user skips level, none hidden' do
+    user = create :user
+    twenty_hour = Script.twenty_hour_script
+    first_script_level = twenty_hour.get_script_level_by_chapter(1)
+    UserLevel.create(
+      user: user,
+      level: first_script_level.level,
+      script: twenty_hour,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+
+    third_script_level = twenty_hour.get_script_level_by_chapter(3)
+    UserLevel.create(
+      user: user,
+      level: third_script_level.level,
+      script: twenty_hour,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+
+    assert_equal(4, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+  end
+
+  test 'can get next_unpassed_visible_progression_level, out of order progress, none hidden' do
+    user = create :user
+    twenty_hour = Script.twenty_hour_script
+    first_script_level = twenty_hour.get_script_level_by_chapter(1)
+    UserLevel.create(
+      user: user,
+      level: first_script_level.level,
+      script: twenty_hour,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+
+    third_script_level = twenty_hour.get_script_level_by_chapter(3)
+    UserLevel.create(
+      user: user,
+      level: third_script_level.level,
+      script: twenty_hour,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+
+    second_script_level = twenty_hour.get_script_level_by_chapter(2)
+    UserLevel.create(
+      user: user,
+      level: second_script_level.level,
+      script: twenty_hour,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+
+    assert_equal(4, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+  end
+
   test 'can get next_unpassed_progression_level if not completed any unplugged levels' do
     user = create :user
     twenty_hour = Script.twenty_hour_script

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3635,7 +3635,7 @@ class UserTest < ActiveSupport::TestCase
       teacher = create :teacher
       twenty_hour = Script.twenty_hour_script
 
-      # user completed the first level
+      # User completed the first level
       first_script_level = twenty_hour.get_script_level_by_chapter(1)
       UserLevel.create(
         user: student,
@@ -3653,8 +3653,6 @@ class UserTest < ActiveSupport::TestCase
 
       # Find the third stage, since the 2nd is hidden
       next_visible_stage = twenty_hour.stages.find {|stage| stage.relative_position == 3}
-
-      next_visible_stage.script_levels.first.chapter
 
       assert_equal(next_visible_stage.script_levels.first, student.next_unpassed_visible_progression_level(twenty_hour))
     end


### PR DESCRIPTION
[LP-573](https://codedotorg.atlassian.net/browse/LP-573)

Currently the orange "Continue" button on student view of unit overview page doesn't work as expected when lessons are hidden.

ACTUAL: Students get a page telling them they're in the wrong place.
<img width="729" alt="Screen Shot 2019-09-09 at 4 17 59 PM" src="https://user-images.githubusercontent.com/12300669/64572764-8c210f80-d31d-11e9-8b30-938cf01fa988.png">

EXPECTED: Students go to the next visible lesson after the visible lesson they most recently completed
 