### PR TITLE
Lesson Extras Warning: handle cases where there isn't a section

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -188,7 +188,7 @@ class ScriptLevelsController < ApplicationController
         @section = current_user.sections[0]
         @user = @section&.students&.find_by(id: params[:user_id])
       end
-      @show_stage_extras_warning = !@section.stage_extras
+      @show_stage_extras_warning = !@section&.stage_extras
     end
 
     # Explicitly return 404 here so that we don't get a 5xx in get_from_cache.


### PR DESCRIPTION
Follow up to #30675 , fix for the case where a teacher is viewing lesson extras outside the context of section as caught by this [HoneyBadger Error](https://app.honeybadger.io/projects/3240/faults/54859557).