### PR TITLE
Extra CSP directive to allow Mapbox to work on ios

### DIFF
--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -45,6 +45,7 @@ module Rack
             "default-src 'self' https:",
             "frame-src 'self' https: blob:",
             "worker-src 'self' blob: ",
+            "child-src blob: ",
             "script-src 'self' https: 'unsafe-inline' https://vaas.acapela-group.com 'unsafe-eval'",
             "style-src 'self' https: 'unsafe-inline'",
             "img-src 'self' https: data: blob:",


### PR DESCRIPTION
We got a bunch of (internal) reports that the HOC map didn't work on ios after switching to Mapbox. Using Saucelabs, the map was fixed when adding the `child-src` directive (which Mapbox did [tell me to do](https://docs.mapbox.com/mapbox-gl-js/overview/#csp-directives)).