### PR TITLE
Oceans promo bash fixes

### DIFF
--- a/pegasus/sites.v3/code.org/public/oceans.haml
+++ b/pegasus/sites.v3/code.org/public/oceans.haml
@@ -83,7 +83,7 @@ theme: responsive
       %p.tutorial-description= hoc_s(:oceans_landing_description)
       %p.tutorial-description= hoc_s(:cs_for_good_hashtag)
       %p.tutorial-specs= hoc_s(:oceans_landing_specs)
-      %a{href: CDO.studio_url('/s/oceans'), target: '_self'}
+      %a{href: CDO.studio_url('/s/oceans/reset'), target: '_self'}
         %button.tutorial-button=I18n.t(:try_now)
 
     .tutorial-details-mobile.mobile-feature
@@ -91,7 +91,7 @@ theme: responsive
       %p.tutorial-description= hoc_s(:oceans_landing_description)
       %p.tutorial-description= hoc_s(:cs_for_good_hashtag)
       %p.tutorial-specs= hoc_s(:oceans_landing_specs)
-      %a{href: CDO.studio_url('/s/oceans'), target: '_self'}
+      %a{href: CDO.studio_url('/s/oceans/reset'), target: '_self'}
         %button.tutorial-button=I18n.t(:try_now)
 
   %div{style: "clear: both; margin-top: 10px;"}

--- a/pegasus/sites.v3/code.org/views/oceans_promo.haml
+++ b/pegasus/sites.v3/code.org/views/oceans_promo.haml
@@ -1,7 +1,7 @@
 %link{href: "/css/oceans-promo.css", rel: "stylesheet"}
 
 .img-container.desktop-feature
-  %img.background-img{src: '/images/fit-1940/oceans/oceans-background.png'}
+  %img.background-img{src: '/images/fit-1940/oceans/oceans-background.png', style: 'border-top-right-radius: 10px; border-top-left-radius: 10px;'}
   %img.sea-creature{src: 'images/oceans/big-sunfish.png'}
   %img.sea-creature{src: 'images/oceans/small-sunfish.png'}
   %img.sea-creature{src: 'images/oceans/turtle.png'}

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -25,12 +25,12 @@
   oceans_landing_title: 'AI for Oceans'
   oceans_landing_description: 'Learn about machine learning and ethical use of AI.'
   cs_for_good_hashtag: '#CSforGood'
-  oceans_landing_specs: 'English only | Grades 3rd+'
-  oceans_landing_explanation: "Computer science is about so much more than coding! Learn about AI, machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems. Enjoy Code.org's first step in a new journey to teach more about AI throughout our curriculum. When you use the AI for Oceans activity you are training real machine learning models. <a href='#behind-the-scenes'>Learn more</a>."
+  oceans_landing_specs: 'English only | Grades 3+'
+  oceans_landing_explanation: "Computer science is about so much more than coding! Learn about AI, machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems. Enjoy Code.org's first step in a new journey to teach more about AI. When you use the AI for Oceans activity you are training real machine learning models. <a href='#behind-the-scenes'>Learn more</a>."
   oceans_landing_teacher_resources: 'Teacher Resources'
   oceans_landing_teacher_resources_desc: 'Lesson plans and activities to help you teach AI, machine learning, training data, and bias, while exploring ethical issues.'
   oceans_landing_resource_button: 'View Resources'
-  oceans_landing_cs_for_good: 'CS For Good'
+  oceans_landing_cs_for_good: 'CS for Good'
   oceans_landing_cs_for_good_desc: 'Resources to help students understand the role computer science could play in creating a more equitable world.'
   oceans_landing_videos: 'Videos about AI and Machine Learning'
   oceans_behind_the_scenes: 'AI for Oceans: Behind the Scenes'
@@ -40,7 +40,7 @@
   social_hoc2019_oceans_title: 'AI for Oceans #CSforGood'
   social_hoc2019_oceans_desc: "Learn about AI, machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems. Computer science is about so much more than coding! Enjoy Code.org's first step in a new journey to teach more about AI throughout our curriculum."
 
-  hoc_overview_oceans_tutorial_header: 'AI For Oceans'
+  hoc_overview_oceans_tutorial_header: 'AI for Oceans'
   hoc_overview_oceans_tutorial_desc: 'Learn about AI, machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems.'
 
   ai_video_title_what_is_ai: 'What is AI?'


### PR DESCRIPTION
1.) "Try Now" button on code.org/oceans goes to `/s/oceans/reset` rather than script overview 
2.) CS For Good -> CS for Good 
3.) AI For Oceans -> AI for Oceans 
4.) Grades 3rd+ -> Grades 3+
5.) remove "throughout the curriculum" per ed team request
6.) Round top corners of tutorial banner:
<img width="1013" alt="Screen Shot 2019-12-02 at 2 00 19 PM" src="https://user-images.githubusercontent.com/12300669/69999791-53549900-150e-11ea-92cd-bac6782b2424.png">
