### PR TITLE
hoc2019: add announcement text to /dance

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/dance-landing/dance.css
+++ b/pegasus/sites.v3/code.org/public/css/dance-landing/dance.css
@@ -4,7 +4,7 @@
 
 .img-dance-stars {
   position: absolute;
-  top: 10px;
+  top: 0px;
   left: 70px;
   width: 330px;
   padding: 20px 10px 10px;
@@ -198,7 +198,8 @@ a:hover {
     left: 50%;
     margin-left: -260px;
     padding: 0;
-    top: 50%;
+    /* A little above the middle while we're showing announcement text below. */
+    top: 40%;
     margin-top: -43px;
   }
 
@@ -249,4 +250,57 @@ a:hover {
   .dance-responsive-padding {
     text-align: center;
   }
+}
+
+/* New announcement text under the artist images, with variants for desktop,
+ * tablet, and mobile. */
+
+.new-announcement {
+  position: absolute;
+  color: white;
+  font-size: 30px;
+  line-height: 30px;
+  top: 230px;
+  text-align: center;
+  width: 460px;
+  font-family: 'Gotham 5r', sans-serif;
+}
+
+.new-announcement .highlight-word {
+  color: rgb(89, 202, 211);
+}
+
+.new-announcement-tablet {
+  position: absolute;
+  bottom: 10%;
+  color: white;
+  font-size: 30px;
+  line-height: 30px;
+  text-align: center;
+  width: 100%;
+  font-family: 'Gotham 5r', sans-serif;
+  .highlight-word {
+    color: rgb(89, 202, 211);
+  }
+}
+
+.new-announcement-tablet .highlight-word {
+  color: rgb(89, 202, 211);
+}
+
+.new-announcement-mobile {
+  color: white;
+  font-size: 30px;
+  line-height: 30px;
+  text-align: center;
+  width: 100%;
+  padding-bottom: 10px;
+  font-family: 'Gotham 5r', sans-serif;
+  .highlight-word {
+    color: rgb(89, 202, 211);
+  }
+}
+
+.new-announcement-mobile .highlight-word {
+  color: rgb(89, 202, 211);
 }

--- a/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
+++ b/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
@@ -9,6 +9,13 @@
     %img.img-dance-stars.desktop-only{src: "/images/fit-300x300/homepage/hoc2019_dance_stars_mobile.png"}
     %img.img-dance-stars.tablet-only{src: "/images/fit-520/homepage/hoc2019_dance_stars.png"}
     %img.img-dance-stars.mobile-only{src: "/images/fit-300x300/homepage/hoc2019_dance_stars_mobile.png"}
+    .new-announcement.desktop-only
+      = hoc_s(:codeorg_homepage_hoc2019_dance_heading)
+    .new-announcement-tablet.tablet-only
+      = hoc_s(:codeorg_homepage_hoc2019_dance_heading)
+    .new-announcement-mobile.mobile-only
+      = hoc_s(:codeorg_homepage_hoc2019_dance_heading)
+
   .col-25.specific-tutorial.right-tutorial.dance-tutorial
     .tutorial-box
       %h2.specific-tutorial-heading.dance-party-h2= I18n.t(:hoc2018_dance_party_box_title)


### PR DESCRIPTION
## desktop

![Screenshot 2019-11-18 14 01 23](https://user-images.githubusercontent.com/2205926/69098414-64c97b80-0a0d-11ea-89c8-3b6ea16ba308.png)

## tablet

![Screenshot 2019-11-18 14 02 50](https://user-images.githubusercontent.com/2205926/69098413-64c97b80-0a0d-11ea-922f-642b19ad2f8f.png)


## mobile

![Screenshot 2019-11-18 14 03 08](https://user-images.githubusercontent.com/2205926/69098412-64c97b80-0a0d-11ea-993f-cb8734ec2099.png)

Followup to https://github.com/code-dot-org/code-dot-org/pull/31900
