### PR TITLE
Skip Bubble Choice Feature on Firefox due to persistent flakiness.

### DIFF
--- a/dashboard/test/ui/features/bubble_choice.feature
+++ b/dashboard/test/ui/features/bubble_choice.feature
@@ -1,3 +1,4 @@
+@no_firefox
 Feature: BubbleChoice
   Scenario: Viewing BubbleChoice progress
     Given I create a teacher-associated student named "Alice"


### PR DESCRIPTION
# Description

The Bubble Choice feature is consistently flakey on Firefox.  Skip it for Firefox only.  There are [future plans](https://codedotorg.atlassian.net/browse/LP-787) to fix this test.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
