### PR TITLE
[student-libraries] changed sizing to 2.5 lines of library items

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryListItem.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryListItem.jsx
@@ -10,7 +10,6 @@ const styles = {
     color: color.dark_charcoal,
     textAlign: 'left',
     display: 'flex',
-    backgroundColor: color.offwhite_gray,
     borderBottom: 'inset'
   },
   libraryName: {

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -25,7 +25,7 @@ const styles = {
     marginTop: 20
   },
   libraryList: {
-    maxHeight: '162px',
+    maxHeight: '140px',
     overflowY: 'auto'
   },
   message: {


### PR DESCRIPTION
# Description
Changed library manager to display 2.5 items instead of 3. We can't force the scrollbar to display in OSX, so we want to display an extra half of an item to show that scrolling can happen.

Additionally, on a 1024x768 screen, 2.5 is the max we can display without the modal itself needing to scroll.

![image](https://user-images.githubusercontent.com/8324574/67886710-2b38db00-fb07-11e9-995e-a5798a645d5e.png)

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1VxMmdHdIeBWCXKofkjEy9MuWcrzeEW3Zt-Ir8pINYdA/edit)
- [jira](https://codedotorg.atlassian.net/browse/STAR-710)
- [all relevant PRs](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Ajmkulwik+archived%3Afalse+student+libraries)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
