### PR TITLE
Add owner info to /levels view

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -86,11 +86,27 @@ class LevelsController < ApplicationController
       }
     ]
 
+    # Add an "owner" filter, only if we're on levelbuilder
+    if Rails.application.config.levelbuilder_mode
+      @search_fields << {
+        name: :owner_id,
+        description: 'By owner:',
+        type: 'select',
+        options: [
+          ['Any owner', ''],
+          *Level.joins(:user).uniq.pluck('users.name, users.id').sort_by {|a| a[0]}
+        ]
+      }
+    end
+
     # Gather filtered search results
     @levels = @levels.order(updated_at: :desc)
     @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%") if params[:name]
     @levels = @levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
     @levels = @levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
+    if Rails.application.config.levelbuilder_mode
+      @levels = @levels.left_joins(:user).where('levels.user_id = ?', params[:owner_id]) if params[:owner_id].present?
+    end
     @levels = @levels.page(params[:page]).per(LEVELS_PER_PAGE)
   end
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -59,13 +59,39 @@ class LevelsController < ApplicationController
   # GET /levels
   # GET /levels.json
   def index
+    # Define search filter fields
+    @search_fields = [
+      {
+        name: :name,
+        description: 'Filter by name:',
+        type: 'text'
+      },
+      {
+        name: :level_type,
+        description: 'By type:',
+        type: 'select',
+        options: [
+          ['All types', ''],
+          *LEVEL_CLASSES.map {|x| [x.name, x.name]}.sort_by {|a| a[0]}
+        ]
+      },
+      {
+        name: :script_id,
+        description: 'By script:',
+        type: 'select',
+        options: [
+          ['All scripts', ''],
+          *Script.valid_scripts(current_user).pluck(:name, :id).sort_by {|a| a[0]}
+        ]
+      }
+    ]
+
+    # Gather filtered search results
     @levels = @levels.order(updated_at: :desc)
     @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%") if params[:name]
     @levels = @levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
     @levels = @levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
     @levels = @levels.page(params[:page]).per(LEVELS_PER_PAGE)
-    @level_types = LEVEL_CLASSES.map(&:name)
-    @scripts = Script.valid_scripts(current_user).pluck(:name, :id).sort_by {|a| a[0]}
   end
 
   # GET /levels/1

--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -38,18 +38,15 @@
 = form_tag levels_path, method: :get do
   %table
     %tr
-      %td= label_tag :name, 'Filter by name:'
-      %td= label_tag :level_type, 'By type:'
-      %td= label_tag :script_id, 'By script'
+      - @search_fields.each do |field|
+        %td= label_tag field[:name], field[:description]
       %td
     %tr
-      %td= text_field_tag :name, params[:name], autofocus: true
-
-      - level_type_options = [['All types', '']].concat @level_types.map {|x| [x, x]}
-      %td= select_tag :level_type, options_for_select(level_type_options, params[:level_type])
-
-      - script_options = [['All scripts', '']].concat @scripts
-      %td= select_tag :script_id, options_for_select(script_options, params[:script_id])
+      - @search_fields.each do |field|
+        - if field[:type] == 'text'
+          %td= text_field_tag field[:name], params[field[:name]]
+        - elsif field[:type] == 'select'
+          %td= select_tag field[:name], options_for_select(field[:options], params[field[:name]])
 
       %td= submit_tag "Search"
 

--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -56,6 +56,8 @@
       %th.controls-column
       %th Name
       %th Type
+      - if Rails.application.config.levelbuilder_mode
+        %th Owner
   %tbody
     - @levels.each do |level|
       %tr
@@ -92,6 +94,10 @@
 
         -# Level type column
         %td= level.class.name
+
+        -# Level owner column (only on levelbuilder)
+        - if Rails.application.config.levelbuilder_mode
+          %td= level.user&.name
 
 = paginate @levels
 %br/


### PR DESCRIPTION
When in levelbuilder mode, adds an "Owner" column and a corresponding filter to the `/levels` view.

We're not enabling this in other environments because the level's `user_id` doesn't necessarily point to the correct user in other environments.