### PR TITLE
Move API-choosing logic from <AssetRow/> to <AssetManager/>

### DIFF
--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -258,11 +258,13 @@ export default class AssetManager extends React.Component {
   };
 
   getAssetRows = () => {
+    const api = this.props.useFilesApi ? filesApi : assetsApi;
+
     return this.state.assets.map(asset => {
       return (
         <AssetRow
           {...this.defaultAssetProps(asset)}
-          useFilesApi={this.props.useFilesApi}
+          api={api}
           onChoose={
             this.props.assetChosen &&
             (() => this.props.assetChosen(asset.filename, asset.timestamp))

--- a/apps/src/code-studio/components/AssetRow.jsx
+++ b/apps/src/code-studio/components/AssetRow.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {assets as assetsApi, files as filesApi} from '@cdo/apps/clientApi';
 import AssetThumbnail from './AssetThumbnail';
 import i18n from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
@@ -24,10 +23,7 @@ export default class AssetRow extends React.Component {
     timestamp: PropTypes.string,
     type: PropTypes.oneOf(['image', 'audio', 'video', 'pdf', 'doc']).isRequired,
     size: PropTypes.number,
-    // Declare a specific API to use. If undefined, useFilesApi prop will decide the API.
-    api: PropTypes.object,
-    // Uses files API if true; uses assets API if false.
-    useFilesApi: PropTypes.bool,
+    api: PropTypes.object.isRequired,
     onChoose: PropTypes.func,
     onDelete: PropTypes.func.isRequired,
     soundPlayer: PropTypes.object,
@@ -44,15 +40,6 @@ export default class AssetRow extends React.Component {
     action: 'normal',
     actionText: '',
     attemptedUsedDelete: false
-  };
-
-  api = () => {
-    const {api, useFilesApi} = this.props;
-    if (api) {
-      return api;
-    } else {
-      return useFilesApi ? filesApi : assetsApi;
-    }
   };
 
   /**
@@ -89,7 +76,7 @@ export default class AssetRow extends React.Component {
   handleDelete = () => {
     this.setState({action: 'deleting', actionText: ''});
 
-    this.api().deleteFile(this.props.name, this.props.onDelete, () => {
+    this.props.api.deleteFile(this.props.name, this.props.onDelete, () => {
       this.setState({
         action: 'confirming delete',
         actionText: i18n.errorDeleting()
@@ -199,7 +186,7 @@ export default class AssetRow extends React.Component {
             type={this.props.type}
             name={this.props.name}
             timestamp={this.props.timestamp}
-            api={this.api()}
+            api={this.props.api}
             soundPlayer={this.props.soundPlayer}
             levelName={this.props.levelName}
           />

--- a/apps/test/unit/code-studio/components/AssetRowTest.js
+++ b/apps/test/unit/code-studio/components/AssetRowTest.js
@@ -6,6 +6,9 @@ import AssetRow from '@cdo/apps/code-studio/components/AssetRow';
 const DEFAULT_PROPS = {
   name: "foo's.bar",
   type: 'image',
+  api: {
+    basePath: name => `/path/to/${name}`
+  },
   onDelete: () => {}
 };
 


### PR DESCRIPTION
Following up on [this comment](https://github.com/code-dot-org/code-dot-org/pull/30218#discussion_r315420020) to move the API-choosing logic out of the <AssetRow/> component 🎉 