### PR TITLE
Fix facebook var name

### DIFF
--- a/pegasus/sites.v3/code.org/views/social_media.haml
+++ b/pegasus/sites.v3/code.org/views/social_media.haml
@@ -1,4 +1,4 @@
-- fb ||= nil
+- facebook ||= nil
 - twitter ||= nil
 - tumblr ||= nil
 - instagam ||= nil


### PR DESCRIPTION
This is causing a pegasus test to fail in the current DTT ([Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1568751549017900)):
![Screen Shot 2019-09-17 at 1 13 15 PM](https://user-images.githubusercontent.com/9812299/65076277-85158500-d94d-11e9-99d6-4d6a817cc5d8.png)
