### PR TITLE
Update HOC certificate to support non-latin languages

### DIFF
--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -10,23 +10,28 @@ def create_certificate_image2(image_path, name, params={})
   name = name.to_s.force_8859_to_utf8.gsub(/@/, '\@').strip
   name = ' ' if name.empty?
 
+  # Load the certificate template
   background = Magick::Image.read(image_path).first
 
+  # The user's name will be put into an image with a transparent background.
+  # This uses 'pango', the OS's text layout engine, in order to dynamically
+  # select the correct font. This is important for handling non-latin
+  # languages.
+  pango_markup = "pango:<span foreground='#575757' font_weight='bold' font_family='Times'>#{name}</span>"
+  name_overlay = Magick::Image.read(pango_markup) do
+    self.background_color = 'none'
+    self.pointsize = 68
+  end.first.trim!
+
+  # x,y offsets
   y = params[:y] || 0
   x = params[:x] || 0
-  width = params[:width] || background.columns
-  height = params[:height] || background.rows
+  # Combine the name image on top of the certificate template image
+  background.composite!(name_overlay, Magick::CenterGravity, x, y, Magick::OverCompositeOp)
 
-  draw = Magick::Draw.new
-  draw.annotate(background, width, height, x, y, name) do
-    draw.gravity = Magick::CenterGravity
-    self.pointsize = 90
-    self.font_family = 'Times'
-    self.font_weight = Magick::BoldWeight
-    self.stroke = 'none'
-    self.fill = 'rgb(87,87,87)'
-  end
-
+  # Free the memory in order to avoid memory leaks (images are stored in /tmp
+  # until destroyed)
+  name_overlay.destroy!
   background
 end
 


### PR DESCRIPTION
# Description
Bug - When a student with non-latin characters (Arabic, Japanese, etc) enters their name into the HOC completion cert field, the resulting certificate does not show their name.
Cause - Imagemagick is the image library being used to generate the certificate. The API being used, `annotate` only supports using one font. There is no font which covers all languages, so using that API will never be good enough for our students.
Fix - Use the Pango (the OS's text layout engine) feature in Imagemagick to figure out the right way to display the text.

## Screenshots
### Before
![cert_before_english](https://user-images.githubusercontent.com/1372238/69395550-44ccdd00-0cd7-11ea-80b8-8e505cfd8740.jpg)

### After
![cert_after_english](https://user-images.githubusercontent.com/1372238/69395559-48f8fa80-0cd7-11ea-8d73-434eb7a1293c.jpg)
![cert_after_arabic](https://user-images.githubusercontent.com/1372238/69395560-4b5b5480-0cd7-11ea-8ea1-4b94fc16f976.jpg)
![cert_after_japanese](https://user-images.githubusercontent.com/1372238/69395564-4dbdae80-0cd7-11ea-9318-2be013ce9876.jpg)
![cert_after_tamil](https://user-images.githubusercontent.com/1372238/69395566-50b89f00-0cd7-11ea-9102-5d7bfd4f9939.jpg)

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-622)

## Testing story
* Manually tested using `./bin/dashboard-server`

# TODO
* Create a backlog item to also fix the non-HOC certificates.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
