### PR TITLE
Fix 500 on hourofcode.org/events/<year>/*

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/events/2014/splat.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/2014/splat.haml
@@ -6,7 +6,7 @@ layout: wide
   require 'country_codes'
   require 'state_abbr'
 
-  HOC_YEAR = 2014.freeze
+  hoc_year = 2014.freeze
   splat = request.splat_path_info[1..-1].split("/").map{ |a| Rack::Utils.escape_html(a) }
   country_code = splat.first
   # must sanitize country_code, which is untrusted user input from URL
@@ -26,7 +26,7 @@ layout: wide
   end
   @header["title"] = "#{hoc_s(:events_all_title)} - #{state ? state : country}"
 
-  results = Forms.events_by_name("HocSignup#{HOC_YEAR}", country_code, state_code)
+  results = Forms.events_by_name("HocSignup#{hoc_year}", country_code, state_code)
   pass unless results.count > 0
 
 %h1= hoc_s(:events_all_title) + ' — ' + (state ? state : country)

--- a/pegasus/sites.v3/hourofcode.com/public/events/2015/splat.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/2015/splat.haml
@@ -6,7 +6,7 @@ layout: wide
   require 'country_codes'
   require 'state_abbr'
 
-  HOC_YEAR = 2015.freeze
+  hoc_year = 2015.freeze
   splat = request.splat_path_info[1..-1].split("/").map{ |a| Rack::Utils.escape_html(a) }
   country_code = splat.first
   # must sanitize country_code, which is untrusted user input from URL
@@ -26,7 +26,7 @@ layout: wide
   end
   @header["title"] = "#{hoc_s(:events_all_title)} - #{state ? state : country}"
 
-  results = Forms.events_by_name("HocSignup#{HOC_YEAR}", country_code, state_code)
+  results = Forms.events_by_name("HocSignup#{hoc_year}", country_code, state_code)
   pass unless results.count > 0
 
 %h1= hoc_s(:events_all_title) + ' — ' + (state ? state : country)

--- a/pegasus/sites.v3/hourofcode.com/public/events/2016/splat.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/events/2016/splat.haml
@@ -7,7 +7,7 @@ nav: events_nav
   require 'country_codes'
   require 'state_abbr'
 
-  HOC_YEAR = 2016.freeze
+  hoc_year = 2016.freeze
   splat = request.splat_path_info[1..-1].split("/").map{ |a| Rack::Utils.escape_html(a) }
   country_code = splat.first
   # must sanitize country_code, which is untrusted user input from URL
@@ -27,7 +27,7 @@ nav: events_nav
   end
   @header["title"] = "#{hoc_s(:events_all_title)} - #{state ? state : country}"
 
-  results = Forms.events_by_name("HocSignup#{HOC_YEAR}", country_code, state_code)
+  results = Forms.events_by_name("HocSignup#{hoc_year}", country_code, state_code)
   pass unless results.count > 0
 
 %h1= hoc_s(:events_all_title) + ' — ' + (state ? state : country)


### PR DESCRIPTION
Fixes a regression introduced during the Sinatra upgrade, because defining ruby constants in HAML templates is no longer allowed.

Should resolve [this Honeybadger error][hb].  Fix is very similar to [this earlier fix][precedent].

Tested on localhost.  Adding a regression test tracked in [PLC-624].

[hb]: https://app.honeybadger.io/projects/34365/faults/57042788
[precedent]: https://github.com/code-dot-org/code-dot-org/pull/31758
[PLC-624]: https://codedotorg.atlassian.net/browse/PLC-624

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
