### PR TITLE
Teacher Application Detail View - Part 2

### DIFF
--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -628,8 +628,8 @@ module Pd::Application
 
         free_lunch_percent = responses[:principal_free_lunch_percent].present? ?
           responses[:principal_free_lunch_percent].to_i :
-          school_stats.frl_eligible_percent
-        free_lunch_percent_cutoff = school_stats.rural_school? ? 40 : 50
+          school_stats&.frl_eligible_percent
+        free_lunch_percent_cutoff = school_stats&.rural_school? ? 40 : 50
 
         meets_scholarship_criteria_scores[:free_lunch_percent] =
           if free_lunch_percent
@@ -640,7 +640,7 @@ module Pd::Application
 
         urm_percent = responses[:principal_underrepresented_minority_percent].present? ?
           responses[:principal_underrepresented_minority_percent].to_i :
-          school_stats.urm_percent
+          school_stats&.urm_percent
 
         meets_scholarship_criteria_scores[:underrepresented_minority_percent] =
           if urm_percent

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -632,14 +632,22 @@ module Pd::Application
         free_lunch_percent_cutoff = school_stats.rural_school? ? 40 : 50
 
         meets_scholarship_criteria_scores[:free_lunch_percent] =
-          free_lunch_percent >= free_lunch_percent_cutoff ? YES : NO
+          if free_lunch_percent
+            free_lunch_percent >= free_lunch_percent_cutoff ? YES : NO
+          else
+            nil
+          end
 
         urm_percent = responses[:principal_underrepresented_minority_percent].present? ?
           responses[:principal_underrepresented_minority_percent].to_i :
           school_stats.urm_percent
 
         meets_scholarship_criteria_scores[:underrepresented_minority_percent] =
