### PR TITLE
Restore "strip leading and trailing space from stage name"

### DIFF
--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -78,15 +78,30 @@ class ScriptDSL < BaseDSL
     @pilot_experiment = experiment
   end
 
+  # This method gets called whenever `stage '...'` is called in the script DSL,
+  # then must be called once again after the entire script DSL has been parsed.
+  #
+  # The first time `stage` is called, set @stage and other instance variables to
+  # represent an empty stage. Subsequent calls to `level '...'` will add levels
+  # to this stage.
+  #
+  # On subsequent calls to `stage`, push the previous stage and its levels onto
+  # the list of @stages, then reset the state to represent another empty stage.
+  #
+  # When called after the entire script DSL has been processed, simply push
+  # the last stage from the script DSL onto the list of @stages.
   def stage(name, properties = {})
     if @stage
+      if @stages.any? {|s| s[:stage] == @stage}
+        raise "a stage named \"#{@stage}\" already exists"
+      end
       @stages << {
         stage: @stage,
         scriptlevels: @scriptlevels,
         stage_extras_disabled: @stage_extras_disabled,
       }.compact
     end
-    @stage = name
+    @stage = name&.strip
     @stage_flex_category = properties[:flex_category]
     @stage_lockable = properties[:lockable]
     @scriptlevels = []

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1057,6 +1057,10 @@ class Script < ActiveRecord::Base
           end
 
         stage.assign_attributes(flex_category: stage_flex_category, lockable: stage_lockable)
+        # Even though stage_name has already been stripped of whitespace,
+        # stage.name might not have been stripped of whitespace, because
+        # find_or_create_by ignores trailing whitespace when comparing.
+        stage.name = stage.name.strip
         stage.save! if stage.changed?
 
         script_level_attributes[:stage_id] = stage.id

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -3888,6 +3888,8 @@ en:
               description_teacher: In this lesson, students continue to use HTML to structure text on web pages, this time with headings.  Students learn how the different heading elements are displayed by default and practice using them to create page and section titles.  Students then start to decide how they will organize their content on their own personal web pages.  In the last level, students begin the project that they will continue to work on throughout the unit.
             CSD Post-Course Survey:
               name: CSD Post-Course Survey
+            Websites for Expression:
+              name: Websites for Expression
         csp2-support:
           title: Unit 2 Online Professional Learning Course
           description_audience: ''
@@ -7566,6 +7568,8 @@ en:
               description_teacher: "Students have spent a lot of time throughout the unit working on their Personal Website. In the final couple of days students finalize their websites.  They work with peers to get feedback, put the finishing touches on the websites, review the rubric and reflect on their process. To cap off the unit, they will share their projects and also a overview of the process they took to get to that final design.\r\n"
             CS Discoveries Post-Course Survey:
               name: CS Discoveries Post-Course Survey
+            Websites for Expression:
+              name: Websites for Expression
         coursea-2018:
           title: Course A (2018)
           assignment_family_title: Course A
@@ -7852,6 +7856,8 @@ en:
               name: Relay Programming
             Graph Paper Programming:
               name: Graph Paper Programming
+            Concept Practice with Minecraft:
+              name: Concept Practice with Minecraft
         courseb-2018:
           title: Course B (2018)
           assignment_family_title: Course B
@@ -8114,6 +8120,8 @@ en:
               name: Unit 5 Assessment 4 - List Algorithms, Functions with Return Values
             Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals):
               name: Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals)
+            Unit 1 Assessment 1 - Binary and Ascii:
+              name: Unit 1 Assessment 1 - Binary and Ascii
           title: CS Principles AP Exam Prep
           description_audience: ''
           description_short: CS Principles AP Exam Prep
@@ -10991,6 +10999,8 @@ en:
               name: Post-Project Test
             CS Discoveries Post Course survey:
               name: CS Discoveries Post Course survey
