### PR TITLE
Volunteer Map: Prefer more recent sign-ups

### DIFF
--- a/pegasus/forms/volunteer_engineer_submission_2015.rb
+++ b/pegasus/forms/volunteer_engineer_submission_2015.rb
@@ -127,7 +127,8 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
       ).
       exclude(
         Sequel.function(:coalesce, Forms.json('data.unsubscribed_s'), '') => UNSUBSCRIBE_FOREVER
-      )
+      ).
+      order(Sequel.desc(:created_at))
 
     # UNSUBSCRIBE_HOC means a volunteer said "I want to unsubscribe until the next Hour of Code".
     # We don't want them to be getting volunteer requests until then.  So, if we're not currently

--- a/pegasus/test/test_form_routes.rb
+++ b/pegasus/test/test_form_routes.rb
@@ -1,5 +1,6 @@
 # Tests for the routes in form_routes.rb
 
+require 'timecop'
 require_relative './test_helper'
 require_relative 'fixtures/fake_dashboard'
 require_relative 'fixtures/mock_pegasus'
@@ -30,30 +31,57 @@ class FormRoutesTest < SequelTestCase
     end
   end
 
-  DEFAULT_DATA = {
-    email_s: 'fake@example.com',
-    name_s: 'fake_name',
-    experience_s: 'university_student_or_researcher',
-    location_s: 'somewhere',
-    location_flexibility_ss: ['onsite'],
-    description_s: 'description',
-    allow_contact_b: '1',
-    age_18_plus_b: '1',
-    email_preference_opt_in_s: 'yes'
-  }.freeze
+  describe 'volunteer_engineer_submission_2015' do
+    before do
+      # Delete all volunteer sign-ups in the test database before each test
+      ::PEGASUS_DB[:forms].where(kind: 'VolunteerEngineerSubmission2015').delete
 
-  def test_volunteer_engineer_submission_2015
-    stubs(:dashboard_user).returns(nil)
-    Pegasus.stubs(:logger).returns(nil)
-    stubs(:request).returns(stub(ip: '1.2.3.4'))
-    row = insert_or_upsert_form('VolunteerEngineerSubmission2015', DEFAULT_DATA.dup)
-    @form = Form.find(id: row[:id])
+      stubs(:dashboard_user).returns(nil)
+      Pegasus.stubs(:logger).returns(nil)
+      stubs(:request).returns(stub(ip: '1.2.3.4'))
+    end
 
-    @form.update(processed_data: {location_p: '37.774929,-122.419416'}.to_json)
+    it 'returns local results' do
+      create_volunteer name: 'Local Person', location: '37.774929,-122.419416'
+      results = search location: '37.774368,-122.428760'
+      assert_equal 0.8236209090344097, results.first['distance']
+    end
 
-    assert_equal 0.8236209090344097,
+    it 'uses reverse chronological order' do
+      Timecop.freeze 3.years.ago do
+        create_volunteer name: 'First Person', location: '35.774929,-122.419416'
+        Timecop.travel 1.year
+        create_volunteer name: 'Second Person', location: '35.774929,-122.419416'
+        Timecop.travel 1.year
+        create_volunteer name: 'Last Person', location: '35.774929,-122.419416'
+      end
+
+      results = search location: '35.774368,-122.428760'
+      assert_equal ['Last Person', 'Second Person', 'First Person'], results.map {|r| r['name_s']}
+    end
+
+    def create_volunteer(name:, location:)
+      row = insert_or_upsert_form('VolunteerEngineerSubmission2015', DEFAULT_DATA.dup.merge(name_s: name))
+      form = Form.find(id: row[:id])
+      form.update(processed_data: {location_p: location}.to_json)
+    end
+
+    def search(location:)
       JSON.parse(
-        VolunteerEngineerSubmission2015.query('coordinates' => '37.774368,-122.428760')
-      )['response']['docs'].first['distance']
+        VolunteerEngineerSubmission2015.query('coordinates' => location)
+      )['response']['docs']
+    end
+
+    DEFAULT_DATA = {
+      email_s: 'fake@example.com',
+      name_s: 'fake_name',
+      experience_s: 'university_student_or_researcher',
+      location_s: 'somewhere',
+      location_flexibility_ss: ['onsite'],
+      description_s: 'description',
+      allow_contact_b: '1',
+      age_18_plus_b: '1',
+      email_preference_opt_in_s: 'yes'
+    }.freeze
   end
 end


### PR DESCRIPTION
[PLC-554](https://codedotorg.atlassian.net/browse/PLC-554): Our [local volunteer search](https://code.org/volunteer/local) has a usability problem:

- We have volunteer sign-ups from 4+ years ago.
- Our search returns a limited number of results.
- Results are ordered oldest-first.

In combination, this means that on crowded areas of the map, newer sign-ups are never showing up in search results.

We've discussed a number of approaches to this problem, and decided the lowest lift for now is to reverse the sort order of local results so that the newest sign-ups show up first.

## Testing story

I've added a unit test that catches this behavior, and the one existing test did not break.  I refactored them both and they now clear out volunteer submissions in the test database before each test, so I believe they're better isolated and more accurately test what they say they do.

Manual testing is a bit tricky on this feature. Here are the steps I took:

1. Get secrets
   In particular, you need `google_maps_client_id` and `google_maps_secret` which can be defined in your locals.yml or configured to be pulled from the secrets manager in `development.yml.erb`.  I did the former.

2. Sign up volunteers
   Use the form at http://localhost.code.org:3000/volunteer to submit several possible volunteers in the same region, with names making their sign-up ordering obvious.

3. Process forms
   Run `bin/cron/process_forms` locally which uses the Google Maps API to geocode the submissions from step 2 and associate the metadata required for them to show up on the local volunteer map.

4. Visit the map
   Visit the map at http://localhost.code.org:3000/volunteer/local and check the region where you added volunteers.  Verify the expected ordering of volunteers in the list on the left.

### Before

![image](https://user-images.githubusercontent.com/1615761/67603342-6f099a00-f72d-11e9-9b10-6d8292f312d9.png)

### After

![image](https://user-images.githubusercontent.com/1615761/67603237-349ffd00-f72d-11e9-8ac7-fdb7a2273dc0.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
