### PR TITLE
Enable Honeybadger breadcrumbs for dashboard

### DIFF
--- a/dashboard/config/honeybadger.yml
+++ b/dashboard/config/honeybadger.yml
@@ -3,3 +3,5 @@ api_key: <%=CDO.dashboard_honeybadger_api_key%>
 exceptions:
   ignore: <%= %w(Sinatra StorageApps).map{|x| "#{x}::NotFound"}.to_json%>
   notify_at_exit: false
+breadcrumbs:
+  enabled: true


### PR DESCRIPTION
Enables the new Honeybadger "breadcrumbs" feature for dashboard.  Does _not_ enable it for pegasus ([here](https://github.com/code-dot-org/code-dot-org/blob/8a739f77abc1b5f267f1ba34448c7538e4f3e205/pegasus/honeybadger.yml)) or our cronjobs project ([here](https://github.com/code-dot-org/code-dot-org/blob/cd0b271fc3c625e192d67872eff95eec1e0b098d/lib/cdo/honeybadger.rb#L62)). I'm starting with dashboard because I think we're likely to get the most use out of Rails' default instrumentation - we can add the others later if we like this.

Here's the breadcrumbs from [a sample error I generated from my development environment](https://app.honeybadger.io/projects/3240/faults/55083763) to demonstrate what sort of logging we'll get out of our application:

![image](https://user-images.githubusercontent.com/1615761/65354133-9526a200-dba3-11e9-9bbd-d5f4e74906bd.png)
![image](https://user-images.githubusercontent.com/1615761/65354157-a7084500-dba3-11e9-8f68-57873e99c98e.png)
![image](https://user-images.githubusercontent.com/1615761/65354196-c3a47d00-dba3-11e9-8d51-f38bf2979bd5.png)

Each breadcrumb can be expanded to view some metadata associated with it.  In the case of ActiveRecord operations, you can see the SQL query (sans parameters) along with some duration info.  I'm not sure how often this will be helpful in tracking down an error, but I do find it interesting.

![image](https://user-images.githubusercontent.com/1615761/65354292-06feeb80-dba4-11e9-938f-8b0ac3813a7a.png)

Note, to get Honeybadger logging working from development I had to:
- Add our `dashboard_honeybadger_api_key` to my `locals.yml`
- Add `report_data: true` to `dashboard/config/honeybadger.yml`
- Temporarily disable the `better_errors` and `binding_of_caller` gems in `Gemfile`

[This troubleshooting page](https://docs.honeybadger.io/lib/ruby/support/troubleshooting.html) was helpful.

I'm having trouble coming up with a validation strategy for a few remaining concerns:

1. Whether it's possible that this additional level of detail in reporting could cause performance issues.
   
   I don't think tracking 40ish small hashes of string values per request should present a problem for our frontends, but on some level we're trusting their implementation for this.  Any additional time to upload this detail on error would probably only be an issue if we suddenly had a very high volume of errors, in which case we have other problems, but I don't want to complicate any such situation.  My suspicion is that we could launch this feature and watch for a change in the performance of our frontends, since autoscaling should help mitigate any issues, but I'd appreciate other suggestions re: validating the impact of this feature.

2. Whether we should be worried about breadcrumbs as an additional vector for leaking sensitive information to Honeybadger.
   
   Based on what I'm seeing in the default instrumentation this shouldn't be a problem - no user-specific data seems to show up in the breadcrumbs logged in my sample error, even though the error has a great deal to do with specific users (moving a teacher into their own section).  We also already send a nontrivial amount of user data to Honeybadger through params and other context uploaded (this is captured in our privacy policy).  As for other, manually-instrumented breadcrumbs, we'll have to manage those the same way we manage other manual `context` or `notify` calls.

Read more about Honeybadger breadcrumbs:

- https://www.honeybadger.io/blog/introducing-breadcrumbs/
- https://docs.honeybadger.io/lib/ruby/getting-started/breadcrumbs.html