### PR TITLE
hoc2019: Two fixes for Minecraft: Education Edition certificate

### DIFF
--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -153,11 +153,11 @@ def certificate_template_for(course)
         'MC_Hour_Of_Code_Certificate_Hero.png'
       elsif course == ScriptConstants::MINECRAFT_AQUATIC_NAME
         'MC_Hour_Of_Code_Certificate_Aquatic.png'
-      elsif course == 'mee'
-        'MC_Hour_Of_Code_Certificate_mee.png'
       else
         'MC_Hour_Of_Code_Certificate.png'
       end
+    elsif course == 'mee'
+      'MC_Hour_Of_Code_Certificate_mee.png'
     else
       'hour_of_code_certificate.jpg'
     end

--- a/pegasus/helpers/hoc_helpers.rb
+++ b/pegasus/helpers/hoc_helpers.rb
@@ -122,7 +122,7 @@ def complete_tutorial(tutorial={})
       )
     end
 
-    site = tutorial[:orgname].try(:include?, 'Code.org') ?
+    site = tutorial[:orgname].try(:include?, 'Code.org') || tutorial[:code].try(:include?, 'mee') ?
       CDO.studio_url('', CDO.default_scheme) : "http://#{row[:referer]}"
 
     destination = "#{site}/congrats?i=#{row[:session]}"


### PR DESCRIPTION
- Redirect from https://code.org/api/hour/finish/mee to correct certificate URL - https://studio.code.org/congrats - when tutorial `code` is `"mee"`.  (We usually only redirect to here when `orgname` is `"Code.org"`, sending external tutorials to the legacy https://code.org/congrats.)
- Load correct certificate image when adding custom name.
