### PR TITLE
Donor: Teacher banner improvements

### DIFF
--- a/apps/src/donorTeacherBanner/donorTeacherBanner.js
+++ b/apps/src/donorTeacherBanner/donorTeacherBanner.js
@@ -13,7 +13,7 @@ registerReducers({isRtl, responsive});
 $(document).ready(initRegionalPartnerSearch);
 
 function showDonorTeacherBanner() {
-  const donorTeacherBannerElement = $('#donor-teacher-banner-container');
+  const donorTeacherBannerElements = $('.donor-teacher-banner-container');
   let options = {};
   let dismissed = false;
 
@@ -41,12 +41,14 @@ function showDonorTeacherBanner() {
     })
     .complete(() => {
       if (!dismissed) {
-        ReactDOM.render(
-          <Provider store={getStore()}>
-            <DonorTeacherBanner options={options} showPegasusLink={false} />
-          </Provider>,
-          donorTeacherBannerElement[0]
-        );
+        donorTeacherBannerElements.each((index, donorTeacherBannerElement) => {
+          ReactDOM.render(
+            <Provider store={getStore()}>
+              <DonorTeacherBanner options={options} showPegasusLink={false} />
+            </Provider>,
+            donorTeacherBannerElement
+          );
+        });
       }
     });
 }

--- a/apps/src/donorTeacherBanner/donorTeacherBanner.js
+++ b/apps/src/donorTeacherBanner/donorTeacherBanner.js
@@ -14,33 +14,40 @@ $(document).ready(initRegionalPartnerSearch);
 
 function showDonorTeacherBanner() {
   const donorTeacherBannerElement = $('#donor-teacher-banner-container');
-  let options;
+  let options = {};
+  let dismissed = false;
 
   $.ajax({
     type: 'GET',
     url: '/dashboardapi/v1/users/me/donor_teacher_banner_details'
   })
     .done(results => {
-      options = {
-        teacherFirstName: results.teacher_first_name,
-        teacherSecondName: results.teacher_second_name,
-        teacherEmail: results.teacher_email,
-        ncesSchoolId: results.nces_school_id,
-        schoolAddress1: results.school_address_1,
-        schoolAddress2: results.school_address_2,
-        schoolAddress3: results.school_address_2,
-        schoolCity: results.school_city,
-        schoolState: results.school_state,
-        schoolZip: results.school_zip
-      };
+      if (results.dismissed) {
+        dismissed = true;
+      } else {
+        options = {
+          teacherFirstName: results.teacher_first_name,
+          teacherSecondName: results.teacher_second_name,
+          teacherEmail: results.teacher_email,
+          ncesSchoolId: results.nces_school_id,
+          schoolAddress1: results.school_address_1,
+          schoolAddress2: results.school_address_2,
+          schoolAddress3: results.school_address_2,
+          schoolCity: results.school_city,
+          schoolState: results.school_state,
+          schoolZip: results.school_zip
+        };
+      }
     })
     .complete(() => {
-      ReactDOM.render(
-        <Provider store={getStore()}>
-          <DonorTeacherBanner options={options} showPegasusLink={false} />
-        </Provider>,
-        donorTeacherBannerElement[0]
-      );
+      if (!dismissed) {
+        ReactDOM.render(
+          <Provider store={getStore()}>
+            <DonorTeacherBanner options={options} showPegasusLink={false} />
+          </Provider>,
+          donorTeacherBannerElement[0]
+        );
+      }
     });
 }
 

