### PR TITLE
Fix typo that was breaking CSP teacher applications

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
@@ -174,7 +174,7 @@ export default class ChooseYourProgram extends LabeledFormComponent {
     }
 
     if (data.program === PROGRAM_CSP) {
-      requiredFields.push('cspWhichGrades', 'csdWhichUnits', 'cspHowOffer');
+      requiredFields.push('cspWhichGrades', 'cspWhichUnits', 'cspHowOffer');
     }
 
     if (data.replaceExisting === 'Yes') {


### PR DESCRIPTION
# Description

I had a typo that required the CSD units question when CSP was the selected program, preventing you from submitting applications for CSP.
