### PR TITLE
Fix peer review display

### DIFF
--- a/dashboard/app/models/peer_review.rb
+++ b/dashboard/app/models/peer_review.rb
@@ -125,7 +125,7 @@ class PeerReview < ActiveRecord::Base
   end
 
   def localized_status_description
-    I18n.t("peer_review.#{status}.description").html_safe if status
+    I18n.t("peer_review.#{status}.description_markdown", markdown: true).html_safe if status
   end
 
   def self.create_for_submission(user_level, level_source_id)


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/30698

Update the i18n accessor defined on the peer review model to reference
the new i18n strings