### PR TITLE
Fix syncing block_categories

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -129,8 +129,16 @@ def localize_level_content
     end
   end
 
-  File.open(File.join(I18N_SOURCE_DIR, "dashboard/block_categories.json"), 'w') do |file|
-    file.write(JSON.pretty_generate(block_category_strings.sort.to_h))
+  File.open(File.join(I18N_SOURCE_DIR, "dashboard/block_categories.yml"), 'w') do |file|
+    # Format strings for consumption by the rails i18n engine
+    formatted_data = {
+      "en" => {
+        "data" => {
+          "block_categories" => block_category_strings.sort.to_h
+        }
+      }
+    }
+    file.write(I18nScriptUtils.to_crowdin_yaml(formatted_data))
   end
 end
 


### PR DESCRIPTION
# Description

In https://github.com/code-dot-org/code-dot-org/pull/29117, I refactored
the sync in process to organize content by level rather than by content
type. As part of that, I also updated `block_categories` to be
serialized into JSON rather than YAML.

Although this change meant we were using a better data serialization
format, it unfortunately is not the format recognized by either rails or
the part of the sync out that distributes rails content:
https://github.com/code-dot-org/code-dot-org/blob/7460a3f7788cf1d19a408b280a076c76472347de/bin/i18n/sync-out.rb#L208-L218

One option for fixing this would be to update the sync out to convert
this content into a format recognized by rails, but in the long term we
would like to update the rails i18n engine itself to be smarter about
the format it expects content to be in. Work to update the sync out
would be wasted in that context, so for this item I prefer to simply
update the sync in to create `block_categories` in the desired format
right off the bat.

## Follow-up:

After running a sync with this change, the existing
`block_categories.json` file should be removed from both crowdin and
this repo.


<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Testing -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-775)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
