### PR TITLE
Performance opt height

### DIFF
--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -24,7 +24,6 @@ import color from '../../util/color';
 import commonStyles from '../../commonStyles';
 import Instructions from './Instructions';
 import styleConstants from '../../styleConstants';
-import {setInstructionsMaxHeightNeeded} from '../../redux/instructions';
 
 var instructions = require('../../redux/instructions');
 
@@ -171,8 +170,7 @@ class InstructionsCSF extends React.Component {
 
     height: PropTypes.number.isRequired,
     maxHeight: PropTypes.number.isRequired,
-    setInstructionsRenderedHeight: PropTypes.func.isRequired,
-    setInstructionsMaxHeightNeeded: PropTypes.func.isRequired
+    setInstructionsRenderedHeight: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -741,9 +739,6 @@ module.exports = connect(
       },
       clearFeedback(height) {
         dispatch(instructions.setFeedback(null));
-      },
-      setInstructionsMaxHeightNeeded(height) {
-        dispatch(setInstructionsMaxHeightNeeded(height));
       }
     };
   },

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -283,7 +283,6 @@ class InstructionsCSF extends React.Component {
         minHeight
       );
       this.props.setInstructionsRenderedHeight(newHeight);
-      this.props.setInstructionsMaxHeightNeeded(maxHeight);
     }
 
     this.props.adjustMaxNeededHeight();

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -377,7 +377,9 @@ class TopInstructions extends Component {
       HEADER_HEIGHT +
       RESIZER_HEIGHT;
 
-    this.props.setInstructionsMaxHeightNeeded(maxNeededHeight);
+    if (this.props.maxHeight !== maxNeededHeight) {
+      this.props.setInstructionsMaxHeightNeeded(maxNeededHeight);
+    }
     return maxNeededHeight;
   };
 


### PR DESCRIPTION
# Description
Removing unnecessary height adjustments to try and optimize the performance that is causing Minecraft to crash browsers.

Performance of connecting blocks on staging, at a x6 throttle
![Screenshot from 2019-09-30 14-16-31](https://user-images.githubusercontent.com/2959170/65920600-4a234080-e394-11e9-97d5-459b5f2217d7.png)

Performance of connecting blocks on this branch, at a x6 throttle
![Screenshot from 2019-09-30 14-20-55](https://user-images.githubusercontent.com/2959170/65920613-56a79900-e394-11e9-8dba-b6c1e8a850aa.png)


## Links

- [COE](https://docs.google.com/document/d/1o53WHEkQ4wo5uMc_uDnfXvd7VlMV-4UO_pt24nV5nTo/edit#bookmark=id.hlaccfevq4l4)


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
