### PR TITLE
avoid long level names when deep copying scripts

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -581,7 +581,8 @@ class Level < ActiveRecord::Base
   #   editor_experiment property to on the newly-created level.
   def clone_with_suffix(new_suffix, editor_experiment: nil)
     # Make sure we don't go over the 70 character limit.
-    new_name = "#{base_name[0..64]}#{new_suffix}"
+    max_index = 70 - new_suffix.length - 1
+    new_name = "#{base_name[0..max_index]}#{new_suffix}"
 
     return Level.find_by_name(new_name) if Level.find_by_name(new_name)
 

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -831,6 +831,20 @@ EOS
     assert_equal 'your_level_1_3', level_3.name
   end
 
+  test 'clone with suffix truncates long names' do
+    # make old name long enough that we'll exceed the 70 character limit on
+    # level names if we don't truncate it before adding the suffix
+    old_name = 'x' * 67
+    suffix = '_long_suffix'
+    assert_equal(12, suffix.length)
+    new_name = 'x' * 58 + suffix
+
+    old_level = create :level, name: old_name, start_blocks: '<xml>foo</xml>'
+    new_level = old_level.clone_with_suffix(suffix)
+    assert_equal new_name, new_level.name
+    assert_equal suffix, new_level.name_suffix
+  end
+
   test 'clone with same suffix copies and shares project template level' do
     template_level = create :level, name: 'template level', start_blocks: '<xml>template</xml>'
     level_1 = create :level, name: 'level 1'

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -836,8 +836,8 @@ EOS
     # level names if we don't truncate it before adding the suffix
     old_name = 'x' * 67
     suffix = '_long_suffix'
-    assert_equal(12, suffix.length)
     new_name = 'x' * 58 + suffix
+    assert_equal(70, new_name.length)
 
     old_level = create :level, name: old_name, start_blocks: '<xml>foo</xml>'
     new_level = old_level.clone_with_suffix(suffix)


### PR DESCRIPTION
# Description

Finishes [LP-1043](https://codedotorg.atlassian.net/browse/LP-1043)

Level names have a maximum length of 70 characters. Today, when copying a level as part of a "deep copy" of a script, we have a hack in place to make sure this limit is not exceeded, assuming the suffix is no more than 4 characters long.

When copying a script for broward, and I may need to use a suffix that's longer than 4 characters. So, this seems like a good time to update this safeguard to work for any length suffix.

Scripts are deep-copied via `Script.find_by_name('time4cs-control-unit-1').clone_with_suffix('broward')`, which then calls `level.clone_with_suffix('_broward')` (note the added `_`) on each level in the script.

## Testing story

Added unit test to cover the new behavior. Existing tests in the same file also provide coverage to prevent regressions in existing functionality.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
