### PR TITLE
Optimizely - Signup Flow

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -21,7 +21,7 @@ const STUDENT_ONLY_FIELDS = [
 // Values loaded from scriptData are always initial values, not the latest
 // (possibly unsaved) user-edited values on the form.
 const scriptData = getScriptData('signup');
-const {usIp, signUpUID} = scriptData;
+const {usIp, signUpUID, provider} = scriptData;
 
 // Auto-fill country and countryCode if we detect a US IP address.
 let schoolData = {
@@ -36,6 +36,7 @@ $(document).ready(() => {
   function init() {
     setUserType(getUserType());
     renderSchoolInfo();
+    trackPageLoadInOptimizely();
   }
 
   let alreadySubmitted = false;
@@ -149,6 +150,21 @@ $(document).ready(() => {
         schoolInfoMountPoint
       );
     }
+  }
+
+  function trackPageLoadInOptimizely() {
+    // record that we have arrived at this stage in the registration process
+    // with Optimizely for the old vs new signup page A/B test.
+    //
+    // TODO elijah: remove this logic once the A/B test has been completed
+    window['optimizely'] = window['optimizely'] || [];
+    window['optimizely'].push({
+      type: 'event',
+      eventName: 'finishSignUpPageLoad',
+      tags: {
+        provider
+      }
+    });
   }
 
   function onCountryChange(_, event) {

--- a/apps/src/sites/studio/pages/devise/registrations/_old_sign_up_form.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_old_sign_up_form.js
@@ -92,6 +92,24 @@ window.SignupManager = function(options) {
       url = '/';
     }
 
+    // record successful form submission with Optimizely for the old vs new
+    // signup page A/B test.
+    //
+    // Note that it's not clear whether or not this effort will be canceled by
+    // the page redirection on the next line. The article at
+    // https://help.optimizely.com/Build_Campaigns_and_Experiments/Custom_events_in_Optimizely_X
+    // implies that custom events are intended for situations exactly like
+    // this, which implies that it won't be. But the developer documentation at
+    // https://developers.optimizely.com/x/solutions/javascript/reference/index.html#function_setevent
+    // make no mention whatsoever of such a feature if it exists.
+    //
+    // TODO elijah: remove this logic once the A/B test has been completed
+    window['optimizely'] = window['optimizely'] || [];
+    window['optimizely'].push({
+      type: 'event',
+      eventName: 'oldSignupFormSubmission'
+    });
+
     window.location.href = url;
   };
 

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -104,7 +104,8 @@
   script_data = {
     signup: {
       usIp: us_ip,
-      signUpUID: "#{session[:sign_up_uid]}"
+      signUpUID: "#{session[:sign_up_uid]}",
+      provider: @user.provider
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/_finish_sign_up.js'), data: script_data}

--- a/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
@@ -1,6 +1,6 @@
 - require 'geocoder'
 - require 'country_codes'
-- resource.user_type ||= params[:user].try(:fetch, :user_type) || User::TYPE_STUDENT
+- resource.user_type ||= params[:user].try(:fetch, :user_type, User::TYPE_STUDENT) || User::TYPE_STUDENT
 - location = Geocoder.search(request.ip).try(:first)
 - us_ip = location.nil? || ['US', 'RD'].include?(location.country_code.to_s.upcase)
 

--- a/dashboard/app/views/devise/registrations/_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_sign_up.html.haml
@@ -11,10 +11,13 @@
         = t('auth.already_signedup')
         = link_to t('nav.user.signin'), new_session_path(resource_name)
 
-  - if SignUpTracking.new_sign_up_experience?(session)
-    = render 'new_sign_up_form'
-  - else
+  -# Render both old and new signup forms to the page, with the new form
+  -# hidden. This setup will then be used by optimizely to situationally
+  -# switch which form is displayed.
+  .old_form
     = render 'old_sign_up_form'
+  .new_form{style: "display: none"}
+    = render 'new_sign_up_form'
 
 %div{style: "clear:both"}
 %br/

--- a/dashboard/app/views/devise/shared/_oauth_links.haml
+++ b/dashboard/app/views/devise/shared/_oauth_links.haml
@@ -25,4 +25,18 @@
         = t('auth.continue_with', provider: t("auth.#{provider}"))
 
 :javascript
+  $('.oauth-sign-in').click(function() {
+    // record oauth sign in with Optimizely for the old vs new signup page A/B test.
+    //
+    // TODO elijah: remove this logic once the A/B test has been completed
+    window['optimizely'] = window['optimizely'] || [];
+    window['optimizely'].push({
+      type: 'event',
+      eventName: 'oauthSignInClicked',
+      tags: {
+        className: $(this).attr('class')
+      }
+    });
+  });
+
   $('.oauth_sign_in').click(dashboard.clientState.reset);


### PR DESCRIPTION
# Description

Implement the old vs new signup form A/B test in optimizely.

Specifically, we want to render both old and new forms on the signup page, with one of them hidden by CSS. Optimizely can then take care of conditionally swapping which form is visible.

After that, we add a few clientside events for some metrics we want to track and Optimizely takes care of everything else!

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [optimizely experiment](https://app.optimizely.com/v2/projects/12977480133/experiments/16844501916)
- [jira](https://codedotorg.atlassian.net/browse/FND-786)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
