### PR TITLE
Hard-code SauceLabs IP addresses to resolve to US

### DIFF
--- a/lib/cdo/geocoder.rb
+++ b/lib/cdo/geocoder.rb
@@ -51,6 +51,25 @@ module Geocoder
       Geocoder.configure(always_raise: previous_always_raise_configuration)
     end
   end
+
+  # Override Geocoder#search to ensure all queries for Sauce Labs IP addresses resolve to the United States.
+  module SauceLabsOverride
+    # Ref: https://support.saucelabs.com/hc/en-us/articles/115003359593-IP-Blocks-Used-by-Sauce-Labs-Services
+    SAUCELABS_CIDR = [
+      IPAddr.new('162.222.72.0/21'),
+      IPAddr.new('66.85.48.0/21')
+    ]
+
+    def search(query, options = {})
+      ip = IPAddr.new(query) rescue nil
+      if SAUCELABS_CIDR.any? {|cidr| cidr.include?(ip)}
+        [OpenStruct.new(country_code: 'US', country: 'United States')]
+      else
+        super
+      end
+    end
+  end
+  singleton_class.prepend SauceLabsOverride
 end
 
 def geocoder_config

--- a/pegasus/test/test_geocoder.rb
+++ b/pegasus/test/test_geocoder.rb
@@ -48,4 +48,8 @@ class GeocoderTest < Minitest::Test
     assert_equal original_configuration, Geocoder::Configuration.instance
     assert_equal [], Geocoder::Configuration.instance.data[:always_raise]
   end
+
+  def test_saucelabs_override
+    assert_equal 'US', Geocoder.search('66.85.52.120').first.country_code
+  end
 end

--- a/pegasus/test/test_request.rb
+++ b/pegasus/test/test_request.rb
@@ -29,6 +29,12 @@ class RequestTest < Minitest::Test
     assert_nil req.location
   end
 
+  def test_saucelabs_ip
+    # This override is hard-coded in cdo/geocoder.
+    req = Rack::Request.new({'HTTP_X_FORWARDED_FOR' => '66.85.52.120'})
+    assert_equal 'US', req.location.country_code
+  end
+
   def test_gdpr
     assert Rack::Request.new('HTTP_CLOUDFRONT_VIEWER_COUNTRY' => 'gb').gdpr?
     refute Rack::Request.new('HTTP_CLOUDFRONT_VIEWER_COUNTRY' => 'us').gdpr?


### PR DESCRIPTION
# Description

Hard-codes [SauceLabs IP address blocks](https://support.saucelabs.com/hc/en-us/articles/115003359593-IP-Blocks-Used-by-Sauce-Labs-Services) to resolve to US, to unblock some implicit dependencies in our UI test suites (that the servers running UI tests are located in the United States).