### PR TITLE
Video restriction audit script

### DIFF
--- a/bin/cron/detect_restricted_videos
+++ b/bin/cron/detect_restricted_videos
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+
+require_relative '../../lib/cdo/only_one'
+exit(1) unless only_one_running?(__FILE__)
+
+require 'csv'
+require 'httparty'
+require 'optparse'
+require_relative '../../deployment'
+
+def player_response(response_text)
+  # The response text is a querystring (&key=value&key=value)
+  # The value we care about is associated with the key 'player_response'
+  # It's a CGI-encoded JSON blob containing details about whether the video is loadable/playable
+  params = response_text.split('&').map {|line| line.split('=')}.select {|line| line.count == 2}.to_h
+  JSON.parse CGI.unescape params['player_response']
+end
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: #{File.basename(__FILE__)} [options]
+
+    This script checks YouTube videos listed in dashboard/config/videos.csv for content
+    restrictions that may affect schools.
+
+    Options:
+  BANNER
+
+  opts.on('--filter=FILTER', 'Only check videos with keys matching given regular expression') do |filter|
+    options[:filter] = filter
+  end
+
+  opts.on('-h', '--help', 'Print this') do
+    puts opts
+    exit
+  end
+end.parse!
+
+video_count = 0
+error_count = 0
+CSV.foreach(dashboard_dir('config/videos.csv'), headers: true) do |row|
+  video_key = row['Key']
+  youtube_code = row['YoutubeCode']
+  if options[:filter]
+    next unless Regexp.new(options[:filter]) =~ video_key
+  end
+  video_count += 1
+  ['Strict', 'Moderate'].each do |mode|
+    responseText = HTTParty.get("https://www.youtube-nocookie.com/get_video_info?video_id=#{youtube_code}", {
+      headers: {
+        "Content-Type" => "application/json",
+        "YouTube-Restrict" => mode
+      }
+    })
+    response = player_response(responseText)
+    if response['playabilityStatus']['status'] != 'OK'
+      error_count += 1
+      puts "#{video_key} (#{mode}): #{response['playabilityStatus']['reason']}"
+    end
+    sleep 0.1
+  end
+end
+puts "Checked #{video_count} videos, #{error_count} problems detected."

--- a/bin/cron/detect_restricted_videos
+++ b/bin/cron/detect_restricted_videos
@@ -8,12 +8,22 @@ require 'httparty'
 require 'optparse'
 require_relative '../../deployment'
 
-def player_response(response_text)
+def check_video_playability(youtube_code, restrict_mode)
+  response_text = HTTParty.get(
+    "https://www.youtube-nocookie.com/get_video_info?video_id=#{youtube_code}",
+    {
+      headers: {
+        "Content-Type" => "application/json",
+        "YouTube-Restrict" => restrict_mode
+      }
+    }
+  )
+
   # The response text is a querystring (&key=value&key=value)
   # The value we care about is associated with the key 'player_response'
   # It's a CGI-encoded JSON blob containing details about whether the video is loadable/playable
-  params = response_text.split('&').map {|line| line.split('=')}.select {|line| line.count == 2}.to_h
-  JSON.parse CGI.unescape params['player_response']
+  response = response_text.split('&').map {|line| line.split('=')}.select {|line| line.count == 2}.to_h
+  (JSON.parse CGI.unescape response['player_response'])['playabilityStatus']
 end
 
 options = {}
@@ -27,7 +37,7 @@ OptionParser.new do |opts|
     Options:
   BANNER
 
-  opts.on('--filter=FILTER', 'Only check videos with keys matching given regular expression') do |filter|
+  opts.on('--filter=REGEXP', 'Only check videos with keys matching given regular expression') do |filter|
     options[:filter] = filter
   end
 
@@ -42,23 +52,23 @@ error_count = 0
 CSV.foreach(dashboard_dir('config/videos.csv'), headers: true) do |row|
   video_key = row['Key']
   youtube_code = row['YoutubeCode']
