### PR TITLE
Make Toolkit - Events Reset Fix

### DIFF
--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -10,6 +10,7 @@ import Firmata from 'firmata';
 import {
   createCircuitPlaygroundComponents,
   cleanupCircuitPlaygroundComponents,
+  enableCircuitPlaygroundComponents,
   componentConstructors
 } from './PlaygroundComponents';
 import {
@@ -192,6 +193,15 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
     }
 
     this.fiveBoard_.on('disconnect', () => this.emit('disconnect'));
+  }
+
+  /**
+   * Enable existing board components
+   */
+  enableComponents() {
+    if (this.prewiredComponents_) {
+      enableCircuitPlaygroundComponents(this.prewiredComponents_);
+    }
   }
 
   /**

--- a/apps/src/lib/kits/maker/PlaygroundComponents.js
+++ b/apps/src/lib/kits/maker/PlaygroundComponents.js
@@ -102,21 +102,26 @@ export function cleanupCircuitPlaygroundComponents(
   }
 
   if (components.soundSensor) {
-    components.soundSensor.disable();
+    components.soundSensor._events = {};
   }
 
   if (components.lightSensor) {
-    components.lightSensor.disable();
+    components.lightSensor._events = {};
   }
 
   if (components.tempSensor) {
-    components.tempSensor.disable();
+    components.tempSensor._events = {};
   }
 
   if (components.accelerometer) {
-    components.accelerometer.stop();
+    components.accelerometer._events = {};
   }
   if (shouldDestroyComponents) {
+    components.soundSensor.destroy();
+    components.lightSensor.destroy();
+    components.tempSensor.destroy();
+    components.accelerometer.stop();
+
     delete components.colorLeds;
     delete components.led;
     delete components.toggleSwitch;

--- a/apps/src/lib/kits/maker/PlaygroundComponents.js
+++ b/apps/src/lib/kits/maker/PlaygroundComponents.js
@@ -101,19 +101,24 @@ export function cleanupCircuitPlaygroundComponents(
     components.buzzer.stop();
   }
 
+  //Disable and clear sensors
   if (components.soundSensor) {
+    components.soundSensor.disable();
     components.soundSensor._events = {};
   }
 
   if (components.lightSensor) {
+    components.lightSensor.disable();
     components.lightSensor._events = {};
   }
 
   if (components.tempSensor) {
+    components.tempSensor.disable();
     components.tempSensor._events = {};
   }
 
   if (components.accelerometer) {
+    components.accelerometer.stop();
     components.accelerometer._events = {};
   }
   if (shouldDestroyComponents) {
@@ -139,6 +144,29 @@ export function cleanupCircuitPlaygroundComponents(
         delete components[`touchPad${pin}`];
       });
     }
+  }
+}
+
+/**
+ * Re-initializes sensor components and accelerometer
+ * @param {Object} components - map of components, as originally returned by
+ *   createCircuitPlaygroundComponents.
+ */
+export function enableCircuitPlaygroundComponents(components) {
+  if (components.soundSensor) {
+    components.soundSensor.enable();
+  }
+
+  if (components.lightSensor) {
+    components.lightSensor.enable();
+  }
+
+  if (components.tempSensor) {
+    components.tempSensor.enable();
+  }
+
+  if (components.accelerometer) {
+    components.accelerometer.start();
   }
 }
 

--- a/apps/src/lib/kits/maker/PlaygroundComponents.js
+++ b/apps/src/lib/kits/maker/PlaygroundComponents.js
@@ -122,11 +122,6 @@ export function cleanupCircuitPlaygroundComponents(
     components.accelerometer._events = {};
   }
   if (shouldDestroyComponents) {
-    components.soundSensor.destroy();
-    components.lightSensor.destroy();
-    components.tempSensor.destroy();
-    components.accelerometer.stop();
-
     delete components.colorLeds;
     delete components.led;
     delete components.toggleSwitch;

--- a/apps/src/lib/kits/maker/toolkit.js
+++ b/apps/src/lib/kits/maker/toolkit.js
@@ -65,6 +65,8 @@ export function connect({interpreter, onDisconnect}) {
   if (currentBoard) {
     commands.injectBoardController(currentBoard);
     currentBoard.installOnInterpreter(interpreter);
+    // When the board is reset, the components are disabled. Re-enable now.
+    currentBoard.enableComponents();
     return Promise.resolve();
   }
 

--- a/apps/test/unit/lib/kits/maker/PlaygroundComponentsTest.js
+++ b/apps/test/unit/lib/kits/maker/PlaygroundComponentsTest.js
@@ -830,34 +830,37 @@ describe('Circuit Playground Components', () => {
       });
     });
 
