### PR TITLE
Account Settings:  "Update" link in Account Settings is not translatable

### DIFF
--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -39,7 +39,7 @@
         %span#displayed-user-email= f.object.email.present? ? f.object.email : '***encrypted***'
         - if current_user.should_see_edit_email_link?
           (
-          %a#edit-email-link{href: '#'}= "Update"
+          %a#edit-email-link{href: '#'}= t('user.update_email')
           )
   - if resource.username.present?
     .field

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -455,6 +455,7 @@ en:
     enter_parent_email: "Enter your parent or guardian's email address (for password recovery)"
     update: "Update Account"
     account_successfully_updated: "Account successfully updated."
+    update_email: "Update"
   user_level:
     completed: 'Completed'
     tried: 'Tried'
@@ -1163,3 +1164,8 @@ en:
     privacy_policy: 'privacy policy'
     logout: 'Logout'
     yes: 'Yes'
+  page_not_found_title: "Page Not Found"
+  page_not_found_header: '404: Page Not Found'
+  page_not_found_description: "The page you are looking for doesn't exist at this address. Check the web address and resubmit. Or, go back to our homepage."
+  page_not_found_button: "Return home"
+

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1164,8 +1164,3 @@ en:
     privacy_policy: 'privacy policy'
     logout: 'Logout'
     yes: 'Yes'
-  page_not_found_title: "Page Not Found"
-  page_not_found_header: '404: Page Not Found'
-  page_not_found_description: "The page you are looking for doesn't exist at this address. Check the web address and resubmit. Or, go back to our homepage."
-  page_not_found_button: "Return home"
-


### PR DESCRIPTION
# Description
The "update" link in account settings is not translatable.

Account settings page in Spanish (update untranslated):
<img width="728" alt="Screen Shot 2019-09-27 at 1 34 38 PM" src="https://user-images.githubusercontent.com/30066710/65800541-9b7cc700-e12b-11e9-9cd7-3e83442dc62d.png">


Fix:
Added new dashboard string
Referenced new string in edit.html.haml

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-396)

## Testing story
The change was manually tested to verify that the link works and the correct English string is displayed. See gif below:
![update_link_translatable](https://user-images.githubusercontent.com/30066710/65800571-ac2d3d00-e12b-11e9-8d40-c579faafe59d.gif)


<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
