### PR TITLE
Add getBehaviorsForSpriteId to Sprite Lab library

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -216,6 +216,10 @@ export const commands = {
     return validationCommands.getNumBehaviorsForSpriteId(spriteId);
   },
 
+  getBehaviorsForSpriteId(spriteId) {
+    return validationCommands.getBehaviorsForSpriteId(spriteId);
+  },
+
   getSpriteIdsInUse() {
     return validationCommands.getSpriteIdsInUse();
   }

--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -21,6 +21,10 @@ export const commands = {
     return coreLibrary.getNumBehaviorsForSpriteId(spriteId);
   },
 
+  getBehaviorsForSpriteId(spriteId) {
+    return coreLibrary.getBehaviorsForSpriteId(spriteId);
+  },
+
   getSpriteIdsInUse() {
     return coreLibrary.getSpriteIdsInUse();
   }

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -89,6 +89,21 @@ export function getNumBehaviorsForSpriteId(spriteId) {
   return numBehaviors;
 }
 
+/**
+ * @param {number} spriteId
+ * @return {[String]} List containing the names of the behaviors associated
+ * with the specified sprite
+ */
+export function getBehaviorsForSpriteId(spriteId) {
+  let spriteBehaviors = [];
+  behaviors.forEach(behavior => {
+    if (behavior.sprite.id === spriteId) {
+      spriteBehaviors.push(behavior.name);
+    }
+  });
+  return spriteBehaviors;
+}
+
 export function getSpriteIdsInUse() {
   let spriteIds = [];
   Object.keys(nativeSpriteMap).forEach(spriteId =>


### PR DESCRIPTION
Adds a way to get all the behaviors (by name) associated with a given sprite from interpreted code.
Requested by curriculum team. See https://codedotorg.slack.com/archives/C946FMBGT/p1569358793055500