-          urm_percent >= 50 ? YES : NO
+          if urm_percent
+            urm_percent >= 50 ? YES : NO
+          else
+            nil
+          end
       end
 
       update(

--- a/dashboard/app/models/pd/application/teacher1920_application.rb
+++ b/dashboard/app/models/pd/application/teacher1920_application.rb
@@ -466,7 +466,7 @@ module Pd::Application
       teacher_answers = full_answers
       principal_application = Pd::Application::PrincipalApproval1920Application.where(application_guid: application_guid).first
       principal_answers = principal_application&.csv_data
-      school_stats = School.find_by_id(school_id)&.school_stats_by_year&.order(school_year: :desc)&.first
+      school_stats = get_latest_school_stats(school_id)
       CSV.generate do |csv|
         row = []
         CSV_COLUMNS[:teacher].each do |k|
@@ -504,6 +504,10 @@ module Pd::Application
     # Additional labels to include in the form data hash
     def self.additional_labels
       ADDITIONAL_KEYS_IN_ANSWERS
+    end
+
+    def get_latest_school_stats(school_id)
+      School.find_by_id(school_id)&.school_stats_by_year&.order(school_year: :desc)&.first
     end
 
     # @override
@@ -620,8 +624,22 @@ module Pd::Application
           meets_minimum_criteria_scores[:principal_implementation] = responses[:principal_implementation] == principal_options[:csp_implementation].first ? YES : NO
         end
 
-        bonus_points_scores[:free_lunch_percent] = (responses[:principal_free_lunch_percent]&.to_i&.>= 50) ? 5 : 0
-        bonus_points_scores[:underrepresented_minority_percent] = ((responses[:principal_underrepresented_minority_percent]).to_i >= 50) ? 5 : 0
+        school_stats = get_latest_school_stats(school_id)
+
+        free_lunch_percent = responses[:principal_free_lunch_percent].present? ?
+          responses[:principal_free_lunch_percent].to_i :
+          school_stats.frl_eligible_percent
+        free_lunch_percent_cutoff = school_stats.rural_school? ? 40 : 50
+
+        meets_scholarship_criteria_scores[:free_lunch_percent] =
+          free_lunch_percent >= free_lunch_percent_cutoff ? YES : NO
+
+        urm_percent = responses[:principal_underrepresented_minority_percent].present? ?
+          responses[:principal_underrepresented_minority_percent].to_i :
+          school_stats.urm_percent
+
+        meets_scholarship_criteria_scores[:underrepresented_minority_percent] =
+          urm_percent >= 50 ? YES : NO
       end
 
       update(

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -117,7 +117,7 @@ class SchoolStatsByYear < ActiveRecord::Base
     # as "rural": town (distant and remote subcategories)
     # and rural (fringe, distant, and remote subcategories).
     %w(town_distant town_remote rural_fringe rural_distant rural_remote).
-      any? {|type| community_type == type}
+      include? community_type
   end
 
   # returns what percent "count" is of the total student enrollment

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -112,7 +112,12 @@ class SchoolStatsByYear < ActiveRecord::Base
   # Returns nil if there is no data. Otherwise returns true or false.
   def rural_school?
     return nil unless community_type
-    community_type.starts_with? 'rural'
+
+    # The Rural Education Achievement Program (REAP) accepts the following NCES locale codes
+    # as "rural": town (distant and remote subcategories)
+    # and rural (fringe, distant, and remote subcategories).
+    %w(town_distant town_remote rural_fringe rural_distant rural_remote).
+      any? {|type| community_type == type}
   end
 
   # returns what percent "count" is of the total student enrollment

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -108,8 +108,11 @@ class SchoolStatsByYear < ActiveRecord::Base
     percent_of_students(frl_eligible_total)
   end
 
+  # Is this a rural school?
+  # Returns nil if there is no data. Otherwise returns true or false.
   def rural_school?
-    community_type&.starts_with? 'rural'
+    return nil unless community_type
+    community_type.starts_with? 'rural'
   end
 
   # returns what percent "count" is of the total student enrollment

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -98,8 +98,18 @@ class SchoolStatsByYear < ActiveRecord::Base
     grade_kg_offered || grade_01_offered || grade_02_offered || grade_03_offered || grade_04_offered || grade_05_offered || grade_06_offered || grade_07_offered || grade_08_offered
   end
 
+  # Percentage of underrepresented minorities students
   def urm_percent
     percent_of_students([student_am_count, student_hi_count, student_bl_count, student_hp_count].compact.reduce(:+))
+  end
+
+  # Percentage of free/reduced lunch eligible students
+  def frl_eligible_percent
+    percent_of_students(frl_eligible_total)
+  end
+
+  def rural_school?
+    community_type&.starts_with? 'rural'
   end
 
   # returns what percent "count" is of the total student enrollment

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -167,6 +167,11 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
     "#{(100.0 * count / total).round(2)}%"
   end
 
+  def yes_no_string(value)
+    return nil unless value
+    value ? Pd::Application::ApplicationBase::YES : Pd::Application::ApplicationBase::NO
+  end
+
   def school_stats
     return {} unless object.try(:school_id)
 
@@ -178,7 +183,7 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
 
     {
       title_i_status: stats.title_i_status,
-      rural_status: stats.rural_school?,
+      rural_status: yes_no_string(stats.rural_school?),
       school_type: school.school_type.try(:titleize),
       frl_eligible_percent: percent_string(stats.frl_eligible_total, stats.students_total),
       urm_percent: percent_string(urm_total, stats.students_total),

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -178,6 +178,7 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
 
     {
       title_i_status: stats.title_i_status,
+      rural_status: stats.rural_school?,
       school_type: school.school_type.try(:titleize),
       frl_eligible_percent: percent_string(stats.frl_eligible_total, stats.students_total),
       urm_percent: percent_string(urm_total, stats.students_total),

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -168,7 +168,7 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
   end
 
   def yes_no_string(value)
-    return nil unless value
+    return nil if value.nil?
     value ? Pd::Application::ApplicationBase::YES : Pd::Application::ApplicationBase::NO
   end
 

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -1022,6 +1022,7 @@ module Api::V1::Pd
         "Contact name for invoicing",
         "Contact email or phone number for invoicing",
         "Title I status code (NCES data)",
+        "Rural status",
         "Total student enrollment (NCES data)",
         "Percentage of students who are eligible to receive free or reduced lunch (NCES data)",
         "Percentage of underrepresented minority students (NCES data)",

--- a/dashboard/test/models/pd/application/teacher1920_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher1920_application_test.rb
@@ -78,19 +78,6 @@ module Pd::Application
       assert_equal Pd::Application::Teacher1920Application::REVIEWING_INCOMPLETE, teacher_application.meets_criteria
     end
 
-    test 'total score calculates the sum of all response scores' do
-      teacher_application = build :pd_teacher1920_application, response_scores: {
-        bonus_points_scores: {
-          free_lunch_percent: '5',
-          underrepresented_minority_percent: '5',
-          able_to_attend_single: TEXT_FIELDS[:able_to_attend_single],
-          csp_which_grades: nil
-        }
-      }.to_json
-
-      assert_equal 10, teacher_application.total_score
-    end
-
     test 'accepted_at updates times' do
       today = Date.today.to_time
       tomorrow = Date.tomorrow.to_time
@@ -319,12 +306,12 @@ module Pd::Application
       csv_header_csd = CSV.parse(Teacher1920Application.csv_header('csd'))[0]
       assert csv_header_csd.include? "To which grades does your school plan to offer CS Discoveries in the 2019-20 school year?"
       refute csv_header_csd.include? "To which grades does your school plan to offer CS Principles in the 2019-20 school year?"
-      assert_equal 100, csv_header_csd.length
+      assert_equal 101, csv_header_csd.length
 
       csv_header_csp = CSV.parse(Teacher1920Application.csv_header('csp'))[0]
       refute csv_header_csp.include? "To which grades does your school plan to offer CS Discoveries in the 2019-20 school year?"
       assert csv_header_csp.include? "To which grades does your school plan to offer CS Principles in the 2019-20 school year?"
-      assert_equal 102, csv_header_csp.length
+      assert_equal 103, csv_header_csp.length
     end
 
     test 'school cache' do
@@ -578,13 +565,13 @@ module Pd::Application
             principal_approval: YES,
             principal_schedule_confirmed: YES,
             principal_diversity_recruitment: YES,
+            free_lunch_percent: YES,
+            underrepresented_minority_percent: YES,
           },
           bonus_points_scores: {
             replace_existing: 5,
             taught_in_past: 2,
             race: 2,
-            free_lunch_percent: 5,
-            underrepresented_minority_percent: 5,
             principal_implementation: 2,
             cs_terms: 2
           },
@@ -637,15 +624,15 @@ module Pd::Application
             previous_yearlong_cdo_pd: YES,
             principal_approval: YES,
             principal_schedule_confirmed: YES,
-            principal_diversity_recruitment: YES
+            principal_diversity_recruitment: YES,
+            free_lunch_percent: YES,
+            underrepresented_minority_percent: YES,
           },
           bonus_points_scores: {
             csp_how_offer: 2,
             replace_existing: 5,
             taught_in_past: 2,
             race: 2,
-            free_lunch_percent: 5,
-            underrepresented_minority_percent: 5
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -738,13 +725,13 @@ module Pd::Application
             principal_approval: NO,
             principal_schedule_confirmed: NO,
             principal_diversity_recruitment: NO,
+            free_lunch_percent: NO,
+            underrepresented_minority_percent: NO,
           },
           bonus_points_scores: {
             replace_existing: 0,
             taught_in_past: 0,
             race: 0,
-            free_lunch_percent: 0,
-            underrepresented_minority_percent: 0,
             cs_terms: 0,
             principal_implementation: 0
           },
@@ -796,15 +783,15 @@ module Pd::Application
             previous_yearlong_cdo_pd: NO,
             principal_approval: NO,
             principal_schedule_confirmed: NO,
-            principal_diversity_recruitment: NO
+            principal_diversity_recruitment: NO,
+            free_lunch_percent: NO,
+            underrepresented_minority_percent: NO,
           },
           bonus_points_scores: {
             csp_how_offer: 0,
             replace_existing: 0,
             taught_in_past: 0,
             race: 0,
-            free_lunch_percent: 0,
-            underrepresented_minority_percent: 0
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)

--- a/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
@@ -272,12 +272,12 @@ module Pd
       principal_implementation: {meets_minimum_criteria_scores: YES_NO, bonus_points_scores: [2, 0]},
       # Scholarship requirements
       previous_yearlong_cdo_pd: YES_NO,
+      free_lunch_percent: YES_NO,
+      underrepresented_minority_percent: YES_NO,
       # Bonus Points
       csp_how_offer: [2, 0],
       replace_existing: [5, 0],
       taught_in_past: [2, 0],
-      free_lunch_percent: [5, 0],
-      underrepresented_minority_percent: [5, 0],
       race: [2, 0]
     }
 
