### PR TITLE
Add ProxySQL to cdo-mysql cookbook

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -113,6 +113,7 @@ cat <<JSON > $FIRST_BOOT
 <% if TEMPLATE == 'cloud_formation_stack.yml.erb' && @database -%>
     "db_writer": "mysql://$DB_USERNAME:$DB_PASSWORD@${AuroraCluster.Endpoint.Address}:${AuroraCluster.Endpoint.Port}/",
     "db_reader": "mysql://$DB_USERNAME:$DB_PASSWORD@${AuroraCluster.ReadEndpoint.Address}:${AuroraCluster.Endpoint.Port}/",
+    "db_cluster_id": "${AuroraCluster}",
 <% end -%>
 <% unless cdn_enabled -%>
     "cdn_enabled": false,

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -645,7 +645,7 @@ Resources:
           - !ImportValue VPC-ELBSecurityGroup # Accept HTTP traffic on daemon
 <%  end -%>
 <% if database %>
-    DependsOn: AuroraMaster
+    DependsOn: Aurora1
 <% end -%>
 <%end-%>
 <% if alarms %>
@@ -704,16 +704,18 @@ Resources:
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
 
-  AuroraMaster:
+<% 2.times do |i| %>
+  Aurora<%=i%>:
     Type: AWS::RDS::DBInstance
     Properties:
-      DBInstanceIdentifier: !Sub "${AWS::StackName}-master"
+      DBInstanceIdentifier: !Sub "${AWS::StackName}-<%=i%>"
       DBClusterIdentifier: !Ref AuroraCluster
       DBInstanceClass: db.r4.large
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
       # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with instance.
       EngineVersion: 5.7.12
+<% end -%>
 
   AuroraClusterDBParameters:
     Type: AWS::RDS::DBClusterParameterGroup

--- a/bin/admin-proxysql
+++ b/bin/admin-proxysql
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+require_relative '../deployment'
+require_relative '../lib/cdo/mysql_console_helper'
+
+raise 'please define CDO.db_proxy_admin' unless CDO.db_proxy_admin
+
+MysqlConsoleHelper.run(CDO.db_proxy_admin, ARGV.join(' ').strip)

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -435,6 +435,7 @@ devinternal_db_writer: !Secret
 db_cluster_id:
 db_admin: !Secret
 reporting_db_admin:
+db_proxy_admin:
 
 db_writer: !Secret
 reporting_db_writer: <%=db_writer%>

--- a/cookbooks/cdo-apps/libraries/cdo_apps.rb
+++ b/cookbooks/cdo-apps/libraries/cdo_apps.rb
@@ -120,6 +120,9 @@ module CdoApps
       # Reload when application is rebuilt.
       subscribes :reload, 'execute[build-cdo]', :delayed
 
+      # Reload when global config is updated to pick up changes.
+      subscribes :reload, 'template[globals]', :delayed
+
       # Ensure globals.yml is up-to-date before (re)starting service.
       notifies :create, 'template[globals]', :before
       only_if {File.exist? init_script}

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -56,13 +56,7 @@ apt_package %w(
   cmake
 )
 
-#multipackage
-
-include_recipe 'cdo-mysql::client'
-# Install local mysql server unless an external db url is provided.
-unless node['cdo-secrets'] && node['cdo-secrets']['db_writer']
-  include_recipe 'cdo-mysql::server'
-end
+include_recipe 'cdo-mysql'
 
 include_recipe 'cdo-ruby'
 

--- a/cookbooks/cdo-mysql/.kitchen.yml
+++ b/cookbooks/cdo-mysql/.kitchen.yml
@@ -1,14 +1,19 @@
 ---
 driver:
-  name: docker
-  use_sudo: false
+  name: dokken
+  chef_version: 15.2.20
+  privileged: true
+verifier:
+  name: inspec
 transport:
-  name: sftp
+  name: dokken
 provisioner:
-  name: chef_zero
-  require_chef_omnibus: 15.2.20
+  name: dokken
 platforms:
   - name: ubuntu-18.04
