### PR TITLE
Add a basic pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+# Description
+
+<!--
+  A summary of the change, including any relevant motivation and context.
+
+  If relevant, include a description both of the existing behavior and of the new behavior.
+-->
+
+## Links
+
+<!--
+  Any relevant links to external resources; ie, specification documents, jira
+  items, related PRs, honeybadger errors, etc
+-->
+
+- [spec]()
+- [jira]()
+
+## Type of change
+
+- [ ] Bug fix <!-- non-breaking change which fixes an issue -->
+- [ ] New feature <!-- non-breaking change which adds functionality -->
+- [ ] Refactoring <!-- no functional changes -->
+- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
+- [ ] Content change <!-- creation of new content or update to existing content -->
+- [ ] Other:  <!-- please explain -->
+
+# Testing story
+
+<!--
+  Does your change include appropriate tests?
+
+  If so, please describe how the tests included in this PR are sufficient
+
+  If not, please explain why this change does not need to be tested.
+-->
+
+# Reviewer Checklist:
+
+- [ ] Tests are passing and seem appropriate
+- [ ] Code is well-commented
+- [ ] New features are translatable or updates will not break translations
+- [ ] Relevant documentation has been added or updated
+- [ ] User impact is well-understood and desirable

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 - [spec]()
 - [jira]()
 
-# Testing story
+## Testing story
 
 <!--
   Does your change include appropriate tests?
@@ -33,5 +33,5 @@
 - [ ] New features are translatable or updates will not break translations
 - [ ] Relevant documentation has been added or updated
 - [ ] User impact is well-understood and desirable
-- [ ] Pull Request is tagged appropriately
+- [ ] Pull Request is labeled appropriately
 - [ ] Follow-up work items (including potential tech debt) are tracked and linked

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,15 +16,6 @@
 - [spec]()
 - [jira]()
 
-## Type of change
-
-- [ ] Bug fix <!-- non-breaking change which fixes an issue -->
-- [ ] New feature <!-- non-breaking change which adds functionality -->
-- [ ] Refactoring <!-- no functional changes -->
-- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
-- [ ] Content change <!-- creation of new content or update to existing content -->
-- [ ] Other:  <!-- please explain -->
-
 # Testing story
 
 <!--
@@ -42,3 +33,5 @@
 - [ ] New features are translatable or updates will not break translations
 - [ ] Relevant documentation has been added or updated
 - [ ] User impact is well-understood and desirable
+- [ ] Pull Request is tagged appropriately
+- [ ] Follow-up work items (including potential tech debt) are tracked and linked

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,18 @@
   If relevant, include a description both of the existing behavior and of the new behavior.
 -->
 
+<!--
+  Other aspects to consider. uncomment and add detail for any that seem necessary:
+-->
+
+<!-- ### Background -->
+<!-- ### Privacy -->
+<!-- ### Security -->
+<!-- ### Caching -->
+<!-- ### Testing -->
+<!-- ### Deployment strategy -->
+<!-- ### Future work -->
+
 ## Links
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,7 +40,7 @@
 
 # Reviewer Checklist:
 
-- [ ] Tests are passing and seem appropriate
+- [ ] Tests provide adequate coverage
 - [ ] Code is well-commented
 - [ ] New features are translatable or updates will not break translations
 - [ ] Relevant documentation has been added or updated


### PR DESCRIPTION
# Description

Adds a template to the project that will automatically populate pull request descriptions, intended to provide guidelines to both PR creators and reviewers to maximize the quality of changes to our codebase.

## Links

- [github documentation](https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository)
- [spec](https://docs.google.com/document/d/1k3Sk9kCYJCQRbjEkcdb3zOOANm17o1-X_LNxhHc_R5Q/edit#heading=h.2e9fbjvby9rm)
- [jira](https://codedotorg.atlassian.net/browse/FND-667)

## Type of change

- [ ] Bug fix <!-- non-breaking change which fixes an issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Refactoring <!-- no functional changes -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Content change <!-- creation of new content or update to existing content -->
- [x] Other: internal/process change  <!-- please explain -->

# Testing story

As this change is scoped entirely to our internal github process, tests are not necessary.

# Reviewer Checklist:

- [ ] Tests are passing and seem appropriate
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable