### PR TITLE
Upgrade Honeybadger gem from 3.3.0 to 4.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,7 +469,7 @@ GEM
     hashery (2.1.2)
     hashie (3.6.0)
     highline (1.6.21)
-    honeybadger (3.3.0)
+    honeybadger (4.5.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)


### PR DESCRIPTION
See the [changelog](https://github.com/honeybadger-io/honeybadger-ruby/blob/master/CHANGELOG.md) for details on all changes.  I carefully reviewed breaking changes in v4.0.0 and didn't find anything we need to update.

Trying this out because I'm curious about the [new "breadcrumbs" feature](https://docs.honeybadger.io/lib/ruby/getting-started/breadcrumbs.html):
![image](https://user-images.githubusercontent.com/1615761/64804506-c835b980-d543-11e9-8a91-fadd19f6625a.png)

Note, I'm _not_ enabling breadcrumbs in this PR, just upgrading the gem to make them an option.  I'd want us to do some additional testing around that feature in particular before enabling it.
