### PR TITLE
Remove gsheet-based summing for state promote

### DIFF
--- a/pegasus/src/database.rb
+++ b/pegasus/src/database.rb
@@ -101,11 +101,11 @@ def k12_access_count
 end
 
 def jobs_nationwide
-  DB[:cdo_state_promote].sum(:cs_jobs_i)
+  @jobs_nationwide ||= DB[:cdo_state_promote].sum(:cs_jobs_i)
 end
 
 def grads_nationwide
-  DB[:cdo_state_promote].sum(:cs_graduates_i)
+  @grads_nationwide ||= DB[:cdo_state_promote].sum(:cs_graduates_i)
 end
 
 def zip_code_from_code(code)

--- a/pegasus/src/database.rb
+++ b/pegasus/src/database.rb
@@ -101,11 +101,11 @@ def k12_access_count
 end
 
 def jobs_nationwide
-  @jobs_nationwide ||= DB[:cdo_state_promote].sum(:cs_jobs_i)
+  $jobs_nationwide ||= DB[:cdo_state_promote].sum(:cs_jobs_i)
 end
 
 def grads_nationwide
-  @grads_nationwide ||= DB[:cdo_state_promote].sum(:cs_graduates_i)
+  $grads_nationwide ||= DB[:cdo_state_promote].sum(:cs_graduates_i)
 end
 
 def zip_code_from_code(code)

--- a/pegasus/src/database.rb
+++ b/pegasus/src/database.rb
@@ -101,11 +101,11 @@ def k12_access_count
 end
 
 def jobs_nationwide
-  DB[:cdo_state_promote].where(state_code_s: "Sum_states").first[:cs_jobs_i]
+  DB[:cdo_state_promote].sum(:cs_jobs_i)
 end
 
 def grads_nationwide
-  DB[:cdo_state_promote].where(state_code_s: "Sum_states").first[:cs_graduates_i]
+  DB[:cdo_state_promote].sum(:cs_graduates_i)
 end
 
 def zip_code_from_code(code)


### PR DESCRIPTION
Long [ago](https://github.com/code-dot-org/code-dot-org/pull/3591) we apparently took advantage of an extra row in the `cdo-state-promote` gsheet that was labeled with `"Sum_states"` rather than a state itself.  This has since caused an issue in [an iterator](https://github.com/code-dot-org/code-dot-org/blob/staging/pegasus/rake/generate_pdfs.rake#L21) when we attempted to generate a PDF for a state of "Sum_states".

With this change, we just do the summing in the SQL query, rather than relying upon the sum generated by the gsheet.  This will allow us to simultaneously remove the row from the gsheet.
