### PR TITLE
Firehose dynamic config

### DIFF
--- a/lib/cdo/firehose.rb
+++ b/lib/cdo/firehose.rb
@@ -37,6 +37,8 @@ class FirehoseClient
   # Posts a record to the analytics stream.
   # @param data [hash] The data to insert into the stream.
   def put_record(data)
+    return unless Gatekeeper.allows('firehose', default: true)
+
     data_with_common_values = add_common_values(data)
 
     if [:development, :test].include? rack_env


### PR DESCRIPTION
# Description

Adds a Gatekeeper flag `firehose` (default `true`) to dynamically disable Firehose logging when set to `false`.

## Background

The call to the [`Firehose:PutRecord`](https://docs.aws.amazon.com/firehose/latest/APIReference/API_PutRecord.html) API is currently performed for some analytics-tracking, and is performed synchronously on the web-application transaction, including the high-scale `show` action on Projects pages. If the Firehose service becomes slow or unresponsive it could become a scaling bottleneck for our application, so this PR adds a switch (default enabled) to disable this service call if needed.