### PR TITLE
Ocean script video levels: use video_rounded_corners and video_full_width

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -15,11 +15,21 @@ videos.createVideoWithFallback = function(
   parentElement,
   options,
   width,
-  height
+  height,
+  fullWidth,
+  roundedCorners
 ) {
   upgradeInsecureOptions(options);
   var video = createVideo(options);
-  video.width(width).height(height);
+  if (fullWidth) {
+    video.addClass('video-player-full-width');
+    parentElement.addClass('video-content-full-width');
+  } else {
+    video.width(width).height(height);
+  }
+  if (roundedCorners) {
+    video.addClass('video-player-rounded-corners');
+  }
   if (parentElement) {
     parentElement.append(video);
   }

--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -45,10 +45,14 @@ $(document).ready(() => {
   const videoOptions = getScriptData('videoOptions');
   const videoWidth = getScriptData('videoWidth');
   const videoHeight = getScriptData('videoHeight');
+  const videoFullWidth = getScriptData('videoFullWidth');
+  const videoRoundedCorners = getScriptData('videoRoundedCorners');
   createVideoWithFallback(
     $('.video-content'),
     videoOptions,
     videoWidth,
-    videoHeight
+    videoHeight,
+    videoFullWidth,
+    videoRoundedCorners
   );
 });

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -760,6 +760,77 @@ $default-modal-width: 640px;
   margin: 0;
 }
 
+.video-player-rounded-corners {
+  border-radius: 10px;
+  border-width: 0;
+}
+
+.video-player-full-width {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.video-content-full-width {
+  position: relative;
+  // Specifically supports 16x9 aspect ratio
+  padding-top: 56.25%;
+}
+
+@media screen and (max-height: 1330px) {
+  .standalone-video-full-width {
+    max-width: 1973px;
+  }
+}
+@media screen and (max-height: 1240px) {
+  .standalone-video-full-width {
+    max-width: 1813px;
+  }
+}
+@media screen and (max-height: 1150px) {
+  .standalone-video-full-width {
+    max-width: 1653px;
+  }
+}
+@media screen and (max-height: 1060px) {
+  .standalone-video-full-width {
+    max-width: 1493px;
+  }
+}
+@media screen and (max-height: 970px) {
+  .standalone-video-full-width {
+    max-width: 1333px;
+  }
+}
+@media screen and (max-height: 880px) {
+  .standalone-video-full-width {
+    max-width: 1173px;
+  }
+}
+@media screen and (max-height: 790px) {
+  .standalone-video-full-width {
+    max-width: 1013px;
+  }
+}
+@media screen and (max-height: 700px) {
+  .standalone-video-full-width {
+    max-width: 853px;
+  }
+}
+@media screen and (max-height: 610px) {
+  .standalone-video-full-width {
+    max-width: 693px;
+  }
+}
+
+.buttons-right-aligned {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: -44px;
+}
+
 .fallback-video-player-failed {
   video, div {
     visibility: hidden;
@@ -2184,6 +2255,9 @@ a.download-video {
     display: inline-block;
   }
 
+  &-full-width {
+    width: unset;
+  }
 }
 
 .multi #markdown.teacher {

--- a/dashboard/app/models/levels/standalone_video.rb
+++ b/dashboard/app/models/levels/standalone_video.rb
@@ -27,6 +27,8 @@ class StandaloneVideo < Level
   serialized_attrs %w(
     skip_dialog
     skip_sound
+    video_rounded_corners
+    video_full_width
   )
 
   before_validation do
@@ -48,6 +50,11 @@ class StandaloneVideo < Level
 
   def concept_level?
     true
+  end
+
+  def enable_scrolling?
+    # ensures we have the small footer when in "full width" mode
+    video_full_width
   end
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -1,15 +1,18 @@
 - video = @level.specified_autoplay_video
 - video_data = {videoOptions: video.summarize(false).to_json,
                 videoHeight: 480,
-                videoWidth: 853}
+                videoWidth: 853,
+                videoRoundedCorners: @level.video_rounded_corners ? "true" : "false",
+                videoFullWidth: @level.video_full_width ? "true" : "false"}
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/levels/_standalone_video.js'), data: video_data}
 
-.standalone-video
+.standalone-video{:class => ('standalone-video-full-width' if @level.video_full_width)}
   - @slides = get_slides_by_video_key(@level.video_key)
 
-  %h1= "Video: #{video.localized_name}"
+  - unless @level.video_full_width
+    %h1= "Video: #{video.localized_name}"
   %div= render(inline: @level.long_instructions, type: :md) if @level.long_instructions
 
   .video-content
@@ -19,6 +22,10 @@
 
   %br/
 
+  - if @level.video_full_width
+    .buttons.buttons-right-aligned
+      %a.btn.btn-large.btn-primary.next-stage.submitButton
+        =t('continue')
   .video-link= link_to t('video.download'), video.download
 
   - if @slides
@@ -32,8 +39,9 @@
   %br/
   %br/
 
-  .buttons
-    %a.btn.btn-large.btn-primary.next-stage.submitButton
-      =t('continue')
+  - unless @level.video_full_width
+    .buttons
+      %a.btn.btn-large.btn-primary.next-stage.submitButton
+        =t('continue')
 
   = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => @level.teacher_markdown}}

