### PR TITLE
Adding Noto fonts to production servers

### DIFF
--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -21,6 +21,7 @@ apt_package %w(
   imagemagick
   libmagickcore-dev
   libmagickwand-dev
+  fonts-noto
 )
 
 # Used by lesson plan generator.


### PR DESCRIPTION
# Description
When testing the HoC certificate on our production servers, I noticed that Korean and some Chinese names weren't working. This PR updates the production server setup scripts to install the Google Noto Font set:
> When text is rendered by a computer, sometimes characters are displayed as “tofu”. They are little boxes to indicate your device doesn’t have a font to display the text.  Google has been developing a font family called Noto, which aims to support all languages with a harmonious look and feel. Noto is Google’s answer to tofu. The name noto is to convey the idea that Google’s goal is to see “no more tofu”. Noto has multiple styles and weights, and is freely available to all. 

## Links
- [Noto Fonts](https://www.google.com/get/noto/)

## Testing story
* Generate certificates by copy/pasting the text below on my [adhoc server](https://adhoc-more-cert-fonts.cdn-code.org/certificates).
```
Hello world!
你好，世界！
Ahoj světe!
Γειά σου Κόσμε!
שלום עולם!
नमस्ते दुनिया!
こんにちは世界！
안녕하세요 세상!
ສະ​ບາຍ​ດີ​ຊາວ​ໂລກ!
नमस्कार संसार!
سلام دنیا!
ሰላም ልዑል!
مرحبا بالعالم!
வணக்கம் உலகம்!
హలో ప్రపంచం!
สวัสดีชาวโลก!
העלא וועלט!
```

# Reviewer Checklist:
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
