### PR TITLE
Disable codecov github comments [ci skip]

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+comment: off
 coverage:
   range: 50..80
   status:


### PR DESCRIPTION
Disabling since comments are currently not super useful / can cause clutter, and development on this is on hold.