### PR TITLE
Require user to be logged in for google rostering routes

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -75,6 +75,7 @@ class ApiController < ApplicationController
   end
 
   def google_classrooms
+    return head :forbidden unless current_user
     query_google_classroom_service do |service|
       response = service.list_courses(teacher_id: 'me')
       render json: response.to_h
@@ -82,6 +83,7 @@ class ApiController < ApplicationController
   end
 
   def import_google_classroom
+    return head :forbidden unless current_user
     course_id = params[:courseId].to_s
     course_name = params[:courseName].to_s
 

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1139,6 +1139,18 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test 'google_classrooms is Forbidden when not signed in' do
+    sign_out :user
+    get :google_classrooms
+    assert_response :forbidden
+  end
+
+  test 'import_google_classroom is Forbidden when not signed in' do
+    sign_out :user
+    get :import_google_classroom
+    assert_response :forbidden
+  end
+
   #
   # Given two arrays, checks that they represent equivalent bags (or multisets)
   # of elements.


### PR DESCRIPTION
The `google_classrooms` and `import_google_classroom` routes in `ApiController` now return Forbidden immediately if the current user is not signed in, instead of hitting a server error a few lines later.

Fixes Honeybadger https://app.honeybadger.io/projects/3240/faults/38832343 as well as
outdated issues https://app.honeybadger.io/projects/3240/faults/34465333, https://app.honeybadger.io/projects/3240/faults/39279307 and
 https://app.honeybadger.io/projects/3240/faults/39083442.