### PR TITLE
add poste_secret to fix adhoc homepage load

### DIFF
--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -4,6 +4,10 @@ chef_local_mode: true
 stub_school_data: true
 db_writer: 'mysql://root@localhost/'
 
+# needed by storage_id helper
+poste_secret: not a real secret
+
+
 # Engineers need to be able to see raw HTTP error pages so they can debug their feature branch on an adhoc.
 custom_error_response: false
 


### PR DESCRIPTION
After starting a new adhoc and signing in, the homepage shows an error trying to load /v3/channels. This is because the storage_id helper relies on `CDO.channels_api_secret` which is derived from `poste_secret`.