### PR TITLE
Consolidate asset config

### DIFF
--- a/apps/docs/build.md
+++ b/apps/docs/build.md
@@ -238,8 +238,7 @@ To further approximate production behavior locally, you can use the rails asset
 pipeline to precompile all assets locally. Once you have built minified js
 locally as described above, here are the additional steps:
 
-1. Edit `dashboard/config/environments/development.rb` by changing 
-   `config.assets.digest` to `true` and `config.assets.compile` to `false`. 
+1. Set `optimize_rails_assets: true` in locals.yml. 
    This will make the rails app look for js files and other assets that have
    already been processed by the rails asset pipeline.
 

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -264,6 +264,8 @@ use_my_apps:
 
 optimize_webpack_assets: true
 
+optimize_rails_assets: true
+
 # Allows your local server to render non-English locales, defaults to false in development.
 # If false, choosing a locale other than English will have no effect.
 # Note: You may need to be in an incognito window to see changes

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -10,6 +10,7 @@ firebase_channel_id_suffix: -DEVELOPMENT-<%=ENV['USER']%>
 
 lint: true
 optimize_webpack_assets: false
+optimize_rails_assets: false
 stub_school_data: true
 daemon: true
 

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -31,9 +31,9 @@ daemon: true
 use_pusher: <%=!ci_test%>
 
 # test environment should use precompiled, minified, digested assets like production,
-# unless it's being used for unit tests. This logic should be kept in sync with
-# the logic for setting config.assets.* under dashboard/config/.
+# unless it's being used for CI or unit tests.
 optimize_webpack_assets: <%=!ci_test%>
+optimize_rails_assets: <%=!ci_test%>
 
 # Since channel ids are derived from user id and other sequential integer ids
 # use a new S3 sources directory for each Test Build to prevent a UI test

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -30,11 +30,6 @@ stub_school_data: true
 daemon: true
 use_pusher: <%=!ci_test%>
 
-# test environment should use precompiled, minified, digested assets like production,
-# unless it's being used for unit tests.
-optimize_webpack_assets: <%=!unit_test%>
-optimize_rails_assets: <%=!unit_test%>
-
 # Since channel ids are derived from user id and other sequential integer ids
 # use a new S3 sources directory for each Test Build to prevent a UI test
 # from inadvertently using a channel id from a previous Test Build.

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -31,9 +31,9 @@ daemon: true
 use_pusher: <%=!ci_test%>
 
 # test environment should use precompiled, minified, digested assets like production,
-# unless it's being used for CI or unit tests.
-optimize_webpack_assets: <%=!ci_test%>
-optimize_rails_assets: <%=!ci_test%>
+# unless it's being used for unit tests.
+optimize_webpack_assets: <%=!unit_test%>
+optimize_rails_assets: <%=!unit_test%>
 
 # Since channel ids are derived from user id and other sequential integer ids
 # use a new S3 sources directory for each Test Build to prevent a UI test

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -115,6 +115,12 @@ module Dashboard
     config.assets.paths << Rails.root.join('../shared/css')
     config.assets.paths << Rails.root.join('../shared/js')
 
