### PR TITLE
Section Assignment: fix NaN bug on CourseScripts

### DIFF
--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -152,7 +152,7 @@ class CourseScript extends Component {
             {!isAssigned &&
               viewAs === ViewType.Teacher &&
               showAssignButton &&
-              selectedSectionId && (
+              selectedSection && (
                 <AssignButton
                   sectionId={selectedSection.id}
                   scriptId={id}


### PR DESCRIPTION
There was a little bug for teachers who didn't have sections viewing the course overview page. 

BEFORE: 
<img width="1004" alt="broken" src="https://user-images.githubusercontent.com/12300669/70345785-a6319780-1811-11ea-9cae-a80932c95012.png">

AFTER: 
<img width="999" alt="fixed" src="https://user-images.githubusercontent.com/12300669/70345787-a7fb5b00-1811-11ea-8fc0-8ecf7e1417a7.png">
