### PR TITLE
Lesson Extras: flag icon should only appear if there are defined bonus levels 

### DIFF
--- a/dashboard/app/models/stage.rb
+++ b/dashboard/app/models/stage.rb
@@ -164,7 +164,7 @@ class Stage < ActiveRecord::Base
         stage_data[:finishText] = I18n.t('nav.header.finished_hoc')
       end
 
-      if !unplugged? && !stage_extras_disabled
+      if !unplugged? && !stage_extras_disabled && !script.get_bonus_script_levels(self).empty?
         stage_data[:stage_extras_level_url] = script_stage_extras_url(script.name, stage_position: relative_position)
       end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -739,6 +739,13 @@ FactoryGirl.define do
         csf_script_level.save
       end
     end
+
+    factory :bonus_script_level do
+      after(:create) do |bonus_script_level|
+        bonus_script_level.bonus = true
+        bonus_script_level.save
+      end
+    end
   end
 
   factory :stage do

--- a/dashboard/test/models/stage_test.rb
+++ b/dashboard/test/models/stage_test.rb
@@ -63,9 +63,13 @@ class StageTest < ActiveSupport::TestCase
     level2 = create :level
     stage2 = create :stage, script: script, stage_extras_disabled: true
     create :script_level, script: script, stage: stage2, levels: [level2]
+    level3 = create :level
+    stage3 = create :stage, script: script
+    create :bonus_script_level, script: script, stage: stage3, levels: [level3]
 
-    assert_match /extras$/, stage.summarize[:stage_extras_level_url]
+    assert_nil stage.summarize[:stage_extras_level_url]
     assert_nil stage2.summarize[:stage_extras_level_url]
+    assert_match /extras$/, stage3.summarize[:stage_extras_level_url]
   end
 
   test "summary for stage with extras where include_bonus_levels is true" do


### PR DESCRIPTION
Problem: The stage extras flag  is visible on all stages when stage_extras_available true is set, even if there are no "extra" levels defined. For example:  https://studio.code.org/s/coursed-2019/stage/1/puzzle/1 should not show the lesson extras flag even if the user is allowed to see lesson extras . Furthermore, clicking on the icon took the user to the sad bee ([Slack thread for reference](https://codedotorg.slack.com/archives/CA3KCSGTD/p1568680676019300)). 

Fix: Only set `stage_extras_level_url` if there are bonus levels for the given stage.  `stage_extras_level_url` in `stage.rb` gets passed as `stageExtrasUrl` via Redux into the `StageProgress` component, which determines whether to show the `StageExtrasProgressBubble` subcomponent (as tested in #30809).