### PR TITLE
Revert "[Spritelab] hide edit button for behaviors if toolbox doesn't have categories"

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -377,7 +377,7 @@ export default {
           .appendTitle(fieldLabel, 'VAR')
           .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
 
-        if (Blockly.useModalFunctionEditor && Blockly.hasCategories) {
+        if (Blockly.useModalFunctionEditor) {
           var editLabel = new Blockly.FieldIcon(Blockly.Msg.FUNCTION_EDIT);
           Blockly.bindEvent_(
             editLabel.fieldGroup_,


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#32252

Josh S reported this morning: Seeing an issue with the Edit button no longer present on function blocks in some SpriteLab levels, may be related to the fix that went out yesterday. See https://codeorg.zendesk.com/agent/tickets/258397

Examples of broken levels:
https://studio.code.org/s/coursef-2019/stage/15/puzzle/1
https://studio.code.org/s/coursef-2019/stage/15/puzzle/2
https://studio.code.org/s/coursef-2019/stage/15/puzzle/3

Before Revert:
<img width="1440" alt="Screen Shot 2019-12-04 at 12 17 11 PM" src="https://user-images.githubusercontent.com/208083/70164948-10baca00-1690-11ea-84fd-aa977d7bd3b9.png">

After Revert:
<img width="1440" alt="Screen Shot 2019-12-04 at 12 17 14 PM" src="https://user-images.githubusercontent.com/208083/70164949-10baca00-1690-11ea-9b05-db06fbbc4ddc.png">
