### PR TITLE
Fix CodeGen for Dance blocks on Levelbuilder

### DIFF
--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -7,7 +7,8 @@ import initializeCodeMirror, {
 import jsonic from 'jsonic';
 import {parseElement} from '@cdo/apps/xml';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
-import {customInputTypes} from '@cdo/apps/p5lab/spritelab/blocks';
+import {customInputTypes as spritelabCustomInputTypes} from '@cdo/apps/p5lab/spritelab/blocks';
+import {customInputTypes as dancelabCustomInputTypes} from '@cdo/apps/dance/blocks';
 import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/P5Lab';
 import animationListModule, {
   setInitialAnimationList
@@ -54,6 +55,12 @@ function onChange(editor) {
 
   const parsedConfig = jsonic(config);
 
+  // Only Dancelab and Spritelab use customInputTypes.
+  const customInputTypes =
+    poolField.value === 'Dancelab'
+      ? dancelabCustomInputTypes
+      : spritelabCustomInputTypes;
+
   const blocksInstalled = installCustomBlocks({
     blockly: Blockly,
     blockDefinitions: [
@@ -65,7 +72,7 @@ function onChange(editor) {
         helperCode: helperEditor && helperEditor.getValue()
       }
     ],
-    customInputTypes // TODO: generalize for other app types.
+    customInputTypes
   });
   const blockName = Object.values(blocksInstalled)[0][0];
   nameField.value = blockName;


### PR DESCRIPTION
# Description
#30979 made it so that Dancelab and Spritelab use different `customInputTypes` (specifically the spritePicker input type). However, the levelbuilder block edit page just pulled the `customInputTypes` from `'@cdo/apps/p5lab/spritelab/blocks'`. This caused incorrect code-gen on the block edit page for dancelab for blocks that use the spritePicker input type.

This change pulls in `customInputTypes` from both `spritelab/` and `dance/` and uses whichever matches the block's block pool.

Before:
![image](https://user-images.githubusercontent.com/8787187/66229666-3418c700-e697-11e9-9996-15edac3bedb9.png)

After:
![image](https://user-images.githubusercontent.com/8787187/66229695-4430a680-e697-11e9-8337-46b46b743a05.png)


<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
