### PR TITLE
PL: Backfill old workshop dates

### DIFF
--- a/bin/oneoff/backfill_data/backfill_old_workshop_dates.rb
+++ b/bin/oneoff/backfill_data/backfill_old_workshop_dates.rb
@@ -23,8 +23,8 @@ ActiveRecord::Base.transaction do
     elsif starting_date < cutoff_date
       puts "Update workshop #{w.id} gets new dates of #{starting_date} - #{ending_date}"
 
-      w.start_date = starting_date
-      w.ending_date = ending_date
+      w.started_at = starting_date
+      w.ended_at = ending_date
       w.save!
 
       total_updated += 1

--- a/bin/oneoff/backfill_data/backfill_old_workshop_dates.rb
+++ b/bin/oneoff/backfill_data/backfill_old_workshop_dates.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+# Script to backfill workshops, that were migrated from Workshop to Pd::Workshop,
+# with their start & stop dates, to prevent them from showing up in dashboards
+# because their states appear to be STATE_NOT_STARTED.
+
+ActiveRecord::Base.transaction do
+  cutoff_date = Date.new(2019, 1, 29)
+  total_problems = 0
+  total_updated = 0
+  total_skipped = 0
+
+  oldest_updated = Date.today
+  newest_updated = Date.new(1944, 12, 12)
+
+  Pd::Workshop.where(started_at: nil, ended_at: nil).each do |w|
+    starting_date = w.workshop_starting_date
+    ending_date = w.workshop_ending_date
+
+    if starting_date.nil? || ending_date.nil?
+      puts "Workshop #{w.id} had problem with starting/ending dates."
+      total_problems += 1
+    elsif starting_date < cutoff_date
+      puts "Update workshop #{w.id} gets new dates of #{starting_date} - #{ending_date}"
+
+      w.start_date = starting_date
+      w.ending_date = ending_date
+      w.save!
+
+      total_updated += 1
+
+      oldest_updated = starting_date if starting_date < oldest_updated
+      newest_updated = starting_date if starting_date > newest_updated
+    else
+      total_skipped += 1
+    end
+  end
+
+  puts "Total updated: #{total_updated}.  Total skipped: #{total_skipped}.  Total problems: #{total_problems}"
+  puts "Oldest updated: #{oldest_updated}.  Newest updated: #{newest_updated}."
+
+  # This script is a dry-run unless we comment out this last line
+  raise ActiveRecord::Rollback.new, "Intentional rollback"
+end

--- a/bin/oneoff/backfill_data/backfill_old_workshop_dates.rb
+++ b/bin/oneoff/backfill_data/backfill_old_workshop_dates.rb
@@ -5,7 +5,7 @@
 # because their states appear to be STATE_NOT_STARTED.
 
 ActiveRecord::Base.transaction do
-  cutoff_date = Date.new(2019, 1, 29)
+  cutoff_date = Date.new(2019, 2, 28)
   total_problems = 0
   total_updated = 0
   total_skipped = 0


### PR DESCRIPTION
The one-off script in https://github.com/code-dot-org/code-dot-org/pull/26763 moved workshops from the old `Workshop` model to the new `Pd::Workshop` model.  These workshops didn't have `started_at` or `ended_at` dates, causing them to have state `STATE_NOT_STARTED`, and they were appearing in workshop dashboards for end-users.

This one-off script backfills the `started_at` and `ended_at` dates based on the sessions attached to the workshops.  It looks for workshops in `Pd::Workshop` with `started_at` and `ended_at` both being `nil`, and the first session start date being earlier than 2/28/2019.

A simulated run on production data had these results:

```
Total updated: 207.  Total skipped: 770.  Total problems: 15
Oldest updated: 2015-06-01 08:00:00 UTC.  Newest updated: 2019-01-31 08:30:00 UTC.
```
