### PR TITLE
Add client-side validation to teacher and principal application

### DIFF
--- a/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
@@ -8,7 +8,7 @@ import LabeledFormComponent from '../../form_components/LabeledFormComponent';
 import PrivacyDialog from '../PrivacyDialog';
 import {PrivacyDialogMode} from '../../constants';
 import SchoolAutocompleteDropdown from '@cdo/apps/templates/SchoolAutocompleteDropdown';
-import {isPercent, isZipCode} from '@cdo/apps/util/formatValidation';
+import {isInt, isPercent, isZipCode} from '@cdo/apps/util/formatValidation';
 import {styles} from '../teacher/TeacherApplicationConstants';
 
 const MANUAL_SCHOOL_FIELDS = [
@@ -394,8 +394,12 @@ export default class PrincipalApprovalComponent extends LabeledFormComponent {
       formatErrors.schoolZipCode = 'Must be a valid zip code';
     }
 
-    if (data.totalStudentEnrollment && data.totalStudentEnrollment <= 0) {
-      formatErrors.totalStudentEnrollment = 'Must be a positive number';
+    if (
+      data.totalStudentEnrollment &&
+      (!isInt(data.totalStudentEnrollment) || data.totalStudentEnrollment <= 0)
+    ) {
+      formatErrors.totalStudentEnrollment =
+        'Must be a valid and positive number';
     }
 
     ['freeLunchPercent', ...RACE_LIST].forEach(key => {

--- a/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
@@ -8,7 +8,7 @@ import LabeledFormComponent from '../../form_components/LabeledFormComponent';
 import PrivacyDialog from '../PrivacyDialog';
 import {PrivacyDialogMode} from '../../constants';
 import SchoolAutocompleteDropdown from '@cdo/apps/templates/SchoolAutocompleteDropdown';
-import {isInt, isPercent} from '@cdo/apps/util/formatValidation';
+import {isPercent, isZipCode} from '@cdo/apps/util/formatValidation';
 import {styles} from '../teacher/TeacherApplicationConstants';
 
 const MANUAL_SCHOOL_FIELDS = [
@@ -138,7 +138,7 @@ export default class PrincipalApprovalComponent extends LabeledFormComponent {
     return (
       <div>
         {this.renderSchoolSection()}
-        {this.inputFor('totalStudentEnrollment')}
+        {this.numberInputFor('totalStudentEnrollment')}
         {this.numberInputFor('freeLunchPercent', {
           min: 0,
           max: 100,
@@ -390,8 +390,12 @@ export default class PrincipalApprovalComponent extends LabeledFormComponent {
   static getErrorMessages(data) {
     let formatErrors = {};
 
-    if (data.totalStudentEnrollment && !isInt(data.totalStudentEnrollment)) {
-      formatErrors.totalStudentEnrollment = 'Must be a valid number';
+    if (data.schoolZipCode && !isZipCode(data.schoolZipCode)) {
+      formatErrors.schoolZipCode = 'Must be a valid zip code';
+    }
+
+    if (data.totalStudentEnrollment && data.totalStudentEnrollment <= 0) {
+      formatErrors.totalStudentEnrollment = 'Must be a positive number';
     }
 
     ['freeLunchPercent', ...RACE_LIST].forEach(key => {
@@ -430,7 +434,9 @@ export default class PrincipalApprovalComponent extends LabeledFormComponent {
       // Sanitize numeric fields (necessary for older browsers that don't
       // automatically enforce numeric inputs)
       ['freeLunchPercent', ...RACE_LIST].forEach(field => {
-        changes[field] = parseFloat(data[field]).toString();
+        if (data[field]) {
+          changes[field] = parseFloat(data[field]).toString();
+        }
       });
     }
 

--- a/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
@@ -218,7 +218,7 @@ export default class ChooseYourProgram extends LabeledFormComponent {
       (data.csHowManyMinutes < 1 || data.csHowManyMinutes > 480)
     ) {
       formatErrors.csHowManyMinutes =
-        'Class section minutes per day must be positive number from 1-480 inclusive';
+        'Class section minutes per day must be between 1 and 480';
     }
 
     if (
@@ -226,7 +226,7 @@ export default class ChooseYourProgram extends LabeledFormComponent {
       (data.csHowManyDaysPerWeek < 1 || data.csHowManyDaysPerWeek > 7)
     ) {
       formatErrors.csHowManyDaysPerWeek =
-        'Class section days per week must be positive number between 1-7 inclusive';
+        'Class section days per week must be between 1 and 7';
     }
 
     if (
@@ -234,7 +234,7 @@ export default class ChooseYourProgram extends LabeledFormComponent {
       (data.csHowManyWeeksPerYear < 1 || data.csHowManyWeeksPerYear > 52)
     ) {
       formatErrors.csHowManyWeeksPerYear =
-        'Class section weeks per year must be positive number from 1-52 inclusive';
+        'Class section weeks per year must be between 1 and 52';
     }
 
     return formatErrors;

--- a/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
@@ -207,4 +207,36 @@ export default class ChooseYourProgram extends LabeledFormComponent {
 
     return changes;
   }
+
+  /**
+   * @override
+   */
+  static getErrorMessages(data) {
+    let formatErrors = {};
+    if (
+      data.csHowManyMinutes &&
+      (data.csHowManyMinutes < 1 || data.csHowManyMinutes > 480)
+    ) {
+      formatErrors.csHowManyMinutes =
+        'Class section minutes per day must be positive number from 1-480 inclusive';
+    }
+
+    if (
+      data.csHowManyDaysPerWeek &&
+      (data.csHowManyDaysPerWeek < 1 || data.csHowManyDaysPerWeek > 7)
+    ) {
+      formatErrors.csHowManyDaysPerWeek =
+        'Class section days per week must be positive number between 1-7 inclusive';
+    }
+
+    if (
+      data.csHowManyWeeksPerYear &&
+      (data.csHowManyWeeksPerYear < 1 || data.csHowManyWeeksPerYear > 52)
+    ) {
+      formatErrors.csHowManyWeeksPerYear =
+        'Class section weeks per year must be positive number from 1-52 inclusive';
+    }
+
+    return formatErrors;
+  }
 }

--- a/apps/src/code-studio/pd/application/teacher/TeachingBackground.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeachingBackground.jsx
@@ -8,7 +8,7 @@ import {
 } from '@cdo/apps/generated/pd/teacherApplicationConstants';
 import {Row, Col, ControlLabel, FormGroup} from 'react-bootstrap';
 import SchoolAutocompleteDropdown from '@cdo/apps/templates/SchoolAutocompleteDropdown';
-import {isEmail} from '@cdo/apps/util/formatValidation';
+import {isEmail, isZipCode} from '@cdo/apps/util/formatValidation';
 import {styles} from './TeacherApplicationConstants';
 
 export default class TeachingBackground extends LabeledFormComponent {
@@ -139,6 +139,10 @@ export default class TeachingBackground extends LabeledFormComponent {
 
     if (data.principalEmail !== data.principalConfirmEmail) {
       formatErrors.principalConfirmEmail = 'Must match above email';
+    }
+
+    if (data.schoolZipCode && !isZipCode(data.schoolZipCode)) {
+      formatErrors.schoolZipCode = 'Must be a valid zip code';
     }
 
     return formatErrors;

--- a/apps/test/unit/code-studio/pd/application/PrincipalApprovalComponentTest.js
+++ b/apps/test/unit/code-studio/pd/application/PrincipalApprovalComponentTest.js
@@ -75,7 +75,7 @@ describe('Principal Approval Component', () => {
     expect(actualFields).to.deep.equal(expectedFields);
   });
 
-  it('Expect student enrollment to be an integer', () => {
+  it('Expect student enrollment to be a positive integer', () => {
     ['10000', '1,000,000'].forEach(validEnrollmentNumber => {
       expect(
         PrincipalApprovalComponent.getErrorMessages({
@@ -85,14 +85,14 @@ describe('Principal Approval Component', () => {
     });
   });
 
-  it('Non integers create errors for student enrollments', () => {
-    ['10.5', 'So many', '0x1234'].forEach(invalidEnrollmentNumber => {
+  it('Invalid values create errors for student enrollments', () => {
+    ['0', '10.5', 'So many', '0x1234'].forEach(invalidEnrollmentNumber => {
       expect(
         PrincipalApprovalComponent.getErrorMessages({
           totalStudentEnrollment: invalidEnrollmentNumber
         })
       ).to.deep.equal({
-        totalStudentEnrollment: 'Must be a valid number'
+        totalStudentEnrollment: 'Must be a valid and positive number'
       });
     });
   });


### PR DESCRIPTION
# Description
Enforce the following constraints from the client side
**In Teacher Application**
- Class section minutes per day must be positive number from 1-480 inclusive
- Class section days per week must be positive number between 1-7 inclusive
- Class section weeks per year must be positive number from 1-52 inclusive
- School Zip Code must be a number
<img width="640" alt="Screen Shot 2019-10-15 at 3 01 14 PM" src="https://user-images.githubusercontent.com/46507039/66873822-4ed42100-ef5e-11e9-89cc-d41072a7f4fa.png">
<img width="424" alt="Screen Shot 2019-10-15 at 2 57 12 PM" src="https://user-images.githubusercontent.com/46507039/66873820-4ed42100-ef5e-11e9-8e6e-fcdf5d6bf0dd.png">

**In Principal approval application**
- Student enrollment must be positive integer
- Avoid turning empty demographics questions into "N/A" when submitting. (They are currently turned into "N/A" because we call `parseFloat` on an empty value, and then transform the result into a string.)
- School zip code should be validated

<img width="420" alt="Screen Shot 2019-10-15 at 3 14 12 PM" src="https://user-images.githubusercontent.com/46507039/66873923-88a52780-ef5e-11e9-97d3-dc3d8553f971.png">
<img width="419" alt="Screen Shot 2019-10-15 at 3 14 33 PM" src="https://user-images.githubusercontent.com/46507039/66873918-85aa3700-ef5e-11e9-9c4c-5c1e16f5e34b.png">

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-231)
