### PR TITLE
Oceans: adjust button styling

### DIFF
--- a/apps/style/fish/style.scss
+++ b/apps/style/fish/style.scss
@@ -9,9 +9,11 @@ button {
   border: none;
   width: 17%;
   padding: 1.5% 3%;
-
   &:focus {
     outline: white auto 5px;
+  }
+  &:active {
+    border: none !important;
   }
 }
 

--- a/apps/style/fish/style.scss
+++ b/apps/style/fish/style.scss
@@ -9,9 +9,11 @@ button {
   border: none;
   width: 17%;
   padding: 1.5% 3%;
+
   &:focus {
     outline: white auto 5px;
   }
+
   &:active {
     border: none !important;
   }


### PR DESCRIPTION
I stumbled over a case where the default border that the dashboard's default button gets when active (i.e. being pressed) was forcing word wrapping to occur, when the button otherwise didn't have it.  It made for a disconcerting flicker in the UI as the button was pressed.

The simplest solution seems to be to not have a border on this button when it's being pressed.
