### PR TITLE
Add experiment server API for new survey rollup UI

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -124,7 +124,10 @@ module Api::V1::Pd
 
     # GET /api/v1/pd/workshops/experiment_survey_report/:id/
     def experiment_survey_report
-      create_generic_survey_report
+      this_ws_report = report_single_workshop(@workshop, current_user)
+      rollup_report = report_rollups_experiment(@workshop, current_user)
+
+      render json: this_ws_report.merge(rollup_report).merge(experiment: true)
     rescue => e
       notify_error e
     end

--- a/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
@@ -14,13 +14,80 @@ module Pd::SurveyPipeline::Helper
     WORKSHOP_TEACHER_ENGAGEMENT_CATEGORY = 'teacher_engagement'
   ]
 
-  # Summarize facilitator-specific and general workshop results from all workshops
-  # that a group of selected facilitators have facilitated.
+  # Roll up facilitator-specific and general workshop survey results from all related workshops.
+  # @note This function will replace report_rollups function.
   #
+  # @param workshop [Pd::Workshop] the workshop user selects, which is used to find related workshops
+  # @param current_user [User] the user requesting survey report
+  # @return [Hash] {:workshopRollups, :facilitatorRollups => rollup_content}
+  # @see SurveyRollupDecoratorExperiment.decorate_facilitator_rollup for data structure of rollup_content
+  #
+  def report_rollups_experiment(workshop, current_user)
+    # Get list of facilitators this user can see
+    facilitator_ids =
+      if current_user.program_manager? || current_user.workshop_organizer? || current_user.workshop_admin?
+        workshop.facilitators.pluck(:id)
+      else
+        [current_user.id]
+      end
+
+    # Roll up facilitator-specific and general workshop results
+    reports = {facilitator_rollups: {}, workshop_rollups: {}}
+
+    facilitator_ids.each do |fid|
+      reports[:facilitator_rollups].deep_merge! report_facilitator_rollup_experiment(fid, workshop, true)
+      reports[:workshop_rollups].deep_merge! report_facilitator_rollup_experiment(fid, workshop, false)
+
+      # TODO: report_partner_rollup()
+      # TODO: report_cdo_rollup()
+    end
+
+    reports
+  end
+
+  # Summarize facilitator-specific results from all related workshops a facilitator have facilitated.
+  # @note This function will replace both report_facilitator_rollup and report_workshop_rollup functions.
+  #
+  # @param facilitator_id [Integer]
   # @param workshop [Pd::Workshop]
-  # @param current_user [User]
-  #
+  # @param only_facilitator_questions [Boolean]
   # @return [Hash]
+  #
+  def report_facilitator_rollup_experiment(facilitator_id, workshop, only_facilitator_questions)
+    context = {
+      current_workshop_id: workshop.id,
+      facilitator_id: facilitator_id,
+    }
+
+    context[:question_categories] = only_facilitator_questions ?
+      [FACILITATOR_EFFECTIVENESS_CATEGORY] :
+      [WORKSHOP_OVERALL_SUCCESS_CATEGORY, WORKSHOP_TEACHER_ENGAGEMENT_CATEGORY]
+
+    related_ws_ids = find_related_workshop_ids(facilitator_id, workshop.course)
+    context[:related_workshop_ids] = related_ws_ids
+
+    # Retrieve data
+    context.merge!(only_facilitator_questions ?
+      retrieve_facilitator_surveys([facilitator_id], related_ws_ids) :
+      retrieve_workshop_surveys(related_ws_ids)
+    )
+
+    # Process data
+    process_rollup_data context
+
+    # Decorate
+    Pd::SurveyPipeline::SurveyRollupDecoratorExperiment.decorate_facilitator_rollup(
+      context, only_facilitator_questions
+    )
+  end
+
+  # Roll up facilitator-specific and general workshop results from all related workshops.
+  #
+  # @param workshop [Pd::Workshop] the workshop user selects, which is used to find related workshops
+  # @param current_user [User] the user requesting survey report
+  # @return [Hash] a hash report with these keys :facilitators, :current_workshop,
+  #   :related_workshops, :facilitator_response_counts, :facilitator_averages, and :errors.
+  # @see SurveyRollupDecorator.decorate_facilitator_rollup for detailed return data structure.
   #
   def report_rollups(workshop, current_user)
     # Filter list of facilitators that the current user can see.
