### PR TITLE
[Applab Datasets] Fix DataTable Styling

### DIFF
--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -43,6 +43,10 @@ const styles = {
     height: 18,
     justifyContent: 'center',
     width: 18
+  },
+  tableWrapper: {
+    flexGrow: 1,
+    overflow: 'scroll'
   }
 };
 
@@ -236,61 +240,63 @@ class DataTable extends React.Component {
             label={msg.paginationLabel()}
           />
         </div>
-        <table>
-          <tbody>
-            <tr>
-              {columnNames.map(columnName => (
-                <ColumnHeader
-                  key={columnName}
-                  coerceColumn={this.coerceColumn}
-                  columnName={columnName}
+        <div style={styles.tableWrapper}>
+          <table style={styles.table}>
+            <tbody>
+              <tr>
+                {columnNames.map(columnName => (
+                  <ColumnHeader
+                    key={columnName}
+                    coerceColumn={this.coerceColumn}
+                    columnName={columnName}
+                    columnNames={columnNames}
+                    deleteColumn={this.deleteColumn}
+                    editColumn={this.editColumn}
+                    /* hide gear icon if an operation is pending on another column */
+                    isEditable={
+                      columnName !== 'id' &&
+                      !(
+                        this.state.pendingColumn &&
+                        this.state.pendingColumn !== columnName
+                      ) &&
+                      !this.state.pendingAdd
+                    }
+                    isEditing={editingColumn === columnName}
+                    isPending={this.state.pendingColumn === columnName}
+                    renameColumn={this.renameColumn}
+                  />
+                ))}
+                <th style={styles.addColumnHeader}>
+                  {this.state.pendingAdd ? (
+                    <FontAwesome icon="spinner" className="fa-spin" />
+                  ) : (
+                    <FontAwesome
+                      id="addColumnButton"
+                      icon="plus"
+                      style={styles.plusIcon}
+                      onClick={this.addColumn}
+                    />
+                  )}
+                </th>
+                <th style={dataStyles.headerCell}>Actions</th>
+              </tr>
+
+              <AddTableRow
+                tableName={this.props.tableName}
+                columnNames={columnNames}
+              />
+
+              {Object.keys(rows).map(id => (
+                <EditTableRow
                   columnNames={columnNames}
-                  deleteColumn={this.deleteColumn}
-                  editColumn={this.editColumn}
-                  /* hide gear icon if an operation is pending on another column */
-                  isEditable={
-                    columnName !== 'id' &&
-                    !(
-                      this.state.pendingColumn &&
-                      this.state.pendingColumn !== columnName
-                    ) &&
-                    !this.state.pendingAdd
-                  }
-                  isEditing={editingColumn === columnName}
-                  isPending={this.state.pendingColumn === columnName}
-                  renameColumn={this.renameColumn}
+                  tableName={this.props.tableName}
+                  record={JSON.parse(rows[id])}
+                  key={id}
                 />
               ))}
-              <th style={styles.addColumnHeader}>
-                {this.state.pendingAdd ? (
-                  <FontAwesome icon="spinner" className="fa-spin" />
-                ) : (
-                  <FontAwesome
-                    id="addColumnButton"
-                    icon="plus"
-                    style={styles.plusIcon}
-                    onClick={this.addColumn}
-                  />
-                )}
-              </th>
-              <th style={dataStyles.headerCell}>Actions</th>
-            </tr>
-
-            <AddTableRow
-              tableName={this.props.tableName}
-              columnNames={columnNames}
-            />
-
-            {Object.keys(rows).map(id => (
-              <EditTableRow
-                columnNames={columnNames}
-                tableName={this.props.tableName}
-                record={JSON.parse(rows[id])}
-                key={id}
-              />
-            ))}
-          </tbody>
-        </table>
+            </tbody>
+          </table>
+        </div>
       </div>
     );
   }

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -43,10 +43,6 @@ const styles = {
     height: 18,
     justifyContent: 'center',
     width: 18
-  },
-  tableWrapper: {
-    flexGrow: 1,
-    overflow: 'scroll'
   }
 };
 
@@ -240,63 +236,61 @@ class DataTable extends React.Component {
             label={msg.paginationLabel()}
           />
         </div>
-        <div style={styles.tableWrapper}>
-          <table style={styles.table}>
-            <tbody>
-              <tr>
-                {columnNames.map(columnName => (
-                  <ColumnHeader
-                    key={columnName}
-                    coerceColumn={this.coerceColumn}
-                    columnName={columnName}
-                    columnNames={columnNames}
-                    deleteColumn={this.deleteColumn}
-                    editColumn={this.editColumn}
-                    /* hide gear icon if an operation is pending on another column */
-                    isEditable={
-                      columnName !== 'id' &&
-                      !(
-                        this.state.pendingColumn &&
-                        this.state.pendingColumn !== columnName
-                      ) &&
-                      !this.state.pendingAdd
-                    }
-                    isEditing={editingColumn === columnName}
-                    isPending={this.state.pendingColumn === columnName}
-                    renameColumn={this.renameColumn}
-                  />
-                ))}
-                <th style={styles.addColumnHeader}>
-                  {this.state.pendingAdd ? (
-                    <FontAwesome icon="spinner" className="fa-spin" />
-                  ) : (
-                    <FontAwesome
-                      id="addColumnButton"
-                      icon="plus"
-                      style={styles.plusIcon}
-                      onClick={this.addColumn}
-                    />
-                  )}
-                </th>
-                <th style={dataStyles.headerCell}>Actions</th>
-              </tr>
-
-              <AddTableRow
-                tableName={this.props.tableName}
-                columnNames={columnNames}
-              />
-
-              {Object.keys(rows).map(id => (
-                <EditTableRow
+        <table style={styles.table}>
+          <tbody>
+            <tr>
+              {columnNames.map(columnName => (
+                <ColumnHeader
+                  key={columnName}
+                  coerceColumn={this.coerceColumn}
+                  columnName={columnName}
                   columnNames={columnNames}
-                  tableName={this.props.tableName}
-                  record={JSON.parse(rows[id])}
-                  key={id}
+                  deleteColumn={this.deleteColumn}
+                  editColumn={this.editColumn}
+                  /* hide gear icon if an operation is pending on another column */
+                  isEditable={
+                    columnName !== 'id' &&
+                    !(
+                      this.state.pendingColumn &&
+                      this.state.pendingColumn !== columnName
+                    ) &&
+                    !this.state.pendingAdd
+                  }
+                  isEditing={editingColumn === columnName}
+                  isPending={this.state.pendingColumn === columnName}
+                  renameColumn={this.renameColumn}
                 />
               ))}
-            </tbody>
-          </table>
-        </div>
+              <th style={styles.addColumnHeader}>
+                {this.state.pendingAdd ? (
+                  <FontAwesome icon="spinner" className="fa-spin" />
+                ) : (
+                  <FontAwesome
+                    id="addColumnButton"
+                    icon="plus"
+                    style={styles.plusIcon}
+                    onClick={this.addColumn}
+                  />
+                )}
+              </th>
+              <th style={dataStyles.headerCell}>Actions</th>
+            </tr>
+
+            <AddTableRow
+              tableName={this.props.tableName}
+              columnNames={columnNames}
+            />
+
+            {Object.keys(rows).map(id => (
+              <EditTableRow
+                columnNames={columnNames}
+                tableName={this.props.tableName}
+                record={JSON.parse(rows[id])}
+                key={id}
+              />
+            ))}
+          </tbody>
+        </table>
       </div>
     );
   }


### PR DESCRIPTION
#30754 accidentally changed some styling of the Data Table view (even with the experiment disabled). Going to leave the scroll bars out, though, because the whole page already scrolls when needed, so we don't need scroll bars on the div containing the table as well.

Before #30754 
![image](https://user-images.githubusercontent.com/8787187/64992175-381bab00-d888-11e9-8f9a-245e36afa10f.png)

With #30754 
![image](https://user-images.githubusercontent.com/8787187/64992215-4964b780-d888-11e9-9c97-2171baa7e575.png)

After:
![image](https://user-images.githubusercontent.com/8787187/64992259-5e414b00-d888-11e9-9809-0ee81f634c87.png)
