### PR TITLE
Tweak workshop landing and regional partner page

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -371,16 +371,14 @@ class RegionalPartnerSearch extends Component {
             <div style={styles.clear} />
 
             <div style={styles.action}>
-              {appState !== WorkshopApplicationStates.now_closed &&
-                (workshopCollections[0].workshops.length > 0 ||
-                  workshopCollections[1].workshops.length > 0) && (
-                  <div>
-                    In addition to attending a five-day summer workshop, the
-                    professional learning program includes up to 4 required
-                    one-day, in-person academic year workshops during the
-                    2019-20 school year.
-                  </div>
-                )}
+              {appState !== WorkshopApplicationStates.now_closed && (
+                <div>
+                  The Professional Learning Program is a yearlong commitment,
+                  consisting of a five-day in-person summer workshop, plus
+                  follow up academic year workshops hosted in-person or
+                  virtually.
+                </div>
+              )}
 
               {appState === WorkshopApplicationStates.now_closed && (
                 <h3>Applications are now closed.</h3>
@@ -417,7 +415,7 @@ class RegionalPartnerSearch extends Component {
               {appState !== WorkshopApplicationStates.now_closed &&
                 partnerInfo.cost_scholarship_information && (
                   <div>
-                    <h3>Scholarship, discounts, and cost information:</h3>
+                    <h3>Program information</h3>
                     <div style={styles.scholarship}>
                       <SafeMarkdown
                         markdown={partnerInfo.cost_scholarship_information}
@@ -428,7 +426,7 @@ class RegionalPartnerSearch extends Component {
 
               {partnerInfo.additional_program_information && (
                 <div>
-                  <h3>Additional program information:</h3>
+                  <h3>More about your Regional Partner</h3>
                   <SafeMarkdown
                     markdown={partnerInfo.additional_program_information}
                   />
@@ -517,7 +515,7 @@ const StartApplicationButton = ({
     notificationText = 'Sign up now to reserve your space!';
   } else {
     notificationHeading =
-      'We still have spaces in the professional learning program!';
+      'We still have spaces in the Professional Learning Program!';
     notificationText = 'It’s not too late to sign up.';
   }
 

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -40,7 +40,7 @@
     = @regional_partner.send("#{course}_cost".to_sym)
 %p
   %strong
-    ="Cost/Scholarship Description"
+    ="Program information"
   = @regional_partner.cost_scholarship_information
 %p
   %strong Additional Partner information


### PR DESCRIPTION
# Description
Small changes for [PLC-504](https://codedotorg.atlassian.net/browse/PLC-504)
On workshop landing page ([example](https://code.org/educate/professional-learning/program-information)): 
- Capitalize _“Professional Learning Program”_
- Update text from _“In addition to attending...”_ to _“The Professional Learning Program is a yearlong commitment...”_. Show this text even when partner has no upcoming workshops.
- Rename “_Scholarship, discounts, and cost information:_” section header to “_Program information_”
- Rename _“Additional program information:”_ header to _“More about your Regional Partner”_

On regional partner page ([example](https://studio.code.org/regional_partners/9))
- Rename _“Cost/Scholarship Description”_ to _“Program information”_

    
