### PR TITLE
[Data Viz] Add visualization modal

### DIFF
--- a/apps/src/storage/dataBrowser/DataVisualizer.jsx
+++ b/apps/src/storage/dataBrowser/DataVisualizer.jsx
@@ -3,6 +3,7 @@ import Radium from 'radium';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
+import DropdownField from './DropdownField';
 import * as dataStyles from './dataStyles';
 import * as rowStyle from '@cdo/apps/applab/designElements/rowStyle';
 
@@ -35,49 +36,29 @@ class DataVisualizer extends React.Component {
     this.setState({isVisualizerOpen: false});
   };
 
-  handleChange = (field, value) => {
-    this.setState({[field]: value});
-  };
-
   render() {
-    const dropdownField = (fieldName, displayName, values) => (
-      <div id={fieldName} style={rowStyle.container}>
-        <label style={rowStyle.description}>{displayName}</label>
-        <select
-          value={this.state[fieldName]}
-          onChange={event => this.handleChange(fieldName, event.target.value)}
-        >
-          <option value="">Select</option>
-          {values.map(value => (
-            <option key={value} value={value}>
-              {value}
-            </option>
-          ))}
-        </select>
-      </div>
-    );
-
     const modalBody = (
       <div>
         <h1> Explore {this.props.tableName} </h1>
         <h2> Overview </h2>
         <div id="selection-area">
-          <div id="chartTitleRow" style={rowStyle.container}>
+          <div style={rowStyle.container}>
             <label style={rowStyle.description}>Chart Title</label>
             <input
               style={rowStyle.input}
+              value={this.state.chartTitle}
               onChange={event =>
-                this.handleChange('chartTitle', event.target.value)
+                this.setState({chartTitle: event.target.value})
               }
             />
           </div>
 
-          {dropdownField('chartType', 'Chart Type', [
-            'Bar Chart',
-            'Histogram',
-            'Cross Tab',
-            'Scatter Plot'
-          ])}
+          <DropdownField
+            displayName="Chart Type"
+            options={['Bar Chart', 'Histogram', 'Cross Tab', 'Scatter Plot']}
+            value={this.state.chartType}
+            onChange={e => this.setState({chartType: e.target.value})}
+          />
 
           {this.state.chartType === 'Histogram' && (
             <div id="numBinsRow" style={rowStyle.container}>
@@ -85,21 +66,35 @@ class DataVisualizer extends React.Component {
               <input
                 style={rowStyle.input}
                 value={this.state.numBins}
-                onChange={event =>
-                  this.handleChange('numBins', event.target.value)
-                }
+                onChange={event => this.setState({numBins: event.target.value})}
               />
             </div>
           )}
           {(this.state.chartType === 'Bar Chart' ||
-            this.state.chartType === 'Histogram') &&
-            dropdownField('values', 'Values', this.props.tableColumns)}
+            this.state.chartType === 'Histogram') && (
+            <DropdownField
+              displayName="Values"
+              options={this.props.tableColumns}
+              value={this.state.values}
+              onChange={e => this.setState({values: e.target.value})}
+            />
+          )}
 
           {(this.state.chartType === 'Cross Tab' ||
             this.state.chartType === 'Scatter Plot') && (
             <div>
-              {dropdownField('xValues', 'X Values', this.props.tableColumns)}
-              {dropdownField('yValues', 'Y Values', this.props.tableColumns)}
+              <DropdownField
+                displayName="X Values"
+                options={this.props.tableColumns}
+                value={this.state.xValues}
+                onChange={e => this.setState({xValues: e.target.value})}
+              />
+              <DropdownField
+                displayName="Y Values"
+                options={this.props.tableColumns}
+                value={this.state.yValues}
+                onChange={e => this.setState({yValues: e.target.value})}
+              />
             </div>
           )}
         </div>
@@ -108,7 +103,7 @@ class DataVisualizer extends React.Component {
     );
 
     return (
-      <span style={[{display: 'inline-block'}]}>
+      <span style={{display: 'inline-block'}}>
         <button
           type="button"
           style={dataStyles.whiteButton}

--- a/apps/src/storage/dataBrowser/DataVisualizer.jsx
+++ b/apps/src/storage/dataBrowser/DataVisualizer.jsx
@@ -40,7 +40,72 @@ class DataVisualizer extends React.Component {
   };
 
   render() {
-    const {chartType, numBins, values, xValues, yValues} = this.state;
+    const dropdownField = (fieldName, displayName, values) => (
+      <div id={fieldName} style={rowStyle.container}>
+        <label style={rowStyle.description}>{displayName}</label>
+        <select
+          value={this.state[fieldName]}
+          onChange={event => this.handleChange(fieldName, event.target.value)}
+        >
+          <option value="">Select</option>
+          {values.map(value => (
+            <option key={value} value={value}>
+              {value}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+
+    const modalBody = (
+      <div>
+        <h1> Explore {this.props.tableName} </h1>
+        <h2> Overview </h2>
+        <div id="selection-area">
+          <div id="chartTitleRow" style={rowStyle.container}>
+            <label style={rowStyle.description}>Chart Title</label>
+            <input
+              style={rowStyle.input}
+              onChange={event =>
+                this.handleChange('chartTitle', event.target.value)
+              }
+            />
+          </div>
+
+          {dropdownField('chartType', 'Chart Type', [
+            'Bar Chart',
+            'Histogram',
+            'Cross Tab',
+            'Scatter Plot'
+          ])}
+
+          {this.state.chartType === 'Histogram' && (
+            <div id="numBinsRow" style={rowStyle.container}>
+              <label style={rowStyle.description}>Bins</label>
+              <input
+                style={rowStyle.input}
+                value={this.state.numBins}
+                onChange={event =>
+                  this.handleChange('numBins', event.target.value)
+                }
+              />
+            </div>
+          )}
+          {(this.state.chartType === 'Bar Chart' ||
+            this.state.chartType === 'Histogram') &&
+            dropdownField('values', 'Values', this.props.tableColumns)}
+
+          {(this.state.chartType === 'Cross Tab' ||
+            this.state.chartType === 'Scatter Plot') && (
+            <div>
+              {dropdownField('xValues', 'X Values', this.props.tableColumns)}
+              {dropdownField('yValues', 'Y Values', this.props.tableColumns)}
+            </div>
+          )}
+        </div>
+        <div id="chart-area" />
+      </div>
+    );
 
     return (
       <span style={[{display: 'inline-block'}]}>
@@ -57,98 +122,7 @@ class DataVisualizer extends React.Component {
           fullWidth
           fullHeight
         >
-          <h1> Explore {this.props.tableName} </h1>
-          <h2> Overview </h2>
-          <div id="selection-area">
-            <div id="chartTitleRow" style={rowStyle.container}>
-              <label style={rowStyle.description}>Chart Title</label>
-              <input
-                style={rowStyle.input}
-                onChange={event =>
-                  this.handleChange('chartTitle', event.target.value)
-                }
-              />
-            </div>
-
-            <div id="chartTypeRow" style={rowStyle.container}>
-              <label style={rowStyle.description}>Chart Type</label>
-              <select
-                value={chartType}
-                onChange={event =>
-                  this.handleChange('chartType', event.target.value)
-                }
-              >
-                <option value="">Select</option>
-                <option value="bar">Bar Chart</option>
-                <option value="histogram">Histogram</option>
-                <option value="crosstab">Cross Tab</option>
-                <option value="scatter">Scatter Plot</option>
-              </select>
-              {chartType === 'histogram' && (
-                <span>
-                  <label style={rowStyle.description}>Bins</label>
-                  <input
-                    style={rowStyle.input}
-                    value={numBins}
-                    onChange={event =>
-                      this.handleChange('numBins', event.target.value)
-                    }
-                  />
-                </span>
-              )}
-            </div>
-            {(chartType === 'bar' || chartType === 'histogram') && (
-              <div id="valuesRow" style={rowStyle.container}>
-                <label style={rowStyle.description}>Values</label>
-                <select
-                  value={values}
-                  onChange={event =>
-                    this.handleChange('values', event.target.value)
-                  }
-                >
-                  <option value="">Select</option>
-                  {this.props.tableColumns.map(columnName => (
-                    <option key={columnName} value={columnName}>
-                      {columnName}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-            {(chartType === 'crosstab' || chartType === 'scatter') && (
-              <div id="xyValuesRow" style={rowStyle.container}>
-                <label style={rowStyle.description}>X Values</label>
-                <select
-                  value={xValues}
-                  onChange={event =>
-                    this.handleChange('xValues', event.target.value)
-                  }
-                >
-                  <option value="">Select</option>
-                  {this.props.tableColumns.map(columnName => (
-                    <option key={columnName} value={columnName}>
-                      {columnName}
-                    </option>
-                  ))}
-                </select>
-                <label style={rowStyle.description}>Y Values</label>
-                <select
-                  value={yValues}
-                  onChange={event =>
-                    this.handleChange('yValues', event.target.value)
-                  }
-                >
-                  <option value="">Select</option>
-                  {this.props.tableColumns.map(columnName => (
-                    <option key={columnName} value={columnName}>
-                      {columnName}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-          </div>
-          <div id="chart-area" />
+          {modalBody}
         </BaseDialog>
       </span>
     );

--- a/apps/src/storage/dataBrowser/DataVisualizer.jsx
+++ b/apps/src/storage/dataBrowser/DataVisualizer.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Radium from 'radium';
+import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
+import * as dataStyles from './dataStyles';
+
+const INITIAL_STATE = {
+  isVisualizerOpen: false
+};
+
+class DataVisualizer extends React.Component {
+  static propTypes = {};
+
+  state = {...INITIAL_STATE};
+
+  handleClose = () => {
+    this.setState({isVisualizerOpen: false});
+  };
+
+  render() {
+    return (
+      <span style={[{display: 'inline-block'}]}>
+        <button
+          type="button"
+          style={dataStyles.whiteButton}
+          onClick={() => this.setState({isVisualizerOpen: true})}
+        >
+          Show Viz (Placeholder)
+        </button>
+        <BaseDialog
+          isOpen={this.state.isVisualizerOpen}
+          handleClose={this.handleClose}
+          fullWidth
+          fullHeight
+        >
+          <p> Placeholder text </p>
+        </BaseDialog>
+      </span>
+    );
+  }
+}
+export default Radium(DataVisualizer);

--- a/apps/src/storage/dataBrowser/DataVisualizer.jsx
+++ b/apps/src/storage/dataBrowser/DataVisualizer.jsx
@@ -1,14 +1,33 @@
 import React from 'react';
 import Radium from 'radium';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import * as dataStyles from './dataStyles';
+import * as rowStyle from '@cdo/apps/applab/designElements/rowStyle';
 
 const INITIAL_STATE = {
-  isVisualizerOpen: false
+  isVisualizerOpen: false,
+  chartTitle: '',
+  chartType: '',
+  numBins: 0,
+  values: '',
+  xValues: '',
+  yValues: ''
 };
 
 class DataVisualizer extends React.Component {
-  static propTypes = {};
+  static propTypes = {
+    // from redux state
+    tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
+    tableName: PropTypes.string.isRequired,
+    // "if all of the keys are integers, and more than half of the keys between 0 and
+    // the maximum key in the object have non-empty values, then Firebase will render
+    // it as an array."
+    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
+    tableRecords: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
+      .isRequired
+  };
 
   state = {...INITIAL_STATE};
 
@@ -16,7 +35,13 @@ class DataVisualizer extends React.Component {
     this.setState({isVisualizerOpen: false});
   };
 
+  handleChange = (field, value) => {
+    this.setState({[field]: value});
+  };
+
   render() {
+    const {chartType, numBins, values, xValues, yValues} = this.state;
+
     return (
       <span style={[{display: 'inline-block'}]}>
         <button
@@ -32,10 +57,105 @@ class DataVisualizer extends React.Component {
           fullWidth
           fullHeight
         >
-          <p> Placeholder text </p>
+          <h1> Explore {this.props.tableName} </h1>
+          <h2> Overview </h2>
+          <div id="selection-area">
+            <div id="chartTitleRow" style={rowStyle.container}>
+              <label style={rowStyle.description}>Chart Title</label>
+              <input
+                style={rowStyle.input}
+                onChange={event =>
+                  this.handleChange('chartTitle', event.target.value)
+                }
+              />
+            </div>
+
+            <div id="chartTypeRow" style={rowStyle.container}>
+              <label style={rowStyle.description}>Chart Type</label>
+              <select
+                value={chartType}
+                onChange={event =>
+                  this.handleChange('chartType', event.target.value)
+                }
+              >
+                <option value="">Select</option>
+                <option value="bar">Bar Chart</option>
+                <option value="histogram">Histogram</option>
+                <option value="crosstab">Cross Tab</option>
+                <option value="scatter">Scatter Plot</option>
+              </select>
+              {chartType === 'histogram' && (
+                <span>
+                  <label style={rowStyle.description}>Bins</label>
+                  <input
+                    style={rowStyle.input}
+                    value={numBins}
+                    onChange={event =>
+                      this.handleChange('numBins', event.target.value)
+                    }
+                  />
+                </span>
+              )}
+            </div>
+            {(chartType === 'bar' || chartType === 'histogram') && (
+              <div id="valuesRow" style={rowStyle.container}>
+                <label style={rowStyle.description}>Values</label>
+                <select
+                  value={values}
+                  onChange={event =>
+                    this.handleChange('values', event.target.value)
+                  }
+                >
+                  <option value="">Select</option>
+                  {this.props.tableColumns.map(columnName => (
+                    <option key={columnName} value={columnName}>
+                      {columnName}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+            {(chartType === 'crosstab' || chartType === 'scatter') && (
+              <div id="xyValuesRow" style={rowStyle.container}>
+                <label style={rowStyle.description}>X Values</label>
+                <select
+                  value={xValues}
+                  onChange={event =>
+                    this.handleChange('xValues', event.target.value)
+                  }
+                >
+                  <option value="">Select</option>
+                  {this.props.tableColumns.map(columnName => (
+                    <option key={columnName} value={columnName}>
+                      {columnName}
+                    </option>
+                  ))}
+                </select>
+                <label style={rowStyle.description}>Y Values</label>
+                <select
+                  value={yValues}
+                  onChange={event =>
+                    this.handleChange('yValues', event.target.value)
+                  }
+                >
+                  <option value="">Select</option>
+                  {this.props.tableColumns.map(columnName => (
+                    <option key={columnName} value={columnName}>
+                      {columnName}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+          <div id="chart-area" />
         </BaseDialog>
       </span>
     );
   }
 }
-export default Radium(DataVisualizer);
+export default connect(state => ({
+  tableColumns: state.data.tableColumns || [],
+  tableRecords: state.data.tableRecords || {},
+  tableName: state.data.tableName || ''
+}))(Radium(DataVisualizer));

--- a/apps/src/storage/dataBrowser/DataVisualizer.jsx
+++ b/apps/src/storage/dataBrowser/DataVisualizer.jsx
@@ -57,7 +57,7 @@ class DataVisualizer extends React.Component {
             displayName="Chart Type"
             options={['Bar Chart', 'Histogram', 'Cross Tab', 'Scatter Plot']}
             value={this.state.chartType}
-            onChange={e => this.setState({chartType: e.target.value})}
+            onChange={event => this.setState({chartType: event.target.value})}
           />
 
           {this.state.chartType === 'Histogram' && (
@@ -76,7 +76,7 @@ class DataVisualizer extends React.Component {
               displayName="Values"
               options={this.props.tableColumns}
               value={this.state.values}
-              onChange={e => this.setState({values: e.target.value})}
+              onChange={event => this.setState({values: event.target.value})}
             />
           )}
 
@@ -87,13 +87,13 @@ class DataVisualizer extends React.Component {
                 displayName="X Values"
                 options={this.props.tableColumns}
                 value={this.state.xValues}
-                onChange={e => this.setState({xValues: e.target.value})}
+                onChange={event => this.setState({xValues: event.target.value})}
               />
               <DropdownField
                 displayName="Y Values"
                 options={this.props.tableColumns}
                 value={this.state.yValues}
-                onChange={e => this.setState({yValues: e.target.value})}
+                onChange={event => this.setState({yValues: event.target.value})}
               />
             </div>
           )}

--- a/apps/src/storage/dataBrowser/DropdownField.jsx
+++ b/apps/src/storage/dataBrowser/DropdownField.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Radium from 'radium';
+import PropTypes from 'prop-types';
+import * as rowStyle from '@cdo/apps/applab/designElements/rowStyle';
+
+class DropdownField extends React.Component {
+  static propTypes = {
+    displayName: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    options: PropTypes.array.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+  };
+
+  render() {
+    return (
+      <div style={rowStyle.container}>
+        <label style={rowStyle.description}>{this.props.displayName}</label>
+        <select value={this.props.value} onChange={this.props.onChange}>
+          <option value="">Select</option>
+          {this.props.options.map(option => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+}
+
+export default Radium(DropdownField);

--- a/apps/src/storage/dataBrowser/TableControls.jsx
+++ b/apps/src/storage/dataBrowser/TableControls.jsx
@@ -4,6 +4,7 @@
  */
 import ConfirmDeleteButton from './ConfirmDeleteButton';
 import ConfirmImportButton from './ConfirmImportButton';
+import DataVisualizer from './DataVisualizer';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import React from 'react';
@@ -63,10 +64,12 @@ class TableControls extends React.Component {
           <span style={styles.tableName}>{this.props.tableName}</span>
         </div>{' '}
         <div style={styles.buttonWrapper}>
+          <DataVisualizer />
+
           <ConfirmDeleteButton
             body={applabMsg.confirmClearTable()}
             buttonText="Clear table"
-            containerStyle={{width: 103}}
+            containerStyle={{width: 103, marginLeft: 10}}
             buttonId="clearTableButton"
             onConfirmDelete={this.props.clearTable}
             title="Clear table"


### PR DESCRIPTION
# Description
Add a button that opens the visualization modal over the data table view.
Button text is not final
![image](https://user-images.githubusercontent.com/8787187/66851765-5086f000-ef30-11e9-8416-5af767b6f2a7.png)

The field selections don't do anything other than set the component state yet, but the dropdowns do populate correctly. 
![image](https://user-images.githubusercontent.com/8787187/66851834-7e6c3480-ef30-11e9-9be0-3a10b10ead15.png)

No i18n for now because none of the exact text is final.

## Links


- [spec](https://docs.google.com/document/d/1s1CQ4SSrpwJtLwI5gJoFzJEbcEXZHQIQ6ikAxB9H3j4/edit)
- [jira](https://codedotorg.atlassian.net/browse/STAR-750)

## Testing story

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
