### PR TITLE
CSF Standards: ProgressBox conditionally shows lesson number

### DIFF
--- a/apps/src/templates/sectionProgress/ProgressBox.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.jsx
@@ -11,7 +11,13 @@ const styles = {
     boxSizing: 'content-box'
   },
   filler: {
-    width: 20
+    width: 20,
+    position: 'absolute'
+  },
+  lessonNumber: {
+    position: 'absolute',
+    zIndex: 2,
+    padding: 2
   }
 };
 
@@ -22,7 +28,9 @@ export default class ProgressBox extends Component {
     imperfect: PropTypes.number,
     perfect: PropTypes.number,
     style: PropTypes.object,
-    stageIsAllAssessment: PropTypes.bool
+    stageIsAllAssessment: PropTypes.bool,
+    showLessonNumber: PropTypes.bool,
+    lessonNumber: PropTypes.number
   };
 
   render() {
@@ -70,6 +78,9 @@ export default class ProgressBox extends Component {
 
     return (
       <div style={boxWithBorderStyle}>
+        {this.props.showLessonNumber && (
+          <div style={styles.lessonNumber}>{this.props.lessonNumber}</div>
+        )}
         <div style={incompleteLevels} />
         <div style={imperfectLevels} />
         <div

--- a/apps/src/templates/sectionProgress/ProgressBox.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.jsx
@@ -17,7 +17,9 @@ const styles = {
   lessonNumber: {
     position: 'absolute',
     zIndex: 2,
-    padding: 2
+    paddingTop: 2,
+    textAlign: 'center',
+    width: 20
   }
 };
 

--- a/apps/src/templates/sectionProgress/ProgressBox.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.jsx
@@ -76,10 +76,14 @@ export default class ProgressBox extends Component {
       height: imperfect
     };
 
+    const lessonNumberStyle = {
+      ...styles.lessonNumber,
+      color: perfect ? color.white : color.charcoal
+    };
     return (
       <div style={boxWithBorderStyle}>
         {this.props.showLessonNumber && (
-          <div style={styles.lessonNumber}>{this.props.lessonNumber}</div>
+          <div style={lessonNumberStyle}>{this.props.lessonNumber}</div>
         )}
         <div style={incompleteLevels} />
         <div style={imperfectLevels} />

--- a/apps/src/templates/sectionProgress/ProgressBox.story.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.story.jsx
@@ -49,6 +49,20 @@ export default storybook => {
       story: () => (
         <ProgressBox started={true} incomplete={0} imperfect={0} perfect={20} />
       )
+    },
+    {
+      name: 'Lesson number',
+      description: `include lesson number`,
+      story: () => (
+        <ProgressBox
+          started={true}
+          incomplete={0}
+          imperfect={0}
+          perfect={20}
+          showLessonNumber={true}
+          lessonNumber={88}
+        />
+      )
     }
   ]);
 };

--- a/apps/src/templates/sectionProgress/ProgressBox.story.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.story.jsx
@@ -51,14 +51,28 @@ export default storybook => {
       )
     },
     {
-      name: 'Lesson number',
-      description: `include lesson number`,
+      name: 'Lesson number, complete',
+      description: `include lesson number with green background`,
       story: () => (
         <ProgressBox
           started={true}
           incomplete={0}
           imperfect={0}
           perfect={20}
+          showLessonNumber={true}
+          lessonNumber={88}
+        />
+      )
+    },
+    {
+      name: 'Lesson number, incomplete',
+      description: `include lesson number with white background`,
+      story: () => (
+        <ProgressBox
+          started={false}
+          incomplete={0}
+          imperfect={0}
+          perfect={0}
           showLessonNumber={true}
           lessonNumber={88}
         />

--- a/apps/src/templates/sectionProgress/ProgressBox.story.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.story.jsx
@@ -74,7 +74,7 @@ export default storybook => {
           imperfect={0}
           perfect={0}
           showLessonNumber={true}
-          lessonNumber={88}
+          lessonNumber={1}
         />
       )
     }


### PR DESCRIPTION
[LP-961](https://codedotorg.atlassian.net/browse/LP-961)
[spec](https://docs.google.com/document/d/1xlm_syljGXIapl72GaKxN63V7kt6syHyvWHuqZhTCfE/edit#)

In preparation for CSF standards work, I extended `ProgressBox` to conditionally show a lesson number. 

<img width="546" alt="Screen Shot 2019-12-10 at 3 18 44 PM" src="https://user-images.githubusercontent.com/12300669/70577626-87f4d000-1b60-11ea-9673-21424f3b68ea.png">
