### PR TITLE
Change comparators in RTL for beeBlocks

### DIFF
--- a/apps/src/maze/beeBlocks.js
+++ b/apps/src/maze/beeBlocks.js
@@ -6,6 +6,7 @@ var msg = require('./locale');
 var blockUtils = require('../block_utils');
 
 var OPERATORS = [['=', '=='], ['<', '<'], ['>', '>']];
+const RTL_OPERATORS = [['=', '=='], ['>', '<'], ['<', '>']];
 
 var TOOLTIPS = {
   '==': Blockly.Msg.LOGIC_COMPARE_TOOLTIP_EQ,
@@ -231,7 +232,7 @@ function addConditionalComparisonBlock(blockly, generator, name, type, arg1) {
       );
       this.appendDummyInput().appendTitle(' ');
       this.appendDummyInput().appendTitle(
-        new blockly.FieldDropdown(OPERATORS),
+        new blockly.FieldDropdown(Blockly.RTL ? RTL_OPERATORS : OPERATORS),
         'OP'
       );
       this.appendDummyInput().appendTitle(' ');


### PR DESCRIPTION
Brought to our attention via Zendesk.
Ticket: https://codedotorg.atlassian.net/browse/STAR-692

This was isolated to bee blocks. It was already handled in other blocks: https://github.com/code-dot-org/code-dot-org/blob/bd15ece9fd831e7c5f471620035dca0a9a4d98b8/apps/src/studio/blocks.js#L3675
The solution to check if the block is in RTL, in which case the sides of the comparison have switch, and to switch the direction of the comparator in those cases.

Before in LTR:
![Screenshot from 2019-09-24 15-02-59](https://user-images.githubusercontent.com/2959170/65553878-c58c7a00-dedc-11e9-9c43-f8df484d7f68.png)
Before in RTL:
![Screenshot from 2019-09-24 15-04-25](https://user-images.githubusercontent.com/2959170/65553887-cb825b00-dedc-11e9-8d59-7ae513af8b09.png)


After in LTR:
![Screenshot from 2019-09-24 14-51-57](https://user-images.githubusercontent.com/2959170/65553911-dc32d100-dedc-11e9-8271-374be8576807.png)
After in RTL:
![Screenshot from 2019-09-24 14-52-16](https://user-images.githubusercontent.com/2959170/65553894-d1783c00-dedc-11e9-8522-007c956dd022.png)

