### PR TITLE
Optimize Pd::Workshop#potential_organizers query

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -334,6 +334,7 @@ install_if require_pg do
   gem 'pg', require: false
 end
 
+gem 'active_record_union'
 gem 'activerecord-import'
 gem 'scenic'
 gem 'scenic-mysql_adapter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_record_query_trace (1.5.3)
+    active_record_union (1.3.0)
+      activerecord (>= 4.0)
     activejob (5.0.7.2)
       activesupport (= 5.0.7.2)
       globalid (>= 0.3.6)
@@ -877,6 +879,7 @@ DEPENDENCIES
   acmesmith (~> 0)
   active_model_serializers!
   active_record_query_trace
+  active_record_union
   activerecord-import
   acts_as_list
   addressable

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -194,7 +194,9 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
 
   # Users who could be re-assigned to be the organizer of this workshop
   def potential_organizers
-    render json: @workshop.potential_organizers
+    render json: @workshop.potential_organizers.pluck(:name, :id).map do |name, id|
+      {label: name, value: id}
+    end
   end
 
   private

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -56,6 +56,8 @@ class Pd::Workshop < ActiveRecord::Base
   has_many :enrollments, class_name: 'Pd::Enrollment', dependent: :destroy, foreign_key: 'pd_workshop_id'
   belongs_to :regional_partner
 
+  has_many :regional_partner_program_managers, source: :program_managers, through: :regional_partner
+
   before_save :process_location, if: -> {location_address_changed?}
   auto_strip_attributes :location_name, :location_address
 
@@ -688,39 +690,30 @@ class Pd::Workshop < ActiveRecord::Base
   end
 
   # Users who could be re-assigned to be the organizer of this workshop
+  # @return [ActiveRecord::Relation]
   def potential_organizers
-    potential_organizer_ids = []
-    potential_organizers = []
-
-    # if there is a regional partner, only that partner's PMs can become the organizer
-    # otherwise, any PM can become the organizer
-    if regional_partner
-      regional_partner.program_managers.each do |pm|
-        potential_organizers << {label: pm.name, value: pm.id}
-      end
-    else
-      UserPermission.where(permission: UserPermission::PROGRAM_MANAGER).pluck(:user_id)&.map do |user_id|
-        potential_organizer_ids << user_id
-      end
-    end
-
-    # any CSF facilitator can become the organizer of a CSF workshhop
-    if course == Pd::Workshop::COURSE_CSF
-      Pd::CourseFacilitator.where(course: Pd::Workshop::COURSE_CSF).pluck(:facilitator_id)&.map do |user_id|
-        potential_organizer_ids << user_id
-      end
-    end
+    user_queries = []
 
     # workshop admins can become the organizer of any workshop
-    UserPermission.where(permission: UserPermission::WORKSHOP_ADMIN).pluck(:user_id)&.map do |user_id|
-      potential_organizer_ids << user_id
+    organizer_roles = [UserPermission::WORKSHOP_ADMIN]
+
+    if regional_partner_id
+      # if there is a regional partner, only that partner's PMs can become the organizer
+      user_queries << regional_partner_program_managers
+    else
+      # otherwise, any PM can become the organizer
+      organizer_roles << UserPermission::PROGRAM_MANAGER
     end
 
-    User.where(id: potential_organizer_ids).pluck(:name, :id)&.map do |name, id|
-      potential_organizers << {label: name, value: id}
+    user_queries << User.joins(:permissions).merge(UserPermission.where(permission: organizer_roles))
+
+    # any CSF facilitator can become the organizer of a CSF workshop
+    if course == Pd::Workshop::COURSE_CSF
+      user_queries << User.joins(:courses_as_facilitator).merge(Pd::CourseFacilitator.where(course: Pd::Workshop::COURSE_CSF))
     end
 
-    potential_organizers
+    # Combine multiple queries into single result set.
+    user_queries.inject(:union)
   end
 
   def can_user_delete?(user)

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1265,7 +1265,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
     # csf workshop has workshop admins, program managers, and other csf facilitators in list
     csf_workshop = create :workshop, course: COURSE_CSF