--- a/dashboard/config/scripts/Ocean_Video_Machine_Learning.level
+++ b/dashboard/config/scripts/Ocean_Video_Machine_Learning.level
@@ -6,7 +6,9 @@
   "user_id": 106,
   "properties": {
     "video_key": "ocean_machine_learning",
-    "display_name": "Video: Machine Learning"
+    "display_name": "Video: Machine Learning",
+    "video_rounded_corners": true,
+    "video_full_width": true
   },
   "published": true,
   "notes": "",

--- a/dashboard/config/scripts/Ocean_Video_Societal_Implications.level
+++ b/dashboard/config/scripts/Ocean_Video_Societal_Implications.level
@@ -6,7 +6,9 @@
   "user_id": 106,
   "properties": {
     "video_key": "ocean_societal_implications",
-    "display_name": "Video: Societal Implications"
+    "display_name": "Video: Societal Implications",
+    "video_rounded_corners": true,
+    "video_full_width": true
   },
   "published": true,
   "notes": "",

--- a/dashboard/config/scripts/Ocean_Video_Training_Data.level
+++ b/dashboard/config/scripts/Ocean_Video_Training_Data.level
@@ -6,7 +6,9 @@
   "user_id": 106,
   "properties": {
     "video_key": "ocean_training_data",
-    "display_name": "Video: Training Data"
+    "display_name": "Video: Training Data",
+    "video_rounded_corners": true,
+    "video_full_width": true
   },
   "published": true,
   "notes": "",


### PR DESCRIPTION
# Description
- Introduced two new attributes to the standalone video level type (not currently exposed in levelbuilder): `video_rounded_corners` and `video_full_width`
- Added both to all video levels in the Ocean script
- `video_rounded_corners` changes the video player to have no border, but round the corners with a 10px radius (matching the current ocean levels from `ml-activities`)
- `video_full_width` does four things:
  - Hides the title above the video
  - Moves the Continue button to the bottom right of the video (matching the `ml-activities` levels)
  - Enables the "small footer" (matching the `ml-activities` levels)
  - Responsiveness: Makes the video player stretch to fill the available page width. `@media` queries are added to CSS to prevent cropping the bottom of the video when the browser height is too small (both are matching the `ml-activities` levels)

*NOTE:* The Continue button doesn't match the style in `ml-activities` at this time because `ml-activities` levels are still based off of wireframes and the design may change

<img width="883" alt="Screen Shot 2019-11-08 at 2 22 35 PM" src="https://user-images.githubusercontent.com/5429146/68514700-558b4680-0233-11ea-99bb-b8b5e110dcfc.png">


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
