### PR TITLE
Fix accuracy of text for lesson extras continue button

### DIFF
--- a/apps/src/code-studio/components/stageExtras/StageExtras.jsx
+++ b/apps/src/code-studio/components/stageExtras/StageExtras.jsx
@@ -17,6 +17,7 @@ const styles = {
 export default class StageExtras extends React.Component {
   static propTypes = {
     stageNumber: PropTypes.number.isRequired,
+    nextStageNumber: PropTypes.number,
     nextLevelPath: PropTypes.string.isRequired,
     showProjectWidget: PropTypes.bool,
     projectTypes: PropTypes.arrayOf(PropTypes.string),
@@ -28,6 +29,7 @@ export default class StageExtras extends React.Component {
   render() {
     const {
       stageNumber,
+      nextStageNumber,
       nextLevelPath,
       bonusLevels,
       sectionId,
@@ -36,7 +38,7 @@ export default class StageExtras extends React.Component {
       projectTypes
     } = this.props;
     const nextMessage = /stage/.test(nextLevelPath)
-      ? msg.extrasNextLesson({number: stageNumber + 1})
+      ? msg.extrasNextLesson({number: nextStageNumber})
       : msg.extrasNextFinish();
 
     return (

--- a/apps/src/sites/studio/pages/scripts/stage_extras.js
+++ b/apps/src/sites/studio/pages/scripts/stage_extras.js
@@ -15,6 +15,7 @@ ReactDOM.render(
   <Provider store={store}>
     <StageExtras
       stageNumber={config.stageNumber}
+      nextStageNumber={config.nextStageNumber}
       nextLevelPath={config.nextLevelPath}
       bonusLevels={config.bonusLevels}
       showProjectWidget={showProjectWidget}

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -218,6 +218,7 @@ class ScriptLevelsController < ApplicationController
     @stage = Script.get_from_cache(params[:script_id]).stage_by_relative_position(params[:stage_position].to_i)
     @script = @stage.script
     @stage_extras = {
+      next_stage_number: @stage.next_level_number_for_stage_extras(current_user),
       stage_number: @stage.relative_position,
       next_level_path: @stage.next_level_path_for_stage_extras(current_user),
       bonus_levels: @script.get_bonus_script_levels(@stage),

--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -250,9 +250,19 @@ class Stage < ActiveRecord::Base
     script_levels.reverse.find(&:valid_progression_level?)
   end
 
-  def next_level_path_for_stage_extras(user)
+  def next_level_for_stage_extras(user)
     level_to_follow = script_levels.last.next_level
     level_to_follow = level_to_follow.next_level while level_to_follow.try(:locked_or_hidden?, user)
-    level_to_follow ? build_script_level_path(level_to_follow) : script_completion_redirect(script)
+    level_to_follow
+  end
+
+  def next_level_path_for_stage_extras(user)
+    next_level_for_stage_extras(user) ?
+      build_script_level_path(next_level_for_stage_extras(user)) : script_completion_redirect(script)
+  end
+
+  def next_level_number_for_stage_extras(user)
+    next_level_for_stage_extras(user) ?
+      next_level_for_stage_extras(user).stage.relative_position : nil
   end
 end

--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -257,12 +257,13 @@ class Stage < ActiveRecord::Base
   end
 
   def next_level_path_for_stage_extras(user)
-    next_level_for_stage_extras(user) ?
-      build_script_level_path(next_level_for_stage_extras(user)) : script_completion_redirect(script)
+    next_level = next_level_for_stage_extras(user)
+    next_level ?
+      build_script_level_path(next_level) : script_completion_redirect(script)
   end
 
   def next_level_number_for_stage_extras(user)
-    next_level_for_stage_extras(user) ?
-      next_level_for_stage_extras(user).stage.relative_position : nil
+    next_level = next_level_for_stage_extras(user)
+    next_level ? next_level.stage.relative_position : nil
   end
 end


### PR DESCRIPTION
[LP-721](https://codedotorg.atlassian.net/browse/LP-721)

The continue button for Lesson Extras text could be inaccurate if the next lesson is hidden. For example, here lesson 5 is hidden.  The button text says "Go on to Lesson 5" but navigates to Lesson 6.

![5-goes-to-6](https://user-images.githubusercontent.com/12300669/64581261-301ab300-d33e-11e9-94f7-a3cb7aad2714.gif)

The code made the assumption that the upcoming lesson to navigate to is always numbered one greater than the current lesson.  This is not always a true assumption when lessons are hidden.  To fix I pass a new prop `nextStageNumber` and use that to generate the text for the continue button, based on the new `next_level_number_for_stage_extras` method that relies on the accurately determined `lesson_to_follow`. 
<img width="1220" alt="Screen Shot 2019-09-09 at 7 57 55 PM" src="https://user-images.githubusercontent.com/12300669/64581338-8851b500-d33e-11e9-9bd8-d59ac74ffcc3.png">

