### PR TITLE
switch back to 'copy and remove' strategy for sync out

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -34,9 +34,12 @@ def rename_from_crowdin_name_to_locale
   # Move directories like `i18n/locales/Italian` to `i18n/locales/it-it` for
   # all languages in our system
   Languages.get_crowdin_name_and_locale.each do |prop|
-    if File.directory?("i18n/locales/#{prop[:crowdin_name_s]}/")
-      FileUtils.mv "i18n/locales/#{prop[:crowdin_name_s]}/.", "i18n/locales/#{prop[:locale_s]}"
-    end
+    next unless File.directory?("i18n/locales/#{prop[:crowdin_name_s]}/")
+
+    # copy and remove rather than moving so we can easily and recursively deal
+    # with existing files
+    FileUtils.cp_r "i18n/locales/#{prop[:crowdin_name_s]}/.", "i18n/locales/#{prop[:locale_s]}"
+    FileUtils.rm_r "i18n/locales/#{prop[:crowdin_name_s]}"
   end
 
   # Now, any remaining directories named after the language name (rather than


### PR DESCRIPTION
# Description

Fixes a bug added in https://github.com/code-dot-org/code-dot-org/pull/31771; specifically, `FileUtils.mv` will complain if there are existing directories that would be overridden by the operation, while `cp_r` can recursively deal with duplicates, which is the desired behavior.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
