### PR TITLE
Advocacy: Fix a link

### DIFF
--- a/pegasus/src/advocacy_site.rb
+++ b/pegasus/src/advocacy_site.rb
@@ -47,7 +47,7 @@ class AdvocacySite
             },
             {
               text_actual: "National landscape state details",
-              url: "https://docs.google.com/document/d/1J3TbEQt3SmIWuha7ooBPvlWpiK-pNVIV5uuQEzNzdkE/edit?usp=sharing",
+              url: "https://docs.google.com/document/d/e/2PACX-1vTIZJaNtmPRBNb7_ZFHBxsGwyZqBSdpJN0iJ_pOgF-K-MNYikEeKTTj49ezDkMFRb1C_1w45gSrkcq6/pub",
               new_tab: true
             },
             {


### PR DESCRIPTION
This fixes the "National landscape state details" link on https://advocacy.code.org.
