### PR TITLE
Remove unused users in separate transactions

### DIFF
--- a/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
+++ b/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
@@ -79,12 +79,14 @@ USERS_TO_DELETE = %w(
   896
 ).map(&:to_i).freeze
 
-ActiveRecord::Base.transaction do
-  # ActiveRecord model destroy will raise an error if it encounters an error destroying a single item in the
-  # array and will not continue destroying the remaining items in the input array.
-  # If needed, an individual User can be restored by id: User.with_deleted.find(id).undestroy
-  User.destroy(USERS_TO_DELETE)
+# ActiveRecord `destroy` can take an array argument, but carrying out all destroys in a single database transaction
+# caused the entire operation to be rolledback when an error was raised destroying a single malformed User.
+USERS_TO_DELETE.each do |user_id|
+  User.destroy(user_id)
 
   # This script is a dry-run unless we comment out this last line
   raise ActiveRecord::Rollback.new, "Intentional rollback"
+  puts "User ID successfully destroyed - #{user_id}"
+rescue StandardError => error
+  puts "Error destroying User ID - #{user_id} / #{error.message}"
 end

--- a/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
+++ b/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
@@ -85,10 +85,11 @@ USERS_TO_DELETE.each do |user_id|
   ActiveRecord::Base.transaction do
     User.destroy(user_id)
 
-    # This script is a dry-run unless we comment out this last line
+    # This script is a dry-run unless we comment out this line.
     raise ActiveRecord::Rollback.new, "Intentional rollback"
+
+    puts "User ID successfully destroyed - #{user_id}"
   end
-  puts "User ID successfully destroyed - #{user_id}"
 rescue StandardError => error
   puts "Error destroying User ID - #{user_id} / #{error.message}"
 end

