### PR TITLE
Implement a few minor style tweaks to the new signup page

### DIFF
--- a/dashboard/app/views/devise/registrations/_new_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_new_sign_up_form.html.haml
@@ -1,4 +1,6 @@
-= render "devise/shared/oauth_links"
+.row
+  .span5{style: "display: flex;"}
+    = render "devise/shared/oauth_links"
 
 %div.horizontal-or
   %hr
@@ -10,8 +12,12 @@
 = form_for(@user, url: users_begin_sign_up_path, html: {class: "signup"}) do |f|
   / Email
   .field-row
-    .field.field-sm
-      = f.label :email
+    .field.field-sm>
+      -# Render email label as "Email&nbsp;*", so the asterisk referencing the
+      -# "student terms" footer can't wrap onto a line all by itself
+      = f.label :email do
+        = succeed '&nbsp;*'.html_safe do
+          = User.human_attribute_name(:email)
       %span.input-sm= f.email_field :email, maxlength: 255
     %span.error.padded= @user.errors[:email]&.first
 
@@ -33,6 +39,8 @@
   %button.submit= t('signup_form.submit')
 
 / More information for students about email storage.
-%div{style: "width: 700px;"}
-  *
-  != t('signup_form.student_terms_markdown', markdown: true)
+.row
+  .span1.text-right
+    = "*"
+  .span8
+    != t('signup_form.student_terms_markdown', markdown: true)

--- a/dashboard/app/views/devise/registrations/_new_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_new_sign_up_form.html.haml
@@ -12,7 +12,7 @@
 = form_for(@user, url: users_begin_sign_up_path, html: {class: "signup"}) do |f|
   / Email
   .field-row
-    .field.field-sm>
+    .field.field-sm
       -# Render email label as "Email&nbsp;*", so the asterisk referencing the
       -# "student terms" footer can't wrap onto a line all by itself
       = f.label :email do


### PR DESCRIPTION
# Description

Specifically:

1. Resize the oauth links to no longer take up the full width of the page
2. Add an asterisk to the "email" field so the student terms footer is clearly referenced by something
3. Make the asterisk and text of the footer colinear

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/66616702-b701bc00-eb86-11e9-9155-452119049735.png) | ![image](https://user-images.githubusercontent.com/244100/66616673-9f2a3800-eb86-11e9-9e93-daff7c12be4a.png)


<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [prereq for this jira item](https://codedotorg.atlassian.net/browse/FND-407)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
