### PR TITLE
only enforce email uniqueness for trusted credential types

### DIFF
--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -48,17 +48,21 @@ class AuthenticationOption < ApplicationRecord
     TWITTER = 'twitter',
     WINDOWS_LIVE = 'windowslive',
     MICROSOFT = 'microsoft_v2_auth',
-  ]
+  ].freeze
+
+  CREDENTIAL_TYPES = [
+    EMAIL = 'email',
+    OAUTH_CREDENTIAL_TYPES,
+  ].flatten.freeze
 
   UNTRUSTED_EMAIL_CREDENTIAL_TYPES = [
     CLEVER,
     POWERSCHOOL
   ].freeze
 
-  CREDENTIAL_TYPES = [
-    EMAIL = 'email',
-    OAUTH_CREDENTIAL_TYPES,
-  ].flatten
+  TRUSTED_EMAIL_CREDENTIAL_TYPES = (
+    CREDENTIAL_TYPES - UNTRUSTED_EMAIL_CREDENTIAL_TYPES
+  ).freeze
 
   SILENT_TAKEOVER_CREDENTIAL_TYPES = [
     FACEBOOK,
@@ -66,7 +70,9 @@ class AuthenticationOption < ApplicationRecord
     # TODO: (madelynkasula) Remove once we are sure users are no longer logging in via windowslive.
     WINDOWS_LIVE,
     MICROSOFT
-  ]
+  ].freeze
+
+  scope :trusted_email, -> {where(credential_type: TRUSTED_EMAIL_CREDENTIAL_TYPES)}
 
   def codeorg_email?
     Mail::Address.new(email).domain == 'code.org'

--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -32,8 +32,8 @@ class AuthenticationOption < ApplicationRecord
   validates :email, no_utf8mb4: true
   validates_email_format_of :email, allow_blank: true, if: :email_changed?, unless: -> {email.to_s.utf8mb4?}
 
-  validate :email_must_be_unique, :hashed_email_must_be_unique,
-    :cred_type_and_auth_id_must_be_unique
+  validate :email_must_be_unique, :hashed_email_must_be_unique, unless: -> {UNTRUSTED_EMAIL_CREDENTIAL_TYPES.include? credential_type}
+  validate :cred_type_and_auth_id_must_be_unique
 
   after_create :set_primary_contact_info
 

--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -55,6 +55,18 @@ class AuthenticationOption < ApplicationRecord
     OAUTH_CREDENTIAL_TYPES,
   ].flatten.freeze
 
+  # "untrusted" emails are a somewhat subtle concept.
+  #
+  # They specifically refer to emails we receive from a provider that
+  #
+  # A) Does not themselves enforce uniqueness and/or
+  # B) Does not allow the user to change the email they have been assigned.
+  #
+  # In this case, we cannot ourselves enforce uniqueness because we don't want
+  # to punish users who were assigned an email that might not be theirs (and
+  # which might conflict with a "trusted" email already in our system). We have
+  # to be careful in these cases to not use the email as an identifier for
+  # user, and instead to rely exclusively on authentication_id
   UNTRUSTED_EMAIL_CREDENTIAL_TYPES = [
     CLEVER,
     POWERSCHOOL

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -551,7 +551,7 @@ class User < ActiveRecord::Base
   # @return [User|nil]
   def self.find_by_email(email)
     return nil if email.blank?
-    migrated_user = AuthenticationOption.find_by(email: email)&.user
+    migrated_user = AuthenticationOption.trusted_email.find_by(email: email)&.user
     migrated_user || User.find_by(email: email)
   end
 
@@ -560,7 +560,7 @@ class User < ActiveRecord::Base
   # @return [User|nil]
   def self.find_by_hashed_email(hashed_email)
     return nil if hashed_email.blank?
-    migrated_user = AuthenticationOption.find_by(hashed_email: hashed_email)&.user
+    migrated_user = AuthenticationOption.trusted_email.find_by(hashed_email: hashed_email)&.user
     migrated_user || User.find_by(hashed_email: hashed_email)
   end
 


### PR DESCRIPTION
# Description

For most credential types, we trust that the email provided by the credential can also be used to identify the user; for example, when a user authenticates with google we can trust that they are also authenticated to use the email associated with their google account.

Unfortunately, that is not true for all credential types; for example, when a user authenticates with clever we cannot trust that they are also authenticated to use the email associated with their clever account, because clever does not verify emails.

Therefore, we only want to enforce email uniqueness for authentication options using trusted credential types.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
