### PR TITLE
AI Oceans: initial skeleton for code.org/hourofcode/overview 

### DIFF
--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -16,6 +16,8 @@ social:
   @header["social"]["og:description"] = hoc_s(:social_hoc2018_global_movement)
   @header["social"]["og:image"] = 'https://' + request.host + '/images/social-media/code-2018-creativity.png'
 
+  launch_ai = DCDO.get('launch_ai', nil)
+
 %link{href: "/css/student.css", rel: "stylesheet"}
 %link{href: "/css/tools.css", rel: "stylesheet"}
 %link{href: "/shared/css/course-blocks.css", rel: "stylesheet", type: "text/css"}
@@ -25,21 +27,52 @@ social:
 
 = I18n.t(:hoc_overview_subtitle)
 
-.full-resource-block{style: "margin-top: 20px;"}
-  %a{href: "/dance"}
-    %img.full-resource-image{src: "/images/dance_party_2019.gif"}
-  .tutorial-info{style: "padding: 30px;"}
-    %span
-      %h2.resource-title= I18n.t(:hoc_overview_dance_title)
-      = I18n.t(:hoc_overview_dance_2019_subtitle)
-    %span
-      %a{href: "/dance"}
-        %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
-      .tutorial-info-guide
-        %a{href: "https://curriculum.code.org/hoc/plugged/8/"}
-          = I18n.t(:hoc_overview_view_teacher_guide)
+- if launch_ai && request.language == 'en'
+  .tile-container-responsive{style: "margin-top: 20px;"}
+    .col-50
+      .tutorial-tile
+        %a{href: CDO.studio_url("/s/applab-intro/reset")}
+          %img.tutorial-tile-img{src: "/images/dance_party_2019.gif"}
+        .tutorial-info
+          %span
+            %h3.tutorial-info-h= I18n.t(:applab_tile_title)
+            .smalltext= I18n.t(:applab_tile_subtitle)
+          %span
+            %a{href: CDO.studio_url("/s/applab-intro/reset")}
+              %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
+            .tutorial-info-guide
+              %a{href: "https://curriculum.code.org/hoc/plugged/7/"}= I18n.t(:applab_tile_teacher_guide)
 
-.tile-container-responsive{style: "margin-top: 20px;"}
+    .col-50
+      .tutorial-tile
+        %a{href: "/dance"}
+          %img.tutorial-tile-img{src: "/images/dance_party_2019.gif"}
+        .tutorial-info
+          %span
+            %h3.tutorial-info-h= I18n.t(:hoc_overview_dance_title)
+            .smalltext= I18n.t(:hoc_overview_dance_2019_subtitle)
+          %span
+            %a{href: "/dance"}
+              %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
+            .tutorial-info-guide
+              %a{href: "https://curriculum.code.org/hoc/plugged/8/"}
+                = I18n.t(:hoc_overview_view_teacher_guide)
+- else
+  .full-resource-block{style: "margin-top: 20px; margin-bottom: 20px;"}
+    %a{href: "/dance"}
+      %img.full-resource-image{src: "/images/dance_party_2019.gif"}
+    .tutorial-info{style: "padding: 30px;"}
+      %span
+        %h2.resource-title= I18n.t(:hoc_overview_dance_title)
+        = I18n.t(:hoc_overview_dance_2019_subtitle)
+      %span
+        %a{href: "/dance"}
+          %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
+        .tutorial-info-guide
+          %a{href: "https://curriculum.code.org/hoc/plugged/8/"}
+            = I18n.t(:hoc_overview_view_teacher_guide)
+
+.tile-container-responsive
   = view :top_hoc_tutorials
 .clear
 

--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -31,20 +31,6 @@ social:
   .tile-container-responsive{style: "margin-top: 20px;"}
     .col-50
       .tutorial-tile
-        %a{href: CDO.studio_url("/s/applab-intro/reset")}
-          %img.tutorial-tile-img{src: "/images/dance_party_2019.gif"}
-        .tutorial-info
-          %span
-            %h3.tutorial-info-h= I18n.t(:applab_tile_title)
-            .smalltext= I18n.t(:applab_tile_subtitle)
-          %span
-            %a{href: CDO.studio_url("/s/applab-intro/reset")}
-              %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
-            .tutorial-info-guide
-              %a{href: "https://curriculum.code.org/hoc/plugged/7/"}= I18n.t(:applab_tile_teacher_guide)
-
-    .col-50
-      .tutorial-tile
         %a{href: "/dance"}
           %img.tutorial-tile-img{src: "/images/dance_party_2019.gif"}
         .tutorial-info
@@ -57,6 +43,22 @@ social:
             .tutorial-info-guide
               %a{href: "https://curriculum.code.org/hoc/plugged/8/"}
                 = I18n.t(:hoc_overview_view_teacher_guide)
+
+    .col-50
+      .tutorial-tile
+        %a{href: "/oceans"}
+          %img.tutorial-tile-img{src: "/images/dance_party_2019.gif"}
+        .tutorial-info
+          %span
+            %h3.tutorial-info-h=hoc_s(:hoc_overview_oceans_tutorial_header)
+            .smalltext=hoc_s(:hoc_overview_oceans_tutorial_desc)
+          %span
+            %a{href: "/oceans"}
+              %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
+            .tutorial-info-guide
+              %a{href: "https://curriculum.code.org/hoc/plugged/8/"}
+                = I18n.t(:hoc_overview_view_teacher_guide)
+
 - else
   .full-resource-block{style: "margin-top: 20px; margin-bottom: 20px;"}
     %a{href: "/dance"}

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -22,6 +22,9 @@
   social_hoc2019_coming_dates: 'The Hour of Code is coming December 9-15, 2019. Computer science is foundational for every student to learn.'
   social_hoc2019_dance: 'Featuring Katy Perry, Shawn Mendes, Panic! At The Disco, Lil Nas X, Jonas Brothers, Nicki Minaj, and 34 more!'
 
+  hoc_overview_oceans_tutorial_header: 'AI Oceans'
+  hoc_overview_oceans_tutorial_desc: "Teach \"A.I.\" to sort between fish and trash while exploring broader artificial intelligence concepts."
+
   codeorg_homepage_hoc2018_curriculum: 'Go further with <a href="%{studio_url}/courses" class="hoc2018-curriculum-link">Code.org courses</a>'
   codeorg_homepage_hoc2018_dance_heading: 'Create your own <span class="highlight-word">Dance&nbsp;Party</span>'
   codeorg_homepage_hoc2018_header_line1: 'The Hour of Code is coming...'
@@ -5916,4 +5919,3 @@
   some: "Some"
   all: "All"
   dont_know: "I don't know"
-


### PR DESCRIPTION
Users viewing the page in English (and launch_ai DCDO flag set for now): 
[eng-ai-launch-hoc-overview.pdf](https://github.com/code-dot-org/code-dot-org/files/3876968/eng-ai-launch-hoc-overview.pdf)

Users viewing the page in a language other than English  (no change from current):
![non-en-non-ai](https://user-images.githubusercontent.com/12300669/69380794-182dac80-0c68-11ea-9bb3-fb166b81412b.png)

Still waiting on and will include in a follow-up:
- [ ]  AI assets for the top promo box 
- [ ] CS For Good assets from the the teal HOC banner mid-page
- [ ] Link to the curriculum guide 
