### PR TITLE
When clicking "Print One Here" on /certificates, use the same certificate as is displayed

### DIFF
--- a/pegasus/sites.v3/code.org/public/certificates.haml
+++ b/pegasus/sites.v3/code.org/public/certificates.haml
@@ -18,7 +18,7 @@ theme: responsive
     Enter up to 30 names, <strong>one per line</strong>. A printable page with personalized #{script_name} certificates will be generated.
   %p{:style=>"float: left; width: 360px; margin-top: 20px;"}<
     Want a blank certificate template to write in your students' names?
-    %a{href: '/images/hour_of_code_certificate.jpg', target: '_blank'} Print one here.
+    %a{href: "/images/#{certificate_template_for(script)}", target: '_blank'} Print one here.
 %br
 %form{:method=>"post", :action=>'/printcertificates'}
   -if script


### PR DESCRIPTION
# Description

If you go to https://code.org/certificates?script=oceans you see the custom certificate associated with the oceans script
![Screenshot 2019-12-03 at 8 17 35 AM](https://user-images.githubusercontent.com/46464143/70068762-74b49400-15a5-11ea-9227-8ab839f28007.png)

However, prior to this change, when you click "Print One Here", you're directed to https://code.org/images/hour_of_code_certificate.jpg. Instead we should direct to the certificate displayed. 

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
