### PR TITLE
Peer Review Dashboard: Sort by submission date, descending

### DIFF
--- a/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::PeerReviewSubmissionsController < ApplicationController
     per = params[:per] || params[:limit] || 50
     user_query = params[:user_q]
 
-    reviews = PeerReview.all.order(created_at: :desc)
+    reviews = PeerReview.all
 
     if user_query.presence
       reviews =
@@ -51,11 +51,18 @@ class Api::V1::PeerReviewSubmissionsController < ApplicationController
       reviews = reviews.where(script: Plc::Course.find(params[:plc_course_id]).plc_course_units.map(&:script))
     end
 
-    reviews = reviews.distinct {|review| [review.submitter, review.level]}
+    # This query gets the latest submission for each user+level, paginated, and returns a
+    # recordset with pagination metadata and correctly-ordered, partially-populated models.
+    reviews = reviews.
+      page(page).
+      per(per).
+      order('id DESC').
+      group(:submitter_id, :level_id).
+      select('max(peer_reviews.id) id, submitter_id, level_id')
 
-    reviews = reviews.page(page).per(per)
-
-    reviews.each do |review|
+    # This query gets matching fully-hydrated models in the correct order.
+    real_reviews = PeerReview.find(reviews.map(&:id))
+    real_reviews.each do |review|
       submissions[review.user_level.id] = PeerReview.get_submission_summary_for_user_level(review.user_level, review.script)
     end
 

--- a/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::PeerReviewSubmissionsController < ApplicationController
     per = params[:per] || params[:limit] || 50
     user_query = params[:user_q]
 
-    reviews = PeerReview.all
+    reviews = PeerReview.all.order(created_at: :desc)
 
     if user_query.presence
       reviews =

--- a/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
@@ -145,17 +145,17 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
     response = JSON.parse(@response.body)
     assert_equal [
       [
-        [@level_1_reviews.first.id, nil, @level_1_reviews.first.updated_at],
-        [@level_1_reviews.second.id, 'escalated', @level_1_reviews.second.updated_at]
+        [@level_3_reviews.first.id, nil, @level_3_reviews.first.updated_at],
+        [@level_3_reviews.second.id, 'escalated', @level_3_reviews.second.updated_at]
       ],
       [
         [@level_2_reviews.first.id, nil, @level_2_reviews.first.updated_at],
         [@level_2_reviews.second.id, 'accepted', @level_2_reviews.second.updated_at]
       ],
       [
-        [@level_3_reviews.first.id, nil, @level_3_reviews.first.updated_at],
-        [@level_3_reviews.second.id, 'escalated', @level_3_reviews.second.updated_at]
-      ],
+        [@level_1_reviews.first.id, nil, @level_1_reviews.first.updated_at],
+        [@level_1_reviews.second.id, 'escalated', @level_1_reviews.second.updated_at]
+      ]
     ], response['submissions'].map {|submission| submission['review_ids']}
 
     # Verify expected pagination metadata
@@ -169,12 +169,12 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
   end
 
   test 'can retrieve a different page of peer review results' do
-    common_scenario
-
     test_page_size = 5
 
     # Create many peer reviews to test pagination
-    create_list :peer_review, 20, reviewer: @submitter, script: @course_unit.script
+    30.times do
+      create_peer_reviews_for_user create :teacher
+    end
 
     get :index, params: {page: 3, per: test_page_size}
     assert_response :success

--- a/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/peer_review_submissions_controller_test.rb
@@ -353,22 +353,7 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
 
   private
 
-  def create_peer_reviews_for_user_and_level(user, level)
-    level_source = create :level_source, level: level
-    user_level = create :user_level,
-      user: user,
-      level: level,
-      level_source: level_source,
-      script: @course_unit.script,
-      best_result: ActivityConstants::UNREVIEWED_SUBMISSION_RESULT
-
-    PeerReview.create_for_submission(user_level, level_source.id)
-  end
-
-  def create_peer_reviews_for_user(user)
-    course_unit = create :plc_course_unit
-    level = create :free_response, peer_reviewable: true
-    create :script_level, script: course_unit.script, levels: [level]
+  def create_peer_reviews_for_user_and_level(user, level, course_unit = @course_unit)
     level_source = create :level_source, level: level
     user_level = create :user_level,
       user: user,
@@ -378,5 +363,12 @@ class Api::V1::PeerReviewSubmissionsControllerTest < ActionController::TestCase
       best_result: ActivityConstants::UNREVIEWED_SUBMISSION_RESULT
 
     PeerReview.create_for_submission(user_level, level_source.id)
+  end
+
+  def create_peer_reviews_for_user(user)
+    course_unit = create :plc_course_unit
+    level = create :free_response, peer_reviewable: true
+    create :script_level, script: course_unit.script, levels: [level]
+    create_peer_reviews_for_user_and_level(user, level, course_unit)
   end
 end


### PR DESCRIPTION
In its current form, the peer review dashboard always shows these old test submissions by Mehal at the top of the default view.

![image](https://user-images.githubusercontent.com/1615761/67441056-2ed0dd00-f5b0-11e9-9e51-42f0994c9d5a.png)

We'll eventually clean up these test submissions, but a more useful change is to reverse the sort order of the dashboard to show the most recent submissions at the top of the first page, which will usually be the ones reviewers are looking for.

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-561)

## Testing story

Unit tests!  I did a little refactoring of the tests for this controller while I was in there so it's easier to write tests without needing to know or work around the `setup_all` context.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
