### PR TITLE
Engineering adjustments to middle-high-2020 page

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high-2020.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high-2020.md.erb
@@ -62,7 +62,7 @@ theme: responsive
  <li>Access to a cohesive set of resources and trade organization discounts</li>
  <li>Awareness and strategies to recruit and foster a diverse and equitable classroom</li>
 </ul>
-<a href="#">What to Expect ></a>
+<a href="#what-to-expect">What to Expect ></a>
 </p>
 </center>
 </div>
@@ -78,7 +78,7 @@ theme: responsive
  <li>The student learning experience as they navigate course content</li>
 </ul>
 <br><br>
-<a href="#">Content and Curriculum ></a>
+<a href="#content-and-curriculum">Content and Curriculum ></a>
 </p>
 </center>
 </div>
@@ -94,7 +94,7 @@ theme: responsive
  <li>Promote diversity in classroom recruitment and enrollment</li>
 </ul>
 <br><br>
-<a href="#">Program Requirements ></a>
+<a href="#program-requirements">Program Requirements ></a>
 </p>
 </center>
 </div>
@@ -129,6 +129,7 @@ theme: responsive
 [/breakoutquote]
 
 <div style="clear: both;"></div>
+<a name="what-to-expect"></a>
 
 ## What to expect
 
@@ -156,8 +157,10 @@ To help you say connected, we've also partnered with ISTE to offer all Code.org 
 <br><br>
 
 <div style="clear: both;"></div>
+<a name="program-requirements"></a>
 
-<h2>Program requirements</h2>
+## Program requirements
+
 <p>Many teachers are surprised to learn just how feasible it is to expand computer science into their schools! You don’t need a fancy computer lab or previous experience teaching CS.</p>
 
 <div class="col-60" style="padding-right: 30px; padding-bottom: 20px;">
@@ -184,6 +187,7 @@ To help you say connected, we've also partnered with ISTE to offer all Code.org 
 </div>
 
 <div style="clear: both;"></div>
+<a name="content-and-curriculum"></a>
 
 ## Content and curriculum
 Code.org provides a complete CS program combining professional learning and the K-12 curriculum, both of which consistently gets high ratings from teachers.

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high-2020.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high-2020.md.erb
@@ -19,14 +19,14 @@ theme: responsive
 
 <div style="clear: both;">
 
-<div class="col-50" style="padding-right: 30px; padding-top: 20px; padding-bottom: 50px;">
+<div class="col-50" style="padding-right: 30px; padding-top: 20px; padding-bottom: 25px;">
 
 <img src="/images/fit-450/marketing/professional-learning-middle-high.jpg">
 <br><br>
 
 </div>
 
-<div class="col-50" style="padding-right: 30px; padding-top: 20px; padding-bottom: 50px;">
+<div class="col-50" style="padding-right: 30px; padding-top: 20px; padding-bottom: 25px;">
 
 <p>Whether you are new to teaching computer science (CS) or have previous experience, the Code.org Professional Learning Program prepares you to teach with confidence and offers year-round support. No CS experience is needed!</p>
 
@@ -40,12 +40,11 @@ theme: responsive
 
 </div>
 
-<div style="clear: both;"></div> 
+<div style="clear: both;"></div>
 
 <div style="clear: both;">
 <div class="col-100">
-<%= view :regional_partner_zip_form %>
-
+<%= view :regional_partner_zip_form_2020 %>
 </div>
 
 </div>
@@ -103,7 +102,7 @@ theme: responsive
 <br>
 <br>
 
-<div style="clear: both;"></div> 
+<div style="clear: both;"></div>
 
 <br><br>
 
@@ -126,10 +125,10 @@ theme: responsive
 [clearboth]
 
 [/clearboth]
-   
+
 [/breakoutquote]
 
-<div style="clear: both;"></div> 
+<div style="clear: both;"></div>
 
 ## What to expect
 
@@ -137,7 +136,7 @@ theme: responsive
 Discuss classroom management and engage in new teaching strategies. Working in small groups, you’ll learn new teaching skills and deepen your understanding of the curriculum content. <br><br>
 
 <h3>Practice classroom teaching and experience student learning</h3>
-You’ll engage with the curriculum both as an instructor and a learner. Becoming an active participant, you’ll gain concrete insight into your students’ perspective, which will aid you in creating strong lesson plans. 
+You’ll engage with the curriculum both as an instructor and a learner. Becoming an active participant, you’ll gain concrete insight into your students’ perspective, which will aid you in creating strong lesson plans.
 
 <h3>Collaborate and share knowledge with fellow educators</h3>
 ​Teachers and facilitators will share their expertise and collaborate on strategies for the classroom, giving you a chance to learn from everyone in the room. Facilitators model pedagogical strategies and participants will share their own approaches by planning and delivering lessons.​
