### PR TITLE
Fix staging url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,5 +62,5 @@ Once you've linted and tested your changes, send us a pull request!  Contributor
 5. A Code.org [developer will ensure our test suite runs on your changes](https://github.com/code-dot-org/code-dot-org/wiki/How-to-run-Circle--tests-on-a-contributor-PR) and will merge your PR to staging for you.
 6. After your pull request is merged into staging, you can review your changes on the following sites:
   * [https://staging.code.org/](https://staging.code.org/)
-  * [https://staging-studio.code.org/](https://staging-studio.studio.code.org/)
+  * [https://staging-studio.code.org/](https://staging-studio.code.org/)
   * [https://staging.csedweek.org/](https://staging.csedweek.org/)


### PR DESCRIPTION
# Description
Hi,

thanks for your work, here is a patch to correct the url in the link of the contributing guide

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