+            Websites for Expression:
+              name: Websites for Expression
         csd3-2019:
           title: CSD Unit 3 - Animations and Games ('19-'20)
           description: " In Unit 3, you’ll build on your coding experience as you program animations, interactive art, and games in Game Lab. The unit starts off with simple shapes and builds up to more sophisticated sprite-based games, using the same programming concepts and the design process computer scientists use daily. In the final project, you’ll develop a personalized, interactive program."
@@ -12898,6 +12908,8 @@ en:
               name: Peer Review and Final Touches
             Project - Website for a Purpose:
               name: Project - Website for a Purpose
+            Websites for Expression:
+              name: Websites for Expression
         csd3-pilot:
           title: CSD Unit 3 - Animations and Games (Pilot Version)
           description: " In Unit 3, you’ll build on your coding experience as you program animations, interactive art, and games in Game Lab. The unit starts off with simple shapes and builds up to more sophisticated sprite-based games, using the same programming concepts and the design process computer scientists use daily. In the final project, you’ll develop a personalized, interactive program."

--- a/dashboard/config/scripts/ECSPD1.script
+++ b/dashboard/config/scripts/ECSPD1.script
@@ -22,7 +22,7 @@ level 'ECSPD1 unit 2 overview'
 level 'ECSPD1 curriculum connections'
 level 'ECSPD1 computational thinker'
 
-stage 'Classroom and workshop style '
+stage 'Classroom and workshop style'
 level 'ECSPD1 unifying themes'
 level 'ECS PD1 classroom culture'
 level 'ECSPD1 your role'

--- a/dashboard/config/scripts/csd2-2017.script
+++ b/dashboard/config/scripts/csd2-2017.script
@@ -17,7 +17,7 @@ stage 'Exploring Websites', flex_category: 'csd2_1'
 level 'CSD U2 L1 Overview', named: true
 level 'CSD U2 Top Websites', named: true
 
-stage 'Websites for Expression ', flex_category: 'csd2_1'
+stage 'Websites for Expression', flex_category: 'csd2_1'
 level 'CSD U2 L2 Overview', named: true
 level 'CSD U2 Expression Exemplars', named: true
 

--- a/dashboard/config/scripts/csd2-2018.script
+++ b/dashboard/config/scripts/csd2-2018.script
@@ -17,7 +17,7 @@ stage 'Exploring Websites', flex_category: 'csd2_1'
 level 'CSD U2L01 TFMD_2018', named: true
 level 'CSD U2 Top Websites_2018', named: true
 
-stage 'Websites for Expression ', flex_category: 'csd2_1'
+stage 'Websites for Expression', flex_category: 'csd2_1'
 level 'CSD U2L02 TFMD_2018', named: true
 level 'CSD U2 Expression Exemplars_2018', named: true
 

--- a/dashboard/config/scripts/csd2-2019.script
+++ b/dashboard/config/scripts/csd2-2019.script
@@ -18,7 +18,7 @@ stage 'Exploring Websites', flex_category: 'csd2_1'
 level 'CSD U2L01 TFMD_2019', named: true
 level 'CSD U2 Top Websites_2018_2019', named: true
 
-stage 'Websites for Expression ', flex_category: 'csd2_1'
+stage 'Websites for Expression', flex_category: 'csd2_1'
 level 'CSD U2L02 TFMD_2019', named: true
 level 'CSD U2 Expression Exemplars_2018_2019', named: true
 

--- a/dashboard/config/scripts/csd2-pilot.script
+++ b/dashboard/config/scripts/csd2-pilot.script
@@ -66,7 +66,7 @@ level 'CSD U2 Image practice_pilot', progression: 'Adding Images'
 level 'CSD U2 Image assessment', progression: 'Adding Images', assessment: true
 level 'CSD U2 Image challenge_pilot', progression: 'Adding Images Challenges', named: true
 
