### PR TITLE
Show teacher announcement for non-English too

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -182,7 +182,7 @@ export default class TeacherHomepage extends Component {
         <HeaderBanner headingText={i18n.homepageHeading()} short={true} />
         <ProtectedStatefulDiv ref="flashes" />
         <ProtectedStatefulDiv ref="teacherReminders" />
-        {isEnglish && showSpecialAnnouncement && (
+        {showSpecialAnnouncement && (
           <SpecialAnnouncementActionBlock hocLaunch={hocLaunch} />
         )}
         {announcement && showAnnouncement && (

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -19,13 +19,13 @@ const styles = {
   textItem: {
     backgroundColor: color.teal,
     padding: 25,
-    minHeight: 260,
+    minHeight: 281,
     boxSizing: 'border-box'
   },
   textItemCyan: {
     backgroundColor: color.light_cyan,
     padding: 25,
-    minHeight: 260,
+    minHeight: 281,
     boxSizing: 'border-box'
   },
   subHeading: {
@@ -46,7 +46,8 @@ const styles = {
   },
   image: {
     width: 485,
-    minHeight: 260
+    minHeight: 260,
+    height: 281
   },
   description: {
     paddingRight: 10,
@@ -222,7 +223,7 @@ export class SpecialAnnouncementActionBlock extends Component {
       <TwoColumnActionBlock
         id="danceparty-2019-announcement"
         imageUrl={pegasus(
-          '/shared/images/fill-540x289/teacher-announcement/hoc2019-danceparty.jpg'
+          '/shared/images/fill-540x300/teacher-announcement/hoc2019-danceparty.jpg'
         )}
         subHeading={i18n.specialAnnouncementHeadingHoc2019DanceParty()}
         description={i18n.specialAnnouncementDescriptionHoc2019DanceParty()}


### PR DESCRIPTION
Previously we weren't showing the teacher homepage announcement for users viewing the site in  languages other than English; now we are. Additionally, now that we're showing the announcement in languages other than English, which might have translated strings longer than English (such as is the case for Spanish), I increased the height of the component to accommodate long translations. 

English before: 
<img width="1018" alt="Screen Shot 2019-12-08 at 5 34 50 PM" src="https://user-images.githubusercontent.com/12300669/70400828-af715e80-19e1-11ea-9b61-09f01be1612b.png">

English after: 
<img width="1007" alt="Screen Shot 2019-12-08 at 5 29 17 PM" src="https://user-images.githubusercontent.com/12300669/70400849-c31cc500-19e1-11ea-992e-9e4cd8c2549f.png">

Spanish before: 
<img width="1009" alt="Screen Shot 2019-12-08 at 5 17 02 PM" src="https://user-images.githubusercontent.com/12300669/70400670-e98e3080-19e0-11ea-90a5-05cedf60db30.png">

Spanish after: 
<img width="992" alt="Screen Shot 2019-12-08 at 5 29 41 PM" src="https://user-images.githubusercontent.com/12300669/70400836-b8fac680-19e1-11ea-9d30-065d2efd1b08.png">