@@ -184,7 +183,7 @@ To help you say connected, we've also partnered with ISTE to offer all Code.org 
 
 </div>
 
-<div style="clear: both;"></div> 
+<div style="clear: both;"></div>
 
 ## Content and curriculum
 Code.org provides a complete CS program combining professional learning and the K-12 curriculum, both of which consistently gets high ratings from teachers.
@@ -228,7 +227,7 @@ Middle and high school teachers will be participating in the Code.org profession
 
 <table style="border-style:hidden; padding-top: 30px; padding-bottom: 30px; padding-right: 20px; padding-left: 20px;">
   <tr>
-    <td colspan="100" style="background-color:#00adbc; color:white; text-align:center; font-style:bold; border-style:hidden; font-size:18px;""> Peer reviewed research shows that school participation in the Code.org program causes an estimated <b>5x increase in students that take and pass the AP CS Principles exam</b>. 
+    <td colspan="100" style="background-color:#00adbc; color:white; text-align:center; font-style:bold; border-style:hidden; font-size:18px;""> Peer reviewed research shows that school participation in the Code.org program causes an estimated <b>5x increase in students that take and pass the AP CS Principles exam</b>.
       </td>
     </tr>
   </table>

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high-2020.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high-2020.md.erb
@@ -10,6 +10,19 @@ theme: responsive
   details summary {
     cursor: pointer;
   }
+
+  a.tertiary-link {
+    color: #00adbc;
+    font-size: 14px;
+    font-family: "Gotham 4r", sans-serif;
+    font-weight: bold;
+    text-decoration: none;
+  }
+    a.tertiary-link .fa {
+      font-size: 12px;
+      font-weight: bold;
+      margin-left: 8px;
+    }
 </style>
 
 
@@ -62,7 +75,10 @@ theme: responsive
  <li>Access to a cohesive set of resources and trade organization discounts</li>
  <li>Awareness and strategies to recruit and foster a diverse and equitable classroom</li>
 </ul>
-<a href="#what-to-expect">What to Expect ></a>
+<a href="#what-to-expect" class="tertiary-link">
+  What to Expect
+  <i class="fa fa-chevron-right"></i>
+</a>
 </p>
 </center>
 </div>
@@ -78,7 +94,10 @@ theme: responsive
  <li>The student learning experience as they navigate course content</li>
 </ul>
 <br><br>
-<a href="#content-and-curriculum">Content and Curriculum ></a>
+<a href="#content-and-curriculum" class="tertiary-link">
+  Content and Curriculum
+  <i class="fa fa-chevron-right"></i>
+</a>
 </p>
 </center>
 </div>
@@ -94,7 +113,10 @@ theme: responsive
  <li>Promote diversity in classroom recruitment and enrollment</li>
 </ul>
 <br><br>
-<a href="#program-requirements">Program Requirements ></a>
+<a href="#program-requirements" class="tertiary-link">
+  Program Requirements
+  <i class="fa fa-chevron-right"></i>
+</a>
 </p>
 </center>
 </div>

--- a/pegasus/sites.v3/code.org/views/regional_partner_zip_form_2020.haml
+++ b/pegasus/sites.v3/code.org/views/regional_partner_zip_form_2020.haml
@@ -42,10 +42,10 @@
     }
 
     .submit-button {
-      color:white;
-      background-color:orange;
-      padding:10px;
-      font-size:1.2em;
+      color: white;
+      background-color: orange;
+      padding: 10px;
+      font-size: 1.2em;
     }
   }
 

--- a/pegasus/sites.v3/code.org/views/regional_partner_zip_form_2020.haml
+++ b/pegasus/sites.v3/code.org/views/regional_partner_zip_form_2020.haml
@@ -1,0 +1,17 @@
+%div{style: 'border: solid #bbb 1px; margin-bottom: 25px;'}
+  .h3{style: 'background-color: #00adbc; color: white; margin-top: 0; padding: 20px 30px; font-size: 24px; font-family: "Gotham 5r", sans-serif;'}
+    Find a Program Near You
+  %div{style: 'display: flex; flex-direction: row; padding: 0.5em 1em;'}
+    %div{style: 'margin-right: 1em'}
+      %p
+        Professional learning programs are hosted by over 60 Regional Partners throughout the U.S.
+        and consist of 9 professional development days.
+      %p
+        %strong 5-day summer workshop + 4 full-day school year sessions
+    %div{style: 'white-space: nowrap'}
+      %form.linktag#pl-zip-form{action: "/educate/professional-learning/program-information", method: "get"}
+        %span{style: "font-size:1.2em"} Zip:
+        %input{type: "text", name: "zip", style: "padding:10px"}
+        - if params[:nominated]
+          %input{type: "text", name: "nominated", value: params[:nominated], hidden: "true"}
+        %input{type: "submit", value: "Submit", style: "color:white; background-color:orange; padding:10px; font-size:1.2em"}

