### PR TITLE
Show image of hourofcode map during the week of hour of code only

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -124,9 +124,8 @@ social:
   -# Map
   - unless @country == 'ma' # Hide map for Morocco because of sensitive border disputes misrepresented in map
     #maparea.full-width
-      -# During pre-Hour of Code season, show the embedded map.
-      -# All other times show a picture of the map.
-      -if hoc_mode == "pre-hoc"
+      -# Show a picture of the map unless it is currently the week of HOC.
+      -if hoc_mode != "actual-hoc"
         = view :hoc_events_map
         .footnote=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))
       -else


### PR DESCRIPTION
# Description
Show image of hourofcode map during the week of hour of code only. There isn't a reason for us to hide the map this early and tbd if we need to hide it during the week of hour of code at all.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
