### PR TITLE
Better navigation through Regional Partner admin tools

### DIFF
--- a/dashboard/app/views/admin_reports/directory.html.haml
+++ b/dashboard/app/views/admin_reports/directory.html.haml
@@ -17,7 +17,9 @@
   For Users
 
 %h3 Regional Partners
-= link_to t('crud.new_model', model: RegionalPartner.model_name.human), new_regional_partner_path
+= link_to "See all Regional Partners", regional_partners_path
+%br
+= link_to "Create a new Regional Partner", new_regional_partner_path
 
 %h3 Pilot Experiments
 - Experiment::PILOT_EXPERIMENTS.each do |pilot|

--- a/dashboard/app/views/regional_partners/index.html.haml
+++ b/dashboard/app/views/regional_partners/index.html.haml
@@ -1,5 +1,17 @@
 - content_for(:head) do
   = stylesheet_link_tag 'css/pd', media: 'all'
+  :scss
+    .main .new-regional-partner {
+      font-size: 20px;
+      line-height: 40px;
+      margin: 10px 0;
+      float: right;
+    }
+
+- if can? :create, RegionalPartner
+  = link_to new_regional_partner_path, class: 'new-regional-partner' do
+    %i.fa.fa-plus-circle
+    = t('crud.new_model', model: RegionalPartner.model_name.human)
 
 %h1 Regional Partners
 


### PR DESCRIPTION
Was just looking at our Regional Partner admin pages today and realized that it's not very clear how to navigate around them.  So I added two things.

One: The `/admin` index page now contains a link to the regional partner list, not just a link to create a new regional partner.

![Screenshot from 2019-11-27 10-58-06](https://user-images.githubusercontent.com/1615761/69752154-7abdf700-1105-11ea-83f2-958e742d7f33.png)

Two: The `/regional_partners` page now contains a link to the "New Regional Partner" form, visible only if you have permission to add a regional partner:

![Screenshot from 2019-11-27 10-57-53](https://user-images.githubusercontent.com/1615761/69752187-8c9f9a00-1105-11ea-95ad-9683d01e2bc0.png)

## Testing story

Manual testing on dev machine.  These are just links on admin pages, and not a behavior requested by anyone else, so I don't feel a need to go add detailed coverage.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
