### PR TITLE
Optimize volunteer map query performance

### DIFF
--- a/pegasus/forms/volunteer_engineer_submission_2015.rb
+++ b/pegasus/forms/volunteer_engineer_submission_2015.rb
@@ -127,7 +127,8 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
       ).
       exclude(
         Sequel.function(:coalesce, Forms.json('data.unsubscribed_s'), '') => UNSUBSCRIBE_FOREVER
-      )
+      ).
+      order(Sequel.desc(:id))
 
     # UNSUBSCRIBE_HOC means a volunteer said "I want to unsubscribe until the next Hour of Code".
     # We don't want them to be getting volunteer requests until then.  So, if we're not currently
@@ -184,16 +185,6 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
       query = query.where Sequel.lit(Forms.json('processed_data.location_p'))
       query = query.where {distance_query < distance}
       fl.push distance_query.as(:distance)
-    end
-
-    # The condition here is a workaround for a performance issue introduced in
-    # https://github.com/code-dot-org/code-dot-org/pull/31493
-    # Our initial query on the volunteer map retrieves 5000 rows with a 3000km radius, and this
-    # order clause slowed it down significantly.
-    # Subsequent queries on the page are limited to 50 rows, 32km, and don't have this perf issue
-    # so we still want to make sure we retrieve the more recent sign-ups.
-    if rows.to_i <= 50
-      query = query.order(Sequel.desc(:created_at))
     end
 
     docs = query.select(

--- a/pegasus/test/test_form_routes.rb
+++ b/pegasus/test/test_form_routes.rb
@@ -48,29 +48,20 @@ class FormRoutesTest < SequelTestCase
 
     it 'uses reverse chronological order' do
       here = '35.774929,-122.419416'
-      create_volunteer name: 'Oldest', created_at: 3.years.ago, location: here
-      create_volunteer name: 'Middle', created_at: 2.years.ago, location: here
-      create_volunteer name: 'Newest', created_at: 1.year.ago, location: here
+      create_volunteer name: 'Oldest', location: here
+      create_volunteer name: 'Middle', location: here
+      create_volunteer name: 'Newest', location: here
       results = search location: here
       assert_equal %w(Newest Middle Oldest), results.map {|r| r['name_s']}
     end
 
-    # Regression test: Ordering results when trying to retrieve a large number of rows
-    # slowed this query down significantly, so we avoid doing it over a certain size.
-    it 'does not try to order results for large requests' do
-      Sequel::Dataset.any_instance.expects(:order).never
-      # 5000 is the default rows retrieved on initial page load for the volunteer map.
-      search location: '35.774929,-122.419416', num_volunteers: '5000'
-    end
-
-    def create_volunteer(name:, location:, created_at: DateTime.now)
+    def create_volunteer(name:, location:)
       row = insert_or_upsert_form(
         'VolunteerEngineerSubmission2015',
         DEFAULT_DATA.dup.merge(name_s: name)
       )
       Form.find(id: row[:id]).update(
-        processed_data: {location_p: location}.to_json,
-        created_at: created_at
+        processed_data: {location_p: location}.to_json
       )
     end
 


### PR DESCRIPTION
[Will wrote](https://codedotorg.slack.com/archives/C03CK49G9/p1572540482008400):

> The change in https://github.com/code-dot-org/code-dot-org/pull/31493 (adding `.order(Sequel.desc(:created_at))` to the end of the volunteer submission Sequel query) caused a performance regression because it confused the query-optimizer enough to start selecting the wrong (very inefficient) index to use.
>
> Before the change, it selected the `kind` index, which allowed the `WHERE kind = 'VolunteerEngineerSubmission2015'` clause to ignore all of the millions of forms, except for the ~20k that are actually volunteer submissions the query cares about.
>
> After the change, it selected the `forms_created_at_index` index, which it tried to use to optimize finding the ordered results, but then wasn't able to filter by `kind`, so it starts scanning through all million forms.
>
> Just another casualty of the not-perfect query-optimizer choosing a non-optimal index in practice. To fix narrowly, you can either add an index hint (e.g., `USE INDEX(kind)`) to the query. Or, another option I found works well enough is to order by `:id` instead of by `:created_at`

So I'm ordering by `id` (adding index hints seems to be a little messy with Sequel) and removing the special behavior that does no ordering on the initial request.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLC-596)
- The story so far:
  - [Volunteer Map: Prefer more recent sign-ups](https://github.com/code-dot-org/code-dot-org/pull/31493)
  - [Volunteer Map: Fix performance regression](https://github.com/code-dot-org/code-dot-org/pull/31541)
  - [Fix ArgumentError in VolunteerEngineerSubmission2015](https://github.com/code-dot-org/code-dot-org/pull/31583)

## Testing story

Unit tests still pass.  I've removed the test for the special no-ordering behavior that I'm removing.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
