### PR TITLE
Make RecentCourses component more flexible

### DIFF
--- a/apps/src/templates/studioHomepages/RecentCourses.jsx
+++ b/apps/src/templates/studioHomepages/RecentCourses.jsx
@@ -26,7 +26,13 @@ export default class RecentCourses extends Component {
     courses: shapes.courses,
     topCourse: shapes.topCourse,
     isTeacher: PropTypes.bool.isRequired,
-    hasFeedback: PropTypes.bool
+    hasFeedback: PropTypes.bool.isRequired
+  };
+
+  static defaultProps = {
+    courses: [],
+    isTeacher: false,
+    hasFeedback: false
   };
 
   render() {

--- a/apps/src/templates/studioHomepages/RecentCourses.jsx
+++ b/apps/src/templates/studioHomepages/RecentCourses.jsx
@@ -33,7 +33,7 @@ export default class RecentCourses extends Component {
     const {courses, topCourse, isTeacher, hasFeedback} = this.props;
     const topFourCourses = courses.slice(0, 4);
     const moreCourses = courses.slice(4);
-    const hasCourse = courses.length > 0 || topCourse !== null;
+    const hasCourse = courses.length > 0 || !!topCourse;
 
     return (
       <div id="recent-courses">

--- a/apps/test/unit/templates/studioHomepages/RecentCoursesTest.js
+++ b/apps/test/unit/templates/studioHomepages/RecentCoursesTest.js
@@ -26,6 +26,20 @@ describe('RecentCourses', () => {
     expect(wrapper.find('SeeMoreCourses').exists()).to.be.false;
   });
 
+  it('SetUpCourses has no course when courses is empty and topCourse is null', () => {
+    const wrapper = shallow(
+      <RecentCourses isTeacher={false} courses={[]} topCourse={null} />
+    );
+    expect(wrapper.find('SetUpCourses').prop('hasCourse')).to.be.false;
+  });
+
+  it('SetUpCourses has no course when courses is empty and topCourse is undefined', () => {
+    const wrapper = shallow(
+      <RecentCourses isTeacher={false} courses={[]} topCourse={undefined} />
+    );
+    expect(wrapper.find('SetUpCourses').prop('hasCourse')).to.be.false;
+  });
+
   it('shows a TopCourse if there is one course', () => {
     const wrapper = shallow(
       <RecentCourses courses={[]} topCourse={topCourse} isTeacher />

--- a/apps/test/unit/templates/studioHomepages/RecentCoursesTest.js
+++ b/apps/test/unit/templates/studioHomepages/RecentCoursesTest.js
@@ -26,17 +26,13 @@ describe('RecentCourses', () => {
     expect(wrapper.find('SeeMoreCourses').exists()).to.be.false;
   });
 
-  it('SetUpCourses has no course when courses is empty and topCourse is null', () => {
-    const wrapper = shallow(
-      <RecentCourses isTeacher={false} courses={[]} topCourse={null} />
-    );
+  it('SetUpCourses has no course when topCourse is null', () => {
+    const wrapper = shallow(<RecentCourses topCourse={null} />);
     expect(wrapper.find('SetUpCourses').prop('hasCourse')).to.be.false;
   });
 
-  it('SetUpCourses has no course when courses is empty and topCourse is undefined', () => {
-    const wrapper = shallow(
-      <RecentCourses isTeacher={false} courses={[]} topCourse={undefined} />
-    );
+  it('SetUpCourses has no course when topCourse is undefined', () => {
+    const wrapper = shallow(<RecentCourses topCourse={undefined} />);
     expect(wrapper.find('SetUpCourses').prop('hasCourse')).to.be.false;
   });
 

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -96,6 +96,7 @@ describe('TeacherHomepage', () => {
     assert.deepEqual(recentCourses.props(), {
       showAllCoursesLink: true,
       isTeacher: true,
+      hasFeedback: false,
       courses: courses,
       topCourse: topCourse
     });


### PR DESCRIPTION
Address a follow-up item noticed during https://github.com/code-dot-org/code-dot-org/pull/30800 to make the `RecentCourses` component behave as expected for any falsy value of `topCourse`, not strictly `null`.

Also introduces some default props for two reasons:

- They make the tests easy to read.
- They let you simply omit falsy boolean props, but still reliably pass `false` through to child components, which is a nice companion pattern to the [recommended style for boolean props](https://github.com/airbnb/javascript/tree/master/react#props).