### PR TITLE
strip leading and trailing space from stage name

### DIFF
--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -80,6 +80,9 @@ class ScriptDSL < BaseDSL
 
   def stage(name, properties = {})
     if @stage
+      if @stages.any? {|s| s[:stage] == @stage}
+        raise "a stage named \"#{@stage}\" already exists"
+      end
       @stages << {
         stage: @stage,
         scriptlevels: @scriptlevels,

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -78,6 +78,18 @@ class ScriptDSL < BaseDSL
     @pilot_experiment = experiment
   end
 
+  # This method gets called whenever `stage '...'` is called in the script DSL,
+  # then must be called once again after the entire script DSL has been parsed.
+  #
+  # The first time `stage` is called, set @stage and other instance variables to
+  # represent an empty stage. Subsequent calls to `level '...'` will add levels
+  # to this stage.
+  #
+  # On subsequent calls to `stage`, push the previous stage and its levels onto
+  # the list of @stages, then reset the state to represent another empty stage.
+  #
+  # When called after the entire script DSL has been processed, simply push
+  # the last stage from the script DSL onto the list of @stages.
   def stage(name, properties = {})
     if @stage
       if @stages.any? {|s| s[:stage] == @stage}

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -86,7 +86,7 @@ class ScriptDSL < BaseDSL
         stage_extras_disabled: @stage_extras_disabled,
       }.compact
     end
-    @stage = name
+    @stage = name&.strip
     @stage_flex_category = properties[:flex_category]
     @stage_lockable = properties[:lockable]
     @scriptlevels = []

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -748,4 +748,30 @@ level 'Level 3'
     assert_equal expected, output
     assert_equal i18n_expected, i18n
   end
+
+  test 'script DSL with trailing space in stage name' do
+    input_dsl = <<~DSL
+      stage 'trailing space '
+      level 'Level 1'
+    DSL
+    output, i18n = ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    expected = DEFAULT_PROPS.merge(
+      {
+        stages: [
+          {
+            stage: "trailing space",
+            scriptlevels: [
+              {stage: "trailing space", levels: [{name: 'Level 1'}]},
+            ]
+          }
+        ],
+      }
+    )
+
+    i18n_expected = {'test' => {'stages' => {
+      "trailing space" => {'name' => "trailing space"},
+    }}}
+    assert_equal expected, output
+    assert_equal i18n_expected, i18n
+  end
 end

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -774,4 +774,32 @@ level 'Level 3'
     assert_equal expected, output
     assert_equal i18n_expected, i18n
   end
+
+  test 'reject script DSL with duplicate stage name' do
+    input_dsl = <<~DSL
+      stage 'duplicate'
+      level 'Level 1'
+      stage 'duplicate'
+      level 'Level 2'
+    DSL
+
+    error = assert_raises do
+      ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    end
+    assert_equal 'a stage named "duplicate" already exists', error.message
+  end
+
+  test 'reject duplicate stage with extra space' do
+    input_dsl = <<~DSL
+      stage 'duplicate'
+      level 'Level 1'
+      stage ' duplicate '
+      level 'Level 2'
+    DSL
+
+    error = assert_raises do
+      ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    end
+    assert_equal 'a stage named "duplicate" already exists', error.message
+  end
 end

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -749,9 +749,9 @@ level 'Level 3'
     assert_equal i18n_expected, i18n
   end
 
-  test 'script DSL with trailing space in stage name' do
+  test 'script DSL with extra space in stage name' do
     input_dsl = <<~DSL
-      stage 'trailing space '
+      stage ' extra space '
       level 'Level 1'
     DSL
     output, i18n = ScriptDSL.parse(input_dsl, 'test.script', 'test')
@@ -759,9 +759,9 @@ level 'Level 3'
       {
         stages: [
           {
-            stage: "trailing space",
+            stage: "extra space",
             scriptlevels: [
-              {stage: "trailing space", levels: [{name: 'Level 1'}]},
+              {stage: "extra space", levels: [{name: 'Level 1'}]},
             ]
           }
         ],
@@ -769,7 +769,7 @@ level 'Level 3'
     )
 
     i18n_expected = {'test' => {'stages' => {
-      "trailing space" => {'name' => "trailing space"},
+      "extra space" => {'name' => "extra space"},
     }}}
     assert_equal expected, output
     assert_equal i18n_expected, i18n


### PR DESCRIPTION
# Description

Finishes https://codedotorg.atlassian.net/browse/LP-404

The bug report says to strip space from the stage name, but that alone is not sufficient to prevent problems with stages being added or renamed whose names only differ by leading or trailing spaces. This PR does two things when populating the database from the script DSL:
* strip leading and trailing space from stage names
* raise an error if two stages are created with the same name (after stripping whitespace)

## Testing story

added unit tests cover the new behavior.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
