### PR TITLE
Restore files api 404 with asset manager fix

### DIFF
--- a/apps/src/clientApi.js
+++ b/apps/src/clientApi.js
@@ -349,7 +349,7 @@ class FilesApi extends CollectionsApi {
   }
 
   /*
-   * Delete all files in project (always creates a new version)
+   * Delete all files in project
    * @param success {Function} callback when successful (includes xhr parameter)
    * @param error {Function} callback when failed (includes xhr parameter)
    */
@@ -357,18 +357,7 @@ class FilesApi extends CollectionsApi {
     // Note: just reset the _beforeFirstWriteHook, but don't call it
     // since we're deleting everything:
     this._beforeFirstWriteHook = null;
-    return ajaxInternal(
-      'DELETE',
-      this.basePath('*'),
-      xhr => {
-        var response = JSON.parse(xhr.response);
-        project().filesVersionId = response.filesVersionId;
-        if (success) {
-          success(xhr, project().filesVersionId);
-        }
-      },
-      error
-    );
+    return ajaxInternal('DELETE', this.basePath('*'), success, error);
   }
 
   /*

--- a/apps/src/code-studio/components/AssetManager.jsx
+++ b/apps/src/code-studio/components/AssetManager.jsx
@@ -131,9 +131,16 @@ export default class AssetManager extends React.Component {
    * when loading the current list of assets.
    * @param xhr
    */
