### PR TITLE
Azure logging

### DIFF
--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -25,9 +25,7 @@ module ImageModeration
       study: 'azure-content-moderation',
       study_group: 'v1',
       event: 'moderation-error',
-      data_json: {
-        error: err
-      }.to_json
+      data_string: err
     )
     :everyone
   end

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -1,5 +1,6 @@
 require 'cdo/azure_content_moderator'
 require 'honeybadger/ruby'
+require 'cdo/firehose'
 
 module ImageModeration
   # Returns a content rating from an external service.
@@ -18,6 +19,16 @@ module ImageModeration
     # behavior is to allow everything through, but we also want to notify
     # Honeybadger so that we can figure out exactly what is going wrong.
     Honeybadger.notify(err)
+
+    # Log to firehose as well, to have longer-lived data
+    FirehoseClient.instance.put_record(
+      study: 'azure-content-moderation',
+      study_group: 'v1',
+      event: 'moderation-error',
+      data_json: {
+        error: err
+      }.to_json
+    )
     :everyone
   end
 end

--- a/lib/test/cdo/test_image_moderation.rb
+++ b/lib/test/cdo/test_image_moderation.rb
@@ -31,6 +31,7 @@ class ImageModerationTest < Minitest::Test
     test_err = AzureContentModerator::AzureError.new('Test error')
     AzureContentModerator.any_instance.stubs(:rate_image).raises(test_err)
     Honeybadger.expects(:notify).once.with(test_err)
+    FirehoseClient.any_instance.expects(:put_record).with({study: 'azure-content-moderation', study_group: 'v1', event: 'moderation-error', data_string: test_err})
     assert_equal :everyone, ImageModeration.rate_image(@image_body, @content_type)
   end
 end


### PR DESCRIPTION
# Description

We currently log successful Azure Content Moderation responses to firehose, but log errors to Honeybadger, where the data only persists for three months. This change logs errors to firehose as well, so we can look back at historical data in the future and get more info on our error rates.

I used the existing study name and group for Azure Content Moderator logging, with the new event 'moderation-error'.
<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1070?atlOrigin=eyJpIjoiMjFkNjhlOGFhOGZiNDg1NTkzMDkyZjhmYWUzODEyZmYiLCJwIjoiaiJ9)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
