### PR TITLE
update proxysql timeouts

### DIFF
--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -43,6 +43,33 @@ mysql_variables=
   # We can disable (set to 0) since our application doesn't use `LAST_INSERT_ID()` in any queries.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-auto_increment_delay_multiplex
   auto_increment_delay_multiplex=0
+
+  # The timeout for a single attempt at checking the Read Only status on a backend server from the proxy.
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-monitor_read_only_timeout
+  # [Milliseconds, default 800]
+  monitor_read_only_timeout=2000
+
+  # When the monitor thread performs a read_only check, AND the check exceeds mysql-monitor_read_only_timeout,
+  # repeat the read_only check up to this many times before setting OFFLINE HARD.
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-monitor_read_only_max_timeout_count
+  # [Default 3]
+  monitor_read_only_max_timeout_count=5
+
+  # The timeout for a single attempt at connecting to a backend server from the proxy.
+  # If this fails, according to the other parameters, the attempt will be retried until too many errors
+  # per second are generated (and the server is automatically shunned) or until the final cut-off is reached
+  # and an error is returned to the client (see mysql-connect_timeout_server_max).
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-connect_timeout_server
+  # [Milliseconds, default 1000]
+  connect_timeout_server=2000
+
+  # The proxy internally pings the connections it has opened in order to keep them alive.
+  # This eliminates the cost of opening a new connection towards a hostgroup when a query needs to be routed,
+  # at the cost of additional memory footprint inside the proxy and some extra traffic.
+  # This is the timeout allowed for those pings to succeed.
+  # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-ping_timeout_server
+  # [Milliseconds, default 200]
+  ping_timeout_server=1000
 }
 
 # https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers


### PR DESCRIPTION
This PR would relax some timeouts in ProxySQL to be more forgiving of short/temporary network blips in AWS infrastructure.