### PR TITLE
Updated views for 2019-20 CSP/CSD cohorts [ci skip]

### DIFF
--- a/aws/redshift/views/csp_csd_teachers_trained.sql
+++ b/aws/redshift/views/csp_csd_teachers_trained.sql
@@ -1,7 +1,3 @@
-DROP VIEW IF EXISTS analysis.csp_csd_teachers_trained CASCADE;
-
--- to figure out
--- 19 teachers who are listed in 2016 and 2017 PD cohort?
 create or replace view analysis.csp_csd_teachers_trained as
 with 
 -- school information collated through manual feedback/editing after teachercons 2017.
@@ -24,22 +20,22 @@ schools_pd_2016 as
 -- takes the school information for the account most recently used if conflicting for a single studio person
 schools_users as
 (
-  select 
-    studio_person_id, 
-    school_id
+  select
+  	studio_person_id,
+  	school_id
   from
   (
     select 
-      studio_person_id, 
-      si.school_id, 
-      row_number() over(partition by studio_person_id order by current_sign_in_at desc) as how_recent
-    from dashboard_production_pii.users u
-      join dashboard_production.school_infos si on si.id = u.school_info_id
-      join analysis.school_stats ss on ss.school_id = si.school_id
-    where si.school_id is not null
-      and (ss.stage_mi = 1 or ss.stage_hi = 1 or ss.stage_hi is null)
+    	u.studio_person_id,
+    	si.school_id,
+    	row_number() over(partition by u.studio_person_id order by usi.last_confirmation_date desc) row_num
+    from dashboard_production_pii.user_school_infos usi
+    join dashboard_production_pii.users u on u.id = usi.user_id
+    join dashboard_production.school_infos si on si.id = usi.school_info_id
+    join analysis.school_stats ss on ss.school_id = si.school_id
+    where (ss.stage_hi = 1 or ss.stage_mi = 1 or ss.stage_hi is null)
   )
-  where how_recent = 1
+  where row_num = 1
 ),
 -- combines information from above three source into a single piece of school information for a studio_person_id
 schools as
@@ -59,14 +55,10 @@ trained_2016 as
     tp.studio_person_id,
     'CS Principles' as course,
     '2016-17' as school_year,
-    case partner
-      when 'Academy for CS Education - Florida International University' then 'Florida International University'
-      when 'The Council of Educational Administrative and Supervisory Organizations of Maryland (CEASOM)' then 'Maryland Codes'
-      when 'Utah STEM Action Center and Utah Board of Education' then 'Utah STEM Action Center'
-      else partner
-    end as regional_partner
+    rp1617.regional_partner_id
   from dashboard_production_pii.teacher_profiles tp
     left join public.bb_regional_partner_matches_cleaned rpm on rpm.studio_person_id = tp.studio_person_id
+    left join public.bb_regional_partner_name_id_mappings_1617 rp1617 on rp1617.regional_partner_name = rpm.partner
   where tp.studio_person_id not in
   (
     select 
@@ -82,56 +74,64 @@ trained_2017 as
     studio_person_id,
     course,
     '2017-18' as school_year,
-    case regional_partner
-      when 'The Council of Educational Administrative and Supervisory Organizations of Maryland (CEASOM)' then 'Maryland Codes'
-      when 'America Campaign - Big Sky Code Academy' then 'Teachers Teaching Tech (MT)'
-      when 'No Partner' then NULL
-      when 'mindSpark Learning and Colorado Education Initiative' then 'mindSpark Learning'
-      when 'The Div' then 'Oklahoma Public School Resource Center (OPSRC)'
-      else regional_partner
-    end as regional_partner
+    regional_partner_id
   from analysis_pii.teachers_trained_2017 tt
     join dashboard_production_pii.users u on u.id = tt.user_id
+    left join public.bb_regional_partner_name_id_mappings_1718 rp1718 on rp1718.regional_partner_name = tt.regional_partner
 ),
