### PR TITLE
Script Editor: "Visible on teacher dashboard" depends on "pilot experiment"

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -61,7 +61,7 @@ export default class ScriptEditor extends React.Component {
     curriculumPath: PropTypes.string,
     pilotExperiment: PropTypes.string,
     editorExperiment: PropTypes.string,
-    announcements: PropTypes.arrayOf(announcementShape),
+    announcements: PropTypes.arrayOf(announcementShape).isRequired,
     supportedLocales: PropTypes.arrayOf(PropTypes.string),
     locales: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
     projectSharing: PropTypes.bool,
@@ -72,6 +72,15 @@ export default class ScriptEditor extends React.Component {
     versionYearOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
     isLevelbuilder: PropTypes.bool
   };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hidden: this.props.hidden,
+      pilotExperiment: this.props.pilotExperiment
+    };
+  }
 
   handleClearProjectWidgetSelectClick = () => {
     $(this.projectWidgetSelect)
@@ -207,22 +216,17 @@ export default class ScriptEditor extends React.Component {
                 ))}
               </select>
             </label>
-            <label>
-              Visible in Teacher Dashboard
-              <input
-                name="visible_to_teachers"
-                type="checkbox"
-                defaultChecked={!this.props.hidden}
-                style={styles.checkbox}
-              />
-              <p>
-                If checked this script will show up in the dropdown on the
-                Teacher Dashboard, for teachers to assign to students.
-              </p>
-            </label>
+            <VisibleInTeacherDashboard
+              checked={!this.state.hidden}
+              disabled={!!this.state.pilotExperiment}
+              onChange={e => this.setState({hidden: !e.target.checked})}
+            />
+            <PilotExperiment
+              value={this.state.pilotExperiment}
+              onChange={e => this.setState({pilotExperiment: e.target.value})}
+            />
           </div>
         )}
-
         <label>
           Display project sharing column in Teacher Dashboard
           <input
@@ -312,16 +316,6 @@ export default class ScriptEditor extends React.Component {
             Check if this course has lesson plans (on Curriculum Builder or in
             PDF form) that we should provide links to.
           </p>
-        </label>
-        <label>
-          Pilot Experiment. If specified, this script will only be accessible to
-          levelbuilders, or to classrooms whose teacher has this user experiment
-          enabled.
-          <input
-            name="pilot_experiment"
-            defaultValue={this.props.pilotExperiment}
-            style={styles.input}
-          />
         </label>
         {this.props.isLevelbuilder && (
           <label>
@@ -506,3 +500,47 @@ export default class ScriptEditor extends React.Component {
     );
   }
 }
+
+const VisibleInTeacherDashboard = props => (
+  <label style={props.disabled ? {opacity: 0.5} : {}}>
+    Visible in Teacher Dashboard
+    <input
+      name="visible_to_teachers"
+      type="checkbox"
+      disabled={props.disabled}
+      checked={props.checked && !props.disabled}
+      onChange={props.onChange}
+      style={styles.checkbox}
+    />
+    <p>
+      If checked this script will show up in the dropdown on the Teacher
+      Dashboard, for teachers to assign to students.
+      {props.disabled && (
+        <em> Disabled because a pilot experiment has been specified below.</em>
+      )}
+    </p>
+  </label>
+);
+VisibleInTeacherDashboard.propTypes = {
+  checked: PropTypes.bool,
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func.isRequired
+};
+
+const PilotExperiment = props => (
+  <label>
+    Pilot Experiment. If specified, this script will only be accessible to
+    levelbuilders, or to classrooms whose teacher has this user experiment
+    enabled.
+    <input
+      name="pilot_experiment"
+      value={props.value || ''}
+      style={styles.input}
+      onChange={props.onChange}
+    />
+  </label>
+);
+PilotExperiment.propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired
+};

--- a/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
@@ -1,0 +1,67 @@
+import {expect} from 'chai';
+import React from 'react';
+import {mount} from 'enzyme';
+import ScriptEditor from '@cdo/apps/lib/script-editor/ScriptEditor';
+
+describe('ScriptEditor', () => {
+  const DEFAULT_PROPS = {
+    announcements: [],
+    excludeCsfColumnInLegend: false,
+    i18nData: {
+      stageDescriptions: []
+    },
+    isLevelbuilder: true,
+    locales: [],
+    name: 'test-script',
+    scriptFamilies: [],
+    teacherResources: [],
+    versionYearOptions: []
+  };
+
+  describe('VisibleInTeacherDashboard', () => {
+    it('is checked when hidden is false', () => {
+      const wrapper = mount(<ScriptEditor {...DEFAULT_PROPS} hidden={false} />);
+      const checkbox = wrapper.find('input[name="visible_to_teachers"]');
+      expect(checkbox.prop('checked')).to.be.true;
+    });
+
+    it('is unchecked when hidden is true', () => {
+      const wrapper = mount(<ScriptEditor {...DEFAULT_PROPS} hidden={true} />);
+      const checkbox = wrapper.find('input[name="visible_to_teachers"]');
+      expect(checkbox.prop('checked')).to.be.false;
+    });
+
+    it('is disabled and unchecked when pilotExperiment is present', () => {
+      const wrapper = mount(
+        <ScriptEditor
+          {...DEFAULT_PROPS}
+          hidden={false}
+          pilotExperiment="test-pilot"
+        />
+      );
+      const checkbox = wrapper.find('input[name="visible_to_teachers"]');
+      expect(checkbox.prop('disabled')).to.be.true;
+      expect(checkbox.prop('checked')).to.be.false;
+    });
+
+    it('updates state as pilotExperiment changes', () => {
+      const wrapper = mount(<ScriptEditor {...DEFAULT_PROPS} hidden={false} />);
+      const visibleInTeacherDashboard = () =>
+        wrapper.find('input[name="visible_to_teachers"]');
+      const pilotExperiment = () =>
+        wrapper.find('input[name="pilot_experiment"]');
+
+      expect(pilotExperiment().prop('value')).to.equal('');
+      expect(visibleInTeacherDashboard().prop('checked')).to.be.true;
+      expect(visibleInTeacherDashboard().prop('disabled')).to.be.false;
+
+      pilotExperiment().simulate('change', {target: {value: 'test-pilot'}});
+      expect(visibleInTeacherDashboard().prop('checked')).to.be.false;
+      expect(visibleInTeacherDashboard().prop('disabled')).to.be.true;
+
+      pilotExperiment().simulate('change', {target: {value: ''}});
+      expect(visibleInTeacherDashboard().prop('checked')).to.be.true;
+      expect(visibleInTeacherDashboard().prop('disabled')).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
A UX improvement that came up in [this Slack conversation](https://codedotorg.slack.com/archives/CA3KCSGTD/p1568236295192500):

![image](https://user-images.githubusercontent.com/1615761/64740698-0df27380-d4ab-11e9-8f30-503bccc46b04.png)

I've made these two fields into simple controlled components and set up a dependency between them, with a brief explanation when the one is disabled.

![Peek 2019-09-11 15-45](https://user-images.githubusercontent.com/1615761/64740792-6295ee80-d4ab-11e9-88dc-f0af176db053.gif)

An additional behavior change in this PR: The `pilot_experiment` field is now only visible to levelbuilders, since it can affect the value of `hidden` which was already only visible to levelbuilders.