### PR TITLE
Hide back to school announcement on teacher homepage

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -175,7 +175,7 @@ export default class TeacherHomepage extends Component {
     const showSpecialAnnouncement = false;
 
     // Hide the regular announcement/notification for now.
-    const showAnnouncement = true;
+    const showAnnouncement = false;
 
     return (
       <div>
@@ -194,7 +194,7 @@ export default class TeacherHomepage extends Component {
               type={announcement.type || 'bullhorn'}
               notice={announcement.heading}
               details={announcement.description}
-              dismissible={false}
+              dismissible={true}
               buttonText={announcement.buttonText}
               buttonLink={announcement.link}
               newWindow={true}


### PR DESCRIPTION
Currently we're showing this Notification on the teacher homepage: 
<img width="1044" alt="Screen Shot 2019-10-29 at 12 13 42 PM" src="https://user-images.githubusercontent.com/12300669/67803352-1b0ef600-fa4a-11e9-82a6-c54713572862.png">
Since we're nearing the end of October, we no longer need to show "Back to School" messaging and we've gotten Zendesk reports of it cluttering the page for teachers who want to get down to business with their sections. 

There are 2 changes here: 

1.) In the future the Notification at the top of the teacher homepage will be dismissible, note the little gray x in the top corner. 
<img width="1034" alt="Screen Shot 2019-10-29 at 12 38 36 PM" src="https://user-images.githubusercontent.com/12300669/67803362-1ea27d00-fa4a-11e9-9b77-350d492c418a.png">

2.) For now we'll hide this announcement completely. 
<img width="1114" alt="Screen Shot 2019-10-29 at 12 40 14 PM" src="https://user-images.githubusercontent.com/12300669/67803371-219d6d80-fa4a-11e9-97dc-95680646397e.png">
