### PR TITLE
Manually restoring translated strings from redactions

### DIFF
--- a/dashboard/config/locales/blocks.fr-FR.yml
+++ b/dashboard/config/locales/blocks.fr-FR.yml
@@ -243,6 +243,7 @@ fr:
             '"verse"': verset
             '"chorus"': chœur
       Dancelab_getEnergy:
+        text: obtenir {RANGE}
         options:
           RANGE:
             '"low"': grave

--- a/dashboard/config/locales/blocks.ja-JP.yml
+++ b/dashboard/config/locales/blocks.ja-JP.yml
@@ -369,6 +369,7 @@ ja:
             '"plus"': プラス
             '"random"': ランダム に
       Dancelab_makeAnonymousDanceSprite:
+        text: "{LOCATION} で新しい{COSTUME} を作成します"
         options:
           COSTUME:
             '"ALIEN"': エイリアン

--- a/dashboard/config/locales/blocks.nl-NL.yml
+++ b/dashboard/config/locales/blocks.nl-NL.yml
@@ -245,6 +245,7 @@ nl:
             '"verse"': couplet
             '"chorus"': refrein
       Dancelab_getEnergy:
+        text: krijg {RANGE}
         options:
           RANGE:
             '"low"': Bass


### PR DESCRIPTION
# Description
We are doing this as a quick translation patch because we don't want to
pull in all translations. We are avoiding a full translation upload
because the codebase is on lockdown due to hourofcode and csedweek
events.

Here are some strings we manually avoided the upload of because they seemed risky to take in the last translation push: https://github.com/code-dot-org/code-dot-org/commit/1cb9c7bbd4083c04a6ce1d4a68f1cff3e90c4b63#diff-0064cdf762fcc0f63c5ad38af6851232L372

Compare the values in the diff against the English versions: https://github.com/code-dot-org/code-dot-org/blob/1cb9c7bbd4083c04a6ce1d4a68f1cff3e90c4b63/dashboard/config/locales/blocks.en.yml

* Note, that I opted to delete the Urdu (Pakistan) string because the ML translation we used seemed to be incorrect. Rather than salvage it, I think we should just default to the english string. This string is only used in one block which is only used in a single 2018 HOC minecraft level.

## Screenshots
### French
![Screenshot from 2019-12-05 13-29-20](https://user-images.githubusercontent.com/1372238/70276095-6b931500-17a7-11ea-84ab-0d0536e0065d.png)
### Netherlands
![Screenshot from 2019-12-05 13-30-38](https://user-images.githubusercontent.com/1372238/70276101-70f05f80-17a7-11ea-9d31-ddb525f16d9d.png)
### Japanese
![Screenshot from 2019-12-05 13-31-28](https://user-images.githubusercontent.com/1372238/70276184-a432ee80-17a7-11ea-9564-25740db069f9.png)
### Missing Urdu string
![Screenshot from 2019-12-05 13-35-14](https://user-images.githubusercontent.com/1372238/70276111-764daa00-17a7-11ea-869b-d34af39f0eef.png)


# Reviewer Checklist:
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately