### PR TITLE
Finish removing Regional Partner role from contact_rollups

### DIFF
--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -503,11 +503,6 @@ class ContactRollups
     log_completion(start)
 
     start = Time.now
-    log "Updating Regional Partner role"
-    append_regional_partner_to_role_list
-    log_completion(start)
-
-    start = Time.now
     log "Updating CSF/CSD/CSP teacher roles"
     # CSF scripts don't have a course mapping - identify CSF teachers by
     # specific scripts

--- a/lib/cdo/contact_rollups_validation.rb
+++ b/lib/cdo/contact_rollups_validation.rb
@@ -61,13 +61,6 @@ class ContactRollupsValidation
       max: 500
     },
     {
-      name: "Regional Partner count",
-      query: "SELECT COUNT(*) from contact_rollups_daily where roles
-              LIKE '%Regional Partner%'",
-      min: 25,
-      max: 250
-    },
-    {
       name: "Petition Signer count",
       query: "SELECT COUNT(*) from contact_rollups_daily WHERE roles
               LIKE '%Petition Signer%'",


### PR DESCRIPTION
Fixes a regression introduced to the `contact_rollups` cronjob in https://github.com/code-dot-org/code-dot-org/pull/30428, showing up in Honeybadger as error https://app.honeybadger.io/projects/3240/faults/54051262.

The specific issue is commit https://github.com/code-dot-org/code-dot-org/commit/0a219fe8ac02e6252ed3967a6254f04efea13afc which removed the method `append_regional_partner_to_role_list` but did not remove the call to that method later in the script.  Here, I've removed the call to that method and relevant surrounding code.

I've also removed the related validation that expects a certain number of contacts with the `"Regional Partner"` role, since this was based on the deprecated `contact` field (see #30428) and going forward we shouldn't expect any contacts with this role.

### Follow-up
We went a long time (more than three weeks) without noticing this issue.  I've [scheduled work this sprint](https://codedotorg.atlassian.net/browse/PLC-472) to make `contact_rollups` alarm more usefully when it breaks.