### PR TITLE
Fix teacher application scholarship evaluation

### DIFF
--- a/dashboard/app/models/pd/application/teacher2021_application.rb
+++ b/dashboard/app/models/pd/application/teacher2021_application.rb
@@ -657,6 +657,7 @@ module Pd::Application
 
       scores = scored_questions.map {|q| response_scores[q]}
 
+      # Need all criteria to be YES to be qualified
       if scores.uniq == [YES]
         YES
       elsif NO.in? scores
@@ -672,12 +673,13 @@ module Pd::Application
 
       scores = scored_questions.map {|q| response_scores[q]}
 
-      if scores.uniq == [YES]
+      # Only need one of the criteria to be YES to be qualified for scholarship
+      if YES.in? scores
         YES
-      elsif NO.in? scores
-        NO
-      else
+      elsif nil.in? scores
         REVIEWING_INCOMPLETE
+      else
+        NO
       end
     end
 

--- a/dashboard/test/models/pd/application/teacher2021_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher2021_application_test.rb
@@ -825,6 +825,29 @@ module Pd::Application
       end
     end
 
+    test 'meets_scholarship_criteria' do
+      application = create :pd_teacher2021_application
+      test_cases = [
+        {underrepresented_minority_percent: YES, free_lunch_percent: YES, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: nil, verdict: YES},
+        {underrepresented_minority_percent: YES, free_lunch_percent: NO, verdict: YES},
+        {underrepresented_minority_percent: nil, free_lunch_percent: YES, verdict: YES},
+        {underrepresented_minority_percent: nil, free_lunch_percent: nil, verdict: REVIEWING_INCOMPLETE},
+        {underrepresented_minority_percent: nil, free_lunch_percent: NO, verdict: REVIEWING_INCOMPLETE},
+        {underrepresented_minority_percent: NO, free_lunch_percent: YES, verdict: YES},
+        {underrepresented_minority_percent: NO, free_lunch_percent: nil, verdict: REVIEWING_INCOMPLETE},
+        {underrepresented_minority_percent: NO, free_lunch_percent: NO, verdict: NO}
+      ]
+
+      test_cases.each do |test_case|
+        input = test_case.slice(:underrepresented_minority_percent, :free_lunch_percent)
+        application.update(response_scores: {meets_scholarship_criteria_scores: input}.to_json)
+
+        output = application.meets_scholarship_criteria
+        assert_equal test_case[:verdict], output, "Wrong result for case #{input}"
+      end
+    end
+
     test 'test update scholarship status' do
       application = create :pd_teacher2021_application
       assert_nil application.scholarship_status


### PR DESCRIPTION
# Description
Change the logic in scholarship evaluation to accept the application when at least one of the criteria is YES.
[PLC-580](https://codedotorg.atlassian.net/browse/PLC-580)

## Testing story
- Add unit test
- Manual test with application on development
  - Manipulate scholarship scores of an application then verify result on teacher application detail view
    ```
    app = Pd::Application::Teacher2021Application.find(1)
    app.update(response_scores: {meets_scholarship_criteria_scores: {underrepresented_minority_percent: 50, free_lunch_percent:nil}, meets_minimum_criteria_scores: {csd_which_grades: 'Yes',committed: 'Yes',plan_to_teach: 'Yes',previous_yearlong_cdo_pd: 'Yes',replace_existing: 'Yes',principal_approval: 'Yes', principal_schedule_confirmed: 'Yes'}}.to_json)
   ```