### PR TITLE
dont add newlines when replacing editor experiment

### DIFF
--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -206,7 +206,7 @@ class DSLDefined < Level
     return dsl_text unless editor_experiment
 
     # remove previous editor experiment
-    dsl_text = dsl_text.sub(/^editor_experiment.*/, '')
+    dsl_text = dsl_text.sub(/\neditor_experiment.*/, '')
 
     # define editor_experiment on the second line of the dsl file.
     index = dsl_text.index("\n")

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -974,7 +974,6 @@ class LevelTest < ActiveSupport::TestCase
       name 'old multi level copy'
       editor_experiment 'new-level-editors'
       title 'Multiple Choice'
-
       question 'What is your favorite color?'
       wrong 'Red'
       wrong 'Green'


### PR DESCRIPTION
# Description

Follow-on to https://github.com/code-dot-org/code-dot-org/pull/32017

there seem to be a number of blank lines accumulating in DSL-defined level files after the `editor_experiment` line. This PR attempts to fix that by removing the preceding newline. Note that this might fail to remove an `editor_experiment` is on the very first line of the file, but that seems unlikely and (though confusing) would be mostly harmless since it'd be overridden by the `editor_experiment` we then added on the second line of the file.

## Testing story

updated existing unit test cases.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
