### PR TITLE
[Applab Datasets] For duplicate tables, show error message properly

### DIFF
--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -37,7 +37,7 @@ class DataLibraryPane extends React.Component {
 
   onError = error => {
     if (error.type === WarningType.DUPLICATE_TABLE_NAME) {
-      this.props.onShowWarning(error);
+      this.props.onShowWarning(error.msg);
     }
   };
 


### PR DESCRIPTION
# Description
The change made in #31371 didn't properly change the call to `onShowWarning()` for the duplicate name case, which caused a React error:
![image](https://user-images.githubusercontent.com/8787187/68065021-8671f580-fce0-11e9-8f3b-60e16e5c0ecd.png)

Fixed by passing `error.msg` to `onShowWarning` instead of `error`:
![image](https://user-images.githubusercontent.com/8787187/68065029-9be71f80-fce0-11e9-97cb-bd1d5483fd8c.png)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
