### PR TITLE
Assignment Updates: Remove assignment confirm dialog

### DIFF
--- a/apps/src/templates/AssignButton.jsx
+++ b/apps/src/templates/AssignButton.jsx
@@ -3,58 +3,30 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import Button from './Button';
 import i18n from '@cdo/locale';
-import ConfirmAssignment from '@cdo/apps/templates/courseOverview/ConfirmAssignment';
-import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import {assignCourseToSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 class AssignButton extends React.Component {
   static propTypes = {
-    section: sectionForDropdownShape,
+    sectionId: PropTypes.number.isRequired,
     courseId: PropTypes.number,
-    scriptId: PropTypes.number,
-    assignmentName: PropTypes.string,
     // Redux
     assignCourseToSection: PropTypes.func.isRequired
   };
 
-  state = {
-    dialogOpen: false,
-    errorString: null
-  };
-
-  onClickAssign = event => {
-    this.setState({dialogOpen: true});
-  };
-
-  onCloseDialog = event => {
-    this.setState({dialogOpen: false});
-  };
-
   assignCourse = () => {
-    const {section, courseId, assignCourseToSection} = this.props;
-    assignCourseToSection(section.id, courseId);
-    this.setState({dialogOpen: false});
+    const {sectionId, courseId, assignCourseToSection} = this.props;
+    assignCourseToSection(sectionId, courseId);
   };
 
   render() {
-    const {section, assignmentName} = this.props;
     return (
       <div>
         <Button
           color={Button.ButtonColor.orange}
           text={i18n.assignToSection()}
           icon="plus"
-          onClick={this.onClickAssign}
+          onClick={this.assignCourse}
         />
-        {this.state.dialogOpen && (
-          <ConfirmAssignment
-            sectionName={section.name}
-            assignmentName={assignmentName}
-            onClose={this.onCloseDialog}
-            onConfirm={this.assignCourse}
-            isHiddenFromSection={false}
-          />
-        )}
       </div>
     );
   }

--- a/apps/src/templates/AssignButton.story.jsx
+++ b/apps/src/templates/AssignButton.story.jsx
@@ -9,10 +9,9 @@ export default storybook => {
       name: 'Assign to section button',
       story: () => (
         <AssignButton
-          section={fakeTeacherSectionsForDropdown[0]}
+          sectionId={fakeTeacherSectionsForDropdown[0].id}
           courseId={100}
           scriptId={20}
-          assignmentName={'Fake Course'}
           assignCourseToSection={action('assignCourseToSection')}
         />
       )

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -66,7 +66,7 @@ class CourseScript extends Component {
 
     // redux provided
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
-    selectedSectionId: PropTypes.string.isRequired,
+    selectedSectionId: PropTypes.number.isRequired,
     hiddenStageState: PropTypes.object.isRequired,
     hasNoSections: PropTypes.bool.isRequired,
     toggleHiddenScript: PropTypes.func.isRequired
@@ -160,7 +160,7 @@ export const UnconnectedCourseScript = CourseScript;
 export default connect(
   state => ({
     viewAs: state.viewAs,
-    selectedSectionId: state.teacherSections.selectedSectionId,
+    selectedSectionId: parseInt(state.teacherSections.selectedSectionId),
     hiddenStageState: state.hiddenStage,
     hasNoSections:
       state.teacherSections.sectionsAreLoaded &&

--- a/apps/src/templates/courseOverview/CourseScript.story.js
+++ b/apps/src/templates/courseOverview/CourseScript.story.js
@@ -27,7 +27,7 @@ const defaultProps = {
     'explores the structure and design of the internet and the implications of ' +
     'those design decisions.',
   viewAs: ViewType.Teacher,
-  selectedSectionId: '',
+  selectedSectionId: 11,
   hiddenStageState: unhiddenState,
   hasNoSections: true,
   toggleHiddenScript: () => {}

--- a/apps/src/templates/courseOverview/CourseScript.story.js
+++ b/apps/src/templates/courseOverview/CourseScript.story.js
@@ -3,7 +3,7 @@ import Immutable from 'immutable';
 import {UnconnectedCourseScript as CourseScript} from './CourseScript';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
-const sectionId = '11';
+const sectionId = 11;
 const courseId = 123;
 const unhiddenState = Immutable.fromJS({
   initialized: false,
@@ -12,7 +12,7 @@ const unhiddenState = Immutable.fromJS({
   scriptsBySection: {}
 });
 const hiddenState = unhiddenState.setIn(
-  ['stagesBySection', sectionId, courseId.toString()],
+  ['stagesBySection', sectionId.toString(), courseId.toString()],
   true
 );
 

--- a/apps/src/templates/teacherDashboard/SectionAssigner.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.jsx
@@ -36,8 +36,7 @@ class SectionAssigner extends Component {
     selectSection: PropTypes.func.isRequired,
     showAssignButton: PropTypes.bool,
     courseId: PropTypes.number,
-    selectedSectionId: PropTypes.number,
-    assignmentName: PropTypes.string
+    selectedSectionId: PropTypes.number
   };
 
   onChangeSection = sectionId => {
@@ -49,7 +48,6 @@ class SectionAssigner extends Component {
       sections,
       showAssignButton,
       courseId,
-      assignmentName,
       selectedSectionId
     } = this.props;
     const selectedSection = sections.find(
@@ -72,11 +70,7 @@ class SectionAssigner extends Component {
             </span>
           )}
           {!selectedSection.isAssigned && showAssignButton && (
-            <AssignButton
-              section={selectedSection}
-              courseId={courseId}
-              assignmentName={assignmentName}
-            />
+            <AssignButton sectionId={selectedSection.id} courseId={courseId} />
           )}
         </div>
       </div>
@@ -88,7 +82,7 @@ export const UnconnectedSectionAssigner = SectionAssigner;
 
 export default connect(
   state => ({
-    selectedSectionId: state.teacherSections.selectedSectionId
+    selectedSectionId: parseInt(state.teacherSections.selectedSectionId)
   }),
   dispatch => ({
     selectSection(sectionId) {


### PR DESCRIPTION
[LP-903](https://codedotorg.atlassian.net/browse/LP-903)
**BEFORE**: confirmation dialog when assigning from course overview 
![confirm-dialog](https://user-images.githubusercontent.com/12300669/67699549-8c2aac80-f969-11e9-923c-30a0a91d6ef1.gif)

**AFTER**: Per request from Product, this PR removes the Assignment Confirmation Dialog from the flow of assigning a course from the course overview page. 
![no-confirm-dialog-3](https://user-images.githubusercontent.com/12300669/67522279-55028580-f661-11e9-94ac-6243f0837b97.gif)

# Reviewer Checklist:

- [x] Tests provide adequate coverage
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
