### PR TITLE
Send Metrics and Firehose events in async buffered batches

### DIFF
--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -69,6 +69,9 @@ class ActiveSupport::TestCase
     UserHelpers.stubs(:random_donor).returns(name_s: 'Someone')
     AWS::S3.stubs(:upload_to_bucket).raises("Don't actually upload anything to S3 in tests... mock it if you want to test it")
     AWS::S3.stubs(:download_from_bucket).raises("Don't actually download anything to S3 in tests... mock it if you want to test it")
+
+    Cdo::Metrics.client ||= Aws::CloudWatch::Client.new(stub_responses: true)
+
     CDO.stubs(override_pegasus: nil)
     CDO.stubs(override_dashboard: nil)
 

--- a/lib/cdo/app_server_hooks.rb
+++ b/lib/cdo/app_server_hooks.rb
@@ -23,18 +23,7 @@ module Cdo
 
     def self.after_fork(host:)
       require 'cdo/aws/metrics'
-      Cdo::Metrics.push(
-        'App Server',
-        [
-          {
-            metric_name: :WorkerBoot,
-            dimensions: [
-              {name: "Host", value: host}
-            ],
-            value: 1
-          }
-        ]
-      )
+      Cdo::Metrics.put('App Server/WorkerBoot', 1, Host: host)
       require 'dynamic_config/gatekeeper'
       require 'dynamic_config/dcdo'
       Gatekeeper.after_fork

--- a/lib/cdo/app_server_metrics.rb
+++ b/lib/cdo/app_server_metrics.rb
@@ -11,7 +11,6 @@ module Cdo
   # all forked worker-processes.
   #
   # Every :interval seconds (default 1), metrics are collected.
-  # Once :report_count metrics (default 60) have been collected, they are asynchronously reported to CloudWatch.
   #
   # The following metrics are collected and reported:
   # `active` - the number of active TCP/socket connections
@@ -35,7 +34,6 @@ module Cdo
 
       @namespace = opts[:namespace] || 'App Server'
       @dimensions = opts[:dimensions] || {}
-      @report_count = opts[:report_count] || 60
       @interval = opts[:interval] || 1
       self.instance = self
     end
@@ -50,12 +48,17 @@ module Cdo
         execute
     end
 
-    # Periodically collect unicorn-listener metrics,
-    # reporting every time `report_count` metrics have been collected.
+    # Periodically collect unicorn-listener metrics.
     def collect_metrics(*_)
-      stat_values = collect_listener_stats + [@stats.max_calling.tap {@stats.max_calling = 0}]
-      @metrics.zip(stat_values) {|stat, val| stat[1] << {timestamp: Time.now, value: val}}
-      report!(@metrics) if @metrics.values.first.count >= @report_count
+      collect_listener_stats.each do |name, value|
+        Cdo::Metrics.put(
+          "#{@namespace}/#{name}",
+          value,
+          @dimensions,
+          storage_resolution: 1,
+          unit: 'Count'
+        )
+      end
     end
 
     # Collect current snapshot of tcp/unix listener stats.
@@ -63,28 +66,11 @@ module Cdo
       stats = {}
       stats.merge! Raindrops::Linux.tcp_listener_stats(@tcp.uniq) if @tcp
       stats.merge! Raindrops::Linux.unix_listener_stats(@unix.uniq) if @unix
-      %i(active queued).map do |name|
-        stats.values.map(&name).inject(:+)
-      end
-    end
-
-    # Report all stats as CloudWatch metrics, then clear the collection.
-    # @param metrics [Hash]
-    def report!(metrics)
-      metric_data = metrics.map do |name, stat|
-        stat.reject {|datum| datum[:value].nil?}.map do |datum|
-          {
-            metric_name: name,
-            dimensions: @dimensions.map {|k, v| {name: k, value: v}},
-            timestamp: datum[:timestamp],
-            value: datum[:value],
-            unit: 'Count',
-            storage_resolution: 1
-          }
-        end
-      end.flatten
-      metrics.values.map(&:clear)
-      Cdo::Metrics.push(@namespace, metric_data)
+      stats = %i(active queued).map do |name|
+        [name, stats.values.map(&name).inject(:+)]
+      end.to_h
+      stats[:calling] = @stats.max_calling.tap {@stats.max_calling = 0}
+      stats
     end
   end
 

--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -2,14 +2,17 @@ require 'aws-sdk-cloudwatch'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'concurrent/async'
 require 'honeybadger/ruby'
+require 'cdo/buffer'
 
 module Cdo
   # Singleton interface for asynchronously sending a collection of CloudWatch metrics in batches.
   class Metrics
     include Singleton
