### PR TITLE
Remove launch_ai flag references for persistent oceans promo content

### DIFF
--- a/apps/src/sites/studio/pages/courses/index.js
+++ b/apps/src/sites/studio/pages/courses/index.js
@@ -22,7 +22,6 @@ function showCourses() {
   const signedOut = coursesData.signedout;
   const modernElementaryCoursesAvailable =
     coursesData.modernelementarycoursesavailable;
-  const showOceans = coursesData.launch_ai;
 
   ReactDOM.render(
     <Provider store={getStore()}>
@@ -34,7 +33,6 @@ function showCourses() {
         codeOrgUrlPrefix={codeOrgUrlPrefix}
         isSignedOut={signedOut}
         modernElementaryCoursesAvailable={modernElementaryCoursesAvailable}
-        showOceans={showOceans}
       />
     </Provider>,
     document.getElementById('courses-container')

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -164,15 +164,13 @@ class CourseBlocksCsfLegacy extends Component {
 
 export class CourseBlocksHoc extends Component {
   static propTypes = {
-    isInternational: PropTypes.bool,
-    showOceans: PropTypes.bool
+    isInternational: PropTypes.bool
   };
 
   componentDidMount() {
-    const thirdTutorial = this.props.showOceans ? '#oceans' : '#applab-intro';
     const tiles = this.props.isInternational
       ? ['#dance-2019', '#aquatic', '#frozen', '#hourofcode']
-      : ['#dance-2019', '#aquatic', thirdTutorial, '#flappy'];
+      : ['#dance-2019', '#aquatic', '#oceans', '#flappy'];
 
     tiles.forEach((tile, index) => {
       $(tile).appendTo(ReactDOM.findDOMNode(this.refs[index]));

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -28,8 +28,7 @@ class Courses extends Component {
     isSignedOut: PropTypes.bool.isRequired,
     linesCount: PropTypes.string.isRequired,
     studentsCount: PropTypes.string.isRequired,
-    modernElementaryCoursesAvailable: PropTypes.bool.isRequired,
-    showOceans: PropTypes.bool
+    modernElementaryCoursesAvailable: PropTypes.bool.isRequired
   };
 
   componentDidMount() {
@@ -44,8 +43,7 @@ class Courses extends Component {
       isEnglish,
       isTeacher,
       isSignedOut,
-      modernElementaryCoursesAvailable,
-      showOceans
+      modernElementaryCoursesAvailable
     } = this.props;
     const headingText = isTeacher
       ? i18n.coursesHeadingTeacher()
@@ -84,14 +82,12 @@ class Courses extends Component {
             {showSpecialTeacherAnnouncement && (
               <SpecialAnnouncementActionBlock />
             )}
-            <CoursesTeacherEnglish showOceans={showOceans} />
+            <CoursesTeacherEnglish />
           </div>
         )}
 
         {/* English, student.  (Also the default to be shown when signed out.) */}
-        {isEnglish && !isTeacher && (
-          <CoursesStudentEnglish showOceans={showOceans} />
-        )}
+        {isEnglish && !isTeacher && <CoursesStudentEnglish />}
 
         {/* Non-English */}
         {!isEnglish && (

--- a/apps/src/templates/studioHomepages/CoursesStudentEnglish.jsx
+++ b/apps/src/templates/studioHomepages/CoursesStudentEnglish.jsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import PropTypes from 'prop-types';
 import ContentContainer from '../ContentContainer';
 import {LocalClassActionBlock} from './TwoColumnActionBlock';
 import {CourseBlocksHoc} from './CourseBlocks';
@@ -12,10 +11,6 @@ import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
  * as well as the default for a signed-out user using English.
  */
 class CoursesStudentEnglish extends Component {
-  static propTypes = {
-    showOceans: PropTypes.bool
-  };
-
   render() {
     return (
       <div>
@@ -30,7 +25,7 @@ class CoursesStudentEnglish extends Component {
           linkText={i18n.teacherCourseHocLinkText()}
           link={pegasus('/hourofcode/overview')}
         >
-          <CourseBlocksHoc showOceans={this.props.showOceans} />
+          <CourseBlocksHoc />
         </ContentContainer>
 
         <LocalClassActionBlock showHeading={true} />

--- a/apps/src/templates/studioHomepages/CoursesTeacherEnglish.jsx
+++ b/apps/src/templates/studioHomepages/CoursesTeacherEnglish.jsx
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import React, {Component} from 'react';
-import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import ContentContainer from '../ContentContainer';
 import {AdministratorResourcesActionBlock} from './TwoColumnActionBlock';
@@ -16,10 +15,6 @@ import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
  * though it may also be shown for a signed-out user using English.
  */
 class CoursesTeacherEnglish extends Component {
-  static propTypes = {
-    showOceans: PropTypes.bool
-  };
-
   componentDidMount() {
     // The components used here are implemented in legacy HAML/CSS rather than React.
     $('.courseexplorer')
@@ -49,7 +44,7 @@ class CoursesTeacherEnglish extends Component {
             link={pegasus('/hourofcode/overview')}
             showLink={true}
           >
-            <CourseBlocksHoc showOceans={this.props.showOceans} />
+            <CourseBlocksHoc />
           </ContentContainer>
 
           <CourseBlocksTools isEnglish={true} />

--- a/dashboard/app/views/courses/index.html.haml
+++ b/dashboard/app/views/courses/index.html.haml
@@ -1,5 +1,4 @@
 :ruby
-  launch_ai = DCDO.get('launch_ai', nil)
   lines_count = fetch_metrics['lines_of_code']
   lines_count = number_with_delimiter(lines_count, :delimiter => ',')
   students_count = fetch_user_metrics['number_students']
@@ -14,7 +13,6 @@
   courses_data[:codeorgurlprefix] = CDO.code_org_url
   courses_data[:signedout] = @is_signed_out
   courses_data[:modernelementarycoursesavailable] = @modern_elementary_courses_available
-  courses_data[:launch_ai] = launch_ai
 
   @page_title = @is_teacher ? I18n.t('courses_page.title_teacher') : I18n.t('courses_page.title_student')
 

--- a/dashboard/app/views/devise/sessions/new.html.haml
+++ b/dashboard/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,3 @@
-- launch_ai = DCDO.get('launch_ai', nil)
-
 %h1= t('signin_form.title')
 
 .flex-container
@@ -44,10 +42,8 @@
 %h3= t('signin.try_heading')
 
 .row
-  - if @is_english && launch_ai
+  - if @is_english
     - course_blocks = [Script::DANCE_PARTY_2019_NAME, Script::MINECRAFT_AQUATIC_NAME, Script::OCEANS_NAME, Script::FLAPPY_NAME]
-  - elsif @is_english
-    - course_blocks = [Script::DANCE_PARTY_2019_NAME, Script::MINECRAFT_AQUATIC_NAME, Script::APPLAB_INTRO, Script::FLAPPY_NAME]
   - else
     - course_blocks = [Script::DANCE_PARTY_2019_NAME, Script::MINECRAFT_AQUATIC_NAME, Script::FROZEN_NAME, Script::HOC_NAME]
 

--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -16,8 +16,6 @@ social:
   @header["social"]["og:description"] = hoc_s(:social_hoc2018_global_movement)
   @header["social"]["og:image"] = 'https://' + request.host + '/images/social-media/code-2018-creativity.png'
 
-  launch_ai = DCDO.get('launch_ai', nil)
-
 %link{href: "/css/student.css", rel: "stylesheet"}
 %link{href: "/css/tools.css", rel: "stylesheet"}
 %link{href: "/shared/css/course-blocks.css", rel: "stylesheet", type: "text/css"}
@@ -27,7 +25,7 @@ social:
 
 = I18n.t(:hoc_overview_subtitle)
 
-- if launch_ai && request.language == 'en'
+- if request.language == 'en'
   .tile-container-responsive{style: "margin-top: 20px;"}
     .col-50
       .tutorial-tile

--- a/pegasus/sites.v3/code.org/public/oceans.haml
+++ b/pegasus/sites.v3/code.org/public/oceans.haml
@@ -3,7 +3,6 @@ title: AI for Oceans
 theme: responsive
 ---
 :ruby
-  launch_ai = DCDO.get('launch_ai', nil)
 
   resources = {
     left_link: "https://curriculum.code.org/hoc/plugged/9/",
@@ -75,7 +74,7 @@ theme: responsive
     margin-top: 0px;
   }
 
-%div{style: "display: #{launch_ai ? 'block' : 'none'}"}
+%div
   .tutorial-promo-container
     = view :oceans_promo
     .tutorial-details.desktop-feature


### PR DESCRIPTION
Now that the promotional content for AI for Oceans is live on the site without issues, I'm removing the `launch_ai` DCDO flag that conditionally shows content on: 

code.org/oceans
code.org/hourofcode/overview
studio.code.org/courses
studio.code.org/users/sign_in

Removal of this flag is important because we want this content to persist beyond the AI for Oceans homepage take over which will end on Friday and is also controlled by this flag. 