### PR TITLE
Overwrite report.program to blockspace if editing blocks

### DIFF
--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -151,8 +151,10 @@ export function setupApp(appOptions) {
       // Our report will already have the correct callback and program
       // in the contained level case, unless we're editing blocks.
       if (appOptions.level.edit_blocks || !appOptions.hasContainedLevels) {
-        var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-        report.program = Blockly.Xml.domToText(xml);
+        if (appOptions.hasContainedLevels) {
+          var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
+          report.program = Blockly.Xml.domToText(xml);
+        }
         report.callback = appOptions.report.callback;
       }
       trackEvent('Activity', 'Lines of Code', window.script_path, report.lines);

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -148,9 +148,11 @@ export function setupApp(appOptions) {
           lastSavedProgram
         );
       }
-      // report.callback will already have the correct milestone post URL in
-      // the contained level case, unless we're editing blocks
+      // Our report will already have the correct callback and program
+      // in the contained level case, unless we're editing blocks.
       if (appOptions.level.edit_blocks || !appOptions.hasContainedLevels) {
+        var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
+        report.program = Blockly.Xml.domToText(xml);
         report.callback = appOptions.report.callback;
       }
       trackEvent('Activity', 'Lines of Code', window.script_path, report.lines);

--- a/apps/src/containedLevels.js
+++ b/apps/src/containedLevels.js
@@ -67,6 +67,11 @@ export function postContainedLevelAttempt({
   // Track the fact that we're currently submitting
   postState = PostState.Started;
 
+  /**
+   * Get report info for our contained level. *Note:* If we are currently editing blocks,
+   * some of the report info will be overwritten in onAttempt() in order to allow levelbuilders
+   * to update blocks (rather than submit the contained level).
+   */
   const reportInfo = getContainedLevelResultInfo();
   onAttempt({
     ...reportInfo,


### PR DESCRIPTION
Fixes [LP-549](https://codedotorg.atlassian.net/browse/LP-549).

When we are editing blocks on a contained level, we want the `program` in our report to the server to be the current blockspace, not the program for the contained level.

### Example
Previously, when I hit "Run," the program below sent to the server was "asdf," since that is the program for the contained level. But, since I'm in edit mode, I want the program to be the blockspace because 1) I'm a levelbuilder editing the blockspace, and 2) when I make a request to the server, I'm hitting `POST /levels/:level_id/update_blocks/start_blocks`.

<img width="1438" alt="Screen Shot 2019-09-12 at 3 30 31 PM" src="https://user-images.githubusercontent.com/9812299/64825482-49a44080-d572-11e9-9130-d4a423a310e5.png">
