### PR TITLE
remove GridEditor from code-studio.js

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -590,6 +590,7 @@ describe('entry tests', () => {
     'levels/editors/_dsl': './src/sites/studio/pages/levels/editors/_dsl.js',
     'levels/editors/_gamelab':
       './src/sites/studio/pages/levels/editors/_gamelab.js',
+    'levels/editors/_grid': './src/sites/studio/pages/levels/editors/_grid.js',
     'levels/editors/_pixelation':
       './src/sites/studio/pages/levels/editors/_pixelation.js',
     'levels/editors/_studio':

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -38,7 +38,6 @@ require('@cdo/apps/code-studio/components/AbuseError');
 require('@cdo/apps/code-studio/components/ReportAbuseForm');
 require('@cdo/apps/code-studio/components/SendToPhone');
 require('@cdo/apps/code-studio/components/SmallFooter');
-require('@cdo/apps/code-studio/components/GridEditor');
 require('@cdo/apps/code-studio/components/Attachments');
 require('selectize');
 

--- a/apps/src/sites/studio/pages/levels/editors/_grid.js
+++ b/apps/src/sites/studio/pages/levels/editors/_grid.js
@@ -1,0 +1,1 @@
+import '@cdo/apps/code-studio/components/GridEditor';

--- a/dashboard/app/views/levels/editors/_grid.html.haml
+++ b/dashboard/app/views/levels/editors/_grid.html.haml
@@ -1,3 +1,6 @@
+- content_for(:head) do
+  %script{src: minifiable_asset_path('js/levels/editors/_grid.js')}
+
 = hidden_field_tag :size, 8
 = f.hidden_field :maze_data
 .field#grid
@@ -57,14 +60,14 @@
       #mazeTable.span5
       .label.span3.offset1
         WHAT THE NUMBERS MEAN:
-        %ul(style="list-style-type:none;margin:0;")
+        %ul{style: "list-style-type:none;margin:0;"}
           %li.border 0 = border/wall
           %li.path 1 = path
           %li.start 2 = start
           %li.end 3 = end (for Maze levels only)
           %li.obstacle 4 = obstacle
         PLAYLAB:
-        %ul(style="list-style-type:none;margin:0;")
+        %ul{style: "list-style-type:none;margin:0;"}
           %li.start 16 = character
           %li.path 1 = waypoint flag
 

--- a/dashboard/app/views/levels/editors/_grid.html.haml
+++ b/dashboard/app/views/levels/editors/_grid.html.haml
@@ -1,5 +1,5 @@
 - content_for(:head) do
-  %script{src: minifiable_asset_path('js/levels/editors/_grid.js')}
+  %script{src: webpack_asset_path('js/levels/editors/_grid.js')}
 
 = hidden_field_tag :size, 8
 = f.hidden_field :maze_data


### PR DESCRIPTION
# Description

This is part of the ongoing project to reduce our initial download size. This PR doesn't use lazy-loading -- rather it removes the GridEditor dependency from code-studio.js, which is loaded on every code studio page, and only loads it on the level edit pages where it is needed. This means it only ever gets loaded within the levelbuilder environment. 

This removes 108KB of JS from the initial download, 70KB of which is in `@code-dot-org/maze`. Most of removed code is highlighted in red below:

<img width="1094" alt="Screen Shot 2019-11-07 at 8 18 29 PM" src="https://user-images.githubusercontent.com/8001765/68449624-bddb1900-019c-11ea-91f9-88846a1d7219.png">

<img width="1501" alt="Screen Shot 2019-11-07 at 8 34 57 PM" src="https://user-images.githubusercontent.com/8001765/68449973-2971b600-019e-11ea-8912-fa6d367cbd82.png">

## Testing story

Manually verified that the grid editor still works while editing at least one levelbuilder level.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
