### PR TITLE
Fix interpreter call stack issue

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -225,7 +225,7 @@
     "webpack-stats-plugin": "^0.2.1"
   },
   "dependencies": {
-    "@code-dot-org/js-interpreter": "1.3.10",
+    "@code-dot-org/js-interpreter": "1.3.11",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
@@ -46,6 +46,13 @@ export default class CustomMarshalingInterpreter extends Interpreter {
         opt_initFunc(thisInterpreter, scope);
       }
     });
+    // Program nodes always have end=0 for some reason (acorn related).
+    // Our code likes them to have end=1 for historical reasons, the result
+    // being that unhandled exceptions will highlight the first character
+    // of the program. The logic below preserves that behavior:
+    if (this.ast && this.ast.type === 'Program') {
+      this.ast.end = 1;
+    }
   }
 
   /**

--- a/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
@@ -270,24 +270,6 @@ export default class CustomMarshalingInterpreter extends Interpreter {
     return super.setProperty(...args);
   }
 
-  step() {
-    const state = this.peekStackFrame();
-    // Program nodes always have end=0 for some reason (acorn related).
-    // The Interpreter.step method assumes that a falsey state.node.end value means
-    // the interpreter is inside polyfill code, because it strips all location information from ast nodes for polyfill code.
-    // This means the interpreter will sometimes step more often than necessary. This is a problem for us when breakpoints
-    // are turned on because the interpreter can step over nodes that we need to check before they get stepped, resulting
-    // in an infinite loop.
-    // See this line in the interpreter code which introduced this behavior:
-    //   https://github.com/NeilFraser/JS-Interpreter/commit/a4ded3ed1de7960cda9177d1bacb6a2526440d14#diff-966ad2ec9f775b3820dd37b4d36b650aR116
-    // TODO: push a fix upstream that checks state.node.end === undefined so the interpreter
-    // doesn't step unnecessarily for Program nodes.
-    if (state && state.node.type === 'Program') {
-      state.node.end = 1;
-    }
-    return super.step();
-  }
-
   // The following overridden methods need to be patched in order to support custom marshaling.
 
   // These changes revert a 10% speedup commit that bypassed hasProperty,

--- a/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
@@ -47,7 +47,12 @@ export default class CustomMarshalingInterpreter extends Interpreter {
       }
     });
     // Program nodes always have end=0 for some reason (acorn related).
-    // Our code likes them to have end=1 for historical reasons, the result
+    // The Interpreter.step method assumes that a falsey state.node.end value means
+    // the interpreter is inside polyfill code, because it strips all location information from ast nodes for polyfill code.
+    // This means the interpreter will sometimes step more often than necessary. This is a problem for us when breakpoints
+    // are turned on because the interpreter can step over nodes that we need to check before they get stepped, resulting
+    // in an infinite loop.
+    // Also, our code likes them to have end=1 for historical reasons, the result
     // being that unhandled exceptions will highlight the first character
     // of the program. The logic below preserves that behavior:
     if (this.ast && this.ast.type === 'Program') {

--- a/apps/test/unit/lib/tools/jsinterpreter/CustomMarshalingInterpreterTest.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/CustomMarshalingInterpreterTest.js
@@ -383,6 +383,34 @@ describe('The CustomMarshalingInterpreter', () => {
     );
   });
 
+  describe('step method', () => {
+    it('does not hit call stack size exceptions with simple polyfill Array.sort code', () => {
+      const interpreter = new CustomMarshalingInterpreter(
+        `var myArray = [];
+         var ARRAY_SIZE = 15;
+         for (var i = 0; i < ARRAY_SIZE; i++) {
+           myArray[i] = ARRAY_SIZE - 1 - i;
+         }
+         myArray.sort();
+        `,
+        new CustomMarshaler({
+          globalProperties: {}
+        })
+      );
+      interpreter.run();
+      const expectedSortedArray = [];
+      const ARRAY_SIZE = 15;
+      for (var i = 0; i < ARRAY_SIZE; i++) {
+        expectedSortedArray[i] = i;
+      }
+      expect(
+        interpreter.marshalInterpreterToNative(
+          interpreter.getValueFromScope('myArray')
+        )
+      ).to.eql(expectedSortedArray);
+    });
+  });
+
   describe('getProperty method', () => {
     it("delegates to the base class's getProperty method by default", () => {
       let interpreterUndefined = interpreter.getProperty(

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1601,10 +1601,10 @@
     test262-harness "^2.4.0"
     yargs "^7.0.1"
 
-"@code-dot-org/js-interpreter@1.3.10":
-  version "1.3.10"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/js-interpreter/-/js-interpreter-1.3.10.tgz#642200b69b34c8bc7636b5daddb8aa554930bd57"
-  integrity sha512-KnG9Q4L3f4y8McEBdytVqYQ5P6916SbCCH0VIpdnlCjYG516bPJ3V+6UcoPeZQBDh/NbF4WcYsDSSNontYA5UA==
+"@code-dot-org/js-interpreter@1.3.11":
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/js-interpreter/-/js-interpreter-1.3.11.tgz#9417863d62420371173015300c2a3917a780e67a"
+  integrity sha512-Pu9GFNzzRJKUKSLIBhvuY3+GHZRxMmFxcF2ZKdJzZnAImHmxdpFblrJcp7tEWohEMmoKFl92iKo0grNrdlNvug==
   dependencies:
     yargs "^7.0.1"
 


### PR DESCRIPTION
# Description

- A simple program running in the interpreter can easily hit a `Maximum call stack size exceeded` exception if it invokes "polyfill" code (e.g. `Array.sort()`). This issue has been present in the interpreter for several years.

Example program:
```
var myArray = [];

for(var i = 0; i < 15; i++){
  myArray.push(randomNumber(0,5));
}

myArray.sort();
```

- The fix is to update to a newer version of our `JS-Interpreter` fork without the offending code that causes the recursion.
- At the same time, I've removed our `step()` implementation. The work to check during every step to assign `node.end = 1` to the `Program` node is now done once in the constructor.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
