### PR TITLE
Hide facilitator summary tables in Application Dashboard

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/application_dashboard.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/application_dashboard.jsx
@@ -44,21 +44,6 @@ const ApplicationDashboardHeader = props => (
 );
 
 const paths = {
-  csf_facilitators: {
-    type: 'facilitator',
-    name: 'CS Fundamentals Facilitator Applications',
-    course: 'csf'
-  },
-  csd_facilitators: {
-    type: 'facilitator',
-    name: 'CS Discoveries Facilitator Applications',
-    course: 'csd'
-  },
-  csp_facilitators: {
-    type: 'facilitator',
-    name: 'CS Principles Facilitator Applications',
-    course: 'csp'
-  },
   csd_teachers: {
     type: 'teacher',
     name: 'CS Discoveries Teacher Applications',

--- a/apps/src/code-studio/pd/application_dashboard/summary.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary.jsx
@@ -85,35 +85,6 @@ export class Summary extends React.Component {
         {this.props.showRegionalPartnerDropdown && <RegionalPartnerDropdown />}
         <h1>{this.props.regionalPartnerFilter.label}</h1>
         <Row>
-          <Col sm={4}>
-            <SummaryTable
-              id="summary-csf-facilitators"
-              caption="CS Fundamentals Facilitators"
-              data={this.state.applications['csf_facilitators']}
-              path="csf_facilitators"
-              applicationType="facilitator"
-            />
-          </Col>
-          <Col sm={4}>
-            <SummaryTable
-              id="summary-csd-facilitators"
-              caption="CS Discoveries Facilitators"
-              data={this.state.applications['csd_facilitators']}
-              path="csd_facilitators"
-              applicationType="facilitator"
-            />
-          </Col>
-          <Col sm={4}>
-            <SummaryTable
-              id="summary-csp-facilitators"
-              caption="CS Principles Facilitators"
-              data={this.state.applications['csp_facilitators']}
-              path="csp_facilitators"
-              applicationType="facilitator"
-            />
-          </Col>
-        </Row>
-        <Row>
           <Col sm={6}>
             <SummaryTable
               id="summary-csd-teachers"

--- a/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
@@ -26,34 +26,13 @@ describe('Summary', () => {
     expect(summary.find('Spinner')).to.have.length(1);
   });
 
-  it('Generates 5 tables in 2 rows after hearing from server', () => {
+  it('Generates 2 tables in 1 rows after hearing from server', () => {
     let server = sinon.fakeServer.create();
 
     server.respondWith('GET', '/api/v1/pd/applications', [
       200,
       {'Content-Type': 'application/json'},
       JSON.stringify({
-        csf_facilitators: {
-          unreviewed: {locked: 0, total: 1},
-          pending: {locked: 0, total: 0},
-          accepted: {locked: 0, total: 0},
-          declined: {locked: 0, total: 0},
-          waitlisted: {locked: 0, total: 0}
-        },
-        csd_facilitators: {
-          unreviewed: {locked: 0, total: 0},
-          pending: {locked: 0, total: 0},
-          accepted: {locked: 0, total: 0},
-          declined: {locked: 0, total: 0},
-          waitlisted: {locked: 0, total: 0}
-        },
-        csp_facilitators: {
-          unreviewed: {locked: 0, total: 0},
-          pending: {locked: 0, total: 0},
-          accepted: {locked: 0, total: 0},
-          declined: {locked: 0, total: 0},
-          waitlisted: {locked: 0, total: 0}
-        },
         csd_teachers: {
           unreviewed: {locked: 0, total: 1},
           pending: {locked: 0, total: 0},
@@ -84,9 +63,8 @@ describe('Summary', () => {
     server.respond();
     summary.update();
     const rows = summary.find(Row);
-    expect(rows).to.have.length(2);
-    expect(rows.at(0).children()).to.have.length(3);
-    expect(rows.at(1).children()).to.have.length(2);
+    expect(rows).to.have.length(1);
+    expect(rows.at(0).children()).to.have.length(2);
 
     expect(summary.find('Spinner')).to.have.length(0);
   });


### PR DESCRIPTION
# Description
Hiding facilitator summary tables in the Application Dashboard since we are not accepting or reviewing facilitator applications this year.

Before
<img width="939" alt="Screen Shot 2019-12-10 at 3 02 23 PM" src="https://user-images.githubusercontent.com/46507039/70576561-187de100-1b5e-11ea-974d-8f7ccb3389f1.png">

After
<img width="741" alt="Screen Shot 2019-12-10 at 2 50 57 PM" src="https://user-images.githubusercontent.com/46507039/70576567-1fa4ef00-1b5e-11ea-83bf-558fc34e4896.png">


### Future work
- [ ] Update `Api::V1::Pd::ApplicationsController#index` action (which serves request to `/api/v1/pd/applications?regional_partner_value=:regional_partner_value` endpoint) to stop returning facilitator applications. One option is to add `no_facilitator_app` parameter to the query. Tracked by [PLC-671](https://codedotorg.atlassian.net/browse/PLC-671)

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-582)

## Testing story
- Unit tests
  - yarn test:entry --entry=test/unit/code-studio/pd/application_dashboard/application_dashboardTest.js
  - yarn test:entry --entry=test/unit/code-studio/pd/application_dashboard/summaryTest.js
- Manual local tests on http://localhost-studio.code.org:3000/pd/application_dashboard/summary

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
