### PR TITLE
Generated code changes to reference dance sprites by name, not variable assignment

### DIFF
--- a/apps/src/dance/blocks.js
+++ b/apps/src/dance/blocks.js
@@ -70,7 +70,7 @@ const customInputTypes = {
         );
     },
     generateCode(block, arg) {
-      return Blockly.JavaScript.translateVarName(block.getTitleValue(arg.name));
+      return `'${block.getTitleValue(arg.name)}'`;
     }
   },
   limitedColourPicker: {

--- a/dashboard/config/blocks/Dancelab/Dancelab_makeNewDanceSprite.json
+++ b/dashboard/config/blocks/Dancelab/Dancelab_makeNewDanceSprite.json
@@ -61,7 +61,6 @@
       },
       {
         "name": "NAME",
-        "assignment": true,
         "customInput": "spritePicker"
       },
       {


### PR DESCRIPTION
# Description
Depends on https://github.com/code-dot-org/dance-party/pull/572
Similar change to #30979 
This PR just changes the new dance sprite block to not be a variable assignment, and changes the generated code for the sprite field to be `"dancer1"` instead of `dancer1`

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-725)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
