### PR TITLE
Fish: responsive sizing

### DIFF
--- a/apps/src/fish/FishView.jsx
+++ b/apps/src/fish/FishView.jsx
@@ -10,14 +10,14 @@ const styles = {
   container: {
     position: 'relative',
     width: '100%',
-    maxWidth: '970px',
+    minWidth: '770px',
     margin: '0 auto',
     userSelect: 'none'
   },
   containerReact: {
     position: 'absolute',
     width: '100%',
-    maxWidth: '970px',
+    minWidth: '770px',
     margin: '0 auto',
     userSelect: 'none',
     fontFamily: 'arial, sans-serif',

--- a/apps/style/fish/style.scss
+++ b/apps/style/fish/style.scss
@@ -26,3 +26,49 @@ button:focus {
     font-size: 60%;
   }
 }
+
+@media screen and (max-height: 1350px) {
+  #container {
+    max-width: 2050px;
+  }
+}
+@media screen and (max-height: 1260px) {
+  #container {
+    max-width: 1890px;
+  }
+}
+@media screen and (max-height: 1170px) {
+  #container {
+    max-width: 1730px;
+  }
+}
+@media screen and (max-height: 1080px) {
+  #container {
+    max-width: 1570px;
+  }
+}
+@media screen and (max-height: 990px) {
+  #container {
+    max-width: 1410px;
+  }
+}
+@media screen and (max-height: 900px) {
+  #container {
+    max-width: 1250px;
+  }
+}
+@media screen and (max-height: 810px) {
+  #container {
+    max-width: 1090px;
+  }
+}
+@media screen and (max-height: 720px) {
+  #container {
+    max-width: 930px;
+  }
+}
+@media screen and (max-height: 630px) {
+  #container {
+    max-width: 770px;
+  }
+}


### PR DESCRIPTION
# Description

* Move to using the full width of the screen - with a min-width (for now) of `770px`
* Added `@media` queries with height breakpoints so we ensure that the bottom of the 16:9 scene is not cropped on the bottom

Tested within standalone and Code Studio - works on all sizes within a 4k 16:9 monitor

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
