### PR TITLE
extract shared dependencies from essential.js and cookieBanner.js entry points

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -605,6 +605,7 @@ describe('entry tests', () => {
     'libraries/edit': './src/sites/studio/pages/libraries/edit.js',
     'scripts/edit': './src/sites/studio/pages/scripts/edit.js',
     'scripts/new': './src/sites/studio/pages/scripts/new.js',
+    'shared/_check_admin': './src/sites/studio/pages/shared/_check_admin.js',
     'shared_blockly_functions/edit':
       './src/sites/studio/pages/shared_blockly_functions/edit.js'
   };
@@ -694,6 +695,12 @@ describe('entry tests', () => {
     'peer_reviews/show': './src/sites/studio/pages/peer_reviews/show.js'
   };
 
+  // Entries which are shared between dashboard and pegasus, which are included
+  // by haml partials in the shared/haml/ directory.
+  const sharedEntries = {
+    cookieBanner: './src/cookieBanner/cookieBanner.js'
+  };
+
   var otherEntries = {
     // Build embedVideo.js in its own step (skipping factor-bundle) so that
     // we don't have to include the large code-studio-common file in the
@@ -714,17 +721,13 @@ describe('entry tests', () => {
     'applab-api': './src/applab/api-entry.js',
     'gamelab-api': './src/p5lab/gamelab/api-entry.js',
 
-    'shared/_check_admin': './src/sites/studio/pages/shared/_check_admin.js',
-
     'census_reviewers/review_reported_inaccuracies':
       './src/sites/studio/pages/census_reviewers/review_reported_inaccuracies.js',
 
     regionalPartnerMiniContact:
       './src/regionalPartnerMiniContact/regionalPartnerMiniContact',
 
-    donorTeacherBanner: './src/donorTeacherBanner/donorTeacherBanner',
-
-    cookieBanner: './src/cookieBanner/cookieBanner.js'
+    donorTeacherBanner: './src/donorTeacherBanner/donorTeacherBanner'
   };
 
   // Create a config for each of our bundles
@@ -742,6 +745,7 @@ describe('entry tests', () => {
           internalEntries,
           pegasusEntries,
           professionalDevelopmentEntries,
+          sharedEntries,
           otherEntries
         ),
         function(val) {
@@ -869,7 +873,8 @@ describe('entry tests', () => {
                   Object.keys(appsEntries),
                   Object.keys(pegasusEntries),
                   Object.keys(professionalDevelopmentEntries),
-                  Object.keys(internalEntries)
+                  Object.keys(internalEntries),
+                  Object.keys(sharedEntries)
                 );
                 return chunkNames.includes(chunk.name);
               },

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -528,6 +528,7 @@ describe('entry tests', () => {
       './src/sites/studio/pages/devise/registrations/_old_sign_up_form.js',
     'devise/registrations/edit':
       './src/sites/studio/pages/devise/registrations/edit.js',
+    essential: './src/sites/studio/pages/essential.js',
     'home/_homepage': './src/sites/studio/pages/home/_homepage.js',
     'layouts/_header': './src/sites/studio/pages/layouts/_header.js',
     'layouts/_race_interstitial':
@@ -694,8 +695,6 @@ describe('entry tests', () => {
   };
 
   var otherEntries = {
-    essential: './src/sites/studio/pages/essential.js',
-
     // Build embedVideo.js in its own step (skipping factor-bundle) so that
     // we don't have to include the large code-studio-common file in the
     // embedded video page, keeping it fairly lightweight.


### PR DESCRIPTION
# Description

This is part of an ongoing effort to reduce the size of the initial page load on every code studio page.

Eliminates **182KB** JS from every code studio page load by allowing common dependencies to be extracted from essential.js and cookieBanner.js.

essential.js is reduced from 100KB to < 1KB by allowing common chunks to be extracted into both code-studio-common.js (dashboard only) and vendors.js (dashboard and pegasus). cookieBanner.js can only have common chunks extracted into the more restricted vendors.js, because it appears on both dashboard and pegasus, so it only drops in size from 100KB to 18KB.

While I was in there, I noticed that `_check_admin.js` (also ~100KB) gets loaded on script and level page loads, so I threw that into the list of components to have shared code extracted from into vendors.js, reducing the size of this entry point to < 1KB.

To recap, here are the rules for which entry points have common code extracted into which shared chunks:
* https://github.com/code-dot-org/code-dot-org/blob/a9541798da493507c66b4e752a990704d79f4f99/apps/Gruntfile.js#L866-L877
* `code-studio-common` (harder to snippet) pulls common code only out of `codeStudioEntries` and `appsEntries`.

## before

babel-polyfill, highlighted, represents about 85% of the total savings:

![Screen Shot 2019-11-19 at 8 32 25 PM](https://user-images.githubusercontent.com/8001765/69219274-638c7180-0b27-11ea-8b58-2d233168535d.png)

## after

the same components are selected, however some of them are now too small to be visible:

![Screen Shot 2019-11-19 at 10 08 43 PM](https://user-images.githubusercontent.com/8001765/69219286-68512580-0b27-11ea-9cf7-7ed920cf2fc5.png)

## Testing story

* `cookie_banner.feature` covers cookie banner functionality.
* `essential.js` contains only logic for filtering what we log to new relic. after this ships, I'll take a peek to make sure this didn't cause a regression in our ability to filter noise out of new relic.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
