### PR TITLE
Check if executing on managed test system

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -85,7 +85,7 @@ def build
     status = begin
       result = RakeUtils.rake_stream_output 'ci'
 
-      if rack_env == :test && git_revision != RakeUtils.git_revision
+      if CDO.test_system? && git_revision != RakeUtils.git_revision
         ChatClient.log "git revision unexpectedly changed from #{git_revision} to #{RakeUtils.git_revision} during DTT", color: 'red'
         raise
       end
@@ -146,9 +146,7 @@ def main
 
       write_build_status rack_env, commit_hash_short, :success
 
-      # Only the managed test server should publish the commit hash of a successful Test Build
-      # This logic prevents staging-next server from corrupting the current successful commit hash.
-      if rack_env == :test && CDO.pegasus_hostname == 'test.code.org'
+      if CDO.test_system?
         ChatClient.log "<@#{DevelopersTopic.dotd}> DTT finished", color: 'purple'
         mark_dtt_green
       end
@@ -185,7 +183,7 @@ def main
 
       write_build_status rack_env, commit_hash_short, :failed
 
-      if rack_env == :test
+      if CDO.test_system?
         DevelopersTopic.set_dtt 'no (robo-DTT failed)'
       end
     end

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -134,6 +134,13 @@ module Cdo
       rack_env&.to_sym == env.to_sym
     end
 
+    # Identify whether we are executing on the managed test system (test.code.org / test-studio.code.org)
+    # to ensure that other systems (such as staging-next or Continuous Integration builds) that are operating
+    # with RACK_ENV=test do not carry out actions on behalf of the managed test system.
+    def test_system?
+      rack_env?(:test) && pegasus_hostname == 'test.code.org'
+    end
+
     # Sets the slogger to use in a test.
     # slogger must support a `write` method.
     def set_slogger_for_test(slogger)


### PR DESCRIPTION
# Description

Distinguish between the managed test system (`test.code.org`) vs the RACK/RAILS `test` "environment" to ensure that only the dedicated test system carries out specific tasks in the build process.  Specifically, ensure that other environments running with `RACK_ENV=test` such as `staging-next` do not incorrectly set the test build status in Slack.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
