### PR TITLE
[Applab Datasets] Paginate and Scroll Preview Modal

### DIFF
--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -5,6 +5,8 @@ import SearchBar from '@cdo/apps/templates/SearchBar';
 import {categories} from './datasetManifest.json';
 import color from '../../util/color';
 import msg from '@cdo/locale';
+import PreviewModal from './PreviewModal';
+import FirebaseStorage from '../firebaseStorage';
 
 const styles = {
   container: {
@@ -24,6 +26,22 @@ const styles = {
 };
 
 class DataLibraryPane extends React.Component {
+  importTable = datasetInfo => {
+    if (datasetInfo.current) {
+      FirebaseStorage.addCurrentTableToProject(
+        datasetInfo.name,
+        () => console.log('success'),
+        err => console.log(err)
+      );
+    } else {
+      FirebaseStorage.copyStaticTable(
+        datasetInfo.name,
+        () => console.log('success'),
+        err => console.log(err)
+      );
+    }
+  };
+
   render() {
     return (
       <div style={styles.container}>
@@ -39,8 +57,10 @@ class DataLibraryPane extends React.Component {
             name={category.name}
             datasets={category.datasets}
             description={category.description}
+            importTable={this.importTable}
           />
         ))}
+        <PreviewModal importTable={this.importTable} />
       </div>
     );
   }

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -58,6 +58,7 @@ class DataTable extends React.Component {
   static propTypes = {
     getColumnNames: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
+    rowsPerPage: PropTypes.number,
     // from redux state
     tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     tableName: PropTypes.string.isRequired,
@@ -198,11 +199,11 @@ class DataTable extends React.Component {
     this.setState({currentPage: number - 1});
   };
 
-  getRowsForCurrentPage() {
+  getRowsForCurrentPage(rowsPerPage) {
     if (this.props.tableRecords['slice']) {
       return this.props.tableRecords.slice(
-        this.state.currentPage * MAX_ROWS_PER_PAGE,
-        (this.state.currentPage + 1) * MAX_ROWS_PER_PAGE
+        this.state.currentPage * rowsPerPage,
+        (this.state.currentPage + 1) * rowsPerPage
       );
     }
     return this.props.tableRecords;
@@ -215,11 +216,12 @@ class DataTable extends React.Component {
     );
     let editingColumn = this.state.editingColumn;
 
+    let rowsPerPage = this.props.rowsPerPage || MAX_ROWS_PER_PAGE;
     let numPages = Math.max(
       1,
-      Math.ceil(Object.keys(this.props.tableRecords).length / MAX_ROWS_PER_PAGE)
+      Math.ceil(Object.keys(this.props.tableRecords).length / rowsPerPage)
     );
-    let rows = this.getRowsForCurrentPage();
+    let rows = this.getRowsForCurrentPage(rowsPerPage);
 
     // Always show at least one column.
     if (columnNames.length === 1) {

--- a/apps/src/storage/dataBrowser/LibraryCategory.jsx
+++ b/apps/src/storage/dataBrowser/LibraryCategory.jsx
@@ -33,7 +33,8 @@ class LibraryCategory extends React.Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
     datasets: PropTypes.arrayOf(PropTypes.string).isRequired,
-    description: PropTypes.string.isRequired
+    description: PropTypes.string.isRequired,
+    importTable: PropTypes.func.isRequired
   };
 
   state = {
@@ -63,7 +64,11 @@ class LibraryCategory extends React.Component {
               {this.props.description}
             </span>
             {this.props.datasets.map(tableName => (
-              <LibraryTable key={tableName} name={tableName} />
+              <LibraryTable
+                key={tableName}
+                name={tableName}
+                importTable={this.props.importTable}
+              />
             ))}
           </div>
         )}

--- a/apps/src/storage/dataBrowser/LibraryTable.jsx
+++ b/apps/src/storage/dataBrowser/LibraryTable.jsx
@@ -2,11 +2,9 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import React from 'react';
 import FontAwesome from '../../templates/FontAwesome';
-import FirebaseStorage from '../firebaseStorage';
 import msg from '@cdo/locale';
 import color from '../../util/color';
 import {showPreview} from '../redux/data';
-import PreviewModal from './PreviewModal';
 import {getDatasetInfo} from './dataUtils';
 
 const styles = {
@@ -56,6 +54,7 @@ const styles = {
 class LibraryTable extends React.Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
+    importTable: PropTypes.func.isRequired,
 
     // from redux dispatch
     onShowPreview: PropTypes.func.isRequired
@@ -71,22 +70,6 @@ class LibraryTable extends React.Component {
     this.setState({
       collapsed: !this.state.collapsed
     });
-
-  importTable = datasetInfo => {
-    if (datasetInfo.current) {
-      FirebaseStorage.addCurrentTableToProject(
-        datasetInfo.name,
-        () => console.log('success'),
-        err => console.log(err)
-      );
-    } else {
-      FirebaseStorage.copyStaticTable(
-        datasetInfo.name,
-        () => console.log('success'),
-        err => console.log(err)
-      );
-    }
-  };
 
   render() {
     const icon = this.state.collapsed ? 'caret-right' : 'caret-down';
@@ -112,17 +95,13 @@ class LibraryTable extends React.Component {
               <button
                 style={styles.import}
                 type="button"
-                onClick={() => this.importTable(this.datasetInfo)}
+                onClick={() => this.props.importTable(this.datasetInfo)}
               >
                 {msg.import()}
               </button>
             </div>
           </div>
         )}
-        <PreviewModal
-          tableName={this.props.name}
-          importTable={this.importTable}
-        />
       </div>
     );
   }

--- a/apps/src/storage/dataBrowser/PreviewModal.jsx
+++ b/apps/src/storage/dataBrowser/PreviewModal.jsx
@@ -28,15 +28,18 @@ class PreviewModal extends React.Component {
     }
     const datasetInfo = getDatasetInfo(this.props.tableName);
     return (
-      <BaseDialog isOpen handleClose={this.props.onClose} fullWidth>
+      <BaseDialog isOpen handleClose={this.props.onClose} fullWidth fullHeight>
         <h1>{this.props.tableName}</h1>
         <p>{datasetInfo.description}</p>
-        <DataTable
-          getColumnNames={(records, columns) =>
-            parseColumnsFromRecords(records)
-          }
-          readOnly
-        />
+        <div style={{overflow: 'scroll', maxHeight: '70%'}}>
+          <DataTable
+            getColumnNames={(records, columns) =>
+              parseColumnsFromRecords(records)
+            }
+            readOnly
+            rowsPerPage={100}
+          />
+        </div>
         <button type="button" onClick={() => this.importTable(datasetInfo)}>
           {msg.import()}
         </button>
@@ -48,7 +51,7 @@ class PreviewModal extends React.Component {
 export default connect(
   state => ({
     isPreviewOpen: state.data.isPreviewOpen,
-    tableName: state.data.tableName
+    tableName: state.data.tableName || ''
   }),
   dispatch => ({
     onClose() {

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -84,6 +84,7 @@ export default class BaseDialog extends React.Component {
     }
     if (this.props.fullHeight) {
       bodyStyle = {
+        ...bodyStyle,
         height: '80%'
       };
     }


### PR DESCRIPTION
Adds pagination and scrolling to the preview modal. Doesn't look super important with this small dataset, but our expected real datasets will have thousands of rows, and we don't want the preview modal to overflow the screen. Scrolling for usability, but also adding pagination for performance (this matches existing behavior in the data table view).

This also moves the PreviewModal to be owned by the DataLibraryPane, not one per LibraryTable. This makes more sense because we should only have one modal at a time, and this makes pagination work correctly.

Before:
![image](https://user-images.githubusercontent.com/8787187/65520055-fc4e9a00-deb4-11e9-952e-594fcfd41535.png)

After:
![image](https://user-images.githubusercontent.com/8787187/65520110-0e303d00-deb5-11e9-8aae-f4c520bf6747.png)
