### PR TITLE
Assignment Updates: better accommodate long section names

### DIFF
--- a/apps/src/lib/ui/PopUpMenu.jsx
+++ b/apps/src/lib/ui/PopUpMenu.jsx
@@ -21,7 +21,7 @@ const menuStyle = {
   borderRadius: 2,
   boxShadow: '3px 3px 3px gray',
   textAlign: 'left',
-  maxWidth: 220
+  maxWidth: 300
 };
 const tailBorderStyle = {
   position: 'absolute',

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
@@ -12,15 +12,15 @@ import queryString from 'query-string';
 
 const styles = {
   select: {
-    height: 34
+    height: 34,
+    width: 300
   },
   addNewSection: {
     borderTop: `1px solid ${color.charcoal}`,
     paddingTop: 16,
     paddingBottom: 8,
-    paddingLeft: 12,
-    paddingRight: 12,
-    width: 196
+    paddingLeft: 20,
+    paddingRight: 12
   }
 };
 

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelectorMenuItem.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelectorMenuItem.jsx
@@ -16,10 +16,6 @@ const styles = {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     paddingLeft: 10
-  },
-  assigned: {
-    marginRight: 5,
-    color: color.level_perfect
   }
 };
 
@@ -31,11 +27,16 @@ export default class TeacherSectionSelectorMenuItem extends Component {
 
   render() {
     const {section, onClick} = this.props;
+    const checkMarkStyle = {
+      marginRight: 5,
+      color: color.level_perfect,
+      visibility: section.isAssigned ? 'visible' : 'hidden'
+    };
+
     return (
       <PopUpMenu.Item onClick={onClick} style={styles.item}>
-        <span style={styles.assigned}>
-          {section.isAssigned && <FontAwesome icon="check" />}
-          {!section.isAssigned && <span>&nbsp;&nbsp;&nbsp;&nbsp;</span>}
+        <span style={checkMarkStyle}>
+          <FontAwesome icon="check" />
         </span>
         <span>{section.name}</span>
       </PopUpMenu.Item>

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelectorMenuItem.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelectorMenuItem.jsx
@@ -9,15 +9,16 @@ const styles = {
   item: {
     height: 28,
     lineHeight: '28px',
-    width: 250,
+    width: 270,
     fontSize: 14,
     fontFamily: '"Gotham 4r", sans-serif',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    textOverflow: 'ellipsis',
+    paddingLeft: 10
   },
   assigned: {
-    marginLeft: 20,
+    marginRight: 5,
     color: color.level_perfect
   }
 };
@@ -32,10 +33,11 @@ export default class TeacherSectionSelectorMenuItem extends Component {
     const {section, onClick} = this.props;
     return (
       <PopUpMenu.Item onClick={onClick} style={styles.item}>
-        <span>{section.name}</span>
         <span style={styles.assigned}>
           {section.isAssigned && <FontAwesome icon="check" />}
+          {!section.isAssigned && <span>&nbsp;&nbsp;&nbsp;&nbsp;</span>}
         </span>
+        <span>{section.name}</span>
       </PopUpMenu.Item>
     );
   }

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelectorMenuItem.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelectorMenuItem.jsx
@@ -9,9 +9,12 @@ const styles = {
   item: {
     height: 28,
     lineHeight: '28px',
-    width: 220,
+    width: 250,
     fontSize: 14,
-    fontFamily: '"Gotham 4r", sans-serif'
+    fontFamily: '"Gotham 4r", sans-serif',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
   },
   assigned: {
     marginLeft: 20,
@@ -28,13 +31,11 @@ export default class TeacherSectionSelectorMenuItem extends Component {
   render() {
     const {section, onClick} = this.props;
     return (
-      <PopUpMenu.Item onClick={onClick}>
-        <div style={styles.item}>
-          <span>{section.name}</span>
-          <span style={styles.assigned}>
-            {section.isAssigned && <FontAwesome icon="check" />}
-          </span>
-        </div>
+      <PopUpMenu.Item onClick={onClick} style={styles.item}>
+        <span>{section.name}</span>
+        <span style={styles.assigned}>
+          {section.isAssigned && <FontAwesome icon="check" />}
+        </span>
       </PopUpMenu.Item>
     );
   }


### PR DESCRIPTION
Following the launch of the Assignment Updates, a [teacher reported via Zendesk ](https://codeorg.zendesk.com/agent/tickets/257050) wonky styling that was preventing them from selecting a section on an overview page. This occurred because the teacher had given her sections long names. 

To fix, I made three modifications:
1.) Increased the width of the dropdown slightly to make more space.
2.) Set overflow to hidden to handle sections with names still longer than the new wider width.
3.) Moved the green checkmark for assigned sections to the left so it would show even for sections with long names rather than disappear when the text was truncated. 

BEFORE: 
<img width="415" alt="Screen Shot 2019-11-20 at 9 34 54 AM" src="https://user-images.githubusercontent.com/12300669/69268904-cf50f780-0b84-11ea-9768-3286f40b25c1.png">

AFTER: 
<img width="512" alt="Screen Shot 2019-11-20 at 12 13 35 PM" src="https://user-images.githubusercontent.com/12300669/69274441-35427c80-0b8f-11ea-8eac-43b4b1433382.png">


