### PR TITLE
Bug Fix: Student has not started level message showing when not appropriate

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3197,7 +3197,9 @@ StudioApp.prototype.isNotStartedLevel = function(config) {
 
   //channel backed levels
   if (
-    ['Gamelab', 'Applab', 'Weblab', 'Spritelab', 'Dance'].includes(config.levelGameName)
+    ['Gamelab', 'Applab', 'Weblab', 'Spritelab', 'Dance'].includes(
+      config.levelGameName
+    )
   ) {
     return config.readonlyWorkspace && !config.channel;
   } else if (!config.level.freePlay && !config.level.containedLevelNames) {

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3195,11 +3195,12 @@ StudioApp.prototype.isResponsiveFromConfig = function(config) {
 StudioApp.prototype.isNotStartedLevel = function(config) {
   const progress = getStore().getState().progress;
 
+  //channel backed levels
   if (
-    ['Gamelab', 'Applab', 'Weblab', 'Spritelab'].includes(config.levelGameName)
+    ['Gamelab', 'Applab', 'Weblab', 'Spritelab', 'Dance'].includes(config.levelGameName)
   ) {
     return config.readonlyWorkspace && !config.channel;
-  } else if (!config.level.freePlay) {
+  } else if (!config.level.freePlay && !config.level.containedLevelNames) {
     return (
       config.readonlyWorkspace &&
       progress.levelProgress[progress.currentLevelId] === undefined

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3191,18 +3191,23 @@ StudioApp.prototype.isResponsiveFromConfig = function(config) {
 /**
  * Checks if the level a teacher is viewing of a students has
  * not been started.
+ * For contained levels don't show the banner ever.
+ * Otherwise if its a channel backed level check for the channel. Lastly
+ * if its not a channel backed level and its not free play we know it has
+ * not been started if no progress has been made.
  */
 StudioApp.prototype.isNotStartedLevel = function(config) {
   const progress = getStore().getState().progress;
 
-  //channel backed levels
-  if (
+  if (config.hasContainedLevels) {
+    return false;
+  } else if (
     ['Gamelab', 'Applab', 'Weblab', 'Spritelab', 'Dance'].includes(
       config.levelGameName
     )
   ) {
     return config.readonlyWorkspace && !config.channel;
-  } else if (!config.level.freePlay && !config.level.containedLevelNames) {
+  } else if (!config.level.freePlay) {
     return (
       config.readonlyWorkspace &&
       progress.levelProgress[progress.currentLevelId] === undefined

--- a/dashboard/test/ui/features/student_not_started_level_warning.feature
+++ b/dashboard/test/ui/features/student_not_started_level_warning.feature
@@ -37,3 +37,20 @@ Scenario: Maze level where student has not started
   And I wait until element ".editor-column" contains text "This student has not started the level."
   Then I see no difference for "student not started warning"
   And I close my eyes
+
+Scenario: Contained level
+  When I open my eyes to test "contained level"
+  When I sign in as "Teacher_Sally" and go home
+  And I wait until element ".uitest-owned-sections" is visible
+
+  And I am on "http://studio.code.org/s/allthethings/stage/41/puzzle/1"
+  And I wait for the page to fully load
+  And I wait until element "#teacher-panel-container" is visible
+  And I wait until element ".uitest-sectionselect:contains(Untitled Section)" is visible
+  And I wait until element ".student-table" is visible
+  And I click selector "#teacher-panel-container tr:nth(1)" to load a new page
+  And I wait for the page to fully load
+
+  And I wait until element ".editor-column" does not contain text "This student has not started the level."
+  Then I see no difference for "no student not started warning"
+  And I close my eyes


### PR DESCRIPTION
# Description

There were two different bugs with the "Student has not started this level" banner

## Bug 1: Contained levels 

The banner would always show on contained levels because the progress for a contained level is actually on the containee level instead of the container level. For now, this hides the banner for all contained levels as it should be obvious from the state of the level if it has been started or not (either they answered the question or not).

| Before | After |
| --- | --- |
| ![Screen Shot 2019-11-06 at 10 53 38 AM](https://user-images.githubusercontent.com/208083/68314170-bd9b2a80-0083-11ea-93f4-95b8323fc6bd.png) | ![Screen Shot 2019-11-06 at 10 49 02 AM](https://user-images.githubusercontent.com/208083/68313733-10281700-0083-11ea-8bd1-bf9af2906300.png) |

## Bug 2: Dance party levels

The banner was showing on dance party levels because its a channel backed level type but it wasn't in the list of channel backed levels we were checking. 

| Before | After |
| --- | --- |
| ![Screen Shot 2019-11-06 at 10 53 29 AM](https://user-images.githubusercontent.com/208083/68314197-cab81980-0083-11ea-8507-c885bcf788c0.png) |  ![Screen Shot 2019-11-06 at 10 48 17 AM](https://user-images.githubusercontent.com/208083/68313758-1b7b4280-0083-11ea-906c-f352bd019be0.png) |

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-823](https://codedotorg.atlassian.net/browse/LP-823)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

I added a UI test for checking that the banner does not show on a contained level.

I did not add a test for dance levels as I think there would be too many cases if we had a UI test for each level type. Instead, right now there is a test for just one channel backed level type and one non-channel backed level type. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
