### PR TITLE
simplify the hoc sync scripts

### DIFF
--- a/bin/i18n/sync-hourofcode-in
+++ b/bin/i18n/sync-hourofcode-in
@@ -6,38 +6,22 @@ require 'fileutils'
 # to a single source folder i18n/locales/source.
 
 def pull_in_files_for_translation
-  loc_dir = "i18n/locales/source/hourofcode"
-  Dir.mkdir(loc_dir) unless Dir.exist?(loc_dir)
-  orig_file = "pegasus/sites.v3/hourofcode.com/i18n/en.yml"
-  FileUtils.cp(orig_file, loc_dir)
+  orig_dir = "pegasus/sites.v3/hourofcode.com/public"
+  dest_dir = "i18n/locales/source/hourofcode"
 
-  orig_dir = Dir["pegasus/sites.v3/hourofcode.com/public/*.{md,md.partial}"]
-  orig_dir.each do |file|
-    loc_dir = "i18n/locales/source/hourofcode"
-    if File.extname(file) == '.partial'
-      loc_dir = "#{loc_dir}/#{File.basename(file, '.partial')}"
-    end
-    FileUtils.cp(file, loc_dir)
-  end
+  # Copy the file containing developer-added strings
+  Dir.mkdir(dest_dir) unless Dir.exist?(dest_dir)
+  FileUtils.cp("pegasus/sites.v3/hourofcode.com/i18n/en.yml", dest_dir)
 
-  orig_dir = Dir["pegasus/sites.v3/hourofcode.com/public/how-to/*.{md,md.partial}"]
-  orig_dir.each do |file|
-    loc_dir = "i18n/locales/source/hourofcode/how-to"
-    Dir.mkdir(loc_dir) unless Dir.exist?(loc_dir)
-    if File.extname(file) == '.partial'
-      loc_dir = "#{loc_dir}/#{File.basename(file, '.partial')}"
+  # Copy the markdown files representing individual page content
+  Dir.glob(File.join(orig_dir, "**/*.{md,md.partial}")).each do |file|
+    dest = file.sub(orig_dir, dest_dir)
+    if File.extname(dest) == '.partial'
+      dest = File.join(File.dirname(dest), File.basename(dest, '.partial'))
     end
-    FileUtils.cp(file, loc_dir)
-  end
 
-  orig_dir = Dir["pegasus/sites.v3/hourofcode.com/public/promote/*.{md,md.partial}"]
-  orig_dir.each do |file|
-    loc_dir = "i18n/locales/source/hourofcode/promote"
-    Dir.mkdir(loc_dir) unless Dir.exist?(loc_dir)
-    if File.extname(file) == '.partial'
-      loc_dir = "#{loc_dir}/#{File.basename(file, '.partial')}"
-    end
-    FileUtils.cp(file, loc_dir)
+    FileUtils.mkdir_p(File.dirname(dest))
+    FileUtils.cp(file, dest)
   end
 end
 

--- a/bin/i18n/sync-hourofcode-out
+++ b/bin/i18n/sync-hourofcode-out
@@ -38,33 +38,24 @@ def copy_from_i18n_source_to_hoc
     next if prop[:locale_s] == "en-US"
     i18n_path = "i18n/locales/#{prop[:locale_s]}/hourofcode"
     hoc_path = "pegasus/sites.v3/hourofcode.com/i18n"
+
+    # Copy the file containing developer-added strings
     FileUtils.cp(i18n_path + "/#{prop[:unique_language_s]}.yml", hoc_path) if File.exist?(i18n_path + "/#{prop[:unique_language_s]}.yml")
 
-    language_folder = hoc_path + "/public/#{prop[:unique_language_s]}"
-    unless File.directory?(language_folder)
-      FileUtils.mkdir_p(language_folder)
-      FileUtils.mkdir_p(language_folder + "/files")
-      FileUtils.mkdir_p(language_folder + "/images")
-      FileUtils.mkdir_p(language_folder + "/how-to")
-      FileUtils.mkdir_p(language_folder + "/promote")
-    end
+    # Copy the markdown files representing individual page content
+    Dir.glob(File.join(i18n_path, "**/*.md")).each do |source_path|
+      # Copy file from the language-specific i18n directory to the
+      # language-specific pegasus directory.
+      source_dir = File.dirname(source_path)
+      dest_dir = source_dir.sub(i18n_path, File.join(hoc_path, "public", prop[:unique_language_s]))
 
-    # Crowdin didn't place nicely with changing the file extensions from md to md.partial
-    # As a hopefully temporary solution, on the sync in we remove the .partial ending and
-    # here we add it back.
-    i18n_dir = Dir["i18n/locales/#{prop[:locale_s]}/hourofcode/*.md"]
-    i18n_dir.each do |file|
-      FileUtils.cp(file, hoc_path + "/public/#{prop[:unique_language_s]}/#{File.basename(file)}.partial")
-    end
+      # Crowdin didn't place nicely with changing the file extensions from md
+      # to md.partial As a hopefully temporary solution, on the sync in we
+      # remove the .partial ending and here we add it back.
+      dest_name = File.basename(source_path) + ".partial"
 
-    i18n_dir = Dir["i18n/locales/#{prop[:locale_s]}/hourofcode/how-to/*.md"]
-    i18n_dir.each do |file|
-      FileUtils.cp(file, hoc_path + "/public/#{prop[:unique_language_s]}/how-to/#{File.basename(file)}.partial")
-    end
-
-    i18n_dir = Dir["i18n/locales/#{prop[:locale_s]}/hourofcode/promote/*.md"]
-    i18n_dir.each do |file|
-      FileUtils.cp(file, hoc_path + "/public/#{prop[:unique_language_s]}/promote/#{File.basename(file)}.partial")
+      FileUtils.mkdir_p(dest_dir)
+      FileUtils.cp(source_path, File.join(dest_dir, dest_name))
     end
 
     puts "Copied locale #{prop[:unique_language_s]}"


### PR DESCRIPTION
In preparation for merging them into the regular code.org sync scripts, condense the HOC sync scripts down to just operate over the whole directory, rather than hardcoding each individual subdirectory