### PR TITLE
remove CDO.pegasus_skip_asset_map

### DIFF
--- a/apps/docs/build.md
+++ b/apps/docs/build.md
@@ -197,7 +197,7 @@ work more like production. Here are the steps to do that:
 
 1. Edit `dashboard/config/environments/development.rb` by changing `config.assets.digest` to
    `true` and `config.assets.compile` to `false`. Edit `locals.yml` by setting `pretty_js` to
-   `false` and `pegasus_skip_asset_map` to `false`. This will make the rails app and pegasus look for minified js files that have
+   `false`. This will make the rails app and pegasus look for minified js files that have
    already been processed by the rails asset pipeline.
 
 2. Run `npm build:dist` inside the `apps` directory. This will generate all the

--- a/apps/docs/build.md
+++ b/apps/docs/build.md
@@ -197,11 +197,11 @@ work more like production. Here are the steps to do that:
 
 1. Edit `dashboard/config/environments/development.rb` by changing `config.assets.digest` to
    `true` and `config.assets.compile` to `false`. Edit `locals.yml` by setting `pretty_js` to
-   `false`. This will make the rails app and pegasus look for minified js files that have
-   already been processed by the rails asset pipeline.
+   `false`. This will make the rails app and pegasus look for minified, digested js files 
+   that have already been processed by the rails asset pipeline.
 
 2. Run `npm build:dist` inside the `apps` directory. This will generate all the
-   production assets used by the dashbaord app.
+   production assets used by the dashboard app.
 
 3. Run `rake assets:precompile` inside the `dashboard` directory. This copy all
    the necessary files into `dashboard/public/assets`.
@@ -209,11 +209,12 @@ work more like production. Here are the steps to do that:
 4. Restart the dashboard server `./bin/dashboard-server` from the root folder.
 
 If you make any changes to the build configuration or the javascript files, you
-will need to redo steps 2-4. Relying on watch mode won't work. If you are having
-a hard time wrapping your head around the minified bundles which get used with
-this configuration, you can try changing `pretty_js` back to `true`
-so that the unminified files get served instead.
+will need to redo steps 2-4. Relying on watch mode won't work.
 
 ### Replicating production behavior locally (short way)
 
-If you believe that the production behavior you are observing has only to do with the js being minified and not with the dashboard asset pipeline, you can quickly build minified JS locally by running `npm run build:dist:debug`. **WARNING** this will output minified js with the `.js` suffix, without the `.min` suffix. If you do this, it's on you to remember to do a regular `npm run build` to get back into a normal state.
+If you believe that the production behavior you are observing has only to do with the js
+being minified and not with the dashboard asset pipeline, you can quickly build minified JS
+locally by running `npm run build:dist:debug`. **WARNING** this will output minified js
+with the `.js` suffix, without the `.min` suffix. If you do this, it's on you to remember
+to do a regular `npm run build` to get back into a normal state.

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -328,7 +328,6 @@ pegasus_sock:
 pegasus_port: 3000
 pegasus_unicorn_name: pegasus
 pegasus_workers: 8
-pegasus_skip_asset_map: false
 sinatra_session_secret:
 
 # Configures Pegasus `settings.read_only`, which affects some (legacy) routes. Not actively used(?)

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -3,7 +3,6 @@
 
 census_map_table_id:
 dashboard_enable_pegasus: true
-pegasus_skip_asset_map: true
 
 firebase_name: cdo-v3-dev
 # provide a unique path for firebase channels data for development, to avoid conflicts in channel ids.

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -25,7 +25,6 @@ db_writer: 'mysql://root@localhost/'
 <% end -%>
 
 db_cluster_id: test-cluster
-pegasus_skip_asset_map: <%=ci_test%>
 netsim_enable_metrics: true
 stub_school_data: true
 daemon: true

--- a/pegasus/helpers/asset_helpers.rb
+++ b/pegasus/helpers/asset_helpers.rb
@@ -20,7 +20,7 @@ class AssetMap
 
   def asset_path(asset)
     # Don't require developers or unit tests to precompile assets.
-    return "/assets/#{asset}" if CDO.pegasus_skip_asset_map
+    return "/assets/#{asset}" if CDO.pretty_js
     raise "Asset map not initialized" unless @asset_map
     asset_path = @asset_map[asset]
     raise "Asset not found in asset map: '#{asset}'" unless asset_path

--- a/pegasus/test/test_asset_helpers.rb
+++ b/pegasus/test/test_asset_helpers.rb
@@ -34,7 +34,7 @@ class AssetHelpersTest < Minitest::Test
       "incorrect minifiable asset path"
   end
 
