### PR TITLE
Temporarily disable automatic chef cookbook updates [ci skip]

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -17,22 +17,24 @@ namespace :ci do
         end
       end
     elsif CDO.daemon && CDO.chef_managed
-      # Temporarily disable automatic chef cookbook updates for Ubuntu upgrade
-      next
 
-      ChatClient.log('Updating Chef cookbooks...')
-      RakeUtils.with_bundle_dir(cookbooks_dir) do
-        # Automatically update Chef cookbook versions in staging environment.
-        RakeUtils.bundle_exec './update_cookbook_versions' if rack_env?(:staging)
-        RakeUtils.bundle_exec 'berks', 'install'
-        if rack_env?(:staging) && GitUtils.file_changed_from_git?(cookbooks_dir)
-          RakeUtils.system 'git', 'add', '.'
-          RakeUtils.system 'git', 'commit', '-m', '"Updated cookbook versions"'
-          RakeUtils.git_push
+      # Temporarily disable automatic chef cookbook updates for Ubuntu upgrade except for envs undergoing upgrade
+      if [].include?(rack_env)
+        ChatClient.log('Updating Chef cookbooks...')
+        RakeUtils.with_bundle_dir(cookbooks_dir) do
+          # Automatically update Chef cookbook versions in staging environment.
+          RakeUtils.bundle_exec './update_cookbook_versions' if rack_env?(:staging)
+          RakeUtils.bundle_exec 'berks', 'install'
+          if rack_env?(:staging) && GitUtils.file_changed_from_git?(cookbooks_dir)
+            RakeUtils.system 'git', 'add', '.'
+            RakeUtils.system 'git', 'commit', '-m', '"Updated cookbook versions"'
+            RakeUtils.git_push
+          end
+          RakeUtils.bundle_exec 'berks', 'upload', (rack_env?(:production) ? '' : '--no-freeze')
+          RakeUtils.bundle_exec 'berks', 'apply', rack_env
         end
-        RakeUtils.bundle_exec 'berks', 'upload', (rack_env?(:production) ? '' : '--no-freeze')
-        RakeUtils.bundle_exec 'berks', 'apply', rack_env
       end
+
       ChatClient.log 'Applying <b>chef</b> profile...'
       RakeUtils.sudo '/opt/chef/bin/chef-client'
     end

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -17,6 +17,9 @@ namespace :ci do
         end
       end
     elsif CDO.daemon && CDO.chef_managed
+      # Temporarily disable automatic chef cookbook updates for Ubuntu upgrade
+      next
+
       ChatClient.log('Updating Chef cookbooks...')
       RakeUtils.with_bundle_dir(cookbooks_dir) do
         # Automatically update Chef cookbook versions in staging environment.


### PR DESCRIPTION
Prerequisite for Ubuntu rollout plan: https://docs.google.com/document/d/1iXg9aZshiRyX3D55vp6nDru4RWZEJXk3veo8apeDE3c
