### PR TITLE
Remove downloaded 'en.yml' file after rewriting

### DIFF
--- a/bin/i18n/hoc_sync_utils.rb
+++ b/bin/i18n/hoc_sync_utils.rb
@@ -61,6 +61,7 @@ class HocSyncUtils
       # rename yml file from en.yml to code
       new_path = File.join(dest_dir, "hourofcode/#{prop[:unique_language_s]}.yml")
       File.write(new_path, new_translation_data.to_yaml)
+      FileUtils.rm old_path
     end
   end
 


### PR DESCRIPTION
# Description

Followup to https://github.com/code-dot-org/code-dot-org/pull/31620

Prior to the linked PR, we would get the downloaded translation data into the right place by renaming the downloaded files and then making manual edits to them.

The linked PR made things a little more precise by having us instead actually parse the data from the downloaded files, modify that data, and then write the results out to the new location.

Unfortunately, this means we ended up with files sticking around at the downloaded location. I forgot to add a `rm`.