### PR TITLE
Annotate ActiveRecord queries not using index

### DIFF
--- a/dashboard/config/initializers/mysql_check_index_used.rb
+++ b/dashboard/config/initializers/mysql_check_index_used.rb
@@ -1,0 +1,41 @@
+# This initializer adds a red [NO INDEX] annotation to SQL notifications printed to the logger
+# for ActiveRecord queries when the MySQL query result has the 'no_index_used' flag set.
+#
+# It also adds a 'raise_on_no_index_used' Rails configuration option, which will enforce index usage
+# by raising NoIndexUsedException if any ActiveRecord query is executed without using an index.
+# Note that MySQL often chooses to ignore an existing index for small or empty tables where the query optimizer
+# decides that a table scan will be more efficient anyway, so this setting may be difficult to use properly.
+
+class NoIndexUsedException < StandardError; end
+module MysqlCheckIndexUsed
+  # Copy/extend logic in AbstractMySQLAdapter#execute, and AbstractAdapter#log.
+  def execute(sql, name = nil)
+    options = {
+      sql:               sql,
+      name:              name,
+      binds:             [],
+      type_casted_binds: [],
+      statement_name:    nil,
+      connection_id:     object_id
+    }
+    @instrumenter.instrument("sql.active_record", options) do
+      @connection.query(sql).tap do |result|
+        if name && name != 'SCHEMA' && result && result.server_flags[:no_index_used]
+          options[:name] += ' ' + '[NO INDEX]'.on_red
+          raise NoIndexUsedException if Rails.application.config.raise_on_no_index_used
+        end
+      end
+    end
+  rescue => e
+    raise translate_exception_class(e, sql)
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  require 'active_record/connection_adapters/mysql2_adapter'
+  ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend MysqlCheckIndexUsed
+end
+
+Rails.application.configure do
+  config.raise_on_no_index_used = false
+end


### PR DESCRIPTION
# Description

This PR adds a red `[NO INDEX]` annotation to ActiveRecord SQL notifications (printed in Rails development console by default) for queries where the MySQL query result has the `no_index_used` flag set:

Before:
![image](https://user-images.githubusercontent.com/56541/68425539-24d7de00-015b-11ea-9431-72855bad8724.png)

After:
![image](https://user-images.githubusercontent.com/56541/68425397-dd515200-015a-11ea-9039-94a6f8a1ca54.png)

This should provide some lightweight DB-optimization guidance for development and debugging.

It also adds a `raise_on_no_index_used` Rails configuration option, which will enforce index usage by raising `NoIndexUsedException` if any ActiveRecord query is executed without using an index. This option is disabled by default, since MySQL often chooses to ignore an existing index for small or empty tables where the query optimizer decides that a table scan will be more efficient anyway. (I thought I would include the option anyway, just in case it may be eventually useful.)

### Background

The MySQL client/server protocol distinguishes queries that make use of an index for efficient lookup, and those that do not use an index (sometimes called 'full table scan' queries). This information is passed in the [Status Flags](https://dev.mysql.com/doc/internals/en/status-flags.html) of the [OK packet](https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html) produced with every MySQL-protocol query response, and is set to the `:no_index_used` key of the [`Mysql2::Result#server_flags`](https://www.rubydoc.info/gems/mysql2/Mysql2%2FResult:server_flags) object produced by the `mysql2` gem.

### Implementation

This PR adds a Rails initializer that patches the `ActiveRecord::ConnectionAdapters::Mysql2Adapter` to add text to the `name`-key string on the `sql.active_record` notification generated for every query, when the `no_index_used` flag on the `Result` object is set.

### Future work

- Filter out benign cases of full-table scans so we can enforce index usage throughout the rest of the application.
- Use the `SUM_NO_INDEX_USED` column of the [`performance_schema.events_statements_summary_by_digest`](https://dev.mysql.com/doc/mysql-perfschema-excerpt/5.6/en/statement-summary-tables.html) Performance Schema summary table to monitor no-index-usage in production.

## Testing story

Manual testing and the existing test suite which could verify that nothing will break as a result of this change.

Tests covering the actual behavior in this PR are deferred fro now- this PR was done quickly to help address an existing pain point in development, and creating a reliable test-case with a no-index query might not be trivial.