### PR TITLE
Correctly identify `markdown` strings in *.multi scripts as translatable strings.

### DIFF
--- a/bin/i18n/SETUP.md
+++ b/bin/i18n/SETUP.md
@@ -3,6 +3,12 @@
 These scripts all require [the Crowdin CLI tool][1] version 2.0.17. Follow the
 instructions there to install for your system.
 
+These scripts also require some dependencies to be installed using NPM. Run the
+following command while in this directory
+```
+npm install
+```
+
 You will additionally need to add a `codeorg_credentials.yml` file to this
 directory (`{project root}/bin/i18n/`) containing the API key for the code.org
 project, and an `hourofcode_credentials.yml` file containing the API key for the

--- a/dashboard/app/dsl/match_dsl.rb
+++ b/dashboard/app/dsl/match_dsl.rb
@@ -22,6 +22,7 @@ class MatchDSL < ContentDSL
     %i(
       questions
       answers
+      markdown
     ).each do |property|
       strings[property] = @hash[property] unless @hash[property].blank?
     end


### PR DESCRIPTION
# Description
Every week, we run a scripts which gather all the strings code.org uses and makes them available for translation. The `markdown` strings in *.multi files were not being identified as strings which need to be translated. This resulted in some levels (as detailed in the JIRA) only being partially translated.

This fix adds flagging of the `markdown` property as a translatable string.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-690)

## Testing story
I ran the scripts for gathering all the translatable strings and verified that the `markdown` property is now available. `bin/i18n/sync-in.rb`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
