### PR TITLE
[Applab Datasets] Populate Preview Modal

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -814,6 +814,12 @@ function setupReduxSubscribers(store) {
       );
     }
 
+    const lastIsPreview = lastState.data && lastState.data.isPreviewOpen;
+    const isPreview = state.data && state.data.isPreviewOpen;
+    if (isDataMode && isPreview && !lastIsPreview) {
+      onDataPreview(state.data.tableName);
+    }
+
     if (
       !lastState.runState ||
       state.runState.isRunning !== lastState.runState.isRunning
@@ -1280,6 +1286,18 @@ function onInterfaceModeChange(mode) {
     }
   }
   requestAnimationFrame(() => showHideWorkspaceCallouts());
+}
+
+function onDataPreview(tableName) {
+  onColumnNames(getSharedDatabase(), tableName, columnNames => {
+    getStore().dispatch(updateTableColumns(tableName, columnNames));
+  });
+
+  getSharedDatabase()
+    .child(`storage/tables/${tableName}/records`)
+    .once('value', snapshot => {
+      getStore().dispatch(updateTableRecords(tableName, snapshot.val()));
+    });
 }
 
 /**

--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -2,7 +2,7 @@ import Radium from 'radium';
 import React from 'react';
 import LibraryCategory from './LibraryCategory';
 import SearchBar from '@cdo/apps/templates/SearchBar';
-import datasetManifest from './datasetManifest.json';
+import {categories} from './datasetManifest.json';
 import color from '../../util/color';
 import msg from '@cdo/locale';
 
@@ -33,7 +33,7 @@ class DataLibraryPane extends React.Component {
           onChange={() => console.log('search!')}
         />
         <hr style={styles.divider} />
-        {datasetManifest.categories.map(category => (
+        {categories.map(category => (
           <LibraryCategory
             key={category.name}
             name={category.name}

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -31,7 +31,7 @@ const styles = {
     overflow: 'scroll'
   },
   pagination: {
-    marginBottom: 20
+    overflow: 'auto'
   },
   plusIcon: {
     alignItems: 'center',

--- a/apps/src/storage/dataBrowser/LibraryCategory.jsx
+++ b/apps/src/storage/dataBrowser/LibraryCategory.jsx
@@ -32,7 +32,7 @@ const styles = {
 class LibraryCategory extends React.Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
-    datasets: PropTypes.arrayOf(PropTypes.object).isRequired,
+    datasets: PropTypes.arrayOf(PropTypes.string).isRequired,
     description: PropTypes.string.isRequired
   };
 
@@ -62,13 +62,8 @@ class LibraryCategory extends React.Component {
             <span style={styles.categoryDescription}>
               {this.props.description}
             </span>
-            {this.props.datasets.map(dataset => (
-              <LibraryTable
-                key={dataset.name}
-                name={dataset.name}
-                description={dataset.description}
-                current={dataset.current}
-              />
+            {this.props.datasets.map(tableName => (
+              <LibraryTable key={tableName} name={tableName} />
             ))}
           </div>
         )}

--- a/apps/src/storage/dataBrowser/LibraryTable.jsx
+++ b/apps/src/storage/dataBrowser/LibraryTable.jsx
@@ -7,6 +7,7 @@ import msg from '@cdo/locale';
 import color from '../../util/color';
 import {showPreview} from '../redux/data';
 import PreviewModal from './PreviewModal';
+import {getDatasetInfo} from './dataUtils';
 
 const styles = {
   tableName: {
@@ -55,8 +56,6 @@ const styles = {
 class LibraryTable extends React.Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired,
-    current: PropTypes.bool.isRequired,
 
     // from redux dispatch
     onShowPreview: PropTypes.func.isRequired
@@ -66,13 +65,15 @@ class LibraryTable extends React.Component {
     collapsed: true
   };
 
+  datasetInfo = getDatasetInfo(this.props.name);
+
   toggleCollapsed = () =>
     this.setState({
       collapsed: !this.state.collapsed
     });
 
   importTable = () => {
-    if (this.props.current) {
+    if (this.datasetInfo.current) {
       // TODO: Implement current tables (see STAR-615)
     } else {
       FirebaseStorage.copyStaticTable(
@@ -89,6 +90,7 @@ class LibraryTable extends React.Component {
 
   render() {
     const icon = this.state.collapsed ? 'caret-right' : 'caret-down';
+
     return (
       <div>
         <a style={styles.tableName} onClick={this.toggleCollapsed}>
@@ -98,7 +100,7 @@ class LibraryTable extends React.Component {
         {!this.state.collapsed && (
           <div style={styles.collapsibleContainer}>
             {/* TODO: Add last updated time */}
-            <div>{this.props.description}</div>
+            <div>{this.datasetInfo.description}</div>
             <div>
               <button
                 style={styles.preview}

