### PR TITLE
Add TTS to dance party extras script

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -820,6 +820,7 @@ class Script < ActiveRecord::Base
       Script::DANCE_PARTY_NAME,
       Script::DANCE_PARTY_EXTRAS_NAME,
       Script::DANCE_PARTY_2019_NAME,
+      Script::DANCE_PARTY_EXTRAS_2019_NAME,
       Script::ARTIST_NAME,
       Script::SPORTS_NAME,
       Script::BASKETBALL_NAME

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -64,6 +64,7 @@ module ScriptConstants
 
       nil,
       DANCE_PARTY_2019_NAME = 'dance-2019'.freeze, # 2019 hour of code
+      DANCE_PARTY_EXTRAS_2019_NAME = 'dance-extras-2019'.freeze, # 2019 hour of code
       DANCE_PARTY_NAME = 'dance'.freeze, # 2018 hour of code
       DANCE_PARTY_EXTRAS_NAME = 'dance-extras'.freeze, # 2018 hour of code
       MINECRAFT_AQUATIC_NAME = 'aquatic'.freeze,

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -67,12 +67,12 @@ class ScriptConstantsTest < Minitest::Test
   end
 
   def test_assignable_info
-    assert_equal 1, ScriptConstants.assignable_info({name: 'dance'})[:position]
-    assert_equal 2, ScriptConstants.assignable_info({name: 'dance-extras'})[:position]
-    assert_equal 3, ScriptConstants.assignable_info({name: 'aquatic'})[:position]
-    assert_equal 4, ScriptConstants.assignable_info({name: 'hero'})[:position]
-    assert_equal 5, ScriptConstants.assignable_info({name: 'mc'})[:position]
-    assert_equal 6, ScriptConstants.assignable_info({name: 'minecraft'})[:position]
+    assert_equal 3, ScriptConstants.assignable_info({name: 'dance'})[:position]
+    assert_equal 4, ScriptConstants.assignable_info({name: 'dance-extras'})[:position]
+    assert_equal 5, ScriptConstants.assignable_info({name: 'aquatic'})[:position]
+    assert_equal 6, ScriptConstants.assignable_info({name: 'hero'})[:position]
+    assert_equal 7, ScriptConstants.assignable_info({name: 'mc'})[:position]
+    assert_equal 8, ScriptConstants.assignable_info({name: 'minecraft'})[:position]
   end
 
   describe 'ScriptConstants::script_in_any_category?' do


### PR DESCRIPTION
# Description

This adds TTS (and also translation) to the dance party extras script.

It also fixes the test_script_contants.rb test which broke with https://github.com/code-dot-org/code-dot-org/pull/31548/


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
