### PR TITLE
Upgrade phantomjs to 2.1.1.0 [test apps][skip ui]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,7 +152,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use jquery as the JavaScript library.
 gem 'jquery-rails'
 
-gem 'phantomjs', '~> 1.9.7.1'
+gem 'phantomjs', '~> 2.1.1.0'
 
 # For emoji in utility output.
 gem 'gemoji'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -616,7 +616,7 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.0.0)
-    phantomjs (1.9.7.1)
+    phantomjs (2.1.1.0)
     powerpack (0.1.1)
     progress (3.3.1)
     pry (0.12.2)
@@ -985,7 +985,7 @@ DEPENDENCIES
   pdf-reader
   petit!
   pg
-  phantomjs (~> 1.9.7.1)
+  phantomjs (~> 2.1.1.0)
   pry
   puma!
   puma_worker_killer


### PR DESCRIPTION
# Description

Since the ubuntu 18 upgrade, PhantomJS consistently crashes when trying to generate pdfs: https://app.honeybadger.io/projects/45435/faults/33478568

This upgrade should fix it. I tested both versions on a fresh ubuntu 18 ec2 instance - the crash repros using 1.9.7.1, but it succeeds on 2.1.1.0.

## Testing story

We use phantomjs primarily for apps testing, so if drone tests succeed hopefully we should be good. If we merge this I'll verify pdf generation on staging manually.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
