### PR TITLE
Drop emoji from section name before saving to the database

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -341,4 +341,14 @@ class Section < ActiveRecord::Base
   def unused_random_code
     CodeGeneration.random_unique_code length: 6, model: Section
   end
+
+  # Drops unicode characters not supported by utf8mb3 strings (most commonly emoji)
+  # from the section name.
+  # We make a best-effort to make the name usable without the removed characters.
+  # We can remove this once our database has utf8mb4 support everywhere.
+  def strip_emoji_from_name
+    self.name = name&.gsub(/[\u{10000}-\u{10FFFF}]/, '')&.strip
+    self.name = I18n.t('sections.default_name', default: 'Untitled Section') unless name.present?
+  end
+  before_validation :strip_emoji_from_name
 end

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -347,7 +347,7 @@ class Section < ActiveRecord::Base
   # We make a best-effort to make the name usable without the removed characters.
   # We can remove this once our database has utf8mb4 support everywhere.
   def strip_emoji_from_name
-    self.name = name&.gsub(/[\u{10000}-\u{10FFFF}]/, '')&.strip
+    self.name = name&.strip_utf8mb4&.strip
     self.name = I18n.t('sections.default_name', default: 'Untitled Section') unless name.present?
   end
   before_validation :strip_emoji_from_name

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -347,7 +347,13 @@ class Section < ActiveRecord::Base
   # We make a best-effort to make the name usable without the removed characters.
   # We can remove this once our database has utf8mb4 support everywhere.
   def strip_emoji_from_name
+    # We don't want to fill in a default name if the caller intentionally tried to clear it.
+    return unless name.present?
+
+    # Drop emoji and other unsupported characters
     self.name = name&.strip_utf8mb4&.strip
+
+    # If dropping emoji resulted in a blank name, use a default
     self.name = I18n.t('sections.default_name', default: 'Untitled Section') unless name.present?
   end
   before_validation :strip_emoji_from_name

--- a/dashboard/test/models/sections/google_classroom_section_test.rb
+++ b/dashboard/test/models/sections/google_classroom_section_test.rb
@@ -26,4 +26,15 @@ class GoogleClassroomSectionTest < ActiveSupport::TestCase
       assert_equal 'Test Section B', section_2.name
     end
   end
+
+  test 'strips emoji from section name' do
+    owner = create :teacher
+    section = GoogleClassroomSection.from_service(
+      '101',
+      owner.id,
+      [],
+      "\u{1F600} Test Section A \u{1F600}"
+    )
+    assert_equal 'Test Section A', section.name
+  end
 end

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -152,6 +152,16 @@ class SectionTest < ActiveSupport::TestCase
     assert_equal ['Name is required'], section.errors.full_messages
   end
 
+  test 'emoji is dropped from section name' do
+    section = create :section, name: "\u{1F600} Test Section A \u{1F600}"
+    assert_equal 'Test Section A', section.name
+  end
+
+  test 'section gets a default name if it is empty after emoji removal' do
+    section = create :section, name: "\u{1F600} \u{1F600} \u{1F600}"
+    assert_equal 'Untitled Section', section.name
+  end
+
   test 'user is required' do
     section = build :section, user: nil
     refute section.valid?


### PR DESCRIPTION
Fixes
https://app.honeybadger.io/projects/3240/faults/37691572
and
https://app.honeybadger.io/projects/3240/faults/38078722

Remove unsupported unicode characters (anything above 0xFFFF, including emoji) from a section name before validation and save, because our database (or at least this table) doesn't currently support utf8mb4 and this causes errors when trying to save a section, in what should essentially be a recoverable situation.

Also strips leading and trailing whitespace from the section name after removing the emoji, and if that leaves the section name entirely empty, uses a default name as a fallback.