### PR TITLE
Remove the commented "Testing" subheading

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,6 @@
 <!-- ### Privacy -->
 <!-- ### Security -->
 <!-- ### Caching -->
-<!-- ### Testing -->
 <!-- ### Deployment strategy -->
 <!-- ### Future work -->
 


### PR DESCRIPTION
Update to the PR template: Removes the commented out "Testing" subheading under the list of considerations for the PR.  It's redundant with the larger (and uncommented by default "Testing Story" heading further down the template.