### PR TITLE
[Collector] Add execution step for failing to pick up

### DIFF
--- a/apps/src/maze/api.js
+++ b/apps/src/maze/api.js
@@ -415,5 +415,7 @@ exports.collect = API_FUNCTION(function(id) {
   var row = Maze.controller.pegmanY;
   if (Maze.controller.subtype.tryCollect(row, col)) {
     Maze.executionInfo.queueAction('pickup', id);
+  } else {
+    Maze.executionInfo.queueAction('fail_pickup', id);
   }
 });

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -662,6 +662,9 @@ module.exports = class Maze {
       case 'pickup':
         this.controller.scheduleDig();
         break;
+      case 'fail_pickup':
+        this.controller.animatedFail(false);
+        break;
       case 'nectar':
         this.controller.subtype.animateGetNectar();
         break;


### PR DESCRIPTION
# Description
We did not add an execution step for failure to collect an item, so the program fails with the previous step highlighted. This is confusing when using step mode.
I'm reusing the animation for backing up into a wall because we don't have an animation for failure to collect an item.

Before:
![image](https://user-images.githubusercontent.com/8787187/67790265-b7c59980-fa32-11e9-9dec-11c8892c2cbd.png)

After:
![image](https://user-images.githubusercontent.com/8787187/67790225-a54b6000-fa32-11e9-81e3-68e5a11571e6.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
