### PR TITLE
[React 16] Fixed bug in PendingButton that sometimes caused the onClick to return 'false' rather than a function

### DIFF
--- a/apps/src/templates/PendingButton.jsx
+++ b/apps/src/templates/PendingButton.jsx
@@ -26,7 +26,7 @@ class PendingButton extends React.Component {
         id={this.props.id}
         style={style}
         className={this.props.className}
-        onClick={!this.props.isPending && this.props.onClick}
+        onClick={this.props.isPending ? () => {} : this.props.onClick}
       >
         {this.props.isPending ? (
           <span>


### PR DESCRIPTION
This is a fix required in React 16.