### PR TITLE
Video: link to fallback player for oceans videos

### DIFF
--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -28,6 +28,16 @@
         =t('continue')
   .video-link= link_to t('video.download'), video.download
 
+  - if @level.video_full_width
+    - if request.original_url.include?("/s/oceans")
+      - if !request.original_url.include?("force_youtube_fallback")
+        - uri = URI.parse(request.original_url)
+        - query = Rack::Utils.parse_query(uri.query)
+        - query["force_youtube_fallback"] = "1"
+        - uri.query = Rack::Utils.build_query(query)
+        &nbsp; | &nbsp;
+        %a{href: uri} Try alternate player
+
   - if @slides
     .slides-link
       |


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/32344, if we don't already have a `force_youtube_fallback` parameter in the URL, then show an extra link in the standalone video player which will add `force_youtube_fallback=1` to the URL parameters and reload the page.

![Screenshot 2019-12-06 15 36 04](https://user-images.githubusercontent.com/2205926/70363777-9bd9c280-183e-11ea-8294-583173bb3bd5.png)
