### PR TITLE
Only trigger toggle switch on state change

### DIFF
--- a/apps/src/lib/kits/maker/Switch.js
+++ b/apps/src/lib/kits/maker/Switch.js
@@ -43,8 +43,6 @@ export default class Switch extends EventEmitter {
      * fired, even if the state didn't change.
      * We cache the last known state of the switch so we only emit events when
      * the switch state changes.
-     * We don't initialize the lastKnownState so that we fire an event the first
-     * time we receive it, when the program starts.
      */
     let lastKnownState = undefined;
 
@@ -79,7 +77,7 @@ export default class Switch extends EventEmitter {
     // Listen to 'open' and 'close' events on the wrapped five.Switch controller.
     // Emit our own events only when we detect a state change.
     fiveSwitch.on('open', () => {
-      if (lastKnownState !== fiveSwitch.openValue) {
+      if (lastKnownState === fiveSwitch.closeValue) {
         this.emit('open');
         this.emit('change', fiveSwitch.openValue);
       }
@@ -87,7 +85,7 @@ export default class Switch extends EventEmitter {
     });
 
     fiveSwitch.on('close', () => {
-      if (lastKnownState !== fiveSwitch.closeValue) {
+      if (lastKnownState === fiveSwitch.openValue) {
         this.emit('close');
         this.emit('change', fiveSwitch.closeValue);
       }

--- a/apps/test/unit/lib/kits/maker/SwitchTest.js
+++ b/apps/test/unit/lib/kits/maker/SwitchTest.js
@@ -60,11 +60,14 @@ describe('Switch', () => {
     });
   });
 
-  describe('events', () => {
+  describe('open events', () => {
     let testObj, openSpy, closeSpy, changeSpy;
 
     beforeEach(() => {
       testObj = new Switch({});
+      // When the johnny five switch is initialized,
+      // it emits an event to represent the initial state
+      fakeJohnnyFiveSwitch.emit('close');
       openSpy = sinon.spy();
       closeSpy = sinon.spy();
       changeSpy = sinon.spy();
@@ -82,15 +85,6 @@ describe('Switch', () => {
       );
     });
 
-    it("emits 'close' and 'change' when the first event from the inner controller is 'close'", () => {
-      fakeJohnnyFiveSwitch.emit('close');
-      expect(openSpy).not.to.have.been.called;
-      expect(closeSpy).to.have.been.calledOnce;
-      expect(changeSpy).to.have.been.calledOnce.and.calledWith(
-        testObj.closeValue
-      );
-    });
-
     it("does not emit extra 'open' events", () => {
       fakeJohnnyFiveSwitch.emit('open');
       fakeJohnnyFiveSwitch.emit('open');
@@ -99,6 +93,40 @@ describe('Switch', () => {
       expect(closeSpy).not.to.have.been.called;
       expect(changeSpy).to.have.been.calledOnce.and.calledWith(
         testObj.openValue
+      );
+    });
+
+    it("emits events when changing from 'open' to 'close' or back", () => {
+      fakeJohnnyFiveSwitch.emit('open');
+      fakeJohnnyFiveSwitch.emit('close');
+      fakeJohnnyFiveSwitch.emit('open');
+      fakeJohnnyFiveSwitch.emit('close');
+      expect(openSpy).to.have.been.calledTwice;
+      expect(closeSpy).to.have.been.calledTwice;
+      expect(changeSpy).to.have.callCount(4);
+    });
+  });
+
+  describe('close events', () => {
+    let testObj, openSpy, closeSpy, changeSpy;
+
+    beforeEach(() => {
+      testObj = new Switch({});
+      fakeJohnnyFiveSwitch.emit('open');
+      openSpy = sinon.spy();
+      closeSpy = sinon.spy();
+      changeSpy = sinon.spy();
+      testObj.on('open', openSpy);
+      testObj.on('close', closeSpy);
+      testObj.on('change', changeSpy);
+    });
+
+    it("emits 'close' and 'change' when the first event from the inner controller is 'close'", () => {
+      fakeJohnnyFiveSwitch.emit('close');
+      expect(openSpy).not.to.have.been.called;
+      expect(closeSpy).to.have.been.calledOnce;
+      expect(changeSpy).to.have.been.calledOnce.and.calledWith(
+        testObj.closeValue
       );
     });
 
@@ -111,16 +139,6 @@ describe('Switch', () => {
       expect(changeSpy).to.have.been.calledOnce.and.calledWith(
         testObj.closeValue
       );
-    });
-
-    it("emits events when changing from 'open' to 'close' or back", () => {
-      fakeJohnnyFiveSwitch.emit('open');
-      fakeJohnnyFiveSwitch.emit('close');
-      fakeJohnnyFiveSwitch.emit('open');
-      fakeJohnnyFiveSwitch.emit('close');
-      expect(openSpy).to.have.been.calledTwice;
-      expect(closeSpy).to.have.been.calledTwice;
-      expect(changeSpy).to.have.callCount(4);
     });
   });
 });


### PR DESCRIPTION
# Description

Previously, we were triggering the 'open' event when the board on initial run. Per discussion in maker-tookit, we decided to update the open/close so it is only triggered when an action is taken (flipping the switch).

## Testing story

Manually tested

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
