### PR TITLE
Assignment Updates: move teacher resources above section selector

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -115,6 +115,23 @@ class ScriptOverviewTopRow extends React.Component {
               assignmentName={scriptTitle}
             />
           )}
+        {experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) &&
+          !professionalLearningCourse &&
+          viewAs === ViewType.Teacher &&
+          resources.length > 0 && (
+            <div style={styles.dropdown}>
+              <DropdownButton
+                text={i18n.teacherResources()}
+                color={Button.ButtonColor.blue}
+              >
+                {resources.map(({type, link}, index) => (
+                  <a key={index} href={link} target="_blank">
+                    {stringForType[type]}
+                  </a>
+                ))}
+              </DropdownButton>
+            </div>
+          )}
         {!professionalLearningCourse &&
           viewAs === ViewType.Teacher &&
           showAssignButton &&
@@ -127,7 +144,8 @@ class ScriptOverviewTopRow extends React.Component {
               scriptId={scriptId}
             />
           )}
-        {!professionalLearningCourse &&
+        {!experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) &&
+          !professionalLearningCourse &&
           viewAs === ViewType.Teacher &&
           resources.length > 0 && (
             <div style={styles.dropdown}>


### PR DESCRIPTION
[LP-942](https://codedotorg.atlassian.net/browse/LP-942)

On the unit overview page with the new section selector behind `assignmentUpdates` flag.
BEFORE:
<img width="813" alt="Screen Shot 2019-11-07 at 7 53 58 PM" src="https://user-images.githubusercontent.com/12300669/68448983-3e4c4a80-019a-11ea-9b96-562847005ee4.png">

AFTER: 

<img width="758" alt="Screen Shot 2019-11-07 at 7 59 52 PM" src="https://user-images.githubusercontent.com/12300669/68449001-502ded80-019a-11ea-88b2-02000cefe867.png">
