### PR TITLE
Fix gateway SSH config to not rely on recursive config [ci skip]

### DIFF
--- a/cookbooks/cdo-users/templates/default/ssh_config.erb
+++ b/cookbooks/cdo-users/templates/default/ssh_config.erb
@@ -1,4 +1,4 @@
-Host *.ec2.internal *.cdn-code.org
+Host staging test levelbuilder-* production-daemon production-console adhoc-* *.ec2.internal *.cdn-code.org
   User ubuntu
   StrictHostKeyChecking no
   PreferredAuthentications publickey


### PR DESCRIPTION
In upgrading to ubuntu 18, our OpenSSH version was upgraded from 6.6 to 7.x, which also includes this bug fix: https://bugzilla.mindrot.org/show_bug.cgi?id=2267

The current version of the ssh config for each user on gateway relies on this bug to work correctly; this PR should fix that.