### PR TITLE
Drop AFE experiment flag on client and server side

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -241,7 +241,7 @@ export default class TeacherHomepage extends Component {
             <div style={styles.clear} />
           </div>
         )}
-       <TeacherSections queryStringOpen={queryStringOpen} locale={locale} />
+        <TeacherSections queryStringOpen={queryStringOpen} locale={locale} />
         <RecentCourses
           courses={courses}
           topCourse={topCourse}

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -17,7 +17,6 @@ import CensusTeacherBanner from '../census2017/CensusTeacherBanner';
 import DonorTeacherBanner, {
   donorTeacherBannerOptionsShape
 } from '@cdo/apps/templates/DonorTeacherBanner';
-import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   clear: {
@@ -232,19 +231,17 @@ export default class TeacherHomepage extends Component {
             <br />
           </div>
         )}
-        {experiments.isEnabled('donorTeacherBanner') &&
-          isEnglish &&
-          this.state.donorBannerName && (
-            <div>
-              <DonorTeacherBanner
-                options={donorTeacherBannerOptions}
-                showPegasusLink={true}
-                source="teacher_home"
-              />
-              <div style={styles.clear} />
-            </div>
-          )}
-        <TeacherSections queryStringOpen={queryStringOpen} locale={locale} />
+        {isEnglish && this.state.donorBannerName && (
+          <div>
+            <DonorTeacherBanner
+              options={donorTeacherBannerOptions}
+              showPegasusLink={true}
+              source="teacher_home"
+            />
+            <div style={styles.clear} />
+          </div>
+        )}
+       <TeacherSections queryStringOpen={queryStringOpen} locale={locale} />
         <RecentCourses
           courses={courses}
           topCourse={topCourse}

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -24,7 +24,6 @@ experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
 experiments.ROLLUP_SURVEY_REPORT = 'rollupSurveyReport';
 experiments.APPLAB_DATASETS = 'applabDatasets';
 experiments.CENSUS_MAP_ON_MAPBOX = 'censusMapOnMapbox';
-experiments.DONOR_TEACHER_BANNER = 'donorTeacherBanner';
 experiments.ASSIGNMENT_UPDATES = 'assignmentUpdates';
 
 /**

--- a/dashboard/app/controllers/experiments_controller.rb
+++ b/dashboard/app/controllers/experiments_controller.rb
@@ -22,7 +22,7 @@ class ExperimentsController < ApplicationController
     redirect_to '/', flash: {notice: "You have successfully joined the experiment '#{params[:experiment_name]}'."}
   end
 
-  VALID_EXPERIMENTS = ['2018-teacher-experience', 'csd-piloters', 'donor-footer']
+  VALID_EXPERIMENTS = ['2018-teacher-experience', 'csd-piloters']
 
   # GET /experiments/set_single_user_experiment/:experiment_name
   def set_single_user_experiment

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -3,7 +3,7 @@
   = tag 'meta', property: 'og:image', content: CDO.studio_url(CDO.shared_image_url('share/girl_cropped.jpg'), 'https:')
   = tag 'meta', property: 'og:description', content: t('share.description')
 
--if current_user&.school_donor_name && Experiment.enabled?(user: current_user, experiment_name: 'donor-footer')
+-if current_user&.school_donor_name
   - content_for :above_footer_content do
     = render partial: 'home/donor_footer'
 


### PR DESCRIPTION
Removes the `donorTeacherBanner` client experiment and the `donor-footer` server-side SingleUserExperiment, launching the new AFE features.