### PR TITLE
Add HoC tagline Indonesian translation

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/id.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/id.yml
@@ -100,8 +100,7 @@ id:
   codeorg_homepage_hoc2018_musician_before: Featuring
   codeorg_homepage_hoc2018_musician_after: and more!
   codeorg_homepage_hoc2018_video: Watch our video
-  hourofcode_homepage_hoc2018_header_line1: Anyone, anywhere can organize an Hour
-    of Code event. One-hour tutorials in over 45 languages. No experience needed.
+  hourofcode_homepage_hoc2018_header_line1: Siapapun, dimanapun bisa menyelenggarakan acara Hour of Code. Tersedia tutorial-tutorial berdurasi satu jam dalam lebih dari 45 bahasa. Tidak perlu pengalaman.
   hourofcode_homepage_hoc2018_header_line2: Ages 4 to 104.
   hoc2018_tutorial_mchoc_description: Gunakan blok kode untuk mengajak Steve atau
     Alex dalam petualangan melintasi dunia Minecraft ini.


### PR DESCRIPTION
A high visibility string was left untranslated on the Indonesian Hour of Code homepage. This translation addresses that. Low risk of a regression because there are no special characters. Added translation in [Crowdin](https://crowdin.com/translate/hour-of-code/595/en-id#304628); built and tested successfully on dev.

Before:
![image](https://user-images.githubusercontent.com/2933346/70301039-19a1bd80-17ae-11ea-8471-d9ef55f64663.png)
After:
![image](https://user-images.githubusercontent.com/2933346/70301056-21f9f880-17ae-11ea-91be-5ccd2d81be58.png)
