### PR TITLE
replace uniq with distinct on /levels page

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -94,7 +94,7 @@ class LevelsController < ApplicationController
         type: 'select',
         options: [
           ['Any owner', ''],
-          *Level.joins(:user).uniq.pluck('users.name, users.id').sort_by {|a| a[0]}
+          *Level.joins(:user).distinct.pluck('users.name, users.id').sort_by {|a| a[0]}
         ]
       }
     end


### PR DESCRIPTION
# Description

Fixes this warning when starting dashboard server:
```
DEPRECATION WARNING: uniq is deprecated and will be removed from Rails 5.1 
(use distinct instead) (called from index at 
/Users/dsb/src/cdo/dashboard/app/controllers/levels_controller.rb:97)
```

Verified that owners column still appears when running in levelbuilder mode, and that it still contains some values.
<img width="1005" alt="Screen Shot 2019-12-03 at 12 06 35 PM" src="https://user-images.githubusercontent.com/8001765/70085590-64acac80-15c5-11ea-9d47-7ffa39f7b9da.png">


## Testing story

No new tests, as this does not add new functionality. Tested manually to verify that there is no regression.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
