### PR TITLE
Split application reads to read-replica

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -112,6 +112,7 @@ cat <<JSON > $FIRST_BOOT
 <% end -%>
 <% if TEMPLATE == 'cloud_formation_stack.yml.erb' && @database -%>
     "db_writer": "mysql://$DB_USERNAME:$DB_PASSWORD@${AuroraCluster.Endpoint.Address}:${AuroraCluster.Endpoint.Port}/",
+    "db_reader": "mysql://$DB_USERNAME:$DB_PASSWORD@${AuroraCluster.ReadEndpoint.Address}:${AuroraCluster.Endpoint.Port}/",
 <% end -%>
 <% unless cdn_enabled -%>
     "cdn_enabled": false,

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -96,7 +96,7 @@ class ActivitiesController < ApplicationController
       params[:lines] = MAX_LINES_OF_CODE if params[:lines] > MAX_LINES_OF_CODE
     end
 
-    @level_source_image = find_or_create_level_source_image(params[:image], @level_source.try(:id))
+    @level_source_image = find_or_create_level_source_image(params[:image], @level_source)
 
     @new_level_completed = false
     if current_user

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -15,6 +15,8 @@ class ActivitiesController < ApplicationController
   MIN_LINES_OF_CODE = 0
   MAX_LINES_OF_CODE = 1000
 
+  use_database_pool milestone: :persistent
+
   def milestone
     # TODO: do we use the :result and :testResult params for the same thing?
     solved = ('true' == params[:result])

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -192,6 +192,8 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
     render json: @workshop, serializer: Api::V1::Pd::WorkshopSummarySerializer
   end
 
+  use_database_pool potential_organizers: :persistent
+
   # Users who could be re-assigned to be the organizer of this workshop
   def potential_organizers
     render json: @workshop.potential_organizers.pluck(:name, :id).map do |name, id|

--- a/dashboard/app/controllers/api/v1/sections_students_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_students_controller.rb
@@ -17,6 +17,8 @@ class Api::V1::SectionsStudentsController < Api::V1::JsonApiController
     render json: summaries
   end
 
+  use_database_pool completed_levels_count: :persistent
+
   # GET /sections/<section_id>/students/completed_levels_count
   def completed_levels_count
     passing_level_counts = UserLevel.count_passed_levels_for_users(@section.students)

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -144,6 +144,8 @@ class ApiController < ApplicationController
     render json: {}
   end
 
+  use_database_pool lockable_state: :persistent
+
   # For a given user, gets the lockable state for each student in each of their sections
   def lockable_state
     unless current_user
@@ -167,6 +169,8 @@ class ApiController < ApplicationController
 
     render json: data
   end
+
+  use_database_pool section_progress: :persistent
 
   def section_progress
     section = load_section
@@ -242,6 +246,8 @@ class ApiController < ApplicationController
     render json: data
   end
 
+  use_database_pool section_level_progress: :persistent
+
   # This API returns data similar to user_progress, but aggregated for all users
   # in the section. It also only returns the "levels" portion
   # If not specified, the API will default to a page size of 50, providing the first page
@@ -303,6 +309,8 @@ class ApiController < ApplicationController
     end
   end
 
+  use_database_pool student_progress: :persistent
+
   def student_progress
     student = load_student(params.require(:student_id))
     section = load_section
@@ -334,6 +342,8 @@ class ApiController < ApplicationController
     render json: summary
   end
 
+  use_database_pool user_progress: :persistent
+
   # Return a JSON summary of the user's progress for params[:script].
   def user_progress
     if current_user
@@ -345,6 +355,8 @@ class ApiController < ApplicationController
       render json: {}
     end
   end
+
+  use_database_pool user_progress_for_stage: :persistent
 
   # Return the JSON details of the users progress on a particular script
   # level and marks the user as having started that level. (Because of the

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -8,9 +8,7 @@ class ApplicationController < ActionController::Base
   include LocaleHelper
   include ApplicationHelper
 
