### PR TITLE
Fix course editor page

### DIFF
--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CourseEditor from '@cdo/apps/templates/courseOverview/CourseEditor';
+import {Provider} from 'react-redux';
+import {getStore} from '@cdo/apps/code-studio/redux';
 
 $(document).ready(showCourseEditor);
 
@@ -14,25 +16,27 @@ function showCourseEditor() {
 
   // Eventually we want to do this all via redux
   ReactDOM.render(
-    <CourseEditor
-      name={courseEditorData.course_summary.name}
-      title={courseEditorData.course_summary.title}
-      familyName={courseEditorData.course_summary.family_name}
-      versionYear={courseEditorData.course_summary.version_year}
-      descriptionShort={courseEditorData.course_summary.description_short}
-      descriptionStudent={courseEditorData.course_summary.description_student}
-      descriptionTeacher={courseEditorData.course_summary.description_teacher}
-      scriptsInCourse={courseEditorData.course_summary.scripts.map(
-        script => script.name
-      )}
-      scriptNames={courseEditorData.script_names.sort()}
-      teacherResources={teacherResources}
-      hasVerifiedResources={
-        courseEditorData.course_summary.has_verified_resources
-      }
-      courseFamilies={courseEditorData.course_families}
-      versionYearOptions={courseEditorData.version_year_options}
-    />,
+    <Provider store={getStore()}>
+      <CourseEditor
+        name={courseEditorData.course_summary.name}
+        title={courseEditorData.course_summary.title}
+        familyName={courseEditorData.course_summary.family_name}
+        versionYear={courseEditorData.course_summary.version_year}
+        descriptionShort={courseEditorData.course_summary.description_short}
+        descriptionStudent={courseEditorData.course_summary.description_student}
+        descriptionTeacher={courseEditorData.course_summary.description_teacher}
+        scriptsInCourse={courseEditorData.course_summary.scripts.map(
+          script => script.name
+        )}
+        scriptNames={courseEditorData.script_names.sort()}
+        teacherResources={teacherResources}
+        hasVerifiedResources={
+          courseEditorData.course_summary.has_verified_resources
+        }
+        courseFamilies={courseEditorData.course_families}
+        versionYearOptions={courseEditorData.version_year_options}
+      />
+    </Provider>,
     document.getElementById('course_editor')
   );
 }

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -4,8 +4,6 @@ import CourseScriptsEditor from './CourseScriptsEditor';
 import ResourcesEditor from './ResourcesEditor';
 import CourseOverviewTopRow from './CourseOverviewTopRow';
 import {resourceShape} from './resourceType';
-import {Provider} from 'react-redux';
-import {getStore} from '@cdo/apps/code-studio/redux';
 
 const styles = {
   input: {
@@ -142,7 +140,7 @@ export default class CourseEditor extends Component {
         <label>
           <h4>Scripts</h4>
           <div>
-            The dropdown(s) below represent the orded set of scripts in this
+            The dropdown(s) below represent the ordered set of scripts in this
             course. To remove a script, just set the dropdown to the default
             (first) value.
           </div>
@@ -163,14 +161,12 @@ export default class CourseEditor extends Component {
             resources={teacherResources}
             maxResources={3}
             renderPreview={resources => (
-              <Provider store={getStore()}>
-                <CourseOverviewTopRow
-                  sectionsForDropdown={[]}
-                  id={-1}
-                  resources={resources}
-                  showAssignButton={false}
-                />
-              </Provider>
+              <CourseOverviewTopRow
+                sectionsForDropdown={[]}
+                id={-1}
+                resources={resources}
+                showAssignButton={false}
+              />
             )}
           />
         </div>

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -165,10 +165,10 @@ export default class CourseEditor extends Component {
             renderPreview={resources => (
               <Provider store={getStore()}>
                 <CourseOverviewTopRow
-                  sectionsInfo={[]}
+                  sectionsForDropdown={[]}
                   id={-1}
-                  title="Unused title"
                   resources={resources}
+                  showAssignButton={false}
                 />
               </Provider>
             )}

--- a/apps/src/templates/courseOverview/CourseScriptsEditor.js
+++ b/apps/src/templates/courseOverview/CourseScriptsEditor.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 
-export default class scriptsInCourseEditor extends Component {
+export default class CourseScriptsEditor extends Component {
   static propTypes = {
     inputStyle: PropTypes.object.isRequired,
     scriptsInCourse: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/apps/test/unit/templates/courseOverview/CourseEditorTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseEditorTest.js
@@ -1,0 +1,52 @@
+import {assert} from '../../../util/reconfiguredChai';
+import React from 'react';
+import {mount} from 'enzyme';
+import CourseEditor from '@cdo/apps/templates/courseOverview/CourseEditor';
+import {
+  stubRedux,
+  restoreRedux,
+  getStore,
+  registerReducers
+} from '@cdo/apps/redux';
+import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {Provider} from 'react-redux';
+
+const defaultProps = {
+  name: 'csp',
+  title: 'Computer Science Principles 2017',
+  familyName: 'CSP',
+  versionYear: '2017',
+  descriptionShort: 'Desc here',
+  descriptionStudent: 'Desc here',
+  descriptionTeacher: 'Desc here',
+  scriptsInCourse: ['CSP Unit 1', 'CSP Unit 2'],
+  scriptNames: ['CSP Unit 1', 'CSP Unit 2'],
+  teacherResources: [],
+  hasVerifiedResources: false,
+  courseFamilies: ['CSP', 'CSD', 'CSF'],
+  versionYearOptions: ['2017', '2018', '2019']
+};
+
+describe('CourseEditor', () => {
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({teacherSections});
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
+  it('renders full course editor page', () => {
+    const wrapper = mount(
+      <Provider store={getStore()}>
+        <CourseEditor {...defaultProps} />
+      </Provider>
+    );
+
+    assert.equal(wrapper.find('textarea').length, 3);
+    assert.equal(wrapper.find('CourseScriptsEditor').length, 1);
+    assert.equal(wrapper.find('ResourcesEditor').length, 1);
+    assert.equal(wrapper.find('CourseOverviewTopRow').length, 1);
+  });
+});


### PR DESCRIPTION
# Description

The levelbuilder page where levelbuilders can edit a course was broken after changes to the CourseOverviewTopRow changed some of the props.  This updates to use the new props for CourseOverviewTopRow so the page now works. In addition, while I added a unit test to make sure we can render the major components on the page and cleaned up some code.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
