### PR TITLE
Assignment Updates: SectionAssigner on course overview

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -348,6 +348,7 @@
   "csfButton": "Try the course ",
   "csfExpressDesc": "Keep going with our intro course! Learn the fundamentals of computer science with drag & drop blocks. Create your own drawings and games.",
   "csfExpressTitle": "CS Fundamentals Express",
+  "currentSection": "Current section",
   "currentUnit": "Current unit:",
   "currentVersion": "Current Version",
   "curriculum": "Curriculum",

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -25,6 +25,7 @@ import AssignmentVersionSelector, {
   setRecommendedAndSelectedVersions
 } from '@cdo/apps/templates/teacherDashboard/AssignmentVersionSelector';
 import StudentFeedbackNotification from '@cdo/apps/templates/feedback/StudentFeedbackNotification';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   main: {
@@ -223,7 +224,9 @@ export default class CourseOverview extends Component {
         {showNotification && <VerifiedResourcesNotification />}
         {isTeacher && (
           <div>
-            <LabeledSectionSelector />
+            {!experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
+              <LabeledSectionSelector />
+            )}
             <CourseOverviewTopRow
               sectionsInfo={sectionsInfo}
               id={id}

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -5,6 +5,7 @@ import Button from '@cdo/apps/templates/Button';
 import {stringForType, resourceShape} from './resourceType';
 import experiments from '@cdo/apps/util/experiments';
 import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
+import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 
 const styles = {
   main: {
@@ -15,12 +16,7 @@ const styles = {
 
 export default class CourseOverviewTopRow extends Component {
   static propTypes = {
-    sectionsInfo: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.number.isRequired,
-        name: PropTypes.string.isRequired
-      })
-    ).isRequired,
+    sectionsInfo: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
     id: PropTypes.number.isRequired,
     title: PropTypes.string.isRequired,
     resources: PropTypes.arrayOf(resourceShape).isRequired,
@@ -32,13 +28,14 @@ export default class CourseOverviewTopRow extends Component {
 
     return (
       <div style={styles.main}>
-        {showAssignButton && (
-          <AssignToSection
-            sectionsInfo={sectionsInfo}
-            courseId={id}
-            assignmentName={title}
-          />
-        )}
+        {!experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) &&
+          showAssignButton && (
+            <AssignToSection
+              sectionsInfo={sectionsInfo}
+              courseId={id}
+              assignmentName={title}
+            />
+          )}
         {resources.map(({type, link}) => (
           <Button
             key={type}

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -3,6 +3,8 @@ import React, {Component} from 'react';
 import AssignToSection from './AssignToSection';
 import Button from '@cdo/apps/templates/Button';
 import {stringForType, resourceShape} from './resourceType';
+import experiments from '@cdo/apps/util/experiments';
+import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
 
 const styles = {
   main: {
@@ -47,6 +49,9 @@ export default class CourseOverviewTopRow extends Component {
             color={Button.ButtonColor.blue}
           />
         ))}
+        {experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
+          <SectionAssigner sections={sectionsInfo} />
+        )}
       </div>
     );
   }

--- a/apps/src/templates/teacherDashboard/SectionAssigner.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
+import i18n from '@cdo/locale';
 import {sectionForDropdownShape} from './shapes';
 import TeacherSectionSelector from './TeacherSectionSelector';
 import AssignedButton from '@cdo/apps/templates/AssignedButton';
@@ -8,8 +9,15 @@ import AssignButton from '@cdo/apps/templates/AssignButton';
 import {selectSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 const styles = {
-  main: {
+  content: {
     display: 'flex'
+  },
+  label: {
+    width: '100%',
+    fontSize: 16,
+    fontFamily: '"Gotham 5r", sans-serif',
+    paddingTop: 10,
+    paddingBottom: 10
   }
 };
 
@@ -41,14 +49,17 @@ class SectionAssigner extends Component {
     const {selectedSection} = this.state;
 
     return (
-      <div style={styles.main}>
-        <TeacherSectionSelector
-          sections={sections}
-          onChangeSection={this.onChangeSection}
-          selectedSection={selectedSection}
-        />
-        {selectedSection.isAssigned && <AssignedButton />}
-        {!selectedSection.isAssigned && <AssignButton />}
+      <div>
+        <div style={styles.label}>{i18n.currentSection()}</div>
+        <div style={styles.content}>
+          <TeacherSectionSelector
+            sections={sections}
+            onChangeSection={this.onChangeSection}
+            selectedSection={selectedSection}
+          />
+          {selectedSection.isAssigned && <AssignedButton />}
+          {!selectedSection.isAssigned && <AssignButton />}
+        </div>
       </div>
     );
   }

--- a/apps/src/templates/teacherDashboard/SectionAssigner.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.jsx
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
+import {connect} from 'react-redux';
 import {sectionForDropdownShape} from './shapes';
 import TeacherSectionSelector from './TeacherSectionSelector';
 import AssignedButton from '@cdo/apps/templates/AssignedButton';
 import AssignButton from '@cdo/apps/templates/AssignButton';
+import {selectSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 const styles = {
   main: {
@@ -11,14 +13,17 @@ const styles = {
   }
 };
 
-export default class SectionAssigner extends Component {
+class SectionAssigner extends Component {
   static propTypes = {
     sections: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
-    initialSelectedSection: PropTypes.object
+    selectedSectionId: PropTypes.string,
+    selectSection: PropTypes.func.isRequired
   };
 
   state = {
-    selectedSection: this.props.initialSelectedSection
+    selectedSection: this.props.sections.find(
+      section => section.id === parseInt(this.props.selectedSectionId)
+    )
   };
 
   onChangeSection = sectionId => {
@@ -48,3 +53,16 @@ export default class SectionAssigner extends Component {
     );
   }
 }
+
+export const UnconnectedSectionAssigner = SectionAssigner;
+
+export default connect(
+  state => ({
+    selectedSectionId: state.teacherSections.selectedSectionId
+  }),
+  dispatch => ({
+    selectSection(sectionId) {
+      dispatch(selectSection(sectionId));
+    }
+  })
+)(SectionAssigner);

--- a/apps/src/templates/teacherDashboard/SectionAssigner.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.jsx
@@ -16,13 +16,13 @@ const styles = {
 class SectionAssigner extends Component {
   static propTypes = {
     sections: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
-    selectedSectionId: PropTypes.string,
+    initialSelectedSectionId: PropTypes.number,
     selectSection: PropTypes.func.isRequired
   };
 
   state = {
     selectedSection: this.props.sections.find(
-      section => section.id === parseInt(this.props.selectedSectionId)
+      section => section.id === this.props.initialSelectedSectionId
     )
   };
 
@@ -58,7 +58,7 @@ export const UnconnectedSectionAssigner = SectionAssigner;
 
 export default connect(
   state => ({
-    selectedSectionId: state.teacherSections.selectedSectionId
+    initialSelectedSectionId: parseInt(state.teacherSections.selectedSectionId)
   }),
   dispatch => ({
     selectSection(sectionId) {

--- a/apps/src/templates/teacherDashboard/SectionAssigner.story.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {UnconnectedSectionAssigner as SectionAssigner} from './SectionAssigner';
+import {action} from '@storybook/addon-actions';
 import {fakeTeacherSectionsForDropdown} from './sectionAssignmentTestHelper';
 
 export default storybook => {
@@ -9,8 +10,9 @@ export default storybook => {
       story: () => (
         <div>
           <SectionAssigner
-            initialSelectedSection={fakeTeacherSectionsForDropdown[0]}
+            initialSelectedSectionId={fakeTeacherSectionsForDropdown[0].id}
             sections={fakeTeacherSectionsForDropdown}
+            selectSection={action('selectSection')}
           />
         </div>
       )

--- a/apps/src/templates/teacherDashboard/SectionAssigner.story.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import SectionAssigner from './SectionAssigner';
+import {UnconnectedSectionAssigner as SectionAssigner} from './SectionAssigner';
 import {fakeTeacherSectionsForDropdown} from './sectionAssignmentTestHelper';
 
 export default storybook => {

--- a/apps/test/unit/templates/teacherDashboard/SectionAssignerTest.js
+++ b/apps/test/unit/templates/teacherDashboard/SectionAssignerTest.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
-import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
+import {UnconnectedSectionAssigner as SectionAssigner} from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
 import {fakeTeacherSectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/sectionAssignmentTestHelper';
 
 describe('SectionAssigner', () => {
   it('renders a TeacherSectionSelector', () => {
     const wrapper = mount(
       <SectionAssigner
-        initialSelectedSection={fakeTeacherSectionsForDropdown[0]}
+        initialSelectedSectionId={fakeTeacherSectionsForDropdown[0].id}
         sections={fakeTeacherSectionsForDropdown}
+        selectSection={() => {}}
       />
     );
 
@@ -19,8 +20,9 @@ describe('SectionAssigner', () => {
   it('renders an AssignButton', () => {
     const wrapper = mount(
       <SectionAssigner
-        initialSelectedSection={fakeTeacherSectionsForDropdown[0]}
+        initialSelectedSectionId={fakeTeacherSectionsForDropdown[0].id}
         sections={fakeTeacherSectionsForDropdown}
+        selectSection={() => {}}
       />
     );
 
@@ -31,8 +33,9 @@ describe('SectionAssigner', () => {
   it('renders an AssignedButton', () => {
     const wrapper = mount(
       <SectionAssigner
-        initialSelectedSection={fakeTeacherSectionsForDropdown[1]}
+        initialSelectedSectionId={fakeTeacherSectionsForDropdown[1].id}
         sections={fakeTeacherSectionsForDropdown}
+        selectSection={() => {}}
       />
     );
 

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -2,7 +2,9 @@
 
 - data = {}
 - data[:course_summary] = course.summarize(@current_user)
-- data[:sections] = @current_user.try{|u| u.sections.where(hidden: false).select(:id, :name)} || []
+- sections = @current_user.try{|u| u.sections.where(hidden: false).select(:id, :name, :course_id)}
+- sections = sections.map { |section| section.attributes.merge!({"isAssigned" => section[:course_id] == course.id})}
+- data[:sections] = sections || []
 - data[:is_teacher] = @current_user.try(:teacher?) || false
 - data[:is_verified_teacher] = @current_user.try(:authorized_teacher?) || false
 - data[:hidden_scripts] = @current_user.try(:get_hidden_script_ids, course)

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -3,7 +3,7 @@
 - data = {}
 - data[:course_summary] = course.summarize(@current_user)
 - sections = @current_user.try{|u| u.sections.where(hidden: false).select(:id, :name, :course_id)}
-- sections = sections.map { |section| section.attributes.merge!({"isAssigned" => section[:course_id] == course.id})}
+- sections = sections&.map { |section| section.attributes.merge!({"isAssigned" => section[:course_id] == course.id})}
 - data[:sections] = sections || []
 - data[:is_teacher] = @current_user.try(:teacher?) || false
 - data[:is_verified_teacher] = @current_user.try(:authorized_teacher?) || false


### PR DESCRIPTION
Continuation of #31272. This PR uses the `SectionAssigner` component on the Course Overview page with real data behind the "assignmentUpdates"  experiment flag. For the selected section, if the current user has assigned or been assigned the course or any unit in the course there will be a green checkmark and the Assigned button. Story and tests have been updated to reflect changes based on connecting to Redux similar to the current `SectionSelector` in use on the Course overview page. 

<img width="1009" alt="Screen Shot 2019-10-17 at 4 13 38 PM" src="https://user-images.githubusercontent.com/12300669/67054691-40bb0780-f0fa-11e9-911b-ebcf1148ab3b.png">

- [spec](https://docs.google.com/document/d/1vJySqyKozUxknkhY1KyQXWzbV-0c1vdnpKvRsAsVrdI/edit)
- [jira LP-706](https://codedotorg.atlassian.net/browse/LP-706) partial

Follow up work:  
There is some functionality in the current SectionSelector not yet implemented in SectionAssigner. 

- [ ] update query params to reflect the id of the selected section 

- [x] show assign button conditionally based on whether the course/unit is a valid option for the selected section #31336

- [ ] similarly, use the `SectionAssigner` on unit overview pages #31328