### PR TITLE
Promote: update link to report

### DIFF
--- a/pegasus/sites.v3/code.org/views/interactive_map.haml
+++ b/pegasus/sites.v3/code.org/views/interactive_map.haml
@@ -40,7 +40,7 @@
     Computer science students graduated into the workforce last year
 
     .summary-button
-      %a{href: 'https://docs.google.com/document/d/1J3TbEQt3SmIWuha7ooBPvlWpiK-pNVIV5uuQEzNzdkE/edit?usp=sharing', target: '_blank'}
+      %a{href: 'https://docs.google.com/document/d/e/2PACX-1vTIZJaNtmPRBNb7_ZFHBxsGwyZqBSdpJN0iJ_pOgF-K-MNYikEeKTTj49ezDkMFRb1C_1w45gSrkcq6/pub', target: '_blank'}
         %button
           See a summary of state efforts
 


### PR DESCRIPTION
This updates a link at https://code.org/promote to point at the 2019 report.

Related to https://github.com/code-dot-org/code-dot-org/pull/30600 and https://github.com/code-dot-org/code-dot-org/pull/31590.
