### PR TITLE
always categorize HoC scripts as HoC, even if they have a version year

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -113,11 +113,14 @@ def localize_level_content
       script_strings.delete_if {|_, value| value.blank?}
 
       script_i18n_directory = "../#{I18N_SOURCE_DIR}/course_content"
+
+      # We want to make sure to categorize HoC scripts as HoC scripts even if
+      # they have a version year, so this ordering is important
       script_i18n_directory =
-        if script.version_year
-          File.join(script_i18n_directory, script.version_year)
-        elsif ScriptConstants.script_in_category?(:hoc, script.name)
+        if ScriptConstants.script_in_category?(:hoc, script.name)
           File.join(script_i18n_directory, "Hour of Code")
+        elsif script.version_year
+          File.join(script_i18n_directory, script.version_year)
         else
           File.join(script_i18n_directory, "other")
         end


### PR DESCRIPTION
# Description

Fixes the issue where `dance-extras-2019` is getting put in the 2019 directory in crowdin; that script (for whatever reason) has a version year even though it's a HoC script.

## Follow-up

After the next sync including this change, we'll want to remove the dance-extras-2019 script from both `i18n/locales/source/course_content/2019` and the corresponding directory in crowdin.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
