### PR TITLE
Enable experiment for new survey UI

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -12,16 +12,20 @@ export default class Results extends React.Component {
     questions: PropTypes.object.isRequired,
     thisWorkshop: PropTypes.object.isRequired,
     sessions: PropTypes.arrayOf(PropTypes.string).isRequired,
+    courseName: PropTypes.string.isRequired,
     facilitators: PropTypes.object,
     facilitatorAverages: PropTypes.object,
     facilitatorResponseCounts: PropTypes.object,
-    courseName: PropTypes.string.isRequired
+    workshopRollups: PropTypes.object,
+    facilitatorRollups: PropTypes.object
   };
 
   static defaultProps = {
     facilitators: {},
     facilitatorAverages: {},
-    facilitatorResponseCounts: {}
+    facilitatorResponseCounts: {},
+    workshopRollups: {},
+    facilitatorRollups: {}
   };
 
   state = {

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -5,6 +5,7 @@ import ChoiceResponses from '../../components/survey_results/choice_responses';
 import FacilitatorAveragesTable from '../../components/survey_results/facilitator_averages_table';
 import TextResponses from '../../components/survey_results/text_responses';
 import _ from 'lodash';
+import experiments from '@cdo/apps/util/experiments';
 
 export default class Results extends React.Component {
   static propTypes = {
@@ -139,11 +140,28 @@ export default class Results extends React.Component {
     ));
   }
 
+  renderSurveyRollups() {
+    return [
+      <Tab
+        eventKey={this.props.sessions.length + 1}
+        key={1}
+        title="Workshop Rollups"
+      />,
+      <Tab
+        eventKey={this.props.sessions.length + 2}
+        key={2}
+        title="Facilitator Rollups"
+      />
+    ];
+  }
+
   render() {
     return (
       <Tabs id="SurveyTab">
         {this.renderAllSessionsResults()}
-        {this.renderFacilitatorAverages()}
+        {experiments.isEnabled(experiments.ROLLUP_SURVEY_REPORT)
+          ? this.renderSurveyRollups()
+          : this.renderFacilitatorAverages()}
       </Tabs>
     );
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
@@ -33,7 +33,11 @@ export class ResultsLoader extends React.Component {
   }
 
   load() {
-    const url = experiments.isEnabled(experiments.ROLLUP_SURVEY_REPORT)
+    const inExperiment = experiments.isEnabled(
+      experiments.ROLLUP_SURVEY_REPORT
+    );
+
+    const url = inExperiment
       ? `/api/v1/pd/workshops/${
           this.props.params['workshopId']
         }/experiment_survey_report`
@@ -57,6 +61,13 @@ export class ResultsLoader extends React.Component {
           facilitatorResponseCounts: data['facilitator_response_counts'],
           courseName: data['course_name']
         });
+
+        if (inExperiment) {
+          this.setState({
+            workshopRollups: data['workshop_rollups'],
+            facilitatorRollups: data['facilitator_rollups']
+          });
+        }
       })
       .fail(jqXHR => {
         this.setState({

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
@@ -51,21 +51,26 @@ export class ResultsLoader extends React.Component {
       dataType: 'json'
     })
       .done(data => {
-        this.setState({
-          loading: false,
-          questions: data['questions'],
-          thisWorkshop: data['this_workshop'],
-          sessions: Object.keys(data['this_workshop']),
-          facilitators: data['facilitators'],
-          facilitatorAverages: data['facilitator_averages'],
-          facilitatorResponseCounts: data['facilitator_response_counts'],
-          courseName: data['course_name']
-        });
-
         if (inExperiment) {
           this.setState({
+            loading: false,
+            questions: data['questions'],
+            thisWorkshop: data['this_workshop'],
+            sessions: Object.keys(data['this_workshop']),
+            courseName: data['course_name'],
             workshopRollups: data['workshop_rollups'],
             facilitatorRollups: data['facilitator_rollups']
+          });
+        } else {
+          this.setState({
+            loading: false,
+            questions: data['questions'],
+            thisWorkshop: data['this_workshop'],
+            sessions: Object.keys(data['this_workshop']),
+            facilitators: data['facilitators'],
+            facilitatorAverages: data['facilitator_averages'],
+            facilitatorResponseCounts: data['facilitator_response_counts'],
+            courseName: data['course_name']
           });
         }
       })


### PR DESCRIPTION
[PLC-318](https://codedotorg.atlassian.net/browse/PLC-318)

This is the first step to update Survey Rollup UI. We're going to hide all new changes under an experiment flag, and roll out features gradually. When the new UI is done and stable, we will swap out the old UI.

The server endpoint which provides data for the new survey UI is [WorkshopSurveyReportController#experiment_survey_report](https://github.com/code-dot-org/code-dot-org/blob/300bab0953061e7c3cc29059d39d06620434b77b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb#L126)

**Current view** 
http://localhost-studio.code.org:3000/pd/workshop_dashboard/daily_survey_results/4?disableExperiments=rollupSurveyReport
<img width="585" alt="Screen Shot 2019-09-20 at 12 38 05 PM" src="https://user-images.githubusercontent.com/46507039/65354175-b1c2da00-dba3-11e9-9b6e-1fb80a38038c.png">

**Experimental view**
http://localhost-studio.code.org:3000/pd/workshop_dashboard/daily_survey_results/4?enableExperiments=rollupSurveyReport
<img width="570" alt="Screen Shot 2019-09-20 at 12 42 17 PM" src="https://user-images.githubusercontent.com/46507039/65354356-301f7c00-dba4-11e9-8943-c255b58628e6.png">
