### PR TITLE
Adding non-latin name support for HOC cert

### DIFF
--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -7,26 +7,37 @@ require_relative '../script_constants'
 # This method returns a newly-allocated Magick::Image object.
 # NOTE: the caller MUST ensure image#destroy! is called on the returned image object to avoid memory leaks.
 def create_certificate_image2(image_path, name, params={})
-  name = name.to_s.force_8859_to_utf8.gsub(/@/, '\@').strip
-  name = ' ' if name.empty?
-
+  # Load the certificate template
   background = Magick::Image.read(image_path).first
 
+  # If the name is just whitespace characters, then return just the certificate
+  # template without a name.
+  name = name.strip
+  return background if name.empty?
+
+  # The user's name will be put into an image with a transparent background.
+  # This uses 'pango', the OS's text layout engine, in order to dynamically
+  # select the correct font. This is important for handling non-latin
+  # languages.
+  name_overlay = Magick::Image.read("pango:#{name}") do
+    # pango:markup is set to false in order to easily prevent pango markup injection
+    # from student names.
+    define('pango', 'markup', false)
+    self.background_color = 'none'
+    self.pointsize = 68
+    self.font = "Times bold"
+    self.fill = "#575757"
+  end.first.trim!
+
+  # x,y offsets
   y = params[:y] || 0
   x = params[:x] || 0
-  width = params[:width] || background.columns
-  height = params[:height] || background.rows
+  # Combine the name image on top of the certificate template image
+  background.composite!(name_overlay, Magick::CenterGravity, x, y, Magick::OverCompositeOp)
 
-  draw = Magick::Draw.new
-  draw.annotate(background, width, height, x, y, name) do
-    draw.gravity = Magick::CenterGravity
-    self.pointsize = 90
-    self.font_family = 'Times'
-    self.font_weight = Magick::BoldWeight
-    self.stroke = 'none'
-    self.fill = 'rgb(87,87,87)'
-  end
-
+  # Free the memory in order to avoid memory leaks (images are stored in /tmp
+  # until destroyed)
+  name_overlay.destroy!
   background
 end
 
@@ -37,7 +48,7 @@ def create_workshop_certificate_image(image_path, fields)
   draw = Magick::Draw.new
 
   fields.each do |field|
-    string = field[:string].to_s.force_8859_to_utf8.gsub(/@/, '\@').strip
+    string = escape_image_magick_string(field[:string].to_s)
     next if string.empty?
 
     y = field[:y] || 0
@@ -58,10 +69,20 @@ def create_workshop_certificate_image(image_path, fields)
   background
 end
 
+# Prepare the given string for using in Image Magick.
+def escape_image_magick_string(string)
+  string = string.force_8859_to_utf8
+  # Escape special Image Magick symbols @, %, and \n
+  string = string.gsub(/^@/, '\@')
+  string = string.gsub(/%/, '\%')
+  string = string.gsub(/\\n/, '\\\\\n')
+  string.strip
+end
+
 # This method returns a newly-allocated Magick::Image object.
 # NOTE: the caller MUST ensure image#destroy! is called on the returned image object to avoid memory leaks.
 def create_course_certificate_image(name, course=nil, sponsor=nil, course_title=nil)
-  name = name.force_8859_to_utf8.gsub(/@/, '\@')
+  name = escape_image_magick_string(name)
   name = ' ' if name.empty?
 
   course ||= ScriptConstants::HOC_NAME

--- a/pegasus/test/test_certificate_image.rb
+++ b/pegasus/test/test_certificate_image.rb
@@ -43,6 +43,16 @@ class CertificateImageTest < Minitest::Test
     assert_image mc_certificate_image, 1754, 1235, 'PNG'
     hoc_certificate_image = create_course_certificate_image('Robot Tester', 'flappy')
     assert_image hoc_certificate_image, 1754, 1235, 'JPEG'
+    hoc_certificate_image_with_ampersand = create_course_certificate_image('Jeffrey & Peter', 'flappy')
+    assert_image hoc_certificate_image_with_ampersand, 1754, 1235, 'JPEG'
+    hoc_certificate_image_with_angle_bracket = create_course_certificate_image('amii <3', 'flappy')
+    assert_image hoc_certificate_image_with_angle_bracket, 1754, 1235, 'JPEG'
+    hoc_certificate_image_with_imagemagick_special_chars = create_course_certificate_image('@\n%', 'flappy')
+    assert_image hoc_certificate_image_with_imagemagick_special_chars, 1754, 1235, 'JPEG'
+    hoc_certificate_image_with_empty_name = create_course_certificate_image('', 'flappy')
+    assert_image hoc_certificate_image_with_empty_name, 1754, 1235, 'JPEG'
+    hoc_certificate_image_with_just_whitespace = create_course_certificate_image(" \n\t", 'flappy')
+    assert_image hoc_certificate_image_with_just_whitespace, 1754, 1235, 'JPEG'
     unspecified_course_image = create_course_certificate_image('Robot Tester', nil)
     assert_image unspecified_course_image, 1754, 1235, 'JPEG'
     blank_named_certificate_image = create_course_certificate_image('Robot Tester', 'course1', nil, 'Course 1')


### PR DESCRIPTION
# Description
As a student with a name consisting of non-latin characters, I want to be able to print my HourOfCode completion certificate
This is the 2nd attempt at this fix. The first try failed because the code did not sanitize the user input, so special characters for Pango and ImageMagick would cause parsing issues.
* Use Pango to render the text. This is needed because Pango can do the correct font selection for the characters in the student's name.
* Turn off Pango markup parsing so users can't inject arbitrary markup and so names with symbols will work correctly e.g. `Jeffery & Tim`, `Amii <3`
* Escape special characters used by image magic: `^@`, `\n`, `%`. This fixes a current bug with our cert rendering. For example, if a student enters the name "Dayne %x", the certificate will print "Dayne 256" or something like that because "%x" gets parsed as the image width by ImageMagick.
* Added unit tests for the actual student names which exposed these bugs in the first production push.

## Screenshots
Here is a screen shot of me putting it a bunch of special characters and confirming the resulting certificate doesn't do anything unexpected.
![cert_with_symbol_fix](https://user-images.githubusercontent.com/1372238/69591635-350d0b80-0feb-11ea-8181-ecd70b541263.jpg)

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-911)
- [Previous PR](https://github.com/code-dot-org/code-dot-org/pull/32078)

## Testing story
* Added unit tests for the actual user inputs which caused HoneyBadger error reports.
* Manual testing using `./bin/dashboard-server`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
