### PR TITLE
Assignment Updates: auto select first unit if a course is assigned to a new section

### DIFF
--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -62,7 +62,11 @@ class AddSectionDialog extends Component {
             />
           )}
           {loginType && (
-            <EditSectionForm title={title} locale={locale} newSection={true} />
+            <EditSectionForm
+              title={title}
+              locale={locale}
+              isNewSection={true}
+            />
           )}
         </PadAndCenter>
       </BaseDialog>

--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -61,7 +61,9 @@ class AddSectionDialog extends Component {
               handleCancel={handleCancel}
             />
           )}
-          {loginType && <EditSectionForm title={title} locale={locale} />}
+          {loginType && (
+            <EditSectionForm title={title} locale={locale} newSection={true} />
+          )}
         </PadAndCenter>
       </BaseDialog>
     );

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -260,7 +260,7 @@ export default class AssignmentSelector extends Component {
     // primary assignment, default the secondary assignment to the first
     // script in the course.
     const noCurrentSecondaryAssignment = selectedSecondaryId === 'null_null';
-    const defaultScriptId = assignments[selectedPrimaryId]
+    const defaultScriptId = assignments[selectedPrimaryId].scriptAssignIds
       ? assignments[selectedPrimaryId].scriptAssignIds[0]
       : null;
     const secondaryId =

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -341,7 +341,6 @@ export default class AssignmentSelector extends Component {
               style={dropdownStyle}
               disabled={disabled}
             >
-              {!newSection && <option value={noAssignment} />}
               {secondaryOptions.map(
                 scriptAssignId =>
                   assignments[scriptAssignId] && (
@@ -350,7 +349,7 @@ export default class AssignmentSelector extends Component {
                     </option>
                   )
               )}
-              {newSection && <option value={noAssignment} />}
+              <option value={noAssignment} />
             </select>
           </div>
         )}

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -218,7 +218,18 @@ export default class AssignmentSelector extends Component {
       selectedAssignmentFamily,
       selectedVersionYear
     );
-    const selectedSecondaryId = noAssignment;
+    const primary = this.props.assignments[selectedPrimaryId];
+    // If the user is setting up a new section and selects a course as the
+    // primary assignment, default the secondary assignment to the first
+    // script in the course.
+    const defaultSecondaryId =
+      this.props.newSection && primary && primary.scriptAssignIds
+        ? primary.scriptAssignIds[0]
+        : null;
+
+    const selectedSecondaryId = this.props.newSection
+      ? defaultSecondaryId
+      : noAssignment;
 
     this.setState(
       {
@@ -247,7 +258,7 @@ export default class AssignmentSelector extends Component {
   };
 
   render() {
-    const {assignments, dropdownStyle, disabled, newSection} = this.props;
+    const {assignments, dropdownStyle, disabled} = this.props;
     let {assignmentFamilies} = this.props;
     const {
       selectedPrimaryId,
@@ -255,18 +266,6 @@ export default class AssignmentSelector extends Component {
       selectedAssignmentFamily,
       versions
     } = this.state;
-
-    // If the user is setting up a new section and selects a course as the
-    // primary assignment, default the secondary assignment to the first
-    // script in the course.
-    const noCurrentSecondaryAssignment = selectedSecondaryId === 'null_null';
-    const defaultScriptId = assignments[selectedPrimaryId].scriptAssignIds
-      ? assignments[selectedPrimaryId].scriptAssignIds[0]
-      : null;
-    const secondaryId =
-      newSection && noCurrentSecondaryAssignment
-        ? defaultScriptId
-        : selectedSecondaryId;
 
     let secondaryOptions;
     const primaryAssignment = assignments[selectedPrimaryId];
@@ -336,7 +335,7 @@ export default class AssignmentSelector extends Component {
             </div>
             <select
               id="uitest-secondary-assignment"
-              value={secondaryId}
+              value={selectedSecondaryId}
               onChange={this.onChangeSecondary}
               style={dropdownStyle}
               disabled={disabled}

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -225,7 +225,7 @@ export default class AssignmentSelector extends Component {
     const defaultSecondaryId =
       this.props.newSection && primary && primary.scriptAssignIds
         ? primary.scriptAssignIds[0]
-        : null;
+        : noAssignment;
 
     const selectedSecondaryId = this.props.newSection
       ? defaultSecondaryId

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -70,7 +70,8 @@ export default class AssignmentSelector extends Component {
     dropdownStyle: PropTypes.object,
     onChange: PropTypes.func,
     disabled: PropTypes.bool,
-    locale: PropTypes.string
+    locale: PropTypes.string,
+    newSection: PropTypes.bool
   };
 
   /**
@@ -246,7 +247,7 @@ export default class AssignmentSelector extends Component {
   };
 
   render() {
-    const {assignments, dropdownStyle, disabled} = this.props;
+    const {assignments, dropdownStyle, disabled, newSection} = this.props;
     let {assignmentFamilies} = this.props;
     const {
       selectedPrimaryId,
@@ -254,6 +255,18 @@ export default class AssignmentSelector extends Component {
       selectedAssignmentFamily,
       versions
     } = this.state;
+
+    // If the user is setting up a new section and selects a course as the
+    // primary assignment, default the secondary assignment to the first
+    // script in the course.
+    const noCurrentSecondaryAssignment = selectedSecondaryId === 'null_null';
+    const defaultScriptId = assignments[selectedPrimaryId]
+      ? assignments[selectedPrimaryId].scriptAssignIds[0]
+      : null;
+    const secondaryId =
+      newSection && noCurrentSecondaryAssignment
+        ? defaultScriptId
+        : selectedSecondaryId;
 
     let secondaryOptions;
     const primaryAssignment = assignments[selectedPrimaryId];
@@ -323,12 +336,12 @@ export default class AssignmentSelector extends Component {
             </div>
             <select
               id="uitest-secondary-assignment"
-              value={selectedSecondaryId}
+              value={secondaryId}
               onChange={this.onChangeSecondary}
               style={dropdownStyle}
               disabled={disabled}
             >
-              <option value={noAssignment} />
+              {!newSection && <option value={noAssignment} />}
               {secondaryOptions.map(
                 scriptAssignId =>
                   assignments[scriptAssignId] && (
@@ -337,6 +350,7 @@ export default class AssignmentSelector extends Component {
                     </option>
                   )
               )}
+              {newSection && <option value={noAssignment} />}
             </select>
           </div>
         )}

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -71,7 +71,7 @@ export default class AssignmentSelector extends Component {
     onChange: PropTypes.func,
     disabled: PropTypes.bool,
     locale: PropTypes.string,
-    newSection: PropTypes.bool
+    isNewSection: PropTypes.bool
   };
 
   /**
@@ -223,11 +223,11 @@ export default class AssignmentSelector extends Component {
     // primary assignment, default the secondary assignment to the first
     // script in the course.
     const defaultSecondaryId =
-      this.props.newSection && primary && primary.scriptAssignIds
+      this.props.isNewSection && primary && primary.scriptAssignIds
         ? primary.scriptAssignIds[0]
         : noAssignment;
 
-    const selectedSecondaryId = this.props.newSection
+    const selectedSecondaryId = this.props.isNewSection
       ? defaultSecondaryId
       : noAssignment;
 

--- a/apps/src/templates/teacherDashboard/EditSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionDialog.jsx
@@ -30,7 +30,7 @@ class EditSectionDialog extends Component {
           <EditSectionForm
             title={i18n.editSectionDetails()}
             locale={this.props.locale}
-            newSection={false}
+            isNewSection={false}
           />
         </PadAndCenter>
       </BaseDialog>

--- a/apps/src/templates/teacherDashboard/EditSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionDialog.jsx
@@ -30,6 +30,7 @@ class EditSectionDialog extends Component {
           <EditSectionForm
             title={i18n.editSectionDetails()}
             locale={this.props.locale}
+            newSection={false}
           />
         </PadAndCenter>
       </BaseDialog>

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -54,6 +54,8 @@ class EditSectionForm extends Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
     locale: PropTypes.string,
+    //Whether the user is adding a brand new section or editing an existing one.
+    newSection: PropTypes.bool,
 
     //Comes from redux
     validGrades: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -120,8 +122,10 @@ class EditSectionForm extends Component {
       handleClose,
       stageExtrasAvailable,
       assignedScriptName,
-      locale
+      locale,
+      newSection
     } = this.props;
+
     if (!section) {
       return null;
     }
@@ -147,6 +151,7 @@ class EditSectionForm extends Component {
             assignmentFamilies={assignmentFamilies}
             disabled={isSaveInProgress}
             locale={locale}
+            newSection={newSection}
           />
           {stageExtrasAvailable(section.scriptId) && (
             <LessonExtrasField
@@ -268,7 +273,8 @@ const AssignmentField = ({
   validAssignments,
   assignmentFamilies,
   disabled,
-  locale
+  locale,
+  newSection
 }) => (
   <div>
     <FieldName>{i18n.course()}</FieldName>
@@ -282,6 +288,7 @@ const AssignmentField = ({
       dropdownStyle={style.dropdown}
       disabled={disabled}
       locale={locale}
+      newSection={newSection}
     />
   </div>
 );
@@ -291,7 +298,8 @@ AssignmentField.propTypes = {
   validAssignments: PropTypes.objectOf(assignmentShape).isRequired,
   assignmentFamilies: PropTypes.arrayOf(assignmentFamilyShape).isRequired,
   disabled: PropTypes.bool,
-  locale: PropTypes.string
+  locale: PropTypes.string,
+  newSection: PropTypes.bool
 };
 
 const LessonExtrasField = ({value, onChange, disabled}) => (

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -55,7 +55,7 @@ class EditSectionForm extends Component {
     title: PropTypes.string.isRequired,
     locale: PropTypes.string,
     //Whether the user is adding a brand new section or editing an existing one.
-    newSection: PropTypes.bool,
+    isNewSection: PropTypes.bool,
 
     //Comes from redux
     validGrades: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -123,7 +123,7 @@ class EditSectionForm extends Component {
       stageExtrasAvailable,
       assignedScriptName,
       locale,
-      newSection
+      isNewSection
     } = this.props;
 
     if (!section) {
@@ -151,7 +151,7 @@ class EditSectionForm extends Component {
             assignmentFamilies={assignmentFamilies}
             disabled={isSaveInProgress}
             locale={locale}
-            newSection={newSection}
+            isNewSection={isNewSection}
           />
           {stageExtrasAvailable(section.scriptId) && (
             <LessonExtrasField
@@ -274,7 +274,7 @@ const AssignmentField = ({
   assignmentFamilies,
   disabled,
   locale,
-  newSection
+  isNewSection
 }) => (
   <div>
     <FieldName>{i18n.course()}</FieldName>
@@ -288,7 +288,7 @@ const AssignmentField = ({
       dropdownStyle={style.dropdown}
       disabled={disabled}
       locale={locale}
-      newSection={newSection}
+      isNewSection={isNewSection}
     />
   </div>
 );
@@ -299,7 +299,7 @@ AssignmentField.propTypes = {
   assignmentFamilies: PropTypes.arrayOf(assignmentFamilyShape).isRequired,
   disabled: PropTypes.bool,
   locale: PropTypes.string,
-  newSection: PropTypes.bool
+  isNewSection: PropTypes.bool
 };
 
 const LessonExtrasField = ({value, onChange, disabled}) => (

--- a/apps/test/unit/templates/teacherDashboard/AssignmentSelectorTest.js
+++ b/apps/test/unit/templates/teacherDashboard/AssignmentSelectorTest.js
@@ -220,14 +220,14 @@ describe('AssignmentSelector', () => {
         .find('option')
         .at(0)
         .text(),
-      ''
+      'Unit 1: Problem Solving'
     );
     assert.equal(
       secondary
         .find('option')
         .at(1)
         .text(),
-      'Unit 1: Problem Solving'
+      ''
     );
     assert.deepEqual(wrapper.instance().getSelectedAssignment(), {
       courseId: 29,

--- a/dashboard/test/ui/features/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_homepage.feature
@@ -126,6 +126,13 @@ Feature: Using the teacher homepage sections feature
     And I wait until element ".uitest-CourseScript" is visible
     Then unit "CSP Unit 2 - Digital Information ('17-'18)" is marked as visible
 
+  Scenario: Assign a Course assigns first Unit in Course by default
+    Given I am on "http://studio.code.org/home"
+    When I see the section set up box
+    And I create a new section with course "Computer Science Principles", version "'17-'18"
+    Then the section table should have 1 rows
+    And the section table row at index 0 has secondary assignment path "/s/csp1-2017"
+
   Scenario: Assign a CSF course with multiple versions
     Given I am on "http://studio.code.org/home"
     When I see the section set up box


### PR DESCRIPTION
# Description

**New Sections** 
When a teacher is a creating a new section and selects a course for the primary assignment dropdown, we will now default the secondary assignment dropdown to the first unit in that course. Previously, we defaulted the secondary assignment dropdown to the empty option. 
![new-section](https://user-images.githubusercontent.com/12300669/66505118-871bc100-ea7f-11e9-8444-5d1e96004b96.gif)

**Existing Sections** 
If a teacher is editing an existing section and a primary and secondary assignment is already selected, we preserve those selections. 
![editing-course-unit-already](https://user-images.githubusercontent.com/12300669/66505309-f691b080-ea7f-11e9-9365-d3c1ca505152.gif)

Even if the secondary assignment selected is empty.  This is because the teacher may have intentionally not assigned a unit.  This is a rare, but valid, use case. 
![editing-course-no-section](https://user-images.githubusercontent.com/12300669/66505226-c5b17b80-ea7f-11e9-8961-acf2328ad0d5.gif)

Additionally, the "no assignment" option is now the last option in the secondary assignment dropdown rather than the first. 

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1vJySqyKozUxknkhY1KyQXWzbV-0c1vdnpKvRsAsVrdI/edit#bookmark=id.mdyvo25xt6km)
- [jira LP-707](https://codedotorg.atlassian.net/browse/LP-707)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
