### PR TITLE
Don't require an EnrollmentModuleAssignment to create a PeerReview

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -110,17 +110,11 @@ class UserLevel < ActiveRecord::Base
   def after_submit
     submitted_level = Level.cache_find(level_id)
 
-    # Create peer reviews after submitting a peer_reviewable solution
+    # Some levels that belong to the professional learning program are peer reviewable.
+    # When submitting such a level, we create a record for a pending peer review, so that
+    # it becomes available for another teacher in the program to review.
     if submitted_level.try(:peer_reviewable?)
-      submitted_script_level = submitted_level.script_levels.find_by(script_id: script_id)
-      learning_module = submitted_script_level&.stage&.plc_learning_module
-      assignment_exists = learning_module && Plc::EnrollmentModuleAssignment.exists?(
-        user_id: user_id,
-        plc_learning_module: learning_module
-      )
-      if assignment_exists
-        PeerReview.create_for_submission(self, level_source_id)
-      end
+      PeerReview.create_for_submission(self, level_source_id)
     end
   end
 

--- a/dashboard/test/models/peer_review_test.rb
+++ b/dashboard/test/models/peer_review_test.rb
@@ -35,9 +35,6 @@ class PeerReviewTest < ActiveSupport::TestCase
 
   setup do
     @script.reload
-    Rails.application.config.stubs(:levelbuilder_mode).returns false
-    Plc::EnrollmentModuleAssignment.stubs(:exists?).with(user_id: @user.id, plc_learning_module: @learning_module).returns(true)
-
     PeerReviewMailer.stubs(:review_completed_receipt).returns(stub(:deliver_now))
   end
 
@@ -47,14 +44,6 @@ class PeerReviewTest < ActiveSupport::TestCase
     end
 
     assert_equal Set[nil, 'escalated'], PeerReview.where(submitter: @user, level: @level).map(&:status).to_set
-  end
-
-  test 'submitting a peer reviewed level when I am not enrolled in the module should not create PeerReview objects' do
-    Plc::EnrollmentModuleAssignment.stubs(:exists?).returns(false)
-
-    assert_no_difference('PeerReview.count') do
-      track_progress @level_source.id
-    end
   end
 
   test 'submitting a non peer reviewable level should not create Peer Review objects' do
@@ -244,10 +233,6 @@ class PeerReviewTest < ActiveSupport::TestCase
     submitter_1 = create :teacher
     submitter_2 = create :teacher
     submitter_3 = create :teacher
-
-    [submitter_1, submitter_2, submitter_3].each do |submitter|
-      Plc::EnrollmentModuleAssignment.stubs(:exists?).with(user_id: submitter.id, plc_learning_module: @learning_module).returns(true)
-    end
 
     level_source_1 = create(:level_source, data: 'Some answer')
     level_source_2 = create(:level_source, data: 'Other answer')

--- a/dashboard/test/models/user_level_test.rb
+++ b/dashboard/test/models/user_level_test.rb
@@ -193,10 +193,13 @@ class UserLevelTest < ActiveSupport::TestCase
   test 'unsubmitting destroys unclaimed peer reviews' do
     level = create(:free_response, peer_reviewable: true)
     script = create :script