--- a/apps/src/storage/dataBrowser/PreviewModal.jsx
+++ b/apps/src/storage/dataBrowser/PreviewModal.jsx
@@ -2,7 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import {hidePreview} from '../redux/data';
+import {getDatasetInfo} from './dataUtils';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
+import DataTable from './DataTable';
 
 class PreviewModal extends React.Component {
   static propTypes = {
@@ -16,9 +18,12 @@ class PreviewModal extends React.Component {
     if (!this.props.isPreviewOpen) {
       return null;
     }
+    const datasetInfo = getDatasetInfo(this.props.tableName);
     return (
       <BaseDialog isOpen handleClose={this.props.onClose} fullWidth>
         <h1>{this.props.tableName}</h1>
+        <p>{datasetInfo.description}</p>
+        <DataTable getColumnNames={(records, columns) => columns} />
       </BaseDialog>
     );
   }

--- a/apps/src/storage/dataBrowser/dataUtils.js
+++ b/apps/src/storage/dataBrowser/dataUtils.js
@@ -1,3 +1,4 @@
+import {tables} from './datasetManifest.json';
 /** @file Utility functions for the data browser. */
 
 /**
@@ -9,6 +10,10 @@ export const ColumnType = {
   NUMBER: 'number',
   BOOLEAN: 'boolean'
 };
+
+export function getDatasetInfo(tableName) {
+  return tables.find(table => table.name === tableName);
+}
 
 /**
  * @param {*} val

--- a/apps/src/storage/dataBrowser/datasetManifest.json
+++ b/apps/src/storage/dataBrowser/datasetManifest.json
@@ -1,110 +1,106 @@
 {
+  "tables": [
+    {
+      "name": "cities",
+      "description": "description cities",
+      "current": false
+    },
+    {
+      "name": "history",
+      "description": "description history",
+      "current": false
+    },
+    {
+      "name": "sports",
+      "description": "description sports",
+      "current": true
+    },
+    {
+      "name": "spotify",
+      "description": "description spotify",
+      "current": true
+    },
+    {
+      "name": "one",
+      "description": "description one",
+      "current": false
+    },
+    {
+      "name": "two",
+      "description": "description two",
+      "current": false
+    },
+    {
+      "name": "three",
+      "description": "description three",
+      "current": false
+    },
+    {
+      "name": "four",
+      "description": "description four",
+      "current": false
+    },
+    {
+      "name": "five",
+      "description": "description five",
+      "current": false
+    },
+    {
+      "name": "six",
+      "description": "description six",
+      "current": false
+    },
+    {
+      "name": "seven",
+      "description": "description seven",
+      "current": false
+    },
+    {
+      "name": "eight",
+      "description": "description eight",
+      "current": false
+    },
+    {
+      "name": "nine",
+      "description": "description nine",
+      "current": false
+    },
+    {
+      "name": "ten",
+      "description": "description ten",
+      "current": false
+    }
+  ],
   "categories": [
     {
       "name": "Test Data",
       "description": "datasets that are in the shared channel in dev firebase",
-      "datasets": [
-        {
-          "name": "cities",
-          "description": "description",
-          "current": false
-        },
-        {
-          "name": "history",
-          "description": "description",
-          "current": false
-        },
-        {
-          "name": "sports",
-          "description": "description",
-          "current": true
-        },
-        {
-          "name": "spotify",
-          "description": "description",
-          "current": true
-        }
-      ]
+      "datasets": ["cities", "history", "sports", "spotify"]
     },
     {
       "name": "Animals",
       "description": "description",
-      "datasets": [
-        {
-          "name": "one",
-          "description": "description one",
-          "current": false
-        },
-        {
-          "name": "two",
-          "description": "description two",
-          "current": false
-        }
-      ]
+      "datasets": ["one", "two"]
     },
     {
       "name": "Arts & Entertainment",
       "description": "description",
-      "datasets": [
-        {
-          "name": "three",
-          "description": "description three",
-          "current": false
-        },
-        {
-          "name": "four",
-          "description": "description four",
-          "current": false
-        }
-      ]
+      "datasets": ["three", "four"]
     },
     {
       "name": "Business & Money",
       "description": "description",
-      "datasets": [
-        {
-          "name": "five",
-          "description": "description five",
-          "current": false
-        },
-        {
-          "name": "six",
-          "description": "description six",
-          "current": false
-        }
-      ]
+      "datasets": ["five", "six"]
     },
     {
       "name": "Education",
       "description": "description",
-      "datasets": [
-        {
-          "name": "seven",
-          "description": "description seven",
-          "current": false
-        },
-        {
-          "name": "eight",
-          "description": "description eight",
-          "current": false
-        },
-        {
-          "name": "nine",
-          "description": "description nine",
-          "current": false
-        }
-      ]
+      "datasets": ["seven", "eight", "nine"]
     },
     {
       "name": "Health & Medicine",
       "description": "description",
-      "datasets": [
-        {
-          "name": "ten",
-          "description": "description ten",
-          "current": false
-        }
-      ]
+      "datasets": ["ten"]
     }
   ]
 }

--- a/apps/src/storage/redux/data.js
+++ b/apps/src/storage/redux/data.js
@@ -89,7 +89,11 @@ export default function(state = initialState, action) {
         .set('isPreviewOpen', true)
         .set('tableName', action.tableName);
     case HIDE_PREVIEW:
-      return state.set('isPreviewOpen', false).set('tableName', '');
+      return state
+        .set('isPreviewOpen', false)
+        .set('tableName', '')
+        .set('tableRecords', {})
+        .set('tableColumns', []);
     default:
       return state;
   }


### PR DESCRIPTION
This PR populates data in the modal when you click preview. Applab subscribes to the redux store directly in order to listen for changes to the preview modal. When the modal opens, it makes the Firebase call and dispatches an `updateTableRecords` action. We had talked about doing this using redux-thunk instead of applab subscribing to the store (see [STAR-675](https://codedotorg.atlassian.net/browse/STAR-675)). For now, however, I don't think this change makes things any worse. It's one more thing that will need to change if we move to using thunks, but it's very similar to the flow for populating the data table view, so it doesn't add complexity to the refactor.

This PR also includes a refactor of how the dataset manifest is structured to make it easier to look up information associated with a dataset by name.

Next step: Add `readOnly` option to `DataTable` so that we can render the table without any of the controls in the preview modal.

Before:
![image](https://user-images.githubusercontent.com/8787187/64974613-fe37ae00-d861-11e9-9a14-b83b30d9c3e6.png)

After:
![image](https://user-images.githubusercontent.com/8787187/64974631-098ad980-d862-11e9-909a-4589df2f42f2.png)
