### PR TITLE
[Applab Datasets] Enable importing Current Tables

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -853,6 +853,28 @@ function setupReduxSubscribers(store) {
       getProjectDatabase().child('counters/tables'),
       tableType.PROJECT
     );
+
+    if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      // /v3/channels/<channel_id>/current_tables tracks which
+      // current tables the project has imported. Here we initialize the
+      // redux list of current tables and keep it in sync
+      let currentTableRef = getProjectDatabase().child('current_tables');
+      currentTableRef.on('child_added', snapshot => {
+        store.dispatch(
+          addTableName(
+            typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key,
+            tableType.SHARED
+          )
+        );
+      });
+      currentTableRef.on('child_removed', snapshot => {
+        store.dispatch(
+          deleteTableName(
+            typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key
+          )
+        );
+      });
+    }
   }
 }
 

--- a/apps/src/storage/dataBrowser/DataBrowser.jsx
+++ b/apps/src/storage/dataBrowser/DataBrowser.jsx
@@ -186,6 +186,7 @@ class DataBrowser extends React.Component {
                   <EditTableListRow
                     key={tableName}
                     tableName={tableName}
+                    tableType={this.props.tableListMap[tableName]}
                     onViewChange={() =>
                       this.props.onViewChange(DataView.TABLE, tableName)
                     }

--- a/apps/src/storage/dataBrowser/EditTableListRow.jsx
+++ b/apps/src/storage/dataBrowser/EditTableListRow.jsx
@@ -10,7 +10,8 @@ import * as dataStyles from './dataStyles';
 class EditTableListRow extends React.Component {
   static propTypes = {
     onViewChange: PropTypes.func.isRequired,
-    tableName: PropTypes.string.isRequired
+    tableName: PropTypes.string.isRequired,
+    tableType: PropTypes.string
   };
 
   handleEdit = () => {
@@ -18,7 +19,7 @@ class EditTableListRow extends React.Component {
   };
 
   handleDelete = () => {
-    FirebaseStorage.deleteTable(this.props.tableName);
+    FirebaseStorage.deleteTable(this.props.tableName, this.props.tableType);
   };
 
   render() {

--- a/apps/src/storage/dataBrowser/LibraryTable.jsx
+++ b/apps/src/storage/dataBrowser/LibraryTable.jsx
@@ -74,16 +74,16 @@ class LibraryTable extends React.Component {
 
   importTable = datasetInfo => {
     if (datasetInfo.current) {
-      // TODO: Implement current tables (see STAR-615)
+      FirebaseStorage.addCurrentTableToProject(
+        datasetInfo.name,
+        () => console.log('success'),
+        err => console.log(err)
+      );
     } else {
       FirebaseStorage.copyStaticTable(
         datasetInfo.name,
-        () => {
-          console.log('success');
-        },
-        err => {
-          console.log(err);
-        }
+        () => console.log('success'),
+        err => console.log(err)
       );
     }
   };

--- a/apps/src/storage/dataBrowser/PreviewModal.jsx
+++ b/apps/src/storage/dataBrowser/PreviewModal.jsx
@@ -5,6 +5,7 @@ import {hidePreview} from '../redux/data';
 import {getDatasetInfo} from './dataUtils';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import DataTable from './DataTable';
+import {parseColumnsFromRecords} from '../firebaseMetadata';
 import msg from '@cdo/locale';
 
 class PreviewModal extends React.Component {
@@ -30,7 +31,12 @@ class PreviewModal extends React.Component {
       <BaseDialog isOpen handleClose={this.props.onClose} fullWidth>
         <h1>{this.props.tableName}</h1>
         <p>{datasetInfo.description}</p>
-        <DataTable getColumnNames={(records, columns) => columns} readOnly />
+        <DataTable
+          getColumnNames={(records, columns) =>
+            parseColumnsFromRecords(records)
+          }
+          readOnly
+        />
         <button type="button" onClick={() => this.importTable(datasetInfo)}>
           {msg.import()}
         </button>

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -27,6 +27,20 @@ export function getColumnRefByName(tableName, columnName) {
     });
 }
 
+// TODO: De-dupe this function with getColumnNamesFromRecords() below
+export function parseColumnsFromRecords(records) {
+  const columnNames = [];
+  Object.keys(records).forEach(id => {
+    const record = JSON.parse(records[id]);
+    Object.keys(record).forEach(column => {
+      if (columnNames.indexOf(column) === -1) {
+        columnNames.push(column);
+      }
+    });
+  });
+  return columnNames;
+}
+
 export function getColumnNamesFromRecords(records) {
   const columnNames = ['id'];
   Object.keys(records).forEach(id => {

--- a/apps/test/unit/storage/FirebaseStorageTest.js
+++ b/apps/test/unit/storage/FirebaseStorageTest.js
@@ -1,5 +1,6 @@
 import {expect} from '../../util/configuredChai';
 import {initFirebaseStorage} from '@cdo/apps/storage/firebaseStorage';
+import {tableType} from '@cdo/apps/storage/redux/data';
 import {
   getProjectDatabase,
   getSharedDatabase,
@@ -463,9 +464,14 @@ describe('FirebaseStorage', () => {
       );
 
       function deleteTable() {
-        FirebaseStorage.deleteTable('mytable', verifyNoTable, error => {
-          throw error;
-        });
+        FirebaseStorage.deleteTable(
+          'mytable',
+          tableType.PROJECT,
+          verifyNoTable,
+          error => {
+            throw error;
+          }
+        );
       }
 
       function verifyNoTable() {


### PR DESCRIPTION
(I think) this is the last major user-facing piece of this!

When you click import on a current table, it adds an entry for that table in `v3/channels/<channel_id>/current_tables`. When you delete a current table, it just removes that entry. 
![image](https://user-images.githubusercontent.com/8787187/65284428-54208600-daee-11e9-918a-4a3b921ea1f2.png)
Applab then listens to changes and adds/removes tables from the redux `tableListMap` as required. #30289 added support to fetch data from the shared channel to render the table.

Note- this PR includes a new function `parseColumnsFromRecords()` that is very similar to the existing `getColumnNamesFromRecords()`. I will de-dupe these functions soon, but running into some really weird bugs (see [link](https://codedotorg.slack.com/archives/CN4T89YP8/p1568919872005700)).