### PR TITLE
hoc2019: dance-2019 certificate page now lists "Keep Dancing"

### DIFF
--- a/apps/src/templates/Congrats.jsx
+++ b/apps/src/templates/Congrats.jsx
@@ -43,6 +43,7 @@ export default class Congrats extends Component {
     const tutorialType =
       {
         dance: 'dance',
+        'dance-2019': 'dance',
         'applab-intro': 'applab',
         aquatic: '2018Minecraft',
         hero: '2017Minecraft',


### PR DESCRIPTION
Going via https://code.org/api/hour/finish/dance-2019 now takes the user to a /congrats page that lists the followup activity.


![Screenshot 2019-11-13 13 48 24](https://user-images.githubusercontent.com/2205926/68807209-497cfb80-061c-11ea-9382-3b43bce2f1bd.png)
