### PR TITLE
Import p5 directly

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -1012,6 +1012,19 @@ describe('entry tests', () => {
     }
   };
 
+  config.uglify = {
+    lib: {
+      files: _.fromPairs(
+        ['p5play/p5.play.js', 'p5play/p5.js'].map(function(src) {
+          return [
+            'build/package/js/' + src.replace(/\.js$/, '.min.js'), // dst
+            'build/package/js/' + src // src
+          ];
+        })
+      )
+    }
+  };
+
   config.watch = {
     // JS files watched by webpack
     style: {
@@ -1179,6 +1192,9 @@ describe('entry tests', () => {
 
   grunt.registerTask('build', [
     'prebuild',
+    // For any minifiable libs, generate minified sources if they do not already
+    // exist in our repo. Skip minification in development environment.
+    envConstants.DEV ? 'noop' : 'uglify:lib',
     envConstants.DEV ? 'webpack:build' : 'webpack:uglify',
     'notify:js-build',
     'postbuild',

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -223,18 +223,19 @@ describe('entry tests', () => {
           src: ['**/*.js'],
           dest: 'build/package/js/ace/'
         },
-        // Pull p5.js and p5.play.js into the package from our forks.
+        // Pull p5.js and p5.play.js into the package from our forks. These are
+        // needed by the gamelab exporter code in production and development.
         {
           expand: true,
           cwd: './node_modules/@code-dot-org/p5/lib',
           src: ['p5.js'],
-          dest: 'build/minifiable-lib/p5play/'
+          dest: 'build/package/js/p5play/'
         },
         {
           expand: true,
           cwd: './node_modules/@code-dot-org/p5.play/lib',
           src: ['p5.play.js'],
-          dest: 'build/minifiable-lib/p5play/'
+          dest: 'build/package/js/p5play/'
         },
         // Piskel must not be minified or digested in order to work properly.
         {
@@ -925,17 +926,6 @@ describe('entry tests', () => {
               to: '[path]/[name]wp[contenthash].[ext]',
               toType: 'template'
             },
-            // Always include unminified, unhashed p5.js and p5.play.js as these
-            // are needed by unit tests and gamelab exporter. The order of these
-            // rules is important to ensure that the minified, hashed copy of
-            // these files appear in the manifest when minifying.
-            {
-              context: 'build/minifiable-lib/',
-              from: 'p5play/p5*.js',
-              to: '[path]/[name].[ext]',
-              toType: 'template',
-              ignore: '*.min.js'
-            },
             // Libraries in this directory are assumed to have .js and .min.js
             // copies of each source file. In development mode, copy only foo.js.
             // In production mode, copy only foo.min.js and rename it to foo.js.
@@ -1019,19 +1009,6 @@ describe('entry tests', () => {
         poll: 1000,
         ignored: /^node_modules\/[^@].*/
       }
-    }
-  };
-
-  config.uglify = {
-    lib: {
-      files: _.fromPairs(
-        ['p5play/p5.play.js', 'p5play/p5.js'].map(function(src) {
-          return [
-            'build/minifiable-lib/' + src.replace(/\.js$/, '.min.js'), // dst
-            'build/minifiable-lib/' + src // src
-          ];
-        })
-      )
     }
   };
 
@@ -1202,9 +1179,6 @@ describe('entry tests', () => {
 
   grunt.registerTask('build', [
     'prebuild',
-    // For any minifiable libs, generate minified sources if they do not already
-    // exist in our repo. Skip minification in development environment.
-    envConstants.DEV ? 'noop' : 'uglify:lib',
     envConstants.DEV ? 'webpack:build' : 'webpack:uglify',
     'notify:js-build',
     'postbuild',

--- a/apps/src/p5lab/P5Wrapper.js
+++ b/apps/src/p5lab/P5Wrapper.js
@@ -1,5 +1,7 @@
 import {getStore} from '@cdo/apps/redux';
 import {allAnimationsSingleFrameSelector} from './animationListModule';
+window.p5 = require('@code-dot-org/p5');
+require('@code-dot-org/p5.play/lib/p5.play');
 var p5SpriteWrapper = require('./P5SpriteWrapper');
 var p5GroupWrapper = require('./P5GroupWrapper');
 import {backgrounds} from './spritelab/backgrounds.json';

--- a/apps/src/p5lab/P5Wrapper.js
+++ b/apps/src/p5lab/P5Wrapper.js
@@ -1,6 +1,7 @@
 import {getStore} from '@cdo/apps/redux';
 import {allAnimationsSingleFrameSelector} from './animationListModule';
-window.p5 = require('@code-dot-org/p5');
+import p5 from '@code-dot-org/p5';
+window.p5 = p5;
 import '@code-dot-org/p5.play/lib/p5.play';
 import p5SpriteWrapper from './P5SpriteWrapper';
 import p5GroupWrapper from './P5GroupWrapper';

--- a/apps/src/p5lab/P5Wrapper.js
+++ b/apps/src/p5lab/P5Wrapper.js
@@ -1,9 +1,9 @@
 import {getStore} from '@cdo/apps/redux';
 import {allAnimationsSingleFrameSelector} from './animationListModule';
 window.p5 = require('@code-dot-org/p5');
-require('@code-dot-org/p5.play/lib/p5.play');
-var p5SpriteWrapper = require('./P5SpriteWrapper');
-var p5GroupWrapper = require('./P5GroupWrapper');
+import '@code-dot-org/p5.play/lib/p5.play';
+import p5SpriteWrapper from './P5SpriteWrapper';
+import p5GroupWrapper from './P5GroupWrapper';
 import {backgrounds} from './spritelab/backgrounds.json';
 import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
 

--- a/dashboard/app/views/levels/_apps_dependencies.html.haml
+++ b/dashboard/app/views/levels/_apps_dependencies.html.haml
@@ -23,11 +23,6 @@
   %link{href: asset_path('css/droplet/droplet.min.css'), rel: 'stylesheet', type: 'text/css'}
   %link{href: asset_path('css/tooltipster/tooltipster.min.css'), rel: 'stylesheet', type: 'text/css'}
 
--# Gamelab script dependencies
-- if use_gamelab
-  %script{src: webpack_asset_path('js/p5play/p5.js')}
-  %script{src: webpack_asset_path('js/p5play/p5.play.js')}
-
 -# Droplet script dependencies (only when editor present)
 - if use_droplet && !hide_source
 


### PR DESCRIPTION
# Description

Import p5.js and p5.play.js directly in gamelab / spritelab / dance levels, rather than pulling those dependencies via separate script tag. Credit to @joshlory for doing most of this work in https://github.com/code-dot-org/code-dot-org/pull/30510 . This PR copies that PR, makes some changes to avoid breaking gamelab exporter, and then removes some recently-added, now-obsolete complexity from the webpack config.

The gamelab exporter still relies on unminified, unhashed copies of p5.js and p5.play.js, so we still provide those. However, since we're removing the webpack_asset_path call for those files, we no longer need hashed versions of them and we no longer need them to be in the manifest.

It's possible that the gamelab exporter would benefit from using minified copies of p5 and p5.play in the future. Because of this, I've also added minified, uhashed p5.min.js and p5.play.min.js to the build output.

## Testing story

Manually verified the following:
* gamelab export successfully exports with both minified or unminified webpack builds
* gamelab exporter unit tests pass locally, with both minified and unminified webpack builds
* p5wp[contenthash].js and p5.playwp[contenthash].js files are removed from the build/package/js output
* unhashed p5.min.js and p5.play.min.js files are added to the build/package/js output
* keys containing p5.js and p5.play.js are removed from the webpack manifest

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
