### PR TITLE
add firehose:PutRecordBatch permissions to application stack

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -133,7 +133,9 @@ Resources:
           # Write analysis events to Firehose.
           # TODO: Import resources into stack.
           - Effect: Allow
-            Action: 'firehose:PutRecord'
+            Action:
+            - 'firehose:PutRecord'
+            - 'firehose:PutRecordBatch'
             Resource: !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/analysis-events"
           # S3 access for student-libraries bucket
           - Effect: Allow


### PR DESCRIPTION
Fix/Followup to #31958 adding new API permissions after changing the Firehose API call used from `put_record` to `put_record_batch`.

Error: https://app.honeybadger.io/projects/3240/faults/57611047