### PR TITLE
hoc2019: Fix homepage hero buttons

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -166,6 +166,13 @@
     $(".caption").css({display: "block", opacity: 0});
 
     showQuote(null, 0);
+
+    // The hero might have an onclick handler; the buttons should prevent it from firing.
+    $("#hero button").each(function() {
+      $(this).click(function (e) {
+        e.stopPropagation();
+      });
+    });
   });
 
   function showQuote(lastImage, nextImage)


### PR DESCRIPTION
The Oceans homepage hero got an `onclick` handler in https://github.com/code-dot-org/code-dot-org/pull/32245, but it turns out if you click a link on top of it, the `onclick` event still propagates, and sometimes the background's click handler wins over the link tag.  The quick solution is to make sure the buttons no longer propagate click events.
