### PR TITLE
Migrating 'html_safe' strings to use the markdown version instead

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1580,6 +1580,10 @@ a.download-video {
     width: 800px;
   }
 
+  .finish-signup #instructions p {
+    display: inline;
+  }
+
   .signup, .finish-signup {
     $school-info-background: #f7f7f7;
     $school-info-border-color: #e5e5e5;
@@ -1693,7 +1697,7 @@ a.download-video {
 
   // OLD SIGN-UP FORM
   .signupform {
-    padding: 20px;
+    padding: 20px 0;
     margin-bottom: 0;
   }
   .itemblock {
@@ -1703,14 +1707,10 @@ a.download-video {
       margin-top: -4px;
       margin-right: 4px;
     }
-
-    label {
-      display: inline-block;
-    }
   }
   .labelblock {
     display: table-cell;
-    width: 140px;
+    width: 180px;
     vertical-align: middle;
   }
   .labelblock-wide {
@@ -1730,7 +1730,24 @@ a.download-video {
     margin-bottom: 5px;
     margin-top: 5px;
   }
-  .terms-checkbox, .race-checkbox {
+
+  label.terms {
+    font-size: inherit;
+    line-height: inherit;
+  }
+  .terms-text {
+    overflow: hidden;
+  }
+  .terms-text p {
+    display: inline;
+    margin: 0;
+  }
+  .terms-checkbox {
+    margin: 0 5px 0 0;
+    float: left;
+  }
+
+  .race-checkbox {
     margin: 0 5px 2px 0;
   }
   .right {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1731,6 +1731,7 @@ a.download-video {
     margin-top: 5px;
   }
 
+  /* FND-893 - Stop using markdown in <Label>s*/
   label.terms {
     font-size: inherit;
     line-height: inherit;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1579,7 +1579,7 @@ a.download-video {
   .finish-signup {
     width: 800px;
   }
-
+  /* FND-893 - Stop using markdown in <Label>s*/
   .finish-signup #instructions p {
     display: inline;
   }

--- a/dashboard/app/assets/stylesheets/interstitial.scss
+++ b/dashboard/app/assets/stylesheets/interstitial.scss
@@ -48,7 +48,21 @@
   overflow: auto;
   overflow-y: scroll;
 }
-#terms-modal .terms-checkbox,
+#terms-modal label.terms {
+  font-size: inherit;
+  line-height: inherit;
+}
+#terms-modal .terms-text {
+  overflow: hidden;
+}
+#terms-modal .terms-text p {
+  display: inline;
+  margin: 0;
+}
+#terms-modal .terms-checkbox {
+  margin: 0 5px 0 0;
+  float: left;
+}
 #race-modal .race-checkbox {
   margin: 0 5px 0 0;
 }

--- a/dashboard/app/assets/stylesheets/interstitial.scss
+++ b/dashboard/app/assets/stylesheets/interstitial.scss
@@ -55,6 +55,7 @@
 #terms-modal .terms-text {
   overflow: hidden;
 }
+/* FND-893 - Stop using markdown in <Label>s*/
 #terms-modal .terms-text p {
   display: inline;
   margin: 0;

--- a/dashboard/app/views/api/accept_terms_reminder.haml
+++ b/dashboard/app/views/api/accept_terms_reminder.haml
@@ -1,5 +1,5 @@
 .accept-terms-reminder
