### PR TITLE
chef fix: install aws-sdk-ec2 gem at compile time

### DIFF
--- a/cookbooks/Berksfile.lock
+++ b/cookbooks/Berksfile.lock
@@ -136,7 +136,7 @@ GRAPH
   cdo-secrets (0.1.8)
   cdo-tippecanoe (0.1.2)
     ark (>= 0.0.0)
-  cdo-users (0.1.26)
+  cdo-users (0.1.27)
     apt (~> 2.6.0)
   cdo-varnish (0.3.243)
     apt (>= 0.0.0)

--- a/cookbooks/cdo-users/metadata.rb
+++ b/cookbooks/cdo-users/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Creates users for the accounts defined in Chef'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.26'
+version          '0.1.27'
 
 depends 'apt', '~> 2.6.0'

--- a/cookbooks/cdo-users/recipes/default.rb
+++ b/cookbooks/cdo-users/recipes/default.rb
@@ -6,7 +6,7 @@
 require 'chef/user'
 require 'chef/client'
 
-chef_gem "aws-sdk-ec2"
+chef_gem("aws-sdk-ec2") {compile_time true}
 require 'aws-sdk-ec2'
 
 apt_package 'awscli' # AWS command-line tools


### PR DESCRIPTION
When running `cdo-users` on a new instance (which only currently happens when rebuilding the `gateway` server), the `aws-sdk-ec2` gem was not found by the recipe, where it was needed at compile-time. This update sets `compile_time true` so that the gem is installed at compile-time, so it will be installed when needed on the first run.

I've also updated (and uploaded) the new cookbook version manually because the auto-update is currently disabled in our CI pipeline.