### PR TITLE
[Applab Data Tab] Don't parse column names from records

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -19,11 +19,7 @@ import * as utils from '../utils';
 import * as dropletConfig from './dropletConfig';
 import {getDatasetInfo} from '../storage/dataBrowser/dataUtils';
 import {initFirebaseStorage} from '../storage/firebaseStorage';
-import {
-  getColumnsRef,
-  onColumnsChange,
-  addMissingColumns
-} from '../storage/firebaseMetadata';
+import {getColumnsRef, onColumnsChange} from '../storage/firebaseMetadata';
 import {getProjectDatabase, getSharedDatabase} from '../storage/firebaseUtils';
 import * as apiTimeoutList from '../lib/util/timeoutList';
 import designMode from './designMode';
@@ -1392,9 +1388,6 @@ function onDataViewChange(view, oldTableName, newTableName) {
         storageRef = sharedStorageRef.child(`tables/${newTableName}/records`);
       } else {
         storageRef = projectStorageRef.child(`tables/${newTableName}/records`);
-      }
-      if (newTableType === tableType.PROJECT) {
-        addMissingColumns(newTableName);
       }
       onColumnsChange(
         newTableType === tableType.PROJECT

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -57,7 +57,6 @@ const INITIAL_STATE = {
 
 class DataTable extends React.Component {
   static propTypes = {
-    getColumnNames: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     rowsPerPage: PropTypes.number,
     // from redux state
@@ -162,12 +161,8 @@ class DataTable extends React.Component {
   };
 
   getNextColumnName() {
-    const names = this.props.getColumnNames(
-      this.props.tableRecords,
-      this.props.tableColumns
-    );
-    let i = names.length;
-    while (names.includes(`column${i}`)) {
+    let i = this.props.tableColumns.length;
+    while (this.props.tableColumns.includes(`column${i}`)) {
       i++;
     }
     return `column${i}`;
@@ -211,10 +206,7 @@ class DataTable extends React.Component {
   }
 
   render() {
-    let columnNames = this.props.getColumnNames(
-      this.props.tableRecords,
-      this.props.tableColumns
-    );
+    let columnNames = [...this.props.tableColumns];
     let editingColumn = this.state.editingColumn;
 
     let rowsPerPage = this.props.rowsPerPage || MAX_ROWS_PER_PAGE;

--- a/apps/src/storage/dataBrowser/DataTableView.jsx
+++ b/apps/src/storage/dataBrowser/DataTableView.jsx
@@ -13,7 +13,6 @@ import {changeView, showWarning, tableType} from '../redux/data';
 import * as dataStyles from './dataStyles';
 import color from '../../util/color';
 import {connect} from 'react-redux';
-import {getColumnNamesFromRecords} from '../firebaseMetadata';
 import experiments from '../../util/experiments';
 
 const MIN_TABLE_WIDTH = 600;
@@ -91,23 +90,6 @@ class DataTableView extends React.Component {
     }
   }
 
-  /**
-   * @param {Array} records Array of JSON-encoded records.
-   * @param {string} columns Array of column names.
-   */
-  getColumnNames(records, columns) {
-    // Make sure 'id' is the first column.
-    const columnNames = getColumnNamesFromRecords(records);
-
-    columns.forEach(columnName => {
-      if (columnNames.indexOf(columnName) === -1) {
-        columnNames.push(columnName);
-      }
-    });
-
-    return columnNames;
-  }
-
   importCsv = (csvData, onComplete) => {
     FirebaseStorage.importCsv(
       this.props.tableName,
@@ -160,17 +142,9 @@ class DataTableView extends React.Component {
   }
 
   render() {
-    let columnNames = this.getColumnNames(
-      this.props.tableRecords,
-      this.props.tableColumns
-    );
-    const visible = DataView.TABLE === this.props.view;
-    const containerStyle = [
-      styles.container,
-      {
-        display: visible ? '' : 'none'
-      }
-    ];
+    if (this.props.view !== DataView.TABLE) {
+      return null;
+    }
     const debugDataStyle = [
       dataStyles.debugData,
       {
@@ -181,7 +155,7 @@ class DataTableView extends React.Component {
       this.props.tableListMap[this.props.tableName] === tableType.SHARED;
 
     return (
-      <div id="dataTable" style={containerStyle} className="inline-flex">
+      <div id="dataTable" style={styles.container} className="inline-flex">
         <div style={dataStyles.viewHeader}>
           <span style={dataStyles.backLink}>
             <a
@@ -204,7 +178,6 @@ class DataTableView extends React.Component {
           </span>
         </div>
         <TableControls
-          columns={columnNames}
           clearTable={this.clearTable}
           importCsv={this.importCsv}
           exportCsv={this.exportCsv}
@@ -212,9 +185,7 @@ class DataTableView extends React.Component {
           readOnly={readOnly}
         />
         <div style={debugDataStyle}>{this.getTableJson()}</div>
-        {!this.state.showDebugView && (
-          <DataTable getColumnNames={this.getColumnNames} readOnly={readOnly} />
-        )}
+        {!this.state.showDebugView && <DataTable readOnly={readOnly} />}
       </div>
     );
   }

--- a/apps/src/storage/dataBrowser/PreviewModal.jsx
+++ b/apps/src/storage/dataBrowser/PreviewModal.jsx
@@ -5,7 +5,6 @@ import {hidePreview} from '../redux/data';
 import {getDatasetInfo} from './dataUtils';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import DataTable from './DataTable';
-import {parseColumnsFromRecords} from '../firebaseMetadata';
 import msg from '@cdo/locale';
 
 class PreviewModal extends React.Component {
@@ -32,13 +31,7 @@ class PreviewModal extends React.Component {
         <h1>{this.props.tableName}</h1>
         <p>{datasetInfo.description}</p>
         <div style={{overflow: 'scroll', maxHeight: '70%'}}>
-          <DataTable
-            getColumnNames={(records, columns) =>
-              parseColumnsFromRecords(records)
-            }
-            readOnly
-            rowsPerPage={100}
-          />
+          <DataTable readOnly rowsPerPage={100} />
         </div>
         <button type="button" onClick={() => this.importTable(datasetInfo)}>
           {msg.import()}

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -27,7 +27,7 @@ export function getColumnRefByName(tableName, columnName) {
     });
 }
 
-function getColumnNamesFromRecords(records) {
+export function getColumnNamesFromRecords(records) {
   const columnNames = [];
   Object.keys(records).forEach(id => {
     const record = JSON.parse(records[id]);
@@ -109,23 +109,16 @@ export function onColumnsChange(database, tableName, callback) {
 /**
  *
  * @param {string} tableName
- * @param {Array.<string>} existingColumnNames
+ * @param {Array.<string>} columns
  * @returns {*}
  */
-export function addMissingColumns(tableName) {
+export function addMissingColumns(tableName, columns) {
   return getColumnNamesSnapshot(tableName).then(existingColumnNames => {
-    const recordsRef = getProjectDatabase().child(
-      `storage/tables/${tableName}/records`
-    );
-    return recordsRef.once('value').then(snapshot => {
-      const recordsData = snapshot.val() || {};
-      getColumnNamesFromRecords(recordsData).forEach(columnName => {
-        if (!existingColumnNames.includes(columnName)) {
-          getColumnsRef(getProjectDatabase(), tableName)
-            .push()
-            .set({columnName});
-        }
-      });
+    let columnsRef = getColumnsRef(getProjectDatabase(), tableName);
+    columns.forEach(columnName => {
+      if (!existingColumnNames.includes(columnName)) {
+        columnsRef.push().set({columnName});
+      }
     });
   });
 }

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -33,7 +33,12 @@ function getColumnNamesFromRecords(records) {
     const record = JSON.parse(records[id]);
     Object.keys(record).forEach(columnName => {
       if (columnNames.indexOf(columnName) === -1) {
-        columnNames.push(columnName);
+        if (columnName === 'id') {
+          // Make sure 'id' is first column
+          columnNames.unshift(columnName);
+        } else {
+          columnNames.push(columnName);
+        }
       }
     });
   });

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -27,22 +27,8 @@ export function getColumnRefByName(tableName, columnName) {
     });
 }
 
-// TODO: De-dupe this function with getColumnNamesFromRecords() below
-export function parseColumnsFromRecords(records) {
+function getColumnNamesFromRecords(records) {
   const columnNames = [];
-  Object.keys(records).forEach(id => {
-    const record = JSON.parse(records[id]);
-    Object.keys(record).forEach(column => {
-      if (columnNames.indexOf(column) === -1) {
-        columnNames.push(column);
-      }
-    });
-  });
-  return columnNames;
-}
-
-export function getColumnNamesFromRecords(records) {
-  const columnNames = ['id'];
   Object.keys(records).forEach(id => {
     const record = JSON.parse(records[id]);
     Object.keys(record).forEach(columnName => {

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -221,7 +221,12 @@ FirebaseStorage.createRecord = function(tableName, record, onSuccess, onError) {
       );
       return recordRef.set(JSON.stringify(record));
     })
-    .then(() => addMissingColumns(tableName, Object.keys(record)))
+    .then(() =>
+      addMissingColumns(
+        tableName,
+        getColumnNamesFromRecords([JSON.stringify(record)])
+      )
+    )
     .then(() => onSuccess(record), onError);
 };
 
@@ -379,7 +384,12 @@ FirebaseStorage.updateRecord = function(
         incrementRateLimitCounters()
           .then(() => updateTableCounters(tableName, 0))
           .then(() => recordRef.set(recordJson))
-          .then(() => addMissingColumns(tableName, Object.keys(record)))
+          .then(() =>
+            addMissingColumns(
+              tableName,
+              getColumnNamesFromRecords([recordJson])
+            )
+          )
           .then(() => onComplete(record, true), onError);
       }
     });

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -220,6 +220,7 @@ FirebaseStorage.createRecord = function(tableName, record, onSuccess, onError) {
       );
       return recordRef.set(JSON.stringify(record));
     })
+    .then(() => addMissingColumns(tableName))
     .then(() => onSuccess(record), onError);
 };
 
@@ -377,6 +378,7 @@ FirebaseStorage.updateRecord = function(
         incrementRateLimitCounters()
           .then(() => updateTableCounters(tableName, 0))
           .then(() => recordRef.set(recordJson))
+          .then(() => addMissingColumns(tableName))
           .then(() => onComplete(record, true), onError);
       }
     });
@@ -547,6 +549,7 @@ FirebaseStorage.copyStaticTable = function(tableName, onSuccess, onError) {
     .then(snapshot => {
       getRecordsRef(tableName).set(snapshot.val());
     })
+    .then(() => addMissingColumns(tableName))
     .then(onSuccess, onError);
 };
 
@@ -605,6 +608,7 @@ FirebaseStorage.createTable = function(tableName, onSuccess, onError) {
           return Promise.resolve();
         });
     })
+    .then(() => addColumnName(tableName, 'id'))
     .then(onSuccess, onError);
 };
 


### PR DESCRIPTION
# Description
We store the column names as metadata in Firebase, so we shouldn't need to parse the column names from the records anymore.

Similar to #32089, but with another change related to how/when we add column names. Instead of adding missing column names to the metadata node when the data view is opened, I think it would be better to keep the metadata node in sync as records change. There are several ways to add/change data that would result in a new column:
1. Programatically creating a record (goes through `FirebaseStorage.createRecord`)
2. Programatically updating an existing record (goes through `FirebaseStorage.updateRecord`)
3. Importing a CSV through the UI (goes through `FirebaseStorage.populateTable`)
4. Adding a column through the UI (goes through `FirebaseStorage.addColumn`, which already correctly adds the new column to the metadata node)
5. Opening a level that has JSON data tables (goes through `FirebaseStorage.populateTable`)
6. Importing a static table for the first time (either through the UI or opening a level that has a static table specified) (goes through `FirebaseStorage.copyStaticTable`)
7. Creating a new table. Right now, this doesn't add anything to the storage or metadata nodes, just adds the table to the counters node. However, since all tables will have an "id" column, I think it makes sense to go ahead and add that to the metadata node right when you create the table.
I've added a call to `FirebaseMetadata.addMissingColumns` on each of these code paths, and removed the call from `applab.js`

Scenarios:
1. dataset preview
![image](https://user-images.githubusercontent.com/8787187/69455810-0c042680-0d1e-11ea-9b12-9233c873a361.png)
2. Imported static dataset
![image](https://user-images.githubusercontent.com/8787187/69455828-145c6180-0d1e-11ea-8a0b-b9d9a6b4ba2a.png)
3. Imported current dataset
![image](https://user-images.githubusercontent.com/8787187/69457265-884c3900-0d21-11ea-8d5f-ae78601e534b.png)
4. Imported csv
![image](https://user-images.githubusercontent.com/8787187/69456764-55557580-0d20-11ea-9108-f57767dc0597.png)
5. Manually created table
![image](https://user-images.githubusercontent.com/8787187/69456825-7cac4280-0d20-11ea-9c64-3e7a0a6c6cd2.png)
6. Programatically created table
![image](https://user-images.githubusercontent.com/8787187/69457218-6fdc1e80-0d21-11ea-859c-ca4f2e3e6193.png)
![image](https://user-images.githubusercontent.com/8787187/69457195-605cd580-0d21-11ea-9d6a-06b9ab007a60.png)
7. Programatically updated record
![image](https://user-images.githubusercontent.com/8787187/69778360-dd8cae00-1158-11ea-816c-48465446f803.png)
![image](https://user-images.githubusercontent.com/8787187/69778537-81765980-1159-11ea-9dca-c1de0f5629a0.png)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
