### PR TITLE
Revert "Combine Strings and Variables: Modify for_counter block"

### DIFF
--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -660,14 +660,11 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: blockly.Msg.CONTROLS_FOR_HELPURL,
     init: function() {
       this.setHSV(322, 0.9, 0.95);
+      this.appendDummyInput()
+        .appendTitle(blockly.Msg.CONTROLS_FOR_INPUT_WITH)
+        .appendTitle(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
       this.interpolateMsg(
-        blockly.Msg.CONTROLS_FOR_INPUT_COUNTER,
-        () => {
-          this.appendDummyInput().appendTitle(
-            new blockly.FieldLabel(msg.loopVariable()),
-            'VAR'
-          );
-        },
+        blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY,
         ['FROM', 'Number', blockly.ALIGN_RIGHT],
         ['TO', 'Number', blockly.ALIGN_RIGHT],
         ['BY', 'Number', blockly.ALIGN_RIGHT],


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#30934

This appears to have broken the block in non-EN languages for several levels. See:

https://codeorg.zendesk.com/agent/tickets/252711
https://codeorg.zendesk.com/agent/tickets/252797
https://codeorg.zendesk.com/agent/tickets/252796
https://codeorg.zendesk.com/agent/tickets/252747

Upon inspection, it looks like the new CONTROLS_FOR_INPUT_COUNTER string is not available on `blockly.Msg` when page is in a non-EN locale. More investigation is needed to figure out why that's the case; reverting this PR to unbreak prod while we investigate.