### PR TITLE
Exclude hidden levels from valid progression levels

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -190,7 +190,6 @@ class ScriptLevel < ActiveRecord::Base
     return false if I18n.locale != I18n.default_locale && stage && stage.spelling_bee?
     return false if locked_or_hidden?(user)
     return false if bonus
-    return false if user && user.script_level_hidden?(self)
     true
   end
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -190,6 +190,7 @@ class ScriptLevel < ActiveRecord::Base
     return false if I18n.locale != I18n.default_locale && stage && stage.spelling_bee?
     return false if locked_or_hidden?(user)
     return false if bonus
+    return false if user && user.script_level_hidden?(self)
     true
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1190,19 +1190,15 @@ class User < ActiveRecord::Base
   end
 
   def stage_hidden?(stage)
-    SectionHiddenStage.where(
+    section_hidden_stages = SectionHiddenStage.where(
       stage_id: stage.id,
       section_id: sections_as_student.pluck(:id)
     )
+    !section_hidden_stages.empty?
   end
 
   def all_stages_hidden?(script)
-    visible_stages = 0
-    script.stages.each do |stage|
-      break unless stage_hidden?(stage)
-      visible_stages += 1
-    end
-    visible_stages == 0
+    script.stages.detect {|stage| !stage_hidden?(stage)}.nil?
   end
 
   # Is the given script hidden for this user (based on the sections that they are in)

--- a/dashboard/test/integration/hidden_level_test.rb
+++ b/dashboard/test/integration/hidden_level_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class HiddenLevelTest < ActionDispatch::IntegrationTest
+  include LevelsHelper # for build_script_level_path
+
+  self.use_transactional_test_case = true
+
+  setup_all do
+    @student = create :student
+    @teacher = create :authorized_teacher
+    @script = create(:script, hideable_stages: true)
+    @stage_1 = create(:stage, script: @script, absolute_position: 1, relative_position: '1')
+    @script_level_1 = create(
+      :script_level,
+      script: @script,
+      stage: @stage_1,
+      position: 1
+    )
+    @section = create(:section, user_id: @teacher.id, script: @script)
+
+    Follower.create!(section_id: @section.id, student_user_id: @student.id, user: @teacher)
+
+    # Hide the first lesson/stage
+    SectionHiddenStage.create(
+      section_id: @section.id,
+      stage_id: @stage_1.id
+    )
+
+    @hidden_sl = @script.script_levels.first
+  end
+
+  test 'authorized teacher viewing hidden level' do
+    sign_in @teacher
+
+    get build_script_level_path(@hidden_sl)
+    assert_response :success
+  end
+
+  test 'student viewing hidden level' do
+    sign_in @student
+
+    assert @student.script_level_hidden?(@hidden_sl)
+    get build_script_level_path(@hidden_sl)
+    assert_response :success
+  end
+end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3605,6 +3605,11 @@ class UserTest < ActiveSupport::TestCase
       # Find the second stage, since the 1st is hidden
       next_visible_stage = twenty_hour.stages.find {|stage| stage.relative_position == 2}
 
+      assert student.script_level_hidden?(twenty_hour.script_levels.first)
+
+      get build_script_level_path(twenty_hour.script_levels.first)
+      assert_response :success
+
       assert_equal(next_visible_stage.script_levels.first, student.next_unpassed_progression_level(twenty_hour))
     end
 


### PR DESCRIPTION
Instead of #30664 and the ensuing chaos I wrapped myself up in, I think I should've made this smaller, more straightforward change. Here I'm adding a check for visibility in `valid_progression_level?` and updating tests to include cases where stages are hidden. 

This solves the original bug logged in  [LP-573](https://codedotorg.atlassian.net/browse/LP-573): 
Currently the orange "Continue" button on student view of unit overview page doesn't work as expected when lessons are hidden.

ACTUAL: Students get a page telling them they're in the wrong place.
<img width="729" alt="Screen Shot 2019-09-09 at 4 17 59 PM" src="https://user-images.githubusercontent.com/12300669/64572764-8c210f80-d31d-11e9-8b30-938cf01fa988.png">

EXPECTED: Students go to the next visible lesson after the visible lesson they most recently completed

If reviewers agree this is the better direction, I'll delete the previous changes and close #30977 ([LP-733](https://codedotorg.atlassian.net/browse/LP-733)). 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked