### PR TITLE
[student-libraries] Allow exporting nested libraries

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
@@ -101,11 +101,12 @@ class LibraryCreationDialog extends React.Component {
         return;
       }
       let librarySource = response.source;
-      response.libraries &&
+      if (response.libraries) {
         response.libraries.forEach(library => {
           librarySource =
             libraryParser.createLibraryClosure(library) + librarySource;
         });
+      }
       this.setState({
         libraryName: libraryParser.sanitizeName(
           dashboard.project.getLevelName()

--- a/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
@@ -100,11 +100,17 @@ class LibraryCreationDialog extends React.Component {
         this.setState({publishState: PublishState.NO_FUNCTIONS});
         return;
       }
+      let librarySource = response.source;
+      response.libraries &&
+        response.libraries.forEach(library => {
+          librarySource =
+            libraryParser.createLibraryClosure(library) + librarySource;
+        });
       this.setState({
         libraryName: libraryParser.sanitizeName(
           dashboard.project.getLevelName()
         ),
-        librarySource: response.source,
+        librarySource: librarySource,
         publishState: PublishState.DONE_LOADING,
         sourceFunctionList: functionsList
       });


### PR DESCRIPTION
# Description
Previously, students who exported a library that used a different library would cause breaks in projects that imported their library. This fixes that issue. Students can now import a library into a project and publish that project as a library.
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-747)
- [spec](https://docs.google.com/document/d/1VxMmdHdIeBWCXKofkjEy9MuWcrzeEW3Zt-Ir8pINYdA/edit)
- [all relevant PRs](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Ajmkulwik+archived%3Afalse+student+libraries)

## Testing story
Updated tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
