### PR TITLE
Test whether Jotform reshaping script causing database connection errors

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -95,7 +95,6 @@
       cronjob at:'5 16 * * *', do:deploy_dir('bin', 'cron', 'calculate_workshop_survey_results')
       cronjob at:'10 5 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups')
       cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_s3')
-      cronjob at:'0 7 * * *', do:deploy_dir('bin', 'cron', 'process_jotform_data')
       cronjob at:'0 11 * * *', do:deploy_dir('bin', 'cron', 'workshops_to_s3')
       cronjob at:'00 17 * * *', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
       cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')


### PR DESCRIPTION
# Description

Seeing database connection errors pop up at midnight. Seeing if removing this cron (which runs nightly and results in a lot of writes) solves the problem.