### PR TITLE
Fix ArgumentError in VolunteerEngineerSubmission2015

### DIFF
--- a/pegasus/forms/volunteer_engineer_submission_2015.rb
+++ b/pegasus/forms/volunteer_engineer_submission_2015.rb
@@ -192,7 +192,7 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
     # order clause slowed it down significantly.
     # Subsequent queries on the page are limited to 50 rows, 32km, and don't have this perf issue
     # so we still want to make sure we retrieve the more recent sign-ups.
-    if rows <= 50
+    if rows.to_i <= 50
       query = query.order(Sequel.desc(:created_at))
     end
 

--- a/pegasus/test/test_form_routes.rb
+++ b/pegasus/test/test_form_routes.rb
@@ -60,7 +60,7 @@ class FormRoutesTest < SequelTestCase
     it 'does not try to order results for large requests' do
       Sequel::Dataset.any_instance.expects(:order).never
       # 5000 is the default rows retrieved on initial page load for the volunteer map.
-      search location: '35.774929,-122.419416', num_volunteers: 5000
+      search location: '35.774929,-122.419416', num_volunteers: '5000'
     end
 
     def create_volunteer(name:, location:, created_at: DateTime.now)


### PR DESCRIPTION
I forgot that this parameter would be a string.  Casting it with `to_i` to resolve. I've also updated the test to catch this scenario.

* I started working on the Volunteer map in https://github.com/code-dot-org/code-dot-org/pull/31493.
* This regression was introduced in https://github.com/code-dot-org/code-dot-org/pull/31541 while trying to fix a performance problem.
* Honeybadger error: https://app.honeybadger.io/projects/34365/faults/56475122
* Slack conversation: https://codedotorg.slack.com/archives/C55JZ1BPZ/p1572393884034500

This small fix for the ArgumentError probably does not fix a more general issue with the performance of the volunteer map query, which may require we rethink the behavior of this page.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
