### PR TITLE
PL: Convert form MarkdownSpan -> SafeMarkdown (simplified)

### DIFF
--- a/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
+++ b/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import FormComponent from './FormComponent';
-import MarkdownSpan from '../components/markdownSpan';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
 export default class LabeledFormComponent extends FormComponent {
   /**
@@ -16,7 +16,14 @@ export default class LabeledFormComponent extends FormComponent {
       return name;
     }
 
-    return <MarkdownSpan>{this.constructor.labels[name]}</MarkdownSpan>;
+    return (
+      <div className="inline_markdown">
+        <SafeMarkdown
+          openExternalLinksInNewTab
+          markdown={this.constructor.labels[name]}
+        />
+      </div>
+    );
   }
 
   indented(depth = 1) {

--- a/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
+++ b/apps/src/code-studio/pd/form_components/LabeledFormComponent.jsx
@@ -17,6 +17,11 @@ export default class LabeledFormComponent extends FormComponent {
     }
 
     return (
+      // SafeMarkdown wraps markdown in a <div> and uses <p> tags for each
+      // paragraph, but the form system was built using a prior markdown
+      // renderer which didn't do that for single-line entries, and so we rely
+      // on some CSS styling in pd.scss to set these elements to
+      // "display: inline" to maintain backwards compatibility.
       <div className="inline_markdown">
         <SafeMarkdown
           openExternalLinksInNewTab

--- a/apps/style/code-studio/pd.scss
+++ b/apps/style/code-studio/pd.scss
@@ -32,6 +32,18 @@
   @include buttons();
   @include user-selects(auto);
 
+  .inline_markdown {
+    display: inline;
+
+    div {
+      display: inline;
+    }
+
+    p {
+      display: inline;
+    }
+  }
+
   a:not(.btn) {
     color: $purple;
     font-family: "Gotham 7r";

--- a/apps/style/code-studio/pd.scss
+++ b/apps/style/code-studio/pd.scss
@@ -32,6 +32,9 @@
   @include buttons();
   @include user-selects(auto);
 
+  // Markdown rendered with SafeMarkdown in LabeledFormComponent is wrapped in
+  // a <div> and uses <p> tags for each paragraph, but the forms system
+  // expects this content to be entirely inline, and so we provide this styling.
   .inline_markdown {
     display: inline;
 


### PR DESCRIPTION
After https://github.com/code-dot-org/code-dot-org/pull/31100 didn't work out, I tried expanding the CSS trickery to cover the various cases we faced: labels consisting of markdown with multiple paragraphs; labels that were plain text; labels that were actual DOM structures; labels that had [markdown in the same paragraph as other content](https://github.com/code-dot-org/code-dot-org/blob/9f617a8dc116cffd56ef412f037d1b48e94fbcd8/apps/src/code-studio/pd/application/teacher/AdditionalDemographicInformation.jsx#L54-L55).  This was complicated by the many different pieces of code that rendered asterisks.

Things got complicated.  To avoid putting the form system or the existing collection of forms at risk of regression, this is an attempt to go to the root of the immediate difficulty.  The previous markdown renderer apparently didn't wrap its content in a `<div>` and one or more `<p>` tags, at least for the single-paragraphs we generally use.  The new markdown renderer does, which is entirely reasonable, but caused our forms' layouts to break.

This PR implements a very simple "backwards compatible" approach.  It wraps the rendered markdown in a CSS class which sets all `<div>` and `<p>` tags to `"display: inline"`.  This means we don't get paragraph support, though it seems unlikely we ever used it.  And it means that all forms render as they did before.
