### PR TITLE
School Info Confirmation Dialog UI Test: skip mobile

### DIFF
--- a/dashboard/test/ui/features/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/school_info_confirmation_dialog.feature
@@ -1,5 +1,6 @@
 @dashboard_db_access
 @no_ie
+@no_mobile
 Feature: School Info Confirmation Dialog
 
 # This test checks three relevant states of the user in the school info confirmation


### PR DESCRIPTION
school_info_confirmation_dialog.feature is failing on IPAD/Iphone.  skip mobile tag added to test to unblock deploy pipeline.  Updated jira task to include new skip tag.