### PR TITLE
Secure Admin Accounts:  Require google sso for admins

### DIFF
--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -62,6 +62,10 @@ class AuthenticationOption < ApplicationRecord
     MICROSOFT
   ]
 
+  def codeorg_email?
+    Mail::Address.new(email).domain == 'code.org'
+  end
+
   def oauth?
     OAUTH_CREDENTIAL_TYPES.include? credential_type
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -508,38 +508,20 @@ class User < ActiveRecord::Base
   # there's a Code.org google sso option present.
   def verify_google_sso_for_admin
     return unless admin?
-    return false unless Mail::Address.new(email).domain == "code.org"
-    puts "#{Mail::Address.new(email).domain}"
-    # return false unless migrated?
-    # unless migrated?
-    #   puts "#{migrated?}"
-    #   puts "****not migrated"
-    #   self.admin = false
-    #   return
-    # end
 
-    # return array of authentication options that is google oauth 2
-    google_oauth = authentication_options&.where(credential_type: AuthenticationOption::GOOGLE)
-    puts "#{google_oauth}"
-    puts "#{google_oauth.empty?}"
+    return false unless migrated?
+
+    # return array of authentication options that is google oauth
+    google_oauth = authentication_options.where(credential_type: AuthenticationOption::GOOGLE)
     if google_oauth.empty?
-      puts "***failing google oauth"
       self.admin = false
       return
     end
 
-    # get an array of all emails
-    email_domains = google_oauth&.map {|o| Mail::Address.new(o.email).domain}
+    # get an array of all email domains
+    email_domains = google_oauth.map {|o| Mail::Address.new(o.email).domain}
     if email_domains.none? {|domain| domain == 'code.org'}
-      puts "***failing email domain"
       self.admin = false
-    end
-
-    unless migrated?
-        puts "#{migrated?}"
-        puts "****not migrated"
-        self.admin = false
-        return
     end
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -507,19 +507,17 @@ class User < ActiveRecord::Base
   # Implement validation that refuses to set admin:true attribute unless
   # there's a Code.org google sso option present.
   def verify_google_sso_for_admin
-    return unless admin?
-
     return false unless migrated?
 
     # return array of authentication options that is google oauth
-    google_oauth = authentication_options.where(credential_type: AuthenticationOption::GOOGLE)
-    if google_oauth.empty?
+    google_oauth = authentication_options&.where(credential_type: AuthenticationOption::GOOGLE)
+    if google_oauth&.empty?
       self.admin = false
       return
     end
 
     # get an array of all email domains
-    email_domains = google_oauth.map {|o| Mail::Address.new(o.email).domain}
+    email_domains = google_oauth&.map {|o| Mail::Address.new(o.email).domain}
     if email_domains.none? {|domain| domain == 'code.org'}
       self.admin = false
     end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -505,9 +505,13 @@ class User < ActiveRecord::Base
   end
 
   # Implement validation that refuses to set admin:true attribute unless
-  # there's a Code.org google sso option present.
+  # there's a Code.org google sso option present.  Unmigrated users are
+  # not allowed to be admins.
   def enforce_google_sso_for_admin
-    return unless migrated?
+    unless migrated?
+      self.admin = false
+      return
+    end
 
     google_oauth = google_oauth_authentications
     if google_oauth&.empty?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -507,7 +507,10 @@ class User < ActiveRecord::Base
   # Implement validation that refuses to set admin:true attribute unless
   # there's a Code.org google sso option present.
   def verify_google_sso_for_admin
-    return false unless migrated?
+    unless migrated?
+      self.admin = false
+      return
+    end
 
     # return array of authentication options that is google oauth
     google_oauth = authentication_options&.where(credential_type: AuthenticationOption::GOOGLE)
@@ -518,7 +521,7 @@ class User < ActiveRecord::Base
 
     # get an array of all email domains
     email_domains = google_oauth&.map {|o| Mail::Address.new(o.email).domain}
