### PR TITLE
Clean up survey pipeline code

### DIFF
--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -21,7 +21,6 @@ const EXPERIMENT_LIFESPAN_HOURS = 12;
 experiments.REDUX_LOGGING = 'reduxLogging';
 experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
   'schoolAutocompleteDropdownNewSearch';
-experiments.ROLLUP_SURVEY_REPORT = 'rollupSurveyReport';
 experiments.APPLAB_DATASETS = 'applabDatasets';
 experiments.CENSUS_MAP_ON_MAPBOX = 'censusMapOnMapbox';
 experiments.ASSIGNMENT_UPDATES = 'assignmentUpdates';

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -136,7 +136,7 @@ module Api::V1::Pd
 
     def create_generic_survey_report
       this_ws_report = report_single_workshop(@workshop, current_user)
-      rollup_report = report_rollups_experiment(@workshop, current_user)
+      rollup_report = report_rollups(@workshop, current_user)
 
       render json: this_ws_report.merge(rollup_report)
     end

--- a/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_pipeline_helper.rb
@@ -14,14 +14,13 @@ module Pd::SurveyPipeline::Helper
   ]
 
   # Roll up facilitator-specific and general workshop survey results from all related workshops.
-  # @note This function will replace report_rollups function.
   #
   # @param workshop [Pd::Workshop] the workshop user selects, which is used to find related workshops
   # @param current_user [User] the user requesting survey report
   # @return [Hash] {:workshopRollups, :facilitatorRollups => rollup_content}
-  # @see SurveyRollupDecoratorExperiment.decorate_facilitator_rollup for data structure of rollup_content
+  # @see SurveyRollupDecorator.decorate_facilitator_rollup for data structure of rollup_content
   #
-  def report_rollups_experiment(workshop, current_user)
+  def report_rollups(workshop, current_user)
     # Get list of facilitators this user can see
     facilitator_ids =
       if current_user.program_manager? || current_user.workshop_organizer? || current_user.workshop_admin?
@@ -34,8 +33,8 @@ module Pd::SurveyPipeline::Helper
     reports = {facilitator_rollups: {}, workshop_rollups: {}}
 
     facilitator_ids.each do |fid|
-      reports[:facilitator_rollups].deep_merge! report_facilitator_rollup_experiment(fid, workshop, true)
-      reports[:workshop_rollups].deep_merge! report_facilitator_rollup_experiment(fid, workshop, false)
+      reports[:facilitator_rollups].deep_merge! report_facilitator_rollup(fid, workshop, true)
+      reports[:workshop_rollups].deep_merge! report_facilitator_rollup(fid, workshop, false)
 
       # TODO: report_partner_rollup()
       # TODO: report_cdo_rollup()
@@ -45,14 +44,13 @@ module Pd::SurveyPipeline::Helper
   end
 
   # Summarize facilitator-specific results from all related workshops a facilitator have facilitated.
-  # @note This function will replace both report_facilitator_rollup and report_workshop_rollup functions.
   #
   # @param facilitator_id [Integer]
   # @param workshop [Pd::Workshop]
   # @param only_facilitator_questions [Boolean]
   # @return [Hash]
   #
-  def report_facilitator_rollup_experiment(facilitator_id, workshop, only_facilitator_questions)
+  def report_facilitator_rollup(facilitator_id, workshop, only_facilitator_questions)
     context = {
       current_workshop_id: workshop.id,
       facilitator_id: facilitator_id,
@@ -75,7 +73,7 @@ module Pd::SurveyPipeline::Helper
     process_rollup_data context
 
     # Decorate
-    Pd::SurveyPipeline::SurveyRollupDecoratorExperiment.decorate_facilitator_rollup(
+    Pd::SurveyPipeline::SurveyRollupDecorator.decorate_facilitator_rollup(
       context, only_facilitator_questions
     )
   end

--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
@@ -1,9 +1,8 @@
 # SurveyRollupDecoratorExperiment combines pieces of survey roll-up data from previous steps
 # of the survey pipeline and organize them in a format that the client view can consume.
-# @note This class will replace Pd::SurveyPipeline::SurveyRollupDecorator.
 
 module Pd::SurveyPipeline
-  class SurveyRollupDecoratorExperiment
+  class SurveyRollupDecorator
     # Create roll-up report to send to client.
     #
     # Return value is a Hash with following keys

--- a/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
+++ b/dashboard/lib/pd/survey_pipeline/survey_rollup_decorator.rb
@@ -1,4 +1,4 @@
-# SurveyRollupDecoratorExperiment combines pieces of survey roll-up data from previous steps
+# SurveyRollupDecorator combines pieces of survey roll-up data from previous steps
 # of the survey pipeline and organize them in a format that the client view can consume.
 
 module Pd::SurveyPipeline


### PR DESCRIPTION
# Description

Continuation of #31355 and #31365. It removes `experiment` suffix from class name and function. There should be only 1 pipeline after this.

[PLC-492](https://codedotorg.atlassian.net/browse/PLC-492)