-  # Commenting this stuff out because even if we don't have a reader configured
-  # it will set stuff in the session.
-  # include SeamlessDatabasePool::ControllerFilter
+  include SeamlessDatabasePool::ControllerFilter
   # use_database_pool :all => :master
 
   # Prevent CSRF attacks by raising an exception.

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -431,7 +431,7 @@ class LevelsController < ApplicationController
     )
     level_source_image = find_or_create_level_source_image(
       params[:image],
-      level_source.try(:id),
+      level_source,
       true
     )
     @level.properties['solution_image_url'] = level_source_image.s3_url if level_source_image

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -74,6 +74,7 @@ class ScriptLevelsController < ApplicationController
     redirect_to(path) && return
   end
 
+  use_database_pool show: :persistent
   def show
     @current_user = current_user && User.includes(:teachers).where(id: current_user.id).first
     authorize! :read, ScriptLevel

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -824,17 +824,17 @@ module LevelsHelper
   # LevelSourceImage using the image data in level_image.
   #
   # @param level_image [String] A base64-encoded image.
-  # @param level_source_id [Integer, nil] The id of a LevelSource or nil.
+  # @param level_source [LevelSource, nil] LevelSource or nil.
   # @param upgrade [Boolean] Whether to replace the saved image if level_image
   #   is higher resolution
   # @returns [LevelSourceImage] A level source image, or nil if one was not
   # created or found.
-  def find_or_create_level_source_image(level_image, level_source_id, upgrade=false)
+  def find_or_create_level_source_image(level_image, level_source, upgrade=false)
     level_source_image = nil
     # Store the image only if the image is set, and either the image has not been
     # saved or the saved image is smaller than the provided image
-    if level_image && level_source_id
-      level_source_image = LevelSourceImage.find_by(level_source_id: level_source_id)
+    if level_image && level_source
+      level_source_image = LevelSourceImage.find_by(level_source: level_source)
       upgradable = false
       if upgrade && level_source_image
         old_image_size = ImageSize.path(level_source_image.s3_url)
@@ -843,7 +843,7 @@ module LevelsHelper
           new_image_size.height > old_image_size.height
       end
       if !level_source_image || upgradable
-        level_source_image = LevelSourceImage.new(level_source_id: level_source_id)
+        level_source_image = LevelSourceImage.new(level_source: level_source)
         unless level_source_image.save_to_s3(Base64.decode64(level_image))
           level_source_image = nil
         end

--- a/dashboard/app/helpers/read_replica_helper.rb
+++ b/dashboard/app/helpers/read_replica_helper.rb
@@ -1,0 +1,23 @@
+require 'dynamic_config/gatekeeper'
+
+module ReadReplicaHelper
+  def self.included(base)
+    SeamlessDatabasePool::ControllerFilter.prepend GatekeeperReadReplica
+  end
+
+  # Wrap SeamlessDatabasePool::ControllerFilter methods in Gatekeeper flag
+  # to allow dynamic control over offloading queries to the read pool.
+  module GatekeeperReadReplica
+    def read_replica?
+      Gatekeeper.allows('dashboard_read_replica')
+    end
+
+    def use_master_db_connection_on_next_request
+      super if read_replica?
+    end
+
+    def set_read_only_connection_for_block(action)
+      read_replica? ? super : yield
+    end
+  end
+end

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -5,7 +5,7 @@
 # configure the read pool
 
 writer = URI.parse(CDO.dashboard_db_writer) if CDO.dashboard_db_writer
-reader = URI.parse(CDO.dashboard_reporting_db_reader) if CDO.dashboard_reporting_db_reader
+reader = URI.parse(CDO.dashboard_db_reader) if CDO.dashboard_db_reader
 %>
 
 mysql_defaults: &mysql_defaults

--- a/lib/cdo/db.rb
+++ b/lib/cdo/db.rb
@@ -2,6 +2,7 @@ require 'sequel'
 require 'sequel/connection_pool/threaded'
 require 'cdo/cache'
 require pegasus_dir 'data/static_models'
+require 'dynamic_config/gatekeeper'
 
 # Connects to database.  Uses the Sequel connection_validator:
 #   http://sequel.jeremyevans.net/rdoc-plugins/files/lib/sequel/extensions/connection_validator_rb.html
