### PR TITLE
use markdown instead of raw html to prevent html injection in the international opt-in thanks page

### DIFF
--- a/dashboard/app/views/pd/international_opt_in/thanks.html.haml
+++ b/dashboard/app/views/pd/international_opt_in/thanks.html.haml
@@ -1,1 +1,1 @@
-!= I18n.t('pd.international_opt_in.thanks', support_email_url: "mailto:support@code.org", teacher_forum_url: "https://forum.code.org")
+!= I18n.t('pd.international_opt_in.thanks_markdown', support_email_url: "mailto:support@code.org", teacher_forum_url: "https://forum.code.org", markdown: true)

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1152,7 +1152,7 @@ en:
       title: 'Workshop Attendance'
       intro: "Thank you for taking time to receive training on Code.org’s curriculum. Our mission to bring computer science education opportunities to all children in all schools around the world would not be possible without you."
       instructions: "Please fill out the form below to indicate that 1) you attended a training workshop run by one of Code.org’s international partners, and 2) you agree to share your information with our international partner in your country so that they can help to support your journey as a computer science teacher."
-      thanks: "Thank you for submitting! We look forward to supporting you as you get to know Code.org’s curriculum and tools. Please keep sharing your questions and feedback with us by writing to us at <a href='%{support_email_url}'>support@code.org</a> or by posting on the <a href='%{teacher_forum_url}' target='_blank'>teacher forum</a>!"
+      thanks_markdown: "Thank you for submitting! We look forward to supporting you as you get to know Code.org’s curriculum and tools. Please keep sharing your questions and feedback with us by writing to us at [support@code.org](%{support_email_url}) or by posting on the [teacher forum](%{teacher_forum_url})!"
     logged_out:
       heading: 'Thanks for your interest in the Professional Learning Program!'
       body: 'To get started, you first need to be logged into your Code.org account. If you’d like more information about the program before you start your application, please check out the <a href="%{url}">Professional Learning Program overview</a>.'


### PR DESCRIPTION
Also has the benefit of removing the insecure "open in new tab" implementation