### PR TITLE
Added oldtownroadremix_lilnasx_long to songs that should tag LilNasX

### DIFF
--- a/apps/src/code-studio/dancePartySongArtistTags.js
+++ b/apps/src/code-studio/dancePartySongArtistTags.js
@@ -44,6 +44,7 @@ export const SongTitlesToArtistTwitterHandle = {
   neverreallyover_katyperry: 'KatyPerry',
   occidentalview_francescogabbani: 'FrankGabbani',
   oldtownroadremix_lilnasx: 'LilNasX',
+  oldtownroadremix_lilnasx_long: 'LilNasX',
   starships_nickiminaj: 'NICKIMINAJ',
   sucker_jonasbrothers: 'JonasBrothers',
   // These tracks available locally, tweet @codeorg to avoid spamming anyone.


### PR DESCRIPTION
# Description
This causes tweets with oldtownroadremix_lilnasx_long to tag LilNaxX
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links



## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
