### PR TITLE
Fix UI Test Dependent on Changing CSF Course Level

### DIFF
--- a/dashboard/config/scripts/allthethings.script
+++ b/dashboard/config/scripts/allthethings.script
@@ -3,6 +3,7 @@ stage_extras_available true
 
 stage 'Jigsaw'
 skin 'jigsaw'
+level_concept_difficulty '{"sequencing":1}'
 level 'blockly:Jigsaw:3'
 
 stage 'Maze'
@@ -12,6 +13,7 @@ level '2-3 Maze 1'
 level '4-5 Maze 4'
 level '4-5 Maze Conditionals 3'
 level 'courseC_maze_programming3', challenge: true
+level 'allthethings-anigif-instructions'
 
 stage 'Artist'
 level 'K-1 Artist1 1'
@@ -156,10 +158,10 @@ level 'Test longassessment levelgroup split new', assessment: true
 stage 'Star wars'
 skin 'hoc2015'
 video_key_for_next_level 'starwars_events'
-level_concept_difficulty '{}'
+level_concept_difficulty '{"sequencing":1}'
 level 'blockly:StudioEC:js_hoc2015_event_two_items'
 skin 'hoc2015x'
-level_concept_difficulty '{}'
+level_concept_difficulty '{"sequencing":1}'
 level 'blockly:Studio:hoc2015_blockly_5'
 
 stage 'Minecraft'

--- a/dashboard/config/scripts/allthethings.script
+++ b/dashboard/config/scripts/allthethings.script
@@ -3,7 +3,6 @@ stage_extras_available true
 
 stage 'Jigsaw'
 skin 'jigsaw'
-level_concept_difficulty '{"sequencing":1}'
 level 'blockly:Jigsaw:3'
 
 stage 'Maze'
@@ -158,10 +157,10 @@ level 'Test longassessment levelgroup split new', assessment: true
 stage 'Star wars'
 skin 'hoc2015'
 video_key_for_next_level 'starwars_events'
-level_concept_difficulty '{"sequencing":1}'
+level_concept_difficulty '{}'
 level 'blockly:StudioEC:js_hoc2015_event_two_items'
 skin 'hoc2015x'
-level_concept_difficulty '{"sequencing":1}'
+level_concept_difficulty '{}'
 level 'blockly:Studio:hoc2015_blockly_5'
 
 stage 'Minecraft'

--- a/dashboard/config/scripts/levels/allthethings-anigif-instructions.level
+++ b/dashboard/config/scripts/levels/allthethings-anigif-instructions.level
@@ -1,7 +1,7 @@
 <Maze>
   <config><![CDATA[{
   "game_id": 25,
-  "created_at": "2019-10-24T16:55:06.000Z",
+  "created_at": "2019-11-07T19:07:11.000Z",
   "level_num": "custom",
   "user_id": 19,
   "properties": {
@@ -11,6 +11,7 @@
     "start_direction": "1",
     "step_mode": "0",
     "is_k1": "true",
+    "ani_gif_url": "/script_assets/k_1_images/instruction_gifs/06_V2.gif",
     "skip_instructions_popup": "true",
     "ideal": "4",
     "never_autoplay_video": "false",
@@ -26,6 +27,7 @@
     "definition_highlight": "false",
     "definition_collapse": "false",
     "disable_examples": "false",
+    "parent_level_id": 18661,
     "preload_asset_list": null,
     "encrypted": "false",
     "instructions_important": "false",
@@ -40,9 +42,8 @@
   },
   "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2019-11-07 14:17:17 -0500\",\"changed\":[\"notes\",\"published\",\"toolbox_blocks\",\"recommended_blocks\",\"solution_blocks\",\"ani_gif_url\",\"preload_asset_list\",\"contained_level_names\"],\"changed_by_id\":1,\"changed_by_email\":\"dev@levelbuilder.com\"}]",
+  "audit_log": "[{\"changed_at\":\"2019-11-07 14:07:28 -0500\",\"changed\":[\"notes\",\"toolbox_blocks\",\"recommended_blocks\",\"solution_blocks\",\"preload_asset_list\"],\"changed_by_id\":1,\"changed_by_email\":\"dev@levelbuilder.com\"}]",
   "level_concept_difficulty": {
-    "sequencing": 2
   }
 }]]></config>
   <blocks>

--- a/dashboard/test/ui/features/challenge_level.feature
+++ b/dashboard/test/ui/features/challenge_level.feature
@@ -25,4 +25,4 @@ Scenario: Submit passing and perfect solutions
 Scenario: Press the skip button
   Given I press "challengePrimaryButton"
   When I press "skipButton"
-  Then I wait until I am on "http://studio.code.org/s/allthethings/stage/3/puzzle/1"
+  Then I wait until I am on "http://studio.code.org/s/allthethings/stage/2/puzzle/7"

--- a/dashboard/test/ui/features/instructions/top_instructions.feature
+++ b/dashboard/test/ui/features/instructions/top_instructions.feature
@@ -16,7 +16,7 @@ Scenario: CSF Top Instructions
   Then I click selector ".fa-chevron-circle-down"
   And I see no difference for "artist long instructions uncollapsed"
 
-  Then I am on "http://studio.code.org/s/course1/stage/4/puzzle/5?noautoplay=true"
+  Then I am on "http://studio.code.org/s/allthethings/stage/2/puzzle/7?noautoplay=true"
   And I wait for the page to fully load
   And I see no difference for "maze short instructions with ani gif"
 


### PR DESCRIPTION
# Description 

Yesterday the deploy was blocked because a curriculum writer changed a feature in a level (studio.code.org/s/course1/stage/4/puzzle/5) which a UI test (`top_instructions`) was dependent on. 

This: 
- Clones the original level
- Adds the cloned level to `allthethings`
- Re-implements the original change: Removing the ani gif from studio.code.org/s/course1/stage/4/puzzle/5  (Record of original change is here: https://github.com/code-dot-org/code-dot-org/commit/441958cda4c95a205541bb004855608959351d27 for `K-1 Maze 5.level`)

## Course 1 Stage 4 Level 5
### Before
<img width="1425" alt="Screen Shot 2019-11-07 at 2 39 08 PM" src="https://user-images.githubusercontent.com/208083/68421507-5f964200-016c-11ea-898c-a25cae3a2ff4.png">

### After
<img width="1420" alt="Screen Shot 2019-11-07 at 2 18 07 PM" src="https://user-images.githubusercontent.com/208083/68421434-3e355600-016c-11ea-87f6-0ae37fee1c7b.png">


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
