### PR TITLE
Add extra context to config-key validation error message

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -14,6 +14,9 @@ CDO.stubs(x: 'foo')
 ```
 
 Properties defined below can be further configured through several overrides.
+
+Overriding any property not defined in the default `config.yml.erb` will raise an error on startup.
+
 The loading order is as follows (1 = highest priority):
 
 1. `ENV`

--- a/lib/test/cdo/test_config.rb
+++ b/lib/test/cdo/test_config.rb
@@ -63,4 +63,22 @@ YAML
     assert_raises(RuntimeError) {config.x = 'a'}
     assert_raises(ArgumentError) {config.y}
   end
+
+  def test_invalid_key
+    config = Cdo::Config.new
+
+    override = Tempfile.new(%w(override .yml))
+    override.write "foo: foo\nbar: bar"
+    override.close
+
+    default = Tempfile.new(%w(default .yml))
+    default.write "foo: foo2"
+    default.close
+
+    config.load_configuration(override.path, default.path)
+
+    ex = assert_raises(Cdo::Config::UnknownKeyError) {config.freeze}
+    assert_match "Remove unknown key not defined in #{default.path}", ex.message
+    assert_match "bar (in #{override.path})", ex.message
+  end
 end


### PR DESCRIPTION
# Description

Make the config-key validation error more helpful with a more detailed error message including the source filename where invalid config keys are being referenced and a reference to further documentation on the configuration system.

Before:

```
Unknown property not in defaults: foo (RuntimeError)
```

After:

```
Invalid configuration (Cdo::Config::UnknownKeyError)
Remove unknown keys not defined in ./config.yml.erb:
foo (in ./locals.yml)
bar (in ./locals.yml)
Refer to ./config/README.md for further documentation.
```

## Testing story

Unit test covering additional behavior included in the PR.