### PR TITLE
PLC data model documentation

### DIFF
--- a/dashboard/app/models/plc/README.md
+++ b/dashboard/app/models/plc/README.md
@@ -1,1 +1,20 @@
-Explanation of PLC Model and objects is here - http://wiki.code.org/display/Operations/Explanation+of+PLC+Model
+# Explanation of the PLC models
+Here's an overview of the different object types for PLC work and details on their relationships.
+ 
+**User** - For PLC, a teacher taking the professional learning class. We will use the existing User object and do not need to add anything to this (yet)
+
+**Professional Learning Course** - A course that the teacher is taking to build their skills. Ex: Teaching Computer Science Principles. A user may be enrolled in multiple courses.
+ 
+**Course Unit** - Corresponds to a `Script` in our regular curriculum structure.  Units belong to courses, modules belong to units.
+ 
+**Learning Module** - A component of a course, like "Internet Safety" or "What are loops?"  Modules are part of units, are part of courses.
+
+**Task** - A thing that someone who is trying to complete a module must do. Ex: a written lesson plan, completing a given script. A module will have one or more task to complete. Every task belongs to exactly one module. Some examples of task types are
+- Script Completion Tasks - completed when a user finishes a given script in code studio
+- Written Assignment Tasks - completed when a user submits some writing
+  - Some of these will be reviewed by instructors, some of these will be reviewed by peers
+- Learning Resources - Although these are not tasks, it makes sense to model them as such. These are links to external sites or videos that a user may find useful. There's no concept of "completing" these (yet) but they should show up as items a user should do
+ 
+**User Course Enrollment** - Maps a user to a course they are enrolled in.
+
+**Enrollment Module Assignment** - Maps a course enrollment to all the modules that they have to complete in order to complete the course.

--- a/dashboard/app/models/plc/course.rb
+++ b/dashboard/app/models/plc/course.rb
@@ -12,6 +12,11 @@
 #  fk_rails_d5fc777f73  (course_id)
 #
 
+# Professional Learning Course
+# A course that the teacher is taking to build their skills.
+# Ex: Teaching Computer Science Principles.
+# A Plc::Course is always tied to a Course in our regular curriculum hierarchy.
+# A user may be enrolled in multiple courses.
 class Plc::Course < ActiveRecord::Base
   has_many :plc_enrollments, class_name: '::Plc::UserCourseEnrollment', foreign_key: 'plc_course_id', dependent: :destroy
   has_many :plc_course_units, class_name: '::Plc::CourseUnit', foreign_key: 'plc_course_id', dependent: :destroy

--- a/dashboard/app/models/plc/course_unit.rb
+++ b/dashboard/app/models/plc/course_unit.rb
@@ -18,6 +18,8 @@
 #  index_plc_course_units_on_script_id      (script_id)
 #
 
+# A named group of learning modules within a PLC course.
+# Corresponds to a Script in our regular curriculum hierarchy.
 class Plc::CourseUnit < ActiveRecord::Base
   belongs_to :script
   belongs_to :plc_course, class_name: '::Plc::Course'

--- a/dashboard/app/models/plc/enrollment_module_assignment.rb
+++ b/dashboard/app/models/plc/enrollment_module_assignment.rb
@@ -16,6 +16,10 @@
 #  module_assignment_lm_index                          (plc_learning_module_id)
 #
 
+# Maps a unit enrollment to all the modules that a teacher must complete in order to
+# complete the unit.
+#
+# Normally created when a teacher enrolls in a workshop with a corresponding PLC course.
 class Plc::EnrollmentModuleAssignment < ActiveRecord::Base
   belongs_to :plc_enrollment_unit_assignment, class_name: '::Plc::EnrollmentUnitAssignment'
   belongs_to :plc_learning_module, class_name: '::Plc::LearningModule'

--- a/dashboard/app/models/plc/enrollment_unit_assignment.rb
+++ b/dashboard/app/models/plc/enrollment_unit_assignment.rb
@@ -18,6 +18,10 @@
 #  index_plc_enrollment_unit_assignments_on_user_id    (user_id)
 #
 
+# Maps a course enrollment to all the units that a teacher must complete in order to
+# complete the course.
+#
+# Normally created when a teacher enrolls in a workshop with a corresponding PLC course.
 class Plc::EnrollmentUnitAssignment < ActiveRecord::Base
   belongs_to :plc_user_course_enrollment, class_name: '::Plc::UserCourseEnrollment'
   belongs_to :plc_course_unit, class_name: '::Plc::CourseUnit'

--- a/dashboard/app/models/plc/learning_module.rb
+++ b/dashboard/app/models/plc/learning_module.rb
@@ -16,6 +16,11 @@
 #  index_plc_learning_modules_on_stage_id            (stage_id)
 #
 
+# A component of a course, like "Internet Safety" or "What are loops?"
+# Modules are independent of courses. Two people taking the same course may have different modules
+# to complete. Additionally, some modules will be part of multiple courses. So courses are not
+# part of modules, and modules are not part of courses.
+# Learning Modules correspond to Stages in our regular curriculum hierarchy.
 class Plc::LearningModule < ActiveRecord::Base
   belongs_to :stage
   belongs_to :plc_course_unit, class_name: '::Plc::CourseUnit', foreign_key: 'plc_course_unit_id'

--- a/dashboard/app/models/plc/task.rb
+++ b/dashboard/app/models/plc/task.rb
@@ -15,6 +15,19 @@
 #  index_plc_tasks_on_script_level_id  (script_level_id)
 #
 
+# A thing that someone who is trying to complete a learning module must do.
+# Ex: a written lesson plan, completing a given script.
+# A module will have one or more tasks to complete. Every task belongs to exactly one module.
+#
+# Some examples of task types are:
+#   Script Completion Tasks - completed when a user finishes a given script in code studio
+#   Written Assignment Tasks - completed when a user submits some writing
+#     Some of these will be reviewed by instructors, some of these will be reviewed by peers
+#   Learning Resources - Although these are not tasks, it makes sense to model them as such.
+#     These are links to external sites or videos that a user may find useful. There's no
+#     concept of "completing" these (yet) but they should show up as items a user should do.
+#
+# Tasks correspond to ScriptLevels in our regular curriculum hierarchy.
 class Plc::Task < ActiveRecord::Base
   belongs_to :script_level
   has_and_belongs_to_many :plc_learning_modules, class_name: '::Plc::LearningModule', foreign_key: 'plc_task_id', association_foreign_key: 'plc_learning_module_id'

--- a/dashboard/app/models/plc/user_course_enrollment.rb
+++ b/dashboard/app/models/plc/user_course_enrollment.rb
@@ -15,6 +15,9 @@
 #  index_plc_user_course_enrollments_on_user_id_and_plc_course_id  (user_id,plc_course_id) UNIQUE
 #
 
+# Maps a user to a course they are enrolled in.
+#
+# Normally created when a teacher enrolls in a workshop with a corresponding PLC course.
 class Plc::UserCourseEnrollment < ActiveRecord::Base
   belongs_to :plc_course, class_name: '::Plc::Course'
   belongs_to :user, class_name: 'User'


### PR DESCRIPTION
Adds the beginning of an explanation of the PLC data model.

Mostly lifted from [this old document](https://docs.google.com/document/d/18VvmToEfu_eYO2CCJvkpfs1LsiEtCnCdmg7SBd3HTv4/edit), formerly a wiki page. (I'm replacing a broken link to that page here as well.)

This change is purely comments, and definitely not perfect - meant as a starting point for future elaboration.