### PR TITLE
[Urgent] Fixed issue with spritelab so it now works in Firefox and Edge

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -440,14 +440,20 @@ exports.appendNewFunctions = function(blocksXml, functionsXml) {
   const sharedFunctionsDom = xml.parseElement(functionsXml);
   const functions = [...sharedFunctionsDom.ownerDocument.firstChild.childNodes];
   for (let func of functions) {
-    const name = document.evaluate(
+    let ownerDocument = func.ownerDocument.evaluate
+      ? func.ownerDocument
+      : document;
+    let startBlocksDocument = startBlocksDom.ownerDocument.evaluate
+      ? startBlocksDom.ownerDocument
+      : document;
+    const name = ownerDocument.evaluate(
       'title[@name="NAME"]/text()',
       func,
       null,
       XPathResult.STRING_TYPE,
       null
     ).stringValue;
-    const type = document.evaluate(
+    const type = ownerDocument.evaluate(
       '@type',
       func,
       null,
@@ -455,7 +461,7 @@ exports.appendNewFunctions = function(blocksXml, functionsXml) {
       null
     ).stringValue;
     const alreadyPresent =
-      document.evaluate(
+      startBlocksDocument.evaluate(
         `//block[@type="${type}"]/title[@name="NAME"][text()="${name}"]`,
         startBlocksDom,
         null,


### PR DESCRIPTION
# Description
Prior to August, Spritelab was broken in IE due to a polyfill of document.evaluate that was unable to be used on element.evaluate. The fix was to use document.evaluate directly. This worked in Chrome and IE, but broke Firefox and Edge. This fix takes a more selective approach and uses document.evaluate only if element.evaluate is not available.
Original attempt: https://github.com/code-dot-org/code-dot-org/pull/30450
document.evaluate allows us to use Shared Functions (i.e. behaviors)

## Links

- [slack discussion](https://codedotorg.slack.com/archives/C1B3PNDL7/p1569610055122600)
- [original issue](https://codedotorg.atlassian.net/browse/STAR-637)
- [when run bug](https://codedotorg.atlassian.net/browse/STAR-718)
- [costume bug](https://codedotorg.atlassian.net/browse/STAR-717)

## Testing story
Hand-tested on project and course levels for Firefox, Edge, IE, and Chrome
N/A <- emergency fix

Original error:
<img width="868" alt="errorInFirefox" src="https://user-images.githubusercontent.com/8324574/65804404-996c3580-e136-11e9-973f-787f10d11cdd.PNG">

Screenshots of it working in IE, Chrome, Edge, and Firefox (in order)
<img width="406" alt="WorksInIE" src="https://user-images.githubusercontent.com/8324574/65804416-aa1cab80-e136-11e9-886e-cb51de20da1f.PNG">
<img width="620" alt="WorksInChrome" src="https://user-images.githubusercontent.com/8324574/65804419-ab4dd880-e136-11e9-9c40-a9441caa6557.PNG">
<img width="608" alt="WorksInEdgeProject" src="https://user-images.githubusercontent.com/8324574/65804428-b0ab2300-e136-11e9-94ff-0d19e38a07eb.PNG">
<img width="1060" alt="WorksInFirefoxProject" src="https://user-images.githubusercontent.com/8324574/65804433-b56fd700-e136-11e9-8b70-83949c75a25e.PNG">

One screenshot of a working level (edge)
<img width="998" alt="WorksInEdgeLevel" src="https://user-images.githubusercontent.com/8324574/65804440-bc96e500-e136-11e9-86cb-3c6ad15ed8f6.PNG">


# Reviewer Checklist:
N/A <- emergency fix
<!--
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
-->