### PR TITLE
Revert "Revert "Render markdown in content-backed DSL-defined levels clientside""

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -538,6 +538,7 @@ describe('entry tests', () => {
       './src/sites/studio/pages/layouts/_terms_interstitial.js',
     'levels/_bubble_choice':
       './src/sites/studio/pages/levels/_bubble_choice.js',
+    'levels/_content': './src/sites/studio/pages/levels/_content.js',
     'levels/_contract_match':
       './src/sites/studio/pages/levels/_contract_match.js',
     'levels/_curriculum_reference':

--- a/apps/src/sites/studio/pages/levels/_content.js
+++ b/apps/src/sites/studio/pages/levels/_content.js
@@ -1,0 +1,18 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDom from 'react-dom';
+
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+
+$(document).ready(() => {
+  // Render Markdown
+  const container = document.getElementById('markdown');
+  if (!container || !container.dataset.markdown) {
+    return;
+  }
+
+  ReactDom.render(
+    React.createElement(SafeMarkdown, container.dataset, null),
+    container
+  );
+});

--- a/apps/src/sites/studio/pages/levels/_content.js
+++ b/apps/src/sites/studio/pages/levels/_content.js
@@ -6,13 +6,14 @@ import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
 $(document).ready(() => {
   // Render Markdown
-  const container = document.getElementById('markdown');
-  if (!container || !container.dataset.markdown) {
-    return;
-  }
+  $('.content-level > .markdown-container').each(function() {
+    if (!this.dataset.markdown) {
+      return;
+    }
 
-  ReactDom.render(
-    React.createElement(SafeMarkdown, container.dataset, null),
-    container
-  );
+    ReactDom.render(
+      React.createElement(SafeMarkdown, this.dataset, null),
+      this
+    );
+  });
 });

--- a/apps/src/sites/studio/pages/levels/_external.js
+++ b/apps/src/sites/studio/pages/levels/_external.js
@@ -6,8 +6,6 @@ import {
 } from '@cdo/apps/code-studio/levels/postOnLoad';
 
 $(document).ready(() => {
-  embedDiscourseForum();
-
   const script = document.querySelector('script[data-external]');
   const data = JSON.parse(script.dataset.external);
 
@@ -23,31 +21,5 @@ $(document).ready(() => {
   postMilestoneForPageLoad();
 
   // handle click on continue (results in navigating to next puzzle)
-  $('.submitButton').click(onContinue);
+  $('.external').on('click', '.submitButton', onContinue);
 });
-
-// Embed a forum thread in an External level by adding <div id='discourse-comments' /> anywhere in the page html
-function embedDiscourseForum() {
-  if ($('#discourse-comments')[0]) {
-    window.discourseUrl =
-      location.hostname === 'studio.code.org'
-        ? '//forum.code.org/'
-        : '//discourse.code.org/';
-    window.discourseEmbedUrl = [
-      location.protocol,
-      '//',
-      location.host,
-      location.pathname
-    ].join('');
-    (function() {
-      var d = document.createElement('script');
-      d.type = 'text/javascript';
-      d.async = true;
-      d.src = window.discourseUrl + 'javascripts/embed.js';
-      (
-        document.getElementsByTagName('head')[0] ||
-        document.getElementsByTagName('body')[0]
-      ).appendChild(d);
-    })();
-  }
-}

--- a/dashboard/app/views/levels/_content.html.haml
+++ b/dashboard/app/views/levels/_content.html.haml
@@ -21,5 +21,5 @@
   / Markdown will be rendered clientside by _content.js
   - if data['markdown'].present?
     - level_markdown = level.try(:localized_replaced_markdown, current_user) || level.localized_property('markdown')
-    #markdown{data: {markdown: level_markdown}}
+    .markdown-container{data: {markdown: level_markdown}}
   = postcontent

--- a/dashboard/app/views/levels/_content.html.haml
+++ b/dashboard/app/views/levels/_content.html.haml
@@ -4,8 +4,12 @@
 - app, data, content_class, source_level, hide_header, postcontent = %i(app data content_class source_level hide_header postcontent).map{ |x| local_assigns[x] }
 - level = source_level || @level
 
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/levels/_content.js')}
+
 - unless data['title'].blank? || hide_header
   %h1!= render_multi_or_match_content(level.localized_property('title')) unless app == 'external'
+
 %div.content-level{class: (content_class unless content_class.blank?)}
   - unless app == 'external'
     - unless data['content1'].blank?
@@ -14,10 +18,8 @@
       %p.content.content2!= render_multi_or_match_content(level.localized_property('content2'))
     - unless data['content3'].blank?
       %p.content.content3!= render_multi_or_match_content(level.localized_property('content3'))
-  / Markdown support using the 'markdown' property.
+  / Markdown will be rendered clientside by _content.js
   - if data['markdown'].present?
-    #markdown
-      - level_markdown = level.try(:localized_replaced_markdown, current_user) || level.localized_property('markdown')
-      / Render markdown text through the ActionView template engine.
-      = ActionView::Base.new.render(inline: level_markdown, type: :md)
+    - level_markdown = level.try(:localized_replaced_markdown, current_user) || level.localized_property('markdown')
+    #markdown{data: {markdown: level_markdown}}
   = postcontent

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -877,7 +877,7 @@ DSL
     sign_in @not_admin
     get :show, params: {id: level}
     assert_response :success
-    assert_select '#markdown', "this is the markdown for #{@not_admin.id}"
+    assert_select '#markdown[data-markdown=?]', "this is the markdown for #{@not_admin.id}"
   end
 
   # test_platformization_partner_calling_get_new_should_receive_success

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -877,7 +877,7 @@ DSL
     sign_in @not_admin
     get :show, params: {id: level}
     assert_response :success
-    assert_select '#markdown[data-markdown=?]', "this is the markdown for #{@not_admin.id}"
+    assert_select '.markdown-container[data-markdown=?]', "this is the markdown for #{@not_admin.id}"
   end
 
   # test_platformization_partner_calling_get_new_should_receive_success


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#31544 (restoring https://github.com/code-dot-org/code-dot-org/pull/29976) and add a bugfix: https://github.com/code-dot-org/code-dot-org/pull/31562/commits/c93669673f24e95bf49a90f11f41020b8457529f

Specifically, we add support for multiple pieces of DSL markdown on a single page:

1. Use a class instead of an ID to identify the markdown container
2. Apply the render logic to all instances of the class rather than to the one instance of the id