### PR TITLE
avoid jitter while resizing instructions

### DIFF
--- a/apps/src/redux/instructions.js
+++ b/apps/src/redux/instructions.js
@@ -103,7 +103,11 @@ export default function reducer(state = {...instructionsInitialState}, action) {
     });
   }
 
-  if (action.type === SET_INSTRUCTIONS_RENDERED_HEIGHT && state.allowResize) {
+  if (
+    action.type === SET_INSTRUCTIONS_RENDERED_HEIGHT &&
+    state.allowResize &&
+    Math.abs(action.renderedHeight - state.renderedHeight) > 1
+  ) {
     return Object.assign({}, state, {
       renderedHeight: action.height,
       expandedHeight: !state.collapsed ? action.height : state.expandedHeight
@@ -112,7 +116,7 @@ export default function reducer(state = {...instructionsInitialState}, action) {
 
   if (
     action.type === SET_INSTRUCTIONS_MAX_HEIGHT_NEEDED &&
-    action.maxNeededHeight !== state.maxNeededHeight &&
+    Math.abs(action.maxNeededHeight - state.maxNeededHeight) > 1 &&
     state.allowResize
   ) {
     return Object.assign({}, state, {

--- a/apps/src/redux/instructions.js
+++ b/apps/src/redux/instructions.js
@@ -106,7 +106,7 @@ export default function reducer(state = {...instructionsInitialState}, action) {
   if (
     action.type === SET_INSTRUCTIONS_RENDERED_HEIGHT &&
     state.allowResize &&
-    Math.abs(action.renderedHeight - state.renderedHeight) > 1
+    Math.abs(action.height - state.renderedHeight) > 1
   ) {
     return Object.assign({}, state, {
       renderedHeight: action.height,


### PR DESCRIPTION
# Description

Fixes a bug in minecraft instructions as described here:
- [zendesk ticket](https://codeorg.zendesk.com/agent/tickets/249986)
- [slack thread](https://codedotorg.slack.com/archives/C039X1ZLX/p1570724739007700)

## Repro steps

1. zoom out to 90%
2. navigate to a minecraft level
3. press run
4. press reset
5. wait a while

usually, the screen becomes unresponsive by this point, and a few seconds later a "maximum stack depth exceeded" error appears. If you do not experience this, you can test whether the problem has been hit by running `window.addEventListener('resize', function() {console.log('resize');}` and pressing Run / Reset again.

## Root cause

The root cause is that the instructions area can get into an infinite loop where it responds to its inputs changing by modifying the same input. In this particular case, it causes the `renderedHeight` to go up and down by 1 forever. The many resize events are secondary to this.

## Solution

Only update the rendered height of the instructions if it is changing by more than 1. This eliminates the specific problem, but would not (for example) protect against other loops which modify the value by say +/- 2 on each iteration.

## Testing story

Manually verified the issue is resolved. Since the repro steps are super-specific and involve changing the screen zoom level, I'm not adding a regression test to catch this exact problem.

## Future work

[LP-838](https://codedotorg.atlassian.net/browse/LP-838) tracks implementing a more robust solution, by eliminating the potential feedback loop rather than just dampening it.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
