### PR TITLE
[student-libraries] Expose functions, comments, and parameters from the JSInterpreter

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -221,7 +221,7 @@
     "webpack-stats-plugin": "^0.2.1"
   },
   "dependencies": {
-    "@code-dot-org/js-interpreter": "^1.3.9",
+    "@code-dot-org/js-interpreter": "1.3.10",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -29,7 +29,7 @@ import designMode from './designMode';
 import applabTurtle from './applabTurtle';
 import applabCommands from './commands';
 import JSInterpreter, {
-  getFunctionsWithComments
+  getFunctionsAndMetadata
 } from '../lib/tools/jsinterpreter/JSInterpreter';
 import JsInterpreterLogger from '../JsInterpreterLogger';
 import * as elementUtils from './designElements/elementUtils';
@@ -350,7 +350,7 @@ Applab.setLevelHtml = function(html) {
 };
 
 Applab.getFunctions = function() {
-  return getFunctionsWithComments(Applab.getCode());
+  return getFunctionsAndMetadata(Applab.getCode());
 };
 
 Applab.onTick = function() {

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -28,7 +28,9 @@ import * as apiTimeoutList from '../lib/util/timeoutList';
 import designMode from './designMode';
 import applabTurtle from './applabTurtle';
 import applabCommands from './commands';
-import JSInterpreter from '../lib/tools/jsinterpreter/JSInterpreter';
+import JSInterpreter, {
+  getFunctionsWithComments
+} from '../lib/tools/jsinterpreter/JSInterpreter';
 import JsInterpreterLogger from '../JsInterpreterLogger';
 import * as elementUtils from './designElements/elementUtils';
 import {shouldOverlaysBeVisible} from '../templates/VisualizationOverlay';
@@ -345,6 +347,10 @@ Applab.setLevelHtml = function(html) {
   // screen is visible.
   designMode.loadDefaultScreen();
   designMode.serializeToLevelHtml();
+};
+
+Applab.getFunctions = function() {
+  return getFunctionsWithComments(Applab.getCode());
 };
 
 Applab.onTick = function() {

--- a/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
@@ -248,7 +248,7 @@ export default class JSInterpreter {
 
   /**
    * Builds a list of objects that contain all metadata about any functions in
-   * the gived code string. Each object in the returned list has the following
+   * the given code string. Each object in the returned list has the following
    * properties:
    * functionName - the name of the function
    * parameters - the names of the parameters passed into the function
@@ -256,6 +256,8 @@ export default class JSInterpreter {
    * multiline, singleline, or multiple singlelines format.
    *
    * @param {string} code - The code to be parsed for functions
+   * @return {array} functionsAndMetadata - all functions from the input 'code'
+   *         along with their relevant metadata
    */
   static getFunctionsAndMetadata(code) {
     // Private helper functions

--- a/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
@@ -137,7 +137,6 @@ export default class JSInterpreter {
    *        debugging (default 0)
    */
   parse(options) {
-    // debugger;
     this.calculateCodeInfo(options);
 
     if (!this.studioApp.hideSource && this.studioApp.editor) {
@@ -238,7 +237,6 @@ export default class JSInterpreter {
       // code to override globals of the same names)
 
       // Now append the user code:
-      // debugger;
       this.interpreter.appendCode(options.code);
       // And repopulate scope since appendCode() doesn't do this automatically:
       this.interpreter.populateScope_(this.interpreter.ast, this.globalScope);

--- a/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
@@ -7,10 +7,10 @@ import JSInterpreter from '@cdo/apps/lib/tools/jsinterpreter/JSInterpreter';
 describe('The JSInterpreter class', function() {
   var jsInterpreter;
 
-  describe('static function getFunctionsWithComments', () => {
+  describe('static function getFunctionsAndMetadata', () => {
     it('returns no comment when no comment is passed', () => {
       let code = 'function testFunction() {}';
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].comment).to.equal('');
     });
 
@@ -18,49 +18,49 @@ describe('The JSInterpreter class', function() {
     it('returns block comments as-is', () => {
       let multiLineComment = 'comment\nanother comment';
       let code = `/*\n${multiLineComment}\n*/\nfunction testFunction() {}`;
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].comment).to.equal(multiLineComment);
     });
 
     it('returns no comment when an empty block comment is passed', () => {
       let code = '/**/\nfunction testFunction() {}';
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].comment).to.equal('');
     });
 
     it('detects block comments with trailing spaces', () => {
       let code = `/*${comment}*/    \nfunction testFunction() {}`;
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].comment).to.equal(`${comment}`);
     });
 
     it('strips stars from JSDocComments', () => {
       let code = `/**\n * ${comment}\n * ${comment}\n */\nfunction testFunction() {}`;
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].comment).to.equal(`${comment}\n${comment}`);
     });
 
-    it('returns multiple single-line comments', () => {
-      let code = `//${comment}\n//${comment}\nfunction testFunction() {}`;
-      let functions = JSInterpreter.getFunctionsWithComments(code);
-      expect(functions[0].comment).to.equal(`${comment}\n${comment}`);
+    it('returns the last single-line comment if there are multiple', () => {
+      let code = `//${comment}\n//${comment}last\nfunction testFunction() {}`;
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
+      expect(functions[0].comment).to.equal(`${comment}last`);
     });
 
     it('returns no comment when an empty comment is passed', () => {
       let code = '//\nfunction testFunction() {}';
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].comment).to.equal('');
     });
 
     it('returns no comment when a comment is more than one line away', () => {
       let code = '//comment\n\nfunction testFunction() {}';
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].comment).to.equal('');
     });
 
     it('returns no parameters when no parameter is passed', () => {
       let code = 'function testFunction() {}';
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].parameters).to.be.an('array').that.is.empty;
     });
 
@@ -68,14 +68,14 @@ describe('The JSInterpreter class', function() {
       let param1 = 'param1';
       let param2 = 'param2';
       let code = `function testFunction(${param1}, ${param2}) {}`;
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].parameters).to.include.members([param1, param2]);
     });
 
     it('returns the name of the function', () => {
       let functionName = 'testFunction';
       let code = `function ${functionName}() {}`;
-      let functions = JSInterpreter.getFunctionsWithComments(code);
+      let functions = JSInterpreter.getFunctionsAndMetadata(code);
       expect(functions[0].functionName).to.equal(functionName);
     });
   });

