### PR TITLE
Add a link to last year's dance party tutorial to /dance page

### DIFF
--- a/pegasus/cache/i18n/en-US.yml
+++ b/pegasus/cache/i18n/en-US.yml
@@ -1665,4 +1665,4 @@
   hoc2019_mc_mee_description1: 'The new Minecraft Hour of Code tutorial is now available in Minecraft: Education Edition for Windows, Mac, and iPad. Learn the basics of coding and explore AI with your students!'
   hoc2019_mc_mee_description2: "Access free resources including a lesson plan, videos, computer science curriculum, and teacher trainings."
   hoc2019_mc_more_coding_resources: "More Coding Resources"
-  hoc2019_dance_previous_versions: "Looking for a previous version of Dance Party?<br />Click here to start <a href='%{dance_2018_link}'>Part 1</a> and <a href='%{dance_extras_2018_link}'>Part 2</a> from last year."
+  hoc2019_dance_previous_versions: "Looking for a previous version of Dance Party?  \nClick here to start [Part 1](%{dance_2018_link}) and [Part 2](%{dance_extras_2018_link}) from last year."

--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -26,13 +26,7 @@ theme: responsive
 =view :dance_teacher_resources
 
 .dance-text-icon-container.desktop-only
-  Looking for a previous version of Dance Party?
-  %br
-    Click here to start
-    %a{href: CDO.studio_url('/s/dance/reset')} Part 1
-    and
-    %a{href: CDO.studio_url('/s/dance-extras/reset')} Part 2
-    from last year.
+  =I18n.t(:hoc2019_dance_previous_versions, dance_2018_link: CDO.studio_url('/s/dance/reset'), dance_extras_2018_link: CDO.studio_url('/s/dance-extras/reset'))
 
 =view :dance_sponsor_logo
 

--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -25,6 +25,15 @@ theme: responsive
 
 =view :dance_teacher_resources
 
+.dance-text-icon-container.desktop-only
+  Looking for a previous version of Dance Party?
+  %br
+    Click here to start
+    %a{href: CDO.studio_url('/s/dance/reset')} Part 1
+    and
+    %a{href: CDO.studio_url('/s/dance-extras/reset')} Part 2
+    from last year.
+
 =view :dance_sponsor_logo
 
 %h2.dance-responsive-padding.add-margintop-between-sections= I18n.t(:hoc2018_dance_featured_student_creations_title)

--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -25,8 +25,8 @@ theme: responsive
 
 =view :dance_teacher_resources
 
-.dance-text-icon-container.desktop-only
-  =I18n.t(:hoc2019_dance_previous_versions, dance_2018_link: CDO.studio_url('/s/dance/reset'), dance_extras_2018_link: CDO.studio_url('/s/dance-extras/reset'))
+.dance-text-icon-container
+  =I18n.t(:hoc2019_dance_previous_versions, dance_2018_link: CDO.studio_url('/s/dance/reset'), dance_extras_2018_link: CDO.studio_url('/s/dance-extras/reset'), markdown: true)
 
 =view :dance_sponsor_logo
 


### PR DESCRIPTION
[PLC-643](https://codedotorg.atlassian.net/browse/PLC-643): Add a link to last year's dance party tutorial to [the /dance page](https://code.org/dance), as specified in the linked Jira item.

It's a small, two-line right-aligned message:

![image](https://user-images.githubusercontent.com/1615761/69676706-260f7300-1056-11ea-86b7-016629a8ed1e.png)

It's visible on both desktop and mobile:

![desktop](https://user-images.githubusercontent.com/1615761/69676218-278c6b80-1055-11ea-984e-a61bfc439b49.png)

![Screenshot from 2019-11-26 13-55-58](https://user-images.githubusercontent.com/1615761/69676225-29eec580-1055-11ea-93b2-6ddf9fb0ddfc.png)

The links begin the respective tutorials.

## Internationalization

This change introduces one new Pegasus string, used on code.org/dance, that will need to be translated.  FYI @castro-jorge.

I did a thoughtless thing and [committed an early version new string](https://github.com/code-dot-org/code-dot-org/pull/32158/commits/99292aa4ba600ca200058b700a1ab1d5c5860cf2) directly from staging while we were in lockdown.  Fortunately Elijah caught me and suggested a better approach:

- I've made the appropriate string changes in [our pegasus i18n spreadsheet](https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit#gid=0).
- I've committed the corresponding change to `pegasus/cache/i18n/en-US.yml`, which we normally wouldn't edit by hand, so that it can be reviewed as part of the triage process.  Since the autocommit on staging is disabled, this shouldn't introduce a conflict.

## Testing story

This is a content change.  Tested locally.  This will also cause a diff in [tutorial_landing_pages.feature](https://github.com/code-dot-org/code-dot-org/blob/6ab8ae5017ab87a4db923f6f33930d1134de12e2/dashboard/test/ui/features/tutorial_landing_pages.feature#L19).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
