### PR TITLE
Explicitly return true from `sanitize_race_data_set_urm`

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -496,6 +496,10 @@ class User < ActiveRecord::Base
     self.races = Policies::Races.sanitized(races).join(',')
     self.races = nil if races.empty?
     self.urm = Policies::Races.any_urm?(races)
+
+    # Make sure we explicitly return true here so Rails doesn't interpret a
+    # potential `self.urm = false` as us trying to halt the callback chain
+    true
   end
 
   def fix_by_user_type

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1268,6 +1268,27 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, user.terms_of_service_version
   end
 
+  test 'sanitize_race_data will set URM to true when appropriate' do
+    @student.update!(races: 'black,hispanic')
+    @student.reload
+    assert @student.urm
+
+    # URM is true when any races are URM
+    @student.update!(races: 'white,black')
+    @student.reload
+    assert @student.urm
+  end
+
+  test 'sanitize_race_data will set URM to false when appropriate' do
+    @student.update!(races: 'white')
+    @student.reload
+    refute @student.urm
+
+    @student.update!(races: 'asian')
+    @student.reload
+    refute @student.urm
+  end
+
   test 'sanitize_race_data sanitizes closed_dialog' do
     @student.update!(races: 'white,closed_dialog')
     @student.reload


### PR DESCRIPTION
# Description

Otherwise, rails will interpret the final line `self.urm = ...` as a return value, which will attempt to halt the callback chain in those cases where `self.urm` is false.

Originally regressed in https://github.com/code-dot-org/code-dot-org/pull/30444

## Testing story

Added some new unit tests that would have caught this error had they existed previously

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
