### PR TITLE
Set varnish nuke limit to very high number [ci skip]

### DIFF
--- a/cookbooks/cdo-varnish/templates/default/varnish.service.erb
+++ b/cookbooks/cdo-varnish/templates/default/varnish.service.erb
@@ -55,6 +55,12 @@ Environment = VARNISH_TTL=120
 # Ref: http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html
 Environment = VARNISH_TIMEOUT_IDLE=65
 
+# When there's not enough space to cache a new response, varnish starts "nuking" old entries from the cache to make room,
+# but if it hits its configured "nuke limit" then it gives up and truncates the response. We set this to a high value
+# to approximate not having this limit, which was the old behavior before our upgrade to Varnish 5. This was
+# recommended by Varnish maintainers in: https://github.com/varnishcache/varnish-cache/issues/1764#issuecomment-323750334
+Environment = VARNISH_NUKE_LIMIT=9999999
+
 ExecStart=
 ExecStart=/usr/sbin/varnishd \
   -a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
@@ -67,6 +73,7 @@ ExecStart=/usr/sbin/varnishd \
   -p thread_pool_max=${VARNISH_MAX_THREADS} \
   -p thread_pool_timeout=${VARNISH_THREAD_TIMEOUT} \
   -p thread_pool_add_delay=${VARNISH_THREAD_POOL_ADD_DELAY} \
-  -p timeout_idle=65 \
+  -p timeout_idle=${VARNISH_TIMEOUT_IDLE} \
   -p vcc_allow_inline_c=true \
+  -p nuke_limit=${VARNISH_NUKE_LIMIT} \
   -F


### PR DESCRIPTION
# Description

Fix for issue described in https://github.com/code-dot-org/code-dot-org/pull/31176

## Links

- https://github.com/varnishcache/varnish-cache/issues/1764#issuecomment-323750334

## Testing story

- @wjordan had previously manually applied this setting on a production frontend instance and saw that it fixed the issue.
- Tested config change with `bundle exec kitchen converge default-ubuntu-1804`:
- varnishd runs successfully with the right params:
```
varnish   6350  0.0  0.2  36992  4416 ?        SLs  19:11   0:00 /usr/sbin/varnishd -a :80 -f /etc/varnish/default.vcl -T :6082 -t 120 -S /etc/varnish/secret -s malloc,0.1G -p thread_pool_min=1000 -p thread_pool_max=4000 -p thread_pool_timeout=120 -p thread_pool_add_delay=2 -p timeout_idle=65 -p vcc_allow_inline_c=true -p nuke_limit=9999999 -F
vcache    6362  0.1  0.3 296892  6828 ?        SLl  19:11   0:00 /usr/sbin/varnishd -a :80 -f /etc/varnish/default.vcl -T :6082 -t 120 -S /etc/varnish/secret -s malloc,0.1G -p thread_pool_min=1000 -p thread_pool_max=4000 -p thread_pool_timeout=120 -p thread_pool_add_delay=2 -p timeout_idle=65 -p vcc_allow_inline_c=true -p nuke_limit=9999999 -F
```
- varnishadm shows `nuke_limit` set correctly:
```
varnish> param.show nuke_limit
200        
nuke_limit
        Value is: 9999999 [allocations]
        Default is: 50
        Minimum is: 0

        Maximum number of objects we attempt to nuke in order to make
        space for a object body.

        NB: We do not know yet if it is a good idea to change this
        parameter, or if the default value is even sensible. Caution is
        advised, and feedback is most welcome.
```