### PR TITLE
Peer review search finds unmigrated users by email

### DIFF
--- a/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
@@ -30,9 +30,7 @@ class Api::V1::PeerReviewSubmissionsController < ApplicationController
     if user_query.presence
       reviews =
         if user_query.include? '@'
-          reviews.
-            joins(submitter: [:primary_contact_info]).
-            where(authentication_options: {email: user_query})
+          reviews.where submitter: User.find_by_email(user_query)
         else
           # I feel safe-ish using fuzzy search against user display names because we are already
           # constrained by our join to the set of users submitting for peer review, which is below


### PR DESCRIPTION
Fixes [PLC-594](https://codedotorg.atlassian.net/browse/PLC-594): Using the email filter on the peer review dashboard does not work when the peer review submitter has an unmigrated account. Regression was introduced August 13th in https://github.com/code-dot-org/code-dot-org/pull/30251.

[Caught by Andrea](https://codedotorg.slack.com/archives/C0T10H26N/p1572374175114800), confirmed, and verified that this may impact a large number of searches because [more than half of teacher accounts are still unmigrated](https://codedotorg.slack.com/archives/C6B838SB0/p1572376723030400).

## Testing story

A new unit test covering this case, using the `:demigrated` factory trait so it'll be easy to find and remove later when all accounts are migrated.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