-  onAssetListFailure = xhr => {
+  onAssetListFailure = ({status}) => {
+    const {useFilesApi} = this.props;
+    if (useFilesApi && status === 404) {
+      // No files in this project yet, proceed with an empty file list
+      this.onAssetListReceived({files: []});
+      return;
+    }
+
     this.setState({
-      statusMessage: 'Error loading asset list: ' + getErrorMessage(xhr.status)
+      statusMessage: 'Error loading asset list: ' + getErrorMessage(status)
     });
   };
 

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -16,7 +16,7 @@ import project from '@cdo/apps/code-studio/initApp/project';
 import {getStore} from '../redux';
 import {TestResults} from '../constants';
 import {queryParams} from '@cdo/apps/code-studio/utils';
-import {makeEnum} from '../utils';
+import {makeEnum, reload} from '../utils';
 import logToCloud from '../logToCloud';
 import firehoseClient from '../lib/util/firehose';
 import {getCurrentId} from '../code-studio/initApp/project';
@@ -97,23 +97,11 @@ WebLab.prototype.init = function(config) {
   config.noHowItWorks = true;
 
   config.afterClearPuzzle = config => {
-    return new Promise((resolve, reject) => {
+    return new Promise((_, reject) => {
       // Delete everything from the service and restart the initial sync
       filesApi.deleteAll(
-        (xhr, filesVersionId) => {
+        xhr => {
           this.fileEntries = null;
-          if (!this.brambleHost) {
-            reject(new Error('no bramble host'));
-            return;
-          }
-          // Force brambleHost to reload based on startSources
-          this.brambleHost.startInitialFileSync(err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          }, true);
           firehoseClient.putRecord(
             {
               study: 'weblab_loading_investigation',
@@ -125,6 +113,15 @@ WebLab.prototype.init = function(config) {
               })
             },
             {includeUserId: true}
+          );
+          // The project has been reset, reload() the page now - don't resolve
+          // the promise, because that will lead to a project.save() that we
+          // don't want or need in this scenario.
+          reload();
+          reject(
+            new Error(
+              'deleteAll succeeded, weblab handling reload to avoid saving'
+            )
           );
         },
         xhr => {
@@ -480,49 +477,50 @@ WebLab.prototype.onIsRunningChange = function() {};
  * Load the file entry list and store it as this.fileEntries
  */
 WebLab.prototype.loadFileEntries = function() {
-  filesApi.getFiles(
-    result => {
-      // Gather information when the weblab manifest is empty but should
-      // contain references to files (i.e. after changes have been made to the project)
-      if (
-        result.filesVersionId &&
-        result.filesVersionId !== '' &&
-        result.files &&
-        result.files.length === 0
-      ) {
-        firehoseClient.putRecord(
-          {
-            study: 'weblab_loading_investigation',
-            study_group: 'empty_manifest',
-            event: 'get_empty_manifest',
-            project_id: getCurrentId()
-          },
-          {includeUserId: true}
-        );
-      }
-      assetListStore.reset(result.files);
-      this.fileEntries = assetListStore.list().map(fileEntry => ({
-        name: fileEntry.filename,
-        url: filesApi.basePath(fileEntry.filename),
-        versionId: fileEntry.versionId
-      }));
-      var latestFilesVersionId = result.filesVersionId;
-      this.initialFilesVersionId =
-        this.initialFilesVersionId || latestFilesVersionId;
+  const onFilesReady = (files, filesVersionId) => {
+    // Gather information when the weblab manifest is empty but should
+    // contain references to files (i.e. after changes have been made to the project)
+    if (filesVersionId && files && files.length === 0) {
+      firehoseClient.putRecord(
+        {
+          study: 'weblab_loading_investigation',
+          study_group: 'empty_manifest',
+          event: 'get_empty_manifest',
+          project_id: getCurrentId()
+        },
+        {includeUserId: true}
+      );
+    }
+    assetListStore.reset(files);
+    this.fileEntries = assetListStore.list().map(fileEntry => ({
+      name: fileEntry.filename,
+      url: filesApi.basePath(fileEntry.filename),
+      versionId: fileEntry.versionId
+    }));
+    this.initialFilesVersionId = this.initialFilesVersionId || filesVersionId;
 
-      if (latestFilesVersionId !== this.initialFilesVersionId) {
-        // After we've detected the first change to the version, we store this
-        // version id so that subsequent writes will continue to replace the
-        // current version (until the browser page reloads)
-        project.filesVersionId = result.filesVersionId;
-      }
-      if (this.brambleHost) {
-        this.brambleHost.syncFiles(() => {});
-      }
-    },
+    if (filesVersionId !== this.initialFilesVersionId) {
+      // After we've detected the first change to the version, we store this
+      // version id so that subsequent writes will continue to replace the
+      // current version (until the browser page reloads)
+      project.filesVersionId = filesVersionId;
+    }
+    if (this.brambleHost) {
+      this.brambleHost.syncFiles(() => {});
+    }
+  };
+
+  filesApi.getFiles(
+    result => onFilesReady(result.files, result.filesVersionId),
     xhr => {
-      console.error('files API failed, status: ' + xhr.status);
-      this.fileEntries = null;
+      if (xhr.status === 404) {
+        // No files in this project yet, proceed with an empty file
+        // list and no start version id
+        onFilesReady([], null);
+      } else {
+        console.error('files API failed, status: ' + xhr.status);
+        this.fileEntries = null;
+      }
     },
     this.getCurrentFilesVersionId()
   );

--- a/apps/test/unit/code-studio/components/AssetManagerTest.js
+++ b/apps/test/unit/code-studio/components/AssetManagerTest.js
@@ -23,7 +23,7 @@ describe('AssetManager', () => {
     xhr.restore();
   });
 
-  describe('componentWillMount', () => {
+  describe('componentDidMount', () => {
     it('gets starter assets if levelName is present', () => {
       const levelName = 'my level name';
       shallow(<AssetManager {...DEFAULT_PROPS} levelName={levelName} />);
@@ -51,6 +51,67 @@ describe('AssetManager', () => {
       shallow(<AssetManager {...DEFAULT_PROPS} projectId={undefined} />);
 
       expect(requests).to.have.length(0);
+    });
+
+    it('gets files with useFilesApi', () => {
+      shallow(<AssetManager {...DEFAULT_PROPS} projectId={'1'} useFilesApi />);
+
+      expect(requests).to.have.length(1);
+      expect(requests[0].method).to.equal('GET');
+      expect(requests[0].url).to.equal('/v3/files/1');
+    });
+
+    it('renders spinner while waiting for files with useFilesApi', () => {
+      const wrapper = shallow(
+        <AssetManager {...DEFAULT_PROPS} projectId={'1'} useFilesApi />
+      );
+
+      // There should be a spinner
+      expect(
+        wrapper.find('i').filterWhere(p => p.hasClass('fa-spinner'))
+      ).to.have.lengthOf(1);
+    });
+
+    it('stops rendering spinner after receiving a files list with useFilesApi', () => {
+      const wrapper = shallow(
+        <AssetManager {...DEFAULT_PROPS} projectId={'1'} useFilesApi />
+      );
+
+      expect(requests).to.have.length(1);
+      requests[0].respond(
+        200,
+        {},
+        JSON.stringify({
+          files: [
+            {
+              filename: 'name.jpg',
+              category: 'image',
+              size: 100,
+              versionId: 'asldfklsakdfj'
+            }
+          ],
+          filesVersionId: 'fake-version'
+        })
+      );
+
+      // There should be no spinner
+      expect(
+        wrapper.find('i').filterWhere(p => p.hasClass('fa-spinner'))
+      ).to.have.lengthOf(0);
+    });
+
+    it('stops rendering spinner after receiving an empty 404 with useFilesApi', () => {
+      const wrapper = shallow(
+        <AssetManager {...DEFAULT_PROPS} projectId={'1'} useFilesApi />
+      );
+
+      expect(requests).to.have.length(1);
+      requests[0].respond(404, {}, 'Not Found');
+
+      // There should be no spinner
+      expect(
+        wrapper.find('i').filterWhere(p => p.hasClass('fa-spinner'))
+      ).to.have.lengthOf(0);
     });
   });
 });

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -566,25 +566,22 @@ class FilesApi < Sinatra::Base
 
     bucket = FileBucket.new
     result = bucket.get(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, env['HTTP_IF_MODIFIED_SINCE'], params['version'])
+    not_found if result[:status] == 'NOT_FOUND'
     not_modified if result[:status] == 'NOT_MODIFIED'
     last_modified result[:last_modified]
 
-    if result[:status] == 'NOT_FOUND'
-      {"filesVersionId": "", "files": []}.to_json
-    else
-      # {
-      #   "filesVersionId": "sadfhkjahfsdj",
-      #   "files": [
-      #     {
-      #       "filename": "name.jpg",
-      #       "category": "image",
-      #       "size": 100,
-      #       "versionId": "asldfklsakdfj"
-      #     }
-      #   ]
-      # }
-      {"filesVersionId": result[:version_id], "files": JSON.load(result[:body])}.to_json
-    end
+    # {
+    #   "filesVersionId": "sadfhkjahfsdj",
+    #   "files": [
+    #     {
+    #       "filename": "name.jpg",
+    #       "category": "image",
+    #       "size": 100,
+    #       "versionId": "asldfklsakdfj"
+    #     }
+    #   ]
+    # }
+    {"filesVersionId": result[:version_id], "files": JSON.load(result[:body])}.to_json
   end
 
   #
@@ -723,18 +720,12 @@ class FilesApi < Sinatra::Base
     # read the manifest
     bucket = FileBucket.new
     manifest_result = bucket.get(encrypted_channel_id, FileBucket::MANIFEST_FILENAME)
-    return {filesVersionId: ""}.to_json if manifest_result[:status] == 'NOT_FOUND'
+    not_found if manifest_result[:status] == 'NOT_FOUND'
     manifest = JSON.load manifest_result[:body]
 
-    abuse_score = StorageApps.get_abuse(encrypted_channel_id)
-
-    # overwrite the manifest file with an empty list
-    response = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, [].to_json, params['files-version'], abuse_score)
-
-    # delete the files
-    bucket.delete_multiple(encrypted_channel_id, manifest.map {|e| e['filename'].downcase}) unless manifest.empty?
-
-    {filesVersionId: response.version_id}.to_json
+    # delete the manifest and all of the files it referenced
+    bucket.delete_multiple(encrypted_channel_id, [FileBucket::MANIFEST_FILENAME].concat(manifest.map {|e| e['filename'].downcase})) unless manifest.empty?
+    no_content
   end
 
   #

--- a/shared/test/files_api_test_helper.rb
+++ b/shared/test/files_api_test_helper.rb
@@ -32,7 +32,7 @@ class FilesApiTestHelper
 
   def list_objects
     get "/v3/#{@endpoint}/#{@channel_id}"
-    JSON.parse(last_response.body)
+    JSON.parse(last_response.body) unless last_response.body.empty?
   end
 
   def get_object(filename, body = '', headers = {})

--- a/shared/test/middleware/files_api/test_public_thumbnails.rb
+++ b/shared/test/middleware/files_api/test_public_thumbnails.rb
@@ -171,11 +171,7 @@ class PublicThumbnailsTest < FilesApiTestBase
 
     # Require that tests delete the assets they upload
     get "v3/files/#{channel_id}"
-    expected_empty_files = {
-      'files' => [],
-      'filesVersionId' => ''
-    }
-    assert_equal(expected_empty_files, JSON.parse(last_response.body))
+    assert not_found?
 
     delete_channel(channel_id)
   end

--- a/shared/test/test_files.rb
+++ b/shared/test/test_files.rb
@@ -15,11 +15,7 @@ class FilesTest < FilesApiTestBase
   def teardown
     # Require that tests delete the assets they upload
     get "v3/files/#{@channel_id}"
-    expected_empty_files = {
-      'files' => [],
-      'filesVersionId' => ''
-    }
-    assert_equal(expected_empty_files, JSON.parse(last_response.body))
+    assert not_found?
     delete_channel(@channel_id)
     @channel_id = nil
   end
@@ -393,9 +389,8 @@ class FilesTest < FilesApiTestBase
   def test_bad_channel_id
     bad_channel_id = 'undefined'
     api = FilesApiTestHelper.new(current_session, 'files', bad_channel_id)
-    file_infos = api.list_objects
-    assert_equal '', file_infos['filesVersionId']
-    assert_equal [], file_infos['files']
+    api.list_objects
+    assert not_found?
     assert_newrelic_metrics []
   end
 


### PR DESCRIPTION
* Restore https://github.com/code-dot-org/code-dot-org/pull/30792 which was reverted because it caused a problem with the `AssetManager`
* Fixed the `AssetManager` to handle the `404` error that will occur when calling `getFiles()` on a brand new project
* Added unit tests for `AssetManager` that provide coverage for this area