### PR TITLE
Update Firebase rules for shared tables

### DIFF
--- a/apps/firebase/rules.bolt
+++ b/apps/firebase/rules.bolt
@@ -30,6 +30,10 @@ path /v3/channels/shared {
   read() { isLoggedIn() }
 }
 
+path /v3/channels/{channelId}/current_tables/{tableName} is Boolean {
+  write() { canAccessChannel(channelId) }
+}
+
 path /v3/channels/{channelId}/serverTime is Number {
   write() { canAccessChannel(channelId) }
 }

--- a/apps/firebase/rules.bolt
+++ b/apps/firebase/rules.bolt
@@ -26,6 +26,10 @@ path /v3/channels/{channelId} {
   read() { canAccessChannel(channelId) }
 }
 
+path /v3/channels/shared {
+  read() { isLoggedIn() }
+}
+
 path /v3/channels/{channelId}/serverTime is Number {
   write() { canAccessChannel(channelId) }
 }


### PR DESCRIPTION
# Description
We want all users of the data tab to be able to access the shared channel, which is where we will store the dataset library. 
This PR also adds a node to each channel to track which current tables the project has imported. For current tables, we don't actually copy the data into the project's channel, so we just need to track a boolean of which tables to display.
![image](https://user-images.githubusercontent.com/8787187/65979303-e6e3ed80-e429-11e9-85f2-84646361dc77.png)

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-714)

## Testing story
I compiled the rules locally, and verified that the generated rules looks right:
![image](https://user-images.githubusercontent.com/8787187/65975355-5acec780-e423-11e9-99f6-19084dfe2fc6.png)
![image](https://user-images.githubusercontent.com/8787187/65979376-0844d980-e42a-11e9-83f7-216d7a14ca83.png)

I then uploaded the new rules to the dev firebase environment, and verified that I was able to access data from the shared channel in my project:
![image](https://user-images.githubusercontent.com/8787187/65975432-776aff80-e423-11e9-9fb6-eb50b79cbd45.png)

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
