### PR TITLE
hoc2019: fix links on /minecraft

### DIFF
--- a/pegasus/sites.v3/code.org/views/minecraft_2019.haml
+++ b/pegasus/sites.v3/code.org/views/minecraft_2019.haml
@@ -4,18 +4,22 @@
   aquatic_image = '/images/mc/mc_aquatic_square_2019.jpg'
   aquatic_title = I18n.t(:hoc2018_mc_aquatic_title)
   aquatic_description = I18n.t(:hoc2019_mc_aquatic_description)
+  aquatic_link = CDO.studio_url('/s/aquatic/reset')
 
   hero_image = '/images/mc/mc_landing_2017_square.jpg'
   hero_title = I18n.t(:minecraft_agent)
   hero_description = I18n.t(:hoc2018_mc_journey)
+  hero_link = CDO.studio_url('/s/hero/reset')
 
   adventurer_image = '/images/mc/mc_adventurer_wide_2019.png'
   adventurer_title = I18n.t(:minecraft_adventurer)
   adventurer_description = I18n.t(:minecraft_adventurer_description)
+  adventurer_link = CDO.studio_url('/s/mc/reset')
 
   designer_image = '/images/mc/mc_designer_wide_2019.jpg'
   designer_title = I18n.t(:minecraft_designer)
   designer_description = I18n.t(:minecraft_designer_description)
+  designer_link = CDO.studio_url('/s/minecraft/reset')
 
 %h1.responsive-padding= I18n.t(:minecraft_tutorials)
 %p.responsive-padding= I18n.t(:minecraft_specs)
@@ -30,7 +34,7 @@
         .mc-tutorial-details
           %h2.mc-h1-second-box= aquatic_title
           %p.mc-tutorial-description= aquatic_description
-          %a{href: CDO.studio_url('/s/mc/reset')}
+          %a{href: aquatic_link}
             %button.primary.padded-button= I18n.t(:minecraft_adventurer_button)
     .tutorial-box{style: "margin-right: 14px;"}
       .img-container
@@ -39,7 +43,7 @@
         .mc-tutorial-details
           %h2.mc-h1-second-box= hero_title
           %p.mc-tutorial-description= hero_description
-          %a{href: CDO.studio_url('/s/minecraft/reset'), target: '_blank'}
+          %a{href: hero_link, target: '_blank'}
             %button.primary= I18n.t(:minecraft_designer_button)
 
     .tutorial-box{style: "height: 150px; overflow: hidden; margin-bottom: 14px"}
@@ -48,7 +52,7 @@
       .mc-tutorial-info
         .mc-tutorial-details
           %h2.mc-h1-second-box= adventurer_title
-          %a{href: CDO.studio_url('/s/hero/reset'), target: '_blank'}
+          %a{href: adventurer_link, target: '_blank'}
             %button.primary= I18n.t(:minecraft_agent_button)
 
     .tutorial-box{style: "height: 150px; overflow: hidden"}
@@ -57,7 +61,7 @@
       .mc-tutorial-info
         .mc-tutorial-details
           %h2.mc-h1-second-box= designer_title
-          %a{href: CDO.studio_url('/s/hero/reset'), target: '_blank'}
+          %a{href: designer_link, target: '_blank'}
             %button= I18n.t(:minecraft_agent_button)
 
 .clear


### PR DESCRIPTION
The links got mixed up in the shuffle; now fixed.  Followup to https://github.com/code-dot-org/code-dot-org/pull/31586
