### PR TITLE
Remove `EngineVersion` from AWS::RDS::DBInstance

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -713,8 +713,7 @@ Resources:
       DBInstanceClass: db.r4.large
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
-      # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with instance.
-      EngineVersion: 5.7.12
+      # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.
 <% end -%>
 
   AuroraClusterDBParameters:


### PR DESCRIPTION
# Description

Small change to CloudFormation application stack template removing `EngineVersion` from the `AWS::RDS::DBInstance` resource for Aurora database. Not specifying an `EngineVersion` (optional parameter) on the instance allows updates to the DBInstance separately from the `DBCluster` in the cloudformation stack.

When not specified, the `EngineVersion` will default to the current version of the `DBCluster`- which is the only allowed version anyway, so this also simplifies the stack configuration.

Needed to unblock related changes merged as part of #30692.