### PR TITLE
Remove unnecessary != in regional partners haml form

### DIFF
--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -36,19 +36,19 @@
     .applications_principal_approval
       %label
         = f.radio_button :applications_principal_approval, RegionalPartner::ALL_REQUIRE_APPROVAL, checked: @regional_partner.applications_principal_approval == RegionalPartner::ALL_REQUIRE_APPROVAL
-        != 'All apps require principal approval'
+        = 'All apps require principal approval'
       %label
         = f.radio_button :applications_principal_approval, RegionalPartner::SELECTIVE_APPROVAL, checked: @regional_partner.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL
-        != 'Selectively require some apps to have principal approval'
+        = 'Selectively require some apps to have principal approval'
   .field
     = f.label nil, "Applications Decision Emails"
     .applications_decision_emails
       %label
         = f.radio_button :applications_decision_emails, RegionalPartner::SENT_BY_PARTNER, checked: @regional_partner.applications_decision_emails == RegionalPartner::SENT_BY_PARTNER
-        != 'Partner sends decision emails'
+        = 'Partner sends decision emails'
       %label
         = f.radio_button :applications_decision_emails, RegionalPartner::SENT_BY_SYSTEM, checked: @regional_partner.applications_decision_emails == RegionalPartner::SENT_BY_SYSTEM
-        != 'System sends decision emails'
+        = 'System sends decision emails'
   .field
     = f.label :link_to_partner_application
     = f.text_field :link_to_partner_application, {style: 'width: 500px'}


### PR DESCRIPTION
These are obviously safe strings but it's not great to use `!=` unless necessary. We're auditing uses of `!=` anyway, so I'm cleaning them up now.