### PR TITLE
Lesson Extras Banner Showing When Not Appropriate

### DIFF
--- a/apps/src/code-studio/components/stageExtras/StageExtras.jsx
+++ b/apps/src/code-studio/components/stageExtras/StageExtras.jsx
@@ -46,7 +46,7 @@ export default class StageExtras extends React.Component {
 
     return (
       <div>
-        {showStageExtrasWarning && <StageExtrasNotification />}
+        {showStageExtrasWarning && sectionId && <StageExtrasNotification />}
 
         <h1>{msg.extrasStageNumberCompleted({number: stageNumber})}</h1>
 

--- a/apps/test/unit/code-studio/components/StageExtrasTest.jsx
+++ b/apps/test/unit/code-studio/components/StageExtrasTest.jsx
@@ -17,21 +17,21 @@ const DEFAULT_PROPS = {
 };
 
 describe('StageExtras', () => {
-  it('does not show stage extras warning if showStageExtrasWarning is false ', () => {
+  it('does not show stage extras warning if showStageExtrasWarning is false', () => {
     const wrapper = shallow(
       <StageExtras {...DEFAULT_PROPS} showStageExtrasWarning={false} />
     );
     expect(wrapper.find('StageExtrasNotification')).to.have.lengthOf(0);
   });
 
-  it('does not show stage extras warning if sectionId is not provided ', () => {
+  it('does not show stage extras warning if sectionId is not provided', () => {
     const wrapper = shallow(
       <StageExtras {...DEFAULT_PROPS} sectionId={null} />
     );
     expect(wrapper.find('StageExtrasNotification')).to.have.lengthOf(0);
   });
 
-  it('show stage extra warning if showStageExtrasWarning and have sectionId ', () => {
+  it('show stage extra warning if showStageExtrasWarning and have sectionId', () => {
     const wrapper = shallow(<StageExtras {...DEFAULT_PROPS} />);
     expect(wrapper.find('StageExtrasNotification')).to.have.lengthOf(1);
   });

--- a/apps/test/unit/code-studio/components/StageExtrasTest.jsx
+++ b/apps/test/unit/code-studio/components/StageExtrasTest.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import StageExtras from '@cdo/apps/code-studio/components/stageExtras/StageExtras';
+import {bonusLevels} from './stageExtraTestHelpers';
+
+const DEFAULT_PROPS = {
+  stageNumber: 1,
+  nextStageNumber: 2,
+  nextLevelPath: '',
+  showProjectWidget: true,
+  projectTypes: [],
+  bonusLevels: bonusLevels,
+  sectionId: 3,
+  userId: 5,
+  showStageExtrasWarning: true
+};
+
+describe('StageExtras', () => {
+  it('does not show stage extras warning if showStageExtrasWarning is false ', () => {
+    const wrapper = shallow(
+      <StageExtras {...DEFAULT_PROPS} showStageExtrasWarning={false} />
+    );
+    expect(wrapper.find('StageExtrasNotification')).to.have.lengthOf(0);
+  });
+
+  it('does not show stage extras warning if sectionId is not provided ', () => {
+    const wrapper = shallow(
+      <StageExtras {...DEFAULT_PROPS} sectionId={null} />
+    );
+    expect(wrapper.find('StageExtrasNotification')).to.have.lengthOf(0);
+  });
+
+  it('show stage extra warning if showStageExtrasWarning and have sectionId ', () => {
+    const wrapper = shallow(<StageExtras {...DEFAULT_PROPS} />);
+    expect(wrapper.find('StageExtrasNotification')).to.have.lengthOf(1);
+  });
+});

--- a/apps/test/unit/code-studio/components/stageExtraTestHelpers.js
+++ b/apps/test/unit/code-studio/components/stageExtraTestHelpers.js
@@ -1,0 +1,109 @@
+export const bonusLevels = [
+  {
+    stageNumber: 1,
+    levels: [
+      {
+        id: 23222,
+        levelId: 5,
+        name: 'courseB_maze_seq_challenge1',
+        type: 'Maze',
+        map: [
+          [0, 0, 0, 0, 0, 0, 0, 0],
+          [0, 0, 1, 1, 1, 1, 2, 0],
+          [0, 0, 1, 1, 1, 1, 1, 0],
+          [0, 0, 1, 1, 1, 1, 1, 0],
+          [0, 0, 1, 4, 4, 1, 1, 0],
+          [0, 0, 1, 1, 3, 4, 1, 0],
+          [0, 0, 1, 1, 1, 1, 1, 0],
+          [0, 0, 0, 0, 0, 0, 0, 0]
+        ],
+        skin: 'birds',
+        level: {
+          startDirection: 2
+        }
+      },
+      {
+        id: 23223,
+        levelId: 6,
+        name: 'courseB_maze_seq_challenge2',
+        type: 'Maze',
+        map: [
+          [0, 0, 0, 0, 0, 0, 0, 0],
+          [0, 1, 1, 1, 4, 1, 3, 0],
+          [0, 1, 1, 0, 1, 1, 4, 0],
+          [0, 1, 0, 1, 1, 0, 1, 0],
+          [0, 1, 1, 1, 0, 1, 1, 0],
+          [0, 1, 1, 0, 1, 1, 1, 0],
+          [0, 2, 1, 1, 1, 1, 1, 0],
+          [0, 0, 0, 0, 0, 0, 0, 0]
+        ],
+        skin: 'birds',
+        level: {
+          startDirection: 2
+        }
+      }
+    ]
+  },
+  {
+    stageNumber: 2,
+    levels: [
+      {
+        id: 23224,
+        levelId: 7,
+        name: 'courseC_artist_prog_challenge1',
+        type: 'Artist',
+        solutionImageUrl:
+          'https://d3p74s6bwmy6t9.cloudfront.net/80cc9bbdbd9a05c1a0cf03500b4eb38c=development/2091.png'
+      },
+      {
+        id: 23225,
+        levelId: 8,
+        name: 'courseC_PlayLab_events_challenge1',
+        type: 'Studio',
+        solutionImageUrl:
+          'https://d3p74s6bwmy6t9.cloudfront.net/0b5d06628b7510904ee392a94065352a=development/2069.png'
+      }
+    ]
+  },
+  {
+    stageNumber: 3,
+    levels: [
+      {
+        id: 23226,
+        levelId: 9,
+        name: 'courseC_artist_prog_challenge1',
+        type: 'Artist',
+        solutionImageUrl:
+          'https://d3p74s6bwmy6t9.cloudfront.net/80cc9bbdbd9a05c1a0cf03500b4eb38c=development/2091.png'
+      },
+      {
+        id: 23227,
+        levelId: 10,
+        name: 'courseB_maze_seq_challenge2',
+        type: 'Maze',
+        map: [
+          [0, 0, 0, 0, 0, 0, 0, 0],
+          [0, 1, 1, 1, 4, 1, 3, 0],
+          [0, 1, 1, 0, 1, 1, 4, 0],
+          [0, 1, 0, 1, 1, 0, 1, 0],
+          [0, 1, 1, 1, 0, 1, 1, 0],
+          [0, 1, 1, 0, 1, 1, 1, 0],
+          [0, 2, 1, 1, 1, 1, 1, 0],
+          [0, 0, 0, 0, 0, 0, 0, 0]
+        ],
+        skin: 'birds',
+        level: {
+          startDirection: 2
+        }
+      },
+      {
+        id: 23228,
+        levelId: 11,
+        name: 'courseC_PlayLab_events_challenge1',
+        type: 'Studio',
+        solutionImageUrl:
+          'https://d3p74s6bwmy6t9.cloudfront.net/0b5d06628b7510904ee392a94065352a=development/2069.png'
+      }
+    ]
+  }
+];

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -189,6 +189,8 @@ class ScriptLevelsController < ApplicationController
         @section = current_user.sections[0]
         @user = @section&.students&.find_by(id: params[:user_id])
       end
+      # This airs on the side of not showing the warning by not showing it if the script we are in
+      # is not the assigned script for the section
       @show_stage_extras_warning = !@section&.stage_extras && @section.script.name == params[:script_id]
     end
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -189,8 +189,8 @@ class ScriptLevelsController < ApplicationController
         @section = current_user.sections[0]
         @user = @section&.students&.find_by(id: params[:user_id])
       end
-      # This airs on the side of not showing the warning by not showing it if the script we are in
-      # is not the assigned script for the section
+      # This errs on the side of showing the warning by only if the script we are in
+      # is the assigned script for the section
       @show_stage_extras_warning = !@section&.stage_extras && @section&.script&.name == params[:script_id]
     end
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -191,7 +191,7 @@ class ScriptLevelsController < ApplicationController
       end
       # This airs on the side of not showing the warning by not showing it if the script we are in
       # is not the assigned script for the section
-      @show_stage_extras_warning = !@section&.stage_extras && @section.script.name == params[:script_id]
+      @show_stage_extras_warning = !@section&.stage_extras && @section&.script&.name == params[:script_id]
     end
 
     # Explicitly return 404 here so that we don't get a 5xx in get_from_cache.

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -189,7 +189,7 @@ class ScriptLevelsController < ApplicationController
         @section = current_user.sections[0]
         @user = @section&.students&.find_by(id: params[:user_id])
       end
-      @show_stage_extras_warning = !@section&.stage_extras
+      @show_stage_extras_warning = !@section&.stage_extras && @section.script.name == params[:script_id]
     end
 
     # Explicitly return 404 here so that we don't get a 5xx in get_from_cache.


### PR DESCRIPTION
# Description

The lesson extras warning banner kept showing up for users when all their sections had lesson extras turned on.  There were two issues going on:
- If you went to a `/extras` page without a `sectionId` param it would show the banner
- If you had a different script assigned than the one you were viewing and that script does not have stage extras (so you would not have said yes or no having them on) it would always show the banner.

Fix:
- Don't show the banner if we don't have a `sectionId`
- Don't show the banner if you are in a different script than the one you have assigned to the chosen section. Note: This is not the ideal fix. We should probably just allow teachers to turn this on and off for a whole section no matter what course/unit is assigned. Follow: [LP-1020](https://codedotorg.atlassian.net/browse/LP-1020) 

## Before
<img width="1440" alt="Screen Shot 2019-11-13 at 1 10 12 PM" src="https://user-images.githubusercontent.com/208083/68791268-ef2d6c00-0616-11ea-8d24-33819d5c4cec.png">

## After
<img width="1440" alt="Screen Shot 2019-11-13 at 1 09 12 PM" src="https://user-images.githubusercontent.com/208083/68791277-f5234d00-0616-11ea-9d30-7d40964c27cc.png">


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-909](https://codedotorg.atlassian.net/browse/LP-909)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Added unit tests `StageExtras` to check that it only shows the warning when we have both `sectionId` and `showStageExtrasWarning`. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
