### PR TITLE
set pretty_js to false in staging environment

### DIFF
--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -3,7 +3,7 @@ github_webhook_secret: !Secret
 zendesk_secret:
 netsim_enable_metrics: true
 lint: true
-pretty_js: true
+pretty_js: false
 daemon: true
 use_pusher:                        true
 netsim_shard_expiry_seconds:       60


### PR DESCRIPTION
Staging was using the configuration which was taken away in https://github.com/code-dot-org/code-dot-org/pull/30826 . This moves staging to the same configuration as test and production, which means staging will start using minified js assets.

If this becomes a problem for debugging, we can look into enabling source maps.