### PR TITLE
Oceans homepage: Hide rogue fish & link to /oceans

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -37,7 +37,13 @@
 
   .clear{style: "clear: both"}
 
-#hero{style: "position:relative; overflow: hidden"}
+- if show_single_hero == "oceans2019"
+  - hero_style = "position:relative; overflow: hidden; cursor: pointer"
+  - hero_onclick = "location.href='/oceans'"
+- else
+  - hero_style = "position:relative; overflow: hidden"
+
+#hero{style: hero_style, onclick: hero_onclick}
   - heroes_arranged.each_with_index do |entry, index|
     -# Preload the first hero image to render immediately, lazy-load the rest to conserve bandwidth.
     - if index == 0

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -37,7 +37,7 @@
 
   .clear{style: "clear: both"}
 
-#hero{style: "position:relative"}
+#hero{style: "position:relative; overflow: hidden"}
   - heroes_arranged.each_with_index do |entry, index|
     -# Preload the first hero image to render immediately, lazy-load the rest to conserve bandwidth.
     - if index == 0

--- a/pegasus/sites.v3/code.org/views/homepage_hero_oceans2019.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero_oceans2019.haml
@@ -82,7 +82,7 @@
     {x: 560, y: 215},    // gorgon-fish
     {x: 495, y: 85},     // orange-fish
     {x: 300, y: 180},    // shark
-    {x: 235, y: 277}     // crab
+    {x: 235, y: 285}     // crab
   ];
   var fishWidths = [
     '85px',  // turtle


### PR DESCRIPTION
As documented in https://github.com/code-dot-org/code-dot-org/pull/32244, we have an issue with rogue fish.

This change simply doesn't render anything off screen by clipping the overflow of the hero banner.

It also tweaks the crab position by a tiny bit.

It also makes the entire hero clickable and links to `/oceans`.

Also verified that this works with the dance party 2019 homepage hero.
