### PR TITLE
Switch to ubuntu 18 in production [ci skip]

### DIFF
--- a/aws/chef-bootstrap.sh
+++ b/aws/chef-bootstrap.sh
@@ -24,7 +24,7 @@ set -o errexit
 # Set script defaults
 ENVIRONMENT=adhoc
 BRANCH=staging
-CHEF_VERSION=12.7.2
+CHEF_VERSION=15.2.20
 RUN_LIST='["recipe[cdo-apps]"]'
 NODE_NAME=$(hostname)
 S3_BUCKET=cdo-dist
@@ -151,4 +151,4 @@ else
 fi
 
 # Run chef-client.
-${CHEF_CLIENT} -c ${CLIENT_RB} -j ${FIRST_BOOT}
+${CHEF_CLIENT} -c ${CLIENT_RB} -j ${FIRST_BOOT} --chef-license accept-silent

--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -32,7 +32,7 @@ module AWS
     STACK_NAME_INVALID_REGEX = /[^[:alnum:]-]/
 
     SSH_KEY_NAME = 'server_access_key'.freeze
-    IMAGE_ID = ENV['IMAGE_ID'] || 'ami-c8580bdf' # ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*
+    IMAGE_ID = ENV['IMAGE_ID'] || 'ami-07d0cf3af28718ef8' # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1
     INSTANCE_TYPE = rack_env?(:production) ? 'm4.10xlarge' : 't2.2xlarge'
     SSH_IP = '0.0.0.0/0'.freeze
     S3_BUCKET = 'cdo-dist'.freeze

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -19,23 +19,21 @@ namespace :ci do
     elsif CDO.daemon && CDO.chef_managed
 
       # Temporarily disable automatic chef cookbook updates for Ubuntu upgrade except for envs undergoing upgrade
-      if [].include?(rack_env)
-        ChatClient.log('Updating Chef cookbooks...')
-        RakeUtils.with_bundle_dir(cookbooks_dir) do
-          # Automatically update Chef cookbook versions in staging environment.
-          RakeUtils.bundle_exec './update_cookbook_versions' if rack_env?(:staging)
-          RakeUtils.bundle_exec 'berks', 'install'
-          if rack_env?(:staging) && GitUtils.file_changed_from_git?(cookbooks_dir)
-            RakeUtils.system 'git', 'add', '.'
-            RakeUtils.system 'git', 'commit', '-m', '"Updated cookbook versions"'
-            RakeUtils.git_push
-          end
-          RakeUtils.bundle_exec 'berks', 'upload', (rack_env?(:production) ? '' : '--no-freeze')
-          RakeUtils.bundle_exec 'berks', 'apply', rack_env
-
-          ChatClient.log 'Applying <b>chef</b> profile...'
-          RakeUtils.sudo '/opt/chef/bin/chef-client'
+      ChatClient.log('Updating Chef cookbooks...')
+      RakeUtils.with_bundle_dir(cookbooks_dir) do
+        # Automatically update Chef cookbook versions in staging environment.
+        RakeUtils.bundle_exec './update_cookbook_versions' if rack_env?(:staging)
+        RakeUtils.bundle_exec 'berks', 'install'
+        if rack_env?(:staging) && GitUtils.file_changed_from_git?(cookbooks_dir)
+          RakeUtils.system 'git', 'add', '.'
+          RakeUtils.system 'git', 'commit', '-m', '"Updated cookbook versions"'
+          RakeUtils.git_push
         end
+        RakeUtils.bundle_exec 'berks', 'upload', (rack_env?(:production) ? '' : '--no-freeze')
+        RakeUtils.bundle_exec 'berks', 'apply', rack_env
+
+        ChatClient.log 'Applying <b>chef</b> profile...'
+        RakeUtils.sudo '/opt/chef/bin/chef-client'
       end
     end
   end


### PR DESCRIPTION
# Description

Final change needed to start using ubuntu 18 in production. Planned sequence of events:

Start sometime after last DTP 

1. Make snapshots of:
- WebServerAMI instance
- production-daemon
- production-console

2. Disable cron on production-daemon

3. make new copies of production-daemon, production-console (from the snapshots)

4. Disable cron on production-daemon-upgrade, reenable on production-daemon

5. Upgrade ubuntu on production-daemon-upgrade, production-console-upgrade

8. Merge this change and get a green DTT

7. Ensure `omnibus_updater` attribute for production is set to `version: 15.2.20`

7. Update `console` entry override attribute on chef production environment to dns name of upgraded console instance

6. Disable cron on production-daemon, reenable on production-daemon-upgrade

9. DTP, which should start a build on production-daemon-upgrade, not production-daemon

10. The CF stack update will cause a new WebServerAMI instance to be created and bootstrapped

## Testing story

Manually tested bootstrapping of a new WebServerAMI instance, and put it into the production LB to receive traffic for ~20 minutes. No significant errors seen in honeybadger.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
