### PR TITLE
/amazon-future-engineer requires authentication

### DIFF
--- a/apps/src/donorTeacherBanner/donorTeacherBanner.js
+++ b/apps/src/donorTeacherBanner/donorTeacherBanner.js
@@ -10,7 +10,7 @@ import initResponsive from '@cdo/apps/code-studio/responsive';
 
 registerReducers({isRtl, responsive});
 
-$(document).ready(initRegionalPartnerSearch);
+$(document).ready(init);
 
 function showDonorTeacherBanner() {
   const donorTeacherBannerElements = $('.donor-teacher-banner-container');
@@ -52,7 +52,18 @@ function showDonorTeacherBanner() {
     });
 }
 
-function initRegionalPartnerSearch() {
+async function init() {
   initResponsive();
-  showDonorTeacherBanner();
+  if (await hasSchoolDonor('Amazon')) {
+    showDonorTeacherBanner();
+    $('.show-if-eligible').show();
+  } else {
+    $('.show-if-not-eligible').show();
+  }
+}
+
+async function hasSchoolDonor(assertedDonorName) {
+  const response = await fetch('/dashboardapi/v1/users/me/school_donor_name');
+  const realDonorName = await response.json();
+  return realDonorName === assertedDonorName;
 }

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -118,6 +118,7 @@ class HttpCache
             ) +
             # TODO: Collapse these paths into /private to simplify Pegasus caching config.
             %w(
+              /amazon-future-engineer*
               /create-company-profile*
               /edit-company-profile*
               /teacher-dashboard*

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -54,6 +54,11 @@ class Api::V1::UsersController < Api::V1::JsonApiController
     end
   end
 
+  # GET /api/v1/users/<user_id>/school_donor_name
+  def get_school_donor_name
+    render json: @user.school_donor_name
+  end
+
   # POST /api/v1/users/<user_id>/using_text_mode
   def post_using_text_mode
     @user.using_text_mode = !!params[:using_text_mode].try(:to_bool)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -597,6 +597,7 @@ Dashboard::Application.routes.draw do
       get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
       get 'users/:user_id/contact_details', to: 'users#get_contact_details'
       get 'users/:user_id/school_name', to: 'users#get_school_name'
+      get 'users/:user_id/school_donor_name', to: 'users#get_school_donor_name'
 
       patch 'user_school_infos/:id/update_last_confirmation_date', to: 'user_school_infos#update_last_confirmation_date'
 
@@ -645,6 +646,7 @@ Dashboard::Application.routes.draw do
 
   get '/dashboardapi/v1/users/:user_id/contact_details', to: 'api/v1/users#get_contact_details'
   get '/dashboardapi/v1/users/:user_id/donor_teacher_banner_details', to: 'api/v1/users#get_donor_teacher_banner_details'
+  get '/dashboardapi/v1/users/:user_id/school_donor_name', to: 'api/v1/users#get_school_donor_name'
   post '/dashboardapi/v1/users/accept_data_transfer_agreement', to: 'api/v1/users#accept_data_transfer_agreement'
   get '/dashboardapi/v1/school-districts/:state', to: 'api/v1/school_districts#index', defaults: {format: 'json'}
   get '/dashboardapi/v1/schools/:school_district_id/:school_type', to: 'api/v1/schools#index', defaults: {format: 'json'}

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -144,4 +144,26 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     get :get_school_name, params: {user_id: '-1'}
     assert_response 403
   end
+
+  test "get_school_donor_name 403s when not signed in" do
+    get :get_school_donor_name, params: {user_id: 'me'}
+    assert_response 403
+  end
+
+  test "get_school_donor_name returns null when no donor is found" do
+    sign_in create :teacher
+    get :get_school_donor_name, params: {user_id: 'me'}
+    assert_response 200
+    assert_equal 'null', response.body
+  end
+
+  test "get_school_donor_name returns donor name" do
+    usi = create :user_school_info
+    create :donor_school, name: 'DonorName', nces_id: usi.school_info.school_id
+
+    sign_in usi.user
+    get :get_school_donor_name, params: {user_id: 'me'}
+    assert_response 200
+    assert_equal '"DonorName"', response.body
+  end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1219,4 +1219,6 @@ FactoryGirl.define do
     time_spent 10
     user_level_id 1
   end
+  
+  factory :donor_school
 end

--- a/pegasus/sites.v3/code.org/public/amazon-future-engineer.md.erb
+++ b/pegasus/sites.v3/code.org/public/amazon-future-engineer.md.erb
@@ -5,6 +5,14 @@ theme: responsive
 
 <% authentication_required! %>
 
+<style>
+  .show-if-eligible, .show-if-not-eligible {
+    display: none;
+  }
+</style>
+
+[show-if-eligible]
+
 <center><img src="/images/marketing/afe-hs.jpg" width="70%"/></center>
 
 # Amazon Future Engineer proudly supports your classroom 
@@ -64,3 +72,11 @@ Take your teaching to the next level with a CSTA+ membership sponsored by Amazon
 # Sign-up today to get started!
 
 <%= view :donor_teacher_banner %>
+
+[/show-if-eligible]
+
+[show-if-not-eligible]
+
+Sorry, this program is only available to select schools. If you have any questions, please contact us [here](https://support.code.org/hc/en-us/requests/new).
+
+[/show-if-not-eligible]

--- a/pegasus/sites.v3/code.org/public/amazon-future-engineer.md.erb
+++ b/pegasus/sites.v3/code.org/public/amazon-future-engineer.md.erb
@@ -3,6 +3,8 @@ title: Amazon Future Engineer
 theme: responsive
 ---
 
+<% authentication_required! %>
+
 <center><img src="/images/marketing/afe-hs.jpg" width="70%"/></center>
 
 # Amazon Future Engineer proudly supports your classroom 

--- a/pegasus/test/test_pegasus_documents.rb
+++ b/pegasus/test/test_pegasus_documents.rb
@@ -29,6 +29,7 @@ class PegasusTest < Minitest::Test
   # All documents expected to return 200 status-codes, with the following exceptions:
   STATUS_EXCEPTIONS = {
     302 => %w[
+      code.org/amazon-future-engineer
       code.org/educate
       code.org/teacher-dashboard
       code.org/teacher-dashboard/review-hociyskvuwa


### PR DESCRIPTION
[PLC-558](https://codedotorg.atlassian.net/browse/PLC-558): https://code.org/amazon-future-engineer will direct the user to sign in if they are not already signed in, and then will only show the page contents if the user is associated with an eligible school - otherwise they'll get a message about the program not being available at their school.

## Testing story

Manual testing for signed out, signed in without donor, and signed in with donor cases.

A few test cases for a new helper route.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
