### PR TITLE
Oceans: Force left-to-right for now

### DIFF
--- a/apps/src/fish/FishView.jsx
+++ b/apps/src/fish/FishView.jsx
@@ -61,7 +61,11 @@ class FishView extends React.Component {
     return (
       <StudioAppWrapper rotateContainerWidth={this.props.mobilePortraitWidth}>
         <CodeWorkspaceContainer topMargin={0}>
-          <ProtectedStatefulDiv id="container" style={styles.container}>
+          <ProtectedStatefulDiv
+            id="container"
+            style={styles.container}
+            dir="ltr"
+          >
             <div id="container-react" style={styles.containerReact} />
             <canvas id="background-canvas" style={styles.backgroundCanvas} />
             <canvas id="activity-canvas" style={styles.activityCanvas} />


### PR DESCRIPTION
The tutorial does not yet support right-to-left, and so we should force left-to-right in case the surrounding page is right-to-left.

### before

![Screenshot 2019-12-04 13 12 01](https://user-images.githubusercontent.com/2205926/70183169-19b09900-169a-11ea-8445-f1481c4e5258.png)

### after

![Screenshot 2019-12-04 13 20 48](https://user-images.githubusercontent.com/2205926/70183170-19b09900-169a-11ea-808c-d21a30e912f5.png)