-    if email_domains.none? {|domain| domain == 'code.org'}
+    if email_domains&.none? {|domain| domain == 'code.org'}
       self.admin = false
     end
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -67,7 +67,8 @@ FactoryGirl.define do
       user_type User::TYPE_TEACHER
       birthday Date.new(1980, 3, 14)
       factory :admin do
-        admin true
+        with_google_authentication_option
+        after(:create) {|user| user.update(admin: true)}
       end
       trait :with_school_info do
         school_info
@@ -355,7 +356,7 @@ FactoryGirl.define do
           email: user.email,
           hashed_email: user.hashed_email,
           credential_type: AuthenticationOption::GOOGLE,
-          authentication_id: 'abcd123',
+          authentication_id: "abcd#{user.id}",
           data: {
             oauth_token: 'some-google-token',
             oauth_refresh_token: 'some-google-refresh-token',

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -356,7 +356,8 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   end
 
   test "revokes the user's admin status" do
-    user = create :teacher, admin: true
+    user = create :admin
+
     assert user.admin?
 
     purge_user user

--- a/dashboard/test/models/concerns/user_permission_grantee_test.rb
+++ b/dashboard/test/models/concerns/user_permission_grantee_test.rb
@@ -196,7 +196,7 @@ class UserPermissionGranteeTest < ActiveSupport::TestCase
 
   test 'admin_changed? equates nil and false' do
     # admins must be teacher
-    teacher = create :teacher
+    teacher = create :admin
 
     # Each row is a test consisting of 3 values in order:
     #   from - the initial state of the admin attribute

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4177,8 +4177,6 @@ class UserTest < ActiveSupport::TestCase
     unmigrated_teacher_without_password.admin = true
     unmigrated_teacher_without_password.save!
 
-    puts "unmigrated #{unmigrated_teacher_without_password.admin}"
-
     refute unmigrated_teacher_without_password.admin
   end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4140,9 +4140,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal teacher.user_school_infos.count, 2
   end
 
+  # test 'does set admin to true when google oauth codeorg account' do
+  #   user = create :teacher, :google_sso_provider, email: 'simone@code.org'
+  #   assert user.admin
+  # end
+
   test 'does set admin to true when google oauth codeorg account' do
-    user = create :teacher, :google_sso_provider, email: 'simone@code.org'
-    assert user.admin
+    email = 'simone@code.org'
+    migrated_teacher = create(:teacher, :with_google_authentication_option, email: email)
+    puts "*****#{migrated_teacher.email}"
+    assert migrated_teacher.admin
   end
 
   test 'does set admin to false when it is not a google oauth codeorg account' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4140,26 +4140,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal teacher.user_school_infos.count, 2
   end
 
-  # test 'does set admin to true when google oauth codeorg account' do
-  #   user = create :teacher, :google_sso_provide, email: 'me+admin@code.org'
-  #   sign_in user
-
-  #   assert_equal true,  user.admin
-  # end
-
   test 'does set admin to true when google oauth codeorg account' do
-    admin = create :admin
-
-    assert_equal true,  user.admin
+    user = create :teacher, :google_sso_provider, email: 'simone@code.org'
+    assert user.admin
   end
 
-  # test 'does set admin to false when it is not a google oauth codeorg account' do
-  #   user = create :teacher, email: 'ra+admin@code.org'
-  #   refute_equal true, user.admin
-  # end
+  test 'does set admin to false when it is not a google oauth codeorg account' do
+  end
 
-  # test 'does set admin to false when it is not a codeorg account' do
-  #   user = create :teacher, :google_sso_provide, email: 'fake_email@gmail.com'
-  #   refute_equal true, user.admin
-  # end
+  test 'does set admin to false when it is not a codeorg account' do
+  end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4141,7 +4141,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'does set admin to true when google oauth codeorg account' do
-    email = 'simone@code.org'
+    email = 'fernhunt@code.org'
     migrated_teacher = create(:teacher, :with_google_authentication_option, email: email)
 
     migrated_teacher.admin = true
@@ -4151,10 +4151,11 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'does set admin to false when it is not a google oauth codeorg account' do
-    email = 'me+admin@code.org'
+    email = 'annieeasley@code.org'
     migrated_teacher = create(:teacher, email: email)
 
-    migrated_teacher.admin = false
+    migrated_teacher.admin = true
+    migrated_teacher.save!
 
     refute migrated_teacher.admin
   end
@@ -4163,7 +4164,8 @@ class UserTest < ActiveSupport::TestCase
     email = 'milesmorales@gmail.com'
     migrated_teacher = create(:teacher, :with_google_authentication_option, email: email)
 
-    migrated_teacher.admin = false
+    migrated_teacher.admin = true
+    migrated_teacher.save!
 
     refute migrated_teacher.admin
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4169,4 +4169,16 @@ class UserTest < ActiveSupport::TestCase
 
     refute migrated_teacher.admin
   end
+
+  test 'does set admin to false when unmigrated teacher account' do
+    unmigrated_teacher_without_password = create :teacher, :demigrated
+    unmigrated_teacher_without_password.update_attribute(:encrypted_password, '')
+
+    unmigrated_teacher_without_password.admin = true
+    unmigrated_teacher_without_password.save!
+
+    puts "unmigrated #{unmigrated_teacher_without_password.admin}"
+
+    refute unmigrated_teacher_without_password.admin
+  end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4139,4 +4139,27 @@ class UserTest < ActiveSupport::TestCase
     assert teacher.update(school_info: school_info)
     assert_equal teacher.user_school_infos.count, 2
   end
+
+  # test 'does set admin to true when google oauth codeorg account' do
+  #   user = create :teacher, :google_sso_provide, email: 'me+admin@code.org'
+  #   sign_in user
+
+  #   assert_equal true,  user.admin
+  # end
+
+  test 'does set admin to true when google oauth codeorg account' do
+    admin = create :admin
+
+    assert_equal true,  user.admin
+  end
+
+  # test 'does set admin to false when it is not a google oauth codeorg account' do
+  #   user = create :teacher, email: 'ra+admin@code.org'
+  #   refute_equal true, user.admin
+  # end
+
+  # test 'does set admin to false when it is not a codeorg account' do
+  #   user = create :teacher, :google_sso_provide, email: 'fake_email@gmail.com'
+  #   refute_equal true, user.admin
+  # end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4140,21 +4140,31 @@ class UserTest < ActiveSupport::TestCase
     assert_equal teacher.user_school_infos.count, 2
   end
 
-  # test 'does set admin to true when google oauth codeorg account' do
-  #   user = create :teacher, :google_sso_provider, email: 'simone@code.org'
-  #   assert user.admin
-  # end
-
   test 'does set admin to true when google oauth codeorg account' do
     email = 'simone@code.org'
     migrated_teacher = create(:teacher, :with_google_authentication_option, email: email)
-    puts "*****#{migrated_teacher.email}"
+
+    migrated_teacher.admin = true
+    migrated_teacher.save!
+
     assert migrated_teacher.admin
   end
 
   test 'does set admin to false when it is not a google oauth codeorg account' do
+    email = 'me+admin@code.org'
+    migrated_teacher = create(:teacher, email: email)
+
+    migrated_teacher.admin = false
+
+    refute migrated_teacher.admin
   end
 
   test 'does set admin to false when it is not a codeorg account' do
+    email = 'milesmorales@gmail.com'
+    migrated_teacher = create(:teacher, :with_google_authentication_option, email: email)
+
+    migrated_teacher.admin = false
+
+    refute migrated_teacher.admin
   end
 end


### PR DESCRIPTION
# Description
The goal of this change is to require google sso for admins.  The attribute, admin, will not be set to true unless code.org google sso option is present.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-705)

## Testing story
The change includes 3 new unit tests (1 positive and 2 negative tests) added to user_test.rb

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