--- a/pegasus/sites.v3/code.org/views/regional_partner_zip_form_2020.haml
+++ b/pegasus/sites.v3/code.org/views/regional_partner_zip_form_2020.haml
@@ -1,17 +1,69 @@
-%div{style: 'border: solid #bbb 1px; margin-bottom: 25px;'}
-  .h3{style: 'background-color: #00adbc; color: white; margin-top: 0; padding: 20px 30px; font-size: 24px; font-family: "Gotham 5r", sans-serif;'}
+:scss
+  /* Teal full content width box with heading */
+  .full-width-box {
+    border: solid #bbb 1px;
+    margin-bottom: 25px;
+
+    .box-title {
+      background-color: #00adbc;
+      color: white;
+      margin-top: 0;
+      padding: 20px 30px;
+      font-size: 24px;
+      font-family: "Gotham 5r", sans-serif;
+    }
+
+    .box-contents {
+      padding: 0.5em 1em;
+    }
+  }
+
+  /* Styles specific to the regional partner zip form */
+  .rp-zip-form {
+    .column-wrapper {
+      display: flex;
+      flex-direction: row;
+    }
+
+    .left-column {
+      margin-right: 1em;
+    }
+
+    .right-column {
+      white-space: nowrap;
+    }
+
+    .zip-label {
+      font-size: 1.2em;
+    }
+
+    .zip-input {
+      padding: 10px;
+    }
+
+    .submit-button {
+      color:white;
+      background-color:orange;
+      padding:10px;
+      font-size:1.2em;
+    }
+  }
+
+.rp-zip-form.full-width-box
+  %h3.box-title
     Find a Program Near You
-  %div{style: 'display: flex; flex-direction: row; padding: 0.5em 1em;'}
-    %div{style: 'margin-right: 1em'}
+  .box-contents.column-wrapper
+    .left-column
       %p
-        Professional learning programs are hosted by over 60 Regional Partners throughout the U.S.
-        and consist of 9 professional development days.
+        Professional learning programs are hosted by over 60 Regional Partners
+        throughout the U.S. and consist of 9 professional development days.
       %p
-        %strong 5-day summer workshop + 4 full-day school year sessions
-    %div{style: 'white-space: nowrap'}
+        %strong
+          5-day summer workshop + 4 full-day school year sessions
+    .right-column
       %form.linktag#pl-zip-form{action: "/educate/professional-learning/program-information", method: "get"}
-        %span{style: "font-size:1.2em"} Zip:
-        %input{type: "text", name: "zip", style: "padding:10px"}
+        %span.zip-label Zip:
+        %input.zip-input{type: "text", name: "zip"}
         - if params[:nominated]
           %input{type: "text", name: "nominated", value: params[:nominated], hidden: "true"}
-        %input{type: "submit", value: "Submit", style: "color:white; background-color:orange; padding:10px; font-size:1.2em"}
+        %input.submit-button{type: "submit", value: "Submit"}


### PR DESCRIPTION
[PLC-548](https://codedotorg.atlassian.net/browse/PLC-548): We are preparing to run a split test on https://code.org/educate/professional-learning/middle-high.  This is a set of changes to the variant we wanted done before we start our experiment.

- Updated the regional partner zip form according to [this mockup](https://docs.google.com/document/d/1pWKGdaOlqeVR2Y2YpCFe6KQXaKzdvEgaWPqZ3yn_9DU/edit#) and [directions in Slack](https://codedotorg.slack.com/archives/C0T10H26N/p1573778022179100).
- Restyled the "What to Expect," "Content and Curriculum" and "Program Requirements" links to match our [tertiary link React component](https://code-dot-org.github.io/cdo-styleguide/?selectedKind=ChevronLinks&selectedStory=Overview&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).
- Implemented jump links within the page.

Here's the new look:
![Screenshot from 2019-11-14 18-16-13](https://user-images.githubusercontent.com/1615761/68911956-8bd13600-070b-11ea-932d-473f9d75de2c.png)


## Testing story

Manual testing of content changes on localhost, and verified that none of my changes affected the original page (the control for our experiment).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
