### PR TITLE
Secure Admin Accounts: Remove password for code studio admins

### DIFF
--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -2,10 +2,15 @@
 
 # Remove passwords for code studio admins
 
+DRY_RUN = true
+
 User.where(admin: true).where.not(encrypted_password: nil).each do |admin|
-  puts "PROCESSING: #{batch_number}..."
   ActiveRecord::Base.transaction do
     admin.update!(encrypted_password: nil)
+
+    raise ActiveRecord::Rollback.new, "Intentional rollback" if DRY_RUN
+    puts "Admin password updated - #{admin}"
   end
-  puts "PROCESSED: #{batch_number}..."
+rescue StandardError => error
+  puts "Error deleting admin's password - #{admin} / #{error.message}"
 end

--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+# Remove passwords for code studio admins
+
+batch_number = 0
+User.where(admin: true).where.not(encrypted_password: nil).find_in_batches(batch_size: 10) do |batch|
+  puts "PROCESSING: #{batch_number}..."
+  ActiveRecord::Base.transaction do
+    batch.each do |user|
+      user.update(encrypted_password: nil)
+    end
+  end
+  puts "PROCESSED: #{batch_number}..."
+  batch_number += 1
+end

--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -61,7 +61,10 @@ ADMIN_IDS = %w(
 
 ADMIN_IDS.each do |admin_id|
   ActiveRecord::Base.transaction do
-    User.find_by(id: admin_id).update!(encrypted_password: nil)
+    User
+      .find(admin_id)
+      .tap {|user| raise "User #{user.id} is not an admin" unless user.admin?}
+      .update!(encrypted_password: nil)
 
     raise ActiveRecord::Rollback.new, "Intentional rollback" if DRY_RUN
     puts "Admin password updated - #{admin_id}"

--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -61,10 +61,10 @@ ADMIN_IDS = %w(
 
 ADMIN_IDS.each do |admin_id|
   ActiveRecord::Base.transaction do
-    User
-      .find(admin_id)
-      .tap {|user| raise "User #{user.id} is not an admin" unless user.admin?}
-      .update!(encrypted_password: nil)
+    User.
+      find(admin_id).
+      tap {|user| raise "User #{user.id} is not an admin" unless user.admin?}.
+      update!(encrypted_password: nil)
 
     raise ActiveRecord::Rollback.new, "Intentional rollback" if DRY_RUN
     puts "Admin password updated - #{admin_id}"

--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -1,16 +1,71 @@
 #!/usr/bin/env ruby
 
+require_relative '../../dashboard/config/environment'
+
 # Remove passwords for code studio admins
 
 DRY_RUN = true
 
-User.where(admin: true).where.not(encrypted_password: nil).each do |admin|
+puts "Processing..."
+
+ADMIN_IDS = %w(
+  15070302
+  15084110
+  15348912
+  15437387
+  15470769
+  15554753
+  15604082
+  15702112
+  16532443
+  18053401
+  23624602
+  24432280
+  24687228
+  25080412
+  25310339
+  25418463
+  27010007
+  27121109
+  27217051
+  28368788
+  29732128
+  32880983
+  36384494
+  37473524
+  37747709
+  38092662
+  39189246
+  40170179
+  41485544
+  42398690
+  43722276
+  43727430
+  45912497
+  46367906
+  47013496
+  47020903
+  47154935
+  47175440
+  47179671
+  47512616
+  48724514
+  49828038
+  50079182
+  51052116
+  54352426
+  54649591
+  56232731
+  56493556
+).map(&:to_i).freeze
+
+ADMIN_IDS.each do |admin_id|
   ActiveRecord::Base.transaction do
-    admin.update!(encrypted_password: nil)
+    User.where(id: admin_id).update(encrypted_password: nil)
 
     raise ActiveRecord::Rollback.new, "Intentional rollback" if DRY_RUN
-    puts "Admin password updated - #{admin}"
+    puts "Admin password updated - #{admin_id}"
   end
 rescue StandardError => error
-  puts "Error deleting admin's password - #{admin} / #{error.message}"
+  puts "Error, admin password is not updated - #{admin_id} / #{error.message}"
 end

--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -61,7 +61,7 @@ ADMIN_IDS = %w(
 
 ADMIN_IDS.each do |admin_id|
   ActiveRecord::Base.transaction do
-    User.where(id: admin_id).update!(encrypted_password: nil)
+    User.find_by(id: admin_id).update!(encrypted_password: nil)
 
     raise ActiveRecord::Rollback.new, "Intentional rollback" if DRY_RUN
     puts "Admin password updated - #{admin_id}"

--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -2,12 +2,10 @@
 
 # Remove passwords for code studio admins
 
-batch_number = 0
 User.where(admin: true).where.not(encrypted_password: nil).each do |admin|
   puts "PROCESSING: #{batch_number}..."
   ActiveRecord::Base.transaction do
     admin.update!(encrypted_password: nil)
   end
   puts "PROCESSED: #{batch_number}..."
-  batch_number += 1
 end

--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -61,7 +61,7 @@ ADMIN_IDS = %w(
 
 ADMIN_IDS.each do |admin_id|
   ActiveRecord::Base.transaction do
-    User.where(id: admin_id).update(encrypted_password: nil)
+    User.where(id: admin_id).update!(encrypted_password: nil)
 
     raise ActiveRecord::Rollback.new, "Intentional rollback" if DRY_RUN
     puts "Admin password updated - #{admin_id}"

--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -3,12 +3,10 @@
 # Remove passwords for code studio admins
 
 batch_number = 0
-User.where(admin: true).where.not(encrypted_password: nil).find_in_batches(batch_size: 10) do |batch|
+User.where(admin: true).where.not(encrypted_password: nil).each do |admin|
   puts "PROCESSING: #{batch_number}..."
   ActiveRecord::Base.transaction do
-    batch.each do |user|
-      user.update(encrypted_password: nil)
-    end
+    admin.update!(encrypted_password: nil)
   end
   puts "PROCESSED: #{batch_number}..."
   batch_number += 1


### PR DESCRIPTION
# Description
Remove password for code studio admins since admins can only sign in via google authentication.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-906)

## Testing story

Dry run was performed and script was tested manually.  

No. of users that have admin privileges that will be impacted below:
```
mysql> SELECT COUNT(*) FROM `users` WHERE `users`.`deleted_at` IS NULL AND `users`.`admin` = 1 AND (`users`.`encrypted_password` IS NOT NULL);
+----------+
| COUNT(*) |
+----------+
|       48 |
+----------+
1 row in set
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
