### PR TITLE
Fix translation of minecraft "place rail"

### DIFF
--- a/apps/src/craft/agent/blocks.js
+++ b/apps/src/craft/agent/blocks.js
@@ -37,7 +37,7 @@ var blocksToDisplayText = {
   planksSpruce: i18n.blockTypePlanksSpruce(),
   pressurePlateUp: i18n.blockTypePressurePlateUp(),
   oreRedstone: i18n.blockTypeOreRedstone(),
-  rails: i18n.blockTypeRail(),
+  rail: i18n.blockTypeRail(),
   railsRedstoneTorch: i18n.blockTypeRailsRedstoneTorch(),
   redstoneWire: i18n.blockTypeRedstoneWire(),
   sand: i18n.blockTypeSand(),

--- a/apps/src/craft/designer/blocks.js
+++ b/apps/src/craft/designer/blocks.js
@@ -49,7 +49,7 @@ const BLOCKS_TO_DISPLAY_TEXT = {
   planksOak: i18n.blockTypePlanksOak(),
   planksSpruce: i18n.blockTypePlanksSpruce(),
   oreRedstone: i18n.blockTypeOreRedstone(),
-  rails: i18n.blockTypeRail(),
+  rail: i18n.blockTypeRail(),
   sand: i18n.blockTypeSand(),
   sandstone: i18n.blockTypeSandstone(),
   stone: i18n.blockTypeStone(),

--- a/apps/src/craft/simple/blocks.js
+++ b/apps/src/craft/simple/blocks.js
@@ -34,7 +34,7 @@ var blocksToDisplayText = {
   planksOak: i18n.blockTypePlanksOak(),
   planksSpruce: i18n.blockTypePlanksSpruce(),
   oreRedstone: i18n.blockTypeOreRedstone(),
-  rails: i18n.blockTypeRail(),
+  rail: i18n.blockTypeRail(),
   sand: i18n.blockTypeSand(),
   sandstone: i18n.blockTypeSandstone(),
   stone: i18n.blockTypeStone(),


### PR DESCRIPTION
# Description

The block being placed is called "rail", not "rails"

## Links

- [jira](https://codedotorg.atlassian.net/browse/FND-754)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