-stage 'Websites for Expression ', flex_category: 'csd2_1'
+stage 'Websites for Expression', flex_category: 'csd2_1'
 level 'CSD U2L08 TFMD_pilot', named: true
 level 'CSD U2 Expression Exemplars_2018_2019_pilot', named: true
 

--- a/dashboard/config/scripts/csp-exam.script
+++ b/dashboard/config/scripts/csp-exam.script
@@ -3,7 +3,7 @@ hideable_stages true
 student_detail_progress_view true
 has_verified_resources true
 
-stage 'Unit 1 Assessment 1 - Binary and Ascii ', lockable: true
+stage 'Unit 1 Assessment 1 - Binary and Ascii', lockable: true
 level 'CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_exam_prep', assessment: true
 
 stage 'Unit 1 Assessment 2 - Internet Protocols, TCP/IP, DNS, HTTP, etc', lockable: true

--- a/dashboard/config/scripts/express-2018.script
+++ b/dashboard/config/scripts/express-2018.script
@@ -117,7 +117,7 @@ level 'courseC_artist_loops8a_2018'
 stage 'Copyright and Creativity'
 level 'courseE_unplugged_CnC_2018'
 
-stage 'Concept Practice with Minecraft '
+stage 'Concept Practice with Minecraft'
 level 'Overworld Move to Sheep'
 level 'Overworld Chop Tree'
 level 'Overworld Shear Sheep'

--- a/dashboard/config/scripts/express-2019.script
+++ b/dashboard/config/scripts/express-2019.script
@@ -143,7 +143,7 @@ level 'courseD_artist_4_2018_2019'
 level 'courseD_artist_5_2018_2019'
 level 'courseD_artist_6_2018_2019'
 
-stage 'Concept Practice with Minecraft ', flex_category: 'csf_loops'
+stage 'Concept Practice with Minecraft', flex_category: 'csf_loops'
 level 'Overworld Move to Sheep_2019'
 level 'Overworld Chop Tree_2019'
 level 'Overworld Shear Sheep_2019'

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1485,6 +1485,28 @@ endvariants
     end
   end
 
+  test 'clone script with suffix when stage name contains trailing space' do
+    script_dsl = <<~DSL
+      stage 'trailing space '
+      level 'Level 1'
+    DSL
+    scripts, _ = Script.setup([@script_file])
+    script = scripts[0]
+
+    Script.stubs(:script_directory).returns('')
+    File.stubs(:read).returns(script_dsl)
+    script_copy = script.clone_with_suffix('copy')
+    assert_equal 'test-fixture-copy', script_copy.name
+
+    assert_equal 1, script_copy.stages.count
+    stage = script_copy.stages.first
+    assert_equal 'trailing space', stage.name
+    assert_equal(
+      'Level 1_copy',
+      stage.script_levels.map(&:levels).flatten.map(&:name).join(',')
+    )
+  end
+
   test "assignable_info: returns assignable info for a script" do
     script = create(:script, name: 'fake-script', hidden: true, stage_extras_available: true)
     assignable_info = script.assignable_info


