### PR TITLE
DOTD: adjust DTS time to account for daylight savings time

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -55,7 +55,7 @@
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','collate_pdfs')
       cronjob at:'30 16,17 * * *', do:deploy_dir('bin', 'cron', 'update_dotd')
       cronjob at:'0 * * * *', do:deploy_dir('bin', 'cron', 'start_broken_link_checker'), notify:'dev+crontab@code.org'
-      cronjob at:'0 19 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      cronjob at:'0 20 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'update_dts')
       cronjob at:'0 17 * * *', do:deploy_dir('bin', 'cron', 'commit_trusted_proxies')
     end


### PR DESCRIPTION
The content scoop of Levelbuilder content into Staging should happen at noon.  

Today, due to daylight savings time, this occurred and hour early at 11am: 
<img width="378" alt="Screen Shot 2019-11-04 at 11 49 17 AM" src="https://user-images.githubusercontent.com/12300669/68152979-8993fe00-fef9-11e9-9702-c978f1692e24.png">

I adjusted the cronjob to rectify the timing. 