### PR TITLE
Update "reset password token invalid" error message

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -28,6 +28,11 @@ en:
       pair_programmer: 'You are currently pair programming with a student who does not have access to this content. To access this content, stop pair programming and try again.'
   activerecord:
     errors:
+      models:
+        user:
+          attributes:
+            reset_password_token:
+              invalid: "is invalid. Note that each link can only be used once to reset your password, and only the most recently sent link will work."
       messages:
         blank: "is required"
         blank_plural: "are required"
@@ -51,6 +56,7 @@ en:
         finish_sign_up_header: 'Finish creating your account'
         finish_sign_up_subheader: 'Fill out the following information to finish creating a Code.org account for <strong>%{email}</strong>.'
         finish_sign_up_subheader_provider: 'Fill out the following information to finish creating a Code.org account with <strong>%{provider}</strong> for <strong>%{email}</strong>.'
+        reset_password_token: "The reset password link you have followed"
         error:
           future: can't be in the future
 


### PR DESCRIPTION
# Description

Specifically, we want to:

1. Stop using the term "token"
2. Communicate that once a token has been used, it can't be used again
3. Communicate that when requesting multiple "reset password" emails, only the most recent will be valid

Before | After
--- | ---
![Screen Shot 2019-10-10 at 14 06 05](https://user-images.githubusercontent.com/244100/66606535-1d76e200-eb67-11e9-82f3-7580ce682313.png) | ![Screen Shot 2019-10-10 at 14 04 47](https://user-images.githubusercontent.com/244100/66606473-f3bdbb00-eb66-11e9-87f6-ba3b64faa17f.png)
