### PR TITLE
Deflake test: workshop_dashboard.feature

### DIFF
--- a/dashboard/test/ui/features/pd/workshop_dashboard.feature
+++ b/dashboard/test/ui/features/pd/workshop_dashboard.feature
@@ -1,11 +1,7 @@
 @dashboard_db_access
 @eyes
-
-
 Feature: Workshop Dashboard
 
-# Skip due to flaky test
-@skip
 Scenario: New workshop: CSF intro
   Given I am a CSF facilitator named "Test CSF Facilitator" for regional partner "Test Partner"
   Then I open the new workshop form

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -55,6 +55,7 @@ Given /^I select the "([^"]*)" facilitator at index (\d+)$/ do |name, index|
   facilitator = "#{name} (#{email})"
 
   steps %Q{
+    And I wait until element "#facilitator#{index}" is visible
     And I select the "#{facilitator}" option in dropdown "facilitator#{index}"
   }
 end


### PR DESCRIPTION
This eyes feature has been flaky lately, so much so that we'd already disabled one of its scenarios.  Here's the recent run history of one scenario:

![image](https://user-images.githubusercontent.com/1615761/65290260-63f69500-db03-11e9-83e6-0be31ee3a4f0.png)

It's been failing on the step where you pick a facilitator from the dropdown, with an error saying the dropdown hasn't appeared yet.  It's known that the dropdown doesn't appear until after you select a course, but we _do_ select a course earlier in the test, and also wait for another change that depends on setting a course, so that seemed like it would be sufficient.

When I did a manual verification today, I noticed that the facilitator list on test was very long - either because we have a lot of tests that create facilitators, or we're not cleaning something up properly.

![facilitator_list](https://user-images.githubusercontent.com/1615761/65290315-a029f580-db03-11e9-9790-0f9a418eaa39.png)

It turns out loading facilitators for this list is a server request, while the other "wait" in this test (`And I wait until element "label:contains('Workshop Type Options')" is visible`) is a faster update.  How much slower is the facilitator load? It took 15 seconds the first time I tried it with my network monitor up:

![Screenshot from 2019-09-19 17-28-49](https://user-images.githubusercontent.com/1615761/65290383-dbc4bf80-db03-11e9-8413-f927f27c4ea0.png)

As a quick fix for the test flakiness I'm adding an implicit wait for the facilitator dropdown to appear as part of the "select facilitator at index" step.  I'm also filing two follow-up tasks:

- [PLC-461](https://codedotorg.atlassian.net/browse/PLC-461) Audit the performance of `/api/v1/pd/course_facilitators`.
- [PLC-462](https://codedotorg.atlassian.net/browse/PLC-462) Clean up old course facilitators on test.