### PR DESCRIPTION
Reverts #32058, restoring #32049, which introduced a failure in `rake seed:scripts` on staging with the following stack trace:
```
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
/Users/dsb/src/cdo/dashboard/app/models/script.rb:1105:in `block in add_script'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:1083:in `each'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:1083:in `add_script'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:945:in `block (2 levels) in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:944:in `map'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:944:in `block in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:917:in `setup'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:119:in `update_scripts'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:144:in `block (2 levels) in <top (required)>'
/Users/dsb/.rbenv/versions/2.5.0/bin/bundle:23:in `load'
/Users/dsb/.rbenv/versions/2.5.0/bin/bundle:23:in `<main>'
```
The previous solution is augmented to account for existing stage names containing trailing spaces. This finishes [LP-404](https://codedotorg.atlassian.net/browse/LP-404). 

## root cause analysis

The root cause of the failure above is as follows:
* some existing stage names in the database contain trailing spaces
* `find_or_create_by` ignores trailing spaces when looking for a stage by name: https://github.com/code-dot-org/code-dot-org/blob/9bda8842086d2126e2dd97de3df2aad9cf4a405f/dashboard/app/models/script.rb#L1052-L1054
* later, we assume that the stage we found can be identified by exact match on the name field: https://github.com/code-dot-org/code-dot-org/blob/9bda8842086d2126e2dd97de3df2aad9cf4a405f/dashboard/app/models/script.rb#L1104 

That assumption is incorrect in the case where the stage name in the database contains a trailing space.

## original problem

I was able to reproduce the original problem described in [LP-404](https://codedotorg.atlassian.net/browse/LP-404) on a fresh staging build by adding or deleting trailing space to the stage name in any script file, and then re-seeding that script. The stack trace is the same as the one shown above.

## proposed solution

The solution implemented here is as follows:
1. start stripping spaces from stage names in script DSL text again, by restoring #32049
2. when updating an existing stage from the script DSL, strip trailing space from the stage name in the DB 
3. manually strip trailing whitespace from stage names in all .script files in our repo (see 00b608915c386ad39f54e960ff74fe74746c2a69)
4. after this PR reaches production, run `Script.find_by_name('csd2-draft').destroy` from rails console on production to destroy one last stage with trailing whitespace, which does not have a corresponding script file because it has been deleted: https://github.com/code-dot-org/code-dot-org/blob/f0903582860ed7cf2fff8acbd8dfddf149bf6dd6/dashboard/config/scripts/csd2-draft.script#L9 this script/stage do not exist in the levelbuilder, staging or test environments. This entire script has only [2 hits in the past year](https://analytics.google.com/analytics/web/#/report/content-pages/a37745279w66217109p68074336/_u.date00=20181123&_u.date01=20191122&explorer-table.filter=~2Fs~2Fcsd2-draft&explorer-table.plotKeys=%5B%5D/), which makes it seem safe to remove. 

The result will be that all stage names will be stripped of trailing whitespace in all non-development environments after the next deploy.

## codepaths

The following 3 codepaths are affected by this solution :
A. `rake seed:scripts`, which is run in every environment during the deploy process
B. `ScriptsController#update`, which is run only when a levelbuilder saves changes to a script (using either the old or new UI) on the levelbuilder machine
C. `Script#clone_with_suffix`, which is run only via rails console on the levelbuilder machine

a more detailed analysis of the affected codepaths can be found [here](https://docs.google.com/document/d/1NjHaxK-L0xOz03tapN54PoNII26kObn_vP72WXKGvb0/edit#). 

## Testing story

* new unit tests on `ScriptDSL.parse` verify that new stage names with trailing spaces will not make it into our system.
* codepath (A) was verified locally by running `rake seed:scripts`. My local DB had all the same stage names with trailing spaces as those I found in levelbuilder or production, and I confirmed this stripped spaces from all of them except the one in `csd2-draft` (see below).
* codepath (B) was verified locally by using the levelbuilder ui to try to add trailing spaces to stage names, which resulted in no changes to the filesystem or local DB. trailing spaces were also stripped from new stage names in the filesystem and local DB.
* codepath (C) is covered end-to-end with a new unit test.
* My local DB contained `csd2-draft`, so I verified locally that `Script.find_by_name('csd2-draft').destroy` deletes that script,  its script levels and its stages, including the one with trailing spaces. It does not delete any levels, which might still be used by other scripts. (see [output](https://github.com/code-dot-org/code-dot-org/files/3882412/destroy-csd2-draft-output.txt))

because this PR eliminates trailing spaces from stage names, I am not adding regression tests for the case where a stage name in the database has trailing spaces.

## I18n

This PR changes the names of some stages in some translated scripts, notably express-2018 which is supported in at least 2 other languages.

## Future work

It's possible a validation or before_save hook could be added to be extra sure we do not introduce stage names with trailing spaces.