-    include Concurrent::Async
-
     cattr_accessor :client
+
+    def initialize
+      @buffer = Hash.new {|h, key| h[key] = Buffer.new(key)}
+    end
 
     # Ref: http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
     ITEMS_PER_REQUEST = 20
@@ -17,56 +20,66 @@ module Cdo
     # Ref: http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
     BYTES_PER_REQUEST = 1024 * 40
 
+    class Buffer < Cdo::Buffer
+      def initialize(namespace)
+        super(
+          batch_events: ITEMS_PER_REQUEST,
+          batch_size: BYTES_PER_REQUEST,
+          batch_interval: 60,
+          min_interval: 0.1
+        )
+        @namespace = namespace
+      end
+
+      def flush(events)
+        client = Metrics.client ||= ::Aws::CloudWatch::Client.new(
+          retry_limit: 3,
+          http_open_timeout: 5,
+          http_read_timeout: 5,
+          http_idle_timeout: 2
+        )
+        client.put_metric_data(
+          namespace: @namespace,
+          metric_data: events
+        )
+      rescue => e
+        Honeybadger.notify(e)
+      end
+    end
+
     # Convenience method to put a single metric to CloudWatch.
     # Accepts a single '[namespace]/[metric_name]' name parameter
     # and a standard Ruby hash.
-    def put(name, value, dimensions={})
+    def put(name, value, dimensions={}, **options)
       namespace, metric_name = name.split('/', 2)
-      push(namespace,
-        [{
-          metric_name: metric_name,
-          dimensions: dimensions.map {|k, v| {name: k, value: v}},
-          value: value
-        }]
-      )
+      metric = {
+        metric_name: metric_name,
+        dimensions: dimensions.map {|k, v| {name: k, value: v}},
+        value: value,
+        timestamp: Time.now
+      }.merge(options)
+      put_metric(namespace, metric)
+    end
+
+    def self.put(name, value, dimensions={}, **options)
+      instance.put(name, value, dimensions, **options)
+    end
+
+    def put_metric(namespace, metric)
+      @buffer[namespace].buffer(metric, metric.to_json.bytesize)
+    end
+
+    def self.put_metric(namespace, metric)
+      instance.put_metric(namespace, metric)
     end
 
     # Asynchronously send a collection of CloudWatch metrics in batches.
     # @param namespace [String]
     # @param metrics [Array<Types::MetricDatum>]
     def self.push(namespace, metrics)
-      instance.async.push(namespace, metrics)
-    end
-
-    def push(namespace, metrics)
-      self.client ||= ::Aws::CloudWatch::Client.new(
-        retry_limit: 3,
-        http_open_timeout: 5,
-        http_read_timeout: 5,
-        http_idle_timeout: 2
-      )
-      batches = []
-      current_batch = []
-      batch_size = 0
       metrics.each do |metric|
-        size = JSON.generate(metric).bytesize
-        if current_batch.length >= ITEMS_PER_REQUEST || batch_size + size > BYTES_PER_REQUEST
-          batches << current_batch
-          current_batch = []
-          batch_size = 0
-        end
-        current_batch << metric
-        batch_size += size
+        put_metric(namespace, metric)
       end
-      batches << current_batch
-      batches.each do |batch|
-        client.put_metric_data(
-          namespace: namespace,
-          metric_data: batch
-        )
-      end
-    rescue => e
-      Honeybadger.notify(e)
     end
   end
 end

