### PR TITLE
prevent html injection in the age interstitial

### DIFF
--- a/dashboard/app/views/layouts/_age_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_age_interstitial.html.haml
@@ -2,14 +2,17 @@
   .modal-dialog
     .modal-content.no-modal-icon
       %h1{style: 'margin: 10px 0;font-size: 32px'}= t('age_interstitial.header')
-      %p{style: 'font-size: 13px; line-height: 18px; color: #333'}!= t('age_interstitial.message').html_safe
+      %p{style: 'font-size: 13px; line-height: 18px; color: #333'}
+        = t('age_interstitial.warning')
+        %br
+        = t('age_interstitial.disclaimer')
       = form_for(current_user, url: registration_url('user'), html: {id: 'edit_user'}) do |f|
         .form-group
           = f.label :age, t('age_interstitial.age')
           = f.select :age, User::AGE_DROPDOWN_OPTIONS, include_blank: true
         .form-group
           = f.submit t('continue'), class: 'btn btn-primary', disabled: true
-      %p{style: 'font-size: 13px; line-height: 18px; color: #333'}!= t('age_interstitial.sign_out', url: destroy_user_session_url)
+      %p{style: 'font-size: 13px; line-height: 18px; color: #333'}!= t('age_interstitial.sign_out_markdown', url: destroy_user_session_url, markdown: true)
 :javascript
   $().ready(function() {
     $("#age-modal").modal('show');

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -767,8 +767,9 @@ en:
   age_interstitial:
     age: Your age
     header: Account Information Update
-    message: "We're in the process of updating our experience to provide you with even stronger privacy protections. To do this, we need existing users to enter their age here.<br/>As always, code.org will never rent, sell or share this information with any third parties."
-    sign_out: 'If you do not wish to provide your age you may <a href="%{url}">sign out</a>.'
+    warning: "We're in the process of updating our experience to provide you with even stronger privacy protections. To do this, we need existing users to enter their age here."
+    disclaimer: "As always, code.org will never rent, sell or share this information with any third parties."
+    sign_out_markdown: 'If you do not wish to provide your age you may [sign out](%{url}).'
   terms_interstitial:
     title: "Updated Terms of Service and Privacy Policy"
     intro_desc: "We updated our Terms of Service and Privacy Policy, as shown below. The changes are effective as of August 24, 2016.  The biggest change: we will <i>no longer store email addresses for student accounts on Code Studio.</i> This is a big deal for us, and we hope it sets a new standard for student privacy in education technology. We've sent you a summary of the other changes via email."


### PR DESCRIPTION
by rewriting one string to use markdown, and by splitting the other one up into two plaintext strings (with the former html added directly in the template)