### PR TITLE
Set topCourse to null if none is available

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -128,6 +128,7 @@ class HomeController < ApplicationController
       if script
         script_level = current_user.next_unpassed_progression_level(script)
       end
+      @homepage_data[:topCourse] = nil
       if script && script_level
         @homepage_data[:topCourse] = {
           assignableName: data_t_suffix('script.name', script[:name], 'title'),


### PR DESCRIPTION
Fixes a subtle regression introduced in https://github.com/code-dot-org/code-dot-org/pull/30753.

Before, when the user had no courses, the `topCourse` passed down as part of `@homepage_data` would be `nil`/`null`.  After that PR, it wasn't passed down at all if the user had no courses, so on the client it read as `undefined`.  That broke a `!== null` check, here:

https://github.com/code-dot-org/code-dot-org/blob/e036347e31c6826b36d7f47e209afe1f1b190488/apps/src/templates/studioHomepages/RecentCourses.jsx#L36

This quick fix restores the old behavior.  It might be prudent to go back and make that check more flexible.

Before (incorrect behavior):
![before](https://user-images.githubusercontent.com/1615761/64992809-867d7980-d889-11e9-8333-f987a6647281.png)

After (back to original behavior):
![after](https://user-images.githubusercontent.com/1615761/64992816-8a110080-d889-11e9-9c6b-0ce846abca7e.png)