--- a/lib/cdo/buffer.rb
+++ b/lib/cdo/buffer.rb
@@ -1,0 +1,154 @@
+require 'concurrent/async'
+require 'concurrent/scheduled_task'
+require 'honeybadger/ruby'
+
+module Cdo
+  # Abstract class to handle asynchronous-buffering and periodic-flushing using a thread pool.
+  # This class is content-agnostic, buffering event objects in memory through #buffer(event, size).
+  # Subclasses implement #flush(events), which will be called periodically as the buffer is flushed in batches.
+  #
+  # Because events are stored in memory, the buffer will be synchronously flushed when the Ruby process exits.
+  class Buffer
+    include Concurrent::Async
+
+    # @param [Integer] batch_events   Maximum number of events in a buffered batch.
+    # @param [Integer] batch_size     Maximum total payload 'size', based on the size parameter passed to #buffer,
+    #                                 in a buffered batch.
+    # @param [Integer] batch_interval Number of seconds after the first buffered item when the batch will flush.
+    # @param [Integer] min_interval   Number of seconds after the previous flush before a flush will occur.
+    #                                 Useful for rate-throttling.
+    def initialize(
+      batch_events: nil,
+      batch_size: nil,
+      batch_interval: nil,
+      min_interval: nil
+    )
+      super()
+      @batch_events = batch_events
+      @batch_size = batch_size
+      @batch_interval = batch_interval
+      @min_interval = min_interval
+
+      @events = Batch.new
+      at_exit {flush!}
+    end
+
+    # Asynchronously adds an event to the buffer.
+    # @param [Object] event
+    # @param [Integer] size
+    def buffer(event, size = nil)
+      size ||= event.is_a?(String) ? event.bytesize : 1
+      raise 'Event exceeds batch size' if @batch_size&.<(size)
+      @events << [event, size]
+      async.try_flush
+    end
+
+    # Implement in subclass.
+    # @param [Array<Object>] events
+    def flush(events)
+    end
+
+    # Synchronously flushes all events in batches until the buffer is empty.
+    def flush!
+      sleep @min_interval.to_f while await.try_flush(true).value
+    end
+
+    # Try to flush a batch of events from the buffer.
+    # Should be called through the thread pool (`async.try_flush` / `await.try_flush`).
+    # @param [Boolean] force flush a batch of events even if the buffer isn't ready.
+    # @return [Float] number of seconds until next batch can be flushed, or `nil` if the buffer is empty.
+    def try_flush(force = false)
+      return nil if @events.empty?
+
+      if force || (wait = batch_ready)&.zero?
+        @last_flush = Concurrent.monotonic_time
+        flush(get_batch)
+        # Try to flush another batch if one is ready.
+        try_flush
+      else
+        flush_in(wait)
+        wait
+      end
+    rescue => e
+      Honeybadger.notify(e)
+      raise
+    end
+
+    private
+
+    # Determine whether a batch of events is ready to be flushed.
+    # @return [Float] Number of seconds until a batch can be flushed, zero if the batch is ready now,
+    #                 or nil if the batch can't be flushed.
+    def batch_ready
+      now = Concurrent.monotonic_time
+
+      # Wait if batch isn't full or old enough.
+      batch_age = now - @events.earliest
+      unless @batch_size&.<=(@events.size) ||
+        @batch_events&.<=(@events.length) ||
+        @batch_interval&.<=(batch_age)
+
+        return @batch_interval && (@batch_interval - batch_age)
+      end
+
+      # Wait if last flush was too recent.
+      flush_age = now - @last_flush.to_f
+      if @min_interval&.>(flush_age)
+        return @min_interval - flush_age
+      end
+
+      0.0
+    end
+
+    # Get a single batch of events based on configured size.
+    def get_batch
+      batch = Batch.new
+      batch << @events.shift until
+        @events.empty? ||
+        @batch_events&.<=(batch.length) ||
+        @batch_size&.<(batch.size + @events.first[1])
+      batch.events
+    end
+
+    # Schedule a future call to #try_flush.
+    # @param [Float] seconds number of seconds to wait.
+    def flush_in(seconds)
+      return unless seconds
+      if @scheduled_task&.state == :pending
+        @scheduled_task.reschedule(seconds)
+      else
+        @scheduled_task = Concurrent::ScheduledTask.execute(seconds, &method(:try_flush))
+      end
+    end
+
+    # Helper class to track total size and earliest element in a batch of events.
+    class Batch < Array
+      attr_reader :size
+
+      def initialize
+        super
+        @size = 0
+      end
+
+      def events
+        map(&:first)
+      end
+
+      # Each item is an Array containing 2-3 elements (event, size, created_at). Sets created_at if not already present.
+      def <<(item)
+        raise "Invalid Batch item: #{item}" unless item.is_a?(Array) && item.length >= 2
+        item.push(Concurrent.monotonic_time) if item.length < 3
+        super(item)
+        @size += item[1]
+      end
+
+      def shift
+        super.tap {|item| @size -= item[1]}
+      end
+
+      def earliest
+        first[2]
+      end
+    end
+  end
+end

--- a/lib/cdo/firehose.rb
+++ b/lib/cdo/firehose.rb
@@ -1,5 +1,7 @@
 require 'singleton'
+require 'cdo/buffer'
 require 'aws-sdk-firehose'
+require 'active_support/core_ext/module/attribute_accessors'
 
 # A wrapper client to the AWS Firehose service.
 # @example
@@ -19,48 +21,48 @@ require 'aws-sdk-firehose'
 #     }
 #   )
 