-  = t('terms_interstitial.reminder_desc', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy')).html_safe
+  = t('terms_interstitial.reminder_desc_markdown', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
   %br
   %br
   %button#review-terms.primary= t('terms_interstitial.review_terms')

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -10,18 +10,18 @@
   %h1= @page_title
 
   = form_for(@user, url: registration_path(@user), html: {class: "finish-signup"}) do |f|
-    %p
+    %div#instructions
       - if @user.provider.present?
         - provider = t("auth.#{@user.provider}")
-        = t('activerecord.attributes.user.finish_sign_up_subheader_provider', provider: provider, email: @user.email).html_safe
+        = t('activerecord.attributes.user.finish_sign_up_subheader_provider_markdown', provider: provider, email: @user.email, markdown: true).html_safe
       - else
-        = t('activerecord.attributes.user.finish_sign_up_subheader', email: @user.email).html_safe
-      %span= link_to 'Cancel', users_cancel_path
+        = t('activerecord.attributes.user.finish_sign_up_subheader_markdown', email: @user.email, markdown: true).html_safe
+      %p= link_to 'Cancel', users_cancel_path
+    %br/
 
     = f.hidden_field :locale, value: locale
     = f.hidden_field :email
     = f.hidden_field :encrypted_password
-
     .field-row
       .field
         = f.label :user_type, t('signup_form.user_type_label')
@@ -34,7 +34,7 @@
         #teacher-name-label{style: "display: none;"}
           = f.label :name, t('activerecord.attributes.user.name').html_safe
         #student-name-label{style: "display: none;"}
-          = f.label :name, t('activerecord.attributes.user.name_example').html_safe
+          = f.label :name, t('activerecord.attributes.user.name_example')
         = f.text_field :name, maxlength: 255
       - if @user.errors[:name].present?
         %span.error.padded= @user.errors[:name].join(', ')
@@ -65,13 +65,14 @@
           = ff.hidden_field :full_address
 
     .checkbox
-      = f.label :terms_of_service_version do
+      = f.label :terms_of_service_version, {class: 'terms'} do
         = f.check_box :terms_of_service_version, {style: "margin-right: 1em"}, User::TERMS_OF_SERVICE_VERSIONS.last
-        = t('terms_interstitial.accept_label', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy')).html_safe
-        %span#student-consent{style: "display: none;"}
-          = t('signup_form.student_consent')
-        - if @user.errors[:terms_of_service_version].present?
-          %span.error= t('signup_form.accept_terms')
+        %div.terms-text
+          = t('terms_interstitial.accept_label_markdown', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
+          %p#student-consent{style: "display: none;"}
+            = t('signup_form.student_consent')
+          - if @user.errors[:terms_of_service_version].present?
+            %span.error= t('signup_form.accept_terms')
 
     -# If GDPR applies, show an additional checkbox.
     - if request.gdpr? || request.params['force_in_eu']

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -10,6 +10,7 @@
   %h1= @page_title
 
   = form_for(@user, url: registration_path(@user), html: {class: "finish-signup"}) do |f|
+    -# FND-893 - Stop using markdown in <Label>s
     %div#instructions
       - if @user.provider.present?
         - provider = t("auth.#{@user.provider}")
@@ -64,6 +65,7 @@
           = ff.hidden_field :country
           = ff.hidden_field :full_address
 
+    -# FND-893 - Stop using markdown in <Label>s
     .checkbox
       = f.label :terms_of_service_version, {class: 'terms'} do
         = f.check_box :terms_of_service_version, {style: "margin-right: 1em"}, User::TERMS_OF_SERVICE_VERSIONS.last

--- a/dashboard/app/views/devise/registrations/_new_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_new_sign_up_form.html.haml
@@ -1,3 +1,4 @@
+%br/
 .row
   .span5{style: "display: flex;"}
     = render "devise/shared/oauth_links"

--- a/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
@@ -113,6 +113,7 @@
           %h1.custom-h1= t('terms_interstitial.privacy_notice')
           = render partial: 'home/privacy_notice'
 
+      -# FND-893 - Stop using markdown in <Label>s
       -# Show terms of service for both student and teacher
       %br
       #terms_of_service_version-block.itemblock

--- a/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
@@ -18,7 +18,7 @@
   .span7.signupblock
     = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: 'signupform'}) do |f|
       #user_type-block.itemblock
-        .labelblock= t('signup_form.user_type_label')
+        = f.label :user_type, t('signup_form.user_type_label'), {class: "labelblock"}
         %select#user_user_type.fieldblock{name: "user[user_type]", type: "select"}
           %option{value: "", selected: true, disabled: true}
           %option{value: User::TYPE_STUDENT}= t('signup_form.user_type_student')
@@ -31,7 +31,7 @@
       = f.hidden_field :hashed_email
 
       #email-block.itemblock
-        .labelblock
+        = f.label :email, {class: "labelblock"} do
           = t('activerecord.attributes.user.email')
           %span.student-options
             *
@@ -40,25 +40,25 @@
 
       - if f.object.password_required?
         #password-block.itemblock
-          .labelblock= t('activerecord.attributes.user.password')
+          = f.label :password, t('activerecord.attributes.user.password'), {class: "labelblock"}
           = f.password_field :password, class: 'input-xlarge fieldblock', maxlength: 255
           .error_in_field
 
         #password_confirmation-block.itemblock
-          .labelblock= t('activerecord.attributes.user.password_confirmation')
+          = f.label :password_confirmation, t('activerecord.attributes.user.password_confirmation'), {class: "labelblock"}
           = f.password_field :password_confirmation, class: 'input-xlarge fieldblock', maxlength: 255
           .error_in_field
 
       #name-block.itemblock
-        #name-student.labelblock!= t('activerecord.attributes.user.name_example')
-        #name-teacher.labelblock{style: "display: none"}= t('activerecord.attributes.user.name')
+        = f.label :name, t('activerecord.attributes.user.name_example'), {id: "name-student", class: "labelblock"}
+        = f.label :name, t('activerecord.attributes.user.name'), {id: "name-teacher", class: "labelblock", style: "display: none;"}
         = f.text_field :name, class: 'input-xlarge fieldblock', maxlength: 255
         .error_in_field
 
       #schooldropdown-block.itemblock{style: "display: none;"}
 
       #age-block.itemblock
-        .labelblock= t('signup_form.age')
+        = f.label :user_age, t('signup_form.age'), {class: "labelblock"}
         %select#user_user_age.fieldblock{name: "user[age]", type: "select"}
           %option{value: "", selected: true, disabled: true}
           - User::AGE_DROPDOWN_OPTIONS.each do |age_option|
@@ -66,7 +66,7 @@
         .error_in_field
 
       #gender-block.itemblock
-        .labelblock= t('signup_form.gender')
+        = f.label :gender, t('signup_form.gender'), {class: "labelblock"}
         = f.select :gender, gender_options, {disabled: '', selected: ''}, {class: 'fieldblock'}
         .error_in_field
 
@@ -117,16 +117,17 @@
       %br
       #terms_of_service_version-block.itemblock
         .error_in_field.checkbox-error
-        %br
-        = f.label :terms_of_service_version do
+        = f.label :terms_of_service_version, {class: 'terms'} do
           = f.check_box :terms_of_service_version, {class: 'terms-checkbox'}, User::TERMS_OF_SERVICE_VERSIONS.last
           -# Teacher text.
-          %span.teacher-options{style: 'display: none'}
-            = t('terms_interstitial.accept_label', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy')).html_safe
-          -# Student text.
-          %span.student-options
-            = t('terms_interstitial.accept_label', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy')).html_safe
-            != t('signup_form.under_13_consent')
+          %div.terms-text
+            %div.teacher-options{style: 'display: none'}
+              = t('terms_interstitial.accept_label_markdown', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
+            -# Student text.
+            %div.student-options
+              = t('terms_interstitial.accept_label_markdown', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
+              %p
+                = t('signup_form.under_13_consent')
 
       -# If GDPR applies, show an additional checkbox.
       #data_transfer_agreement_accepted-block.itemblock

--- a/dashboard/app/views/devise/registrations/_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_sign_up.html.haml
@@ -5,9 +5,9 @@
     .span9
       %h1= t('signup_form.title')
       - if @already_hoc_registered
-        %p= t('signup_form.hoc_already_signed_up_content_post_hoc', studio_url: CDO.studio_url('/')).html_safe
+        %p= t('signup_form.hoc_already_signed_up_content_post_hoc_markdown', studio_url: CDO.studio_url('/'), markdown: true).html_safe
       - else
-        %p= t('signup_form.overview').html_safe
+        %p= t('signup_form.overview_markdown', markdown: true).html_safe
         = t('auth.already_signedup')
         = link_to t('nav.user.signin'), new_session_path(resource_name)
 

--- a/dashboard/app/views/devise/registrations/_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_sign_up.html.haml
@@ -3,11 +3,12 @@
 #signup
   .row
     .span9
+      -# FND-893 - Stop using markdown inside headers
       %h1= t('signup_form.title')
       - if @already_hoc_registered
-        %p= t('signup_form.hoc_already_signed_up_content_post_hoc_markdown', studio_url: CDO.studio_url('/'), markdown: true).html_safe
+        = t('signup_form.hoc_already_signed_up_content_post_hoc_markdown', studio_url: CDO.studio_url('/'), markdown: true).html_safe
       - else
-        %p= t('signup_form.overview_markdown', markdown: true).html_safe
+        = t('signup_form.overview_markdown', markdown: true).html_safe
         = t('auth.already_signedup')
         = link_to t('nav.user.signin'), new_session_path(resource_name)
 

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -119,6 +119,7 @@
         = form.text_field :username, maxlength: 255
     - else
       .field
+        -# FND-893 - Stop using markdown in <Label>s
         = form.label :personal_email, class: "label-bold" do
           = t('activerecord.attributes.user.personal_email_markdown', url: CDO.studio_url('users/edit/?noEmail=true'), markdown: true).html_safe
         = form.email_field :email, placeholder: '', autocomplete: 'off', maxlength: 255
@@ -138,9 +139,9 @@
       .field
         = form.label t('user.create_personal_login_under_13_parent_email'), class: "label-bold"
         = form.text_field :parent_email, maxlength: 255
-    %p= t('user.create_personal_login_terms_markdown', terms_of_service_url: CDO.code_org_url('/tos'), markdown: true).html_safe
+    = t('user.create_personal_login_terms_markdown', terms_of_service_url: CDO.code_org_url('/tos'), markdown: true).html_safe
     - unless no_email
-      %p= t('user.create_personal_login_email_note_markdown', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
+      = t('user.create_personal_login_email_note_markdown', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
     %div= form.submit t('crud.submit'), id: 'create-personal-login', class: 'btn btn-warning'
 
 -# Separately-submittable form section allowing the user to edit their own

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -120,7 +120,7 @@
     - else
       .field
         = form.label :personal_email, class: "label-bold" do
-          = t('activerecord.attributes.user.personal_email', url: CDO.studio_url('users/edit/?noEmail=true')).html_safe
+          = t('activerecord.attributes.user.personal_email_markdown', url: CDO.studio_url('users/edit/?noEmail=true'), markdown: true).html_safe
         = form.email_field :email, placeholder: '', autocomplete: 'off', maxlength: 255
     .field
       = form.label :password, maxlength: 255, class: "label-bold"
@@ -138,9 +138,9 @@
       .field
         = form.label t('user.create_personal_login_under_13_parent_email'), class: "label-bold"
         = form.text_field :parent_email, maxlength: 255
-    %p= t('user.create_personal_login_terms', terms_of_service_url: CDO.code_org_url('/tos')).html_safe
+    %p= t('user.create_personal_login_terms_markdown', terms_of_service_url: CDO.code_org_url('/tos'), markdown: true).html_safe
     - unless no_email
-      %p= t('user.create_personal_login_email_note', privacy_policy_url: CDO.code_org_url('/privacy')).html_safe
+      %p= t('user.create_personal_login_email_note_markdown', privacy_policy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
     %div= form.submit t('crud.submit'), id: 'create-personal-login', class: 'btn btn-warning'
 
 -# Separately-submittable form section allowing the user to edit their own

--- a/dashboard/app/views/layouts/_terms_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_terms_interstitial.html.haml
@@ -24,6 +24,7 @@
         = render partial: 'home/privacy_notice'
 
       %br
+      / FND-893 - Stop using markdown in <Label>s
       .left
         = form_for(current_user, url: registration_url('user'), html: {id: 'edit_user'}) do |f|
           .form-group

--- a/dashboard/app/views/layouts/_terms_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_terms_interstitial.html.haml
@@ -10,7 +10,7 @@
           = t('terms_interstitial.print')
       .clear
       .scroll-box
-        = t('terms_interstitial.intro_desc').html_safe
+        = t('terms_interstitial.intro_desc_markdown', markdown: true).html_safe
         %br
         %br
         = t('terms_interstitial.intro_instructions')
@@ -27,9 +27,10 @@
       .left
         = form_for(current_user, url: registration_url('user'), html: {id: 'edit_user'}) do |f|
           .form-group
-            = f.label :terms_of_service_version do
+            = f.label :terms_of_service_version, {class: 'terms'} do
               = f.check_box :terms_of_service_version, {class: 'terms-checkbox'}, current_user.latest_terms_version
-              = t('terms_interstitial.accept_label', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy')).html_safe
+              %div.terms-text
+                = t('terms_interstitial.accept_label_markdown', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
           .form-group
             = f.submit t('terms_interstitial.accept'), id: 'accept-terms-submit', class: 'btn primary-button disabled-button', disabled: true
           = tag(:input, :type => "hidden", :name => request_forgery_protection_token.to_s, :value => form_authenticity_token)

--- a/dashboard/app/views/zendesk_session/index.html.haml
+++ b/dashboard/app/views/zendesk_session/index.html.haml
@@ -1,1 +1,1 @@
-%p!= t('zendesk_too_young_message_markdown', markdown: true)
+= t('zendesk_too_young_message_markdown', markdown: true)

--- a/dashboard/app/views/zendesk_session/index.html.haml
+++ b/dashboard/app/views/zendesk_session/index.html.haml
@@ -1,1 +1,1 @@
-%p!= t('zendesk_too_young_message')
+%p!= t('zendesk_too_young_message_markdown', markdown: true)

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -64,8 +64,17 @@ module Cdo
       def translate(locale, key, options = ::I18n::EMPTY_HASH)
         translation = super(locale, key, options)
         if options.fetch(:markdown, false)
-          # The safe_links_only just makes sure that the URL is a "safe" web one which starts with: "#", "/", "http://", "https://", "ftp://", "mailto:"
-          # However, it isn't good enough because it ignores URLS which are just '/' or start with '//'.
+          # The safe_links_only just makes sure that the URL is a "safe" web
+          # one which starts with: "#", "/", "http://", "https://", "ftp://",
+          # "mailto:" However, it isn't good enough because it ignores URLS
+          # which are just '/' or start with '//'.  Although I couldn't find
+          # documentation about what "safe" means, I think its meant to limit
+          # URLs to using known safe ones because the future is unknown.
+          # Imagine someone on Crowdin changing the URL to be
+          # "bitcoin://send.coin/to/evil-account". It's hard to predict what
+          # future URLs will be like, so its easier to just filter for the
+          # currently known ones. The actual "safe" think we should be doing is
+          # redacting all URLs in strings given to outside translators.
           @renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::Safe.new(safe_links_only: false))
           @renderer.render(translation)
         else

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -64,7 +64,9 @@ module Cdo
       def translate(locale, key, options = ::I18n::EMPTY_HASH)
         translation = super(locale, key, options)
         if options.fetch(:markdown, false)
-          @renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::Safe)
+          # The safe_links_only just makes sure that the URL is a "safe" web one which starts with: "#", "/", "http://", "https://", "ftp://", "mailto:"
+          # However, it isn't good enough because it ignores URLS which are just '/' or start with '//'.
+          @renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::Safe.new(safe_links_only: false))
           @renderer.render(translation)
         else
           translation


### PR DESCRIPTION
# Description
We had translated strings which had raw HTML in them. We have created a "_markdown" version of these strings and this PR is where we use them. All the updates are around the sign-in screens or instances where we accept the TOS. There are also some styling changes in order to make things more consistent between the sign in pages.
* Changed markdown renderer options so that `/` and `//` URLs can be rendered correctly.
* Used new translated "_markdown" strings on the old/new sign-in pages and the homepage TOS pop-up.
* Updated the "old" sign-in page to use `<label>`s so that it was similar to the "new" sign-in page and also to improve accessibility.
* Tweaked spacing slightly to make things more even and consistent.

## Screenshots
### _old_sign_up_form
![_old_sign_up_form](https://user-images.githubusercontent.com/1372238/68812287-896acf80-066a-11ea-8fa6-55ef796439d8.png)
### _new_sign_up_form
![_new_sign_up_form](https://user-images.githubusercontent.com/1372238/68721697-236b4300-05ab-11ea-92ec-ffff37dfa6e4.png)
### _finish_sign_up
Note* you can ignore the "****". It renders that way because I did a hack to render this page and I forgot to fill in the user e-mail before taking a screenshot. I have tested that it correctly displays the e-mail.
![_finish_sign_up](https://user-images.githubusercontent.com/1372238/68812306-94bdfb00-066a-11ea-89b9-54a5824a40b4.png)
### accept_terms_reminder
![accept_terms_reminder](https://user-images.githubusercontent.com/1372238/68721701-282ff700-05ab-11ea-8305-fdb66cea622f.png)

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-818)

## Testing story
* `./bin/dashboard-server`
  Manually tested using (Linux) X (Chrome, Firefox)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
