### PR TITLE
Add spritelab animation bucket to Cloudformation config

### DIFF
--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -20,7 +20,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-        
   SpritelabAnimationBucket:
     Type: 'AWS::S3::Bucket'
     Properties:

--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -20,3 +20,22 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+        
+  SpritelabAnimationBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: 'cdo-spritelab-animation-library'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: 'aws:kms'
+      VersioningConfiguration:
+        Status: 'Enabled'
+      LoggingConfiguration:
+        DestinationBucketName: 'cdo-logs'
+        LogFilePrefix: 's3/cdo-spritelab-animation-library'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true


### PR DESCRIPTION
# Description
We want to separate the animation assets for SpriteLab and GameLab. Currently, both are served from the `cdo-animation-library` S3 bucket. 
1. Create `cdo-spritelab-animation-library` S3 bucket
2. Populate bucket with all Spritelab animation assets
3. Add endpoints for spritelab to [animation_library_api](https://github.com/code-dot-org/code-dot-org/blob/staging/shared/middleware/animation_library_api.rb)
4. Change Sprite Lab levels and projects to reference animation assets only from the spritelab bucket

## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-858)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
