### PR TITLE
[student-libraries] Enabled library tooltips from comments.

### DIFF
--- a/apps/src/blockTooltips/DropletFunctionTooltip.html.ejs
+++ b/apps/src/blockTooltips/DropletFunctionTooltip.html.ejs
@@ -15,7 +15,13 @@
     <%= getPrefixedName() %>(<% for (var i = 0; i < locals.parameters.length; i++) { -%><%- locals.parameters[i].name -%><% if (i < locals.parameters.length - 1) { -%>, <% } -%><% } -%>)
   <% } %>
 </div>
-<% if (locals.functionShortDescription) { %><div><%= locals.functionShortDescription %></div><% } %>
+<% if (locals.functionShortDescription) { %>
+  <% locals.functionShortDescription.split('\n').map(function(descriptionLine) { %>
+    <div>
+      <%= descriptionLine %>
+    </div>
+  <% }) %>
+<% } %>
 <% if (locals.showExamplesLink) { %>
   <div class="tooltip-example-link">
     <a href="javascript:void(0);">See examples</a>

--- a/apps/src/blockTooltips/DropletFunctionTooltip.js
+++ b/apps/src/blockTooltips/DropletFunctionTooltip.js
@@ -63,9 +63,11 @@ var DropletFunctionTooltip = function(appMsg, definition) {
   /** @type {?string} */
   this.customDocURL = definition.customDocURL;
 
-  var description = this.getLocalization(this.descriptionKey());
-  if (description) {
-    this.description = description();
+  var localizedDescription = this.getLocalization(this.descriptionKey());
+  if (definition.comment) {
+    this.description = definition.comment;
+  } else if (localizedDescription) {
+    this.description = localizedDescription();
   }
 
   var signatureOverride = this.getLocalization(this.signatureOverrideKey());

--- a/apps/src/code-studio/components/libraries/libraryParser.js
+++ b/apps/src/code-studio/components/libraries/libraryParser.js
@@ -35,7 +35,8 @@ function createDropletConfig(functions, libraryName) {
 
     let individualConfig = {
       func: `${libraryName}.${currentFunction.functionName}`,
-      category: 'Functions'
+      category: 'Functions',
+      comment: currentFunction.comment
     };
 
     if (currentFunction.parameters && currentFunction.parameters.length > 0) {

--- a/apps/test/unit/code-studio/components/libraries/libraryParserTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryParserTest.js
@@ -145,6 +145,43 @@ describe('Library parser', () => {
       );
     });
 
+    it('is able to parse functions with comments', () => {
+      let functionName = 'func';
+      let comment = 'comment';
+      let category = 'Functions';
+      let selectedFunctions = [
+        {
+          functionName: functionName,
+          comment: comment
+        }
+      ];
+
+      let expectedDropletConfig = [
+        {
+          func: emptyLibraryName + '.' + functionName,
+          category: category,
+          comment: comment
+        }
+      ];
+
+      let expectedFunctions = `${functionName}: ${functionName}`;
+      expect(
+        parser.createLibraryJson(
+          emptyCode,
+          selectedFunctions,
+          emptyLibraryName,
+          emptyDescription
+        )
+      ).to.deep.equal(
+        JSON.stringify({
+          name: emptyLibraryName,
+          description: emptyDescription,
+          dropletConfig: expectedDropletConfig,
+          source: closureCreator(emptyLibraryName, emptyCode, expectedFunctions)
+        })
+      );
+    });
+
     it('is able to parse functions with parameters', () => {
       let firstFunctionName = 'first';
       let secondFunctionName = 'second';


### PR DESCRIPTION
# Description
When a student adds comments to their library functions, they are now displayed in the tooltips of their library blocks

![LibrariesComments](https://user-images.githubusercontent.com/8324574/67438786-40fb4d00-f5a9-11e9-9e98-9e74194f0ab6.gif)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
- [spec](https://docs.google.com/document/d/1VxMmdHdIeBWCXKofkjEy9MuWcrzeEW3Zt-Ir8pINYdA/edit)
- [jira](https://codedotorg.atlassian.net/browse/STAR-710)
- [all relevant PRs](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Ajmkulwik+archived%3Afalse+student+libraries)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
