### PR TITLE
PL: Fix legacy regional partner contact form for non-US IPs

### DIFF
--- a/apps/src/schoolInfoManager.js
+++ b/apps/src/schoolInfoManager.js
@@ -358,6 +358,11 @@ export default function SchoolInfoManager(existingOptions) {
   // values if they were provided.
 
   if (existingOptions) {
+    if (existingOptions.assumeUsa) {
+      $('#school-country-group').hide();
+      $('#school-country').val('US');
+    }
+
     if (existingOptions.country) {
       $('#school-country')
         .val(existingOptions.country)

--- a/apps/test/unit/schoolInfoManagerTest.js
+++ b/apps/test/unit/schoolInfoManagerTest.js
@@ -1,0 +1,38 @@
+import {assertVisible, assertHidden} from '../util/assertions';
+import SchoolInfoManager from '@cdo/apps/schoolInfoManager';
+import {enforceDocumentBodyCleanup} from '../util/testUtils';
+
+// This is the very beginning of testing for SchoolInfoManager.
+// It can be expanded to give full coverage.
+// Right now, it just tests the "assume USA" option.
+
+describe('schoolInfoManagerTest', () => {
+  enforceDocumentBodyCleanup({checkEveryTest: true}, () => {
+    let rootElement, options;
+
+    beforeEach(() => {
+      options = {};
+
+      rootElement = document.createElement('div');
+      rootElement.innerHTML = `
+      <div id="school-country-group">
+      </div>`;
+      document.body.appendChild(rootElement);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(rootElement);
+    });
+
+    it('hides country when assume USA', () => {
+      const optionsAssumeUsa = {...options, assumeUsa: true};
+      SchoolInfoManager(optionsAssumeUsa);
+      assertHidden('#school-country-group');
+    });
+
+    it('shows country when do not assume USA', () => {
+      SchoolInfoManager(options);
+      assertVisible('#school-country-group');
+    });
+  });
+});

--- a/dashboard/app/views/shared/_school_info.html.haml
+++ b/dashboard/app/views/shared/_school_info.html.haml
@@ -91,13 +91,7 @@
     var options = #{existing_school_info.to_json};
     var suppressScrolling = #{!!(local_assigns[:suppress_scrolling])};
     options['suppressScrolling'] = suppressScrolling;
-
-    var assumeUsa = #{!!(local_assigns[:assume_usa])};
-
-    if (assumeUsa) {
-      $('#school-country-group').hide();
-      $('#school-country').val('US');
-    }
+    options['assumeUsa'] = #{!!(local_assigns[:assume_usa])};
 
     // Send through some values that the JavaScript will need.
     window.schoolInfoManager = new SchoolInfoManager(options);

--- a/dashboard/app/views/shared/_school_info.html.haml
+++ b/dashboard/app/views/shared/_school_info.html.haml
@@ -96,7 +96,7 @@
 
     if (assumeUsa) {
       $('#school-country-group').hide();
-      $('#school-country').val('United States');
+      $('#school-country').val('US');
     }
 
     // Send through some values that the JavaScript will need.


### PR DESCRIPTION
The legacy regional partner contact form at https://studio.code.org/pd/regional_partner_contact/new had a bug when the visitor's IP address was non-US.  The form tells its school-info partial to assume the visitor is in the US.  The partial hides the real country dropdown while the form provides its own which simply offers US vs. non-US.  The partial also attempts to set the real country dropdown to the `"United States"`.  Unfortunately it should have been attempting to set it to `"US"` which is the actual value of that option.

Visitors geocoded to the US (or on localhost) didn't encounter this problem because separate [initialization code](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/schoolInfoManager.js#L361-L364) inside the `SchoolInfoManager` set the real country dropdown to `"US"`, but non-US visitors never got this rescue.

One result of this problem was that affected users choosing Public or Private in the school type dropdown  weren't seeing the ZIP or state fields appear, because the code to make them visible also checks that country is "US".  

I suspect this had a knock-on effect in which we weren't matching to regional partners for the automatically-generated emails because we didn't have the ZIP or state in the submitted contact forms.