### PR TITLE
Fix style of survey rollup table

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -21,7 +21,7 @@ export class SurveyRollupTable extends React.Component {
   constructor(props) {
     super(props);
 
-    this.questionDenominator = {
+    this.categoryDenominator = {
       facilitator_effectiveness: 7,
       teacher_engagement: props.courseName === COURSE_CSF ? 5 : 7,
       overall_success: 7
@@ -107,7 +107,7 @@ export class SurveyRollupTable extends React.Component {
 
   renderAverage(value, category) {
     return value
-      ? `${value.toFixed(2)} / ${this.questionDenominator[category]}`
+      ? `${value.toFixed(2)} / ${this.categoryDenominator[category]}`
       : '-';
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Table} from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import {COURSE_CSF} from '../../workshopConstants';
 
 const questionCategories = [
   'facilitator_effectiveness',
@@ -11,6 +12,7 @@ const questionCategories = [
 
 export class SurveyRollupTable extends React.Component {
   static propTypes = {
+    courseName: PropTypes.string.isRequired,
     rollups: PropTypes.object.isRequired,
     questions: PropTypes.object.isRequired,
     facilitators: PropTypes.object.isRequired
@@ -18,6 +20,12 @@ export class SurveyRollupTable extends React.Component {
 
   constructor(props) {
     super(props);
+
+    this.questionDenominator = {
+      facilitator_effectiveness: 7,
+      teacher_engagement: props.courseName === COURSE_CSF ? 5 : 7,
+      overall_success: 7
+    };
   }
 
   /**
@@ -43,7 +51,8 @@ export class SurveyRollupTable extends React.Component {
           question_found = true;
           orderedRows.push({
             key: question_name,
-            label: questions[question_name]
+            label: questions[question_name],
+            category: category
           });
         }
       });
@@ -96,6 +105,12 @@ export class SurveyRollupTable extends React.Component {
     }));
   }
 
+  renderAverage(value, category) {
+    return value
+      ? `${value.toFixed(2)} / ${this.questionDenominator[category]}`
+      : '-';
+  }
+
   render() {
     let orderedColumns = this.createOrderedColumns();
 
@@ -127,12 +142,18 @@ export class SurveyRollupTable extends React.Component {
           {/*Next rows are average scores of categories and questions*/}
           {orderedRows.map((row, i) => (
             <tr key={i} style={row.isCategory ? {borderTop: 'solid'} : {}}>
+              {/* First cell is category/question text */}
               <td style={row.isCategory ? {} : {paddingLeft: '30px'}}>
                 {row.label}
               </td>
+
+              {/* Next cells are category/question average scores in each scenario */}
               {orderedColumns.map((column, j) => (
                 <td key={j}>
-                  {this.props.rollups[column.key].averages[row.key]}
+                  {this.renderAverage(
+                    this.props.rollups[column.key].averages[row.key],
+                    row.category || row.key
+                  )}
                 </td>
               ))}
             </tr>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -33,7 +33,8 @@ export class SurveyRollupTable extends React.Component {
       // The order is category name first, then questions in that category
       orderedRows.push({
         key: category,
-        label: _.startCase(category)
+        label: _.startCase(category),
+        isCategory: true
       });
 
       let question_found = false;
@@ -110,7 +111,7 @@ export class SurveyRollupTable extends React.Component {
           <tr>
             <th />
             {orderedColumns.map((column, i) => (
-              <td key={i}>{column.label}</td>
+              <th key={i}>{column.label}</th>
             ))}
           </tr>
         </thead>
@@ -125,8 +126,10 @@ export class SurveyRollupTable extends React.Component {
 
           {/*Next rows are average scores of categories and questions*/}
           {orderedRows.map((row, i) => (
-            <tr key={i}>
-              <td>{row.label}</td>
+            <tr key={i} style={row.isCategory ? {borderTop: 'solid'} : {}}>
+              <td style={row.isCategory ? {} : {paddingLeft: '30px'}}>
+                {row.label}
+              </td>
               {orderedColumns.map((column, j) => (
                 <td key={j}>
                   {this.props.rollups[column.key].averages[row.key]}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -107,7 +107,7 @@ export class SurveyRollupTable extends React.Component {
 
   renderAverage(value, category) {
     return value
-      ? `${value.toFixed(2)} / ${this.categoryDenominator[category]}`
+      ? `${value.toFixed(1)} / ${this.categoryDenominator[category]}`
       : '-';
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.story.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import SurveyRollupTable from '../../components/survey_results/survey_rollup_table';
 import reactBootstrapStoryDecorator from '../../../reactBootstrapStoryDecorator';
+import {COURSE_CSF} from '../../workshopConstants';
 
 const facilitator_rollups = {
   facilitators: {
@@ -165,6 +166,7 @@ export default storybook => {
         name: 'Facilitator Rollup Table',
         story: () => (
           <SurveyRollupTable
+            courseName="CS Principles"
             rollups={facilitator_rollups.rollups}
             questions={facilitator_rollups.questions}
             facilitators={facilitator_rollups.facilitators}
@@ -175,6 +177,7 @@ export default storybook => {
         name: 'Workshop Rollup Table',
         story: () => (
           <SurveyRollupTable
+            courseName={COURSE_CSF}
             rollups={workshop_rollups.rollups}
             questions={workshop_rollups.questions}
             facilitators={workshop_rollups.facilitators}

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -158,6 +158,7 @@ export default class Results extends React.Component {
           title="Workshop Rollups"
         >
           <SurveyRollupTable
+            courseName={this.props.courseName}
             rollups={this.props.workshopRollups.rollups}
             questions={this.props.workshopRollups.questions}
             facilitators={this.props.workshopRollups.facilitators}
@@ -175,6 +176,7 @@ export default class Results extends React.Component {
           title="Facilitator Rollups"
         >
           <SurveyRollupTable
+            courseName={this.props.courseName}
             rollups={this.props.facilitatorRollups.rollups}
             questions={this.props.facilitatorRollups.questions}
             facilitators={this.props.facilitatorRollups.facilitators}


### PR DESCRIPTION
# Description
Update style of the new survey roll-up table to match the current roll-up table (different content, just same style).
[PLC-495](https://codedotorg.atlassian.net/browse/PLC-495)

**Before**
<img width="644" alt="Screen Shot 2019-10-17 at 12 45 48 PM" src="https://user-images.githubusercontent.com/46507039/67042134-178b7e80-f0dc-11e9-9082-cd9e70026df3.png">

**After**
Should look the same as https://studio.code.org/pd/workshop_dashboard/daily_survey_results/7434
<img width="624" alt="Screen Shot 2019-10-17 at 2 34 23 PM" src="https://user-images.githubusercontent.com/46507039/67049551-537a1000-f0eb-11e9-8351-44d36925aded.png">


