### PR TITLE
Refactor DailySurveyDecorator

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -111,26 +111,28 @@ export default class Results extends React.Component {
   }
 
   renderFacilitatorAverages() {
-    return Object.keys(this.props.facilitators).map((facilitator_id, i) => (
-      <Tab
-        eventKey={this.props.sessions.length + i + 1}
-        key={i}
-        title={this.props.facilitators[facilitator_id]}
-      >
-        <FacilitatorAveragesTable
-          facilitatorAverages={
-            this.props.facilitatorAverages[
-              this.props.facilitators[facilitator_id]
-            ]
-          }
-          facilitatorId={parseInt(facilitator_id, 10)}
-          facilitatorName={this.props.facilitators[facilitator_id]}
-          questions={this.props.facilitatorAverages['questions']}
-          courseName={this.props.courseName}
-          facilitatorResponseCounts={this.props.facilitatorResponseCounts}
-        />
-      </Tab>
-    ));
+    return Object.keys(this.props.facilitators || {}).map(
+      (facilitator_id, i) => (
+        <Tab
+          eventKey={this.props.sessions.length + i + 1}
+          key={i}
+          title={this.props.facilitators[facilitator_id]}
+        >
+          <FacilitatorAveragesTable
+            facilitatorAverages={
+              this.props.facilitatorAverages[
+                this.props.facilitators[facilitator_id]
+              ]
+            }
+            facilitatorId={parseInt(facilitator_id, 10)}
+            facilitatorName={this.props.facilitators[facilitator_id]}
+            questions={this.props.facilitatorAverages['questions']}
+            courseName={this.props.courseName}
+            facilitatorResponseCounts={this.props.facilitatorResponseCounts}
+          />
+        </Tab>
+      )
+    );
   }
 
   render() {

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -11,10 +11,16 @@ export default class Results extends React.Component {
     questions: PropTypes.object.isRequired,
     thisWorkshop: PropTypes.object.isRequired,
     sessions: PropTypes.arrayOf(PropTypes.string).isRequired,
-    facilitators: PropTypes.object.isRequired,
-    facilitatorAverages: PropTypes.object.isRequired,
-    facilitatorResponseCounts: PropTypes.object.isRequired,
+    facilitators: PropTypes.object,
+    facilitatorAverages: PropTypes.object,
+    facilitatorResponseCounts: PropTypes.object,
     courseName: PropTypes.string.isRequired
+  };
+
+  static defaultProps = {
+    facilitators: {},
+    facilitatorAverages: {},
+    facilitatorResponseCounts: {}
   };
 
   state = {
@@ -111,28 +117,26 @@ export default class Results extends React.Component {
   }
 
   renderFacilitatorAverages() {
-    return Object.keys(this.props.facilitators || {}).map(
-      (facilitator_id, i) => (
-        <Tab
-          eventKey={this.props.sessions.length + i + 1}
-          key={i}
-          title={this.props.facilitators[facilitator_id]}
-        >
-          <FacilitatorAveragesTable
-            facilitatorAverages={
-              this.props.facilitatorAverages[
-                this.props.facilitators[facilitator_id]
-              ]
-            }
-            facilitatorId={parseInt(facilitator_id, 10)}
-            facilitatorName={this.props.facilitators[facilitator_id]}
-            questions={this.props.facilitatorAverages['questions']}
-            courseName={this.props.courseName}
-            facilitatorResponseCounts={this.props.facilitatorResponseCounts}
-          />
-        </Tab>
-      )
-    );
+    return Object.keys(this.props.facilitators).map((facilitator_id, i) => (
+      <Tab
+        eventKey={this.props.sessions.length + i + 1}
+        key={i}
+        title={this.props.facilitators[facilitator_id]}
+      >
+        <FacilitatorAveragesTable
+          facilitatorAverages={
+            this.props.facilitatorAverages[
+              this.props.facilitators[facilitator_id]
+            ]
+          }
+          facilitatorId={parseInt(facilitator_id, 10)}
+          facilitatorName={this.props.facilitators[facilitator_id]}
+          questions={this.props.facilitatorAverages['questions']}
+          courseName={this.props.courseName}
+          facilitatorResponseCounts={this.props.facilitatorResponseCounts}
+        />
+      </Tab>
+    ));
   }
 
   render() {

--- a/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
@@ -183,9 +183,7 @@ module Pd::SurveyPipeline::Helper
 
     Pd::SurveyPipeline::DailySurveyModifier.augment_questions_for_display context[:parsed_questions]
 
-    Pd::SurveyPipeline::DailySurveyDecorator.process_data context
-
-    context[:decorated_summaries]
+    Pd::SurveyPipeline::DailySurveyDecorator.decorate_single_workshop context
   end
 
   private

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -261,7 +261,6 @@ module Api::V1::Pd
         "course_name" => nil,
         "questions" => {},
         "this_workshop" => {},
-        "all_my_workshops" => {},
         "facilitators" => {
           f_id => f_name
         },

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -317,11 +317,7 @@ module Api::V1::Pd
       expected_result = {
         "course_name" => nil,
         "questions" => {},
-        "this_workshop" => {},
-        "all_my_workshops" => {},
-        "facilitators" => {},
-        "facilitator_averages" => {},
-        "facilitator_response_counts" => {}
+        "this_workshop" => {}
       }
 
       sign_in @admin

--- a/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/daily_survey_decorator_test.rb
@@ -27,7 +27,7 @@ module Pd::SurveyPipeline
       parsed_questions = {
         form_id => {
           '1' => {type: 'radio', name: 'importance', text: 'CS is important?', order: 1,
-            options: ['Disagree', 'Neutral', 'Agree'],
+            options: %w(Disagree Neutral Agree),
             option_map: {'Disagree': 1, 'Neutral': 2, 'Agree': 3}, answer_type: 'singleSelect'},
           '2' => {type: 'textarea', name: 'feedback', text: 'Free-format feedback', order: 2,
             answer_type: 'text'}
@@ -85,10 +85,6 @@ module Pd::SurveyPipeline
             }
           }
         },
-        all_my_workshops: {},
-        facilitators: {},
-        facilitator_averages: {},
-        facilitator_response_counts: {},
         errors: []
       }
 
@@ -99,9 +95,9 @@ module Pd::SurveyPipeline
         current_user: @workshop_admin
       }
 
