### PR TITLE
Hide named checkbox

### DIFF
--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -81,7 +81,7 @@ const tooltipText = {
     'Show this level on a line by itself, with the Display Name of the level as the label. This option is deprecated. Please specify a progression name instead.',
   challenge: 'Show students the Challenge dialog when viewing this level.',
   progression:
-    'Group this level with other levels in the same progression, with this text as the label. This overrides the "named" checkbox, which is now deprecated.'
+    'Group this level with other levels in the same progression, with this text as the label.'
 };
 
 const ArrowRenderer = ({onMouseDown}) => {

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -78,10 +78,10 @@ const tooltipText = {
   assessment:
     'Visibly mark this level as an assessment, and show it in the Assessments tab in Teacher Dashboard.',
   named:
-    'Show this level on a line by itself, with the Display Name of the level as the label.',
+    'Show this level on a line by itself, with the Display Name of the level as the label. This option is deprecated. Please specify a progression name instead.',
   challenge: 'Show students the Challenge dialog when viewing this level.',
   progression:
-    'Group this level with other levels in the same progression, with this text as the label. This overrides the "named" checkbox.'
+    'Group this level with other levels in the same progression, with this text as the label. This overrides the "named" checkbox, which is now deprecated.'
 };
 
 const ArrowRenderer = ({onMouseDown}) => {

--- a/apps/src/lib/script-editor/LevelTokenDetails.jsx
+++ b/apps/src/lib/script-editor/LevelTokenDetails.jsx
@@ -74,8 +74,6 @@ const styles = {
   }
 };
 
-const scriptLevelOptions = ['assessment', 'named', 'challenge'];
-
 const tooltipText = {
   assessment:
     'Visibly mark this level as an assessment, and show it in the Assessments tab in Teacher Dashboard.',
@@ -110,7 +108,11 @@ export class UnconnectedLevelTokenDetails extends Component {
       // Variants are deprecated. Only show them if they are already in use.
       // If the number of variants is reduced to 1, keep showing the Add
       // Variants button for the rest of this editing session.
-      showAddVariants: props.level.ids.length > 1
+      showAddVariants: props.level.ids.length > 1,
+      // Named levels are deprecated. Only show the checkbox if the level is
+      // already marked as named, otherwise the author can name the level by
+      // specifying a name in the progression field.
+      showNamed: props.level.named
     };
   }
 
@@ -173,6 +175,10 @@ export class UnconnectedLevelTokenDetails extends Component {
     Object.keys(tooltipText).forEach(option => {
       tooltipIds[option] = _.uniqueId();
     });
+    const scriptLevelOptions = ['assessment', 'challenge'];
+    if (this.state.showNamed) {
+      scriptLevelOptions.push('named');
+    }
     return (
       <div style={styles.levelTokenActive}>
         <span className="level-token-checkboxes">

--- a/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
+++ b/apps/test/unit/lib/script-editor/LevelTokenDetailsTest.js
@@ -24,6 +24,13 @@ const defaultLevel = {
   activeId: 2
 };
 
+const assertCheckboxVisible = (wrapper, name, visible) => {
+  const label = wrapper
+    .find('.level-token-checkboxes')
+    .findWhere(n => n.name() === 'label' && n.text().includes(name));
+  expect(label).to.have.lengthOf(visible ? 1 : 0);
+};
+
 const assertChecked = (wrapper, name, checked) => {
   const label = wrapper
     .find('.level-token-checkboxes')
@@ -78,7 +85,10 @@ describe('LevelTokenDetails', () => {
   it('renders with default props', () => {
     const wrapper = shallow(<LevelTokenDetails {...defaultProps} />);
 
-    assertChecked(wrapper, 'named', false);
+    assertCheckboxVisible(wrapper, 'named', false);
+    assertCheckboxVisible(wrapper, 'assessment', true);
+    assertCheckboxVisible(wrapper, 'challenge', true);
+
     assertChecked(wrapper, 'assessment', false);
     assertChecked(wrapper, 'challenge', false);
 


### PR DESCRIPTION
# Description

finishes [LP-752](https://codedotorg.atlassian.net/browse/LP-752)

By default, each level in a stage appears as a bubble in a row without any special name:

![Screen Shot 2019-11-18 at 2 05 56 PM](https://user-images.githubusercontent.com/8001765/69098031-a279d480-0a0c-11ea-9f9f-4bbfe0d8bb3d.png)

If you want to give a lesson or group of lessons a name, you do so via `named` or `progression`: 

script overview page:
![Screen Shot 2019-11-18 at 2 07 19 PM](https://user-images.githubusercontent.com/8001765/69098164-f1276e80-0a0c-11ea-9ddd-8441ee1b9256.png)

script edit gui page:
![Screen Shot 2019-11-18 at 2 13 21 PM](https://user-images.githubusercontent.com/8001765/69098550-a9edad80-0a0d-11ea-80d4-5232acfba5a2.png)

when using the `named` checkbox, you also have to go into each level and specify the `display_name` there: https://github.com/code-dot-org/code-dot-org/blob/24eb3b0b9731c75a818cd9714b76fd91ce63b8d8/dashboard/config/scripts/levels/CSD%20U2L04%20TFMD_2019.level#L9-L8

Because you can accomplish the same goal more easily by just specifying a progression name on the one level you want to name, this PR deprecates the `named` checkbox by hiding it in the edit UI unless it was already in use:

![Screen Shot 2019-11-18 at 2 17 51 PM](https://user-images.githubusercontent.com/8001765/69098841-3b5d1f80-0a0e-11ea-9d2b-a28e010a37ef.png)

it also reorders the checkboxes, but that shouldn't matter because no one is using this UI yet.

## Testing story

verified end-to-end manually (see screenshots). updated existing unit test to verify absence of named checkbox. existing tests cover presence of named checkbox.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
