### PR TITLE
[Spritelab] hide edit button for behaviors if toolbox doesn't have categories

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -377,7 +377,7 @@ export default {
           .appendTitle(fieldLabel, 'VAR')
           .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
 
-        if (Blockly.useModalFunctionEditor) {
+        if (Blockly.useModalFunctionEditor && Blockly.hasCategories) {
           var editLabel = new Blockly.FieldIcon(Blockly.Msg.FUNCTION_EDIT);
           Blockly.bindEvent_(
             editLabel.fieldGroup_,


### PR DESCRIPTION
# Description
Same as #32167 but against `staging`


Before:
![image](https://user-images.githubusercontent.com/8787187/69683871-32ea9180-106b-11ea-8711-dca0755af31a.png)

[Updated] After:
![image](https://user-images.githubusercontent.com/8787187/69684230-b8bb0c80-106c-11ea-93d7-241347ef4f65.png)


Levels with categories are unaffected:
![image](https://user-images.githubusercontent.com/8787187/69683942-71804c00-106b-11ea-8c48-98a9ab0909f1.png)