### PR TITLE
create pilot admin pages

### DIFF
--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -72,4 +72,11 @@ class AdminSearchController < ApplicationController
     end
     redirect_to :lookup_section
   end
+
+  def show_pilot
+    pilot_name = params[:pilot_name]
+    return head :bad_request unless Experiment::PILOT_EXPERIMENTS.include?(pilot_name)
+    user_ids =  SingleUserExperiment.where(name: pilot_name).map(&:min_user_id)
+    @emails = User.where(id: user_ids).pluck(:email)
+  end
 end

--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -74,9 +74,9 @@ class AdminSearchController < ApplicationController
   end
 
   def show_pilot
-    pilot_name = params[:pilot_name]
-    return head :bad_request unless Experiment::PILOT_EXPERIMENTS.include?(pilot_name)
-    user_ids =  SingleUserExperiment.where(name: pilot_name).map(&:min_user_id)
+    @pilot_name = params[:pilot_name]
+    return head :bad_request unless Experiment::PILOT_EXPERIMENTS.include?(@pilot_name)
+    user_ids =  SingleUserExperiment.where(name: @pilot_name).map(&:min_user_id)
     @emails = User.where(id: user_ids).pluck(:email)
   end
 end

--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -45,6 +45,11 @@ class Experiment < ApplicationRecord
     platformization-partners
   )
 
+  PILOT_EXPERIMENTS = %w(
+    csd-piloters
+    csp-piloters
+  )
+
   def self.get_editor_experiment(user)
     LEVEL_EDITOR_EXPERIMENTS.find do |experiment|
       Experiment.enabled?(user: user, experiment_name: experiment)

--- a/dashboard/app/views/admin_reports/directory.html.haml
+++ b/dashboard/app/views/admin_reports/directory.html.haml
@@ -20,5 +20,7 @@
 = link_to t('crud.new_model', model: RegionalPartner.model_name.human), new_regional_partner_path
 
 %h3 Pilot Experiments
-= link_to 'CSD Piloters', show_pilot_path(pilot_name: 'csd-piloters')
-= link_to 'CSP Piloters', show_pilot_path(pilot_name: 'csp-piloters')
+%p
+  = link_to 'CSD Piloters', show_pilot_path(pilot_name: 'csd-piloters')
+%p
+  = link_to 'CSP Piloters', show_pilot_path(pilot_name: 'csp-piloters')

--- a/dashboard/app/views/admin_reports/directory.html.haml
+++ b/dashboard/app/views/admin_reports/directory.html.haml
@@ -18,3 +18,7 @@
 
 %h3 Regional Partners
 = link_to t('crud.new_model', model: RegionalPartner.model_name.human), new_regional_partner_path
+
+%h3 Pilot Experiments
+= link_to 'CSD Piloters', show_pilot_path(pilot_name: 'csd-piloters')
+= link_to 'CSP Piloters', show_pilot_path(pilot_name: 'csp-piloters')

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -1,3 +1,5 @@
+%h1
+  = @pilot_name
 %table
   %tr
     %th

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -1,0 +1,8 @@
+%table
+  %tr
+    %th
+      %span Email
+  - @emails.each do |email|
+    %tr
+      %td
+        %span= email

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -322,6 +322,7 @@ Dashboard::Application.routes.draw do
   get '/admin/lookup_section', to: 'admin_search#lookup_section', as: 'lookup_section'
   post '/admin/lookup_section', to: 'admin_search#lookup_section'
   post '/admin/undelete_section', to: 'admin_search#undelete_section', as: 'undelete_section'
+  get '/admin/pilots/:pilot_name', to: 'admin_search#show_pilot', as: 'show_pilot'
 
   # internal engineering dashboards
   get '/admin/dynamic_config', to: 'dynamic_config#show', as: 'dynamic_config_state'

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -116,4 +116,23 @@ class AdminSearchControllerTest < ActionController::TestCase
     post :lookup_section, params: {section_code: @teacher_section.code}
     assert_redirected_to_sign_in
   end
+
+  #
+  # pilot experiment tests
+  #
+
+  test 'non-admin cannot view list of piloters' do
+    sign_in @not_admin
+    get :show_pilot, params: {pilot_name: 'csd-piloters'}
+    assert_response :forbidden
+  end
+
+  test 'piloter shows up in list of piloters' do
+    create :teacher, pilot_experiment: 'csd-piloters', email: 'csd@example.com'
+    create :teacher, pilot_experiment: 'csp-piloters', email: 'csp@example.com'
+    get :show_pilot, params: {pilot_name: 'csd-piloters'}
+    assert_response :success
+    assert_select 'table tr td', 1
+    assert_select 'table tr td', 'csd@example.com'
+  end
 end


### PR DESCRIPTION
# Background

Finishes [LP-701](https://codedotorg.atlassian.net/browse/LP-701)

# Description

* adds admin-only pages which show the email address of every teacher in the csd-piloters and csp-piloters experiments
* adds links to those pages to the /admin page

![Screen Shot 2019-09-26 at 5 43 54 PM](https://user-images.githubusercontent.com/8001765/65734079-3a4ee800-e086-11e9-9e45-7bd0d0167936.png)

![Screen Shot 2019-09-26 at 5 45 49 PM](https://user-images.githubusercontent.com/8001765/65734082-3cb14200-e086-11e9-9138-68af9a9e902f.png)

# Reviewer Checklist:

- [x] Tests provide adequate coverage
- [ ] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
