### PR TITLE
Assignment Updates:  re-enable UI tests

### DIFF
--- a/dashboard/test/ui/features/assignment_on_overview_pages.feature
+++ b/dashboard/test/ui/features/assignment_on_overview_pages.feature
@@ -19,7 +19,7 @@ Feature: (Un)Assign on script and course overview pages
     And I press the first ".uitest-unassign-button" element
     # One assign button for each of 9 currently unassigned units in this course,
     # and one at the top of the page indicating the course is assigned
-    And I wait for 3 seconds
+    And I wait until element ".uitest-unassign-button" is not visible
     Then the overview page contains 10 assign buttons
     And I press the first ".uitest-assign-button" element
     And I wait until element ".uitest-unassign-button" is visible

--- a/dashboard/test/ui/features/assignment_on_overview_pages.feature
+++ b/dashboard/test/ui/features/assignment_on_overview_pages.feature
@@ -1,4 +1,3 @@
-@skip
 @no_ie
 @no_mobile
 Feature: (Un)Assign on script and course overview pages
@@ -20,7 +19,7 @@ Feature: (Un)Assign on script and course overview pages
     And I press the first ".uitest-unassign-button" element
     # One assign button for each of 9 currently unassigned units in this course,
     # and one at the top of the page indicating the course is assigned
-    And I wait for the page to fully load
+    And I wait for 3 seconds
     Then the overview page contains 10 assign buttons
     And I press the first ".uitest-assign-button" element
     And I wait until element ".uitest-unassign-button" is visible
@@ -53,7 +52,6 @@ Feature: (Un)Assign on script and course overview pages
     And check that the URL contains "courses/csp-2017"
     And I wait until element ".uitest-CourseScript" is visible
     And I wait until element ".uitest-unassign-button" is visible
-    And I wait until element ".uitest-assigned" is visible
     And I press the first ".uitest-unassign-button" element
     And I press the first ".uitest-togglehidden" element
     And I press the first ".uitest-go-to-unit-button" element to load a new page


### PR DESCRIPTION
This re-enables (and modifies slightly) the UI tests for the Section Assignment Updates which were skipped due to flakiness in # 31892. 

The flakiness was happening because when a teacher unassigns a course, the React state of the overview page updates to re-render `AssignButton`s in place of `UnassignButton`s. In these tests, I'm relying on an accurate count of how many `AssignButton`s are on the page.  So if the test counted the buttons before the state fully updated and component fully re-rendered, there were only 8 buttons instead of the 10 I'm checking for. I can't simply wait for the element to appear because there are already 8 of that element on the page. Instead I add in a little bit of wait time to ensure all of the updates have happened _before_ counting the buttons. 

Also, teachers will no longer see the `Assigned` component due to changes from #31977, so I've updated the tests to reflect this change. 