### PR TITLE
Oceans: more responsive changes

### DIFF
--- a/apps/src/fish/FishView.jsx
+++ b/apps/src/fish/FishView.jsx
@@ -10,14 +10,14 @@ const styles = {
   container: {
     position: 'relative',
     width: '100%',
-    minWidth: '770px',
+    minWidth: '480px',
     margin: '0 auto',
     userSelect: 'none'
   },
   containerReact: {
     position: 'absolute',
     width: '100%',
-    minWidth: '770px',
+    minWidth: '480px',
     margin: '0 auto',
     userSelect: 'none',
     fontFamily: '"Gotham 4r", arial, sans-serif',

--- a/apps/style/fish/style.scss
+++ b/apps/style/fish/style.scss
@@ -19,19 +19,32 @@ button {
   font-size: 18px;
 }
 
+/*
+ * Primary aim is to fit the width up to 0.9 of the screen width.
+ * Secondary aim is that the vertical fits on the screen.
+ * (0.9 lets us get the native 930px on a 1024px screen.. though with
+ * a bit of a manual adjustment up due to rounding.)
+ *
+ * e.g.
+ * Given a screen min-width of 800px, the screen min-height should be
+ * (800 * 0.9) / 16 * 9 + 110 (where the 110 represents the header height).
+ * And the max-width of the container should be (800 * 0.9).
+ * And the font-size is (18px * (800 * 0.9 / 930)
+ */
 @media screen {
-  #container { max-width: 770px; }
-  #container-react { font-size: calc(18px * 770 / 930); }
+  #container { max-width: 480px; }
+  #container-react { font-size: calc(18px * 480 / 930); }
 }
-@media screen and (min-width: 1024px) and (min-height: 576px) {
+@media screen and (min-width: 800px) and (min-height: 515px) {
+  #container { max-width: 720px; }
+  #container-react { font-size: calc(18px * 720 / 930); }
+}
+@media screen and (min-width: 1024px) and (min-height: 628px) {
   #container { max-width: 930px; }
   #container-react { font-size: calc(18px * 930 / 930); }
 }
-@media screen and (min-width: 1280px) and (min-height: 720px) {
+@media screen and (min-width: 1137px) and (min-height: 685px) {
   #container { max-width: 1024px; }
   #container-react { font-size: calc(18px * 1024 / 930); }
 }
-@media screen and (min-width: 1440px) and (min-height: 810px) {
-  #container { max-width: 1280px; }
-  #container-react { font-size: calc(18px * 1280 / 930); }
-}
+


### PR DESCRIPTION
Fewer responsive changes, more accurate vertical changes, a cap at 1024px wide, and a much smaller minimum size with the hope that this might work on some landscape phones.

Correlates to https://github.com/code-dot-org/ml-activities/pull/275
