### PR TITLE
Update CSP Support course links

### DIFF
--- a/dashboard/config/courses/csp-2017.course
+++ b/dashboard/config/courses/csp-2017.course
@@ -35,7 +35,7 @@
       ],
       [
         "professionalLearning",
-        "https://studio.code.org/courses/csp-support"
+        "https://studio.code.org/courses/CSP%20Support"
       ]
     ],
     "has_verified_resources": true,

--- a/dashboard/config/scripts/deeper_learning_recommendations_csp.external
+++ b/dashboard/config/scripts/deeper_learning_recommendations_csp.external
@@ -6,8 +6,8 @@ markdown <<MARKDOWN
 
 For each unit, there are a few ways you can prepare for the deeper learning reflection prompts. In general, it’s important to have a sense of what each lesson is about, and how the lessons fit together. The best way to get to that point is by reading lessons and doing the activities yourself. Here are a few tips for getting up to speed on the lessons in the curriculum: 
 
-- Read and do the actual lessons! This means work through the core activities in the lessons after you’ve read the lesson plan. If it exists, watch the teaching tips videos for the lesson. 
-- Look at the resources published via the [teacher-facing online professional learning course](https://studio.code.org/courses/csp-support). Note that for every unit, there are resources that do the following: Provide an overview of key elements of the unit as a whole; Provide guidance on the connections between lessons; Give insight into underlying CS content in the lessons; Provide space to think about key teaching practices in each unit. 
+- Read and do the actual lessons! This means work through the core activities in the lessons after you’ve read the lesson plan. If it exists, watch the teaching tips videos for the lesson.
+- Look at the resources published via the [teacher-facing online professional learning course](https://studio.code.org/courses/CSP%20Support). Note that for every unit, there are resources that do the following: Provide an overview of key elements of the unit as a whole; Provide guidance on the connections between lessons; Give insight into underlying CS content in the lessons; Provide space to think about key teaching practices in each unit.
     - [unit 1 online PL course >>](https://studio.code.org/s/csp1-support)
     - [unit 2 online PL course >>](https://studio.code.org/s/csp2-support)
     - [unit 3 online PL course >>](https://studio.code.org/s/csp3-support)

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/curriculum.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/curriculum.md
@@ -64,7 +64,7 @@ ________________
 ## **Teacher Online Support**
 
 
-- [CS Principles Online Support](https://studio.code.org/courses/csp-support)
+- [CS Principles Online Support](https://studio.code.org/courses/CSP%20Support)
 - [Teacher Forums](http://forum.code.org/): These forums are program specific and are a great way for teachers to help each other with questions about their online coursework and workshops. We recommend giving your teachers a space to help each other answer questions, and collaborate.
 - [Support.code.org](https://support.code.org/hc/en-us): Code.org updates answers to new questions every week. See answers to teacher questions and submit new ones here.
 


### PR DESCRIPTION
We recently [deprecated custom slug-ification of PLC course names](https://github.com/code-dot-org/code-dot-org/pull/30779). I left a [Honeybadger notification](https://github.com/code-dot-org/code-dot-org/blob/1383089c2460f68112c91c68eb4d711b33c9900b/dashboard/app/controllers/courses_controller.rb#L59) in place to detect if course slugs were still being used anywhere.  It turns out they were: We had [five hits to `/courses/csp-support` in the last week.](https://app.honeybadger.io/projects/3240/faults/55091903#notice-summary)

I don't have referrers for those particular events, but I found three places in our repo we were directly referencing this old link to the "CSP Support" course. This PR updates them to use the new URL, which uses the unmodified course name.

# Testing Story

Ran `rake build` and `rake seed:incremental` locally, and visited the updated course page link to make sure it works.