### PR TITLE
added https:// to hoc link on intl about page

### DIFF
--- a/pegasus/sites.v3/code.org/public/international/about.md.partial
+++ b/pegasus/sites.v3/code.org/public/international/about.md.partial
@@ -8,7 +8,7 @@ video_player: true
 
 <div class="col-60", style="padding-right:20px;">
 
-Code.org® is a nonprofit dedicated to expanding access to computer science in schools and increasing participation by women and underrepresented minorities. Our vision is that every student in every school has the opportunity to learn computer science, just like biology, chemistry, or algebra. We provide the most broadly used curriculum for teaching computer science in primary and secondary school and also organize the annual <a href="hourofcode.com">Hour of Code</a> campaign, which has engaged 10% of all students in the world. Code.org is supported by generous donors including Amazon, Facebook, Google, the Infosys Foundation, Microsoft, and <a href="/about/donors">many more</a>.
+Code.org® is a nonprofit dedicated to expanding access to computer science in schools and increasing participation by women and underrepresented minorities. Our vision is that every student in every school has the opportunity to learn computer science, just like biology, chemistry, or algebra. We provide the most broadly used curriculum for teaching computer science in primary and secondary school and also organize the annual <a href="https://hourofcode.com">Hour of Code</a> campaign, which has engaged 10% of all students in the world. Code.org is supported by generous donors including Amazon, Facebook, Google, the Infosys Foundation, Microsoft, and <a href="/about/donors">many more</a>.
 
 </div>
 


### PR DESCRIPTION
Previous href redirected users to https://code.org/international/hourofcode.com (which gives a 404) instead of hourofcode.com. I added https:// to the href so that it would resolve correctly