-  def test_no_asset_map
+  def test_missing_asset_map_without_pretty_js_raises
     # This directory does not have a manifest file in it.
     # Update the asset map to be nil.
     CDO.stubs(:dashboard_assets_dir).returns('./test/fixtures/')
@@ -52,7 +52,7 @@ class AssetHelpersTest < Minitest::Test
     assert_equal 'Asset map not initialized', e.message
   end
 
-  def test_skip_flag_when_no_asset_map
+  def test_missing_asset_map_with_pretty_js_succeeds
     # This directory does not have a manifest file in it.
     # Update the asset map to be nil.
     CDO.stubs(:dashboard_assets_dir).returns('./test/fixtures/')
@@ -64,7 +64,7 @@ class AssetHelpersTest < Minitest::Test
       "should recover gracefully when no asset map for minifiable asset"
   end
 
-  def test_asset_not_in_map
+  def test_asset_not_in_map_without_pretty_js_raises
     CDO.stubs(:pretty_js).returns(false)
 
     e = assert_raises RuntimeError do
@@ -78,7 +78,7 @@ class AssetHelpersTest < Minitest::Test
     assert_equal "Asset not found in asset map: '#{MINIFIED_ASSET_NOT_IN_MAP}'", e.message
   end
 
-  def test_skip_flag_when_asset_not_in_map
+  def test_asset_not_in_map_with_pretty_js_succeeds
     CDO.stubs(:pretty_js).returns(true)
     assert_equal ASSET_PATH_NOT_IN_MAP, @asset_map.asset_path(ASSET_NOT_IN_MAP),
       "should recover gracefully when unminifiable asset is not found"

--- a/pegasus/test/test_asset_helpers.rb
+++ b/pegasus/test/test_asset_helpers.rb
@@ -6,7 +6,7 @@ class AssetHelpersTest < Minitest::Test
   UNDIGESTED_ASSET_PATH = "/assets/js/public/abcxyz/index.js".freeze
   UNMINIFIED_ASSET_PATH = "/assets/js/public/abcxyz/"\
     'index-ef90e2acd9003ff8b8bac522e6ce107da641d3b85aba5f58c77d5d28f77a496a.js'.freeze
-  MINIFIED_ASSET_PATH = "/assets/js/public/abcxyz/"\
+  MINIFIED_DIGESTED_ASSET_PATH = "/assets/js/public/abcxyz/"\
     'index.min-5bb3b68c6f92cf8409eb7d0649cf572ffa0c66fca1b02b887b4454cab553daef.js'.freeze
   UNMINIFIED_ASSET_NOT_IN_MAP = 'foo.js'.freeze
   MINIFIED_ASSET_NOT_IN_MAP = 'foo.min.js'.freeze
@@ -30,7 +30,7 @@ class AssetHelpersTest < Minitest::Test
     CDO.stubs(:pretty_js).returns(false)
     assert_equal UNMINIFIED_ASSET_PATH, @asset_map.asset_path(UNMINIFIED_ASSET_NAME),
       "incorrect unminifiable asset path"
-    assert_equal MINIFIED_ASSET_PATH, @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal MINIFIED_DIGESTED_ASSET_PATH, @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NAME),
       "incorrect minifiable asset path"
   end
 

--- a/pegasus/test/test_asset_helpers.rb
+++ b/pegasus/test/test_asset_helpers.rb
@@ -2,15 +2,15 @@ require_relative './test_helper'
 require_relative '../helpers/asset_helpers'
 
 class AssetHelpersTest < Minitest::Test
-  UNMINIFIED_ASSET_NAME = 'js/public/abcxyz/index.js'.freeze
-  UNDIGESTED_ASSET_PATH = "/assets/js/public/abcxyz/index.js".freeze
+  ASSET_NAME = 'js/public/abcxyz/index.js'.freeze
+  ASSET_PATH = "/assets/js/public/abcxyz/index.js".freeze
   DIGESTED_ASSET_PATH = "/assets/js/public/abcxyz/"\
     'index-ef90e2acd9003ff8b8bac522e6ce107da641d3b85aba5f58c77d5d28f77a496a.js'.freeze
   MINIFIED_DIGESTED_ASSET_PATH = "/assets/js/public/abcxyz/"\
     'index.min-5bb3b68c6f92cf8409eb7d0649cf572ffa0c66fca1b02b887b4454cab553daef.js'.freeze
-  UNMINIFIED_ASSET_NOT_IN_MAP = 'foo.js'.freeze
+  ASSET_NOT_IN_MAP = 'foo.js'.freeze
   MINIFIED_ASSET_NOT_IN_MAP = 'foo.min.js'.freeze
-  UNDIGESTED_ASSET_PATH_NOT_IN_MAP = "/assets/foo.js".freeze
+  ASSET_PATH_NOT_IN_MAP = "/assets/foo.js".freeze
 
   def setup
     CDO.stubs(:dashboard_assets_dir).returns('./test/fixtures/dashboard_assets')
