### PR TITLE
Continue Button: deprecate next_unpassed_progression_level

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -129,7 +129,7 @@ class HomeController < ApplicationController
 
     script = current_user.primary_script
     if script
-      script_level = current_user.next_unpassed_progression_level(script)
+      script_level = current_user.next_unpassed_visible_progression_level(script)
     end
     @homepage_data[:topCourse] = nil
     if script && script_level

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -129,7 +129,7 @@ class HomeController < ApplicationController
 
     script = current_user.primary_script
     if script
-      script_level = current_user.next_unpassed_visible_progression_level(script)
+      script_level = current_user.next_unpassed_valid_progression_level(script)
     end
     @homepage_data[:topCourse] = nil
     if script && script_level

--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -10,7 +10,7 @@ class MakerController < ApplicationController
     authenticate_user!
 
     csd_unit_6_script = MakerController.maker_script current_user
-    current_level = current_user.next_unpassed_visible_progression_level(csd_unit_6_script)
+    current_level = current_user.next_unpassed_valid_progression_level(csd_unit_6_script)
     @csd_unit_6 = {
       assignableName: data_t_suffix('script.name', csd_unit_6_script[:name], 'title'),
       lessonName: current_level.stage.localized_title,

--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -10,7 +10,7 @@ class MakerController < ApplicationController
     authenticate_user!
 
     csd_unit_6_script = MakerController.maker_script current_user
-    current_level = current_user.next_unpassed_progression_level(csd_unit_6_script)
+    current_level = current_user.next_unpassed_visible_progression_level(csd_unit_6_script)
     @csd_unit_6 = {
       assignableName: data_t_suffix('script.name', csd_unit_6_script[:name], 'title'),
       lessonName: current_level.stage.localized_title,

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -280,7 +280,7 @@ class ScriptLevelsController < ApplicationController
 
   def user_or_session_level
     if current_user
-      current_user.next_unpassed_visible_progression_level(@script)
+      current_user.next_unpassed_valid_progression_level(@script)
     else
       find_next_level_for_session(@script)
     end

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -184,7 +184,7 @@ module UsersHelper
       end
     end
 
-    user_data[:current_stage] = user.next_unpassed_progression_level(script).stage.id unless exclude_level_progress || script.script_levels.empty?
+    user_data[:current_stage] = user.next_unpassed_visible_progression_level(script).stage.id unless exclude_level_progress || script.script_levels.empty?
 
     user_data.compact
   end

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -184,7 +184,7 @@ module UsersHelper
       end
     end
 
-    user_data[:current_stage] = user.next_unpassed_visible_progression_level(script).stage.id unless exclude_level_progress || script.script_levels.empty?
+    user_data[:current_stage] = user.next_unpassed_valid_progression_level(script).stage.id unless exclude_level_progress || script.script_levels.empty?
 
     user_data.compact
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1055,7 +1055,7 @@ class User < ActiveRecord::Base
     # will be redirected to /congrats.
     return nil if completed?(script)
 
-    visible_sls = visible_script_levels(script).reject {|sl| sl.bonus || sl.level.unplugged? || sl.locked?(self)}
+    visible_sls = visible_script_levels(script).reject {|sl| sl.bonus || sl.level.unplugged?}
 
     sl_level_ids = visible_sls.map(&:level_ids).flatten
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1082,19 +1082,18 @@ class User < ActiveRecord::Base
     # Find the script_level that goes with the most recent user_level
     most_recent_sl = visible_sls.find {|sl| sl.level_id == most_recent_ul.level_id}
 
-    # If the user started but didn't finish a level, go to that level.
-    return most_recent_sl unless most_recent_ul.passing?
-
     last_visible_level = visible_sls.max_by(&:chapter)
+
+    # If the user started but didn't finish a level, go to that level.
+    # Or if the user completed the last level but not all previous levels.
+    return most_recent_sl if most_recent_sl == last_visible_level || !most_recent_ul.passing?
 
     visible_incomplete_sls = visible_sls.find_all {|sl| visible_incomplete_level_ids.include?(sl.level_id)}
 
     first_visible_incomplete_level = visible_incomplete_sls.min_by(&:chapter)
 
-    # The user has completed the last level in the progression, but not all
-    # previous levels, return the first visible incomplete script_level
     return first_visible_incomplete_level || first_visible_level if
-      (most_recent_sl == last_visible_level) || most_recent_sl.nil?
+      most_recent_sl.nil?
 
     # Find the chapter for the script_level that goes with the most recent user_level
     most_recent_completed_chapter = most_recent_sl.chapter

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1060,7 +1060,7 @@ class User < ActiveRecord::Base
     sl_level_ids = visible_sls.map(&:level_ids).flatten
 
     # Levels the user made progress in
-    ul_level_ids = user_levels_by_level(script).keys
+    ul_level_ids = user_levels.where(script: script).map(&:level_id)
 
     visible_completed_level_ids = sl_level_ids & ul_level_ids
     visible_incomplete_level_ids = sl_level_ids - ul_level_ids
@@ -1081,6 +1081,9 @@ class User < ActiveRecord::Base
 
     # Find the script_level that goes with the most recent user_level
     most_recent_sl = visible_sls.find {|sl| sl.level_id == most_recent_ul.level_id}
+
+    # If the user started but didn't finish a level, go to that level.
+    return most_recent_sl unless most_recent_ul.passing?
 
     last_visible_level = visible_sls.max_by(&:chapter)
 

--- a/dashboard/app/views/shared/_course_progress_block.html.haml
+++ b/dashboard/app/views/shared/_course_progress_block.html.haml
@@ -18,5 +18,5 @@
     - else
       =link_to script_url(script.id) do
         .audiencebar.bottombartext.continuelight= t('home.view_course')
-      %a{href: build_script_level_url(current_user.next_unpassed_progression_level(script))}
+      %a{href: build_script_level_url(current_user.next_unpassed_visible_progression_level(script))}
         .bottombar.bottombartext.continue{style: 'bottom: 0; position: absolute'}= t('continue')

--- a/dashboard/app/views/shared/_course_progress_block.html.haml
+++ b/dashboard/app/views/shared/_course_progress_block.html.haml
@@ -18,5 +18,5 @@
     - else
       =link_to script_url(script.id) do
         .audiencebar.bottombartext.continuelight= t('home.view_course')
-      %a{href: build_script_level_url(current_user.next_unpassed_visible_progression_level(script))}
+      %a{href: build_script_level_url(current_user.next_unpassed_valid_progression_level(script))}
         .bottombar.bottombartext.continue{style: 'bottom: 0; position: absolute'}= t('continue')

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -20,7 +20,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level,
       level_source: create(:level_source, level: level)
 
-    assert_cached_queries(13) do
+    assert_cached_queries(14) do
       get script_stage_script_level_path(
         script_id: script.name,
         stage_position: 1,

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -20,7 +20,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level,
       level_source: create(:level_source, level: level)
 
-    assert_cached_queries(11) do
+    assert_cached_queries(13) do
       get script_stage_script_level_path(
         script_id: script.name,
         stage_position: 1,

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -921,7 +921,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(4, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_progression_level if not completed any unplugged levels' do
+  test 'can get next_unpassed_visible_progression_level if not completed any unplugged levels' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
     twenty_hour.script_levels.each do |script_level|
@@ -935,10 +935,10 @@ class UserTest < ActiveSupport::TestCase
         best_result: Activity::MINIMUM_PASS_RESULT
       )
     end
-    assert_equal(35, user.next_unpassed_progression_level(twenty_hour).chapter)
+    assert_equal(35, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_progression_level, not tainted by other user progress' do
+  test 'can get next_unpassed_visible_progression_level, not tainted by other user progress' do
     user = create :user
     other_user = create :user
     twenty_hour = Script.twenty_hour_script
@@ -952,15 +952,16 @@ class UserTest < ActiveSupport::TestCase
         best_result: Activity::MINIMUM_PASS_RESULT
       )
     end
-    assert_equal(2, user.next_unpassed_progression_level(twenty_hour).chapter)
+    assert_equal(2, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_progression_level when most recent level is not passed' do
+  test 'can get next_unpassed_visible_progression_level when most recent level is not passed' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
 
     twenty_hour.script_levels.each do |script_level|
       next if script_level.chapter != 3
+      puts script_level.level.unplugged?
       UserLevel.create(
         user: user,
         level: script_level.level,
@@ -972,10 +973,10 @@ class UserTest < ActiveSupport::TestCase
 
     # The level we most recently had progress on we did not pass, so that's
     # where we should go
-    assert_equal(3, user.next_unpassed_progression_level(twenty_hour).chapter)
+    assert_equal(3, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_progression_level when most recent level is last level' do
+  test 'can get next_unpassed_visible_progression_level when most recent level is last level' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
 
@@ -990,10 +991,10 @@ class UserTest < ActiveSupport::TestCase
 
     # User's most recent progress is on last level in script. There's nothing
     # following it, so just return to the last level
-    assert_equal(script_level.chapter, user.next_unpassed_progression_level(twenty_hour).chapter)
+    assert_equal(script_level.chapter, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_progression_level when most recent level is only followed by unplugged levels' do
+  test 'can get next_unpassed_visible_progression_level when most recent level is only followed by unplugged levels' do
     user = create :user
     script = create :script
 
@@ -1015,10 +1016,10 @@ class UserTest < ActiveSupport::TestCase
     # User's most recent progress is on second last level of script, but none of
     # the levels after it are "progression" levels. Just return to the last level
     # we made progress on.
-    assert_equal(2, user.next_unpassed_progression_level(script).chapter)
+    assert_equal(2, user.next_unpassed_visible_progression_level(script).chapter)
   end
 
-  test 'can get next_unpassed_progression_level when most recent level not a progression level' do
+  test 'can get next_unpassed_visible_progression_level when most recent level not a progression level' do
     user = create :user
     script = create :script
 
@@ -1040,10 +1041,10 @@ class UserTest < ActiveSupport::TestCase
 
     # User's most recent progress is on unplugged level, that is followed by another
     # unplugged level. We should end up at the first non unplugged level
-    assert_equal(4, user.next_unpassed_progression_level(script).chapter)
+    assert_equal(4, user.next_unpassed_visible_progression_level(script).chapter)
   end
 
-  test 'can get next_unpassed_progression_level when we have no progress' do
+  test 'can get next_unpassed_visible_progression_level when we have no progress' do
     user = create :user
     script = create :script
 
@@ -1053,10 +1054,10 @@ class UserTest < ActiveSupport::TestCase
 
     # User's most recent progress is on unplugged level, that is followed by another
     # unplugged level. We should end up at the first non unplugged level
-    assert_equal(1, user.next_unpassed_progression_level(script).chapter)
+    assert_equal(1, user.next_unpassed_visible_progression_level(script).chapter)
   end
 
-  test 'can get next_unpassed_progression_level when last updated user_level is inside a level group' do
+  test 'can get next_unpassed_visible_progression_level when last updated user_level is inside a level group' do
     user = create :user
     script = create :script
 
@@ -1090,7 +1091,7 @@ class UserTest < ActiveSupport::TestCase
 
     assert(user_level1.updated_at < user_level2.updated_at)
 
-    next_script_level = user.next_unpassed_progression_level(script)
+    next_script_level = user.next_unpassed_visible_progression_level(script)
     refute next_script_level.nil?
   end
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -801,14 +801,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 'tester', user.username
   end
 
-  test 'can get next_unpassed_visible_progression_level, no progress, none hidden' do
+  test 'can get next_unpassed_valid_progression_level, no progress, none hidden' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
     assert twenty_hour.script_levels.first.level.unplugged?
-    assert_equal(2, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+    assert_equal(2, user.next_unpassed_valid_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level, progress, none hidden' do
+  test 'can get next_unpassed_valid_progression_level, progress, none hidden' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
     second_script_level = twenty_hour.get_script_level_by_chapter(2)
@@ -819,10 +819,10 @@ class UserTest < ActiveSupport::TestCase
       attempts: 1,
       best_result: Activity::MINIMUM_PASS_RESULT
     )
-    assert_equal(3, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+    assert_equal(3, user.next_unpassed_valid_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level, user skips level, none hidden' do
+  test 'can get next_unpassed_valid_progression_level, user skips level, none hidden' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
     first_script_level = twenty_hour.get_script_level_by_chapter(1)
@@ -843,10 +843,10 @@ class UserTest < ActiveSupport::TestCase
       best_result: Activity::MINIMUM_PASS_RESULT
     )
 
-    assert_equal(4, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+    assert_equal(4, user.next_unpassed_valid_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level, out of order progress, none hidden' do
+  test 'can get next_unpassed_valid_progression_level, out of order progress, none hidden' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
     first_script_level = twenty_hour.get_script_level_by_chapter(1)
@@ -876,10 +876,10 @@ class UserTest < ActiveSupport::TestCase
       best_result: Activity::MINIMUM_PASS_RESULT
     )
 
-    assert_equal(4, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+    assert_equal(4, user.next_unpassed_valid_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level, completed script, none hidden' do
+  test 'can get next_unpassed_valid_progression_level, completed script, none hidden' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
 
@@ -894,10 +894,10 @@ class UserTest < ActiveSupport::TestCase
     end
     user.stubs(:completed?).returns(true)
 
-    assert_nil user.next_unpassed_visible_progression_level(twenty_hour)
+    assert_nil user.next_unpassed_valid_progression_level(twenty_hour)
   end
 
-  test 'can get next_unpassed_visible_progression_level, last level complete, but script not complete, none hidden' do
+  test 'can get next_unpassed_valid_progression_level, last level complete, but script not complete, none hidden' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
 
@@ -919,10 +919,10 @@ class UserTest < ActiveSupport::TestCase
       best_result: Activity::MINIMUM_PASS_RESULT
     )
 
-    assert_equal(4, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+    assert_equal(4, user.next_unpassed_valid_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level if not completed any unplugged levels' do
+  test 'can get next_unpassed_valid_progression_level if not completed any unplugged levels' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
     twenty_hour.script_levels.each do |script_level|
@@ -936,10 +936,10 @@ class UserTest < ActiveSupport::TestCase
         best_result: Activity::MINIMUM_PASS_RESULT
       )
     end
-    assert_equal(35, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+    assert_equal(35, user.next_unpassed_valid_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level, not tainted by other user progress' do
+  test 'can get next_unpassed_valid_progression_level, not tainted by other user progress' do
     user = create :user
     other_user = create :user
     twenty_hour = Script.twenty_hour_script
@@ -953,10 +953,10 @@ class UserTest < ActiveSupport::TestCase
         best_result: Activity::MINIMUM_PASS_RESULT
       )
     end
-    assert_equal(2, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+    assert_equal(2, user.next_unpassed_valid_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level when most recent level is not passed' do
+  test 'can get next_unpassed_valid_progression_level when most recent level is not passed' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
 
@@ -973,10 +973,10 @@ class UserTest < ActiveSupport::TestCase
 
     # The level we most recently had progress on we did not pass, so that's
     # where we should go
-    assert_equal(3, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+    assert_equal(3, user.next_unpassed_valid_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level when most recent level is last level' do
+  test 'can get next_unpassed_valid_progression_level when most recent level is last level' do
     user = create :user
     twenty_hour = Script.twenty_hour_script
 
@@ -993,10 +993,10 @@ class UserTest < ActiveSupport::TestCase
     # have not completed previous levels, so go to the first incomplete,
     # visible level.
     assert twenty_hour.script_levels.first.level.unplugged?
-    assert_equal(2, user.next_unpassed_visible_progression_level(twenty_hour).chapter)
+    assert_equal(2, user.next_unpassed_valid_progression_level(twenty_hour).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level when most recent level is only followed by unplugged levels' do
+  test 'can get next_unpassed_valid_progression_level when most recent level is only followed by unplugged levels' do
     user = create :user
     script = create :script
 
@@ -1018,10 +1018,10 @@ class UserTest < ActiveSupport::TestCase
     # User's most recent progress is on second last level of script, but none of
     # the levels after it are "progression" levels. Just return to the last level
     # we made progress on.
-    assert_equal(2, user.next_unpassed_visible_progression_level(script).chapter)
+    assert_equal(2, user.next_unpassed_valid_progression_level(script).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level when most recent level is unplugged' do
+  test 'can get next_unpassed_valid_progression_level when most recent level is unplugged' do
     user = create :user
     script = create :script
 
@@ -1043,10 +1043,10 @@ class UserTest < ActiveSupport::TestCase
 
     # User's most recent progress is on unplugged level, that is followed by another
     # unplugged level. We should end up at the first non unplugged level
-    assert_equal(1, user.next_unpassed_visible_progression_level(script).chapter)
+    assert_equal(1, user.next_unpassed_valid_progression_level(script).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level when we have no progress' do
+  test 'can get next_unpassed_valid_progression_level when we have no progress' do
     user = create :user
     script = create :script
 
@@ -1056,10 +1056,10 @@ class UserTest < ActiveSupport::TestCase
 
     # User's most recent progress is on unplugged level, that is followed by another
     # unplugged level. We should end up at the first non unplugged level
-    assert_equal(1, user.next_unpassed_visible_progression_level(script).chapter)
+    assert_equal(1, user.next_unpassed_valid_progression_level(script).chapter)
   end
 
-  test 'can get next_unpassed_visible_progression_level when last updated user_level is inside a level group' do
+  test 'can get next_unpassed_valid_progression_level when last updated user_level is inside a level group' do
     user = create :user
     script = create :script
 
@@ -1096,7 +1096,7 @@ class UserTest < ActiveSupport::TestCase
 
     assert(user_level1.updated_at < user_level2.updated_at)
 
-    next_script_level = user.next_unpassed_visible_progression_level(script)
+    next_script_level = user.next_unpassed_valid_progression_level(script)
     refute next_script_level.nil?
   end
 
@@ -3614,7 +3614,7 @@ class UserTest < ActiveSupport::TestCase
       SectionHiddenScript.create(section_id: section2.id, script_id: @script3.id)
     end
 
-    test 'can get next_unpassed_visible_progression_level, progress, hidden' do
+    test 'can get next_unpassed_valid_progression_level, progress, hidden' do
       student = create :student
       teacher = create :teacher
       twenty_hour = Script.twenty_hour_script
@@ -3639,10 +3639,10 @@ class UserTest < ActiveSupport::TestCase
       # Find the seventh stage, since the 5th is hidden and 6th is unplugged
       next_visible_stage = twenty_hour.stages.find {|stage| stage.relative_position == 7}
 
-      assert_equal(next_visible_stage.script_levels.first, student.next_unpassed_visible_progression_level(twenty_hour))
+      assert_equal(next_visible_stage.script_levels.first, student.next_unpassed_valid_progression_level(twenty_hour))
     end
 
-    test 'can get next_unpassed_visible_progression_level, last level complete, but script not complete, first hidden' do
+    test 'can get next_unpassed_valid_progression_level, last level complete, but script not complete, first hidden' do
       student = create :student
       teacher = create :teacher
       twenty_hour = Script.twenty_hour_script
@@ -3664,7 +3664,7 @@ class UserTest < ActiveSupport::TestCase
       # Find the second stage, since the 1st is hidden
       next_visible_stage = twenty_hour.stages.find {|stage| stage.relative_position == 2}
 
-      assert_equal(next_visible_stage.script_levels.first, student.next_unpassed_visible_progression_level(twenty_hour))
+      assert_equal(next_visible_stage.script_levels.first, student.next_unpassed_valid_progression_level(twenty_hour))
     end
 
     test "user in two sections, both attached to script" do


### PR DESCRIPTION
[LP-733](https://codedotorg.atlassian.net/browse/LP-733) follow up to #30664

`next_unpassed_progress_level` -> `next_unpassed_valid_progression_level` by replacing all of the uses and updating relevant test cases. 

`next_unpassed_valid_progression_level` is used to determine where to direct users when they click the orange continue button on their top assignable on the homepage or at the top of the unit overview page. 

The "rules": 
- users should never be sent to a hidden level (new behavior)
- users should never be sent a bonus level (consistent with old behavior)
- users should never be sent to an unplugged level (consistent with old behavior) 
- where to redirect is based on the most recently worked on level 
           - progress on unplugged levels is excluded (new behavior) 
           - if a level is worked on, but not passed go back to that level (consistent with old behavior)
           - completing last level progression sends user to congrats (consistent with old behavior) 

