### PR TITLE
Optimize UserLevel#count_passed_levels_for_users query

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_students_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_students_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::SectionsStudentsController < Api::V1::JsonApiController
 
   # GET /sections/<section_id>/students/completed_levels_count
   def completed_levels_count
-    passing_level_counts = UserLevel.count_passed_levels_for_users(@section.students.pluck(:id))
+    passing_level_counts = UserLevel.count_passed_levels_for_users(@section.students)
     completed_levels_count_per_student = {}
     @section.students.each do |student|
       completed_levels_count_per_student[student.id] = passing_level_counts[student.id] || 0

--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -173,9 +173,9 @@ class UserLevel < ActiveRecord::Base
   end
 
   # Get number of passed levels per user for the given set of user IDs
-  # @param [Array<Integer>] user_ids
+  # @param [ActiveRecord::Relation<Collection<User>>] users
   # @return [Hash<Integer, Integer>] user_id => passed_level_count
-  def self.count_passed_levels_for_users(user_ids)
-    where(user_id: user_ids).passing.group(:user_id).count
+  def self.count_passed_levels_for_users(users)
+    joins(:user).merge(users).passing.group(:user_id).count
   end
 end

--- a/dashboard/test/models/user_level_test.rb
+++ b/dashboard/test/models/user_level_test.rb
@@ -322,7 +322,7 @@ class UserLevelTest < ActiveSupport::TestCase
       create :student, :with_puzzles, num_puzzles: 10 - n
     end
 
-    passing_level_counts = UserLevel.count_passed_levels_for_users(students.map(&:id))
+    passing_level_counts = UserLevel.count_passed_levels_for_users(User.where(id: students.map(&:id)))
     assert_equal(
       {
         students[0].id => 10,


### PR DESCRIPTION
# Description

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

This PR optimizes `UserLevel#count_passed_levels_for_users`, a query computing the passed-level count of all users in a section. Instead of first fetching all ids of `section.students` and then passing a list of id integers to a second query, combine the two queries using a `join` with an `ActiveRecord::Relation`.


## Testing story

Updated relevant unit test to reflect slightly updated API of this method.

Comparison of SQL queries generated by the ActiveRecord code:

Before:
```
SELECT  `sections`.* FROM `sections` WHERE `sections`.`deleted_at` IS NULL
 AND `sections`.`id` = # LIMIT 1

SELECT `users`.`id` FROM `users`
 INNER JOIN `followers` ON `users`.`id` = `followers`.`student_user_id`
 WHERE `users`.`deleted_at` IS NULL AND `followers`.`deleted_at` IS NULL
 AND `followers`.`section_id` = # ORDER BY name

SELECT COUNT(*) AS count_all, `user_levels`.`user_id` AS user_levels_user_id
 FROM `user_levels`
 WHERE `user_levels`.`user_id` IN (#, #, #, #, ...) AND (best_result >= 20)
 GROUP BY  `user_levels`.`user_id`
```

After:
```
SELECT COUNT(*) AS count_all, `user_levels`.`user_id` AS user_levels_user_id
 FROM `user_levels`
 INNER JOIN `users` ON `users`.`id` = `user_levels`.`user_id` AND `users`.`deleted_at` IS NULL
 INNER JOIN `followers` ON `users`.`id` = `followers`.`student_user_id`
 WHERE `users`.`deleted_at` IS NULL AND `followers`.`deleted_at` IS NULL AND
 `followers`.`section_id` = # AND (best_result >= 20) GROUP BY `user_levels`.`user_id`
 ORDER BY name
```

Sample explain plan / query-cost estimate comparison:

Before (cost **15549.61**):
```json
EXPLAIN: {
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "15549.61"
    },
    "grouping_operation": {
      "using_filesort": false,
      "table": {
        "table_name": "user_levels",
        "access_type": "range",
        "possible_keys": [
          "index_user_levels_on_user_id_and_level_id_and_script_id"
        ],
        "key": "index_user_levels_on_user_id_and_level_id_and_script_id",
        "used_key_parts": [
          "user_id"
        ],
        "key_length": "4",
        "rows_examined_per_scan": 10944,
        "rows_produced_per_join": 3647,
        "filtered": "33.33",
        "index_condition": "(`dashboard_production`.`user_levels`.`user_id` in (#, #, #, #, [...etc...]))",
        "cost_info": {
          "read_cost": "14820.08",
          "eval_cost": "729.53",
          "prefix_cost": "15549.61",
          "data_read_per_join": "199K"
        },
        "used_columns": [
          "id",
          "user_id",
          "best_result"
        ],
        "attached_condition": "(`dashboard_production`.`user_levels`.`best_result` >= 20)"
      }
    }
  }
}
```

After (cost **1293.38**):
```json
EXPLAIN: {
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "1293.38"
    },
    "ordering_operation": {
      "using_filesort": true,
      "grouping_operation": {
        "using_temporary_table": true,
        "using_filesort": false,
        "nested_loop": [
          {
            "table": {
              "table_name": "followers",
              "access_type": "ref",
              "possible_keys": [
                "index_followers_on_student_user_id",
                "index_followers_on_section_id_and_student_user_id"
              ],
              "key": "index_followers_on_section_id_and_student_user_id",
              "used_key_parts": [
                "section_id"
              ],
              "key_length": "5",
              "ref": [
                "const"
              ],
              "rows_examined_per_scan": 304,
              "rows_produced_per_join": 30,
              "filtered": "10.00",
              "cost_info": {
                "read_cost": "304.00",
                "eval_cost": "6.08",
                "prefix_cost": "364.80",
                "data_read_per_join": "972"
              },
              "used_columns": [
                "id",
                "student_user_id",
                "section_id",
                "deleted_at"
              ],
              "attached_condition": "isnull(`dashboard_production`.`followers`.`deleted_at`)"
            }
          },
          {
            "table": {
              "table_name": "users",
              "access_type": "eq_ref",
              "possible_keys": [
                "PRIMARY",
                "index_users_on_deleted_at"
              ],
              "key": "PRIMARY",
              "used_key_parts": [
                "id"
              ],
              "key_length": "4",
              "ref": [
                "dashboard_production.followers.student_user_id"
              ],
              "rows_examined_per_scan": 1,
              "rows_produced_per_join": 15,
              "filtered": "50.00",
              "cost_info": {
                "read_cost": "30.40",
                "eval_cost": "3.04",
                "prefix_cost": "401.28",
                "data_read_per_join": "230K"
              },
              "used_columns": [
                "id",
                "name",
                "deleted_at"
              ],
              "attached_condition": "(isnull(`dashboard_production`.`users`.`deleted_at`) and isnull(`dashboard_production`.`users`.`deleted_at`))"
            }
          },
          {
            "table": {
              "table_name": "user_levels",
              "access_type": "ref",
              "possible_keys": [
                "index_user_levels_on_user_id_and_level_id_and_script_id"
              ],
              "key": "index_user_levels_on_user_id_and_level_id_and_script_id",
              "used_key_parts": [
                "user_id"
              ],
              "key_length": "4",
              "ref": [
                "dashboard_production.followers.student_user_id"
              ],
              "rows_examined_per_scan": 48,
              "rows_produced_per_join": 247,
              "filtered": "33.33",
              "cost_info": {
                "read_cost": "743.42",
                "eval_cost": "49.56",
                "prefix_cost": "1293.38",
                "data_read_per_join": "13K"
              },
              "used_columns": [
                "id",
                "user_id",
                "best_result"
              ],
              "attached_condition": "(`dashboard_production`.`user_levels`.`best_result` >= 20)"
            }
          }
        ]
      }
    }
  }
}

```