### PR TITLE
[Spritelab] hide edit button for behaviors if toolbox doesn't have categories

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -377,7 +377,7 @@ export default {
           .appendTitle(fieldLabel, 'VAR')
           .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
 
-        if (Blockly.useModalFunctionEditor) {
+        if (Blockly.useModalFunctionEditor && Blockly.hasCategories) {
           var editLabel = new Blockly.FieldIcon(Blockly.Msg.FUNCTION_EDIT);
           Blockly.bindEvent_(
             editLabel.fieldGroup_,


### PR DESCRIPTION
# Description
We want to disallow editing the behavior if the toolbox does *not* have categories.
Before:
![image](https://user-images.githubusercontent.com/8787187/69683871-32ea9180-106b-11ea-8711-dca0755af31a.png)

[Updated] After:
![image](https://user-images.githubusercontent.com/8787187/69684230-b8bb0c80-106c-11ea-93d7-241347ef4f65.png)


Levels with categories are unaffected:
![image](https://user-images.githubusercontent.com/8787187/69683942-71804c00-106b-11ea-8c48-98a9ab0909f1.png)

## Links


- [jira](https://codedotorg.atlassian.net/browse/STAR-834)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
