### PR TITLE
Add Droplet `list.join(separator)` block to the default toolbox

### DIFF
--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -35,6 +35,7 @@ var stringMethodPrefix = '[string].';
 var arrayMethodPrefix = '[list].';
 
 var stringBlockPrefix = 'str.';
+var arrayBlockPrefix = 'list.';
 
 // Configure shared APIs for App Lab
 // We wrap this because it runs before window.Applab exists
@@ -878,6 +879,16 @@ export var blocks = [
     noAutocomplete: true,
     tipPrefix: arrayMethodPrefix,
     type: 'property'
+  },
+  {
+    func: 'join',
+    blockPrefix: arrayBlockPrefix,
+    category: 'Variables',
+    modeOptionName: '*.join',
+    tipPrefix: arrayBlockPrefix,
+    paletteParams: ['separator'],
+    params: ['"-"'],
+    type: 'value'
   },
   {
     func: 'insertItem',

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -270,6 +270,7 @@ module SharedConstants
       "insertItem": null,
       "appendItem": null,
       "removeItem": null,
+      "join": null,
 
       // Functions
       "functionParams_none": null,


### PR DESCRIPTION
Request from @gtw for the CSP pilot.

![image](https://user-images.githubusercontent.com/413693/68818056-9e2e6f80-0638-11ea-8c8e-68c605913af4.png)

Droplet block config options are super confusing — we should fix!