### PR TITLE
Extract `youtube_embed` helper method into page_helpers

### DIFF
--- a/pegasus/helpers/page_helpers.rb
+++ b/pegasus/helpers/page_helpers.rb
@@ -75,3 +75,16 @@ def combine_css(*paths)
   digest = Digest::MD5.hexdigest(css_min)
   [css_min, digest]
 end
+
+# Used by code.org/curriculum/concepts
+def youtube_embed(youtube_url)
+  if youtube_url[/youtu\.be\/([^\?]*)/]
+    youtube_id = $1
+  else
+    # Regex from # http://stackoverflow.com/questions/3452546/javascript-regex-how-to-get-youtube-video-id-from-url/4811367#4811367
+    youtube_url[/^.*((v\/)|(embed\/)|(watch\?))\??v?=?([^\&\?]*).*/]
+    youtube_id = $5
+  end
+
+  %Q{<iframe title="YouTube video player" width="250" height="141" src="http://www.youtube.com/embed/#{youtube_id}" frameborder="0" allowfullscreen></iframe>}
+end

--- a/pegasus/sites.v3/code.org/public/curriculum/concepts/index.md.erb
+++ b/pegasus/sites.v3/code.org/public/curriculum/concepts/index.md.erb
@@ -25,40 +25,7 @@ video_player: true
   </div>
 </div>
 
-<%
-def youtube_embed(youtube_url)
-  if youtube_url[/youtu\.be\/([^\?]*)/]
-    youtube_id = $1
-  else
-    # Regex from # http://stackoverflow.com/questions/3452546/javascript-regex-how-to-get-youtube-video-id-from-url/4811367#4811367
-    youtube_url[/^.*((v\/)|(embed\/)|(watch\?))\??v?=?([^\&\?]*).*/]
-    youtube_id = $5
-  end
-
-  %Q{<iframe title="YouTube video player" width="250" height="141" src="http://www.youtube.com/embed/#{ youtube_id }" frameborder="0" allowfullscreen></iframe>}
-end
-
-# => <iframe title="YouTube video player" width="250" height="141" src="http://www.youtube.com/embed/jJrzIdDUfT4" frameborder="0" allowfullscreen></iframe>
-
-
-
-
-
-
-
-
-concept = 'Algorithms'
-# lessons = DB[:cdo_concepts_csf].where(mainConcept_s:concept)
-lessons = DB[:cdo_concepts_csf]
-words = DB[:cdo_concepts_csf]
-counts = Hash.new 0
-	words.each do |mainConcept_s|
-  	counts[mainConcept_s] += 1
-end
-%>
-
 [content]
-
 
 <!-- Use this only if we have extra info to share
 <table>
@@ -102,7 +69,7 @@ Each of these activities can either be used alone or with other computer science
     </tr>
   </thead>
 
-   <% lessons.each_with_index do |lesson, index|
+   <% DB[:cdo_concepts_csf].each_with_index do |lesson, index|
     	# Get the course number formatted well
 
      theCourse = lesson[:courseLesson_s]
@@ -146,13 +113,6 @@ Each of these activities can either be used alone or with other computer science
     </tr>
     <% end %>
 </table>
-
-
-
-
-
-
-
 
 [/content]
 


### PR DESCRIPTION
# Description

Also clean up some unused ruby in the curriculum concepts page.

## Testing story

Verified that the page looks the same before and after this change.

Note that this page currently has some broken visuals on production, which this PR does not address (see https://codedotorg.slack.com/archives/C0T0PNTM3/p1572989529452200 for context)

localhost | production
--- | ---
![image](https://user-images.githubusercontent.com/244100/68250631-26c46480-ffd6-11e9-8e09-c01d37a96c8d.png) | ![image](https://user-images.githubusercontent.com/244100/68250291-78b8ba80-ffd5-11e9-951a-2caef7318b16.png)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
