### PR TITLE
app dashboard and application forms don't have to have the years in sync

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -227,9 +227,9 @@ module Api::V1::Pd
       when :csp_facilitators
         return applications_of_type.csp
       when :csd_teachers
-        return applications_of_type.csd.where(application_year: APPLICATION_CURRENT_YEAR)
+        return applications_of_type.csd.where(application_year: DASHBOARD_APPLICATION_YEAR)
       when :csp_teachers
-        return applications_of_type.csp.where(application_year: APPLICATION_CURRENT_YEAR)
+        return applications_of_type.csp.where(application_year: DASHBOARD_APPLICATION_YEAR)
       else
         raise ActiveRecord::RecordNotFound
       end

--- a/dashboard/app/models/pd/application/active_application_models.rb
+++ b/dashboard/app/models/pd/application/active_application_models.rb
@@ -4,6 +4,7 @@ module Pd
       include ApplicationConstants
 
       APPLICATION_CURRENT_YEAR = YEAR_19_20
+      DASHBOARD_APPLICATION_YEAR = YEAR_19_20
 
       # Active (this year's) application classes and factories
       TEACHER_APPLICATION_CLASS = Teacher1920Application


### PR DESCRIPTION
# Description

Allow the application dashboard to show a different year's applications from the currently open application forms. This will allow us to show the newer application form, but keep last year's applications visible in the dashboard for partners to download until we update `DASHBOARD_APPLICATION_YEAR`.

### Future work

Update `DASHBOARD_APPLICATION_YEAR` when ready for the dashboard to show this year's applications.

## Links

- [jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=PLC-506)