### PR TITLE
Migration: Add index to user_level_infos

### DIFF
--- a/dashboard/app/models/user_level_info.rb
+++ b/dashboard/app/models/user_level_info.rb
@@ -6,6 +6,10 @@
 #  time_spent    :integer          default(0)
 #  user_level_id :integer          unsigned
 #
+# Indexes
+#
+#  index_user_level_infos_on_user_level_id  (user_level_id) UNIQUE
+#
 
 # This model is meant to support the UserLevel model. The UserLevel table has gotten
 # too large and adding new columns to it can cause problems with production so we created

--- a/dashboard/db/migrate/20191105014617_add_index_to_user_level_info.rb
+++ b/dashboard/db/migrate/20191105014617_add_index_to_user_level_info.rb
@@ -1,0 +1,5 @@
+class AddIndexToUserLevelInfo < ActiveRecord::Migration[5.0]
+  def change
+    add_index :user_level_infos, :user_level_id, unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191023192120) do
+ActiveRecord::Schema.define(version: 20191105014617) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1435,6 +1435,7 @@ ActiveRecord::Schema.define(version: 20191023192120) do
   create_table "user_level_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "time_spent",    default: 0
     t.bigint  "user_level_id",             unsigned: true
+    t.index ["user_level_id"], name: "index_user_level_infos_on_user_level_id", unique: true, using: :btree
   end
 
   create_table "user_levels", id: :bigint, unsigned: true, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
Fix-forward for a [performance regression Will identified](https://codedotorg.slack.com/archives/C03CK49G9/p1572917737056800) after code-dot-org/code-dot-org#31592 deployed, caused by queries against `user_level_infos`.

Alternatively, see the revert here: https://github.com/code-dot-org/code-dot-org/pull/31687