### PR TITLE
Stop showing cohort capacity

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/cohort_calculator.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_calculator.jsx
@@ -28,22 +28,13 @@ export default class CohortCalculator extends React.Component {
     super(props);
 
     this.state = {
-      loadingCapacity: null,
-      capacity: null,
-      loadingRegistrationCount: null,
-      registered: null
+      loadingEnrollmentCount: null,
+      enrolled: null
     };
   }
 
   componentDidMount() {
     this.loadData();
-  }
-
-  getPartnerCapacity(role, regional_partner_value) {
-    return $.get({
-      url: `/api/v1/regional_partners/capacity?role=${role}&regional_partner_value=${regional_partner_value}`,
-      dataType: 'json'
-    });
   }
 
   getPartnerRegistrationCount(role, regional_partner_value) {
@@ -54,21 +45,7 @@ export default class CohortCalculator extends React.Component {
   }
 
   loadData(regionalPartnerFilterValue) {
-    this.setState({loadingCapacity: true, loadingRegistrationCount: true});
-
-    this.getPartnerCapacity(
-      this.props.role,
-      this.props.regionalPartnerFilterValue
-    )
-      .done(data => {
-        this.setState({
-          loadingCapacity: false,
-          capacity: data.capacity
-        });
-      })
-      .fail(() => {
-        this.setState({loadingCapacity: false});
-      });
+    this.setState({loadingEnrollmentCount: true});
 
     this.getPartnerRegistrationCount(
       this.props.role,
@@ -76,61 +53,42 @@ export default class CohortCalculator extends React.Component {
     )
       .done(data => {
         this.setState({
-          loadingRegistrationCount: false,
-          registered: data.enrolled
+          loadingEnrollmentCount: false,
+          enrolled: data.enrolled
         });
       })
       .fail(() => {
-        this.setState({loadingRegistrationCount: false});
+        this.setState({loadingEnrollmentCount: false});
       });
   }
 
   render() {
     return (
-      this.state.capacity && (
-        <div style={styles.tableWrapper}>
-          <Table striped condensed>
-            <caption>Cohort Calculator</caption>
-            <thead>
-              <tr>
-                <th />
-                <th>Total</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Available Seats</td>
-                <td>
-                  {this.state.loadingCapacity
-                    ? 'Loading...'
-                    : this.state.capacity}
-                </td>
-              </tr>
-              <tr>
-                {/*TODO: add hover text explaining what these fields represent*/}
-                <td>Accepted</td>
-                <td>{this.props.accepted}</td>
-              </tr>
-              <tr>
-                <td>Remaining Capacity</td>
-                <td>
-                  {this.state.capacity &&
-                    this.state.capacity -
-                      Math.max(this.props.accepted, this.state.registered)}
-                </td>
-              </tr>
-              <tr>
-                <td>Registered</td>
-                <td>
-                  {this.state.loadingRegistrationCount
-                    ? 'Loading...'
-                    : this.state.registered}
-                </td>
-              </tr>
-            </tbody>
-          </Table>
-        </div>
-      )
+      <div style={styles.tableWrapper}>
+        <Table striped condensed>
+          <caption>Cohort Calculator</caption>
+          <thead>
+            <tr>
+              <th />
+              <th>Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Accepted</td>
+              <td>{this.props.accepted}</td>
+            </tr>
+            <tr>
+              <td>Registered</td>
+              <td>
+                {this.state.loadingEnrollmentCount
+                  ? 'Loading...'
+                  : this.state.enrolled}
+              </td>
+            </tr>
+          </tbody>
+        </Table>
+      </div>
     );
   }
 }

--- a/apps/src/code-studio/pd/application_dashboard/cohort_calculator.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_calculator.jsx
@@ -83,7 +83,7 @@ export default class CohortCalculator extends React.Component {
               <td>
                 {this.state.loadingEnrollmentCount
                   ? 'Loading...'
-                  : this.state.enrolled}
+                  : this.state.enrolled || '-'}
               </td>
             </tr>
           </tbody>

--- a/apps/test/unit/code-studio/pd/application_dashboard/cohort_calculatorTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/cohort_calculatorTest.js
@@ -20,16 +20,15 @@ describe('Cohort Calculator', () => {
     });
 
     it('Is loading', () => {
-      expect(cohortCalculator.state('loadingCapacity')).to.be.true;
-      expect(cohortCalculator.state('loadingRegistrationCount')).to.be.true;
+      expect(cohortCalculator.state('loadingEnrollmentCount')).to.be.true;
     });
     it('Does not render a table', () => {
       expect(cohortCalculator.find('table')).to.have.length(0);
     });
   });
 
