### PR TITLE
[Applab Datasets] Fix off-by-one error in upload scripts

### DIFF
--- a/bin/cron/applab_datasets/weather
+++ b/bin/cron/applab_datasets/weather
@@ -135,7 +135,7 @@ def get_weather_data
     WeatherForecastOffice.new('Seattle', 'Washington', '98115'),
     WeatherForecastOffice.new('Spokane', 'Washington', '99224')
   ]
-  records = []
+  records = {}
   columns = %w(id city state timestamp temp_min temp_max weather icon wind_speed)
   id = 1
   forecast_offices.each do |office|
@@ -155,7 +155,7 @@ def get_weather_data
         measurement["weather"][0]["icon"],
         measurement["wind"]["speed"]
       )
-      records.push(row.to_h.to_json)
+      records[id] = row.to_h.to_json
       id += 1
     end
   end

--- a/bin/oneoff/applab_datasets/upload_csv_to_firebase
+++ b/bin/oneoff/applab_datasets/upload_csv_to_firebase
@@ -13,18 +13,18 @@ def number?(num)
 end
 
 def parse_csv(filename)
-  records = []
+  records = {}
   id = 1
   table = CSV.parse(File.read(filename), headers: true)
   table.each do |row|
     record = OpenStruct.new
     record.id = id
-    id += 1
     table.headers.each do |col|
       value = (number? row[col]) ? row[col].to_f : row[col]
       record[col] = value
     end
-    records.push(record.to_h.to_json)
+    records[id] = record.to_h.to_json
+    id += 1
   end
   return records, table.headers
 end


### PR DESCRIPTION
# Description
ids for the purpose of the Data Tab are 1-indexed. I had set the id on each record correctly, but put them all in an array (0-indexed) and set them in firebase that way. As a result, the id on each record, did not match the id of the firebase node. This resulted in off-by-one errors when trying to edit or delete records
Before:
![image](https://user-images.githubusercontent.com/8787187/69743677-ad5ef400-10f3-11ea-9b21-5d0f58c4ef69.png)
After:
![image](https://user-images.githubusercontent.com/8787187/69743692-b3ed6b80-10f3-11ea-9fd3-bf6eed8b5dd8.png)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
