### PR TITLE
Add two indexes to pd_attendances

### DIFF
--- a/dashboard/app/models/pd/attendance.rb
+++ b/dashboard/app/models/pd/attendance.rb
@@ -13,8 +13,10 @@
 #
 # Indexes
 #
+#  index_pd_attendances_on_marked_by_user_id             (marked_by_user_id)
 #  index_pd_attendances_on_pd_enrollment_id              (pd_enrollment_id)
 #  index_pd_attendances_on_pd_session_id_and_teacher_id  (pd_session_id,teacher_id) UNIQUE
+#  index_pd_attendances_on_teacher_id                    (teacher_id)
 #
 
 class Pd::Attendance < ActiveRecord::Base

--- a/dashboard/db/migrate/20191122183555_add_indexes_to_attendances.rb
+++ b/dashboard/db/migrate/20191122183555_add_indexes_to_attendances.rb
@@ -1,0 +1,10 @@
+class AddIndexesToAttendances < ActiveRecord::Migration[5.0]
+  # The ExpiredDeletedAccountPurger must look up Pd::Attendances by both teacher_id and
+  # marked_by_user_id in order to remove information related to the user being purged.
+  # We observed that these queries, though low in volume, where accounting for 40% of
+  # our DB load during the 2-hour window when this task was running.
+  def change
+    add_index :pd_attendances, :teacher_id
+    add_index :pd_attendances, :marked_by_user_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191106165209) do
+ActiveRecord::Schema.define(version: 20191122183555) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -612,8 +612,10 @@ ActiveRecord::Schema.define(version: 20191106165209) do
     t.datetime "deleted_at"
     t.integer  "pd_enrollment_id"
     t.integer  "marked_by_user_id",              comment: "User id for the partner or admin who marked this teacher in attendance, or nil if the teacher self-attended."
+    t.index ["marked_by_user_id"], name: "index_pd_attendances_on_marked_by_user_id", using: :btree
     t.index ["pd_enrollment_id"], name: "index_pd_attendances_on_pd_enrollment_id", using: :btree
     t.index ["pd_session_id", "teacher_id"], name: "index_pd_attendances_on_pd_session_id_and_teacher_id", unique: true, using: :btree
+    t.index ["teacher_id"], name: "index_pd_attendances_on_teacher_id", using: :btree
   end
 
   create_table "pd_course_facilitators", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
We've observed elevated write latency every night for a while now, and it's clearly coming from the ExpiredDeletedAccountPurger process.

Suresh dug in a bit today and discovered that two queries against `pd_attendances` were accounting for 40% of our query load during that window.  That's probably these two:

https://github.com/code-dot-org/code-dot-org/blob/6e72634a4932fb6003915bccc1467732f4a5536d/lib/cdo/delete_accounts_helper.rb#L106-L108

It turns out we didn't have indexes on `teacher_id` or `marked_by_user_id` here.  Fixing that.  Unconcerned about the cost of additional indexes because this is a relatively low-traffic table with about 100k rows.

## Testing story

Migrated up, down, and up again in local environment.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
