### PR TITLE
[student-libraries] Added permissions for students to view the list of their classmates projects.

### DIFF
--- a/dashboard/app/controllers/api/v1/projects/section_projects_controller.rb
+++ b/dashboard/app/controllers/api/v1/projects/section_projects_controller.rb
@@ -1,8 +1,10 @@
 class Api::V1::Projects::SectionProjectsController < ApplicationController
-  load_and_authorize_resource :section
+  check_authorization
+  load_resource :section
 
   # GET /api/v1/projects/section/<section_id>
   def index
+    authorize! :list_projects, @section
     render json: ProjectsList.fetch_section_projects(@section)
   end
 end

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -63,6 +63,8 @@ class ApplicationController < ActionController::Base
     if !current_user && request.format == :html
       # we don't know who you are, you can try to sign in
       authenticate_user!
+    elsif rack_env? :development
+      raise
     else
       # we know who you are, you shouldn't be here
       head :forbidden

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -82,8 +82,7 @@ class Ability
       can [:get_feedbacks, :count, :increment_visit_count, :index], TeacherFeedback, student_id: user.id
 
       can :list_projects, Section do |section|
-        return true if can? :manage, section
-        user.sections_as_student.include?(section)
+        can?(:manage, section) || user.sections_as_student.include?(section)
       end
 
       if user.teacher?

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -81,6 +81,11 @@ class Ability
       can :index, Section, user_id: user.id
       can [:get_feedbacks, :count, :increment_visit_count, :index], TeacherFeedback, student_id: user.id
 
+      can :list_projects, Section do |section|
+        return true if can? :manage, section
+        user.sections_as_student.include?(section)
+      end
+
       if user.teacher?
         can :manage, Section, user_id: user.id
         can :manage, :teacher

--- a/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
@@ -46,9 +46,16 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
 
   test_user_gets_response_for(
     :index,
-    name: 'student cannot access section projects',
-    response: :forbidden,
+    name: 'student can access their own section projects',
     user: -> {@student},
+    params: -> {{section_id: @section.id}}
+  )
+
+  test_user_gets_response_for(
+    :index,
+    name: 'student cannot access another sections projects',
+    response: :forbidden,
+    user: :student,
     params: -> {{section_id: @section.id}}
   )
 


### PR DESCRIPTION
# Description
This work is part of a feature that allows students to share their projects as libraries.

In order to import another student's library, students need to be able to view the list of libraries that other students in their class have published. This can be achieved using the already-existing student project metadata in pegasus. Previously, the section_projects was accessible only by a teacher (the owner of the section). This change makes it available to a student in the class as well.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1VxMmdHdIeBWCXKofkjEy9MuWcrzeEW3Zt-Ir8pINYdA/edit)
- [jira](https://codedotorg.atlassian.net/browse/STAR-710)
- [all relevant PRs](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Ajmkulwik+archived%3Afalse+student+libraries)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