-  describe('After receiving null capacity from server', () => {
-    const data = {capacity: null};
+  describe('After receiving enrollment count from server', () => {
+    const data = {enrolled: 1};
     const regionalPartnerFilterValue = AllPartnersValue;
     let server;
     let cohortCalculator;
@@ -38,7 +37,7 @@ describe('Cohort Calculator', () => {
       server = sinon.fakeServer.create();
       server.respondWith(
         'GET',
-        `/api/v1/regional_partners/capacity?role=csp_teachers&regional_partner_value=${regionalPartnerFilterValue}`,
+        `/api/v1/regional_partners/enrolled?role=csp_teachers&regional_partner_value=${regionalPartnerFilterValue}`,
         [200, {'Content-Type': 'json'}, JSON.stringify(data)]
       );
 
@@ -57,42 +56,10 @@ describe('Cohort Calculator', () => {
     });
 
     it('Is no longer loading', () => {
-      expect(cohortCalculator.state('loadingCapacity')).to.be.false;
+      expect(cohortCalculator.state('loadingEnrollmentCount')).to.be.false;
     });
-    it('Does not render anything', () => {
-      expect(cohortCalculator.html()).to.be.null;
-    });
-  });
-
-  describe('After receiving non-null capacity from server', () => {
-    const data = {capacity: 25};
-    const regionalPartnerFilterValue = 1;
-    let server;
-    let cohortCalculator;
-    before(() => {
-      server = sinon.fakeServer.create();
-      server.respondWith(
-        'GET',
-        `/api/v1/regional_partners/capacity?role=csp_teachers&regional_partner_value=${regionalPartnerFilterValue}`,
-        [200, {'Content-Type': 'json'}, JSON.stringify(data)]
-      );
-
-      cohortCalculator = shallow(
-        <CohortCalculator
-          regionalPartnerFilterValue={regionalPartnerFilterValue}
-          role="csp_teachers"
-          accepted={0}
-        />
-      );
-
-      server.respond();
-    });
-    after(() => {
-      server.restore();
-    });
-
-    it('Is no longer loading', () => {
-      expect(cohortCalculator.state('loadingCapacity')).to.be.false;
+    it('Get correct enrollment count from server', () => {
+      expect(cohortCalculator.state('enrolled')).to.equal(data.enrolled);
     });
     it('Renders a table', () => {
       cohortCalculator.update();

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -14,12 +14,6 @@
   .field
     = f.label :urban
     = f.check_box :urban
-  .field
-    = f.label :cohort_capacity_csd
-    = f.text_field :cohort_capacity_csd
-  .field
-    = f.label :cohort_capacity_csp
-    = f.text_field :cohort_capacity_csp
   - %w(csd csp).each do |course|
     - %w(teacher facilitator).each do |role|
       .field

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -17,12 +17,6 @@
 %p
   %strong Urban:
   = @regional_partner.urban? ? 'Yes' : 'No'
-%p
-  %strong CSD Cohort Capacity:
-  = @regional_partner.cohort_capacity_csd
-%p
-  %strong CSP Cohort Capacity:
-  = @regional_partner.cohort_capacity_csp
 - %w(csd csp).each do |course|
   - %w(teacher facilitator).each do |role|
     - %w(open close).each do |state|

--- a/dashboard/test/controllers/api/v1/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/regional_partners_controller_test.rb
@@ -249,13 +249,13 @@ class Api::V1::RegionalPartnersControllerTest < ActionController::TestCase
   test 'show regional partner summer workshops for valid partner ID' do
     regional_partner = create :regional_partner_beverly_hills
 
-    get :show, partner_id: regional_partner.id
+    get :show, params: {partner_id: regional_partner.id}
     assert_response :success
     assert_equal regional_partner.contact_name, JSON.parse(@response.body)['contact_name']
   end
 
   test 'show regional partner summer workshops for invalid partner ID' do
-    get :show, partner_id: "YY"
+    get :show, params: {partner_id: "YY"}
     assert_response :success
     assert_equal "no_partner", JSON.parse(@response.body)['error']
   end
@@ -265,7 +265,7 @@ class Api::V1::RegionalPartnersControllerTest < ActionController::TestCase
 
     regional_partner = create :regional_partner_beverly_hills
 
-    get :find, zip_code: 90210
+    get :find, params: {zip_code: 90210}
     assert_response :success
     assert_equal regional_partner.contact_name, JSON.parse(@response.body)['contact_name']
   end
@@ -276,7 +276,7 @@ class Api::V1::RegionalPartnersControllerTest < ActionController::TestCase
 
     regional_partner = create :regional_partner_illinois
 
-    get :find, zip_code: 60415
+    get :find, params: {zip_code: 60415}
     assert_response :success
     assert_equal regional_partner.contact_name, JSON.parse(@response.body)['contact_name']
   end
@@ -285,13 +285,13 @@ class Api::V1::RegionalPartnersControllerTest < ActionController::TestCase
     mock_washington_object = OpenStruct.new(state_code: "WA")
     Geocoder.expects(:search).returns([mock_washington_object])
 
-    get :find, zip_code: 98104
+    get :find, params: {zip_code: 98104}
     assert_response :success
     assert_equal "no_partner", JSON.parse(@response.body)['error']
   end
 
   test 'find no regional partner summer workshops for invalid ZIP code' do
-    get :find, zip_code: "XX"
+    get :find, params: {zip_code: "XX"}
     assert_response :success
     assert_equal "no_state", JSON.parse(@response.body)['error']
   end
@@ -299,7 +299,7 @@ class Api::V1::RegionalPartnersControllerTest < ActionController::TestCase
   test 'find no regional partner summer workshops for non-existent ZIP code' do
     Geocoder.expects(:search).returns([])
 
-    get :find, zip_code: 11111
+    get :find, params: {zip_code: 11111}
     assert_response :success
     assert_equal "no_state", JSON.parse(@response.body)['error']
   end


### PR DESCRIPTION
# Description
[PLC-574](https://codedotorg.atlassian.net/browse/PLC-574)
- Remove "available seats" and "remaining capacity" rows from the cohort calculator
  <img width="115" alt="Screen Shot 2019-10-23 at 2 46 17 PM" src="https://user-images.githubusercontent.com/46507039/67436699-e9a6ae00-f5a3-11e9-8335-4389bb872ee1.png">

- Remove logic restricting the cohort calculator to only display when a partner has specified their cohort size.
- Remove "Cohort capacity csd" and "Cohort capacity csp" fields from the regional partner edit view and the regional partner info view

## Testing story
Manual tests on local host.
* Regional partner info view: http://localhost-studio.code.org:3000/regional_partners/1
* Regional partner edit view: http://localhost-studio.code.org:3000/regional_partners/1/edit
* Teacher Cohort view: http://localhost-studio.code.org:3000/pd/application_dashboard/csd_teachers
* Teacher Quick view: http://localhost-studio.code.org:3000/pd/application_dashboard/csd_teachers_cohort

