### PR TITLE
Teacher Application: Updates to application notification emails

### DIFF
--- a/dashboard/app/views/pd/application/teacher_application_mailer/_expectations.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/_expectations.html.haml
@@ -9,4 +9,4 @@
     %li
       Intend to teach this curriculum in the school year
       (If this has changed since you first applied, please let me know
-      as soon as possible so that your application can be withdrawn).
+      as soon as possible so we can evaluate your application again).

--- a/dashboard/app/views/pd/application/teacher_application_mailer/accepted_no_cost_registration.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/accepted_no_cost_registration.html.haml
@@ -35,12 +35,8 @@
     Code.org.
   Moving forward, I will be your main point of contact
   for this program, including all communication regarding your
-  summer and school-year workshops.
-
-%p{style: 'margin-bottom: 0'}
-  Please direct all questions or concerns to:
-  %div{style: 'padding-left: 2em'}
-    = render partial: 'partner_signature'
+  summer and school-year workshops. Please let me know if you
+  have any questions or concerns.
 
 %p
   Here are your important next steps:

--- a/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval.html.haml
@@ -39,16 +39,17 @@
     %li To attend up to four, one-day local workshops during the school year (usually held on Saturdays)
     %li To teach the course in the school year.
 
-%p{style: 'margin-bottom: 0'}
-  Please direct all questions or concerns to:
-  %div{style: 'padding-left: 2em'}
-    = render partial: 'partner_signature'
-
 %p
-  For more information about Code.org’s professional development programs, please visit
-  = link_to('https://code.org/educate', 'https://code.org/educate') + '.'
-  Please let us know if you have any questions.
-  Thank you very much for your support of computer science for every student!
+  For more information about
+  = link_to('Code.org', 'https://code.org') + "'s"
+  professional development programs, please visit
+  = link_to('https://code.org/educate', 'https://code.org/educate')
+  and refer to this
+  = link_to('brochure', 'https://code.org/files/programs/codeorg-program-brochure.pdf')
+  that highlights how to bring computer science to your school.
+  Please send any additional questions to
+  = link_to('teacher@code.org', 'mailto:teacher@code.org') + '.'
+  Thank you very much for your support of computer science for all!
 
 %p
   = render partial: 'partner_signature'

--- a/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval_teacher_reminder.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval_teacher_reminder.html.haml
@@ -22,9 +22,16 @@
     %li You hope to teach the course in the 2019-20 school year
 
 %p
-  Please direct all questions or concerns to:
-  %div{style: 'padding-left: 2em'}
-    = render partial: 'partner_signature'
+  For more information about
+  = link_to('Code.org', 'https://code.org') + "'s"
+  professional development programs, please visit
+  = link_to('https://code.org/educate', 'https://code.org/educate')
+  and refer to this
+  = link_to('brochure', 'https://code.org/files/programs/codeorg-program-brochure.pdf')
+  that highlights how to bring computer science to your school.
+  Please send any additional questions to
+  = link_to('teacher@code.org', 'mailto:teacher@code.org') + '.'
+  Thank you very much for your support of computer science for all!
 
 %p
-  For more information about Code.org’s professional development programs, please visit http://code.org/educate. Thank you very much! We look forward to reviewing your application!
+  = render partial: 'partner_signature'


### PR DESCRIPTION
([PLC-261](https://codedotorg.atlassian.net/browse/PLC-261)) As spec'd in [this document](https://docs.google.com/document/d/1ihETTeI-q0-RItkioOhjR8LbrHlnvWz9nsQ4ZxEVXWQ/edit)

# Changed emails
Note, I'm only posting screenshots of the "with partner" variants of these mailers.  The "with partner but no contact" and "without partner" variants all contain matching changes, by design.

`accepted_no_cost_registration`

![image](https://user-images.githubusercontent.com/1615761/67433760-90d41700-f59d-11e9-808b-926c49883b7e.png)

`principal_approval`

![image](https://user-images.githubusercontent.com/1615761/67433827-b2350300-f59d-11e9-8975-71522c97c465.png)

`principal_approval_teacher_reminder`

![image](https://user-images.githubusercontent.com/1615761/67433881-d1339500-f59d-11e9-9fe4-be026516ebe5.png)

`registration_sent`

![image](https://user-images.githubusercontent.com/1615761/67433945-f45e4480-f59d-11e9-8fe6-740aecbe8bef.png)
