### PR TITLE
extract 'should see inline answer' logic from user model into standalone policy object

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -816,7 +816,7 @@ module LevelsHelper
   # Should the multi calling on this helper function include answers to be rendered into the client?
   # Caller indicates whether the level is standalone or not.
   def include_multi_answers?(standalone)
-    standalone || current_user.try(:should_see_inline_answer?, @script_level)
+    standalone || Policies::InlineAnswer.visible?(current_user, @script_level)
   end
 
   # Finds the existing LevelSourceImage corresponding to the specified level

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2009,15 +2009,6 @@ class User < ActiveRecord::Base
     TERMS_OF_SERVICE_VERSIONS.last
   end
 
-  def should_see_inline_answer?(script_level)
-    return true if Rails.application.config.levelbuilder_mode
-
-    script = script_level.try(:script)
-
-    (authorized_teacher? && script && !script.professional_learning_course?) ||
-      (script_level && UserLevel.find_by(user: self, level: script_level.level).try(:readonly_answers))
-  end
-
   def show_census_teacher_banner?
     # Must have an NCES school to show the banner
     users_school = try(:school_info).try(:school)

--- a/dashboard/app/views/levels/_level_group.haml
+++ b/dashboard/app/views/levels/_level_group.haml
@@ -44,7 +44,7 @@
           = render partial: 'levels/single_multi', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt, tight_layout: true}
         - elsif level_class == "text_match"
           -# For students (or teachers doing PD), clear out all answers.
-          - unless current_user.try(:should_see_inline_answer?, @script_level)
+          - unless Policies::InlineAnswer.visible?(current_user, @script_level)
             - level.properties['answers'] = nil
           = render partial: 'levels/single_text_match', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt }
         - elsif level_class == "free_response"

--- a/dashboard/app/views/levels/_match_answer.html.haml
+++ b/dashboard/app/views/levels/_match_answer.html.haml
@@ -1,5 +1,5 @@
 / Show the correct answer to authorized teachers
-- if current_user.try(:should_see_inline_answer?, @script_level)
+- if Policies::InlineAnswer.visible?(current_user, @script_level)
   #markdown.teacher.hide-as-student
     %h3= t('teacher.answer')
     .content

--- a/dashboard/app/views/levels/_multi_answer.html.haml
+++ b/dashboard/app/views/levels/_multi_answer.html.haml
@@ -1,5 +1,5 @@
 / Show the correct answer to authorized teachers
-- if current_user.try(:should_see_inline_answer?, @script_level)
+- if Policies::InlineAnswer.visible?(current_user, @script_level)
   - correct_answers = data['answers'].each_with_index.map do |answer, index|
     - next unless answer['correct']
     - letter = standalone ? nil : Multi.value_to_letter(index)

--- a/dashboard/lib/policies/inline_answer.rb
+++ b/dashboard/lib/policies/inline_answer.rb
@@ -1,14 +1,23 @@
+# This class contains policies relating to our "teachers can view levels with
+# the answers included" feature
 class Policies::InlineAnswer
+  # Returns a boolean indicating whether or not the given user should be
+  # allowed to view answers for the given script_level
   def self.visible?(user, script_level)
     return true if Rails.application.config.levelbuilder_mode
     return false unless user
     return false unless script_level
 
+    # Authorized teachers can view answers, except for those scripts that
+    # teachers are supposed to interface with as though they were students (ie,
+    # professional learning scripts)
     script = script_level.try(:script)
     return true if user.authorized_teacher? &&
       script &&
       !script.professional_learning_course?
 
+    # Teachers can also put stages into a readonly mode in which students are
+    # able to view the answers
     user_level = UserLevel.find_by(user: user, level: script_level.level)
     return true if user_level.try(:readonly_answers)
 

--- a/dashboard/lib/policies/inline_answer.rb
+++ b/dashboard/lib/policies/inline_answer.rb
@@ -1,0 +1,17 @@
+class Policies::InlineAnswer
+  def self.visible?(user, script_level)
+    return true if Rails.application.config.levelbuilder_mode
+    return false unless user
+    return false unless script_level
+
+    script = script_level.try(:script)
+    return true if user.authorized_teacher? &&
+      script &&
+      !script.professional_learning_course?
+
+    user_level = UserLevel.find_by(user: user, level: script_level.level)
+    return true if user_level.try(:readonly_answers)
+
+    false
+  end
+end

--- a/dashboard/test/lib/policies/inline_answer_test.rb
+++ b/dashboard/test/lib/policies/inline_answer_test.rb
@@ -2,8 +2,21 @@ require 'test_helper'
 
 class InlineAnswerTest < ActiveSupport::TestCase
   setup_all do
