### PR TITLE
automatically request reviews from the cdo/i18n team on all i18n sync PRs

### DIFF
--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -120,7 +120,8 @@ def create_in_up_pr
     head: IN_UP_BRANCH,
     title: "I18n sync In & Up #{Date.today.strftime('%m/%d')}"
   )
-  GitHub.label_pull_request(in_up_pr, ["i18n"])
+  GitHub.label_pull_request(in_up_pr, "i18n")
+  GitHub.request_review(in_up_pr, "code-dot-org/i18n")
   puts "Created In & Up PR: #{GitHub.url(in_up_pr)}"
 end
 
@@ -188,7 +189,8 @@ def create_down_out_pr
     head: DOWN_OUT_BRANCH,
     title: "I18n sync Down & Out #{Date.today.strftime('%m/%d')}"
   )
-  GitHub.label_pull_request(down_out_pr, ["i18n"])
+  GitHub.label_pull_request(down_out_pr, "i18n")
+  GitHub.request_review(in_up_pr, "code-dot-org/i18n")
 
   puts "Created Down & Out PR: #{GitHub.url(down_out_pr)}"
 

--- a/lib/cdo/github.rb
+++ b/lib/cdo/github.rb
@@ -56,6 +56,18 @@ module GitHub
     response['number']
   end
 
+  # Octokit Documentation: http://octokit.github.io/octokit.rb/Octokit/Client/Reviews.html#request_pull_request_review-instance_method
+  # @param id [String | Integer] the numeric id of the pull request for which to request a review
+  # @param reviewers [String | Array[String]] string or array of strings representing the user or users from whom to request a review
+  # @return [Array[String]] the resulting reviewers for the PR
+  def self.request_review(id, reviewers)
+    configure_octokit
+    reviewers = [reviewers] unless reviewers.is_a? Array
+    response = Octokit.request_pull_request_review(REPO, id, reviewers)
+
+    response['reviewers']
+  end
+
   # Octokit Documentation: http://octokit.github.io/octokit.rb/Octokit/Client/Issues.html#update_issue-instance_method
   # @param base [String | Integer] the numeric id of the PR to be updated
   # @param lables [Array[String]] array of strings to be set as new labels for the PR

--- a/lib/cdo/github.rb
+++ b/lib/cdo/github.rb
@@ -70,11 +70,12 @@ module GitHub
 
   # Octokit Documentation: http://octokit.github.io/octokit.rb/Octokit/Client/Issues.html#update_issue-instance_method
   # @param base [String | Integer] the numeric id of the PR to be updated
-  # @param lables [Array[String]] array of strings to be set as new labels for the PR
+  # @param lables [String | Array[String]] string or array of strings to be set as new labels for the PR
   # @raise [Exception] From calling Octokit.create_pull_request.
   # @return [Array[String]] the resulting labels for the PR
   def self.label_pull_request(id, labels)
     configure_octokit
+    labels = [labels] unless labels.is_a? Array
     response = Octokit.update_issue(REPO, id, {labels: labels})
 
     response['labels'].map {|label| label[:name]}


### PR DESCRIPTION
also update the "label_pull_request" helper to allow calling it with a single label, rather than always requiring an array.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
