### PR TITLE
Omit video-js from initial download

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -553,6 +553,7 @@ describe('entry tests', () => {
     'levels/_teacher_panel':
       './src/sites/studio/pages/levels/_teacher_panel.js',
     'levels/_text_match': './src/sites/studio/pages/levels/_text_match.js',
+    'levels/_unplug': './src/sites/studio/pages/levels/_unplug.js',
     'levels/_widget': './src/sites/studio/pages/levels/_widget.js',
     'levels/show': './src/sites/studio/pages/levels/show.js',
     'maker/discountcode': './src/sites/studio/pages/maker/discountcode.js',

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -571,7 +571,8 @@ describe('entry tests', () => {
     'teacher_dashboard/show':
       './src/sites/studio/pages/teacher_dashboard/show.js',
     'teacher_feedbacks/index':
-      './src/sites/studio/pages/teacher_feedbacks/index.js'
+      './src/sites/studio/pages/teacher_feedbacks/index.js',
+    'videos/test': './src/sites/studio/pages/videos/test.js'
   };
 
   var internalEntries = {

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -20,7 +20,6 @@ var project = require('@cdo/apps/code-studio/initApp/project');
 var createCallouts = require('@cdo/apps/code-studio/callouts').default;
 var reporting = require('@cdo/apps/code-studio/reporting');
 var LegacyDialog = require('@cdo/apps/code-studio/LegacyDialog');
-var showVideoDialog = require('@cdo/apps/code-studio/videos').showVideoDialog;
 import {
   lockContainedLevelAnswers,
   getContainedLevelId
@@ -186,7 +185,9 @@ export function setupApp(appOptions) {
     onContinue: function() {
       var lastServerResponse = reporting.getLastServerResponse();
       if (lastServerResponse.videoInfo) {
-        showVideoDialog(lastServerResponse.videoInfo);
+        import('@cdo/apps/code-studio/videos').then(videos => {
+          videos.showVideoDialog(lastServerResponse.videoInfo);
+        });
       } else if (lastServerResponse.endOfStageExperience) {
         const body = document.createElement('div');
         const stageInfo = lastServerResponse.previousStageInfo;
@@ -236,7 +237,9 @@ export function setupApp(appOptions) {
         if (hasInstructions) {
           appOptions.autoplayVideo.onClose = afterVideoCallback;
         }
-        showVideoDialog(appOptions.autoplayVideo);
+        import('@cdo/apps/code-studio/videos').then(videos => {
+          videos.showVideoDialog(appOptions.autoplayVideo);
+        });
       } else {
         if (hasVideo && noAutoplay) {
           clientState.recordVideoSeen(appOptions.autoplayVideo.key);

--- a/apps/src/code-studio/levels/dialogHelper.js
+++ b/apps/src/code-studio/levels/dialogHelper.js
@@ -145,7 +145,9 @@ export function processResults(onComplete, beforeHook) {
         }
 
         if (lastServerResponse.videoInfo) {
-          window.dashboard.videos.showVideoDialog(lastServerResponse.videoInfo);
+          import('@cdo/apps/code-studio/videos').then(videos => {
+            videos.showVideoDialog(lastServerResponse.videoInfo);
+          });
         } else if (lastServerResponse.endOfStageExperience) {
           const body = document.createElement('div');
           const stageInfo = lastServerResponse.previousStageInfo;

--- a/apps/src/code-studio/reference_area.js
+++ b/apps/src/code-studio/reference_area.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-var showVideoDialog = require('./videos').showVideoDialog;
 
 // It would be nice if we could share this with the addClickTouchEvent in
 // apps/src/dom.js
@@ -25,18 +24,20 @@ module.exports = function activateReferenceAreaOnLoad() {
       addClickTouchEvent(
         $(this),
         $.proxy(function() {
-          showVideoDialog(
-            {
-              src: $(this).attr('data-src'),
-              name: $(this).attr('data-name'),
-              key: $(this).attr('data-key'),
-              download: $(this).attr('data-download'),
-              thumbnail: $(this).attr('data-thumbnail'),
-              enable_fallback: true,
-              autoplay: true
-            },
-            true
-          );
+          import('./videos').then(({showVideoDialog}) => {
+            showVideoDialog(
+              {
+                src: $(this).attr('data-src'),
+                name: $(this).attr('data-name'),
+                key: $(this).attr('data-key'),
+                download: $(this).attr('data-download'),
+                thumbnail: $(this).attr('data-thumbnail'),
+                enable_fallback: true,
+                autoplay: true
+              },
+              true
+            );
+          });
         }, this)
       );
     });

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -56,7 +56,6 @@ window.dashboard.levelCompletions = require('@cdo/apps/code-studio/levelCompleti
 window.dashboard.popupWindow = require('@cdo/apps/code-studio/popup-window');
 window.dashboard.reporting = require('@cdo/apps/code-studio/reporting');
 window.dashboard.header = require('@cdo/apps/code-studio/header');
-window.dashboard.videos = require('@cdo/apps/code-studio/videos');
 window.dashboard.assets = require('@cdo/apps/code-studio/assets');
 window.dashboard.pairing = require('@cdo/apps/code-studio/pairing');
 window.dashboard.project = require('@cdo/apps/code-studio/initApp/project');

--- a/apps/src/sites/studio/pages/levels/_external.js
+++ b/apps/src/sites/studio/pages/levels/_external.js
@@ -4,6 +4,9 @@ import {
   postMilestoneForPageLoad,
   onContinue
 } from '@cdo/apps/code-studio/levels/postOnLoad';
+window.dashboard = window.dashboard || {};
+import videos from '@cdo/apps/code-studio/videos';
+window.dashboard.videos = videos;
 
 $(document).ready(() => {
   const script = document.querySelector('script[data-external]');

--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -4,7 +4,6 @@ import {
   postMilestoneForPageLoad,
   onContinue
 } from '@cdo/apps/code-studio/levels/postOnLoad';
-import {createVideoWithFallback} from '@cdo/apps/code-studio/videos';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 $(document).ready(() => {
@@ -45,10 +44,13 @@ $(document).ready(() => {
   const videoOptions = getScriptData('videoOptions');
   const videoWidth = getScriptData('videoWidth');
   const videoHeight = getScriptData('videoHeight');
-  createVideoWithFallback(
-    $('.video-content'),
-    videoOptions,
-    videoWidth,
-    videoHeight
-  );
+
+  import('@cdo/apps/code-studio/videos').then(({createVideoWithFallback}) => {
+    createVideoWithFallback(
+      $('.video-content'),
+      videoOptions,
+      videoWidth,
+      videoHeight
+    );
+  });
 });

--- a/apps/src/sites/studio/pages/levels/_unplug.js
+++ b/apps/src/sites/studio/pages/levels/_unplug.js
@@ -1,0 +1,3 @@
+window.dashboard = window.dashboard || {};
+import videos from '@cdo/apps/code-studio/videos';
+window.dashboard.videos = videos;

--- a/apps/src/sites/studio/pages/levels/editors/_all.js
+++ b/apps/src/sites/studio/pages/levels/editors/_all.js
@@ -1,5 +1,6 @@
 /* global levelbuilder */
 import $ from 'jquery';
+import videos from '@cdo/apps/code-studio/videos';
 
 $(document).ready(initPage);
 
@@ -78,12 +79,7 @@ function initPage() {
     if (selectionValue) {
       var videoInfo = videoInfos[selectionValue];
       $('.video-preview').html(
-        window.dashboard.videos.createVideoWithFallback(
-          null,
-          videoInfo,
-          400,
-          400
-        )
+        videos.createVideoWithFallback(null, videoInfo, 400, 400)
       );
       $('.video-preview').show();
     } else {

--- a/apps/src/sites/studio/pages/videos/test.js
+++ b/apps/src/sites/studio/pages/videos/test.js
@@ -1,0 +1,3 @@
+window.dashboard = window.dashboard || {};
+import videos from '@cdo/apps/code-studio/videos';
+window.dashboard.videos = videos;

--- a/apps/src/templates/VideoThumbnail.jsx
+++ b/apps/src/templates/VideoThumbnail.jsx
@@ -1,4 +1,3 @@
-import {showVideoDialog} from '@cdo/apps/code-studio/videos';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {videoDataShape} from './types';
@@ -33,18 +32,20 @@ export default class VideoThumbnail extends Component {
         style={styles.videoLink}
         onClick={() => {
           this.props.onClick && this.props.onClick();
-          showVideoDialog(
-            {
-              src: video.src,
-              name: video.name,
-              key: video.key,
-              download: video.download,
-              thumbnail: video.thumbnail,
-              enable_fallback: video.enable_fallback,
-              autoplay: video.autoplay
-            },
-            true
-          );
+          import('@cdo/apps/code-studio/videos').then(({showVideoDialog}) => {
+            showVideoDialog(
+              {
+                src: video.src,
+                name: video.name,
+                key: video.key,
+                download: video.download,
+                thumbnail: video.thumbnail,
+                enable_fallback: video.enable_fallback,
+                autoplay: video.autoplay
+              },
+              true
+            );
+          });
         }}
       >
         <img

--- a/dashboard/app/views/levels/_unplug.html.haml
+++ b/dashboard/app/views/levels/_unplug.html.haml
@@ -11,6 +11,9 @@
 
 = stylesheet_link_tag '/blockly/video-js/video-js', media: 'all'
 
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/levels/_unplug.js')}
+
 .unplugged
   %h1= try_t("data.unplugged.#{unplugged}.title")
 

--- a/dashboard/app/views/videos/test.html.haml
+++ b/dashboard/app/views/videos/test.html.haml
@@ -60,6 +60,9 @@
     \/
     %a{href: '?'} off
 
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/videos/test.js')}
+
 :javascript
   var formLink = {
     template: "https://docs.google.com/forms/d/1yIdim-dyUWcmDQWTV-YeimE9tBUvWK-H7ZULItQ9rR8/viewform?entry.1520933088=browser&entry.515663950=youtubeReachable&entry.1331880569=flashInstalled",


### PR DESCRIPTION
# Description

This PR is part of an ongoing effort to reduce our initial JS download size. It removes `video-js` (57KB) as a global dependency in code-studio.js, and then also lazy-loads it from the places that use it. The change in entry point size can be seen as follows:

before:
![Screen Shot 2019-11-08 at 8 51 27 AM](https://user-images.githubusercontent.com/8001765/68495678-894f7780-0205-11ea-9b87-7e986c02e512.png)

after:
![Screen Shot 2019-11-08 at 8 55 25 AM](https://user-images.githubusercontent.com/8001765/68495688-8d7b9500-0205-11ea-9920-8d0fe2265159.png)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
