### PR TITLE
Re-enable: Arrow buttons now work on touchscreen laptops. Includes IE fix.

### DIFF
--- a/apps/src/dom.js
+++ b/apps/src/dom.js
@@ -67,6 +67,28 @@ var addEvent = function(
         e.preventDefault();
       }
 
+      // ---- Workaround for IE 11 (2019) ----
+      // Background: PreventDefault is not recognized in IE. In IE 11, a click
+      // event will fire the following events:
+      // MSPointerDown -> pointerdown -> MSPointerUp -> pointerup -> click
+      // This exact same sequence of events happens whether the event originated
+      // from a touch, a trackpad, or a mouse. mousedown, mouseup, and mousemove
+      // events behave similarly. Because of this behavior, we can (and should)
+      // remove the event handlers that are not specific to IE 11 as soon as an
+      // IE 11 event is fired. This will prevent duplicate events from happening
+      // such as double click.
+      let IEEvents = [
+        'pointerdown',
+        'MSPointerDown',
+        'pointermove',
+        'MSPointerMove',
+        'pointerup',
+        'MSPointerUp'
+      ];
+      if (IEEvents.includes(touchEvent)) {
+        unbindEvent('click');
+      }
+
       handler.call(this, e);
     });
   }

--- a/apps/src/dom.js
+++ b/apps/src/dom.js
@@ -9,7 +9,7 @@ exports.addReadyListener = function(callback) {
 exports.getTouchEventName = function(eventName) {
   var isIE11Touch = window.navigator.pointerEnabled;
   var isIE10Touch = window.navigator.msPointerEnabled;
-  var isStandardTouch = 'ontouchend' in document.documentElement;
+  var isStandardTouch = !(isIE11Touch || isIE10Touch);
 
   var key;
   if (isIE11Touch) {
@@ -66,7 +66,7 @@ var addEvent = function(
       if (suppressTouchDefault) {
         e.preventDefault();
       }
-      unbindEvent('click');
+
       handler.call(this, e);
     });
   }


### PR DESCRIPTION
# Description

This is the second attempt at enabling touch on touch-enabled-laptops for certain buttons.

See https://github.com/code-dot-org/code-dot-org/pull/31924 for full details. Failing tests are now passing locally.

The original PR (https://github.com/code-dot-org/code-dot-org/pull/31924) was reverted due to a toggle issue in IE 11. See https://github.com/code-dot-org/code-dot-org/pull/31972 for details.

The toggle now works as expected:
![toggleLikeButtonWorks](https://user-images.githubusercontent.com/8324574/69102709-14a3e680-0a18-11ea-8aab-5ce66994ad48.gif)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
See https://github.com/code-dot-org/code-dot-org/pull/31924 for full details


## Testing story
See https://github.com/code-dot-org/code-dot-org/pull/31924 for full details


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