--- all teachers trained in 2017
+-- all teachers trained in 2018
 trained_2018 as
 (
   select 
     studio_person_id,
     course,
     '2018-19' as school_year,
-    rp.name regional_partner,
     tt.regional_partner_id
   from analysis_pii.teachers_trained_2018 tt
-    join dashboard_production_pii.regional_partners rp on rp.id = tt.regional_partner_id
+),
+-- all teachers trained in 2019
+trained_2019 as
+(
+  select 
+    studio_person_id,
+    course,
+    '2019-20' as school_year,
+    tt.regional_partner_id,
+    case when source = 'scholarship' then 1 else 0 end as scholarship
+  from analysis_pii.teachers_trained_2019 tt
 )
 select 
-  t.*, 
-  rp.id regional_partner_id, 
+  t.*,
+  0 as scholarship,
   sc.school_id
 from trained_2016 t
   join schools sc on sc.studio_person_id = t.studio_person_id
-  left join dashboard_production_pii.regional_partners rp on rp.name = t.regional_partner
 
 union all
 
 select 
   t.*, 
-  rp.id regional_partner_id, 
+  0 as scholarship,
   sc.school_id
 from trained_2017 t
   join schools sc on sc.studio_person_id = t.studio_person_id
-  left join dashboard_production_pii.regional_partners rp on rp.name = t.regional_partner
   
 union all
 
 select 
   t.*, 
+  0 as scholarship,
   sc.school_id
 from trained_2018 t
+  join schools sc on sc.studio_person_id = t.studio_person_id
+  
+union all
+
+select 
+  t.*,
+  sc.school_id
+from trained_2019 t
   join schools sc on sc.studio_person_id = t.studio_person_id
 
 with no schema binding;
 
-GRANT ALL PRIVILEGES ON analysis.csp_csd_teachers_trained TO GROUP admin;
-GRANT SELECT ON analysis.csp_csd_teachers_trained TO GROUP reader, GROUP reader_pii;

