### PR TITLE
Revert "Enable Performance Insights to display Aurora-specific wait events"

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -183,14 +183,8 @@ AuroraReportingCluster:
 
 # System variables for the Aurora DB writer.
 AuroraWriter:
-  # Performance Schema and several related Parameter Group settings are enabled automatically on an Aurora Instance
-  # when Performance Insights is enabled on the Instance.  These additional, automatically applied, settings
-  # enable Performance Insights to display detailed Aurora-specific wait events.  Explicitly setting
-  # performance_schema=1 disables the RDS service automatically enabling the related settings that allow for detailed
-  # wait events to be logged in Performance Insights, so we do NOT set it.
-  # https://docs.aws.amazon.com/en_pv/AmazonRDS/latest/AuroraUserGuide/USER_PerfInsights.Enabling.html
-  # Note that our Percona Monitoring server also relies on performance_schema=1 being set automatically by RDS.
-  performance_schema: null
+  # Enable Performance Schema.
+  performance_schema: 1
 
   # Relax transaction isolation for improved concurrency under load.
   tx_isolation: READ-COMMITTED


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#31127

Reverting because an issue in RDS sometimes prevents older parameter groups from setting `performance_schema` .  The template generated was valid, but the Stack update could not be applied to the `DATA-production` stack.
```
2019-10-11 01:14:29 UTC- AuroraWriterDBParameters [UPDATE_FAILED]: The following parameters are not defined for the specified group: performance_schema_max_table_handles, performance_schema_users_size, performance_schema_max_table_instances, performance_schema_max_rwlock_classes, performance_schema_max_rwlock_instances, performance_schema_setup_objects_size, performance_schema_max_program_instances, performance_schema_session_connect_attrs_size, performance_schema_max_table_lock_stat, performance_schema_max_statement_classes, performance_schema_max_stage_classes, performance_schema_max_thread_classes, performance_schema_max_socket_instances, performance_schema_max_sql_text_length, performance_schema_max_statement_stack, performance_schema_max_socket_classes, performance_schema_max_thread_instances, performance_schema_setup_actors_size (Service: AmazonRDS; Status Code: 400; Error Code: InvalidParameterValue; Request ID: 7013a98d-189d-49c9-ae16-4cfcb9512ba0)
.2019-10-11 01:14:32 UTC- DATA-production [UPDATE_ROLLBACK_IN_PROGRESS]: The following resource(s) failed to update: [AuroraWriterDBParameters].
```