### PR TITLE
Regression test: Can update blocks in CSF instructions inline feedback

### DIFF
--- a/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {assert} from 'chai';
+import InstructionsCSF from '@cdo/apps/templates/instructions/InstructionsCSF';
+import {Provider} from 'react-redux';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux
+} from '@cdo/apps/redux';
+import instructions, {
+  setFeedback,
+  setInstructionsConstants
+} from '@cdo/apps/redux/instructions';
+import authoredHints from '@cdo/apps/redux/authoredHints';
+import pageConstants, {setPageConstants} from '@cdo/apps/redux/pageConstants';
+import isRtl from '@cdo/apps/code-studio/isRtlRedux';
+
+describe('InstructionsCSF', () => {
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({authoredHints, instructions, isRtl, pageConstants});
+    getStore().dispatch(
+      setPageConstants({
+        showNextHint: function() {},
+        skinId: 'dance'
+      })
+    );
+    getStore().dispatch(
+      setInstructionsConstants({
+        longInstructions: 'Use this new block.'
+      })
+    );
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
+  it('can change feedback when rendering different blockly blocks', () => {
+    const wrapper = mount(
+      <Provider store={getStore()}>
+        <InstructionsCSF {...DEFAULT_PROPS} />
+      </Provider>
+    );
+
+    failWithMessage('Repeat block: <xml><block type="controls_repeat"/></xml>');
+    assertFeedbackContainsText(wrapper, '>repeat</text>');
+
+    failWithMessage('If block: <xml><block type="controls_if"/></xml>');
+    assertFeedbackContainsText(wrapper, '>if</text>');
+  });
+
+  function failWithMessage(message) {
+    getStore().dispatch(setFeedback({message, isFailure: true}));
+  }
+
+  function assertFeedbackContainsText(wrapper, text) {
+    assert.include(
+      wrapper
+        .getDOMNode()
+        .querySelector(
+          '.uitest-topInstructions-inline-feedback xml svg:nth-of-type(2)'
+        ).innerHTML,
+      text
+    );
+  }
+});
+
+const DEFAULT_PROPS = {
+  adjustMaxNeededHeight: function() {},
+  handleClickCollapser: function() {}
+};

--- a/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
@@ -57,14 +57,7 @@ describe('InstructionsCSF', () => {
   }
 
   function assertFeedbackContainsText(wrapper, text) {
-    assert.include(
-      wrapper
-        .getDOMNode()
-        .querySelector(
-          '.uitest-topInstructions-inline-feedback xml svg:nth-of-type(2)'
-        ).innerHTML,
-      text
-    );
+    assert.include(wrapper.getDOMNode().querySelector('xml').innerHTML, text);
   }
 });
 


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/31473: We removed this test from that PR because it caused a Phantom-specific failure and we needed to get the fix out in time for a playtest this afternoon.  This PR restores the test with a fix for Phantom.