### PR TITLE
Adjust default UI-test parallel count

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -29,7 +29,7 @@ namespace :test do
         '-d', CDO.site_host('studio.code.org'),
         '-p', CDO.site_host('code.org'),
         '--db', # Ensure features that require database access are run even if the server name isn't "test"
-        '--parallel', '120',
+        '--parallel', (Parallel.processor_count * 2).to_s,
         '--magic_retry',
         '--with-status-page',
         '--fail_fast',


### PR DESCRIPTION
Use `(nproc * 2)` parallel threads for UI tests. Given the current `m5.24xlarge` instance (96 vCPUs) which is currently underutilized (~40% CPU max during a test run), this will increase the current setting from `120` to `192`.

We might wish to encode a more advanced calculation for this number in the future (e.g, based on more relevant resources/thresholds than just CPU-count). This change will just be a step in this direction, and an incremental increase to the current fixed number (since we don't change CPU count often on this instance).