### PR TITLE
Assignment Updates: show Assigned to students on script overview

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverview.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverview.jsx
@@ -49,6 +49,7 @@ class ScriptOverview extends React.Component {
     courseName: PropTypes.string,
     locale: PropTypes.string,
     showAssignButton: PropTypes.bool,
+    assignedSectionId: PropTypes.number,
 
     // redux provided
     perLevelProgress: PropTypes.object.isRequired,
@@ -118,7 +119,8 @@ class ScriptOverview extends React.Component {
       courseName,
       locale,
       showAssignButton,
-      userId
+      userId,
+      assignedSectionId
     } = this.props;
 
     const displayRedirectDialog =
@@ -179,6 +181,7 @@ class ScriptOverview extends React.Component {
               isRtl={isRtl}
               resources={teacherResources}
               showAssignButton={showAssignButton}
+              assignedSectionId={assignedSectionId}
             />
           </div>
         )}

--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -13,6 +13,7 @@ import {
 } from '@cdo/apps/templates/courseOverview/resourceType';
 import experiments from '@cdo/apps/util/experiments';
 import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
+import Assigned from '@cdo/apps/templates/Assigned';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
@@ -57,6 +58,7 @@ class ScriptOverviewTopRow extends React.Component {
     ).isRequired,
     sectionsForDropdown: PropTypes.arrayOf(sectionForDropdownShape).isRequired,
     selectedSectionId: PropTypes.number,
+    assignedSectionId: PropTypes.number,
     currentCourseId: PropTypes.number,
     professionalLearningCourse: PropTypes.bool,
     scriptProgress: PropTypes.oneOf([NOT_STARTED, IN_PROGRESS, COMPLETED]),
@@ -83,7 +85,8 @@ class ScriptOverviewTopRow extends React.Component {
       viewAs,
       isRtl,
       resources,
-      showAssignButton
+      showAssignButton,
+      assignedSectionId
     } = this.props;
 
     return (
@@ -102,6 +105,7 @@ class ScriptOverviewTopRow extends React.Component {
               size={Button.ButtonSize.large}
               style={{marginLeft: 10}}
             />
+            {assignedSectionId && <Assigned />}
           </div>
         )}
         {!professionalLearningCourse &&

--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -105,7 +105,8 @@ class ScriptOverviewTopRow extends React.Component {
               size={Button.ButtonSize.large}
               style={{marginLeft: 10}}
             />
-            {assignedSectionId && <Assigned />}
+            {experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) &&
+              assignedSectionId && <Assigned />}
           </div>
         )}
         {!professionalLearningCourse &&

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -179,6 +179,7 @@ progress.renderCourseProgress = function(scriptData) {
         locale={scriptData.locale}
         showAssignButton={scriptData.show_assign_button}
         userId={scriptData.user_id}
+        assignedSectionId={scriptData.assigned_section_id}
       />
     </Provider>,
     mountPoint

--- a/apps/src/templates/Assigned.jsx
+++ b/apps/src/templates/Assigned.jsx
@@ -1,0 +1,26 @@
+import React, {Component} from 'react';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import color from '@cdo/apps/util/color';
+import i18n from '@cdo/locale';
+
+const styles = {
+  assigned: {
+    color: color.level_perfect,
+    fontSize: 16,
+    fontFamily: '"Gotham 5r", sans-serif',
+    lineHeight: '36px',
+    marginLeft: 10,
+    verticalAlign: 'top'
+  }
+};
+
+export default class Assigned extends Component {
+  render() {
+    return (
+      <span style={styles.assigned}>
+        <FontAwesome icon="check" />
+        {i18n.assigned()}
+      </span>
+    );
+  }
+}

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -6,6 +6,7 @@ import i18n from '@cdo/locale';
 import Button from '../Button';
 import CourseScriptTeacherInfo from './CourseScriptTeacherInfo';
 import AssignButton from '@cdo/apps/templates/AssignButton';
+import Assigned from '@cdo/apps/templates/Assigned';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {
@@ -15,7 +16,6 @@ import {
 import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import experiments from '@cdo/apps/util/experiments';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 const styles = {
   main: {
@@ -48,14 +48,6 @@ const styles = {
     marginBottom: 12,
     marginLeft: 0,
     marginRight: 0
-  },
-  assigned: {
-    color: color.level_perfect,
-    fontSize: 16,
-    fontFamily: '"Gotham 5r", sans-serif',
-    lineHeight: '36px',
-    marginLeft: 10,
-    verticalAlign: 'top'
   },
   flex: {
     display: 'flex'
@@ -154,10 +146,7 @@ class CourseScript extends Component {
             />
             {isAssigned &&
               experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
-                <span style={styles.assigned}>
-                  <FontAwesome icon="check" />
-                  {i18n.assigned()}
-                </span>
+                <Assigned />
               )}
             {!isAssigned &&
               viewAs === ViewType.Teacher &&


### PR DESCRIPTION
# Description
[LP-946](https://codedotorg.atlassian.net/browse/LP-946)
[spec](https://docs.google.com/document/d/1vJySqyKozUxknkhY1KyQXWzbV-0c1vdnpKvRsAsVrdI/edit)

I extracted this little bit of UI into a reusable component: 
<img width="110" alt="Screen Shot 2019-11-07 at 4 26 45 PM" src="https://user-images.githubusercontent.com/12300669/68439370-2fef3600-017c-11ea-9bfe-3f9d7f1b8bd2.png">

Then used it to display whether the unit is assigned to a student viewing the script overview page.
<img width="1140" alt="Screen Shot 2019-11-07 at 8 50 44 PM" src="https://user-images.githubusercontent.com/12300669/68451038-0ba65000-01a2-11ea-811b-01f530cec67c.png">


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
