### PR TITLE
Do batch inserts in create_rollup_tables

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -143,92 +143,104 @@ def main
   raise "contained_level_answers too big: #{contained_levels_answers.size} rows exceeds limit of 100000" if contained_level_answers.size > 100_000
   raise "level_sources too big: #{level_sources_multi_types.size} rows exceeds limit of 100000" if level_sources_multi_types.size > 100_000
 
-  # Truncate the existing tables.
-  %w(
-    contained_levels
-    contained_level_answers
-    level_sources_multi_types
-  ).each do |table_name|
-    ActiveRecord::Base.connection.execute(
-      "TRUNCATE #{table_name}"
-    )
-  end
+  # Maximum rows to insert per query
+  batch_size = 2000
 
   # Write the data to the DB tables.
   ActiveRecord::Base.transaction do
-    contained_levels.each do |contained_level_row|
-      ActiveRecord::Base.connection.execute(
-        <<SQL
-          INSERT INTO contained_levels (
-            created_at,
-            updated_at,
-            level_group_level_id,
-            contained_level_id,
-            contained_level_type,
-            contained_level_page,
-            contained_level_position,
-            contained_level_text
-          )
-          VALUES (
-            "#{TIME_NOW}",
-            "#{TIME_NOW}",
-            #{contained_level_row[:level_id]},
-            #{contained_level_row[:contained_level_id]},
-            "#{contained_level_row[:contained_level_type]}",
-            #{contained_level_row[:contained_level_page]},
-            #{contained_level_row[:contained_level_position]},
-            "#{contained_level_row[:contained_level_text]}"
-          )
-SQL
-      )
+    ActiveRecord::Base.connection.execute 'TRUNCATE contained_levels'
+    contained_levels.each_slice(batch_size) do |batch|
+      ActiveRecord::Base.connection.execute <<~SQL
+        INSERT INTO contained_levels (
+          created_at,
+          updated_at,
+          level_group_level_id,
+          contained_level_id,
+          contained_level_type,
+          contained_level_page,
+          contained_level_position,
+          contained_level_text
+        )
+        VALUES
+        #{batch.map {|row| contained_levels_row(row)}.join(",\n")}
+      SQL
     end
   end
+
   ActiveRecord::Base.transaction do
-    contained_level_answers.each do |contained_level_answer_row|
-      ActiveRecord::Base.connection.execute(
-        <<SQL
-          INSERT INTO contained_level_answers (
-            created_at,
-            updated_at,
-            level_id,
-            answer_number,
-            answer_text,
-            correct
-          )
-          VALUES (
-            "#{TIME_NOW}",
-            "#{TIME_NOW}",
-            #{contained_level_answer_row[:contained_level_id]},
-            #{contained_level_answer_row[:answer_number]},
-            "#{contained_level_answer_row[:answer_text]}",
-            #{contained_level_answer_row[:correct]}
-          )
-SQL
-      )
+    ActiveRecord::Base.connection.execute 'TRUNCATE contained_level_answers'
+    contained_level_answers.each_slice(batch_size) do |batch|
+      ActiveRecord::Base.connection.execute <<~SQL
+        INSERT INTO contained_level_answers (
+          created_at,
+          updated_at,
+          level_id,
+          answer_number,
+          answer_text,
+          correct
+        )
+        VALUES
+        #{batch.map {|row| contained_level_answers_row(row)}.join(",\n")}
+      SQL
     end
   end
+
   ActiveRecord::Base.transaction do
-    level_sources_multi_types.each do |level_sources_multi_types_row|
-      ActiveRecord::Base.connection.execute(
-        <<SQL
-          INSERT INTO level_sources_multi_types (
-            level_source_id,
-            level_id,
-            data,
-            md5,
-            hidden
-          )
-          VALUES (
-            #{level_sources_multi_types_row[:level_source_id]},
-            #{level_sources_multi_types_row[:level_id]},
-            "#{level_sources_multi_types_row[:data]}",
-            "#{level_sources_multi_types_row[:md5]}",
-            #{level_sources_multi_types_row[:hidden]}
-          )
-SQL
-      )
+    ActiveRecord::Base.connection.execute 'TRUNCATE level_sources_multi_types'
+    level_sources_multi_types.each_slice(batch_size) do |batch|
+      ActiveRecord::Base.connection.execute <<~SQL
+        INSERT INTO level_sources_multi_types (
+          level_source_id,
+          level_id,
+          data,
+          md5,
+          hidden
+        )
+        VALUES
+        #{batch.map {|row| level_sources_multi_types_row(row)}.join(",\n")}
+      SQL
     end
   end
+end
+
+def contained_levels_row(row_hash)
+  <<~ROW
+    (
+      "#{TIME_NOW}",
+      "#{TIME_NOW}",
+      #{row_hash[:level_id]},
+      #{row_hash[:contained_level_id]},
+      "#{row_hash[:contained_level_type]}",
+      #{row_hash[:contained_level_page]},
+      #{row_hash[:contained_level_position]},
+      "#{row_hash[:contained_level_text]}"
+    )
+  ROW
+end
+
+def contained_level_answers_row(row_hash)
+  <<~ROW
+    (
+      "#{TIME_NOW}",
+      "#{TIME_NOW}",
+      #{row_hash[:contained_level_id]},
+      #{row_hash[:answer_number]},
+      "#{row_hash[:answer_text]}",
+      #{row_hash[:correct]}
+    )
+  ROW
+end
+
+def level_sources_multi_types_row(row_hash)
+  <<~ROW
+    (
+      #{row_hash[:level_source_id]},
+      #{row_hash[:level_id]},
+      "#{row_hash[:data]}",
+      "#{row_hash[:md5]}",
+      #{row_hash[:hidden]}
+    )
+  ROW
 end
 
 main if only_one_running?(__FILE__)

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -3,8 +3,10 @@
 # This script populates (after truncating) the contained_levels,
 # contained_level_answers, and the level_sources_multi_type tables.
 
