### PR TITLE
generate unhashed copies of assets needed by applab/gamelab exporters

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -1192,7 +1192,6 @@ describe('entry tests', () => {
 
   grunt.registerTask('postbuild', [
     'newer:copy:static',
-    'newer:copy:unhash',
     'newer:sass',
     'compile-firebase-rules'
   ]);
@@ -1204,7 +1203,8 @@ describe('entry tests', () => {
     envConstants.DEV ? 'noop' : 'uglify:lib',
     envConstants.DEV ? 'webpack:build' : 'webpack:uglify',
     'notify:js-build',
-    'postbuild'
+    'postbuild',
+    envConstants.DEV ? 'noop' : 'newer:copy:unhash'
   ]);
 
   grunt.registerTask('rebuild', ['clean', 'build']);

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -296,6 +296,26 @@ describe('entry tests', () => {
           dest: 'build/minifiable-lib/fileupload/'
         }
       ]
+    },
+    unhash: {
+      files: [
+        {
+          expand: true,
+          cwd: 'build/package/js',
+          // The applab and gamelab exporters need unhashed copies of these files.
+          src: [
+            'webpack-runtimewp*.min.js',
+            'applab-apiwp*.min.js',
+            'gamelab-apiwp*.min.js'
+          ],
+          dest: 'build/package/js',
+          // e.g. webpack-runtimewp0123456789aabbccddee.min.js --> webpack-runtime.min.js
+          rename: function(dest, src) {
+            var outputFile = src.replace(/wp[0-9a-f]{20}/, '');
+            return path.join(dest, outputFile);
+          }
+        }
+      ]
     }
   };
 
@@ -1172,6 +1192,7 @@ describe('entry tests', () => {
 
   grunt.registerTask('postbuild', [
     'newer:copy:static',
+    'newer:copy:unhash',
     'newer:sass',
     'compile-firebase-rules'
   ]);


### PR DESCRIPTION
# Description

Fixes a problem in production where applab and gamelab exporters fail to find the following assets:

```
/blockly/js/webpack-runtime.min.js
/blockly/js/applab-api.min.js
/blockly/js/gamelab-api.min.js
```

## Testing story

Manually verified that `npm build:dist` generates the missing files listed above in apps/build/package/js.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
