### PR TITLE
Obsolete: Optimize webpack assets

### DIFF
--- a/apps/docs/build.md
+++ b/apps/docs/build.md
@@ -217,7 +217,7 @@ the following:
 
 0. Make sure you have `build_apps: true` and `use_my_apps: true` in locals.yml.
 
-1. set `pretty_js: false` in locals.yml. This will make dashboard and pegasus
+1. set `optimize_webpack_assets: true` in locals.yml. This will make dashboard and pegasus
    use the webpack manifest to find your js assets (which now have content 
    hashes in the filename) rather than looking for unhashed filenames.
 

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -262,6 +262,8 @@ build_apps: false
 # If false, dashboard will try to use a prepackaged version from S3.
 use_my_apps:
 
+optimize_webpack_assets: true
+
 # Allows your local server to render non-English locales, defaults to false in development.
 # If false, choosing a locale other than English will have no effect.
 # Note: You may need to be in an incognito window to see changes
@@ -362,8 +364,6 @@ lint: false
 # Whether to stub schools and school_districts table with much smaller data,
 # saving a total of 4 min 30 sec during rake seed. Default: true (in development).
 stub_school_data: false
-
-pretty_js: false
 
 disable_s3_image_uploads: false
 

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -9,7 +9,7 @@ firebase_name: cdo-v3-dev
 firebase_channel_id_suffix: -DEVELOPMENT-<%=ENV['USER']%>
 
 lint: true
-pretty_js: true
+optimize_webpack_assets: false
 stub_school_data: true
 daemon: true
 

--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -3,7 +3,6 @@ github_webhook_secret: !Secret
 zendesk_secret:
 netsim_enable_metrics: true
 lint: true
-pretty_js: false
 daemon: true
 use_pusher:                        true
 netsim_shard_expiry_seconds:       60

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -33,7 +33,7 @@ use_pusher: <%=!ci_test%>
 # test environment should use precompiled, minified, digested assets like production,
 # unless it's being used for unit tests. This logic should be kept in sync with
 # the logic for setting config.assets.* under dashboard/config/.
-pretty_js: <%=ci_test%>
+optimize_webpack_assets: <%=!ci_test%>
 
 # Since channel ids are derived from user id and other sequential integer ids
 # use a new S3 sources directory for each Test Build to prevent a UI test

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -260,7 +260,7 @@ class Blockly < Level
           baseUrl: Blockly.base_url,
           app: game.try(:app),
           droplet: uses_droplet?,
-          pretty: Rails.configuration.pretty_apps ? '' : '.min',
+          pretty: CDO.optimize_webpack_assets ? '.min' : '',
         }
       )
     end

--- a/dashboard/config/environments/adhoc.rb
+++ b/dashboard/config/environments/adhoc.rb
@@ -33,14 +33,8 @@ Dashboard::Application.configure do
   # Version of your assets, change this if you want to expire all your assets.
   config.assets.version = '1.0'
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = true
-
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = false
 
   # Log condensed lines to syslog for centralized logging.
   config.lograge.enabled = true

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -58,9 +58,6 @@ Dashboard::Application.configure do
   # skip precompiling of all assets on the first request for any asset.
   config.assets.check_precompiled_asset = false
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = true
-
   # Whether or not to skip script preloading. Setting this to true
   # significantly speeds up server startup time
   config.skip_script_preload = true

--- a/dashboard/config/environments/production.rb
+++ b/dashboard/config/environments/production.rb
@@ -78,9 +78,6 @@ Dashboard::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = false
-
   # Log condensed lines to syslog for centralized logging.
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Cee.new

