### PR TITLE
omit exporter code from initial download

### DIFF
--- a/apps/src/applab/Exporter.js
+++ b/apps/src/applab/Exporter.js
@@ -23,8 +23,8 @@ import exportExpoSplashPng from '../templates/export/expo/splash.png';
 import logToCloud from '../logToCloud';
 import {getAppOptions} from '@cdo/apps/code-studio/initApp/loadApp';
 import project from '@cdo/apps/code-studio/initApp/project';
+import {EXPO_SDK_VERSION} from '../util/exporterConstants';
 import {
-  EXPO_SDK_VERSION,
   extractSoundAssets,
   createPackageFilesFromZip,
   createPackageFilesFromExpoFiles,

--- a/apps/src/code-studio/components/ExportDialog/Dialog.jsx
+++ b/apps/src/code-studio/components/ExportDialog/Dialog.jsx
@@ -4,7 +4,10 @@ import {connect} from 'react-redux';
 import BaseDialog from '../../../templates/BaseDialog';
 import AbuseError from '../AbuseError';
 import color from '../../../util/color';
-import {PLATFORM_ANDROID, DEFAULT_PLATFORM} from '../../../util/exporter';
+import {
+  PLATFORM_ANDROID,
+  DEFAULT_PLATFORM
+} from '../../../util/exporterConstants';
 import {hideExportDialog} from '../exportDialogRedux';
 import i18n from '@cdo/locale';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';

--- a/apps/src/code-studio/components/ExportDialog/GeneratingPage.jsx
+++ b/apps/src/code-studio/components/ExportDialog/GeneratingPage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import i18n from '@cdo/locale';
 import color from '../../../util/color';
-import {PLATFORM_ANDROID, PLATFORM_IOS} from '../../../util/exporter';
+import {PLATFORM_ANDROID, PLATFORM_IOS} from '../../../util/exporterConstants';
 import SendToPhone from '../SendToPhone';
 import commonStyles from './styles';
 

--- a/apps/src/code-studio/components/ExportDialog/PlatformPage.jsx
+++ b/apps/src/code-studio/components/ExportDialog/PlatformPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import color from '../../../util/color';
-import {PLATFORM_ANDROID, PLATFORM_IOS} from '../../../util/exporter';
+import {PLATFORM_ANDROID, PLATFORM_IOS} from '../../../util/exporterConstants';
 import experiments from '../../../util/experiments';
 import commonStyles from './styles';
 

--- a/apps/src/p5lab/gamelab/Exporter.js
+++ b/apps/src/p5lab/gamelab/Exporter.js
@@ -20,8 +20,8 @@ import exportExpoSplashPng from '@cdo/apps/templates/export/expo/splash.png';
 import logToCloud from '@cdo/apps/logToCloud';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {APP_WIDTH, APP_HEIGHT} from '../constants';
+import {EXPO_SDK_VERSION} from '../../util/exporterConstants';
 import {
-  EXPO_SDK_VERSION,
   extractSoundAssets,
   createPackageFilesFromZip,
   createPackageFilesFromExpoFiles,

--- a/apps/src/util/exporter.js
+++ b/apps/src/util/exporter.js
@@ -12,13 +12,9 @@ import * as assetPrefix from '../assetManagement/assetPrefix';
 import exportExpoAppJsonEjs from '../templates/export/expo/app.json.ejs';
 import exportExpoPackagedFilesEjs from '../templates/export/expo/packagedFiles.js.ejs';
 import exportExpoPackagedFilesEntryEjs from '../templates/export/expo/packagedFilesEntry.js.ejs';
+import {EXPO_SDK_VERSION, PLATFORM_ANDROID} from './exporterConstants';
 
-export const EXPO_SDK_VERSION = '34.0.0';
-export const EXPO_REACT_NATIVE_WEBVIEW_VERSION = '7.2.4';
-
-export const PLATFORM_ANDROID = 'android';
-export const PLATFORM_IOS = 'ios';
-export const DEFAULT_PLATFORM = PLATFORM_ANDROID;
+const EXPO_REACT_NATIVE_WEBVIEW_VERSION = '7.2.4';
 
 export function createPackageFilesFromZip(zip, appName) {
   const moduleList = [];

--- a/apps/src/util/exporterConstants.js
+++ b/apps/src/util/exporterConstants.js
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Constants used by applab and gamelab exporters. Keep these
+ * separate so that they can be referenced without pulling in the exporter code
+ * and its dependencies (167KB).
+ */
+
+export const EXPO_SDK_VERSION = '34.0.0';
+
+export const PLATFORM_ANDROID = 'android';
+export const PLATFORM_IOS = 'ios';
+export const DEFAULT_PLATFORM = PLATFORM_ANDROID;


### PR DESCRIPTION
# Description

This is part of an ongoing effort to reduce the amount of js served on every code studio page.

Today, several large exporter dependencies get pulled into the layouts/_header.js entry point, which is served on every code studio page load. This PR fixes that by extracting the constants needed by the ExporterDialog into a separate js file, and then importing only those constants instead of importing the entire exporter and its dependencies. This **eliminates 265KB of JS code** from every code studio page.

huge credit to @breville for spotting this as the names of some large dependencies flashed across the screen during our last engineering demos!

## before

The before shot highlights 167KB of most-easily-identifiable dependencies:

![Screen Shot 2019-11-08 at 3 30 03 PM](https://user-images.githubusercontent.com/8001765/68517496-ae131180-023c-11ea-8bfc-4e84bcd56e5a.png)

## after

... but if you look closely at the before and after, you can see that `layouts/_header.js` shrunk from 316KB to just 51KB!

![Screen Shot 2019-11-08 at 3 22 43 PM](https://user-images.githubusercontent.com/8001765/68517259-a43cde80-023b-11ea-89f4-597dc1afd306.png)

Because of the way things are set up, these dependencies are disappearing from layout/_header.js and aren't appearing anywhere new -- they are already in the `common.js` bundle, which is shared by all tutorials (applab, gamelab, artist, etc), but not other code studio pages. So, this refactoring is pure win in terms of JS size.

## Testing story

I am relying on existing test coverage of the exporter code to ensure that nothing has broken.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
