### PR TITLE
Oceans homepage: handle off screen fish

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_hero_oceans2019.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero_oceans2019.haml
@@ -52,6 +52,11 @@
     left: 737px;
   }
 
+  @media screen and (max-width: 1080px)
+  {
+    .snail { display: none; }
+  }
+
 .img-container.desktop-feature
   %img.sea-creature{src: 'images/oceans/turtle.png'}
   .scanning-bot
@@ -101,13 +106,18 @@
         var swayOffsetX = Math.sin(((swayValue * Math.PI) / 180) * 2) * 25;
         var swayOffsetY = Math.sin(((swayValue * Math.PI) / 180) * 6) * 2;
         var x = fishLocations[index].x + swayOffsetX;
+        var swimSpace = fishLocations[index].x + 150;
         var y;
         if (index == 6) {
           y = fishLocations[index].y;
         } else {
           y = fishLocations[index].y + swayOffsetY;
         }
-        $(this).css({left: x, top: y, display: 'block', width: fishWidths[index]});
+        if ($(window).width() < swimSpace) {
+          $(this).css({display: 'none'})
+        } else {
+          $(this).css({left: x, top: y, display: 'block', width: fishWidths[index]});
+        }
       });
     }, 1000 / 30);
   });


### PR DESCRIPTION
Right now, by  scrolling horizontally beyond the background image, you can see rogue fish on the signed out code.org homepage.
<img width="514" alt="Screen Shot 2019-12-02 at 8 40 56 PM" src="https://user-images.githubusercontent.com/12300669/70021137-726e1d80-1544-11ea-8511-5ef7a496e204.png">

This change makes it so we only show a sea creature if there is enough space for it to swim without going outside the background
![shrinking-swim-space](https://user-images.githubusercontent.com/12300669/70021163-8b76ce80-1544-11ea-961c-d4f87fd7ebc9.gif)

