### PR TITLE
Adding spinner and test

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
@@ -8,6 +8,7 @@ import libraryParser from './libraryParser';
 import i18n from '@cdo/locale';
 import PadAndCenter from '@cdo/apps/templates/teacherDashboard/PadAndCenter';
 import {Heading1, Heading2} from '@cdo/apps/lib/ui/Headings';
+import Spinner from '../../pd/components/spinner';
 
 const styles = {
   alert: {
@@ -26,6 +27,10 @@ const styles = {
   },
   textarea: {
     width: 400
+  },
+  centerSpinner: {
+    display: 'flex',
+    justifyContent: 'center'
   }
 };
 
@@ -118,7 +123,11 @@ class LibraryCreationDialog extends React.Component {
 
   displayFunctions = () => {
     if (!this.state.loadingFinished) {
-      return <div id="loading">Loading...</div>;
+      return (
+        <div style={styles.centerSpinner}>
+          <Spinner />
+        </div>
+      );
     }
     let keyIndex = 0;
     return (

--- a/apps/test/unit/code-studio/components/libraries/LibraryCreationDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryCreationDialogTest.js
@@ -3,8 +3,9 @@ import React from 'react';
 import {mount} from 'enzyme';
 import {UnconnectedLibraryCreationDialog as LibraryCreationDialog} from '@cdo/apps/code-studio/components/libraries/LibraryCreationDialog.jsx';
 import libraryParser from '@cdo/apps/code-studio/components/libraries/libraryParser';
-import LibraryClientApi from '../../../../../src/code-studio/components/libraries/LibraryClientApi';
+import LibraryClientApi from '@cdo/apps/code-studio/components/libraries/LibraryClientApi';
 import sinon from 'sinon';
+import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 
 const LIBRARY_SOURCE =
   '/*\n' +
@@ -99,7 +100,7 @@ describe('LibraryCreationDialog', () => {
 
     it('displays loading while in the loading state', () => {
       expect(wrapper.find(SUBMIT_SELECTOR).exists()).to.be.false;
-      expect(wrapper.find('#loading').exists()).to.be.true;
+      expect(wrapper.find(Spinner).exists()).to.be.true;
     });
 
     it('description is required', () => {


### PR DESCRIPTION
# Description


Follow up on this PR: https://github.com/code-dot-org/code-dot-org/pull/31303
Replace `Loading . . . ` text with a loading spinner:
![Screenshot from 2019-10-22 18-14-42](https://user-images.githubusercontent.com/2959170/67348040-962b5600-f4f8-11e9-9420-f64754ef4688.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links


- [spec]()
- [jira](https://codedotorg.atlassian.net/browse/STAR-775)

## Testing story
Updated unit tests to reflect the changes

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
