### PR TITLE
Hide Clear Response button

### DIFF
--- a/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
+++ b/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
@@ -167,20 +167,6 @@ export class SelectedStudentInfo extends React.Component {
               />
             </div>
           )}
-          {/* Hidden because currently we are deleting UserLevels when
-          some clicks this button which means we lose all record of the
-          student working on that level.
-          TODO: Once a system is implemented for users to
-          reset progress uncomment this code to bring back this
-          button to reset a contained level for a student.
-          {level.contained && (
-            <Button
-              text={i18n.clearResponse()}
-              color="blue"
-              onClick={this.onClearResponse}
-              disabled={level.status === LevelStatus.not_tried}
-            />
-          )}*/}
         </div>
         <RadiumFontAwesome
           icon="caret-right"

--- a/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
+++ b/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
@@ -167,6 +167,12 @@ export class SelectedStudentInfo extends React.Component {
               />
             </div>
           )}
+          {/* Hidden because currently we are deleting UserLevels when
+          some clicks this button which means we lose all record of the
+          student working on that level.
+          TODO: Once a system is implemented for users to
+          reset progress uncomment this code to bring back this
+          button to reset a contained level for a student.
           {level.contained && (
             <Button
               text={i18n.clearResponse()}
@@ -174,7 +180,7 @@ export class SelectedStudentInfo extends React.Component {
               onClick={this.onClearResponse}
               disabled={level.status === LevelStatus.not_tried}
             />
-          )}
+          )}*/}
         </div>
         <RadiumFontAwesome
           icon="caret-right"

--- a/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
@@ -61,7 +61,8 @@ describe('SelectedStudentInfo', () => {
     );
 
     expect(wrapper.contains('Last Updated:')).to.equal(true);
-    expect(wrapper.find('Button')).to.have.length(1);
+    /* Button is hidden currently. See SelectedStudentInfo for details
+    expect(wrapper.find('Button')).to.have.length(1); */
   });
 
   it('displays time and who they worked with as navigator if paired as driver on level', () => {

--- a/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
@@ -61,8 +61,6 @@ describe('SelectedStudentInfo', () => {
     );
 
     expect(wrapper.contains('Last Updated:')).to.equal(true);
-    /* Button is hidden currently. See SelectedStudentInfo for details
-    expect(wrapper.find('Button')).to.have.length(1); */
   });
 
   it('displays time and who they worked with as navigator if paired as driver on level', () => {


### PR DESCRIPTION
# Description

The Clear Response button for contained levels currently allows a teacher to reset a student's contained level response by deleting the UserLevel.  Once that has been deleted we have no record of the student's response. 

In addition, a student would have to sign out to see that a teacher cleared their work because we keep a record of the student completing that work in SessionStorage so in many cases this button seemed broken to users.

This PR hides the Clear Response button so that users are not deleting UserLevels. Follow up work to this is to come up with a system for all levels that will allow someone to reset progress without hard deleting past attempt data. 

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-435)

## Testing story

Updated unit tests to not look for the button for now.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
