### PR TITLE
Fix continue button on external markdown levels

### DIFF
--- a/apps/src/sites/studio/pages/levels/_external.js
+++ b/apps/src/sites/studio/pages/levels/_external.js
@@ -20,8 +20,14 @@ $(document).ready(() => {
   // make milestone post
   postMilestoneForPageLoad();
 
-  // handle click on continue (results in navigating to next puzzle)
-  $('.submitButton').click(function() {
+  // Handle click on the continue button (results in navigating to next puzzle)
+  // Note: We're using this pattern instead of
+  //   $('.submitButton').click(...)
+  // on purpose, because .submitButton may not exist yet when this code is run.
+  // By using a static ancestor jQuery will automatically bind the event handler later
+  // when .submitButton is added to the DOM.
+  // @see https://stackoverflow.com/q/203198
+  $('.full_container').on('click', '.submitButton', function() {
     onContinue();
   });
 });

--- a/dashboard/test/ui/features/level_navigation.feature
+++ b/dashboard/test/ui/features/level_navigation.feature
@@ -6,3 +6,9 @@ Scenario: External Video Level
   And I wait to see ".submitButton"
   Then I click ".submitButton" to load a new page
   Then I wait until I am on "http://studio.code.org/s/coursec-2019/stage/15/puzzle/1"
+
+Scenario: External Markdown Level
+  Given I am on "http://studio.code.org/s/allthethings/stage/21/puzzle/1"
+  And I wait to see ".submitButton"
+  Then I click ".submitButton" to load a new page
+  And I wait until I am on "http://studio.code.org/s/allthethings/stage/21/puzzle/2"


### PR DESCRIPTION
Fixes the continue button on external markdown levels.  This regressed in https://github.com/code-dot-org/code-dot-org/pull/31726 when we were trying to fix the continue button for external video levels, but we swapped in a jQuery expression that removed the dependency on a particular static parent, but also removed the lazy-binding feature that markdown levels were depending on (the submit button might be added after this code runs in external markdown levels).

As a solution, I'm putting back the lazy-binding code with a more generic static parent that's present in both level types.  I've also added a regression test using an existing allthethings level the demonstrated this problem.

Raised [in Slack](https://codedotorg.slack.com/archives/CA3KCSGTD/p1573765609181600) by @joshlory

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
