### PR TITLE
Levels controller cleanup

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -246,7 +246,7 @@ class TopInstructions extends Component {
     if (serverLevelId) {
       promises.push(
         $.ajax({
-          url: `/levels/${serverLevelId}/get_rubric/`,
+          url: `/levels/${serverLevelId}/get_rubric`,
           method: 'GET',
           contentType: 'application/json;charset=UTF-8'
         }).done(data => {

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -9,7 +9,7 @@ class LevelsController < ApplicationController
   include ActiveSupport::Inflector
   before_action :authenticate_user!, except: [:show, :embed_level, :get_rubric]
   before_action :require_levelbuilder_mode, except: [:show, :index, :embed_level, :get_rubric]
-  load_and_authorize_resource except: [:create, :update_blocks]
+  load_and_authorize_resource except: [:create]
 
   before_action :set_level, only: [:show, :edit, :update, :destroy]
 
@@ -132,7 +132,7 @@ class LevelsController < ApplicationController
     )
     view_options(full_width: true)
     @game = @level.game
-    @callback = level_update_blocks_path @level, type
+    @callback = update_blocks_level_path @level, type
 
     # Ensure the simulation ends right away when the user clicks 'Run' while editing blocks
     if @level.is_a? Studio
@@ -148,9 +148,10 @@ class LevelsController < ApplicationController
     render :show
   end
 
+  # POST /levels/:id/update_blocks/:type
+  # Change a blockset in the level configuration
   def update_blocks
-    @level = Level.find(params[:level_id])
-    authorize! :update, @level
+    return head :forbidden unless @level.custom?
     blocks_xml = params[:program]
     type = params[:type]
     set_solution_image_url(@level) if type == 'solution_blocks'

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -9,8 +9,7 @@ class LevelsController < ApplicationController
   include ActiveSupport::Inflector
   before_action :authenticate_user!, except: [:show, :embed_level, :get_rubric]
   before_action :require_levelbuilder_mode, except: [:show, :index, :embed_level, :get_rubric]
-  load_and_authorize_resource except: [:create, :update_blocks, :edit_blocks, :embed_level, :get_rubric]
-  check_authorization except: [:get_rubric]
+  load_and_authorize_resource except: [:create, :update_blocks, :edit_blocks, :embed_level]
 
   before_action :set_level, only: [:show, :edit, :update, :destroy]
 
@@ -87,18 +86,17 @@ class LevelsController < ApplicationController
   def edit
   end
 
-  # GET all the information for the mini rubric
+  # GET /levels/:id/get_rubric
+  # Get all the information for the mini rubric
   def get_rubric
-    @level = Level.find_by(id: params[:level_id])
-    if @level.mini_rubric&.to_bool
-      render json: {
-        keyConcept: @level.rubric_key_concept,
-        performanceLevel1: @level.rubric_performance_level_1,
-        performanceLevel2: @level.rubric_performance_level_2,
-        performanceLevel3: @level.rubric_performance_level_3,
-        performanceLevel4: @level.rubric_performance_level_4
-      }
-    end
+    return head :no_content unless @level.mini_rubric&.to_bool
+    render json: {
+      keyConcept: @level.rubric_key_concept,
+      performanceLevel1: @level.rubric_performance_level_1,
+      performanceLevel2: @level.rubric_performance_level_2,
+      performanceLevel3: @level.rubric_performance_level_3,
+      performanceLevel4: @level.rubric_performance_level_4
+    }
   end
 
   # Action for using blockly workspace as a toolbox/startblock editor.

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -9,7 +9,7 @@ class LevelsController < ApplicationController
   include ActiveSupport::Inflector
   before_action :authenticate_user!, except: [:show, :embed_level, :get_rubric]
   before_action :require_levelbuilder_mode, except: [:show, :index, :embed_level, :get_rubric]
-  load_and_authorize_resource except: [:create, :update_blocks, :edit_blocks, :embed_level]
+  load_and_authorize_resource except: [:create, :update_blocks, :edit_blocks]
 
   before_action :set_level, only: [:show, :edit, :update, :destroy]
 
@@ -300,9 +300,9 @@ class LevelsController < ApplicationController
     render(status: :not_acceptable, text: invalid)
   end
 
+  # GET /levels/:id/embed_level
+  # Show level styles for embedding in another page
   def embed_level
-    authorize! :read, :level
-    @level = Level.find(params[:level_id])
     @game = @level.game
     level_view_options(
       @level.id,

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -163,9 +163,6 @@ class LevelsController < ApplicationController
   end
 
   def update_properties
-    @level = Level.find(params[:level_id])
-    authorize! :update, @level
-
     changes = JSON.parse(request.body.read)
     changes.each do |key, value|
       @level.properties[key] = value

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -9,7 +9,7 @@ class LevelsController < ApplicationController
   include ActiveSupport::Inflector
   before_action :authenticate_user!, except: [:show, :embed_level, :get_rubric]
   before_action :require_levelbuilder_mode, except: [:show, :index, :embed_level, :get_rubric]
-  load_and_authorize_resource except: [:create, :update_blocks, :edit_blocks]
+  load_and_authorize_resource except: [:create, :update_blocks]
 
   before_action :set_level, only: [:show, :edit, :update, :destroy]
 
@@ -99,11 +99,10 @@ class LevelsController < ApplicationController
     }
   end
 
+  # GET /levels/:id/edit_blocks/:type
   # Action for using blockly workspace as a toolbox/startblock editor.
   # Expects params[:type] which can be either 'toolbox_blocks' or 'start_blocks'
   def edit_blocks
-    @level = Level.find(params[:level_id])
-    authorize! :edit, @level
     type = params[:type]
     blocks_xml = @level.properties[type].presence || @level[type] || EMPTY_XML
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -651,7 +651,7 @@ module LevelsHelper
         :iframe,
         '',
         {
-          src: url_for(level_id: level.id, controller: :levels, action: :embed_level).strip,
+          src: url_for(id: level.id, controller: :levels, action: :embed_level).strip,
           width: (width ? width.strip : '100%'),
           scrolling: 'no',
           seamless: 'seamless',

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -55,6 +55,11 @@ class Ability
       can? :read, level
     end
 
+    # If you can update a level, you can also do these things:
+    can [:update_properties], Level do |level|
+      can? :update, level
+    end
+
     if user.persisted?
       can :manage, user
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -56,7 +56,7 @@ class Ability
     end
 
     # If you can update a level, you can also do these things:
-    can [:edit_blocks, :update_properties], Level do |level|
+    can [:edit_blocks, :update_blocks, :update_properties], Level do |level|
       can? :update, level
     end
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -56,7 +56,7 @@ class Ability
     end
 
     # If you can update a level, you can also do these things:
-    can [:update_properties], Level do |level|
+    can [:edit_blocks, :update_properties], Level do |level|
       can? :update, level
     end
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -48,8 +48,12 @@ class Ability
       Pd::InternationalOptIn,
       :maker_discount
     ]
-    can :get_rubric, Level
     cannot :index, Level
+
+    # If you can see a level, you can also do these things:
+    can [:embed_level, :get_rubric], Level do |level|
+      can? :read, level
+    end
 
     if user.persisted?
       can :manage, user

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -48,6 +48,7 @@ class Ability
       Pd::InternationalOptIn,
       :maker_discount
     ]
+    can :get_rubric, Level
     cannot :index, Level
 
     if user.persisted?

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -14,15 +14,15 @@
             = link_to '[E]dit', edit_level_path(@level), { accesskey: 'e', title: "Edit this level. Can use the browser-dependent accesskey shortcut for quick access." }
             - if @level.is_a? Blockly
               %ul
-                %li= link_to "[s]tart (#{Blockly.count_xml_blocks(@level.start_blocks)})", level_edit_blocks_path(@level, :start_blocks), { accesskey: 's' }
+                %li= link_to "[s]tart (#{Blockly.count_xml_blocks(@level.start_blocks)})", edit_blocks_level_path(@level, :start_blocks), { accesskey: 's' }
                 - unless @level.uses_droplet?
-                  %li= link_to 's[o]lution', level_edit_blocks_path(@level, :solution_blocks), { accesskey: 'o' }
-                  %li= link_to '[t]oolbox', level_edit_blocks_path(@level, :toolbox_blocks), { accesskey: 't' }
-                  %li= link_to "required (#{Blockly.count_xml_blocks(@level.required_blocks)})", level_edit_blocks_path(@level, :required_blocks)
-                  %li= link_to "recommended (#{Blockly.count_xml_blocks(@level.recommended_blocks)})", level_edit_blocks_path(@level, :recommended_blocks)
-                  %li= link_to "initialization (#{Blockly.count_xml_blocks(@level.initialization_blocks)})", level_edit_blocks_path(@level, :initialization_blocks)
+                  %li= link_to 's[o]lution', edit_blocks_level_path(@level, :solution_blocks), { accesskey: 'o' }
+                  %li= link_to '[t]oolbox', edit_blocks_level_path(@level, :toolbox_blocks), { accesskey: 't' }
+                  %li= link_to "required (#{Blockly.count_xml_blocks(@level.required_blocks)})", edit_blocks_level_path(@level, :required_blocks)
+                  %li= link_to "recommended (#{Blockly.count_xml_blocks(@level.recommended_blocks)})", edit_blocks_level_path(@level, :recommended_blocks)
+                  %li= link_to "initialization (#{Blockly.count_xml_blocks(@level.initialization_blocks)})", edit_blocks_level_path(@level, :initialization_blocks)
                 - if @level.is_a? Artist
-                  %li= link_to 'pre-draw', level_edit_blocks_path(@level, :predraw_blocks)
+                  %li= link_to 'pre-draw', edit_blocks_level_path(@level, :predraw_blocks)
               - unless @level.uses_droplet?
                 %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
                   Copy workspace to clipboard

--- a/dashboard/app/views/levels/editors/_artist.html.haml
+++ b/dashboard/app/views/levels/editors/_artist.html.haml
@@ -33,7 +33,7 @@
     ], selected: @level.auto_run)
   = selector
 .field
-  = link_to 'Edit Predraw Blocks', level_edit_blocks_path(@level, :predraw_blocks) unless @level.new_record?
+  = link_to 'Edit Predraw Blocks', edit_blocks_level_path(@level, :predraw_blocks) unless @level.new_record?
   = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'predraw'}
   :javascript
     levelbuilder.initializeCodeMirror('level_predraw_blocks', '#{@level.uses_droplet? ? 'javascript' : 'xml'}');