@@ -19,18 +19,18 @@ class AssetHelpersTest < Minitest::Test
 
   def test_asset_map_pretty
     CDO.stubs(:pretty_js).returns(true)
-    assert_equal UNDIGESTED_ASSET_PATH, @asset_map.asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal ASSET_PATH, @asset_map.asset_path(ASSET_NAME),
       "incorrect unminifiable asset path"
     # Should return the unminified path because pretty_js is true
-    assert_equal UNDIGESTED_ASSET_PATH, @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal ASSET_PATH, @asset_map.minifiable_asset_path(ASSET_NAME),
       "incorrect minifiable asset path"
   end
 
   def test_asset_map_ugly
     CDO.stubs(:pretty_js).returns(false)
-    assert_equal DIGESTED_ASSET_PATH, @asset_map.asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal DIGESTED_ASSET_PATH, @asset_map.asset_path(ASSET_NAME),
       "incorrect unminifiable asset path"
-    assert_equal MINIFIED_DIGESTED_ASSET_PATH, @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal MINIFIED_DIGESTED_ASSET_PATH, @asset_map.minifiable_asset_path(ASSET_NAME),
       "incorrect minifiable asset path"
   end
 
@@ -42,12 +42,12 @@ class AssetHelpersTest < Minitest::Test
     CDO.stubs(:pretty_js).returns(false)
 
     e = assert_raises RuntimeError do
-      @asset_map.asset_path(UNMINIFIED_ASSET_NAME)
+      @asset_map.asset_path(ASSET_NAME)
     end
     assert_equal 'Asset map not initialized', e.message
 
     e = assert_raises RuntimeError do
-      @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NAME)
+      @asset_map.minifiable_asset_path(ASSET_NAME)
     end
     assert_equal 'Asset map not initialized', e.message
   end
@@ -58,9 +58,9 @@ class AssetHelpersTest < Minitest::Test
     CDO.stubs(:dashboard_assets_dir).returns('./test/fixtures/')
     @asset_map = AssetMap.clone.instance
     CDO.stubs(:pretty_js).returns(true)
-    assert_equal UNDIGESTED_ASSET_PATH, @asset_map.asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal ASSET_PATH, @asset_map.asset_path(ASSET_NAME),
       "should recover gracefully when no asset map for unminifiable asset"
-    assert_equal UNDIGESTED_ASSET_PATH, @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal ASSET_PATH, @asset_map.minifiable_asset_path(ASSET_NAME),
       "should recover gracefully when no asset map for minifiable asset"
   end
 
@@ -68,21 +68,21 @@ class AssetHelpersTest < Minitest::Test
     CDO.stubs(:pretty_js).returns(false)
 
     e = assert_raises RuntimeError do
-      @asset_map.asset_path(UNMINIFIED_ASSET_NOT_IN_MAP)
+      @asset_map.asset_path(ASSET_NOT_IN_MAP)
     end
-    assert_equal "Asset not found in asset map: '#{UNMINIFIED_ASSET_NOT_IN_MAP}'", e.message
+    assert_equal "Asset not found in asset map: '#{ASSET_NOT_IN_MAP}'", e.message
 
     e = assert_raises RuntimeError do
-      @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NOT_IN_MAP)
+      @asset_map.minifiable_asset_path(ASSET_NOT_IN_MAP)
     end
     assert_equal "Asset not found in asset map: '#{MINIFIED_ASSET_NOT_IN_MAP}'", e.message
   end
 
   def test_skip_flag_when_asset_not_in_map
     CDO.stubs(:pretty_js).returns(true)
-    assert_equal UNDIGESTED_ASSET_PATH_NOT_IN_MAP, @asset_map.asset_path(UNMINIFIED_ASSET_NOT_IN_MAP),
+    assert_equal ASSET_PATH_NOT_IN_MAP, @asset_map.asset_path(ASSET_NOT_IN_MAP),
       "should recover gracefully when unminifiable asset is not found"
-    assert_equal UNDIGESTED_ASSET_PATH_NOT_IN_MAP, @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NOT_IN_MAP),
+    assert_equal ASSET_PATH_NOT_IN_MAP, @asset_map.minifiable_asset_path(ASSET_NOT_IN_MAP),
       "should recover gracefully when minifiable asset is not found"
   end
 end

--- a/pegasus/test/test_asset_helpers.rb
+++ b/pegasus/test/test_asset_helpers.rb
@@ -4,7 +4,7 @@ require_relative '../helpers/asset_helpers'
 class AssetHelpersTest < Minitest::Test
   UNMINIFIED_ASSET_NAME = 'js/public/abcxyz/index.js'.freeze
   UNDIGESTED_ASSET_PATH = "/assets/js/public/abcxyz/index.js".freeze
