### PR TITLE
Reference Dance Sprites by name, not variable assignment.

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -43,7 +43,7 @@
     "@code-dot-org/blockly": "3.5.4",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
-    "@code-dot-org/dance-party": "0.0.42",
+    "@code-dot-org/dance-party": "0.0.43",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -11,6 +11,7 @@ import Sounds from '../Sounds';
 import {TestResults} from '../constants';
 import {DancelabReservedWords} from './constants';
 import DanceParty from '@code-dot-org/dance-party/src/p5.dance';
+import DanceAPI from '@code-dot-org/dance-party/src/api';
 import ResourceLoader from '@code-dot-org/dance-party/src/ResourceLoader';
 import danceMsg from './locale';
 import {
@@ -603,128 +604,7 @@ Dance.prototype.execute = async function() {
 
 Dance.prototype.initInterpreter = function() {
   const nativeAPI = this.nativeAPI;
-  const sprites = [];
-
-  const api = {
-    setBackground: color => {
-      nativeAPI.setBackground(color.toString());
-    },
-    // DEPRECATED
-    // An old block may refer to this version of the command,
-    // so we're keeping it around for backwards-compat.
-    // @see https://github.com/code-dot-org/dance-party/issues/469
-    setBackgroundEffect: (effect, palette = 'default') => {
-      nativeAPI.setBackgroundEffect(effect.toString(), palette.toString());
-    },
-    setBackgroundEffectWithPalette: (effect, palette = 'default') => {
-      nativeAPI.setBackgroundEffect(effect.toString(), palette.toString());
-    },
-    // DEPRECATED
-    // An old block may refer to this version of the command,
-    // so we're keeping it around for backwards-compat.
-    // @see https://github.com/code-dot-org/dance-party/issues/469
-    setForegroundEffect: effect => {
-      nativeAPI.setForegroundEffect(effect.toString());
-    },
-    setForegroundEffectExtended: effect => {
-      nativeAPI.setForegroundEffect(effect.toString());
-    },
-    makeAnonymousDanceSprite: (costume, location) => {
-      sprites.push(nativeAPI.makeNewDanceSprite(costume, null, location));
-    },
-    makeNewDanceSprite: (costume, name, location) => {
-      return Number(
-        sprites.push(nativeAPI.makeNewDanceSprite(costume, name, location)) - 1
-      );
-    },
-    makeNewDanceSpriteGroup: (n, costume, layout) => {
-      nativeAPI.makeNewDanceSpriteGroup(n, costume, layout);
-    },
-    getCurrentDance: spriteIndex => {
-      return nativeAPI.getCurrentDance(sprites[spriteIndex]);
-    },
-    changeMoveLR: (spriteIndex, move, dir) => {
-      nativeAPI.changeMoveLR(sprites[spriteIndex], move, dir);
-    },
-    doMoveLR: (spriteIndex, move, dir) => {
-      nativeAPI.doMoveLR(sprites[spriteIndex], move, dir);
-    },
-    changeMoveEachLR: (group, move, dir) => {
-      nativeAPI.changeMoveEachLR(group, move, dir);
-    },
-    doMoveEachLR: (group, move, dir) => {
-      nativeAPI.doMoveEachLR(group, move, dir);
-    },
-    layoutSprites: (group, format) => {
-      nativeAPI.layoutSprites(group, format);
-    },
-    setTint: (spriteIndex, val) => {
-      nativeAPI.setTint(sprites[spriteIndex], val);
-    },
-    setTintInline: (spriteIndex, val) => {
-      nativeAPI.setTint(sprites[spriteIndex], val);
-    },
-    setTintEach: (group, val) => {
-      nativeAPI.setTintEach(group, val);
-    },
-    setTintEachInline: (group, val) => {
-      nativeAPI.setTintEach(group, val);
-    },
-    setVisible: (spriteIndex, val) => {
-      nativeAPI.setVisible(sprites[spriteIndex], val);
-    },
-    setVisibleEach: (group, val) => {
-      nativeAPI.setVisibleEach(group, val);
-    },
-    setProp: (spriteIndex, property, val) => {
-      nativeAPI.setProp(sprites[spriteIndex], property, val);
-    },
-    setPropEach: (group, property, val) => {
-      nativeAPI.setPropEach(group, property, val);
-    },
-    setPropRandom: (spriteIndex, property) => {
-      nativeAPI.setPropRandom(sprites[spriteIndex], property);
-    },
-    getProp: (spriteIndex, property, val) => {
-      return nativeAPI.setProp(sprites[spriteIndex], property, val);
-    },
-    changePropBy: (spriteIndex, property, val) => {
-      nativeAPI.changePropBy(sprites[spriteIndex], property, val);
-    },
-    jumpTo: (spriteIndex, location) => {
-      nativeAPI.jumpTo(sprites[spriteIndex], location);
-    },
-    setDanceSpeed: (spriteIndex, speed) => {
-      nativeAPI.setDanceSpeed(sprites[spriteIndex], speed);
-    },
-    setDanceSpeedEach: (group, speed) => {
-      nativeAPI.setDanceSpeedEach(group, speed);
-    },
-    getEnergy: range => {
-      return Number(nativeAPI.getEnergy(range));
-    },
-    getTime: unit => {
-      return Number(nativeAPI.getTime(unit));
-    },
-    startMapping: (spriteIndex, property, val) => {
-      return nativeAPI.startMapping(sprites[spriteIndex], property, val);
-    },
-    stopMapping: (spriteIndex, property, val) => {
-      return nativeAPI.stopMapping(sprites[spriteIndex], property, val);
-    },
-    changeColorBy: (input, method, amount) => {
-      return nativeAPI.changeColorBy(input, method, amount);
-    },
-    mixColors: (color1, color2) => {
-      return nativeAPI.mixColors(color1, color2);
-    },
-    randomColor: () => {
-      return nativeAPI.randomColor();
-    },
-    getCurrentTime: () => {
-      return nativeAPI.getCurrentTime();
-    }
-  };
+  const api = new DanceAPI(nativeAPI);
 
   const studentCode = this.studioApp_.getCode();
 

--- a/apps/src/dance/blocks.js
+++ b/apps/src/dance/blocks.js
@@ -70,7 +70,7 @@ const customInputTypes = {
         );
     },
     generateCode(block, arg) {
-      return Blockly.JavaScript.translateVarName(block.getTitleValue(arg.name));
+      return `'${block.getTitleValue(arg.name)}'`;
     }
   },
   limitedColourPicker: {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -903,9 +903,12 @@
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@code-dot-org/craft/-/craft-0.2.2.tgz#4b117337a5a601613f2d38514aa50ba972362939"
 
-"@code-dot-org/dance-party@0.0.42":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/dance-party/-/dance-party-0.0.42.tgz#8a46a7cd79a0d9447f80db2748be43cb2f55900e"
+"@code-dot-org/dance-party@0.0.43":
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/dance-party/-/dance-party-0.0.43.tgz#de78bee12d80c43aa45b614797ce1403b02cdcf6"
+  integrity sha512-YPPxfBm7Nj/amzbGIwG+TbJ/kJZVDC5aWDCExkbOXV4772tuHqRZQTqgGPlvLMIdsTJOpA3sg2bGlW8aH2vOlg==
+  optionalDependencies:
+    canvas "^1.6.13"
 
 "@code-dot-org/johnny-five@0.11.1-cdo.2":
   version "0.11.1-cdo.2"
@@ -3994,6 +3997,13 @@ caniuse-lite@^1.0.30000844:
 caniuse-lite@^1.0.30000884, caniuse-lite@^1.0.30000947, caniuse-lite@^1.0.30000955:
   version "1.0.30000957"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz#fb1026bf184d7d62c685205358c3b24b9e29f7b3"
+
+canvas@^1.6.13:
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-1.6.13.tgz#8cb4e9abbea9e615a377890ffac50277a1167c73"
+  integrity sha512-XAfzfEOHZ3JIPjEV+WSI6PpISgUta3dgmndWbsajotz+0TQOX/jDpp2kawjRERatOGv9sMMzk5auB3GKEKA6hg==
+  dependencies:
+    nan "^2.10.0"
 
 canvg@gabelerner/canvg:
   version "1.0.0"
@@ -10527,6 +10537,11 @@ mute-stream@~0.0.4:
 nan@2.4.x, nan@^2.3.0, nan@^2.3.2, nan@^2.3.5:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.4.0.tgz#fb3c59d45fe4effe215f0b890f8adf6eb32d2232"
+
+nan@^2.10.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 nan@^2.9.2:
   version "2.13.1"

--- a/dashboard/config/blocks/Dancelab/Dancelab_makeNewDanceSprite.json
+++ b/dashboard/config/blocks/Dancelab/Dancelab_makeNewDanceSprite.json
@@ -61,7 +61,6 @@
       },
       {
         "name": "NAME",
-        "assignment": true,
         "customInput": "spritePicker"
       },
       {


### PR DESCRIPTION
# Description
Most of this change happened in https://github.com/code-dot-org/dance-party/pull/571 and https://github.com/code-dot-org/dance-party/pull/572
Now we just need to:
- bump the dance version
- Pull the API from the dance repo and get rid of the duplicated api in Dance.js
- Change generated code for sprite variables
- Change the `dancelab_makeNewDanceSprite` block to not be variable assignment

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