--- a/dashboard/app/views/levels/editors/_blockly_xml_editors.html.haml
+++ b/dashboard/app/views/levels/editors/_blockly_xml_editors.html.haml
@@ -11,26 +11,26 @@
     =link_to 'here', 'https://github.com/code-dot-org/code-dot-org/wiki/%5BLevelbuilder%5D-Navigating-the-Blockly-Workspace-Editors', target: '_blank'
 
   .field
-    = link_to 'Edit Toolbox Blocks', level_edit_blocks_path( @level, :toolbox_blocks) unless @level.new_record?
+    = link_to 'Edit Toolbox Blocks', edit_blocks_level_path( @level, :toolbox_blocks) unless @level.new_record?
     = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'toolbox'}
 
   .field
-    = link_to 'Edit Start Blocks', level_edit_blocks_path(@level, :start_blocks) unless @level.new_record?
+    = link_to 'Edit Start Blocks', edit_blocks_level_path(@level, :start_blocks) unless @level.new_record?
     = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'start'}
 
   .field
-    = link_to 'Edit Required Blocks', level_edit_blocks_path(@level, :required_blocks) unless @level.new_record?
+    = link_to 'Edit Required Blocks', edit_blocks_level_path(@level, :required_blocks) unless @level.new_record?
     = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'required'}
 
   .field