-require_relative '../../dashboard/config/environment'
 require 'cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
+require_relative '../../dashboard/config/environment'
 
 TIME_NOW = DateTime.now.strftime('%F %T').freeze
 
@@ -242,5 +244,3 @@ def level_sources_multi_types_row(row_hash)
     )
   ROW
 end
-
-main if only_one_running?(__FILE__)

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -37,7 +37,7 @@ def get_contained_question(contained_level)
   if contained_question_text.nil?
     return contained_question_markdown
   end
-  return "(TEXT) #{contained_question_text} (MARKDOWN) #{contained_question_markdown}"
+  "(TEXT) #{contained_question_text} (MARKDOWN) #{contained_question_markdown}"
 end
 
 def main

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -149,59 +149,53 @@ def main
   batch_size = 2000
 
   # Write the data to the DB tables.
-  ActiveRecord::Base.transaction do
-    ActiveRecord::Base.connection.execute 'TRUNCATE contained_levels'
-    contained_levels.each_slice(batch_size) do |batch|
-      ActiveRecord::Base.connection.execute <<~SQL
-        INSERT INTO contained_levels (
-          created_at,
-          updated_at,
-          level_group_level_id,
-          contained_level_id,
-          contained_level_type,
-          contained_level_page,
-          contained_level_position,
-          contained_level_text
-        )
-        VALUES
-        #{batch.map {|row| contained_levels_row(row)}.join(",\n")}
-      SQL
-    end
+  ActiveRecord::Base.connection.execute 'TRUNCATE contained_levels'
+  contained_levels.each_slice(batch_size) do |batch|
+    ActiveRecord::Base.connection.execute <<~SQL
+      INSERT INTO contained_levels (
+        created_at,
+        updated_at,
+        level_group_level_id,
+        contained_level_id,
+        contained_level_type,
+        contained_level_page,
+        contained_level_position,
+        contained_level_text
+      )
+      VALUES
+      #{batch.map {|row| contained_levels_row(row)}.join(",\n")}
+    SQL
   end
 
-  ActiveRecord::Base.transaction do
-    ActiveRecord::Base.connection.execute 'TRUNCATE contained_level_answers'
-    contained_level_answers.each_slice(batch_size) do |batch|
-      ActiveRecord::Base.connection.execute <<~SQL
-        INSERT INTO contained_level_answers (
-          created_at,
-          updated_at,
-          level_id,
-          answer_number,
-          answer_text,
-          correct
-        )
-        VALUES
-        #{batch.map {|row| contained_level_answers_row(row)}.join(",\n")}
-      SQL
-    end
+  ActiveRecord::Base.connection.execute 'TRUNCATE contained_level_answers'
+  contained_level_answers.each_slice(batch_size) do |batch|
+    ActiveRecord::Base.connection.execute <<~SQL
+      INSERT INTO contained_level_answers (
+        created_at,
+        updated_at,
+        level_id,
+        answer_number,
+        answer_text,
+        correct
+      )
+      VALUES
+      #{batch.map {|row| contained_level_answers_row(row)}.join(",\n")}
+    SQL
   end
 
-  ActiveRecord::Base.transaction do
-    ActiveRecord::Base.connection.execute 'TRUNCATE level_sources_multi_types'
-    level_sources_multi_types.each_slice(batch_size) do |batch|
-      ActiveRecord::Base.connection.execute <<~SQL
-        INSERT INTO level_sources_multi_types (
-          level_source_id,
-          level_id,
-          data,
-          md5,
-          hidden
-        )
-        VALUES
-        #{batch.map {|row| level_sources_multi_types_row(row)}.join(",\n")}
-      SQL
-    end
+  ActiveRecord::Base.connection.execute 'TRUNCATE level_sources_multi_types'
+  level_sources_multi_types.each_slice(batch_size) do |batch|
+    ActiveRecord::Base.connection.execute <<~SQL
+      INSERT INTO level_sources_multi_types (
+        level_source_id,
+        level_id,
+        data,
+        md5,
+        hidden
+      )
+      VALUES
+      #{batch.map {|row| level_sources_multi_types_row(row)}.join(",\n")}
+    SQL
   end
 end
 


### PR DESCRIPTION
While trying to track down a performance issue last night, we noticed that the `create_rollup_tables` task that runs at 1am PST every night truncates three tables and then inserts more than 30,000 rows using individual queries.  That's a lot of queries to run from one process in a few seconds.

I've modified the script to do inserts in batches of 2000 rows, so now it should generate dozens of queries instead of thousands.  I've also removed the transactions, which don't provide any protection against the `TRUNCATE` operations anyway.

I think there's a larger discussion that needs to happen soon:
- The output of this task is only used for analytics - why does it run on production-daemon, and why does it write to our production database?

## Testing story

Re-run locally with and without transactions, with different batch sizes, spot-checking that the same rows (and same number of rows) get inserted into the target tables.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
