### PR TITLE
Home: top course should be most recently assigned, most recent progress

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1684,7 +1684,8 @@ class User < ActiveRecord::Base
   end
 
   def primary_script
-    working_on_scripts.first.try(:cached)
+    return most_recently_assigned_script if can_access_most_recently_assigned_script?
+    script_with_most_recent_progress
   end
 
   # Returns integer days since account creation, rounded down

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1579,10 +1579,8 @@ class User < ActiveRecord::Base
 
     # Filter out user_scripts that are already covered by a course
     course_scripts_script_ids = courses_as_student.map(&:default_course_scripts).flatten.pluck(:script_id).uniq
-
     user_scripts = in_progress_and_completed_scripts.
       select {|user_script| !course_scripts_script_ids.include?(user_script.script_id)}
-
     user_script_data = user_scripts.map do |user_script|
       # Skip this script if we are excluding the primary script and this is the
       # primary script.


### PR DESCRIPTION
[LP-770](https://codedotorg.atlassian.net/browse/LP-770)

Elizabeth noticed that teachers and students in the CSD pilot group couldn't find the assigned CSD pilot scripts on the homepage. They were there when the View More courses button was clicked, but buried in the users' other courses/scripts. The expectation is that the pilot scripts should appear first in the courses section as a top course because they were most recently assigned. 

This highlighted a bug wherein hidden scripts were excluded from being a user's top course even if they should be visible due to the user's enrollment in a pilot experiment. 

A user's top course (more accurately "assignable" since it could be a course OR a script) is based on the logic for `primary_script`. Previously `primary_script` was the first in the collection of `working_on_scripts` for the user. `working_on_scripts` was the group of scripts where user_scripts.completed_at is null, which doesn't take experiment enrollment into account. We were also relying on the order these user_scripts were returned in the array rather than looking at timestamps. This resulted in the pilot script appearing for the user, but not as a top assignable. 

BEFORE:
<img width="1035" alt="Screen Shot 2019-09-25 at 10 44 45 AM" src="https://user-images.githubusercontent.com/12300669/65649338-0e1a6500-dfbb-11e9-8189-cc757a0d96df.png">

I updated the `primary_script` logic to set the top course to the most recently assigned script if the user has permission to see that script; if that doesn't exist use the script the user most recently made progress in. 
AFTER:
<img width="1034" alt="Screen Shot 2019-09-25 at 5 38 19 PM" src="https://user-images.githubusercontent.com/12300669/65649411-50dc3d00-dfbb-11e9-9954-2de8eb84ae0a.png">


**Notes about hiding (because I always have to re-remind myself)**: 

 Scripts with the pilot [experiment property](https://github.com/code-dot-org/code-dot-org/blob/1ad9501b39f1079a0546ff5ea4a104e9d2a1714f/dashboard/config/scripts/csd3-pilot.script#L11) [are hidden](https://github.com/code-dot-org/code-dot-org/blob/1ad9501b39f1079a0546ff5ea4a104e9d2a1714f/dashboard/app/models/script.rb#L72) for users who do not have [pilot access](https://github.com/code-dot-org/code-dot-org/blob/1ad9501b39f1079a0546ff5ea4a104e9d2a1714f/dashboard/app/models/script.rb#L1652) that matches the experiment name unless the user has hidden_script_access. 

This is different from hiding a script in the teacher dashboard: 
<img width="762" alt="Screen Shot 2019-09-25 at 5 23 30 PM" src="https://user-images.githubusercontent.com/12300669/65649011-ac0d3000-dfb9-11e9-9080-66b4cb764f5d.png">

And also different from when a teacher hides a script (or stage) for the students in their section:
<img width="741" alt="Screen Shot 2019-09-25 at 5 23 11 PM" src="https://user-images.githubusercontent.com/12300669/65649014-afa0b700-dfb9-11e9-96ea-4c03f7186f03.png">