--- a/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
@@ -7,6 +7,79 @@ import JSInterpreter from '@cdo/apps/lib/tools/jsinterpreter/JSInterpreter';
 describe('The JSInterpreter class', function() {
   var jsInterpreter;
 
+  describe('static function getFunctionsWithComments', () => {
+    it('returns no comment when no comment is passed', () => {
+      let code = 'function testFunction() {}';
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].comment).to.equal('');
+    });
+
+    let comment = 'comment';
+    it('returns block comments as-is', () => {
+      let multiLineComment = 'comment\nanother comment';
+      let code = `/*\n${multiLineComment}\n*/\nfunction testFunction() {}`;
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].comment).to.equal(multiLineComment);
+    });
+
+    it('returns no comment when an empty block comment is passed', () => {
+      let code = '/**/\nfunction testFunction() {}';
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].comment).to.equal('');
+    });
+
+    it('detects block comments with trailing spaces', () => {
+      let code = `/*${comment}*/    \nfunction testFunction() {}`;
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].comment).to.equal(`${comment}`);
+    });
+
+    it('strips stars from JSDocComments', () => {
+      let code = `/**\n * ${comment}\n * ${comment}\n */\nfunction testFunction() {}`;
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].comment).to.equal(`${comment}\n${comment}`);
+    });
+
+    it('returns multiple single-line comments', () => {
+      let code = `//${comment}\n//${comment}\nfunction testFunction() {}`;
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].comment).to.equal(`${comment}\n${comment}`);
+    });
+
+    it('returns no comment when an empty comment is passed', () => {
+      let code = '//\nfunction testFunction() {}';
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].comment).to.equal('');
+    });
+
+    it('returns no comment when a comment is more than one line away', () => {
+      let code = '//comment\n\nfunction testFunction() {}';
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].comment).to.equal('');
+    });
+
+    it('returns no parameters when no parameter is passed', () => {
+      let code = 'function testFunction() {}';
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].parameters).to.be.an('array').that.is.empty;
+    });
+
+    it('returns all parameters passed', () => {
+      let param1 = 'param1';
+      let param2 = 'param2';
+      let code = `function testFunction(${param1}, ${param2}) {}`;
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].parameters).to.include.members([param1, param2]);
+    });
+
+    it('returns the name of the function', () => {
+      let functionName = 'testFunction';
+      let code = `function ${functionName}() {}`;
+      let functions = JSInterpreter.getFunctionsWithComments(code);
+      expect(functions[0].functionName).to.equal(functionName);
+    });
+  });
+
   function initWithCode(code) {
     // Setup a jsInterpreter instance with `hideSource: true` so an editor isn't
     // needed.

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -936,9 +936,10 @@
     test262-harness "^2.4.0"
     yargs "^7.0.1"
 
-"@code-dot-org/js-interpreter@^1.3.9":
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/js-interpreter/-/js-interpreter-1.3.9.tgz#a29b3914f38e1655816d745cea80c24e76758001"
+"@code-dot-org/js-interpreter@1.3.10":
+  version "1.3.10"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/js-interpreter/-/js-interpreter-1.3.10.tgz#642200b69b34c8bc7636b5daddb8aa554930bd57"
+  integrity sha512-KnG9Q4L3f4y8McEBdytVqYQ5P6916SbCCH0VIpdnlCjYG516bPJ3V+6UcoPeZQBDh/NbF4WcYsDSSNontYA5UA==
   dependencies:
     yargs "^7.0.1"
 


### PR DESCRIPTION
Added functionality to the JSInterpreter to parse student code for functions along with their comments and parameters.

For a sample of what student comments could look like, see this project: https://studio.code.org/projects/applab/TUd7VzCGUL5pVK-LqRLi-9Z1xtw-R-KinEDnVeA2pag/edit

This pairs with this PR in the JSInterpreter library: https://github.com/code-dot-org/JS-Interpreter/pull/32

This is in preparation for the student-libraries feature described in this spec: https://docs.google.com/document/d/1VxMmdHdIeBWCXKofkjEy9MuWcrzeEW3Zt-Ir8pINYdA/edit