### PR TITLE
Remove links to last year's tutorials on /dance

### DIFF
--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -25,9 +25,6 @@ theme: responsive
 
 =view :dance_teacher_resources
 
-.dance-text-icon-container
-  =I18n.t(:hoc2019_dance_previous_versions, dance_2018_link: CDO.studio_url('/s/dance/reset'), dance_extras_2018_link: CDO.studio_url('/s/dance-extras/reset'), markdown: true)
-
 =view :dance_sponsor_logo
 
 %h2.dance-responsive-padding.add-margintop-between-sections= I18n.t(:hoc2018_dance_featured_student_creations_title)


### PR DESCRIPTION
Reverts most of https://github.com/code-dot-org/code-dot-org/pull/32161 but leaves the actual loc string in place so translations from CrowdIn can be added as usual.

We ran into [a very confusing issue](https://codedotorg.slack.com/archives/C0T0PNTM3/p1574901168297300) on staging where this string is not being rendered as markdown, and we don't understand why.  Since it's late and we're about to go on break, I propose simply rolling back this change.