### PR TITLE
Use studio url for card title

### DIFF
--- a/apps/src/templates/projects/ProjectCard.jsx
+++ b/apps/src/templates/projects/ProjectCard.jsx
@@ -121,7 +121,7 @@ export default class ProjectCard extends React.Component {
           </div>
           <a
             style={styles.titleLink}
-            href={url}
+            href={studio(url)}
             target={isPublicGallery ? '_blank' : undefined}
           >
             <div


### PR DESCRIPTION
# Description

Found a small bug on /dance where the title links in our "Featured Student Creations" tiles were pointing to code.org instead of studio.code.org. The image links (which people are more likely to click) were already using studio URLs.

**Before:**
<img width="1034" alt="Screen Shot 2019-12-03 at 4 11 04 PM" src="https://user-images.githubusercontent.com/9812299/70100966-54f28f80-15e8-11ea-9ddf-69bd5e8b2a0e.png">

**After:**
<img width="1034" alt="Screen Shot 2019-12-03 at 4 10 06 PM" src="https://user-images.githubusercontent.com/9812299/70100967-54f28f80-15e8-11ea-9fb7-6784529d960d.png">
