### PR TITLE
Quick-exit cronjob fix

### DIFF
--- a/dashboard/bin/process_pd_workshop_ends
+++ b/dashboard/bin/process_pd_workshop_ends
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
-require_relative '../config/environment'
+exit unless only_one_running?(__FILE__)
 
 # When a workshop is ended, we might need to send exit survey emails.  They need
 # to be sent from production-daemon, and so we do it here.
-
-Pd::Workshop.process_ends if only_one_running?(__FILE__)
+require_relative '../config/environment'
+Pd::Workshop.process_ends


### PR DESCRIPTION
Perform `only_one_running` check before loading environment in the `process_pd_workshop_ends` cronjob.

We run this cronjob every minute to generate certificates and send post-workshop emails.  Each minute when it starts, it should check if it's already running and immediately quit if it is.  However, because under some circumstances it can take more than a minute to load our application environment, it's possible to get a cascading failure of many of these jobs running, leading to out of memory errors. ([Slack conversation](https://codedotorg.slack.com/archives/C03CK49G9/p1568665355014200)).

This change performs the check before we load the application environment to avoid this issue in the future.