### PR TITLE
remove ngrok hostnames from startWebRequest whitelist

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -73,9 +73,6 @@ class XhrProxyController < ApplicationController
     rejseplanen.dk
     maker.ifttt.com
     noaa.gov
-    nuevaschool.ngrok.io
-    nuevaschool2.ngrok.io
-    nuevaschool3.ngrok.io
     numbersapi.com
     random.org
     restcountries.eu


### PR DESCRIPTION
# Description

When we added these entries in https://github.com/code-dot-org/code-dot-org/pull/18380, we thought they might be a bit of a security risk if they became used by anyone else so we decided to set up a reminder to remove them from the list. Nuevaschool has confirmed in https://codeorg.zendesk.com/agent/tickets/253074 that they aren't using these any more, and so now they're being removed.