--- a/apps/src/donorTeacherBanner/donorTeacherBanner.js
+++ b/apps/src/donorTeacherBanner/donorTeacherBanner.js
@@ -15,41 +15,34 @@ $(document).ready(initRegionalPartnerSearch);
 function showDonorTeacherBanner() {
   const donorTeacherBannerElements = $('.donor-teacher-banner-container');
   let options = {};
-  let dismissed = false;
 
   $.ajax({
     type: 'GET',
     url: '/dashboardapi/v1/users/me/donor_teacher_banner_details'
   })
     .done(results => {
-      if (results.dismissed) {
-        dismissed = true;
-      } else {
-        options = {
-          teacherFirstName: results.teacher_first_name,
-          teacherSecondName: results.teacher_second_name,
-          teacherEmail: results.teacher_email,
-          ncesSchoolId: results.nces_school_id,
-          schoolAddress1: results.school_address_1,
-          schoolAddress2: results.school_address_2,
-          schoolAddress3: results.school_address_2,
-          schoolCity: results.school_city,
-          schoolState: results.school_state,
-          schoolZip: results.school_zip
-        };
-      }
+      options = {
+        teacherFirstName: results.teacher_first_name,
+        teacherSecondName: results.teacher_second_name,
+        teacherEmail: results.teacher_email,
+        ncesSchoolId: results.nces_school_id,
+        schoolAddress1: results.school_address_1,
+        schoolAddress2: results.school_address_2,
+        schoolAddress3: results.school_address_2,
+        schoolCity: results.school_city,
+        schoolState: results.school_state,
+        schoolZip: results.school_zip
+      };
     })
     .complete(() => {
-      if (!dismissed) {
-        donorTeacherBannerElements.each((index, donorTeacherBannerElement) => {
-          ReactDOM.render(
-            <Provider store={getStore()}>
-              <DonorTeacherBanner options={options} showPegasusLink={false} />
-            </Provider>,
-            donorTeacherBannerElement
-          );
-        });
-      }
+      donorTeacherBannerElements.each((index, donorTeacherBannerElement) => {
+        ReactDOM.render(
+          <Provider store={getStore()}>
+            <DonorTeacherBanner options={options} showPegasusLink={false} />
+          </Provider>,
+          donorTeacherBannerElement
+        );
+      });
     });
 }
 

