### PR TITLE
Impose max call stack size in JS interpreter

### DIFF
--- a/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
@@ -9,6 +9,8 @@ import {generateAST} from '@code-dot-org/js-interpreter';
 
 import {setIsDebuggerPaused} from '../../../redux/runState';
 
+const MAX_CALL_STACK_SIZE = 10000;
+
 const StepType = {
   RUN: 0,
   IN: 1,
@@ -672,6 +674,9 @@ export default class JSInterpreter {
         this.logStep_();
       }
       this.executionError = safeStepInterpreter(this);
+      if (this.interpreter.getStackDepth() > MAX_CALL_STACK_SIZE) {
+        this.executionError = new Error('Maximum call stack size exceeded.');
+      }
       if (!this.executionError && this.interpreter.getStackDepth()) {
         const state = this.interpreter.peekStackFrame(),
           nodeType = state.node.type;


### PR DESCRIPTION
# Description
Currently, infinite recursion freezes the browser tab. I'm setting the max stack size to 10,000. This value was picked somewhat arbitrarily, but it's in the range of what browsers do (IE is ~7.5k, Chrome is ~15k, Safari is ~30k). I don't have any data to back this, but my expectation is that this limit is high enough that all legitimate use-cases should be well-below this limit.

![image](https://user-images.githubusercontent.com/8787187/68882254-b0a1bb00-06c3-11ea-99f1-42169350785e.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-406)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
