### PR TITLE
Assignment Updates: show assigned for students on course overview

### DIFF
--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -113,7 +113,11 @@ class CourseScript extends Component {
       return null;
     }
 
-    const isAssigned = assignedSectionId === parseInt(selectedSectionId);
+    const assignedToStudent = viewAs === ViewType.Student && assignedSectionId;
+    const assignedByTeacher =
+      viewAs === ViewType.Teacher &&
+      assignedSectionId === parseInt(selectedSectionId);
+    const isAssigned = assignedToStudent || assignedByTeacher;
 
     return (
       <div


### PR DESCRIPTION
Follow up to #31293 where if the user is a teacher and a script is assigned to the selected section we show a green checkmark and "assigned" on the unit box for that script on the course overview page. This PR extends the logic slightly so that students will also see the checkmark and assigned label if any of their sections have been assigned that particular script. Since students do not select a section, here I just use the presence of `assignedSectionId` rather than checking its value as I did with teachers. 

<img width="1045" alt="Screen Shot 2019-10-23 at 2 06 19 PM" src="https://user-images.githubusercontent.com/12300669/67434792-b6622000-f59f-11e9-9db0-85f346de3bc9.png">

- [spec](https://docs.google.com/document/d/1vJySqyKozUxknkhY1KyQXWzbV-0c1vdnpKvRsAsVrdI/edit#bookmark=id.2pywcek2omng)
- [jira, LP-706](https://codedotorg.atlassian.net/browse/LP-706)

