### PR TITLE
Student has not started level warning too long

### DIFF
--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -33,7 +33,6 @@ const styles = {
   studentNotStartedWarning: {
     zIndex: 99,
     backgroundColor: color.lightest_red,
-    width: '100%',
     height: 20,
     padding: 5,
     opacity: 0.9

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -35,7 +35,8 @@ const styles = {
     backgroundColor: color.lightest_red,
     height: 20,
     padding: 5,
-    opacity: 0.9
+    opacity: 0.9,
+    position: 'relative'
   }
 };
 

--- a/dashboard/test/ui/features/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/student_not_started_level_warning.feature
@@ -1,0 +1,39 @@
+@eyes
+Feature: Student Has Not Started Level Warning
+
+  Background:
+    Given I create an authorized teacher-associated student named "Sally"
+
+Scenario: Game lab level where student has not started
+  When I open my eyes to test "game lab student has not started"
+  When I sign in as "Teacher_Sally" and go home
+  And I wait until element ".uitest-owned-sections" is visible
+
+  And I am on "http://studio.code.org/s/allthethings/stage/38/puzzle/3"
+  And I wait for the page to fully load
+  And I wait until element "#teacher-panel-container" is visible
+  And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
+  And I wait until element ".student-table" is visible
+  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I wait for the page to fully load
+
+  And I wait until element ".editor-column" contains text "This student has not started the level."
+  Then I see no difference for "student not started warning"
+  And I close my eyes
+
+Scenario: Maze level where student has not started
+  When I open my eyes to test "game lab student has not started"
+  When I sign in as "Teacher_Sally" and go home
+  And I wait until element ".uitest-owned-sections" is visible
+
+  And I am on "http://studio.code.org/s/allthethings/stage/4/puzzle/2"
+  And I wait for the page to fully load
+  And I wait until element "#teacher-panel-container" is visible
+  And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
+  And I wait until element ".student-table" is visible
+  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I wait for the page to fully load
+
+  And I wait until element ".editor-column" contains text "This student has not started the level."
+  Then I see no difference for "student not started warning"
+  And I close my eyes


### PR DESCRIPTION
# Bug 1 

Red box was too long. By removing width specification it follows sizing of parent elements.

## Before

![Screen Shot 2019-09-26 at 11 34 29 AM](https://user-images.githubusercontent.com/208083/65703077-1f628080-e052-11e9-8e59-70d4242f6353.png)

## After

![Screen Shot 2019-09-26 at 11 36 52 AM](https://user-images.githubusercontent.com/208083/65703100-27babb80-e052-11e9-9cbf-674f7859991f.png)

# Bug 2

On Game Lab Levels the "student has not started" message was showing behind the code workspace area. Position relative fixed this.

## Before

![Screen Shot 2019-09-26 at 12 40 14 PM](https://user-images.githubusercontent.com/208083/65722350-17b6d200-e07a-11e9-9c09-7fa4234f72c3.png)


## After (Plus fix from Bug 1)

<img width="711" alt="Screen Shot 2019-09-26 at 4 24 48 PM" src="https://user-images.githubusercontent.com/208083/65722405-2ef5bf80-e07a-11e9-90ca-651e196a5625.png">

# Also added in an eyes test to help prevent this from regressing again without us knowing.
