### PR TITLE
Add ProxySQL admin script to manage fallback weights

### DIFF
--- a/cookbooks/cdo-mysql/files/default/update_servers.sql
+++ b/cookbooks/cdo-mysql/files/default/update_servers.sql
@@ -1,0 +1,43 @@
+-- This script maintains 'fallback' servers within reader hostgroups
+-- by setting `weight` values high for primary and low for fallback servers.
+--
+-- * HG0 (writer) and HG1 (reader) are hostgroups managed by existing monitors.
+-- * HG1 weights are updated to favor readers with a fallback to the writer.
+-- * HG2 is created as a 'primary-reader' hostgroup, with the same servers as HG1
+--   but weights inverted, so it favors the writer with a fallback to readers.
+
+-- Note: although the ProxySQL admin interface uses the MySQL client protocol,
+-- it uses the SQLite dialect for its SQL-query syntax.
+
+DELETE FROM `mysql_servers`;
+
+-- Copy `runtime_mysql_servers` to `mysql_servers`, with HG2 copied from HG1.
+INSERT INTO `mysql_servers` SELECT * FROM `runtime_mysql_servers` WHERE `hostgroup_id` != 2;
+UPDATE `mysql_servers` SET `hostgroup_id` = 2 WHERE `hostgroup_id` = 1;
+INSERT INTO `mysql_servers` SELECT * FROM `runtime_mysql_servers` WHERE `hostgroup_id` = 1;
+
+-- Update weights on servers.
+UPDATE `mysql_servers` SET `weight` = CASE
+  WHEN ( -- Test if row is a writer (hostname exists in HG0)
+    `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 0))
+  ) THEN
+    -- Set writer weight low for HG1, high for HG2.
+    CASE WHEN (`hostgroup_id` = 1) THEN 1 ELSE 10000000 END
+  ELSE
+    -- Set reader weight high for HG1, low for HG2.
+    CASE WHEN (`hostgroup_id` = 1) THEN 10000000 ELSE 1 END
+  END;
+
+-- Return count of changed rows (where `mysql_servers` is different from `runtime_mysql_servers`).
+-- (Simulate FULL OUTER JOIN using a UNION of LEFT OUTER JOINs.)
+SELECT COUNT(*) AS diff FROM (
+  SELECT * FROM `mysql_servers`
+    LEFT OUTER JOIN `runtime_mysql_servers`
+        USING (hostgroup_id, hostname, weight)
+  WHERE `runtime_mysql_servers`.hostgroup_id IS NULL
+UNION ALL
+  SELECT * FROM `runtime_mysql_servers`
+    LEFT OUTER JOIN `mysql_servers`
+        USING (hostgroup_id, hostname, weight)
+  WHERE `mysql_servers`.hostgroup_id IS NULL
+);

--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -4,8 +4,8 @@
 # Variable definitions:
 # https://github.com/sysown/proxysql/wiki/Global-variables
 
-datadir="/var/lib/proxysql"
-errorlog="/var/lib/proxysql/proxysql.log"
+datadir="<%=@data_dir%>"
+errorlog="<%=@data_dir%>/proxysql.log"
 
 # https://github.com/sysown/proxysql/wiki/Global-variables#admin-variables
 admin_variables=
@@ -36,11 +36,6 @@ mysql_variables=
   monitor_username="<%= @reader.user %>"
   monitor_password="<%= @reader.password %>"
 
-  # When a node change its read_only value from 1 to 0, this variable determines
-  # if the node should be present in both hostgroups or not.
-  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-monitor_writer_is_also_reader
-  monitor_writer_is_also_reader=false
-
   # If this variable is set, after an OK packet with `last_insert_id` is received,
   # multiplexing is temporary disabled for the number of queries specified (default 5).
   # This prevents inconsistent results if a query containing `LAST_INSERT_ID()` uses a
@@ -53,7 +48,7 @@ mysql_variables=
 # https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers
 mysql_servers =
 (
-<% [@writer, @reader].each_with_index do |server, hostgroup| -%>
+<% [@writer, @reader].uniq.product([1, 2]).push([@writer, 0]).each do |server, hostgroup| -%>
   {
     address =        "<%= server.host %>"
     port =            <%= server.port || 3306 %>
@@ -79,7 +74,8 @@ mysql_aws_aurora_hostgroups:
   {
     writer_hostgroup=0
     reader_hostgroup=1
-    new_reader_weight=1
+    new_reader_weight=10000000
+    writer_is_also_reader=1
     domain_name="<%=@writer.host.sub(/[^.]*/, '')%>"
   }
 )
@@ -127,11 +123,12 @@ mysql_query_rules:
     apply=1
   },
   {
-    # Global read-write split on SELECT, disabled by default (set active=1 to enable).
+    # Send writer-user SELECTs to the primary-reader (HG2).
     rule_id=3
-    active=0
+    username="<%= @writer.user %>"
+    active=1
     match_pattern="^SELECT"
-    destination_hostgroup=1
+    destination_hostgroup=2
     apply=1
   },
   {


### PR DESCRIPTION
# Description

Update to ProxySQL configuration to include low-priority 'fallback servers', which will reroute queries to alternate servers in a hostgroup only when the other higher-priority servers are unavailable (e.g., during a failover or temporary outage). This should improve the availability and reliability of read queries in our database architecture.

Fallback servers are only useful for hostgroups only executing reads (`SELECT` queries), because only one server will accept write queries at a time.

Hostgroup 1 executes `reader`-user queries on read-replicas. With this change, this hostgroup will fallback to the writer instance if no read-replicas are available.

This PR adds Hostgroup 2 which contains the same servers as Hostgroup 1, but with opposite weights- it favors the writer instance, with fallback to read-replicas if the writer is not available. A new query rule routes all `writer`-user `SELECT` queries to Hostgroup 2.

Although fallback-server configuration is not natively supported by ProxySQL, it can be approximated by setting the `weight` value highest (`10000000`) for active servers, and lowest (`1`) for the fallback servers. This custom [`mysql_servers`](https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers) configuration is updated through ProxySQL's [admin interface](https://github.com/sysown/proxysql/wiki#configuring-proxysql-via-the-admin-interface), via a SQL script (invoked via `mysql` client by a small Bash script) that the [ProxySQL Scheduler](https://github.com/sysown/proxysql/wiki/Scheduler) runs every second to keep the `weight`s properly configured for all the servers in each hostgroup.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [Admin Interface (ProxySQL)](https://github.com/sysown/proxysql/wiki#configuring-proxysql-via-the-admin-interface)
- [`mysql_servers` (ProxySQL)](https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers)
- [Scheduler (ProxySQL)](https://github.com/sysown/proxysql/wiki/Scheduler)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Tested manually on an adhoc instance.