### PR TITLE
Clean up HomeController index logic

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -98,7 +98,11 @@ class HomeController < ApplicationController
     )
   end
 
+  # Set all local variables needed to render the signed-in homepage.
+  # @raise if called when the user is not signed in.
   def init_homepage
+    raise 'init_homepage can only be called when there is a current_user' unless current_user
+
     @homepage_data = {}
     @homepage_data[:valid_grades] = Section.valid_grades
     @homepage_data[:stageExtrasScriptIds] = Script.stage_extras_script_ids
@@ -107,95 +111,93 @@ class HomeController < ApplicationController
     @homepage_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)
     @homepage_data[:providers] = current_user.providers
 
-    if current_user
-      @force_race_interstitial = params[:forceRaceInterstitial]
-      @force_school_info_confirmation_dialog = params[:forceSchoolInfoConfirmationDialog]
-      @force_school_info_interstitial = params[:forceSchoolInfoInterstitial]
+    @force_race_interstitial = params[:forceRaceInterstitial]
+    @force_school_info_confirmation_dialog = params[:forceSchoolInfoConfirmationDialog]
+    @force_school_info_interstitial = params[:forceSchoolInfoInterstitial]
 
-      student_sections = current_user.sections_as_student.map(&:summarize_without_students)
+    student_sections = current_user.sections_as_student.map(&:summarize_without_students)
 
-      # Students and teachers will receive a @top_course for their primary
-      # script, so we don't want to include that script (if it exists) in the
-      # regular lists of recent scripts.
-      exclude_primary_script = true
-      @homepage_data[:courses] = current_user.recent_courses_and_scripts(exclude_primary_script)
+    # Students and teachers will receive a @top_course for their primary
+    # script, so we don't want to include that script (if it exists) in the
+    # regular lists of recent scripts.
+    exclude_primary_script = true
+    @homepage_data[:courses] = current_user.recent_courses_and_scripts(exclude_primary_script)
 
-      @homepage_data[:hasFeedback] = current_user.student? && TeacherFeedback.where(
-        student_id: current_user.id
-      ).count > 0
+    @homepage_data[:hasFeedback] = current_user.student? && TeacherFeedback.where(
+      student_id: current_user.id
+    ).count > 0
 
-      script = current_user.primary_script
-      if script
-        script_level = current_user.next_unpassed_progression_level(script)
-      end
-      @homepage_data[:topCourse] = nil
-      if script && script_level
-        @homepage_data[:topCourse] = {
-          assignableName: data_t_suffix('script.name', script[:name], 'title'),
-          lessonName: script_level.stage.localized_title,
-          linkToOverview: script_path(script),
-          linkToLesson: script_next_path(script, 'next')
-        }
-      end
+    script = current_user.primary_script
+    if script
+      script_level = current_user.next_unpassed_progression_level(script)
+    end
+    @homepage_data[:topCourse] = nil
+    if script && script_level
+      @homepage_data[:topCourse] = {
+        assignableName: data_t_suffix('script.name', script[:name], 'title'),
+        lessonName: script_level.stage.localized_title,
+        linkToOverview: script_path(script),
+        linkToLesson: script_next_path(script, 'next')
+      }
+    end
 
-      if current_user.teacher?
-        unless current_user.donor_teacher_banner_dismissed
-          donor_banner_name = current_user.school_donor_name
-        end
-
-        donor_banner_name ||= params[:forceDonorTeacherBanner]
-        show_census_banner = !!(!donor_banner_name && current_user.show_census_teacher_banner?)
-
-        @homepage_data[:isTeacher] = true
-        @homepage_data[:hocLaunch] = DCDO.get('hoc_launch', CDO.default_hoc_launch)
-        @homepage_data[:joined_sections] = student_sections
-        @homepage_data[:announcement] = DCDO.get('announcement_override', nil)
-        @homepage_data[:hiddenScripts] = current_user.get_hidden_script_ids
-        @homepage_data[:showCensusBanner] = show_census_banner
-        @homepage_data[:donorBannerName] = donor_banner_name
-
-        if show_census_banner
-          teachers_school = current_user.school_info.school
-          school_stats = SchoolStatsByYear.where(school_id: teachers_school.id).order(school_year: :desc).first
-
-          @homepage_data[:censusQuestion] = school_stats.try(:has_high_school_grades?) ? "how_many_20_hours" : "how_many_10_hours"
-          @homepage_data[:currentSchoolYear] = current_census_year
-          @homepage_data[:ncesSchoolId] = teachers_school.id
-          @homepage_data[:teacherName] = current_user.name
-          @homepage_data[:teacherId] = current_user.id
-          @homepage_data[:teacherEmail] = current_user.email
-        elsif donor_banner_name
-          teachers_school = current_user.last_complete_school_info.school
-
-          donor_teacher_banner_options = {}
-          donor_teacher_banner_options[:teacherFirstName] = current_user.short_name
-          donor_teacher_banner_options[:teacherSecondName] = current_user.second_name
-          donor_teacher_banner_options[:teacherEmail] = current_user.email
-          donor_teacher_banner_options[:ncesSchoolId] = teachers_school.id
-          donor_teacher_banner_options[:schoolAddress1] = teachers_school.address_line1
-          donor_teacher_banner_options[:schoolAddress2] = teachers_school.address_line2
-          donor_teacher_banner_options[:schoolAddress3] = teachers_school.address_line3
-          donor_teacher_banner_options[:schoolCity] = teachers_school.city
-          donor_teacher_banner_options[:schoolState] = teachers_school.state
-          donor_teacher_banner_options[:schoolZip] = teachers_school.zip
-
-          @homepage_data[:donorTeacherBannerOptions] = donor_teacher_banner_options
-
-          @homepage_data[:teacherId] = current_user.id
-        end
-      else
-        @homepage_data[:isTeacher] = false
-        @homepage_data[:sections] = student_sections
-        @homepage_data[:studentId] = current_user.id
+    if current_user.teacher?
+      unless current_user.donor_teacher_banner_dismissed
+        donor_banner_name = current_user.school_donor_name
       end
 
