### PR TITLE
[Applab Dataset] Added levelbuilder setting for importing a data table

### DIFF
--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -42,6 +42,7 @@ class Applab < Blockly
     log_conditions
     data_tables
     data_properties
+    data_library_tables
     hide_view_data_button
     show_debug_watch
     expand_debugger

--- a/dashboard/app/views/levels/editors/_applab.html.haml
+++ b/dashboard/app/views/levels/editors/_applab.html.haml
@@ -86,6 +86,12 @@
     levelbuilder.initializeCodeMirror('level_data_tables', 'javascript');
 
 .field
+  = f.label :data_library_tables,'Dataset Libraries'
+  Comma-separated list of dataset libraries you would like to pre-load in the level.
+  %br
+  = f.text_area :data_library_tables, value: @level.data_library_tables
+
+.field
   = f.label 'Key-Value Data'
   You can copy the data array from the debug view in the Data tab in App Lab.
   %pre

--- a/dashboard/app/views/levels/editors/_droplet.html.haml
+++ b/dashboard/app/views/levels/editors/_droplet.html.haml
@@ -31,7 +31,7 @@
     = f.label :text_mode_at_start, 'Always start with text', :value => 'true'
 
 .field
-  = f.label :start_libraries,'Libraries'
+  = f.label :start_libraries,'User-Created Toolbox Libraries'
   = f.text_area :start_libraries, value: @level.start_libraries
 :ruby
   script_data = {


### PR DESCRIPTION
# Description
Levelbuilders now have the ability to add datasets from the dataset library into an applab level.


**Levelbuilder field:**
![image](https://user-images.githubusercontent.com/8324574/68149407-b7c20f80-fef2-11e9-9331-604ad3dc16e8.png)
^ this produces the following appOptions data:
```
appOptions.level.dataLibraryTables
"foo,bar"
```
<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-795)
- TODO: Add dropdown to levelbuilder that includes the list of dataset libraries

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
