### PR TITLE
Show student not started warning on free play levels

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3207,7 +3207,7 @@ StudioApp.prototype.isNotStartedLevel = function(config) {
     )
   ) {
     return config.readonlyWorkspace && !config.channel;
-  } else if (!config.level.freePlay) {
+  } else {
     return (
       config.readonlyWorkspace &&
       progress.levelProgress[progress.currentLevelId] === undefined


### PR DESCRIPTION
# Description

[LP-983](https://codedotorg.atlassian.net/browse/LP-983)

Remove the unneeded restriction which prevented showing the student not started warning banner on non-channel backed free play levels.

| Before | After |
| --- | --- |
| <img width="1440" alt="Screen Shot 2019-11-15 at 10 30 12 AM" src="https://user-images.githubusercontent.com/208083/68954904-eb265900-0792-11ea-9855-c30483900a8d.png"> | <img width="1440" alt="Screen Shot 2019-11-15 at 10 29 18 AM" src="https://user-images.githubusercontent.com/208083/68954856-d5189880-0792-11ea-9580-66b92ef849a1.png">  |

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
