### PR TITLE
Fixing facilitator dashboard eyes test failure

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -1021,8 +1021,8 @@ export class DetailViewContents extends React.Component {
   renderDetailViewTableLayout = () => {
     const sectionsToRemove =
       this.props.applicationData.application_type === ApplicationTypes.teacher
-        ? ['section5AdditionalDemographicInformation', 'section6Submission']
-        : ['section6Submission'];
+        ? ['additionalDemographicInformation']
+        : ['submission'];
 
     return (
       <div>


### PR DESCRIPTION
Facilitator application dashboard eyes test [failed](https://eyes.applitools.com/app/test-results/00000251830523473421/00000251830523307119/steps/3?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor) because  section names were recently changed in this PR https://github.com/code-dot-org/code-dot-org/pull/31124. 

This fix is to update correct section names.
Note: Teacher application no longer has a `submission` section.