### PR TITLE
Ensure Level uses script-cache for relevant queries

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -376,6 +376,23 @@ class Level < ActiveRecord::Base
     update_attribute(:ideal_level_source_id, ideal_level_source.id) if ideal_level_source
   end
 
+  # Ensure Level uses script-cache for relevant queries.
+  def self.find(id)
+    find_by(id: id)
+  end
+
+  # Ensure Level uses script-cache for relevant queries.
+  def self.find_by(opts)
+    other = opts.dup
+    id = other.delete(:id)&.to_i
+    name = other.delete(:name)
+    if (id || name) && other.empty?
+      Script.cache_find_level(id || name)
+    else
+      super(opts)
+    end
+  end
+
   def self.find_by_key(key)
     # this is the key used in the script files, as a way to uniquely
     # identify a level that can be defined by the .level file or in a

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -405,7 +405,7 @@ class Script < ActiveRecord::Base
     # the db. Note the field trickery is to allow passing an ID as a string,
     # which some tests rely on (unsure about non-tests).
     field = level_identifier.to_i.to_s == level_identifier.to_s ? :id : :name
-    level = Level.find_by!(field => level_identifier)
+    level = Level.where(field => level_identifier).take!
     # Cache the level by ID and by name, unless it wasn't found.
     @@level_cache[level.id] = level if level && should_cache?
     @@level_cache[level.name] = level if level && should_cache?

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -89,4 +89,17 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
   end
+
+  test 'get_rubric' do
+    script = Script.hoc_2014_script
+    stage = script.stages.first
+    level = stage.script_levels.first.levels.first
+
+    assert_cached_queries(0) do
+      get get_rubric_level_path(
+        id: level.id
+      )
+      assert_response :success
+    end
+  end
 end


### PR DESCRIPTION
This PR overloads `Level#find` and `Level#find_by` to return the script-cached objects instead of querying the database for each Level find.

Adds a `get_rubric` DB query test to prevent regressions on this new high-traffic route.