### PR TITLE
Donors: UI tweaks to donor teacher banner

### DIFF
--- a/apps/src/donorTeacherBanner/donorTeacherBanner.js
+++ b/apps/src/donorTeacherBanner/donorTeacherBanner.js
@@ -37,7 +37,7 @@ function showDonorTeacherBanner() {
     .complete(() => {
       ReactDOM.render(
         <Provider store={getStore()}>
-          <DonorTeacherBanner options={options} />
+          <DonorTeacherBanner options={options} showPegasusLink={false} />
         </Provider>,
         donorTeacherBannerElement[0]
       );

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -4,6 +4,7 @@ import React, {Component} from 'react';
 import Button from './Button';
 import color from '@cdo/apps/util/color';
 import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
+import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 
 const styles = {
   heading: {
@@ -88,7 +89,8 @@ export const donorTeacherBannerOptionsShape = PropTypes.shape({
 export default class DonorTeacherBanner extends Component {
   static propTypes = {
     options: donorTeacherBannerOptionsShape,
-    onDismiss: PropTypes.func
+    onDismiss: PropTypes.func,
+    showPegasusLink: PropTypes.bool
   };
 
   initialState = {
@@ -160,7 +162,12 @@ export default class DonorTeacherBanner extends Component {
           </div>
           <div style={styles.paragraph}>
             Would you like to participate in the Amazon Future Engineer Program?
-            Learn more
+            {this.props.showPegasusLink && (
+              <span>
+                &nbsp;
+                <a href={pegasus('/amazon-future-engineer')}>Learn more</a>
+              </span>
+            )}
           </div>
           <div>
             <div>

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -6,13 +6,23 @@ import color from '@cdo/apps/util/color';
 import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 
 const styles = {
+  heading: {
+    marginTop: 25
+  },
   button: {
     marginLeft: 7,
     marginRight: 7,
     marginTop: 15
   },
   checkbox: {
-    margin: '0 7px 0 0'
+    margin: '0 7px 4px 0',
+    cursor: 'pointer',
+    verticalAlign: 'middle'
+  },
+  checkboxDisabled: {
+    margin: '0 7px 4px 0',
+    cursor: 'not-allowed',
+    verticalAlign: 'middle'
   },
   clear: {
     clear: 'both'
@@ -44,9 +54,14 @@ const styles = {
   paragraph: {
     marginBottom: 10
   },
+  label: {
+    fontFamily: '"Gotham 4r", sans-serif',
+    cursor: 'pointer'
+  },
   radio: {
     verticalAlign: 'top',
-    marginRight: 10
+    marginRight: 10,
+    cursor: 'pointer'
   },
   permissionEnabled: {},
   permissionDisabled: {
@@ -134,7 +149,9 @@ export default class DonorTeacherBanner extends Component {
     return (
       <div style={styles.main}>
         <div style={styles.message}>
-          <h2>Free stuff from Amazon for your classroom</h2>
+          <h2 style={styles.heading}>
+            Free stuff from Amazon for your classroom
+          </h2>
           <div style={styles.paragraph}>
             Amazon Future Engineer offers free support for participating
             Code.org classrooms, including posters, free CSTA+ membership,
@@ -147,7 +164,7 @@ export default class DonorTeacherBanner extends Component {
           </div>
           <div>
             <div>
-              <label>
+              <label style={styles.label}>
                 <input
                   type="radio"
                   id="participateYes"
@@ -161,7 +178,7 @@ export default class DonorTeacherBanner extends Component {
               </label>
             </div>
             <div>
-              <label>
+              <label style={styles.label}>
                 <input
                   type="radio"
                   id="participateNo"
@@ -177,13 +194,17 @@ export default class DonorTeacherBanner extends Component {
           </div>
           <hr />
           <div style={permissionStyle}>
-            <label>
+            <label style={styles.label}>
               <input
                 type="checkbox"
                 name={name}
                 checked={this.state.permission}
                 onChange={this.onPermissionChange}
-                style={styles.checkbox}
+                style={
+                  this.state.participate
+                    ? styles.checkbox
+                    : styles.checkboxDisabled
+                }
                 disabled={this.state.participate !== true}
               />
               I give Code.org permission to share my name, email address, and

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -263,6 +263,7 @@ export default class TeacherHomepage extends Component {
               <DonorTeacherBanner
                 options={donorTeacherBannerOptions}
                 onDismiss={() => this.dismissDonorTeacherBanner()}
+                showPegasusLink={true}
               />
               <div style={styles.clear} />
             </div>

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -264,6 +264,7 @@ export default class TeacherHomepage extends Component {
                 options={donorTeacherBannerOptions}
                 onDismiss={() => this.dismissDonorTeacherBanner()}
               />
+              <div style={styles.clear} />
             </div>
           )}
         <TeacherSections queryStringOpen={queryStringOpen} locale={locale} />


### PR DESCRIPTION
- Mouse cursors are now consistent between dashboard and pegasus.
- Checkbox is better positioned.
- Dashboard has space below the banner.
- Pegasus has layout and font weights closer to dashboard.
- The "Learn more" link now works, and is only shown on the dashboard.

Followup to https://github.com/code-dot-org/code-dot-org/pull/30591

### dashboard

![Screenshot 2019-09-16 19 59 51](https://user-images.githubusercontent.com/2205926/64949715-27d1f300-d8bd-11e9-8162-40a764cffdbb.png)

### pegasus

![Screenshot 2019-09-16 20 00 09](https://user-images.githubusercontent.com/2205926/64949724-2dc7d400-d8bd-11e9-9673-92b1141d0af6.png)

