### PR TITLE
Make some Queued Account Purges auto-retryable

### DIFF
--- a/dashboard/app/models/queued_account_purge.rb
+++ b/dashboard/app/models/queued_account_purge.rb
@@ -34,7 +34,6 @@ class QueuedAccountPurge < ApplicationRecord
   # Some errors are known to be intermittent, such as external services being temporarily
   # unavailable. If an account purge was queued for one of these reasons, our system can
   # automatically retry it on the next run without developer intervention.
-  # @return [Boolean] Whether this queued purge can be auto-retried.
   AUTO_RETRYABLE_REASONS = %w{Pardot::InvalidApiKeyException}
   scope :needing_manual_review, -> {where.not(reason_for_review: AUTO_RETRYABLE_REASONS)}
 

--- a/dashboard/app/models/queued_account_purge.rb
+++ b/dashboard/app/models/queued_account_purge.rb
@@ -31,6 +31,13 @@
 class QueuedAccountPurge < ApplicationRecord
   belongs_to :user
 
+  # Some errors are known to be intermittent, such as external services being temporarily
+  # unavailable. If an account purge was queued for one of these reasons, our system can
+  # automatically retry it on the next run without developer intervention.
+  # @return [Boolean] Whether this queued purge can be auto-retried.
+  AUTO_RETRYABLE_REASONS = %w{Pardot::InvalidApiKeyException}
+  scope :needing_manual_review, -> {where.not(reason_for_review: AUTO_RETRYABLE_REASONS)}
+
   # Used by developers to resolve an account purge queued for manual review,
   # after they've investigated the account and decided it's ready to purge.
   def resolve!

--- a/dashboard/lib/expired_deleted_account_purger.rb
+++ b/dashboard/lib/expired_deleted_account_purger.rb
@@ -117,7 +117,7 @@ class ExpiredDeletedAccountPurger
   end
 
   def expired_soft_deleted_accounts
-    user_ids_needing_manual_review = QueuedAccountPurge.pluck(:user_id)
+    user_ids_needing_manual_review = QueuedAccountPurge.needing_manual_review.pluck(:user_id)
     soft_deleted_accounts.
       where(
         'deleted_at BETWEEN :start_date AND :end_date',

--- a/dashboard/test/factories/queued_account_purges.rb
+++ b/dashboard/test/factories/queued_account_purges.rb
@@ -17,5 +17,9 @@ FactoryGirl.define do
   factory :queued_account_purge do
     user
     reason_for_review "Fake reason."
+
+    trait :autoretryable do
+      reason_for_review "Pardot::InvalidApiKeyException"
+    end
   end
 end

--- a/dashboard/test/lib/expired_deleted_account_purger_test.rb
+++ b/dashboard/test/lib/expired_deleted_account_purger_test.rb
@@ -192,6 +192,20 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
     refute_includes picked_users, needs_manual_review
   end
 
+  test 'does locate accounts that are queued but also auto-retryable' do
+    autodeleteable = create :student, deleted_at: 3.days.ago
+    autoretryable = create :student, deleted_at: 3.days.ago
+    create :queued_account_purge, :autoretryable, user: autoretryable
+
+    picked_users = ExpiredDeletedAccountPurger.new(
+      deleted_after: 4.days.ago,
+      deleted_before: 2.days.ago
+    ).send :expired_soft_deleted_accounts
+
+    assert_includes picked_users, autodeleteable
+    assert_includes picked_users, autoretryable
+  end
+
   #
   # Tests over full behavior
   #

--- a/dashboard/test/models/queued_account_purge_test.rb
+++ b/dashboard/test/models/queued_account_purge_test.rb
@@ -46,4 +46,18 @@ class QueuedAccountPurgeTest < ActiveSupport::TestCase
     end
     refute_nil QueuedAccountPurge.find_by_id(qap.id)
   end
+
+  test "needing_manual_review normally includes everything" do
+    q1 = create :queued_account_purge
+    q2 = create :queued_account_purge
+    assert_includes QueuedAccountPurge.needing_manual_review, q1
+    assert_includes QueuedAccountPurge.needing_manual_review, q2
+  end
+
+  test "needing_manual_review omits Pardot::InvalidApiKeyException" do
+    q1 = create :queued_account_purge
+    q2 = create :queued_account_purge, reason_for_review: 'Pardot::InvalidApiKeyException'
+    assert_includes QueuedAccountPurge.needing_manual_review, q1
+    refute_includes QueuedAccountPurge.needing_manual_review, q2
+  end
 end


### PR DESCRIPTION
Specifically, makes accounts queued with the error `Pardot::InvalidApiKeyException` auto-retryable, because this error is known to be intermittent and we don't really need developer intervention to try it again on the next run. (As currently configured, the next run will be the next evening.)

Doing this now because we've had a number of accounts queued due to this issue (and no others) in the last month, and the solution has always been simply for a dev to go try it again.

I considered an alternative design, which is not to put auto-retryable errors into the QueuedAccountPurge table at all, and simply let them be picked up by the next run's normal search for expired deleted accounts. I've decided against this option because I think it's helpful to see these in the queue even if they're going to be retried automatically; if they were to start failing _consistently_, not putting them into the queue might mask a legitimate problem.