### PR TITLE
Add IE11 compatibility banner for Oceans/Fish HoC levels

### DIFF
--- a/apps/src/util/unsupportedBrowserWarning.js
+++ b/apps/src/util/unsupportedBrowserWarning.js
@@ -20,6 +20,8 @@ export var checkForUnsupportedBrowsersOnLoad = function() {
         } else if (appOptions.app === 'gamelab') {
           textDivId = '#gamelab-unsupported-tablet';
         }
+      } else if (isIE11() && appOptions.app === 'fish') {
+        textDivId = '#oceans-unsupported-browser';
       } else if (isIE11() && appOptions.app === 'weblab') {
         textDivId = '#weblab-unsupported-browser';
       } else if (

--- a/dashboard/app/views/layouts/_unsupported_browser.html.haml
+++ b/dashboard/app/views/layouts/_unsupported_browser.html.haml
@@ -5,6 +5,7 @@
   #unsupported-browser.banner-text{style: 'display: none'}!= t("compatibility.upgrade.unsupported_message", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true)
   #applab-unsupported-tablet.banner-text{style: 'display: none'}= t("compatibility.upgrade.applab_unsupported_tablet")
   #gamelab-unsupported-tablet.banner-text{style: 'display: none'}= t("compatibility.upgrade.gamelab_unsupported_tablet")
+  #oceans-unsupported-browser.banner-text{style: 'display: none'}= t("compatibility.upgrade.oceans_unsupported_browser")
   #weblab-unsupported-browser.banner-text{style: 'display: none'}= t("compatibility.upgrade.weblab_unsupported_browser")
   #weblab-unsupported-local-storage.banner-text{style: 'display: none'}= t("compatibility.upgrade.weblab_unsupported_locale_storage")
   %i.fa.fa-close.close-button.banner-icon#dismiss-icon{style: 'display: none; cursor: pointer', onclick: '$("#warning-banner").slideUp();'}

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -582,6 +582,7 @@ en:
       link: "Learn more"
       applab_unsupported_tablet: "App Lab works best on a desktop or laptop computer with a mouse and keyboard. You may experience issues using this tool on your current device."
       gamelab_unsupported_tablet: "Game Lab works best on a desktop or laptop computer with a mouse and keyboard. You may experience issues using this tool on your current device."
+      oceans_unsupported_browser: "This browser is not supported for this tutorial. Please try visiting this page using Edge, Chrome, Firefox, or another modern browser."
       weblab_unsupported_browser: "Unfortunately, we're currently experiencing issues with loading Web Lab on this browser. You may want to use a different browser until this is resolved. Sorry for the inconvenience."
       weblab_unsupported_locale_storage: "You may experience issues using Web Lab in Private Browsing mode. Please reload your project in normal mode. Sorry for the inconvenience."
   slow_loading: 'This is taking longer than usual...'


### PR DESCRIPTION
# Description
- HoC Oceans levels don't have reasonable performance on IE11. Add a banner to the top with text to indicate that the student should try accessing the page with another browser.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
