### PR TITLE
[Dance Party] Add makeAnonymousDanceSprite to api

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -629,6 +629,9 @@ Dance.prototype.initInterpreter = function() {
     setForegroundEffectExtended: effect => {
       nativeAPI.setForegroundEffect(effect.toString());
     },
+    makeAnonymousDanceSprite: (costume, location) => {
+      sprites.push(nativeAPI.makeNewDanceSprite(costume, null, location));
+    },
     makeNewDanceSprite: (costume, name, location) => {
       return Number(
         sprites.push(nativeAPI.makeNewDanceSprite(costume, name, location)) - 1
@@ -748,12 +751,12 @@ Dance.prototype.computeCharactersReferenced = function(studentCode) {
   // charactersReferencedSet with the results:
   const charactersReferencedSet = new Set();
   const charactersRegExp = new RegExp(
-    /^.*makeNewDanceSprite(?:Group)?\([^"]*"([^"]*)[^\r\n]*/,
+    /^.*make(Anonymous|New)DanceSprite(?:Group)?\([^"]*"([^"]*)[^\r\n]*/,
     'gm'
   );
   let match;
   while ((match = charactersRegExp.exec(studentCode))) {
-    const characterName = match[1];
+    const characterName = match[2];
     charactersReferencedSet.add(characterName);
   }
   return Array.from(charactersReferencedSet);


### PR DESCRIPTION
# Description
Block added here: https://github.com/code-dot-org/code-dot-org/commit/6fd4577f8ee9bc837d6ccef85c6e9b57450dfb1b#diff-0740db7939a5e290ea147015002e67ff

This just adds the command to the Dance API so the block works.
![image](https://user-images.githubusercontent.com/8787187/66235134-40575100-e6a4-11e9-9422-26da05432707.png)


Also changes the regex we use to determine which costumes are in use. Now matches `makeNewDanceSprite`, `makeNewDanceSpriteGroup`, and `makeAnonymousDanceSprite`. It also matches `makeAnonymousDanceSpriteGroup`, but I don't think that's an issue because we control the generated code, so this will just never be a match.

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