+    driver:
+      image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
     run_list:
       - recipe[apt]
 suites:
@@ -19,3 +24,11 @@ suites:
     run_list:
       - recipe[cdo-mysql::server]
       - recipe[test-mysql::stop]
+  - name: readwrite
+    run_list:
+      - recipe[test-mysql::readwrite]
+      - recipe[cdo-mysql::proxy]
+    attributes:
+      cdo-secrets:
+        db_writer: mysql://root:test-password@127.0.0.1:3300
+        db_reader: mysql://root:test-password@127.0.0.1:3301

--- a/cookbooks/cdo-mysql/attributes/default.rb
+++ b/cookbooks/cdo-mysql/attributes/default.rb
@@ -1,0 +1,9 @@
+default['cdo-mysql'] = {
+  proxy: {
+    enabled: false,
+    port: 6033,
+    admin: 'mysql2://admin:admin@127.0.0.1:6032'
+  }
+}
+default['cdo-secrets'] = {
+}

--- a/cookbooks/cdo-mysql/recipes/default.rb
+++ b/cookbooks/cdo-mysql/recipes/default.rb
@@ -4,4 +4,10 @@
 #
 
 include_recipe 'cdo-mysql::client'
-include_recipe 'cdo-mysql::server'
+
+# Install server unless an external writer endpoint is provided.
+writer = URI.parse(node['cdo-secrets']['db_writer'].to_s)
+include_recipe 'cdo-mysql::server' unless writer.hostname
+
+# Install proxy if enabled.
+include_recipe 'cdo-mysql::proxy' if node['cdo-mysql']['proxy']['enabled']

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -1,0 +1,68 @@
+# Configure ProxySQL integration.
+
+# https://github.com/sysown/proxysql#ubuntu--debian
+apt_repository "proxysql" do
+  uri "http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/#{node['lsb']['codename']}/"
+  distribution nil
+  components ['./']
+  key "https://repo.proxysql.com/ProxySQL/repo_pub_key"
+end
+
+apt_package 'proxysql' do
+  version '2.0.7'
+  action :upgrade
+end
+
+# Recursively resolve CNAME entries to get the last-resolved domain.
+def get_cname(domain)
+  require 'resolv'
+  Resolv::DNS.open do |dns|
+    loop do
+      domain = dns.getresource(domain, Resolv::DNS::Resource::IN::CNAME)&.name.to_s
+    end
+  end
+rescue Resolv::ResolvError
+  domain
+end
+
+writer = URI.parse(node['cdo-secrets']['db_writer'] || 'mysql2://root@localhost/')
+reader = URI.parse((node['cdo-secrets']['db_reader'] || writer).to_s)
+
+# If this is an Aurora cluster, resolve instance-endpoint hostnames
+# to help with instance auto-discovery.
+if (is_aurora = !!node['cdo-secrets']['db_cluster_id'])
+  [writer, reader].each {|server| server.host = get_cname(server.host)}
+end
+
+admin = URI.parse(node['cdo-mysql']['proxy']['admin'])
+proxy_port = node['cdo-mysql']['proxy']['port']
+
+template 'proxysql.cnf' do
+  path "/etc/#{name}"
+  source 'proxysql.cnf.erb'
+  variables(
+    is_aurora: is_aurora,
+    writer: writer,
+    reader: reader,
+    admin: admin,
+    port: proxy_port
+  )
+end
+
+# Proxysql reads persisted configuration from disk instead of configuration file if present.
+# Remove persisted configuration on any changes to ensure full reload.
+file '/var/lib/proxysql/proxysql.db' do
+  action :nothing
+  subscribes :delete, 'template[proxysql.cnf]', :immediately
+end
+
+service 'proxysql' do
+  supports status: true, restart: true
+  action [:enable, :start]
+  subscribes :restart, 'template[proxysql.cnf]', :immediately
+end
+
+# Override application config to use proxy endpoint for DB reads and writes.
+node.override['cdo-secrets']['db_writer'] = writer.dup.tap {|r| r.hostname = '127.0.0.1'; r.port = proxy_port}.to_s
+node.override['cdo-secrets']['db_reader'] = reader.dup.tap {|r| r.hostname = '127.0.0.1'; r.port = proxy_port}.to_s
+node.override['cdo-secrets']['db_proxy_admin'] = admin.to_s

