### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# See
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# for usage
+
+# Files containing internationalization strings
+/i18n/ @code-dot-org/i18n
+/apps/i18n/ @code-dot-org/i18n
+/dashboard/config/locales/ @code-dot-org/i18n
+/pegasus/cache/i18n/ @code-dot-org/i18n
+/pegasus/sites.v3/*/i18n/ @code-dot-org/i18n
+
+# Scripts controlling the internationalization sync
+/bin/i18n/ @code-dot-org/i18n
+/bin/i18n-codeorg/ @code-dot-org/i18n


### PR DESCRIPTION
# Description

Adds a [`CODEOWNERS`](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) file to our repository. Quoting from the linked documentation:

> You can use a CODEOWNERS file to define individuals or teams that are responsible for code in a repository.

The original motivation here is that we'd like @code-dot-org/i18n to be automatically added to the weekly i18n sync pull requests; one option would be to do something like https://github.com/code-dot-org/code-dot-org/pull/31716 and explicitly request review from that team on those PRs, but a more comprehensive option is to use existing code ownerships rules to explicitly define that team's ownership.

This file can also be leveraged by other future teams.

## Links

- [jira](https://codedotorg.atlassian.net/browse/FND-771)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
