### PR TITLE
Stop manually slugifying PLC course names

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -1,3 +1,5 @@
+require 'cdo/honeybadger'
+
 class CoursesController < ApplicationController
   include VersionRedirectOverrider
 
@@ -54,6 +56,7 @@ class CoursesController < ApplicationController
       course = Course.get_from_cache(course_name)
       # only support this alternative course name for plc courses
       raise ActiveRecord::RecordNotFound unless course.try(:plc_course)
+      Honeybadger.notify "Deprecated PLC course name logic used for course #{course_name}"
     end
 
     if course.plc_course

--- a/dashboard/app/models/plc/course.rb
+++ b/dashboard/app/models/plc/course.rb
@@ -18,8 +18,4 @@ class Plc::Course < ActiveRecord::Base
   belongs_to :course, class_name: '::Course', foreign_key: 'course_id', dependent: :destroy, required: true
 
   delegate :name, to: :course
-
-  def get_url_name
-    name.downcase.tr(' ', '-')
-  end
 end

--- a/dashboard/app/models/plc/user_course_enrollment.rb
+++ b/dashboard/app/models/plc/user_course_enrollment.rb
@@ -78,7 +78,7 @@ class Plc::UserCourseEnrollment < ActiveRecord::Base
   def summarize
     {
       courseName: plc_course.name,
-      link: Rails.application.routes.url_helpers.course_path(plc_course.get_url_name),
+      link: Rails.application.routes.url_helpers.course_path(plc_course.course),
       status: status,
       courseUnits: plc_unit_assignments.sort_by {|a| a.plc_course_unit.unit_order || 0}.map do |unit_assignment|
         {

--- a/dashboard/app/views/peer_reviews/show.html.haml
+++ b/dashboard/app/views/peer_reviews/show.html.haml
@@ -6,7 +6,7 @@
   - if @peer_review.script.professional_learning_course?
     #breadcrumb
     - course_unit = @peer_review.script.plc_course_unit
-    - react_props = {unit_name: course_unit.unit_name, unit_view_path: script_path(course_unit.script), course_view_path: course_path(course_unit.plc_course.get_url_name), page_name: t('flex_category.peer_review')}
+    - react_props = {unit_name: course_unit.unit_name, unit_view_path: script_path(course_unit.script), course_view_path: course_path(course_unit.plc_course.course), page_name: t('flex_category.peer_review')}
     :javascript
       ReactDOM.render(
         React.createElement(window.dashboard.plcHeader, #{react_props.to_json}),

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -3,7 +3,7 @@
 - additional_script_data = {course_name: @script.course&.name, show_redirect_warning: @show_redirect_warning, redirect_script_url: @redirect_script_url, section: @section, user_type: current_user&.user_type, user_id: current_user&.id, is_verified_teacher: current_user&.authorized_teacher?, locale: Script.locale_english_name_map[request.locale]}
 - scriptOverviewData = {scriptData: script_data.merge(additional_script_data)}
 - if @script.professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
-  -  scriptOverviewData[:plcBreadcrumb] = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.get_url_name)}
+  -  scriptOverviewData[:plcBreadcrumb] = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.course)}
 - content_for(:head) do
   %script{ src: minifiable_asset_path('js/scripts/show.js'), data: {scriptoverview: scriptOverviewData.to_json }}
 

--- a/dashboard/test/controllers/courses_controller_integration_test.rb
+++ b/dashboard/test/controllers/courses_controller_integration_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CoursesControllerTest < ActionDispatch::IntegrationTest
+class CoursesControllerIntegrationTest < ActionDispatch::IntegrationTest
   self.use_transactional_test_case = true
 
   test "show: plc courses get sent to user_course_enrollments_controller" do

--- a/dashboard/test/controllers/courses_controller_integration_test.rb
+++ b/dashboard/test/controllers/courses_controller_integration_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class CoursesControllerTest < ActionDispatch::IntegrationTest
+  self.use_transactional_test_case = true
+
+  test "show: plc courses get sent to user_course_enrollments_controller" do
+    sign_in create :teacher
+    # Note: We intentionally use a complex-ish course name here, similar to what
+    # our real PLC course names look like.
+    plc_course = create :plc_course, name: "CS Discoveries Deeper Learning 2119 - 2120"
+    get course_path(plc_course.course)
+    assert_template 'plc/user_course_enrollments/index'
+  end
+
+  # We'd like to deprecate this behavior as soon as we're confident nothing depends on it
+  test "show: plc course names get titleized" do
+    sign_in create :teacher
+    create :plc_course, name: "My Plc"
+    get '/courses/my_plc'
+    assert_template 'plc/user_course_enrollments/index'
+  end
+end

--- a/dashboard/test/controllers/courses_controller_integration_test.rb
+++ b/dashboard/test/controllers/courses_controller_integration_test.rb
@@ -4,6 +4,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
   self.use_transactional_test_case = true
 
   test "show: plc courses get sent to user_course_enrollments_controller" do
+    Honeybadger.expects(:notify).never
     sign_in create :teacher
     # Note: We intentionally use a complex-ish course name here, similar to what
     # our real PLC course names look like.