--- a/aws/redshift/views/quarterly_workshop_attendance_view.sql
+++ b/aws/redshift/views/quarterly_workshop_attendance_view.sql
@@ -1,0 +1,136 @@
+DROP VIEW IF EXISTS quarterly_workshop_attendance_view CASCADE;
+
+CREATE OR REPLACE VIEW analysis.quarterly_workshop_attendance_view AS
+SELECT u.studio_person_id,
+       pdw.course,
+       sy.school_year,
+       MAX(CASE WHEN pdw.subject IN 
+        (
+          '1-day Academic Year, Units 1 and 2',
+          '2-day Academic Year, Units 1 to 3',
+          'Workshop 1: Unit 3',
+          '2-day, Workshops 1+2: Units 3-4 and Explore Task',
+          '2-day, Workshops 1+2: Units 3 and 4'
+        ) 
+        and pda.id is not null THEN 1 ELSE 0 END) q1,
+       MAX(CASE WHEN pdw.subject IN 
+        (
+          '1-day Academic Year, Unit 3',
+          '2-day Academic Year, Units 1 to 3',
+          'Workshop 2: Unit 4',
+          'Workshop 2: Unit 4 and Explore Task',
+          '2-day, Workshops 1+2: Units 3-4 and Explore Task',
+          '2-day, Workshops 1+2: Units 3 and 4'
+        ) 
+        and pda.id is not null THEN 1 ELSE 0 END) q2,
+       MAX(CASE WHEN pdw.subject IN 
+        (
+          '1-day Academic Year, Units 4 and 5',
+          '1-day Academic Year, Unit 4 + Explore Prep', 
+          '2-day Academic Year, Units 4 and 5 + AP Prep',
+          '2-day Academic Year, Units 4 to 6',
+          'Workshop 3: Unit 5 and Create Task',
+          'Workshop 3: Unit 5',
+          '2-day, Workshops 3+4: Unit 5, Create Task, and Multiple Choice Exam',
+          '2-day, Workshops 3+4: Units 5 and 6'
+        ) 
+        and pda.id is not null THEN 1 ELSE 0 END) q3,
+       MAX(CASE WHEN pdw.subject IN 
+        (
+          '1-day Academic Year, Unit 6',
+          '1-day Academic Year, Unit 5 + Create Prep',
+          '2-day Academic Year, Units 4 and 5 + AP Prep',
+          '2-day Academic Year, Units 4 to 6',
+          'Workshop 4: Unit 5 and Multiple Choice Exam',
+          'Workshop 4: Unit 6',
+          '2-day, Workshops 3+4: Unit 5, Create Task, and Multiple Choice Exam',
+          '2-day, Workshops 3+4: Units 5 and 6'
+        ) 
+        and pda.id is not null THEN 1 ELSE 0 END) q4,
+       MAX(CASE WHEN pdw.subject IN 
+        (
+          '1-day Academic Year, Units 1 and 2',
+          '2-day Academic Year, Units 1 to 3',
+          'Workshop 1: Unit 3',
+          '2-day, Workshops 1+2: Units 3-4 and Explore Task',
+          '2-day, Workshops 1+2: Units 3 and 4'
+        ) 
+        THEN 1 ELSE 0 END) q1_enrolled,
+       MAX(CASE WHEN pdw.subject IN 
+        (
+          '1-day Academic Year, Unit 3',
+          '2-day Academic Year, Units 1 to 3',
+          'Workshop 2: Unit 4',
+          'Workshop 2: Unit 4 and Explore Task',
+          '2-day, Workshops 1+2: Units 3-4 and Explore Task',
+          '2-day, Workshops 1+2: Units 3 and 4'
+        ) 
+        THEN 1 ELSE 0 END) q2_enrolled,
+       MAX(CASE WHEN pdw.subject IN 
+        (
+          '1-day Academic Year, Units 4 and 5',
+          '1-day Academic Year, Unit 4 + Explore Prep', 
+          '2-day Academic Year, Units 4 and 5 + AP Prep',
+          '2-day Academic Year, Units 4 to 6',
+          'Workshop 3: Unit 5 and Create Task',
+          'Workshop 3: Unit 5',
+          '2-day, Workshops 3+4: Unit 5, Create Task, and Multiple Choice Exam',
+          '2-day, Workshops 3+4: Units 5 and 6'
+        ) 
+        THEN 1 ELSE 0 END) q3_enrolled,
+       MAX(CASE WHEN pdw.subject IN 
+        (
+          '1-day Academic Year, Unit 6',
+          '1-day Academic Year, Unit 5 + Create Prep',
+          '2-day Academic Year, Units 4 and 5 + AP Prep',
+          '2-day Academic Year, Units 4 to 6',
+          'Workshop 4: Unit 5 and Multiple Choice Exam',
+          'Workshop 4: Unit 6',
+          '2-day, Workshops 3+4: Unit 5, Create Task, and Multiple Choice Exam',
+          '2-day, Workshops 3+4: Units 5 and 6'
+        ) 
+        THEN 1 ELSE 0 END) q4_enrolled
+FROM dashboard_production_pii.pd_workshops pdw
+  JOIN dashboard_production_pii.pd_sessions pds 
+    ON pds.pd_workshop_id = pdw.id
+  JOIN dashboard_production_pii.pd_enrollments pde 
+    ON pde.pd_workshop_id = pdw.id
+  LEFT JOIN dashboard_production_pii.pd_attendances pda 
+    ON pda.pd_enrollment_id = pde.id
+  JOIN dashboard_production_pii.users u 
+    ON u.id = pde.user_id
+  JOIN analysis.school_years sy on pds.start between sy.started_at and sy.ended_at
+WHERE pdw.course IN ('CS Principles','CS Discoveries')
+AND   pds.start >= '2017-08-01'
+AND   pdw.deleted_at IS NULL
+AND   pdw.subject IN (
+-- CSP
+'1-day Academic Year, Units 1 and 2',
+'1-day Academic Year, Unit 3',
+'1-day Academic Year, Unit 4 + Explore Prep',
+'1-day Academic Year, Unit 5 + Create Prep',
+'2-day Academic Year, Units 1 to 3',
+'2-day Academic Year, Units 4 and 5 + AP Prep',
+  -- 2019-2020
+'Workshop 1: Unit 3',
+'Workshop 2: Unit 4 and Explore Task',
+'Workshop 3: Unit 5 and Create Task',
+'Workshop 4: Unit 5 and Multiple Choice Exam',
+'2-day, Workshops 1+2: Units 3-4 and Explore Task',
+'2-day, Workshops 3+4: Unit 5, Create Task, and Multiple Choice Exam',
+-- CSD
+'1-day Academic Year, Units 1 and 2',
+'1-day Academic Year, Unit 3',
+'1-day Academic Year, Units 4 and 5',
+'1-day Academic Year, Unit 6',
+'2-day Academic Year, Units 1 to 3',
+'2-day Academic Year, Units 4 to 6',
+  -- 2019-2020
+'Workshop 1: Unit 3',
+'Workshop 2: Unit 4',
+'Workshop 3: Unit 5',
+'Workshop 4: Unit 6',
+'2-day, Workshops 1+2: Units 3 and 4',
+'2-day, Workshops 3+4: Units 5 and 6')
+GROUP BY 1,2,3
+WITH NO SCHEMA BINDING;

