### PR TITLE
update to proxysql update_servers script

### DIFF
--- a/cookbooks/cdo-mysql/files/default/update_servers.sql
+++ b/cookbooks/cdo-mysql/files/default/update_servers.sql
@@ -9,12 +9,11 @@
 -- Note: although the ProxySQL admin interface uses the MySQL client protocol,
 -- it uses the SQLite dialect for its SQL-query syntax.
 
-DELETE FROM `mysql_servers`;
-
--- Copy `runtime_mysql_servers` to `mysql_servers`, with HG2 copied from HG1.
-INSERT INTO `mysql_servers` SELECT * FROM `runtime_mysql_servers` WHERE `hostgroup_id` != 2;
-UPDATE `mysql_servers` SET `hostgroup_id` = 2 WHERE `hostgroup_id` = 1;
-INSERT INTO `mysql_servers` SELECT * FROM `runtime_mysql_servers` WHERE `hostgroup_id` = 1;
+-- Copy `runtime_mysql_servers` to `mysql_servers`
+REPLACE INTO `mysql_servers` SELECT * FROM `runtime_mysql_servers` WHERE `hostgroup_id` != 2;
+-- Set HG2 copied from HG1.
+REPLACE INTO `mysql_servers` (hostgroup_id, hostname, port, status, weight)
+    SELECT 2, hostname, port, status, weight FROM `mysql_servers` WHERE `hostgroup_id` = 1;
 
 -- Update weights on servers.
 UPDATE `mysql_servers` SET `weight` = CASE


### PR DESCRIPTION
This PR adjusts the `update_servers` script added in #31639 
 to behave a bit more cautiously in dynamically updating the list of active servers. It also adjusts the command used to invoke `mysql` client within the script so that any output to standard-error is passed along (and recorded in proxysql log) rather than silenced.

### Background

This fix is a response to an edge-case observed in production where the `mysql_servers` list had been removed seconds after proxysql-service initialization, causing the frontend to fail to serve traffic until the proxysql service was manually restarted. (This issue seems to be extremely rare- out of several hundred instance launches over the past few weeks, it has only occurred once so far.)

### Testing

I've tested this change on an adhoc and it provisioned without any issues. At this point I haven't yet reproduced the exact edge-case observed in production, so I'm not fully confident this fix will definitely prevent the observed issue from recurring.