### PR TITLE
Applab: set label textRendering to optimizeSpeed for Safari/Chrome sizing compatibility

### DIFF
--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -920,6 +920,7 @@ applabCommands.textLabel = function(opts) {
   newLabel.id = opts.elementId;
   newLabel.style.position = 'relative';
   newLabel.style.borderStyle = 'solid';
+  newLabel.style.textRendering = 'optimizeSpeed';
   elementLibrary.setAllPropertiesToCurrentTheme(
     newLabel,
     Applab.activeScreen()

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -920,6 +920,7 @@ applabCommands.textLabel = function(opts) {
   newLabel.id = opts.elementId;
   newLabel.style.position = 'relative';
   newLabel.style.borderStyle = 'solid';
+  // Set optimizeSpeed to ensure better text size consistency between Safari and Chrome
   newLabel.style.textRendering = 'optimizeSpeed';
   elementLibrary.setAllPropertiesToCurrentTheme(
     newLabel,

--- a/apps/src/applab/designElements/label.jsx
+++ b/apps/src/applab/designElements/label.jsx
@@ -203,6 +203,7 @@ export default {
     element.textContent = 'text';
     element.style.maxWidth = applabConstants.APP_WIDTH + 'px';
     element.style.borderStyle = 'solid';
+    element.style.textRendering = 'optimizeSpeed';
     elementLibrary.setAllPropertiesToCurrentTheme(
       element,
       designMode.activeScreen()
@@ -213,9 +214,13 @@ export default {
   },
 
   onDeserialize: function(element) {
-    // Set background color style for older projects that didn't set them on create:
+    // Set background color style for older projects that didn't set it on create:
     if (!element.style.backgroundColor) {
       element.style.backgroundColor = themeValues.label.backgroundColor.classic;
+    }
+    // Set text rendering style for older projects that didn't set it on create:
+    if (!element.style.textRendering) {
+      element.style.textRendering = 'optimizeSpeed';
     }
     // Set border styles for older projects that didn't set them on create:
     elementUtils.setDefaultBorderStyles(element);

--- a/apps/src/applab/designElements/label.jsx
+++ b/apps/src/applab/designElements/label.jsx
@@ -203,6 +203,7 @@ export default {
     element.textContent = 'text';
     element.style.maxWidth = applabConstants.APP_WIDTH + 'px';
     element.style.borderStyle = 'solid';
+    // Set optimizeSpeed to ensure better text size consistency between Safari and Chrome
     element.style.textRendering = 'optimizeSpeed';
     elementLibrary.setAllPropertiesToCurrentTheme(
       element,
@@ -220,6 +221,7 @@ export default {
     }
     // Set text rendering style for older projects that didn't set it on create:
     if (!element.style.textRendering) {
+      // Set optimizeSpeed to ensure better text size consistency between Safari and Chrome
       element.style.textRendering = 'optimizeSpeed';
     }
     // Set border styles for older projects that didn't set them on create:


### PR DESCRIPTION
* Safari and Chrome are measuring text differently with our default label font in applab (`Arial Black`). Prior to this change, if you create a text label in design mode and change the text to `LYoWAT - ff fi fl ffl`, it updates the text label to be 159px in Safari and 160px in Chrome. If you run the applab project authored in Safari in Chrome, the last word in the text will wrap (and be cropped).
* Fix: Set the `text-rendering` CSS style to [`optimizeSpeed`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering) when we create text labels. With this change, both browsers now measure this text to be 160px wide.
* NOTE: we could apply this generally to all design elements, but this change only modifies the text label, as this is the only place where we measure in design mode as the text is modified and precisely set the size of the UI control based on that measurement.
* See repro case here: https://studio.code.org/projects/applab/ysChSNE5a4PPud58o5qM-sjMwbLrqahM9O-fmuW31HM/view