### PR TITLE
Porting 1920 teacher application changes to 2021 version

### DIFF
--- a/dashboard/app/models/pd/application/teacher2021_application.rb
+++ b/dashboard/app/models/pd/application/teacher2021_application.rb
@@ -495,7 +495,7 @@ module Pd::Application
       teacher_answers = full_answers
       principal_application = Pd::Application::PrincipalApproval2021Application.where(application_guid: application_guid).first
       principal_answers = principal_application&.csv_data
-      school_stats = School.find_by_id(school_id)&.school_stats_by_year&.order(school_year: :desc)&.first
+      school_stats = get_latest_school_stats(school_id)
       CSV.generate do |csv|
         row = []
         CSV_COLUMNS[:teacher].each do |k|
@@ -533,6 +533,10 @@ module Pd::Application
     # Additional labels to include in the form data hash
     def self.additional_labels
       ADDITIONAL_KEYS_IN_ANSWERS
+    end
+
+    def get_latest_school_stats(school_id)
+      School.find_by_id(school_id)&.school_stats_by_year&.order(school_year: :desc)&.first
     end
 
     # @override
@@ -625,8 +629,31 @@ module Pd::Application
             NO
           end
 
-        bonus_points_scores[:free_lunch_percent] = (responses[:principal_free_lunch_percent]&.to_i&.>= 50) ? 5 : 0
+        school_stats = get_latest_school_stats(school_id)
         bonus_points_scores[:underrepresented_minority_percent] = ((responses[:principal_underrepresented_minority_percent]).to_i >= 50) ? 5 : 0
