### PR TITLE
hoc2019: Fix link on /dance

### DIFF
--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -52,7 +52,7 @@ theme: responsive
   %h2= I18n.t(:hoc2018_dance_amazon_learn_more_future_engineer_subheading_title)
 
   .full-resource-block{style: "margin-top: 20px;"}
-    %a{href: "/dance"}
+    %a{href: "https://www.amazonfutureengineer.com", target: "_blank"}
       %img.full-resource-image{src: "/images/AFE-person-2019.jpg"}
     .tutorial-info{style: "padding: 30px;"}
       %span


### PR DESCRIPTION
Clicking the AFE image now goes to the correct website.

Excellent catch by @Erin007.