### PR TITLE
Assignment Updates: showAssignButton shouldn't hide the section selection dropdown

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -115,19 +115,17 @@ class ScriptOverviewTopRow extends React.Component {
               </DropdownButton>
             </div>
           )}
-        {!professionalLearningCourse &&
-          viewAs === ViewType.Teacher &&
-          showAssignButton && (
-            <SectionAssigner
-              sections={sectionsForDropdown}
-              selectedSectionId={selectedSectionId}
-              assignmentName={scriptTitle}
-              showAssignButton={showAssignButton}
-              courseId={currentCourseId}
-              scriptId={scriptId}
-              forceReload={true}
-            />
-          )}
+        {!professionalLearningCourse && viewAs === ViewType.Teacher && (
+          <SectionAssigner
+            sections={sectionsForDropdown}
+            selectedSectionId={selectedSectionId}
+            assignmentName={scriptTitle}
+            showAssignButton={showAssignButton}
+            courseId={currentCourseId}
+            scriptId={scriptId}
+            forceReload={true}
+          />
+        )}
         <div style={isRtl ? styles.left : styles.right}>
           <span>
             <ProgressDetailToggle />


### PR DESCRIPTION
I was incorrectly using the value of `showAssignButton` to determine whether to show the `SectionAssigner` on the script overview page, which meant that the `TeacherSectionSelector` did not appear when it should have. `SectionAssigner` should always show the dropdown and use the value of `showAssignButton` to determine when to show the `AssignButton`.