### PR TITLE
Fix volunteer map load time

### DIFF
--- a/pegasus/forms/volunteer_engineer_submission_2015.rb
+++ b/pegasus/forms/volunteer_engineer_submission_2015.rb
@@ -9,9 +9,9 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
   # and after each Hour of Code.
   UNSUBSCRIBE_HOC = "untilhoc".freeze
   UNSUBSCRIBE_FOREVER = "forever".freeze
-  DEFAULT_DISTANCE_KM = 40
-  DEFAULT_DISTANCE_MILES = 25
-  DEFAULT_NUM_VOLUNTEERS = 100
+  DEFAULT_DISTANCE_MILES = 20
+  DEFAULT_DISTANCE_KM = 32
+  DEFAULT_NUM_VOLUNTEERS = 50
 
   def self.normalize(data)
     result = {}

--- a/pegasus/forms/volunteer_engineer_submission_2015.rb
+++ b/pegasus/forms/volunteer_engineer_submission_2015.rb
@@ -9,8 +9,8 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
   # and after each Hour of Code.
   UNSUBSCRIBE_HOC = "untilhoc".freeze
   UNSUBSCRIBE_FOREVER = "forever".freeze
-  DEFAULT_DISTANCE = 24 # kilometers
-  DEFAULT_NUM_VOLUNTEERS = 10
+  DEFAULT_DISTANCE = 40 # kilometers
+  DEFAULT_NUM_VOLUNTEERS = 100
 
   def self.normalize(data)
     result = {}

--- a/pegasus/forms/volunteer_engineer_submission_2015.rb
+++ b/pegasus/forms/volunteer_engineer_submission_2015.rb
@@ -9,7 +9,8 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
   # and after each Hour of Code.
   UNSUBSCRIBE_HOC = "untilhoc".freeze
   UNSUBSCRIBE_FOREVER = "forever".freeze
-  DEFAULT_DISTANCE = 40 # kilometers
+  DEFAULT_DISTANCE_KM = 40
+  DEFAULT_DISTANCE_MILES = 25
   DEFAULT_NUM_VOLUNTEERS = 100
 
   def self.normalize(data)
@@ -140,7 +141,7 @@ class VolunteerEngineerSubmission2015 < VolunteerEngineerSubmission
     end
 
     coordinates = params['coordinates']
-    distance = params['distance'] || DEFAULT_DISTANCE
+    distance = params['distance'] || DEFAULT_DISTANCE_KM
     rows = params['num_volunteers'] || DEFAULT_NUM_VOLUNTEERS
 
     unless params['location_flexibility_ss'].nil_or_empty?

