### PR TITLE
Oceans: fix rotation image

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1838,6 +1838,28 @@ StudioApp.prototype.fixViewportForSmallScreens_ = function(viewport, config) {
   }
   var width = Math.max(minWidth, desiredWidth);
   var scale = deviceWidth / width;
+
+  var content = [
+    'width=' + width,
+    'minimal-ui',
+    'initial-scale=' + scale,
+    'maximum-scale=' + scale,
+    'minimum-scale=' + scale,
+    'target-densityDpi=device-dpi',
+    'user-scalable=no'
+  ];
+  viewport.setAttribute('content', content.join(', '));
+};
+
+/**
+ *
+ */
+StudioApp.prototype.fixViewportForSpecificWidthForSmallScreens_ = function(
+  viewport,
+  width
+) {
+  const scale = screen.width / width;
+
   var content = [
     'width=' + width,
     'minimal-ui',

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -7,6 +7,16 @@ import {setAssetPath} from '@code-dot-org/ml-activities/dist/assetPath';
 import {TestResults} from '@cdo/apps/constants';
 
 /**
+ * On small mobile devices, when in portrait orientation, we show an overlay
+ * image telling the user to rotate their device to landscape mode.  Because
+ * the fish app is able to render at a minimum width of 480px, we set this
+ * width to be somewhat larger.  We will use this width to set the viewport
+ * on the mobile device, and correspondingly to scale up the overlay image to
+ * properly fit on the mobile device for that viewport.
+ */
+const MOBILE_PORTRAIT_WIDTH = 600;
+
+/**
  * An instantiable Fish class
  */
 
@@ -59,7 +69,7 @@ Fish.prototype.init = function(config) {
     if (viewport) {
       this.studioApp_.fixViewportForSpecificWidthForSmallScreens_(
         viewport,
-        600
+        MOBILE_PORTRAIT_WIDTH
       );
     }
 
@@ -76,7 +86,7 @@ Fish.prototype.init = function(config) {
 
   ReactDOM.render(
     <Provider store={getStore()}>
-      <FishView onMount={onMount} />
+      <FishView onMount={onMount} mobilePortraitWidth={MOBILE_PORTRAIT_WIDTH} />
     </Provider>,
     document.getElementById(config.containerId)
   );

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -57,7 +57,10 @@ Fish.prototype.init = function(config) {
     // Fixes viewport for small screens.  Also usually done by studioApp_.init().
     var viewport = document.querySelector('meta[name="viewport"]');
     if (viewport) {
-      this.studioApp_.fixViewportForSmallScreens_(viewport, config);
+      this.studioApp_.fixViewportForSpecificWidthForSmallScreens_(
+        viewport,
+        600
+      );
     }
 
     this.initMLActivities();

--- a/apps/src/fish/FishView.jsx
+++ b/apps/src/fish/FishView.jsx
@@ -58,7 +58,7 @@ class FishView extends React.Component {
 
   render() {
     return (
-      <StudioAppWrapper>
+      <StudioAppWrapper rotateContainerWidth={600}>
         <CodeWorkspaceContainer topMargin={0}>
           <ProtectedStatefulDiv id="container" style={styles.container}>
             <div id="container-react" style={styles.containerReact} />

--- a/apps/src/fish/FishView.jsx
+++ b/apps/src/fish/FishView.jsx
@@ -49,7 +49,8 @@ class FishView extends React.Component {
   static propTypes = {
     isProjectLevel: PropTypes.bool.isRequired,
     isReadOnlyWorkspace: PropTypes.bool.isRequired,
-    onMount: PropTypes.func.isRequired
+    onMount: PropTypes.func.isRequired,
+    mobilePortraitWidth: PropTypes.number.isRequired
   };
 
   componentDidMount() {
@@ -58,7 +59,7 @@ class FishView extends React.Component {
 
   render() {
     return (
-      <StudioAppWrapper rotateContainerWidth={600}>
+      <StudioAppWrapper rotateContainerWidth={this.props.mobilePortraitWidth}>
         <CodeWorkspaceContainer topMargin={0}>
           <ProtectedStatefulDiv id="container" style={styles.container}>
             <div id="container-react" style={styles.containerReact} />

--- a/apps/src/templates/RotateContainer.jsx
+++ b/apps/src/templates/RotateContainer.jsx
@@ -14,7 +14,8 @@ const styles = {
     right: 0,
     bottom: 0,
     width: '100%',
-    height: '100%'
+    height: '100%',
+    opacity: 0.5
   },
   rotateContainerInner: {
     backgroundPosition: '50% 50%',
@@ -42,29 +43,38 @@ const styles = {
  */
 export default class RotateContainer extends React.Component {
   static propTypes = {
-    assetUrl: PropTypes.func.isRequired
+    assetUrl: PropTypes.func.isRequired,
+    width: PropTypes.number
   };
 
   render() {
-    // In StudioApp.prototype.fixViewportForSmallScreens_ we end up scaling our
-    // viewport so that things look good in landscape mode. Unfortunately, this
-    // means that we can't dependably use CSS to size our rotate container in a
-    // way that works across ios and android.
-    // What we do is to figure out the scaling factor fixViewportForSmallScreens_
-    // is going to use and set our width relative to that factor.
-    // In addition, I've added an outer container that fills up the whole space
-    // with a white background, so that if you scroll off of the inner container
-    // you see white instead of the codeApp
+    let width, height;
+    if (this.props.width) {
+      width = this.props.width;
+      height = '100%';
+    } else {
+      // In StudioApp.prototype.fixViewportForSmallScreens_ we end up scaling our
+      // viewport so that things look good in landscape mode. Unfortunately, this
+      // means that we can't dependably use CSS to size our rotate container in a
+      // way that works across ios and android.
+      // What we do is to figure out the scaling factor fixViewportForSmallScreens_
+      // is going to use and set our width relative to that factor.
+      // In addition, I've added an outer container that fills up the whole space
+      // with a white background, so that if you scroll off of the inner container
+      // you see white instead of the codeApp
 
-    const scale = screen.height / 900;
+      const scale = screen.height / 900;
+      width = window.screen.width / scale;
+      height = window.screen.height;
+    }
 
     return (
       <div id="rotateContainer" style={styles.rotateContainer}>
         <div
           style={{
             ...styles.rotateContainerInner,
-            width: window.screen.width / scale,
-            height: window.screen.height,
+            width: width,
+            height: height,
             backgroundImage:
               'url(' +
               this.props.assetUrl('media/turnphone_horizontal.png') +

--- a/apps/src/templates/RotateContainer.jsx
+++ b/apps/src/templates/RotateContainer.jsx
@@ -14,8 +14,7 @@ const styles = {
     right: 0,
     bottom: 0,
     width: '100%',
-    height: '100%',
-    opacity: 0.5
+    height: '100%'
   },
   rotateContainerInner: {
     backgroundPosition: '50% 50%',

--- a/apps/src/templates/StudioAppWrapper.jsx
+++ b/apps/src/templates/StudioAppWrapper.jsx
@@ -12,7 +12,8 @@ class StudioAppWrapper extends React.Component {
     assetUrl: PropTypes.func.isRequired,
     isEmbedView: PropTypes.bool.isRequired,
     isShareView: PropTypes.bool.isRequired,
-    children: PropTypes.node
+    children: PropTypes.node,
+    rotateContainerWidth: PropTypes.number
   };
 
   requiresLandscape() {
@@ -23,7 +24,10 @@ class StudioAppWrapper extends React.Component {
     return (
       <div>
         {this.requiresLandscape() && (
-          <RotateContainer assetUrl={this.props.assetUrl} />
+          <RotateContainer
+            assetUrl={this.props.assetUrl}
+            width={this.props.rotateContainerWidth}
+          />
         )}
         {this.props.children}
         <div className="clear" />


### PR DESCRIPTION
In the new Oceans script, the device rotation image shown on portrait layout was not showing properly.  This is a fix for that issue, targeted at the Oceans script, but it could be generalised later, since this apparently happens for some other tutorials too.

All screenshots in this PR are shown with the rotation image at half opacity, to see what's happening beneath it.

Here's a screenshot of the problem on a real iPhone:

![iphone_bug](https://user-images.githubusercontent.com/2205926/69893346-f1edb980-12c4-11ea-9518-516343c34b98.PNG)

And if we scroll up, we can see more about the problem:

![iphone_bug_scrolled_up](https://user-images.githubusercontent.com/2205926/69893348-05008980-12c5-11ea-8a8e-4bf1e59b5821.PNG)

On an actual iPhone, this view is scrollable.  In Chrome's device mode it's not, but the issue is otherwise the same.  The issue here is that the viewport's dimensions and scaling have made the viewport bigger than the physical screen.

Here's the fix running on an actual iPhone:

![iphone_bug_fix](https://user-images.githubusercontent.com/2205926/69893359-39744580-12c5-11ea-882c-df4393b6756c.PNG)

The fix is fairly simple in this case.  We know that the Oceans tutorial can scale down to 480px wide, and so we set the viewport to be 600px wide.  We also set the scaling on the viewport so that the 600px is what's displayed on the physical screen.  We finally adjust the scaling on the rotation image to fill that space.


### Details

Here is the viewport before the fix:

```
<meta name="viewport" content="width=900, minimal-ui, initial-scale=0.9022222222222223, maximum-scale=0.9022222222222223, minimum-scale=0.9022222222222223, target-densityDpi=device-dpi, user-scalable=no">
```

And after, for a variety of emulated iOS devices, along with screenshots of them in Chrome device mode:

#### iPhone 5:
```
<meta name="viewport" content="width=600, minimal-ui, initial-scale=0.5333333333333333, maximum-scale=0.5333333333333333, minimum-scale=0.5333333333333333, target-densityDpi=device-dpi, user-scalable=no">
```

![after_fix_rotation_iphone5](https://user-images.githubusercontent.com/2205926/69893370-5872d780-12c5-11ea-92bc-78537a5c6312.png)


#### iPhone X:
```
<meta name="viewport" content="width=600, minimal-ui, initial-scale=0.625, maximum-scale=0.625, minimum-scale=0.625, target-densityDpi=device-dpi, user-scalable=no">
```

![after_fix_rotation](https://user-images.githubusercontent.com/2205926/69893373-5e68b880-12c5-11ea-93e0-40793df17048.png)

#### iPad:
```
<meta name="viewport" content="width=600, minimal-ui, initial-scale=1.28, maximum-scale=1.28, minimum-scale=1.28, target-densityDpi=device-dpi, user-scalable=no">
```

![after_fix_rotation_ipad](https://user-images.githubusercontent.com/2205926/69893374-63c60300-12c5-11ea-8b39-43a27153877f.png)

What I didn't manage to root cause was why this might be an issue for some tutorials, but not others, but I suspect that some of them end up with a content width wider than that effectively set by the viewport width and scale, and therefore the page becomes scrollable on an iOS device when it shouldn't have been.  We should investigate a broader fix after Hour of Code 2019.
