### PR TITLE
Download link for external videos & style tweaks 

### DIFF
--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -31,8 +31,12 @@
 
 - if video && use_large_video_player
   .clear
-  .video-container.external-video-container
-  %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
+  .video-container.external-video-container{{style: 'max-width: 970px; margin: auto'}}
+  .button-box{{style: 'width: 970px; margin: auto'}}
+    %a.btn.btn-large.btn-primary.next-stage.submitButton.pull-right= t('continue')
+    - if video.download
+      %a.video-download.btn.btn-large.pull-left{href: video.download}
+        = t('video.download')
 
 .clear
 

--- a/dashboard/test/ui/features/level_navigation.feature
+++ b/dashboard/test/ui/features/level_navigation.feature
@@ -2,6 +2,7 @@ Feature: Continue button on levels
 
 Scenario: External Video Level
   Given I am on "http://studio.code.org/s/coursec-2019/stage/14/puzzle/1"
+  And I wait to see ".video-download"
   And I wait to see ".submitButton"
   Then I click ".submitButton" to load a new page
   Then I wait until I am on "http://studio.code.org/s/coursec-2019/stage/15/puzzle/1"


### PR DESCRIPTION
External video levels were a little mis-aligned [LP-775](https://codedotorg.atlassian.net/browse/LP-775) and they didn't have a download video button  [LP-774](https://codedotorg.atlassian.net/browse/LP-774). So I added in the button, aligned elements on the page and per request from @fontie715 styled the "Download" button to be more consistent with the "Continue" button.  I also added a little test update to ensure the "Download" button appears. 

BEFORE: 
<img width="1201" alt="Screen Shot 2019-11-11 at 5 05 58 PM" src="https://user-images.githubusercontent.com/12300669/68634314-dfdce000-04a9-11ea-81f0-d0405a219108.png">


AFTER: 
<img width="1109" alt="Screen Shot 2019-11-11 at 5 29 00 PM" src="https://user-images.githubusercontent.com/12300669/68634308-d6537800-04a9-11ea-8b07-da4e1c419ff8.png">
