### PR TITLE
Add InstructionsCSFTest

### DIFF
--- a/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {assert} from 'chai';
+import InstructionsCSF from '@cdo/apps/templates/instructions/InstructionsCSF';
+import {Provider} from 'react-redux';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux
+} from '@cdo/apps/redux';
+import instructions, {
+  setFeedback,
+  setInstructionsConstants
+} from '@cdo/apps/redux/instructions';
+import authoredHints from '@cdo/apps/redux/authoredHints';
+import pageConstants, {setPageConstants} from '@cdo/apps/redux/pageConstants';
+import isRtl from '@cdo/apps/code-studio/isRtlRedux';
+
+describe('InstructionsCSF', () => {
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({authoredHints, instructions, isRtl, pageConstants});
+    getStore().dispatch(
+      setPageConstants({
+        showNextHint: function() {},
+        skinId: 'dance'
+      })
+    );
+    getStore().dispatch(
+      setInstructionsConstants({
+        longInstructions: 'Use this new block.'
+      })
+    );
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
+  it('can change feedback when rendering different blockly blocks', () => {
+    const wrapper = mount(
+      <Provider store={getStore()}>
+        <InstructionsCSF {...DEFAULT_PROPS} />
+      </Provider>
+    );
+
+    failWithMessage('Repeat block: <xml><block type="controls_repeat"/></xml>');
+    assertFeedbackContainsText(wrapper, '>repeat</text>');
+
+    failWithMessage('If block: <xml><block type="controls_if"/></xml>');
+    assertFeedbackContainsText(wrapper, '>if</text>');
+  });
+
+  function failWithMessage(message) {
+    getStore().dispatch(setFeedback({message, isFailure: true}));
+  }
+
+  function assertFeedbackContainsText(wrapper, text) {
+    assert.include(
+      wrapper
+        .getDOMNode()
+        .querySelector('.uitest-topInstructions-inline-feedback').innerHTML,
+      text
+    );
+  }
+});
+
+const DEFAULT_PROPS = {
+  adjustMaxNeededHeight: function() {},
+  handleClickCollapser: function() {}
+};


### PR DESCRIPTION
# Description
Original work done by @islemaster with #31473 
I just changed the querySelector from `'.uitest-topInstructions-inline-feedback xml svg:nth-of-type(2)'` to `'.uitest-topInstructions-inline-feedback'` so that it passes on PhantomJS


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
