### PR TITLE
School Info Confirmation Dialog UI Test:  add deleted step back to ui test

### DIFF
--- a/dashboard/test/ui/features/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/school_info_confirmation_dialog.feature
@@ -29,6 +29,7 @@ Scenario: School Info Confirmation Dialog
   And I select the "Public" option in dropdown "school-type"
   And I wait until element "#nces_school" is visible
   Then I press keys "Alakanuk School" for element "#nces_school"
+  Then I wait until element ".VirtualizedSelectOption:contains('Alakanuk School - Alakanuk, AK 99554')" is visible
   Then I press ".VirtualizedSelectOption:contains('Alakanuk School - Alakanuk, AK 99554')" using jQuery
   Then I press "#save-button" using jQuery
 


### PR DESCRIPTION
Inadvertently deleted a step from ui-test.  See parent PR:  [30794](https://github.com/code-dot-org/code-dot-org/pull/30794)