### PR TITLE
Scholarship warning appears when expected

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
@@ -211,7 +211,7 @@ export default class SummerWorkshop extends LabeledFormComponent {
     if (
       this.props.data.planToTeach &&
       !this.props.data.planToTeach.includes(
-        'Yes, I plan to teach this course this year (2020-21)'
+        'Yes, I plan to teach this course this year (2020-2021)'
       ) &&
       this.props.data.payFee &&
       this.props.data.payFee.includes('No, ')


### PR DESCRIPTION
# Description

In the teacher application, the scholarship warning was appearing even when the teacher was planning to teach the course, which is incorrect. This prevents it from showing in that case.