--- a/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
+++ b/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
@@ -82,11 +82,12 @@ USERS_TO_DELETE = %w(
 # ActiveRecord `destroy` can take an array argument, but carrying out all destroys in a single database transaction
 # caused the entire operation to be rolledback when an error was raised destroying a single malformed User.
 USERS_TO_DELETE.each do |user_id|
-  User.destroy(user_id)
+  ActiveRecord::Base.transaction do
+    User.destroy(user_id)
 
-  # This script is a dry-run unless we comment out this line.
-  raise ActiveRecord::Rollback.new, "Intentional rollback"
-
+    # This script is a dry-run unless we comment out this last line
+    raise ActiveRecord::Rollback.new, "Intentional rollback"
+  end
   puts "User ID successfully destroyed - #{user_id}"
 rescue StandardError => error
   puts "Error destroying User ID - #{user_id} / #{error.message}"

--- a/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
+++ b/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
@@ -84,8 +84,9 @@ USERS_TO_DELETE = %w(
 USERS_TO_DELETE.each do |user_id|
   User.destroy(user_id)
 
-  # This script is a dry-run unless we comment out this last line
+  # This script is a dry-run unless we comment out this line.
   raise ActiveRecord::Rollback.new, "Intentional rollback"
+
   puts "User ID successfully destroyed - #{user_id}"
 rescue StandardError => error
   puts "Error destroying User ID - #{user_id} / #{error.message}"

--- a/bin/oneoff/wipe_data/remove_unused_production_users
+++ b/bin/oneoff/wipe_data/remove_unused_production_users
@@ -47,12 +47,14 @@ USERS_TO_DELETE = %w(
   39270846
 ).map(&:to_i).freeze
 
-ActiveRecord::Base.transaction do
-  # ActiveRecord model destroy will raise an error if it encounters an error destroying a single item in the
-  # array and will not continue destroying the remaining items in the input array.
-  # If needed, an individual User can be restored by id: User.with_deleted.find(id).undestroy
-  User.destroy(USERS_TO_DELETE)
+# ActiveRecord `destroy` can take an array argument, but carrying out all destroys in a single database transaction
+# can cause the entire operation to be rolledback when an error was raised destroying a single malformed User.
+USERS_TO_DELETE.each do |user_id|
+  User.destroy(user_id)
 
   # This script is a dry-run unless we comment out this last line
   raise ActiveRecord::Rollback.new, "Intentional rollback"
+  puts "User ID successfully destroyed - #{user_id}"
+rescue StandardError => error
+  puts "Error destroying User ID - #{user_id} / #{error.message}"
 end

--- a/bin/oneoff/wipe_data/remove_unused_production_users
+++ b/bin/oneoff/wipe_data/remove_unused_production_users
@@ -53,10 +53,11 @@ USERS_TO_DELETE.each do |user_id|
   ActiveRecord::Base.transaction do
     User.destroy(user_id)
 
-    # This script is a dry-run unless we comment out this last line
+    # This script is a dry-run unless we comment out this line.
     raise ActiveRecord::Rollback.new, "Intentional rollback"
+
+    puts "User ID successfully destroyed - #{user_id}"
   end
-  puts "User ID successfully destroyed - #{user_id}"
 rescue StandardError => error
   puts "Error destroying User ID - #{user_id} / #{error.message}"
 end

--- a/bin/oneoff/wipe_data/remove_unused_production_users
+++ b/bin/oneoff/wipe_data/remove_unused_production_users
@@ -50,11 +50,12 @@ USERS_TO_DELETE = %w(
 # ActiveRecord `destroy` can take an array argument, but carrying out all destroys in a single database transaction
 # can cause the entire operation to be rolledback when an error was raised destroying a single malformed User.
 USERS_TO_DELETE.each do |user_id|
-  User.destroy(user_id)
+  ActiveRecord::Base.transaction do
+    User.destroy(user_id)
 
-  # This script is a dry-run unless we comment out this line.
-  raise ActiveRecord::Rollback.new, "Intentional rollback"
-
+    # This script is a dry-run unless we comment out this last line
+    raise ActiveRecord::Rollback.new, "Intentional rollback"
+  end
   puts "User ID successfully destroyed - #{user_id}"
 rescue StandardError => error
   puts "Error destroying User ID - #{user_id} / #{error.message}"

--- a/bin/oneoff/wipe_data/remove_unused_production_users
+++ b/bin/oneoff/wipe_data/remove_unused_production_users
@@ -52,8 +52,9 @@ USERS_TO_DELETE = %w(
 USERS_TO_DELETE.each do |user_id|
   User.destroy(user_id)
 
-  # This script is a dry-run unless we comment out this last line
+  # This script is a dry-run unless we comment out this line.
   raise ActiveRecord::Rollback.new, "Intentional rollback"
+
   puts "User ID successfully destroyed - #{user_id}"
 rescue StandardError => error
   puts "Error destroying User ID - #{user_id} / #{error.message}"


### PR DESCRIPTION
# Description

The script implemented in #31029 encountered errors, due to issues with a subset of users in the list.  Update the script to destroy each user in its own transaction.


### Background

On `levelbuilder` all changes were rolled back due to an error with a User:

```
DEPRECATION WARNING: Returning `false` in Active Record and Active Model callbacks will not implicitly halt a callback chain in Rails 5.1. To explicitly halt the callback chain, please use `throw :abort` instead. (called from block in transaction at /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:187)
Traceback (most recent call last):
        52: from bin/oneoff/wipe_data/remove_unused_levelbuilder_users:82:in `<main>'
        51: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:211:in `transaction'
        50: from /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:186:in `transaction'
        49: from /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:260:in `use_master_connection'
        48: from /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:187:in `block in transaction'
        47: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
        46: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
        45: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
        44: from bin/oneoff/wipe_data/remove_unused_levelbuilder_users:86:in `block in <main>'
        43: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/querying.rb:8:in `destroy'
        42: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/relation.rb:492:in `destroy'
        41: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/relation.rb:492:in `map'
        40: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/relation.rb:492:in `block in destroy'
        39: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/relation.rb:494:in `destroy'
        38: from /var/lib/gems/2.5.0/gems/paranoia-2.3.1/lib/paranoia.rb:77:in `destroy'
        37: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:310:in `transaction'
        36: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:211:in `transaction'
        35: from /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:186:in `transaction'
        34: from /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:260:in `use_master_connection'
        33: from /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:187:in `block in transaction'
        32: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
        31: from /var/lib/gems/2.5.0/gems/paranoia-2.3.1/lib/paranoia.rb:78:in `block in destroy'
        30: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:90:in `run_callbacks'
        29: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:750:in `_run_destroy_callbacks'
        28: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
        27: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:454:in `call'
        26: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:454:in `each'
        25: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:454:in `block in call'
        24: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:170:in `block in halting'
        23: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:769:in `block in deprecated_false_terminator'
        22: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:769:in `catch'
        21: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:770:in `block (2 levels) in deprecated_false_terminator'
        20: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:169:in `block (2 levels) in halting'
        19: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:398:in `block in make_lambda'
        18: from /var/lib/gems/2.5.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:398:in `instance_exec'
        17: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/associations/builder/association.rb:140:in `block in add_destroy_callbacks'
        16: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/associations/has_many_association.rb:34:in `handle_dependency'
        15: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/associations/collection_association.rb:245:in `destroy_all'
        14: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/associations/collection_association.rb:297:in `destroy'
        13: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/associations/collection_association.rb:528:in `delete_or_destroy'
        12: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/associations/collection_association.rb:204:in `transaction'
        11: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:211:in `transaction'
        10: from /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:186:in `transaction'
         9: from /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:260:in `use_master_connection'
         8: from /var/lib/gems/2.5.0/bundler/gems/seamless_database_pool-c9a5c2bc92ef/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb:187:in `block in transaction'
         7: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
         6: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/associations/collection_association.rb:205:in `block in transaction'
         5: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/associations/collection_association.rb:528:in `block in delete_or_destroy'
         4: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/associations/collection_association.rb:535:in `remove_records'
         3: from /var/lib/gems/2.5.0/gems/composite_primary_keys-9.0.10/lib/composite_primary_keys/associations/has_many_association.rb:8:in `delete_records'
         2: from /var/lib/gems/2.5.0/gems/composite_primary_keys-9.0.10/lib/composite_primary_keys/associations/has_many_association.rb:8:in `each'
         1: from /var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/persistence.rb:205:in `destroy!'
/var/lib/gems/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/persistence.rb:588:in `_raise_record_not_destroyed': Failed to destroy the record (ActiveRecord::RecordNotDestroyed)
```

<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