+
+  # Skip checking this video if it doesn't match a provided filter
   if options[:filter]
     next unless Regexp.new(options[:filter]) =~ video_key
   end
-  video_count += 1
-  ['Strict', 'Moderate'].each do |mode|
-    responseText = HTTParty.get("https://www.youtube-nocookie.com/get_video_info?video_id=#{youtube_code}", {
-      headers: {
-        "Content-Type" => "application/json",
-        "YouTube-Restrict" => mode
-      }
-    })
-    response = player_response(responseText)
-    if response['playabilityStatus']['status'] != 'OK'
+
+  # Check both Strict and Moderate restricted mode for each video
+  %w(Strict Moderate).each do |restrict_mode|
+    playability = check_video_playability youtube_code, restrict_mode
+    if playability['status'] != 'OK'
       error_count += 1
-      puts "#{video_key} (#{mode}): #{response['playabilityStatus']['reason']}"
+      puts "#{video_key} (#{restrict_mode}): #{playability['reason']}"
     end
-    sleep 0.1
   end
+
+  video_count += 1
+  print "Checked #{video_count} videos...\r"
+  $stdout.flush
 end
 puts "Checked #{video_count} videos, #{error_count} problems detected."


### PR DESCRIPTION
A Ruby script (to be run manually, for now) that checks whether our curriculum videos are playable in [YouTube's Restricted Mode](https://support.google.com/youtube/answer/7354993?hl=en) (both "strict" and "moderate" variants), which is used by many schools, libraries, and other institutions that may use our curriculum.

```
Usage: detect_restricted_videos [options]

This script checks YouTube videos listed in dashboard/config/videos.csv for content
restrictions that may affect schools.

Options:
        --filter=REGEXP   Only check videos with keys matching given regular expression
    -h, --help            Print this

```

## Context

Restricted mode is a YouTube feature used by schools and other organizations. It prevents users from viewing videos based on a hidden content safety rating (not to be confused with the visible rating system used for monetized videos).  This rating gets applied to videos by an automated filtering system in most cases, and videos may be restricted after upload/edit until they get through the automated review queue.  Which videos are blocked depends on their hidden rating, the restriction level set by the district ("strict" or "moderate"), and how the video is being accessed.

Restricted mode can be applied in a few ways. There's a network-layer restriction (via a DNS rewrite for HTTP headers) and GSuite account overrides with optional approver accounts that can unblock particular videos for particular users or groups.  (See [documentation here](https://support.google.com/a/answer/6214622?visit_id=637112643884679767-972909816&rd=1) that you must have a GSuite administrator account to read in its entirety.)  Because our embedded videos are served from `youtube-nocookie.com` to protect student privacy, the GSuite account overrides (including unblocked videos) don't apply when students are viewing videos on our site, and instead students will be affected by whatever network-layer restriction is in place for `youtube-nocookie.com`.  This can be checked from within a network using the diagnostic page at [youtube.com/check_content_restrictions](https://www.youtube.com/check_content_restrictions).

Here is an example diagnostic result for a district that is depending on the account-specific behaviors for `youtube.com` but has applied the recommended "Strict" DNS rewrite to `youtube-nocookie.com`, thus blocking embedded videos on our site that did not receive a perfectly clean rating from YouTube's automated system.

<img width="817" alt="Screen Shot 2019-12-06 at 3 16 11 PM" src="https://user-images.githubusercontent.com/1615761/71848794-5569c480-3085-11ea-9d48-6c771fba7adb.png">

Our automated video fallback is not currently kicking in when a video fails to load due to restricted mode. There's a form to request that videos be unrestricted [on this support page](https://support.google.com/youtube/answer/7354993?hl=en).

## Testing story

Test with `bin/cron/detect_restricted_videos --filter="ocean|dance|mc"`

For now I'd like to merge this as a utility script to be run manually, for our records.  Eventually it'd be nice to convert this to a cronjob (like our broken link checker) that actively checks for issues with our videos.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
