### PR TITLE
Enable drone builds on staging next feature branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -290,6 +290,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 6dfc29c91fbca03b97a0335e0ef0b3d19a2cc12e034cd34ea9e93408d44ad763
+hmac: 01ee6c1bbb77b26fa4056b0077f005ce737a8c5070ee7e50131c8adcc22f9c57
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -89,7 +89,8 @@ volumes:
 
 trigger:
   branch:
-  - staging
+  - 'staging'
+  - 'staging-next'
   event:
   - pull_request
 
@@ -112,7 +113,7 @@ steps:
   commands:
   - git clone --branch $DRONE_SOURCE_BRANCH  --depth 100 $DRONE_GIT_HTTP_URL .
   - git reset --hard $DRONE_COMMIT
-  # Also fetch the target branch (which is staging for pull requests.) We need this for determining which tests to run based on changed files.
+  # Also fetch the target branch (which is staging or staging-next for pull requests.) We need this for determining which tests to run based on changed files.
   - git remote set-branches --add origin $DRONE_TARGET_BRANCH
   - git fetch --depth 100 origin $DRONE_TARGET_BRANCH
   # Merge so we're up-to-date with the target before running tests. We only do this for UI tests, not unit tests,
@@ -202,7 +203,8 @@ volumes:
 
 trigger:
   branch:
-  - staging
+  - 'staging'
+  - 'staging-next'
   event:
   - pull_request
 ---


### PR DESCRIPTION
# Description

We are starting to triage and limit changes merged to the `staging` branch in advance of Hour of Code.  Engineers will be creating feature branches off of the `staging-next` branch for changes that will be merged into the mainline after Hour of Code.  Update Drone so that we run Continuous Integration builds on `staging-next` feature branches.


## Links

https://codedotorg.atlassian.net/browse/XTEAM-235


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