--- a/aws/redshift/views/regional_partner_stats_csp_csd_view.sql
+++ b/aws/redshift/views/regional_partner_stats_csp_csd_view.sql
@@ -1,6 +1,4 @@
-DROP VIEW IF EXISTS analysis_pii.regional_partner_stats_csp_csd_view CASCADE;
-
-create view analysis_pii.regional_partner_stats_csp_csd_view 
+create or replace view analysis_pii.regional_partner_stats_csp_csd_view 
 AS
 with completed as
 (
@@ -24,102 +22,130 @@ started as
   from analysis.csp_csd_started_teachers cc
   join dashboard_production_pii.users u on u.id = cc.user_id
 ),
-pd_enrollments_2016 as
-  ( select u.studio_person_id, 
-         FIRST_VALUE(pde.first_name) OVER (PARTITION BY u.studio_person_id  ORDER BY (CASE WHEN  pde.first_name IS NULL THEN 1 ELSE 2 END), pde.pd_workshop_id DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING ) as first_name,
-         FIRST_VALUE(pde.last_name) OVER (PARTITION BY u.studio_person_id ORDER BY (CASE WHEN  pde.last_name IS NULL THEN 1 ELSE 2 END), pde.pd_workshop_id DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING ) as last_name,
-         FIRST_VALUE(pde.email) OVER (PARTITION BY u.studio_person_id ORDER BY (CASE WHEN  pde.email IS NULL THEN 1 ELSE 2 END), pde.pd_workshop_id DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING ) as email
-      from dashboard_production_pii.pd_enrollments pde
-      join dashboard_production.users u
-        on u.id = pde.user_id
-      join dashboard_production_pii.pd_workshops pw
-        on pde.pd_workshop_id = pw.id
-      join analysis.school_years sy 
-        on pw.started_at between sy.started_at and sy.ended_at
-      where school_year = '2016-17'
- ),
-teachers_trained_2017 as
+names as
 (
-select tt17.*, u.studio_person_id
-  FROM analysis_pii.teachers_trained_2017 tt17
-  JOIN dashboard_production.users u 
-    ON tt17.user_id = u.id
-)      
-  SELECT distinct 
-         d.studio_person_id,
-         coalesce(tt18.first_name, tt17.first_name, pd16.first_name) as first_name,
-         coalesce(tt18.last_name, tt17.last_name, pd16.last_name) as last_name,
-         coalesce(tt18.email, tt17.email, pd16.email) as email,
-         d.course,
-         d.school_year as school_year_trained,
-         sa.school_year as school_year_taught,
-         CASE WHEN rp.name is null THEN 'No Partner' ELSE rp.name END as regional_partner_name,
-         rp.id as regional_partner_id,
-         d.school_id school_id,
-         ss_summer_pd.school_name school_name,
-         ss_summer_pd.city city,
-         ss_summer_pd.state state,
-         ss_summer_pd.school_district_name school_district_name,
-         ss_summer_pd.school_district_id school_district_id,
-         ss_summer_pd.high_needs high_needs,
-         ss_summer_pd.rural rural,
-         qwa.q1,
-         qwa.q2,
-         qwa.q3,
-         qwa.q4,
-         case when (q1 + q2 + q3 + q4) >= 3 then 1 else 0 end as retained,
-         case when c.studio_person_id is not null then 1 else 0 end as completed,
-         case when s.studio_person_id is not null then 1 else 0 end as started,
-         tmp.script_most_progress,
-         tmp.students_script_most_progress,
-         sa.sections,
-         sa.students,
-         sa.students_started,
-         sa.students_completed,
-         sa.students_female,
-         sa.students_gender,
-         sa.students_urm,
-         sa.students_black,
-         sa.students_hispanic,
-         sa.students_native,
-         sa.students_hawaiian,
-         sa.students_race
-  FROM analysis.csp_csd_teachers_trained d
-  LEFT JOIN analysis_pii.teachers_trained_2018 tt18
-        ON d.studio_person_id = tt18.studio_person_id
-  LEFT JOIN teachers_trained_2017 tt17
-        ON d.studio_person_id = tt17.studio_person_id
-  LEFT JOIN pd_enrollments_2016 pd16
-        ON d.studio_person_id = pd16.studio_person_id
-  -- schools
-  LEFT JOIN analysis.school_stats ss_summer_pd 
-         ON ss_summer_pd.school_id = d.school_id
-  -- attendance
-  LEFT JOIN analysis.quarterly_workshop_attendance qwa 
-         ON qwa.studio_person_id = d.studio_person_id
-        AND qwa.course = d.course 
-        AND qwa.school_year = d.school_year
+  select 
+  	studio_person_id,
+  	first_name,
+  	last_name
+  from
+  (
+  	select
+  		studio_person_id,
+  		first_name,
+  		last_name,
+  		row_number() over(partition by studio_person_id order by created_at desc) row_num
+  	from
+  	(
+  		select
+  			u.studio_person_id,
+  			pde.first_name,
+  			pde.last_name,
+  			pde.created_at
+  		from dashboard_production_pii.pd_enrollments pde
+  		join dashboard_production_pii.users u on u.id = pde.user_id
+  		where first_name is not null
+  		and last_name is not null
+		
+  		union all
+		
+  		select 
+  			u.studio_person_id,
+  			json_extract_path_text(form_data, 'firstName') first_name,
+  			json_extract_path_text(form_data, 'lastName') last_name,
+  			pda.created_at
+  		from dashboard_production_pii.pd_applications pda
+  		join dashboard_production_pii.users u on u.id = pda.user_id
+  		where json_extract_path_text(form_data, 'firstName') != ''
+  		and json_extract_path_text(form_data, 'lastName') != ''
+  	)
+  )
+  where row_num = 1
+),
+emails as
+(
+  select
+  	studio_person_id,
+  	listagg(distinct email, ', ') emails
+  from dashboard_production_pii.users
+  where user_type = 'teacher'
+  group by 1
+)
+SELECT distinct 
+       d.studio_person_id,
+       n.first_name as first_name,
+       n.last_name as last_name,
+       e.emails as email,
+       d.course,
+       scholarship,
+       d.school_year as school_year_trained,
+       sa.school_year as school_year_taught,
+       CASE WHEN rp.name is null THEN 'No Partner' ELSE rp.name END as regional_partner_name,
+       rp.id as regional_partner_id,
+       d.school_id school_id,
+       ss_summer_pd.school_name school_name,
+       ss_summer_pd.city city,
+       ss_summer_pd.state state,
+       ss_summer_pd.school_district_name school_district_name,
+       ss_summer_pd.school_district_id school_district_id,
+       ss_summer_pd.high_needs high_needs,
+       ss_summer_pd.rural rural,
+       qwa.q1,
+       qwa.q2,
+       qwa.q3,
+       qwa.q4,
+       qwa.q1_enrolled,
+       qwa.q2_enrolled,
+       qwa.q3_enrolled,
+       qwa.q4_enrolled,
+       case when (q1 + q2 + q3 + q4) >= 3 then 1 else 0 end as retained,
+       case when c.studio_person_id is not null then 1 else 0 end as completed,
+       case when s.studio_person_id is not null then 1 else 0 end as started,
+       tmp.script_most_progress,
+       tmp.students_script_most_progress,
+       sa.sections,
+       sa.students,
+       sa.students_started,
+       sa.students_completed,
+       sa.students_female,
+       sa.students_gender,
+       sa.students_urm,
+       sa.students_black,
+       sa.students_hispanic,
+       sa.students_native,
+       sa.students_hawaiian,
+       sa.students_race
+FROM analysis.csp_csd_teachers_trained d
+LEFT JOIN names n
+      ON d.studio_person_id = n.studio_person_id
+LEFT JOIN emails e
+      ON d.studio_person_id = e.studio_person_id
+-- schools
+LEFT JOIN analysis.school_stats ss_summer_pd 
+       ON ss_summer_pd.school_id = d.school_id
+-- attendance
+LEFT JOIN analysis.quarterly_workshop_attendance_view qwa 
+       ON qwa.studio_person_id = d.studio_person_id
+      AND qwa.course = d.course 
+      AND qwa.school_year = d.school_year
 --pii tables (regional partner names, person names, emails, locations)
