### PR TITLE
Add Lever snippet to about/jobs

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/jobs.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/jobs.md.erb
@@ -26,8 +26,13 @@ Launched in 2013, Code.org&reg; is a nonprofit dedicated to expanding access to 
 **[Working at Code.org](#info)**
 
 **We are currently hiring for:**
-<div class="hire-jobs"></div>
-<script id="hire-embed-loader" async defer src="https://hire.withgoogle.com/s/embed/hire-jobs.js?company=codeorg"></script>
+<div id='lever-jobs-container'></div>
+<script type='text/javascript'>
+
+  window.leverJobsOptions = {accountName: 'Code.org', includeCss: true};
+
+</script>
+<script type='text/javascript' src='https://andreasmb.github.io/lever-jobs-embed/index.js'></script>
 
 ## <a name="info" href="#info">Working at Code.org</a>
 
@@ -42,7 +47,7 @@ We believe computer science and computer programming should be part of the core 
 We offer a comprehensive employee benefits package that includes:
 
 - Competitive Salary
-- Technology subsidy consistent with our Bring Your Own Device environment 
+- Technology subsidy consistent with our Bring Your Own Device environment
 - Flexible, engaging working environment
 - Monthly unlimited ORCA pass or equal value transit subsidy; located near public transit hub in Seattle, WA
 - Paid time off: 3 weeks vacation annually, sick leave, and 'winter break' office closure the two weeks that include Christmas and New Years.
@@ -56,5 +61,3 @@ We offer a comprehensive employee benefits package that includes:
 No relocation packages
 
 **Don't see a good fit? <a href="mailto:jobs@code.org">Drop us a line</a> and a resume and let us know why you want to work for us and what you would bring to our team.**
-
-

--- a/pegasus/sites.v3/code.org/public/about/jobs.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/jobs.md.erb
@@ -4,6 +4,7 @@ nav: about_nav
 video_player: true
 theme: responsive
 ---
+<link rel="stylesheet" type="text/css" rel= "stylesheet" href="/css/jobs.css" />
 
 # Job Openings at Code.org
 
@@ -11,6 +12,7 @@ theme: responsive
 
 <% facebook = {:u=>'https://youtu.be/mTGSiB4kB18'} %>
 <% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+
 
 <%=view :display_video_thumbnail, id: "codeorg_recruiting", video_code: "mTGSiB4kB18", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: "false", download_path: "http://videos.code.org/social/about-codeorg.mp4" %>
 
@@ -29,7 +31,7 @@ Launched in 2013, Code.org&reg; is a nonprofit dedicated to expanding access to 
 <div id='lever-jobs-container'></div>
 <script type='text/javascript'>
 
-  window.leverJobsOptions = {accountName: 'Code.org', includeCss: true};
+  window.leverJobsOptions = {accountName: 'Code.org'};
 
 </script>
 <script type='text/javascript' src='https://andreasmb.github.io/lever-jobs-embed/index.js'></script>

--- a/pegasus/sites.v3/code.org/public/css/jobs.css
+++ b/pegasus/sites.v3/code.org/public/css/jobs.css
@@ -1,0 +1,7 @@
+.lever-job-tag {
+  margin-left: 10px;
+}
+
+ul li:before {
+  content: "";
+}


### PR DESCRIPTION
Code.org is switching from Hire to Lever to manage job postings. Based on these instructions from Megan G. https://launchpad.lever.co/hc/en-us/articles/115005145623-Build-an-inviting-career-site?flash_digest=6a6847b7aa7f77908191e81ed62b0211f2c4227c I added the snippet generated from https://andreasmb.github.io/lever-jobs-embed/ to jobs.md.erb and added a bit of styling polish. 

<img width="826" alt="Screen Shot 2019-12-04 at 2 31 03 PM" src="https://user-images.githubusercontent.com/12300669/70187407-f50cef00-16a2-11ea-968b-6f69794c5622.png">
