### PR TITLE
Destroy resolved QueuedAccountPurges

### DIFF
--- a/dashboard/app/models/queued_account_purge.rb
+++ b/dashboard/app/models/queued_account_purge.rb
@@ -43,4 +43,10 @@ class QueuedAccountPurge < ApplicationRecord
     AccountPurger.new(bypass_safety_constraints: true).purge_data_for_account User.with_deleted.find(user_id)
     destroy!
   end
+
+  # It's possible to have a QueuedAccountPurge still around, pointing at an account that
+  # has already been purged.  This method finds and removes those records.
+  def self.clean_up_resolved_records!
+    all.select {|qap| User.with_deleted.find(qap.user_id).purged_at.present?}.each(&:destroy!)
+  end
 end

--- a/dashboard/app/models/queued_account_purge.rb
+++ b/dashboard/app/models/queued_account_purge.rb
@@ -50,6 +50,9 @@ class QueuedAccountPurge < ApplicationRecord
   # It's possible to have a QueuedAccountPurge still around, pointing at an account that
   # has already been purged.  This method finds and removes those records.
   def self.clean_up_resolved_records!
+    # Not too worried about efficiency here because:
+    # a) It runs once every night, close to nadir traffic.
+    # b) Number of selected records should always be double-digits and below.
     joins(:user).where.not(users: {purged_at: nil}).destroy_all
   end
 end

--- a/dashboard/lib/expired_deleted_account_purger.rb
+++ b/dashboard/lib/expired_deleted_account_purger.rb
@@ -71,6 +71,8 @@ class ExpiredDeletedAccountPurger
       QueuedAccountPurge.create(user: account, reason_for_review: err.message) unless @dry_run
       @num_accounts_queued += 1
     end
+
+    QueuedAccountPurge.clean_up_resolved_records!
   rescue StandardError => err
     yell err.message
     raise


### PR DESCRIPTION
Due to an increase in intermittent Pardot errors, we recently [made some QueuedAccountPurges autoretryable](https://github.com/code-dot-org/code-dot-org/pull/30909). (See also [this change to reporting from this task](https://github.com/code-dot-org/code-dot-org/pull/30959).) To our surprise, the queue depth still continued to increase.

It turns out the auto-retry was working, but the `QueuedAccountPurge` records associated with the retried accounts were not being cleared.

This change adds a step right at the end of the nightly task to clean up any resolved `QueuedAccountPurge` records.  One benefit of this design is that it will retroactively clean up our queue on production next time it runs, so no manual correction to the production database is required.

## Links

- The old [Hard-deleting Accounts Tech Spec](https://docs.google.com/document/d/1l2kB4COz8-NwZfNCGufj7RfdSm-B3waBmLenc6msWVs/edit#heading=h.51yyvew9081b)

## Testing story

I've included unit tests for the new behavior, which is how we cover all of our account purge code.  Please consider whether there are any cases I've missed.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