-    it('calls disable on the soundSensor', () => {
+    it('calls disable on the soundSensor and clears events', () => {
       const spy = sinon.spy(components.soundSensor, 'disable');
       cleanupCircuitPlaygroundComponents(
         components,
         true /* shouldDestroyComponents */
       );
       expect(spy).to.have.been.calledOnce;
+      expect(components.soundSensor._events.length).to.equal(0);
     });
 
-    it('calls disable on the lightSensor', () => {
+    it('calls disable on the lightSensor and clears events', () => {
       const spy = sinon.spy(components.lightSensor, 'disable');
       cleanupCircuitPlaygroundComponents(
         components,
         true /* shouldDestroyComponents */
       );
       expect(spy).to.have.been.calledOnce;
+      expect(components.lightSensor._events.length).to.equal(0);
     });
 
-    it('calls disable on the tempSensor', () => {
+    it('calls disable on the tempSensor and clears events', () => {
       const spy = sinon.spy(components.tempSensor, 'disable');
       cleanupCircuitPlaygroundComponents(
         components,
         true /* shouldDestroyComponents */
       );
       expect(spy).to.have.been.calledOnce;
+      expect(components.tempSensor._events.length).to.equal(0);
     });
 
-    it('calls stop on the accelerometer', () => {
+    it('calls stop on the accelerometer and clears events', () => {
       // Spy on the controller template, because stop() ends up readonly on
       // the returned component.
       const spy = sinon.spy(Playground.Accelerometer.stop, 'value');
@@ -873,6 +876,8 @@ describe('Circuit Playground Components', () => {
         } catch (e) {
           assertionError = e;
         }
+
+        expect(components.accelerometer._events.length).to.equal(0);
 
         spy.restore();
         if (assertionError) {

--- a/apps/test/unit/lib/kits/maker/PlaygroundComponentsTest.js
+++ b/apps/test/unit/lib/kits/maker/PlaygroundComponentsTest.js
@@ -834,30 +834,31 @@ describe('Circuit Playground Components', () => {
       const spy = sinon.spy(components.soundSensor, 'disable');
       cleanupCircuitPlaygroundComponents(
         components,
-        true /* shouldDestroyComponents */
+        false /* shouldDestroyComponents */
       );
+      console.log(components.soundSensor._events);
       expect(spy).to.have.been.calledOnce;
-      expect(components.soundSensor._events.length).to.equal(0);
+      expect(components.soundSensor._events).to.be.empty;
     });
 
     it('calls disable on the lightSensor and clears events', () => {
       const spy = sinon.spy(components.lightSensor, 'disable');
       cleanupCircuitPlaygroundComponents(
         components,
-        true /* shouldDestroyComponents */
+        false /* shouldDestroyComponents */
       );
       expect(spy).to.have.been.calledOnce;
-      expect(components.lightSensor._events.length).to.equal(0);
+      expect(components.lightSensor._events).to.be.empty;
     });
 
     it('calls disable on the tempSensor and clears events', () => {
       const spy = sinon.spy(components.tempSensor, 'disable');
       cleanupCircuitPlaygroundComponents(
         components,
-        true /* shouldDestroyComponents */
+        false /* shouldDestroyComponents */
       );
       expect(spy).to.have.been.calledOnce;
-      expect(components.tempSensor._events.length).to.equal(0);
+      expect(components.tempSensor._events).to.be.empty;
     });
 
     it('calls stop on the accelerometer and clears events', () => {
@@ -867,7 +868,7 @@ describe('Circuit Playground Components', () => {
       return createCircuitPlaygroundComponents(board).then(components => {
         cleanupCircuitPlaygroundComponents(
           components,
-          true /* shouldDestroyComponents */
+          false /* shouldDestroyComponents */
         );
 
         let assertionError;
@@ -877,7 +878,7 @@ describe('Circuit Playground Components', () => {
           assertionError = e;
         }
 
-        expect(components.accelerometer._events.length).to.equal(0);
+        expect(components.accelerometer._events).to.be.empty;
 
         spy.restore();
         if (assertionError) {


### PR DESCRIPTION
# Description
This PR clears the events on the board when reset and then re-enables the components when run.

## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-682)

## Testing story

Includes tests that the events are emptied when the board is reset.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
