### PR TITLE
allow partners to view levels on /levels page

### DIFF
--- a/dashboard/app/views/levels/_list.html.haml
+++ b/dashboard/app/views/levels/_list.html.haml
@@ -87,7 +87,7 @@
 
         -# Level name column, linked to view action if permitted
         %td
-          - if can? :view, level
+          - if can? :show, level
             = link_to level.name, level, title: t('crud.show')
           - else
             = level.name


### PR DESCRIPTION
# Description

Finishes [LP-1032](https://codedotorg.atlassian.net/browse/LP-1032)

Allows partners to view levels they see at https://levelbuilder-studio.code.org/levels by linkifying the level name.

before:
![Screen Shot 2019-11-18 at 4 34 08 PM](https://user-images.githubusercontent.com/8001765/69105836-7157cf00-0a21-11ea-8823-09b858a2ab52.png)

after:
![Screen Shot 2019-11-18 at 4 33 44 PM](https://user-images.githubusercontent.com/8001765/69105842-74eb5600-0a21-11ea-9b79-077e86595b6d.png)

no change in behavior for those with levelbuilder permissions.

## Testing story

This change seems small enough and the SLA is low enough that I haven't added any tests for this change.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
