### PR TITLE
wait for page navigation after pressing unsubmit button

### DIFF
--- a/dashboard/test/ui/features/applab_submittable.feature
+++ b/dashboard/test/ui/features/applab_submittable.feature
@@ -42,7 +42,7 @@ Scenario: Submit anything, teacher is able to unsubmit
   And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
   And I wait to see "#teacher-panel-container"
   Then I wait until element "#unsubmit-button-uitest" is visible
-  And I press "#unsubmit-button-uitest" using jQuery
+  And I press "#unsubmit-button-uitest" using jQuery to load a new page
 
   # Unsubmit should be disabled now
   And I wait for the page to fully load


### PR DESCRIPTION
applab_submittable has been flaky. here is an example failure: https://app.saucelabs.com/tests/8dfbf66f9c6243dfa794d38330a162ad#97

![Screen Shot 2019-09-19 at 10 11 40 AM](https://user-images.githubusercontent.com/8001765/65265670-4b1bbe80-dac6-11e9-9c6e-90d84cb92f99.png)

Because we are waiting for the page to fully load on the next line, we can conclude that clicking unsubmit causes a navigation. But we can also see from this test that we are not properly waiting for the current page to unload before we wait for the new page to load. therefore the solution is to wait for the page to unload.