### PR TITLE
Enable Proxysql on frontends by default

### DIFF
--- a/cookbooks/cdo-mysql/attributes/default.rb
+++ b/cookbooks/cdo-mysql/attributes/default.rb
@@ -1,6 +1,7 @@
 default['cdo-mysql'] = {
   proxy: {
-    enabled: false,
+    # Enable proxy on non-daemon app-servers by default.
+    enabled: node['cdo-apps'] && !node['cdo-apps']['daemon'],
     port: 6033,
     admin: 'mysql2://admin:admin@127.0.0.1:6032'
   }

--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -40,6 +40,14 @@ mysql_variables=
   # if the node should be present in both hostgroups or not.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-monitor_writer_is_also_reader
   monitor_writer_is_also_reader=false
+
+  # If this variable is set, after an OK packet with `last_insert_id` is received,
+  # multiplexing is temporary disabled for the number of queries specified (default 5).
+  # This prevents inconsistent results if a query containing `LAST_INSERT_ID()` uses a
+  # different connection from the one where auto-increment was used.
+  # We can disable (set to 0) since our application doesn't use `LAST_INSERT_ID()` in any queries.
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-auto_increment_delay_multiplex
+  mysql-auto_increment_delay_multiplex=0
 }
 
 # https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers


### PR DESCRIPTION
# Description

Updates the Chef-attribute default for `node['cdo-mysql']['proxy']['enabled']` to enable ProxySQL integration on frontends by default. (Specifically, any non-`daemon` app-server instance will have the integration enabled by default, which is only production frontends in our infrastructure.)

This integration will remain disabled on `daemon` instances, because the various build/test/setup SQL queries sent via the CI-build process on daemon servers are more complicated and less thoroughly tested at this point, and the benefits of ProxySQL are only most relevant to the production-frontend environment.

Also includes a fix for one remaining multiplexing issue by setting `mysql-auto_increment_delay_multiplex` to `0` in the proxysql configuration.

This integration has been thoroughly tested on live production frontends without significant remaining issues.