### PR TITLE
Add plugged lesson counts for 2019 courses [ci skip]

### DIFF
--- a/aws/redshift/tables/csf_plugged_stage_counts.sql
+++ b/aws/redshift/tables/csf_plugged_stage_counts.sql
@@ -25,7 +25,16 @@ insert into analysis.csf_plugged_stage_counts values
 (307,10),
 (309,8),
 (310,8),
-(341,9);
+(341,9),
+-- 2019 courses
+(369,7),
+(370,6),
+(366,10),
+(360,12),
+(361,13),
+(357,13),
+(363,27),
+(371,12);
 
 GRANT ALL PRIVILEGES ON analysis.csf_plugged_stage_counts TO GROUP admin;
 GRANT SELECT ON analysis.csf_plugged_stage_counts TO GROUP reader, GROUP reader_pii;


### PR DESCRIPTION
We have a "course completion" metric that relies on students having attempted a level in every "plugged" (ie, a lesson that mostly takes place on the computer) lesson. Having the number of plugged lessons per course is needed to calculate the # of students completing our new CSF courses.