### PR TITLE
Install missing dependency for puppeteer / chrome headless [ci skip]

### DIFF
--- a/cookbooks/cdo-apps/recipes/generate_pdf.rb
+++ b/cookbooks/cdo-apps/recipes/generate_pdf.rb
@@ -1,3 +1,5 @@
+apt_package 'libxss1'
+
 yarn_install "#{node[:home]}/#{node.chef_environment}/bin/generate-pdf" do
   user node[:current_user]
   action :run


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/compare/pdf-fix

Script fails on staging with:

```
ubuntu@staging:~/staging/bin/generate-pdf$ node generatePdf.js -u https://staging.code.org/advocacy/state-facts/NY?pdf_version=true -o /tmp/NY.pdf
(node:2870) UnhandledPromiseRejectionWarning: Error: Failed to launch chrome!
/home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/.local-chromium/linux-686378/chrome-linux/chrome: error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory

TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
```

Troubleshooting link suggests using `ldd` to check for missing dependencies; libxss1 appears to be the only one:

```
ubuntu@staging:~/staging/bin/generate-pdf$ ldd /home/ubuntu/staging/bin/generate-pdf/node_modules/puppeteer/.local-chromium/linux-686378/chrome-linux/chrome | grep not
	libXss.so.1 => not found
```