### PR TITLE
show level group after saving edits to it

### DIFF
--- a/dashboard/app/views/levels/_level_group.haml
+++ b/dashboard/app/views/levels/_level_group.haml
@@ -10,7 +10,7 @@
 - current_page = params[:puzzle_page] || 1
 
 -# Is this a survey where we've already submitted
-- user_level = UserLevel.find_by(user: current_user, script: @script_level.script, level: @level)
+- user_level = UserLevel.find_by(user: current_user, script: @script_level&.script, level: @level)
 - submitted_survey = @script_level.try(:anonymous?) && current_user && user_level.try(:submitted?)
 
 .level-group

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -475,6 +475,13 @@ class LevelsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should show level group" do
+    level_group = create :level_group, :with_sublevels, name: 'lg'
+    level_group.save!
+    get :show, params: {id: level_group.id}
+    assert_response :success
+  end
+
   test "should show level on test env" do
     Rails.env = "test"
     get :show, params: {id: @level}


### PR DESCRIPTION
# Description

https://github.com/code-dot-org/code-dot-org/pull/30990 broke the ability to view a level group at a URL like https://levelbuilder-studio.code.org/levels/19652, which is where you end up after you edit it:

![Screen Shot 2019-11-22 at 10 44 21 AM](https://user-images.githubusercontent.com/8001765/69451802-1bcb3d00-0d15-11ea-81da-425450b2e6f9.png)

This PR fixes that, and adds a test.

## Testing story

new unit test to cover regressed case.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
