### PR TITLE
hoc2019: Fix new robotics partner images

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/announcements.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/announcements.haml
@@ -13,6 +13,6 @@
         =hoc_s(:front_join_us_robotics_link)
       - providers.each do |provider|
         %a.category-link.robotics-provider{href: provider[:url], target: "_blank"}
-          %img{style: "width: 100%; margin-bottom: 20px", src: "/images/fit-200/robotics/hoc2019/#{provider[:id]}-logo.png"}
-          %img{style: "width: 100%", src: "/images/fit-200/robotics/hoc2019/#{provider[:id]}-image.png"}
+          %img{style: "width: 100%; margin-bottom: 20px", src: "/images/fit-200/robotics/hoc2019/#{provider[:id].downcase}-logo.png"}
+          %img{style: "width: 100%", src: "/images/fit-200/robotics/hoc2019/#{provider[:id].downcase}-image.png"}
     .clear


### PR DESCRIPTION
On operating systems with case-sensitive file systems, the image wasn't found.

Followup to https://github.com/code-dot-org/code-dot-org/pull/31460