--- a/dashboard/config/environments/staging.rb
+++ b/dashboard/config/environments/staging.rb
@@ -76,9 +76,6 @@ Dashboard::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = true
-
   # Log condensed lines to syslog for centralized logging.
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Cee.new

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -21,9 +21,6 @@ Dashboard::Application.configure do
   config.public_file_server.enabled = true
   config.public_file_server.headers = {'Cache-Control' => "public, max-age=3600, s-maxage=1800"}
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = false
-
   # test environment should use precompiled, minified, digested assets like production,
   # unless it's being used for unit tests.
   ci_test = !!(ENV['UNIT_TEST'] || ENV['CI'])

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -86,7 +86,7 @@ class ActiveSupport::TestCase
     DCDO.clear
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
-    CDO.stubs(:pretty_js).returns(true)
+    CDO.stubs(:optimize_webpack_assets).returns(false)
   end
 
   teardown do

--- a/lib/cdo/asset_helper.rb
+++ b/lib/cdo/asset_helper.rb
@@ -20,7 +20,7 @@ class AssetHelper
     #
     # Never skip the manifest lookup when using the prebuilt apps package in
     # development because this would generate invalid urls.
-    skip_manifest = CDO.pretty_js && CDO.use_my_apps
+    skip_manifest = !CDO.optimize_webpack_assets && CDO.use_my_apps
     return "/assets/#{asset}" if skip_manifest
     path = webpack_manifest[asset]
     raise "Invalid webpack asset name: '#{asset}'" unless path

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -24,7 +24,7 @@ namespace :build do
       RakeUtils.npm_rebuild 'phantomjs-prebuilt'
 
       ChatClient.log 'Building <b>apps</b>...'
-      npm_target = (rack_env?(:development) || ENV['CI']) ? 'build' : 'build:dist'
+      npm_target = CDO.optimize_webpack_assets ? 'build:dist' : 'build'
       RakeUtils.system "npm run #{npm_target}"
       File.write(commit_hash, calculate_apps_commit_hash)
     end

--- a/lib/test/cdo/test_asset_helper.rb
+++ b/lib/test/cdo/test_asset_helper.rb
@@ -5,7 +5,7 @@ class AssetHelpersTest < Minitest::Test
   def setup
     AssetHelper.any_instance.stubs(:webpack_manifest_path).returns('./test/fixtures/webpack-manifest.json')
     @asset_helper = AssetHelper.clone.instance
-    CDO.stubs(:pretty_js).returns(false)
+    CDO.stubs(:optimize_webpack_assets).returns(true)
   end
 
   def test_valid_asset
@@ -30,16 +30,16 @@ class AssetHelpersTest < Minitest::Test
     end
   end
 
-  def test_valid_asset_with_pretty_js
-    CDO.stubs(:pretty_js).returns(true)
+  def test_valid_asset_with_unoptimized_webpack_assets
+    CDO.stubs(:optimize_webpack_assets).returns(false)
     assert_equal(
       '/assets/js/cookieBanner.js',
       @asset_helper.webpack_asset_path('js/cookieBanner.js')
     )
   end
 
-  def test_missing_manifest_with_pretty_js
-    CDO.stubs(:pretty_js).returns(true)
+  def test_missing_manifest_with_unoptimized_webpack_assets
+    CDO.stubs(:optimize_webpack_assets).returns(false)
     AssetHelper.any_instance.stubs(:webpack_manifest_path).returns('./test/fixtures/nonexistent.json')
     assert_equal(
       '/assets/js/cookieBanner.js',


### PR DESCRIPTION
# Description

Follow-on to https://github.com/code-dot-org/code-dot-org/pull/31148

there are [way too many asset-related configuration parameters and conditionals](https://docs.google.com/spreadsheets/d/1qgGExrh0R8FuBtxbttDQbhgTcxa746IGNCDNiuN15v4/edit#gid=614620598) in our system, some of which consist of inline checks for which environment we're in and whether we're currently running in drone. This PR make some of that logic more declarative, by using the `CDO.optimize_webpack_assets` flag to control all aspects of whether we are using minified js.

## Testing story

I am relying on our existing tests running in drone and on the test machine to validate that this change doesn't break anything.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