-    = link_to 'Edit Recommended Blocks', level_edit_blocks_path(@level, :recommended_blocks) unless @level.new_record?
+    = link_to 'Edit Recommended Blocks', edit_blocks_level_path(@level, :recommended_blocks) unless @level.new_record?
     = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'recommended'}
 
   .field
-    = link_to 'Edit Initialization Blocks', level_edit_blocks_path(@level, :initialization_blocks) unless @level.new_record?
+    = link_to 'Edit Initialization Blocks', edit_blocks_level_path(@level, :initialization_blocks) unless @level.new_record?
     = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'initialization'}
 
   -if @level.respond_to? :solution_blocks
     .field
-      = link_to 'Edit Solution Blocks', level_edit_blocks_path(@level, :solution_blocks) unless @level.new_record?
+      = link_to 'Edit Solution Blocks', edit_blocks_level_path(@level, :solution_blocks) unless @level.new_record?
       = render partial: 'levels/editors/collapsible_block_editor', locals: {f: f, xml_id: 'solution'}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -223,10 +223,10 @@ Dashboard::Application.routes.draw do
   resources :levels do
     get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
     post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
-    post 'update_properties'
     member do
       get 'get_rubric'
       get 'embed_level'
+      post 'update_properties'
       post 'clone'
     end
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -222,11 +222,11 @@ Dashboard::Application.routes.draw do
 
   resources :levels do
     get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
-    get 'embed_level', to: 'levels#embed_level', as: 'embed_level'
     post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
     post 'update_properties'
     member do
       get 'get_rubric'
+      get 'embed_level'
       post 'clone'
     end
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -221,12 +221,12 @@ Dashboard::Application.routes.draw do
   resources :libraries
 
   resources :levels do
-    get 'get_rubric', to: 'levels#get_rubric'
     get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
     get 'embed_level', to: 'levels#embed_level', as: 'embed_level'
     post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
     post 'update_properties'
     member do
+      get 'get_rubric'
       post 'clone'
     end
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -221,12 +221,12 @@ Dashboard::Application.routes.draw do
   resources :libraries
 
   resources :levels do
-    post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
     member do
       get 'get_rubric'
       get 'embed_level'
       get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
       post 'update_properties'
+      post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
       post 'clone'
     end
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -221,11 +221,11 @@ Dashboard::Application.routes.draw do
   resources :libraries
 
   resources :levels do
