### PR TITLE
Port the `trySend` fix to Node SerialPort implementation

### DIFF
--- a/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/CircuitPlaygroundBoard.js
@@ -385,9 +385,49 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
       ? SerialPort
       : ChromeSerialPort.SerialPort;
 
-    return new SerialPortType(portName, {
+    const port = new SerialPortType(portName, {
       baudRate: SERIAL_BAUD
     });
+
+    if (isNodeSerialAvailable()) {
+      const queue = [];
+      let sendPending = false;
+      const oldWrite = port.write;
+
+      // eslint-disable-next-line no-inner-declarations
+      function trySend(buffer) {
+        if (buffer) {
+          queue.push(buffer);
+        }
+
+        if (sendPending || queue.length === 0) {
+          // Exhausted pending send buffer.
+          return;
+        }
+
+        if (queue.length > 512) {
+          throw new Error(
+            'Send queue is full! More than 512 pending messages.'
+          );
+        }
+
+        const toSend = queue.shift();
+        sendPending = true;
+        oldWrite.call(port, toSend, 'binary', function() {
+          sendPending = false;
+
+          if (queue.length !== 0) {
+            trySend();
+          }
+        });
+      }
+
+      port.write = function() {
+        trySend.apply(port, arguments);
+      };
+    }
+
+    return port;
   }
 
   /**


### PR DESCRIPTION
Same approach as https://github.com/code-dot-org/chrome-serial-app/pull/2 but for the default Node SerialPort.

When manually testing, this fixes the connection flakiness we've been seeing in the Maker App on OS X.