### PR TITLE
Remove performance_schema from parameter group so RDS can manage it.

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -183,8 +183,14 @@ AuroraReportingCluster:
 
 # System variables for the Aurora DB writer.
 AuroraWriter:
-  # Enable Performance Schema.
-  performance_schema: 1
+  # Performance Schema and several related Parameter Group settings are enabled automatically on an Aurora Instance
+  # when Performance Insights is enabled on the Instance.  These additional, automatically applied, settings
+  # enable Performance Insights to display detailed Aurora-specific wait events.  Explicitly setting
+  # performance_schema=1 disables the RDS service automatically enabling the related settings that allow for detailed
+  # wait events to be logged in Performance Insights, so we do NOT set it.
+  # https://docs.aws.amazon.com/en_pv/AmazonRDS/latest/AuroraUserGuide/USER_PerfInsights.Enabling.html
+  # Note that our Percona Monitoring server also relies on performance_schema=1 being set automatically by RDS.
+  performance_schema: null
 
   # Relax transaction isolation for improved concurrency under load.
   tx_isolation: READ-COMMITTED

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -190,7 +190,6 @@ AuroraWriter:
   # wait events to be logged in Performance Insights, so we do NOT set it.
   # https://docs.aws.amazon.com/en_pv/AmazonRDS/latest/AuroraUserGuide/USER_PerfInsights.Enabling.html
   # Note that our Percona Monitoring server also relies on performance_schema=1 being set automatically by RDS.
-  performance_schema: null
 
   # Relax transaction isolation for improved concurrency under load.
   tx_isolation: READ-COMMITTED


### PR DESCRIPTION
# Description

We manually reset the `performance_schema` setting in the writer parameter group via the web console and then re-enabled Performance Insights so that RDS would automatically enable performance_schema and related settings on the writer and reader instances on 10/12/2019.

This change removes the explicit configuration of `performance_schema` setting to synchronize our CloudFormation template/stack with the actual configuration of this parameter group.

### Testing
```
$ bundle exec rake stack:data:validate RAILS_ENV=production
Listing changes to existing stack `DATA-production`:
Modify AuroraWriterDBParameters [AWS::RDS::DBParameterGroup] Properties (Parameters)
```


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
