### PR TITLE
Improve reporting from account purger cronjob

### DIFF
--- a/dashboard/lib/expired_deleted_account_purger.rb
+++ b/dashboard/lib/expired_deleted_account_purger.rb
@@ -147,7 +147,7 @@ class ExpiredDeletedAccountPurger
     log_link = upload_activity_log
     if rack_env? :production
       if manual_reviews_needed > 0
-        notify "#{summary} #{log_link}"
+        warn "#{summary} #{log_link}"
       else
         say "#{summary} #{log_link}"
       end
@@ -225,7 +225,7 @@ class ExpiredDeletedAccountPurger
   end
 
   # Send warning messages to #cron-daily and #user-accounts
-  def notify(message)
+  def warn(message)
     say message, 'cron-daily', color: 'yellow'
     say message, 'user-accounts', color: 'yellow'
   end

--- a/dashboard/lib/expired_deleted_account_purger.rb
+++ b/dashboard/lib/expired_deleted_account_purger.rb
@@ -156,10 +156,6 @@ class ExpiredDeletedAccountPurger
     upload_metrics metrics unless @dry_run
   end
 
-  def manual_review_queue_depth
-    QueuedAccountPurge.count
-  end
-
   def build_metrics(review_queue_depth)
     {
       # Number of accounts purged during this run

--- a/dashboard/lib/expired_deleted_account_purger.rb
+++ b/dashboard/lib/expired_deleted_account_purger.rb
@@ -221,18 +221,27 @@ class ExpiredDeletedAccountPurger
     " <a href='#{log_url}'>☁ Log on S3</a>"
   end
 
-  # Send error messages to #cron-daily
+  # Send error messages to #cron-daily and #user-accounts
   def yell(message)
     @log.puts message
-    say message, color: 'red', notify: 1
+    say message, 'cron-daily', color: 'red', notify: 1
+    say message, 'user-accounts', color: 'red', notify: 1
+  end
+
+  # Send warning messages to #cron-daily and #user-accounts
+  def notify(message)
+    say message, 'cron-daily', color: 'yellow'
+    say message, 'user-accounts', color: 'yellow'
   end
 
   # Send messages to Slack #cron-daily
-  def say(message, options = {})
-    ChatClient.message 'cron-daily', prefixed(message), options
+  def say(message, channel = 'cron-daily', options = {})
+    ChatClient.message channel, prefixed(message), options
   end
 
   def prefixed(message)
-    "ExpiredDeletedAccountPurger#{@dry_run ? ' (dry-run)' : ''}: #{message}"
+    "*ExpiredDeletedAccountPurger*#{@dry_run ? ' (dry-run)' : ''}" \
+    " <https://github.com/code-dot-org/code-dot-org/blob/production/dashboard/lib/expired_deleted_account_purger.rb|(source)>" \
+    "\n#{message}"
   end
 end

--- a/dashboard/lib/expired_deleted_account_purger.rb
+++ b/dashboard/lib/expired_deleted_account_purger.rb
@@ -19,6 +19,8 @@ require 'cdo/chat_client'
 #
 # @see Technical Spec: Hard-deleting accounts
 # https://docs.google.com/document/d/1l2kB4COz8-NwZfNCGufj7RfdSm-B3waBmLenc6msWVs/edit
+# @see Account Purger Cloudwatch dashboard
+# https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Purged-Accounts
 #
 class ExpiredDeletedAccountPurger
   class SafetyConstraintViolation < RuntimeError; end


### PR DESCRIPTION
I recently [added support for auto-retrying certain Queued Account Purges](https://github.com/code-dot-org/code-dot-org/pull/30909) because we were seeing quite a bit of noise from intermittent Pardot API failures.  However, our daily reporting in Slack wasn't updated to accurately communicate when no developer intervention was needed:

![image](https://user-images.githubusercontent.com/1615761/65636271-d699c180-df96-11e9-9fe7-8298005e6efc.png)

Here, I'm making some changes to make this daily reporting more accurate, and to help the right people notice and respond when action _is_ required.

- The message now lists the actual number of accounts requiring _manual_ review.
- When manual review is actually required, the cronjob will also notify `#user-accounts` and color-code the message yellow.
- When an unexpected error occurs, the cronjob will also notify `#user-accounts` and color-code the message red.
- The message formatting has been updated with a link to the relevant code (similar to our *The Daily Zendesk* notifications) and a link to the Cloudwatch dashboard has been added to the linked file, to make it easier for developers to track down relevant documentation when this (hopefully) rare event occurs.

# Testing

Unit tests updated to check that appropriate logs are generated in different scenarios (this shares a lot of code with the Slack notifications).