### PR TITLE
Default notifications to Liz when partner is missing

### DIFF
--- a/dashboard/app/mailers/pd/application/teacher_application_mailer.rb
+++ b/dashboard/app/mailers/pd/application/teacher_application_mailer.rb
@@ -1,5 +1,6 @@
 module Pd::Application
   class TeacherApplicationMailer < ActionMailer::Base
+    CODE_ORG_DEFAULT_NOTIFICATION_EMAIL = 'Liz Gauthier <liz.gauthier@code.org>'
     default from: 'Code.org <noreply@code.org>'
     default bcc: MailerConstants::PLC_EMAIL_LOG
 
@@ -65,12 +66,9 @@ module Pd::Application
     def principal_approval_completed_partner(teacher_application)
       @application = teacher_application
 
-      partner_contact_email = @application.formatted_partner_contact_email
-      raise "Partner contact email is required, application id #{@application.id}" unless partner_contact_email
-
       mail(
         from: 'Liz Gauthier <teacher@code.org>',
-        to: partner_contact_email,
+        to: @application.formatted_partner_contact_email || CODE_ORG_DEFAULT_NOTIFICATION_EMAIL,
         subject: 'A principal has completed the principal approval form'
       )
     end

--- a/dashboard/app/models/pd/application/teacher2021_application.rb
+++ b/dashboard/app/models/pd/application/teacher2021_application.rb
@@ -158,15 +158,6 @@ module Pd::Application
     end
 
     # @override
-    def queue_email(email_type, deliver_now: false)
-      if email_type == :principal_approval_completed_partner && formatted_partner_contact_email.nil?
-        CDO.log.info "Skipping principal_approval_completed_partner for application id #{id}"
-      else
-        super
-      end
-    end
-
-    # @override
     def self.options
       super.merge(
         {

--- a/dashboard/test/models/pd/application/teacher2021_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher2021_application_test.rb
@@ -453,26 +453,6 @@ module Pd::Application
       assert_equal %w(cspWhichGrades cspHowOffer), application.errors.messages[:form_data]
     end
 
-    test 'queue_email skips principal_approval_completed_partner with no partner email address' do
-      application = build :pd_teacher2021_application
-      application.expects(:formatted_partner_contact_email).returns(nil)
-      CDO.log.expects(:info).with("Skipping principal_approval_completed_partner for application id #{application.id}")
-
-      assert_does_not_create Email do
-        application.queue_email :principal_approval_completed_partner
-      end
-    end
-
-    test 'queue_email queues up principal_approval_completed_partner with a partner email address' do
-      application = build :pd_teacher2021_application
-      application.expects(:formatted_partner_contact_email).returns('partner@ex.net')
-      CDO.log.expects(:info).never
-
-      assert_creates Email do
-        application.queue_email :principal_approval_completed_partner
-      end
-    end
-
     test 'should_send_decision_email?' do
       application = build :pd_teacher2021_application, status: :pending
 


### PR DESCRIPTION
Application notification emails that would normally go to our regional
partners should instead be sent to Liz when no partner was matched for a
given application.  At this time there's only one such notification
(that a principal approval form was completed) and we were simply
skipping it when no partner was found.

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-546)
- Recent work in this space: https://github.com/code-dot-org/code-dot-org/pull/31236

## Testing story

Tested with the mailer changes with the mailer preview feature:

![image](https://user-images.githubusercontent.com/1615761/67347364-b22df800-f4f6-11e9-85a5-5407e5ce031d.png)

Otherwise removed code and no-longer-relevant unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
