### PR TITLE
PL: Improve ZIP code lookups

### DIFF
--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -195,7 +195,7 @@ class RegionalPartner < ActiveRecord::Base
             # Geocoder can raise a number of errors including SocketError, with a common base of StandardError
             # See https://github.com/alexreisner/geocoder#error-handling
             Retryable.retryable(on: StandardError) do
-              state = Geocoder.search({zip: zip_code})&.first&.state_code
+              state = Geocoder.search(zip_code)&.first&.state_code
             end
           end
         rescue StandardError => e


### PR DESCRIPTION
Back in https://github.com/code-dot-org/code-dot-org/pull/26639, I changed the code that uses the Geocoder to look up a ZIP, to get its state, from 
```
Geocoder.search(zip_code)
```
 to 
```
Geocoder.search({zip: zip_code})
```
It turns out that this change to the latter currently prevents us from successfully looking up some ZIP codes.  (And in fact, the test case zip of `73620` given in that PR now only succeeds when using the former!)

This change updates the code so that it uses the former again.

At first, I was going to try the former technique and then the latter, as prepped in https://github.com/code-dot-org/code-dot-org/pull/30894.  But then I looked at the data that we've been recording since https://github.com/code-dot-org/code-dot-org/pull/25279.

First, I took the ZIP codes that actually resolved to partners (either via state or directly via ZIP code) and found that right now, of the 1000 most common ZIP codes, 81 would have been found by the former but not by the latter.  And 0 would have been found by the latter but not the former.  32 would have been found by neither.  I'm not sure whether things might have been better than that a while ago (as the `73620` situation would suggest that there's been some deterioration over the year) but at any rate it shows there is no reason now to not switch to the former.  (I was examining this data by accident but it turned out to be interesting anyway.)

Second, I looked at the ZIP codes which didn't resolve to states via geocoder.  Of the 1000 most common strings that looked like good candidates for ZIP codes, 983 survived a hand-scrub.  471 of them would have been found with the former but not by the latter.  0 would have been found by the latter but not the former.  330 would not have been found by neither, leaving 182 to have been found by either.  This is a pretty clear sign that it's best to switch to the former.

I'll also set a reminder to examine new ZIP codes entered after this change goes live to see if we're missing any by not doing the latter any more, but right now it feels unlikely to be the case.

