### PR TITLE
School Info Confirmation Dialog UI Test

### DIFF
--- a/dashboard/test/ui/features/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/school_info_confirmation_dialog.feature
@@ -17,8 +17,8 @@ Scenario: School Info Confirmation Dialog
   # The date of the teacher's account is updated to 7 days ago to simulate time travel
   # This enables the condition (see school_info_interstitial helper.rb) that checks
   # the age of the account to determine when to show the school info interstitial.
-  And I update user "Teacher_Chuba" created_at timestamp
-  # One week later, the teacher sees the prompt to complete the school info interstitial
+  And eight days pass for user "Teacher_Chuba"
+  # One week after account creation, the teacher sees the prompt to complete the school info interstitial
   Then I reload the page
   And I wait to see ".modal"
 
@@ -27,17 +27,17 @@ Scenario: School Info Confirmation Dialog
   And element "#school-type" is visible
   And I select the "Public" option in dropdown "school-type"
   And I wait until element "#nces_school" is visible
-  Then I press keys "Alakanuk School" for element "#nces_school"
+  # Then I press keys "Alakanuk School" for element "#nces_school"
   Then I wait until element ".VirtualizedSelectOption:contains('Alakanuk School - Alakanuk, AK 99554')" is visible
   Then I press ".VirtualizedSelectOption:contains('Alakanuk School - Alakanuk, AK 99554')" using jQuery
   Then I press "#save-button" using jQuery
 
   # One week later, the teacher does not see the prompt
-  And I update user "Teacher_Chuba" last_seen_school_info_interstitial
+  And eight days pass for user "Teacher_Chuba"
   Then I reload the page
   And element ".modal" is not visible
 
   # One year later, the teacher sees the school info confirmation dialog
-  And I update user "Teacher_Chuba" last_confirmation_date and last_seen_school_info_interstitial
+  And one year passes for user "Teacher_Chuba"
   Then I reload the page
   And element ".modal-body" is visible

--- a/dashboard/test/ui/features/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/school_info_confirmation_dialog.feature
@@ -1,0 +1,8 @@
+Feature: School Info Confirmation Dialog
+
+Scenario: One week later, user receives prompt to complete school info interstitial
+  Given I am on "https://studio.code.org/users/sign_up"
+  And I create a teacher named "Chuba" and go home
+  And I update user "Chuba" account creation date
+  Then I reload the page
+  And I see ".modal"

--- a/dashboard/test/ui/features/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/school_info_confirmation_dialog.feature
@@ -1,8 +1,43 @@
+@dashboard_db_access
 Feature: School Info Confirmation Dialog
 
-Scenario: One week later, user receives prompt to complete school info interstitial
-  Given I am on "https://studio.code.org/users/sign_up"
-  And I create a teacher named "Chuba" and go home
-  And I update user "Chuba" account creation date
+# This test checks three relevant states of the user in the school info confirmation
+# dialog flow:
+# 1. The initial flow is when a user creates a new account and does not fill out
+# all the fields in the school info interstitial.
+# 2. The user receives prompt to complete school info interstitial 7 days after
+# account creation and completes school info.
+# 3. A week later, the user should not receive a prompt to complete school info
+# 4. A year later after the user has completed school info, the user sees prompt to
+# confirm or update current school info.
+
+Scenario: School Info Confirmation Dialog
+  # Teacher account is created with partial school info
+  Given I create a teacher named "Teacher_Chuba" and go home
+  # The date of the teacher's account is updated to 7 days ago to simulate time travel
+  # This enables the condition (see school_info_interstitial helper.rb) that checks
+  # the age of the account to determine when to show the school info interstitial.
+  And I update user "Teacher_Chuba" created_at timestamp
+  # One week later, the teacher sees the prompt to complete the school info interstitial
   Then I reload the page
-  And I see ".modal"
+  And I wait to see ".modal"
+
+  # Teacher completes school info interstitial
+  And element "#react-select-2--value" contains text "United States"
+  And element "#school-type" is visible
+  And I select the "Public" option in dropdown "school-type"
+  And I wait until element "#nces_school" is visible
+  Then I press keys "A Seattle Public School - Seattle, " for element "#nces_school"
+  Then I wait until element ".VirtualizedSelectOption:contains('A Seattle Public School - Seattle, WA 98122')" is visible
+  Then I press ".VirtualizedSelectOption:contains('A Seattle Public School - Seattle, WA 98122')" using jQuery
+  Then I press "#save-button" using jQuery
+
+  # One week later, the teacher does not see the prompt
+  And I update user "Teacher_Chuba" last_seen_school_info_interstitial
+  Then I reload the page
+  And element ".modal" is not visible
+
+  # One year later, the teacher sees the school info confirmation dialog
+  And I update user "Teacher_Chuba" last_confirmation_date and last_seen_school_info_interstitial
+  Then I reload the page
+  And element ".modal-body" is visible

--- a/dashboard/test/ui/features/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/school_info_confirmation_dialog.feature
@@ -27,9 +27,9 @@ Scenario: School Info Confirmation Dialog
   And element "#school-type" is visible
   And I select the "Public" option in dropdown "school-type"
   And I wait until element "#nces_school" is visible
