### PR TITLE
Revert combine strings and variables in for_counter block #30791

### DIFF
--- a/apps/lib/blockly/en_us.js
+++ b/apps/lib/blockly/en_us.js
@@ -41,7 +41,6 @@ Blockly.Msg.CONTROLS_FOREACH_INPUT_ITEM = "for each item";
 Blockly.Msg.CONTROLS_FOREACH_TOOLTIP = "For each item in a list, set the variable '%1' to the item, and then do some statements.";
 Blockly.Msg.CONTROLS_FOR_HELPURL = "https://code.google.com/p/blockly/wiki/Loops#count_with";
 Blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY = "from %1 to %2 count by %3";
-Blockly.Msg.CONTROLS_FOR_INPUT_COUNTER = "for %1 from %2 to %3 count by %4";
 Blockly.Msg.CONTROLS_FOR_INPUT_WITH = "for";
 Blockly.Msg.CONTROLS_FOR_TOOLTIP = "Have the variable %1 take on the values from the start number to the end number, counting by the specified interval, and do the specified blocks.";
 Blockly.Msg.CONTROLS_IF_ELSEIF_TOOLTIP = "Add a condition to the if block.";

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -660,14 +660,11 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: blockly.Msg.CONTROLS_FOR_HELPURL,
     init: function() {
       this.setHSV(322, 0.9, 0.95);
+      this.appendDummyInput()
+        .appendTitle(blockly.Msg.CONTROLS_FOR_INPUT_WITH)
+        .appendTitle(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
       this.interpolateMsg(
-        Blockly.Msg.CONTROLS_FOR_INPUT_COUNTER,
-        () => {
-          this.appendDummyInput().appendTitle(
-            new blockly.FieldLabel(msg.loopVariable()),
-            'VAR'
-          );
-        },
+        blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY,
         ['FROM', 'Number', blockly.ALIGN_RIGHT],
         ['TO', 'Number', blockly.ALIGN_RIGHT],
         ['BY', 'Number', blockly.ALIGN_RIGHT],


### PR DESCRIPTION
This is to revert the changes made to the for_counter block in loops.  The for_counter block is not visible in non-EN languages.  The for-counter block was modified as part of this work item.  Upon investigation, it was determined that the new string was not included in the last i18n sync as the change was merged after the i18n sync.  

[jira ticket](https://codedotorg.atlassian.net/browse/STAR-689)

[revert](https://github.com/code-dot-org/code-dot-org/pull/30791)