### PR TITLE
cache Dance Party 2019 in CloudFront

### DIFF
--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -20,7 +20,8 @@ class HttpCache
   # A list of script levels that should not be cached, even though they are
   # in a cacheable script, because they are project-backed.
   UNCACHED_SCRIPT_LEVEL_PATHS = [
-    '/s/dance/stage/1/puzzle/13'
+    '/s/dance/stage/1/puzzle/13',
+    '/s/dance-2019/stage/1/puzzle/10'
   ]
 
   # A map from script name to script level URL pattern.
@@ -36,6 +37,7 @@ class HttpCache
     sports
     basketball
     dance
+    dance-2019
   ).map do |script_name|
     # Most scripts use the default route pattern.
     [script_name, "/s/#{script_name}/stage/*"]

--- a/cookbooks/cdo-varnish/test/shared/shared.rb
+++ b/cookbooks/cdo-varnish/test/shared/shared.rb
@@ -491,10 +491,12 @@ module HttpCacheTest
 
       it 'Strips cookies from the penultimate dance level' do
         assert strips_session_specific_cookies_from_request? '/s/dance/stage/1/puzzle/12'
+        assert strips_session_specific_cookies_from_request? '/s/dance-2019/stage/1/puzzle/9'
       end
 
       it 'Does not strip cookies from the last dance level' do
         refute strips_session_specific_cookies_from_request? '/s/dance/stage/1/puzzle/13'
+        refute strips_session_specific_cookies_from_request? '/s/dance-2019/stage/1/puzzle/10'
       end
 
       it 'Strips cookies from an aquatic level' do


### PR DESCRIPTION
# Description

Ensure that Dance Party 2019 level pages are cached in CloudFront (except the final project-backed level).



## Testing story


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
