### PR TITLE
Allow admins to access standard site features

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -130,10 +130,6 @@ class ProjectsController < ApplicationController
 
   # GET /projects
   def index
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     unless current_user
       redirect_to '/projects/public'
     end
@@ -216,10 +212,6 @@ class ProjectsController < ApplicationController
   end
 
   def load
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     return if redirect_under_13_without_tos_teacher(@level)
     if current_user
       channel = StorageApps.new(storage_id_for_current_user).most_recent(params[:key])
@@ -233,10 +225,6 @@ class ProjectsController < ApplicationController
   end
 
   def create_new
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     return if redirect_under_13_without_tos_teacher(@level)
     channel = ChannelToken.create_channel(
       request.ip,
@@ -262,10 +250,6 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     if params.key?(:nosource)
       # projects can optionally be embedded without making their source
       # available. to keep people from just twiddling the url to get to the
@@ -345,19 +329,11 @@ class ProjectsController < ApplicationController
   end
 
   def edit
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     return if redirect_under_13_without_tos_teacher(@level)
     show
   end
 
   def remix
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     return if redirect_under_13_without_tos_teacher(@level)
     src_channel_id = params[:channel_id]
     begin

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -260,5 +260,9 @@ class Ability
     if user.permission?(UserPermission::CENSUS_REVIEWER)
       can :manage, Census::CensusInaccuracyInvestigation
     end
+
+    if user.admin?
+      can :manage, :all
+    end
   end
 end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -260,20 +260,5 @@ class Ability
     if user.permission?(UserPermission::CENSUS_REVIEWER)
       can :manage, Census::CensusInaccuracyInvestigation
     end
-
-    if user.admin?
-      can :manage, :all
-
-      cannot :manage, [
-        Activity,
-        Game,
-        Level,
-        Course,
-        Script,
-        ScriptLevel,
-        UserLevel,
-        UserScript
-      ]
-    end
   end
 end


### PR DESCRIPTION
# Description

After recent changes to our account policies, we want to allow admin accounts to access projects, scripts and levels so that code.org staff do not need to switch accounts so often. See https://codedotorg.slack.com/archives/C3MJGK03F/p1571952258000500 for discussion.

## Testing story

Manually verified that an admin can now access projects, scripts and levels. Since this change only affects workflows of internal users, additional unit tests do not seem necessary.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