+    @authorized_teacher = create :authorized_teacher
     @teacher = create :teacher
     @student = create :student
+  end
+
+  test 'visible? returns true for authorized teachers' do
+    assert Policies::InlineAnswer.visible?(@authorized_teacher, create(:script_level))
+  end
+
+  test 'visible? returns false for non teachers' do
+    refute Policies::InlineAnswer.visible?(@student, create(:script_level))
+  end
+
+  test 'visible? returns false for non-authorized teachers' do
+    refute Policies::InlineAnswer.visible?(@teacher, create(:script_level))
   end
 
   test 'visible? returns true in levelbuilder' do
@@ -13,12 +26,14 @@ class InlineAnswerTest < ActiveSupport::TestCase
     assert Policies::InlineAnswer.visible?(@student, create(:script_level))
   end
 
-  test 'visible? returns false for non teachers' do
-    assert_not Policies::InlineAnswer.visible?(@student, create(:script_level))
+  test 'visible? returns false for PLC courses (even for authorized teachers)' do
+    plc_script = create(:script, professional_learning_course: true)
+    refute Policies::InlineAnswer.visible?(@teacher, create(:script_level, script: plc_script))
   end
 
-  test 'visible? returns true for authorized teachers in csp' do
-    create(:plc_user_course_enrollment, plc_course: create(:plc_course), user: @teacher)
-    assert Policies::InlineAnswer.visible?(@teacher, create(:script_level))
+  test 'visible? returns true for all kinds of users if the stage is in readonly mode for that user' do
+    script_level = create(:script_level)
+    create(:user_level, user: @student, level: script_level.level, submitted: true, readonly_answers: true)
+    assert Policies::InlineAnswer.visible?(@student, script_level)
   end
 end

--- a/dashboard/test/lib/policies/inline_answer_test.rb
+++ b/dashboard/test/lib/policies/inline_answer_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class InlineAnswerTest < ActiveSupport::TestCase
+  setup_all do
+    @teacher = create :teacher
+    @student = create :student
+  end
+
+  test 'visible? returns true in levelbuilder' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    assert Policies::InlineAnswer.visible?(@student, nil)
+    assert Policies::InlineAnswer.visible?(@student, create(:script_level))
+  end
+
+  test 'visible? returns false for non teachers' do
+    assert_not Policies::InlineAnswer.visible?(@student, create(:script_level))
+  end
+
+  test 'visible? returns true for authorized teachers in csp' do
+    create(:plc_user_course_enrollment, plc_course: create(:plc_course), user: @teacher)
+    assert Policies::InlineAnswer.visible?(@teacher, create(:script_level))
+  end
+end

--- a/dashboard/test/lib/policies/inline_answer_test.rb
+++ b/dashboard/test/lib/policies/inline_answer_test.rb
@@ -28,7 +28,7 @@ class InlineAnswerTest < ActiveSupport::TestCase
 
   test 'visible? returns false for PLC courses (even for authorized teachers)' do
     plc_script = create(:script, professional_learning_course: true)
-    refute Policies::InlineAnswer.visible?(@teacher, create(:script_level, script: plc_script))
+    refute Policies::InlineAnswer.visible?(@authorized_teacher, create(:script_level, script: plc_script))
   end
 
   test 'visible? returns true for all kinds of users if the stage is in readonly mode for that user' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2754,23 +2754,6 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should_see_inline_answer? returns true in levelbuilder' do
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-
-    assert @student.should_see_inline_answer?(nil)
-    assert @student.should_see_inline_answer?(create(:script_level))
-  end
-
-  test 'should_see_inline_answer? returns false for non teachers' do
-    assert_not @student.should_see_inline_answer?(create(:script_level))
-  end
-
-  test 'should_see_inline_answer? returns true for authorized teachers in csp' do
-    user = create :teacher
-    create(:plc_user_course_enrollment, plc_course: (create :plc_course), user: user)
-    assert user.should_see_inline_answer?((create :script_level))
-  end
-
   test 'account_age_days should return days since account creation' do
     student = create :student, created_at: DateTime.now - 10
     assert student.account_age_days == 10


### PR DESCRIPTION
also rewrite the method a bit to make some of the logic more clear

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-714)
- [original PR that added this method](https://github.com/code-dot-org/code-dot-org/pull/9760)

## Testing story

Existing tests for this method have been moved from user_test to a new test file specific to this policy

# Reviewer Checklist:

- [x] Tests provide adequate coverage
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
