### PR TITLE
Use new survey pipeline for both summer and academic-year workshops

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -6,7 +6,6 @@ import SurveyRollupTable from '../../components/survey_results/survey_rollup_tab
 import FacilitatorAveragesTable from '../../components/survey_results/facilitator_averages_table';
 import TextResponses from '../../components/survey_results/text_responses';
 import _ from 'lodash';
-import experiments from '@cdo/apps/util/experiments';
 
 export default class Results extends React.Component {
   static propTypes = {
@@ -192,9 +191,7 @@ export default class Results extends React.Component {
     return (
       <Tabs id="SurveyTab">
         {this.renderAllSessionsResults()}
-        {experiments.isEnabled(experiments.ROLLUP_SURVEY_REPORT)
-          ? this.renderSurveyRollups()
-          : this.renderFacilitatorAverages()}
+        {this.renderSurveyRollups()}
       </Tabs>
     );
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -12,7 +12,7 @@ export default class Results extends React.Component {
     questions: PropTypes.object.isRequired,
     thisWorkshop: PropTypes.object.isRequired,
     sessions: PropTypes.arrayOf(PropTypes.string).isRequired,
-    courseName: PropTypes.string.isRequired,
+    courseName: PropTypes.string,
     facilitators: PropTypes.object,
     facilitatorAverages: PropTypes.object,
     facilitatorResponseCounts: PropTypes.object,
@@ -23,9 +23,7 @@ export default class Results extends React.Component {
   static defaultProps = {
     facilitators: {},
     facilitatorAverages: {},
-    facilitatorResponseCounts: {},
-    workshopRollups: {},
-    facilitatorRollups: {}
+    facilitatorResponseCounts: {}
   };
 
   state = {

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {Tab, Tabs} from 'react-bootstrap';
 import ChoiceResponses from '../../components/survey_results/choice_responses';
 import SurveyRollupTable from '../../components/survey_results/survey_rollup_table';
-import FacilitatorAveragesTable from '../../components/survey_results/facilitator_averages_table';
 import TextResponses from '../../components/survey_results/text_responses';
 import _ from 'lodash';
 
@@ -13,21 +12,8 @@ export default class Results extends React.Component {
     thisWorkshop: PropTypes.object.isRequired,
     sessions: PropTypes.arrayOf(PropTypes.string).isRequired,
     courseName: PropTypes.string,
-    facilitators: PropTypes.object,
-    facilitatorAverages: PropTypes.object,
-    facilitatorResponseCounts: PropTypes.object,
     workshopRollups: PropTypes.object,
     facilitatorRollups: PropTypes.object
-  };
-
-  static defaultProps = {
-    facilitators: {},
-    facilitatorAverages: {},
-    facilitatorResponseCounts: {}
-  };
-
-  state = {
-    facilitatorIds: Object.keys(this.props.facilitators)
   };
 
   /**
@@ -115,29 +101,6 @@ export default class Results extends React.Component {
       >
         <br />
         {this.renderResultsForSession(session)}
-      </Tab>
-    ));
-  }
-
-  renderFacilitatorAverages() {
-    return Object.keys(this.props.facilitators).map((facilitator_id, i) => (
-      <Tab
-        eventKey={this.props.sessions.length + i + 1}
-        key={i}
-        title={this.props.facilitators[facilitator_id]}
-      >
-        <FacilitatorAveragesTable
-          facilitatorAverages={
-            this.props.facilitatorAverages[
-              this.props.facilitators[facilitator_id]
-            ]
-          }
-          facilitatorId={parseInt(facilitator_id, 10)}
-          facilitatorName={this.props.facilitators[facilitator_id]}
-          questions={this.props.facilitatorAverages['questions']}
-          courseName={this.props.courseName}
-          facilitatorResponseCounts={this.props.facilitatorResponseCounts}
-        />
       </Tab>
     ));
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
@@ -4,7 +4,6 @@ import $ from 'jquery';
 import Spinner from '../../../components/spinner';
 import Results from './results';
 import color from '@cdo/apps/util/color';
-import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   errorContainer: {
@@ -33,17 +32,9 @@ export class ResultsLoader extends React.Component {
   }
 
   load() {
-    const inExperiment = experiments.isEnabled(
-      experiments.ROLLUP_SURVEY_REPORT
-    );
-
-    const url = inExperiment
-      ? `/api/v1/pd/workshops/${
-          this.props.params['workshopId']
-        }/experiment_survey_report`
-      : `/api/v1/pd/workshops/${
-          this.props.params['workshopId']
-        }/generic_survey_report`;
+    const url = `/api/v1/pd/workshops/${
+      this.props.params['workshopId']
+    }/experiment_survey_report`;
 
     this.loadRequest = $.ajax({
       method: 'GET',
@@ -51,28 +42,15 @@ export class ResultsLoader extends React.Component {
       dataType: 'json'
     })
       .done(data => {
-        if (inExperiment) {
-          this.setState({
-            loading: false,
-            questions: data['questions'],
-            thisWorkshop: data['this_workshop'],
-            sessions: Object.keys(data['this_workshop']),
-            courseName: data['course_name'],
-            workshopRollups: data['workshop_rollups'],
-            facilitatorRollups: data['facilitator_rollups']
-          });
-        } else {
-          this.setState({
-            loading: false,
-            questions: data['questions'],
-            thisWorkshop: data['this_workshop'],
-            sessions: Object.keys(data['this_workshop']),
-            facilitators: data['facilitators'],
-            facilitatorAverages: data['facilitator_averages'],
-            facilitatorResponseCounts: data['facilitator_response_counts'],
-            courseName: data['course_name']
-          });
-        }
+        this.setState({
+          loading: false,
+          questions: data['questions'],
+          thisWorkshop: data['this_workshop'],
+          sessions: Object.keys(data['this_workshop']),
+          courseName: data['course_name'],
+          workshopRollups: data['workshop_rollups'],
+          facilitatorRollups: data['facilitator_rollups']
+        });
       })
       .fail(jqXHR => {
         this.setState({

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/resultsTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/resultsTest.js
@@ -110,38 +110,42 @@ describe('Local Summer Workshop Daily Survey Results class', () => {
             }
           }}
           sessions={['Pre Workshop', 'Day 1']}
-          facilitators={{
-            1: 'Facilitator 1',
-            2: 'Facilitator 2'
-          }}
-          facilitatorAverages={{
-            'Facilitator 1': {
-              q1: {
-                this_workshop: 4.5,
-                all_my_workshops: 4.0
-              }
-            },
-            'Facilitator 2': {
-              q1: {
-                this_workshop: 1.5,
-                all_my_workshops: 2.0
+          courseName="Course Name"
+          workshopRollups={{
+            rollups: {
+              this_ws: {
+                workshop_id: 1,
+                response_count: 1,
+                averages: {overall_success_0: 7, overall_success: 7}
               }
             },
             questions: {
-              q1: 'Question 1'
-            }
-          }}
-          facilitatorResponseCounts={{
-            all_my_workshops: {
-              1: 40,
-              2: 50
+              overall_success_0: 'I feel more prepared to teach'
             },
-            this_workshop: {
-              1: 10,
-              2: 8
+            facilitators: {
+              '1': 'Facilitator Person 1'
             }
           }}
-          courseName="Course Name"
+          facilitatorRollups={{
+            rollups: {
+              facilitator_1_single_ws: {
+                facilitator_id: 1,
+                workshop_id: 1,
+                response_count: 1,
+                averages: {
+                  facilitator_effectiveness_0: 7,
+                  facilitator_effectiveness: 7
+                }
+              }
+            },
+            questions: {
+              facilitator_effectiveness_0:
+                'Demonstrated knowledge of the curriculum.'
+            },
+            facilitators: {
+              '1': 'Facilitator Person 1'
+            }
+          }}
         />
       </Provider>
     );
@@ -167,13 +171,13 @@ describe('Local Summer Workshop Daily Survey Results class', () => {
       results
         .find('Tab')
         .at(2)
-        .find('FacilitatorAveragesTable')
+        .find('SurveyRollupTable')
     ).to.have.length(1);
     expect(
       results
         .find('Tab')
         .at(3)
-        .find('FacilitatorAveragesTable')
+        .find('SurveyRollupTable')
     ).to.have.length(1);
   });
 });


### PR DESCRIPTION
# Description
Swapping the new survey pipeline and the new UI in to service. Both summer and academic-year-workshop surveys will use the new pipeline.

These are the current flows. After the change, the default flow will be the same as the experimental one. (Experiment flag is removed.)


<img width="465" alt="Screen Shot 2019-10-18 at 1 13 02 PM" src="https://user-images.githubusercontent.com/46507039/67125328-6e12be80-f1a9-11e9-8f40-e49b5a114b4c.png">

There are 2 steps after this PR to complete the transition. They will be in separate PRs.

Next step https://github.com/code-dot-org/code-dot-org/pull/31365

<img width="467" alt="Screen Shot 2019-10-18 at 1 01 48 PM" src="https://user-images.githubusercontent.com/46507039/67124557-9f8a8a80-f1a7-11e9-9b84-48989c131b60.png">

Next next step https://github.com/code-dot-org/code-dot-org/pull/31366

<img width="465" alt="Screen Shot 2019-10-18 at 1 01 59 PM" src="https://user-images.githubusercontent.com/46507039/67124558-9f8a8a80-f1a7-11e9-9c83-7a542378e819.png">

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-492)