### PR TITLE
reduce parallelism of eyes and ui tests on the test machine

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -29,7 +29,7 @@ namespace :test do
         '-d', CDO.site_host('studio.code.org'),
         '-p', CDO.site_host('code.org'),
         '--db', # Ensure features that require database access are run even if the server name isn't "test"
-        '--parallel', '120',
+        '--parallel', '100',
         '--magic_retry',
         '--with-status-page',
         '--fail_fast',
@@ -62,7 +62,7 @@ namespace :test do
         '--magic_retry',
         '--with-status-page',
         '-f', eyes_features.join(","),
-        '--parallel', (eyes_features.count * 2).to_s
+        '--parallel', '45'
       )
       if failed_browser_count == 0
         message = '⊙‿⊙ Eyes tests for <b>dashboard</b> succeeded, no changes detected.'


### PR DESCRIPTION
# Description

The number of flaky UI test failures has been on the rise lately. This PR is an experiment to see if reducing the number of UI tests we are running in parallel will bring the flakiness rate back down.

Here are the results of a recent auto-green test run:
![Screen Shot 2019-11-14 at 3 53 05 PM](https://user-images.githubusercontent.com/8001765/68906062-0c863700-06f8-11ea-8050-969ab1b678ba.png)

Because there are more UI tests than the previous parallelism, I reduced the parallelism by 16%. Because there are fewer eyes tests than the previous parallelism, I took the number of eyes tests and reduced that number by 16%. I reduced both parallelisms by the same amount because they are currently taking about the same amount of time to complete in an auto-green run.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
