### PR TITLE
Adding '\' sanitization for certificates

### DIFF
--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -95,10 +95,20 @@ end
 # Prepare the given string for using in Image Magick.
 def escape_image_magick_string(string)
   string = string.force_8859_to_utf8
-  # Escape special Image Magick symbols @, %, and \n
-  string = string.gsub(/^@/, '\@')
-  string = string.gsub(/%/, '\%')
-  string = string.gsub(/\\n/, '\\\\\n')
+  # Escape special Image Magick symbols \, @, %, and \n
+  # Note we are using the gsub block replacement in order to avoid having to do
+  # extra '\' escaping. Otherwise we would have to write '\\\\\\' to insert two
+  # backslashes into the string. Using the block replacement results in normal
+  # string behavior: '\\\\' results in a string with two backslashes. See the
+  # String.gsub docs for more details.  This is for the sake of readable code.
+  # literal \ replaced with literal \\
+  string = string.gsub(/\\/) {'\\\\'}
+  # @ at the front of the string replaced with literal \@
+  string = string.gsub(/^@/) {'\\@'}
+  # % replaced with literal \%
+  string = string.gsub(/%/) {'\\%'}
+  # new-line character replaced with literal \\n
+  string = string.gsub(/\n/) {'\\\\n'}
   string.strip
 end
 

--- a/pegasus/test/test_certificate_image.rb
+++ b/pegasus/test/test_certificate_image.rb
@@ -75,6 +75,23 @@ class CertificateImageTest < Minitest::Test
     assert_image twenty_hour_certificate_image, 1754, 1240, 'JPEG'
   end
 
+  def test_escape_image_magick_string
+    # Imagemagick will interperate a '@' at the beginning of a string to be a
+    # filepath
+    assert_equal '\\@hello', escape_image_magick_string('@hello')
+    # '@' in the middle of a string is fine.
+    assert_equal 'hello@world.com', escape_image_magick_string('hello@world.com')
+    # '%' is a special imagemagick symbol for inserting image metadata such as
+    # width.
+    assert_equal 'width=\\%x', escape_image_magick_string('width=%x')
+    # Strings shouldn't allow new-line characters.
+    assert_equal '\\\\n', escape_image_magick_string("\n")
+    # Imagemagick will interperate '\\n' as a new-line.
+    assert_equal '\\\\n', escape_image_magick_string('\\n')
+    # Nothing should be escaped with a '\' so just print any '\'s.
+    assert_equal '\\\\', escape_image_magick_string('\\')
+  end
+
   private
 
   def assert_image(image, width, height, format)


### PR DESCRIPTION
# Description 
We received some error reports that certificates were failing to be
generated when a student used a name with just a backslash character.
This change adds better handling of backslashes and also refactors the
input sanitization to be more readable and includes unit tests.
* Added substitution of `\` for `\\`
* Refactored string substitutions to use the block syntax in order to skip the backslash parsing done by `gsub` in order to improve readability. [More deets](https://code-examples.net/en/q/178846)
* Added unit tests

## Links
- [Honeybadger](https://app.honeybadger.io/projects/34365/faults/57678018)

## Testing story
* Unit tests
* Manually generated certificates
  * Visit http://localhost.code.org:3000/certificates
  * Use the following input and verify the certificates look good.
```
day\ne
@/bin/sh
dayne@code.org
\
dayne%xcode
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
