### PR TITLE
Don't automatically run chef-client [ci skip]

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -32,11 +32,11 @@ namespace :ci do
           end
           RakeUtils.bundle_exec 'berks', 'upload', (rack_env?(:production) ? '' : '--no-freeze')
           RakeUtils.bundle_exec 'berks', 'apply', rack_env
+
+          ChatClient.log 'Applying <b>chef</b> profile...'
+          RakeUtils.sudo '/opt/chef/bin/chef-client'
         end
       end
-
-      ChatClient.log 'Applying <b>chef</b> profile...'
-      RakeUtils.sudo '/opt/chef/bin/chef-client'
     end
   end
 


### PR DESCRIPTION
Temporary change for ubuntu upgrade. This will allow us to manually update cookbooks and run `chef-client` on a new `staging-ubuntu-upgrade` instance, while the old staging instance is unaffected and can still be used by developers.