-    get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
     post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
     member do
       get 'get_rubric'
       get 'embed_level'
+      get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
       post 'update_properties'
       post 'clone'
     end

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -851,7 +851,7 @@ class LevelsControllerTest < ActionController::TestCase
     level = create :artist
     sign_out @levelbuilder
 
-    get :embed_level, params: {level_id: level}
+    get :embed_level, params: {id: level}
     assert_response :success
   end
 

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -27,15 +27,8 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "should get rubric" do
-    level = create(:level,
-      mini_rubric: 'true',
-      rubric_key_concept: 'This is the key concept',
-      rubric_performance_level_1: 'This is great',
-      rubric_performance_level_2: 'This is good',
-      rubric_performance_level_3: 'This is okay',
-      rubric_performance_level_4: 'This is bad'
-    )
-    get :get_rubric, params: {level_id: level.id}
+    level = create_level_with_rubric
+    get :get_rubric, params: {id: level.id}
     assert_equal JSON.parse(@response.body), {
       "keyConcept" => "This is the key concept",
       "performanceLevel1" => "This is great",
@@ -43,6 +36,37 @@ class LevelsControllerTest < ActionController::TestCase
       "performanceLevel3" => "This is okay",
       "performanceLevel4" => "This is bad"
     }
+  end
+
+  test "anonymous user can get_rubric" do
+    sign_out @levelbuilder
+    level = create_level_with_rubric
+    get :get_rubric, params: {id: level.id}
+    assert_equal JSON.parse(@response.body), {
+      "keyConcept" => "This is the key concept",
+      "performanceLevel1" => "This is great",
+      "performanceLevel2" => "This is good",
+      "performanceLevel3" => "This is okay",
+      "performanceLevel4" => "This is bad"
+    }
+  end
+
+  test "empty success response for get_rubric on rubricless level" do
+    level = create :level
+    get :get_rubric, params: {id: level.id}
+    assert_response :no_content
+    assert_equal '', @response.body
+  end
+
+  def create_level_with_rubric
+    create(:level,
+      mini_rubric: 'true',
+      rubric_key_concept: 'This is the key concept',
+      rubric_performance_level_1: 'This is great',
+      rubric_performance_level_2: 'This is good',
+      rubric_performance_level_3: 'This is okay',
+      rubric_performance_level_4: 'This is bad'
+    )
   end
 
   test "should get index" do

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -365,7 +365,7 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should update App Lab starter code and starter HTML" do
     post :update_properties, params: {
-      level_id: create(:applab).id,
+      id: create(:applab).id,
     }, body: {
       start_html: '<h1>foo</h1>',
       start_blocks: 'console.log("hello world");',
@@ -375,6 +375,18 @@ class LevelsControllerTest < ActionController::TestCase
     level = assigns(:level)
     assert_equal '<h1>foo</h1>', level.properties['start_html']
     assert_equal 'console.log("hello world");', level.properties['start_blocks']
+  end
+
+  test "non-levelbuilder cannot update_properties" do
+    sign_out @levelbuilder
+    sign_in create(:teacher)
+    post :update_properties, params: {
+      id: create(:applab).id,
+    }, body: {
+      start_html: '<h1>foo</h1>'
+    }.to_json
+
+    assert_response :forbidden
   end
 
   test "should update solution image when updating solution blocks" do

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -489,7 +489,7 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should get edit blocks" do
     @level.update(toolbox_blocks: @program)
-    get :edit_blocks, params: {level_id: @level.id, type: 'toolbox_blocks'}
+    get :edit_blocks, params: {id: @level.id, type: 'toolbox_blocks'}
     assert_equal @program, assigns[:level_view_options_map][@level.id][:start_blocks]
   end
 

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -19,7 +19,7 @@ class LevelsControllerTest < ActionController::TestCase
     enable_level_source_image_s3_urls
 
     @default_update_blocks_params = {
-      level_id: @level.id,
+      id: @level.id,
       game_id: @level.game.id,
       type: 'toolbox_blocks',
       program: @program,
@@ -442,11 +442,10 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should not edit level if not custom level" do
     level = Script.twenty_hour_script.levels.first
-    can_edit = Ability.new(@levelbuilder).can? :edit, level
-    assert_equal false, can_edit
+    refute Ability.new(@levelbuilder).can? :edit, level
 
     post :update_blocks, params: @default_update_blocks_params.merge(
-      level_id: level.id,
+      id: level.id,
       game_id: level.game.id,
     )
     assert_response :forbidden


### PR DESCRIPTION
Realized during https://github.com/code-dot-org/code-dot-org/pull/30662 that `/levels` contains a bunch of resource-ish routes that weren't following Rails+CanCanCan resource routing and loading conventions.  Therefore, here's an attempt at cleanup of those remaining routes.

Totally open to suggestions for better ways to do this!