### PR TITLE
Remove newSongs flag

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -40,7 +40,6 @@ import {
 } from './songs';
 import {SongTitlesToArtistTwitterHandle} from '../code-studio/dancePartySongArtistTags';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import experiments from '@cdo/apps/util/experiments';
 
 const ButtonState = {
   UP: 0,
@@ -183,9 +182,8 @@ Dance.prototype.awaitTimingMetrics = function() {
 
 Dance.prototype.initSongs = async function(config) {
   let is2019Script =
-    (config.scriptName === 'dance-2019' ||
-      config.scriptName === 'dance-extras-2019') &&
-    experiments.isEnabled('newSongs');
+    config.scriptName === 'dance-2019' ||
+    config.scriptName === 'dance-extras-2019';
   const songManifest = await getSongManifest(
     config.useRestrictedSongs,
     is2019Script


### PR DESCRIPTION
# Description
Removes the newSongs flag so new songs appear on the dance-2019 and dance-extras-2019.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
