### PR TITLE
[student-libraries] Added CloudFormation template for the new student libraries bucket

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -135,6 +135,10 @@ Resources:
           - Effect: Allow
             Action: 'firehose:PutRecord'
             Resource: !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/analysis-events"
+          # S3 access for student-libraries bucket
+          - Effect: Allow
+            Action: 's3:*'
+            Resource: !Sub "arn:aws:s3:::cdo-v3-libraries/libraries_<%=environment%>*"
           # General s3 access.
           # TODO: Further restrict permissions to grant least privilege.
           - Effect: Allow

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -137,8 +137,15 @@ Resources:
             Resource: !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/analysis-events"
           # S3 access for student-libraries bucket
           - Effect: Allow
-            Action: 's3:*'
-            Resource: !Sub "arn:aws:s3:::cdo-v3-libraries/libraries_<%=environment%>*"
+            Action:
+              - 's3:DeleteObject'
+              - 's3:DeleteObjectVersion'
+              - 's3:GetObject'
+              - 's3:GetObjectVersion'
+              - 's3:PutObject'
+              - 's3:ReplicateObject'
+              - 's3:RestoreObject'
+            Resource: 'arn:aws:s3:::cdo-v3-libraries/libraries_<%=environment%>/*'
           # General s3 access.
           # TODO: Further restrict permissions to grant least privilege.
           - Effect: Allow

--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: 'S3 Buckets'
+Resources:
+  ## Create S3 bucket for student libraries
+  LibraryBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: 'cdo-v3-libraries'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: 'aws:kms'
+      VersioningConfiguration:
+        Status: 'Enabled'
+      LoggingConfiguration:
+        DestinationBucketName: 'cdo-logs'
+        LogFilePrefix: 's3/cdo-v3-libraries'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true


### PR DESCRIPTION
We tested this template and created a sample libraries bucket and stack. After this PR is approved, I will delete those test artifacts and create the final version.

The stack currently lives here: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/changesets?filteringText=&filteringStatus=active&viewNested=true&hideStacks=false&stackId=arn%3Aaws%3Acloudformation%3Aus-east-1%3A475661607190%3Astack%2Ftest-libraries-bucket%2F236efd30-da61-11e9-8642-12f81177eb92 

The bucket currently lives here: https://s3.console.aws.amazon.com/s3/buckets/cdo-v3-libraries/?region=us-east-1&tab=overview

Note that the bucket currently has "Object-level logging" set to enabled. Although we don't think this is necessary for this bucket, it appears to be a default setting, and we left it enabled.

Additional permissions should be set here prior to this PR being merged: https://github.com/code-dot-org/code-dot-org/blob/ca6bdeb6c5c6571ac4b4a03eba53bcd37372747c/aws/cloudformation/cloud_formation_stack.yml.erb#L139