### PR TITLE
[Applab Data Tab] Don't parse column names from records

### DIFF
--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -57,7 +57,6 @@ const INITIAL_STATE = {
 
 class DataTable extends React.Component {
   static propTypes = {
-    getColumnNames: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     rowsPerPage: PropTypes.number,
     // from redux state
@@ -162,12 +161,8 @@ class DataTable extends React.Component {
   };
 
   getNextColumnName() {
-    const names = this.props.getColumnNames(
-      this.props.tableRecords,
-      this.props.tableColumns
-    );
-    let i = names.length;
-    while (names.includes(`column${i}`)) {
+    let i = this.props.tableColumns.length;
+    while (this.props.tableColumns.includes(`column${i}`)) {
       i++;
     }
     return `column${i}`;
@@ -211,10 +206,7 @@ class DataTable extends React.Component {
   }
 
   render() {
-    let columnNames = this.props.getColumnNames(
-      this.props.tableRecords,
-      this.props.tableColumns
-    );
+    let columnNames = this.props.tableColumns;
     let editingColumn = this.state.editingColumn;
 
     let rowsPerPage = this.props.rowsPerPage || MAX_ROWS_PER_PAGE;

--- a/apps/src/storage/dataBrowser/DataTableView.jsx
+++ b/apps/src/storage/dataBrowser/DataTableView.jsx
@@ -13,7 +13,6 @@ import {changeView, showWarning, tableType} from '../redux/data';
 import * as dataStyles from './dataStyles';
 import color from '../../util/color';
 import {connect} from 'react-redux';
-import {getColumnNamesFromRecords} from '../firebaseMetadata';
 import experiments from '../../util/experiments';
 
 const MIN_TABLE_WIDTH = 600;
@@ -91,23 +90,6 @@ class DataTableView extends React.Component {
     }
   }
 
-  /**
-   * @param {Array} records Array of JSON-encoded records.
-   * @param {string} columns Array of column names.
-   */
-  getColumnNames(records, columns) {
-    // Make sure 'id' is the first column.
-    const columnNames = getColumnNamesFromRecords(records);
-
-    columns.forEach(columnName => {
-      if (columnNames.indexOf(columnName) === -1) {
-        columnNames.push(columnName);
-      }
-    });
-
-    return columnNames;
-  }
-
   importCsv = (csvData, onComplete) => {
     FirebaseStorage.importCsv(
       this.props.tableName,
@@ -160,17 +142,9 @@ class DataTableView extends React.Component {
   }
 
   render() {
-    let columnNames = this.getColumnNames(
-      this.props.tableRecords,
-      this.props.tableColumns
-    );
-    const visible = DataView.TABLE === this.props.view;
-    const containerStyle = [
-      styles.container,
-      {
-        display: visible ? '' : 'none'
-      }
-    ];
+    if (this.props.view !== DataView.TABLE) {
+      return null;
+    }
     const debugDataStyle = [
       dataStyles.debugData,
       {
@@ -181,7 +155,7 @@ class DataTableView extends React.Component {
       this.props.tableListMap[this.props.tableName] === tableType.SHARED;
 
     return (
-      <div id="dataTable" style={containerStyle} className="inline-flex">
+      <div id="dataTable" style={styles.container} className="inline-flex">
         <div style={dataStyles.viewHeader}>
           <span style={dataStyles.backLink}>
             <a
@@ -204,7 +178,6 @@ class DataTableView extends React.Component {
           </span>
         </div>
         <TableControls
-          columns={columnNames}
           clearTable={this.clearTable}
           importCsv={this.importCsv}
           exportCsv={this.exportCsv}
@@ -212,9 +185,7 @@ class DataTableView extends React.Component {
           readOnly={readOnly}
         />
         <div style={debugDataStyle}>{this.getTableJson()}</div>
-        {!this.state.showDebugView && (
-          <DataTable getColumnNames={this.getColumnNames} readOnly={readOnly} />
-        )}
+        {!this.state.showDebugView && <DataTable readOnly={readOnly} />}
       </div>
     );
   }

--- a/apps/src/storage/dataBrowser/PreviewModal.jsx
+++ b/apps/src/storage/dataBrowser/PreviewModal.jsx
@@ -5,7 +5,6 @@ import {hidePreview} from '../redux/data';
 import {getDatasetInfo} from './dataUtils';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import DataTable from './DataTable';
-import {parseColumnsFromRecords} from '../firebaseMetadata';
 import msg from '@cdo/locale';
 
 class PreviewModal extends React.Component {
@@ -32,13 +31,7 @@ class PreviewModal extends React.Component {
         <h1>{this.props.tableName}</h1>
         <p>{datasetInfo.description}</p>
         <div style={{overflow: 'scroll', maxHeight: '70%'}}>
-          <DataTable
-            getColumnNames={(records, columns) =>
-              parseColumnsFromRecords(records)
-            }
-            readOnly
-            rowsPerPage={100}
-          />
+          <DataTable readOnly rowsPerPage={100} />
         </div>
         <button type="button" onClick={() => this.importTable(datasetInfo)}>
           {msg.import()}

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -27,20 +27,6 @@ export function getColumnRefByName(tableName, columnName) {
     });
 }
 
-// TODO: De-dupe this function with getColumnNamesFromRecords() below
-export function parseColumnsFromRecords(records) {
-  const columnNames = [];
-  Object.keys(records).forEach(id => {
-    const record = JSON.parse(records[id]);
-    Object.keys(record).forEach(column => {
-      if (columnNames.indexOf(column) === -1) {
-        columnNames.push(column);
-      }
-    });
-  });
-  return columnNames;
-}
-
 export function getColumnNamesFromRecords(records) {
   const columnNames = ['id'];
   Object.keys(records).forEach(id => {


### PR DESCRIPTION
# Description
We store the column names as metadata in Firebase, so we shouldn't need to parse the column names from the records anymore.

Scenarios:
1. dataset preview
![image](https://user-images.githubusercontent.com/8787187/69455810-0c042680-0d1e-11ea-9b12-9233c873a361.png)
2. Imported static dataset
![image](https://user-images.githubusercontent.com/8787187/69455828-145c6180-0d1e-11ea-8a0b-b9d9a6b4ba2a.png)
3. Imported current dataset
![image](https://user-images.githubusercontent.com/8787187/69457265-884c3900-0d21-11ea-8d5f-ae78601e534b.png)
4. Imported csv
![image](https://user-images.githubusercontent.com/8787187/69456764-55557580-0d20-11ea-9108-f57767dc0597.png)
5. Manually created table
![image](https://user-images.githubusercontent.com/8787187/69456825-7cac4280-0d20-11ea-9c64-3e7a0a6c6cd2.png)
6. Programatically created table
![image](https://user-images.githubusercontent.com/8787187/69457218-6fdc1e80-0d21-11ea-859c-ca4f2e3e6193.png)
![image](https://user-images.githubusercontent.com/8787187/69457195-605cd580-0d21-11ea-9d6a-06b9ab007a60.png)


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
