### PR TITLE
Have a default translation for Plc::LearningModule type

### DIFF
--- a/dashboard/app/models/plc/enrollment_unit_assignment.rb
+++ b/dashboard/app/models/plc/enrollment_unit_assignment.rb
@@ -81,7 +81,7 @@ class Plc::EnrollmentUnitAssignment < ActiveRecord::Base
     if plc_course_unit.has_evaluation?
       Plc::LearningModule::MODULE_TYPES.select {|type| categories_for_stage.include?(type)}.each do |flex_category|
         module_category = flex_category
-        category_name = I18n.t("flex_category.#{module_category}")
+        category_name = I18n.t("flex_category.#{module_category}", default: I18n.t('flex_category.required'))
         summary << {
           category: category_name,
           status: module_assignment_for_type(flex_category).try(:status) || Plc::EnrollmentModuleAssignment::NOT_STARTED,


### PR DESCRIPTION
Noticed by @Hamms in https://github.com/code-dot-org/code-dot-org/pull/31013#discussion_r329273960 - a missing translation is possible here.  We should have a default translation.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [original discussion](https://github.com/code-dot-org/code-dot-org/pull/31013#discussion_r329273960)
- [jira](https://codedotorg.atlassian.net/browse/PLC-501)

## Testing story

Quick manual test in local console.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