--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -1,0 +1,145 @@
+# libconfig file format:
+# http://www.hyperrealm.com/libconfig/libconfig_manual.html#Configuration-Files
+
+# Variable definitions:
+# https://github.com/sysown/proxysql/wiki/Global-variables
+
+datadir="/var/lib/proxysql"
+errorlog="/var/lib/proxysql/proxysql.log"
+
+# https://github.com/sysown/proxysql/wiki/Global-variables#admin-variables
+admin_variables=
+{
+  admin_credentials="<%=@admin.user%>:<%=@admin.password%>"
+  mysql_ifaces="<%=@admin.host%>:<%=@admin.port%>"
+}
+
+# https://github.com/sysown/proxysql/wiki/Global-variables#mysql-variables
+mysql_variables=
+{
+  # The number of background threads that ProxySQL uses in order to process MySQL traffic.
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-threads
+  threads=<%=node[:cpu][:total]%>
+
+  # Semicolon-separated list of hostname:port entries for interfaces for incoming MySQL traffic.
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-interfaces
+  interfaces="127.0.0.1:<%= @port %>"
+
+  # The server version with which the proxy will respond to the clients.
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-server_version
+  server_version="5.7.12-proxysql"
+
+  # The user needs only USAGE privileges to connect, ping and check read_only.
+  # The user needs also REPLICATION CLIENT if it needs to monitor replication lag.
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-monitor_username
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-monitor_password
+  monitor_username="<%= @reader.user %>"
+  monitor_password="<%= @reader.password %>"
+
+  # When a node change its read_only value from 1 to 0, this variable determines
+  # if the node should be present in both hostgroups or not.
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-monitor_writer_is_also_reader
+  monitor_writer_is_also_reader=false
+}
+
+# https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers
+mysql_servers =
+(
+<% [@writer, @reader].each_with_index do |server, hostgroup| -%>
+  {
+    address =        "<%= server.host %>"
+    port =            <%= server.port || 3306 %>
+    hostgroup =       <%= hostgroup %>
+    max_connections = <%= node[:cpu][:total] * 2 %>
+  },
+<% end -%>
+)
+
+<% if @is_aurora -%>
+# https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_replication_hostgroups
+mysql_replication_hostgroups:
+(
+  {
+    writer_hostgroup=0
+    reader_hostgroup=1
+    check_type="innodb_read_only"
+  }
+)
+
+mysql_aws_aurora_hostgroups:
+(
+  {
+    writer_hostgroup=0
+    reader_hostgroup=1
+    new_reader_weight=1
+    domain_name="<%=@writer.host.sub(/[^.]*/, '')%>"
+  }
+)
+<% end -%>
+
+# https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_users
+mysql_users:
+(
+<% if @writer.user != @reader.user -%>
+  {
+    username = "<%= @reader.user %>"
+    password = "<%= @reader.password %>"
+    # Send all reader-user queries to reader hostgroup (1) by default.
+    default_hostgroup = 1
+  },
+<% end -%>
+  {
+    username = "<%= @writer.user %>"
+    password = "<%= @writer.password %>"
+    default_hostgroup = 0
+  }
+)
+
+# https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_query_rules
+mysql_query_rules:
+(
+  {
+    # Workaround for query-cache DEPRECATE_EOF bug:
+    # Rewrite all SELECT queries to include a unique comment.
+    # This will make proxysql queries distinct from any other clients' queries,
+    # so the query cache will store them separately.
+    rule_id=1
+    active=1
+    match_digest="^SELECT "
+    match_pattern="^(\S+) "
+    replace_pattern="SELECT /*proxysql*/ "
+  },
+  {
+    # SELECT .* FOR UPDATE is an exception to read-write splitting on SELECT,
+    # it needs to be sent to writer.
+    rule_id=2
+    active=1
+    match_pattern="^SELECT .* FOR UPDATE$"
+    destination_hostgroup=0
+    apply=1
+  },
+  {
+    # Global read-write split on SELECT, disabled by default (set active=1 to enable).
+    rule_id=3
+    active=0
+    match_pattern="^SELECT"
+    destination_hostgroup=1
+    apply=1
+  },
+  {
+    # ar_internal_metadata performs read-after-write from ActiveRecord DB-setup logic.
+    # Send all queries on this table to writer.
+    rule_id=4
+    active=1
+    match_pattern="FROM `ar_internal_metadata`"
+    destination_hostgroup=0
+    apply=1
+  },
+  {
+    # Handle SET command used by application.
+    rule_id=5
+    active=1
+    match_digest="SET @@wait_timeout"
+    multiplex=2
+  },
+)

