### PR TITLE
Translation:  add new blockly string

### DIFF
--- a/apps/lib/blockly/en_us.js
+++ b/apps/lib/blockly/en_us.js
@@ -41,6 +41,7 @@ Blockly.Msg.CONTROLS_FOREACH_INPUT_ITEM = "for each item";
 Blockly.Msg.CONTROLS_FOREACH_TOOLTIP = "For each item in a list, set the variable '%1' to the item, and then do some statements.";
 Blockly.Msg.CONTROLS_FOR_HELPURL = "https://code.google.com/p/blockly/wiki/Loops#count_with";
 Blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY = "from %1 to %2 count by %3";
+Blockly.Msg.CONTROLS_FOR_INPUT_COUNTER = "for %1 from %2 to %3 count by %4";
 Blockly.Msg.CONTROLS_FOR_INPUT_WITH = "for";
 Blockly.Msg.CONTROLS_FOR_TOOLTIP = "Have the variable %1 take on the values from the start number to the end number, counting by the specified interval, and do the specified blocks.";
 Blockly.Msg.CONTROLS_IF_ELSEIF_TOOLTIP = "Add a condition to the if block.";


### PR DESCRIPTION
New blockly string is added before modifying for_counter block.  This will ensure the string is part of the i18n sync and exists in non-EN locales prior to any code changes to avoid user impact.

If the for_counter block is modified without the string existing in Crowdin, it will cause an error when the locale is non-EN.  The string does not default to English.

[revert](https://github.com/code-dot-org/code-dot-org/pull/30849)