### PR TITLE
School Info Confirmation Dialog UI Test : enable mobile

### DIFF
--- a/dashboard/test/ui/features/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/school_info_confirmation_dialog.feature
@@ -1,6 +1,5 @@
 @dashboard_db_access
 @no_ie
-@no_mobile
 Feature: School Info Confirmation Dialog
 
 # This test checks three relevant states of the user in the school info confirmation


### PR DESCRIPTION
# Description
Mobile is re-enabled in the ui-test, "school_info_confirmation_dialog.feature".  Due to the react 
 upgrade the ui-test was failing on iPad and iPhone.

Relevant PR:
  Mobile is skipped:  https://github.com/code-dot-org/code-dot-org/pull/30803

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&projectKey=FND&modal=detail&selectedIssue=FND-728)

## Testing story
  Passing tests on mobile: 
- iPad
![iPad_test](https://user-images.githubusercontent.com/30066710/65727195-e6cfa080-e06b-11e9-9167-876b80dfd2f2.gif)

- iPhone
![iPhone_test](https://user-images.githubusercontent.com/30066710/65727179-dddecf00-e06b-11e9-901a-4d74520b7037.gif)

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient



  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked

