### PR TITLE
Retrieve slack_start_build_token from secrets manager in staging [ci skip]

### DIFF
--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -1,4 +1,5 @@
 slack_endpoint_broken_links: !Secret
+slack_start_build_token: !Secret
 github_webhook_secret: !Secret
 zendesk_secret:
 netsim_enable_metrics: true


### PR DESCRIPTION
# Description

`/restart-staging-build` slack command currently not working: https://codedotorg.slack.com/archives/C0T0PNTM3/p1571084880054400

I think it's because the `slack_start_build_token` value is currently not retrieved from secrets manager:

https://github.com/code-dot-org/code-dot-org/blob/staging/pegasus/routes/dev/dev_routes.rb#L21

```
[staging] dashboard > CDO.slack_start_build_token
=> nil
```
