### PR TITLE
Fish: Fix the layout of the rotate device UI

### DIFF
--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -54,6 +54,12 @@ Fish.prototype.init = function(config) {
     bodyElement.className = bodyElement.className + ' pin_bottom';
     container.className = container.className + ' pin_bottom';
 
+    // Fixes viewport for small screens.  Also usually done by studioApp_.init().
+    var viewport = document.querySelector('meta[name="viewport"]');
+    if (viewport) {
+      this.studioApp_.fixViewportForSmallScreens_(viewport, config);
+    }
+
     this.initMLActivities();
   };
 


### PR DESCRIPTION
The rotate device UI, shown on narrow devices when in portrait layout, was not showing correctly for the fish app.  Calling one extra function normally called by `studioApp.init()` fixes up the viewport so that it looks correct.

## before

![Screenshot 2019-11-23 21 25 48](https://user-images.githubusercontent.com/2205926/69490148-6691a580-0e38-11ea-8e11-60d658f5a795.png)

## after

![Screenshot 2019-11-23 21 19 20](https://user-images.githubusercontent.com/2205926/69490149-6691a580-0e38-11ea-9766-a0b15c16ab13.png)

The slightly overlap between text and image is consistent with what's currently on production.