@@ -287,8 +287,6 @@ module Pd
         :csp_how_offer,
         :replace_existing,
         :taught_in_past,
-        :free_lunch_percent,
-        :underrepresented_minority_percent,
         :race,
         :principal_implementation
       ],
@@ -297,7 +295,9 @@ module Pd
         :previous_yearlong_cdo_pd,
         :principal_approval,
         :principal_schedule_confirmed,
-        :principal_diversity_recruitment
+        :principal_diversity_recruitment,
+        :underrepresented_minority_percent,
+        :free_lunch_percent,
       ],
       criteria_score_questions_csd: [
         :regional_partner_name,

--- a/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher1920_application_constants.rb
@@ -111,6 +111,7 @@ module Pd
         ),
       school_stats_and_principal_approval_section: {
         title_i_status: 'Title I status',
+        rural_status: 'Rural Status',
         school_type: 'School Type',
         total_student_enrollment: 'Total Student Enrollment',
         free_lunch_percent: 'Percent of students that receive free/reduced lunch',
@@ -205,6 +206,7 @@ module Pd
       },
       nces: {
         title_i_status: "Title I status code (NCES data)",
+        rural_status: "Rural status",
         students_total: "Total student enrollment (NCES data)",
         frl_eligible_total: "Percentage of students who are eligible to receive free or reduced lunch (NCES data)",
         urm_percent: "Percentage of underrepresented minority students (NCES data)",
@@ -241,6 +243,7 @@ module Pd
       contact_invoicing_detail: {principal: :principal_contact_invoicing_detail},
 
       title_i_status: {stats: :title_i_status},
+      rural_status: {stats: :rural_status},
       school_type: {teacher: :school_type, stats: :school_type},
       total_student_enrollment: {principal: :principal_total_enrollment, stats: :students_total},
       free_lunch_percent: {principal: :principal_free_lunch_percent, stats: :frl_eligible_percent},
@@ -435,6 +438,7 @@ module Pd
       ],
       nces: [
         :title_i_status,
+        :rural_status,
         :students_total,
         :frl_eligible_total,
         :urm_percent,


### PR DESCRIPTION
## Description

1. Change "Free lunch percent" and  "URM percent" responses from Bonus fields to “Meets scholarship requirements?” fields
2. Add new row for "Rural status" in Principal Approval and School Information section. Data come from NCES.

## Compare
Before
<img width="586" alt="Screen Shot 2019-10-04 at 3 23 01 PM" src="https://user-images.githubusercontent.com/46507039/66246491-5deae180-e6c9-11e9-82cc-55fa6bfc9fa8.png">

After
<img width="584" alt="Screen Shot 2019-10-04 at 3 23 12 PM" src="https://user-images.githubusercontent.com/46507039/66246492-5e837800-e6c9-11e9-9db8-d2c0c7570ea4.png">

Before
<img width="421" alt="Screen Shot 2019-10-04 at 5 14 15 PM" src="https://user-images.githubusercontent.com/46507039/66246648-7c051180-e6ca-11e9-9d94-363ca6bd88e0.png">

After
<img width="418" alt="Screen Shot 2019-10-04 at 5 14 03 PM" src="https://user-images.githubusercontent.com/46507039/66246647-7c051180-e6ca-11e9-8331-b001a68806fe.png">

## Links
- [PR part 1](https://github.com/code-dot-org/code-dot-org/pull/31090)
- [spec](https://docs.google.com/document/d/1CHjjb7AUUgtX0_deNoxJKeyMjD6DYHjqfQMCjKS1quQ/view)
- [jira](https://codedotorg.atlassian.net/browse/PLC-442)
- [jira subtask](https://codedotorg.atlassian.net/browse/PLC-509)

## Testing
Unit tests + manually test with real data on adhoc.

Before (production)
https://studio.code.org/pd/application_dashboard/csd_teachers/21694

After (adhoc)
https://adhoc-ha-adhoc-studio.cdn-code.org/pd/application_dashboard/csd_teachers/21694

