### PR TITLE
move dance 2018 scripts to the end of the list

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -65,8 +65,6 @@ module ScriptConstants
       nil,
       DANCE_PARTY_2019_NAME = 'dance-2019'.freeze, # 2019 hour of code
       DANCE_PARTY_EXTRAS_2019_NAME = 'dance-extras-2019'.freeze, # 2019 hour of code
-      DANCE_PARTY_NAME = 'dance'.freeze, # 2018 hour of code
-      DANCE_PARTY_EXTRAS_NAME = 'dance-extras'.freeze, # 2018 hour of code
       MINECRAFT_AQUATIC_NAME = 'aquatic'.freeze,
       MINECRAFT_HERO_NAME = 'hero'.freeze,
       MINECRAFT_NAME = 'mc'.freeze,
@@ -88,6 +86,8 @@ module ScriptConstants
       SPORTS_NAME = 'sports'.freeze,
       HOC_NAME = 'hourofcode'.freeze, # 2014 hour of code
       OCEANS_NAME = 'oceans'.freeze,
+      DANCE_PARTY_NAME = 'dance'.freeze, # 2018 hour of code
+      DANCE_PARTY_EXTRAS_NAME = 'dance-extras'.freeze, # 2018 hour of code
     ],
     csf_international: [
       COURSE1_NAME = 'course1'.freeze,

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -67,12 +67,12 @@ class ScriptConstantsTest < Minitest::Test
   end
 
   def test_assignable_info
-    assert_equal 3, ScriptConstants.assignable_info({name: 'dance'})[:position]
-    assert_equal 4, ScriptConstants.assignable_info({name: 'dance-extras'})[:position]
-    assert_equal 5, ScriptConstants.assignable_info({name: 'aquatic'})[:position]
-    assert_equal 6, ScriptConstants.assignable_info({name: 'hero'})[:position]
-    assert_equal 7, ScriptConstants.assignable_info({name: 'mc'})[:position]
-    assert_equal 8, ScriptConstants.assignable_info({name: 'minecraft'})[:position]
+    assert_equal 1, ScriptConstants.assignable_info({name: 'dance-2019'})[:position]
+    assert_equal 2, ScriptConstants.assignable_info({name: 'dance-extras-2019'})[:position]
+    assert_equal 3, ScriptConstants.assignable_info({name: 'aquatic'})[:position]
+    assert_equal 4, ScriptConstants.assignable_info({name: 'hero'})[:position]
+    assert_equal 5, ScriptConstants.assignable_info({name: 'mc'})[:position]
+    assert_equal 6, ScriptConstants.assignable_info({name: 'minecraft'})[:position]
   end
 
   describe 'ScriptConstants::script_in_any_category?' do


### PR DESCRIPTION
# Description

Finishes https://codedotorg.atlassian.net/browse/LP-1039

Now that we have `dance-2019` and `dance-extras-2019`, the `dance` and `dance-extras` courses from 2018 need to be moved to the end of the Hour of Code section in this dropdown:

![Screen Shot 2019-11-20 at 10 29 01 AM](https://user-images.githubusercontent.com/8001765/69266820-c3fbcd00-0b80-11ea-9613-a650f6b961ee.png)

The other changes requested in the Jira item have been made via levelbuilder UI.

## Testing story

Updated existing tests enforcing the order in the assignment dropdown.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
