### PR TITLE
Recognize match levels as complete when all slots are filled

### DIFF
--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -51,6 +51,7 @@ export default class Match {
 
   getResult() {
     let wrongAnswer = false;
+    let valid = true;
 
     const elements = $(this.container).find('.match_slots li');
 
@@ -63,6 +64,7 @@ export default class Match {
       if (originalIndex === null) {
         // nothing dragged in this slot yet
         wrongAnswer = true;
+        valid = false;
 
         xmark.hide();
       } else if (originalIndex !== String(index)) {
@@ -80,7 +82,8 @@ export default class Match {
     return {
       response: response,
       result: !wrongAnswer,
-      errorDialog: wrongAnswer ? <MatchErrorDialog /> : null
+      errorDialog: wrongAnswer ? <MatchErrorDialog /> : null,
+      valid
     };
   }
   getAppName() {

--- a/dashboard/test/ui/features/level_group.feature
+++ b/dashboard/test/ui/features/level_group.feature
@@ -88,3 +88,40 @@ Scenario: Match levels within level group
 
   # no answers are draggable
   And element ".ui-draggable" is not visible
+
+@no_ie
+Scenario: Submit all answers, including match levels
+  Given I am on "http://studio.code.org/s/allthethings/stage/33/puzzle/1?noautoplay=true"
+  And I wait to see ".submitButton"
+  And element ".submitButton" is visible
+
+  When element ".level-group-content:nth(1) .multi-question" contains text "The standard QWERTY keyboard has"
+
+  # Select answers to all three multis.
+
+  And I press ".level-group-content:nth(0) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth(1) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth(2) .answerbutton[index=0]" using jQuery
+  And I press ".level-group-content:nth(2) .answerbutton[index=1]" using jQuery
+
+  # Select answers to both match levels.
+
+  And I scroll the ".level-group-content:nth(3)" element into view
+  And I drag match level 0 unplaced answer 0 to empty slot 0
+  And I drag match level 0 unplaced answer 0 to empty slot 0
+  And I drag match level 0 unplaced answer 0 to empty slot 0
+  And I drag match level 0 unplaced answer 0 to empty slot 0
+  And match level 0 contains 0 empty slots
+
+  And I scroll the ".level-group-content:nth(4)" element into view
+  And I drag match level 1 unplaced answer 0 to empty slot 0
+  And I drag match level 1 unplaced answer 0 to empty slot 0
+  And I drag match level 1 unplaced answer 0 to empty slot 0
+  And I drag match level 1 unplaced answer 0 to empty slot 0
+  And I drag match level 1 unplaced answer 0 to empty slot 0
+  And match level 1 contains 0 empty slots
+
+  Given I press ".submitButton:first" using jQuery
+  And I wait to see ".modal"
+  And element ".modal-body" contains text "You cannot edit your assessment after submitting it."
+  And element ".modal-body" does not contain text "You left some questions incomplete."

--- a/dashboard/test/ui/features/level_group.feature
+++ b/dashboard/test/ui/features/level_group.feature
@@ -20,6 +20,9 @@ Scenario: Submit three answers.
 
   And I press ".submitButton:first" using jQuery
   And I wait to see ".modal"
+  And element ".modal-body" contains text "You cannot edit your assessment after submitting it."
+  And element ".modal-body" contains text "You left some questions incomplete."
+
   And I press ".modal #ok-button" using jQuery to load a new page
 
   # Go back to the page to see that same options are selected.


### PR DESCRIPTION
# Background

Fixes [LP-750](https://codedotorg.atlassian.net/browse/LP-750)

# Description

When submitting a multi page assessment (a LevelGroup with multiple pages), one of the following two ui strings is displayed based on whether all questions have been answered: https://github.com/code-dot-org/code-dot-org/blob/80aee100a1e0144c85efe5632422ef7a21e8363b/apps/i18n/common/en_us.json#L1404-L1405

This decision is made based on whether each of the sublevels has a submitted answer which is "valid", which means that the question has a complete (though not necessarily correct) answer: https://github.com/code-dot-org/code-dot-org/blob/d4419ae6120a5e39118999e35253eb891c06dc08/apps/src/sites/studio/pages/levels/_level_group.js#L137-L166

other level types set `valid` as follows: https://github.com/code-dot-org/code-dot-org/blob/1cad5ac667f9ed1a3aa31063e6d06bd21a78e2bd/apps/src/code-studio/levels/multi.js#L202-L206

This PR brings the implementation of match levels to define `valid` in a similar manner, and adds a UI test to confirm that it worked.

# Testing

Ideally, match levels would be implemented in React / JS, and this change would be covered by a unit test instead of a UI test. but since match levels are a combination of haml and jquery, the UI test included in this PR seems like the best and only way to test this change given our options.

# Reviewer Checklist:

- [x] Tests provide adequate coverage
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
