### PR TITLE
Part 1: Remove unminify plugin

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -736,6 +736,9 @@ describe('entry tests', () => {
       optimization: {
         minimizer: [
           new UglifyJsPlugin({
+            // Excludes these from minification to avoid breaking functionality,
+            // but still adds .min to the output filename suffix.
+            exclude: [/\/blockly.js$/, /\/brambleHost.js$/],
             cache: true,
             parallel: true,
             sourceMap: envConstants.DEBUG_MINIFIED

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -9,6 +9,7 @@ var checkEntryPoints = require('./script/checkEntryPoints');
 var {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 var {StatsWriterPlugin} = require('webpack-stats-plugin');
 var sass = require('node-sass');
+var UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = function(grunt) {
   process.env.mocha_entry = grunt.option('entry') || '';
@@ -734,15 +735,11 @@ describe('entry tests', () => {
       mode: minify ? 'production' : 'development',
       optimization: {
         minimizer: [
-          compiler => {
-            const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-            const plugin = new UglifyJsPlugin({
-              cache: true,
-              parallel: true,
-              sourceMap: envConstants.DEBUG_MINIFIED
-            });
-            plugin.apply(compiler);
-          }
+          new UglifyJsPlugin({
+            cache: true,
+            parallel: true,
+            sourceMap: envConstants.DEBUG_MINIFIED
+          })
         ],
 
         // We use a single, named runtimeChunk in order to be able to load

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -8,7 +8,6 @@ var envConstants = require('./envConstants');
 var checkEntryPoints = require('./script/checkEntryPoints');
 var {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 var {StatsWriterPlugin} = require('webpack-stats-plugin');
-var UnminifiedWebpackPlugin = require('unminified-webpack-plugin');
 var sass = require('node-sass');
 
 module.exports = function(grunt) {
@@ -879,10 +878,7 @@ describe('entry tests', () => {
           : []),
         new StatsWriterPlugin({
           fields: ['assetsByChunkName', 'assets']
-        }),
-        // Needed because our production environment relies on an unminified
-        // (but digested) version of certain files such as blockly.js.
-        new UnminifiedWebpackPlugin()
+        })
       ],
       minify: minify,
       watch: watch,

--- a/apps/package.json
+++ b/apps/package.json
@@ -208,7 +208,6 @@
     "sprintf-js": "^1.0.3",
     "style-loader": "^0.13.1",
     "uglifyjs-webpack-plugin": "^2.1.1",
-    "unminified-webpack-plugin": "^2.0.0",
     "url-loader": "^0.5.7",
     "video.js": "4.5.2",
     "vmsg": "^0.3.6",

--- a/apps/package.json
+++ b/apps/package.json
@@ -207,7 +207,7 @@
     "sortabular": "^1.6.0",
     "sprintf-js": "^1.0.3",
     "style-loader": "^0.13.1",
-    "uglifyjs-webpack-plugin": "^2.1.1",
+    "uglifyjs-webpack-plugin": "^2.2.0",
     "url-loader": "^0.5.7",
     "video.js": "4.5.2",
     "vmsg": "^0.3.6",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3841,7 +3841,7 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
-cacache@^11.0.2, cacache@^11.2.0:
+cacache@^11.0.2:
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
   dependencies:
@@ -3856,6 +3856,27 @@ cacache@^11.0.2, cacache@^11.2.0:
     move-concurrently "^1.0.1"
     promise-inflight "^1.0.1"
     rimraf "^2.6.2"
+    ssri "^6.0.1"
+    unique-filename "^1.1.1"
+    y18n "^4.0.0"
+
+cacache@^12.0.2:
+  version "12.0.3"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
+  integrity sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==
+  dependencies:
+    bluebird "^3.5.5"
+    chownr "^1.1.1"
+    figgy-pudding "^3.5.1"
+    glob "^7.1.4"
+    graceful-fs "^4.1.15"
+    infer-owner "^1.0.3"
+    lru-cache "^5.1.1"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.3"
     ssri "^6.0.1"
     unique-filename "^1.1.1"
     y18n "^4.0.0"
@@ -4540,7 +4561,7 @@ commander@2.17.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
-commander@^2.11.0, commander@^2.18.0:
+commander@^2.11.0, commander@^2.18.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
 
@@ -6680,7 +6701,7 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
-find-cache-dir@^2.0.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   dependencies:
@@ -7227,6 +7248,18 @@ glob@^6.0.4:
 glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -8516,6 +8549,11 @@ indexes-of@^1.0.1:
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+
+infer-owner@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
+  integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -13924,6 +13962,11 @@ serialize-javascript@^1.4.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
 
+serialize-javascript@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
+  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+
 serializerr@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/serializerr/-/serializerr-1.0.3.tgz#12d4c5aa1c3ffb8f6d1dc5f395aa9455569c3f91"
@@ -15291,11 +15334,12 @@ uglify-js@^2.6:
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
 
-uglify-js@^3.0.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.1.tgz#29cb91e76c9941899bc74b075ad0e6da9250abd5"
+uglify-js@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
+  integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
   dependencies:
-    commander "~2.19.0"
+    commander "~2.20.0"
     source-map "~0.6.1"
 
 uglify-js@~2.2.1:
@@ -15327,18 +15371,20 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uglifyjs-webpack-plugin@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.1.2.tgz#70e5c38fb2d35ee887949c2a0adb2656c23296d5"
+uglifyjs-webpack-plugin@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz#e75bc80e7f1937f725954c9b4c5a1e967ea9d0d7"
+  integrity sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==
   dependencies:
-    cacache "^11.2.0"
-    find-cache-dir "^2.0.0"
+    cacache "^12.0.2"
+    find-cache-dir "^2.1.0"
+    is-wsl "^1.1.0"
     schema-utils "^1.0.0"
-    serialize-javascript "^1.4.0"
+    serialize-javascript "^1.7.0"
     source-map "^0.6.1"
-    uglify-js "^3.0.0"
-    webpack-sources "^1.1.0"
-    worker-farm "^1.5.2"
+    uglify-js "^3.6.0"
+    webpack-sources "^1.4.0"
+    worker-farm "^1.7.0"
 
 uid-number@~0.0.6:
   version "0.0.6"
@@ -15934,6 +15980,14 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-sources@^1.4.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
+  integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
+  dependencies:
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
+
 webpack-stats-plugin@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/webpack-stats-plugin/-/webpack-stats-plugin-0.2.1.tgz#1f5bac13fc25d62cbb5fd0ff646757dc802b8595"
@@ -16057,6 +16111,13 @@ wordwrap@~0.0.2:
 worker-farm@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
+  dependencies:
+    errno "~0.1.7"
+
+worker-farm@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
+  integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -15522,10 +15522,6 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
-unminified-webpack-plugin@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/unminified-webpack-plugin/-/unminified-webpack-plugin-2.0.0.tgz#9cd9c3f420003e968d6ed5ea365085be5e72df14"
-
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -631,7 +631,7 @@ module LevelsHelper
       @blockly_loaded = true
       blocks = blocks + content_tag(:div, '', {id: 'codeWorkspace', style: 'display: none'}) +
       content_tag(:style, '.blocklySvg { background: none; }') +
-      content_tag(:script, '', src: asset_path('js/blockly.js')) +
+      content_tag(:script, '', src: minifiable_asset_path('js/blockly.js')) +
       content_tag(:script, '', src: asset_path("js/#{js_locale}/blockly_locale.js")) +
       content_tag(:script, '', src: minifiable_asset_path('js/common.js')) +
       content_tag(:script, '', src: asset_path("js/#{js_locale}/#{app}_locale.js")) +

--- a/dashboard/app/views/blocks/edit.html.haml
+++ b/dashboard/app/views/blocks/edit.html.haml
@@ -1,5 +1,5 @@
 - content_for(:head) do
-  %script{src: asset_path('js/blockly.js')}
+  %script{src: minifiable_asset_path('js/blockly.js')}
   %script{src: asset_path("js/#{js_locale}/blockly_locale.js")}
   %script{src: minifiable_asset_path('js/blocks/edit.js')}
   = stylesheet_link_tag 'css/levelbuilder', media: 'all'

--- a/dashboard/app/views/blocks/index.html.haml
+++ b/dashboard/app/views/blocks/index.html.haml
@@ -1,5 +1,5 @@
 - content_for(:head) do
-  %script{src: asset_path('js/blockly.js')}
+  %script{src: minifiable_asset_path('js/blockly.js')}
   %script{src: asset_path("js/#{js_locale}/blockly_locale.js")}
   %script{src: minifiable_asset_path('js/blocks/index.js')}
 

--- a/dashboard/app/views/levels/_apps_dependencies.html.haml
+++ b/dashboard/app/views/levels/_apps_dependencies.html.haml
@@ -54,7 +54,7 @@
 
 -# Blockly script dependencies
 - if use_blockly
-  %script{src: asset_path('js/blockly.js')}
+  %script{src: minifiable_asset_path('js/blockly.js')}
   %script{src: asset_path("js/#{js_locale}/blockly_locale.js")}
 
 -# Common script dependencies

--- a/dashboard/app/views/shared_blockly_functions/edit.html.haml
+++ b/dashboard/app/views/shared_blockly_functions/edit.html.haml
@@ -1,5 +1,5 @@
 - content_for(:head) do
-  %script{src: asset_path('js/blockly.js')}
+  %script{src: minifiable_asset_path('js/blockly.js')}
   %script{src: asset_path("js/#{js_locale}/blockly_locale.js")}
   = stylesheet_link_tag 'css/levelbuilder', media: 'all'
 

--- a/dashboard/app/views/weblab_host/index.html.haml
+++ b/dashboard/app/views/weblab_host/index.html.haml
@@ -5,5 +5,5 @@
     #bramble{style: 'height: 100vh;overflow: hidden;'}
     -# webpack-runtime.js must appear exactly once on any page containing webpack entries
     %script{src: asset_path('js/webpack-runtime.js')}
-    %script{src: asset_path('js/bramble/thirdparty/require.min.js'), 'data-main': asset_path('js/brambleHost.js')}
-    =# DEVMODE: %script{src: asset_path('http://127.0.0.1:8000/src/thirdparty/require.min.js'), 'data-main': asset_path('js/brambleHost.js')}
+    %script{src: asset_path('js/bramble/thirdparty/require.min.js'), 'data-main': minifiable_asset_path('js/brambleHost.js')}
+    =# DEVMODE: %script{src: asset_path('http://127.0.0.1:8000/src/thirdparty/require.min.js'), 'data-main': minifiable_asset_path('js/brambleHost.js')}

--- a/dashboard/app/views/weblab_host/index.html.haml
+++ b/dashboard/app/views/weblab_host/index.html.haml
@@ -4,6 +4,6 @@
   %body{style: 'margin: 0'}
     #bramble{style: 'height: 100vh;overflow: hidden;'}
     -# webpack-runtime.js must appear exactly once on any page containing webpack entries
-    %script{src: asset_path('js/webpack-runtime.js')}
+    %script{src: minifiable_asset_path('js/webpack-runtime.js')}
     %script{src: asset_path('js/bramble/thirdparty/require.min.js'), 'data-main': minifiable_asset_path('js/brambleHost.js')}
     =# DEVMODE: %script{src: asset_path('http://127.0.0.1:8000/src/thirdparty/require.min.js'), 'data-main': minifiable_asset_path('js/brambleHost.js')}


### PR DESCRIPTION
### Background

See [webpack content hashing design doc](https://docs.google.com/document/d/1vJ3EpaT8ch6UMLP21IovZIgOzS-QhU4G1kv3azZPmZo/edit#)

This PR performs further simplification in advance of moving js content hashing into webpack.

Today, we use `UnminifiedWebpackPlugin` because there are two assets which we pass through webpack and want to use unminified copies of in production. The current solution is to include unminified copies of _all_ js files produced by webpack, and then let the application decide whether to request the minified or unminified asset.

All of this is fine, except that `UnminifiedWebpackPlugin` and `WebpackManifestPlugin` do not play nicely and produce the following undesirable manifest format:
```
{ 
  "cookieBanner.js": "/assets/js/cookieBanner.d90978a8439431440869.min.js",
  "cookieBanner.d90978a8439431440869.js": "/assets/js/cookieBanner.d90978a8439431440869.js",
}
```
Rather than try to fix the manifest output, I'm taking this opportunity to eliminate unnecessary duplication of assets in our apps package.

### Description
* stop providing unminified copies of all webpack js assets
* exclude `blockly.js` and `brambleHost.js` file contents from minification (though their filenames will still contain `min`)
* use `minifiable_asset_path` to access all webpack js assets including webpack-runtime.js

In production mode this gives a single, useful entry in the manifest for each asset:
```
{ 
  "cookieBanner.js": "/assets/js/cookieBanner.d90978a8439431440869.min.js"
}
```
(note that the work to turn on manifests and filename hashing is not included in this PR)

### Testing

There are 3 things I am aware of to pay special attention to in testing this change:
* blockly levels, which depend on blockly.js
* weblab levels, which depend on brambleHost.js
* applab/gamelab exporters, which use some conditional logic when deciding where to find webpack-runtime.js: https://github.com/code-dot-org/code-dot-org/blob/ef180fdd7bc08bdf3bfe1a029b176de21a63b879/apps/src/util/exporter.js#L280-L284

All 3 of these features have sufficient UI test coverage. The passing drone run indicates that these features are working properly in development mode. The test machine will verify that these are working properly in production mode. 

I have manually verified that blockly and weblab levels are still working after doing a production build locally, and inspection of the exporter code above suggests that it should be resilient as long as one copy (minified or unminified) of webpack-runtime exists in the package.