### PR TITLE
escape single quotes in stage name and progression in script dsl

### DIFF
--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -310,9 +310,9 @@ class ScriptDSL < BaseDSL
   def self.serialize_stages(script)
     s = []
     script.stages.each do |stage|
-      t = "stage '#{stage.name}'"
+      t = "stage '#{escape(stage.name)}'"
       t += ', lockable: true' if stage.lockable
-      t += ", flex_category: '#{stage.flex_category}'" if stage.flex_category
+      t += ", flex_category: '#{escape(stage.flex_category)}'" if stage.flex_category
       s << t
       stage.script_levels.each do |sl|
         type = 'level'
@@ -366,15 +366,19 @@ class ScriptDSL < BaseDSL
 
       s << "level_concept_difficulty '#{level.summarize_concept_difficulty}'" if level.level_concept_difficulty
     end
-    l = "#{type} '#{level.key.gsub("'") {"\\'"}}'"
+    l = "#{type} '#{escape(level.key)}'"
     l += ', active: false' if experiments.empty? && active == false
     l += ', active: true' if experiments.any? && (active == true || active.nil?)
     l += ", experiments: #{experiments.to_json}" if experiments.any?
-    l += ", progression: '#{progression}'" if progression
+    l += ", progression: '#{escape(progression)}'" if progression
     l += ', named: true' if named
     l += ', assessment: true' if assessment
     l += ', challenge: true' if challenge
     s << l
     s
+  end
+
+  def self.escape(str)
+    str.gsub("'") {"\\'"}
   end
 end

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -720,7 +720,7 @@ DSL
   end
 
   test 'script DSL with single quotes' do
-    input_dsl = <<-DSL.gsub(/^\s+/, '')
+    input_dsl = <<~DSL
       stage 'Bob\\'s stage'
       level 'Level 1', progression: 'Bob\\'s progression'
       level 'Level 2'

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -718,4 +718,35 @@ DSL
     output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
     assert_equal expected, output
   end
+
+  test 'script DSL with single quotes' do
+    input_dsl = <<-DSL.gsub(/^\s+/, '')
+      stage 'Bobs stage'
+      level 'Level 1', progression: 'Bobs progression'
+      level 'Level 2'
+    DSL
+    assert_includes(input_dsl, "Bobs stage")
+    assert_includes(input_dsl, "Bobs progression")
+    output, i18n = ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    expected = DEFAULT_PROPS.merge(
+      {
+        stages: [
+          {
+            stage: "Bobs stage",
+            scriptlevels: [
+              {stage: "Bobs stage", levels: [{name: 'Level 1'}], properties: {progression: "Bobs progression"}},
+              {stage: "Bobs stage", levels: [{name: 'Level 2'}]},
+            ]
+          }
+        ],
+      }
+    )
+
+    i18n_expected = {'test' => {'stages' => {
+      "Bobs stage" => {'name' => "Bobs stage"},
+    }}}
+    assert_equal expected, output
+    assert_equal i18n_expected, i18n
+  end
 end
+

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -721,21 +721,21 @@ DSL
 
   test 'script DSL with single quotes' do
     input_dsl = <<-DSL.gsub(/^\s+/, '')
-      stage 'Bobs stage'
-      level 'Level 1', progression: 'Bobs progression'
+      stage 'Bob\\'s stage'
+      level 'Level 1', progression: 'Bob\\'s progression'
       level 'Level 2'
     DSL
-    assert_includes(input_dsl, "Bobs stage")
-    assert_includes(input_dsl, "Bobs progression")
+    assert_includes(input_dsl, "Bob\\'s stage")
+    assert_includes(input_dsl, "Bob\\'s progression")
     output, i18n = ScriptDSL.parse(input_dsl, 'test.script', 'test')
     expected = DEFAULT_PROPS.merge(
       {
         stages: [
           {
-            stage: "Bobs stage",
+            stage: "Bob's stage",
             scriptlevels: [
-              {stage: "Bobs stage", levels: [{name: 'Level 1'}], properties: {progression: "Bobs progression"}},
-              {stage: "Bobs stage", levels: [{name: 'Level 2'}]},
+              {stage: "Bob's stage", levels: [{name: 'Level 1'}], properties: {progression: "Bob's progression"}},
+              {stage: "Bob's stage", levels: [{name: 'Level 2'}]},
             ]
           }
         ],
@@ -743,10 +743,9 @@ DSL
     )
 
     i18n_expected = {'test' => {'stages' => {
-      "Bobs stage" => {'name' => "Bobs stage"},
+      "Bob's stage" => {'name' => "Bob's stage"},
     }}}
     assert_equal expected, output
     assert_equal i18n_expected, i18n
   end
 end
-


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/LP-300

Because curriculum writers have said they will still need the text-based stage editor even once they have the gui stage editor, it is now time to fix this bug.