### PR TITLE
Assignment Updates: unassign from course overview

### DIFF
--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -6,6 +6,7 @@ import i18n from '@cdo/locale';
 import Button from '../Button';
 import CourseScriptTeacherInfo from './CourseScriptTeacherInfo';
 import AssignButton from '@cdo/apps/templates/AssignButton';
+import UnassignButton from '@cdo/apps/templates/UnassignButton';
 import Assigned from '@cdo/apps/templates/Assigned';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
@@ -146,13 +147,17 @@ class CourseScript extends Component {
               className="uitest-go-to-unit-button"
             />
             {isAssigned &&
+              viewAs === ViewType.Student &&
               experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
                 <Assigned />
               )}
+            {isAssigned && viewAs === ViewType.Teacher && selectedSectionId && (
+              <UnassignButton sectionId={selectedSectionId} />
+            )}
             {!isAssigned &&
               viewAs === ViewType.Teacher &&
               showAssignButton &&
-              selectedSection &&
+              selectedSectionId &&
               experiments.isEnabled(experiments.ASSIGNMENT_UPDATES) && (
                 <AssignButton
                   sectionId={selectedSectionId}


### PR DESCRIPTION
[LP- 1030](https://codedotorg.atlassian.net/browse/LP-1030)

Currently with the `assignmentUpdates` experiment flag enabled, a teacher can assign a unit from the course overview page.  However,  they can't unassign that unit because for both students and teachers, we're showing the assigned checkmark. 
<img width="1079" alt="Screen Shot 2019-11-18 at 1 21 55 PM" src="https://user-images.githubusercontent.com/12300669/69097279-161ae200-0a0b-11ea-881e-56a9431178df.png">

This update allows teachers to unassign units from the course overview page. 
![unassign-from-course-overview](https://user-images.githubusercontent.com/12300669/69097304-2468fe00-0a0b-11ea-933f-aa63c990c778.gif)

