### PR TITLE
Remove unused config.pretty_apps and appOptions.pretty

### DIFF
--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -47,7 +47,6 @@ const APP_OPTIONS_WHITELIST = {
   baseUrl: true,
   app: true,
   droplet: true,
-  pretty: true,
   level: {
     skin: true,
     editCode: true,

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -16,7 +16,6 @@
  * @property {string} baseUrl
  * @property {string} app
  * @property {boolean} droplet
- * @property {'.min'|''} pretty - todo: no longer used?
  * @property {Level|Artist|Blockly} level
  * @property {boolean} showUnusedBlocks
  * @property {boolean} fullWidth

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -260,7 +260,6 @@ class Blockly < Level
           baseUrl: Blockly.base_url,
           app: game.try(:app),
           droplet: uses_droplet?,
-          pretty: CDO.optimize_webpack_assets ? '.min' : '',
         }
       )
     end

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -260,7 +260,7 @@ class Blockly < Level
           baseUrl: Blockly.base_url,
           app: game.try(:app),
           droplet: uses_droplet?,
-          pretty: Rails.configuration.pretty_apps ? '' : '.min',
+          pretty: CDO.optimize_webpack_assets ? '.min' : '',
         }
       )
     end

--- a/dashboard/config/environments/adhoc.rb
+++ b/dashboard/config/environments/adhoc.rb
@@ -33,14 +33,8 @@ Dashboard::Application.configure do
   # Version of your assets, change this if you want to expire all your assets.
   config.assets.version = '1.0'
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = true
-
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = false
 
   # Log condensed lines to syslog for centralized logging.
   config.lograge.enabled = true

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -58,9 +58,6 @@ Dashboard::Application.configure do
   # skip precompiling of all assets on the first request for any asset.
   config.assets.check_precompiled_asset = false
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = true
-
   # Whether or not to skip script preloading. Setting this to true
   # significantly speeds up server startup time
   config.skip_script_preload = true

--- a/dashboard/config/environments/production.rb
+++ b/dashboard/config/environments/production.rb
@@ -78,9 +78,6 @@ Dashboard::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = false
-
   # Log condensed lines to syslog for centralized logging.
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Cee.new

--- a/dashboard/config/environments/staging.rb
+++ b/dashboard/config/environments/staging.rb
@@ -76,9 +76,6 @@ Dashboard::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = true
-
   # Log condensed lines to syslog for centralized logging.
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Cee.new

--- a/dashboard/config/environments/test.rb
+++ b/dashboard/config/environments/test.rb
@@ -21,9 +21,6 @@ Dashboard::Application.configure do
   config.public_file_server.enabled = true
   config.public_file_server.headers = {'Cache-Control' => "public, max-age=3600, s-maxage=1800"}
 
-  # Whether or not to display pretty apps (formerly called blockly).
-  config.pretty_apps = false
-
   # test environment should use precompiled, minified, digested assets like production,
   # unless it's being used for unit tests.
   ci_test = !!(ENV['UNIT_TEST'] || ENV['CI'])


### PR DESCRIPTION
# Description

Follow-on to https://github.com/code-dot-org/code-dot-org/pull/31216 . I was about to consolidate `config.pretty_apps` into `CDO.optimize_webpack_assets`, but then realized `config.pretty_apps` and `appOptions.pretty` are completely unused so I am removing both.

## Testing story

I am relying on existing automated tests to catch any surprise code that may have depended on these.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
