### PR TITLE
hoc2019: Fix homepage clicking

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -37,13 +37,7 @@
 
   .clear{style: "clear: both"}
 
-- if show_single_hero == "oceans2019"
-  - hero_style = "position:relative; overflow: hidden; cursor: pointer"
-  - hero_onclick = "location.href='/oceans'"
-- else
-  - hero_style = "position:relative; overflow: hidden"
-
-#hero{style: hero_style, onclick: hero_onclick}
+#hero{style: "position: relative; overflow: hidden"}
   - heroes_arranged.each_with_index do |entry, index|
     -# Preload the first hero image to render immediately, lazy-load the rest to conserve bandwidth.
     - if index == 0
@@ -96,11 +90,11 @@
         %span{style: "white-space: nowrap"}= hoc_s(:codeorg_homepage_hoc2018_musician_after)
 
   - elsif show_single_hero == "oceans2019"
-    #actions{style: "text-align: left"}
+    #actions{style: "text-align: left; cursor: pointer", onclick: "location.href='/oceans'"}
       = main_actions
 
-    .blank{style: "height: 54px"}
-      &nbsp;
+      .blank{style: "height: 54px"}
+        &nbsp;
 
   - elsif show_single_hero
     #actions


### PR DESCRIPTION
While we fixed action button clicks from propagating to the background click handler in https://github.com/code-dot-org/code-dot-org/pull/32267, there were some other clicks in the header (for example the sign-in button) that were still falling through.

This reduces the area that has a click handler to just the majority of the hero, and no longer includes the header.
