### PR TITLE
[Sprite Lab/ Dance Party] Generate unique names for named sprites/dancers

### DIFF
--- a/apps/src/dance/blocks.js
+++ b/apps/src/dance/blocks.js
@@ -46,11 +46,7 @@ const customInputTypes = {
       };
       block.superSetTitleValue = block.setTitleValue;
       block.setTitleValue = function(newValue, name) {
-        if (
-          inputConfig.assignment &&
-          name === inputConfig.name &&
-          block.blockSpace.isFlyout
-        ) {
+        if (name === inputConfig.name && block.blockSpace.isFlyout) {
           newValue = Blockly.Variables.generateUniqueName(newValue);
         }
         block.superSetTitleValue(newValue, name);

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -225,11 +225,7 @@ const customInputTypes = {
       };
       block.superSetTitleValue = block.setTitleValue;
       block.setTitleValue = function(newValue, name) {
-        if (
-          inputConfig.assignment &&
-          name === inputConfig.name &&
-          block.blockSpace.isFlyout
-        ) {
+        if (name === inputConfig.name && block.blockSpace.isFlyout) {
           newValue = Blockly.Variables.generateUniqueName(newValue);
         }
         block.superSetTitleValue(newValue, name);


### PR DESCRIPTION
# Description
Regression from #31138 and #30979 
Named sprites are no longer variable assignments, but we still want to generate unique names for them.
Dance
Before:
![image](https://user-images.githubusercontent.com/8787187/67506143-6471d680-f641-11e9-897f-f99debc9b7ec.png)

After:
![image](https://user-images.githubusercontent.com/8787187/67506075-43a98100-f641-11e9-826d-2b6e52d09692.png)


Sprite Lab
Before:
![image](https://user-images.githubusercontent.com/8787187/67505989-1c52b400-f641-11e9-9332-b52b1327acdd.png)

After:
![image](https://user-images.githubusercontent.com/8787187/67506015-2a083980-f641-11e9-8b9b-4de5a724af0b.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
