### PR TITLE
Use new song manifest in LB

### DIFF
--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -57,10 +57,11 @@ class Dancelab < GamelabJr
   end
 
   def self.hoc_songs
-    manifest_json = AWS::S3.create_client.get_object(bucket: 'cdo-sound-library', key: 'hoc_song_meta/songManifest.json')[:body].read
+    manifest_json = AWS::S3.create_client.get_object(bucket: 'cdo-sound-library', key: 'hoc_song_meta/songManifest2019.json')[:body].read
     manifest = JSON.parse(manifest_json)
     manifest['songs'].map do |song|
       name = "#{song['text']}#{song['pg13'] ? ' (PG-13)' : ''}"
+      name = "#{song['2019'] ? '(2019) ' : ''}#{name}"
       [name, song['id']]
     end
   end


### PR DESCRIPTION
# Description
Updates the LB default song dropdown to point to the 2019 song manifest. Songs that are 2019 exclusives will have a `(2019) ` prepended to the title.
Link to screen capture of example: https://codedotorg.slack.com/archives/CC2QHV7SR/p1573087804139800

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Tested locally. Screen capture of local test linked above.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
