### PR TITLE
Move libraries to the advanced share menu

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1303,6 +1303,7 @@
   "setupCoursesStudent": "Browse Code.org's courses to find your next challenge.",
   "share": "Share",
   "shareLibrary": "Share as library",
+  "shareLibraryWithClassmate": "Share the functions in your project with a friend or classmate.",
   "shareFailure": "Sorry, we can't share this program.",
   "shareSettingEnableButton": "Enable sharing advanced projects for all students",
   "shareSettingDisableButton": "Disable sharing advanced projects for all students",

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -371,9 +371,7 @@ class AdvancedShareOptions extends React.Component {
   renderLibraryTab = () => {
     return (
       <div>
-        <p style={style.p}>
-          Share the functions in your project with a friend or classmate.
-        </p>
+        <p style={style.p}>{i18n.shareLibraryWithClassmate()}</p>
         <button
           type="button"
           onClick={this.props.openLibraryCreationDialog}

--- a/apps/src/code-studio/components/AdvancedShareOptions.jsx
+++ b/apps/src/code-studio/components/AdvancedShareOptions.jsx
@@ -4,7 +4,10 @@ import PropTypes from 'prop-types';
 import QRCode from 'qrcode.react';
 import * as color from '../../util/color';
 import {CIPHER, ALPHABET} from '../../constants';
+import {connect} from 'react-redux';
+import experiments from '@cdo/apps/util/experiments';
 import i18n from '@cdo/locale';
+import {hideShareDialog, showLibraryCreationDialog} from './shareDialogRedux';
 
 const INSTRUCTIONS_LINK =
   'https://codeorg.zendesk.com/knowledge/articles/360004789872';
@@ -93,7 +96,8 @@ const style = {
 const ShareOptions = {
   EXPORT: 'export',
   EXPORT_EXPO: 'exportExpo',
-  EMBED: 'embed'
+  EMBED: 'embed',
+  LIBRARY: 'library'
 };
 
 class AdvancedShareOptions extends React.Component {
@@ -101,6 +105,8 @@ class AdvancedShareOptions extends React.Component {
     shareUrl: PropTypes.string.isRequired,
     allowExportExpo: PropTypes.bool.isRequired,
     exportApp: PropTypes.func,
+    librariesEnabled: PropTypes.bool,
+    openLibraryCreationDialog: PropTypes.func.isRequired,
     onExpand: PropTypes.func.isRequired,
     expanded: PropTypes.bool.isRequired,
     i18n: PropTypes.object.isRequired,
@@ -362,6 +368,23 @@ class AdvancedShareOptions extends React.Component {
     );
   }
 
+  renderLibraryTab = () => {
+    return (
+      <div>
+        <p style={style.p}>
+          Share the functions in your project with a friend or classmate.
+        </p>
+        <button
+          type="button"
+          onClick={this.props.openLibraryCreationDialog}
+          style={{marginLeft: 0}}
+        >
+          {i18n.shareLibrary()}
+        </button>
+      </div>
+    );
+  };
+
   renderAdvancedListItem = (option, name) => {
     return (
       <li
@@ -377,14 +400,20 @@ class AdvancedShareOptions extends React.Component {
   };
 
   render() {
-    let {expanded, exportApp, allowExportExpo, onExpand} = this.props;
+    let {
+      expanded,
+      exportApp,
+      allowExportExpo,
+      onExpand,
+      librariesEnabled
+    } = this.props;
     let {selectedOption} = this.state;
     if (!selectedOption) {
       // no options are available. Render nothing.
       return null;
     }
-    let optionsNav;
-    let selectedTab;
+
+    let optionsNav, selectedTab, libraryTab;
     if (expanded) {
       let exportTab = null;
       let exportExpoTab = null;
@@ -404,12 +433,22 @@ class AdvancedShareOptions extends React.Component {
         ShareOptions.EMBED,
         this.props.i18n.t('project.embed')
       );
+      if (
+        experiments.isEnabled(experiments.STUDENT_LIBRARIES) ||
+        librariesEnabled
+      ) {
+        libraryTab = this.renderAdvancedListItem(
+          ShareOptions.LIBRARY,
+          i18n.shareLibrary()
+        );
+      }
       optionsNav = (
         <div>
           <ul style={style.nav.ul}>
             {exportExpoTab}
             {exportTab}
             {embedTab}
+            {libraryTab}
           </ul>
         </div>
       );
@@ -422,6 +461,9 @@ class AdvancedShareOptions extends React.Component {
           break;
         case ShareOptions.EMBED:
           selectedTab = this.renderEmbedTab();
+          break;
+        case ShareOptions.LIBRARY:
+          selectedTab = this.renderLibraryTab();
           break;
       }
     }
@@ -441,4 +483,14 @@ class AdvancedShareOptions extends React.Component {
   }
 }
 
-export default Radium(AdvancedShareOptions);
+export default connect(
+  state => ({
+    librariesEnabled: state.pageConstants.librariesEnabled
+  }),
+  dispatch => ({
+    openLibraryCreationDialog() {
+      dispatch(showLibraryCreationDialog());
+      dispatch(hideShareDialog());
+    }
+  })
+)(Radium(AdvancedShareOptions));

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -12,18 +12,13 @@ import color from '../../util/color';
 import * as applabConstants from '../../applab/constants';
 import * as p5labConstants from '@cdo/apps/p5lab/constants';
 import {SongTitlesToArtistTwitterHandle} from '../dancePartySongArtistTags';
-import {
-  hideShareDialog,
-  unpublishProject,
-  showLibraryCreationDialog
-} from './shareDialogRedux';
+import {hideShareDialog, unpublishProject} from './shareDialogRedux';
 import DownloadReplayVideoButton from './DownloadReplayVideoButton';
 import {showPublishDialog} from '../../templates/projects/publishDialog/publishDialogRedux';
 import PublishDialog from '../../templates/projects/publishDialog/PublishDialog';
 import {createHiddenPrintWindow} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import experiments from '@cdo/apps/util/experiments';
 import LibraryCreationDialog from './libraries/LibraryCreationDialog';
 import LibraryClientApi from './libraries/LibraryClientApi';
 
@@ -153,7 +148,6 @@ class ShareAllowedDialog extends React.Component {
     }).isRequired,
     allowExportExpo: PropTypes.bool.isRequired,
     exportApp: PropTypes.func,
-    librariesEnabled: PropTypes.bool,
     icon: PropTypes.string,
     shareUrl: PropTypes.string.isRequired,
     // Only applicable to Dance Party projects, used to Tweet at song artist.
@@ -171,7 +165,6 @@ class ShareAllowedDialog extends React.Component {
     onClose: PropTypes.func.isRequired,
     onShowPublishDialog: PropTypes.func.isRequired,
     onUnpublish: PropTypes.func.isRequired,
-    openLibraryCreationDialog: PropTypes.func.isRequired,
     hideBackdrop: BaseDialog.propTypes.hideBackdrop,
     canShareSocial: PropTypes.bool.isRequired,
     userSharingDisabled: PropTypes.bool
@@ -423,16 +416,6 @@ class ShareAllowedDialog extends React.Component {
                       className="no-mc"
                     />
                   )}
-                  {(experiments.isEnabled(experiments.STUDENT_LIBRARIES) ||
-                    this.props.librariesEnabled) && (
-                    <button
-                      type="button"
-                      onClick={this.props.openLibraryCreationDialog}
-                      style={styles.button}
-                    >
-                      {i18n.shareLibrary()}
-                    </button>
-                  )}
                   <DownloadReplayVideoButton
                     style={styles.button}
                     onError={this.replayVideoNotFound}
@@ -529,7 +512,6 @@ export default connect(
   state => ({
     allowExportExpo: state.pageConstants.allowExportExpo || false,
     exportApp: state.pageConstants.exportApp,
-    librariesEnabled: state.pageConstants.librariesEnabled,
     isOpen: state.shareDialog.isOpen,
     isUnpublishPending: state.shareDialog.isUnpublishPending
   }),
@@ -541,10 +523,6 @@ export default connect(
     },
     onUnpublish(projectId) {
       dispatch(unpublishProject(projectId));
-    },
-    openLibraryCreationDialog() {
-      dispatch(showLibraryCreationDialog());
-      dispatch(hideShareDialog());
     }
   })
 )(ShareAllowedDialog);


### PR DESCRIPTION
# Description
This moves the "Share as Library" button into the advanced share menu.

![advancedShareDialog2](https://user-images.githubusercontent.com/8324574/70279402-4680b100-176b-11ea-8844-22d3d726d33b.gif)

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-873)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
