### PR TITLE
Add new songs to dance part extras

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -183,7 +183,9 @@ Dance.prototype.awaitTimingMetrics = function() {
 
 Dance.prototype.initSongs = async function(config) {
   let is2019Script =
-    config.scriptName === 'dance-2019' && experiments.isEnabled('newSongs');
+    (config.scriptName === 'dance-2019' ||
+      config.scriptName === 'dance-extras-2019') &&
+    experiments.isEnabled('newSongs');
   const songManifest = await getSongManifest(
     config.useRestrictedSongs,
     is2019Script


### PR DESCRIPTION
# Description
Adds the new song manifest to the dance-extras-2019 script, in addition to the dance-2019 script. Still behind 'newSongs' flag.

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
