### PR TITLE
Oceans: Late-breaking content changes

### DIFF
--- a/pegasus/sites.v3/code.org/public/oceans.haml
+++ b/pegasus/sites.v3/code.org/public/oceans.haml
@@ -75,22 +75,21 @@ theme: responsive
   }
 
 %div
-  .tutorial-promo-container
-    = view :oceans_promo
-    .tutorial-details.desktop-feature
-      %h1.tutorial-heading= hoc_s(:oceans_landing_title)
-      %p.tutorial-description= hoc_s(:oceans_landing_description)
-      %p.tutorial-description= hoc_s(:cs_for_good_hashtag)
-      %p.tutorial-specs= hoc_s(:oceans_landing_specs)
-      %a{href: CDO.studio_url('/s/oceans/reset'), target: '_self'}
+  %a{href: CDO.studio_url('/s/oceans/reset'), target: '_self', style: "font-family: 'Gotham 4r', sans-serif; text-decoration: none"}
+    .tutorial-promo-container
+      = view :oceans_promo
+      .tutorial-details.desktop-feature
+        %h1.tutorial-heading= hoc_s(:oceans_landing_title)
+        %p.tutorial-description= hoc_s(:oceans_landing_description)
+        %p.tutorial-description= hoc_s(:cs_for_good_hashtag)
+        %p.tutorial-specs= hoc_s(:oceans_landing_specs)
         %button.tutorial-button=I18n.t(:try_now)
 
-    .tutorial-details-mobile.mobile-feature
-      %h1.tutorial-heading.tutorial-heading-mobile= hoc_s(:oceans_landing_title)
-      %p.tutorial-description= hoc_s(:oceans_landing_description)
-      %p.tutorial-description= hoc_s(:cs_for_good_hashtag)
-      %p.tutorial-specs= hoc_s(:oceans_landing_specs)
-      %a{href: CDO.studio_url('/s/oceans/reset'), target: '_self'}
+      .tutorial-details-mobile.mobile-feature
+        %h1.tutorial-heading.tutorial-heading-mobile= hoc_s(:oceans_landing_title)
+        %p.tutorial-description= hoc_s(:oceans_landing_description)
+        %p.tutorial-description= hoc_s(:cs_for_good_hashtag)
+        %p.tutorial-specs= hoc_s(:oceans_landing_specs)
         %button.tutorial-button=I18n.t(:try_now)
 
   %div{style: "clear: both; margin-top: 10px;"}

--- a/pegasus/sites.v3/code.org/public/oceans.haml
+++ b/pegasus/sites.v3/code.org/public/oceans.haml
@@ -99,6 +99,30 @@ theme: responsive
 
   = view :resource_boxes, resources: resources
 
+  :css
+    .microsoft-partnership {
+      font-size: 24px;
+      text-align: center;
+      margin-top: 60px;
+    }
+
+    .microsoft-thanks {
+      font-size: 14px;
+      text-align: center;
+      padding-top: 20px;
+      margin-bottom: 85px;
+      margin-left: 18%;
+      margin-right: 18%;
+    }
+
+  .microsoft-partnership
+    = I18n.t(:hoc2018_mc_with_microsoft)
+    &nbsp;
+    %img{src: "images/fit-240/avatars/microsoft.jpg"}
+
+  .microsoft-thanks
+    = I18n.t(:hoc2018_mc_thank_microsoft)
+
   = view :ai_videos
 
   = view :ai_ml_resources_table

