### PR TITLE
PL: Tweak to script to backfill old workshop dates

### DIFF
--- a/bin/oneoff/backfill_data/backfill_old_workshop_dates.rb
+++ b/bin/oneoff/backfill_data/backfill_old_workshop_dates.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require_relative '../../../dashboard/config/environment'
+
 # Script to backfill workshops, that were migrated from Workshop to Pd::Workshop,
 # with their start & stop dates, to prevent them from showing up in dashboards
 # because their states appear to be STATE_NOT_STARTED.


### PR DESCRIPTION
Just a small tweak that was necessary to run the backfill script.

Followup to https://github.com/code-dot-org/code-dot-org/pull/31020
