### PR TITLE
Part 2: Generate webpack manifest and add asset helper

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -11,6 +11,7 @@ var {StatsWriterPlugin} = require('webpack-stats-plugin');
 var UnminifiedWebpackPlugin = require('unminified-webpack-plugin');
 var sass = require('node-sass');
 var UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+var ManifestPlugin = require('webpack-manifest-plugin');
 
 module.exports = function(grunt) {
   process.env.mocha_entry = grunt.option('entry') || '';
@@ -883,7 +884,11 @@ describe('entry tests', () => {
         // Unit tests require certain unminified files to have been built.
         new UnminifiedWebpackPlugin({
           include: [/^webpack-runtime/, /^applab-api/, /^gamelab-api/]
+        }),
+        new ManifestPlugin({
+          basePath: 'js/'
         })
+
       ],
       minify: minify,
       watch: watch,

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -699,7 +699,7 @@ describe('entry tests', () => {
     var watch = options.watch;
 
     return webpackConfig.create({
-      output: path.resolve(__dirname, OUTPUT_DIR),
+      outputDir: path.resolve(__dirname, OUTPUT_DIR),
       entries: _.mapValues(
         _.extend(
           {},

--- a/apps/package.json
+++ b/apps/package.json
@@ -217,6 +217,7 @@
     "webpack-dev-server": "^3.2.1",
     "webpack-hot-middleware": "^2.10.0",
     "webpack-livereload-plugin": "^0.8.1",
+    "webpack-manifest-plugin": "^2.0.4",
     "webpack-notifier": "^1.4.1",
     "webpack-stats-plugin": "^0.2.1"
   },

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -321,16 +321,17 @@ function create(options) {
   var optimization = options.optimization;
   var mode = options.mode;
 
+  // When debugging minified code, use the .js suffix (rather than .min.js)
+  // to allow the application to load minified js locally without running it
+  // through the rails asset pipeline. This is much simpler than hacking the
+  // application to load .min.js locally.
+  const suffix = minify && !debugMinify ? '.min.js' : '.js';
+
   var config = _.extend({}, baseConfig, {
     output: {
       path: outputDir,
       publicPath: '/assets/js/',
-
-      // When debugging minified code, use the .js suffix (rather than .min.js)
-      // to allow the application to load minified js locally without running it
-      // through the rails asset pipeline. This is much simpler than hacking the
-      // application to load .min.js locally.
-      filename: '[name].' + (minify && !debugMinify ? 'min.' : '') + 'js'
+      filename: `[name]${suffix}`
     },
     devtool: !process.env.CI && options.minify ? 'source-map' : devtool,
     entry: entries,

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -309,7 +309,7 @@ var karmaConfig = _.extend({}, baseConfig, {
  * @param {Array} options.externals - list of webpack externals
  */
 function create(options) {
-  var outputDir = options.output;
+  var outputDir = options.outputDir;
   var entries = options.entries;
   var minify = options.minify;
   var watch = options.watch;

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -6931,7 +6931,7 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   dependencies:
@@ -9821,6 +9821,11 @@ lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
 
+"lodash@>=3.5 <5", lodash@^4.16.1:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 lodash@^3.10.1, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -9832,11 +9837,6 @@ lodash@^4.0.0, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lod
 lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@~4.17.10, lodash@~4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-
-lodash@^4.16.1:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lodash@~0.9.2:
   version "0.9.2"
@@ -15968,6 +15968,15 @@ webpack-log@^2.0.0:
   dependencies:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
+
+webpack-manifest-plugin@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz#e4ca2999b09557716b8ba4475fb79fab5986f0cd"
+  integrity sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==
+  dependencies:
+    fs-extra "^7.0.0"
+    lodash ">=3.5 <5"
+    tapable "^1.0.0"
 
 webpack-notifier@^1.4.1:
   version "1.4.1"

--- a/lib/cdo/asset_helper.rb
+++ b/lib/cdo/asset_helper.rb
@@ -7,12 +7,18 @@ class AssetHelper
     ''
   end
 
-  def initialize
-    @webpack_manifest = JSON.parse(File.read(webpack_manifest_path))
+  def webpack_manifest
+    @webpack_manifest ||= JSON.parse(File.read(webpack_manifest_path))
   end
 
   def webpack_asset_path(asset)
-    path = @webpack_manifest[asset]
+    # Skip manifest lookup in certain environments where the manifest may not be
+    # available. In development, where the webpack bundle has been built in
+    # development mode, this produces valid url to an unminified, undigested
+    # asset. In unit tests, this often just needs to return a stub value without
+    # raising an exception.
+    return "/blockly/#{asset}" if CDO.pretty_js
+    path = webpack_manifest[asset]
     raise "Invalid webpack asset name: '#{asset}'" unless path
     path
   end

--- a/lib/cdo/asset_helper.rb
+++ b/lib/cdo/asset_helper.rb
@@ -1,0 +1,23 @@
+require 'singleton'
+
+class AssetHelper
+  include Singleton
+
+  def webpack_manifest_path
+    ''
+  end
+
+  def initialize
+    @webpack_manifest = JSON.parse(File.read(webpack_manifest_path))
+  end
+
+  def webpack_asset_path(asset)
+    path = @webpack_manifest[asset]
+    raise "Invalid webpack asset name: '#{asset}'" unless path
+    path
+  end
+end
+
+def webpack_asset_path(asset)
+  AssetHelper.instance.webpack_asset_path(asset)
+end

--- a/lib/test/cdo/test_asset_helper.rb
+++ b/lib/test/cdo/test_asset_helper.rb
@@ -5,6 +5,7 @@ class AssetHelpersTest < Minitest::Test
   def setup
     AssetHelper.any_instance.stubs(:webpack_manifest_path).returns('./test/fixtures/webpack-manifest.json')
     @asset_helper = AssetHelper.clone.instance
+    CDO.stubs(:pretty_js).returns(false)
   end
 
   def test_valid_asset
@@ -20,5 +21,29 @@ class AssetHelpersTest < Minitest::Test
       @asset_helper.webpack_asset_path('invalid.js')
     end
     assert_equal "Invalid webpack asset name: 'invalid.js'", e.message
+  end
+
+  def test_missing_manifest
+    AssetHelper.any_instance.stubs(:webpack_manifest_path).returns('./test/fixtures/nonexistent.json')
+    assert_raises Errno::ENOENT do
+      @asset_helper.webpack_asset_path('js/cookieBanner.js')
+    end
+  end
+
+  def test_valid_asset_with_pretty_js
+    CDO.stubs(:pretty_js).returns(true)
+    assert_equal(
+      '/blockly/js/cookieBanner.js',
+      @asset_helper.webpack_asset_path('js/cookieBanner.js')
+    )
+  end
+
+  def test_missing_manifest_with_pretty_js
+    CDO.stubs(:pretty_js).returns(true)
+    AssetHelper.any_instance.stubs(:webpack_manifest_path).returns('./test/fixtures/nonexistent.json')
+    assert_equal(
+      '/blockly/js/cookieBanner.js',
+      @asset_helper.webpack_asset_path('js/cookieBanner.js')
+    )
   end
 end

--- a/lib/test/cdo/test_asset_helper.rb
+++ b/lib/test/cdo/test_asset_helper.rb
@@ -1,0 +1,24 @@
+require_relative '../test_helper'
+require_relative '../../cdo/asset_helper'
+
+class AssetHelpersTest < Minitest::Test
+  def setup
+    AssetHelper.any_instance.stubs(:webpack_manifest_path).returns('./test/fixtures/webpack-manifest.json')
+    @asset_helper = AssetHelper.clone.instance
+  end
+
+  def test_valid_asset
+    assert_equal(
+      '/blockly/js/cookieBanner.d90978a8439431440869.min.js',
+      @asset_helper.webpack_asset_path('js/cookieBanner.js'),
+      "incorrect webpack asset path"
+    )
+  end
+
+  def test_invalid_asset
+    e = assert_raises RuntimeError do
+      @asset_helper.webpack_asset_path('invalid.js')
+    end
+    assert_equal "Invalid webpack asset name: 'invalid.js'", e.message
+  end
+end

--- a/lib/test/fixtures/webpack-manifest.json
+++ b/lib/test/fixtures/webpack-manifest.json
@@ -1,0 +1,7 @@
+{
+  "js/webpack-runtime.js": "/blockly/js/webpack-runtime.338c9dacc207fe9b1eb4.min.js",
+  "js/vendors.js": "/blockly/js/vendors.b54aa8aa165e50793d97.min.js",
+  "js/code.org/public/educate/curriculum/courses.js": "/blockly/js/code.org/public/educate/curriculum/courses.f757a2800a643278c289.min.js",
+  "js/code.org/views/theme_common_head_after.js": "/blockly/js/code.org/views/theme_common_head_after.475288729fcf6b3540bb.min.js",
+  "js/cookieBanner.js": "/blockly/js/cookieBanner.d90978a8439431440869.min.js"
+}


### PR DESCRIPTION
### Background

See [webpack content hashing design doc](https://docs.google.com/document/d/1vJ3EpaT8ch6UMLP21IovZIgOzS-QhU4G1kv3azZPmZo/edit#)

### Description

This PR contains the following steps:
* let webpack start generating a manifest.json file 
* create a `webpack_asset_path` helper which can be used by both dashboard and pegasus