### PR TITLE
[Dancelab] Bump version, add start/stopMappingEach to freeplay level

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -43,7 +43,7 @@
     "@code-dot-org/blockly": "3.5.5",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
-    "@code-dot-org/dance-party": "1.0.0",
+    "@code-dot-org/dance-party": "1.0.1",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -903,10 +903,10 @@
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@code-dot-org/craft/-/craft-0.2.2.tgz#4b117337a5a601613f2d38514aa50ba972362939"
 
-"@code-dot-org/dance-party@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/dance-party/-/dance-party-1.0.0.tgz#8614365506025e6f61545a6b7a8495ee30d05221"
-  integrity sha512-zcOlP/0IUsmicjDdrFYhhS9WMyZ7eoIgH77nssY5RDGQqmDXoXz9ARgxSFzG2aEGpdCHxmT5RY2hAtXXnq/WTA==
+"@code-dot-org/dance-party@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/dance-party/-/dance-party-1.0.1.tgz#1c78132791485a003c5022113afe669ed58834a6"
+  integrity sha512-IQ8bTTmbTBOyhGz4+u/NYEijWKTkUHsvtP0fPKvXJTm56vKNMozTbgHpColzruyQoJ3s9AC5t3dIOrLClkgaPA==
   optionalDependencies:
     canvas "^1.6.13"
 

--- a/dashboard/config/scripts/levels/New Dance Lab Project.level
+++ b/dashboard/config/scripts/levels/New Dance Lab Project.level
@@ -136,6 +136,16 @@
             <title name="MOVE">MOVES.Clown</title>
             <title name="DIR">-1</title>
           </block>
+          <block type="Dancelab_startMappingEach">
+            <title name="GROUP">sprites</title>
+            <title name="PROPERTY">"scale"</title>
+            <title name="RANGE">"bass"</title>
+          </block>
+          <block type="Dancelab_stopMappingEach">
+            <title name="GROUP">sprites</title>
+            <title name="PROPERTY">"scale"</title>
+            <title name="RANGE">"bass"</title>
+          </block>
           <block type="Dancelab_alternateMoves">
             <title name="GROUP">sprites</title>
             <title name="N">2</title>


### PR DESCRIPTION
# Description
Bumps dance version, which adds `start/stopMappingEach` to the dance api
Also adds the two blocks to the freeplay level.
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
