### PR TITLE
Restore ERB in YAML header for email templates

### DIFF
--- a/pegasus/emails/dashboard.html
+++ b/pegasus/emails/dashboard.html
@@ -1,19 +1,20 @@
+---
 <%
-  formatted_from = "Code.org <noreply@code.org>"
-  if defined?(from) && from != nil
-    if from.include? '<'
-      formatted_from = from
-    else
-      formatted_from = "Code.org <#{from}>"
-    end
+formatted_from = "Code.org <noreply@code.org>"
+if defined?(from) && from != nil
+  if from.include? '<'
+    formatted_from = from
+  else
+    formatted_from = "Code.org <#{from}>"
   end
-  @header["from"] = formatted_from
-  @header["subject"] = subject
-  @header["reply-to"] = reply_to
-  @header["cc"] = cc
-  @header["bcc"] = bcc
+end
 %>
-
+from: <%= formatted_from.inspect %>
+subject: <%= subject.inspect %>
+reply-to: <%= reply_to&.inspect %>
+cc: <%= cc&.inspect %>
+bcc: <%= bcc&.inspect %>
+---
 <%= body %>
 
 <img src="<%= tracking_pixel %>"/>

--- a/pegasus/emails/teacher_application_acceptance_group_1_csp.md
+++ b/pegasus/emails/teacher_application_acceptance_group_1_csp.md
@@ -1,7 +1,8 @@
 ---
 from: 'Sarah Fairweather (Code.org) <teacher@code.org>'  
+subject: "Congratulations from <%= regional_partner_name_s %> and Code.org! Respond by April 21st"
+
 ---
-<% @header["subject"] = "Congratulations from #{regional_partner_name_s} and Code.org! Respond by April 21st" %>
 
 Hi <%= preferred_first_name_s %>,
 

--- a/pegasus/emails/volunteer_contact_2015_receipt.md
+++ b/pegasus/emails/volunteer_contact_2015_receipt.md
@@ -1,16 +1,15 @@
 ---
+<%
+def format_email_address(email, name='')
+  name = "\"#{name.gsub('"', '\"').gsub("'","\\'")}\"" if name =~ /[;,\"\'\(\)]/
+  "#{name} <#{email}>".strip
+end
+%>
+to: <%= format_email_address(volunteer_email_s, volunteer_name_s).inspect %>
 from: 'Code.org Volunteers <volunteers@code.org>'
+reply-to: <%= format_email_address(email_s, name_s).inspect %>
 subject: "A teacher is requesting your help"
 ---
-
-<%
-  def format_email_address(email, name='')
-    name = "\"#{name.gsub('"', '\"').gsub("'","\\'")}\"" if name =~ /[;,\"\'\(\)]/
-    "#{name} <#{email}>".strip
-  end
-  @header["to"] = format_email_address(volunteer_email_s, volunteer_name_s)
-  @header["reply-to"] = format_email_address(email_s, name_s)
-%>
 
 <% update_preferences = "https://#{CDO.canonical_hostname('code.org')}/volunteer/engineer/edit/#{volunteer_secret_s}/" %>
 


### PR DESCRIPTION
# Description

As it turns out, emails don't use the rendering logic I updated in https://github.com/code-dot-org/code-dot-org/pull/31362 and so don't need to stop using ERB in their YAML header just yet; they use https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/pegasus/text_render.rb, specifically https://github.com/code-dot-org/code-dot-org/blob/8bfb480e91fec4a6e39d3727634d26f85b73f4df/lib/cdo/pegasus/text_render.rb#L190-L205 which still supports ERB (see https://github.com/code-dot-org/code-dot-org/blob/8bfb480e91fec4a6e39d3727634d26f85b73f4df/bin/cron/deliver_poste_messages#L63-L74 for more details).

In addition, they actually only define `@header` if one is detected, so the change to assign metadata directly to that variable was failing because it never got initialized. Reverting these templates to their old format fixes things for now, and I'll track longer-term work to update YamlEngine

## Testing story

I plan to investigate why this bug wasn't caught by our tests and to add appropriate testing in a follow-up PR; I just want to get this merged ASAP to unblock the pipeline.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
