### PR TITLE
combine duplicate OAUTH_CREDENTIAL_TYPES constants into one

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -138,7 +138,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     prepare_locale_cookie user
 
-    if User::OAUTH_PROVIDERS_UNTRUSTED_EMAIL.include?(provider) && user.persisted?
+    if AuthenticationOption::UNTRUSTED_EMAIL_CREDENTIAL_TYPES.include?(provider) && user.persisted?
       handle_untrusted_email_signin user, provider
     elsif allows_silent_takeover(user, auth_hash)
       user = silent_takeover user, auth_hash

--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -37,6 +37,7 @@ class AuthenticationOption < ApplicationRecord
 
   after_create :set_primary_contact_info
 
+  # Powerschool note: the Powerschool plugin lives at https://github.com/code-dot-org/powerschool
   OAUTH_CREDENTIAL_TYPES = [
     CLEVER = 'clever',
     FACEBOOK = 'facebook',
@@ -48,6 +49,11 @@ class AuthenticationOption < ApplicationRecord
     WINDOWS_LIVE = 'windowslive',
     MICROSOFT = 'microsoft_v2_auth',
   ]
+
+  UNTRUSTED_EMAIL_CREDENTIAL_TYPES = [
+    CLEVER,
+    POWERSCHOOL
+  ].freeze
 
   CREDENTIAL_TYPES = [
     EMAIL = 'email',

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -391,7 +391,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test 'login: oauth takeover transfers sections to taken over account' do
-    User::OAUTH_PROVIDERS_UNTRUSTED_EMAIL.each do |provider|
+    AuthenticationOption::UNTRUSTED_EMAIL_CREDENTIAL_TYPES.each do |provider|
       teacher = create :teacher
       section = create :section, user: teacher, login_type: 'clever'
       oauth_student = create :student, provider: provider
@@ -412,7 +412,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test 'login: oauth takeover does not happen if takeover is expired' do
-    User::OAUTH_PROVIDERS_UNTRUSTED_EMAIL.each do |provider|
+    AuthenticationOption::UNTRUSTED_EMAIL_CREDENTIAL_TYPES.each do |provider|
       teacher = create :teacher
       section = create :section, user: teacher, login_type: 'clever'
       oauth_student = create :student, provider: provider
@@ -435,7 +435,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test 'login: oauth takeover takes over account when account has no activity' do
-    User::OAUTH_PROVIDERS_UNTRUSTED_EMAIL.each do |provider|
+    AuthenticationOption::UNTRUSTED_EMAIL_CREDENTIAL_TYPES.each do |provider|
       oauth_student = create :student, provider: provider
       student = create :student
 
@@ -455,7 +455,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test 'login: oauth takeover does nothing if account has activity' do
-    User::OAUTH_PROVIDERS_UNTRUSTED_EMAIL.each do |provider|
+    AuthenticationOption::UNTRUSTED_EMAIL_CREDENTIAL_TYPES.each do |provider|
       oauth_student = create :student, provider: provider
       student = create :student
       level = create(:level)


### PR DESCRIPTION
# Description

Rather than defining the same thing in both User and Authentication Option, just use the AO constant everywhere.

Also move the "untrusted email" constant into Authentication Option.

In both cases, we choose the Authentication Option model over the User model to keep domain-specific code closer to the domain-specific model than to the generic one.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
