### PR TITLE
fix override_dashboard stub in Dashboard test helper

### DIFF
--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -42,6 +42,8 @@ Rails.application.reload_routes! if defined?(Rails) && defined?(Rails.applicatio
 require File.expand_path('../../config/environment', __FILE__)
 I18n.load_path += Dir[Rails.root.join('test', 'en.yml')]
 I18n.backend.reload!
+CDO.stubs(override_pegasus: nil)
+CDO.stubs(override_dashboard: nil)
 
 Rails.application.routes.default_url_options[:host] = CDO.dashboard_hostname
 Dashboard::Application.config.action_mailer.default_url_options = {host: CDO.canonical_hostname('studio.code.org'), protocol: 'https'}


### PR DESCRIPTION
Invoke #stub in initialization to stub later calls in the init sequence.
Fixes a unit-test failure in environments where `override_dashboard` is set.