### PR TITLE
Update one-off script to import LCDs

### DIFF
--- a/bin/oneoff/import_concept_difficulty_tags.rb
+++ b/bin/oneoff/import_concept_difficulty_tags.rb
@@ -5,30 +5,20 @@ require 'cdo/properties'
 require 'csv'
 
 # Import level concept difficulty tags from a gsheet (downloaded as a series of
-# CSVs). When we cloned the CSF courses from 2017 to 2018, the LCDs did not get
+# CSVs). When we cloned the CSF courses from 2017 to 2018 and 2018 to 2019, the LCDs did not get
 # cloned with them so we're doing a mass import.
-
-# The given CSV contained headers that didn't map exactly to our defined LCDs,
-# so we perform a simple mapping in code
-HEADERS_TO_CONCEPTS = {
-  sequence_algorithms: ConceptDifficulties::SEQUENCING,
-  repeat: ConceptDifficulties::REPEAT_LOOPS,
-  functions_wparams: ConceptDifficulties::FUNCTIONS_WITH_PARAMS
-}
 
 def main(csv_dir)
   %w(CourseA CourseB CourseC CourseD CourseE CourseF).each do |course|
     CSV.foreach("#{csv_dir}/#{course}.csv", headers: true,  header_converters: :symbol) do |row|
-      concept_difficulties = Hash[row.to_hash.compact.map do |key, val|
-        [HEADERS_TO_CONCEPTS.fetch(key, key.to_s), val]
-      end].delete_if do |key, _val|
-        !LevelConceptDifficulty::CONCEPTS.include?(key)
-      end
-
       level = Level.find_by(name: row.fetch(:level_name))
       unless level
         puts "cannot find #{row.fetch(:level_name)}"
         next
+      end
+
+      concept_difficulties = row.to_hash.compact.delete_if do |key, _val|
+        !LevelConceptDifficulty::CONCEPTS.include?(key.to_s)
       end
 
       lcd = LevelConceptDifficulty.find_or_create_by(level: level)

--- a/bin/oneoff/import_concept_difficulty_tags.rb
+++ b/bin/oneoff/import_concept_difficulty_tags.rb
@@ -25,7 +25,8 @@ def main(csv_dir)
 
       if concept_difficulties.any? {|key, value| lcd[key] != value}
         lcd.update!(concept_difficulties)
-        level.write_custom_level_file
+        file_path = Level.level_file_path(level.name)
+        File.write(file_path, level.to_xml)
       end
     end
   end

--- a/bin/oneoff/import_concept_difficulty_tags.rb
+++ b/bin/oneoff/import_concept_difficulty_tags.rb
@@ -9,7 +9,7 @@ require 'csv'
 # cloned with them so we're doing a mass import.
 
 def main(csv_dir)
-  %w(CourseA CourseB CourseC CourseD CourseE CourseF).each do |course|
+  %w(CourseA CourseB CourseC CourseD CourseE CourseF PreExpress Express).each do |course|
     CSV.foreach("#{csv_dir}/#{course}.csv", headers: true,  header_converters: :symbol) do |row|
       level = Level.find_by(name: row.fetch(:level_name))
       unless level


### PR DESCRIPTION
Making some tweaks to the LCD-import script based off of our [CSF 2019 Tagging](https://docs.google.com/spreadsheets/d/16pXcrksyAW7N1dmYxLCG3K-NT_QsjVE0X0zUqIofUyo/edit) doc.

Once this has been merged and makes its way to the levelbuilder env, I will:
- Copy the CSV files in the doc above to the levelbuilder machine
- Make a branch off of the `levelbuilder` branch
- Run this script
- Make a PR against my branch and levelbuilder