### PR TITLE
Remove @visible_sections variable now that @sections change is deployed

### DIFF
--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -3,7 +3,6 @@ class TeacherDashboardController < ApplicationController
 
   def show
     @section = @section.summarize
-    @visible_sections = current_user.sections.where(hidden: false).map(&:summarize)
     @sections = current_user.sections.map(&:summarize)
   end
 end

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -2,7 +2,6 @@
   teacher_dashboard_data = {}
   teacher_dashboard_data[:studioUrlPrefix] = CDO.studio_url('', CDO.default_scheme)
   teacher_dashboard_data[:pegasusUrlPrefix] = CDO.code_org_url('', CDO.default_scheme)
-  teacher_dashboard_data[:visibleSections] = @visible_sections
   teacher_dashboard_data[:sections] = @sections
   teacher_dashboard_data[:section] = @section
 


### PR DESCRIPTION
Follow-up to #30617.

Removing `@visible_sections` server-side now that the client-side changes have been deployed, where `@visible_sections` is no longer used.