### PR TITLE
Use dokken for cdo-varnish kitchen tests [ci skip]

### DIFF
--- a/cookbooks/cdo-varnish/.kitchen.yml
+++ b/cookbooks/cdo-varnish/.kitchen.yml
@@ -1,33 +1,32 @@
 ---
-transport:
-  name: sftp
 driver:
-  name: docker
-  use_sudo: false
-  privileged: true
+  name: dokken
+  chef_version: 12.7.2
+
+transport:
+  name: dokken
 
 provisioner:
-  name: chef_zero
-  require_chef_omnibus: 12.6.0
-  environments_path: test/environments
-  client_rb:
-    node_name: test_varnish
-    environment: integration
+  name: dokken
 
 platforms:
-  - name: ubuntu-14.04
-    run_list:
-      - recipe[apt]
-    attributes:
-      cdo-apps:
-        dashboard:
-          port: 8080
-        pegasus:
-          port: 8081
-        i18n:
-          languages:
-            en: English
-            fr: French
+- name: ubuntu-14.04
+  driver:
+    image: dokken/ubuntu-14.04
+    pid_one_command: /sbin/init
+  attributes:
+    cdo-apps:
+      dashboard:
+        port: 8080
+      pegasus:
+        port: 8081
+      i18n:
+        languages:
+          en: English
+          fr: French
+  run_list:
+  - recipe[apt]
+
 suites:
   - name: default
     run_list:

--- a/cookbooks/cdo-varnish/.kitchen.yml
+++ b/cookbooks/cdo-varnish/.kitchen.yml
@@ -27,10 +27,14 @@ platforms:
   run_list:
   - recipe[apt]
 
+verifier:
+  root_path: '/opt/verifier'
+
 suites:
   - name: default
     run_list:
       - recipe[varnish_test]
+#      - recipe[minitest-handler]
   - name: cloudfront
     run_list:
       - recipe[varnish_test]

--- a/cookbooks/cdo-varnish/.kitchen.yml
+++ b/cookbooks/cdo-varnish/.kitchen.yml
@@ -8,6 +8,9 @@ transport:
 
 provisioner:
   name: dokken
+  environments_path: test/environments
+  client_rb:
+    environment: integration
 
 platforms:
 - name: ubuntu-14.04

--- a/cookbooks/cdo-varnish/.kitchen.yml
+++ b/cookbooks/cdo-varnish/.kitchen.yml
@@ -31,13 +31,13 @@ platforms:
   - recipe[apt]
 
 verifier:
+  # Needed for test discovery: https://github.com/someara/kitchen-dokken/issues/78#issuecomment-298314150
   root_path: '/opt/verifier'
 
 suites:
   - name: default
     run_list:
       - recipe[varnish_test]
-#      - recipe[minitest-handler]
   - name: cloudfront
     run_list:
       - recipe[varnish_test]

--- a/cookbooks/cdo-varnish/Berksfile
+++ b/cookbooks/cdo-varnish/Berksfile
@@ -2,4 +2,7 @@ source 'https://supermarket.chef.io'
 
 metadata
 cookbook 'varnish_test', path: './test/cookbooks/varnish_test'
-cookbook 'ark'
+
+cookbook 'apt', '~> 2.6.0' # 6.0.0 requires Chef >= 12.9
+cookbook 'ark', '< 4.0.0' # 4.0.0 requires Chef >= 13.4
+cookbook 'seven_zip', '< 3.0.0' # 3.0.0 requires Chef >= 13

--- a/cookbooks/cdo-varnish/test/cookbooks/varnish_test/recipes/default.rb
+++ b/cookbooks/cdo-varnish/test/cookbooks/varnish_test/recipes/default.rb
@@ -3,8 +3,7 @@ apt_package 'openjdk-7-jre-headless'
 
 require 'etc'
 user = Etc.getlogin
-#home = Etc.getpwnam(user).dir
-home = '/root'
+home = Etc.getpwnam(user).dir
 
 remote_file "#{home}/mock.jar" do
   source 'http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock/1.57/wiremock-1.57-standalone.jar'

--- a/cookbooks/cdo-varnish/test/cookbooks/varnish_test/recipes/default.rb
+++ b/cookbooks/cdo-varnish/test/cookbooks/varnish_test/recipes/default.rb
@@ -3,7 +3,8 @@ apt_package 'openjdk-7-jre-headless'
 
 require 'etc'
 user = Etc.getlogin
-home = Etc.getpwnam(user).dir
+#home = Etc.getpwnam(user).dir
+home = '/root'
 
 remote_file "#{home}/mock.jar" do
   source 'http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock/1.57/wiremock-1.57-standalone.jar'

--- a/cookbooks/cdo-varnish/test/shared/shared.rb
+++ b/cookbooks/cdo-varnish/test/shared/shared.rb
@@ -35,6 +35,7 @@ module Cdo
         mock_started = $?.exitstatus == 0
       end
       `curl -s -X POST #{LOCALHOST}:#{DASHBOARD_PORT}/__admin/mappings/new -d '#{{request: {method: 'GET', url: '/'}, response: {status: 200}}.to_json}'`
+      `curl -s -X POST #{LOCALHOST}:#{DASHBOARD_PORT}/__admin/mappings/new -d '#{{request: {method: 'GET', url: '/health_check'}, response: {status: 200}}.to_json}'`
       `sleep 1` until system("curl -sf #{LOCALHOST}:#{VARNISH_PORT}/health_check.dashboard")
       puts 'setup finished'
       [pid, ngrok_pid]


### PR DESCRIPTION
This PR gets these tests working again in preparation for the next change, which will be to upgrade to ubuntu 18 and varnish 5.

* Switch to dokken since it's the current recommended kitchen driver
* Added `curl -s -X POST #{LOCALHOST}:#{DASHBOARD_PORT}/__admin/mappings/new -d '#{{request: {method: 'GET', url: '/health_check'}, response: {status: 200}}.to_json}'` to wiremock test setup, since we wait for varnish to make a successful health check to the mocked backend before we proceed with the tests.
* Pinned dependency versions in `cdo-varnish/Berksfile` since I was getting conflicts - is this the right way to do this? Does this affect anything aside from the tests?

Steps taken to verify changes:
* `bundle exec kitchen converge default-ubuntu-1404`
* `bundle exec kitchen verify default-ubuntu-1404`

```
Finished tests in 1.219307s, 18.0430 tests/s, 59.8701 assertions/s.

22 tests, 73 assertions, 0 failures, 0 errors, 4 skips
```

Note: the first time running `verify` on after creating and converging, I get this failure:

```
-----> Installing Busser plugin: busser-minitest
No entry for terminal type "unknown";
using dumb terminal settings.
       Plugin minitest installed (version 0.3.0)
-----> Running postinstall for minitest plugin
/opt/chef/embedded/lib/ruby/site_ruby/2.1.0/rubygems/installer.rb:607:in `ensure_required_ruby_version_met': bundler requires Ruby version >= 2.3.0. (Gem::InstallError)
```

Rerunning `verify` succeeds, and all subsequent runs succeed as well, so I ignored this for now. This may get fixed in the chef version upgrades to come with the ubuntu upgrade.

