### PR TITLE
fix dashboard unit tests which rely on webpack assets

### DIFF
--- a/lib/cdo/asset_helper.rb
+++ b/lib/cdo/asset_helper.rb
@@ -20,7 +20,7 @@ class AssetHelper
     #
     # Never skip the manifest lookup when using the prebuilt apps package in
     # development because this would generate invalid urls.
-    skip_manifest = CDO.pretty_js && CDO.use_my_apps
+    skip_manifest = CDO.pretty_js && !(rack_env?(:development) && !CDO.use_my_apps)
     return "/assets/#{asset}" if skip_manifest
     path = webpack_manifest[asset]
     raise "Invalid webpack asset name: '#{asset}'" unless path


### PR DESCRIPTION
# Description

https://github.com/code-dot-org/code-dot-org/pull/31148 broke dashboard tests on the test machine because stubbing `CDO.pretty_apps` became insufficient to skip looking up assets in the webpack manifest during unit tests. these dashboard tests failed on the test machine but passed in drone because drone adds `use_my_apps: true` to its locals.yml files.

As explained in the comments visible in the diff, the reason for this complexity is to make it so that developers do not get the optimization settings wrong when switching between locally built and prebuilt apps. developers should only have to enable optimized js if they are actively developing something which requires building and running optimized js locally.

## Testing story

patched this change into the test machine and verified that `rake test:dashboard_ci` is passing

# Reviewer Checklist:

- [x] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
