### PR TITLE
Fixes for upgrade to chef client 15 [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -28,7 +28,7 @@ frontends = @frontends = rack_env?(:production) || ENV['FRONTENDS']
 database = @database = [:staging, :test, :levelbuilder, :adhoc].include?(rack_env) || ENV['DATABASE']
 load_balancer = @load_balancer = !rack_env?(:adhoc) || ENV['FRONTENDS']
 alarms = @alarms = !rack_env?(:adhoc) || ENV['ALARMS']
-chef_version = '12.7.2'
+chef_version = '15.2.20'
 
 unless dry_run
   update_certs.call unless load_balancer
@@ -175,7 +175,7 @@ Resources:
     DependsOn: WebServerAMI
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT60M
+        Timeout: PT120M
         Count: 1
   WebServerAMI:
     Type: AWS::EC2::Instance

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -33,7 +33,7 @@ namespace :ci do
         RakeUtils.bundle_exec 'berks', 'apply', rack_env
 
         ChatClient.log 'Applying <b>chef</b> profile...'
-        RakeUtils.sudo '/opt/chef/bin/chef-client'
+        RakeUtils.sudo '/opt/chef/bin/chef-client --chef-license accept-silent'
       end
     end
   end
@@ -105,7 +105,7 @@ end
 # Returns true if upgrade succeeded, false if failed.
 def upgrade_frontend(name, hostname)
   ChatClient.log "Upgrading <b>#{name}</b> (#{hostname})..."
-  command = 'sudo /opt/chef/bin/chef-client'
+  command = 'sudo /opt/chef/bin/chef-client --chef-license accept-silent'
   log_path = aws_dir "deploy-#{name}.log"
   begin
     RakeUtils.system "ssh -i ~/.ssh/deploy-id_rsa #{hostname} '#{command} 2>&1' >> #{log_path}"


### PR DESCRIPTION
# Description

These are the necessary changes for the upgrade to ubuntu 18 to fix issues that came up during the first ubuntu 18 deployment.

* accepting the chef-client license - now necessary with chef client 15, at least the first run on an instance; I missed adding it here in the previous change.
* Increasing timeout for provisioning the WebServerAMI instance - took longer than 1 hour when provisioning from scratch, mostly due to the time spent precompiling assets.

## Testing story

Already made locally on production-daemon instance. Will undo those once this is merged.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