+    level_source = create :level_source
 
     ul = UserLevel.create(
       user: @user,
       level: level,
+      script: script,
+      level_source: level_source,
       attempts: 0,
       submitted: true,
       best_result: Activity::UNREVIEWED_SUBMISSION_RESULT
@@ -215,10 +218,13 @@ class UserLevelTest < ActiveSupport::TestCase
   test 'other changes do not destroy unclaimed peer reviews' do
     level = create(:free_response, peer_reviewable: true)
     script = create :script
+    level_source = create :level_source
 
     ul = UserLevel.create(
       user: @user,
       level: level,
+      script: script,
+      level_source: level_source,
       attempts: 0,
       submitted: true,
       best_result: Activity::UNREVIEWED_SUBMISSION_RESULT


### PR DESCRIPTION
Solves a case where PD teacher submissions are not made peer-reviewable when they should be, by removing a requirement (originally introduced in https://github.com/code-dot-org/code-dot-org/pull/12916) that a `Plc::EnrollmentModuleAssignment` exist before creating a `PeerReview` record.

# The problem

A couple of times this year, our education team has had to ask us to investigate missing peer reviews.  In each case, a teacher had recently submitted a PL task (i.e. a free-response question) that should have resulted in a peer review record showing up in the [peer review dashboard](https://studio.code.org/peer_reviews/dashboard) (requires permission) and being distributed to other teachers for peer review. Initial investigation yielded the following insights:

1. No [`PeerReview`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/peer_review.rb) had been created for these submissions.

2. The `PeerReviews` should have been created by this logic on `UserLevel`:

   https://github.com/code-dot-org/code-dot-org/blob/ebb8936181b790b99d63495d0e1928d188ae7837/dashboard/app/models/user_level.rb#L113-L124

   It essentially enforces two requirements: That the level is peer reviewable, and that the submitting teacher is assigned to the relevant learning module.

3. The levels have all been correctly marked `peer_reviewable?`.

4. The `Plc::EnrollmentModuleAssignment` is missing.

This left us with two "why" questions needing further investigation:

1. Why is the `EnrollmentModuleAssignment` missing?
2. Why do we require an `EnrollmentModuleAssignment` to create a peer review?

## Why is the `EnrollmentModuleAssignment` missing?

Answering this question required a dive into the PLC curriculum hierarchy.

![IMG_20190927_125938](https://user-images.githubusercontent.com/1615761/65817369-f1e51680-e1ba-11e9-89c8-0e2b1922d208.jpg)

For background, we've got our normal curriculum hierarchy:

> [`Course`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/course.rb) > [`Script`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/script.rb) > [`Stage`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/stage.rb) > [`ScriptLevel`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/script_level.rb) > [`Level`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/levels/level.rb)

(It's actually more complex than that, but those are the bits relevant to PLC.)

Then, PLC has a parallel curriculum hierarchy that ties back into the normal one (and semi-duplicates it).

> [`Plc::Course`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/plc/course.rb) > [`Plc::CourseUnit`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/plc/course_unit.rb) > [`Plc::LearningModule`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/plc/learning_module.rb) > [`Plc::Task`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/plc/task.rb)

Just so, our normal curriculum has a user-data hierarchy which tracks things like assignments, progress, lock states:

> [`UserScript`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/user_script.rb) > [`UserLevel`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/user_level.rb)

...and PLC has a parallel user-data hierarchy:

> [`UserCourseEnrollment`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/plc/user_course_enrollment.rb) > [`EnrollmentUnitAssignment`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/plc/enrollment_unit_assignment.rb) > [`EnrollmentModuleAssignment`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/plc/enrollment_module_assignment.rb)

All this means that diagnosing problems in the PLC curriculum space involves holding a large number of models and relationships in your head.  This is one reason problems in PLC can take a very long time to debug. (Why does PLC have all this parallel curriculum hierarchy? I learned from @joshlory that all this duplication is the result of a half-finished refactor at some point in the distant past, and there might be some hope of unifying the two hierarchies in the future!)

In the specific case we're studying (diagrammed above), the `UserCourseEnrollment` and `EnrollmentUnitAssignment` existed, but the `EnrollmentModuleAssignment` was missing.  So my next question was: 

### When does all of this get created?

A `UserCourseEnrollment` is automatically created when a teacher enrolls in a workshop that has an associated online learning course, here:

https://github.com/code-dot-org/code-dot-org/blob/52ab1daeb80d985758a5c9006932288f25b05892/dashboard/app/models/pd/enrollment.rb#L321-L325

Its `after_save` hook, in turn, creates `EnrollmentUnitAssignments` here:

https://github.com/code-dot-org/code-dot-org/blob/52ab1daeb80d985758a5c9006932288f25b05892/dashboard/app/models/plc/user_course_enrollment.rb#L29

https://github.com/code-dot-org/code-dot-org/blob/52ab1daeb80d985758a5c9006932288f25b05892/dashboard/app/models/plc/user_course_enrollment.rb#L67-L76

And the `EnrollmentUnitAssignment` in turn has an after-save hook that creates `EnrollmentModuleAssignments`:

https://github.com/code-dot-org/code-dot-org/blob/ebb8936181b790b99d63495d0e1928d188ae7837/dashboard/app/models/plc/enrollment_unit_assignment.rb#L33

https://github.com/code-dot-org/code-dot-org/blob/ebb8936181b790b99d63495d0e1928d188ae7837/dashboard/app/models/plc/enrollment_unit_assignment.rb#L41-L47

https://github.com/code-dot-org/code-dot-org/blob/ebb8936181b790b99d63495d0e1928d188ae7837/dashboard/app/models/plc/enrollment_unit_assignment.rb#L116-L124

In short: Teacher enrolls in a workshop, and the whole hierarchy of PLC user-data gets automagically created, under normal circumstances.  You may have noticed that we create `EnrollmentModuleAssignments` only for _required_ `LearningModules`; more on that later, but for the moment it's sufficient to know that _all_ `LearningModules` in this scenario are "required."

### What went wrong in this case:

The dates in blue in the diagram above are creation dates.  This year, the ed team is doing a rolling release of the course, so we see users enrolled before all of the `LearningModules` existed!  The magic building out the user-data hierarchy when enrollment occurs can't make `EnrollmentModuleAssignments` for modules that don't exist yet, and no logic exists to create those assignments later when the `LearningModule` is created.  Thus, we get the interally-inconsistent state of a teacher enrolled in a course and unit but not in the required modules in that unit.

## Why do we require an `EnrollmentModuleAssignment` to create a peer review?

This is not entirely clear, but we can infer parts of it.

The change that originally introduced this logic is called ["Unenrolled users should not create peer reviews - their work should just be submitted."](https://github.com/code-dot-org/code-dot-org/pull/12916)  No other documentation is provided.  I conclude that this behavior is intentional, and designed to solve a problem found around that time.

The only conversation I've found in our Slack history around this change is [from January 27th](https://codedotorg.slack.com/archives/C0T10H26N/p1485545241001247):

![image](https://user-images.githubusercontent.com/1615761/65897328-dff2a780-e363-11e9-8258-627dcaffa1e8.png)

So far I haven't found any further references to this issue in email history or meeting notes.  The note about "outside their focus area" is a bit of a puzzle, as focus areas isn't something we've talked about in the last couple of years.  However, I suspect it lines up with the "unenrolled" part of the PR description.  So my next question is, how do you end up with an unenrolled user submitting PD tasks?

We noted earlier that any teacher enrolled in the `Plc::Course` should also end up enrolled in all _required_ `Plc::LearningModules`.  What does that mean?

There are three module types:

https://github.com/code-dot-org/code-dot-org/blob/ebb8936181b790b99d63495d0e1928d188ae7837/dashboard/app/models/plc/learning_module.rb#L25-L29

...and it turns out, since February 2017 the only type we've created is "required."

```sql
> select DATE_FORMAT(created_at, '%Y-%m') year, module_type, count(id) from plc_learning_modules group by year, module_type;
+---------+-------------+-----------+
| year    | module_type | count(id) |
+---------+-------------+-----------+
| 2016-06 | required    |         4 |
| 2016-07 | content     |         8 |
| 2016-07 | practice    |         2 |
| 2016-07 | required    |        56 |
| 2016-09 | content     |         6 |
| 2016-09 | practice    |         8 |
| 2016-09 | required    |         1 |
| 2016-10 | required    |       352 |
| 2016-11 | content     |         8 |
| 2016-11 | practice    |         8 |
| 2016-11 | required    |        22 |
| 2016-12 | content     |         3 |
| 2016-12 | practice    |         4 |
| 2016-12 | required    |         4 |
| 2017-01 | required    |         9 |
| 2017-02 | content     |         5 |
| 2017-02 | practice    |         4 |
| 2017-02 | required    |         1 |
| 2017-06 | required    |        10 |
| 2017-07 | required    |        22 |
| 2018-05 | required    |        45 |
| 2018-06 | required    |         5 |
| 2018-07 | required    |         2 |
| 2019-04 | required    |         1 |
| 2019-05 | required    |        12 |
| 2019-07 | required    |         3 |
| 2019-08 | required    |        19 |
| 2019-09 | required    |         3 |
+---------+-------------+-----------+
28 rows in set (0.00 sec)
```

We have created `EnrollmentModuleAssignments` for some of those old modules, but a tiny number compared to required modules:

```sql
> select DATE_FORMAT(ema.created_at, '%Y') year, lm.module_type, count(ema.id) from plc_enrollment_module_assignments ema inner join plc_learning_modules lm on ema.plc_learning_module_id = lm.id group by year, lm.module_type;
+------+-------------+---------------+
| year | module_type | count(ema.id) |
+------+-------------+---------------+
| 2016 | content     |            18 |
| 2016 | practice    |            18 |
| 2016 | required    |         30293 |
| 2017 | content     |           263 |
| 2017 | practice    |           275 |
| 2017 | required    |         25768 |
| 2018 | content     |           125 |
| 2018 | practice    |           126 |
| 2018 | required    |         11030 |
| 2019 | content     |            23 |
| 2019 | practice    |            25 |
| 2019 | required    |         52392 |
+------+-------------+---------------+
12 rows in set (0.35 sec)
```

I asked our education team about this.  They also suspect it's an old feature, no longer used:

> I think this might be an outdated structure at this point.
> The content/practice/required paradigm was from the old online pd that had self assessment built in to assign specific stages based on what people were least familiar with.

## What now?

We have several problems to solve now:

1. Some `EnrollmentModuleAssignments` should have been created, but were not.
2. There are future `EnrollmentModuleAssignments` that should be created, but as the code currently works, will not be. (As soon as this week.)
3. Some `PeerReviews` should have been created, but were not. (This is currently blocking.)
4. There are future `PeerReviews` that will need to be created, but as the code currently works, will not be. (As soon as this week.)

**This PR only addresses item 4,** by removing the dependency on items 1 and 2.

My next task is to address item 3 with a backfill script. ([PLC-493](https://codedotorg.atlassian.net/browse/PLC-493))

As of now, missing Peer Reviews is the only known user bad from items 1 and 2.  I'm taking a follow-up task ([PLC-494](https://codedotorg.atlassian.net/browse/PLC-494)) to confirm that is the case, and if so, plan to defer this cleanup work in favor of simply deprecating the `EnrollmentModuleAssignment` model.  If not, we'll address items 1 and 2.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLC-484)
- [Slack](https://codedotorg.slack.com/archives/C0T10H26N/p1569521176080300)
- [Original implementation](https://github.com/code-dot-org/code-dot-org/pull/12916)

## Testing story

Unit test updates - please see inline comments for details.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
