### PR TITLE
Add new song manifest to dance party

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -40,6 +40,7 @@ import {
 } from './songs';
 import {SongTitlesToArtistTwitterHandle} from '../code-studio/dancePartySongArtistTags';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import experiments from '@cdo/apps/util/experiments';
 
 const ButtonState = {
   UP: 0,
@@ -181,7 +182,12 @@ Dance.prototype.awaitTimingMetrics = function() {
 };
 
 Dance.prototype.initSongs = async function(config) {
-  const songManifest = await getSongManifest(config.useRestrictedSongs);
+  let is2019Script =
+    config.scriptName === 'dance-2019' && experiments.isEnabled('newSongs');
+  const songManifest = await getSongManifest(
+    config.useRestrictedSongs,
+    is2019Script
+  );
   const songData = parseSongOptions(songManifest);
   const selectedSong = getSelectedSong(songManifest, config);
 

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -6,12 +6,20 @@ import Sounds from '../Sounds';
  * @param useRestrictedSongs {boolean} if true, request signed cloudfront
  * cookies in parallel with the request for the manifest, and use /restricted/
  * urls instead of curriculum.code.org urls for music files.
+ * @param is2019Script {boolean} if true, request the songs from the 2019 Dance Party
+ * Otherwise, use the songs from the Dance Party in 2018.
  * @returns {Promise<*>} The song manifest.
  */
-export async function getSongManifest(useRestrictedSongs) {
-  const manifestFilename = useRestrictedSongs
-    ? 'songManifest.json'
-    : 'testManifest.json';
+export async function getSongManifest(useRestrictedSongs, is2019Script) {
+  let manifestFilename = 'testManifest.json';
+  if (useRestrictedSongs) {
+    if (is2019Script) {
+      manifestFilename = 'songManifest2019.json';
+    } else {
+      manifestFilename = 'songManifest.json';
+    }
+  }
+
   const songManifestPromise = fetch(
     `/api/v1/sound-library/hoc_song_meta/${manifestFilename}`
   ).then(response => response.json());


### PR DESCRIPTION
# Description
Adds new songManifest to danceparty. Songs uploaded to S3 on October 31st, so songlist is update to date as of then. I will track an item to periodically update the manifest as we get closer to release.

New song manifest is currently behind 'newSongs' experiment flag.
Tested locally that running with flag displays new songs in dance-2019.
# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
