### PR TITLE
Export fix for Android 10

### DIFF
--- a/apps/src/templates/export/expo/App.js.ejs
+++ b/apps/src/templates/export/expo/App.js.ejs
@@ -18,6 +18,7 @@ export default class App extends React.Component {
 <% if (!hasDataAPIs) { -%>
       age: DataWarning.AGE_MINIMUM,
 <% } -%>
+      needsEmptyRender: Platform.OS === 'android',
     };
   }
 
@@ -92,7 +93,7 @@ export default class App extends React.Component {
   }
 
   render() {
-    const { age, height, indexUri, loaded } = this.state;
+    const { age, height, indexUri, loaded, needsEmptyRender } = this.state;
 
     if (!age || age < DataWarning.AGE_MINIMUM) {
       return (
@@ -106,14 +107,22 @@ export default class App extends React.Component {
       );
     }
 
+    const showWebView = !!height && indexUri;
+
+    if (showWebView && needsEmptyRender) {
+      // Workaround for react-native-webview issue with Android 10
+      // See https://github.com/react-native-community/react-native-webview/issues/656#issuecomment-551312436
+      this.setState({needsEmptyRender: false});
+    }
+
     return (
       <View onLayout={this.onLayout} style={styles.container}>
-        {!!height && indexUri && <View style={this.webViewContainerStyle()}>
+        {showWebView && <View style={this.webViewContainerStyle()}>
           <WebView
             allowUniversalAccessFromFileURLs
             originWhitelist={['*']}
             allowFileAccess
-            source={{uri: indexUri}}
+            source={needsEmptyRender ? undefined : {uri: indexUri}}
             style={Platform.OS === 'ios' ? styles.webViewIOS : styles.webViewAndroid}
             javaScriptEnabled
             mediaPlaybackRequiresUserAction={false}

--- a/apps/src/templates/export/expo/package.exported_json
+++ b/apps/src/templates/export/expo/package.exported_json
@@ -11,6 +11,6 @@
     "expo": "^34.0.0",
     "expo-cli": "^3.1.1",
     "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-34.0.0.tar.gz"
   }
 }


### PR DESCRIPTION
# Description
* Our exported app template (itself a React Native app) has a bug because its `WebView` component doesn't load `file:` URL content properly on Android 10. Fortunately, there is a workaround, which I have applied to our app template
* Unrelated: our "export native app to ZIP" feature (which is internal only and not part of the App Export beta) had an issue where the Expo 34 SDK was still using the Expo 33 version of react-native (fixed)

## Links
[Explanation of the bug and workaround](https://github.com/react-native-community/react-native-webview/issues/656#issuecomment-551312436)

## Testing story
Verified with manual testing on Android simulator and Google Pixel 3 device

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
