### PR TITLE
Provide fallback value when organizer no longer exists

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.story.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.story.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import reactBootstrapStoryDecorator from '../reactBootstrapStoryDecorator';
+import {EnrolledWorkshopsTable} from './EnrolledWorkshops';
+
+const workshops = [
+  // Have all required and non-required data
+  {
+    id: 1,
+    sessions: [],
+    location_name: 'My house',
+    location_address: '123 Fake Street',
+    on_map: false,
+    funded: false,
+    course: 'course',
+    subject: 'subject',
+    enrolled_teacher_count: 10,
+    capacity: 15,
+    facilitators: [],
+    organizer: {name: 'organizer_name', email: 'organizer_email'},
+    enrollment_code: 'code1'
+  },
+  // Non required data is null
+  {
+    id: 2,
+    sessions: [],
+    location_name: 'My house',
+    location_address: null,
+    on_map: false,
+    funded: false,
+    course: 'course',
+    subject: null,
+    enrolled_teacher_count: 10,
+    capacity: 15,
+    facilitators: [],
+    organizer: {name: null, email: null},
+    enrollment_code: null
+  }
+];
+
+export default storybook => {
+  storybook
+    .storiesOf('EnrolledWorkshopsTable', module)
+    .addDecorator(reactBootstrapStoryDecorator)
+    .addStoryTable([
+      {
+        name: 'EnrolledWorkshopsTable',
+        story: () => <EnrolledWorkshopsTable workshops={workshops} />
+      }
+    ]);
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/types.js
+++ b/apps/src/code-studio/pd/workshop_dashboard/types.js
@@ -13,8 +13,8 @@ const workshopShape = PropTypes.shape({
   capacity: PropTypes.number.isRequired,
   facilitators: PropTypes.array.isRequired,
   organizer: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    email: PropTypes.string.isRequired
+    name: PropTypes.string,
+    email: PropTypes.string
   }).isRequired,
   enrollment_code: PropTypes.string
 });

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/EnrolledWorkshopsTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/EnrolledWorkshopsTest.jsx
@@ -54,7 +54,7 @@ describe('EnrolledWorkshops', () => {
       enrolled_teacher_count: 10,
       capacity: 15,
       facilitators: [],
-      organizer: {name: 'organizer_name', email: 'organizer_email'},
+      organizer: {name: null, email: null},
       enrollment_code: 'code3',
       state: 'Ended'
     }

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -45,6 +45,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
   def organizer
     {id: object.organizer.id, name: object.organizer.name, email: object.organizer.email}
   rescue StandardError
+    # Fallback value if workshop organizer, who is an user, no longer exists
     {id: nil, name: nil, email: nil}
   end
 

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -44,6 +44,8 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
 
   def organizer
     {id: object.organizer.id, name: object.organizer.name, email: object.organizer.email}
+  rescue StandardError
+    {id: nil, name: nil, email: nil}
   end
 
   def facilitators

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -44,8 +44,8 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
 
   def organizer
     {id: object.organizer.id, name: object.organizer.name, email: object.organizer.email}
-  rescue StandardError
-    # Fallback value if workshop organizer, who is an user, no longer exists
+  rescue
+    # Fallback value if workshop organizer, who is a user, no longer exists
     {id: nil, name: nil, email: nil}
   end
 


### PR DESCRIPTION
# Description
[Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/255476) reports that  **My Professional Learning** page failed to load. This error is also recorded in [honeybadger](https://app.honeybadger.io/projects/3240/faults/49722319).

The reason is in one of the workshops user has enrolled in, the organizer no longer exists. Workshop organizers are just a registered users and their accounts can be deleted.

The fix is to return a fallback value when we fail to retrieve organizer info, and update the client code to not expect that organizer info is always available.

## Testing story
- bundle exec rails test test/controllers/api/v1/pd/workshops_controller_test.rb
- bundle exec rails test test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
- yarn test:entry --entry=test/unit/code-studio/pd/professional_learning_landing/EnrolledWorkshopsTest.jsx
- apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.story.jsx

# Reviewer Checklist:

- [x] Tests provide adequate coverage
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