+
+        free_lunch_percent = responses[:principal_free_lunch_percent].present? ?
+          responses[:principal_free_lunch_percent].to_i :
+          school_stats&.frl_eligible_percent
+        free_lunch_percent_cutoff = school_stats&.rural_school? ? 40 : 50
+
+        meets_scholarship_criteria_scores[:free_lunch_percent] =
+          if free_lunch_percent
+            free_lunch_percent >= free_lunch_percent_cutoff ? YES : NO
+          else
+            nil
+          end
+
+        urm_percent = responses[:principal_underrepresented_minority_percent].present? ?
+          responses[:principal_underrepresented_minority_percent].to_i :
+          school_stats&.urm_percent
+
+        meets_scholarship_criteria_scores[:underrepresented_minority_percent] =
+          if urm_percent
+            urm_percent >= 50 ? YES : NO
+          else
+            nil
+          end
       end
 
       update(

--- a/dashboard/app/models/pd/application/teacher2021_application.rb
+++ b/dashboard/app/models/pd/application/teacher2021_application.rb
@@ -568,7 +568,14 @@ module Pd::Application
         meets_scholarship_criteria_scores[:plan_to_teach] = responses[:plan_to_teach] == options[:plan_to_teach].first ? YES : NO
       end
 
-      bonus_points_scores[:replace_existing] = responses[:replace_existing].in?(options[:replace_existing].values_at(1, 2)) ? 5 : 0
+      meets_minimum_criteria_scores[:replace_existing] =
+        if responses[:replace_existing] == YES
+          NO
+        elsif responses[:replace_existing] == TEXT_FIELDS[:i_dont_know_explain]
+          nil
+        else
+          YES
+        end
 
       # Section 3
       if course == 'csd'
@@ -609,13 +616,13 @@ module Pd::Application
             nil
           end
 
-        bonus_points_scores[:replace_existing] =
+        meets_minimum_criteria_scores[:replace_existing] =
           if responses[:principal_wont_replace_existing_course] == principal_options[:replace_course][1]
-            5
-          elsif responses[:principal_wont_replace_existing_course]&.in? [principal_options[:replace_course][0], principal_options[:replace_course][2]]
-            0
-          else
+            YES
+          elsif responses[:principal_wont_replace_existing_course] == TEXT_FIELDS[:i_dont_know_explain]
             nil
+          else
+            NO
           end
 
         bonus_points_scores[:free_lunch_percent] = (responses[:principal_free_lunch_percent]&.to_i&.>= 50) ? 5 : 0

--- a/dashboard/app/models/pd/application/teacher2021_application.rb
+++ b/dashboard/app/models/pd/application/teacher2021_application.rb
@@ -630,7 +630,6 @@ module Pd::Application
           end
 
         school_stats = get_latest_school_stats(school_id)
-        bonus_points_scores[:underrepresented_minority_percent] = ((responses[:principal_underrepresented_minority_percent]).to_i >= 50) ? 5 : 0
 
         free_lunch_percent = responses[:principal_free_lunch_percent].present? ?
           responses[:principal_free_lunch_percent].to_i :

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -98,8 +98,26 @@ class SchoolStatsByYear < ActiveRecord::Base
     grade_kg_offered || grade_01_offered || grade_02_offered || grade_03_offered || grade_04_offered || grade_05_offered || grade_06_offered || grade_07_offered || grade_08_offered
   end
 
+  # Percentage of underrepresented minorities students
   def urm_percent
     percent_of_students([student_am_count, student_hi_count, student_bl_count, student_hp_count].compact.reduce(:+))
+  end
+
+  # Percentage of free/reduced lunch eligible students
+  def frl_eligible_percent
+    percent_of_students(frl_eligible_total)
+  end
+
+  # Is this a rural school?
+  # Returns nil if there is no data. Otherwise returns true or false.
+  def rural_school?
+    return nil unless community_type
+
+    # The Rural Education Achievement Program (REAP) accepts the following NCES locale codes
+    # as "rural": town (distant and remote subcategories)
+    # and rural (fringe, distant, and remote subcategories).
+    %w(town_distant town_remote rural_fringe rural_distant rural_remote).
+      include? community_type
   end
 
   # returns what percent "count" is of the total student enrollment

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -167,6 +167,11 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
     "#{(100.0 * count / total).round(2)}%"
   end
 
+  def yes_no_string(value)
+    return nil if value.nil?
+    value ? Pd::Application::ApplicationBase::YES : Pd::Application::ApplicationBase::NO
+  end
+
   def school_stats
     return {} unless object.try(:school_id)
 
@@ -178,6 +183,7 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
 
     {
       title_i_status: stats.title_i_status,
+      rural_status: yes_no_string(stats.rural_school?),
       school_type: school.school_type.try(:titleize),
       frl_eligible_percent: percent_string(stats.frl_eligible_total, stats.students_total),
       urm_percent: percent_string(urm_total, stats.students_total),

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -1019,7 +1019,7 @@ module Api::V1::Pd
         "Contact name for invoicing",
         "Contact email or phone number for invoicing",
         "Title I status code (NCES data)",
-        "Rural status",
+        "Rural Status",
         "Total student enrollment (NCES data)",
         "Percentage of students who are eligible to receive free or reduced lunch (NCES data)",
         "Percentage of underrepresented minority students (NCES data)",

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -1019,6 +1019,7 @@ module Api::V1::Pd
         "Contact name for invoicing",
         "Contact email or phone number for invoicing",
         "Title I status code (NCES data)",
+        "Rural status",
         "Total student enrollment (NCES data)",
         "Percentage of students who are eligible to receive free or reduced lunch (NCES data)",
         "Percentage of underrepresented minority students (NCES data)",

--- a/dashboard/test/models/pd/application/teacher2021_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher2021_application_test.rb
@@ -551,6 +551,7 @@ module Pd::Application
             csd_which_grades: YES,
             plan_to_teach: YES,
             committed: YES,
+            replace_existing: YES,
             principal_schedule_confirmed: YES,
           },
           meets_scholarship_criteria_scores: {
@@ -561,7 +562,6 @@ module Pd::Application
             principal_diversity_recruitment: YES,
           },
           bonus_points_scores: {
-            replace_existing: 5,
             race: 2,
             free_lunch_percent: 5,
             underrepresented_minority_percent: 5,
@@ -601,6 +601,7 @@ module Pd::Application
             csp_which_grades: YES,
             plan_to_teach: YES,
             committed: YES,
+            replace_existing: YES,
             principal_schedule_confirmed: YES,
           },
           meets_scholarship_criteria_scores: {
@@ -612,7 +613,6 @@ module Pd::Application
           },
           bonus_points_scores: {
             csp_how_offer: 2,
-            replace_existing: 5,
             race: 2,
             free_lunch_percent: 5,
             underrepresented_minority_percent: 5
@@ -645,6 +645,7 @@ module Pd::Application
             csp_which_grades: YES,
             plan_to_teach: YES,
             committed: YES,
+            replace_existing: YES,
           },
           meets_scholarship_criteria_scores: {
             plan_to_teach: YES,
@@ -652,7 +653,6 @@ module Pd::Application
           },
           bonus_points_scores: {
             csp_how_offer: 2,
-            replace_existing: 5,
             race: 2
           },
         }.deep_stringify_keys,
@@ -689,6 +689,7 @@ module Pd::Application
             regional_partner_name: NO,
             csd_which_grades: NO,
             committed: NO,
