### PR TITLE
Fixed rotate screen issue in Android.

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1858,7 +1858,11 @@ StudioApp.prototype.fixViewportForSpecificWidthForSmallScreens_ = function(
   viewport,
   width
 ) {
-  const scale = screen.width / width;
+  // iOS sets the screen width to the min of width and height. Android sets the
+  // screen width to the landscape width. We take the min of width and height
+  // here to enforce consistent behavior.
+  let screenWidth = Math.min(screen.width, screen.height);
+  const scale = screenWidth / width;
 
   var content = [
     'width=' + width,

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -31,7 +31,7 @@ const tiles = maze.tiles;
 const createResultsHandlerForSubtype = require('./results/utils')
   .createResultsHandlerForSubtype;
 
-const MOBILE_PORTRAIT_WIDTH = 600;
+const MOBILE_PORTRAIT_WIDTH = 700;
 
 module.exports = class Maze {
   constructor() {
@@ -217,10 +217,12 @@ module.exports = class Maze {
     // by calling fixViewportForSpecificWidthForSmallScreens_ after the init is
     // finished.
     var viewport = document.querySelector('meta[name="viewport"]');
-    studioApp().fixViewportForSpecificWidthForSmallScreens_(
-      viewport,
-      MOBILE_PORTRAIT_WIDTH
-    );
+    if (viewport) {
+      studioApp().fixViewportForSpecificWidthForSmallScreens_(
+        viewport,
+        MOBILE_PORTRAIT_WIDTH
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
# Description
## Issue
Previously, two PRs had been made to make the "Rotate Screen" image display correctly on iOS Safari. 
https://github.com/code-dot-org/code-dot-org/pull/32206 
https://github.com/code-dot-org/code-dot-org/pull/32240 

Those PRs, however, broke the same levels on Android mobile if you load those levels in landscape mode. This happened because iOS sets screen.width to the shortest screen measurement and screen.height to the longest. Android sets screen.width to the horizontal screen measurement and screen.height to the vertical measurement.
<img src="https://user-images.githubusercontent.com/8324574/70172086-dbf54580-1684-11ea-98ab-6f5d641f2760.jpg" height="200" />
<img src="https://user-images.githubusercontent.com/8324574/70172089-dc8ddc00-1684-11ea-9fa8-9db1171e3d09.jpg" height="200" />
<img src="https://user-images.githubusercontent.com/8324574/70172087-dbf54580-1684-11ea-81b1-587ef2791149.jpg" height="200" />
<img src="https://user-images.githubusercontent.com/8324574/70172088-dc8ddc00-1684-11ea-9086-2a73106eabb6.jpg" width="200" />

## Fix
This PR fixes that issue by explicitly choosing the width for scaling purposes to be the shortest screen measurement.
<img src="https://user-images.githubusercontent.com/8324574/70173007-c5e88480-1686-11ea-9ea2-aa2b17f199ce.jpg" height="200" />
<img src="https://user-images.githubusercontent.com/8324574/70173006-c5e88480-1686-11ea-9c0f-76edba98e595.jpg" height="200" />
<img src="https://user-images.githubusercontent.com/8324574/70173004-c5e88480-1686-11ea-82f2-7047549e7ef5.jpg" height="200" />
<img src="https://user-images.githubusercontent.com/8324574/70173005-c5e88480-1686-11ea-9e01-d39674c310e6.jpg" width="200" />

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
