### PR TITLE
Enable incorrectly skipped varnish Accept-Language test [ci skip]

### DIFF
--- a/cookbooks/cdo-varnish/test/cookbooks/varnish_test/recipes/default.rb
+++ b/cookbooks/cdo-varnish/test/cookbooks/varnish_test/recipes/default.rb
@@ -2,8 +2,8 @@ include_recipe 'cdo-varnish'
 apt_package 'openjdk-7-jre-headless'
 
 require 'etc'
-user = Etc.getlogin
-home = Etc.getpwnam(user).dir
+user = Etc.getpwuid.name
+home = Etc.getpwuid.dir
 
 remote_file "#{home}/mock.jar" do
   source 'http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock/1.57/wiremock-1.57-standalone.jar'

--- a/cookbooks/cdo-varnish/test/shared/shared.rb
+++ b/cookbooks/cdo-varnish/test/shared/shared.rb
@@ -251,7 +251,7 @@ module HttpCacheTest
       end
 
       it 'Handles Accept-Language behaviors' do
-        skip 'Not implemented in Rack yet' unless environment == 'integration'
+        skip 'Not implemented in Rack yet' unless environment.to_s == 'integration'
         # URL contains whitelisted 'Accept-Language' header
         url = build_url 's/starwars/stage/1/puzzle'
         text_en = 'Hello World!'


### PR DESCRIPTION
More assertions run after this change:

```
Finished tests in 1.305439s, 16.8526 tests/s, 79.6667 assertions/s.

22 tests, 104 assertions, 0 failures, 0 errors, 3 skips
```

Compared to 73 in https://github.com/code-dot-org/code-dot-org/pull/30702