### PR TITLE
Revert Revert "404 page dashboard - Route 404 errors to haml page" #31284

### DIFF
--- a/dashboard/app/assets/stylesheets/errors.scss
+++ b/dashboard/app/assets/stylesheets/errors.scss
@@ -1,86 +1,88 @@
 @import "color";
 @import "font";
 
-body {
-  font-family: 'Gotham 4r', sans-serif;
-  font-size: 14px;
-  line-height: 22px;
-  font-weight: normal;
-  color: $dimgray;
-  margin: 0;
-}
+.not-found-page {
+  body {
+    font-family: 'Gotham 4r', sans-serif;
+    font-size: 14px;
+    line-height: 22px;
+    font-weight: normal;
+    color: $dimgray;
+    margin: 0;
+  }
 
-h1 {
-  color: $purple;
-  font-size: 28px;
-  font-family: 'Gotham 7r', sans-serif;
-  margin-top: 50px;
-  margin-bottom: 30px;
-  line-height: 1.2em;
-}
+  h1 {
+    color: $purple;
+    font-size: 28px;
+    font-family: 'Gotham 7r', sans-serif;
+    margin-top: 50px;
+    margin-bottom: 30px;
+    line-height: 1.2em;
+  }
 
-button {
-  -webkit-appearance: none;
-  -webkit-user-select: none;
-  -webkit-writing-mode: horizontal-tb;
-  align-items: flex-start;
-  background-color: $orange;
-  border-color: $orange;
-  background-image: none;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  border-image-outset: 0;
-  border-image-repeat: stretch;
-  border-image-slice: 100%;
-  border-image-source: none;
-  border-image-width: 1;
-  border-left-style: solid;
-  border-left-width: 1px;
-  border-right-style: solid;
-  border-right-width: 1px;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-  border-top-style: solid;
-  border-top-width: 1px;
-  box-sizing: border-box;
-  color: $white;
-  cursor: pointer;
-  display: inline-block;
-  font-family: 'Gotham 4r', sans-serif;
-  font-size: 14px;
-  font-weight: normal;
-  height: 34px;
-  letter-spacing: normal;
-  line-height: 20px;
-  margin-bottom: 0;
-  margin-left: 0;
-  margin-right: 0;
-  margin-top: 30px;
-  padding-bottom: 6px;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  text-align: center;
-  text-indent: 0;
-  text-shadow: none;
-  text-transform: none;
-  vertical-align: middle;
-  white-space: nowrap;
-  word-spacing: 0;
-  writing-mode: lr-tb;
-}
+  button {
+    -webkit-appearance: none;
+    -webkit-user-select: none;
+    -webkit-writing-mode: horizontal-tb;
+    align-items: flex-start;
+    background-color: $orange;
+    border-color: $orange;
+    background-image: none;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    border-image-outset: 0;
+    border-image-repeat: stretch;
+    border-image-slice: 100%;
+    border-image-source: none;
+    border-image-width: 1;
+    border-left-style: solid;
+    border-left-width: 1px;
+    border-right-style: solid;
+    border-right-width: 1px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-top-style: solid;
+    border-top-width: 1px;
+    box-sizing: border-box;
+    color: $white;
+    cursor: pointer;
+    display: inline-block;
+    font-family: 'Gotham 4r', sans-serif;
+    font-size: 14px;
+    font-weight: normal;
+    height: 34px;
+    letter-spacing: normal;
+    line-height: 20px;
+    margin-bottom: 0;
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 30px;
+    padding-bottom: 6px;
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 6px;
+    text-align: center;
+    text-indent: 0;
+    text-shadow: none;
+    text-transform: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    word-spacing: 0;
+    writing-mode: lr-tb;
+  }
 
-.error-image {
-  margin-top: 50px;
-}
+  .error-image {
+    margin-top: 50px;
+  }
 
-.error-parent {
-  text-align: center;
-}
+  .error-parent {
+    text-align: center;
+  }
 
-.error-child {
-  display: inline-block;
-  max-width: 300px;
+  .error-child {
+    display: inline-block;
+    max-width: 300px;
+  }
 }

--- a/dashboard/app/views/errors/not_found.html.haml
+++ b/dashboard/app/views/errors/not_found.html.haml
@@ -1,11 +1,12 @@
-.error-parent
-  .error-child
-    %img{src: '/shared/images/sad-bee-avatar.png', alt: I18n.t(:page_not_found_title)}
-    %br
-    .error-message
-      %h1= I18n.t(:page_not_found_header)
-      = I18n.t(:page_not_found_description)
+.not-found-page
+  .error-parent
+    .error-child
+      %img{src: '/shared/images/sad-bee-avatar.png', alt: I18n.t(:page_not_found_title)}
       %br
-      %br
-      %a{href: '/'}
-        %button= I18n.t(:page_not_found_button)
+      .error-message
+        %h1= I18n.t(:page_not_found_header)
+        = I18n.t(:page_not_found_description)
+        %br
+        %br
+        %a{href: '/'}
+          %button= I18n.t(:page_not_found_button)


### PR DESCRIPTION
# Description
The styles in the errors.scss were applied to all pages and specifically altered the run the button.  A new class id (.not-found-page) was added to errors.scss so the styles are only applied to the 404 (not found page)

[revert](https://github.com/code-dot-org/code-dot-org/pull/31284)

Before
<img width="481" alt="Screen Shot 2019-10-16 at 10 59 44 PM" src="https://user-images.githubusercontent.com/30066710/66981521-d9a14280-f068-11e9-882f-e4d94f025169.png">


After
<img width="486" alt="Screen Shot 2019-10-16 at 10 59 11 PM" src="https://user-images.githubusercontent.com/30066710/66981558-efaf0300-f068-11e9-9449-67c0d3a36c88.png">



<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
