### PR TITLE
gracefully recover from empty stage name

### DIFF
--- a/apps/src/lib/script-editor/FlexGroup.jsx
+++ b/apps/src/lib/script-editor/FlexGroup.jsx
@@ -85,7 +85,10 @@ class FlexGroup extends Component {
   };
 
   handleAddStage = position => {
-    this.props.addStage(position, prompt('Enter new stage name'));
+    const newStageName = prompt('Enter new stage name');
+    if (newStageName) {
+      this.props.addStage(position, newStageName);
+    }
   };
 
   setTargetStage = targetStagePos => {


### PR DESCRIPTION
# Description

finishes https://codedotorg.atlassian.net/browse/LP-1031

when you go to create a new stage and then press cancel, it breaks the page:

![empty-stage-before](https://user-images.githubusercontent.com/8001765/69100504-2da99900-0a12-11ea-92b2-ee80d5f56e7f.gif)

This PR allows the page to keep working normally after canceling.

## Testing story

This change seems small enough that I just verified it manually.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
