### PR TITLE
Oceans: style updates + version bump

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -48,7 +48,7 @@
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "1.1.0",
-    "@code-dot-org/ml-activities": "0.0.17",
+    "@code-dot-org/ml-activities": "0.0.18",
     "@code-dot-org/p5.play": "^1.3.12-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/style/fish/style.scss
+++ b/apps/style/fish/style.scss
@@ -9,10 +9,6 @@ button {
   border: none;
   padding: 1.5% 3%;
 
-  &:focus {
-    outline: white auto 5px;
-  }
-
   &:active {
     border: none !important;
   }
@@ -50,4 +46,3 @@ button {
   #container { max-width: 1024px; }
   #container-react { font-size: calc(18px * 1024 / 930); }
 }
-

--- a/apps/style/fish/style.scss
+++ b/apps/style/fish/style.scss
@@ -7,7 +7,6 @@ button {
   font-size: 120%;
   border-radius: 5px;
   border: none;
-  width: 17%;
   padding: 1.5% 3%;
 
   &:focus {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -954,10 +954,10 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-1.1.0.tgz#7c8185adf06a9172e3bde4ccd6f6738a787b2a7c"
 
-"@code-dot-org/ml-activities@0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.17.tgz#eab35e2613e55fd859d9d9db3356ed2afbdf9d35"
-  integrity sha512-Fd2Aa1yOaLzokngakK5MbyLHWbjtKh8juOApenGu8u63dk5XJbw2EGpM5Vy9qdDZevvEK8HDwcpPIkDk9nWE+Q==
+"@code-dot-org/ml-activities@0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.18.tgz#d240b697690572d69776304d04d89a87f5b4298a"
+  integrity sha512-z80OwGTIVTzJA01GS2uaV7xyygbL1JgATpxPbqduIoUQrRlgtASNv5D0ethy3Jbc2eWrWMuREwEs8ILapbLXog==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"


### PR DESCRIPTION
- The Oceans tutorial on dashboard had a fixed button width, while it doesn't in its own repo.  By removing this width, we avoid wrapping its content onto a second line.
- Remove the focus outline on buttons ([corresponding PR in ml-activities](https://github.com/code-dot-org/ml-activities/pull/296))
- Bump ml-activities version to `0.0.18`