### PR TITLE
Multi 2 must choose 2 answers to be correct

### DIFF
--- a/dashboard/app/controllers/api/v1/assessments_controller.rb
+++ b/dashboard/app/controllers/api/v1/assessments_controller.rb
@@ -149,7 +149,7 @@ class Api::V1::AssessmentsController < Api::V1::JsonApiController
                 level_result[:student_result] = []
                 level_result[:status] = "unsubmitted"
               # Deep comparison of arrays of indexes
-              elsif student_result.present? && student_result - answer_indexes == []
+              elsif student_result.present? && student_result - answer_indexes == [] && answer_indexes.length == student_result.length
                 multi_count_correct += 1
                 level_result[:status] = "correct"
               else

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -244,6 +244,77 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
     assert_equal expected_response, JSON.parse(@response.body)
   end
 
+  test "multi choose 2 questions are only correct if both answers are correct" do
+    # Sign in and create a new script.
+    sign_in @teacher
+    script = create :script
+
+    # Set up an assessment for that script.
+    sub_level1 = create :multi, name: 'level_multi2_correct', type: 'Multi',
+                        properties: {"answers": [{"text" => "Incorrect Answer", "correct" => false},
+                                                 {"text" => "Incorrect Answer", "correct" => false},
+                                                 {"text" => "Correct Answer", "correct" => true},
+                                                 {"text" => "Correct Answer", "correct" => true}]}
+    sub_level2 = create :multi, name: 'level_multi2_incorrect_only_one_choice', type: 'Multi',
+                        properties: {"answers": [{"text" => "Incorrect Answer", "correct" => false},
+                                                 {"text" => "Incorrect Answer", "correct" => false},
+                                                 {"text" => "Correct Answer", "correct" => true},
+                                                 {"text" => "Correct Answer", "correct" => true}]}
+
+    level1 = create :level_group, name: 'LevelGroupLevel1', type: 'LevelGroup'
+    level1.properties['title'] =  'Long assessment 1'
+    level1.properties['pages'] = [{levels: ['level_multi2_correct', 'level_multi2_incorrect_only_one_choice']}]
+    level1.save!
+    create :script_level, script: script, levels: [level1], assessment: true
+
+    # Student has completed an assessment.
+    level_source = create(
+      :level_source,
+      level: level1,
+      data: %Q({"#{sub_level1.id}":{"result":"2,3"},"#{sub_level2.id}":{"result":"3"}})
+    )
+    create :activity, user: @student_1, level: level1,
+           level_source: level_source
+
+    updated_at = Time.now
+
+    user_level = create :user_level, user: @student_1, best_result: 100, script: script, level: level1, submitted: true, updated_at: updated_at, level_source: level_source
+
+    # Call the controller method.
+    get :section_responses, params: {
+      section_id: @section.id,
+      script_id: script.id
+    }
+
+    assert_response :success
+
+    # Stage translation missing because we don't actually generate i18n files in tests.
+    expected_response = {
+      @student_1.id.to_s => {
+        "student_name" => @student_1.name,
+          "responses_by_assessment" => {
+            level1.id.to_s => {
+              "stage" => "translation missing: en-US.data.script.name.#{script.name}.title",
+              "puzzle" => 1,
+              "question" => "Long assessment 1",
+              "url" => "http://test.host/s/#{script.name}/stage/1/puzzle/1?section_id=#{@section.id}&user_id=#{@student_1.id}",
+              "multi_correct" => 1,
+              "multi_count" => 2,
+              "match_correct" => 0,
+              "match_count" => 0,
+              "submitted" => true,
+              "timestamp" => user_level[:updated_at],
+              "level_results" => [
+                {"type" => "Multi", "student_result" => [2, 3], "status" => "correct",},
+                {"type" => "Multi", "student_result" => [3], "status" => "incorrect",}
+              ]
+            }
+          }
+      }
+    }
+    assert_equal expected_response, JSON.parse(@response.body)
+  end
+
   test "gets no anonymous survey data via assessment responses call" do
     # Sign in as teacher and create a new script.
     sign_in @teacher


### PR DESCRIPTION
# Description

We now mark multi-choice answer wrong if a student does not give all the correct answers.

| Before | After |
| --- | --- |
| <img width="1440" alt="Screen Shot 2019-11-15 at 10 40 29 AM" src="https://user-images.githubusercontent.com/208083/68963764-bc65ae00-07a5-11ea-80eb-cc127e9f5908.png">| <img width="1440" alt="Screen Shot 2019-11-15 at 10 50 32 AM" src="https://user-images.githubusercontent.com/208083/68963763-bc65ae00-07a5-11ea-91f3-d24224fcbf06.png">|

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-927](https://codedotorg.atlassian.net/browse/LP-927)

## Testing story

I added a unit test to check that if a student gives one correct answer for a Multi2 they get marked as wrong.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
