### PR TITLE
Fix a UI test by waiting until button click will work

### DIFF
--- a/dashboard/test/ui/features/user_menu.feature
+++ b/dashboard/test/ui/features/user_menu.feature
@@ -60,6 +60,7 @@ Scenario: Pair Programming
   Given I create a student named "Thing_Two"
   And I join the section
   Given I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/7?noautoplay=true"
+  And I wait for the page to fully load
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Thing_Two"
   And I click selector ".display_name"


### PR DESCRIPTION
From viewing Sauce Labs video of the UI test running on Safari, it appears the main app was still loading when we attempted to click the button to show the user dropdown menu, and the menu never dropped down. 

Waiting until the whole page is loaded appears to ensure that the JS to drop the menu down is ready to run when we do the click.