### PR TITLE
Change font to Gotham 4r for fish activity

### DIFF
--- a/apps/src/fish/FishView.jsx
+++ b/apps/src/fish/FishView.jsx
@@ -20,7 +20,7 @@ const styles = {
     minWidth: '770px',
     margin: '0 auto',
     userSelect: 'none',
-    fontFamily: 'arial, sans-serif',
+    fontFamily: '"Gotham 4r", arial, sans-serif',
     fontSize: '18px',
     color: 'rgb(30,30,30)'
   },


### PR DESCRIPTION
Make the default font for /s/ocean "Gotham 4r" instead of arial.