### PR TITLE
Remove broken "smaller posters" from hourofcode.com

### DIFF
--- a/i18n/locales/source/hourofcode/promote/resources.md
+++ b/i18n/locales/source/hourofcode/promote/resources.md
@@ -21,7 +21,6 @@ A new poster set is available featuring Malala, Stephen Curry, Shakira and more!
 
 {{ promote_new_posters }}
 
-* Want to download smaller versions of these posters? <a href="https://www.dropbox.com/sh/8dqt7p9ioc4hnmu/AABQfTWLTPVh2Kgy32PSvLU3a?dl=0" target="_blank">Download them here</a>.
 * Looking for our posters from previous years? [Find them here]({{ promote/previous_posters_url }})!
 
 

--- a/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
@@ -23,7 +23,6 @@ A new poster set is available featuring Malala, Stephen Curry, Shakira and more!
 
 {{ promote_new_posters }}
 
-* Want to download smaller versions of these posters? <a href="https://www.dropbox.com/sh/8dqt7p9ioc4hnmu/AABQfTWLTPVh2Kgy32PSvLU3a?dl=0" target="_blank">Download them here</a>.
 * Looking for our posters from previous years? [Find them here]({{ promote/previous_posters_url }})!
 
 


### PR DESCRIPTION
Removes a broken link from hourofcode.com/us/promote/resources#posters and the corresponding text, which reads:

> Want to download smaller versions of these posters? [Download them here][0].

This was [pointed out in Slack](https://codedotorg.slack.com/archives/C06E60KL4/p1573490670134900) again today, even though I thought I did this a couple of weeks ago. It'd be nice to fix this link but we have no idea where this share went, so we'll do that as a follow-up after we remove the broken link.

[0]: https://www.dropbox.com/sh/8dqt7p9ioc4hnmu/AABQfTWLTPVh2Kgy32PSvLU3a?dl=0


## Testing story

Manually tested on local machine. This is a content change and shouldn't require further automated testing.  There doesn't seem to be an eyes test over this page.

![image](https://user-images.githubusercontent.com/1615761/68609991-8f469200-046b-11ea-9876-db48def641c1.png)

Note: We recently fixed the [broken link checker](https://github.com/code-dot-org/code-dot-org/blob/staging/tools/scripts/brokenLinkChecker/brokenLinkChecker.js) which should help catch things like this faster in the future.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
