### PR TITLE
hoc2019: reduce height of code.org/ launch hero

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/homepage.css
+++ b/pegasus/sites.v3/code.org/public/css/homepage.css
@@ -132,7 +132,7 @@ body.modal-open .supreme-container{
   font-size: 44px;
   line-height: 44px;
   color: white;
-  margin-top: 40px;
+  margin-top: 0px;
   margin-bottom: 20px;
 }
 
@@ -181,7 +181,7 @@ body.modal-open .supreme-container{
 }
 
 #homepage .action_buttons {
-  margin-bottom: 100px;
+  margin-bottom: 20px;
 }
 
 #homepage #actions a {


### PR DESCRIPTION
This followup to https://github.com/code-dot-org/code-dot-org/pull/31214 reduces the height of the launch hero so that we can continue to showcase all the other things that we also do.

### desktop

![Screenshot 2019-10-14 14 26 18](https://user-images.githubusercontent.com/2205926/66784359-10bbfc00-ee8f-11e9-86b7-3214c1a49bcb.png)

### mobile

![Screenshot 2019-10-14 14 26 43](https://user-images.githubusercontent.com/2205926/66784358-10bbfc00-ee8f-11e9-8361-e5534c39462d.png)

