### PR TITLE
Fix fallback full-width video player layout

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -24,6 +24,8 @@ videos.createVideoWithFallback = function(
   if (fullWidth) {
     video.addClass('video-player-full-width');
     parentElement.addClass('video-content-full-width');
+    width = '100%';
+    height = '100%';
   } else {
     video.width(width).height(height);
   }
@@ -342,8 +344,23 @@ function youTubeAvailabilityEndpointURL(noCookie) {
 // Precondition: $('#video') must exist on the DOM before this function is called.
 function addFallbackVideoPlayer(videoInfo, playerWidth, playerHeight) {
   var fallbackPlayerID = 'fallbackPlayer' + Date.now();
+
+  // If we have want the video player to be at 100% width & 100% height, then
+  // let's assume we are attaching to a container that is relative, and we want
+  // to expand to its edges.  This is currently implemented by a standalone
+  // video.
+  let containerDivStyle;
+  if (playerWidth === '100%' && playerHeight === '100%') {
+    containerDivStyle =
+      'position: absolute; top: 0; bottom: 0; left: 0; right: 0';
+  } else {
+    containerDivStyle = '';
+  }
+
   var playerCode =
-    '<div><video id="' +
+    '<div style="' +
+    containerDivStyle +
+    '"><video id="' +
     fallbackPlayerID +
     '" ' +
     'width="' +


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/31797 added support for full-width videos, notably standalone video levels which feature a video player that expands responsively to fill the screen.  However, the layout was broken for the fallback video player.

This fix gets the fallback player filling the same space as the YouTube video would.  It's fairly straightforward: in the case of a "full-width" video, our code sets its width and height to be "100%" rather than a specific pixel width.  Then, knowing that its host is a "position: relative" div of the desired location and dimensions, an intermediate div marks itself as "position: absolute" and extending to the four bounding edges of that parent.  The fallback player video is attached to that, as before.

Being so close to Hour of Code 2019, manual testing has been done to ensure no regressions.  In particular, the following levels have been loaded up and all appear to work as before:
```
/s/oceans/stage/1/puzzle/1 (full-width standalone with YouTube)
/s/allthethings/stage/34/puzzle/1 (regular standalone with YouTube)
/s/allthethings/stage/34/puzzle/1?force_youtube_fallback=1 (regular standalone with fallback player)
/s/allthethings/stage/2/puzzle/1 (maze level with pop-up Youtube)
/s/allthethings/stage/2/puzzle/1?force_youtube_fallback (maze level with pop-up fallback player)
```

### before
![fallback-player-before](https://user-images.githubusercontent.com/2205926/70120398-5a200080-1621-11ea-9ccd-0b49936aba2e.png)

### after
![fallback-player-after](https://user-images.githubusercontent.com/2205926/70120397-5a200080-1621-11ea-998e-ee6424535c3f.png)