-  Then I press keys "A Seattle Public School - Seattle, " for element "#nces_school"
-  Then I wait until element ".VirtualizedSelectOption:contains('A Seattle Public School - Seattle, WA 98122')" is visible
-  Then I press ".VirtualizedSelectOption:contains('A Seattle Public School - Seattle, WA 98122')" using jQuery
+  Then I press keys "Alakanuk School" for element "#nces_school"
+  Then I wait until element ".VirtualizedSelectOption:contains('Alakanuk School - Alakanuk, AK 99554')" is visible
+  Then I press ".VirtualizedSelectOption:contains('Alakanuk School - Alakanuk, AK 99554')" using jQuery
   Then I press "#save-button" using jQuery
 
   # One week later, the teacher does not see the prompt

--- a/dashboard/test/ui/features/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/school_info_confirmation_dialog.feature
@@ -27,7 +27,7 @@ Scenario: School Info Confirmation Dialog
   And element "#school-type" is visible
   And I select the "Public" option in dropdown "school-type"
   And I wait until element "#nces_school" is visible
-  # Then I press keys "Alakanuk School" for element "#nces_school"
+  Then I press keys "Alakanuk School" for element "#nces_school"
   Then I wait until element ".VirtualizedSelectOption:contains('Alakanuk School - Alakanuk, AK 99554')" is visible
   Then I press ".VirtualizedSelectOption:contains('Alakanuk School - Alakanuk, AK 99554')" using jQuery
   Then I press "#save-button" using jQuery

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1712,24 +1712,22 @@ Then /^page text does (not )?contain "([^"]*)"$/ do |negation, text|
   expect(body_text.include?(text)).to eq(negation.nil?)
 end
 
-And(/^I update user "([^"]*)" created_at timestamp$/) do |name|
+def pass_time_for_user(name, amount_of_time)
   require_rails_env
   user = User.find_by_email_or_hashed_email(@users[name][:email])
-  user.created_at = 8.days.ago
+  user.created_at = amount_of_time
+  user.last_seen_school_info_interstitial = amount_of_time if user.last_seen_school_info_interstitial
   user.save!
+  user.user_school_infos.each do |info|
+    info.last_confirmation_date = amount_of_time
+    info.save!
+  end
 end
 
-And(/^I update user "([^"]*)" last_seen_school_info_interstitial$/) do |name|
-  require_rails_env
-  user = User.find_by_email_or_hashed_email(@users[name][:email])
-  user.last_seen_school_info_interstitial = 8.days.ago
-  user.save!
+And(/^eight days pass for user "([^"]*)"$/) do |name|
+  pass_time_for_user name, 8.days.ago
 end
 
-And(/^I update user "([^"]*)" last_confirmation_date and last_seen_school_info_interstitial$/) do |name|
-  require_rails_env
-  user = User.find_by_email_or_hashed_email(@users[name][:email])
-  user.last_seen_school_info_interstitial = 7.days.ago
-  user.save!
-  user.user_school_infos.last.update(last_confirmation_date: 1.year.ago)
+And(/^one year passes for user "([^"]*)"$/) do |name|
+  pass_time_for_user name, 1.year.ago
 end

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1711,3 +1711,10 @@ Then /^page text does (not )?contain "([^"]*)"$/ do |negation, text|
   body_text = @browser.execute_script('return document.body && document.body.textContent;').to_s
   expect(body_text.include?(text)).to eq(negation.nil?)
 end
+
+And (/^I update user "([^"]*)" account creation date$/) do |name|
+  require_rails_env
+  user = User.find_by_email_or_hashed_email(@users[name][:email])
+  user.created_at = 7.days.ago
+  user.save!
+end

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1712,9 +1712,24 @@ Then /^page text does (not )?contain "([^"]*)"$/ do |negation, text|
   expect(body_text.include?(text)).to eq(negation.nil?)
 end
 
-And (/^I update user "([^"]*)" account creation date$/) do |name|
+And(/^I update user "([^"]*)" created_at timestamp$/) do |name|
   require_rails_env
   user = User.find_by_email_or_hashed_email(@users[name][:email])
-  user.created_at = 7.days.ago
+  user.created_at = 8.days.ago
   user.save!
+end
+
+And(/^I update user "([^"]*)" last_seen_school_info_interstitial$/) do |name|
+  require_rails_env
+  user = User.find_by_email_or_hashed_email(@users[name][:email])
+  user.last_seen_school_info_interstitial = 8.days.ago
+  user.save!
+end
+
+And(/^I update user "([^"]*)" last_confirmation_date and last_seen_school_info_interstitial$/) do |name|
+  require_rails_env
+  user = User.find_by_email_or_hashed_email(@users[name][:email])
+  user.last_seen_school_info_interstitial = 7.days.ago
+  user.save!
+  user.user_school_infos.last.update(last_confirmation_date: 1.year.ago)
 end


### PR DESCRIPTION
Ui test to test when a user sees the school confirmation dialog and school info interstitial

The user scenarios tested:
- User enters partial school info
- One week later, teacher sees school info interstitial and completes the form 
- One week later, teacher does not receive prompt to complete school info 
- One year later, teacher sees  the confirmation dialog

### Ui-test
![ui_test_school_info](https://user-images.githubusercontent.com/30066710/64825779-4b223880-d573-11e9-8560-91beb9ca4781.gif)
