### PR TITLE
[student-libraries] Added library description to library display

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryClientApi.js
+++ b/apps/src/code-studio/components/libraries/LibraryClientApi.js
@@ -89,6 +89,7 @@ export default class LibraryClientApi {
                     .filter(library => !!library.libraryName)
                     .map(library => {
                       library.name = library.libraryName;
+                      library.description = library.libraryDescription;
                       return library;
                     });
                   libraries.forEach(library => {

--- a/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
@@ -68,7 +68,8 @@ class LibraryCreationDialog extends React.Component {
     this.props.onClose();
   };
 
-  publish = () => {
+  publish = event => {
+    event.preventDefault();
     let formElements = this.formElements.elements;
     let selectedFunctionList = [];
     let libraryDescription = '';
@@ -99,7 +100,10 @@ class LibraryCreationDialog extends React.Component {
         );
       }
     );
-    dashboard.project.setLibraryName(this.state.libraryName);
+    dashboard.project.setLibraryData(
+      this.state.libraryName,
+      libraryDescription
+    );
   };
 
   validateInput = () => {

--- a/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
@@ -100,10 +100,8 @@ class LibraryCreationDialog extends React.Component {
         );
       }
     );
-    dashboard.project.setLibraryData(
-      this.state.libraryName,
-      libraryDescription
-    );
+    dashboard.project.setLibraryName(this.state.libraryName);
+    dashboard.project.setLibraryDescription(libraryDescription);
   };
 
   validateInput = () => {

--- a/apps/src/code-studio/components/libraries/LibraryListItem.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryListItem.jsx
@@ -89,7 +89,7 @@ export default class LibraryListItem extends React.Component {
           </button>
         )}
         <span style={styles.description}>