@@ -67,8 +68,10 @@ def sequel_connect(writer, reader, validation_frequency: nil, query_timeout: nil
     db_options[:flags] = ::Mysql2::Client::MULTI_STATEMENTS
   end
 
-  if (reader_uri = URI(reader)).host != URI(writer).host
-    db_options[:servers] = {read_only: {host: reader_uri.host}}
+  if (reader_uri = URI(reader)).host != URI(writer).host &&
+    Gatekeeper.allows('pegasus_read_replica')
+
+    db_options[:servers] = {read_only: Sequel::Database.send(:uri_to_options, reader_uri)}
   end
   db = Sequel.connect writer, db_options
 


### PR DESCRIPTION
# Description

Split application reads to read-replica, controlled by `(pegasus|dashboard)_read_replica` gatekeeper flags (disabled by default).

- In `dashboard`, application read-splitting is handled by the [`seamless_database_pool`](https://github.com/bdurand/seamless_database_pool) adapter's `SeamlessDatabasePool::ControllerFilter` component. I've patched the methods in this component to control read_replica offloading at runtime based on the `dashboard_read_replica` gatekeeper flag for easier testing/rollback.

For the incremental step in this PR I've manually enabled a small handful of Rails controller-actions for read splitting, including a handful of `Api` actions, `ScriptLevels#show` and `Activities#milestone` (our highest-volume actions), and two actions with known slow queries (`SectionsStudents#completed_levels_count` and `Workshops#potential_organizers`).

- In `pegasus`, application read-splitting is handled by Sequel's built-in [replica support](https://github.com/jeremyevans/sequel/blob/master/doc/sharding.rdoc#single-primary-single-replica), using the hard-coded `:read_only` server hash option that offloads `SELECT` queries to the specified server. All I've done in this PR is further instrument the existing read-splitting to remain off unless the `pegasus_read_replica` flag is enabled (which I don't intend to do as part of this initial incremental step). This is necessary to prevent read-splitting from being unintentionally enabled for all `pegasus` queries when changing `db_reader` to the Aurora reader endpoint.

### Background

Offloading application reads to a read-replica cluster endpoint will help improve overall database performance within RDS Aurora.

Our existing application codebase was already configured for read-splitting via the above methods, whenever `db_reader` and `db_writer` URI's `host` values were set differently. However, they haven't been different in production for several years (currently only the `username` and `password` values are different), which is why a carefully controlled deployment-rollout is needed to reduce risk of unintended problems in features developed without read-splitting.

Although the Aurora reader endpoint should provide reliable, mostly-up-to-date query results (currently within <25ms), read-splitting introduces a slight behavior change in the case of 'read after write' queries occurring within a single application-transaction (which can occur more quickly than the 25ms replication lag). One example of this is calling `#reload` on a newly-created autoincrement-id ActiveRecord model: https://github.com/code-dot-org/code-dot-org/blob/4e1c7dec18a34cce6ef50bd7874e2319a8a66fa6/dashboard/app/models/course.rb#L190-L191:

Though these cases can cause issues they are likely quite rare, and once identified they can be mitigated by wrapping the problem queries in a single database transaction (which will send all queries to the writer endpoint).

The longer-term goal is to identify these problematic read-after-write operations in our application through testing and validation so we can enable read-write splitting globally without any manual, complicated read-splitting instrumentation throughout the application, which will be the simplest and most maintainable, as well as best-performing, configuration long-term.

### Testing

Manually tested in development with `db_writer` set to `will@localhost` and `db_reader` configured to `will2@127.0.0.1` (so the host names would be different), ensuring that reads within the selected controller-actions were sent through the `will2` when `dashboard_read_replica` flag was enabled and through `will` when disabled. Also confirmed that `pegasus` queries were all sent to the `db_writer` endpoint only.

### Deployment strategy

- [x] Ensure CI tests passing
- [ ] Test in canary frontend instance
  - [x] Manually deploy commit to canary
  - [x] Manually update `db_reader` in canary
  - [x] Enable gatekeeper flag in `production` env
  - [x] Ensure canary serves requests without errors
  - [x] Disable gatekeeper flag
- [x] Merge PR to deploy with flag off
  - [ ] Update `db_reader` in production env before deploy
- [ ] Turn on flag and monitor for errors
- [ ] Merge followup PR to set flag default to true