### PR TITLE
Make Sprite Lab docs available in help header

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -311,6 +311,8 @@ en:
       app_lab_tutorials: "App Lab Tutorials"
       game_lab_documentation: "Game Lab Documentation"
       game_lab_tutorials: "Game Lab Tutorials"
+      sprite_lab_documentation: "Sprite Lab Documentation"
+      sprite_lab_tutorials: "Sprite Lab Tutorials"
       educate_overview: "Educator Overview"
       educate_elementary: "Elementary School"
       educate_middle: "Middle School"

--- a/lib/cdo/help_header.rb
+++ b/lib/cdo/help_header.rb
@@ -8,7 +8,7 @@ class HelpHeader
 
     # Help-related.
 
-    if options[:level] && options[:level].try(:is_project_level) && options[:level].game == Game.gamelab
+    if options[:level] && options[:level].game == Game.gamelab
       entries << {
         title: I18n.t("#{loc_prefix}game_lab_documentation"),
         url: "https://docs.code.org/gamelab/",
@@ -22,7 +22,7 @@ class HelpHeader
       }
     end
 
-    if options[:level] && options[:level].try(:is_project_level) && options[:level].game == Game.applab
+    if options[:level] && options[:level].game == Game.applab
       entries << {
         title: I18n.t("#{loc_prefix}app_lab_documentation"),
         url: "https://docs.code.org/applab/",
@@ -33,6 +33,20 @@ class HelpHeader
         title: I18n.t("#{loc_prefix}app_lab_tutorials"),
         url: CDO.code_org_url('/educate/applab'),
         id: "applab-tutorials"
+      }
+    end
+
+    if options[:level] && options[:level].game == Game.spritelab
+      entries << {
+        title: I18n.t("#{loc_prefix}sprite_lab_documentation"),
+        url: "https://docs.code.org/spritelab/",
+        id: "spritelab-docs"
+      }
+
+      entries << {
+        title: I18n.t("#{loc_prefix}sprite_lab_tutorials"),
+        url: CDO.code_org_url('/educate/spritelab'),
+        id: "spritelab-tutorials"
       }
     end
 

--- a/lib/test/test_help_header.rb
+++ b/lib/test/test_help_header.rb
@@ -29,7 +29,7 @@ class HelpHeaderTest < Minitest::Test
     assert_includes_id contents, "applab-tutorials"
   end
 
-  def test_help_header_content_spritelab
+  def test_help_header_content_spritelab_level
     contents = HelpHeader.get_help_contents({level: LevelSpriteLab.new, script_level: nil, user_type: nil, language: "en"})
     assert_includes_id contents, "spritelab-docs"
     assert_includes_id contents, "spritelab-tutorials"

--- a/lib/test/test_help_header.rb
+++ b/lib/test/test_help_header.rb
@@ -7,25 +7,31 @@ class HelpHeaderTest < Minitest::Test
     assert items.find {|e| e[:id] == id}
   end
 
-  def test_hamburger_content_script_level
+  def test_help_header_content_script_level
     contents = HelpHeader.get_help_contents({level: nil, script_level: Level.new, user_type: nil, language: "en", request: nil})
     assert_includes_id contents, "report-bug"
   end
 
-  def test_hamburger_content_level
+  def test_help_header_content_level
     contents = HelpHeader.get_help_contents({level: Level.new, script_level: nil, user_type: nil, language: "en", request: nil})
     assert_includes_id contents, "report-bug"
   end
 
-  def test_hamburger_content_gamelab_project_level
+  def test_help_header_content_gamelab_level
     contents = HelpHeader.get_help_contents({level: LevelGameLab.new, script_level: nil, user_type: nil, language: "en"})
     assert_includes_id contents, "gamelab-docs"
     assert_includes_id contents, "gamelab-tutorials"
   end
 
-  def test_hamburger_content_applab_project_level
+  def test_help_header_content_applab_level
     contents = HelpHeader.get_help_contents({level: LevelAppLab.new, script_level: nil, user_type: nil, language: "en"})
     assert_includes_id contents, "applab-docs"
     assert_includes_id contents, "applab-tutorials"
+  end
+
+  def test_help_header_content_spritelab
+    contents = HelpHeader.get_help_contents({level: LevelSpriteLab.new, script_level: nil, user_type: nil, language: "en"})
+    assert_includes_id contents, "spritelab-docs"
+    assert_includes_id contents, "spritelab-tutorials"
   end
 end

--- a/lib/test/test_helper.rb
+++ b/lib/test/test_helper.rb
@@ -15,15 +15,15 @@ class Level
   def try(property)
     false
   end
+
+  def game
+    "couldBeAnyLab"
+  end
 end
 
 class LevelAppLab
   def report_bug_url(request)
     "url"
-  end
-
-  def try(property)
-    property == :is_project_level
   end
 
   def game
@@ -36,12 +36,18 @@ class LevelGameLab
     "url"
   end
 
-  def try(property)
-    property == :is_project_level
+  def game
+    "GameLab"
+  end
+end
+
+class LevelSpriteLab
+  def report_bug_url(request)
+    "url"
   end
 
   def game
-    "GameLab"
+    "SpriteLab"
   end
 end
 
@@ -52,5 +58,9 @@ class Game
 
   def self.applab
     "AppLab"
+  end
+
+  def self.spritelab
+    "SpriteLab"
   end
 end


### PR DESCRIPTION
Primary goal here was to add links for docs and tutorials on Sprite Lab levels.

Looks like this:

![image](https://user-images.githubusercontent.com/25372625/65630879-22df0480-df8b-11e9-88d3-54929fb4b48b.png)

Did some manual testing using these levels (assume screenshots same as ^^^):

Sprite Lab project backed: /s/coursee-2019/stage/6/puzzle/3
Sprite Lab non project backed: /s/coursee-2019/stage/6/puzzle/2
(appropriately) doesn't show up in, say, Artist levels: /s/coursee-2019/stage/2/puzzle/3

At the same time, I (hopefully) made docs visible on App Lab and Game Lab levels. 

I could use some guidance if there is proper testing to be added here, but I tested manually by looking at project backed and non-project backed levels of each type (screenshots all look the same as above, just with appropriate lab):

App Lab not project backed: /s/csp3-2019/stage/5/puzzle/4
App Lab project backed: /s/csp3-2019/stage/8/puzzle/13

Game Lab not project backed: /s/csd3-2019/stage/3/puzzle/7
Game Lab project backed: /s/csd3-2019/stage/17/puzzle/12

My impression from some code/data spelunking is that the `options[:level].try(:is_project_level)` condition that I removed just limits docs/tutorials being shown in blank standalone projects, like what you get if you click "Make an animation or game" here:

https://code.org/educate/spritelab

There are a total of 44 levels that have `is_project_level` = true in their properties, all with names like:

New App Lab Project
New Artist Project
New Basketball Project
New Bounce Project
New Dance Lab Project
New Flappy Project
New Frozen Project
New Game Lab Jr Project
New Game Lab Project