-      if current_user.school_donor_name
-        donor_footer_options = {}
-        donor_footer_options[:donorName] = current_user.school_donor_name
-        donor_footer_options[:logos] = Dir.glob("app/assets/images/donor_logos/#{current_user.school_donor_name}/*").sort
+      donor_banner_name ||= params[:forceDonorTeacherBanner]
+      show_census_banner = !!(!donor_banner_name && current_user.show_census_teacher_banner?)
 
-        @homepage_data[:donorFooterOptions] = donor_footer_options
+      @homepage_data[:isTeacher] = true
+      @homepage_data[:hocLaunch] = DCDO.get('hoc_launch', CDO.default_hoc_launch)
+      @homepage_data[:joined_sections] = student_sections
+      @homepage_data[:announcement] = DCDO.get('announcement_override', nil)
+      @homepage_data[:hiddenScripts] = current_user.get_hidden_script_ids
+      @homepage_data[:showCensusBanner] = show_census_banner
+      @homepage_data[:donorBannerName] = donor_banner_name
+
+      if show_census_banner
+        teachers_school = current_user.school_info.school
+        school_stats = SchoolStatsByYear.where(school_id: teachers_school.id).order(school_year: :desc).first
+
+        @homepage_data[:censusQuestion] = school_stats.try(:has_high_school_grades?) ? "how_many_20_hours" : "how_many_10_hours"
+        @homepage_data[:currentSchoolYear] = current_census_year
+        @homepage_data[:ncesSchoolId] = teachers_school.id
+        @homepage_data[:teacherName] = current_user.name
+        @homepage_data[:teacherId] = current_user.id
+        @homepage_data[:teacherEmail] = current_user.email
+      elsif donor_banner_name
+        teachers_school = current_user.last_complete_school_info.school
+
+        donor_teacher_banner_options = {}
+        donor_teacher_banner_options[:teacherFirstName] = current_user.short_name
+        donor_teacher_banner_options[:teacherSecondName] = current_user.second_name
+        donor_teacher_banner_options[:teacherEmail] = current_user.email
+        donor_teacher_banner_options[:ncesSchoolId] = teachers_school.id
+        donor_teacher_banner_options[:schoolAddress1] = teachers_school.address_line1
+        donor_teacher_banner_options[:schoolAddress2] = teachers_school.address_line2
+        donor_teacher_banner_options[:schoolAddress3] = teachers_school.address_line3
+        donor_teacher_banner_options[:schoolCity] = teachers_school.city
+        donor_teacher_banner_options[:schoolState] = teachers_school.state
+        donor_teacher_banner_options[:schoolZip] = teachers_school.zip
+
+        @homepage_data[:donorTeacherBannerOptions] = donor_teacher_banner_options
+
+        @homepage_data[:teacherId] = current_user.id
       end
+    else
+      @homepage_data[:isTeacher] = false
+      @homepage_data[:sections] = student_sections
+      @homepage_data[:studentId] = current_user.id
+    end
+
+    if current_user.school_donor_name
+      donor_footer_options = {}
+      donor_footer_options[:donorName] = current_user.school_donor_name
+      donor_footer_options[:logos] = Dir.glob("app/assets/images/donor_logos/#{current_user.school_donor_name}/*").sort
+
+      @homepage_data[:donorFooterOptions] = donor_footer_options
     end
   end
 end


### PR DESCRIPTION
Follow up to an audit suggested in https://github.com/code-dot-org/code-dot-org/pull/30800.  The `init_homepage` private method on `HomeController` had a surprising `if current_user` block, even though code earlier in the method assumed a `current_user` was present.  It turns out this is a safe assumption, because the only place we call `init_homepage` is here, with a prior `authenticate_user!` call that will redirect to sign-in if needed:

https://github.com/code-dot-org/code-dot-org/blob/9558d909115ab13b33c7e6fa695d7d371cc4e559/dashboard/app/controllers/home_controller.rb#L62-L68

So I'm adding a doc comment, a guard clause that we _should_ never hit, and removing the unnecessary if-block.  Reviewing without whitespace highly recommended.