### PR TITLE
do not show stage edit gui if any script level variants have experiments

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -41,6 +41,7 @@ const CURRICULUM_UMBRELLAS = ['CSF', 'CSD', 'CSP'];
 export default class ScriptEditor extends React.Component {
   static propTypes = {
     beta: PropTypes.bool,
+    betaWarning: PropTypes.string,
     name: PropTypes.string.isRequired,
     i18nData: PropTypes.object.isRequired,
     hidden: PropTypes.bool,
@@ -114,6 +115,7 @@ export default class ScriptEditor extends React.Component {
   };
 
   render() {
+    const {betaWarning} = this.props;
     const textAreaRows = this.props.stageLevelData
       ? this.props.stageLevelData.split('\n').length + 5
       : 10;
@@ -475,9 +477,11 @@ export default class ScriptEditor extends React.Component {
           <FlexGroup />
         ) : (
           <div>
-            <a href="?beta=true">
-              Try the beta Script Editor (will reload the page without saving)
-            </a>
+            {betaWarning || (
+              <a href="?beta=true">
+                Try the beta Script Editor (will reload the page without saving)
+              </a>
+            )}
             <textarea
               id="script_text"
               name="script_text"

--- a/apps/src/sites/studio/pages/scripts/_form.js
+++ b/apps/src/sites/studio/pages/scripts/_form.js
@@ -56,6 +56,7 @@ export default function initPage(scriptEditorData) {
     <Provider store={store}>
       <ScriptEditor
         beta={scriptEditorData.beta}
+        betaWarning={scriptEditorData.betaWarning}
         name={scriptEditorData.script.name}
         i18nData={scriptEditorData.i18n}
         hidden={valueOr(scriptData.hidden, true)}

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -81,12 +81,13 @@ class ScriptsController < ApplicationController
   end
 
   def edit
+    beta = params[:beta].present?
     @show_all_instructions = params[:show_all_instructions]
     @script_data = {
       script: @script ? @script.summarize_for_edit : {},
       i18n: @script ? @script.summarize_i18n : {},
-      beta: params[:beta].present?,
-      levelKeyList: params[:beta] && Level.key_list,
+      beta: beta,
+      levelKeyList: beta && Level.key_list,
       stageLevelData: @script_file,
       locales: options_for_locale_select,
       script_families: ScriptConstants::FAMILY_NAMES,

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -82,6 +82,18 @@ class ScriptsController < ApplicationController
 
   def edit
     @show_all_instructions = params[:show_all_instructions]
+    @script_data = {
+      script: @script ? @script.summarize_for_edit : {},
+      i18n: @script ? @script.summarize_i18n : {},
+      beta: params[:beta].present?,
+      levelKeyList: params[:beta] && Level.key_list,
+      stageLevelData: @script_file,
+      locales: options_for_locale_select,
+      script_families: ScriptConstants::FAMILY_NAMES,
+      version_year_options: Script.get_version_year_options,
+      flex_category_map: I18n.t('flex_category'),
+      is_levelbuilder: current_user.levelbuilder?
+    }
   end
 
   def update

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -82,6 +82,9 @@ class ScriptsController < ApplicationController
 
   def edit
     beta = params[:beta].present?
+    if @script.script_levels.any?(&:has_experiment?)
+      beta = false
+    end
     @show_all_instructions = params[:show_all_instructions]
     @script_data = {
       script: @script ? @script.summarize_for_edit : {},

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -84,12 +84,14 @@ class ScriptsController < ApplicationController
     beta = params[:beta].present?
     if @script.script_levels.any?(&:has_experiment?)
       beta = false
+      beta_warning = "The beta Script Editor is not available, because it does not support level variants with experiments."
     end
     @show_all_instructions = params[:show_all_instructions]
     @script_data = {
       script: @script ? @script.summarize_for_edit : {},
       i18n: @script ? @script.summarize_i18n : {},
       beta: beta,
+      betaWarning: beta_warning,
       levelKeyList: beta && Level.key_list,
       stageLevelData: @script_file,
       locales: options_for_locale_select,

--- a/dashboard/app/views/scripts/_form.html.haml
+++ b/dashboard/app/views/scripts/_form.html.haml
@@ -14,19 +14,8 @@
   - else
     = f.hidden_field :name
   .edit_container
-  - include_stages = params[:beta].present?
-  - scriptData = {script: @script ? @script.summarize_for_edit : {},
-                  i18n: @script ? @script.summarize_i18n : {},
-                  beta: params[:beta].present?,
-                  levelKeyList: params[:beta] && Level.key_list,
-                  stageLevelData: @script_file,
-                  locales: options_for_locale_select,
-                  script_families: ScriptConstants::FAMILY_NAMES,
-                  version_year_options: Script.get_version_year_options,
-                  flex_category_map: I18n.t('flex_category'),
-                  is_levelbuilder: current_user.levelbuilder?}
   %script{src: webpack_asset_path('js/scripts/_form.js'),
-          data: {levelBuilderEditScript: scriptData.to_json}}
+          data: {levelBuilderEditScript: @script_data.to_json}}
 
 - if @show_all_instructions
   - @script.stages.each do |stage|

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -530,4 +530,36 @@ class ScriptsControllerTest < ActionController::TestCase
     get :show, params: {id: 'coursea'}
     assert_redirected_to "/s/dogs2"
   end
+
+  test 'uses gui editor when script levels have variants without experiments' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    (1..2).map {|n| create(:level, name: "Level #{n}")}
+    script_file = File.join(self.class.fixture_path, "test-fixture-variants.script")
+    Script.setup([script_file])
+
+    get :edit, params: {id: 'test-fixture-variants', beta: true}
+    assert_response :success
+    assert_select "script[data-levelbuildereditscript]"
+    assert_select "script[data-levelbuildereditscript]" do |elements|
+      assert elements.first['data-levelbuildereditscript'].match?(/"beta":true/)
+    end
+  end
+
+  test 'uses dsl editor when script levels have variants with experiments' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    (1..2).map {|n| create(:level, name: "Level #{n}")}
+    script_file = File.join(self.class.fixture_path, "test-fixture-experiments.script")
+    Script.setup([script_file])
+
+    get :edit, params: {id: 'test-fixture-experiments'}
+    assert_response :success
+    assert_select "script[data-levelbuildereditscript]"
+    assert_select "script[data-levelbuildereditscript]" do |elements|
+      assert elements.first['data-levelbuildereditscript'].match?(/"beta":false/)
+    end
+  end
 end

--- a/dashboard/test/fixtures/test-fixture-experiments.script
+++ b/dashboard/test/fixtures/test-fixture-experiments.script
@@ -1,0 +1,5 @@
+stage 'Stage1'
+variants
+  level 'Level 1', active: true, experiments: ["control"]
+  level 'Level 2',  experiments: ["hypothesis"]
+endvariants


### PR DESCRIPTION
## Description

Our latest thinking is that new level-building tools should exclude deprecated features when possible. Though not officially deprecated yet, the level-swapping feature (a.k.a. `variants`) is a good candidate for deprecation because it is not actively used in current courses.

Therefore, instead of adding support for editing experiments on script level variants to the GUI stage editor, simply send the user back to the text-based stage editor when these experiments are present. This doesn't really increase our dependency on the text-based editor because our content editor team says they will want to keep using it regardless.

## Links

- [LP-679](https://codedotorg.atlassian.net/browse/LP-679)

## Testing story

new unit tests verify beta flag value in script data json.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
