### PR TITLE
Fix continue button on external video levels

### DIFF
--- a/apps/src/sites/studio/pages/levels/_external.js
+++ b/apps/src/sites/studio/pages/levels/_external.js
@@ -21,5 +21,7 @@ $(document).ready(() => {
   postMilestoneForPageLoad();
 
   // handle click on continue (results in navigating to next puzzle)
-  $('.external').on('click', '.submitButton', onContinue);
+  $('.submitButton').click(function() {
+    onContinue();
+  });
 });

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -49,6 +49,7 @@ namespace :seed do
     'pre-express-2017',
     'coursea-2018',
     'coursea-2019',
+    'coursec-2019',
     'coursee-2019',
     'csp1-2017',
     'csp2-2017',

--- a/dashboard/test/ui/features/level_navigation.feature
+++ b/dashboard/test/ui/features/level_navigation.feature
@@ -1,0 +1,7 @@
+Feature: Continue button on levels
+
+Scenario: External Video Level
+  Given I am on "http://studio.code.org/s/coursec-2019/stage/14/puzzle/1"
+  And I wait to see ".submitButton"
+  Then I click ".submitButton" to load a new page
+  Then I wait until I am on "http://studio.code.org/s/coursec-2019/stage/15/puzzle/1"


### PR DESCRIPTION
## Description
[LP-952](https://codedotorg.atlassian.net/browse/LP-952)

Previously the continue button on external video levels was not advancing the user to the next level in the progression as reported on [Zendesk](https://codeorg.zendesk.com/agent/tickets/254782). 

Now, it is: 
![continue-continues](https://user-images.githubusercontent.com/12300669/68261443-ffc95b00-fff4-11e9-9d6a-894637eae620.gif)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
