### PR TITLE
Prevent HTML injection in tutorial beta header

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1350,6 +1350,12 @@ a.download-video {
     #heading {
       width: 700px;
     }
+
+    /**
+     * betatext can be used to style a span directly, or betacontainer can be
+     * used on a node containing markdown to apply the beta styling to all
+     * **strong** nodes in the markdown
+     */
     .betatext, .betacontainer strong {
       background: $white;
       color: $cyan;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1350,7 +1350,7 @@ a.download-video {
     #heading {
       width: 700px;
     }
-    .betatext {
+    .betatext, .betacontainer strong {
       background: $white;
       color: $cyan;
       padding: 2px 4px;

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -35,8 +35,8 @@
           = link_to image_tag(@script.banner_image), path, class: 'uitest-script-next-banner'
 
       - if @script.beta?
-        %p.lightgreytext
-          != t('landing.prerelease_hoc2014')
+        .betacontainer
+          != t('landing.prerelease_tutorial', markdown: true)
 
     #stats
       .user-stats-block

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -687,8 +687,7 @@ en:
     header_artist: "Code art"
     report_abuse: "Report Abuse"
   landing:
-    prerelease: "This course is in <span class='betatext'>beta</span>.  This means it is not the final version of the course, and is subject to revision as feedback is received and improvements are made."
-    prerelease_hoc2014: "This tutorial is in <span class='betatext'>beta</span>.  It is subject to revision as feedback is received and improvements are made."
+    prerelease_tutorial: "This tutorial is in **beta**.  It is subject to revision as feedback is received and improvements are made."
     report_bug: "Report Bug"
     support: "Get Help"
     support_url: "//support.code.org"

--- a/shared/css/course-blocks.scss
+++ b/shared/css/course-blocks.scss
@@ -37,7 +37,7 @@
   height: 40px;
 }
 
-.betatext {
+.betatext, .betacontainer strong {
   color: $realyellow;
   background-color: $charcoal;
   border-radius: 5px;

--- a/shared/css/course-blocks.scss
+++ b/shared/css/course-blocks.scss
@@ -37,6 +37,11 @@
   height: 40px;
 }
 
+/**
+ * betatext can be used to style a span directly, or betacontainer can be used
+ * on a node containing markdown to apply the beta styling to all **strong**
+ * nodes in the markdown
+ */
 .betatext, .betacontainer strong {
   color: $realyellow;
   background-color: $charcoal;


### PR DESCRIPTION
Specifically, replace the inline span in the string with a simple `<strong>` tag, and add some styling to the string's container element to style any internal `<strong>` tags appropriately.

Before | After
--- | ---
![Screen Shot 2019-09-12 at 14 24 20](https://user-images.githubusercontent.com/244100/64822084-16a97f00-d569-11e9-85f8-d827d2d8af21.png) | ![Screen Shot 2019-09-12 at 14 23 56](https://user-images.githubusercontent.com/244100/64822086-16a97f00-d569-11e9-8a59-5e5dfd871981.png)

Note as a side effect, the "beta" text is now bolded. I don't think that's a concern, but I'm open to un-bolding it if desired.

