### PR TITLE
Don't cache pdfs in varnish [ci skip]

### DIFF
--- a/cookbooks/cdo-varnish/templates/default/default.vcl.erb
+++ b/cookbooks/cdo-varnish/templates/default/default.vcl.erb
@@ -144,6 +144,12 @@ if (req.http.X-Cookie-language_) {
 <%= setup_behavior(config, 'req', &method(:process_proxy)) %>
 ###
 
+# Don't cache potentially large files to avoid aborted connections due to hitting the "nuke limit":
+# https://varnish-misc.varnish-cache.narkive.com/tUrH8ayo/question-about-an-lru-error
+if (req.url ~ "^.*\.pdf$") {
+  return (pass);
+}
+
 # Override builtin VCL with customizations:
 # 1. Allow caching whitelisted cookies.
 # 2. Return 403 instead of (pipe) on unsupported HTTP request methods.

--- a/cookbooks/cdo-varnish/test/cookbooks/varnish_test/recipes/default.rb
+++ b/cookbooks/cdo-varnish/test/cookbooks/varnish_test/recipes/default.rb
@@ -6,7 +6,18 @@ user = Etc.getpwuid.name
 home = Etc.getpwuid.dir
 
 remote_file "#{home}/mock.jar" do
-  source 'http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock/1.57/wiremock-1.57-standalone.jar'
+  source 'http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.25.0/wiremock-standalone-2.25.0.jar'
+  backup false
+  owner user
+end
+
+# Set up file(s) served by wiremock in tests.
+directory "#{home}/__files" do
+  owner user
+  group user
+end
+template "#{home}/__files/fakepdf.pdf" do
+  source 'fakepdf.pdf.erb'
   backup false
   owner user
 end


### PR DESCRIPTION
# Description

This fix is just a proof of concept so far; looking for feedback on the exact conditions on which we should not cache. Looking at file extension seemed the easiest to implement / most predictable, but I could also see using the Content-Length or Content-Type headers.

Attempting to fix issue where https://advocacy.code.org/2019_state_of_cs.pdf fails during high traffic. The root cause appears to be varnish attempting to make space for the large pdf in the cache by evicting old objects, but running into its configured "nuke limit" before it can make enough space. In this case it apparently just aborts the connection partway through. See: https://varnish-misc.varnish-cache.narkive.com/tUrH8ayo/question-about-an-lru-error

For more context see:
https://codedotorg.slack.com/archives/C03CK49G9/p1570481266384600
https://codedotorg.slack.com/archives/C03CK49G9/p1570552395389700

### Testing
Tested using `bundle exec kitchen converge default-ubuntu-1804` and `bundle exec kitchen verify default-ubuntu-1804`. Newly added test fails without the vcl change and passes with it.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