+            replace_existing: NO,
             principal_schedule_confirmed: NO,
           },
           meets_scholarship_criteria_scores: {
@@ -698,7 +699,6 @@ module Pd::Application
             principal_diversity_recruitment: NO,
           },
           bonus_points_scores: {
-            replace_existing: 0,
             race: 0,
             free_lunch_percent: 0,
             underrepresented_minority_percent: 0,
@@ -737,6 +737,7 @@ module Pd::Application
             regional_partner_name: NO,
             csp_which_grades: NO,
             committed: NO,
+            replace_existing: NO,
             principal_schedule_confirmed: NO,
           },
           meets_scholarship_criteria_scores: {
@@ -747,7 +748,6 @@ module Pd::Application
           },
           bonus_points_scores: {
             csp_how_offer: 0,
-            replace_existing: 0,
             race: 0,
             free_lunch_percent: 0,
             underrepresented_minority_percent: 0
@@ -777,7 +777,8 @@ module Pd::Application
 
       application.auto_score!
 
-      assert_equal 0, application.response_scores_hash[:bonus_points_scores][:replace_existing]
+      assert_equal NO,
+        application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing]
 
       application.update_form_data_hash(
         {
@@ -788,7 +789,8 @@ module Pd::Application
 
       application.auto_score!
 
-      assert_equal 5, application.response_scores_hash[:bonus_points_scores][:replace_existing]
+      assert_equal YES,
+        application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing]
     end
 
     test 'nil results when applicable' do
@@ -810,8 +812,8 @@ module Pd::Application
       response_scores_hash = application.response_scores_hash
 
       assert_nil response_scores_hash[:meets_minimum_criteria_scores][:principal_schedule_confirmed]
+      assert_nil response_scores_hash[:meets_minimum_criteria_scores][:replace_existing]
       assert_nil response_scores_hash[:meets_scholarship_criteria_scores][:principal_schedule_confirmed]
-      assert_nil response_scores_hash[:bonus_points_scores][:replace_existing]
     end
 
     test 'principal_approval_state' do

--- a/dashboard/test/models/pd/application/teacher2021_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher2021_application_test.rb
@@ -78,19 +78,6 @@ module Pd::Application
       assert_equal Pd::Application::Teacher2021Application::REVIEWING_INCOMPLETE, teacher_application.meets_criteria
     end
 
-    test 'total score calculates the sum of all response scores' do
-      teacher_application = build :pd_teacher2021_application, response_scores: {
-        bonus_points_scores: {
-          free_lunch_percent: '5',
-          underrepresented_minority_percent: '5',
-          able_to_attend_single: TEXT_FIELDS[:able_to_attend_single],
-          csp_which_grades: nil
-        }
-      }.to_json
-
-      assert_equal 10, teacher_application.total_score
-    end
-
     test 'accepted_at updates times' do
       today = Date.today.to_time
       tomorrow = Date.tomorrow.to_time
@@ -319,12 +306,12 @@ module Pd::Application
       csv_header_csd = CSV.parse(Teacher2021Application.csv_header('csd'))[0]
       assert csv_header_csd.include? "To which grades does your school plan to offer CS Discoveries in the 2020-21 school year?"
       refute csv_header_csd.include? "To which grades does your school plan to offer CS Principles in the 2020-21 school year?"
-      assert_equal 97, csv_header_csd.length
+      assert_equal 98, csv_header_csd.length
 
       csv_header_csp = CSV.parse(Teacher2021Application.csv_header('csp'))[0]
       refute csv_header_csp.include? "To which grades does your school plan to offer CS Discoveries in the 2020-21 school year?"
       assert csv_header_csp.include? "To which grades does your school plan to offer CS Principles in the 2020-21 school year?"
-      assert_equal 99, csv_header_csp.length
+      assert_equal 100, csv_header_csp.length
     end
 
     test 'school cache' do
@@ -560,11 +547,11 @@ module Pd::Application
             principal_approval: YES,
             principal_schedule_confirmed: YES,
             principal_diversity_recruitment: YES,
+            free_lunch_percent: YES,
+            underrepresented_minority_percent: YES,
           },
           bonus_points_scores: {
             race: 2,
-            free_lunch_percent: 5,
-            underrepresented_minority_percent: 5,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -609,13 +596,13 @@ module Pd::Application
             previous_yearlong_cdo_pd: YES,
             principal_approval: YES,
             principal_schedule_confirmed: YES,
-            principal_diversity_recruitment: YES
+            principal_diversity_recruitment: YES,
+            free_lunch_percent: YES,
+            underrepresented_minority_percent: YES,
           },
           bonus_points_scores: {
             csp_how_offer: 2,
             race: 2,
-            free_lunch_percent: 5,
-            underrepresented_minority_percent: 5
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -697,11 +684,11 @@ module Pd::Application
             principal_approval: NO,
             principal_schedule_confirmed: NO,
             principal_diversity_recruitment: NO,
+            free_lunch_percent: NO,
+            underrepresented_minority_percent: NO,
           },
           bonus_points_scores: {
             race: 0,
-            free_lunch_percent: 0,
-            underrepresented_minority_percent: 0,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
@@ -744,13 +731,13 @@ module Pd::Application
             previous_yearlong_cdo_pd: NO,
             principal_approval: NO,
             principal_schedule_confirmed: NO,
-            principal_diversity_recruitment: NO
+            principal_diversity_recruitment: NO,
+            free_lunch_percent: NO,
+            underrepresented_minority_percent: NO,
           },
           bonus_points_scores: {
             csp_how_offer: 0,
             race: 0,
-            free_lunch_percent: 0,
-            underrepresented_minority_percent: 0
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)

