### PR TITLE
hoc2019: Update "Share on Twitter" text at hourofcode.com/thanks a bit

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -358,7 +358,7 @@
 
   twitter_default_text: "I'm participating in this year's #HourOfCode, are you? @codeorg"
   twitter_donor_text: "This year's #HourOfCode is about creativity. I’m in! Are you? (Thanks %{random_donor} for supporting @codeorg)"
-  twitter_donor_text_2019: "This year's #HourOfCode is about #CSForGood. I’m in! Are you? (Thanks %{random_donor} for supporting @codeorg)"
+  twitter_donor_text_2019: "This year's #HourOfCode is about #CSforGood. I’m in! Are you? (Thanks %{random_donor} for supporting @codeorg)"
 
   hoc_faq_title: 'FAQs'
   hoc_faq_what_is_hoc_q: 'What is the Hour of Code?'


### PR DESCRIPTION
The hashtag is #CSforGood rather than #CSForGood.

Followup to https://github.com/code-dot-org/code-dot-org/pull/31269