--- a/cookbooks/cdo-mysql/test/cookbooks/test-mysql/Berksfile
+++ b/cookbooks/cdo-mysql/test/cookbooks/test-mysql/Berksfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+source 'https://supermarket.chef.io'
+
+metadata

--- a/cookbooks/cdo-mysql/test/cookbooks/test-mysql/metadata.rb
+++ b/cookbooks/cdo-mysql/test/cookbooks/test-mysql/metadata.rb
@@ -1,3 +1,4 @@
 name    'test-mysql'
 version '0.1.0'
 depends 'cdo-mysql'
+depends 'mysql', '~> 8.5.1'

--- a/cookbooks/cdo-mysql/test/cookbooks/test-mysql/recipes/readwrite.rb
+++ b/cookbooks/cdo-mysql/test/cookbooks/test-mysql/recipes/readwrite.rb
@@ -1,0 +1,39 @@
+# Run two local mysql services in a read-write setup.
+
+include_recipe 'cdo-mysql::repo'
+
+mysql_client 'default' do
+  package_name %w(mysql-client libmysqlclient-dev)
+  action :create
+end
+
+# Create two mysql services, sharing the same data directory.
+%w(writer reader).each do |id|
+  reader = id == 'reader'
+  endpoint = URI.parse(node['cdo-secrets']["db_#{id}"])
+  mysql_service id do
+    package_name 'mysql-server'
+    data_dir '/data'
+    bind_address '0.0.0.0'
+    port endpoint.port
+    initial_root_password endpoint.password
+    version '5.7'
+    action :create
+  end
+
+  mysql_config id do
+    instance id
+    source 'mysqld.erb'
+    variables(
+      server_id: reader ? '1' : '0',
+      mysql_instance: id,
+      read_only: reader
+    )
+    # Reader can start only when writer is stopped.
+    notifies(:stop, 'mysql_service[writer]', :immediately) if reader
+    notifies :start, "mysql_service[#{id}]", :immediately
+    notifies :restart, "mysql_service[#{id}]", :immediately
+    notifies(:start, 'mysql_service[writer]', :immediately) if reader
+    action :create
+  end
+end

--- a/cookbooks/cdo-mysql/test/cookbooks/test-mysql/templates/default/mysqld.erb
+++ b/cookbooks/cdo-mysql/test/cookbooks/test-mysql/templates/default/mysqld.erb
@@ -1,0 +1,12 @@
+[mysqld]
+innodb_flush_log_at_trx_commit = 1
+log_bin = /var/log/mysql-<%= @mysql_instance %>/mysql-bin.log
+log_error = /var/log/mysql-<%= @mysql_instance %>/error.log
+relay-log = /var/log/mysql-<%= @mysql_instance %>/mysql-relay-bin.log
+log_output=TABLE,FILE
+general_log = 1
+general_log_file = /var/log/mysql-<%= @mysql_instance %>/general.log
+server-id = <%= @server_id %>
+<% if @read_only -%>
+innodb_read_only = 1 
+<% end -%>

