### PR TITLE
Allow level names with periods

### DIFF
--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -21,7 +21,7 @@ class LevelStarterAssetsController < ApplicationController
   # GET /level_starter_assets/:level_name/:filename
   # Returns requested file body as an IO stream.
   def file
-    friendly_name = "#{params[:filename]}.#{params[:format]}"
+    friendly_name = params[:filename]
     uuid_name = @level.starter_assets[friendly_name]
     file_obj = get_object(uuid_name)
     content_type = file_content_type(File.extname(uuid_name))
@@ -62,7 +62,7 @@ class LevelStarterAssetsController < ApplicationController
   # but does not delete the asset from S3 as other levels may still be
   # using it.
   def destroy
-    if @level.remove_starter_asset!("#{params[:filename]}.#{params[:format]}")
+    if @level.remove_starter_asset!(params[:filename])
       return head :no_content
     else
       return head :unprocessable_entity

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -233,7 +233,7 @@ Dashboard::Application.routes.draw do
 
   post 'level_assets/upload', to: 'level_assets#upload'
 
-  resources :level_starter_assets, only: [:show], param: 'level_name' do
+  resources :level_starter_assets, only: [:show], param: 'level_name', constraints: {level_name: /[^\/]+/} do
     member do
       get '/:filename', to: 'level_starter_assets#file'
       post '', to: 'level_starter_assets#upload'

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -64,7 +64,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     }
     level = create(:applab, starter_assets: level_starter_assets)
 
-    get :file, params: {level_name: level.name, filename: 'ty', format: 'png'}
+    get :file, params: {level_name: level.name, filename: 'ty.png'}
 
     assert_equal 'hello, world!', response.body
     assert_equal 'image/png', response.headers['Content-Type']

--- a/dashboard/test/integration/routes_test.rb
+++ b/dashboard/test/integration/routes_test.rb
@@ -33,4 +33,9 @@ class RoutesTest < ActionDispatch::IntegrationTest
     assert_caching_disabled response.headers['Cache-Control']
     assert_not_nil cookies['_learn_session_test']
   end
+
+  def test_level_starter_assets_handles_periods
+    assert_generates('level_starter_assets/level_name.with.periods', {controller: 'level_starter_assets', action: 'show', level_name: 'level_name.with.periods'})
+    assert_generates('level_starter_assets/level_name_no_periods', {controller: 'level_starter_assets', action: 'show', level_name: 'level_name_no_periods'})
+  end
 end


### PR DESCRIPTION
# Description

Level names with periods, like `Finalize Your Chaser Game v.1_2019` were breaking the level assets controller because they were getting routed as: `"level_name"=>"Finalize Your Chaser Game v", "format"=>"1_2019"`. According the Rails documentation: https://guides.rubyonrails.org/routing.html#specifying-constraints, we can specify constraints on our params. The `level name` of the `level_start_assets` route is now enabled to handle anything but slashes.


Address current livesite issue that can be seen by trying to complete: `/s/csp5-2019/stage/1/puzzle/22`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