--- a/lib/cdo/shared_constants/pd/teacher2021_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher2021_application_constants.rb
@@ -109,6 +109,7 @@ module Pd
         },
       school_stats_and_principal_approval_section: {
         title_i_status: 'Title I status',
+        rural_status: 'Rural Status',
         school_type: 'School Type',
         total_student_enrollment: 'Total Student Enrollment',
         free_lunch_percent: 'Percent of students eligible to receive free/reduced lunch',
@@ -201,6 +202,7 @@ module Pd
       },
       nces: {
         title_i_status: "Title I status code (NCES data)",
+        rural_status: 'Rural Status',
         students_total: "Total student enrollment (NCES data)",
         frl_eligible_total: "Percentage of students who are eligible to receive free or reduced lunch (NCES data)",
         urm_percent: "Percentage of underrepresented minority students (NCES data)",
@@ -237,6 +239,7 @@ module Pd
       contact_invoicing_detail: {principal: :principal_contact_invoicing_detail},
 
       title_i_status: {stats: :title_i_status},
+      rural_status: {stats: :rural_status},
       school_type: {teacher: :school_type, stats: :school_type},
       total_student_enrollment: {principal: :principal_total_enrollment, stats: :students_total},
       free_lunch_percent: {principal: :principal_free_lunch_percent, stats: :frl_eligible_percent},
@@ -269,10 +272,10 @@ module Pd
       principal_implementation: {meets_minimum_criteria_scores: YES_NO, bonus_points_scores: [2, 0]},
       # Scholarship requirements
       previous_yearlong_cdo_pd: YES_NO,
+      free_lunch_percent: YES_NO,
+      underrepresented_minority_percent: YES_NO,
       # Bonus Points
       csp_how_offer: [2, 0],
-      free_lunch_percent: [5, 0],
-      underrepresented_minority_percent: [5, 0],
       race: [2, 0]
     }
 
@@ -290,7 +293,9 @@ module Pd
         :previous_yearlong_cdo_pd,
         :principal_approval,
         :principal_schedule_confirmed,
-        :principal_diversity_recruitment
+        :principal_diversity_recruitment,
+        :underrepresented_minority_percent,
+        :free_lunch_percent,
       ],
       criteria_score_questions_csd: [
         :regional_partner_name,
@@ -427,6 +432,7 @@ module Pd
       ],
       nces: [
         :title_i_status,
+        :rural_status,
         :students_total,
         :frl_eligible_total,
         :urm_percent,

--- a/lib/cdo/shared_constants/pd/teacher2021_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher2021_application_constants.rb
@@ -262,6 +262,7 @@ module Pd
       cs_total_course_hours: YES_NO,
       plan_to_teach: YES_NO,
       committed: YES_NO,
+      replace_existing: YES_NO,
       principal_approval: YES_NO,
       principal_schedule_confirmed: YES_NO,
       principal_diversity_recruitment: YES_NO,
@@ -270,7 +271,6 @@ module Pd
       previous_yearlong_cdo_pd: YES_NO,
       # Bonus Points
       csp_how_offer: [2, 0],
-      replace_existing: [5, 0],
       free_lunch_percent: [5, 0],
       underrepresented_minority_percent: [5, 0],
       race: [2, 0]
@@ -280,7 +280,6 @@ module Pd
     SCOREABLE_QUESTIONS = {
       bonus_points: [
         :csp_how_offer,
-        :replace_existing,
         :free_lunch_percent,
         :underrepresented_minority_percent,
         :race,
@@ -299,6 +298,7 @@ module Pd
         :cs_total_course_hours,
         :plan_to_teach,
         :committed,
+        :replace_existing,
         :principal_implementation
       ],
       criteria_score_questions_csp: [
@@ -307,6 +307,7 @@ module Pd
         :cs_total_course_hours,
         :plan_to_teach,
         :committed,
+        :replace_existing,
         :principal_implementation
       ]
     }


### PR DESCRIPTION
# Description

Porting the changes below from Teacher 1920 Application to Teacher 2021 Application. This PR is (almost) **identical** to the compilation of #31116 and #31090.

1. Change Expanding CS question from a bonus-point question to a minimum criteria question.
2. Change "Free lunch percent" and "URM percent" responses from Bonus fields to “Meets scholarship requirements?” fields
3. Add new row for "Rural status" in Principal Approval and School Information section. Data come from NCES.

## Links
[PLC-535](https://codedotorg.atlassian.net/browse/PLC-535)