### PR TITLE
hoc2019: Update test hoc_mode to "soon-hoc"

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -341,7 +341,7 @@ proxy: false # If true, generated URLs will not include explicit port numbers in
 # Run dashboard-server with the level editing interface enabled (for admins)
 levelbuilder_mode:
 
-default_hoc_mode:   pre-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode:   soon-hoc # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''       # overridden by 'hoc_launch' DCDO param, except in :test
 
 localize_apps: false


### PR DESCRIPTION
This will tell the test machine to use `hoc_mode` of `"soon-hoc"` and will ensure tests in the DTT run in this mode.
