### PR TITLE
Update the Regional Partner Playbook nav

### DIFF
--- a/pegasus/sites.v3/code.org/views/regional_partner_playbook_nav.haml
+++ b/pegasus/sites.v3/code.org/views/regional_partner_playbook_nav.haml
@@ -13,7 +13,7 @@
       'Partner Network'=>'/educate/regional-partner/playbook/directory',
       'Payment Information'=>'/educate/regional-partner/playbook/payments',
       'Reporting and Evaluations'=>'/educate/regional-partner/playbook/reporting-and-evaluations',
-      'Teacher & District Recruitment'=>'/educate/regional-partner/playbook/teacher-recruitment',
+      'District & School Recruitment'=>'/educate/regional-partner/playbook/teacher-recruitment',
       'Teachers & Curriculum'=>'/educate/regional-partner/playbook/curriculum',
       'Timeline'=>'/educate/regional-partner/playbook/timeline',
       'Training Materials'=>'/educate/regional-partner/playbook/training-materials',


### PR DESCRIPTION
[PLC-607] Changes "Teacher & District Recruitment" to "District & School Recruitment" in the regional partner playbook navigation sidebar, an important detail that I missed in https://github.com/code-dot-org/code-dot-org/pull/31596.

Tested content update on local machine.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/1615761/68814232-198a2400-062d-11ea-8d49-47d491be573b.png) | ![after](https://user-images.githubusercontent.com/1615761/68814237-1b53e780-062d-11ea-9324-caff32088ed3.png) |



[PLC-607]: https://codedotorg.atlassian.net/browse/PLC-607

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
