### PR TITLE
Add repeat to toolbox for Spelling Bee levels

### DIFF
--- a/apps/src/maze/wordsearchLevels.js
+++ b/apps/src/maze/wordsearchLevels.js
@@ -10,7 +10,10 @@ var wordSearchToolbox = function() {
     blockUtils.blockOfType('maze_moveNorth') +
       blockUtils.blockOfType('maze_moveSouth') +
       blockUtils.blockOfType('maze_moveEast') +
-      blockUtils.blockOfType('maze_moveWest')
+      blockUtils.blockOfType('maze_moveWest') +
+      `<block type="controls_repeat_simplified_dropdown">
+          <title name="TIMES" config="2-10">???</title>
+        </block>`
   );
 };
 


### PR DESCRIPTION
# Description
Add repeat block to spelling bee toolboxes.

Before:
![image](https://user-images.githubusercontent.com/8787187/65908097-88136b00-e37a-11e9-8bd1-2aa4d302dc21.png)

After:
![image](https://user-images.githubusercontent.com/8787187/65908020-59959000-e37a-11e9-93e7-734ee16d7e14.png)

## Links
Requested via [Zendesk](https://codeorg.zendesk.com/agent/tickets/250132)

## Testing story

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
