### PR TITLE
PL: Update the teacher application confirmation email for 2020-21 season

### DIFF
--- a/dashboard/app/views/pd/application/teacher_application_mailer/confirmation.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/confirmation.html.haml
@@ -1,14 +1,14 @@
 - partner_name = @application.regional_partner&.name || 'Code.org'
-- twitter_share_link = 'https://twitter.com/intent/tweet?text=I%20just%20signed%20up%20for%20Code.org%27s%20Professional%20Learning%20Program%20to%20teach%20computer%20science%20in%20my%20classroom.%20Join%20me%20and%20sign%20up%20here%21%20code.org%2Fapply&source=clicktotweet&related=clicktotweet'
 
 %p
   Hello
   = @application.first_name + ','
 
 %p
-  Thank you for submitting your application to join
+  Thank you for your interest in
   = "#{@application.regional_partner&.name || 'Code.org'}'s"
   Professional Learning Program!
+  We've received your application.
   = @application.regional_partner&.name || 'We'
   will review your application soon.
 
@@ -26,13 +26,7 @@
   Or, visit
   = link_to 'https://code.org/educate', 'https://code.org/educate'
   for additional resources and opportunities to connect with other computer science educators.
-
-%p
-  Finally, help us
-  = link_to twitter_share_link do
-    spread the word in a tweet
-  to encourage more teachers to join your local CS teaching community.
-  Thank you for supporting computer science for all!
+  Thank you for supporting computer science for every student!
 
   - if @application.regional_partner
     %p{style: 'margin-bottom: 0'}


### PR DESCRIPTION
The teacher application confirmation email for 2020-21 has been updated.  Here are rendered previews of variants:

## with partner

![Screenshot 2019-10-10 17 33 48](https://user-images.githubusercontent.com/2205926/66616155-79039880-eb84-11e9-8856-574a87625b9b.png)

## with partner, no contact

![Screenshot 2019-10-10 17 34 00](https://user-images.githubusercontent.com/2205926/66616154-79039880-eb84-11e9-9730-048c5db9b43b.png)

## without partner

![Screenshot 2019-10-10 17 34 15](https://user-images.githubusercontent.com/2205926/66616153-79039880-eb84-11e9-94da-df52422a54ad.png)



