### PR TITLE
Donors: Teacher banner stores response details

### DIFF
--- a/apps/src/donorTeacherBanner/donorTeacherBanner.js
+++ b/apps/src/donorTeacherBanner/donorTeacherBanner.js
@@ -40,7 +40,11 @@ function showDonorTeacherBanner() {
       donorTeacherBannerElements.each((index, donorTeacherBannerElement) => {
         ReactDOM.render(
           <Provider store={getStore()}>
-            <DonorTeacherBanner options={options} showPegasusLink={false} />
+            <DonorTeacherBanner
+              options={options}
+              showPegasusLink={false}
+              source="marketing"
+            />
           </Provider>,
           donorTeacherBannerElement
         );

--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -89,7 +89,8 @@ export const donorTeacherBannerOptionsShape = PropTypes.shape({
 export default class DonorTeacherBanner extends Component {
   static propTypes = {
     options: donorTeacherBannerOptionsShape,
-    showPegasusLink: PropTypes.bool
+    showPegasusLink: PropTypes.bool,
+    source: PropTypes.string.isRequired
   };
 
   initialState = {
@@ -126,7 +127,11 @@ export default class DonorTeacherBanner extends Component {
   dismissWithCallbacks(onSuccess, onFailure) {
     $.ajax({
       url: '/dashboardapi/v1/users/me/dismiss_donor_teacher_banner',
-      type: 'post'
+      type: 'post',
+      data: {
+        participate: this.state.participate,
+        source: this.props.source
+      }
     })
       .done(onSuccess)
       .fail(onFailure);

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -241,6 +241,7 @@ export default class TeacherHomepage extends Component {
               <DonorTeacherBanner
                 options={donorTeacherBannerOptions}
                 showPegasusLink={true}
+                source="teacher_home"
               />
               <div style={styles.clear} />
             </div>

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -112,7 +112,10 @@ class Api::V1::UsersController < Api::V1::JsonApiController
 
   # POST /api/v1/users/<user_id>/dismiss_donor_teacher_banner
   def dismiss_donor_teacher_banner
-    @user.donor_teacher_banner_dismissed = true
+    @user.donor_teacher_banner_dismissed = {
+      participate: params[:participate].to_s == "true",
+      source: params[:source]
+    }
     @user.save
 
     head :ok

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -113,10 +113,11 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
   test 'a post request to dismiss_donor_teacher_banner' do
     test_user = create :user
     sign_in(test_user)
-    post :dismiss_donor_teacher_banner, params: {user_id: 'me'}
+    post :dismiss_donor_teacher_banner, params: {user_id: 'me', participate: true, source: 'marketing'}
     assert_response :success
     test_user.reload
-    assert_equal true, test_user.donor_teacher_banner_dismissed
+    dismissed_value = {'participate' => true, 'source' => 'marketing'}
+    assert_equal dismissed_value, test_user.donor_teacher_banner_dismissed
   end
 
   test "a get request to get school_name returns school object" do


### PR DESCRIPTION
To enable deeper analysis, when a signed-in user submits a response to the Donor Teacher Banner, we now store whether they want to participate, and the source page of their interaction.  The source page will be either `"teacher_home"` or `"marketing"`.

The user object can end up with a value like one of these:

```
"donor_teacher_banner_dismissed"=>{"participate"=>true, "source"=>"teacher_home"}

"donor_teacher_banner_dismissed"=>{"participate"=>false, "source"=>"marketing"}
```