### PR TITLE
Auto print login cards

### DIFF
--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -219,6 +219,11 @@ class WordOrPictureLogins extends React.Component {
     let printWindow = window.open('', windowName, '');
     const {section} = this.props;
 
+    printWindow.document.open();
+    printWindow.addEventListener('load', event => {
+      printWindow.print();
+    });
+
     printWindow.document.write(
       `<html><head><title>${i18n.printLoginCards_windowTitle({
         sectionName: section.name
@@ -227,6 +232,7 @@ class WordOrPictureLogins extends React.Component {
     printWindow.document.write('<body onafterprint="self.close()">');
     printWindow.document.write(printArea);
     printWindow.document.write('</body></html>');
+    printWindow.document.close();
   };
 
   render() {


### PR DESCRIPTION
# Description

Call print on the login cards page but it would print before the secret pictures loaded so we removed the print command thinking users could just print it themselves. 

We found out that wasn't working great for users so we decided to bring back calling print for the user but after waiting for the page to load fully. So this calls print once all parts of the login card page is loaded.

<img width="1440" alt="Screen Shot 2019-12-05 at 2 04 17 PM" src="https://user-images.githubusercontent.com/208083/70265663-dffa9380-1768-11ea-85ad-56878749363a.png">


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-892)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

What is the best way to test this? A UI test?

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
