### PR TITLE
Course Overview: check for selectedSection before checking for scriptId

### DIFF
--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -128,7 +128,9 @@ class CourseScript extends Component {
       section => section.id === selectedSectionId
     );
     const assignedByTeacher =
-      viewAs === ViewType.Teacher && selectedSection.scriptId === id;
+      viewAs === ViewType.Teacher &&
+      selectedSection &&
+      selectedSection.scriptId === id;
     const isAssigned = assignedToStudent || assignedByTeacher;
 
     return (


### PR DESCRIPTION
Currently users trying to go to a course overview page who do not have any sections see a blank page, with this error in the console: 
<img width="836" alt="Screen Shot 2019-11-01 at 9 01 09 AM" src="https://user-images.githubusercontent.com/12300669/68039307-16845080-fc89-11e9-8b1f-351c2af0fd2f.png">
The error occurs because if there are no sections, there isn't a selectedSection, which means I shouldn't be checking the scriptId for the selectedSection. This fix handles that scenario and the course overview page will render successfully for users without sections. 