### PR TITLE
Ignore gh-ost tables when generating schema.rb

### DIFF
--- a/dashboard/config/environment.rb
+++ b/dashboard/config/environment.rb
@@ -17,4 +17,4 @@ Dashboard::Application.initialize!
 # and we won't be migrating it to other environments. However, it shouldn't belong in
 # the schema, and we don't want it to show up when generating the schema on the prod
 # database. This line will ignore that table.
-ActiveRecord::SchemaDumper.ignore_tables = ['overflow_activities']
+ActiveRecord::SchemaDumper.ignore_tables = ['overflow_activities', /^_/]

--- a/dashboard/config/environment.rb
+++ b/dashboard/config/environment.rb
@@ -17,4 +17,7 @@ Dashboard::Application.initialize!
 # and we won't be migrating it to other environments. However, it shouldn't belong in
 # the schema, and we don't want it to show up when generating the schema on the prod
 # database. This line will ignore that table.
+# It also will ignore tables starting with an underscore, which are temporarily created
+# when we use the gh-ost online migration tool to migrate large tables
+# without significant downtime.
 ActiveRecord::SchemaDumper.ignore_tables = ['overflow_activities', /^_/]


### PR DESCRIPTION
When running database migrations on large tables using [gh-ost](https://github.com/code-dot-org/code-dot-org/pull/30425), we generate temporary tables that generate schema conflicts when the we try to run other migrations.

All of these temporary tables begin with an underscore -- this PR tells ActiveRecord to ignore tables beginning with an underscore when generating `schema.rb`

Tested this locally by creating a table with a name starting with an underscore, then regenerating `schema.rb` using `bundle exec rake db:schema:dump`. The new table did not appear in `schema.rb`