### PR TITLE
[Applab Datasets] Upload columns metadata for shared tables

### DIFF
--- a/bin/cron/upload_to_firebase
+++ b/bin/cron/upload_to_firebase
@@ -21,6 +21,7 @@ def get_weather_data
     WeatherForecastOffice.new("Wakefield", "Virginia", "23888")
   ]
   records = []
+  columns = %w(id city state timestamp temp_min temp_max weather icon wind_speed)
   id = 1
   forecast_offices.each do |office|
     url = "http://api.openweathermap.org/data/2.5/forecast?zip=#{office.zip},us&units=imperial&appid=c719e74bc77b787d940386405e0cbb83"
@@ -43,7 +44,7 @@ def get_weather_data
       id += 1
     end
   end
-  return records
+  return records, columns
 end
 
 def parse_csv(filename)
@@ -59,17 +60,18 @@ def parse_csv(filename)
     end
     records.push(record.to_h.to_json)
   end
-  return records
+  return records, table.headers
 end
 
 def main
   fb = FirebaseHelper.new('shared')
   if ARGV.empty?
-    records = get_weather_data
-    fb.upload_shared_table('openweathermap', records)
+    records, columns = get_weather_data
+    fb.delete_shared_table('openweathermap')
+    fb.upload_shared_table('openweathermap', records, columns)
   else
-    records = parse_csv ARGV[0]
-    fb.upload_shared_table(ARGV[1], records)
+    records, columns = parse_csv ARGV[0]
+    fb.upload_shared_table(ARGV[1], records, columns)
   end
 end
 

--- a/shared/middleware/helpers/firebase_helper.rb
+++ b/shared/middleware/helpers/firebase_helper.rb
@@ -29,11 +29,15 @@ class FirebaseHelper
   def delete_shared_table(table_name)
     @firebase.delete("/v3/channels/shared/counters/tables/#{table_name}")
     @firebase.delete("/v3/channels/shared/storage/tables/#{table_name}/records")
+    @firebase.delete("/v3/channels/shared/metadata/tables/#{table_name}/columns")
   end
 
-  def upload_shared_table(table_name, records)
+  def upload_shared_table(table_name, records, columns)
     @firebase.set("/v3/channels/shared/counters/tables/#{table_name}", {"lastId": records.length, "rowCount": records.length})
     @firebase.set("/v3/channels/shared/storage/tables/#{table_name}/records", records)
+    columns.each do |column|
+      @firebase.push("v3/channels/shared/metadata/tables/#{table_name}/columns", {columnName: column})
+    end
   end
 
   def self.delete_channel(encrypted_channel_id)


### PR DESCRIPTION
# Description
The metadata at `v3/channels/shared/metadata/tables/#{table_name}/columns` is used to set the column names in the redux state. We weren't uploading this metadata for shared tables. I didn't notice this issue because the data table view parses column names from the records, so everything seemed to be working. However, `this.props.tableColumns` was `[]` for all current tables, which became an issue in trying to implement the Data Visualizer. This PR makes sure we upload column metadata as well. 

![image](https://user-images.githubusercontent.com/8787187/66947311-85b24180-f007-11e9-8f0e-0b7d5b58e142.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
