### PR TITLE
Put animated gif back because a UI test depends on it.

### DIFF
--- a/dashboard/config/scripts/levels/K-1 Maze 5.level
+++ b/dashboard/config/scripts/levels/K-1 Maze 5.level
@@ -11,6 +11,7 @@
     "start_direction": "1",
     "step_mode": "0",
     "is_k1": "true",
+    "ani_gif_url": "/script_assets/k_1_images/instruction_gifs/06_V2.gif",
     "skip_instructions_popup": "true",
     "ideal": "4",
     "never_autoplay_video": "false",
@@ -25,22 +26,9 @@
     "examples_required": "false",
     "definition_highlight": "false",
     "definition_collapse": "false",
-    "disable_examples": "false",
-    "preload_asset_list": null,
-    "encrypted": "false",
-    "instructions_important": "false",
-    "mini_rubric": "false",
-    "disable_procedure_autopopulate": "false",
-    "top_level_procedure_autopopulate": "false",
-    "hide_share_and_remix": "false",
-    "disable_if_else_editing": "false",
-    "show_type_hints": "false",
-    "maze_data": null,
-    "shape_shift": "false"
+    "disable_examples": "false"
   },
-  "published": true,
-  "notes": "",
-  "audit_log": "[{\"changed_at\":\"2019-11-06 15:07:35 +0000\",\"changed\":[\"notes\",\"published\",\"toolbox_blocks\",\"recommended_blocks\",\"solution_blocks\",\"ani_gif_url\",\"contained_level_names\",\"preload_asset_list\"],\"changed_by_id\":831,\"changed_by_email\":\"mike.harvey@code.org\"}]",
+  "published": false,
   "level_concept_difficulty": {
     "sequencing": 2
   }


### PR DESCRIPTION
# Description

Revert the curriculum team's removal of an animated gif from Instructions in a level in Course 1 because [a UI/Eyes test depends on it](https://github.com/code-dot-org/code-dot-org/blob/441958cda4c95a205541bb004855608959351d27/dashboard/test/ui/features/instructions/top_instructions.feature#L23).  The animated gif was removed for legitimate reasons, but is not urgent and can be reverted per the curriculum writer.

### Future work

Clone the level into /s/allthethings, re-add the anigif into the cloned level, and update the test to reference the new level instead of live course content


## Links

Log of test failing https://saucelabs.com/tests/e814540076da4d269fa1fae5589e88d6



# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
