### PR TITLE
Refactor DataVisualizer + test

### DIFF
--- a/apps/src/storage/dataBrowser/DataVisualizer.jsx
+++ b/apps/src/storage/dataBrowser/DataVisualizer.jsx
@@ -15,7 +15,8 @@ const INITIAL_STATE = {
   numBins: 0,
   values: '',
   xValues: '',
-  yValues: ''
+  yValues: '',
+  parsedRecords: []
 };
 
 class DataVisualizer extends React.Component {
@@ -56,21 +57,71 @@ class DataVisualizer extends React.Component {
 
   updateChart = () => {
     const targetDiv = document.getElementById('chart-area');
-    const records =
-      Object.keys(this.props.tableRecords).length > 0 &&
-      this.props.tableRecords.map(tableRecord => JSON.parse(tableRecord));
-    if (this.state.chartType === 'Bar Chart' && this.state.values) {
-      var chart = new GoogleChart.MaterialBarChart(targetDiv);
-      const chartData = this.aggregateRecordsByColumn(
-        records,
-        this.state.values
-      );
-      chart.drawChart(chartData, [this.state.values, 'count']);
+    if (!targetDiv) {
+      return;
+    }
+
+    let chart;
+    let chartData;
+    const columns = [];
+    const options = {};
+    switch (this.state.chartType) {
+      case 'Bar Chart':
+        if (this.state.values) {
+          chart = new GoogleChart.MaterialBarChart(targetDiv);
+          chartData = this.aggregateRecordsByColumn(
+            this.state.parsedRecords,
+            this.state.values
+          );
+          columns.push(this.state.values, 'count');
+        }
+        break;
+      case 'Histogram':
+        console.warn(`${this.state.chartType} not yet implemented`);
+        break;
+      case 'Cross Tab':
+        console.warn(`${this.state.chartType} not yet implemented`);
+        break;
+      case 'Scatter Plot':
+        console.warn(`${this.state.chartType} not yet implemented`);
+        break;
+      default:
+        console.warn(`unknown chart type ${this.state.chartType}`);
+        break;
+    }
+    if (chart && chartData) {
+      chart.drawChart(chartData, columns, options);
     }
   };
 
+  parseRecords = () => {
+    if (Object.keys(this.props.tableRecords).length === 0) {
+      return [];
+    } else {
+      let parsedRecords = [];
+      this.props.tableRecords.forEach(record => {
+        if (record) {
+          parsedRecords.push(JSON.parse(record));
+        }
+      });
+      return parsedRecords;
+    }
+  };
+
+  componentDidUpdate(previousProps, prevState) {
+    if (this.props !== previousProps) {
+      this.setState({parsedRecords: this.parseRecords()});
+    }
+  }
+
   render() {
-    this.updateChart();
+    if (
+      this.state.isVisualizerOpen &&
+      this.props.tableRecords &&
+      this.state.chartType
+    ) {
+      this.updateChart();
+    }
 
     const modalBody = (
       <div>

--- a/apps/src/storage/dataBrowser/DataVisualizer.jsx
+++ b/apps/src/storage/dataBrowser/DataVisualizer.jsx
@@ -109,7 +109,14 @@ class DataVisualizer extends React.Component {
   };
 
   componentDidUpdate(previousProps, prevState) {
-    if (this.props !== previousProps) {
+    const visualizerJustOpened =
+      !prevState.isVisualizerOpen && this.state.isVisualizerOpen;
+
+    const recordsChangedWithVisualizerOpen =
+      this.props.tableRecords !== previousProps.tableRecords &&
+      this.state.isVisualizerOpen;
+
+    if (visualizerJustOpened || recordsChangedWithVisualizerOpen) {
       this.setState({parsedRecords: this.parseRecords()});
     }
   }

--- a/apps/test/unit/storage/dataBrowser/DataVisualizerTest.js
+++ b/apps/test/unit/storage/dataBrowser/DataVisualizerTest.js
@@ -32,7 +32,12 @@ describe('DataVisualizer', () => {
     beforeEach(() => {
       wrapper = shallow(<DataVisualizer {...DEFAULT_PROPS} />);
       sinon.spy(wrapper.instance(), 'parseRecords');
+    });
+
+    it('parses records immediately when the visualizer opens', () => {
+      expect(wrapper.instance().parseRecords).not.toHaveBeenCalled;
       wrapper.instance().handleOpen();
+      expect(wrapper.instance().parseRecords).to.have.been.calledOnce;
     });
 
     it('ignores empty records', () => {
@@ -46,6 +51,7 @@ describe('DataVisualizer', () => {
       ];
 
       wrapper.setProps({tableRecords: tableRecords});
+      wrapper.instance().handleOpen();
       expect(wrapper.instance().state.parsedRecords).to.deep.equal(
         expectedParsedRecords
       );
@@ -66,6 +72,7 @@ describe('DataVisualizer', () => {
           '{"id":3,"name":"charlie","age":9,"male":true}'
         ]
       });
+      wrapper.instance().handleOpen();
       expect(wrapper.instance().state.parsedRecords).to.deep.equal(
         expectedParsedRecords
       );

--- a/apps/test/unit/storage/dataBrowser/DataVisualizerTest.js
+++ b/apps/test/unit/storage/dataBrowser/DataVisualizerTest.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
+import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import {UnconnectedDataVisualizer as DataVisualizer} from '@cdo/apps/storage/dataBrowser/DataVisualizer';
@@ -7,11 +8,7 @@ import {UnconnectedDataVisualizer as DataVisualizer} from '@cdo/apps/storage/dat
 const DEFAULT_PROPS = {
   tableColumns: ['Name', 'Age', 'Male'],
   tableName: 'testTable',
-  tableRecords: [
-    '{"id":1,"name":"alice","age":7,"male":false}',
-    '{"id":2,"name":"bob","age":8,"male":true}',
-    '{"id":3,"name":"charlie","age":9,"male":true}'
-  ]
+  tableRecords: []
 };
 
 describe('DataVisualizer', () => {
@@ -28,5 +25,70 @@ describe('DataVisualizer', () => {
 
     wrapper.instance().handleOpen();
     expect(wrapper.find(BaseDialog).prop('isOpen')).to.be.true;
+  });
+
+  describe('parseRecords', () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = shallow(<DataVisualizer {...DEFAULT_PROPS} />);
+      sinon.spy(wrapper.instance(), 'parseRecords');
+      wrapper.instance().handleOpen();
+    });
+
+    it('ignores empty records', () => {
+      let tableRecords = [];
+      // tableRecords[0] is empty
+      tableRecords[1] = '{"id":1,"name":"alice","age":7,"male":false}';
+      tableRecords[2] = '{"id":2,"name":"bob","age":8,"male":true}';
+      let expectedParsedRecords = [
+        {id: 1, name: 'alice', age: 7, male: false},
+        {id: 2, name: 'bob', age: 8, male: true}
+      ];
+
+      wrapper.setProps({tableRecords: tableRecords});
+      expect(wrapper.instance().state.parsedRecords).to.deep.equal(
+        expectedParsedRecords
+      );
+      expect(wrapper.instance().parseRecords).to.have.been.calledOnce;
+    });
+
+    it('Only reparses records when they change', () => {
+      let expectedParsedRecords = [
+        {id: 1, name: 'alice', age: 7, male: false},
+        {id: 2, name: 'bob', age: 8, male: true},
+        {id: 3, name: 'charlie', age: 9, male: true}
+      ];
+      // Setting new records will cause them to be parsed
+      wrapper.setProps({
+        tableRecords: [
+          '{"id":1,"name":"alice","age":7,"male":false}',
+          '{"id":2,"name":"bob","age":8,"male":true}',
+          '{"id":3,"name":"charlie","age":9,"male":true}'
+        ]
+      });
+      expect(wrapper.instance().state.parsedRecords).to.deep.equal(
+        expectedParsedRecords
+      );
+      expect(wrapper.instance().parseRecords).to.have.been.calledOnce;
+
+      // Updating state but not records does not cause records to be re-parsed
+      wrapper.instance().setState({chartType: 'Bar Chart'});
+      expect(wrapper.instance().parseRecords).to.have.been.calledOnce;
+
+      // Updating records causes them to be re-parsed
+      wrapper.setProps({
+        tableRecords: [
+          '{"id":1,"name":"alice","age":7,"male":false}',
+          '{"id":2,"name":"bob","age":8,"male":true}',
+          '{"id":3,"name":"charlie","age":9,"male":true}',
+          '{"id":4,"name":"dana","age":10,"male":false}'
+        ]
+      });
+      expectedParsedRecords.push({id: 4, name: 'dana', age: 10, male: false});
+      expect(wrapper.instance().state.parsedRecords).to.deep.equal(
+        expectedParsedRecords
+      );
+      expect(wrapper.instance().parseRecords).to.have.been.calledTwice;
+    });
   });
 });


### PR DESCRIPTION
# Description
- Only parse records when they change, not every time the component updates. I'm going to use this pattern for other data operations, too, for example determining which columns are numeric.
- Only call updateChart if the modal is open and there is a chart type selected (otherwise there's nothing to update)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
