### PR TITLE
Fix linter error in user deletion script

### DIFF
--- a/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
+++ b/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
@@ -7,6 +7,9 @@ require_relative '../../../dashboard/config/environment'
 
 exit unless rack_env?(:levelbuilder) && CDO.dashboard_hostname == 'levelbuilder-studio.code.org'
 
+# This script is a dry-run unless we change this line.
+DRY_RUN = true
+
 USERS_TO_DELETE = %w(
   2
   14
@@ -85,8 +88,7 @@ USERS_TO_DELETE.each do |user_id|
   ActiveRecord::Base.transaction do
     User.destroy(user_id)
 
-    # This script is a dry-run unless we comment out this line.
-    raise ActiveRecord::Rollback.new, "Intentional rollback"
+    raise ActiveRecord::Rollback.new, "Intentional rollback" if DRY_RUN
 
     puts "User ID successfully destroyed - #{user_id}"
   end

--- a/bin/oneoff/wipe_data/remove_unused_production_users
+++ b/bin/oneoff/wipe_data/remove_unused_production_users
@@ -7,6 +7,9 @@ require_relative '../../../dashboard/config/environment'
 
 exit unless rack_env?(:production) && CDO.dashboard_hostname == 'studio.code.org'
 
+# This script is a dry-run unless we change this line.
+DRY_RUN = true
+
 USERS_TO_DELETE = %w(
   1652546
   1901680
@@ -53,8 +56,7 @@ USERS_TO_DELETE.each do |user_id|
   ActiveRecord::Base.transaction do
     User.destroy(user_id)
 
-    # This script is a dry-run unless we comment out this line.
-    raise ActiveRecord::Rollback.new, "Intentional rollback"
+    raise ActiveRecord::Rollback.new, "Intentional rollback" if DRY_RUN
 
     puts "User ID successfully destroyed - #{user_id}"
   end


### PR DESCRIPTION
The statement that printed success status for each deletion was flagged as unreachable code by the linter.  Use a constant to make the dry run logic conditional.