### PR TITLE
Don't wait for CloudFront invalidation to finish

### DIFF
--- a/bin/flush_cache
+++ b/bin/flush_cache
@@ -24,6 +24,6 @@ unless app_servers.empty?
     execute varnish_ban_cmd, raise_on_non_zero_exit: false
   end
 end
-CDO.log.info 'Flushing CloudFront caches (up to 15 min)...'
+CDO.log.info 'Flushing CloudFront caches...'
 AWS::CloudFront.invalidate_caches
 CDO.log.info 'All done!'

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -82,7 +82,7 @@ module AWS
       CLOUDFRONT_ALIAS_CACHE
     end
 
-    def self.invalidate_caches
+    def self.invalidate_caches(wait: false)
       require 'aws-sdk-cloudfront'
       puts 'Creating CloudFront cache invalidations...'
       cloudfront = Aws::CloudFront::Client.new(
@@ -110,12 +110,14 @@ module AWS
       end
       invalidations.compact!
       puts "Invalidations created: #{invalidations.count}"
-      invalidations.map do |app, id, invalidation|
-        cloudfront.wait_until(:invalidation_completed, distribution_id: id, id: invalidation) do |waiter|
-          waiter.max_attempts = 120 # wait up to 40 minutes for invalidations
-          waiter.before_wait {|_| puts "Waiting for #{app} cache invalidation.."}
+      if wait
+        invalidations.map do |app, id, invalidation|
+          cloudfront.wait_until(:invalidation_completed, distribution_id: id, id: invalidation) do |waiter|
+            waiter.max_attempts = 120 # wait up to 40 minutes for invalidations
+            waiter.before_wait {|_| puts "Waiting for #{app} cache invalidation.."}
+          end
+          puts "#{app} cache invalidated!"
         end
-        puts "#{app} cache invalidated!"
       end
     end
 


### PR DESCRIPTION
# Description

Update `CloudFront#invalidate_caches` to not wait for CloudFront invalidation requests to complete by default. (Adds a new `wait` parameter that defaults to `false`.)

### Background

Invalidating CloudFront distributions prevents certain kinds of stale content (for example, when non-content-hashed Pegasus assets are modified), which is why we run this task after each CI build. However, sometimes the CloudFront service is very slow to service invalidation requests, which can hang for up to 40 minutes and eventually fail the current CI build.

In most cases, it won't cause any issue to proceed with the CI build without explicitly waiting for the invalidation to complete. With this change, we choose to favor quicker CI builds over ensuring 100% fully-flushed caches before every CI build completes.

This will make CI builds complete more quickly, and prevent errors when CloudFront invalidation times out.