### PR TITLE
Revert "Arrow buttons now work on touchscreen laptops."

### DIFF
--- a/apps/src/dom.js
+++ b/apps/src/dom.js
@@ -9,7 +9,7 @@ exports.addReadyListener = function(callback) {
 exports.getTouchEventName = function(eventName) {
   var isIE11Touch = window.navigator.pointerEnabled;
   var isIE10Touch = window.navigator.msPointerEnabled;
-  var isStandardTouch = !(isIE11Touch || isIE10Touch);
+  var isStandardTouch = 'ontouchend' in document.documentElement;
 
   var key;
   if (isIE11Touch) {
@@ -66,7 +66,7 @@ var addEvent = function(
       if (suppressTouchDefault) {
         e.preventDefault();
       }
-
+      unbindEvent('click');
       handler.call(this, e);
     });
   }


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#31924

Was causing an issue with the "like" button on certain levels on IE.

Details: https://codedotorg.slack.com/archives/CN4T89YP8/p1574107462006800

![toggleLikeButton](https://user-images.githubusercontent.com/8324574/69091459-30e75980-09ff-11ea-9aaf-69d47e282c99.gif)

