### PR TITLE
stop importing selectize globally

### DIFF
--- a/apps/src/schoolInfoManager.js
+++ b/apps/src/schoolInfoManager.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import 'selectize';
 
 export default function SchoolInfoManager(existingOptions) {
   var districtListFirstLoad = true;

--- a/apps/src/sites/code.org/pages/public/pd-workshop-survey/splat.js
+++ b/apps/src/sites/code.org/pages/public/pd-workshop-survey/splat.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import VariableFormGroup from '@cdo/apps/code-studio/pd/workshop_survey/VariableFormGroup';
+import 'selectize';
 
 $(document).ready(function() {
   $('#pd-workshop-survey-form')

--- a/apps/src/sites/hourofcode.com/pages/public/index.js
+++ b/apps/src/sites/hourofcode.com/pages/public/index.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import SchoolAutocompleteDropdownWithLabel from '@cdo/apps/templates/census2017/SchoolAutocompleteDropdownWithLabel.jsx';
+import 'selectize';
 
 let schoolData = {
   nces: '',

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -40,7 +40,6 @@ require('@cdo/apps/code-studio/components/SendToPhone');
 require('@cdo/apps/code-studio/components/SmallFooter');
 require('@cdo/apps/code-studio/components/GridEditor');
 require('@cdo/apps/code-studio/components/Attachments');
-require('selectize');
 
 // Prevent callstack exceptions when opening multiple dialogs
 // http://stackoverflow.com/a/15856139/2506748


### PR DESCRIPTION
# Description

This PR is part of an ongoing effort to reduce our initial JS download size on code studio pages.

Today, `selectize` (36KB) is imported globally in code-studio.js, which means it's included on every code studio page. This PR stops importing it globally, and only imports it in the entry points that need it, specifically importing it in all the places under `apps/src` which call `.selectize()`. The following output shows that `selectize` is no longer included in the shared bundle, and is instead included in 3 other entry points:

before:

<img width="591" alt="Screen Shot 2019-11-07 at 9 54 38 PM" src="https://user-images.githubusercontent.com/8001765/68453089-67280c00-01a9-11ea-870d-7bdb26e86fc8.png">

after:

<img width="591" alt="Screen Shot 2019-11-07 at 9 55 19 PM" src="https://user-images.githubusercontent.com/8001765/68453096-6d1ded00-01a9-11ea-98ed-58463bdf306d.png">

## Caveats

Ordinarily, we'd want to take an extra step to let the three entry points share a single copy of `selectize` via lazy-loading, however I'm punting on this because these pages are using jquery and we'll probably want to eventually rewrite them in react anyway, perhaps using `react-virtualized-select`. 

Also, Pegasus pages have a different way of loading selectize, which is to use a script tag to load selectize.min.js on the pages that need it. This PR should have no affect on those pages.

To summarize these caveats, I'm not going out of my way to worry about performance on pages which use jquery instead of react or which use js outside of apps/src, because those are not the recommended ways to write UI code in our system. If we want to improve the performance of those pages, we should consider moving them into apps/src + react first.

## Testing story

I am relying on existing test coverage to catch any regressions in the affected features.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
