### PR TITLE
Fix wrong module name

### DIFF
--- a/dashboard/app/views/pd/misc_survey/new.haml
+++ b/dashboard/app/views/pd/misc_survey/new.haml
@@ -1,4 +1,4 @@
-- if SchoolInfoInterstitial.show?(current_user) || @force_school_info_interstitial
+- if SchoolInfoInterstitialHelper.show?(current_user) || @force_school_info_interstitial
   = render partial: 'layouts/school_info_interstitial', locals: {show_header: false, user: current_user, form_name: "user[school_info_attributes]"}
 
 = render partial: 'pd/jotform_loader'


### PR DESCRIPTION
Continuation of https://github.com/code-dot-org/code-dot-org/pull/31096

The wrong name causes 500 error when loading https://studio.code.org/pd/misc_survey/other_workshop.
It works again with the correct name (test locally).