### PR TITLE
Fixing /yourschool Mapbox size and button size

### DIFF
--- a/apps/src/templates/census2017/CensusMapReplacement.jsx
+++ b/apps/src/templates/census2017/CensusMapReplacement.jsx
@@ -387,29 +387,29 @@ export default class CensusMapReplacement extends Component {
 
   render() {
     return (
-      <div>
+      <div id="census-map">
         <div id="mapbox" className="full-width">
           <div id="inmaplegend" className="legend">
             <div className="legend-title">Legend</div>
-            <div className="color green" />
+            <div className="color legend-offers-cs" />
             <div className="caption">Offers computer science</div>
-            <div className="color blue" />
+            <div className="color legend-limited-cs" />
             <div className="caption">Limited or no CS opportunities</div>
-            <div className="color yellow" />
+            <div className="color legend-inconclusive-cs" />
             <div className="caption">Inconclusive data</div>
-            <div className="color white" />
+            <div className="color legend-no-data-cs" />
             <div className="caption">No Data</div>
           </div>
         </div>
         <div id="belowmaplegend" className="legend">
           <div className="legend-title">Legend</div>
-          <div className="color green" />
+          <div className="color legend-offers-cs" />
           <div className="caption">Offers computer science</div>
-          <div className="color blue" />
+          <div className="color legend-limited-cs" />
           <div className="caption">Limited or no CS opportunities</div>
-          <div className="color yellow" />
+          <div className="color legend-inconclusive-cs" />
           <div className="caption">Inconclusive data</div>
-          <div className="color white" />
+          <div className="color legend-no-data-cs" />
           <div className="caption">No Data</div>
         </div>
         <div id="map-footer">

--- a/pegasus/sites.v3/code.org/public/css/census-map.css
+++ b/pegasus/sites.v3/code.org/public/css/census-map.css
@@ -25,7 +25,8 @@
 }
 
 #mapbox {
-  height: 500px;
+  width: 100%;
+  padding-bottom: 56.25%;
 }
 
 #footer-text {
@@ -179,4 +180,24 @@
 .census-info-window .inaccuracy-link {
   text-align: center;
   font-size: 11px;
+}
+
+#census-map .legend-offers-cs {
+  background-color: #66DC57;
+}
+
+#census-map .legend-limited-cs {
+  background-color: #989CF8;
+}
+
+#census-map .legend-inconclusive-cs {
+  background-color: #FFFDA6;
+}
+
+#census-map .legend-no-data-cs {
+  background-color: #FFFFFF;
+}
+
+.mapboxgl-map button {
+  margin: 0px;
 }


### PR DESCRIPTION
# Description
The Mapbox map on code.org/yourschool had a fixed size which made it
troublesome to use on small screens. The size of the map now scales
appropriately to the size of the screen.

Some CSS style names were also refactored to match best practices.

The margin around the Mapbox buttons were also fixed.
## Screenshots
### Before
![Kazam_screenshot_00007](https://user-images.githubusercontent.com/1372238/68452293-fa813180-01e9-11ea-870d-f1bb4898ce7b.png)

### After
![Kazam_screenshot_00008](https://user-images.githubusercontent.com/1372238/68452298-fe14b880-01e9-11ea-898a-6e0db813848c.png)

## Links
- [Current /yourschool page](https://code.org/yourschool?enableExperiments=censusMapOnMapbox)
- [jira](https://codedotorg.atlassian.net/browse/FND-746)

## Testing story
* Ran locally and manually verified (Linux) X (Firefox, Chrome)
`cd apps; yarn && npm build; cd..`
`./bin/dashboard-server`
  * http://localhost:3000/yourschool?enableExperiments=censusMapOnMapbox

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