--- a/pegasus/sites.v3/code.org/views/ai_ml_resources_table.haml
+++ b/pegasus/sites.v3/code.org/views/ai_ml_resources_table.haml
@@ -1,9 +1,9 @@
 :ruby
   ai_activities = [
     {
-      url: "https://teachablemachine.withgoogle.com/",
-      title: hoc_s(:ai_activity_teachable),
-      description: hoc_s(:ai_activity_teachable_desc)
+      url: "https://aka.ms/minecrafthourofcode",
+      title: hoc_s(:ai_resource_minecraft),
+      description: hoc_s(:ai_resource_minecraft_desc)
     },
     {
       url: "https://quickdraw.withgoogle.com/",
@@ -11,29 +11,23 @@
       description: hoc_s(:ai_activity_quick_draw_desc)
     },
     {
+      url: "https://teachablemachine.withgoogle.com/",
+      title: hoc_s(:ai_activity_teachable),
+      description: hoc_s(:ai_activity_teachable_desc)
+    },
+    {
       url: "https://experiments.withgoogle.com/collection/ai",
       title: hoc_s(:ai_activity_experiments),
       description: hoc_s(:ai_activity_experiments_desc)
     },
     {
-      url: "https://mixlab.withgoogle.com/",
-      title: hoc_s(:ai_activity_mixlab),
-      description: hoc_s(:ai_activity_mixlab_desc)
-    },
-    {
-      url: "http://nvidia-research-mingyuliu.com/gaugan",
-      title: hoc_s(:ai_activity_gaugan),
-      description: hoc_s(:ai_activity_gaugan_desc)
+      url: "https://www.zooniverse.org/projects/meredithspalmer/snapshot-mountain-zebra/classify?reload=0&workflow=11445",
+      title: hoc_s(:ai_activity_zooniverse),
+      description: hoc_s(:ai_activity_zooniverse_desc)
     }
   ]
 
   ai_ml_resources = [
-    {
-      url: "https://aka.ms/minecrafthourofcode",
-      title: hoc_s(:ai_resource_minecraft),
-      description: hoc_s(:ai_resource_minecraft_desc),
-      audience: hoc_s(:ai_audience_k12)
-    },
     {
       url: "https://machinelearningforkids.co.uk/",
       title: hoc_s(:ai_resource_ml_for_kids),
@@ -75,7 +69,7 @@
     - ai_activities.each do |activity|
       %tr
         %td
-          %a{href: activity[:url]}
+          %a{href: activity[:url], target: '_blank'}
             =activity[:title]
         %td=activity[:description]
 
@@ -89,7 +83,7 @@
     - ai_ml_resources.each do |activity|
       %tr
         %td
-          %a{href: activity[:url]}
+          %a{href: activity[:url], target: '_blank'}
             =activity[:title]
         %td=activity[:description]
         %td=activity[:audience]

--- a/pegasus/sites.v3/code.org/views/ai_ml_resources_table.haml
+++ b/pegasus/sites.v3/code.org/views/ai_ml_resources_table.haml
@@ -1,9 +1,9 @@
 :ruby
   ai_activities = [
-    {
-      url: "https://aka.ms/minecrafthourofcode",
-      title: hoc_s(:ai_resource_minecraft),
-      description: hoc_s(:ai_resource_minecraft_desc)
+   {
+      url: "https://www.microsoft.com/en-us/ai/seeing-ai",
+      title: hoc_s(:ai_activity_seeing_ai),
+      description: hoc_s(:ai_activity_seeing_ai_desc)
     },
     {
       url: "https://quickdraw.withgoogle.com/",
@@ -28,6 +28,12 @@
   ]
 
   ai_ml_resources = [
+    {
+      url: "https://aka.ms/minecrafthourofcode",
+      title: hoc_s(:ai_resource_minecraft),
+      description: hoc_s(:ai_resource_minecraft_desc),
+      audience: hoc_s(:ai_audience_k12)
+    },
     {
       url: "https://machinelearningforkids.co.uk/",
       title: hoc_s(:ai_resource_ml_for_kids),

--- a/pegasus/sites.v3/code.org/views/ai_videos.haml
+++ b/pegasus/sites.v3/code.org/views/ai_videos.haml
@@ -1,6 +1,11 @@
 :ruby
   videos = [
     {
+      id: 'seeing_ai',
+      code: 'DybczED-GKE',
+      text: hoc_s(:ai_video_title_seeing_ai)
+    },
+    {
       id: 'ml_human_bias',
       code: '59bMh59JQDo',
       text: hoc_s(:ai_video_title_ml_human_bias)

--- a/pegasus/sites.v3/code.org/views/oceans_promo.haml
+++ b/pegasus/sites.v3/code.org/views/oceans_promo.haml
@@ -14,7 +14,7 @@
   %img.ai-light{src: 'images/oceans/bot-beam-puddle.png'}
   %img.ai-fish{src: 'images/oceans/fish-in-beam.png'}
 
-%img.mobile.mobile-feature{src: 'images/oceans/mobile-ai.png'}
+%img.mobile.mobile-feature{src: 'images/oceans/mobile-ai.png', style: 'border-top-right-radius: 10px; border-top-left-radius: 10px;'}
 
 :javascript
   $time =

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -78,10 +78,8 @@
   ai_activity_quick_draw_desc: 'Can a neural network learn to recognize doodling?'
   ai_activity_experiments: 'AI Experiments with Google'
   ai_activity_experiments_desc: 'Start exploring machine learning through pictures, drawings, language, music, and more.'
-  ai_activity_mixlab: 'MixLab'
-  ai_activity_mixlab_desc: 'Make music using voice commands.'
-  ai_activity_gaugan: 'GauGAN Beta'
-  ai_activity_gaugan_desc: 'Paint photo-realistic landscapes with the help of AI.'
+  ai_activity_zooniverse: 'Zooniverse - Snapshot Mountain Zebra'
+  ai_activity_zooniverse_desc: 'Help protect the endangered Cape Mountain Zebra by identifying the different animals in the images.'
 
   codeorg_homepage_hoc2018_curriculum: 'Go further with <a href="%{studio_url}/courses" class="hoc2018-curriculum-link">Code.org courses</a>'
   codeorg_homepage_hoc2018_dance_heading: 'Create your own <span class="highlight-word">Dance&nbsp;Party</span>'

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -49,6 +49,7 @@
   ai_video_title_ml_big_small_prickly: 'Machine Learning: Solving Problems Big, Small and Prickly'
   ai_video_title_ethics_of_ai: 'Ethics of AI'
   ai_video_title_ml_human_bias: 'Machine Learning and Human Bias'
+  ai_video_title_seeing_ai: 'Seeing AI: Making the visual world more accessible'
 
   activity: 'Activity'
   name: 'Name'
@@ -72,10 +73,12 @@
   ai_audience_hs: 'High school'
 
   ai_activity_header: 'Activities Powered by AI and ML'
-  ai_activity_teachable: 'Teachable Machine'
-  ai_activity_teachable_desc: 'Train a computer to recognize your own images, sounds, and poses.'
+  ai_activity_seeing_ai: 'Seeing AI'
+  ai_activity_seeing_ai_desc: 'A free app that narrates the world around you in a variety of languages.'
   ai_activity_quick_draw: 'Quick, Draw!'
   ai_activity_quick_draw_desc: 'Can a neural network learn to recognize doodling?'
+  ai_activity_teachable: 'Teachable Machine'
+  ai_activity_teachable_desc: 'Train a computer to recognize your own images, sounds, and poses.'
   ai_activity_experiments: 'AI Experiments with Google'
   ai_activity_experiments_desc: 'Start exploring machine learning through pictures, drawings, language, music, and more.'
   ai_activity_zooniverse: 'Zooniverse - Snapshot Mountain Zebra'


### PR DESCRIPTION
Just a few content changes for [code.org/oceans](https://code.org/oceans).

![oceans-full-page-2](https://user-images.githubusercontent.com/2205926/70167245-25409780-167b-11ea-9dcb-05e4879947dd.png)

