### PR TITLE
Make chef version configurable through erb variable [ci skip]

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -14,7 +14,7 @@ apt-get -y install python3-pip curl
 test "$(pip3 show awscli)" || pip3 install awscli
 
 STACK=${AWS::StackName}
-CHEF_VERSION=12.7.2
+CHEF_VERSION=<%=chef_version%>
 REGION=${AWS::Region}
 BRANCH=${Branch}
 S3_BUCKET=<%=s3_bucket%>
@@ -138,7 +138,7 @@ cat <<JSON > $FIRST_BOOT
 JSON
 
 # Provision via Chef.
-OPTIONS="<%=local_mode ? '-z ' : ''%> -b $BRANCH -n $NODE_NAME -r '$RUN_LIST' -e $ENVIRONMENT"
+OPTIONS="<%=local_mode ? '-z ' : ''%> -b $BRANCH -n $NODE_NAME -r '$RUN_LIST' -e $ENVIRONMENT -v $CHEF_VERSION"
 sudo -u ubuntu bash -c "aws s3 cp s3://$S3_BUCKET/<%=CHEF_KEY%>/bootstrap-$STACK.sh - | sudo bash -s -- $OPTIONS"
 [ $? -eq 0 ] && STATUS=SUCCESS || STATUS=<%=daemon ? 'SUCCESS' : 'FAILURE'%>
 

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -28,6 +28,7 @@ frontends = @frontends = rack_env?(:production) || ENV['FRONTENDS']
 database = @database = [:staging, :test, :levelbuilder, :adhoc].include?(rack_env) || ENV['DATABASE']
 load_balancer = @load_balancer = !rack_env?(:adhoc) || ENV['FRONTENDS']
 alarms = @alarms = !rack_env?(:adhoc) || ENV['ALARMS']
+chef_version = '12.7.2'
 
 unless dry_run
   update_certs.call unless load_balancer
@@ -189,7 +190,8 @@ Resources:
           ],
           commit: commit,
           shutdown: true,
-          daemon: false
+          daemon: false,
+          chef_version: chef_version
         )%>
   AMI<%=ami%>: <%= lambda_fn.call 'AMIManager',
     DependsOn: "AMICreate#{ami}",
@@ -619,7 +621,8 @@ Resources:
           ],
           commit: nil, # track branch
           shutdown: false,
-          daemon: true
+          daemon: true,
+          chef_version: chef_version
         )%>
       NetworkInterfaces:
       - AssociatePublicIpAddress: true


### PR DESCRIPTION
This will allow us to change the chef version per environment, as part of the ubuntu upgrade rollout.