### PR TITLE
Prevent html injection in sign up form: Use string that includes markdown

### DIFF
--- a/dashboard/app/views/devise/registrations/_new_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_new_sign_up_form.html.haml
@@ -35,4 +35,4 @@
 / More information for students about email storage.
 %div{style: "width: 700px;"}
   *
-  != t('signup_form.student_terms')
+  != t('signup_form.student_terms_markdown', markdown: true)


### PR DESCRIPTION
# Description
Replace the string "signup_form.student_terms" with "signup_form.student_terms_markdown"

signup_form.student_terms_markdown uses markdown to prevent html injection in the signup form.

"student_terms" string does not exist

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
