### PR TITLE
Confirm before deleting levels, stages or groups via gui editor

### DIFF
--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -189,6 +189,8 @@ class FlexGroup extends Component {
                 type={ControlTypes.Group}
                 position={afterStage}
                 total={Object.keys(groups).length}
+                itemType="Flex Category"
+                itemName={group || '(none)'}
               />
             </div>
             <div style={styles.groupBody}>

--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -189,8 +189,7 @@ class FlexGroup extends Component {
                 type={ControlTypes.Group}
                 position={afterStage}
                 total={Object.keys(groups).length}
-                itemType="Flex Category"
-                itemName={group || '(none)'}
+                name={group || '(none)'}
               />
             </div>
             <div style={styles.groupBody}>

--- a/apps/src/lib/script-editor/LevelToken.jsx
+++ b/apps/src/lib/script-editor/LevelToken.jsx
@@ -5,7 +5,7 @@ import {Motion, spring} from 'react-motion';
 import color from '../../util/color';
 import {borderRadius, levelTokenMargin} from './constants';
 import LevelTokenDetails from './LevelTokenDetails';
-import {toggleExpand, removeLevel} from './editorRedux';
+import {toggleExpand} from './editorRedux';
 import {levelShape} from './shapes';
 
 const styles = {
@@ -99,7 +99,7 @@ class LevelToken extends Component {
   };
 
   handleRemove = () => {
-    this.props.removeLevel(this.props.stagePosition, this.props.level.position);
+    this.props.removeLevel(this.props.level.position);
   };
 
   render() {
@@ -184,9 +184,6 @@ export default connect(
   dispatch => ({
     toggleExpand(stage, level) {
       dispatch(toggleExpand(stage, level));
-    },
-    removeLevel(stage, level) {
-      dispatch(removeLevel(stage, level));
     }
   })
 )(LevelToken);

--- a/apps/src/lib/script-editor/OrderControls.jsx
+++ b/apps/src/lib/script-editor/OrderControls.jsx
@@ -58,8 +58,8 @@ export class UnconnectedOrderControls extends Component {
     const {showConfirm} = this.state;
     const {type, name} = this.props;
     const text =
-      `Are you sure you want to delete the ${type} named "${name}" ` +
-      'and all its contents?';
+      `Are you sure you want to remove the ${type} named "${name}" ` +
+      'and all its contents from the script?';
     return (
       <div style={styles.controls}>
         <i

--- a/apps/src/lib/script-editor/OrderControls.jsx
+++ b/apps/src/lib/script-editor/OrderControls.jsx
@@ -15,7 +15,7 @@ const styles = {
   }
 };
 
-class OrderControls extends Component {
+export class UnconnectedOrderControls extends Component {
   static propTypes = {
     move: PropTypes.func.isRequired,
     remove: PropTypes.func.isRequired,
@@ -92,7 +92,7 @@ class OrderControls extends Component {
   }
 }
 
-export default connect(
+const OrderControls = connect(
   state => ({}),
   dispatch => ({
     move(type, position, direction) {
@@ -106,4 +106,6 @@ export default connect(
         : dispatch(removeStage(position));
     }
   })
-)(OrderControls);
+)(UnconnectedOrderControls);
+
+export default OrderControls;

--- a/apps/src/lib/script-editor/OrderControls.jsx
+++ b/apps/src/lib/script-editor/OrderControls.jsx
@@ -22,8 +22,7 @@ class OrderControls extends Component {
     type: PropTypes.oneOf(Object.keys(ControlTypes)).isRequired,
     position: PropTypes.number.isRequired,
     total: PropTypes.number.isRequired,
-    itemType: PropTypes.string.isRequired,
-    itemName: PropTypes.string.isRequired
+    name: PropTypes.string.isRequired
   };
 
   state = {
@@ -57,9 +56,9 @@ class OrderControls extends Component {
 
   render() {
     const {showConfirm} = this.state;
-    const {itemType, itemName} = this.props;
+    const {type, name} = this.props;
     const text =
-      `Are you sure you want to delete the ${itemType} named "${itemName}" ` +
+      `Are you sure you want to delete the ${type} named "${name}" ` +
       'and all its contents?';
     return (
       <div style={styles.controls}>

--- a/apps/src/lib/script-editor/OrderControls.jsx
+++ b/apps/src/lib/script-editor/OrderControls.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {ControlTypes} from './constants';
 import {moveGroup, moveStage, removeGroup, removeStage} from './editorRedux';
+import Dialog from '../../templates/Dialog';
 
 const styles = {
   controls: {
@@ -20,7 +21,13 @@ class OrderControls extends Component {
     remove: PropTypes.func.isRequired,
     type: PropTypes.oneOf(Object.keys(ControlTypes)).isRequired,
     position: PropTypes.number.isRequired,
-    total: PropTypes.number.isRequired
+    total: PropTypes.number.isRequired,
+    itemType: PropTypes.string.isRequired,
+    itemName: PropTypes.string.isRequired
+  };
+
+  state = {
+    showConfirm: false
   };
 
   handleMoveUp = () => {
@@ -36,10 +43,24 @@ class OrderControls extends Component {
   };
 
   handleRemove = () => {
+    this.setState({showConfirm: true});
+  };
+
+  handleConfirm = () => {
+    this.setState({showConfirm: false});
     this.props.remove(this.props.type, this.props.position);
   };
 
+  handleClose = () => {
+    this.setState({showConfirm: false});
+  };
+
   render() {
+    const {showConfirm} = this.state;
+    const {itemType, itemName} = this.props;
+    const text =
+      `Are you sure you want to delete the ${itemType} named "${itemName}" ` +
+      'and all its contents?';
     return (
       <div style={styles.controls}>
         <i
@@ -56,6 +77,16 @@ class OrderControls extends Component {
           onMouseDown={this.handleRemove}
           style={styles.controlIcon}
           className="fa fa-trash"
+        />
+        <Dialog
+          body={text}
+          cancelText="Cancel"
+          confirmText="Delete"
+          confirmType="danger"
+          isOpen={showConfirm}
+          handleClose={this.handleClose}
+          onCancel={this.handleClose}
+          onConfirm={this.handleConfirm}
         />
       </div>
     );

--- a/apps/src/lib/script-editor/RemoveLevelDialog.jsx
+++ b/apps/src/lib/script-editor/RemoveLevelDialog.jsx
@@ -1,0 +1,59 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {removeLevel} from './editorRedux';
+import Dialog from '../../templates/Dialog';
+
+/**
+ * Dialog which confirms removal of the level in the specified position
+ * within the stage.
+ */
+class RemoveLevelDialog extends Component {
+  static propTypes = {
+    stage: PropTypes.object.isRequired,
+    // Position of level to remove. Dialog opens when this is set.
+    levelPosToRemove: PropTypes.number,
+    handleClose: PropTypes.func.isRequired,
+
+    // provided by redux
+    removeLevel: PropTypes.func.isRequired,
+    levelKeyList: PropTypes.object.isRequired
+  };
+
+  handleConfirm = () => {
+    const {stage, levelPosToRemove, removeLevel, handleClose} = this.props;
+    removeLevel(stage.position, levelPosToRemove);
+    handleClose();
+  };
+
+  render() {
+    const {stage, handleClose, levelPosToRemove} = this.props;
+    let confirmText;
+    if (levelPosToRemove) {
+      const levelId = stage.levels[levelPosToRemove - 1].activeId;
+      const levelName = this.props.levelKeyList[levelId];
+      confirmText = `Are you sure you want to remove the level named "${levelName}" from the script?`;
+    }
+    return (
+      <Dialog
+        body={confirmText}
+        cancelText="Cancel"
+        confirmText="Delete"
+        confirmType="danger"
+        isOpen={!!levelPosToRemove}
+        handleClose={handleClose}
+        onCancel={handleClose}
+        onConfirm={this.handleConfirm}
+      />
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    levelKeyList: state.levelKeyList
+  }),
+  {
+    removeLevel
+  }
+)(RemoveLevelDialog);

--- a/apps/src/lib/script-editor/RemoveLevelDialog.jsx
+++ b/apps/src/lib/script-editor/RemoveLevelDialog.jsx
@@ -8,7 +8,7 @@ import Dialog from '../../templates/Dialog';
  * Dialog which confirms removal of the level in the specified position
  * within the stage.
  */
-class RemoveLevelDialog extends Component {
+export class UnconnectedRemoveLevelDialog extends Component {
   static propTypes = {
     stage: PropTypes.object.isRequired,
     // Position of level to remove. Dialog opens when this is set.
@@ -49,11 +49,12 @@ class RemoveLevelDialog extends Component {
   }
 }
 
-export default connect(
+const RemoveLevelDialog = connect(
   state => ({
     levelKeyList: state.levelKeyList
   }),
   {
     removeLevel
   }
-)(RemoveLevelDialog);
+)(UnconnectedRemoveLevelDialog);
+export default RemoveLevelDialog;

--- a/apps/src/lib/script-editor/RemoveLevelDialog.jsx
+++ b/apps/src/lib/script-editor/RemoveLevelDialog.jsx
@@ -28,15 +28,15 @@ class RemoveLevelDialog extends Component {
 
   render() {
     const {stage, handleClose, levelPosToRemove} = this.props;
-    let confirmText;
+    let bodyText;
     if (levelPosToRemove) {
       const levelId = stage.levels[levelPosToRemove - 1].activeId;
       const levelName = this.props.levelKeyList[levelId];
-      confirmText = `Are you sure you want to remove the level named "${levelName}" from the script?`;
+      bodyText = `Are you sure you want to remove the level named "${levelName}" from the script?`;
     }
     return (
       <Dialog
-        body={confirmText}
+        body={bodyText}
         cancelText="Cancel"
         confirmText="Delete"
         confirmType="danger"

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -250,25 +250,24 @@ export class UnconnectedStageCard extends Component {
           </label>
         </div>
         {stage.levels.map(level => (
-          <div key={level.position + '_' + level.ids[0]}>
-            <LevelToken
-              ref={levelToken => {
-                if (levelToken) {
-                  const metrics = ReactDOM.findDOMNode(
-                    levelToken
-                  ).getBoundingClientRect();
-                  this.metrics[level.position] = metrics;
-                }
-              }}
-              level={level}
-              stagePosition={stage.position}
-              dragging={!!draggedLevelPos}
-              draggedLevelPos={level.position === draggedLevelPos}
-              delta={this.state.currentPositions[level.position - 1] || 0}
-              handleDragStart={this.handleDragStart}
-              removeLevel={this.handleRemoveLevel}
-            />
-          </div>
+          <LevelToken
+            ref={levelToken => {
+              if (levelToken) {
+                const metrics = ReactDOM.findDOMNode(
+                  levelToken
+                ).getBoundingClientRect();
+                this.metrics[level.position] = metrics;
+              }
+            }}
+            key={level.position + '_' + level.ids[0]}
+            level={level}
+            stagePosition={stage.position}
+            dragging={!!draggedLevelPos}
+            draggedLevelPos={level.position === draggedLevelPos}
+            delta={this.state.currentPositions[level.position - 1] || 0}
+            handleDragStart={this.handleDragStart}
+            removeLevel={this.handleRemoveLevel}
+          />
         ))}
         <div style={styles.bottomControls}>
           {!this.state.editingFlexCategory && (

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -226,6 +226,8 @@ export class UnconnectedStageCard extends Component {
             type={ControlTypes.Stage}
             position={stage.position}
             total={this.props.stagesCount}
+            itemType="Stage"
+            itemName={this.props.stage.name}
           />
           <label style={styles.stageLockable}>
             Require teachers to unlock this stage before students in their

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -246,24 +246,25 @@ export class UnconnectedStageCard extends Component {
           </label>
         </div>
         {stage.levels.map(level => (
-          <LevelToken
-            ref={levelToken => {
-              if (levelToken) {
-                const metrics = ReactDOM.findDOMNode(
-                  levelToken
-                ).getBoundingClientRect();
-                this.metrics[level.position] = metrics;
-              }
-            }}
-            key={level.position + '_' + level.ids[0]}
-            level={level}
-            stagePosition={stage.position}
-            dragging={!!draggedLevelPos}
-            draggedLevelPos={level.position === draggedLevelPos}
-            delta={this.state.currentPositions[level.position - 1] || 0}
-            handleDragStart={this.handleDragStart}
-            removeLevel={this.handleRemoveLevel}
-          />
+          <div key={level.position + '_' + level.ids[0]}>
+            <LevelToken
+              ref={levelToken => {
+                if (levelToken) {
+                  const metrics = ReactDOM.findDOMNode(
+                    levelToken
+                  ).getBoundingClientRect();
+                  this.metrics[level.position] = metrics;
+                }
+              }}
+              level={level}
+              stagePosition={stage.position}
+              dragging={!!draggedLevelPos}
+              draggedLevelPos={level.position === draggedLevelPos}
+              delta={this.state.currentPositions[level.position - 1] || 0}
+              handleDragStart={this.handleDragStart}
+              removeLevel={this.handleRemoveLevel}
+            />
+          </div>
         ))}
         <div style={styles.bottomControls}>
           {!this.state.editingFlexCategory && (

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -9,6 +9,7 @@ import {
   reorderLevel,
   moveLevelToStage,
   addLevel,
+  removeLevel,
   setStageLockable,
   setFlexCategory
 } from './editorRedux';
@@ -61,6 +62,7 @@ export class UnconnectedStageCard extends Component {
     reorderLevel: PropTypes.func.isRequired,
     moveLevelToStage: PropTypes.func.isRequired,
     addLevel: PropTypes.func.isRequired,
+    removeLevel: PropTypes.func.isRequired,
     setStageLockable: PropTypes.func.isRequired,
     stagesCount: PropTypes.number.isRequired,
     stage: PropTypes.object.isRequired,
@@ -183,6 +185,10 @@ export class UnconnectedStageCard extends Component {
     this.props.addLevel(this.props.stage.position);
   };
 
+  handleRemoveLevel = levelPos => {
+    this.props.removeLevel(this.props.stage.position, levelPos);
+  };
+
   handleEditFlexCategory = () => {
     this.setState({
       editingFlexCategory: true
@@ -256,6 +262,7 @@ export class UnconnectedStageCard extends Component {
             draggedLevelPos={level.position === draggedLevelPos}
             delta={this.state.currentPositions[level.position - 1] || 0}
             handleDragStart={this.handleDragStart}
+            removeLevel={this.handleRemoveLevel}
           />
         ))}
         <div style={styles.bottomControls}>
@@ -301,6 +308,7 @@ export default connect(
     reorderLevel,
     moveLevelToStage,
     addLevel,
+    removeLevel,
     setStageLockable,
     setFlexCategory
   }

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -9,13 +9,12 @@ import {
   reorderLevel,
   moveLevelToStage,
   addLevel,
-  removeLevel,
   setStageLockable,
   setFlexCategory
 } from './editorRedux';
 import FlexCategorySelector from './FlexCategorySelector';
 import color from '../../util/color';
-import Dialog from '../../templates/Dialog';
+import RemoveLevelDialog from './RemoveLevelDialog';
 
 const styles = {
   checkbox: {
@@ -63,15 +62,13 @@ export class UnconnectedStageCard extends Component {
     reorderLevel: PropTypes.func.isRequired,
     moveLevelToStage: PropTypes.func.isRequired,
     addLevel: PropTypes.func.isRequired,
-    removeLevel: PropTypes.func.isRequired,
     setStageLockable: PropTypes.func.isRequired,
     stagesCount: PropTypes.number.isRequired,
     stage: PropTypes.object.isRequired,
     stageMetrics: PropTypes.object.isRequired,
     setFlexCategory: PropTypes.func.isRequired,
     setTargetStage: PropTypes.func.isRequired,
-    targetStagePos: PropTypes.number,
-    levelKeyList: PropTypes.object.isRequired
+    targetStagePos: PropTypes.number
   };
 
   /**
@@ -192,14 +189,6 @@ export class UnconnectedStageCard extends Component {
     this.setState({levelPosToRemove: levelPos});
   };
 
-  handleConfirm = () => {
-    this.props.removeLevel(
-      this.props.stage.position,
-      this.state.levelPosToRemove
-    );
-    this.setState({levelPosToRemove: null});
-  };
-
   handleClose = () => {
     this.setState({levelPosToRemove: null});
   };
@@ -235,12 +224,6 @@ export class UnconnectedStageCard extends Component {
   render() {
     const {stage, targetStagePos} = this.props;
     const {draggedLevelPos, levelPosToRemove} = this.state;
-    let confirmText;
-    if (levelPosToRemove) {
-      const levelIdToRemove = stage.levels[levelPosToRemove - 1].activeId;
-      const levelNameToRemove = this.props.levelKeyList[levelIdToRemove];
-      confirmText = `Are you sure you want to remove the level named "${levelNameToRemove}" from the script?`;
-    }
     const isTargetStage = targetStagePos === stage.position;
     return (
       <div style={isTargetStage ? styles.targetStageCard : styles.stageCard}>
@@ -319,15 +302,10 @@ export class UnconnectedStageCard extends Component {
             />
           )}
         </div>
-        <Dialog
-          body={confirmText}
-          cancelText="Cancel"
-          confirmText="Delete"
-          confirmType="danger"
-          isOpen={!!levelPosToRemove}
+        <RemoveLevelDialog
+          stage={stage}
+          levelPosToRemove={levelPosToRemove}
           handleClose={this.handleClose}
-          onCancel={this.handleClose}
-          onConfirm={this.handleConfirm}
         />
       </div>
     );
@@ -335,14 +313,11 @@ export class UnconnectedStageCard extends Component {
 }
 
 export default connect(
-  state => ({
-    levelKeyList: state.levelKeyList
-  }),
+  state => ({}),
   {
     reorderLevel,
     moveLevelToStage,
     addLevel,
-    removeLevel,
     setStageLockable,
     setFlexCategory
   }

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -302,6 +302,8 @@ export class UnconnectedStageCard extends Component {
             />
           )}
         </div>
+        {/* This dialog lives outside LevelToken because moving it inside can
+           interfere with drag and drop or fail to show the modal backdrop. */}
         <RemoveLevelDialog
           stage={stage}
           levelPosToRemove={levelPosToRemove}

--- a/apps/src/lib/script-editor/StageCard.jsx
+++ b/apps/src/lib/script-editor/StageCard.jsx
@@ -226,8 +226,7 @@ export class UnconnectedStageCard extends Component {
             type={ControlTypes.Stage}
             position={stage.position}
             total={this.props.stagesCount}
-            itemType="Stage"
-            itemName={this.props.stage.name}
+            name={this.props.stage.name}
           />
           <label style={styles.stageLockable}>
             Require teachers to unlock this stage before students in their

--- a/apps/test/unit/lib/script-editor/OrderControlsTest.js
+++ b/apps/test/unit/lib/script-editor/OrderControlsTest.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+
+import {UnconnectedOrderControls as OrderControls} from '@cdo/apps/lib/script-editor/OrderControls';
+import {ControlTypes} from '../../../../src/lib/script-editor/constants';
+
+describe('OrderControls', () => {
+  let move, remove, defaultProps;
+  beforeEach(() => {
+    move = sinon.spy();
+    remove = sinon.spy();
+    defaultProps = {
+      move,
+      remove,
+      type: ControlTypes.Stage,
+      position: 1,
+      total: 2,
+      name: 'My Stage'
+    };
+  });
+  it('renders default props', () => {
+    const wrapper = mount(<OrderControls {...defaultProps} />);
+    expect(wrapper.find('.fa-trash')).to.have.lengthOf(1);
+  });
+  it('shows confirmation dialog before deleting', () => {
+    const wrapper = mount(<OrderControls {...defaultProps} />);
+    expect(wrapper.find('.fa-trash')).to.have.lengthOf(1);
+
+    wrapper.find('.fa-trash').simulate('mousedown');
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(1);
+    expect(wrapper.find('.modal-body').text()).to.include(
+      'Are you sure you want to delete'
+    );
+    expect(remove).not.to.have.been.called;
+
+    const deleteButton = wrapper.find('button').at(1);
+    expect(deleteButton.text()).to.include('Delete');
+    deleteButton.simulate('click');
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(0);
+    expect(remove).to.have.been.calledOnce;
+  });
+});

--- a/apps/test/unit/lib/script-editor/OrderControlsTest.js
+++ b/apps/test/unit/lib/script-editor/OrderControlsTest.js
@@ -31,7 +31,7 @@ describe('OrderControls', () => {
     wrapper.find('.fa-trash').simulate('mousedown');
     expect(wrapper.find('.modal-body')).to.have.lengthOf(1);
     expect(wrapper.find('.modal-body').text()).to.include(
-      'Are you sure you want to delete'
+      'Are you sure you want to remove'
     );
     expect(remove).not.to.have.been.called;
 

--- a/apps/test/unit/lib/script-editor/OrderControlsTest.js
+++ b/apps/test/unit/lib/script-editor/OrderControlsTest.js
@@ -41,4 +41,14 @@ describe('OrderControls', () => {
     expect(wrapper.find('.modal-body')).to.have.lengthOf(0);
     expect(remove).to.have.been.calledOnce;
   });
+  it('does not delete on confirmation dialog cancel', () => {
+    const wrapper = mount(<OrderControls {...defaultProps} />);
+    wrapper.find('.fa-trash').simulate('mousedown');
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(1);
+    const cancelButton = wrapper.find('button').at(0);
+    expect(cancelButton.text()).to.include('Cancel');
+    cancelButton.simulate('click');
+    expect(remove).not.to.have.been.called;
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(0);
+  });
 });

--- a/apps/test/unit/lib/script-editor/RemoveLevelDialogTest.js
+++ b/apps/test/unit/lib/script-editor/RemoveLevelDialogTest.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+
+import {UnconnectedRemoveLevelDialog as RemoveLevelDialog} from '@cdo/apps/lib/script-editor/RemoveLevelDialog';
+
+const levelKeyList = {
+  22: 'Level Twenty Two'
+};
+
+describe('RemoveLevelDialog', () => {
+  let handleClose, removeLevel, props;
+  beforeEach(() => {
+    handleClose = sinon.spy();
+    removeLevel = sinon.spy();
+    props = {
+      stage: {
+        position: 3,
+        levels: [
+          {
+            position: 1,
+            activeId: 22,
+            ids: [22]
+          }
+        ]
+      },
+      levelPosToRemove: 1,
+      handleClose,
+      removeLevel,
+      levelKeyList
+    };
+  });
+
+  it('is initially closed', () => {
+    props.levelPosToRemove = null;
+    const wrapper = mount(<RemoveLevelDialog {...props} />);
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(0);
+  });
+  it('is open when level is specified', () => {
+    const wrapper = mount(<RemoveLevelDialog {...props} />);
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(1);
+  });
+  it('removes level on confirm', () => {
+    const wrapper = mount(<RemoveLevelDialog {...props} />);
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(1);
+
+    const body = wrapper.find('.modal-body');
+    const deleteButton = body.find('button').at(1);
+    expect(deleteButton.text()).to.include('Delete');
+    deleteButton.simulate('click');
+    expect(removeLevel).to.have.been.calledWith(3, 1);
+    expect(handleClose).to.have.been.calledOnce;
+  });
+  it('does not remove level on cancel', () => {
+    const wrapper = mount(<RemoveLevelDialog {...props} />);
+    expect(wrapper.find('.modal-body')).to.have.lengthOf(1);
+
+    const body = wrapper.find('.modal-body');
+    const cancelButton = body.find('button').at(0);
+    expect(cancelButton.text()).to.include('Cancel');
+    cancelButton.simulate('click');
+    expect(removeLevel).not.to.have.been.called;
+    expect(handleClose).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
# Description

Finishes [LP-753](https://codedotorg.atlassian.net/browse/LP-753)

Displays a confirmation dialog when you go to remove any of the following via the stage edit gui:
* flex group
* stage
* level

![confirm-stage-delete](https://user-images.githubusercontent.com/8001765/68982532-36a12d00-07bc-11ea-9dca-76e81e9e70b7.gif)

## Testing story

Manually verified confirm / cancel / close in each scenario. new unit test for OrderControls delete flow and RemoveLevelDialog. No UI tests yet due to blocking infrastructure problems, but I may have found a way to add a partial UI test in a next PR.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
