### PR TITLE
Fix counselor/admin workshop survey

### DIFF
--- a/pegasus/sites.v3/code.org/public/pd-workshop-survey/counselor-admin/splat.haml
+++ b/pegasus/sites.v3/code.org/public/pd-workshop-survey/counselor-admin/splat.haml
@@ -25,11 +25,6 @@ title: "Workshop Survey for Counselors and Administrators"
   # We can't access workshop.course_name here, but follow the same pattern anyway for consistency.
   course_name = course == 'Admin' ? 'Administrator' : 'Counselor'
 
-  def local_view(name, options = {})
-    options[:form] = PdWorkshopSurveyCounselorAdmin
-    view "pd_survey_controls/#{name.to_s}", options
-  end
-
 :javascript
   window.pdWorkshopSurvey = {
     enrollmentCode: "#{enrollment_code}"
@@ -65,7 +60,8 @@ title: "Workshop Survey for Counselors and Administrators"
 
     .main-section
       .form-group
-        = local_view :multi_select,
+        = view "pd_survey_controls/multi_select",
+          form: PdWorkshopSurveyCounselorAdmin,
           name: 'how_heard_ss[]',
           label: 'How did you hear about this workshop? (select all that apply)'
       .form-group{id: 'how-heard-other-wrapper', style: 'display: none;'}
@@ -76,7 +72,8 @@ title: "Workshop Survey for Counselors and Administrators"
           %input.form-control{name: 'how_heard_other_s', placeholder: 'Other', type: 'text'}
 
       .form-group
-        = local_view :single_select,
+        = view "pd_survey_controls/single_select",
+          form: PdWorkshopSurveyCounselorAdmin,
           name: 'received_clear_communication_s',
           label: 'I received clear communication about when and where the workshop would take place.'
 
@@ -104,7 +101,9 @@ title: "Workshop Survey for Counselors and Administrators"
           label: 'This professional development has changed my opinion about the value of computer science.'
         }]
 
-      = local_view :agree_scale_select_table, items: agree_scale_questions
+      = view "pd_survey_controls/agree_scale_select_table",
+          form: PdWorkshopSurveyCounselorAdmin,
+          items: agree_scale_questions
 
       .form-group
         :ruby
@@ -112,17 +111,20 @@ title: "Workshop Survey for Counselors and Administrators"
             On a scale from 1-6, with 1 being not at all interested and 6 being extremely interested,
             how interested were you in participating in this PD session prior to arriving?
           )
-        = local_view :single_select,
+        = view "pd_survey_controls/single_select",
+          form: PdWorkshopSurveyCounselorAdmin,
           name: 'how_interested_before_s',
           label: how_interested_before_label
 
       .form-group
-        = local_view :single_select,
+        = view "pd_survey_controls/single_select",
+          form: PdWorkshopSurveyCounselorAdmin,
           name: 'pacing_s',
           label: 'The pacing for this workshop was…'
 
       .form-group
-        = local_view :single_select,
+        = view "pd_survey_controls/single_select",
+          form: PdWorkshopSurveyCounselorAdmin,
           name: 'attendee_type_s',
           label: 'I am an:'
 
@@ -152,17 +154,22 @@ title: "Workshop Survey for Counselors and Administrators"
       }]
 
     .admin-section{style: 'display: none;'}
-      = local_view :agree_scale_select_table, items: admin_agree_scale_questions + all_agree_scale_questions
+      = view "pd_survey_controls/agree_scale_select_table",
+          form: PdWorkshopSurveyCounselorAdmin,
+          items: admin_agree_scale_questions + all_agree_scale_questions
 
     .counselor-section{style: 'display: none;'}
-      = local_view :agree_scale_select_table, items: counselor_agree_scale_questions + all_agree_scale_questions
+      = view "pd_survey_controls/agree_scale_select_table",
+          form: PdWorkshopSurveyCounselorAdmin,
+          items: counselor_agree_scale_questions + all_agree_scale_questions
 
     .main-section
       .form-group
-      = local_view :multi_select,
-        name: 'interested_in_offering_ss[]',
-        label: 'I’m interested in offering the following programs at my school site/district next year (check all that apply):',
-        required: false
+      = view "pd_survey_controls/multi_select",
+          form: PdWorkshopSurveyCounselorAdmin,
+          name: 'interested_in_offering_ss[]',
+          label: 'I’m interested in offering the following programs at my school site/district next year (check all that apply):',
+          required: false
 
       .form-group
         %label.control-label{for: 'things_facilitator_did_well_s'}


### PR DESCRIPTION
[PLC-619] Our counselor/admin workshop surveys would not load after the Sinatra upgrade last week because they define a method in a HAML template.

Surfaced today in [this Honeybadger error][hb], with only one error instance.

Solved for now by removing the method defined in this template and duplicating its code throughout the template instead (which doesn't seem like a lot of duplication anyway, and the method was very specific to this view). Note that this is nearly identical to [Ha's fix for the CSF Intro workshop survey][previous-fix]. We're trying not to overinvest in these old pegasus surveys because we'd like to deprecate them in favor of a new system next year.

Performed local manual testing of the issue and fix.  Following up with a regression test is tracked in [PLC-620].

[hb]: https://app.honeybadger.io/projects/34365/faults/57388698
[previous-fix]: https://github.com/code-dot-org/code-dot-org/pull/31817
[PLC-619]: https://codedotorg.atlassian.net/browse/PLC-619
[PLC-620]: https://codedotorg.atlassian.net/browse/PLC-620

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
