### PR TITLE
Export Android App: Add Beta to dialog title, remove from experiment

### DIFF
--- a/apps/src/code-studio/components/ExportDialog/Dialog.jsx
+++ b/apps/src/code-studio/components/ExportDialog/Dialog.jsx
@@ -692,7 +692,7 @@ class ExportDialog extends React.Component {
           className="modal-content no-modal-icon"
           style={{position: 'relative'}}
         >
-          <p className="dialog-title">Export your project</p>
+          <p className="dialog-title">Export your project (Beta)</p>
           {isAbusive && (
             <AbuseError
               i18n={{

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -7,7 +7,6 @@ import {CIPHER, ALPHABET} from '../../constants';
 import {files as filesApi} from '../../clientApi';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {AbuseConstants} from '@cdo/apps/util/sharedConstants';
-import experiments from '@cdo/apps/util/experiments';
 
 // Attempt to save projects every 30 seconds
 var AUTOSAVE_INTERVAL = 30 * 1000;
@@ -514,16 +513,12 @@ var projects = (module.exports = {
     );
   },
 
-  // Currently, only applab when the experiment is enabled. Hide if
-  // hideShareAndRemix is set on the level.
+  // Currently, only applab and gamelab.
+  // Hide if hideShareAndRemix is set on the level.
   shouldShowExport() {
     const {level = {}, app} = appOptions;
     const {hideShareAndRemix} = level;
-    return (
-      !hideShareAndRemix &&
-      (app === 'applab' || app === 'gamelab') &&
-      experiments.isEnabled('exportExpo')
-    );
+    return !hideShareAndRemix && (app === 'applab' || app === 'gamelab');
   },
 
   showHeaderForProjectBacked() {


### PR DESCRIPTION
* Add "Beta" terminology to the Android app export dialog title and expose the Export button in the Code Studio UI for Applab and Gamelab (removing it from the `exportExpo` experiment)
* The next page makes it clear that iOS is not yet supported (per the original UI spec)

<img width="741" alt="Screen Shot 2019-09-09 at 7 32 00 PM" src="https://user-images.githubusercontent.com/5429146/64579729-bdf39f80-d338-11e9-94d7-1829ca8c9d75.png">
<img width="742" alt="Screen Shot 2019-09-09 at 7 35 23 PM" src="https://user-images.githubusercontent.com/5429146/64579806-fbf0c380-d338-11e9-9036-a90a2e28cb19.png">

