### PR TITLE
Add commit hook to warn when creating new table or adding new column

### DIFF
--- a/tools/hooks/scary_changes.rb
+++ b/tools/hooks/scary_changes.rb
@@ -44,9 +44,11 @@ class ScaryChangeDetector
     return if changes.empty? || !(@changed_lines.include?("add_column") || !@changed_lines.include?("create_table"))
 
     puts red <<-EOS
+
         Looks like you are creating a table or adding a column in this migration:
         #{changes.join("\n")}
         Do you have all the indexes needed for this change?
+
     EOS
   end
 

--- a/tools/hooks/scary_changes.rb
+++ b/tools/hooks/scary_changes.rb
@@ -21,6 +21,7 @@ class ScaryChangeDetector
           @deleted << filename
         end
       end
+      @changed_lines = `git diff --cached --unified=0`
     end
     @all = @added + @deleted + @modified
   end
@@ -36,6 +37,17 @@ class ScaryChangeDetector
     puts "There will be a deploy glitch that affects any students with progress in the scripts " \
       "that contain this level. To avoid this you can deploy this model code before deploying " \
       "the code that adds it to scripts."
+  end
+
+  def detect_new_table_or_new_column
+    changes = @all.grep(/^dashboard\/db\/migrate\//)
+    return if changes.empty? || !(@changed_lines.include?("add_column") || !@changed_lines.include?("create_table"))
+
+    puts red <<-EOS
+        Looks like you are creating a table or adding a column in this migration:
+        #{changes.join("\n")}
+        Do you have all the indexes needed for this change?
+    EOS
   end
 
   def detect_missing_yarn_lock
@@ -96,6 +108,7 @@ class ScaryChangeDetector
 
   def detect_scary_changes
     detect_new_models
+    detect_new_table_or_new_column
     detect_missing_yarn_lock
     detect_special_files
     detect_dropbox_conflicts


### PR DESCRIPTION
# Description

Follow up work for [COE where UserLevelInfo did not have an index for `user_level_id`](https://docs.google.com/document/d/1Qv4KgM9ALFBuwPLfaawBIVK6t81G-kdas7pqDzbrt_8/).

[LP-982](https://codedotorg.atlassian.net/browse/LP-982)

This creates a pre-commit hook that looks for when changed files in `dashboard/db/migrate` include `add_column` or `create_table` in the change.  It warns the person committing with the following message:

![Screen Shot 2019-11-15 at 3 31 29 PM](https://user-images.githubusercontent.com/208083/68973906-67359680-07bd-11ea-9ac9-62a9747f8117.png)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
