### PR TITLE
Simplify exporter tests

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -306,7 +306,9 @@ describe('entry tests', () => {
           src: [
             'webpack-runtimewp*.js',
             'webpack-runtimewp*.min.js',
+            'applab-apiwp*.js',
             'applab-apiwp*.min.js',
+            'gamelab-apiwp*.js',
             'gamelab-apiwp*.min.js'
           ],
           dest: 'build/package/js',

--- a/apps/test/unit/applab/ExporterTest.js
+++ b/apps/test/unit/applab/ExporterTest.js
@@ -686,26 +686,29 @@ describe('Applab Exporter,', function() {
 
           new Function(getAppOptionsFile())();
           setAppOptions(Object.assign(window.APP_OPTIONS, {isExported: true}));
-
-          // load unminified webpack-runtime and applab-api from the webpack
-          // output directory, allowing for any hash that may have been added to
-          // the filename and making sure not to match any minified files.
-
           // webpack-runtime must appear exactly once on any page containing webpack entries.
-          testUtils.loadContext(
-            require.context(
-              '../../../build/package/js/',
-              false,
-              /webpack-runtime(wp[a-f0-9]{20})?.js/
-            )
+          let context = require.context(
+            '../../../build/package/js/',
+            false,
+            /webpack-runtime(wp[a-f0-9]{20})?.js/
           );
-          testUtils.loadContext(
-            require.context(
-              '../../../build/package/js/',
-              false,
-              /applab-api(wp[a-f0-9]{20})?.js/
-            )
+          assert.equal(
+            1,
+            context.keys().length,
+            'could not find webpack-runtime in build/package/js'
           );
+          context.keys().forEach(context);
+          context = require.context(
+            '../../../build/package/js/',
+            false,
+            /applab-api(wp[a-f0-9]{20})?.js/
+          );
+          assert.equal(
+            1,
+            context.keys().length,
+            'could not find applab-api in build/package/js'
+          );
+          context.keys().forEach(context);
 
           new Function(zipFiles['my-app/code.js'])();
           if (globalPromiseName) {

--- a/apps/test/unit/applab/ExporterTest.js
+++ b/apps/test/unit/applab/ExporterTest.js
@@ -657,6 +657,14 @@ describe('Applab Exporter,', function() {
     });
   });
 
+  describe('globally exposed functions', () => {
+    beforeEach(() => {
+      // webpack-runtime must appear exactly once on any page containing webpack entries.
+      require('../../../build/package/js/webpack-runtime.js');
+      require('../../../build/package/js/applab-api.js');
+    });
+  });
+
   function runExportedApp(code, html, done, globalPromiseName) {
     server.respondImmediately = true;
     let zipPromise = Exporter.exportAppToZip('my-app', code, html);
@@ -687,29 +695,8 @@ describe('Applab Exporter,', function() {
           new Function(getAppOptionsFile())();
           setAppOptions(Object.assign(window.APP_OPTIONS, {isExported: true}));
           // webpack-runtime must appear exactly once on any page containing webpack entries.
-          let context = require.context(
-            '../../../build/package/js/',
-            false,
-            /webpack-runtime(wp[a-f0-9]{20})?.js/
-          );
-          assert.equal(
-            1,
-            context.keys().length,
-            'could not find webpack-runtime in build/package/js'
-          );
-          context.keys().forEach(context);
-          context = require.context(
-            '../../../build/package/js/',
-            false,
-            /applab-api(wp[a-f0-9]{20})?.js/
-          );
-          assert.equal(
-            1,
-            context.keys().length,
-            'could not find applab-api in build/package/js'
-          );
-          context.keys().forEach(context);
-
+          require('../../../build/package/js/webpack-runtime.js');
+          require('../../../build/package/js/applab-api.js');
           new Function(zipFiles['my-app/code.js'])();
           if (globalPromiseName) {
             await window[globalPromiseName];

--- a/apps/test/unit/applab/ExporterTest.js
+++ b/apps/test/unit/applab/ExporterTest.js
@@ -657,14 +657,6 @@ describe('Applab Exporter,', function() {
     });
   });
 
-  describe('globally exposed functions', () => {
-    beforeEach(() => {
-      // webpack-runtime must appear exactly once on any page containing webpack entries.
-      require('../../../build/package/js/webpack-runtime.js');
-      require('../../../build/package/js/applab-api.js');
-    });
-  });
-
   function runExportedApp(code, html, done, globalPromiseName) {
     server.respondImmediately = true;
     let zipPromise = Exporter.exportAppToZip('my-app', code, html);

--- a/apps/test/unit/gamelab/ExporterTest.js
+++ b/apps/test/unit/gamelab/ExporterTest.js
@@ -410,14 +410,6 @@ describe('The Gamelab Exporter,', function() {
     });
   });
 
-  describe('globally exposed functions', () => {
-    beforeEach(() => {
-      // webpack-runtime must appear exactly once on any page containing webpack entries.
-      require('../../../build/package/js/webpack-runtime.js');
-      require('../../../build/package/js/gamelab-api.js');
-    });
-  });
-
   function runExportedApp(code, animationOpts, done, globalPromiseName) {
     const originalP5 = window.p5;
     const originalPreload = window.preload;

--- a/apps/test/unit/gamelab/ExporterTest.js
+++ b/apps/test/unit/gamelab/ExporterTest.js
@@ -410,6 +410,14 @@ describe('The Gamelab Exporter,', function() {
     });
   });
 
+  describe('globally exposed functions', () => {
+    beforeEach(() => {
+      // webpack-runtime must appear exactly once on any page containing webpack entries.
+      require('../../../build/package/js/webpack-runtime.js');
+      require('../../../build/package/js/gamelab-api.js');
+    });
+  });
+
   function runExportedApp(code, animationOpts, done, globalPromiseName) {
     const originalP5 = window.p5;
     const originalPreload = window.preload;
@@ -441,25 +449,9 @@ describe('The Gamelab Exporter,', function() {
             );
             window.$ = require('jquery');
 
-            // load unminified webpack-runtime and gamelab-api from the webpack
-            // output directory, allowing for any hash that may have been added to
-            // the filename and making sure not to match any minified files.
-
             // webpack-runtime must appear exactly once on any page containing webpack entries.
-            testUtils.loadContext(
-              require.context(
-                '../../../build/package/js/',
-                false,
-                /webpack-runtime(wp[a-f0-9]{20})?.js/
-              )
-            );
-            testUtils.loadContext(
-              require.context(
-                '../../../build/package/js/',
-                false,
-                /gamelab-api(wp[a-f0-9]{20})?.js/
-              )
-            );
+            require('../../../build/package/js/webpack-runtime.js');
+            require('../../../build/package/js/gamelab-api.js');
 
             //
             // Note: we are simulating a p5.js environment and manually calling

--- a/apps/test/util/testUtils.js
+++ b/apps/test/util/testUtils.js
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 const project = require('@cdo/apps/code-studio/initApp/project');
 const assets = require('@cdo/apps/code-studio/assets');
 import i18n from '@cdo/apps/code-studio/i18n';
-import {assert} from './deprecatedChai';
 export {
   throwOnConsoleErrorsEverywhere,
   throwOnConsoleWarningsEverywhere,
@@ -385,19 +384,4 @@ export function enforceDocumentBodyCleanup(
 
     describe('', runTestCases);
   });
-}
-
-/**
- * Ensures the require.context call matched exactly one file, and loads
- * that file as though it had been require()d directly. See:
- * https://webpack.js.org/guides/dependency-management/
- * @param context The result of a require.context call.
- */
-export function loadContext(context) {
-  assert.equal(
-    1,
-    context.keys().length,
-    'expected require.context to match exactly one file'
-  );
-  context.keys().forEach(context);
 }


### PR DESCRIPTION
# Background

Follow-on to https://github.com/code-dot-org/code-dot-org/pull/31330 which broke the applab and gamelab exporter tests on the test machine. #31330 got a green drone run, but I forgot to also run those tests after locally building a minified js package, which is what happens on the test machine.

# Description

In addition to fixing the tests, this PR moves us back onto a model where the unit tests expect unhashed copies of applab-api.js, webpack-runtime.js, etc to exist in the bundle. This seems acceptable and even beneficial as long as the corresponding production code is also depending on some of the same unhashed asset names, since it increases the chances that tests will break if a change is made that would break production exporter code. Caveats to the previous statement:
1. the exporter code should really have end-to-end tests (e.g. UI tests) to catch breakages, rather than relying on unit tests
2. the set of unhashed filenames depended on by these tests is slightly different from those used in production, so there's no guarantee these tests will catch a problem which breaks production.

## Testing story

Test-only change which fixes broken tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
