### PR TITLE
update cdo-cloudwatch-logger

### DIFF
--- a/cookbooks/cdo-cloudwatch-logger/recipes/default.rb
+++ b/cookbooks/cdo-cloudwatch-logger/recipes/default.rb
@@ -7,16 +7,16 @@
 include_recipe 'cdo-awscli'
 
 fifo = '/var/log/cloudwatch'
-script_path = '/usr/local/bin'
 
+execute("mkfifo #{fifo}") {creates fifo}
+file(fifo) {owner 'syslog'; action :touch}
+
+script_path = '/usr/local/bin'
 file 'cloudwatch-logger' do
   path "#{script_path}/#{name}"
   content <<BASH
 #!/bin/bash
-FIFO=#{fifo}
-[ -p "$FIFO" ] || mkfifo $FIFO
-chown syslog: $FIFO
-(while true ; do cat $FIFO ; done) | \
+(while true ; do cat #{fifo} ; done) | \
 aws logs push \
   --log-group-name #{node.environment}-syslog \
   --log-stream-name "$(hostname)-$$" \


### PR DESCRIPTION
Fixes a permissions-issue bug in cloudwatch-logger fifo creation.
Attempting to create the fifo within the `cloudwatch-logger` upstart script fails because the upstart user running the script lacks permissions to create files within `/var/log`.

With this update, the fifo is created as `root` (and owner updated to `syslog`) from Chef resources.

([`INF-151`](https://codedotorg.atlassian.net/browse/INF-151))