### PR TITLE
remove the User.user_level_for helper, replace it with plain rails

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -317,7 +317,11 @@ class ScriptLevelsController < ApplicationController
       readonly_view_options
     elsif @user && current_user && @user != current_user
       # load other user's solution for teachers viewing their students' solution
-      @user_level = @user.user_level_for(@script_level, @level)
+      @user_level = UserLevel.find_by(
+        user: @user,
+        script: @script_level.script,
+        level: @level
+      )
       level_source = @user_level.try(:level_source)
       readonly_view_options
     elsif current_user
@@ -325,7 +329,11 @@ class ScriptLevelsController < ApplicationController
       @last_activity = current_user.last_attempt(@level, @script)
       level_source = @last_activity.try(:level_source)
 
-      user_level = current_user.user_level_for(@script_level, @level)
+      user_level = UserLevel.find_by(
+        user: current_user,
+        script: @script_level.script,
+        level: @level
+      )
       if user_level && user_level.submitted?
         level_view_options(
           @level.id,

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -168,7 +168,11 @@ ruby
       # anonymity.
       results = section.students.map do |student|
         # Skip student if they haven't submitted for this LevelGroup.
-        user_level = student.user_level_for(script_level, script_level.level)
+        user_level = UserLevel.find_by(
+          user: student,
+          script: script_level.script,
+          level: script_level.level
+        )
         next unless user_level.try(:submitted)
 
         get_sublevel_result(sublevel, student.last_attempt(sublevel).try(:level_source).try(:data))

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -205,7 +205,11 @@ class ScriptLevel < ActiveRecord::Base
     # in the stage, which is an assessment. Thus, to answer the question of
     # whether the nth level is locked, we must look at the last level
     last_script_level = stage.script_levels.last
-    user_level = user.user_level_for(last_script_level, last_script_level.oldest_active_level)
+    user_level = UserLevel.find_by(
+      user: user,
+      script: last_script_level.script,
+      level: last_script_level.oldest_active_level
+    )
     # There will initially be no user_level for the assessment level, at which
     # point it is considered locked. As soon as it gets unlocked, we will always
     # have a user_level

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1024,13 +1024,6 @@ class User < ActiveRecord::Base
     user_levels.where(script: stage.script, level: levels).pluck(:level_id, :best_result).to_h
   end
 
-  def user_level_for(script_level, level)
-    user_levels.find_by(
-      script_id: script_level.script_id,
-      level_id: level.id
-    )
-  end
-
   def has_activity?
     user_levels.attempted.exists?
   end

--- a/dashboard/app/views/levels/_level_group.haml
+++ b/dashboard/app/views/levels/_level_group.haml
@@ -10,7 +10,8 @@
 - current_page = params[:puzzle_page] || 1
 
 -# Is this a survey where we've already submitted
-- submitted_survey = @script_level.try(:anonymous?) && current_user && current_user.user_level_for(@script_level, @level).try(:submitted?)
+- user_level = UserLevel.find_by(user: current_user, script: @script_level.script, level: @level)
+- submitted_survey = @script_level.try(:anonymous?) && current_user && user_level.try(:submitted?)
 
 .level-group
   - @pages.each do |page|

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -885,19 +885,17 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     sign_in @teacher
 
     fake_last_attempt = 'STUDENT_LAST_ATTEMPT_SOURCE'
-    User.any_instance.
-      expects(:user_level_for).
-      returns(
-        create(:user_level,
-          user: @student,
-          level_source: create(:level_source, data: fake_last_attempt)
-        )
-      )
 
     user_storage_id = storage_id_for_user_id(@student.id)
 
     level = create :applab
     script_level = create :script_level, levels: [level]
+    create(:user_level,
+      user: @student,
+      script: script_level.script,
+      level: script_level.level,
+      level_source: create(:level_source, data: fake_last_attempt)
+    )
 
     create :channel_token, level: level, storage_id: user_storage_id
 
@@ -918,19 +916,17 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     sign_in @project_validator
 
     fake_last_attempt = 'STUDENT_LAST_ATTEMPT_SOURCE'
-    User.any_instance.
-      expects(:user_level_for).
-      returns(
-        create(:user_level,
-          user: @student,
-          level_source: create(:level_source, data: fake_last_attempt)
-        )
-      )
 
     user_storage_id = storage_id_for_user_id(@student.id)
 
     level = create :applab
     script_level = create :script_level, levels: [level]
+    create(:user_level,
+      user: @student,
+      script: script_level.script,
+      level: script_level.level,
+      level_source: create(:level_source, data: fake_last_attempt)
+    )
 
     create :channel_token, level: level, storage_id: user_storage_id
 
@@ -954,17 +950,15 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     user_storage_id = storage_id_for_user_id(other_student.id)
 
     fake_last_attempt = 'STUDENT_LAST_ATTEMPT_SOURCE'
-    User.any_instance.
-      expects(:user_level_for).
-      returns(
-        create(:user_level,
-          user: other_student,
-          level_source: create(:level_source, data: fake_last_attempt)
-        )
-      )
 
     level = create :applab
     script_level = create :script_level, levels: [level]
+    create(:user_level,
+      user: @student,
+      script: script_level.script,
+      level: script_level.level,
+      level_source: create(:level_source, data: fake_last_attempt)
+    )
 
     create :channel_token, level: level, storage_id: user_storage_id
 
@@ -985,17 +979,15 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     sign_in @teacher
 
     fake_last_attempt = 'STUDENT_LAST_ATTEMPT_SOURCE'
-    User.any_instance.
-      expects(:user_level_for).
-      returns(
-        create(:user_level,
-          user: @student,
-          level_source: create(:level_source, data: fake_last_attempt)
-        )
-      )
 
     level = create :applab
     script_level = create :script_level, levels: [level]
+    create(:user_level,
+      user: @student,
+      script: script_level.script,
+      level: script_level.level,
+      level_source: create(:level_source, data: fake_last_attempt)
+    )
 
     get :show, params: {
       script_id: script_level.script,


### PR DESCRIPTION
# Description

The current helper method `User.user_level_for` doesn't actually encapsulate any special logic, instead just providing some mild syntactic sugar for a pretty standard ActiveRecord method call. I'm torn about whether or not this is a useful kind of helper to have. On the one hand, using standard ActiveRecord syntax every time we want to retrieve this kind of data is undeniably more verbose. On the other hand, it doesn't seem unreasonably so and by using standard methods our functionality is more explicit.

How do folks feel about this change? Is it a good direction for us to move in, or is the simplicity for clarity tradeoff here not worth it?

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-714)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
