### PR TITLE
refactor pegasus db.rake execute_db_statement

### DIFF
--- a/lib/cdo/mysql_console_helper.rb
+++ b/lib/cdo/mysql_console_helper.rb
@@ -11,15 +11,15 @@ module MysqlConsoleHelper
     opts.join(' ')
   end
 
-  def self.run(connection_uri, args)
-    db = URI.parse connection_uri
+  def self.run(db, args, warn: true)
+    db = URI.parse(db) unless db.is_a?(URI)
     warning =
       "*****************************************************************\n"\
       "*** You are connecting to the master production database.     ***\n"\
       "*** Please connect to the reporting database instead via      ***\n"\
       "*** bin/dashboard-reporting-sql or bin/pegasus-reporting-sql. ***\n"\
       "*****************************************************************"
-    puts warning if db.host.start_with?('production')
+    puts warning if warn && db.host.start_with?('production')
 
     mysql_command = "mysql #{options(db)}"
     mysql_command += " --execute=\"#{args}\"" unless args.empty?

--- a/pegasus/rake/db.rake
+++ b/pegasus/rake/db.rake
@@ -7,25 +7,18 @@ end
 # Creates the MySQL database with the given database if it doesn't exist already.
 def create_database(uri)
   db = URI.parse(uri)
-  execute_db_statement(db, "CREATE DATABASE IF NOT EXISTS #{db.path[1..-1]}")
+  execute_db_statement(db, "CREATE DATABASE IF NOT EXISTS #{db.path.slice!(1..-1)}")
 end
 
 # Drops the MySQL database
 def drop_database(uri)
   db = URI.parse(uri)
-  execute_db_statement(db, "DROP DATABASE #{db.path[1..-1]}")
+  execute_db_statement(db, "DROP DATABASE #{db.path.slice!(1..-1)}")
 end
 
 def execute_db_statement(db, statement)
-  command = [
-    'mysql',
-    "--user=#{db.user}",
-    "--host=#{db.host}",
-  ]
-  command << "--execute=\"#{statement}\""
-  command << "--password=#{db.password}" unless db.password.nil?
-
-  system command.join(' ')
+  require_relative '../../lib/cdo/mysql_console_helper'
+  MysqlConsoleHelper.run(db, statement, warn: false)
 end
 
 namespace :db do


### PR DESCRIPTION
Small refactoring to a Pegasus rake helper method `execute_db_statement` to reuse logic for composing mysql-client cli arguments from `MysqlConsoleHelper`.

I've added an extra `warn` option (default true) so that the existing warning message can be optionally skipped when not needed.

This PR indirectly fixes a bug where a non-standard `port` is part of the DB connection uri, which MysqlConsoleHelper's logic handles correctly but the pegasus rake-helper one currently does not.