-          {this.displayDescription(library.description)}
+          {library.description}
           <br />
           {library.studentName && (
             <span style={styles.author}>Author: {library.studentName}</span>

--- a/apps/src/code-studio/components/libraries/LibraryListItem.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryListItem.jsx
@@ -52,10 +52,6 @@ export default class LibraryListItem extends React.Component {
     onAdd: PropTypes.func
   };
 
-  displayDescription = _ => {
-    return "My Library's very long description that goes off the page.";
-  };
-
   moreDetails = _ => {
     return 'See More Details';
   };

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -564,12 +564,6 @@ var projects = (module.exports = {
       this.setTitle(newName);
     }
   },
-  deleteLibraryData(callback) {
-    current = current || {};
-    current.libraryName = undefined;
-    current.libraryDescription = undefined;
-    this.updateChannels_(callback);
-  },
   setLibraryDescription(description, callback) {
     current = current || {};
     if (description && current.libraryDescription !== description) {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -179,6 +179,17 @@ var projects = (module.exports = {
   },
 
   /**
+   * @returns {string} description of the most recently published library from the
+   * project, or undefined if we don't have a current project
+   */
+  getCurrentLibraryDescription() {
+    if (!current) {
+      return;
+    }
+    return current.libraryDescription;
+  },
+
+  /**
    * This method is used so that it can be mocked for unit tests.
    */
   getUrl() {
@@ -553,13 +564,23 @@ var projects = (module.exports = {
       this.setTitle(newName);
     }
   },
-  setLibraryData(newName, description, callback) {
+  deleteLibraryData(callback) {
     current = current || {};
-    let doUpdate = description && current.libraryDescription !== description;
-    doUpdate = doUpdate || (newName && current.libraryName !== newName);
-    if (doUpdate) {
-      current.libraryName = newName || current.libraryName;
-      current.libraryDescription = description || current.libraryDescription;
+    current.libraryName = undefined;
+    current.libraryDescription = undefined;
+    this.updateChannels_(callback);
+  },
+  setLibraryDescription(description, callback) {
+    current = current || {};
+    if (description && current.libraryDescription !== description) {
+      current.libraryDescription = description;
+      this.updateChannels_(callback);
+    }
+  },
+  setLibraryName(newName, callback) {
+    current = current || {};
+    if (newName && current.libraryName !== newName) {
+      current.libraryName = newName;
       this.updateChannels_(callback);
     }
   },

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -553,10 +553,13 @@ var projects = (module.exports = {
       this.setTitle(newName);
     }
   },
-  setLibraryName(newName, callback) {
+  setLibraryData(newName, description, callback) {
     current = current || {};
-    if (newName && current.libraryName !== newName) {
-      current.libraryName = newName;
+    let doUpdate = description && current.libraryDescription !== description;
+    doUpdate = doUpdate || (newName && current.libraryName !== newName);
+    if (doUpdate) {
+      current.libraryName = newName || current.libraryName;
+      current.libraryDescription = description || current.libraryDescription;
       this.updateChannels_(callback);
     }
   },

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -531,25 +531,6 @@ describe('project.js', () => {
     });
   });
 
-  describe('deleteLibraryData()', () => {
-    it('deletes the library name and description', () => {
-      let oldDescription = 'description';
-      let oldName = 'Name';
-      setData({libraryDescription: oldDescription, libraryName: oldName});
-      sinon.stub(project, 'updateChannels_');
-
-      expect(project.getCurrentLibraryDescription()).to.equal(oldDescription);
-      expect(project.getCurrentLibraryName()).to.equal(oldName);
-      project.deleteLibraryData();
-      expect(project.getCurrentLibraryDescription()).to.be.undefined;
-      expect(project.getCurrentLibraryName()).to.be.undefined;
-      expect(project.updateChannels_).to.have.been.called;
-
-      setData({});
-      project.updateChannels_.restore();
-    });
-  });
-
   describe('setProjectLibraries()', () => {
     beforeEach(() => {
       sinon

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -503,6 +503,53 @@ describe('project.js', () => {
     });
   });
 
+  describe('setLibraryDescription()', () => {
+    it('updates the current library description', () => {
+      let oldDescription = 'description';
+      let newDescription = 'My library does something cool';
+      setData({libraryDescription: oldDescription});
+      sinon.stub(project, 'updateChannels_');
+
+      expect(project.getCurrentLibraryDescription()).to.equal(oldDescription);
+      project.setLibraryDescription(newDescription);
+      expect(project.getCurrentLibraryDescription()).to.equal(newDescription);
+      expect(project.updateChannels_).to.have.been.called;
+
+      setData({});
+      project.updateChannels_.restore();
+    });
+
+    it('does nothing if no description is passed', () => {
+      sinon.stub(project, 'updateChannels_');
+
+      expect(project.getCurrentLibraryDescription()).to.be.undefined;
+      project.setLibraryDescription();
+      expect(project.getCurrentLibraryDescription()).to.be.undefined;
+      expect(project.updateChannels_).to.have.not.been.called;
+
+      project.updateChannels_.restore();
+    });
+  });
+
+  describe('deleteLibraryData()', () => {
+    it('deletes the library name and description', () => {
+      let oldDescription = 'description';
+      let oldName = 'Name';
+      setData({libraryDescription: oldDescription, libraryName: oldName});
+      sinon.stub(project, 'updateChannels_');
+
+      expect(project.getCurrentLibraryDescription()).to.equal(oldDescription);
+      expect(project.getCurrentLibraryName()).to.equal(oldName);
+      project.deleteLibraryData();
+      expect(project.getCurrentLibraryDescription()).to.be.undefined;
+      expect(project.getCurrentLibraryName()).to.be.undefined;
+      expect(project.updateChannels_).to.have.been.called;
+
+      setData({});
+      project.updateChannels_.restore();
+    });
+  });
+
   describe('setProjectLibraries()', () => {
     beforeEach(() => {
       sinon

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -186,6 +186,7 @@ module ProjectsList
         channel: channel_id,
         name: project_value['name'],
         libraryName: project_value['libraryName'],
+        libraryDescription: project_value['libraryDescription'],
         studentName: student&.name,
         thumbnailUrl: project_value['thumbnailUrl'],
         type: project_type(project_value['level']),


### PR DESCRIPTION
# Description
Stores and displays any descriptions a user has added to a library.

![LibraryDescription](https://user-images.githubusercontent.com/8324574/67439889-72c1e300-f5ac-11e9-98e6-c4ccc399ebf9.gif)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
- [spec](https://docs.google.com/document/d/1VxMmdHdIeBWCXKofkjEy9MuWcrzeEW3Zt-Ir8pINYdA/edit)
- [jira](https://codedotorg.atlassian.net/browse/STAR-710)
- [all relevant PRs](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Ajmkulwik+archived%3Afalse+student+libraries)
## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
