### PR TITLE
Clone p5specialFunctions to unusedConfig

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -320,7 +320,7 @@ P5Lab.prototype.init = function(config) {
     // Store p5specialFunctions in the unusedConfig array so we don't give warnings
     // about these functions not being called:
     // Clone p5specialFunctions so we can remove 'setup' from unusedConfig but not p5specialFunctions
-    config.unusedConfig = this.p5Wrapper.p5specialFunctions.slice(0);
+    config.unusedConfig = [...this.p5Wrapper.p5specialFunctions];
     // remove 'setup' from unusedConfig so that we can show a warning for redefining it.
     if (config.unusedConfig.indexOf('setup') !== -1) {
       config.unusedConfig.splice(config.unusedConfig.indexOf('setup'), 1);

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -319,7 +319,8 @@ P5Lab.prototype.init = function(config) {
 
     // Store p5specialFunctions in the unusedConfig array so we don't give warnings
     // about these functions not being called:
-    config.unusedConfig = this.p5Wrapper.p5specialFunctions;
+    // Clone p5specialFunctions so we can remove 'setup' from unusedConfig but not p5specialFunctions
+    config.unusedConfig = this.p5Wrapper.p5specialFunctions.slice(0);
     // remove 'setup' from unusedConfig so that we can show a warning for redefining it.
     if (config.unusedConfig.indexOf('setup') !== -1) {
       config.unusedConfig.splice(config.unusedConfig.indexOf('setup'), 1);

--- a/apps/test/integration/levelSolutions/gamelab/setup.js
+++ b/apps/test/integration/levelSolutions/gamelab/setup.js
@@ -1,0 +1,29 @@
+import {gamelabLevelDefinition} from '../../gamelabLevelDefinition';
+import {testAsyncProgramGameLab} from '../../util/levelTestHelpers';
+
+module.exports = {
+  app: 'gamelab',
+  skinId: 'gamelab',
+  levelDefinition: gamelabLevelDefinition,
+  tests: [
+    testAsyncProgramGameLab(
+      'setup works',
+      `
+        function setup() {
+          console.log('setup');
+        }
+        function draw() {
+          console.log('draw');
+        }
+      `,
+      function isProgramDone() {
+        var debugOutput = document.getElementById('debug-output');
+        return debugOutput.textContent.includes('draw');
+      },
+      function validateResult(assert) {
+        var debugOutput = document.getElementById('debug-output');
+        assert.include(debugOutput.textContent, 'setup');
+      }
+    )
+  ]
+};


### PR DESCRIPTION
#29116 broke projects that redefine `setup()`. The goal is to warn against redefining `setup()` but still allow it to work.

This enables that by cloning `p5specialFunctions` so we can remove 'setup' from `unusedConfig` but not from `p5specialFunctions`