### PR TITLE
Assignment Updates: use real data to show "assigned" on a CourseScript

### DIFF
--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -240,6 +240,7 @@ export default class CourseOverview extends Component {
             name={script.name}
             id={script.id}
             description={script.description}
+            assignedSectionId={script.assigned_section_id}
           />
         ))}
       </div>

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -62,6 +62,7 @@ class CourseScript extends Component {
     name: PropTypes.string,
     id: PropTypes.number.isRequired,
     description: PropTypes.string,
+    assignedSectionId: PropTypes.number,
 
     // redux provided
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
@@ -98,7 +99,8 @@ class CourseScript extends Component {
       viewAs,
       selectedSectionId,
       hiddenStageState,
-      hasNoSections
+      hasNoSections,
+      assignedSectionId
     } = this.props;
 
     const isHidden = isScriptHiddenForSection(
@@ -110,6 +112,8 @@ class CourseScript extends Component {
     if (isHidden && viewAs === ViewType.Student) {
       return null;
     }
+
+    const isAssigned = assignedSectionId === parseInt(selectedSectionId);
 
     return (
       <div
@@ -129,7 +133,7 @@ class CourseScript extends Component {
             color={Button.ButtonColor.gray}
             className="uitest-go-to-unit-button"
           />
-          {experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
+          {isAssigned && experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
             <span style={styles.assigned}>
               <FontAwesome icon="check" />
               {i18n.assigned()}

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -277,7 +277,7 @@ class Course < ApplicationRecord
       description_teacher: I18n.t("data.course.name.#{name}.description_teacher", default: ''),
       scripts: scripts_for_user(user).map do |script|
         include_stages = false
-        script.summarize(include_stages).merge!(script.summarize_i18n(include_stages))
+        script.summarize(include_stages, user).merge!(script.summarize_i18n(include_stages))
       end,
       teacher_resources: teacher_resources,
       has_verified_resources: has_verified_resources?,

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1329,6 +1329,10 @@ class Script < ActiveRecord::Base
     has_older_script_progress = has_older_version_progress?(user)
     user_script = user && user_scripts.find_by(user: user)
 
+    # If the current user is assigned to this script, get the section
+    # that assigned it.
+    assigned_section_id = user&.assigned_script?(self) ? user.section_for_script(self)&.id : nil
+
     summary = {
       id: id,
       name: name,
@@ -1366,7 +1370,8 @@ class Script < ActiveRecord::Base
       project_sharing: project_sharing,
       curriculum_umbrella: curriculum_umbrella,
       family_name: family_name,
-      version_year: version_year
+      version_year: version_year,
+      assigned_section_id: assigned_section_id
     }
 
     summary[:stages] = stages.map {|stage| stage.summarize(include_bonus_levels)} if include_stages


### PR DESCRIPTION
# Description
We're in the process of updating how teachers assign courses and units to sections and clarifying in the UI which sections are assigned to which courses or units as detailed in the linked spec below.  
This is a continuation of #31071 in which I use real data about the user's section assignment to determine whether to show the "Assigned" indicator for assigned units on the course overview page based on the selected section. 

<img width="1066" alt="Screen Shot 2019-10-15 at 3 04 31 PM" src="https://user-images.githubusercontent.com/12300669/66873968-a6728c80-ef5e-11e9-92ae-5ee38cca90f8.png">

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1vJySqyKozUxknkhY1KyQXWzbV-0c1vdnpKvRsAsVrdI/edit#bookmark=id.2pywcek2omng)
- [jira, LP-706](https://codedotorg.atlassian.net/browse/LP-706)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
