### PR TITLE
Add firehose logging for user interaction with the navigation bar

### DIFF
--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -18,7 +18,6 @@ import {
 
 import progress from './progress';
 import {getStore} from '../redux';
-import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 /**
  * Dynamic header generation and event bindings for header actions.
@@ -248,15 +247,5 @@ header.showTryAgainDialog = () => {
 header.hideTryAgainDialog = () => {
   getStore().dispatch(setShowTryAgainDialog(false));
 };
-
-// header.logToFirehose = detail => {
-//   return firehoseClient.putRecord(
-//     {
-//       study: 'navigation_bar',
-//       event: detail.nav_menu_clicked
-//     },
-//     {alwaysPut: true} // For testing purposes to confirm data is logged to firehose.  Remove before merging PR
-//   );
-// };
 
 export default header;

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -250,13 +250,11 @@ header.hideTryAgainDialog = () => {
 };
 
 header.logToFirehose = detail => {
+  console.log('detail', detail);
   return firehoseClient.putRecord(
     {
       study: 'navigation_bar',
-      event: 'nav_menu_clicked',
-      data_json: JSON.stringify({
-        nav: detail.nav_menu_clicked
-      })
+      event: detail.nav_menu_clicked
     },
     {alwaysPut: true} // For testing purposes to confirm data is logged to firehose.  Remove before merging PR
   );

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -252,14 +252,13 @@ header.hideTryAgainDialog = () => {
 header.logToFirehose = detail => {
   return firehoseClient.putRecord(
     {
-      study: 'user-interraction-nav',
-      event: 'navigation_bar',
+      study: 'navigation_bar',
+      event: 'nav_menu_clicked',
       data_json: JSON.stringify({
         nav: detail.nav_menu_clicked
-        // user
       })
     },
-    {alwaysPut: true}
+    {alwaysPut: true} // For testing purposes to confirm data is logged to firehose.  Remove before merging PR
   );
 };
 

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -18,7 +18,7 @@ import {
 
 import progress from './progress';
 import {getStore} from '../redux';
-import firehoseClient from '../../../apps/src/lib/util/firehose';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 /**
  * Dynamic header generation and event bindings for header actions.
@@ -250,15 +250,13 @@ header.hideTryAgainDialog = () => {
 };
 
 header.logToFirehose = detail => {
-  console.log(detail);
-  console.log('hello world');
-  firehoseClient.putRecord(
+  return firehoseClient.putRecord(
     {
-      study: 'nav_bar_menu',
-      study_group: 'projects',
-      event: 'number_of_clicks',
+      study: 'user-interraction-nav',
+      event: 'navigation_bar',
       data_json: JSON.stringify({
-        detail: detail
+        nav: detail.nav_menu_clicked
+        // user
       })
     },
     {alwaysPut: true}

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -18,6 +18,7 @@ import {
 
 import progress from './progress';
 import {getStore} from '../redux';
+import firehoseClient from '../../../apps/src/lib/util/firehose';
 
 /**
  * Dynamic header generation and event bindings for header actions.
@@ -246,6 +247,22 @@ header.showTryAgainDialog = () => {
 
 header.hideTryAgainDialog = () => {
   getStore().dispatch(setShowTryAgainDialog(false));
+};
+
+header.logToFirehose = detail => {
+  console.log(detail);
+  console.log('hello world');
+  firehoseClient.putRecord(
+    {
+      study: 'nav_bar_menu',
+      study_group: 'projects',
+      event: 'number_of_clicks',
+      data_json: JSON.stringify({
+        detail: detail
+      })
+    },
+    {includeUserId: true}
+  );
 };
 
 export default header;

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -250,7 +250,6 @@ header.hideTryAgainDialog = () => {
 };
 
 header.logToFirehose = detail => {
-  console.log('detail', detail);
   return firehoseClient.putRecord(
     {
       study: 'navigation_bar',

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -261,7 +261,7 @@ header.logToFirehose = detail => {
         detail: detail
       })
     },
-    {includeUserId: true}
+    {alwaysPut: true}
   );
 };
 

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -249,14 +249,14 @@ header.hideTryAgainDialog = () => {
   getStore().dispatch(setShowTryAgainDialog(false));
 };
 
-header.logToFirehose = detail => {
-  return firehoseClient.putRecord(
-    {
-      study: 'navigation_bar',
-      event: detail.nav_menu_clicked
-    },
-    {alwaysPut: true} // For testing purposes to confirm data is logged to firehose.  Remove before merging PR
-  );
-};
+// header.logToFirehose = detail => {
+//   return firehoseClient.putRecord(
+//     {
+//       study: 'navigation_bar',
+//       event: detail.nav_menu_clicked
+//     },
+//     {alwaysPut: true} // For testing purposes to confirm data is logged to firehose.  Remove before merging PR
+//   );
+// };
 
 export default header;

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -368,7 +368,7 @@ function getSingleton() {
 }
 
 function putRecord(data, options) {
-  getSingleton().then(firehoseClient =>
+  return getSingleton().then(firehoseClient =>
     firehoseClient.putRecord(data, options)
   );
 }

--- a/apps/src/sites/studio/pages/layouts/_header.js
+++ b/apps/src/sites/studio/pages/layouts/_header.js
@@ -14,5 +14,3 @@ if (container.length) {
     container[0]
   );
 }
-
-export const fil = '_header';

--- a/apps/src/sites/studio/pages/layouts/_header.js
+++ b/apps/src/sites/studio/pages/layouts/_header.js
@@ -16,16 +16,46 @@ if (container.length) {
   );
 }
 
-document.querySelectorAll('.headerlink').forEach(link => {
-  console.log(link);
+function recordLinkEvent(link, studyText, eventText) {
   link.addEventListener('click', event => {
     console.log(event);
     console.log(event.target.id);
-    event.preventDefault();
-    firehoseClient.putRecord({
-      study: 'navigation_bar_not_on_the_edge',
-      event: event.target.dataset.linkTitle,
-      data_json: event.target.dataset.secondaryLink
-    });
+    //debugger;
+    firehoseClient.putRecord(
+      {
+        study: studyText,
+        event: eventText,
+        data_json: JSON.stringify({
+          tab_title: event.target.dataset.linkTitle,
+          link_url: event.target.dataset.secondaryLink
+        })
+      },
+      {alwaysPut: true} // For testing purposes to confirm data is logged to firehose.  Remove before merging PR
+    );
   });
+}
+
+// Progress, Course catalog, Dashboard & Professional Learning links
+document.querySelectorAll('.headerlink').forEach(link => {
+  console.log(link);
+
+  recordLinkEvent(link, 'nav_bar', 'header_links');
 });
+
+// dashboard logo
+document.querySelectorAll('.header_logo').forEach(link => {
+  console.log(link);
+  //debugger;
+  recordLinkEvent(link, 'nav_bar', 'dashboard_logo');
+});
+
+// create menu
+
+// help button
+document.querySelectorAll('.linktag').forEach(link => {
+  console.log(link);
+  //debugger;
+  recordLinkEvent(link, 'nav_bar', 'help_button');
+});
+
+// hamburger menu

--- a/apps/src/sites/studio/pages/layouts/_header.js
+++ b/apps/src/sites/studio/pages/layouts/_header.js
@@ -22,12 +22,10 @@ document.querySelectorAll('.headerlink').forEach(link => {
     console.log(event);
     console.log(event.target.id);
     event.preventDefault();
-    firehoseClient.putRecord(
-      {
-        study: 'navigation_bar_trial_1',
-        event: event.id
-      },
-      {alwaysPut: true} // For testing purposes to confirm data is logged to firehose.  Remove before merging PR
-    );
+    firehoseClient.putRecord({
+      study: 'navigation_bar_not_on_the_edge',
+      event: event.target.dataset.linkTitle,
+      data_json: event.target.dataset.secondaryLink
+    });
   });
 });

--- a/apps/src/sites/studio/pages/layouts/_header.js
+++ b/apps/src/sites/studio/pages/layouts/_header.js
@@ -14,3 +14,5 @@ if (container.length) {
     container[0]
   );
 }
+
+export const fil = '_header';

--- a/apps/src/sites/studio/pages/layouts/_header.js
+++ b/apps/src/sites/studio/pages/layouts/_header.js
@@ -4,6 +4,7 @@ import {Provider} from 'react-redux';
 
 import ProjectInfo from '@cdo/apps/code-studio/components/header/ProjectInfo';
 import {getStore} from '@cdo/apps/redux';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const container = document.getElementsByClassName('project_info');
 if (container.length) {
@@ -14,3 +15,19 @@ if (container.length) {
     container[0]
   );
 }
+
+document.querySelectorAll('.headerlink').forEach(link => {
+  console.log(link);
+  link.addEventListener('click', event => {
+    console.log(event);
+    console.log(event.target.id);
+    event.preventDefault();
+    firehoseClient.putRecord(
+      {
+        study: 'navigation_bar_trial_1',
+        event: event.id
+      },
+      {alwaysPut: true} // For testing purposes to confirm data is logged to firehose.  Remove before merging PR
+    );
+  });
+});

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -85,8 +85,7 @@
             - else
               .headerlinks.hide_on_tablet
                 - Hamburger.get_header_contents(header_contents_options).each do |entry|
-                  %a.headerlink{id: entry[:id], href: entry[:url]}= entry[:title]
-                  -# %a.headerlink{id: entry[:id], onclick: "event.preventDefault(); logToFirehose({nav_menu_clicked: '#{entry[:title]}'}, '#{entry[:url]}');",  href: entry[:url]}= entry[:title]
+                  %a.headerlink{id: entry[:id], href: entry[:url], data: {"link-title": "#{entry[:title]}", "secondary-link": "#{entry[:url]}"}}= entry[:title]
 
           .header_right
             - if !@hide_sign_in_option && signin_button_enabled
@@ -138,10 +137,3 @@
 
 - content_for(:body_scripts) do
   %script{type: "text/javascript", src: webpack_asset_path('js/layouts/_header.js')}
-
-:javascript
-  function logToFirehose(detail, url) {
-    dashboard.header.logToFirehose(detail).finally(function() {
-      window.location.href = url;
-    });
-  }

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -138,10 +138,7 @@
 - content_for(:body_scripts) do
   %script{type: "text/javascript", src: webpack_asset_path('js/layouts/_header.js')}
 
-
 :javascript
-   function logToFirehose(detail, url) {
-      dashboard.header.logToFirehose(detail)
-      .then(function() { window.location.href = url })
-      .catch(function() { window.location.href = url })
-    }
+  dashboard.header.logToFirehose(detail).finally(function() {
+    window.location.href = url;
+  });

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -85,7 +85,7 @@
             - else
               .headerlinks.hide_on_tablet
                 - Hamburger.get_header_contents(header_contents_options).each do |entry|
-                  %a.headerlink{id: entry[:id], onclick: "event.preventDefault(); logToFirehose({nav_menu_clicked: '#{entry[:title]}', user_id: 2}, '#{entry[:url]}');",  href: entry[:url]}= entry[:title]
+                  %a.headerlink{id: entry[:id], onclick: "event.preventDefault(); logToFirehose({nav_menu_clicked: '#{entry[:title]}'}, '#{entry[:url]}');",  href: entry[:url]}= entry[:title]
 
           .header_right
             - if !@hide_sign_in_option && signin_button_enabled

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -85,7 +85,8 @@
             - else
               .headerlinks.hide_on_tablet
                 - Hamburger.get_header_contents(header_contents_options).each do |entry|
-                  %a.headerlink{id: entry[:id], onclick: "event.preventDefault(); logToFirehose({nav_menu_clicked: '#{entry[:title]}'}, '#{entry[:url]}');",  href: entry[:url]}= entry[:title]
+                  %a.headerlink{id: entry[:id], href: entry[:url]}= entry[:title]
+                  -# %a.headerlink{id: entry[:id], onclick: "event.preventDefault(); logToFirehose({nav_menu_clicked: '#{entry[:title]}'}, '#{entry[:url]}');",  href: entry[:url]}= entry[:title]
 
           .header_right
             - if !@hide_sign_in_option && signin_button_enabled

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -85,7 +85,7 @@
             - else
               .headerlinks.hide_on_tablet
                 - Hamburger.get_header_contents(header_contents_options).each do |entry|
-                  %a.headerlink{id: entry[:id], href: entry[:url]}= entry[:title]
+                  %a.headerlink{id: entry[:id], onclick: "logToFirehose({nav_menu_clicked: '#{entry[:title]}', user_id: 2})",  href: entry[:url]}= entry[:title]
 
           .header_right
             - if !@hide_sign_in_option && signin_button_enabled
@@ -137,3 +137,9 @@
 
 - content_for(:body_scripts) do
   %script{type: "text/javascript", src: webpack_asset_path('js/layouts/_header.js')}
+
+
+:javascript
+   function logToFirehose(detail) {
+      dashboard.header.logToFirehose(detail);
+    }

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -85,7 +85,7 @@
             - else
               .headerlinks.hide_on_tablet
                 - Hamburger.get_header_contents(header_contents_options).each do |entry|
-                  %a.headerlink{id: entry[:id], onclick: "logToFirehose({nav_menu_clicked: '#{entry[:title]}', user_id: 2})",  href: entry[:url]}= entry[:title]
+                  %a.headerlink{id: entry[:id], onclick: "event.preventDefault(); logToFirehose({nav_menu_clicked: '#{entry[:title]}', user_id: 2}, '#{entry[:url]}');",  href: entry[:url]}= entry[:title]
 
           .header_right
             - if !@hide_sign_in_option && signin_button_enabled
@@ -140,6 +140,8 @@
 
 
 :javascript
-   function logToFirehose(detail) {
-      dashboard.header.logToFirehose(detail);
+   function logToFirehose(detail, url) {
+      dashboard.header.logToFirehose(detail)
+      .then(function() { window.location.href = url })
+      .catch(function() { window.location.href = url })
     }

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -139,6 +139,8 @@
   %script{type: "text/javascript", src: webpack_asset_path('js/layouts/_header.js')}
 
 :javascript
-  dashboard.header.logToFirehose(detail).finally(function() {
-    window.location.href = url;
-  });
+  function logToFirehose(detail, url) {
+    dashboard.header.logToFirehose(detail).finally(function() {
+      window.location.href = url;
+    });
+  }

--- a/shared/haml/help_button.haml
+++ b/shared/haml/help_button.haml
@@ -8,11 +8,7 @@
 .help_button{class: "hide-mobile", id: "help-button"}
   .help_contents{style: 'display: none', id: "help-contents"}
     - help_items.each do |entry|
-      %a.linktag{id: entry[:id], href: entry[:url]}=entry[:title]
+    %a.linktag{id: entry[:id], href: entry[:url], data: {"link-title": "#{entry[:title]}", "secondary-link": "#{entry[:url]}", "user-id":"#{current_user.blank? ? '' : current_user.id}"}}= entry[:title]
 
   %i.help_icon.clicktag{class: "fa fa-question-circle hide-mobile", id: "help-icon"}
     %span{style: "pointer-events: none"}
-
-
-
-


### PR DESCRIPTION
# Description
We want to add logging that will allow us to answer the following questions about user interaction with the nav-bar:

What tab is clicked (number of clicks)?  
Determine bounce rate (for example: a user clicked on the top-level menu icon but didn't find what they were looking for and didn't choose any of the options)
Page url interaction

This PR sends data to firehose when the "projects", "dashboard", "course catalog" or "professional learning) tab is clicked. 

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-843)

## Testing story
Output in redshift

Query:  
```
select event, count(*)
from analysis.events
where study = 'navigation_bar'
group by event
```

<img width="787" alt="Screen Shot 2019-11-25 at 12 58 12 PM" src="https://user-images.githubusercontent.com/30066710/69587690-272f9a00-0f9b-11ea-840f-6cf3b59dea16.png">

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
