### PR TITLE
Un-hide sloth from the create sprite group block

### DIFF
--- a/dashboard/config/blocks/Dancelab/Dancelab_makeNewDanceSpriteGroup.json
+++ b/dashboard/config/blocks/Dancelab/Dancelab_makeNewDanceSpriteGroup.json
@@ -117,6 +117,10 @@
             "\"SHARK\""
           ],
           [
+            "sloths",
+            "\"SLOTH\""
+          ],
+          [
             "unicorns",
             "\"UNICORN\""
           ]


### PR DESCRIPTION
Hotfixing directly to prod for the email blast tomorrow, as blocks don't need to go through an apps build step on the Test machine.