### PR TITLE
Update section assignment metrics logging to v1

### DIFF
--- a/apps/src/templates/courseOverview/AssignToSection.js
+++ b/apps/src/templates/courseOverview/AssignToSection.js
@@ -78,7 +78,7 @@ class AssignToSection extends Component {
         });
         firehoseClient.putRecord({
           study: 'assignment',
-          study_group: 'v1',
+          study_group: 'v0',
           event: scriptId ? 'unit_overview' : 'course_overview',
           data_json: JSON.stringify({
             section_id: result.id,

--- a/apps/src/templates/courseOverview/AssignToSection.js
+++ b/apps/src/templates/courseOverview/AssignToSection.js
@@ -78,7 +78,7 @@ class AssignToSection extends Component {
         });
         firehoseClient.putRecord({
           study: 'assignment',
-          study_group: 'v0',
+          study_group: 'v1',
           event: scriptId ? 'unit_overview' : 'course_overview',
           data_json: JSON.stringify({
             section_id: result.id,

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -791,7 +791,7 @@ export default function teacherSections(state = initialState, action) {
     ) {
       firehoseClient.putRecord({
         study: 'assignment',
-        study_group: 'v0',
+        study_group: 'v1',
         event: newSection ? 'create_section' : 'edit_section_details',
         data_json: JSON.stringify(assignmentData)
       });


### PR DESCRIPTION
# Description

We initially used a `study_group` of 'v0' in our logging, to indicate that the section assignment updates had not gone live. Now that we are turning on the new section assignment experience, update the `study_group` to 'v1'.
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