-    potential_organizer_ids = csf_workshop.potential_organizers.map {|org| org[:value]}
+    potential_organizer_ids = csf_workshop.potential_organizers.ids
 
     assert potential_organizer_ids.include? workshop_admin.id
     assert potential_organizer_ids.include? program_manager.id
@@ -1275,7 +1275,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
     # non-csf workshop without regional partner has workshop admins and all program managers in list
     csd_workshop = create :workshop, course: COURSE_CSD
-    potential_organizer_ids = csd_workshop.potential_organizers.map {|org| org[:value]}
+    potential_organizer_ids = csd_workshop.potential_organizers.ids
     assert potential_organizer_ids.include? workshop_admin.id
     assert potential_organizer_ids.include? program_manager.id
     # facilitators cannot be organizers for non-csf workshops
@@ -1285,7 +1285,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop_partner = create :regional_partner
     workshop_partner_program_manager = create :program_manager, regional_partner: workshop_partner
     csd_workshop.regional_partner = workshop_partner
-    potential_organizer_ids = csd_workshop.potential_organizers.map {|org| org[:value]}
+    potential_organizer_ids = csd_workshop.potential_organizers.ids
     assert potential_organizer_ids.include? workshop_admin.id
     assert potential_organizer_ids.include? workshop_partner_program_manager.id
     refute potential_organizer_ids.include? program_manager.id


### PR DESCRIPTION
# Description

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

Optimizes `Pd::Workshop#potential_organizers` logic using several `JOIN`s plus [`UNION`](https://dev.mysql.com/doc/refman/5.7/en/union.html) to reduce to a single ActiveRecord query.

Adds the [`active_record_union`](https://github.com/brianhempel/active_record_union) gem to support combining multiple `ActiveRecord::Relation` scopes via `UNION` into another `ActiveRecord::Relation` representing one SQL query.

In the process I changed the signature slightly, so that the model method returns a general-purpose `ActiveRecord::Relation<User>` representing the query, while the controller uses `#pluck` to pick specific values into a hash for the JSON response. I think this follows the model/controller separation a bit more cleanly.

### Background

This action is currently slow, in part due to an incorrect query plan selection that is possibly due to [MySQL Bug#81341](https://bugs.mysql.com/bug.php?id=81341). This optimization works around this bug by changing the type of query performed (using `JOIN` and `UNION` instead of `SELECT ... WHERE id IN (1, 2, 3, ...)`.

<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- https://dev.mysql.com/doc/refman/5.7/en/union.html
- https://github.com/brianhempel/active_record_union

## Testing story

Updated the existing unit test covering this logic.

Query/performance comparison (running `pd_workshop.potential_organizers`):

Before:
```
(6.9ms)  SELECT `user_permissions`.`user_id` FROM `user_permissions` WHERE
 `user_permissions`.`permission` = 'program_manager'

(1.3ms)  SELECT `pd_course_facilitators`.`facilitator_id` FROM `pd_course_facilitators` WHERE
 `pd_course_facilitators`.`course` = 'CS Fundamentals'

(0.4ms)  SELECT `user_permissions`.`user_id` FROM `user_permissions` WHERE
 `user_permissions`.`permission` = 'workshop_admin'

(7495.4ms)  SELECT `users`.`name`, `users`.`id` FROM `users` WHERE `users`.`deleted_at` IS NULL
 AND `users`.`id` IN (#, #, #, #, #, ... etc ...)
```

Running last query directly: `503 rows in set (7.68 sec)`

After:
```
(28.4ms)  SELECT `users`.`name`, `users`.`id` FROM ( (SELECT `users`.* FROM `users` INNER JOIN
 `user_permissions` ON `user_permissions`.`user_id` = `users`.`id` WHERE `users`.`deleted_at`
 IS NULL AND `user_permissions`.`permission` IN ('workshop_admin', 'program_manager'))
 UNION (SELECT `users`.* FROM `users` INNER JOIN `pd_course_facilitators` ON
 `pd_course_facilitators`.`facilitator_id` = `users`.`id` WHERE `users`.`deleted_at` IS NULL AND
 `pd_course_facilitators`.`course` = 'CS Fundamentals') ) `users`
```

Running last query directly: `503 rows in set (0.03 sec)`