### PR TITLE
Disable Aurora binary logging

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -144,7 +144,7 @@ Replica:
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
   # Disable binary logging to improve write performance.
-  binlog_format: OFF
+  binlog_format: 'OFF'
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -143,16 +143,8 @@ Replica:
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
-  # When using row-based logging, the master writes events to the binary log that indicate how individual table rows are changed.
-  # Replication of the master to the slave works by copying the events representing the changes to the table rows to the slave.
-  # ROW required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  binlog_format: ROW
-  # When enabled, this variable causes the master to write a checksum for each event in the binary log.
-  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
-  # NONE required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  binlog_checksum: NONE
+  # Disable binary logging to improve write performance.
+  binlog_format: OFF
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE


### PR DESCRIPTION
# Description

Disable production Aurora cluster binary logging to improve write query performance and because there are alternative technical designs for the features that were using binary logging.

### Background

Binary logging was primarily being used to support the streaming of data from the MySQL database to the Redshift cluster.  We are 

### Testing

```
$ bundle exec rake stack:data:validate RAILS_ENV=production

Listing changes to existing stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
```

### Deployment strategy

The production Aurora cluster writer instance must be restarted during an off-peak usage time period for this change to take effect, which will result in about 3 minutes of downtime.



# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
