### PR TITLE
add pipe scripts for slack logging

### DIFF
--- a/bin/i18n/slack_error
+++ b/bin/i18n/slack_error
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require_relative '../../deployment'
+require 'cdo/chat_client'
+
+ARGF.each_line do |line|
+  ChatClient.log(line, {color: :red})
+end

--- a/bin/i18n/slack_log
+++ b/bin/i18n/slack_log
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require_relative '../../deployment'
+require 'cdo/chat_client'
+
+ARGF.each_line do |line|
+  ChatClient.log(line)
+end


### PR DESCRIPTION
# Description

Adds a couple of scripts that we will be able to use to log the results of the i18n sync to slack. Specifically, each script will pipe any given stdin stream directly to the slack channel appropriate to the environment in which it is being used; one script will display input normally, the other will display input as an error.

This means we can combine these scripts to report both `stdout` and `stderr` appropriately. For example, say we have a script like `example.rb`:

```ruby
$stdout.puts "stdout"
$stderr.puts "stderr"
```

We can run this script like `ruby example.rb | slack_log` to pipe just stdout to slack, or like `(ruby example.rb | slack_log) |& slack_error` to pipe stdout to slack regularly, and stderr to slack as an error.

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