-  UNMINIFIED_ASSET_PATH = "/assets/js/public/abcxyz/"\
+  DIGESTED_ASSET_PATH = "/assets/js/public/abcxyz/"\
     'index-ef90e2acd9003ff8b8bac522e6ce107da641d3b85aba5f58c77d5d28f77a496a.js'.freeze
   MINIFIED_DIGESTED_ASSET_PATH = "/assets/js/public/abcxyz/"\
     'index.min-5bb3b68c6f92cf8409eb7d0649cf572ffa0c66fca1b02b887b4454cab553daef.js'.freeze
@@ -28,7 +28,7 @@ class AssetHelpersTest < Minitest::Test
 
   def test_asset_map_ugly
     CDO.stubs(:pretty_js).returns(false)
-    assert_equal UNMINIFIED_ASSET_PATH, @asset_map.asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal DIGESTED_ASSET_PATH, @asset_map.asset_path(UNMINIFIED_ASSET_NAME),
       "incorrect unminifiable asset path"
     assert_equal MINIFIED_DIGESTED_ASSET_PATH, @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NAME),
       "incorrect minifiable asset path"

--- a/pegasus/test/test_asset_helpers.rb
+++ b/pegasus/test/test_asset_helpers.rb
@@ -19,10 +19,10 @@ class AssetHelpersTest < Minitest::Test
 
   def test_asset_map_pretty
     CDO.stubs(:pretty_js).returns(true)
-    assert_equal UNMINIFIED_ASSET_PATH, @asset_map.asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal UNDIGESTED_ASSET_PATH, @asset_map.asset_path(UNMINIFIED_ASSET_NAME),
       "incorrect unminifiable asset path"
     # Should return the unminified path because pretty_js is true
-    assert_equal UNMINIFIED_ASSET_PATH, @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NAME),
+    assert_equal UNDIGESTED_ASSET_PATH, @asset_map.minifiable_asset_path(UNMINIFIED_ASSET_NAME),
       "incorrect minifiable asset path"
   end
 

--- a/pegasus/test/test_asset_helpers.rb
+++ b/pegasus/test/test_asset_helpers.rb
@@ -13,7 +13,6 @@ class AssetHelpersTest < Minitest::Test
   UNDIGESTED_ASSET_PATH_NOT_IN_MAP = "/assets/foo.js".freeze
 
   def setup
-    CDO.stubs(:pegasus_skip_asset_map).returns(false)
     CDO.stubs(:dashboard_assets_dir).returns('./test/fixtures/dashboard_assets')
     @asset_map = AssetMap.clone.instance
   end
@@ -58,7 +57,6 @@ class AssetHelpersTest < Minitest::Test
     # Update the asset map to be nil.
     CDO.stubs(:dashboard_assets_dir).returns('./test/fixtures/')
     @asset_map = AssetMap.clone.instance
-    CDO.stubs(:pegasus_skip_asset_map).returns(true)
     CDO.stubs(:pretty_js).returns(true)
     assert_equal UNDIGESTED_ASSET_PATH, @asset_map.asset_path(UNMINIFIED_ASSET_NAME),
       "should recover gracefully when no asset map for unminifiable asset"
@@ -81,7 +79,6 @@ class AssetHelpersTest < Minitest::Test
   end
 
   def test_skip_flag_when_asset_not_in_map
-    CDO.stubs(:pegasus_skip_asset_map).returns(true)
     CDO.stubs(:pretty_js).returns(true)
     assert_equal UNDIGESTED_ASSET_PATH_NOT_IN_MAP, @asset_map.asset_path(UNMINIFIED_ASSET_NOT_IN_MAP),
       "should recover gracefully when unminifiable asset is not found"


### PR DESCRIPTION
### Background

In order to implement [webpack code splitting](https://webpack.js.org/guides/code-splitting/) a.k.a. lazy loading, we must first move the responsibility of adding cache-busting hashes/digests out of the rails asset pipeline and into webpack. This PR performs some initial clean-up to make this process easier.

### Description

This PR removes some complexity from pegasus asset handling by consolidating `CDO.pegasus_skip_asset_map` into `CDO.pretty_js`. Thee two variables are already set to the same value in every environment (see modified `config/*.yml.erb` files), so all this eliminates is the local development scenario where asset digesting can be enabled without minification.

Developers will still be able to run the most useful scenarios as outlined in [build.md](https://github.com/code-dot-org/code-dot-org/commit/68323d7d2223c2180ca6814f7f7d5a23db8cd76a#diff-1c0b3456c9097c37376217f075c73680R191).

Finally this PR does some naming improvements to the pegasus asset tests.