### PR TITLE
no_mobile for assignment overview test

### DIFF
--- a/dashboard/test/ui/features/assignment_on_overview_pages.feature
+++ b/dashboard/test/ui/features/assignment_on_overview_pages.feature
@@ -1,4 +1,5 @@
 @no_ie
+@no_mobile
 Feature: (Un)Assign on script and course overview pages
 
   Background:


### PR DESCRIPTION
Consistent failures on iPad caught on 11/13 because this test shouldn't run on mobile since the relevant pages are not responsive and I'm using steps to input in a text box in a way that doesn't play nicely on ie or mobile. 