--- a/apps/src/donorTeacherBanner/donorTeacherBanner.js
+++ b/apps/src/donorTeacherBanner/donorTeacherBanner.js
@@ -21,18 +21,20 @@ function showDonorTeacherBanner() {
     url: '/dashboardapi/v1/users/me/donor_teacher_banner_details'
   })
     .done(results => {
-      options = {
-        teacherFirstName: results.teacher_first_name,
-        teacherSecondName: results.teacher_second_name,
-        teacherEmail: results.teacher_email,
-        ncesSchoolId: results.nces_school_id,
-        schoolAddress1: results.school_address_1,
-        schoolAddress2: results.school_address_2,
-        schoolAddress3: results.school_address_2,
-        schoolCity: results.school_city,
-        schoolState: results.school_state,
-        schoolZip: results.school_zip
-      };
+      if (results) {
+        options = {
+          teacherFirstName: results.teacher_first_name,
+          teacherSecondName: results.teacher_second_name,
+          teacherEmail: results.teacher_email,
+          ncesSchoolId: results.nces_school_id,
+          schoolAddress1: results.school_address_1,
+          schoolAddress2: results.school_address_2,
+          schoolAddress3: results.school_address_2,
+          schoolCity: results.school_city,
+          schoolState: results.school_state,
+          schoolZip: results.school_zip
+        };
+      }
     })
     .complete(() => {
       donorTeacherBannerElements.each((index, donorTeacherBannerElement) => {

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -89,7 +89,6 @@ export const donorTeacherBannerOptionsShape = PropTypes.shape({
 export default class DonorTeacherBanner extends Component {
   static propTypes = {
     options: donorTeacherBannerOptionsShape,
-    onDismiss: PropTypes.func,
     showPegasusLink: PropTypes.bool
   };
 
@@ -121,10 +120,25 @@ export default class DonorTeacherBanner extends Component {
 
     this.setState({submitted: true});
 
-    if (this.props.onDismiss) {
-      this.props.onDismiss();
-    }
+    this.dismiss();
   };
+
+  dismissWithCallbacks(onSuccess, onFailure) {
+    $.ajax({
+      url: '/dashboardapi/v1/users/me/dismiss_donor_teacher_banner',
+      type: 'post'
+    })
+      .done(onSuccess)
+      .fail(onFailure);
+  }
+
+  logDismissError = xhr => {
+    console.log(`Failed to dismiss donor teacher banner! ${xhr.responseText}`);
+  };
+
+  dismiss() {
+    this.dismissWithCallbacks(null, this.logDismissError);
+  }
 
   renderDonorForm() {
     const permissionStyle = this.state.participate

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -175,11 +175,15 @@ export default class DonorTeacherBanner extends Component {
             computing resources.
           </div>
           <div style={styles.paragraph}>
-            Would you like to participate in the Amazon Future Engineer Program?
+            Would you like to participate in the{' '}
+            {!this.props.showPegasusLink && (
+              <span>Amazon Future Engineer Program?</span>
+            )}
             {this.props.showPegasusLink && (
               <span>
-                &nbsp;
-                <a href={pegasus('/amazon-future-engineer')}>Learn more</a>
+                <a href={pegasus('/amazon-future-engineer')}>
+                  Amazon Future Engineer Program? Learn more
+                </a>
               </span>
             )}
           </div>

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -277,13 +277,15 @@ export default class DonorTeacherBanner extends Component {
             disabled={buttonDisabled}
           />
 
-          <Button
-            href={pegasus('/amazon-future-engineer')}
-            style={styles.button}
-            color={Button.ButtonColor.gray}
-            size="large"
-            text="Learn more"
-          />
+          {this.props.showPegasusLink && (
+            <Button
+              href={pegasus('/amazon-future-engineer')}
+              style={styles.button}
+              color={Button.ButtonColor.gray}
+              size="large"
+              text="Learn more"
+            />
+          )}
         </div>
         <div style={styles.clear} />
       </div>

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -276,6 +276,14 @@ export default class DonorTeacherBanner extends Component {
             text="Submit"
             disabled={buttonDisabled}
           />
+
+          <Button
+            href={pegasus('/amazon-future-engineer')}
+            style={styles.button}
+            color={Button.ButtonColor.gray}
+            size="large"
+            text="Learn more"
+          />
         </div>
         <div style={styles.clear} />
       </div>

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -162,6 +162,11 @@ export default class DonorTeacherBanner extends Component {
       schoolZip: 'school-zip'
     };
 
+    const schoolLink =
+      'https://support.code.org/hc/en-us/articles/360031291431-What-does-school-information-refer-to-';
+    const amazonLink =
+      'https://www.amazon.com/gp/help/customer/display.html?ie=UTF8&nodeId=468496';
+
     return (
       <div style={styles.main}>
         <div style={styles.message}>
@@ -232,12 +237,17 @@ export default class DonorTeacherBanner extends Component {
                 }
                 disabled={this.state.participate !== true}
               />
-              I give Code.org permission to share my name, email address, and
-              school information with Amazon.com (required to participate). Use
-              of your personal information by Amazon is subject to Amazon’s
-              Privacy Policy. You may be required to agree to additional terms
-              and conditions with Amazon directly.{' '}
-              <span style={styles.red}>*</span>
+              I give Code.org permission to share my name, email address, and{' '}
+              <a href={schoolLink} target="_blank">
+                school name and ID
+              </a>{' '}
+              with Amazon.com (required to participate). Use of your personal
+              information by Amazon is subject to{' '}
+              <a href={amazonLink} target="_blank">
+                Amazon’s Privacy Policy
+              </a>
+              . You may be required to agree to additional terms and conditions
+              with Amazon directly. <span style={styles.red}>*</span>
             </label>
           </div>
 

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -142,28 +142,6 @@ export default class TeacherHomepage extends Component {
     this.hideCensusBanner();
   };
 
-  dismissDonorTeacherBannerWithCallbacks(onSuccess, onFailure) {
-    $.ajax({
-      url: `/api/v1/users/${this.props.teacherId}/dismiss_donor_teacher_banner`,
-      type: 'post'
-    })
-      .done(onSuccess)
-      .fail(onFailure);
-  }
-
-  logDismissDonorTeacherBannerError = xhr => {
-    console.error(
-      `Failed to dismiss donor teacher banner! ${xhr.responseText}`
-    );
-  };
-
-  dismissDonorTeacherBanner() {
-    this.dismissDonorTeacherBannerWithCallbacks(
-      null,
-      this.logDismissDonorTeacherBannerError
-    );
-  }
-
   componentDidMount() {
     // The component used here is implemented in legacy HAML/CSS rather than React.
     $('#teacher_reminders')
@@ -262,7 +240,6 @@ export default class TeacherHomepage extends Component {
             <div>
               <DonorTeacherBanner
                 options={donorTeacherBannerOptions}
-                onDismiss={() => this.dismissDonorTeacherBanner()}
                 showPegasusLink={true}
               />
               <div style={styles.clear} />

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -35,23 +35,19 @@ class Api::V1::UsersController < Api::V1::JsonApiController
 
   # GET /api/v1/users/<user_id>/get_donor_teacher_banner_details
   def get_donor_teacher_banner_details
-    if current_user.donor_teacher_banner_dismissed
-      render json: {dismissed: true}
-    else
-      teachers_school = current_user.last_complete_school_info&.school
-      render json: {
-        teacher_first_name: current_user.short_name,
-        teacher_second_name: current_user.second_name,
-        teacher_email: current_user.email,
-        nces_school_id: teachers_school&.id,
-        school_address_1: teachers_school&.address_line1,
-        school_address_2: teachers_school&.address_line2,
-        school_address_3: teachers_school&.address_line3,
-        school_city: teachers_school&.city,
-        school_state: teachers_school&.state,
-        school_zip: teachers_school&.zip
-      }
-    end
+    teachers_school = current_user.last_complete_school_info&.school
+    render json: {
+      teacher_first_name: current_user.short_name,
+      teacher_second_name: current_user.second_name,
+      teacher_email: current_user.email,
+      nces_school_id: teachers_school&.id,
+      school_address_1: teachers_school&.address_line1,
+      school_address_2: teachers_school&.address_line2,
+      school_address_3: teachers_school&.address_line3,
+      school_city: teachers_school&.city,
+      school_state: teachers_school&.state,
+      school_zip: teachers_school&.zip
+    }
   end
 
   # POST /api/v1/users/<user_id>/using_text_mode

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -35,19 +35,23 @@ class Api::V1::UsersController < Api::V1::JsonApiController
 
   # GET /api/v1/users/<user_id>/get_donor_teacher_banner_details
   def get_donor_teacher_banner_details
-    teachers_school = current_user.last_complete_school_info&.school
-    render json: {
-      teacher_first_name: current_user.short_name,
-      teacher_second_name: current_user.second_name,
-      teacher_email: current_user.email,
-      nces_school_id: teachers_school&.id,
-      school_address_1: teachers_school&.address_line1,
-      school_address_2: teachers_school&.address_line2,
-      school_address_3: teachers_school&.address_line3,
-      school_city: teachers_school&.city,
-      school_state: teachers_school&.state,
-      school_zip: teachers_school&.zip
-    }
+    if current_user.teacher?
+      teachers_school = current_user.last_complete_school_info&.school
+      render json: {
+        teacher_first_name: current_user.short_name,
+        teacher_second_name: current_user.second_name,
+        teacher_email: current_user.email,
+        nces_school_id: teachers_school&.id,
+        school_address_1: teachers_school&.address_line1,
+        school_address_2: teachers_school&.address_line2,
+        school_address_3: teachers_school&.address_line3,
+        school_city: teachers_school&.city,
+        school_state: teachers_school&.state,
+        school_zip: teachers_school&.zip
+      }
+    else
+      head :no_content
+    end
   end
 
   # POST /api/v1/users/<user_id>/using_text_mode

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -38,18 +38,18 @@ class Api::V1::UsersController < Api::V1::JsonApiController
     if current_user.donor_teacher_banner_dismissed
       render json: {dismissed: true}
     else
-      teachers_school = current_user.school_info.school
+      teachers_school = current_user.last_complete_school_info&.school
       render json: {
         teacher_first_name: current_user.short_name,
         teacher_second_name: current_user.second_name,
         teacher_email: current_user.email,
-        nces_school_id: teachers_school.id,
-        school_address_1: teachers_school.address_line1,
-        school_address_2: teachers_school.address_line2,
-        school_address_3: teachers_school.address_line3,
-        school_city: teachers_school.city,
-        school_state: teachers_school.state,
-        school_zip: teachers_school.zip
+        nces_school_id: teachers_school&.id,
+        school_address_1: teachers_school&.address_line1,
+        school_address_2: teachers_school&.address_line2,
+        school_address_3: teachers_school&.address_line3,
+        school_city: teachers_school&.city,
+        school_state: teachers_school&.state,
+        school_zip: teachers_school&.zip
       }
     end
   end

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -35,19 +35,23 @@ class Api::V1::UsersController < Api::V1::JsonApiController
 
   # GET /api/v1/users/<user_id>/get_donor_teacher_banner_details
   def get_donor_teacher_banner_details
-    teachers_school = current_user.school_info.school
-    render json: {
-      teacher_first_name: current_user.short_name,
-      teacher_second_name: current_user.second_name,
-      teacher_email: current_user.email,
-      nces_school_id: teachers_school.id,
-      school_address_1: teachers_school.address_line1,
-      school_address_2: teachers_school.address_line2,
-      school_address_3: teachers_school.address_line3,
-      school_city: teachers_school.city,
-      school_state: teachers_school.state,
-      school_zip: teachers_school.zip
-    }
+    if current_user.donor_teacher_banner_dismissed
+      render json: {dismissed: true}
+    else
+      teachers_school = current_user.school_info.school
+      render json: {
+        teacher_first_name: current_user.short_name,
+        teacher_second_name: current_user.second_name,
+        teacher_email: current_user.email,
+        nces_school_id: teachers_school.id,
+        school_address_1: teachers_school.address_line1,
+        school_address_2: teachers_school.address_line2,
+        school_address_3: teachers_school.address_line3,
+        school_city: teachers_school.city,
+        school_state: teachers_school.state,
+        school_zip: teachers_school.zip
+      }
+    end
   end
 
   # POST /api/v1/users/<user_id>/using_text_mode

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -662,6 +662,9 @@ Dashboard::Application.routes.draw do
   # Routes used by census
   post '/dashboardapi/v1/census/:form_version', to: 'api/v1/census/census#create', defaults: {format: 'json'}
 
+  # Routes used by donor teacher banner
+  post '/dashboardapi/v1/users/:user_id/dismiss_donor_teacher_banner', to: 'api/v1/users#dismiss_donor_teacher_banner'
+
   # We want to allow searchs with dots, for instance "St. Paul", so we specify
   # the constraint on :q to match anything but a slash.
   # @see http://guides.rubyonrails.org/routing.html#specifying-constraints

--- a/pegasus/sites.v3/code.org/views/donor_teacher_banner.haml
+++ b/pegasus/sites.v3/code.org/views/donor_teacher_banner.haml
@@ -1,7 +1,4 @@
-- source_page_id ||= nil
-- notes ||= nil
-
-#donor-teacher-banner-container
+.donor-teacher-banner-container
 
 - js_locale = request.locale.to_s.downcase.tr('-', '_')
 %script{src: asset_path("js/#{js_locale}/common_locale.js")}


### PR DESCRIPTION
A collection of Donor Teacher Banner improvements:

- The banner can now be dismissed on pegasus, though it only records this on the server if the user is signed in.
  - That said, pegasus will always show the banner, even if the user has previously dismissed it.  This gives users who dismissed it (whether with a "yes" or a "no") a second chance to fill it out.
  - Note that the dashboard APIs that the banner calls when running in pegasus, to get pre-populated information and set the dismissal, will both return 403 errors if there is not a signed in user, but the user should not see anything amiss unless they're looking carefully at their browser developer tools.  The API to get pre-populated information will return a 204 ("No Content") if a student is signed in.
  - Signed out user and signed in students will now also see the banner on pegasus.
- The link to the pegasus page now contains more of the sentence text.
- The permission text is updated and has two links that open in new tabs.
  - The rest of the label text still checks the checkbox.
- The banner gets a new "Learn more" button on dashboard.
-  The banner works on pegasus when there is no school.
  - While the Donor Teacher Banner on dashboard only shows when we have found an appropriate school for that teacher, on pegasus we show the banner under all conditions, including when a teacher hasn't yet set their school.  Now, we cope with the missing school and its missing fields in the pre-population information.
- The banner can appear more than once on a pegasus page.  The two implementations are driven by the same initial information but then operate independently of one other.

Followup to https://github.com/code-dot-org/code-dot-org/pull/30591

### dashboard

![Screenshot 2019-09-17 15 42 54](https://user-images.githubusercontent.com/2205926/65014616-88ffd200-d962-11e9-88e5-4f0e683ad5b8.png)

### pegasus

![Screenshot 2019-09-17 15 43 03](https://user-images.githubusercontent.com/2205926/65014615-88ffd200-d962-11e9-87d1-a37aa28599d6.png)