--- a/cookbooks/cdo-mysql/test/integration/readwrite/inspec/test_spec.rb
+++ b/cookbooks/cdo-mysql/test/integration/readwrite/inspec/test_spec.rb
@@ -1,0 +1,60 @@
+describe service('proxysql') do
+  it {should be_enabled}
+  it {should be_running}
+end
+
+def cmd(exec, match = nil)
+  describe command(exec) do
+    if match
+      its('stdout') {should match match}
+    else
+      its('exit_status') {should eq 0}
+    end
+  end
+end
+
+def mysql(query, match = nil)
+  cmd "mysql -BNe '#{query}' -h 127.0.0.1 -u root -ptest-password -P 6033", match
+end
+
+def admin(query, match = nil)
+  cmd "mysql -BNe '#{query}' -h 127.0.0.1 -uadmin -padmin -P 6032", match
+end
+
+writer = $writer = '/var/log/mysql-writer/general.log'
+reader = $reader = '/var/log/mysql-reader/general.log'
+
+# Assert query went to reader and not writer.
+def assert_reader(match)
+  cmd "cat #{$reader}", match
+  cmd "cat #{$writer}", /(?!#{match})/
+end
+
+# Assert query went to writer and not reader.
+def assert_writer(match)
+  cmd "cat #{$writer}", match
+  cmd "cat #{$reader}", /(?!#{match})/
+end
+
+cmd "truncate -s0 #{writer}"
+cmd "truncate -s0 #{reader}"
+
+# Enable read-write splitting through proxysql admin.
+admin 'UPDATE mysql_query_rules set active = 1 where rule_id = 3; LOAD MYSQL QUERY RULES TO RUNTIME;'
+
+# Simple tests to ensure proxy handles read-write splitting:
+
+# DDL goes to writer.
+sql = 'CREATE DATABASE IF NOT EXISTS TEST'
+mysql sql
+assert_writer sql
+
+# SELECT goes to reader.
+sql = 'SELECT 5'
+mysql sql, '5'
+assert_reader sql
+
+# SELECT in transaction goes to writer.
+select = 'SELECT 9'
+mysql "START TRANSACTION; #{select}; COMMIT", '9'
+assert_writer select

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -188,7 +188,7 @@ class Course < ApplicationRecord
       CourseScript.where(course: self, script: script).destroy_all
     end
     # Reload model so that default_course_scripts is up to date
-    reload
+    transaction {reload}
   end
 
   # Get the assignable info for this course, then update translations

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -51,8 +51,9 @@ mysql_defaults: &mysql_defaults
     username: <%= writer.user || 'root' %>
     password: <%= writer.password || '' %>
     host: <%= writer.host || 'localhost' %>
+    port: <%= writer.port || 3306 %>
     database: <%= writer.path.sub(%r{^/},"") || "dashboard_#{Rails.env}" %>
-  <% if reader && reader.host != writer.host %>
+  <% if reader && reader != writer %>
     # When there is a separate read-only database configured, do NOT
     # include the master database in the read pool.
     # Ref: https://github.com/bdurand/seamless_database_pool#the-master-connection
@@ -63,6 +64,7 @@ mysql_defaults: &mysql_defaults
    - username: <%= reader.user %>
      password: <%= reader.password %>
      host: <%= reader.host %>
+     port: <%= reader.port || 3306 %>
      database: <%= reader.path.sub(%r{^/},"") %>
   <% end %>
 
@@ -89,6 +91,7 @@ test:
   username: <%= writer.user || 'root' %>
   password: <%= writer.password || '' %>
   host: <%= writer.host || 'localhost' %>
+  port: <%= writer.port || 3306 %>
   pool: <%= ENV['CI'] ? 20 : 5 %>
   database: dashboard_test<%= ENV['TEST_ENV_NUMBER'] %>
   connect_timeout: 2

--- a/dashboard/lib/tasks/seed_in_test.rake
+++ b/dashboard/lib/tasks/seed_in_test.rake
@@ -1,6 +1,13 @@
 Rake::Task['db:test:prepare'].enhance do
   ActiveRecord::Base.establish_connection(:test)
   Rake::Task['db:fixtures:load'].invoke
+  require 'cdo/db_utils'
+  DBUtils.reload_proxy_backends
   Rake::Task['seed:test'].invoke
   ActiveRecord::Base.establish_connection(ENV['RAILS_ENV'].to_sym)
+end
+
+Rake::Task['db:test:purge'].enhance do
+  require 'cdo/db_utils'
+  DBUtils.reload_proxy_backends
 end

--- a/dashboard/lib/tasks/setup_or_migrate.rake
+++ b/dashboard/lib/tasks/setup_or_migrate.rake
@@ -3,8 +3,8 @@ require 'active_record/errors'
 namespace :db do
   def database_exists?
     Rake::Task['environment'].invoke
-    ActiveRecord::Base.connection
-  rescue ActiveRecord::NoDatabaseError
+    ActiveRecord::Base.connection.execute('SHOW TABLES')
+  rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
     false
   else
     true

--- a/lib/cdo/db.rb
+++ b/lib/cdo/db.rb
@@ -68,7 +68,7 @@ def sequel_connect(writer, reader, validation_frequency: nil, query_timeout: nil
     db_options[:flags] = ::Mysql2::Client::MULTI_STATEMENTS
   end
 
-  if (reader_uri = URI(reader)).host != URI(writer).host &&
+  if (reader_uri = URI(reader)) != URI(writer) &&
     Gatekeeper.allows('pegasus_read_replica')
 
     db_options[:servers] = {read_only: Sequel::Database.send(:uri_to_options, reader_uri)}

--- a/lib/cdo/db_utils.rb
+++ b/lib/cdo/db_utils.rb
@@ -1,0 +1,24 @@
+require 'cdo/rake_utils'
+
+module DBUtils
+  # Workaround for 'No database selected' issue with ProxySQL schema cache.
+  # Ref: https://github.com/sysown/proxysql/issues/698#issuecomment-279771373
+  def self.reload_proxy_backends
+    # Do nothing if proxy is not configured.
+    return unless CDO.db_proxy_admin
+
+    # Note: The admin-interface solution does NOT currently work.
+    # require 'cdo/mysql_console_helper'
+    # MysqlConsoleHelper.run CDO.db_proxy_admin, <<~SQL
+    # UPDATE mysql_servers SET status='OFFLINE_HARD';
+    # LOAD MYSQL SERVERS TO RUNTIME;
+    # UPDATE mysql_servers SET status='ONLINE';
+    # LOAD MYSQL SERVERS TO RUNTIME;
+    # SQL
+
+    # Only restart if service is active.
+    return unless system('service proxysql status >/dev/null 2>&1')
+    RakeUtils.restart_service('proxysql')
+    sleep 2
+  end
+end


### PR DESCRIPTION
This PR adds a `cdo-mysql::proxy` PR which integrates ProxySQL into our application stack for MySQL-connection pooling (multiplexing) and (optional, disabled by default) read-write splitting.

The integration will be disabled by default, and enabled by setting `node['cdo-mysql']['proxy']['enabled']` to `true`.

When enabled, the `proxysql` service will be installed from its Debian package, the `db_writer` and `db_reader` configuration values will be used as the writer and reader endpoints within the proxysql configuration, and updated `db_writer` and `db_reader` values will be written to `globals.yml` pointing to the proxy endpoint.

ProxySQL has a MySQL-based runtime configuration admin interface, which can be accessed through the `bin/admin-proxysql` helper.

I've also added a test-kitchen integration test to ensure proxysql installation, as well as some rudimentary tests verifying the read-write splitting functionality.

### Rollout plan
- [x] Merge this PR, default disabled
- [ ] Run on a canary frontend
  - [ ] Launch canary frontend
  - [ ] Remove frontend from rotation
  - [ ] Manually enable proxysql configuration on the node
  - [ ] Run chef-client to install / configure proxysql
  - [ ] Re-add frontend to rotation
- [ ] Monitor logs/metrics, ensure stable operation and reduced connection count from the canary frontend
- [ ] Merge a followup PR with default enabled