### PR TITLE
alternateMoves block

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -43,7 +43,7 @@
     "@code-dot-org/blockly": "3.5.5",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
-    "@code-dot-org/dance-party": "0.0.47",
+    "@code-dot-org/dance-party": "0.0.49",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -903,10 +903,10 @@
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@code-dot-org/craft/-/craft-0.2.2.tgz#4b117337a5a601613f2d38514aa50ba972362939"
 
-"@code-dot-org/dance-party@0.0.47":
-  version "0.0.47"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/dance-party/-/dance-party-0.0.47.tgz#e37b22a10629cb13a50a9f1dee590b1275cefd88"
-  integrity sha512-f+OECyrMJB21o+ZSL+IgTpen7TnfmTMdBrtgRKxu6NjWUFwHefFaeDCQCKIYxBv1lAxyQuAf585AQEuuIL5ssQ==
+"@code-dot-org/dance-party@0.0.49":
+  version "0.0.49"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/dance-party/-/dance-party-0.0.49.tgz#66cb62bc587294d70675682556993df9d7a7a9f1"
+  integrity sha512-VoqQcagr4LDV4E/fTdMBzcPEbolK/pQdAK7qA1x8Vp9xuqRT99avKKvWIf/FIK73skyxpS9Y6TQRjZ6F1CtNKA==
   optionalDependencies:
     canvas "^1.6.13"
 

--- a/dashboard/config/blocks/Dancelab/Dancelab_alternateMoves.json
+++ b/dashboard/config/blocks/Dancelab/Dancelab_alternateMoves.json
@@ -1,0 +1,179 @@
+{
+  "category": "Groups",
+  "config": {
+    "func": "alternateMoves",
+    "inline": false,
+    "blockText": "{GROUP} alternate every {N} measures \nbetween {MOVE1} and {MOVE2}",
+    "color": [
+      270,
+      ".7",
+      ".7"
+    ],
+    "args": [
+      {
+        "name": "GROUP",
+        "options": [
+          [
+            "all",
+            "sprites"
+          ],
+          [
+            "aliens",
+            "\"ALIEN\""
+          ],
+          [
+            "bears",
+            "\"BEAR\""
+          ],
+          [
+            "cats",
+            "\"CAT\""
+          ],
+          [
+            "dogs",
+            "\"DOG\""
+          ],
+          [
+            "ducks",
+            "\"DUCK\""
+          ],
+          [
+            "frogs",
+            "\"FROG\""
+          ],
+          [
+            "moose",
+            "\"MOOSE\""
+          ],
+          [
+            "pineapples",
+            "\"PINEAPPLE\""
+          ],
+          [
+            "robots",
+            "\"ROBOT\""
+          ],
+          [
+            "sharks",
+            "\"SHARK\""
+          ],
+          [
+            "unicorns",
+            "\"UNICORN\""
+          ]
+        ]
+      },
+      {
+        "name": "N",
+        "type": "ClampedNumber(0.1,)",
+        "field": true
+      },
+      {
+        "name": "MOVE1",
+        "options": [
+          [
+            "Body Roll",
+            "MOVES.Roll"
+          ],
+          [
+            "Clap High",
+            "MOVES.ClapHigh"
+          ],
+          [
+            "Dab",
+            "MOVES.Dab"
+          ],
+          [
+            "Double Down",
+            "MOVES.DoubleJam"
+          ],
+          [
+            "Drop",
+            "MOVES.Drop"
+          ],
+          [
+            "Floss",
+            "MOVES.Floss"
+          ],
+          [
+            "Fresh",
+            "MOVES.Fresh"
+          ],
+          [
+            "Gangnam",
+            "MOVES.Clown"
+          ],
+          [
+            "Star",
+            "MOVES.Kick"
+          ],
+          [
+            "This or That",
+            "MOVES.ThisOrThat"
+          ],
+          [
+            "Zombie",
+            "MOVES.Thriller"
+          ],
+          [
+            "None",
+            "MOVES.Rest"
+          ]
+        ]
+      },
+      {
+        "name": "MOVE2",
+        "options": [
+          [
+            "Body Roll",
+            "MOVES.Roll"
+          ],
+          [
+            "Clap High",
+            "MOVES.ClapHigh"
+          ],
+          [
+            "Dab",
+            "MOVES.Dab"
+          ],
+          [
+            "Double Down",
+            "MOVES.DoubleJam"
+          ],
+          [
+            "Drop",
+            "MOVES.Drop"
+          ],
+          [
+            "Floss",
+            "MOVES.Floss"
+          ],
+          [
+            "Fresh",
+            "MOVES.Fresh"
+          ],
+          [
+            "Gangnam",
+            "MOVES.Clown"
+          ],
+          [
+            "Star",
+            "MOVES.Kick"
+          ],
+          [
+            "This or That",
+            "MOVES.ThisOrThat"
+          ],
+          [
+            "Zombie",
+            "MOVES.Thriller"
+          ],
+          [
+            "None",
+            "MOVES.Rest"
+          ]
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Description
Relies on https://github.com/code-dot-org/dance-party/pull/590
Adds the new block:
![image](https://user-images.githubusercontent.com/8787187/68519972-40b9ad80-0249-11ea-820c-c3732e366005.png)

A couple notes:
- The block does not have the arrow dropdowns. `move1` is implemented as Left and `move2` is Right.
- Random, Next, and Previous are not in the dropdown.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