@@ -41,20 +108,11 @@ module Pd::SurveyPipeline::Helper
     reports
   end
 
-  # Summarize facilitator-specific results from all related workshops
-  # that a facilitator have facilitated.
+  # Summarize facilitator-specific results from all related workshops a facilitator have facilitated.
   #
-  # @param facilitator_id [Number] a valid user id
-  # @param workshop [Pd::Workshop] a valid workshop
-  #
-  # @return [Hash{:facilitators, :facilitator_response_counts, :facilitator_averages, :errors => Hash, Array}]
-  #   facilitators: {facilitator_id => fac_name}
-  #   facilitator_response_counts: {this_workshop, all_my_workshops => {facilitator_id => count}}
-  #   facilitator_averages: {
-  #     fac_name => {qcategory, qname => {this_workshop, all_my_workshops => score}},
-  #     questions => {qname => qtext}
-  #    }
-  #   errors: Array
+  # @param facilitator_id [Integer]
+  # @param workshop [Pd::Workshop]
+  # @return [Hash]
   #
   def report_facilitator_rollup(facilitator_id, workshop)
     context = {
@@ -70,8 +128,17 @@ module Pd::SurveyPipeline::Helper
 
     # Process data
     process_rollup_data context
+
+    # Decorate
+    Pd::SurveyPipeline::SurveyRollupDecorator.decorate_facilitator_rollup(context)
   end
 
+  # Summarize general workshop results from all related workshops a facilitator have facilitated.
+  #
+  # @param facilitator_id [Integer]
+  # @param workshop [Pd::Workshop]
+  # @return [Hash]
+  #
   def report_workshop_rollup(facilitator_id, workshop)
     context = {
       current_workshop_id: workshop.id,
@@ -86,6 +153,9 @@ module Pd::SurveyPipeline::Helper
 
     # Process data
     process_rollup_data context
+
+    # Decorate
+    Pd::SurveyPipeline::SurveyRollupDecorator.decorate_facilitator_rollup(context)
   end
 
   def process_rollup_data(context)
@@ -139,16 +209,12 @@ module Pd::SurveyPipeline::Helper
     Pd::SurveyPipeline::GenericMapper.new(
       group_config: group_config_this_ws, map_config: map_config_this_ws
     ).process_data context
-
-    # Decorate
-    Pd::SurveyPipeline::SurveyRollupDecorator.decorate_facilitator_rollup context
   end
 
   # Summarize all survey results for a workshop.
   #
   # @param workshop [Pd::Workshop]
   # @param current_user [User]
-  #
   # @return [Hash]
   #
   def report_single_workshop(workshop, current_user)

--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator_experiment.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator_experiment.rb
@@ -1,0 +1,181 @@
+# SurveyRollupDecoratorExperiment combines pieces of survey roll-up data from previous steps
+# of the survey pipeline and organize them in a format that the client view can consume.
+# @note This class will replace Pd::SurveyPipeline::SurveyRollupDecorator.
+
+module Pd::SurveyPipeline
+  class SurveyRollupDecoratorExperiment
+    # Create roll-up report to send to client.
+    #
+    # Return value is a Hash with following keys
+    # :rollups [Hash<scenario_name, scenario_content>]. scenario_content is a Hash with these keys
+    #   :averages [Hash<question_name, Float>]
+    #   :response_count [Integer]
+    #   :facilitator_id [Integer]
+    #   :workshop_id [Integer]
+    #   :all_workshop_ids [Array<Integer>]
+    #   :course_name [String]
+    # :questions [Hash<question_name, question_text>]
+    # :facilitators [Hash<facilitator_id, facilitator_name>]
+    #
+    # @param data [Hash]
+    # @option data [Integer] :facilitator_id a facilitator in the current workshop
+    # @option data [Integer] :current_workshop_id the main workshop user is requesting survey results for
+    # @option data [Array<Integer>] :related_workshop_ids workshops related to the current workshop and the selected facilitator
+    # @option data [Hash] :parsed_questions questions parsed from Pd::SurveyQuestion
+    # @option data [Array<String>] :question_categories categories for roll-up results
+    # @option data [Array<Hash>] :question_answer_joined questions & answers joined together
+    # @option data [Array<Hash>] :summaries survey result summaries
+    # @param only_facilitator_questions [Boolean]
+    # @return [Hash]
+    #
+    def self.decorate_facilitator_rollup(data, only_facilitator_questions)
+      report = {
+        rollups: {},
+        questions: {},
+        facilitators: {}
+      }
+
+      facilitator_id = data[:facilitator_id]
+      report[:facilitators][facilitator_id] = get_user_name_by_id(facilitator_id)
+
+      report[:questions] =
+        get_category_questions data[:parsed_questions], data[:question_categories]
+
+      # For single workshop scenario (survey results come from one workshop), we only add
+      # facilitator id to scenario name if questions are facilitator-specific.
+      # (There are 2 type of questions, facilitator-specific and general workshop questions.)
+      single_ws_scenario =
+        only_facilitator_questions ? "facilitator_#{facilitator_id}_single_ws" : "single_ws"
+
+      report[:rollups][single_ws_scenario] = {
+        averages: get_averages_single_ws(data),
+        response_count: get_submission_count_single_ws(data),
+        workshop_id: data[:current_workshop_id]
+      }
+      report[:rollups][single_ws_scenario][:facilitator_id] = facilitator_id if only_facilitator_questions
+
+      # For scenario that collects survey results from multiple related workshops, it is always
+      # facilitator-specific because each facilitator has different set of related workshops.
+      # Thus, no matter what the question type is, we always add facilitator id to the scenario name.
+      all_ws_scenario = "facilitator_#{facilitator_id}_all_ws"
+
+      report[:rollups][all_ws_scenario] = {
+        averages: get_averages_all_ws(data),
+        response_count: get_submission_count_all_ws(data),
+        facilitator_id: facilitator_id,
+        all_workshop_ids: data[:related_workshop_ids]
+      }
+
+      report
+    end
+
+    # TODO: make these class methods private
+    def self.get_submission_count_single_ws(data)
+      get_submission_count(
+        data[:question_answer_joined], data[:question_categories], data[:current_workshop_id]
+      )
+    end
+
+    def self.get_submission_count_all_ws(data)
+      get_submission_count data[:question_answer_joined], data[:question_categories]
+    end
+
+    def self.get_averages_single_ws(data)
+      question_averages = get_question_averages data[:summaries], data[:current_workshop_id]
+      category_averages = get_category_averages data[:question_categories], question_averages
+      question_averages.merge(category_averages)
+    end
+
+    def self.get_averages_all_ws(data)
+      question_averages = get_question_averages data[:summaries]
+      category_averages = get_category_averages data[:question_categories], question_averages
+      question_averages.merge(category_averages)
+    end
+
+    # @note Copied from SurveyRollupDecorator.get_user_name_by_id
+    def self.get_user_name_by_id(id)
+      User.find(id)&.name || "UserId_#{id}"
+    end
+
+    # Get all questions in the selected categories.
+    # @note Copied from SurveyRollupDecorator.get_category_questions
+    #
+    # @param [Hash] parsed_questions {form_id => {question_id => question_content}}
+    # @param [Array<String>] categories
+    # @return [Hash] {question_name => question_text}.
+    #
+    def self.get_category_questions(parsed_questions = {}, categories = [])
+      result = {}
+      parsed_questions&.each_pair do |_, form_questions|
+        form_questions.each_pair do |_, q_content|
+          q_name = q_content[:name]
+          next if result.key? q_name
+          next if categories.none? {|category| q_name.start_with? "#{category}_"}
+
+          result[q_name] = q_content[:text]
+        end
+      end
+
+      result
+    end
+
+    # Count number of unique submissions that have answers for any question in
+    # the selected categories.
+    # @note Modified from SurveyRollupDecorator.get_submission_counts
+    #
+    # @param [Hash] question_with_answers combination of questions and answers
+    # @param [Array<String>] categories category names
+    # @param [Integer] workshop_id limit counting to a specific workshop
+    # @return [Integer] submission count
+    #
+    def self.get_submission_count(question_with_answers = [], categories = [], workshop_id = nil)
+      submissions_ids = Set[]
+      question_with_answers.each do |qa|
+        next if workshop_id && qa[:workshop_id] != workshop_id
+        next if qa[:answer].blank?
+        next unless categories.any? {|category| qa[:name].start_with? "#{category}_"}
+
+        submissions_ids.add qa[:submission_id]
+      end
+
+      submissions_ids.length
+    end
+
+    # Get question average scores for selected workshop_id value.
+    # @note Modified from SurveyRollupDecorator.get_question_averages
+    #
+    # @param [Array<Hash>] summaries
+    # @param [Integer] workshop_id
+    # @return [Hash] {question_name => avg_score}]
+    #
+    def self.get_question_averages(summaries = [], workshop_id = nil)
+      {}.tap do |result|
+        summaries.each do |summary|
+          # Acceptable workshop id value is either nil or the specified workshop_id
+          next if summary[:workshop_id] != workshop_id
+          result[summary[:name]] = summary[:reducer_result].round(2)
+        end
+      end
+    end
+
+    # Get average results of all questions in the same category.
+    # @note Modified from SurveyRollupDecorator.get_category_averages
+    #
+    # @param [Array<String>] categories category names
+    # @param [Hash] question_averages {question_name => avg_score}
+    # @return [Hash] {category_name => avg_score}
+    #
+    def self.get_category_averages(categories = [], question_averages = {})
+      {}.tap do |result|
+        categories.each do |category|
+          category_scores =
+            question_averages.select {|q_name, _| q_name.start_with? "#{category}_"}.
+              values.compact
+
+          result[category] = category_scores.present? ?
+              (category_scores.sum * 1.0 / category_scores.length).round(2) : nil
+        end
+      end
+    end
+  end
+end

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -249,13 +249,13 @@ module Api::V1::Pd
       )
     end
 
-    test 'experiment_survey_report: return empty result for workshop without responds' do
-      csf_201_ws = create :csf_deep_dive_workshop
+    test 'generic_survey_report: return empty result for workshop without responds' do
+      ayw_ws = create :csp_academic_year_workshop, num_facilitators: 1
 
       # This test assumes there's one facilitator in the workshop
-      assert_equal 1, csf_201_ws.facilitators.count
-      f_id = csf_201_ws.facilitators.first.id.to_s
-      f_name = csf_201_ws.facilitators.first.name
+      assert_equal 1, ayw_ws.facilitators.count
+      f_id = ayw_ws.facilitators.first.id.to_s
+      f_name = ayw_ws.facilitators.first.name
 
       expected_result = {
         "course_name" => nil,
@@ -293,7 +293,7 @@ module Api::V1::Pd
       }
 
       sign_in @admin
-      get :experiment_survey_report, params: {workshop_id: csf_201_ws.id}
+      get :generic_survey_report, params: {workshop_id: ayw_ws.id}
       result = JSON.parse(@response.body).slice(*expected_result.keys)
 
       assert_equal expected_result, result


### PR DESCRIPTION
[PLC-318](https://codedotorg.atlassian.net/browse/PLC-318)

To support new [survey roll-up UI](https://docs.google.com/spreadsheets/d/1IU0vXpznNmd8J1F4_MdgUX_VIYT0tx6F6_lSXWpbX4o/edit#gid=0) and be ready to add new calculation such as partner result roll-up and CDO result roll-up, we need to tweak the data format returned by server. 

This PR adds an experimental API to returns data in that format without affecting the current pipeline. 

The next PR will add client-side component to consume the returned data.

**New UI mock-up**
![Screen Shot 2019-09-26 at 11 50 27 AM](https://user-images.githubusercontent.com/46507039/65716379-e0352f00-e053-11e9-93f2-42288e1a5960.png)

**API Endpoint**
`http://studio.code.org/api/v1/pd/workshops/<workshop_id>/experiment_survey_report`
Don't need to use experiment flag.

**Returned JSON data structure**
```bash
tab_name (e.g. workshop_rollups, facilitator_rollups)
├── rows (e.g. questions)
├── columns (e.g. rollups)
│   └── column name (e.g. single_ws, all_ws)
│         ├── cells (e.g. averages)
│         └── metadata (e.g. response count, facilitator_id, workshop_id, all_workshop_ids, course_name)
└── lookup (e.g. facilitators, partners)
```
