### PR TITLE
[Sprite Lab] Fix getThisSprite

### DIFF
--- a/apps/src/p5lab/spritelab/commands/spriteCommands.js
+++ b/apps/src/p5lab/spritelab/commands/spriteCommands.js
@@ -40,10 +40,10 @@ export const commands = {
   getThisSprite(which, extraArgs) {
     if (extraArgs) {
       if (which === 'this') {
-        return extraArgs.sprite;
+        return {id: extraArgs.sprite};
       }
       if (which === 'other') {
-        return extraArgs.target;
+        return {id: extraArgs.target};
       }
     }
   },


### PR DESCRIPTION
# Description
#30979 changed the expected format of the arguments to core library functioons and I didn't change the getThisSprite block to match.

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
