### PR TITLE
Change classicmaze to Classic Maze

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -12,7 +12,7 @@ module ScriptConstants
 
   MINECRAFT_TEACHER_DASHBOARD_NAME = 'Minecraft Adventurer'.freeze
   MINECRAFT_DESIGNER_TEACHER_DASHBOARD_NAME = 'Minecraft Designer'.freeze
-  HOC_TEACHER_DASHBOARD_NAME = 'classicmaze'.freeze
+  HOC_TEACHER_DASHBOARD_NAME = 'Classic Maze - Angry Bird'.freeze
 
   # The order here matters. The first category a script appears under will be
   # the category it belongs to in course dropdowns. The order of scripts within

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -12,7 +12,7 @@ module ScriptConstants
 
   MINECRAFT_TEACHER_DASHBOARD_NAME = 'Minecraft Adventurer'.freeze
   MINECRAFT_DESIGNER_TEACHER_DASHBOARD_NAME = 'Minecraft Designer'.freeze
-  HOC_TEACHER_DASHBOARD_NAME = 'Classic Maze - Angry Bird'.freeze
+  HOC_TEACHER_DASHBOARD_NAME = 'Classic Maze'.freeze
 
   # The order here matters. The first category a script appears under will be
   # the category it belongs to in course dropdowns. The order of scripts within


### PR DESCRIPTION
In the assignment dropdown the link to studio.code.org/s/hourofcode was listed as "classicmaze" which was confusing to teachers as reported in [Zendesk](https://codeorg.zendesk.com/agent/tickets/257277). I updated the name to "Classic Maze" 

BEFORE:
<img width="386" alt="Screen Shot 2019-11-21 at 4 32 59 PM" src="https://user-images.githubusercontent.com/12300669/69388083-a2800b80-0c7c-11ea-8646-982c391a3941.png">


AFTER: 
<img width="377" alt="Screen Shot 2019-11-21 at 4 26 06 PM" src="https://user-images.githubusercontent.com/12300669/69388010-6ea4e600-0c7c-11ea-81b2-206e6a2c0fc6.png">
