### PR TITLE
Fix the rotate-screen image on iOS Safari for maze levels

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -356,7 +356,7 @@ StudioApp.prototype.init = function(config) {
   // Fixes viewport for small screens.
   var viewport = document.querySelector('meta[name="viewport"]');
   if (viewport) {
-    this.fixViewportForSmallScreens_(viewport, 600);
+    this.fixViewportForSmallScreens_(viewport, config);
   }
 
   var blockCount = document.getElementById('blockCounter');

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -356,7 +356,7 @@ StudioApp.prototype.init = function(config) {
   // Fixes viewport for small screens.
   var viewport = document.querySelector('meta[name="viewport"]');
   if (viewport) {
-    this.fixViewportForSmallScreens_(viewport, config);
+    this.fixViewportForSmallScreens_(viewport, 600);
   }
 
   var blockCount = document.getElementById('blockCounter');

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -31,7 +31,7 @@ const tiles = maze.tiles;
 const createResultsHandlerForSubtype = require('./results/utils')
   .createResultsHandlerForSubtype;
 
-const MOBILE_PORTRAIT_WIDTH = 1000;
+const MOBILE_PORTRAIT_WIDTH = 600;
 
 module.exports = class Maze {
   constructor() {
@@ -67,7 +67,6 @@ module.exports = class Maze {
     // replace studioApp() methods with our own
     studioApp().runButtonClick = this.runButtonClick_;
     studioApp().reset = this.reset_;
-    studioApp().fixViewportForSmallScreens_ = studioApp().fixViewportForSpecificWidthForSmallScreens_;
 
     const skin = config.skin;
     const level = config.level;
@@ -211,6 +210,16 @@ module.exports = class Maze {
         />
       </Provider>,
       document.getElementById(config.containerId)
+    );
+
+    // studioApp.init calls fixViewportForSmallScreens_ which incorrectly
+    // positions the "Rotate Container" image on iOS devices. We correct this
+    // by calling fixViewportForSpecificWidthForSmallScreens_ after the init is
+    // finished.
+    var viewport = document.querySelector('meta[name="viewport"]');
+    studioApp().fixViewportForSpecificWidthForSmallScreens_(
+      viewport,
+      MOBILE_PORTRAIT_WIDTH
     );
   }
 

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -31,6 +31,8 @@ const tiles = maze.tiles;
 const createResultsHandlerForSubtype = require('./results/utils')
   .createResultsHandlerForSubtype;
 
+const MOBILE_PORTRAIT_WIDTH = 1000;
+
 module.exports = class Maze {
   constructor() {
     this.scale = {
@@ -65,6 +67,7 @@ module.exports = class Maze {
     // replace studioApp() methods with our own
     studioApp().runButtonClick = this.runButtonClick_;
     studioApp().reset = this.reset_;
+    studioApp().fixViewportForSmallScreens_ = studioApp().fixViewportForSpecificWidthForSmallScreens_;
 
     const skin = config.skin;
     const level = config.level;
@@ -204,6 +207,7 @@ module.exports = class Maze {
         <AppView
           visualizationColumn={visualizationColumn}
           onMount={studioApp().init.bind(studioApp(), config)}
+          rotateContainerWidth={MOBILE_PORTRAIT_WIDTH}
         />
       </Provider>,
       document.getElementById(config.containerId)

--- a/apps/src/templates/AppView.jsx
+++ b/apps/src/templates/AppView.jsx
@@ -20,7 +20,8 @@ class AppView extends React.Component {
 
     // not provided by redux
     visualizationColumn: PropTypes.element,
-    onMount: PropTypes.func.isRequired
+    onMount: PropTypes.func.isRequired,
+    rotateContainerWidth: PropTypes.number
   };
 
   componentDidMount() {
@@ -34,7 +35,7 @@ class AppView extends React.Component {
     });
 
     return (
-      <StudioAppWrapper>
+      <StudioAppWrapper rotateContainerWidth={this.props.rotateContainerWidth}>
         <Overlay />
         <div id="visualizationColumn" className={visualizationColumnClassNames}>
           {this.props.visualizationColumn}


### PR DESCRIPTION
# Description

Previously, going to studio.code.org/hoc/1 and then studio.code.org/hoc/3 on an iOS device would cause the rotate image to display partly offscreen.
![image](https://user-images.githubusercontent.com/8324574/70080406-56599300-15bb-11ea-915f-d7cf8bd28144.png)


This applies the fix from a the same issue in the oceans HOC tutorial https://github.com/code-dot-org/code-dot-org/pull/32206

![image](https://user-images.githubusercontent.com/8324574/70080204-fbc03700-15ba-11ea-849a-48d2b4cd227e.png)

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-836)

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
