### PR TITLE
Fix broken link on hourofcode.com/us/how-to/afterschool

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/how-to/afterschool.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/how-to/afterschool.md.partial
@@ -83,6 +83,6 @@ Kick off your Hour of Code by inspiring participants and discussing how computer
 - Review the [Hour of Code FAQ](https://support.code.org/hc/en-us/categories/200147083-Hour-of-Code).
 
 ## What comes after the Hour of Code?
-The Hour of Code is just the first step on a journey to learn more about how technology works and how to create software applications. Help students continue their journey and encourage them to [learn more online](<%= codeorg_url('/learn/beyond') %>)!
+The Hour of Code is just the first step on a journey to learn more about how technology works and how to create software applications. Help students continue their journey and encourage them to [learn more online](/beyond)!
 
 {{ signup_button }}


### PR DESCRIPTION
[PLC-603](https://codedotorg.atlassian.net/browse/PLC-603): Fix the broken "learn more online" link at the bottom of https://hourofcode.com/us/how-to/afterschool to point to https://hourofcode.com/beyond

Question for reviewers: Do I also need to change the copy of this at `[cdo]/i18n/locales/source/hourofcode/how-to/afterschool.md`?

## Testing story

Content change; tested locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
