### PR TITLE
Concurrent ChannelToken#find_or_create_channel_token

### DIFF
--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -33,12 +33,15 @@ class ChannelToken < ActiveRecord::Base
     storage_app = StorageApps.new(user_storage_id)
     # If `create` fails because it was beat by a competing request, a second
     # `find_by` should succeed.
-    Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do
-      # your own channel
-      find_or_create_by!(level: level.host_level, storage_id: user_storage_id) do |ct|
-        # Get a new channel_id.
-        channel = create_channel ip, storage_app, data: data, standalone: false
-        _, ct.storage_app_id = storage_decrypt_channel_id(channel)
+    # Read from primary to minimize write conflicts.
+    SeamlessDatabasePool.use_master_connection do
+      Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do
+        # your own channel
+        find_or_create_by!(level: level.host_level, storage_id: user_storage_id) do |ct|
+          # Get a new channel_id.
+          channel = create_channel ip, storage_app, data: data, standalone: false
+          _, ct.storage_app_id = storage_decrypt_channel_id(channel)
+        end
       end
     end
   end


### PR DESCRIPTION
# Description

Updates `ChannelToken#find_or_create_channel_token` to explicitly read from the primary instance, to minimize concurrent-create conflicts.

This is an alternative to #31427 and should be a bit less risky implementation, as it minimizes changes to the existing code's optimistic-lock pattern already in place, and just directs the existing query to the primary instance.

### Background

Previously, within controller-actions marked as `use_database_pool [action]: :persistent`, all reads would be performed on the read-replica. This method in particular, while not one of our highest-volume queries, produces the most write-conflict duplicate-key errors in our application. These are mostly benign since they are retried (this is an 'optimistic-lock' pattern), the errors produce warnings in ProxySQL logs, and also cause the connection to be discarded, so it would be helpful to minimize conflicts by always performing these optimistic-lock reads from the primary instance.

## Testing story

- Existing unit test 'find_or_create_channel_token sets storage_id and storage_app_id' covers this method to ensure the application behavior is unchanged in the simple case.
- There's no existing test coverage on concurrent-create conflict, or to simulate/stub primary-replica read latency. This could be added but would take some non-trivial additional work.