-STREAM_NAME = 'analysis-events'.freeze
+class FirehoseClient < Cdo::Buffer
+  STREAM_NAME = 'analysis-events'.freeze
 
-class FirehoseClient
   include Singleton
+  cattr_accessor :client
 
-  REGION = 'us-east-1'.freeze
+  # Ref: https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecordBatch.html
+  ITEMS_PER_REQUEST = 500
+
+  # Ref: https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecordBatch.html
+  BYTES_PER_REQUEST = 1024 * 1024 * 4
 
   # Initializes the @firehose to an AWS Firehose client.
   def initialize
-    if [:development, :test].include? rack_env
-      return
+    super(
+      batch_events: ITEMS_PER_REQUEST,
+      batch_size: BYTES_PER_REQUEST,
+      batch_interval: 10,
+      min_interval: 0.1
+    )
+    unless [:development, :test].include? rack_env
+      self.client = Aws::Firehose::Client.new
     end
-    @firehose = Aws::Firehose::Client.new(region: REGION)
   end
 
   # Posts a record to the analytics stream.
   # @param data [hash] The data to insert into the stream.
   def put_record(data)
-    data_with_common_values = add_common_values(data)
+    buffer({data: add_common_values(data).to_json})
+  end
 
-    if [:development, :test].include? rack_env
-      CDO.log.info "Skipped sending record to #{STREAM_NAME}: "
-      CDO.log.info data
-      return
+  def flush(events)
+    if client
+      client.put_record_batch(
+        {
+          delivery_stream_name: STREAM_NAME,
+          records: events
+        }
+      )
+    else
+      CDO.log.info "Skipped sending records to #{STREAM_NAME}:\n#{events}"
     end
-
-    # TODO(asher): Determine whether these should be cached and batched via
-    # put_record_batch. See
-    #   http://docs.aws.amazon.com/sdkforruby/api/Aws/Firehose/Client.html#put_record_batch-instance_method
-    # for documentation.
-    @firehose.put_record(
-      {
-        delivery_stream_name: STREAM_NAME,
-        record: {data: data_with_common_values.to_json}
-      }
-    )
-  # Swallow and log all errors because an issue sending analytics should not prevent the caller from continuing.
-  rescue StandardError => error
-    # TODO(suresh): if the exception is Firehose ServiceUnavailableException, we should consider
-    # backing off and retrying.
-    # See http://docs.aws.amazon.com/sdkforruby/api/Aws/Firehose/Client.html#put_record-instance_method.
-    Honeybadger.notify(error)
   end
 
   private
@@ -69,12 +71,10 @@ class FirehoseClient
   # @param data [hash] The data to add the key-value pairs to.
   # @return [hash] The data, including the newly added key-value pairs.
   def add_common_values(data)
