### PR TITLE
Revert "PL: Convert teacher application MarkdownSpan -> SafeMarkdown"

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/AboutYou.jsx
+++ b/apps/src/code-studio/pd/application/teacher/AboutYou.jsx
@@ -258,9 +258,10 @@ const NameInput = ({
   errorMessage
 }) => (
   <FormGroup controlId={id} validationState={validationState}>
-    <div className="markdown_label markdown_label_required">
-      <ControlLabel>{label}</ControlLabel>
-    </div>
+    <ControlLabel>
+      {label}
+      {REQUIRED}
+    </ControlLabel>
     <FormControl
       type="text"
       componentClass="input"
@@ -279,3 +280,5 @@ NameInput.propTypes = {
   errorMessage: PropTypes.node,
   handleChange: PropTypes.func
 };
+
+const REQUIRED = <span style={{color: 'red'}}>&nbsp;*</span>;

--- a/apps/src/code-studio/pd/form_components/ButtonList.jsx
+++ b/apps/src/code-studio/pd/form_components/ButtonList.jsx
@@ -145,14 +145,6 @@ class ButtonList extends React.Component {
       validationState = 'error';
     }
 
-    // We wrap the ControlLabel in a div with a class name that specifies
-    // whether the field is required or not.  If it is required, some CSS
-    // in pd.scss adds a red asterisk after the end of the last <p> inside
-    // this div.
-    const labelClassName = this.props.required
-      ? 'markdown_label markdown_required'
-      : 'markdown_label markdown_not_required';
-
     const columnCount = this.props.columnCount ? this.props.columnCount : 1;
 
     return (
@@ -161,9 +153,10 @@ class ButtonList extends React.Component {
         controlId={this.props.groupName}
         validationState={validationState}
       >
-        <div className={labelClassName}>
-          <ControlLabel>{this.props.label}</ControlLabel>
-        </div>
+        <ControlLabel>
+          {this.props.label}
+          {this.props.required && <span style={{color: 'red'}}> *</span>}
+        </ControlLabel>
         <FormGroup style={{columnCount: columnCount}}>
           {this.renderInputComponents()}
         </FormGroup>

--- a/apps/src/code-studio/pd/form_components/FieldGroup.jsx
+++ b/apps/src/code-studio/pd/form_components/FieldGroup.jsx
@@ -9,6 +9,8 @@ import {
   Col
 } from 'react-bootstrap';
 
+const REQUIRED = <span style={{color: 'red'}}>&nbsp;*</span>;
+
 export default class FieldGroup extends React.Component {
   constructor(props) {
     super(props);
@@ -64,21 +66,14 @@ export default class FieldGroup extends React.Component {
       ...props
     } = this.props;
 
-    // We wrap the ControlLabel in a div with a class name that specifies
-    // whether the field is required or not.  If it is required, some CSS
-    // in pd.scss adds a red asterisk after the end of the last <p> inside
-    // this div.
-    const labelClassName = required
-      ? 'markdown_label markdown_required'
-      : 'markdown_label markdown_not_required';
-
     return (
       <FormGroup controlId={id} validationState={validationState}>
         <Row>
           <Col {...labelWidth}>
-            <div className={labelClassName}>
-              <ControlLabel>{label}</ControlLabel>
-            </div>
+            <ControlLabel>
+              {label}
+              {required && REQUIRED}
+            </ControlLabel>
           </Col>
           {inlineControl && this.renderControl(controlWidth, children, props)}
         </Row>

--- a/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
+++ b/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import FormComponent from './FormComponent';
-import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import MarkdownSpan from '../components/markdownSpan';
 
 export default class LabeledFormComponent extends FormComponent {
   /**
@@ -16,12 +16,7 @@ export default class LabeledFormComponent extends FormComponent {
       return name;
     }
 
-    return (
-      <SafeMarkdown
-        openExternalLinksInNewTab
-        markdown={this.constructor.labels[name]}
-      />
-    );
+    return <MarkdownSpan>{this.constructor.labels[name]}</MarkdownSpan>;
   }
 
   indented(depth = 1) {

--- a/apps/src/code-studio/pd/form_components/QuestionsTable.jsx
+++ b/apps/src/code-studio/pd/form_components/QuestionsTable.jsx
@@ -52,14 +52,6 @@ class QuestionRow extends React.Component {
   }
 
   render() {
-    // We wrap the ControlLabel in a div with a class name that specifies
-    // whether the field is required or not.  If it is required, some CSS
-    // in pd.scss adds a red asterisk after the end of the last <p> inside
-    // this div.
-    const labelClassName = this.props.question.required
-      ? 'markdown_label markdown_required'
-      : 'markdown_label markdown_not_required';
-
     return (
       <tr>
         <td>
@@ -67,9 +59,12 @@ class QuestionRow extends React.Component {
             controlId={this.props.question.name}
             validationState={this.getValidationState()}
           >
-            <div className={labelClassName}>
-              <ControlLabel>{this.props.question.label}</ControlLabel>
-            </div>
+            <ControlLabel>
+              {this.props.question.label}
+              {this.props.question.required && (
+                <span className="form-required-field"> *</span>
+              )}
+            </ControlLabel>
           </FormGroup>
         </td>
         {this.props.options.map(this.buildColumn)}

--- a/apps/style/code-studio/pd.scss
+++ b/apps/style/code-studio/pd.scss
@@ -1,5 +1,4 @@
 @import "color";
-
 @import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/buttons";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/variables";
 @import "mixins";
@@ -32,19 +31,6 @@
   @import "bootstrap-sass/assets/stylesheets/bootstrap";
   @include buttons();
   @include user-selects(auto);
-
-  // Markdown content for label of required answer, as used in various forms,
-  // should get red asterisk at the end of last <p>.
-  .markdown_required p:last-of-type::after {
-    content: ' *';
-    color: $red;
-  }
-
-  // Markdown content for label, as used various in forms, doesn't need margin
-  // below the last <p>.
-  .markdown_label p:last-of-type {
-    margin-bottom: 0px
-  }
 
   a:not(.btn) {
     color: $purple;

--- a/apps/test/unit/code-studio/pd/form_components/ButtonListTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/ButtonListTest.js
@@ -34,9 +34,7 @@ describe('ButtonList', () => {
       expect(
         radioList.containsMatchingElement(
           <FormGroup id="favoritePet" controlId="favoritePet">
-            <div className="markdown_label markdown_not_required">
-              <ControlLabel>What is your favorite pet?</ControlLabel>
-            </div>
+            <ControlLabel>What is your favorite pet?</ControlLabel>
             <FormGroup>
               <Radio value="Cat" label="Cat" name="favoritePet">
                 Cat
@@ -82,9 +80,7 @@ describe('ButtonList', () => {
       expect(
         checkboxList.containsMatchingElement(
           <FormGroup id="favoritePet" controlId="favoritePet">
-            <div className="markdown_label markdown_not_required">
-              <ControlLabel>What is your favorite pet?</ControlLabel>
-            </div>
+            <ControlLabel>What is your favorite pet?</ControlLabel>
             <FormGroup>
               <Checkbox value="Cat" label="Cat" name="favoritePet">
                 Cat


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#31100.  Eyes tests caught some asterisks that disappeared, so I'll debug that before restoring.
