### PR TITLE
Handle submissionless rows gracefully in Peer Review CSV

### DIFF
--- a/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
@@ -101,8 +101,8 @@ class Api::V1::PeerReviewSubmissionsController < ApplicationController
         submission_times = submission_times_by_user_script_level[[user_level.user_id, user_level.script_id, user_level.level_id]]
         peer_review_submissions[user_level.level.name] = {
           status: result_to_status(user_level.best_result),
-          first_submission_date: submission_times.min&.strftime("%-m/%-d/%Y"),
-          last_submission_date: submission_times.max&.strftime("%-m/%-d/%Y")
+          first_submission_date: submission_times&.min&.strftime("%-m/%-d/%Y"),
+          last_submission_date: submission_times&.max&.strftime("%-m/%-d/%Y")
         }
       end
 


### PR DESCRIPTION
[PLC-618] Test and fix a relatively rare case with Peer Reviews where a UserLevel exists but no PeerReviews do yet.  This is worth covering and supporting if only because we've had so many data issues with this system in the past.

I've tried to construct a plausible scenario for testing, although I'm not sure this situation is easy to get into with our UI as it currently exists.

This should address [this Honeybadger error][hb].

[PLC-618]: https://codedotorg.atlassian.net/browse/PLC-618
[hb]: https://app.honeybadger.io/projects/3240/faults/57023032

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
