### PR TITLE
Fixes for oceans social share 

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -31,7 +31,7 @@
   oceans_landing_cs_for_good: 'CS For Good'
   oceans_landing_cs_for_good_desc: 'Resources to help students understand the role computer science could play in creating a more equitable world.'
 
-  social_hoc2019_oceans_title: 'AI for Oceans #CSForGood'
+  social_hoc2019_oceans_title: 'AI for Oceans #CSforGood'
   social_hoc2019_oceans_desc: "Learn about AI, machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems. Computer science is about so much more than coding! Enjoy Code.org's first step in a new journey to teach more about AI throughout our curriculum."
 
   hoc_overview_oceans_tutorial_header: 'AI For Oceans'

--- a/pegasus/src/social_metadata.rb
+++ b/pegasus/src/social_metadata.rb
@@ -27,7 +27,7 @@ def get_social_metadata_for_page(request)
     dance_2019: {path: "/images/social-media/dance-social-2019.png", width: 1200, height: 630},
     hoc_thanks: {path: "/images/hourofcode-2015-video-thumbnail.png", width: 1440, height: 900},
     hoc_2019_social: {path: "/shared/images/social-media/hoc2019_social.png", width: 1200, height: 630},
-    oceans: {path: "images/social-media/oceans_social.png", width: 1200, height: 630}
+    oceans: {path: "/shared/images/social-media/oceans_social.png", width: 1200, height: 630}
   }
 
   # Important:


### PR DESCRIPTION
The social share image for AI Oceans wasn't correct because the path to the image was incorrect.  

Current: 
<img width="1068" alt="Screen Shot 2019-11-27 at 10 31 07 PM" src="https://user-images.githubusercontent.com/12300669/69782567-429ad080-1166-11ea-9311-7397dbfab4f5.png">
Expected: 
<img width="428" alt="Screen Shot 2019-11-27 at 10 37 54 PM" src="https://user-images.githubusercontent.com/12300669/69782727-b341ed00-1166-11ea-8f2b-a8733c615168.png">

While I was here I also updated "CSForGood" to "CSforGood" per this [Slack thread](https://codedotorg.slack.com/archives/CMV01LWPL/p1574891171023600?thread_ts=1574890747.022000&cid=CMV01LWPL). 