### PR TITLE
Lesson Extras: updates for StageProgressTest 

### DIFF
--- a/apps/test/unit/code-studio/components/progress/StageProgressTest.js
+++ b/apps/test/unit/code-studio/components/progress/StageProgressTest.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {assert} from 'chai';
 import {UnconnectedStageProgress as StageProgress} from '@cdo/apps/code-studio/components/progress/StageProgress';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
-import experiments from '@cdo/apps/util/experiments';
 import {shallow} from 'enzyme';
 
 describe('StageProgress', () => {
@@ -13,7 +12,6 @@ describe('StageProgress', () => {
       }
     ],
     stageId: 1,
-    stageExtrasUrl: '/extras',
     onStageExtras: false
   };
 
@@ -23,13 +21,15 @@ describe('StageProgress', () => {
     assert.equal(wrapper.find('ProgressBubble').length, 1);
   });
 
-  describe('stage extras experiment', () => {
-    before(() => experiments.setEnabled('stageExtras', true));
-    after(() => experiments.setEnabled('stageExtras', false));
+  it('does not include stage extras when there is not a stageExtrasUrl', () => {
+    const wrapper = shallow(<StageProgress {...defaultProps} />);
+    assert.equal(wrapper.find('StageExtrasProgressBubble').length, 0);
+  });
 
-    it('includes stage extras', () => {
-      const wrapper = shallow(<StageProgress {...defaultProps} />);
-      assert.equal(wrapper.find('StageExtrasProgressBubble').length, 1);
-    });
+  it('includes stage extras when there is a stageExtrasUrl', () => {
+    const wrapper = shallow(
+      <StageProgress {...defaultProps} stageExtrasUrl={'/extras'} />
+    );
+    assert.equal(wrapper.find('StageExtrasProgressBubble').length, 1);
   });
 });


### PR DESCRIPTION
En route to debugging an issue with the Lesson Extras icon appearing when it shouldn't, I noticed `StageProgressTest` was out of date. I updated by removing the reference to an experiment that is no longer underway and test cases when the `StageExtrasProgressBubble` should be shown and when it should not. 