### PR TITLE
[student-libraries] Multiple single-line comments in a row are now parsed as a multiline comment.

### DIFF
--- a/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
@@ -300,7 +300,6 @@ export default class JSInterpreter {
     codeFunctions.forEach(codeFunction => {
       let fullComment = '';
       let comment = getPrecedingComment(allComments, codeFunction.start);
-      // let commentText = comment ? comment.text : '';
       if (comment && comment.isBlockComment) {
         fullComment = comment.text;
         if (fullComment[0] === '*') {

--- a/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
@@ -298,17 +298,27 @@ export default class JSInterpreter {
     });
 
     codeFunctions.forEach(codeFunction => {
+      let fullComment = '';
       let comment = getPrecedingComment(allComments, codeFunction.start);
-      let commentText = comment ? comment.text : '';
-      if (comment && comment.isBlockComment && commentText[0] === '*') {
-        // For a JSDoc style comment, acorn doesn't strip the * that starts
-        // each line, so we do that here.
-        commentText = commentText
-          .substr(1)
-          .split('\n * ')
-          .join('\n');
+      // let commentText = comment ? comment.text : '';
+      if (comment && comment.isBlockComment) {
+        fullComment = comment.text;
+        if (fullComment[0] === '*') {
+          // For a JSDoc style comment, acorn doesn't strip the * that starts
+          // each line, so we do that here.
+          fullComment = fullComment
+            .substr(1)
+            .split('\n * ')
+            .join('\n');
+        }
+      } else {
+        while (comment) {
+          // Find all adjacent singleline comments preceding the function
+          fullComment = comment.text.trim() + '\n' + fullComment;
+          comment = getPrecedingComment(allComments, comment.startLocation);
+        }
       }
-      commentText = commentText.trim();
+      fullComment = fullComment.trim();
 
       let params = codeFunction.params.map(param => {
         return param.name;
@@ -317,7 +327,7 @@ export default class JSInterpreter {
       functionsAndMetadata.push({
         functionName: codeFunction.id.name,
         parameters: params,
-        comment: commentText
+        comment: fullComment
       });
     });
 

--- a/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
@@ -40,10 +40,10 @@ describe('The JSInterpreter class', function() {
       expect(functions[0].comment).to.equal(`${comment}\n${comment}`);
     });
 
-    it('returns the last single-line comment if there are multiple', () => {
-      let code = `//${comment}\n//${comment}last\nfunction testFunction() {}`;
+    it('returns multiple single-line comments', () => {
+      let code = `//${comment}\n//${comment}\nfunction testFunction() {}`;
       let functions = JSInterpreter.getFunctionsAndMetadata(code);
-      expect(functions[0].comment).to.equal(`${comment}last`);
+      expect(functions[0].comment).to.equal(`${comment}\n${comment}`);
     });
 
     it('returns no comment when an empty comment is passed', () => {


### PR DESCRIPTION
# Description
Since we couldn't make a multiline comment block, we instead decided to support multiple single-line comment blocks as if they were a multiline comment block.

That means these two will be interpreted the same way from a library's perspective.
![image](https://user-images.githubusercontent.com/8324574/67909704-6950f180-fb3d-11e9-89fd-ae95b01f3736.png)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1VxMmdHdIeBWCXKofkjEy9MuWcrzeEW3Zt-Ir8pINYdA/edit)
- [jira](https://codedotorg.atlassian.net/browse/STAR-710)
- [all relevant PRs](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Ajmkulwik+archived%3Afalse+student+libraries)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
