### PR TITLE
Add piloter

### DIFF
--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -81,6 +81,17 @@ class AdminSearchController < ApplicationController
   end
 
   def add_to_pilot
-    puts "ADDING"
+    email = params[:email]
+    pilot_name = params[:pilot_name]
+    user = User.find_by_email_or_hashed_email(email)
+    if !user
+      flash[:alert] = "An account with the email address #{email} does not exist"
+    elsif user.student?
+      flash[:alert] = "Cannot add a student to the pilot"
+    else
+      SingleUserExperiment.find_or_create_by!(min_user_id: user.id, name: pilot_name)
+      flash[:notice] = "Successfully added #{email} to #{pilot_name}!"
+    end
+    redirect_to action: 'show_pilot', pilot_name: pilot_name
   end
 end

--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -79,4 +79,8 @@ class AdminSearchController < ApplicationController
     user_ids =  SingleUserExperiment.where(name: @pilot_name).map(&:min_user_id)
     @emails = User.where(id: user_ids).pluck(:email)
   end
+
+  def add_to_pilot
+    puts "ADDING"
+  end
 end

--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -83,6 +83,7 @@ class AdminSearchController < ApplicationController
   def add_to_pilot
     email = params[:email]
     pilot_name = params[:pilot_name]
+    return head :bad_request unless Experiment::PILOT_EXPERIMENTS.include?(pilot_name)
     user = User.find_by_email_or_hashed_email(email)
     if !user
       flash[:alert] = "An account with the email address #{email} does not exist"

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -1,5 +1,9 @@
 %h1
   = @pilot_name
+= form_tag(controller: 'admin_search', action: 'add_to_pilot', method: "post") do
+  = label_tag(:email, "Add teacher to pilot")
+  = text_field_tag(:email, nil, placeholder: "Email")
+  = submit_tag("Add")
 %table
   %tr
     %th

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -1,8 +1,9 @@
 %h1
   = @pilot_name
-= form_tag(controller: 'admin_search', action: 'add_to_pilot', method: "post") do
-  = text_field_tag(:email, nil, placeholder: "Teacher's email")
-  = submit_tag("Add")
+= form_tag controller: 'admin_search', action: 'add_to_pilot', method: "post" do
+  = text_field_tag :email, nil, placeholder: "Teacher's email"
+  = hidden_field_tag 'pilot_name', @pilot_name
+  = submit_tag "Add"
 %table
   %tr
     %th

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -1,8 +1,7 @@
 %h1
   = @pilot_name
 = form_tag(controller: 'admin_search', action: 'add_to_pilot', method: "post") do
-  = label_tag(:email, "Add teacher to pilot")
-  = text_field_tag(:email, nil, placeholder: "Email")
+  = text_field_tag(:email, nil, placeholder: "Teacher's email")
   = submit_tag("Add")
 %table
   %tr

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -1,9 +1,9 @@
 %h1
   = @pilot_name
 = form_tag controller: 'admin_search', action: 'add_to_pilot', method: "post" do
-  = text_field_tag :email, nil, placeholder: "Teacher's email"
+  = text_field_tag :email, nil, placeholder: "Teacher's email", style: 'margin-bottom: 0'
   = hidden_field_tag 'pilot_name', @pilot_name
-  = submit_tag "Add"
+  = submit_tag "Add", class: 'btn'
 %table
   %tr
     %th

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -326,6 +326,7 @@ Dashboard::Application.routes.draw do
   post '/admin/lookup_section', to: 'admin_search#lookup_section'
   post '/admin/undelete_section', to: 'admin_search#undelete_section', as: 'undelete_section'
   get '/admin/pilots/:pilot_name', to: 'admin_search#show_pilot', as: 'show_pilot'
+  post '/admin/add_to_pilot', to: 'admin_search#add_to_pilot', as: 'add_to_pilot'
 
   # internal engineering dashboards
   get '/admin/dynamic_config', to: 'dynamic_config#show', as: 'dynamic_config_state'

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -135,4 +135,34 @@ class AdminSearchControllerTest < ActionController::TestCase
     assert_select 'table tr td', 1
     assert_select 'table tr td', 'csd@example.com'
   end
+
+  #
+  # add_to_pilot tests
+  #
+
+  test 'can add teacher to pilot' do
+    teacher = create :teacher
+    pilot_name = 'csd-piloters'
+    post :add_to_pilot, params: {email: teacher.email, pilot_name: pilot_name}
+
+    assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+  end
+
+  test 'cannot add student to pilot' do
+    student = create :student
+    pilot_name = 'csd-piloters'
+    post :add_to_pilot, params: {email: student.email, pilot_name: pilot_name}
+
+    refute SingleUserExperiment.find_by(min_user_id: student.id, name: pilot_name).present?
+  end
+
+  test 'non-admin cannot add teacher to pilot' do
+    teacher = create :teacher
+    pilot_name = 'csd-piloters'
+
+    sign_in @not_admin
+    post :add_to_pilot, params: {email: teacher.email, pilot_name: pilot_name}
+
+    refute SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+  end
 end


### PR DESCRIPTION
# Description

Allow admins to add teachers to the CSD and CSP pilots from the admin pages, instead of requiring engineering help.

<img width="635" alt="Screen Shot 2019-11-07 at 1 12 21 PM" src="https://user-images.githubusercontent.com/224089/68428074-425b7680-0160-11ea-8291-583048a42e8f.png">

Success:
<img width="1010" alt="Screen Shot 2019-11-07 at 10 35 12 AM" src="https://user-images.githubusercontent.com/224089/68417263-eb977200-014a-11ea-800a-f6f61e228086.png">

Error when trying to add a student:
<img width="996" alt="Screen Shot 2019-11-07 at 10 40 39 AM" src="https://user-images.githubusercontent.com/224089/68417405-37e2b200-014b-11ea-97c8-f3e7d5576ebf.png">

Error when adding an email not associated with an account:
<img width="1000" alt="Screen Shot 2019-11-07 at 10 41 39 AM" src="https://user-images.githubusercontent.com/224089/68417454-4fba3600-014b-11ea-9ff4-d2e5b8953f85.png">


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-804](https://codedotorg.atlassian.net/browse/LP-804?atlOrigin=eyJpIjoiOWRmMzFjNzBjNTdjNDIwOThhMTBiMmJmN2Y4ZWEzMjQiLCJwIjoiaiJ9)

## Testing story

Added unit tests
<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