+    # Whether to fallback to assets pipeline if a precompiled asset is missed.
+    config.assets.compile = !CDO.optimize_rails_assets
+
+    # Generate digests for assets URLs which do not contain webpack hashes.
+    config.assets.digest = CDO.optimize_rails_assets
+
     config.assets.precompile += %w(
       js/*
       css/*.css

--- a/dashboard/config/environments/adhoc.rb
+++ b/dashboard/config/environments/adhoc.rb
@@ -17,18 +17,12 @@ Dashboard::Application.configure do
   # https://github.com/rails/rails/issues/27273
   config.consider_all_requests_local = false
 
-  # Use digests.
-  config.assets.digest = true
-
   config.action_controller.perform_caching = true
   config.public_file_server.enabled = true
   config.public_file_server.headers = {'Cache-Control' => "public, max-age=86400, s-maxage=43200"}
 
   # Set to :debug to see everything in the log.
   config.log_level = :info
-
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
 
   # Version of your assets, change this if you want to expire all your assets.
   config.assets.version = '1.0'

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -51,8 +51,6 @@ Dashboard::Application.configure do
   # number of complex assets.
   # config.assets.debug = true
 
-  config.assets.digest = false
-
   config.assets.quiet = true
 
   # skip precompiling of all assets on the first request for any asset.

--- a/dashboard/config/environments/production.rb
+++ b/dashboard/config/environments/production.rb
@@ -33,12 +33,6 @@ Dashboard::Application.configure do
   # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
-
-  # Generate digests for assets URLs.
-  config.assets.digest = true
-
   # Version of your assets, change this if you want to expire all your assets.
   config.assets.version = '1.0'
 

--- a/dashboard/config/environments/staging.rb
+++ b/dashboard/config/environments/staging.rb
@@ -33,12 +33,6 @@ Dashboard::Application.configure do
   # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
-
-  # Generate digests for assets URLs.
-  config.assets.digest = true
-
   # Version of your assets, change this if you want to expire all your assets.
   config.assets.version = '1.0'
 

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -31,12 +31,6 @@ Dashboard::Application.configure do
     # config.assets.js_compressor = :uglifier
     # config.assets.css_compressor = :sass
 
-    # Do not fallback to assets pipeline if a precompiled asset is missed.
-    config.assets.compile = false
-
-    # Generate digests for assets URLs.
-    config.assets.digest = true
-
     # Version of your assets, change this if you want to expire all your assets.
     config.assets.version = '1.0'
   end

--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -52,6 +52,7 @@ localize_apps: true
 dashboard_enable_pegasus: true
 dashboard_workers: 5
 skip_seed_all: true
+optimize_webpack_assets: true
 optimize_rails_assets: true
 no_https_store: true
 override_dashboard: \"localhost-studio.code.org\"

--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -52,6 +52,7 @@ localize_apps: true
 dashboard_enable_pegasus: true
 dashboard_workers: 5
 skip_seed_all: true
+optimize_rails_assets: true
 " >> locals.yml
 echo "Wrote secrets from env vars into locals.yml."
 set -x

--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -53,18 +53,6 @@ dashboard_enable_pegasus: true
 dashboard_workers: 5
 skip_seed_all: true
 optimize_rails_assets: true
-" >> locals.yml
-echo "Wrote secrets from env vars into locals.yml."
-set -x
-
-# name: rake install
-RAKE_VERBOSE=true bundle exec rake install --trace
-
-# name: rake build
-RAKE_VERBOSE=true bundle exec rake build --trace
-
-# apply test settings for after unit tests
-echo "
 no_https_store: true
 override_dashboard: \"localhost-studio.code.org\"
 override_pegasus: \"localhost.code.org\"
@@ -75,6 +63,14 @@ assets_s3_directory: assets_circle/$CIRCLE_BUILD_NUM
 files_s3_directory: files_circle/$CIRCLE_BUILD_NUM
 sources_s3_directory: sources_circle/$CIRCLE_BUILD_NUM
 " >> locals.yml
+echo "Wrote secrets from env vars into locals.yml."
+set -x
+
+# name: rake install
+RAKE_VERBOSE=true bundle exec rake install --trace
+
+# name: rake build
+RAKE_VERBOSE=true bundle exec rake build --trace
 
 # name: seed ui tests
 bundle exec rake circle:seed_ui_test --trace

--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -52,8 +52,6 @@ localize_apps: true
 dashboard_enable_pegasus: true
 dashboard_workers: 5
 skip_seed_all: true
-optimize_webpack_assets: true
-optimize_rails_assets: true
 no_https_store: true
 override_dashboard: \"localhost-studio.code.org\"
 override_pegasus: \"localhost.code.org\"

--- a/docker/unit_tests.sh
+++ b/docker/unit_tests.sh
@@ -32,6 +32,8 @@ localize_apps: true
 dashboard_enable_pegasus: true
 dashboard_workers: 5
 skip_seed_all: true
+optimize_webpack_assets: false
+optimize_rails_assets: false
 google_maps_api_key: boguskey
 " >> locals.yml
 echo "Wrote secrets from env vars into locals.yml."

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -98,6 +98,11 @@ namespace :build do
       # Skip asset precompile in development.
       # Also skip on CI services (e.g. Circle) where we will precompile assets later, right before UI tests.
       if CDO.optimize_rails_assets
+        # If we did not optimize webpack assets, then rails asset precompilation
+        # will add digests to the names of webpack assets, after which webpack
+        # will be unable to find them.
+        raise "do not optimize rails assets without optimized webpack assets" unless CDO.optimize_webpack_assets
+
         ChatClient.log 'Cleaning <b>dashboard</b> assets...'
         RakeUtils.rake 'assets:clean'
         ChatClient.log 'Precompiling <b>dashboard</b> assets...'

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -96,7 +96,6 @@ namespace :build do
       end
 
       # Skip asset precompile in development.
-      # Also skip on CI services (e.g. Circle) where we will precompile assets later, right before UI tests.
       if CDO.optimize_rails_assets
         # If we did not optimize webpack assets, then rails asset precompilation
         # will add digests to the names of webpack assets, after which webpack

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -95,9 +95,9 @@ namespace :build do
         end
       end
 
-      # Skip asset precompile in development where `config.assets.digest = false`.
+      # Skip asset precompile in development.
       # Also skip on CI services (e.g. Circle) where we will precompile assets later, right before UI tests.
-      unless rack_env?(:development) || ENV['CI']
+      if CDO.optimize_rails_assets
         ChatClient.log 'Cleaning <b>dashboard</b> assets...'
         RakeUtils.rake 'assets:clean'
         ChatClient.log 'Precompiling <b>dashboard</b> assets...'

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -74,7 +74,7 @@ namespace :circle do
   end
 
   desc 'Runs UI tests only if the tag specified is present in the most recent commit message.'
-  task run_ui_tests: [:recompile_assets] do
+  task :run_ui_tests do
     unless CircleUtils.ui_test_container?
       ChatClient.log "Wrong container, skipping"
       next
@@ -161,19 +161,6 @@ namespace :circle do
 
     Dir.chdir('dashboard') do
       RakeUtils.rake_stream_output 'seed:cached_ui_test'
-    end
-  end
-
-  desc 'Rebuild dashboard assets with updated locals.yml settings before running UI tests'
-  task :recompile_assets do
-    if CircleUtils.tagged?(SKIP_UI_TESTS_TAG)
-      ChatClient.log "Commit message: '#{CircleUtils.circle_commit_message}' contains [#{SKIP_UI_TESTS_TAG}], skipping UI tests for this run."
-      next
-    end
-
-    system 'rm', '-rf', dashboard_dir('tmp', 'cache', 'assets')
-    Dir.chdir(dashboard_dir) do
-      RakeUtils.rake 'assets:precompile'
     end
   end
 end


### PR DESCRIPTION
# Description

This PR consolidates the following configuration parameters/logic into a single variable `CDO.optimize_rails_assets`:
* `config.assets.compile`
* `config.assets.digest`
* whether to `rake assets:precompile`

This PR also eliminates some complexity from drone ui test config:
* eliminates redundant `rake circle: recompile_assets` step, because assets are now precompiled during `rake build`
* eliminates separate groupings of locals.yml params, which fixes UI tests that depend on `CDO.override_pegasus` being set during asset compilation

Having done all that, we also have to also 

* enable `CDO.optimize_webpack_assets` for drone UI tests

because our servers do not work properly in the configuration where `optimize_webpack_assets` is false and `optimize_rail_assets` is true. This is because webpack relies on the assets it produces (in dashboard/public/blockly) being passed through the rails asset pipeline (to dashboard/public/assets) without rails adding its own digest, and our mechanism for doing this is to skip adding a rails digest only when a webpack hash is already present, as described here: https://github.com/code-dot-org/code-dot-org/blob/9aa96b05fd2e06c8d6d7ee173fc858878f19f440/dashboard/lib/tasks/asset_sync.rake#L47

I can't quite explain why the problem described in the previous paragraph was not causing all ui tests to fail in drone runs prior to this PR, but I do feel good about eliminating this poorly-understood configuration and making drone run more similarly to our test and production servers.

## Alternative

Alternately, we could run drone ui tests without `optimize_webpack_assets` or `optimize_rails_assets`, to make drone runs more like local development. This scenario [failed with unclear errors](https://drone.cdn-code.org/code-dot-org/code-dot-org/6399/2/5) when I tried it earlier, but if we prefer to head in that direction I could investigate it as a next step.

## Links

* see https://github.com/code-dot-org/code-dot-org/pull/31216 for similar past work, which consolidated `CDO.optimize_webpack_assets`
* further background: our js in the apps/ directory is passed first through webpack, and then through rails asset pipeline (a.k.a. sprockets). For documentation of this process, see: https://github.com/code-dot-org/code-dot-org/blob/9a14b8b40561ae01f6ab7aac4fed28f8b107595b/apps/docs/build.md#brief-production-build-overview 

## Testing story

No new tests because no new functionality has been added. I am relying on drone + DTT to catch any breakages.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
