### PR TITLE
[Applab Datasets] Added table names to the levelbuilder page

### DIFF
--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -1,5 +1,8 @@
 /** @file JavaScript run only on the applab level edit page. */
 import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import datasets from '@cdo/apps/storage/dataBrowser/datasetManifest.json';
 
 $(document).ready(function() {
   const makerBlocks = {
@@ -58,4 +61,14 @@ $(document).ready(function() {
       editor.getDoc().setValue(JSON.stringify(functionsWithMaker, null, ' '));
     }
   });
+  let tableNames = datasets.tables.map(table => table.name).join(',');
+  ReactDOM.render(
+    <div>
+      <b>Options: </b>
+      {tableNames}
+    </div>,
+    $('<div></div>')
+      .insertBefore('#level_data_library_tables')
+      .get(0)
+  );
 });

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -2,6 +2,7 @@
 import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
 import datasets from '@cdo/apps/storage/dataBrowser/datasetManifest.json';
 
 $(document).ready(function() {
@@ -61,14 +62,53 @@ $(document).ready(function() {
       editor.getDoc().setValue(JSON.stringify(functionsWithMaker, null, ' '));
     }
   });
-  let tableNames = datasets.tables.map(table => table.name).join(',');
+
+  const data = getScriptData('applabOptions');
+  class DataLibrary extends React.Component {
+    state = {
+      value: data.data_library_tables.split(','),
+      tableNames: datasets.tables.map(table => table.name)
+    };
+
+    handleChange = event => {
+      let options = event.target.options;
+      let value = [];
+      for (var i = 0; i < options.length; i++) {
+        if (options[i].selected) {
+          value.push(options[i].value);
+        }
+      }
+      this.setState({value: value});
+      $('#level_data_library_tables').val(value);
+    };
+
+    render() {
+      return (
+        <div>
+          (shift-click or cmd-click to select multiple)
+          <br />
+          <select
+            defaultValue={this.state.value}
+            multiple={true}
+            onChange={this.handleChange}
+          >
+            {this.state.tableNames.map(name => {
+              return (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+      );
+    }
+  }
+
   ReactDOM.render(
-    <div>
-      <b>Options: </b>
-      {tableNames}
-    </div>,
+    <DataLibrary />,
     $('<div></div>')
-      .insertBefore('#level_data_library_tables')
+      .insertAfter(`label[for="level_data_library_tables"]`)
       .get(0)
   );
 });

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -64,10 +64,10 @@ $(document).ready(function() {
   });
 
   const data = getScriptData('applabOptions');
+  const tableNames = datasets.tables.map(table => table.name);
   class DataLibrary extends React.Component {
     state = {
-      value: data.data_library_tables.split(','),
-      tableNames: datasets.tables.map(table => table.name)
+      value: data.data_library_tables ? data.data_library_tables.split(',') : []
     };
 
     handleChange = event => {
@@ -78,6 +78,20 @@ $(document).ready(function() {
           value.push(options[i].value);
         }
       }
+      this.setValue(value);
+    };
+
+    selectAll = event => {
+      event.preventDefault();
+      this.setValue(tableNames);
+    };
+
+    clearAll = event => {
+      event.preventDefault();
+      this.setValue([]);
+    };
+
+    setValue = value => {
       this.setState({value: value});
       $('#level_data_library_tables').val(value);
     };
@@ -85,14 +99,22 @@ $(document).ready(function() {
     render() {
       return (
         <div>
-          (shift-click or cmd-click to select multiple)
-          <br />
+          <div>(shift-click or cmd-click to select multiple)</div>
+          <div>
+            <a href="#" onClick={this.selectAll}>
+              Select All
+            </a>
+            <span> | </span>
+            <a href="#" onClick={this.clearAll}>
+              Select None
+            </a>
+          </div>
           <select
-            defaultValue={this.state.value}
+            value={this.state.value}
             multiple={true}
             onChange={this.handleChange}
           >
-            {this.state.tableNames.map(name => {
+            {tableNames.map(name => {
               return (
                 <option key={name} value={name}>
                   {name}

--- a/apps/src/storage/dataBrowser/datasetManifest.json
+++ b/apps/src/storage/dataBrowser/datasetManifest.json
@@ -1,16 +1,10 @@
 {
   "tables": [
     {
-      "name": "openweathermap",
-      "description": "5 day 3 hour forecast from 5 cities",
-      "current": true
-    },
-    {
       "name": "cats",
       "description": "Information about different cat breeds",
       "current": false
     },
-
     {
       "name": "dogs",
       "description": "Information about different dog breeds",
@@ -20,88 +14,18 @@
       "name": "states",
       "description": "Interesting facts & statistics of the 50 states",
       "current": false
-    },
-    {
-      "name": "one",
-      "description": "description one",
-      "current": false
-    },
-    {
-      "name": "two",
-      "description": "description two",
-      "current": false
-    },
-    {
-      "name": "three",
-      "description": "description three",
-      "current": false
-    },
-    {
-      "name": "four",
-      "description": "description four",
-      "current": false
-    },
-    {
-      "name": "five",
-      "description": "description five",
-      "current": false
-    },
-    {
-      "name": "six",
-      "description": "description six",
-      "current": false
-    },
-    {
-      "name": "seven",
-      "description": "description seven",
-      "current": false
-    },
-    {
-      "name": "eight",
-      "description": "description eight",
-      "current": false
-    },
-    {
-      "name": "nine",
-      "description": "description nine",
-      "current": false
-    },
-    {
-      "name": "ten",
-      "description": "description ten",
-      "current": false
     }
   ],
   "categories": [
     {
       "name": "Test Data",
       "description": "datasets that are in the shared channel in dev firebase",
-      "datasets": ["openweathermap", "cats", "dogs", "states"]
+      "datasets": ["cats", "dogs", "states"]
     },
     {
       "name": "Animals",
       "description": "description",
-      "datasets": ["one", "two"]
-    },
-    {
-      "name": "Arts & Entertainment",
-      "description": "description",
-      "datasets": ["three", "four"]
-    },
-    {
-      "name": "Business & Money",
-      "description": "description",
-      "datasets": ["five", "six"]
-    },
-    {
-      "name": "Education",
-      "description": "description",
-      "datasets": ["seven", "eight", "nine"]
-    },
-    {
-      "name": "Health & Medicine",
-      "description": "description",
-      "datasets": ["ten"]
+      "datasets": ["cats", "dogs"]
     }
   ]
 }

--- a/dashboard/app/views/levels/editors/_applab.html.haml
+++ b/dashboard/app/views/levels/editors/_applab.html.haml
@@ -86,12 +86,6 @@
     levelbuilder.initializeCodeMirror('level_data_tables', 'javascript');
 
 .field
-  = f.label :data_library_tables,'Dataset Libraries'
-  Comma-separated list of dataset libraries you would like to pre-load in the level.
-  %br
-  = f.text_area :data_library_tables, value: @level.data_library_tables
-
-.field
   = f.label 'Key-Value Data'
   You can copy the data array from the debug view in the Data tab in App Lab.
   %pre
@@ -106,6 +100,11 @@
   :javascript
     levelbuilder.initializeCodeMirror('level_data_properties', 'javascript');
 
+.field
+  = f.label :data_library_tables,'Dataset Libraries'
+  Comma-separated list of dataset libraries you would like to pre-load in the level.
+  %br
+  = f.text_area :data_library_tables, value: @level.data_library_tables
 
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_view_data_button, description: "Hide Data Button"}

--- a/dashboard/app/views/levels/editors/_applab.html.haml
+++ b/dashboard/app/views/levels/editors/_applab.html.haml
@@ -102,16 +102,13 @@
 
 .field
   = f.label :data_library_tables,'Dataset Libraries'
-  Comma-separated list of dataset libraries you would like to pre-load in the level.
-  %br
-  = f.text_area :data_library_tables, value: @level.data_library_tables
+  = f.text_area :data_library_tables, value: @level.data_library_tables, readonly: true
 
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :hide_view_data_button, description: "Hide Data Button"}
 
 .field
   = render partial: 'levels/editors/checkboxes', locals: {f: f, field_name: :debugger_disabled, description: "Disable code debugger (Console is still enabled)"}
-
 
 .field
   = f.label :helper_libraries
@@ -122,3 +119,12 @@
     %a.select_none{href: '#'} none
     (shift-click or cmd-click to select multiple).
   = f.select :helper_libraries, (Library.distinct.pluck(:name) + (@level.helper_libraries || [])).uniq.sort, {}, {multiple: true}
+
+:ruby
+  script_data = {
+    applabOptions: {
+      data_library_tables: @level.data_library_tables
+    }.to_json
+  }
+%script{src: webpack_asset_path('js/levels/editors/_applab.js'),
+        data: script_data}


### PR DESCRIPTION
# Description
Allows levelbuilders to use a multiselect to add data library table names on levelbuilder.

![image](https://user-images.githubusercontent.com/8324574/68235719-975c8880-ffb8-11e9-866b-920451c7ff10.png)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
