### PR TITLE
Fixes applab and gamelab exporters by providing more unminified dependencies

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -304,6 +304,7 @@ describe('entry tests', () => {
           cwd: 'build/package/js',
           // The applab and gamelab exporters need unhashed copies of these files.
           src: [
+            'webpack-runtimewp*.js',
             'webpack-runtimewp*.min.js',
             'applab-apiwp*.min.js',
             'gamelab-apiwp*.min.js'

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -923,15 +923,16 @@ describe('entry tests', () => {
               to: '[path]/[name]wp[contenthash].[ext]',
               toType: 'template'
             },
-            // Always include unminified, unhashed p5.js as this is needed by
-            // unit tests. The order of these rules is important to ensure that
-            // the minified, hashed copy of p5.js appears in the manifest when
-            // minifying.
+            // Always include unminified, unhashed p5.js and p5.play.js as these
+            // are needed by unit tests and gamelab exporter. The order of these
+            // rules is important to ensure that the minified, hashed copy of
+            // these files appear in the manifest when minifying.
             {
               context: 'build/minifiable-lib/',
-              from: '**/p5.js',
+              from: 'p5play/p5*.js',
               to: '[path]/[name].[ext]',
-              toType: 'template'
+              toType: 'template',
+              ignore: '*.min.js'
             },
             // Libraries in this directory are assumed to have .js and .min.js
             // copies of each source file. In development mode, copy only foo.js.


### PR DESCRIPTION
# Background

![gamelab-export-404](https://user-images.githubusercontent.com/8001765/67052454-1d408e80-f0f3-11e9-9941-c1b1399c3194.png)

today gamelab export fails because of 404s on webpack-runtime.js and p5.play.js . this was a regression introduced in https://github.com/code-dot-org/code-dot-org/pull/30901 . previously, a similar problem in applab was addressed by https://github.com/code-dot-org/code-dot-org/pull/31187 , however that came up short of fixing either exporter because:
1. for reasons not clear to me, applab and gamelab exporter are both requesting unminified webpack-runtime.js in production, whereas #31187 only supplied webpack.min.js . see [#gamelab](https://codedotorg.slack.com/archives/C0T0EGENQ/p1571345746009300) for context
2. gamelab exporter also needs unminified p5.play.js, which was not provided by #31187

# Description

Fixes applab and gamelab exporters by providing unminified, unhashed webpack-runtime.js and p5.play.js . See comments adjacent to changed lines for documentation of how the current process works for deciding which files to output.

## Testing story

Manually verified the following:
1. only the following two files were added to the output of `yarn build:dist`:
  ```
  build/package/js/p5play/p5.play.js
  build/package/js/webpack-runtime.js
  ```
2. applab and gamelab exporter work locally when built and run with minified js, and are loading the newly generated assets:
![Screen Shot 2019-10-17 at 3 38 22 PM](https://user-images.githubusercontent.com/8001765/67052811-372ea100-f0f4-11e9-89e5-e4cd6f98cf9e.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