@@ -14,6 +15,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
 
   # We'd like to deprecate this behavior as soon as we're confident nothing depends on it
   test "show: plc course names get titleized" do
+    Honeybadger.expects(:notify)
     sign_in create :teacher
     create :plc_course, name: "My Plc"
     get '/courses/my_plc'

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -10,8 +10,6 @@ class CoursesControllerTest < ActionController::TestCase
     @levelbuilder = create :levelbuilder
 
     Script.stubs(:should_cache?).returns true
-    plc_course = create :plc_course, name: 'My Plc'
-    @course_plc = plc_course.course
     @course_regular = create :course, name: 'non-plc-course'
 
     # stub writes so that we dont actually make updates to filesystem
@@ -27,16 +25,6 @@ class CoursesControllerTest < ActionController::TestCase
   test_user_gets_response_for :index, response: :success, user: :user, queries: 3
 
   # Tests for show
-
-  test "show: plc courses get sent to user_course_enrollments_controller" do
-    get :show, params: {course_name: @course_plc.name}
-    assert_template 'plc/user_course_enrollments/index'
-  end
-
-  test "show: plc course names get titleized" do
-    get :show, params: {course_name: 'my_plc'}
-    assert_template 'plc/user_course_enrollments/index'
-  end
 
   test "show: regular courses get sent to show" do
     get :show, params: {course_name: @course_regular.name}

--- a/dashboard/test/models/plc/user_course_enrollment_test.rb
+++ b/dashboard/test/models/plc/user_course_enrollment_test.rb
@@ -44,7 +44,7 @@ class Plc::UserCourseEnrollmentTest < ActiveSupport::TestCase
     enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @course)
     expected_summary = {
       courseName: @course.name,
-      link: Rails.application.routes.url_helpers.course_path(@course.get_url_name),
+      link: Rails.application.routes.url_helpers.course_path(@course.course),
       status: enrollment.status,
       courseUnits: [
         {

--- a/dashboard/test/ui/features/plc/course_unit_navigation.feature
+++ b/dashboard/test/ui/features/plc/course_unit_navigation.feature
@@ -3,7 +3,7 @@ Feature: Basic navigation for PLC stuff
 Background:
   Given I am a teacher
   And I am enrolled in a plc course
-  Given I am on "http://studio.code.org/courses/all-the-plc-things"
+  Given I am on "http://studio.code.org/courses/All%20The%20PLC%20Things"
   And I wait to see ".course_unit_sections"
 
 Scenario: Basic navigation and ribbon changing works as expected
@@ -15,7 +15,7 @@ Scenario: Basic navigation and ribbon changing works as expected
   And I wait to see ".uitest-plcbreadcrumb"
   Then I fake completion of the assessment
   Then I click selector ".uitest-plcbreadcrumb a"
-  And I get redirected to "/courses/all-the-plc-things" via "dashboard"
+  And I get redirected to "/courses/All%20The%20PLC%20Things" via "dashboard"
   And I wait to see ".course_unit_sections"
   Then I verify progress for the selector ".course_unit_section a:nth-child(3) .ribbon" is "completed"
   Then I click selector ".course_unit_section a:nth-child(4)"
@@ -25,6 +25,6 @@ Scenario: Basic navigation and ribbon changing works as expected
   Then I type "Test Answer" into "textarea"
   Then I click selector ".submitButton"
   And I get redirected to "/s/alltheplcthings/stage/10/puzzle/7" via "dashboard"
-  Given I am on "http://studio.code.org/courses/all-the-plc-things"
+  Given I am on "http://studio.code.org/courses/All%20The%20PLC%20Things"
   And I wait to see ".course_unit_sections"
   Then I verify progress for the selector ".course_unit_section a:nth-child(4) .ribbon" is "in_progress"


### PR DESCRIPTION
[PLC-452](https://codedotorg.atlassian.net/browse/PLC-452): Some of our PLC course links (including breadcrumbs) [are broken (Slack)](https://codedotorg.slack.com/archives/C0T10H26N/p1568401706006500) because we've been manually slug-ifying the PLC course names for our URLs with:

```rb
name.downcase.tr(' ', '-')
```

...and trying to restore them with...

```rb
name.tr('-', '_').titleize
```

This worked fine for the one simple test case we had in place (`My Plc <=> my_plc`) but our real course names don't look like that.  A recent broken example:

```rb
# The real course name
"CS Discoveries Deeper Learning 2019 - 2020"
# Slug-ified
"cs-discoveries-deeper-learning-2019---2020"
# Unsuccessfully restored
"Cs Discoveries Deeper Learning 2019   2020"
```

This PR removes the "slugification" code and replaces it with a more typical use of the `course_path` helper, passing it a `Course` model and letting it perform all the appropriate URL encoding so that the links work fine when they're used later.

I've left the following "un-slug" code in place for now, in case there are any links or bookmarks out there still depending on the old behavior:

https://github.com/code-dot-org/code-dot-org/blob/1838c6ea9d7697eaa2fcaf35ea65ae7b240050ea/dashboard/app/controllers/courses_controller.rb#L49-L57

We'll watch for remaining uses of this path and remove it when we're confident it's no longer needed.