### PR TITLE
Logging promo card clicks from congrats

### DIFF
--- a/apps/src/templates/StudentsBeyondHoc.jsx
+++ b/apps/src/templates/StudentsBeyondHoc.jsx
@@ -8,6 +8,7 @@ import {LocalClassActionBlock} from './studioHomepages/TwoColumnActionBlock';
 import {tutorialTypes} from './tutorialTypes.js';
 import {cardSets} from './congratsBeyondHocActivityCards';
 import {ResponsiveSize} from '@cdo/apps/code-studio/responsiveRedux';
+import _ from 'lodash';
 
 const styles = {
   heading: {
@@ -140,6 +141,7 @@ class StudentsBeyondHoc extends Component {
         specificCardSet = 'signedOutDefaultCards';
     }
     const cards = cardSets[specificCardSet];
+    const cardIds = _.map(cards, 'id');
 
     // 2017 Minecraft Tutorial has a share link that can be used on Minecraft // Education to import code. Check if the 2017 Minecraft tutorial was
     // completed; if it was, update the Minecraft share link for the card that // goes to Minecraft Education.
@@ -163,7 +165,7 @@ class StudentsBeyondHoc extends Component {
     return (
       <div style={styles.container}>
         <h1 style={headingStyle}>{heading}</h1>
-        <VerticalImageResourceCardRow cards={cards} />
+        <VerticalImageResourceCardRow cards={cards} cardIds={cardIds} />
         {isEnglish && (
           <CourseBlocksStudentGradeBands
             showContainer={false}

--- a/apps/src/templates/VerticalImageResourceCard.jsx
+++ b/apps/src/templates/VerticalImageResourceCard.jsx
@@ -95,7 +95,7 @@ class VerticalImageResourceCard extends Component {
     cardIds: PropTypes.array
   };
 
-  logToFirehose = (eventName, overrideData = {}) => {
+  logToFirehose = () => {
     let data = {
       card_options: this.props.cardIds
     };

--- a/apps/src/templates/VerticalImageResourceCard.jsx
+++ b/apps/src/templates/VerticalImageResourceCard.jsx
@@ -4,6 +4,7 @@ import Radium from 'radium';
 import {connect} from 'react-redux';
 import color from '../util/color';
 import Button from './Button';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   card: {
@@ -89,7 +90,21 @@ class VerticalImageResourceCard extends Component {
     image: PropTypes.string.isRequired,
     isRtl: PropTypes.bool.isRequired,
     MCShareLink: PropTypes.string,
-    jumbo: PropTypes.bool
+    jumbo: PropTypes.bool,
+    // For logging
+    cardIds: PropTypes.array
+  };
+
+  logToFirehose = (eventName, overrideData = {}) => {
+    let data = {
+      card_options: this.props.cardIds
+    };
+
+    firehoseClient.putRecord({
+      study: 'congrats_promo_box_click',
+      event: this.props.link,
+      data_json: JSON.stringify(data)
+    });
   };
 
   render() {
@@ -155,6 +170,7 @@ class VerticalImageResourceCard extends Component {
             color={Button.ButtonColor.gray}
             text={buttonText}
             style={[styles.button, localeStyle]}
+            onClick={this.logToFirehose}
           />
         </div>
       </div>

--- a/apps/src/templates/VerticalImageResourceCardRow.jsx
+++ b/apps/src/templates/VerticalImageResourceCardRow.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ContentContainer from './ContentContainer';
 import ResourceCardResponsiveContainer from './studioHomepages/ResourceCardResponsiveContainer';
 import VerticalImageResourceCard from './VerticalImageResourceCard';
@@ -10,11 +11,13 @@ import shapes from './studioHomepages/shapes';
 
 export default class VerticalImageResourceCardRow extends Component {
   static propTypes = {
-    cards: shapes.courses
+    cards: shapes.courses,
+    // For logging
+    cardIds: PropTypes.array
   };
 
   render() {
-    const {cards} = this.props;
+    const {cards, cardIds} = this.props;
     return (
       <ContentContainer heading="" description="" hideBottomMargin={true}>
         <ResourceCardResponsiveContainer>
@@ -27,6 +30,7 @@ export default class VerticalImageResourceCardRow extends Component {
               link={card.link}
               image={card.image}
               MCShareLink={card.MCShareLink}
+              cardIds={cardIds}
             />
           ))}
         </ResourceCardResponsiveContainer>

--- a/apps/src/templates/congratsBeyondHocActivityCards.js
+++ b/apps/src/templates/congratsBeyondHocActivityCards.js
@@ -2,6 +2,7 @@ import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import i18n from '@cdo/locale';
 
 const CSFExpress = {
+  id: 'csf-express',
   title: i18n.csfExpressTitle(),
   description: i18n.csfExpressDesc(),
   link: '/s/express',
@@ -10,6 +11,7 @@ const CSFExpress = {
 };
 
 const CSFAccelerated = {
+  id: 'csf-accelerated',
   title: i18n.csfAcceleratedTitle(),
   description: i18n.csfAcceleratedDesc(),
   link: '/s/20-hour',
@@ -18,6 +20,7 @@ const CSFAccelerated = {
 };
 
 const CourseCatalog = {
+  id: 'course-catalog',
   title: i18n.courseCatalogTitle(),
   description: i18n.courseCatalogDescription(),
   link: '/courses',
@@ -26,6 +29,7 @@ const CourseCatalog = {
 };
 
 const CreateAccount = {
+  id: 'create-account',
   title: i18n.createAccount(),
   description: i18n.createAccountDesc(),
   link: '/users/sign_up',
@@ -34,6 +38,7 @@ const CreateAccount = {
 };
 
 const CreateAccountApplab = {
+  id: 'create-account-applab',
   title: i18n.createAccount(),
   description: i18n.createAccountApplabDesc(),
   link: '/users/sign_up',
@@ -42,6 +47,7 @@ const CreateAccountApplab = {
 };
 
 const AnotherHoC = {
+  id: 'another-hoc',
   title: i18n.anotherHoCTitle(),
   description: i18n.anotherHoCDesc(),
   link: pegasus('/hourofcode/overview'),
@@ -50,6 +56,7 @@ const AnotherHoC = {
 };
 
 const ApplabTutorial = {
+  id: 'applab-tutorial',
   title: i18n.applabTutorialTitle(),
   description: i18n.applabTutorialDesc(),
   link: '/s/applab-intro/reset',
@@ -58,6 +65,7 @@ const ApplabTutorial = {
 };
 
 const ApplabMarketing = {
+  id: 'applab-marketing',
   title: i18n.applabMarketingTitle(),
   description: i18n.applabMarketingDesc(),
   link: pegasus('/applab'),
@@ -66,6 +74,7 @@ const ApplabMarketing = {
 };
 
 const ApplabProject = {
+  id: 'applab-project',
   title: i18n.applabProjectTitle(),
   description: i18n.applabProjectDesc(),
   link: '/projects/applab/new',
@@ -74,6 +83,7 @@ const ApplabProject = {
 };
 
 const OldMinecraft = {
+  id: 'old-minecraft',
   title: i18n.pre2017MinecraftTitle(),
   description: i18n.pre2017MinecraftDesc(),
   link: 'https://education.minecraft.net/hour-of-code',
@@ -82,6 +92,7 @@ const OldMinecraft = {
 };
 
 const HeroMinecraft = {
+  id: 'hero-minecraft',
   title: i18n.minecraft2017Title(),
   description: i18n.minecraft2017Desc(),
   link: 'https://education.minecraft.net/hour-of-code',
@@ -93,6 +104,7 @@ const HeroMinecraft = {
 // This card is displayed when you complete the Code.org MC Aquatic tutorial.
 // The takes you to the Microsoft Minecraft page.
 const AquaticMinecraft = {
+  id: 'aquatic-minecraft',
   title: i18n.minecraftAquaticTitle(),
   description: i18n.minecraftAquaticDesc(),
   link: 'http://aka.ms/hoc2018',
@@ -103,6 +115,7 @@ const AquaticMinecraft = {
 // This card is displayed to promote the MC Aquatic tutorial after finishing
 // another Hour of Code activity.
 const AquaticMinecraftPromo = {
+  id: 'aquatic-minecraft-promo',
   title: i18n.minecraftAquaticPromoTitle(),
   description: i18n.minecraftAquaticPromoDesc(),
   link: '/s/aquatic/reset',
@@ -111,6 +124,7 @@ const AquaticMinecraftPromo = {
 };
 
 const DanceParty = {
+  id: 'dance-party',
   title: i18n.dancePartyTitle(),
   description: i18n.dancePartyDesc(),
   link: '/s/dance/reset',
@@ -119,6 +133,7 @@ const DanceParty = {
 };
 
 const DancePartyFollowUp = {
+  id: 'dance-party-extras',
   title: i18n.danceAfterPartyTitle(),
   description: i18n.danceAfterPartyDesc(),
   link: '/s/dance-extras-2019/reset',


### PR DESCRIPTION
We currently have a fairly elaborate matrix of options for which 3 cards to show on studio.code.org/congrats based on which tutorial the user finished, signed in v. signed out, age 13 + or younger, in English or not, etc. For example:
<img width="1019" alt="Screen Shot 2019-12-03 at 12 24 22 PM" src="https://user-images.githubusercontent.com/12300669/70101820-0a264700-15eb-11ea-9a81-e80a32593729.png">

As part of work to simplify this logic and ultimately combine studio.code.org/congrats and code.org/congrats we'd like to gather some metrics during CSEdWeek about the frequency with which users click on these promotional boxes. I've adding logging here to track which 3 cards where shown and which was clicked. 