### PR TITLE
Revert "Revert "Assignment Updates: SectionAssigner on unit overview""

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverview.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverview.jsx
@@ -22,7 +22,11 @@ import {
   onDismissRedirectDialog,
   dismissedRedirectDialog
 } from '@cdo/apps/util/dismissVersionRedirect';
-import {assignmentVersionShape} from '@cdo/apps/templates/teacherDashboard/shapes';
+import {
+  assignmentVersionShape,
+  sectionForDropdownShape
+} from '@cdo/apps/templates/teacherDashboard/shapes';
+import experiments from '@cdo/apps/util/experiments';
 
 /**
  * Stage progress component used in level header and script overview.
@@ -56,6 +60,7 @@ class ScriptOverview extends React.Component {
         name: PropTypes.string.isRequired
       })
     ).isRequired,
+    sections: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
     currentCourseId: PropTypes.number,
     scriptHasLockableStages: PropTypes.bool.isRequired,
     scriptAllowsHiddenStages: PropTypes.bool.isRequired,
@@ -94,6 +99,7 @@ class ScriptOverview extends React.Component {
       viewAs,
       isRtl,
       sectionsInfo,
+      sections,
       currentCourseId,
       scriptHasLockableStages,
       scriptAllowsHiddenStages,
@@ -150,11 +156,14 @@ class ScriptOverview extends React.Component {
             />
             {!professionalLearningCourse &&
               viewAs === ViewType.Teacher &&
-              (scriptHasLockableStages || scriptAllowsHiddenStages) && (
+              (scriptHasLockableStages || scriptAllowsHiddenStages) &&
+              !experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
                 <LabeledSectionSelector reloadOnSectionChange={true} />
               )}
             <ScriptOverviewTopRow
               sectionsInfo={sectionsInfo}
+              sections={sections}
+              selectedSectionId={parseInt(selectedSectionId)}
               professionalLearningCourse={professionalLearningCourse}
               scriptProgress={scriptProgress}
               scriptId={scriptId}

--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -10,6 +10,9 @@ import {
   stringForType,
   resourceShape
 } from '@cdo/apps/templates/courseOverview/resourceType';
+import experiments from '@cdo/apps/util/experiments';
+import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
+import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 
 export const NOT_STARTED = 'NOT_STARTED';
 export const IN_PROGRESS = 'IN_PROGRESS';
@@ -50,6 +53,8 @@ export default class ScriptOverviewTopRow extends React.Component {
         name: PropTypes.string.isRequired
       })
     ).isRequired,
+    sections: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
+    selectedSectionId: PropTypes.number,
     currentCourseId: PropTypes.number,
     professionalLearningCourse: PropTypes.bool,
     scriptProgress: PropTypes.oneOf([NOT_STARTED, IN_PROGRESS, COMPLETED]),
@@ -65,6 +70,8 @@ export default class ScriptOverviewTopRow extends React.Component {
   render() {
     const {
       sectionsInfo,
+      sections,
+      selectedSectionId,
       currentCourseId,
       professionalLearningCourse,
       scriptProgress,
@@ -97,7 +104,8 @@ export default class ScriptOverviewTopRow extends React.Component {
         )}
         {!professionalLearningCourse &&
           viewAs === ViewType.Teacher &&
-          showAssignButton && (
+          showAssignButton &&
+          !experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
             <AssignToSection
               sectionsInfo={sectionsInfo}
               courseId={currentCourseId}
@@ -105,6 +113,13 @@ export default class ScriptOverviewTopRow extends React.Component {
               assignmentName={scriptTitle}
             />
           )}
+        {experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
+          <SectionAssigner
+            sections={sections}
+            initialSelectedSectionId={selectedSectionId}
+            showAssignButton={showAssignButton}
+          />
+        )}
         {!professionalLearningCourse &&
           viewAs === ViewType.Teacher &&
           resources.length > 0 && (

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -173,6 +173,7 @@ progress.renderCourseProgress = function(scriptData) {
         locale={scriptData.locale}
         showAssignButton={scriptData.show_assign_button}
         userId={scriptData.user_id}
+        sections={scriptData.sections}
       />
     </Provider>,
     mountPoint

--- a/apps/src/templates/teacherDashboard/SectionAssigner.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.jsx
@@ -30,9 +30,10 @@ class SectionAssigner extends Component {
   };
 
   state = {
-    selectedSection: this.props.sections.find(
-      section => section.id === this.props.initialSelectedSectionId
-    )
+    selectedSection:
+      this.props.sections.find(
+        section => section.id === this.props.initialSelectedSectionId
+      ) || this.props.sections[0]
   };
 
   onChangeSection = sectionId => {

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewTest.js
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewTest.js
@@ -21,6 +21,7 @@ const defaultProps = {
   viewAs: ViewType.Teacher,
   isRtl: false,
   sectionsInfo: [],
+  sections: [],
   scriptHasLockableStages: false,
   scriptAllowsHiddenStages: false,
   versions: []

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
@@ -15,6 +15,7 @@ import ResourceType from '@cdo/apps/templates/courseOverview/resourceType';
 import ProgressDetailToggle from '@cdo/apps/templates/progress/ProgressDetailToggle';
 
 const defaultProps = {
+  sections: [],
   sectionsInfo: [],
   scriptProgress: NOT_STARTED,
   scriptId: 42,

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -73,6 +73,9 @@ class CoursesController < ApplicationController
       return
     end
 
+    sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :course_id)}
+    @sections_with_assigned_info = sections.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == course.id})}
+
     render 'show', locals: {course: course, redirect_warning: params[:redirect_warning] == 'true'}
   end
 

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -74,7 +74,7 @@ class CoursesController < ApplicationController
     end
 
     sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :course_id)}
-    @sections_with_assigned_info = sections.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == course.id})}
+    @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == course.id})}
 
     render 'show', locals: {course: course, redirect_warning: params[:redirect_warning] == 'true'}
   end

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -43,6 +43,8 @@ class ScriptsController < ApplicationController
 
     @show_redirect_warning = params[:redirect_warning] == 'true'
     @section = current_user&.sections&.find_by(id: params[:section_id])&.summarize
+    sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :script_id)}
+    @sections_with_assigned_info = sections.map {|section| section.attributes.merge!({"isAssigned" => section[:script_id] == @script.id})}
   end
 
   def index

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -44,7 +44,7 @@ class ScriptsController < ApplicationController
     @show_redirect_warning = params[:redirect_warning] == 'true'
     @section = current_user&.sections&.find_by(id: params[:section_id])&.summarize
     sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :script_id)}
-    @sections_with_assigned_info = sections.map {|section| section.attributes.merge!({"isAssigned" => section[:script_id] == @script.id})}
+    @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:script_id] == @script.id})}
   end
 
   def index

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -2,9 +2,7 @@
 
 - data = {}
 - data[:course_summary] = course.summarize(@current_user)
-- sections = @current_user.try{|u| u.sections.where(hidden: false).select(:id, :name, :course_id)}
-- sections = sections&.map { |section| section.attributes.merge!({"isAssigned" => section[:course_id] == course.id})}
-- data[:sections] = sections || []
+- data[:sections] = @sections_with_assigned_info || []
 - data[:is_teacher] = @current_user.try(:teacher?) || false
 - data[:is_verified_teacher] = @current_user.try(:authorized_teacher?) || false
 - data[:hidden_scripts] = @current_user.try(:get_hidden_script_ids, course)

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -1,6 +1,6 @@
 -# This variable will get any data we need to pass along to scripts/show.js
 - script_data = @script.summarize(true, current_user)
-- additional_script_data = {course_name: @script.course&.name, show_redirect_warning: @show_redirect_warning, redirect_script_url: @redirect_script_url, section: @section, user_type: current_user&.user_type, user_id: current_user&.id, is_verified_teacher: current_user&.authorized_teacher?, locale: Script.locale_english_name_map[request.locale]}
+- additional_script_data = {course_name: @script.course&.name, show_redirect_warning: @show_redirect_warning, redirect_script_url: @redirect_script_url, section: @section, user_type: current_user&.user_type, user_id: current_user&.id, is_verified_teacher: current_user&.authorized_teacher?, locale: Script.locale_english_name_map[request.locale], sections: @sections_with_assigned_info}
 - scriptOverviewData = {scriptData: script_data.merge(additional_script_data)}
 - if @script.professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
   -  scriptOverviewData[:plcBreadcrumb] = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.course)}


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#31375 

I added in the required `sections` prop to `ScriptOverviewTest` and `ScriptOverviewTopRowTest`. I think this wasn't caught it tests initially because the base branch wasn't staging when PR #31318 was first opened, and tests didn't run after I switched the base to staging before merge even thought it looked like they did. 