### PR TITLE
use markdown instead of raw html to prevent html injection in the CSF courses header

### DIFF
--- a/dashboard/app/views/home/_all_courses.html.haml
+++ b/dashboard/app/views/home/_all_courses.html.haml
@@ -43,4 +43,4 @@
 
 .csf-courses-header
   .row
-    .span12.twolineheader!= t('home.heading_elementary')
+    .span12.twolineheader!= t('home.heading_elementary_markdown', markdown: true)

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -494,11 +494,7 @@ en:
     test_videos_help: 'Test our new video player at your school'
     try_beta_courses: 'New! Try our beta courses for K-5 students'
     use_as_teacher: 'Use this site as a teacher'
-    heading_hoc2014: "<h2>The Hour of Code for</h2><h1>All Ages</h1>"
-    heading_elementary: "<h2>20 hour courses for</h2><h1>Computer Science Fundamentals (all ages)</h1>"
-    heading_apps: "<h2>Fun for</h2><h1>Everybody</h1>"
-    heading_tools: "<h2>Ready for the next step?</h2><h1>Tools for Middle and High School</h1>"
-    heading_legacy: "<h2>Our accelerated course for</h2><h1>All Ages</h1>"
+    heading_elementary_markdown: "## 20 hour courses for\n\n# Computer Science Fundamentals (all ages)"
     your_gallery: Gallery
     no_primary_course: "Try a Code Studio course"
     choose_next_course: "Try a Code Studio course by choosing one below"


### PR DESCRIPTION
Also remove some no-longer-used i18n strings