### PR TITLE
Ignore X-Forwarded-Host request header

### DIFF
--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -41,6 +41,12 @@ module Cdo
       @site ||= site_from_host
     end
 
+    # Patch: don't use X_FORWARDED_HOST header when determining host from request headers.
+    def host_with_port
+      get_header(Rack::HTTP_HOST) ||
+        "#{get_header(Rack::SERVER_NAME) || get_header(Rack::SERVER_ADDR)}:#{get_header(Rack::SERVER_PORT)}"
+    end
+
     def site_from_host
       host_parts = host
       # staging-studio.code.org -> ['staging', 'studio', 'code', 'org']

--- a/pegasus/test/test_request.rb
+++ b/pegasus/test/test_request.rb
@@ -41,4 +41,12 @@ class RequestTest < Minitest::Test
     )
     assert Rack::Request.new('REMOTE_ADDR' => user_ip).gdpr?
   end
+
+  def test_x_forwarded_host
+    request = Rack::Request.new(
+      'HTTP_X_FORWARDED_HOST' => 'code.org',
+      'HTTP_HOST' => 'hourofcode.com'
+    )
+    assert_equal 'hourofcode.com', request.site
+  end
 end


### PR DESCRIPTION
# Description

Patches [`Rack::Request#host_with_port`](https://github.com/rack/rack/blob/2.0.7/lib/rack/request.rb#L225-L231) to not use [`X-Forwarded-Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host) header when
determining host from request headers.

This fixes a bug where a manually-crafted `X-Forwarded-Host` header in a request to domain-A can return page content intended for domain-B. This can poison the http-proxy cache which only varies based on the `Host` header, causing future requests to domain A (even without the crafted header) to return incorrect responses with the domain-B content.

## Testing story

Added unit test fails before the change and passes with it.