### PR TITLE
Update ml-activities to 0.0.12, reference its assets separately

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -176,6 +176,12 @@ describe('entry tests', () => {
         },
         {
           expand: true,
+          cwd: 'node_modules/@code-dot-org/ml-activities/dist/assets',
+          src: ['**'],
+          dest: 'build/package/media/skins/fish'
+        },
+        {
+          expand: true,
           cwd: 'node_modules/scratch-blocks/media',
           src: ['**'],
           dest: 'build/package/media/scratch-blocks'

--- a/apps/package.json
+++ b/apps/package.json
@@ -48,7 +48,7 @@
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "1.1.0",
-    "@code-dot-org/ml-activities": "0.0.11",
+    "@code-dot-org/ml-activities": "0.0.12",
     "@code-dot-org/p5.play": "^1.3.12-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import FishView from './FishView';
 import {Provider} from 'react-redux';
 import {getStore} from '../redux';
-import {initAll} from '@code-dot-org/ml-activities';
+import {setAssetPath} from '@code-dot-org/ml-activities/dist/assetPath';
 import {TestResults} from '@cdo/apps/constants';
 
 /**
@@ -98,6 +98,10 @@ Fish.prototype.initMLActivities = function() {
   // Set up initial state
   const canvas = document.getElementById('activity-canvas');
   const backgroundCanvas = document.getElementById('background-canvas');
+
+  setAssetPath('/blockly/media/skins/fish/');
+
+  const {initAll} = require('@code-dot-org/ml-activities');
 
   // Set initial state for UI elements.
   initAll({

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -954,11 +954,14 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-1.1.0.tgz#7c8185adf06a9172e3bde4ccd6f6738a787b2a7c"
 
-"@code-dot-org/ml-activities@0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.11.tgz#0dd4d388ec92a32371b7f958e90c24e3d234434d"
-  integrity sha512-WjxeUwATiaBhHA+hj/xlBNHn3flCNk5z5Vc1T+32LdSii0cUcftpWoBhpcAHhG3+47So6JxNgYQy9F4GoS8Ljg==
+"@code-dot-org/ml-activities@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.12.tgz#b8ab2acb8bbff79034276134d2fcc8b9d80c6a3d"
+  integrity sha512-2Lssg2bOXPm8zXstmD54hitpz0DvzbRo0/zTN0lxJtZvs9vlLOnn+RzpCwd31WEW+/3RGufelul9FBfb5kyvzA==
   dependencies:
+    "@fortawesome/fontawesome-svg-core" "^1.2.25"
+    "@fortawesome/free-solid-svg-icons" "^5.11.2"
+    "@fortawesome/react-fontawesome" "^0.1.7"
     react-typist "^2.0.5"
 
 "@code-dot-org/p5.play@^1.3.12-cdo":
@@ -1078,6 +1081,32 @@
 "@emotion/weak-memoize@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.1.3.tgz#b700d97385fa91affed60c71dfd51c67e9dad762"
+
+"@fortawesome/fontawesome-common-types@^0.2.25":
+  version "0.2.25"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.25.tgz#6df015905081f2762e5cfddeb7a20d2e9b16c786"
+  integrity sha512-3RuZPDuuPELd7RXtUqTCfed14fcny9UiPOkdr2i+cYxBoTOfQgxcDoq77fHiiHcgWuo1LoBUpvGxFF1H/y7s3Q==
+
+"@fortawesome/fontawesome-svg-core@^1.2.25":
+  version "1.2.25"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.25.tgz#24b03391d14f0c6171e8cad7057c687b74049790"
+  integrity sha512-MotKnn53JKqbkLQiwcZSBJVYtTgIKFbh7B8+kd05TSnfKYPFmjKKI59o2fpz5t0Hzl35vVGU6+N4twoOpZUrqA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.25"
+
+"@fortawesome/free-solid-svg-icons@^5.11.2":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.11.2.tgz#2f2f1459743a27902b76655a0d0bc5ec4d945631"
+  integrity sha512-zBue4i0PAZJUXOmLBBvM7L0O7wmsDC8dFv9IhpW5QL4kT9xhhVUsYg/LX1+5KaukWq4/cbDcKT+RT1aRe543sg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.25"
+
+"@fortawesome/react-fontawesome@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.7.tgz#c004ca75c15c5a1218101e8f042b8da8dec0c4b5"
+  integrity sha512-AHWSzOsHBe5vqOkrvs+CKw+8eLl+0XZsVixOWhTPpGpOA8WQUbVU6J9cmtAvTaxUU5OIf+rgxxF8ZKc3BVldxg==
+  dependencies:
+    prop-types "^15.5.10"
 
 "@icons/material@^0.2.4":
   version "0.2.4"


### PR DESCRIPTION
# Description

* Upgrade `ml-activities` to `0.0.12`
* Modify `Gruntfile.js` to copy `ml-activities` assets into `build/package/media/skins/fish`
* Call new `setAssetPath()` helper from `ml-activities` to set the path to `/blockly/media/skins/fish/` before using a runtime `require()` to call `initAll()`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
