### PR TITLE
Volunteer Map: Fix performance regression

### DIFF
--- a/pegasus/forms/volunteer_engineer_submission_2015.rb
+++ b/pegasus/forms/volunteer_engineer_submission_2015.rb
@@ -127,8 +127,7 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
       ).
       exclude(
         Sequel.function(:coalesce, Forms.json('data.unsubscribed_s'), '') => UNSUBSCRIBE_FOREVER
-      ).
-      order(Sequel.desc(:created_at))
+      )
 
     # UNSUBSCRIBE_HOC means a volunteer said "I want to unsubscribe until the next Hour of Code".
     # We don't want them to be getting volunteer requests until then.  So, if we're not currently
@@ -185,6 +184,16 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
       query = query.where Sequel.lit(Forms.json('processed_data.location_p'))
       query = query.where {distance_query < distance}
       fl.push distance_query.as(:distance)
+    end
+
+    # The condition here is a workaround for a performance issue introduced in
+    # https://github.com/code-dot-org/code-dot-org/pull/31493
+    # Our initial query on the volunteer map retrieves 5000 rows with a 3000km radius, and this
+    # order clause slowed it down significantly.
+    # Subsequent queries on the page are limited to 50 rows, 32km, and don't have this perf issue
+    # so we still want to make sure we retrieve the more recent sign-ups.
+    if rows <= 50
+      query = query.order(Sequel.desc(:created_at))
     end
 
     docs = query.select(

--- a/pegasus/test/test_form_routes.rb
+++ b/pegasus/test/test_form_routes.rb
@@ -55,6 +55,14 @@ class FormRoutesTest < SequelTestCase
       assert_equal %w(Newest Middle Oldest), results.map {|r| r['name_s']}
     end
 
+    # Regression test: Ordering results when trying to retrieve a large number of rows
+    # slowed this query down significantly, so we avoid doing it over a certain size.
+    it 'does not try to order results for large requests' do
+      Sequel::Dataset.any_instance.expects(:order).never
+      # 5000 is the default rows retrieved on initial page load for the volunteer map.
+      search location: '35.774929,-122.419416', num_volunteers: 5000
+    end
+
     def create_volunteer(name:, location:, created_at: DateTime.now)
       row = insert_or_upsert_form(
         'VolunteerEngineerSubmission2015',
@@ -66,9 +74,12 @@ class FormRoutesTest < SequelTestCase
       )
     end
 
-    def search(location:)
+    def search(location:, num_volunteers: nil)
       JSON.parse(
-        VolunteerEngineerSubmission2015.query('coordinates' => location)
+        VolunteerEngineerSubmission2015.query(
+          'coordinates' => location,
+          'num_volunteers' => num_volunteers
+        )
       )['response']['docs']
     end
 


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/31493 introduced a performance regression in the volunteer map. We started seeing query timeouts ([reported in Honeybadger](https://app.honeybadger.io/projects/34365/faults/56432518/fa019714-f9cd-11e9-90c3-6b42292e4a59#notice-summary) and [New Relic](https://rpm.newrelic.com/accounts/501463/applications/3346604/transactions#id=5b22436f6e74726f6c6c65722f53696e617472612f446f63756d656e74732f504f5354202f666f726d732f3a6b696e642f7175657279222c22225d&tab-detail_56af35d8-f9d1-11e9-8075-0242ac110007_1842_5002=database_queries&app_trace_id=56af35d8-f9d1-11e9-8075-0242ac110007_1842_5002)) for the initial search query on page load.

That initial query retrieves 5000 volunteers with a 3000km radius.  Subsequent user-initiated searches have a limit of 50 volunteers and a 32km radius.  Since we observed performance issues with the large initial search but not with the small, local searches, I'm removing the ordering clause from the large search as a quick workaround.  For other exploration of the performance issue, see [this Slack thread](https://codedotorg.slack.com/archives/CC4U03GA0/p1572302314034400).

There are lots of ways we could make this better in the future.  For example, we could have the map default to an approximation of the client's location, or a default local location we choose, instead of trying to load so many results on a national map.

@hacodeorg observed that the slow query was slow on our pegasus production database but not on our pegasus-reporting database.

## Testing story

I've added a unit test for the new behavior.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