--- a/pegasus/sites.v3/code.org/public/js/volunteer-local.js
+++ b/pegasus/sites.v3/code.org/public/js/volunteer-local.js
@@ -68,17 +68,8 @@ function getParams(form_data) {
 
   // Default showing US results
   if (!gmap_loc) {
-    gmap_loc = "37.6,-95.665";
-
-    params.push({
-      name: "distance",
-      value: 3000
-    });
-
-    params.push({
-      name: "num_volunteers",
-      value: 5000
-    });
+    // Westlake park, Seattle
+    gmap_loc = "47.611089,-122.337034";
   }
 
   params.push({

--- a/pegasus/sites.v3/code.org/views/volunteer_map.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_map.haml
@@ -42,16 +42,16 @@
         %label.control-label.small{for: "distance"} Within
         %div
           %select#distance.form-control{name: "distance", type: "select"}
-            %option{selected: distance.nil_or_empty?, value: ""}= "15 miles"
+            %option{selected: distance.nil_or_empty?, value: ""}= "25 miles"
             -VolunteerEngineerSubmission2015.distances.each do |key, value|
               %option{value: key, selected: (distance||[]).include?(key.to_s)}= value
       .form-group.col-xs-2
         %label.control-label.small{for: "num_volunteers"} Show no more than
         %div
           %select#num_volunteers.form-control{name: "num_volunteers", type: "select"}
-            %option{selected: num_volunteers.nil_or_empty?, value: ""}= "10 volunteers"
+            %option{selected: num_volunteers.nil_or_empty?, value: ""}= "100 volunteers"
             -VolunteerEngineerSubmission2015.num_volunteers.each do |key, value|
-              %option{value: key, selected: (num_volunteers||[]).include?(key.to_s)}= value
+              %option{value: key, selected: (num_volunteers || []).include?(key.to_s)}= value
 
 
 #volunteer-search-results.row.top-margin

--- a/pegasus/sites.v3/code.org/views/volunteer_map.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_map.haml
@@ -16,10 +16,10 @@
 
 %form#volunteer-search-form{role: "form", onsubmit: "event.preventDefault();"}
   #volunteer-search-facets.form-section.row
-    %h3.col-xs-12.top-margin Narrow your search
+    %h3.col-xs-12.top-margin Search your location
     .form-section.row.no-margin
       .form-group.col-xs-4
-        %input#location.form-control{name: "location", placeholder: "Search my location", type: "text", value: search_location}
+        %input#location.form-control{name: "location", placeholder: "ZIP code, city and state/country", type: "text", value: search_location}
       .form-group.col-xs-2.submit-btn
         %button#btn-submit{type: "submit", style: "margin-top: 0px"} Search
 

--- a/pegasus/sites.v3/code.org/views/volunteer_map.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_map.haml
@@ -42,14 +42,14 @@
         %label.control-label.small{for: "distance"} Within
         %div
           %select#distance.form-control{name: "distance", type: "select"}
-            %option{selected: distance.nil_or_empty?, value: ""}= "25 miles"
+            %option{selected: distance.nil_or_empty?, value: ""}= "#{VolunteerEngineerSubmission2015::DEFAULT_DISTANCE_MILES} miles"
             -VolunteerEngineerSubmission2015.distances.each do |key, value|
               %option{value: key, selected: (distance||[]).include?(key.to_s)}= value
       .form-group.col-xs-2
         %label.control-label.small{for: "num_volunteers"} Show no more than
         %div
           %select#num_volunteers.form-control{name: "num_volunteers", type: "select"}
-            %option{selected: num_volunteers.nil_or_empty?, value: ""}= "100 volunteers"
+            %option{selected: num_volunteers.nil_or_empty?, value: ""}= "#{VolunteerEngineerSubmission2015::DEFAULT_NUM_VOLUNTEERS} volunteers"
             -VolunteerEngineerSubmission2015.num_volunteers.each do |key, value|
               %option{value: key, selected: (num_volunteers || []).include?(key.to_s)}= value
 


### PR DESCRIPTION
# Description
[Local volunteer map](https://code.org/volunteer/local) has a performance issue on **first load.** The page currently takes about 15-30s to load (without filter) because it tries to display 5000 volunteers at once. This will significantly impact users experience when they want helps for HoC.

After investigation, the main reason for the slowness is to render 5000 pins on Google Maps. 
The fix is to reduce the number of pins on **first load** by reducing search distance and volunteer count. Specifically, I set the starting search location to Seattle, with 20 mile radius and max 50 volunteers. 

**Screenshots**
First load:
<img width="740" alt="Screen Shot 2019-12-03 at 4 20 25 PM" src="https://user-images.githubusercontent.com/46507039/70101135-dd713000-15e8-11ea-8b85-9a25a3c97efe.png">

Searches specific location with default distance (20 miles) and volunteer count (50):
<img width="742" alt="Screen Shot 2019-12-03 at 4 18 21 PM" src="https://user-images.githubusercontent.com/46507039/70101109-c9c5c980-15e8-11ea-823d-6765f94e5cfb.png">

Examples of further filtering:
<img width="742" alt="Screen Shot 2019-12-03 at 4 21 31 PM" src="https://user-images.githubusercontent.com/46507039/70101179-05609380-15e9-11ea-96e2-bf84d4952181.png">

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-592)

## Testing story
- Tested on local machines using fake 10k volunteers

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
