### PR TITLE
Prevent html injection in sign out page: Use string that includes markdown

### DIFF
--- a/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
@@ -150,7 +150,7 @@
       %br/
       *
       -# Temporarily use student_terms so that existing translations get used.
-      != t('signup_form.student_terms')
+      != t('signup_form.student_terms_markdown', markdown: true)
 
   .span5{style: "display: flex;"}
     %div.vertical-or


### PR DESCRIPTION
Replace the string "signup_form.student_terms" with "signup_form.student_terms_markdown"

signup_form.student_terms_markdown uses markdown to prevent html injection in the signup form.

"student_terms" string does not exist

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
- [jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&projectKey=FND&modal=detail&selectedIssue=FND-723)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
