### PR TITLE
AI -> artificial intelligence, use short desc on course block

### DIFF
--- a/dashboard/app/helpers/course_block_helper.rb
+++ b/dashboard/app/helpers/course_block_helper.rb
@@ -181,8 +181,8 @@ module CourseBlockHelper
       },
       Script::OCEANS_NAME => {
         url: CDO.code_org_url('/oceans'),
-        title: 'AI for Oceans',
-        body: 'Learn about machine learning and ethical use of AI. #CSforGood'
+        title: data_t_suffix('script.name', id, 'title'),
+        body: data_t_suffix('script.name', id, 'description_short')
       }
     }
 

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -26,7 +26,7 @@
   oceans_landing_description: 'Learn about machine learning and ethical use of AI.'
   cs_for_good_hashtag: '#CSforGood'
   oceans_landing_specs: 'English only | Grades 3+'
-  oceans_landing_explanation: "Computer science is about so much more than coding! Learn about AI, machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems. Enjoy Code.org's first step in a new journey to teach more about AI. When you use the AI for Oceans activity you are training real machine learning models. <a href='#behind-the-scenes'>Learn more</a>."
+  oceans_landing_explanation: "Computer science is about so much more than coding! Learn about artificial intelligence (AI), machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems. Enjoy Code.org's first step in a new journey to teach more about AI. When you use the AI for Oceans activity you are training real machine learning models. <a href='#behind-the-scenes'>Learn more</a>."
   oceans_landing_teacher_resources: 'Teacher Resources'
   oceans_landing_teacher_resources_desc: 'Lesson plans and activities to help you teach AI, machine learning, training data, and bias, while exploring ethical issues.'
   oceans_landing_resource_button: 'View Resources'
@@ -41,7 +41,7 @@
   social_hoc2019_oceans_desc: "Learn about AI, machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems. Computer science is about so much more than coding! Enjoy Code.org's first step in a new journey to teach more about AI throughout our curriculum."
 
   hoc_overview_oceans_tutorial_header: 'AI for Oceans'
-  hoc_overview_oceans_tutorial_desc: 'Learn about AI, machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems.'
+  hoc_overview_oceans_tutorial_desc: 'Learn about artificial intelligence (AI), machine learning, training data, and bias, while exploring ethical issues and how AI can be used to address world problems.'
 
   ai_video_title_what_is_ai: 'What is AI?'
   ai_video_title_phone_knows_dog: 'How does your phone know this is a dog?'


### PR DESCRIPTION
A few string tweaks...

"artificial intelligence (AI)" on code.org/hourofcode/overview
<img width="493" alt="Screen Shot 2019-12-03 at 6 06 31 PM" src="https://user-images.githubusercontent.com/12300669/70106691-2f21b680-15f9-11ea-8eec-ea182951ca20.png">

"artificial intelligence (AI)" on code.org/oceans 
<img width="997" alt="Screen Shot 2019-12-03 at 6 09 37 PM" src="https://user-images.githubusercontent.com/12300669/70106750-55475680-15f9-11ea-8f9b-955122682dc2.png">

course block uses on sign in page and studio.code.org/courses now uses the tutorial name and description from the gsheet

<img width="246" alt="Screen Shot 2019-12-03 at 6 14 16 PM" src="https://user-images.githubusercontent.com/12300669/70106808-7b6cf680-15f9-11ea-8b82-06d506bcb3a5.png">

