### PR TITLE
Fix proxysql config variable

### DIFF
--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -47,7 +47,7 @@ mysql_variables=
   # different connection from the one where auto-increment was used.
   # We can disable (set to 0) since our application doesn't use `LAST_INSERT_ID()` in any queries.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-auto_increment_delay_multiplex
-  mysql-auto_increment_delay_multiplex=0
+  auto_increment_delay_multiplex=0
 }
 
 # https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers


### PR DESCRIPTION
Followup to #31428. This fixes a typo in the config-file format for the added `auto_increment_delay_multiplex` variable.