### PR TITLE
[Data Tab][Cleanup] Rename getColumnNames and onColumnNames

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -21,7 +21,7 @@ import {getDatasetInfo} from '../storage/dataBrowser/dataUtils';
 import {initFirebaseStorage} from '../storage/firebaseStorage';
 import {
   getColumnsRef,
-  onColumnNames,
+  onColumnsChange,
   addMissingColumns
 } from '../storage/firebaseMetadata';
 import {getProjectDatabase, getSharedDatabase} from '../storage/firebaseUtils';
@@ -1345,7 +1345,7 @@ function onInterfaceModeChange(mode) {
 }
 
 function onDataPreview(tableName) {
-  onColumnNames(getSharedDatabase(), tableName, columnNames => {
+  onColumnsChange(getSharedDatabase(), tableName, columnNames => {
     getStore().dispatch(updateTableColumns(tableName, columnNames));
   });
 
@@ -1396,7 +1396,7 @@ function onDataViewChange(view, oldTableName, newTableName) {
       if (newTableType === tableType.PROJECT) {
         addMissingColumns(newTableName);
       }
-      onColumnNames(
+      onColumnsChange(
         newTableType === tableType.PROJECT
           ? getProjectDatabase()
           : getSharedDatabase(),

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -54,18 +54,6 @@ export function getColumnNamesFromRecords(records) {
   return columnNames;
 }
 
-/**
- * @param {string} tableName
- * @returns {Promise} Promise containing an array of column names.
- */
-export function getColumnNames(tableName) {
-  const columnsRef = getColumnsRef(getProjectDatabase(), tableName);
-  return columnsRef.once('value').then(snapshot => {
-    const columnsData = snapshot.val() || {};
-    return _.values(columnsData).map(column => column.columnName);
-  });
-}
-
 export function addColumnName(tableName, columnName) {
   return getColumnRefByName(tableName, columnName).then(columnRef => {
     if (!columnRef) {
@@ -98,7 +86,28 @@ export function renameColumnName(tableName, oldName, newName) {
   });
 }
 
-export function onColumnNames(database, tableName, callback) {
+/**
+ * @param {string} tableName
+ * @returns {Promise} Promise containing an array of column names.
+ * Gets a one-time snapshot of the column names for the given table at
+ * /<channelId>/metadata/tables/<tableName>/columns
+ */
+export function getColumnNamesSnapshot(tableName) {
+  const columnsRef = getColumnsRef(getProjectDatabase(), tableName);
+  return columnsRef.once('value').then(snapshot => {
+    const columnsData = snapshot.val() || {};
+    return _.values(columnsData).map(column => column.columnName);
+  });
+}
+
+/**
+ * @param database
+ * @param {string} tableName
+ * @param callback
+ * Sets up a listener on /<channelId>/metadata/tables/<tableName>/columns and calls the
+ * provided callback whenever the columns change.
+ */
+export function onColumnsChange(database, tableName, callback) {
   getColumnsRef(database, tableName).on('value', snapshot => {
     const columnsData = snapshot.val() || {};
     const columnNames = _.values(columnsData).map(column => column.columnName);
@@ -113,7 +122,7 @@ export function onColumnNames(database, tableName, callback) {
  * @returns {*}
  */
 export function addMissingColumns(tableName) {
-  return getColumnNames(tableName).then(existingColumnNames => {
+  return getColumnNamesSnapshot(tableName).then(existingColumnNames => {
     const recordsRef = getProjectDatabase().child(
       `storage/tables/${tableName}/records`
     );

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -87,10 +87,10 @@ export function renameColumnName(tableName, oldName, newName) {
 }
 
 /**
- * @param {string} tableName
- * @returns {Promise} Promise containing an array of column names.
  * Gets a one-time snapshot of the column names for the given table at
  * /<channelId>/metadata/tables/<tableName>/columns
+ * @param {string} tableName
+ * @returns {Promise} Promise containing an array of column names.
  */
 export function getColumnNamesSnapshot(tableName) {
   const columnsRef = getColumnsRef(getProjectDatabase(), tableName);
@@ -101,11 +101,11 @@ export function getColumnNamesSnapshot(tableName) {
 }
 
 /**
+ * Sets up a listener on /<channelId>/metadata/tables/<tableName>/columns and calls the
+ * provided callback whenever the columns change.
  * @param database
  * @param {string} tableName
  * @param callback
- * Sets up a listener on /<channelId>/metadata/tables/<tableName>/columns and calls the
- * provided callback whenever the columns change.
  */
 export function onColumnsChange(database, tableName, callback) {
   getColumnsRef(database, tableName).on('value', snapshot => {

--- a/apps/test/unit/storage/firebaseMetadataTest.js
+++ b/apps/test/unit/storage/firebaseMetadataTest.js
@@ -3,8 +3,8 @@ import {
   addColumnName,
   deleteColumnName,
   renameColumnName,
-  getColumnNames,
-  onColumnNames
+  getColumnNamesSnapshot,
+  onColumnsChange
 } from '@cdo/apps/storage/firebaseMetadata';
 import {
   init,
@@ -38,17 +38,17 @@ describe('firebaseMetadata', () => {
   });
 
   it('adds column names', done => {
-    getColumnNames('mytable')
+    getColumnNamesSnapshot('mytable')
       .then(columnNames => {
         expect(columnNames).to.deep.equal([]);
         return addColumnName('mytable', 'foo');
       })
-      .then(() => getColumnNames('mytable'))
+      .then(() => getColumnNamesSnapshot('mytable'))
       .then(columnNames => {
         expect(columnNames).to.deep.equal(['foo']);
         return addColumnName('mytable', 'bar');
       })
-      .then(() => getColumnNames('mytable'))
+      .then(() => getColumnNamesSnapshot('mytable'))
       .then(columnNames => {
         expect(columnNames).to.deep.equal(['foo', 'bar']);
         done();
@@ -59,7 +59,7 @@ describe('firebaseMetadata', () => {
     addColumnName('mytable', 'foo')
       .then(() => addColumnName('mytable', 'bar'))
       .then(() => renameColumnName('mytable', 'bar', 'baz'))
-      .then(() => getColumnNames('mytable'))
+      .then(() => getColumnNamesSnapshot('mytable'))
       .then(columnNames => {
         expect(columnNames).to.deep.equal(['foo', 'baz']);
         done();
@@ -70,7 +70,7 @@ describe('firebaseMetadata', () => {
     addColumnName('mytable', 'foo')
       .then(() => addColumnName('mytable', 'bar'))
       .then(() => deleteColumnName('mytable', 'foo'))
-      .then(() => getColumnNames('mytable'))
+      .then(() => getColumnNamesSnapshot('mytable'))
       .then(columnNames => {
         expect(columnNames).to.deep.equal(['bar']);
         done();
@@ -86,7 +86,7 @@ describe('firebaseMetadata', () => {
       ['foo', 'baz'],
       ['baz']
     ];
-    onColumnNames(getProjectDatabase(), 'mytable', columnNames => {
+    onColumnsChange(getProjectDatabase(), 'mytable', columnNames => {
       expect(columnNames).to.deep.equal(expectedNames[count]);
       count++;
       if (count === expectedNames.length) {


### PR DESCRIPTION
# Description
These two functions are very similar, but not the same, so renaming them to make that more clear. They both read the value at the same firebase node: `/<channelId>/metadata/tables/<tableName>/columns`.

`getColumnNamesSnapshot` reads the value a single time and returns a Promise containing the column names.
`onColumnsChange` listens to changes on the node and calls the provided callback *every time* the value changes
## Testing story
Naming change only, so no new tests needed.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
