### PR TITLE
combine strings and variables in for_counter block

### DIFF
--- a/apps/lib/blockly/en_us.js
+++ b/apps/lib/blockly/en_us.js
@@ -41,6 +41,7 @@ Blockly.Msg.CONTROLS_FOREACH_INPUT_ITEM = "for each item";
 Blockly.Msg.CONTROLS_FOREACH_TOOLTIP = "For each item in a list, set the variable '%1' to the item, and then do some statements.";
 Blockly.Msg.CONTROLS_FOR_HELPURL = "https://code.google.com/p/blockly/wiki/Loops#count_with";
 Blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY = "from %1 to %2 count by %3";
+Blockly.Msg.CONTROLS_FOR_INPUT_COUNTER = "for %1 from %2 to %3 count by %4";
 Blockly.Msg.CONTROLS_FOR_INPUT_WITH = "for";
 Blockly.Msg.CONTROLS_FOR_TOOLTIP = "Have the variable %1 take on the values from the start number to the end number, counting by the specified interval, and do the specified blocks.";
 Blockly.Msg.CONTROLS_IF_ELSEIF_TOOLTIP = "Add a condition to the if block.";

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -650,11 +650,14 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: blockly.Msg.CONTROLS_FOR_HELPURL,
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput()
-        .appendTitle(blockly.Msg.CONTROLS_FOR_INPUT_WITH)
-        .appendTitle(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
       this.interpolateMsg(
-        blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY,
+        Blockly.Msg.CONTROLS_FOR_INPUT_COUNTER,
+        () => {
+          this.appendDummyInput().appendTitle(
+            new blockly.FieldLabel(msg.loopVariable()),
+            'VAR'
+          );
+        },
         ['FROM', 'Number', blockly.ALIGN_RIGHT],
         ['TO', 'Number', blockly.ALIGN_RIGHT],
         ['BY', 'Number', blockly.ALIGN_RIGHT],


### PR DESCRIPTION
<img width="525" alt="Screen Shot 2019-09-07 at 2 42 41 AM" src="https://user-images.githubusercontent.com/30066710/64568753-66d9d480-d310-11e9-8dbf-9c2dbd0ea659.png">

Follow-up:  
[jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&projectKey=FND&view=planning&selectedIssue=FND-729)
The string "Blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY" is also used in "Blockly.Blocks.controls_for" block.  Follow-up work to update "controls_for" block (loops.js) to use interpolateMsg function.

https://github.com/code-dot-org/blockly/blob/4300559452ce50bfd29511ca7c90c022eca8cd1e/blocks/loops.js#L94
