### PR TITLE
Add i18n-dev to ssh config [ci skip]

### DIFF
--- a/cookbooks/cdo-users/templates/default/ssh_config.erb
+++ b/cookbooks/cdo-users/templates/default/ssh_config.erb
@@ -1,4 +1,4 @@
-Host staging test levelbuilder-* production-daemon production-console adhoc-* *.ec2.internal *.cdn-code.org
+Host staging test levelbuilder-* production-daemon production-console i18n-dev adhoc-* *.ec2.internal *.cdn-code.org
   User ubuntu
   StrictHostKeyChecking no
   PreferredAuthentications publickey


### PR DESCRIPTION
# Description

Missed `i18n-dev` in https://github.com/code-dot-org/code-dot-org/pull/30950

We might want to figure out a more general solution to include all instances listed in the config, but committing this now to unblock.
