### PR TITLE
Temporarily remove banner from afe marketing page

### DIFF
--- a/pegasus/sites.v3/code.org/public/amazon-future-engineer.md.erb
+++ b/pegasus/sites.v3/code.org/public/amazon-future-engineer.md.erb
@@ -13,8 +13,6 @@ As a Code.org classroom supported by Amazon Future Engineer, **you’re invited 
  
 AFE has partnered with Code.org to offer these resources and benefits to you and your students at no cost and without having to join a waitlist! 
 
-<%= view :donor_teacher_banner %>
-
 <%=view :solid_block_header, :title=>"Benefits for your classroom include:"%>
 
 ## Extended Learning on Cloud Computing with AWS Educate
@@ -51,9 +49,3 @@ Amazon Future Engineer will also provide more than 2,000 schools that serve stud
 
 ## Free CSTA+ Membership
 Take your teaching to the next level with a CSTA+ membership sponsored by Amazon Future Engineer. You’ll receive monthly educational resources like members-only webinars and newsletters, priority access and discounts to CSTA+ conferences and events, and free or discounted teaching aids and online courses.
-
-*** 
-
-# Sign-up today to get started!
-
-<%= view :donor_teacher_banner %>


### PR DESCRIPTION
Revertible commit to hide the banner on this page as requested by AFE until page is hidden behind login