### PR TITLE
[Applab Datasets] Enforce that tables must be uniquely named

### DIFF
--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -1,5 +1,8 @@
 import Radium from 'radium';
 import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {showWarning} from '../redux/data';
 import LibraryCategory from './LibraryCategory';
 import SearchBar from '@cdo/apps/templates/SearchBar';
 import {categories} from './datasetManifest.json';
@@ -26,18 +29,32 @@ const styles = {
 };
 
 class DataLibraryPane extends React.Component {
+  static propTypes = {
+    // from redux dispatch
+    onShowWarning: PropTypes.func.isRequired
+  };
+
+  onError = error => {
+    if (
+      typeof error === 'string' &&
+      error.includes('There is already a table with name')
+    ) {
+      this.props.onShowWarning(error);
+    }
+  };
+
   importTable = datasetInfo => {
     if (datasetInfo.current) {
       FirebaseStorage.addCurrentTableToProject(
         datasetInfo.name,
         () => console.log('success'),
-        err => console.log(err)
+        this.onError
       );
     } else {
       FirebaseStorage.copyStaticTable(
         datasetInfo.name,
         () => console.log('success'),
-        err => console.log(err)
+        this.onError
       );
     }
   };
@@ -66,4 +83,11 @@ class DataLibraryPane extends React.Component {
   }
 }
 
-export default Radium(DataLibraryPane);
+export default connect(
+  state => ({}),
+  dispatch => ({
+    onShowWarning(warningMsg, warningTitle) {
+      dispatch(showWarning(warningMsg, warningTitle));
+    }
+  })
+)(Radium(DataLibraryPane));

--- a/apps/src/storage/dataBrowser/DataOverview.jsx
+++ b/apps/src/storage/dataBrowser/DataOverview.jsx
@@ -66,7 +66,8 @@ class DataOverview extends React.Component {
           typeof error === 'string' &&
           (error.includes('maximum number of tables') ||
             error.includes('The table name is invalid') ||
-            error.includes('The table was renamed'))
+            error.includes('The table was renamed') ||
+            error.includes('There is already a table with name'))
         ) {
           this.props.onShowWarning(error);
         } else {

--- a/apps/src/storage/firebaseUtils.js
+++ b/apps/src/storage/firebaseUtils.js
@@ -79,6 +79,10 @@ export function getRecordsRef(tableName) {
   return getProjectDatabase().child(`storage/tables/${tableName}/records`);
 }
 
+export function getProjectCountersRef(tableName) {
+  return getProjectDatabase().child(`counters/tables/${tableName}`);
+}
+
 export function getSharedDatabase() {
   return getFirebase().child('v3/channels/shared');
 }

--- a/apps/test/unit/storage/FirebaseStorageTest.js
+++ b/apps/test/unit/storage/FirebaseStorageTest.js
@@ -403,6 +403,122 @@ describe('FirebaseStorage', () => {
         );
       }
     });
+
+    it('Cannot overwrite existing project table', done => {
+      const expectedTableData = {
+        1: '{"id":1,"col1":"value1"}'
+      };
+      getSharedDatabase()
+        .child('counters/tables/mytable')
+        .set({lastId: 1, rowCount: 1});
+      getSharedDatabase()
+        .child('storage/tables/mytable/records')
+        .set(expectedTableData);
+
+      FirebaseStorage.copyStaticTable(
+        'mytable',
+        () => {
+          FirebaseStorage.createTable(
+            'mytable',
+            () => {
+              throw 'unexpectedly allowed to overwrite existing table';
+            },
+            err => {
+              expect(err.indexOf('There is already a table with name') !== -1)
+                .to.be.true;
+              done();
+            }
+          );
+        },
+        () => {
+          throw 'error';
+        }
+      );
+    });
+
+    it('Cannot overwrite existing current table', done => {
+      const expectedTableData = {
+        1: '{"id":1,"col1":"value1"}'
+      };
+      getSharedDatabase()
+        .child('counters/tables/mytable')
+        .set({lastId: 1, rowCount: 1});
+      getSharedDatabase()
+        .child('storage/tables/mytable/records')
+        .set(expectedTableData);
+
+      FirebaseStorage.addCurrentTableToProject(
+        'mytable',
+        () => {
+          FirebaseStorage.createTable(
+            'mytable',
+            () => {
+              throw 'unexpectedly allowed to overwrite existing table';
+            },
+            err => {
+              expect(err.indexOf('There is already a table with name') !== -1)
+                .to.be.true;
+              done();
+            }
+          );
+        },
+        () => {
+          throw 'error';
+        }
+      );
+    });
+  });
+
+  describe('addCurrentTableToProject', () => {
+    it('Sets the flag in the current_tables', done => {
+      const expectedTableData = {
+        1: '{"id":1,"col1":"value1"}'
+      };
+      getSharedDatabase()
+        .child('counters/tables/mytable')
+        .set({lastId: 1, rowCount: 1});
+      getSharedDatabase()
+        .child('storage/tables/mytable/records')
+        .set(expectedTableData);
+
+      FirebaseStorage.addCurrentTableToProject(
+        'mytable',
+        () => {
+          getProjectDatabase()
+            .child('current_tables/mytable')
+            .once('value')
+            .then(snapshot => {
+              expect(snapshot.val()).to.be.true;
+              done();
+            });
+        },
+        err => {
+          throw err;
+        }
+      );
+    });
+
+    it('Cannot overwrite existing project table', done => {
+      FirebaseStorage.createTable(
+        'mytable',
+        () => {
+          FirebaseStorage.addCurrentTableToProject(
+            'mytable',
+            () => {
+              throw 'unexpectedly allowed to overwrite existing table';
+            },
+            err => {
+              expect(err.indexOf('There is already a table with name') !== -1)
+                .to.be.true;
+              done();
+            }
+          );
+        },
+        () => {
+          throw 'error';
+        }
+      );
+    });
   });
 
   describe('copyStaticTable', () => {
@@ -422,6 +538,50 @@ describe('FirebaseStorage', () => {
       FirebaseStorage.copyStaticTable(
         'mytable',
         () => validateTableData(expectedTableData, done),
+        () => {
+          throw 'error';
+        }
+      );
+    });
+
+    it('Cannot overwrite an existing project table', done => {
+      FirebaseStorage.createTable(
+        'mytable',
+        () => {
+          FirebaseStorage.copyStaticTable(
+            'mytable',
+            () => {
+              throw 'unexpectedly allowed to overwrite existing table';
+            },
+            err => {
+              expect(err.indexOf('There is already a table with name') !== -1)
+                .to.be.true;
+              done();
+            }
+          );
+        },
+        () => {
+          throw 'error';
+        }
+      );
+    });
+
+    it('Cannot overwrite an existing current table', done => {
+      FirebaseStorage.addCurrentTableToProject(
+        'mytable',
+        () => {
+          FirebaseStorage.copyStaticTable(
+            'mytable',
+            () => {
+              throw 'unexpectedly allowed to overwrite existing table';
+            },
+            err => {
+              expect(err.indexOf('There is already a table with name') !== -1)
+                .to.be.true;
+              done();
+            }
+          );
+        },
         () => {
           throw 'error';
         }


### PR DESCRIPTION
# Description
We would like to enforce that there are no name collisions between current tables and project tables. This change will prevent you from either importing or creating a table with the same name as an existing table.

![image](https://user-images.githubusercontent.com/8787187/66877875-2bb06e00-ef6c-11e9-8632-b9d0546df6bc.png)

## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-762)

## Testing story

Unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
