### PR TITLE
Export: upgrade to Expo SDK 34

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -240,7 +240,7 @@
     "rosie": "^2.0.1",
     "selectize": "^0.12.4",
     "snack-build": "0.0.1",
-    "snack-sdk": "2.3.1",
+    "snack-sdk": "2.3.4",
     "wgxpath": "^1.2.0",
     "whatwg-fetch": "^2.0.3"
   }

--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -3,7 +3,6 @@ import $ from 'jquery';
 import _ from 'lodash';
 import JSZip from 'jszip';
 import {saveAs} from 'filesaver.js';
-import {SnackSession} from 'snack-sdk';
 
 import * as applabConstants from './constants';
 import * as assetPrefix from '../assetManagement/assetPrefix';
@@ -24,12 +23,12 @@ import exportExpoSplashPng from '../templates/export/expo/splash.png';
 import logToCloud from '../logToCloud';
 import {getAppOptions} from '@cdo/apps/code-studio/initApp/loadApp';
 import project from '@cdo/apps/code-studio/initApp/project';
-import {EXPO_SESSION_SECRET} from '../constants';
 import {
   EXPO_SDK_VERSION,
   extractSoundAssets,
   createPackageFilesFromZip,
   createPackageFilesFromExpoFiles,
+  createSnackSession,
   rewriteAssetUrls,
   getEnvironmentPrefix,
   fetchWebpackRuntime
@@ -554,15 +553,7 @@ export default {
       'DataWarning.js': {contents: exportExpoDataWarningJs, type: 'CODE'}
     };
 
-    const session = new SnackSession({
-      sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
-      files,
-      name: `project-${project.getCurrentId()}`,
-      sdkVersion: EXPO_SDK_VERSION,
-      user: {
-        sessionSecret: config.expoSession || EXPO_SESSION_SECRET
-      }
-    });
+    const session = createSnackSession(files, config.expoSession);
 
     // Important that index.html comes first:
     const fileAssets = [

--- a/apps/src/p5lab/gamelab/Exporter.js
+++ b/apps/src/p5lab/gamelab/Exporter.js
@@ -3,7 +3,6 @@
 import $ from 'jquery';
 import JSZip from 'jszip';
 import {saveAs} from 'filesaver.js';
-import {SnackSession} from 'snack-sdk';
 
 import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
 import download from '@cdo/apps/assetManagement/download';
@@ -21,12 +20,12 @@ import exportExpoSplashPng from '@cdo/apps/templates/export/expo/splash.png';
 import logToCloud from '@cdo/apps/logToCloud';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {APP_WIDTH, APP_HEIGHT} from '../constants';
-import {EXPO_SESSION_SECRET} from '@cdo/apps/constants';
 import {
   EXPO_SDK_VERSION,
   extractSoundAssets,
   createPackageFilesFromZip,
   createPackageFilesFromExpoFiles,
+  createSnackSession,
   rewriteAssetUrls,
   getEnvironmentPrefix,
   fetchWebpackRuntime
@@ -344,15 +343,7 @@ export default {
       'DataWarning.js': {contents: exportExpoDataWarningJs, type: 'CODE'}
     };
 
-    const session = new SnackSession({
-      sessionId: `${getEnvironmentPrefix()}-${project.getCurrentId()}`,
-      files,
-      name: `project-${project.getCurrentId()}`,
-      sdkVersion: EXPO_SDK_VERSION,
-      user: {
-        sessionSecret: config.expoSession || EXPO_SESSION_SECRET
-      }
-    });
+    const session = createSnackSession(files, config.expoSession);
 
     // Important that index.html comes first:
     const fileAssets = [

--- a/apps/src/templates/export/expo/App.js.ejs
+++ b/apps/src/templates/export/expo/App.js.ejs
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Platform, StyleSheet, View, WebView } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
+import { WebView } from 'react-native-webview';
 import { AppLoading } from 'expo';
 
 import CustomAsset from './CustomAsset';
@@ -118,7 +119,6 @@ export default class App extends React.Component {
             mediaPlaybackRequiresUserAction={false}
             scrollEnabled={false}
             bounces={false}
-            scalesPageToFit={Platform.OS === 'ios'}
             onLoad={this.onLoad}
           />
         </View>}

--- a/apps/src/templates/export/expo/CustomAsset.exported_js
+++ b/apps/src/templates/export/expo/CustomAsset.exported_js
@@ -1,4 +1,5 @@
-import { Asset, FileSystem } from 'expo';
+import { Asset } from 'expo-asset';
+import * as FileSystem from 'expo-file-system';
 
 export default class CustomAsset {
   constructor({ asset, fileName }) {

--- a/apps/src/templates/export/expo/package.exported_json
+++ b/apps/src/templates/export/expo/package.exported_json
@@ -8,8 +8,8 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^33.0.7",
-    "expo-cli": "^2.20.10",
+    "expo": "^34.0.0",
+    "expo-cli": "^3.1.1",
     "react": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz"
   }

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -14179,10 +14179,10 @@ snack-build@0.0.1:
     babel-runtime "^6.23.0"
     graphql-request "^1.8.2"
 
-snack-sdk@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/snack-sdk/-/snack-sdk-2.3.1.tgz#cc194aede2210671bfa63ee736942ca6a511867c"
-  integrity sha512-aCLUtA9ltHQ0+bDj0qAHcu+qWrY+/inPWs8tSH7D1NO3UJiXyv6vIZUlztk/lvlY/5lMdfuy91iV+mN0Va9BBg==
+snack-sdk@2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/snack-sdk/-/snack-sdk-2.3.4.tgz#a1c1492292052e91d7d9a65cf994dfba5b2b4c05"
+  integrity sha512-po6BghsYZZQ9Y9zeyWXynWJySIF6HBuM9jEVEuf/z/50DPyzuYupNHxz7p6WCcFwOSJowWFwzkG7uZ4SSn9HCA==
   dependencies:
     babel-runtime "^6.23.0"
     diff "^3.2.0"


### PR DESCRIPTION
* Upgrade the exported projects that we generate to use Expo SDK 34 (this includes Android 64 bit app support, which is now required in order to submit apps to the Google Play store) - details [here](https://blog.expo.io/expo-sdk-34-is-now-available-4f7825239319)
* Factored a new helper function: `createSnackSession()` so that applab and gamelab can share this code
* Adjusted React Native code due to Expo changes with modular imports (`Asset`, `FileSystem`)
* Adjusted React Native code to import `WebView` from separate `react-native-webview` package

Manual testing:
* Verified on iOS simulator within Expo app
* Verified on Android simulator within Expo app
* Built APK and verified on Android simulator
