### PR TITLE
Display confirmation dialog when deleting from stage edit gui

### DIFF
--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -189,6 +189,8 @@ class FlexGroup extends Component {
                 type={ControlTypes.Group}
                 position={afterStage}
                 total={Object.keys(groups).length}
+                itemType="Flex Category"
+                itemName={group || '(none)'}
               />
             </div>
             <div style={styles.groupBody}>

--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -189,8 +189,7 @@ class FlexGroup extends Component {
                 type={ControlTypes.Group}
                 position={afterStage}
                 total={Object.keys(groups).length}
-                itemType="Flex Category"
-                itemName={group || '(none)'}
+                name={group || '(none)'}
               />
             </div>
             <div style={styles.groupBody}>

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -7,6 +7,7 @@ import {borderRadius, levelTokenMargin} from './constants';
 import LevelTokenDetails from './LevelTokenDetails';
 import {toggleExpand, removeLevel} from './editorRedux';
 import {levelShape} from './shapes';
+import Dialog from '../../templates/Dialog';
 
 const styles = {
   levelToken: {
@@ -87,6 +88,10 @@ class LevelToken extends Component {
     handleDragStart: PropTypes.func.isRequired
   };
 
+  state = {
+    showConfirm: false
+  };
+
   handleDragStart = e => {
     this.props.handleDragStart(this.props.level.position, e);
   };
@@ -99,12 +104,23 @@ class LevelToken extends Component {
   };
 
   handleRemove = () => {
+    this.setState({showConfirm: true});
+  };
+
+  handleConfirm = () => {
     this.props.removeLevel(this.props.stagePosition, this.props.level.position);
+    this.setState({showConfirm: false});
+  };
+
+  handleClose = () => {
+    this.setState({showConfirm: false});
   };
 
   render() {
     const {draggedLevelPos} = this.props;
     const levelName = this.props.levelKeyList[this.props.level.activeId];
+    const confirmText = `Are you sure you want to delete the level named "${levelName}"?`;
+    const {showConfirm} = this.state;
     const springConfig = {stiffness: 1000, damping: 80};
     return (
       <div>
@@ -177,6 +193,18 @@ class LevelToken extends Component {
             </div>
           )}
         </Motion>
+        {showConfirm && (
+          <Dialog
+            body={confirmText}
+            cancelText="Cancel"
+            confirmText="Delete"
+            confirmType="danger"
+            isOpen={true}
+            handleClose={this.handleClose}
+            onCancel={this.handleClose}
+            onConfirm={this.handleConfirm}
+          />
+        )}
       </div>
     );
   }

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -104,6 +104,7 @@ class LevelToken extends Component {
 
   render() {
     const {draggedLevelPos} = this.props;
+    const levelName = this.props.levelKeyList[this.props.level.activeId];
     const springConfig = {stiffness: 1000, damping: 80};
     return (
       <Motion
@@ -138,7 +139,7 @@ class LevelToken extends Component {
               <i className="fa fa-arrows-v" />
             </div>
             <span style={styles.levelTokenName} onMouseDown={this.toggleExpand}>
-              {this.props.levelKeyList[this.props.level.activeId]}
+              {levelName}
               {this.props.level.ids.length > 1 && (
                 <span style={styles.tag}>
                   {this.props.level.ids.length} variants

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -140,6 +140,7 @@ class LevelToken extends Component {
                   shadow: 0
                 }
           }
+          key={this.props.level.position}
         >
           {// Use react-motion to interpolate the following values and create
           // smooth transitions.

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -107,73 +107,78 @@ class LevelToken extends Component {
     const levelName = this.props.levelKeyList[this.props.level.activeId];
     const springConfig = {stiffness: 1000, damping: 80};
     return (
-      <Motion
-        style={
-          draggedLevelPos
-            ? {
-                y: this.props.dragging ? this.props.delta : 0,
-                scale: spring(1.02, springConfig),
-                shadow: spring(5, springConfig)
-              }
-            : {
-                y: this.props.dragging
-                  ? spring(this.props.delta, springConfig)
-                  : 0,
-                scale: 1,
-                shadow: 0
-              }
-        }
-        key={this.props.level.position}
-      >
-        {// Use react-motion to interpolate the following values and create
-        // smooth transitions.
-        ({y, scale, shadow}) => (
-          <div
-            style={Object.assign({}, styles.levelToken, {
-              transform: `translate3d(0, ${y}px, 0) scale(${scale})`,
-              boxShadow: `${color.shadow} 0 ${shadow}px ${shadow * 3}px`,
-              zIndex: draggedLevelPos ? 1000 : 500 - this.props.level.position
-            })}
-          >
-            <div style={styles.reorder} onMouseDown={this.handleDragStart}>
-              <i className="fa fa-arrows-v" />
-            </div>
-            <span style={styles.levelTokenName} onMouseDown={this.toggleExpand}>
-              {levelName}
-              {this.props.level.ids.length > 1 && (
-                <span style={styles.tag}>
-                  {this.props.level.ids.length} variants
-                </span>
-              )}
-              {this.props.level.challenge && (
-                <span style={styles.tag}>challenge</span>
-              )}
-              {/* progression supercedes named, so only show the named tag
+      <div>
+        <Motion
+          style={
+            draggedLevelPos
+              ? {
+                  y: this.props.dragging ? this.props.delta : 0,
+                  scale: spring(1.02, springConfig),
+                  shadow: spring(5, springConfig)
+                }
+              : {
+                  y: this.props.dragging
+                    ? spring(this.props.delta, springConfig)
+                    : 0,
+                  scale: 1,
+                  shadow: 0
+                }
+          }
+          key={this.props.level.position}
+        >
+          {// Use react-motion to interpolate the following values and create
+          // smooth transitions.
+          ({y, scale, shadow}) => (
+            <div
+              style={Object.assign({}, styles.levelToken, {
+                transform: `translate3d(0, ${y}px, 0) scale(${scale})`,
+                boxShadow: `${color.shadow} 0 ${shadow}px ${shadow * 3}px`,
+                zIndex: draggedLevelPos ? 1000 : 500 - this.props.level.position
+              })}
+            >
+              <div style={styles.reorder} onMouseDown={this.handleDragStart}>
+                <i className="fa fa-arrows-v" />
+              </div>
+              <span
+                style={styles.levelTokenName}
+                onMouseDown={this.toggleExpand}
+              >
+                {levelName}
+                {this.props.level.ids.length > 1 && (
+                  <span style={styles.tag}>
+                    {this.props.level.ids.length} variants
+                  </span>
+                )}
+                {this.props.level.challenge && (
+                  <span style={styles.tag}>challenge</span>
+                )}
+                {/* progression supercedes named, so only show the named tag
                   when the level is behaving like a named level. */}
-              {this.props.level.named && !this.props.level.progression && (
-                <span style={styles.tag}>named</span>
+                {this.props.level.named && !this.props.level.progression && (
+                  <span style={styles.tag}>named</span>
+                )}
+                {this.props.level.assessment && (
+                  <span style={styles.tag}>assessment</span>
+                )}
+                {this.props.level.progression && (
+                  <span style={styles.progressionTag}>
+                    {this.props.level.progression}
+                  </span>
+                )}
+              </span>
+              <div style={styles.remove} onMouseDown={this.handleRemove}>
+                <i className="fa fa-times" />
+              </div>
+              {this.props.level.expand && (
+                <LevelTokenDetails
+                  level={this.props.level}
+                  stagePosition={this.props.stagePosition}
+                />
               )}
-              {this.props.level.assessment && (
-                <span style={styles.tag}>assessment</span>
-              )}
-              {this.props.level.progression && (
-                <span style={styles.progressionTag}>
-                  {this.props.level.progression}
-                </span>
-              )}
-            </span>
-            <div style={styles.remove} onMouseDown={this.handleRemove}>
-              <i className="fa fa-times" />
             </div>
-            {this.props.level.expand && (
-              <LevelTokenDetails
-                level={this.props.level}
-                stagePosition={this.props.stagePosition}
-              />
-            )}
-          </div>
-        )}
-      </Motion>
+          )}
+        </Motion>
+      </div>
     );
   }
 }

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -124,7 +124,6 @@ class LevelToken extends Component {
                   shadow: 0
                 }
           }
-          key={this.props.level.position}
         >
           {// Use react-motion to interpolate the following values and create
           // smooth transitions.

--- a/apps/src/lib/script-editor/OrderControls.jsx
+++ b/apps/src/lib/script-editor/OrderControls.jsx
@@ -15,7 +15,7 @@ const styles = {
   }
 };
 
-class OrderControls extends Component {
+export class UnconnectedOrderControls extends Component {
   static propTypes = {
     move: PropTypes.func.isRequired,
     remove: PropTypes.func.isRequired,
@@ -92,7 +92,7 @@ class OrderControls extends Component {
   }
 }
 
-export default connect(
+const OrderControls = connect(
   state => ({}),
   dispatch => ({
     move(type, position, direction) {
@@ -106,4 +106,6 @@ export default connect(
         : dispatch(removeStage(position));
     }
   })
-)(OrderControls);
+)(UnconnectedOrderControls);
+
+export default OrderControls;

--- a/apps/src/lib/script-editor/OrderControls.jsx
+++ b/apps/src/lib/script-editor/OrderControls.jsx
@@ -22,8 +22,7 @@ class OrderControls extends Component {
     type: PropTypes.oneOf(Object.keys(ControlTypes)).isRequired,
     position: PropTypes.number.isRequired,
     total: PropTypes.number.isRequired,
-    itemType: PropTypes.string.isRequired,
-    itemName: PropTypes.string.isRequired
+    name: PropTypes.string.isRequired
   };
 
   state = {
@@ -57,9 +56,9 @@ class OrderControls extends Component {
 
   render() {
     const {showConfirm} = this.state;
-    const {itemType, itemName} = this.props;
+    const {type, name} = this.props;
     const text =
-      `Are you sure you want to delete the ${itemType} named "${itemName}" ` +
+      `Are you sure you want to delete the ${type} named "${name}" ` +
       'and all its contents?';
     return (
       <div style={styles.controls}>

--- a/apps/src/lib/script-editor/OrderControls.jsx
+++ b/apps/src/lib/script-editor/OrderControls.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {ControlTypes} from './constants';
 import {moveGroup, moveStage, removeGroup, removeStage} from './editorRedux';
+import Dialog from '../../templates/Dialog';
 
 const styles = {
   controls: {
@@ -20,7 +21,13 @@ class OrderControls extends Component {
     remove: PropTypes.func.isRequired,
     type: PropTypes.oneOf(Object.keys(ControlTypes)).isRequired,
     position: PropTypes.number.isRequired,
-    total: PropTypes.number.isRequired
+    total: PropTypes.number.isRequired,
+    itemType: PropTypes.string.isRequired,
+    itemName: PropTypes.string.isRequired
+  };
+
+  state = {
+    showConfirm: false
   };
 
   handleMoveUp = () => {
@@ -36,10 +43,24 @@ class OrderControls extends Component {
   };
 
   handleRemove = () => {
+    this.setState({showConfirm: true});
+  };
+
+  handleConfirm = () => {
+    this.setState({showConfirm: false});
     this.props.remove(this.props.type, this.props.position);
   };
 
+  handleClose = () => {
+    this.setState({showConfirm: false});
+  };
+
   render() {
+    const {showConfirm} = this.state;
+    const {itemType, itemName} = this.props;
+    const text =
+      `Are you sure you want to delete the ${itemType} named "${itemName}" ` +
+      'and all its contents?';
     return (
       <div style={styles.controls}>
         <i
@@ -56,6 +77,16 @@ class OrderControls extends Component {
           onMouseDown={this.handleRemove}
           style={styles.controlIcon}
           className="fa fa-trash"
+        />
+        <Dialog
+          body={text}
+          cancelText="Cancel"
+          confirmText="Delete"
+          confirmType="danger"
+          isOpen={showConfirm}
+          handleClose={this.handleClose}
+          onCancel={this.handleClose}
+          onConfirm={this.handleConfirm}
         />
       </div>
     );

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -226,6 +226,8 @@ export class UnconnectedStageCard extends Component {
             type={ControlTypes.Stage}
             position={stage.position}
             total={this.props.stagesCount}
+            itemType="Stage"
+            itemName={this.props.stage.name}
           />
           <label style={styles.stageLockable}>
             Require teachers to unlock this stage before students in their

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -226,8 +226,7 @@ export class UnconnectedStageCard extends Component {
             type={ControlTypes.Stage}
             position={stage.position}
             total={this.props.stagesCount}
-            itemType="Stage"
-            itemName={this.props.stage.name}
+            name={this.props.stage.name}
           />
           <label style={styles.stageLockable}>
             Require teachers to unlock this stage before students in their

--- a/apps/test/unit/lib/script-editor/OrderControlsTest.js
+++ b/apps/test/unit/lib/script-editor/OrderControlsTest.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+
+import {UnconnectedOrderControls as OrderControls} from '@cdo/apps/lib/script-editor/OrderControls';
+import {ControlTypes} from '../../../../src/lib/script-editor/constants';
+
+describe('OrderControls', () => {
+  let move, remove, defaultProps;
+  beforeEach(() => {
+    move = sinon.spy();
+    remove = sinon.spy();
+    defaultProps = {
+      move,
+      remove,
+      type: ControlTypes.Stage,
+      position: 1,
+      total: 2,
+      name: 'My Stage'
+    };
+  });
+  it('renders default props', () => {
+    const wrapper = mount(<OrderControls {...defaultProps} />);
+    expect(wrapper.find('.fa-trash')).to.have.lengthOf(1);
+  });
+  it('shows confirmation dialog before deleting', () => {
+    const wrapper = mount(<OrderControls {...defaultProps} />);
+    expect(wrapper.find('.fa-trash')).to.have.lengthOf(1);
+
+    wrapper.find('.fa-trash').simulate('mousedown');
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(1);
+    expect(wrapper.find('.modal-body').text()).to.include(
+      'Are you sure you want to delete'
+    );
+    expect(remove).not.to.have.been.called;
+
+    const deleteButton = wrapper.find('button').at(1);
+    expect(deleteButton.text()).to.include('Delete');
+    deleteButton.simulate('click');
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(0);
+    expect(remove).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
# Description

Finishes [LP-753](https://codedotorg.atlassian.net/browse/LP-753)

Displays a confirmation dialog when you go to remove any of the following via the stage edit gui:
* flex group
* stage
* level

![confirm-stage-delete](https://user-images.githubusercontent.com/8001765/68982532-36a12d00-07bc-11ea-9dca-76e81e9e70b7.gif)

## Testing story

Manually verified confirm / cancel / close in each scenario. new unit test for OrderControls delete flow.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
