### PR TITLE
Remove aurora database from default adhoc stack

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -24,8 +24,7 @@ commit = ENV['COMMIT'] || `git ls-remote origin #{branch}`.split.first
 ami = commit[0..4]
 
 frontends = @frontends = rack_env?(:production) || ENV['FRONTENDS']
-# TODO: Remove adhoc from this list when we have upgraded to the latest Ubuntu to fix Chef installation of MySQL.
-database = @database = [:staging, :test, :levelbuilder, :adhoc].include?(rack_env) || ENV['DATABASE']
+database = @database = [:staging, :test, :levelbuilder].include?(rack_env) || ENV['DATABASE']
 load_balancer = @load_balancer = !rack_env?(:adhoc) || ENV['FRONTENDS']
 alarms = @alarms = !rack_env?(:adhoc) || ENV['ALARMS']
 chef_version = '15.2.20'


### PR DESCRIPTION
# Description

Followup to #30134. Now that our infrastructure has been upgraded to Ubuntu 18 (#31053), MySQL 5.7 packages should once again be available from the official repository, so we can install mysql locally in adhoc deployments instead of setting up an Aurora cluster.

Note that any existing adhoc deployments with long-lived data they wish to keep should not merge this commit into their existing branch, since it will destroy an existing Aurora cluster and replace it with a local mysql installation. (This is an unsupported use case so we don't spend extra time designing ongoing migration of existing adhoc deployments through breaking infra changes- @sureshc will update existing documentation to make this more clear.)