### PR TITLE
Donors: teacher banner now placed on marketing page

### DIFF
--- a/pegasus/sites.v3/code.org/public/amazon-future-engineer.md.erb
+++ b/pegasus/sites.v3/code.org/public/amazon-future-engineer.md.erb
@@ -1,24 +1,24 @@
 ---
 title: Amazon Future Engineer
-video_player: true
 theme: responsive
 ---
 
-[banner file]
-## Amazon Future Engineer is a four-part, childhood-to-career program aimed at inspiring and educating 10 million students from underrepresented and underserved communities each year to try computer science and coding. 
+<%= view :donor_teacher_banner %>
+
+## Amazon Future Engineer is a four-part, childhood-to-career program aimed at inspiring and educating 10 million students from underrepresented and underserved communities each year to try computer science and coding.
 
 ### Here’s how it works:
- 
-[k8 pic]
+
+*k8 pic*
 
 K-8: Amazon Future Engineer provides ~10 million students each year with afterschool computer science workshops, coding camps hosted at schools and various Amazon locations, and online computer science courses. We are particularly focused on making sure more students from underrepresented and underserved communities give computer science a try because research shows they are far more likely to pursue computer science later into their academic career if they can have this early exposure. Most of our online courses, after school sessions, and coding camps are facilitated by our partners Coding with Kids. We also fund inspiring experiences such as Code.org’s Hour of Code: Dance Party– try it out!
- 
-[HS pic]
+
+*HS pic*
 
 High School: By Fall 2019, Amazon Future Engineer will provide more than 2,000 schools that serve students from underrepresented and underserved communities across the country with Intro to Computer Science and AP Computer Science classes through curriculum providers. Amazon’s funding provides preparatory lessons, tutorials, professional development for teachers, fully sequenced and paced digital curriculum for students, and live online support every day of the week for both teachers and students. The full-year courses are designed to inspire, prepare, and propel students in their pursuit of a computer science education. All students participating in this program will also receive a free membership to AWS Educate, which provides them with free access to computing power in the AWS Cloud for their coding projects and content to learn about cloud computing.
- 
-[scholar/intern pic]
+
+*scholar/intern pic*
 
 Scholarship: Amazon Future Engineer provides 100 students from underrepresented and underserved communities planning to study computer science at a four-year college or university with $10,000/year scholarships. We work with Scholarship America to manage these prestigious 4-year scholarships specifically focused on students pursuing a computer science degree.
- 
+
 Internship: Amazon Future Engineer offers the 100 scholarship recipients a guaranteed, paid internship at Amazon after their first year of college. Most college students do not have access to software engineering internships until later in their college years. Amazon Future Engineer believes this early exposure will better support the college students on their career path. It gives students the chance to apply their computer science skills in a practical setting, and can reinforce their interest in the industry. Interns partner with a technical mentor and manager, as well as other interns, to innovate and create new features and services on behalf of Amazon customers.

--- a/pegasus/sites.v3/code.org/public/educate/donor-teacher-banner.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/donor-teacher-banner.md.erb
@@ -1,8 +1,0 @@
----
-title: Donor Teacher Banner
-theme: responsive
----
-
-# Teacher Donor Banner
-
-<%= view :donor_teacher_banner %>


### PR DESCRIPTION
This removes the temporary https:/code.org/educate/donor-teacher-banner and puts the donor teacher banner on the marketing page at https://code.org/amazon-future-engineer.

Followup to https://github.com/code-dot-org/code-dot-org/pull/30591

![Screenshot 2019-09-13 10 44 21](https://user-images.githubusercontent.com/2205926/64830464-e5d25400-d613-11e9-9095-30f73f772954.png)
