### PR TITLE
Collapse stage descriptions

### DIFF
--- a/apps/src/lib/script-editor/StageDescriptions.jsx
+++ b/apps/src/lib/script-editor/StageDescriptions.jsx
@@ -63,9 +63,9 @@ export default class StageDescriptions extends React.Component {
     mismatchedStages: []
   };
 
-  expand = () => {
+  toggleExpanded = () => {
     this.setState({
-      collapsed: false
+      collapsed: !this.state.collapsed
     });
   };
 
@@ -138,11 +138,9 @@ export default class StageDescriptions extends React.Component {
       <div>
         <h4>Stage Descriptions</h4>
         <div style={styles.main}>
-          {this.state.collapsed && (
-            <button type="button" className="btn" onClick={this.expand}>
-              Click to Expand
-            </button>
-          )}
+          <button type="button" className="btn" onClick={this.toggleExpanded}>
+            {this.state.collapsed ? 'Click to Expand' : 'Click to Collapse'}
+          </button>
           {!this.state.collapsed && (
             <div>
               {currentDescriptions.map((stage, index) => {

--- a/apps/src/lib/script-editor/StageDescriptions.jsx
+++ b/apps/src/lib/script-editor/StageDescriptions.jsx
@@ -204,7 +204,6 @@ export default class StageDescriptions extends React.Component {
                 />
               )}
               <button
-                id="import-stage-descriptions"
                 type="button"
                 className="btn"
                 disabled={!!this.state.buttonText}

--- a/apps/src/lib/script-editor/StageDescriptions.jsx
+++ b/apps/src/lib/script-editor/StageDescriptions.jsx
@@ -204,6 +204,7 @@ export default class StageDescriptions extends React.Component {
                 />
               )}
               <button
+                id="import-stage-descriptions"
                 type="button"
                 className="btn"
                 disabled={!!this.state.buttonText}

--- a/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
+++ b/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
@@ -37,13 +37,10 @@ describe('StageDescriptions', () => {
     );
     assert.equal(wrapper.state('collapsed'), true);
     assert.equal(wrapper.childAt(1).children().length, 1);
-    assert.equal(
-      wrapper
-        .childAt(1)
-        .childAt(0)
-        .type(),
-      'button'
-    );
+
+    const button = wrapper.childAt(1).childAt(0);
+    assert.equal(button.type(), 'button');
+    assert.include(button.text(), 'Expand');
   });
 
   it('uncollapses on click', () => {
@@ -56,18 +53,17 @@ describe('StageDescriptions', () => {
     wrapper.find('button').simulate('click');
     assert.equal(wrapper.state('collapsed'), false);
 
-    // button replaced by a div
-    assert.equal(wrapper.childAt(1).children().length, 1);
-    assert.equal(
-      wrapper
-        .childAt(1)
-        .childAt(0)
-        .type(),
-      'div'
-    );
+    const button = wrapper.childAt(1).childAt(0);
+    assert.equal(button.type(), 'button');
+    assert.include(button.text(), 'Collapse');
+
+    // button followed by a div
+    assert.equal(wrapper.childAt(1).children().length, 2);
+    const descriptions = wrapper.childAt(1).childAt(1);
+    assert.equal(descriptions.type(), 'div');
 
     assert.equal(
-      wrapper.find('button').text(),
+      descriptions.find('button').text(),
       'Import from Curriculum Builder'
     );
   });

--- a/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
+++ b/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
@@ -53,7 +53,7 @@ describe('StageDescriptions', () => {
     wrapper.find('button').simulate('click');
     assert.equal(wrapper.state('collapsed'), false);
 
-    const button = wrapper.childAt(1).childAt(0);
+    let button = wrapper.childAt(1).childAt(0);
     assert.equal(button.type(), 'button');
     assert.include(button.text(), 'Collapse');
 
@@ -70,7 +70,8 @@ describe('StageDescriptions', () => {
     // collapses after subsequent button click
     button.simulate('click');
     assert.equal(wrapper.state('collapsed'), true);
-    assert.include(button.text(), 'Collapse');
+    button = wrapper.childAt(1).childAt(0);
+    assert.include(button.text(), 'Expand');
     assert.equal(wrapper.childAt(1).children().length, 1);
   });
 

--- a/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
+++ b/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
@@ -66,6 +66,12 @@ describe('StageDescriptions', () => {
       descriptions.find('button').text(),
       'Import from Curriculum Builder'
     );
+
+    // collapses after subsequent button click
+    button.simulate('click');
+    assert.equal(wrapper.state('collapsed'), true);
+    assert.include(button.text(), 'Collapse');
+    assert.equal(wrapper.childAt(1).children().length, 1);
   });
 
   it('updates button while importing', () => {

--- a/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
+++ b/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
@@ -82,16 +82,19 @@ describe('StageDescriptions', () => {
       />
     );
     wrapper.setState({collapsed: false});
+    let descriptions = wrapper.childAt(1).childAt(1);
+
     assert.equal(
-      wrapper.find('button').text(),
+      descriptions.find('button').text(),
       'Import from Curriculum Builder'
     );
 
     // now click import button
-    wrapper.find('button').simulate('click');
+    descriptions.find('button').simulate('click');
 
+    descriptions = wrapper.childAt(1).childAt(1);
     assert.equal(wrapper.state('buttonText'), 'Querying server...');
-    assert.equal(wrapper.find('button').text(), 'Querying server...');
+    assert.equal(descriptions.find('button').text(), 'Querying server...');
   });
 
   it('extracts importedDescriptions/mismatchedStages from response', () => {
@@ -103,7 +106,9 @@ describe('StageDescriptions', () => {
     );
     wrapper.setState({collapsed: false});
     // now click import button
-    wrapper.find('button').simulate('click');
+    const importButton = wrapper.find('button').at(1);
+    assert.equal(importButton.text(), 'Import from Curriculum Builder');
+    importButton.simulate('click');
 
     assert.equal(requests.length, 1);
     assert.equal(


### PR DESCRIPTION
# Description

Finishes https://codedotorg.atlassian.net/browse/LP-756

after clicking expand, show a "collapse" button instead of just hiding the expand button.

before:
![Screen Shot 2019-11-04 at 2 53 25 PM](https://user-images.githubusercontent.com/8001765/68164906-e18b2e80-ff12-11e9-903f-f3761cbb62f8.png)

after:
![Screen Shot 2019-11-04 at 2 52 31 PM](https://user-images.githubusercontent.com/8001765/68164863-ccae9b00-ff12-11e9-9a0e-b87f9c04d2b4.png)

## Testing story

Unit tests have been updated to cover new behavior.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
