### PR TITLE
Add instances to LB through CF for non-prod stacks [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -46,8 +46,8 @@ self.log_resource_filter.push 'FrontendLaunchConfig', 'ASGCount'
 if %w(autoscale-prod test staging levelbuilder).include? stack_name
   self.daemon_instance_id = {
     'autoscale-prod' => 'i-436d69dd',
-    'test' => 'i-f85e6666',
-    'staging' => 'i-57a3afc7',
+    'test' => 'i-004727200191f3251',
+    'staging' => 'i-02e6cdc765421ab34',
     'levelbuilder' => 'i-03a540ccf70cc8138'
   }[stack_name]
 else
@@ -253,8 +253,8 @@ Resources:
       ConnectionDrainingPolicy:
         Enabled: true
         Timeout: 300
-<%   if !frontends && daemon -%>
-      Instances: [!Ref <%=daemon%>]
+<%   if !frontends && daemon_instance_id -%>
+      Instances: [<%=daemon_instance_id%>]
 <%   end -%>
 <% end -%>
 

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -45,10 +45,10 @@ self.log_resource_filter.push 'FrontendLaunchConfig', 'ASGCount'
 # TODO migrate stacks to cloudformation-provisioned instances.
 if %w(autoscale-prod test staging levelbuilder).include? stack_name
   self.daemon_instance_id = {
-    'autoscale-prod' => 'i-436d69dd',
+    'autoscale-prod' => 'i-08f5f8ace0a473b8d',
     'test' => 'i-004727200191f3251',
     'staging' => 'i-02e6cdc765421ab34',
-    'levelbuilder' => 'i-03a540ccf70cc8138'
+    'levelbuilder' => 'i-0907b146f7e6503f6'
   }[stack_name]
 else
   self.daemon = 'Daemon'


### PR DESCRIPTION
# Description
Perhaps due to oversight, before this change, we were never hitting the code path to add instances to the LoadBalancer through CloudFormation. In general it makes sense to do this for our non-prod managed environments.

This change also includes updated instance IDs for the new `staging` and `test` instances provisioned for the ubuntu upgrade earlier this week.

## Testing story
```
circleci@ea134e34b9ec:~/code-dot-org$ RAILS_ENV=staging bundle exec rake stack:validate
GetSecretValue: staging/cdo/db_writer
AWS CloudFormation Template for Code.org application
Parameters:
DatabaseUsername: master
Listing changes to existing stack `staging`:
Modify DaemonMemoryUtilizationAlarm [AWS::CloudWatch::Alarm] Properties (Dimensions)
Modify DaemonStorageUtilizationAlarm [AWS::CloudWatch::Alarm] Properties (Dimensions)
Modify LoadBalancer [AWS::ElasticLoadBalancing::LoadBalancer] Properties (Instances)
Modify OriginDNS [AWS::Route53::RecordSetGroup] Properties (RecordSets, RecordSets)
```

```
circleci@ea134e34b9ec:~/code-dot-org$ RAILS_ENV=test bundle exec rake stack:validate
AWS CloudFormation Template for Code.org application
Parameters:
DatabaseUsername: master
Listing changes to existing stack `test`:
Modify DaemonMemoryUtilizationAlarm [AWS::CloudWatch::Alarm] Properties (Dimensions)
Modify DaemonStorageUtilizationAlarm [AWS::CloudWatch::Alarm] Properties (Dimensions)
Modify LoadBalancer [AWS::ElasticLoadBalancing::LoadBalancer] Properties (Instances)
Modify OriginDNS [AWS::Route53::RecordSetGroup] Properties (RecordSets, RecordSets)
```

```
circleci@ea134e34b9ec:~/code-dot-org$ RAILS_ENV=production STACK_NAME=autoscale-prod bundle exec rake stack:validate
GetSecretValue: production/cdo/db_writer
AWS CloudFormation Template for Code.org application
Listing changes to existing stack `autoscale-prod`:
Modify DashboardCDN [AWS::CloudFront::Distribution] Properties Replacement: Conditional (DistributionConfig)
Modify DashboardDNS [AWS::Route53::RecordSetGroup] Properties (RecordSets)
```

I'm not sure what the DNS changes are for - possibly just because the LoadBalancer resource is being changed?

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
