### PR TITLE
Add specific messaging for the "link account" functionality

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -106,7 +106,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     )
 
     if auth_option.save
-      flash.notice = I18n.t('user.account_successfully_updated')
+      provider = I18n.t(auth_option.credential_type, scope: "auth", default: "")
+      flash.notice = auth_option.email.blank? ?
+        I18n.t('user.auth_option_saved_no_email', provider: provider) :
+        I18n.t('user.auth_option_saved', provider: provider, email: auth_option.email)
     else
       flash.alert = get_connect_provider_errors(auth_option)
     end

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -474,6 +474,8 @@ en:
     enter_parent_email: "Enter your parent or guardian's email address (for password recovery)"
     update: "Update Account"
     account_successfully_updated: "Account successfully updated."
+    auth_option_saved: "You have successfully linked your %{provider} account with email %{email}."
+    auth_option_saved_no_email: "You have successfully linked your %{provider} account."
     update_email: "Update"
   user_level:
     completed: 'Completed'

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1494,6 +1494,34 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal expected_notice, flash.notice
   end
 
+  test "connect_provider: return messaging specific to linked account" do
+    provider = AuthenticationOption::SILENT_TAKEOVER_CREDENTIAL_TYPES.sample
+
+    [User::TYPE_STUDENT, User::TYPE_TEACHER].each do |user_type|
+      user = create user_type
+      auth = generate_auth_user_hash(
+        provider: provider,
+        email: user.email
+      )
+      @request.env['omniauth.auth'] = auth
+
+      Timecop.freeze do
+        setup_should_connect_provider(user, 2.days.from_now)
+        get provider
+
+        assert_redirected_to 'http://test.host/users/edit'
+
+        provider_name = I18n.t(provider, scope: :auth)
+        expected_notice = user.teacher? ?
+          I18n.t('user.auth_option_saved', provider: provider_name, email: user.email) :
+          I18n.t('user.auth_option_saved_no_email', provider: provider_name)
+
+        assert_equal expected_notice, flash.notice
+        sign_out user
+      end
+    end
+  end
+
   test 'silent_takeover: Adds email to teacher account missing email' do
     # Set up existing account
     malformed_account = create :teacher, :demigrated


### PR DESCRIPTION
# Description

new messaging explicitly names the provider that was linked and (if possible) the email of the linked account.

With Email | Without Email
--- | ---
![email](https://user-images.githubusercontent.com/244100/69390123-132a2680-0c83-11ea-95a6-529f8b35d1fb.jpg) | ![no email](https://user-images.githubusercontent.com/244100/69390125-132a2680-0c83-11ea-8b36-841e73827edf.jpg)

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-768)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
