### PR TITLE
Make two eyes tests have different names

### DIFF
--- a/dashboard/test/ui/features/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/student_not_started_level_warning.feature
@@ -22,7 +22,7 @@ Scenario: Game lab level where student has not started
   And I close my eyes
 
 Scenario: Maze level where student has not started
-  When I open my eyes to test "game lab student has not started"
+  When I open my eyes to test "maze student has not started"
   When I sign in as "Teacher_Sally" and go home
   And I wait until element ".uitest-owned-sections" is visible
 


### PR DESCRIPTION
I had the two eyes tests in here with the same name so they were not working correctly.

<img width="1273" alt="Screen Shot 2019-09-27 at 2 25 39 PM" src="https://user-images.githubusercontent.com/208083/65793325-8ad04f00-e133-11e9-9792-7d8c0807515e.png">
