### PR TITLE
Create new survey rollup UI

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -109,8 +109,8 @@ export class SurveyRollupTable extends React.Component {
           {/*Column headers*/}
           <tr>
             <th />
-            {orderedColumns.map(column => (
-              <td>{column.label}</td>
+            {orderedColumns.map((column, i) => (
+              <td key={i}>{column.label}</td>
             ))}
           </tr>
         </thead>
@@ -118,17 +118,19 @@ export class SurveyRollupTable extends React.Component {
           {/*First row is response counts*/}
           <tr>
             <td>Total responses</td>
-            {orderedColumns.map(column => (
-              <td>{this.props.rollups[column.key].response_count}</td>
+            {orderedColumns.map((column, i) => (
+              <td key={i}>{this.props.rollups[column.key].response_count}</td>
             ))}
           </tr>
 
           {/*Next rows are average scores of categories and questions*/}
-          {orderedRows.map(row => (
-            <tr>
+          {orderedRows.map((row, i) => (
+            <tr key={i}>
               <td>{row.label}</td>
-              {orderedColumns.map(column => (
-                <td>{this.props.rollups[column.key].averages[row.key]}</td>
+              {orderedColumns.map((column, j) => (
+                <td key={j}>
+                  {this.props.rollups[column.key].averages[row.key]}
+                </td>
               ))}
             </tr>
           ))}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -60,14 +60,14 @@ export class SurveyRollupTable extends React.Component {
     let label = '';
 
     if (facilitatorId) {
-      let posessiveName = `${facilitatorLookup[facilitatorId]}' ${
+      let possessiveName = `${facilitatorLookup[facilitatorId]}'${
         _.endsWith(name, 's') ? '' : 's'
       }`;
 
       if (workshopId) {
-        label = `${posessiveName} average for this workshop`;
+        label = `${possessiveName} average for this workshop`;
       } else {
-        label = `Average across all of ${posessiveName} ${courseName} workshops`;
+        label = `Average across all of ${possessiveName} ${courseName} workshops`;
       }
     } else {
       if (workshopId) {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -1,30 +1,131 @@
 import React from 'react';
 import {Table} from 'react-bootstrap';
 import PropTypes from 'prop-types';
-import {PermissionPropType} from '../../permission';
+import _ from 'lodash';
+
+const questionCategories = [
+  'facilitator_effectiveness',
+  'teacher_engagement',
+  'overall_success'
+];
 
 export class SurveyRollupTable extends React.Component {
   static propTypes = {
-    data: PropTypes.object.isRequired,
-    permission: PermissionPropType.isRequired
+    rollups: PropTypes.object.isRequired,
+    questions: PropTypes.object.isRequired,
+    facilitators: PropTypes.object.isRequired
   };
 
   constructor(props) {
     super(props);
   }
 
+  /**
+   *
+   * @param {Array} categories
+   * @param {Object} questions
+   * @returns {Array}
+   */
+  createOrderedRows(categories, questions) {
+    let orderedRows = [];
+
+    categories.forEach(category => {
+      orderedRows.push({
+        key: category,
+        label: _.startCase(category)
+      });
+
+      let question_found = false;
+      Object.keys(questions).forEach(question_name => {
+        if (question_name.startsWith(category)) {
+          question_found = true;
+          orderedRows.push({
+            key: question_name,
+            label: questions[question_name]
+          });
+        }
+      });
+
+      // Don't keep category without any questions
+      if (!question_found) {
+        orderedRows.pop();
+      }
+    });
+
+    return orderedRows;
+  }
+
+  createColumnLabel(facilitatorId, workshopId, courseName, facilitatorLookup) {
+    let label = '';
+
+    if (facilitatorId) {
+      let posessiveName = `${facilitatorLookup[facilitatorId]}' ${
+        _.endsWith(name, 's') ? '' : 's'
+      }`;
+
+      if (workshopId) {
+        label = `${posessiveName} average for this workshop`;
+      } else {
+        label = `Average across all of ${posessiveName} ${courseName} workshops`;
+      }
+    } else {
+      if (workshopId) {
+        label = `Average for this workshop`;
+      }
+    }
+
+    return label;
+  }
+
+  createOrderedColumns() {
+    return Object.keys(this.props.rollups).map(scenario_key => ({
+      key: scenario_key,
+      label:
+        this.createColumnLabel(
+          this.props.rollups[scenario_key].facilitator_id,
+          this.props.rollups[scenario_key].workshop_id,
+          this.props.rollups[scenario_key].course_name,
+          this.props.facilitators
+        ) || scenario_key.toString
+    }));
+  }
+
   render() {
+    let orderedColumns = this.createOrderedColumns();
+    let orderedRows = this.createOrderedRows(
+      questionCategories,
+      this.props.questions
+    );
+
     return (
       <Table bordered>
         <thead>
+          {/*Column headers*/}
           <tr>
-            <th>Hello</th>
+            <th />
+            {orderedColumns.map(column => (
+              <td>{column.label}</td>
+            ))}
           </tr>
         </thead>
         <tbody>
+          {/*First row is response counts*/}
           <tr>
-            <td>World</td>
+            <td>Response Count</td>
+            {orderedColumns.map(column => (
+              <td>{this.props.rollups[column.key].response_count}</td>
+            ))}
           </tr>
+
+          {/*Next rows are average scores of categories and questions*/}
+          {orderedRows.map(row => (
+            <tr>
+              <td>{row.label}</td>
+              {orderedColumns.map(column => (
+                <td>{this.props.rollups[column.key].averages[row.key]}</td>
+              ))}
+            </tr>
+          ))}
         </tbody>
       </Table>
     );

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -21,15 +21,16 @@ export class SurveyRollupTable extends React.Component {
   }
 
   /**
-   *
+   * Order rows that appear in roll-up table
    * @param {Array} categories
    * @param {Object} questions
-   * @returns {Array}
+   * @returns {Array} Array of {key, label} objects
    */
   createOrderedRows(categories, questions) {
     let orderedRows = [];
 
     categories.forEach(category => {
+      // The order is category name first, then questions in that category
       orderedRows.push({
         key: category,
         label: _.startCase(category)
@@ -46,7 +47,7 @@ export class SurveyRollupTable extends React.Component {
         }
       });
 
-      // Don't keep category without any questions
+      // Don't keep category that doesn't have any questions
       if (!question_found) {
         orderedRows.pop();
       }
@@ -77,6 +78,10 @@ export class SurveyRollupTable extends React.Component {
     return label;
   }
 
+  /**
+   * Order columns that appear in roll-up table
+   * @return {Array} Array of {key, label} objects
+   */
   createOrderedColumns() {
     return Object.keys(this.props.rollups).map(scenario_key => ({
       key: scenario_key,
@@ -92,6 +97,7 @@ export class SurveyRollupTable extends React.Component {
 
   render() {
     let orderedColumns = this.createOrderedColumns();
+
     let orderedRows = this.createOrderedRows(
       questionCategories,
       this.props.questions

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -117,7 +117,7 @@ export class SurveyRollupTable extends React.Component {
         <tbody>
           {/*First row is response counts*/}
           <tr>
-            <td>Response Count</td>
+            <td>Total responses</td>
             {orderedColumns.map(column => (
               <td>{this.props.rollups[column.key].response_count}</td>
             ))}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {Table} from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import {PermissionPropType} from '../../permission';
+
+export class SurveyRollupTable extends React.Component {
+  static propTypes = {
+    data: PropTypes.object.isRequired,
+    permission: PermissionPropType.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <Table bordered>
+        <thead>
+          <tr>
+            <th>Hello</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>World</td>
+          </tr>
+        </tbody>
+      </Table>
+    );
+  }
+}
+
+export default SurveyRollupTable;

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import SurveyRollupTable from '../../components/survey_results/survey_rollup_table';
+import reactBootstrapStoryDecorator from '../../../reactBootstrapStoryDecorator';
+
+export default storybook => {
+  storybook
+    .storiesOf('SurveyRollupTable', module)
+    .addDecorator(reactBootstrapStoryDecorator)
+    .addStoryTable([
+      {
+        name: 'Survey Rollup Table',
+        story: () => <SurveyRollupTable data={{}} />
+      }
+    ]);
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
@@ -9,17 +9,17 @@ const facilitator_rollups = {
   },
   questions: {
     facilitator_effectiveness_1494688268261028618:
-      'During my workshop, {facilitatorName} did the following: -> Demonstrated knowledge of the curriculum.',
+      'Demonstrated knowledge of the curriculum.',
     facilitator_effectiveness_9145365597108923713:
-      'During my workshop, {facilitatorName} did the following: -> Built and sustained an equitable learning environment in our workshop.',
+      'Built and sustained an equitable learning environment in our workshop.',
     facilitator_effectiveness_6627891197594983630:
-      'During my workshop, {facilitatorName} did the following: -> Kept the workshop and participants on track.',
+      'Kept the workshop and participants on track.',
     facilitator_effectiveness_10623511283632440781:
-      'During my workshop, {facilitatorName} did the following: -> Supported productive workshop discussions.',
+      'Supported productive workshop discussions.',
     facilitator_effectiveness_8015784983354522873:
-      'During my workshop, {facilitatorName} did the following: -> Helped me see ways to create and support an equitable learning environment for my students.',
+      'Helped me see ways to create and support an equitable learning environment for my students.',
     facilitator_effectiveness_16129913079128962044:
-      'During my workshop, {facilitatorName} did the following: -> Demonstrated a healthy working relationship with their co-facilitator (if applicable).'
+      'Demonstrated a healthy working relationship with their co-facilitator (if applicable).'
   },
   rollups: {
     facilitator_1124_single_ws: {
@@ -80,23 +80,23 @@ const workshop_rollups = {
   },
   questions: {
     overall_success_2136245491560413670:
-      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e I feel more prepared to teach the material covered in this workshop than before I came.',
+      'I feel more prepared to teach the material covered in this workshop than before I came.',
     overall_success_9121793211174253549:
-      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e I know where to go if I need help preparing to teach this material.',
+      'I know where to go if I need help preparing to teach this material.',
     overall_success_5502876428019550646:
-      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e This professional development was suitable for my level of experience with teaching CS.',
+      'This professional development was suitable for my level of experience with teaching CS.',
     overall_success_3964718812856239438:
-      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e I feel connected to a community of computer science teachers.',
+      'I feel connected to a community of computer science teachers.',
     overall_success_6174705123632039779:
-      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e I would recommend this professional development to others',
+      'I would recommend this professional development to others',
     teacher_engagement_8809902359007963123:
-      'How much do you agree or disagree with the following statements about your level of engagement in the workshop? -\u003e I found the activities we did in this workshop interesting and engaging.',
+      'I found the activities we did in this workshop interesting and engaging.',
     teacher_engagement_12316562461560038168:
-      'How much do you agree or disagree with the following statements about your level of engagement in the workshop? -\u003e I was highly active and participated a lot in the workshop activities.',
+      'I was highly active and participated a lot in the workshop activities.',
     teacher_engagement_8566597854585674670:
-      "How much do you agree or disagree with the following statements about your level of engagement in the workshop? -\u003e When I'm not in Code.org workshops, I frequently talk about ideas or content from the workshop with others.",
+      'I frequently talk about ideas or content from the workshop with others.',
     teacher_engagement_12383077849665641424:
-      'How much do you agree or disagree with the following statements about your level of engagement in the workshop? -\u003e I am definitely planning to make use of ideas and content covered in this workshop in my classroom.'
+      'I am planning to make use of ideas and content covered in this workshop in my classroom.'
   },
   rollups: {
     this_ws: {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
@@ -164,7 +164,6 @@ export default storybook => {
         name: 'Facilitator Rollup Table',
         story: () => (
           <SurveyRollupTable
-            key={1}
             rollups={facilitator_rollups.rollups}
             questions={facilitator_rollups.questions}
             facilitators={facilitator_rollups.facilitators}
@@ -175,7 +174,6 @@ export default storybook => {
         name: 'Workshop Rollup Table',
         story: () => (
           <SurveyRollupTable
-            key={2}
             rollups={workshop_rollups.rollups}
             questions={workshop_rollups.questions}
             facilitators={workshop_rollups.facilitators}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
@@ -169,9 +169,7 @@ export default storybook => {
             facilitators={facilitator_rollups.facilitators}
           />
         )
-      }
-    ])
-    .addStoryTable([
+      },
       {
         name: 'Workshop Rollup Table',
         story: () => (

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
@@ -4,69 +4,68 @@ import reactBootstrapStoryDecorator from '../../../reactBootstrapStoryDecorator'
 
 const facilitator_rollups = {
   facilitators: {
-    '1124': 'Facilitator Person 1',
-    '1125': 'Facilitator Person 2'
+    '1': 'Facilitator Person 1',
+    '2': 'Facilitator Person 2'
   },
   questions: {
-    facilitator_effectiveness_1494688268261028618:
-      'Demonstrated knowledge of the curriculum.',
-    facilitator_effectiveness_9145365597108923713:
+    facilitator_effectiveness_0: 'Demonstrated knowledge of the curriculum.',
+    facilitator_effectiveness_1:
       'Built and sustained an equitable learning environment in our workshop.',
-    facilitator_effectiveness_6627891197594983630:
-      'Kept the workshop and participants on track.',
-    facilitator_effectiveness_10623511283632440781:
-      'Supported productive workshop discussions.',
-    facilitator_effectiveness_8015784983354522873:
+    facilitator_effectiveness_2: 'Kept the workshop and participants on track.',
+    facilitator_effectiveness_3: 'Supported productive workshop discussions.',
+    facilitator_effectiveness_4:
       'Helped me see ways to create and support an equitable learning environment for my students.',
-    facilitator_effectiveness_16129913079128962044:
+    facilitator_effectiveness_5:
       'Demonstrated a healthy working relationship with their co-facilitator (if applicable).'
   },
   rollups: {
-    facilitator_1124_single_ws: {
-      facilitator_id: 1124,
-      workshop_id: 347,
+    facilitator_1_single_ws: {
+      facilitator_id: 1,
+      workshop_id: 1,
       response_count: 1,
       averages: {
-        facilitator_effectiveness_1494688268261028618: 1.0,
-        facilitator_effectiveness_6627891197594983630: 4.0,
-        facilitator_effectiveness_8015784983354522873: 3.0,
-        facilitator_effectiveness_16129913079128962044: 1.0,
+        facilitator_effectiveness_0: 1.0,
+        facilitator_effectiveness_2: 4.0,
+        facilitator_effectiveness_4: 3.0,
+        facilitator_effectiveness_5: 1.0,
         facilitator_effectiveness: 2.25
       }
     },
-    facilitator_1124_all_ws: {
-      facilitator_id: 1124,
-      all_workshop_ids: [347],
+    facilitator_1_all_ws: {
+      facilitator_id: 1,
+      all_workshop_ids: [1],
+      course_name: 'CS Principles',
       response_count: 1,
       averages: {
-        facilitator_effectiveness_1494688268261028618: 1.0,
-        facilitator_effectiveness_6627891197594983630: 4.0,
-        facilitator_effectiveness_8015784983354522873: 3.0,
-        facilitator_effectiveness_16129913079128962044: 1.0,
+        facilitator_effectiveness_0: 1.0,
+        facilitator_effectiveness_2: 4.0,
+        facilitator_effectiveness_4: 3.0,
+        facilitator_effectiveness_5: 1.0,
         facilitator_effectiveness: 2.25
       }
     },
-    facilitator_1125_single_ws: {
-      facilitator_id: 1125,
-      workshop_id: 347,
+    facilitator_2_single_ws: {
+      facilitator_id: 2,
+      workshop_id: 1,
       response_count: 1,
       averages: {
-        facilitator_effectiveness_1494688268261028618: 1.0,
-        facilitator_effectiveness_6627891197594983630: 4.0,
-        facilitator_effectiveness_8015784983354522873: 3.0,
-        facilitator_effectiveness_16129913079128962044: 1.0,
+        facilitator_effectiveness_0: 1.0,
+        facilitator_effectiveness_2: 4.0,
+        facilitator_effectiveness_4: 3.0,
+        facilitator_effectiveness_5: 1.0,
         facilitator_effectiveness: 2.25
       }
     },
-    facilitator_1125_all_ws: {
-      facilitator_id: 1125,
-      all_workshop_ids: [347],
+    facilitator_2_all_ws: {
+      facilitator_id: 2,
+      all_workshop_ids: [1],
+      course_name: 'CS Principles',
       response_count: 1,
       averages: {
-        facilitator_effectiveness_1494688268261028618: 1.0,
-        facilitator_effectiveness_6627891197594983630: 4.0,
-        facilitator_effectiveness_8015784983354522873: 3.0,
-        facilitator_effectiveness_16129913079128962044: 1.0,
+        facilitator_effectiveness_0: 1.0,
+        facilitator_effectiveness_2: 4.0,
+        facilitator_effectiveness_4: 3.0,
+        facilitator_effectiveness_5: 1.0,
         facilitator_effectiveness: 2.25
       }
     }
@@ -75,79 +74,81 @@ const facilitator_rollups = {
 
 const workshop_rollups = {
   facilitators: {
-    '1124': 'Facilitator Person 1',
-    '1125': 'Facilitator Person 2'
+    '1': 'Facilitator Person 1',
+    '2': 'Facilitator Person 2'
   },
   questions: {
-    overall_success_2136245491560413670:
+    overall_success_0:
       'I feel more prepared to teach the material covered in this workshop than before I came.',
-    overall_success_9121793211174253549:
+    overall_success_1:
       'I know where to go if I need help preparing to teach this material.',
-    overall_success_5502876428019550646:
+    overall_success_2:
       'This professional development was suitable for my level of experience with teaching CS.',
-    overall_success_3964718812856239438:
+    overall_success_3:
       'I feel connected to a community of computer science teachers.',
-    overall_success_6174705123632039779:
+    overall_success_4:
       'I would recommend this professional development to others',
-    teacher_engagement_8809902359007963123:
+    teacher_engagement_0:
       'I found the activities we did in this workshop interesting and engaging.',
-    teacher_engagement_12316562461560038168:
+    teacher_engagement_1:
       'I was highly active and participated a lot in the workshop activities.',
-    teacher_engagement_8566597854585674670:
+    teacher_engagement_2:
       'I frequently talk about ideas or content from the workshop with others.',
-    teacher_engagement_12383077849665641424:
+    teacher_engagement_3:
       'I am planning to make use of ideas and content covered in this workshop in my classroom.'
   },
   rollups: {
     this_ws: {
-      workshop_id: 347,
+      workshop_id: 1,
       response_count: 1,
       averages: {
-        overall_success_2136245491560413670: 6.0,
-        overall_success_9121793211174253549: 7.0,
-        overall_success_5502876428019550646: 6.0,
-        overall_success_3964718812856239438: 6.0,
-        overall_success_6174705123632039779: 7.0,
-        teacher_engagement_8809902359007963123: 7.0,
-        teacher_engagement_12316562461560038168: 6.0,
-        teacher_engagement_8566597854585674670: 6.0,
-        teacher_engagement_12383077849665641424: 7.0,
+        overall_success_0: 6.0,
+        overall_success_1: 7.0,
+        overall_success_2: 6.0,
+        overall_success_3: 6.0,
+        overall_success_4: 7.0,
+        teacher_engagement_0: 7.0,
+        teacher_engagement_1: 6.0,
+        teacher_engagement_2: 6.0,
+        teacher_engagement_3: 7.0,
         overall_success: 6.4,
         teacher_engagement: 6.5
       }
     },
-    facilitator_1124_all_ws: {
-      facilitator_id: 1124,
-      all_workshop_ids: [347],
+    facilitator_1_all_ws: {
+      facilitator_id: 1,
+      all_workshop_ids: [1],
+      course_name: 'CS Principles',
       response_count: 1,
       averages: {
-        overall_success_2136245491560413670: 6.0,
-        overall_success_9121793211174253549: 7.0,
-        overall_success_5502876428019550646: 6.0,
-        overall_success_3964718812856239438: 6.0,
-        overall_success_6174705123632039779: 7.0,
-        teacher_engagement_8809902359007963123: 7.0,
-        teacher_engagement_12316562461560038168: 6.0,
-        teacher_engagement_8566597854585674670: 6.0,
-        teacher_engagement_12383077849665641424: 7.0,
+        overall_success_0: 6.0,
+        overall_success_1: 7.0,
+        overall_success_2: 6.0,
+        overall_success_3: 6.0,
+        overall_success_4: 7.0,
+        teacher_engagement_0: 7.0,
+        teacher_engagement_1: 6.0,
+        teacher_engagement_2: 6.0,
+        teacher_engagement_3: 7.0,
         overall_success: 6.4,
         teacher_engagement: 6.5
       }
     },
-    facilitator_1125_all_ws: {
-      facilitator_id: 1125,
-      all_workshop_ids: [347],
+    facilitator_2_all_ws: {
+      facilitator_id: 2,
+      all_workshop_ids: [1],
+      course_name: 'CS Principles',
       response_count: 1,
       averages: {
-        overall_success_2136245491560413670: 6.0,
-        overall_success_9121793211174253549: 7.0,
-        overall_success_5502876428019550646: 6.0,
-        overall_success_3964718812856239438: 6.0,
-        overall_success_6174705123632039779: 7.0,
-        teacher_engagement_8809902359007963123: 7.0,
-        teacher_engagement_12316562461560038168: 6.0,
-        teacher_engagement_8566597854585674670: 6.0,
-        teacher_engagement_12383077849665641424: 7.0,
+        overall_success_0: 6.0,
+        overall_success_1: 7.0,
+        overall_success_2: 6.0,
+        overall_success_3: 6.0,
+        overall_success_4: 7.0,
+        teacher_engagement_0: 7.0,
+        teacher_engagement_1: 6.0,
+        teacher_engagement_2: 6.0,
+        teacher_engagement_3: 7.0,
         overall_success: 6.4,
         teacher_engagement: 6.5
       }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
@@ -2,14 +2,185 @@ import React from 'react';
 import SurveyRollupTable from '../../components/survey_results/survey_rollup_table';
 import reactBootstrapStoryDecorator from '../../../reactBootstrapStoryDecorator';
 
+const facilitator_rollups = {
+  facilitators: {
+    '1124': 'Facilitator Person 1',
+    '1125': 'Facilitator Person 2'
+  },
+  questions: {
+    facilitator_effectiveness_1494688268261028618:
+      'During my workshop, {facilitatorName} did the following: -> Demonstrated knowledge of the curriculum.',
+    facilitator_effectiveness_9145365597108923713:
+      'During my workshop, {facilitatorName} did the following: -> Built and sustained an equitable learning environment in our workshop.',
+    facilitator_effectiveness_6627891197594983630:
+      'During my workshop, {facilitatorName} did the following: -> Kept the workshop and participants on track.',
+    facilitator_effectiveness_10623511283632440781:
+      'During my workshop, {facilitatorName} did the following: -> Supported productive workshop discussions.',
+    facilitator_effectiveness_8015784983354522873:
+      'During my workshop, {facilitatorName} did the following: -> Helped me see ways to create and support an equitable learning environment for my students.',
+    facilitator_effectiveness_16129913079128962044:
+      'During my workshop, {facilitatorName} did the following: -> Demonstrated a healthy working relationship with their co-facilitator (if applicable).'
+  },
+  rollups: {
+    facilitator_1124_single_ws: {
+      facilitator_id: 1124,
+      workshop_id: 347,
+      response_count: 1,
+      averages: {
+        facilitator_effectiveness_1494688268261028618: 1.0,
+        facilitator_effectiveness_6627891197594983630: 4.0,
+        facilitator_effectiveness_8015784983354522873: 3.0,
+        facilitator_effectiveness_16129913079128962044: 1.0,
+        facilitator_effectiveness: 2.25
+      }
+    },
+    facilitator_1124_all_ws: {
+      facilitator_id: 1124,
+      all_workshop_ids: [347],
+      response_count: 1,
+      averages: {
+        facilitator_effectiveness_1494688268261028618: 1.0,
+        facilitator_effectiveness_6627891197594983630: 4.0,
+        facilitator_effectiveness_8015784983354522873: 3.0,
+        facilitator_effectiveness_16129913079128962044: 1.0,
+        facilitator_effectiveness: 2.25
+      }
+    },
+    facilitator_1125_single_ws: {
+      facilitator_id: 1125,
+      workshop_id: 347,
+      response_count: 1,
+      averages: {
+        facilitator_effectiveness_1494688268261028618: 1.0,
+        facilitator_effectiveness_6627891197594983630: 4.0,
+        facilitator_effectiveness_8015784983354522873: 3.0,
+        facilitator_effectiveness_16129913079128962044: 1.0,
+        facilitator_effectiveness: 2.25
+      }
+    },
+    facilitator_1125_all_ws: {
+      facilitator_id: 1125,
+      all_workshop_ids: [347],
+      response_count: 1,
+      averages: {
+        facilitator_effectiveness_1494688268261028618: 1.0,
+        facilitator_effectiveness_6627891197594983630: 4.0,
+        facilitator_effectiveness_8015784983354522873: 3.0,
+        facilitator_effectiveness_16129913079128962044: 1.0,
+        facilitator_effectiveness: 2.25
+      }
+    }
+  }
+};
+
+const workshop_rollups = {
+  facilitators: {
+    '1124': 'Facilitator Person 1',
+    '1125': 'Facilitator Person 2'
+  },
+  questions: {
+    overall_success_2136245491560413670:
+      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e I feel more prepared to teach the material covered in this workshop than before I came.',
+    overall_success_9121793211174253549:
+      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e I know where to go if I need help preparing to teach this material.',
+    overall_success_5502876428019550646:
+      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e This professional development was suitable for my level of experience with teaching CS.',
+    overall_success_3964718812856239438:
+      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e I feel connected to a community of computer science teachers.',
+    overall_success_6174705123632039779:
+      'How much do you agree or disagree with the following statements about the workshop overall? -\u003e I would recommend this professional development to others',
+    teacher_engagement_8809902359007963123:
+      'How much do you agree or disagree with the following statements about your level of engagement in the workshop? -\u003e I found the activities we did in this workshop interesting and engaging.',
+    teacher_engagement_12316562461560038168:
+      'How much do you agree or disagree with the following statements about your level of engagement in the workshop? -\u003e I was highly active and participated a lot in the workshop activities.',
+    teacher_engagement_8566597854585674670:
+      "How much do you agree or disagree with the following statements about your level of engagement in the workshop? -\u003e When I'm not in Code.org workshops, I frequently talk about ideas or content from the workshop with others.",
+    teacher_engagement_12383077849665641424:
+      'How much do you agree or disagree with the following statements about your level of engagement in the workshop? -\u003e I am definitely planning to make use of ideas and content covered in this workshop in my classroom.'
+  },
+  rollups: {
+    this_ws: {
+      workshop_id: 347,
+      response_count: 1,
+      averages: {
+        overall_success_2136245491560413670: 6.0,
+        overall_success_9121793211174253549: 7.0,
+        overall_success_5502876428019550646: 6.0,
+        overall_success_3964718812856239438: 6.0,
+        overall_success_6174705123632039779: 7.0,
+        teacher_engagement_8809902359007963123: 7.0,
+        teacher_engagement_12316562461560038168: 6.0,
+        teacher_engagement_8566597854585674670: 6.0,
+        teacher_engagement_12383077849665641424: 7.0,
+        overall_success: 6.4,
+        teacher_engagement: 6.5
+      }
+    },
+    facilitator_1124_all_ws: {
+      facilitator_id: 1124,
+      all_workshop_ids: [347],
+      response_count: 1,
+      averages: {
+        overall_success_2136245491560413670: 6.0,
+        overall_success_9121793211174253549: 7.0,
+        overall_success_5502876428019550646: 6.0,
+        overall_success_3964718812856239438: 6.0,
+        overall_success_6174705123632039779: 7.0,
+        teacher_engagement_8809902359007963123: 7.0,
+        teacher_engagement_12316562461560038168: 6.0,
+        teacher_engagement_8566597854585674670: 6.0,
+        teacher_engagement_12383077849665641424: 7.0,
+        overall_success: 6.4,
+        teacher_engagement: 6.5
+      }
+    },
+    facilitator_1125_all_ws: {
+      facilitator_id: 1125,
+      all_workshop_ids: [347],
+      response_count: 1,
+      averages: {
+        overall_success_2136245491560413670: 6.0,
+        overall_success_9121793211174253549: 7.0,
+        overall_success_5502876428019550646: 6.0,
+        overall_success_3964718812856239438: 6.0,
+        overall_success_6174705123632039779: 7.0,
+        teacher_engagement_8809902359007963123: 7.0,
+        teacher_engagement_12316562461560038168: 6.0,
+        teacher_engagement_8566597854585674670: 6.0,
+        teacher_engagement_12383077849665641424: 7.0,
+        overall_success: 6.4,
+        teacher_engagement: 6.5
+      }
+    }
+  }
+};
+
 export default storybook => {
   storybook
     .storiesOf('SurveyRollupTable', module)
     .addDecorator(reactBootstrapStoryDecorator)
     .addStoryTable([
       {
-        name: 'Survey Rollup Table',
-        story: () => <SurveyRollupTable data={{}} />
+        name: 'Facilitator Rollup Table',
+        story: () => (
+          <SurveyRollupTable
+            rollups={facilitator_rollups.rollups}
+            questions={facilitator_rollups.questions}
+            facilitators={facilitator_rollups.facilitators}
+          />
+        )
+      }
+    ])
+    .addStoryTable([
+      {
+        name: 'Workshop Rollup Table',
+        story: () => (
+          <SurveyRollupTable
+            rollups={workshop_rollups.rollups}
+            questions={workshop_rollups.questions}
+            facilitators={workshop_rollups.facilitators}
+          />
+        )
       }
     ]);
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
@@ -164,6 +164,7 @@ export default storybook => {
         name: 'Facilitator Rollup Table',
         story: () => (
           <SurveyRollupTable
+            key={1}
             rollups={facilitator_rollups.rollups}
             questions={facilitator_rollups.questions}
             facilitators={facilitator_rollups.facilitators}
@@ -174,6 +175,7 @@ export default storybook => {
         name: 'Workshop Rollup Table',
         story: () => (
           <SurveyRollupTable
+            key={2}
             rollups={workshop_rollups.rollups}
             questions={workshop_rollups.questions}
             facilitators={workshop_rollups.facilitators}

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -146,20 +146,29 @@ export default class Results extends React.Component {
   }
 
   renderSurveyRollups() {
+    // TODO: display tab only when data is available
     return [
       <Tab
         eventKey={this.props.sessions.length + 1}
         key={1}
         title="Workshop Rollups"
       >
-        <SurveyRollupTable data={this.props.workshopRollups} />
+        <SurveyRollupTable
+          rollups={this.props.workshopRollups.rollups}
+          questions={this.props.workshopRollups.questions}
+          facilitators={this.props.workshopRollups.facilitators}
+        />
       </Tab>,
       <Tab
         eventKey={this.props.sessions.length + 2}
         key={2}
         title="Facilitator Rollups"
       >
-        <SurveyRollupTable data={this.props.facilitatorRollups} />
+        <SurveyRollupTable
+          rollups={this.props.facilitatorRollups.rollups}
+          questions={this.props.facilitatorRollups.questions}
+          facilitators={this.props.facilitatorRollups.facilitators}
+        />
       </Tab>
     ];
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Tab, Tabs} from 'react-bootstrap';
 import ChoiceResponses from '../../components/survey_results/choice_responses';
+import SurveyRollupTable from '../../components/survey_results/survey_rollup_table';
 import FacilitatorAveragesTable from '../../components/survey_results/facilitator_averages_table';
 import TextResponses from '../../components/survey_results/text_responses';
 import _ from 'lodash';
@@ -150,12 +151,16 @@ export default class Results extends React.Component {
         eventKey={this.props.sessions.length + 1}
         key={1}
         title="Workshop Rollups"
-      />,
+      >
+        <SurveyRollupTable data={this.props.workshopRollups} />
+      </Tab>,
       <Tab
         eventKey={this.props.sessions.length + 2}
         key={2}
         title="Facilitator Rollups"
-      />
+      >
+        <SurveyRollupTable data={this.props.facilitatorRollups} />
+      </Tab>
     ];
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -146,31 +146,44 @@ export default class Results extends React.Component {
   }
 
   renderSurveyRollups() {
-    // TODO: display tab only when data is available
-    return [
-      <Tab
-        eventKey={this.props.sessions.length + 1}
-        key={1}
-        title="Workshop Rollups"
-      >
-        <SurveyRollupTable
-          rollups={this.props.workshopRollups.rollups}
-          questions={this.props.workshopRollups.questions}
-          facilitators={this.props.workshopRollups.facilitators}
-        />
-      </Tab>,
-      <Tab
-        eventKey={this.props.sessions.length + 2}
-        key={2}
-        title="Facilitator Rollups"
-      >
-        <SurveyRollupTable
-          rollups={this.props.facilitatorRollups.rollups}
-          questions={this.props.facilitatorRollups.questions}
-          facilitators={this.props.facilitatorRollups.facilitators}
-        />
-      </Tab>
-    ];
+    let tabs = [];
+    let key = 0;
+
+    if (this.props.workshopRollups) {
+      key += 1;
+      tabs.push(
+        <Tab
+          eventKey={this.props.sessions.length + key}
+          key={key}
+          title="Workshop Rollups"
+        >
+          <SurveyRollupTable
+            rollups={this.props.workshopRollups.rollups}
+            questions={this.props.workshopRollups.questions}
+            facilitators={this.props.workshopRollups.facilitators}
+          />
+        </Tab>
+      );
+    }
+
+    if (this.props.facilitatorRollups) {
+      key += 1;
+      tabs.push(
+        <Tab
+          eventKey={this.props.sessions.length + key}
+          key={key}
+          title="Facilitator Rollups"
+        >
+          <SurveyRollupTable
+            rollups={this.props.facilitatorRollups.rollups}
+            questions={this.props.facilitatorRollups.questions}
+            facilitators={this.props.facilitatorRollups.facilitators}
+          />
+        </Tab>
+      );
+    }
+
+    return tabs;
   }
 
   render() {

--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator_experiment.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator_experiment.rb
@@ -63,7 +63,8 @@ module Pd::SurveyPipeline
         averages: get_averages_all_ws(data),
         response_count: get_submission_count_all_ws(data),
         facilitator_id: facilitator_id,
-        all_workshop_ids: data[:related_workshop_ids]
+        all_workshop_ids: data[:related_workshop_ids],
+        course_name: Pd::Workshop.find(data[:current_workshop_id]).course
       }
 
       report


### PR DESCRIPTION
# Description

Continue from https://github.com/code-dot-org/code-dot-org/pull/30975, this PR adds new UI component that consumes data returned by experiment API. Any change to make the UI looks better will be in another PR.

**_Facilitator roll-up tab_**
![Screen Shot 2019-09-30 at 9 47 52 AM](https://user-images.githubusercontent.com/46507039/65898908-6b216c80-e367-11e9-8547-da56991f8874.png)

**_Workshop roll-up tab_**
![Screen Shot 2019-09-30 at 9 47 40 AM](https://user-images.githubusercontent.com/46507039/65898930-75436b00-e367-11e9-9a1f-71168f25e5a2.png)


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLC-318)
- [spec](https://docs.google.com/spreadsheets/d/1IU0vXpznNmd8J1F4_MdgUX_VIYT0tx6F6_lSXWpbX4o/edit?pli=1#gid=0)

## Testing story
- Use Storybook for local test.
- Use adhoc machine for testing with real production data.
  - Academic year workshops
    - https://adhoc-ha-adhoc-studio.cdn-code.org/pd/workshop_dashboard/daily_survey_results/6858
    - https://adhoc-ha-adhoc-studio.cdn-code.org/pd/workshop_dashboard/daily_survey_results/7219
  - 5-day Summer workshops
     - https://adhoc-ha-adhoc-studio.cdn-code.org/pd/workshop_dashboard/daily_survey_results/5420
    - https://adhoc-ha-adhoc-studio.cdn-code.org/pd/workshop_dashboard/daily_survey_results/5988
   - CSF Deep Dive workshops
      - https://adhoc-ha-adhoc-studio.cdn-code.org/pd/workshop_dashboard/daily_survey_results/7775
      - https://adhoc-ha-adhoc-studio.cdn-code.org/pd/workshop_dashboard/daily_survey_results/7652
  - Notes
     - You may need to create an account on the adhoc. Let me know if you need admin permission.
     - Append `?enableExperiments=rollupSurveyReport` to URL to see the new UI. Add `?disableExperiments=rollupSurveyReport` to go back to the old UI.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
