### PR TITLE
update ml-activities to 0.0.9, use initAll() only

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -48,7 +48,7 @@
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "1.1.0",
-    "@code-dot-org/ml-activities": "0.0.8",
+    "@code-dot-org/ml-activities": "0.0.9",
     "@code-dot-org/p5.play": "^1.3.12-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -3,15 +3,7 @@ import ReactDOM from 'react-dom';
 import FishView from './FishView';
 import {Provider} from 'react-redux';
 import {getStore} from '../redux';
-import {
-  initModel,
-  constants,
-  Modes,
-  setState,
-  setSetStateCallback,
-  renderCanvas,
-  UI
-} from '@code-dot-org/ml-activities';
+import {initAll} from '@code-dot-org/ml-activities';
 import {TestResults} from '@cdo/apps/constants';
 
 /**
@@ -106,36 +98,14 @@ Fish.prototype.initMLActivities = function() {
   // Set up initial state
   const canvas = document.getElementById('activity-canvas');
   const backgroundCanvas = document.getElementById('background-canvas');
-  canvas.width = backgroundCanvas.width = constants.canvasWidth;
-  canvas.height = backgroundCanvas.height = constants.canvasHeight;
 
   // Set initial state for UI elements.
-  const state = setState({
-    currentMode: Modes.Loading,
+  initAll({
     canvas,
     backgroundCanvas,
     appMode: mode,
     onContinue
   });
-
-  // Initialize our first model.
-  initModel(state);
-
-  // Start the canvas renderer.  It will self-perpetute by calling
-  // requestAnimationFrame on itself.
-  renderCanvas();
-
-  // Render the UI.
-  renderUI();
-
-  // And have the render UI handler be called every time state is set.
-  setSetStateCallback(renderUI);
-};
-
-// Tell React to explicitly render the UI.
-export const renderUI = () => {
-  const renderElement = document.getElementById('container-react');
-  ReactDOM.render(<UI />, renderElement);
 };
 
 export default Fish;

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -954,10 +954,10 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-1.1.0.tgz#7c8185adf06a9172e3bde4ccd6f6738a787b2a7c"
 
-"@code-dot-org/ml-activities@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.8.tgz#c2b1379e4003f82fb0f947178a152a9d25c3c4bc"
-  integrity sha512-KkCyOhbYEFY/ITUd8CZVnyu2VPgIMN5b0WCEa8Haf+SC5Rr/GPbrunHweVidrsnlF+ilJDQBVyhqYpG5dSgzxQ==
+"@code-dot-org/ml-activities@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.9.tgz#fd698b2a47141ec3dc2ac4ace00977379ab0926b"
+  integrity sha512-gKBwPkeKYZZHr29qlcIrqBteJspg2nFG33HJxPLvPkX9fPbCsssDExx9SS99dVexbaYz+Z0S7rBgNx0rA22qMQ==
 
 "@code-dot-org/p5.play@^1.3.12-cdo":
   version "1.3.12-cdo"


### PR DESCRIPTION
# Description
* Simplify how we init `ml-activities` by using a new `initAll()` export, which requires that we update to `ml-activities` version `0.0.9`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