-  LEFT JOIN dashboard_production_pii.regional_partners rp  
-       ON d.regional_partner_id = rp.id 
+LEFT JOIN dashboard_production_pii.regional_partners rp  
+     ON d.regional_partner_id = rp.id 
 -- analysis tables
-  LEFT JOIN analysis.student_activity_csp_csd sa 
-         ON sa.studio_person_id = d.studio_person_id 
-         AND sa.school_year >= d.school_year 
-  LEFT JOIN started s
-       ON s.studio_person_id = d.studio_person_id
-      AND s.course = d.course
-      AND s.school_year = sa.school_year
-  LEFT JOIN completed c
-         ON c.studio_person_id = d.studio_person_id
-        AND c.course = d.course   
-        AND c.school_year  = s.school_year  
-  LEFT JOIN analysis.teacher_most_progress_csp_csd tmp 
-         ON tmp.studio_person_id = d.studio_person_id
-         AND tmp.school_year = sa.school_year
-WITH NO SCHEMA BINDING;
+LEFT JOIN analysis.student_activity_csp_csd_view sa 
+       ON sa.studio_person_id = d.studio_person_id 
+       AND sa.school_year >= d.school_year 
+LEFT JOIN started s
+     ON s.studio_person_id = d.studio_person_id
+    AND s.course = d.course
+    AND s.school_year = sa.school_year
+LEFT JOIN completed c
+       ON c.studio_person_id = d.studio_person_id
+      AND c.course = d.course   
+      AND c.school_year  = s.school_year  
+LEFT JOIN analysis.teacher_most_progress_csp_csd_view tmp 
+       ON tmp.studio_person_id = d.studio_person_id
+       AND tmp.school_year = sa.school_year
+with no schema binding;
 
-
-GRANT INSERT, TRIGGER, UPDATE, REFERENCES, RULE, DELETE, SELECT ON analysis_pii.regional_partner_stats_csp_csd_view TO dev;
-GRANT SELECT ON analysis_pii.regional_partner_stats_csp_csd_view  TO GROUP reader_pii;
-GRANT REFERENCES, TRIGGER, UPDATE, SELECT, INSERT, RULE, DELETE ON analysis_pii.regional_partner_stats_csp_csd_view  TO GROUP admin;
+GRANT SELECT ON analysis_pii.regional_partner_stats_csp_csd_view TO reader_pii;


### PR DESCRIPTION
Updates to regional partner-facing views.

Major updates:
1. Get `first_name` and `last_name` for all teachers from most recent enrollment in a workshop or application to PD.
2. Add `quarterly_workshop_attendance_view` (not previously on GitHub)
3. Add `scholarship` field to `csp_csd_teachers_trained` (0 for all previous year, mix of 0/1 for teachers trained for 2019-20 school year).
4. `email` visible to regional partners is comma-separated list of emails from all of known accounts for a given teacher.