### PR TITLE
Add translations for a few prominent strings that landed after the Dec. 2 cutoff

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/de.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/de.yml
@@ -106,7 +106,7 @@ de:
   hourofcode_homepage_hoc2018_header_line2: Altersgruppe 4 bis 104.
   hoc2018_tutorial_mchoc_description: Verwende Code-Blöcke, um Steve oder Alex in
     ein Abenteuer durch die Minecraft-Welt zu schicken.
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: Probieren Sie die neue <span class="highlight-word">Dance&nbsp;Party!</span>
   cookie_banner_message: Indem Sie unsere Website weiter benutzen oder auf "Ich stimme
     zu" klicken, stimmen Sie der Speicherung von Cookies auf Ihrem Computer oder Gerät
     zu.

--- a/pegasus/sites.v3/hourofcode.com/i18n/el.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/el.yml
@@ -108,7 +108,7 @@ el:
   hourofcode_homepage_hoc2018_header_line2: Ηλικίες από 4 έως 104.
   hoc2018_tutorial_mchoc_description: Χρησιμοποιήστε μπλοκ κώδικα για να οδηγήσετε
     την Alex ή τον Steve σε μία περιπέτεια μέσα από αυτόν τον κόσμο του Minecraft
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: Δοκιμάστε το νέο <span class="highlight-word">Dance&nbsp;Party!</span>
   cookie_banner_message: Συνεχίζοντας την περιήγηση στην ιστοσελίδα μας ή κάνοντας
     κλικ στο "Συμφωνώ", συμφωνείτε με την αποθήκευση cookies στον υπολογιστή ή τη
     συσκευή σας.

--- a/pegasus/sites.v3/hourofcode.com/i18n/es.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/es.yml
@@ -106,7 +106,7 @@ es:
   hourofcode_homepage_hoc2018_header_line2: Edades entre 4 y 104.
   hoc2018_tutorial_mchoc_description: Utiliza bloques de código para hacer que Alex
     o Steve participen en una aventura por el mundo de Minecraft.
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: Prueba la nueva <span class="highlight-word">Fiesta&nbsp;de&nbsp;Baile!</span>
   cookie_banner_message: Si continúas navegando en nuestro sitio web o haces clic
     en "Acepto", aceptas que se almacenen cookies en tu ordenador o dispositivo.
   cookie_banner_more_information: Vea Políticas de Privacidad de Code.org.

--- a/pegasus/sites.v3/hourofcode.com/i18n/es.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/es.yml
@@ -511,7 +511,7 @@ es:
   hoc_faq_devices_q: "¿Qué dispositivos debo usar para mis estudiantes?"
   hoc_faq_devices_a: Los tutoriales de Code.org funcionan en todos los dispositivos
     y navegadores. Puedes ver más información sobre las necesidades tecnológicas del
-    tutorial de Code.org en < a href = '%{codeorg_url}/educate/it'>. Las necesidades
+    tutorial de Code.org en <a href = '%{codeorg_url}/educate/it'>. Las necesidades
     tecnológicas de los tutoriales que no son de Code.org pueden encontrarse en <a
     href =''%{codeorg_url}/learn'> en la descripción específica del tutorial. ¡No
     olvides que también ofrecemos actividades sin conexión si tu escuela no puede

--- a/pegasus/sites.v3/hourofcode.com/i18n/fr.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/fr.yml
@@ -107,7 +107,7 @@ fr:
   hourofcode_homepage_hoc2018_header_line2: 'Âge : de 4 à 104 ans.'
   hoc2018_tutorial_mchoc_description: Utilise des blocs de code pour accompagner Alex
     ou Steve dans leur aventures au sein de cet univers Minecraft.
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: Essayez la nouvelle <span class="highlight-word">Dance&nbsp;Party&nbsp;!</span>
   cookie_banner_message: En poursuivant votre navigation sur ce site ou en cliquant
     sur « J’accepte », vous acceptez le stockage de cookies sur votre ordinateur ou
     appareil mobile.

--- a/pegasus/sites.v3/hourofcode.com/i18n/hi.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/hi.yml
@@ -105,7 +105,7 @@ hi:
   hourofcode_homepage_hoc2018_header_line2: 4 से 104 उम्र।
   hoc2018_tutorial_mchoc_description: एक नई गतिविधि के साथ Minecraft ऑवर ऑफ़ कोड के
     लिए वापस आ गया है! कोड के साथ Minecraft के माध्यम से यात्रा करें।
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: नई <span class="highlight-word">Dance&nbsp;Party!</span>
   cookie_banner_message: हमारी साइट को लगातार ब्राउज करके या "मैं सहमत हूं” पर क्लिक
     करके, आप अपने कंप्यूटर या डिवाइस पर कुकीज स्टोर करने के लिए सहमति देते हैं।
   cookie_banner_more_information: Code.org की गोपनीयता नीति देखें।

--- a/pegasus/sites.v3/hourofcode.com/i18n/hu.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/hu.yml
@@ -105,7 +105,7 @@ hu:
   hourofcode_homepage_hoc2018_header_line2: "-től 104 éves korig."
   hoc2018_tutorial_mchoc_description: Minecraft is back for the Hour of Code with
     a brand new activity! Journey through Minecraft with code.
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: Próbáld ki az új <span class="highlight-word">Dance&nbsp;Party!</span>
   cookie_banner_message: Az oldal további használatával, valamint az egyetértek gombra
     kattintással elfogadod a Cookie-k számítógépen történő tárolását.
   cookie_banner_more_information: Itt találod a Code.org adatvédelmi elveit.