-    data_with_common_values = data.merge(
+    data.merge(
       created_at: DateTime.now,
       environment: rack_env,
       device: 'server-side'.to_json
     )
-    data_with_common_values[user_id] ||= current_user.id if current_user
-    data_with_common_values
   end
 end

--- a/lib/test/cdo/test_app_server_metrics.rb
+++ b/lib/test/cdo/test_app_server_metrics.rb
@@ -15,9 +15,15 @@ class AppServerMetricsTest < Minitest::Test
     @app = Rack::Builder.app do
       use Cdo::AppServerMetrics,
         interval: 0,
-        report_count: 2,
         listeners: [TCP_LISTENER, SOCKET_LISTENER]
       run ok
+    end
+  end
+
+  def expect_metrics(*metrics)
+    @sequence ||= sequence('metrics')
+    metrics.each do |name, value|
+      Cdo::Metrics.expects(:put).with("App Server/#{name}", value, {}, {storage_resolution: 1, unit: 'Count'}).in_sequence(@sequence)
     end
   end
 
@@ -32,16 +38,14 @@ class AppServerMetricsTest < Minitest::Test
       with([SOCKET_LISTENER]).times(2).
       returns({SOCKET_LISTENER => Raindrops::ListenStats.new(0, 0)})
 
-    Cdo::Metrics.expects(:push).with do |namespace, data|
-      namespace == 'App Server' &&
-        data.group_by {|d| d[:metric_name]}.
-          map {|k, v| {k => v.map {|x| x[:value]}}} ==
-          [
-            {active: [1, 3]},
-            {queued: [2, 4]},
-            {calling: [1, 1]}
-          ]
-    end
+    expect_metrics(
+      [:active, 1],
+      [:queued, 2],
+      [:calling, 1],
+      [:active, 3],
+      [:queued, 4],
+      [:calling, 1]
+    )
 
     get '/'
     get '/'
@@ -50,11 +54,10 @@ class AppServerMetricsTest < Minitest::Test
   def test_reporting_task
     listener = Cdo::AppServerMetrics.new(nil,
       interval: 0.1,
-      report_count: 2,
       listeners: [TCP_LISTENER, SOCKET_LISTENER]
     )
     listener.spawn_reporting_task
-    Cdo::Metrics.expects(:push).at_least(1)
+    Cdo::Metrics.expects(:put).at_least(1)
     sleep 1
   ensure
     listener && listener.shutdown

--- a/lib/test/cdo/test_buffer.rb
+++ b/lib/test/cdo/test_buffer.rb
@@ -1,0 +1,42 @@
+require_relative '../test_helper'
+require 'cdo/buffer'
+
+class BufferTest < Minitest::Test
+  class BufferTestClass < Cdo::Buffer
+    def flushed
+      (@flushed ||= [])
+    end
+
+    def flush(events)
+      flushed.push(events)
+    end
+
+    def flushes
+      flushed.length
+    end
+  end
+
+  def test_batch_events
+    b = BufferTestClass.new(batch_events: 2)
+    7.times {b.buffer('foo')}
+    b.flush!
+    assert_equal 4, b.flushes
+  end
+
+  def test_batch_size
+    b = BufferTestClass.new(batch_size: 5)
+    7.times {b.buffer('HI')}
+    b.flush!
+    assert_equal 4, b.flushes
+  end
+
+  def test_batch_interval
+    b = BufferTestClass.new(batch_interval: 0.1)
+    7.times {b.buffer('bar')}
+    assert_equal 0, b.flushes
+    sleep 0.2
+    assert_equal 1, b.flushes
+    b.flush!
+    assert_equal 1, b.flushes
+  end
+end

--- a/lib/test/cdo/test_firehose.rb
+++ b/lib/test/cdo/test_firehose.rb
@@ -1,0 +1,22 @@
+require_relative '../test_helper'
+require 'cdo/firehose'
+
+class FirehoseTest < Minitest::Test
+  def setup
+    @client = FirehoseClient.client = Aws::Firehose::Client.new(stub_responses: true)
+  end
+
+  def teardown
+    FirehoseClient.client = nil
+  end
+
+  def test_firehose
+    FirehoseClient.instance.put_record({})
+    FirehoseClient.instance.flush!
+    api_request = @client.api_requests.first
+    assert_equal :put_record_batch, api_request[:operation_name]
+    data = JSON.parse(api_request[:params][:records].first[:data])
+    assert_equal '"server-side"', data['device']
+    assert_equal FirehoseClient::STREAM_NAME, api_request[:params][:delivery_stream_name]
+  end
+end


### PR DESCRIPTION
# Description

Refactors the `Cdo::Metrics` and `FirehoseClient` helper classes to send their events in asynchronous, buffered batches to their respective AWS APIs. This allows application-controllers to record CloudWatch metrics or send Firehose analytics-events to Redshift without delaying the response.

### Background

We had planned to buffer+batch server-side Firehose-event API calls for several years, since the initial Firehose helper implementation (#13375) was added in Feb 2017: https://github.com/code-dot-org/code-dot-org/blob/8427501e5df8b3cd936d929b5176abbf8e19f670/lib/cdo/firehose.rb#L18-L21

In addition to making more efficient use of the batch APIs, a buffer/batch pattern also makes its calls asynchronous, which eliminates a synchronous dependency on the AWS services underlying the APIs called. This will prevent application impact when these third-party services experience any unexpected latency/downtime.

### Implementation

This PR introduces an abstract `Cdo::Buffer` class, which uses [`concurrent-ruby`](https://github.com/ruby-concurrency/concurrent-ruby)'s [`Async`](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Async.html) and [`ScheduledTask`](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/ScheduledTask.html) constructs to handle asynchronous-buffering and periodic-flushing using a thread pool. The class is content-agnostic, buffering events in memory through a `#buffer(event, size)` method, and calling `#flush(events)` (implemented by subclass) to flush batches of events when needed.

Several config options control the rate of event-flushing:
- `batch_events`: Specifies a maximum number of events that will make the buffer 'full'.
- `batch_size`: Specifies a maximum total payload 'size' (determined by the `size` parameter passed to `#buffer`), that will make the buffer 'full'.
- `batch_interval`: Specifies a number of seconds after the previous flush when a flush will occur even if not 'full'.
- `min_interval`: Specifies a number of seconds after the previous flush when a flush will _not_ occur. Useful for rate-throttling.