### PR TITLE
Escape asset name using double quote

### DIFF
--- a/apps/src/code-studio/components/AssetRow.jsx
+++ b/apps/src/code-studio/components/AssetRow.jsx
@@ -118,7 +118,7 @@ export default class AssetRow extends React.Component {
     }
 
     let usage = $('#visualization').find(
-      `[src*=\'${encodeURIComponent(this.props.name).replace("'", "\\'")}']`
+      `[src*="${encodeURIComponent(this.props.name)}"]`
     ).length;
 
     switch (this.state.action) {

--- a/apps/test/unit/code-studio/components/AssetRowTest.js
+++ b/apps/test/unit/code-studio/components/AssetRowTest.js
@@ -4,7 +4,7 @@ import {mount} from 'enzyme';
 import AssetRow from '@cdo/apps/code-studio/components/AssetRow';
 
 const DEFAULT_PROPS = {
-  name: "foo's.bar",
+  name: `fo\'o's.bar`,
   type: 'image',
   api: {
     basePath: name => `/path/to/${name}`
@@ -13,11 +13,11 @@ const DEFAULT_PROPS = {
 };
 
 describe('AssetRow', () => {
-  it('recognizes assets with an apostrophe in the src string', () => {
+  it('recognizes assets with apostrophes and escaped apostrophes in the src string', () => {
     var visualization = document.createElement('div');
     visualization.id = 'visualization';
     var child = document.createElement('div');
-    child.setAttribute('src', "foo's.bar");
+    child.setAttribute('src', `fo\'o's.bar`);
     visualization.appendChild(child);
     document.body.appendChild(visualization);
     const wrapper = mount(


### PR DESCRIPTION
# Description
A sound with both escaped and unescaped single quotes (such as `bell\'s bell's.mp3`). breaks the asset manager:
![image](https://user-images.githubusercontent.com/8787187/66154269-ef772800-e5d1-11e9-9aa0-3aca66ab133a.png)
![image](https://user-images.githubusercontent.com/8787187/66154282-f867f980-e5d1-11e9-8ff6-ff128d57db9d.png)

This PR implements the change Dave suggested in #28953.
![image](https://user-images.githubusercontent.com/8787187/66154429-42e97600-e5d2-11e9-8c7d-34b1c6ee8c3a.png)


## Links

- [zendesk](https://codeorg.zendesk.com/agent/tickets/251433)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