-      DailySurveyDecorator.process_data context
+      result = DailySurveyDecorator.decorate_single_workshop context
 
-      assert_equal expected_result, context[:decorated_summaries]
+      assert_equal expected_result, result
     end
 
     test 'decorate general survey results' do
@@ -155,10 +151,6 @@ module Pd::SurveyPipeline
             facilitator: {}
           }
         },
-        all_my_workshops: {},
-        facilitators: {},
-        facilitator_averages: {},
-        facilitator_response_counts: {},
         errors: []
       }
 
@@ -169,9 +161,9 @@ module Pd::SurveyPipeline
         current_user: @workshop_admin
       }
 
-      DailySurveyDecorator.process_data context
+      result = DailySurveyDecorator.decorate_single_workshop context
 
-      assert_equal expected_result, context[:decorated_summaries]
+      assert_equal expected_result, result
     end
 
     test 'index questions by form ids and question names' do
@@ -208,17 +200,17 @@ module Pd::SurveyPipeline
       data = @summary_data_permission_test
       user = @facilitators.first
 
-      assert_equal true, DailySurveyDecorator.data_visible_to_user?(user, data[0])
-      assert_equal false, DailySurveyDecorator.data_visible_to_user?(user, data[1])
-      assert_equal true, DailySurveyDecorator.data_visible_to_user?(user, data[2])
+      assert_equal true, DailySurveyDecorator.summary_visible_to_user?(user, data[0])
+      assert_equal false, DailySurveyDecorator.summary_visible_to_user?(user, data[1])
+      assert_equal true, DailySurveyDecorator.summary_visible_to_user?(user, data[2])
     end
 
-    test 'program mamager and workshop admin see all facilitator results' do
+    test 'program manager and workshop admin see all facilitator results' do
       data = @summary_data_permission_test
       users = [@program_manager, @workshop_admin]
 
       users.product(data).each do |user, data_row|
-        assert_equal true, DailySurveyDecorator.data_visible_to_user?(user, data_row)
+        assert_equal true, DailySurveyDecorator.summary_visible_to_user?(user, data_row)
       end
     end
 
@@ -228,6 +220,7 @@ module Pd::SurveyPipeline
       form_id = '1122334455'.to_i
 
       survey_metadata_to_context = {
+        # Array<workshop_id, day, facilitator_id, form_id> => context_name
         [workshop.id, 0, facilitator.id, form_id] => 'Facilitators',
         [workshop.id, 0, nil, form_id] => 'Pre Workshop',
         [workshop.id, 1, nil, form_id] => 'Post Workshop',
@@ -247,6 +240,7 @@ module Pd::SurveyPipeline
       form_id = '1122334455'.to_i
 
       survey_metadata_to_context = {
+        # Array<workshop_id, day, facilitator_id, form_id> => context_name
         [workshop.id, 0, nil, form_id] => 'Pre Workshop',
         [workshop.id, 1, nil, form_id] => 'Day 1',
         [workshop.id, 1, facilitator.id, form_id] => 'Day 1'
@@ -265,6 +259,7 @@ module Pd::SurveyPipeline
       post_ws_form_id = '82115646319154'.to_i
 
       survey_metadata_to_context = {
+        # Array<workshop_id, day, facilitator_id, form_id> => context_name
         [workshop.id, 0, nil, daily_form_id] => 'Invalid',
         [workshop.id, 1, nil, daily_form_id] => 'Day 1',
         [workshop.id, 1, facilitator.id, daily_form_id] => 'Day 1',

--- a/dashboard/test/lib/pd/survey_pipeline/survey_pipeline_worker_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/survey_pipeline_worker_test.rb
@@ -1,5 +1,5 @@
 module Pd::SurveyPipeline
-  class DailySurveyDecoratorTest < ActiveSupport::TestCase
+  class SurveyPipelineWorkerTest < ActiveSupport::TestCase
     test 'raise if missing input key' do
       input = {key1: nil}
       required_keys = [:key1, :key2, :key3]


### PR DESCRIPTION
[PLC-431](https://codedotorg.atlassian.net/browse/PLC-431)
This PR does a few things
1. Refactor DailySurveyDecorator to not extend from SurveyPipelineWorker to make the class simpler.
2. Remove unused empty fields in survey summary report. 
3. Update UI to behave correctly with the removed fields in the report. 
4. Refactor function name and variable name to make their meaning clearer.
5. Update function comments. Remove redundant comments. 

This PR doesn't change functionality of the class.