### PR TITLE
[Applab Datasets] Delete columns before pushing new ones to Firebase

### DIFF
--- a/shared/middleware/helpers/firebase_helper.rb
+++ b/shared/middleware/helpers/firebase_helper.rb
@@ -35,6 +35,7 @@ class FirebaseHelper
   def upload_shared_table(table_name, records, columns)
     @firebase.set("/v3/channels/shared/counters/tables/#{table_name}", {"lastId": records.length, "rowCount": records.length})
     @firebase.set("/v3/channels/shared/storage/tables/#{table_name}/records", records)
+    @firebase.delete("/v3/channels/shared/metadata/tables/#{table_name}/columns")
     columns.each do |column|
       @firebase.push("v3/channels/shared/metadata/tables/#{table_name}/columns", {columnName: column})
     end

--- a/shared/test/middleware/helpers/test_firebase_helper.rb
+++ b/shared/test/middleware/helpers/test_firebase_helper.rb
@@ -30,4 +30,21 @@ class FirebaseHelperTest < Minitest::Test
     Firebase::Client.expects(:new).returns(stub(:delete, nil))
     FirebaseHelper.delete_channel fake_channel_name
   end
+
+  def test_delete_shared_table
+    Firebase::Client.expects(:new).returns(stub(:delete, nil))
+    fb = FirebaseHelper.new('shared')
+    fb.delete_shared_table 'fake-table-name'
+  end
+
+  def test_upload_shared_table
+    fake_table_name = 'fake-table-name'
+    fb_client = mock
+    fb_client.expects(:delete).with("/v3/channels/shared/metadata/tables/#{fake_table_name}/columns").returns(nil)
+    fb_client.expects(:set).twice.returns(nil)
+    fb_client.expects(:push).twice.returns(nil)
+    Firebase::Client.expects(:new).returns(fb_client)
+    fb = FirebaseHelper.new('shared')
+    fb.upload_shared_table(fake_table_name, [{id: 1, name: 'alice'}, {id: 2, name: 'bob'}], ['id', 'name'])
+  end
 end


### PR DESCRIPTION
# Description
Small change to the upload script for shared tables. `/v3/channels/shared/counters/tables/#{table_name}` and `/v3/channels/shared/storage/tables/#{table_name}/records` are updated using `set()` which fully overwrites the node, but `/v3/channels/shared/metadata/tables/#{table_name}/columns` is updated by pushing the column names, so we need to delete the previous columns before pushing new ones. Otherwise we will end up with duplicate column names every time the script runs.

Before (running the script twice):
![image](https://user-images.githubusercontent.com/8787187/69655346-31997480-102b-11ea-8e8b-e00c87c201e5.png)

After (running the script twice):
![image](https://user-images.githubusercontent.com/8787187/69655243-ff881280-102a-11ea-976c-8bf7f338ba4a.png)


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
