### PR TITLE
[Data Tab][Cleanup] Rename DataProperties to KVPairs

### DIFF
--- a/apps/src/storage/dataBrowser/DataBrowser.jsx
+++ b/apps/src/storage/dataBrowser/DataBrowser.jsx
@@ -5,8 +5,7 @@ import color from '../../util/color';
 import msg from '@cdo/locale';
 import AddTableListRow from './AddTableListRow';
 import EditTableListRow from './EditTableListRow';
-import EditKeyRow from './EditKeyRow';
-import AddKeyRow from './AddKeyRow';
+import KVPairs from './KVPairs';
 import * as dataStyles from './dataStyles';
 import {connect} from 'react-redux';
 import {changeView, showWarning} from '../redux/data';
@@ -203,25 +202,7 @@ class DataBrowser extends React.Component {
                 : styles.inactiveBody
             }
           >
-            <table>
-              <tbody>
-                <tr>
-                  <th style={dataStyles.headerCell}>Key</th>
-                  <th style={dataStyles.headerCell}>Value</th>
-                  <th style={dataStyles.headerCell}>Actions</th>
-                </tr>
-
-                <AddKeyRow onShowWarning={this.props.onShowWarning} />
-
-                {Object.keys(this.props.keyValueData).map(key => (
-                  <EditKeyRow
-                    key={key}
-                    keyName={key}
-                    value={JSON.parse(this.props.keyValueData[key])}
-                  />
-                ))}
-              </tbody>
-            </table>
+            <KVPairs />
           </div>
         </div>
       </div>

--- a/apps/src/storage/dataBrowser/DataWorkspace.jsx
+++ b/apps/src/storage/dataBrowser/DataWorkspace.jsx
@@ -1,7 +1,7 @@
 import {ApplabInterfaceMode} from '../../applab/constants';
 import {DataView} from '../constants';
 import DataOverview from './DataOverview';
-import DataProperties from './DataProperties';
+import KVPairs from './KVPairs';
 import DataTableView from './DataTableView';
 import Dialog from '../../templates/Dialog';
 import PropTypes from 'prop-types';
@@ -90,7 +90,7 @@ class DataWorkspace extends React.Component {
 
         <div id="data-mode-container" style={styles.container}>
           <DataOverview />
-          <DataProperties />
+          {!experiments.isEnabled(experiments.APPLAB_DATASETS) && <KVPairs />}
           <DataTableView />
         </div>
         <Dialog

--- a/apps/src/storage/dataBrowser/KVPairs.jsx
+++ b/apps/src/storage/dataBrowser/KVPairs.jsx
@@ -12,6 +12,7 @@ import React from 'react';
 import {changeView, showWarning} from '../redux/data';
 import {connect} from 'react-redux';
 import * as dataStyles from './dataStyles';
+import experiments from '../../util/experiments';
 
 const styles = {
   container: {
@@ -25,7 +26,7 @@ const styles = {
   }
 };
 
-class DataProperties extends React.Component {
+class KVPairs extends React.Component {
   static propTypes = {
     // from redux state
     view: PropTypes.oneOf(Object.keys(DataView)),
@@ -72,6 +73,32 @@ class DataProperties extends React.Component {
         display: this.state.showDebugView ? '' : 'none'
       }
     ];
+
+    const kvTable = (
+      <table style={keyValueDataStyle}>
+        <tbody>
+          <tr>
+            <th style={dataStyles.headerCell}>Key</th>
+            <th style={dataStyles.headerCell}>Value</th>
+            <th style={dataStyles.headerCell}>Actions</th>
+          </tr>
+
+          <AddKeyRow onShowWarning={this.props.onShowWarning} />
+
+          {Object.keys(this.props.keyValueData).map(key => (
+            <EditKeyRow
+              key={key}
+              keyName={key}
+              value={JSON.parse(this.props.keyValueData[key])}
+            />
+          ))}
+        </tbody>
+      </table>
+    );
+
+    if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      return kvTable;
+    }
     return (
       <div id="dataProperties" style={containerStyle}>
         <div style={dataStyles.viewHeader}>
@@ -101,25 +128,7 @@ class DataProperties extends React.Component {
 
         <div style={debugDataStyle}>{this.getKeyValueJson()}</div>
 
-        <table style={keyValueDataStyle}>
-          <tbody>
-            <tr>
-              <th style={dataStyles.headerCell}>Key</th>
-              <th style={dataStyles.headerCell}>Value</th>
-              <th style={dataStyles.headerCell}>Actions</th>
-            </tr>
-
-            <AddKeyRow onShowWarning={this.props.onShowWarning} />
-
-            {Object.keys(this.props.keyValueData).map(key => (
-              <EditKeyRow
-                key={key}
-                keyName={key}
-                value={JSON.parse(this.props.keyValueData[key])}
-              />
-            ))}
-          </tbody>
-        </table>
+        {kvTable}
       </div>
     );
   }
@@ -138,4 +147,4 @@ export default connect(
       dispatch(changeView(view));
     }
   })
-)(Radium(DataProperties));
+)(Radium(KVPairs));


### PR DESCRIPTION
# Description
`DataProperties` is the name of the component that shows the user their key/value pairs and allows them to add, edit, and delete pairs. Renaming to `KVPairs` to be clearer. 
Also refactoring to be reusable in `DataBrowser` when the experiment is on

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->
## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
