### PR TITLE
Print student privacy PDFs

### DIFF
--- a/apps/src/sites/code.org/pages/views/share_privacy.js
+++ b/apps/src/sites/code.org/pages/views/share_privacy.js
@@ -28,8 +28,18 @@ $(document).ready(function() {
 
     // Prevent repeatedly adding this iframe if button pressed repeatedly
     if (!$('#iFramePdf').length) {
+      let pdfToPrintHash = {
+        '/privacy/student-privacy': '/files/privacy-policy-csf.pdf',
+        '/privacy/student-privacy-csd': '/files/privacy-policy-csd.pdf',
+        '/privacy/student-privacy-csp': '/files/privacy-policy-csp.pdf'
+      };
+
+      let pdfToPrint = pdfToPrintHash[window.location.pathname];
+
       let iFramePdf = $(
-        '<iframe id="iFramePdf" src="/files/privacy-policy-csp.pdf" style="display:none;"></iframe>'
+        '<iframe id="iFramePdf" src=' +
+          pdfToPrint +
+          ' style="display:none;"></iframe>'
       );
       $('body').append(iFramePdf);
     }

--- a/apps/src/sites/code.org/pages/views/share_privacy.js
+++ b/apps/src/sites/code.org/pages/views/share_privacy.js
@@ -28,12 +28,14 @@ $(document).ready(function() {
 
     // Prevent repeatedly adding this iframe if button pressed repeatedly
     if (!$('#iFramePdf').length) {
-      let iFramePdf = $('<iframe id="iFramePdf" src="/files/privacy-policy-csp.pdf" style="display:none;"></iframe>');
+      let iFramePdf = $(
+        '<iframe id="iFramePdf" src="/files/privacy-policy-csp.pdf" style="display:none;"></iframe>'
+      );
       $('body').append(iFramePdf);
     }
 
-    let getMyFrame = document.getElementById("iFramePdf");
-    getMyFrame.focus();
-    getMyFrame.contentWindow.print();
+    let getPrintFrame = document.getElementById('iFramePdf');
+    getPrintFrame.focus();
+    getPrintFrame.contentWindow.print();
   });
 });

--- a/apps/src/sites/code.org/pages/views/share_privacy.js
+++ b/apps/src/sites/code.org/pages/views/share_privacy.js
@@ -4,6 +4,12 @@
 
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 
+const LOCATION_TO_PDF_MAPPING = {
+  '/privacy/student-privacy': '/files/privacy-policy-csf.pdf',
+  '/privacy/student-privacy-csd': '/files/privacy-policy-csd.pdf',
+  '/privacy/student-privacy-csp': '/files/privacy-policy-csp.pdf'
+};
+
 $(document).ready(function() {
   $('#share_on_remind').click(function() {
     firehoseClient.putRecord({
@@ -26,26 +32,21 @@ $(document).ready(function() {
       event: 'printed'
     });
 
-    // Prevent repeatedly adding this iframe if button pressed repeatedly
-    if (!$('#iFramePdf').length) {
-      let pdfToPrintHash = {
-        '/privacy/student-privacy': '/files/privacy-policy-csf.pdf',
-        '/privacy/student-privacy-csd': '/files/privacy-policy-csd.pdf',
-        '/privacy/student-privacy-csp': '/files/privacy-policy-csp.pdf'
-      };
+    let printFrame = document.getElementById('iFramePdf');
+    if (!printFrame) {
+      const pdfToPrint = LOCATION_TO_PDF_MAPPING[window.location.pathname];
 
-      let pdfToPrint = pdfToPrintHash[window.location.pathname];
+      const iFramePdf = $(`
+        <iframe
+          id="iFramePdf"
+          src="${pdfToPrint}"
+        ></iframe>
+      `);
 
-      let iFramePdf = $(
-        '<iframe id="iFramePdf" src=' +
-          pdfToPrint +
-          ' style="display:none;"></iframe>'
-      );
       $('body').append(iFramePdf);
+      printFrame = iFramePdf[0];
     }
-
-    let getPrintFrame = document.getElementById('iFramePdf');
-    getPrintFrame.focus();
-    getPrintFrame.contentWindow.print();
+    printFrame.focus();
+    printFrame.contentWindow.print();
   });
 });

--- a/apps/src/sites/code.org/pages/views/share_privacy.js
+++ b/apps/src/sites/code.org/pages/views/share_privacy.js
@@ -25,5 +25,15 @@ $(document).ready(function() {
       study_group: 'share_student_privacy',
       event: 'printed'
     });
+
+    // Prevent repeatedly adding this iframe if button pressed repeatedly
+    if (!$('#iFramePdf').length) {
+      let iFramePdf = $('<iframe id="iFramePdf" src="/files/privacy-policy-csp.pdf" style="display:none;"></iframe>');
+      $('body').append(iFramePdf);
+    }
+
+    let getMyFrame = document.getElementById("iFramePdf");
+    getMyFrame.focus();
+    getMyFrame.contentWindow.print();
   });
 });

--- a/apps/src/sites/code.org/pages/views/share_privacy.js
+++ b/apps/src/sites/code.org/pages/views/share_privacy.js
@@ -40,6 +40,7 @@ $(document).ready(function() {
         <iframe
           id="iFramePdf"
           src="${pdfToPrint}"
+          style="display:none;"
         ></iframe>
       `);
 

--- a/pegasus/sites.v3/code.org/views/share_privacy.haml
+++ b/pegasus/sites.v3/code.org/views/share_privacy.haml
@@ -25,7 +25,7 @@
     href: "mailto:?to=&subject=" + URI.encode(email_subject) + "&body=" + URI.encode(email_body), target:'_blank', id: 'email_button'}
     %i.fa.fa-envelope{"aria-hidden": "true"}
     Email
-  %a{class: 'print-button', href: "javascript:window.print()", id: 'print_button'}
+  %a{class: 'print-button', href: "javascript:void(0)", id: 'print_button'}
     %i.fa.fa-print{"aria-hidden": "true"}
     Print
 %div{style: 'clear: both'}


### PR DESCRIPTION
# Description

Prints the PDF version of the student privacy page for CSF, CSD, and CSP. Historically, the print button would print something poorly formatted, like the following:

![image](https://user-images.githubusercontent.com/25372625/68497306-1c3de100-0209-11ea-9de5-9e24a573eeaf.png)

Attempted [a version of this ](https://github.com/code-dot-org/code-dot-org/pull/31503) where we would have a general stylesheet for Code.org, but proved too risky. This PR takes a more limited approach and just prints the appropriate PDF for each course.

Although functional (in my local testing), I am certain this could benefit from some improvements. Questions I have:
1. I'm hard coding URL paths here, which is probably not a best practice.
2. I'm using an object to map URLs to PDFs, which might not be good practice in itself (independent of the hard coding).
3. Formatting of my jQuery iframe seems clunky.
4. What kinds of tests can/should I add here?

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
