### PR TITLE
dangerouslySetInnerHTML - enable no danger linter rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,7 @@ module.exports = {
     "react/no-string-refs": "off",
     "react/no-unescaped-entities": "off",
     "react/self-closing-comp": "error",
+    "react/no-danger" : "error",
     semi: "off", // enforced by babel/semi
     "space-before-blocks": "error",
     strict: "error"


### PR DESCRIPTION
# Description
Enable "no-danger" linter rule to warn on _html

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-290)
- [dangrouslySetInnerHTML](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md)

## Testing story
Tested linting rule on [markdownSpan.jsx](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/pd/components/markdownSpan.jsx#L22)

-removed comment to disable lint (```// eslint-disable-line react/no-danger```)

terminal output:
```
 22:9  error  Dangerous property 'dangerouslySetInnerHTML' found  react/no-danger

✖ 1 problem (1 error, 0 warnings)

Traceback (most recent call last):
	4: from tools/hooks/lint.rb:99:in `<main>'
	3: from tools/hooks/lint.rb:91:in `do_linting'
	2: from tools/hooks/lint.rb:91:in `each'
	1: from tools/hooks/lint.rb:94:in `block in do_linting'
tools/hooks/lint.rb:78:in `lint_failure': Lint failed (RuntimeError)
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
