### PR TITLE
Swap in production URL for AFE CTA

### DIFF
--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -258,7 +258,7 @@ export default class DonorTeacherBanner extends Component {
 
           <form
             id="hidden_form"
-            action="https://afe.qa.amazon-blogs.psdops.com/code-org-afe"
+            action="https://teachers-amazon-future-engineer.com/"
             method="post"
             target="_blank"
           >
@@ -305,7 +305,7 @@ export default class DonorTeacherBanner extends Component {
           notice="Your response has been submitted!"
           details="Thank you for your response.  If you are not redirected to the form in a few moments,"
           detailsLinkText="click here"
-          detailsLink="https://afe.qa.amazon-blogs.psdops.com/code-org-afe"
+          detailsLink="https://teachers-amazon-future-engineer.com/"
           detailsLinkNewWindow={true}
           dismissible={true}
         />


### PR DESCRIPTION
# Description

We got a final URL for the AFE form.  Swapping it in for the test URL we had in place before.

We're not live yet - we've still got experiments in place to hide this feature.

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-476)

## Testing story

No tests included - this is configuration, and we'll have to do integration testing manually with AFE.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
