### PR TITLE
Revert "Record time spent"

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -168,7 +168,6 @@ class StudioApp extends EventEmitter {
      * @type {?number}
      */
     this.initTime = undefined;
-    this.startTimeMilestone = undefined;
 
     /**
      * If true, we don't show blockspace. Used when viewing shared levels
@@ -353,7 +352,6 @@ StudioApp.prototype.init = function(config) {
 
   // Record time at initialization.
   this.initTime = new Date().getTime();
-  this.startTimeMilestone = new Date().getTime();
 
   // Fixes viewport for small screens.
   var viewport = document.querySelector('meta[name="viewport"]');
@@ -1715,14 +1713,9 @@ StudioApp.prototype.report = function(options) {
   var report = Object.assign({}, options, {
     pass: this.feedback_.canContinueToNextLevel(options.testResult),
     time: new Date().getTime() - this.initTime,
-    timeSinceLastMilestone: new Date().getTime() - this.startTimeMilestone,
     attempt: this.attempts,
     lines: this.feedback_.getNumBlocksUsed()
   });
-
-  // After we log the reported time we should update the start time of the milestone
-  // otherwise if we don't leave the page we are compounding the total time
-  this.startTimeMilestone = new Date().getTime();
 
   this.lastTestResult = options.testResult;
 

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -194,8 +194,6 @@ class ActivitiesController < ApplicationController
       end
     end
 
-    record_time_spent(@user_level)
-
     passed = ActivityConstants.passing?(test_result)
     if lines > 0 && passed
       current_user.total_lines += lines
@@ -212,23 +210,6 @@ class ActivitiesController < ApplicationController
         level_source_id: @level_source_image.level_source_id,
         autosaved: true
       )
-    end
-  end
-
-  # Record the time spent on a level by creating or updating the UserLevelInfo table
-  # for the UserLevel for the current user, level, and script
-  def record_time_spent(user_level)
-    if user_level
-      user_level_info = UserLevelInfo.find_by(
-        user_level_id: user_level.id
-      )
-    end
-
-    if user_level_info
-      # Add past time spent to current time spent on level
-      user_level_info.update(time_spent: [user_level_info.time_spent + [params[:timeSinceLastMilestone].to_i, 0].max, MAX_INT_MILESTONE].min)
-    else
-      UserLevelInfo.create(user_level_id: user_level.id, time_spent: [[params[:timeSinceLastMilestone].to_i, 0].max, MAX_INT_MILESTONE].min)
     end
   end
 

--- a/dashboard/app/models/user_level_info.rb
+++ b/dashboard/app/models/user_level_info.rb
@@ -7,9 +7,5 @@
 #  user_level_id :integer          unsigned
 #
 
-# This model is meant to support the UserLevel model. The UserLevel table has gotten
-# too large and adding new columns to it can cause problems with production so we created
-# this model in order to store further information about a UserLevel.
-
 class UserLevelInfo < ApplicationRecord
 end

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -42,7 +42,6 @@ class ActivitiesControllerTest < ActionController::TestCase
       result: 'true',
       testResult: '100',
       time: '1000',
-      timeSinceLastMilestone: '500',
       app: 'test',
       program: '<hey>'
     }
@@ -146,28 +145,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     post :milestone, params: params
     assert_response :success
-  end
-
-  test "milestone creates new UserLevelInfo if none existed" do
-    params = @milestone_params
-
-    post :milestone, params: params
-    assert_response :success
-
-    assert_equal UserLevel.last.id, UserLevelInfo.last.user_level_id
-    assert_equal params[:timeSinceLastMilestone].to_i, UserLevelInfo.last.time_spent
-  end
-
-  test "milestone updates existing UserLevelInfo" do
-    params = @milestone_params
-
-    user_level = UserLevel.create(level: @script_level.level, user: @user, script: @script_level.script)
-    user_level_info = UserLevelInfo.create(user_level_id: user_level.id, time_spent: 1000)
-
-    post :milestone, params: @milestone_params
-    assert_response :success
-
-    assert_equal user_level_info.time_spent + params[:timeSinceLastMilestone].to_i, UserLevelInfo.find_by(user_level_id: user_level.id).time_spent
   end
 
   test "milestone creates userlevel with specified level when scriptlevel has multiple levels" do

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -65,7 +65,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sl = Script.find_by_name('course1').script_levels[2]
     params = {program: 'fake program', testResult: 100, result: 'true'}
 
-    assert_cached_queries(9) do
+    assert_cached_queries(6) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id
@@ -81,7 +81,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     sl = Script.find_by_name('course1').script_levels[2]
     params = {program: 'fake program', testResult: 0, result: 'false'}
 
-    assert_cached_queries(9) do
+    assert_cached_queries(6) do
       post milestone_path(
         user_id: student.id,
         script_level_id: sl.id


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#31592 due to a [performance regression Will identified](https://codedotorg.slack.com/archives/C03CK49G9/p1572917737056800) after this change deployed, caused by queries against `user_level_infos`.

Alternatively, see the fix-forward here: https://github.com/code-dot-org/code-dot-org/pull/31688