--- a/pegasus/sites.v3/hourofcode.com/i18n/it.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/it.yml
@@ -106,7 +106,7 @@ it:
   hourofcode_homepage_hoc2018_header_line2: Da 4 a 104 anni.
   hoc2018_tutorial_mchoc_description: Utilizza blocchi di codice per portare Alex
     o Steve in un'avventura nel mondo di Minecraft.
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: Prova il nuovo <span class="highlight-word">Dance&nbsp;Party!</span>
   cookie_banner_message: Cliccando "Accetto." accetti la memorizzazione dei cookie
     sul tuo computer o dispositivo.
   cookie_banner_more_information: Vedi la Privacy Policy di Code.org.

--- a/pegasus/sites.v3/hourofcode.com/i18n/ja.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/ja.yml
@@ -102,7 +102,7 @@ ja:
   hourofcode_homepage_hoc2018_header_line1: 世界中の誰でもHour of Codeのイベントを開催できます。45以上の言語の1時間のチュートリアルが用意されています。経験は必要ありません。
   hourofcode_homepage_hoc2018_header_line2: 4歳から104歳まで。
   hoc2018_tutorial_mchoc_description: コードブロックで、アレックスやスティーブをマインクラフト世界の冒険に連れ出しましょう。
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: 新しい <span class="highlight-word">Dance&nbsp;Party</span> をお試しください
   cookie_banner_message: このサイトの閲覧を継続するか「同意する」をクリックすることで、クッキーがあなたのコンピューターやデバイスに保存されることに同意することになります。
   cookie_banner_more_information: Code.orgのプライバシーポリシーを参照する。
   cookie_banner_accept: 同意する

--- a/pegasus/sites.v3/hourofcode.com/i18n/ko.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/ko.yml
@@ -103,7 +103,8 @@ ko:
     분량의 튜토리얼이 45개 이상의 언어로 제공됩니다. 사전 학습이 필요하지 않습니다.
   hourofcode_homepage_hoc2018_header_line2: 4세부터 104세까지 사용할 수 있습니다.
   hoc2018_tutorial_mchoc_description: 코드 블록을 사용해 알렉스나 스티브가 마인크래프트 세계에서 모험을 펼치게 하세요.
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: 새 <span class="highlight-word">Dance&nbsp;Party</span>를
+    해보세요!
   cookie_banner_message: By continuing to browse our site or clicking "I agree," you
     agree to the storing of cookies on your computer or device.
   cookie_banner_more_information: See Code.org's Privacy Policy.

--- a/pegasus/sites.v3/hourofcode.com/i18n/ph.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/ph.yml
@@ -104,7 +104,7 @@ ph:
   hourofcode_homepage_hoc2018_header_line2: Ages 4 to 104.
   hoc2018_tutorial_mchoc_description: Ang Minecraft ay nagbabalik para sa Hour of
     Code kasama ng bagong aktibidad! Paglalakbay patungo sa Minecraft sa Code.
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: Subukan ang bagong <span class="highlight-word">Dance&nbsp;Party!</span>
   cookie_banner_message: By continuing to browse our site or clicking "I agree," you
     agree to the storing of cookies on your computer or device.
   cookie_banner_more_information: See Code.org's Privacy Policy.

--- a/pegasus/sites.v3/hourofcode.com/i18n/sv.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/sv.yml
@@ -106,7 +106,7 @@ sv:
   hourofcode_homepage_hoc2018_header_line2: Åldrarna 4 till 104.
   hoc2018_tutorial_mchoc_description: Använd kodblock för att ta Alex eller Steve
     på ett äventyr genom denna Minecraftvärld.
-  codeorg_homepage_hoc2019_dance_heading: Try the new <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading: Prova nya <span class="highlight-word">Dance&nbsp;Party!</span>
   cookie_banner_message: Genom att fortsätta på vår webbplats eller klicka "Jag godkänner"
     så godkänner du att vi lagrar cookies på din dator eller enhet.
   cookie_banner_more_information: Läs Code.org:s sekretesspolicy.


### PR DESCRIPTION
Early on we set a final translation push for Dec. 2nd.

![image](https://user-images.githubusercontent.com/413693/70396941-580fc600-19c2-11ea-9350-be7f70024be5.png)

Last week, we took PR https://github.com/code-dot-org/code-dot-org/pull/32209 "I18n sync Down & Out 12/02".

![image](https://user-images.githubusercontent.com/413693/70396910-0f580d00-19c2-11ea-881c-eba8de1e6a5f.png)

Unfortunately the actual sync process was kicked off around 4:30pm on Dec. 1st, and missed a few last-minute strings. This was compounded by the delay from Translate By Humans. Final strings continued to come in throughout the week.

The [Dec. 5th down & out PR](https://github.com/code-dot-org/code-dot-org/pull/32297/commits/2cfd77cd63f5d014cff6bce7bbc84aa6fb91bda5) would've included these string changes, but I recommended against taking it ([Slack thread](https://codedotorg.slack.com/archives/C0T0UQH0R/p1575506745169100)), mistakenly thinking we already had strings from Dec. 2nd.

---

This PR adds 10 translations for "Try the new Dance Party!" text on the homepage, and fixes a small syntax error in the `es-es` locale for hourofcode.com.