### PR TITLE
CSF Standards: Add standards to progress tab toggle

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1361,6 +1361,7 @@
   "stageNotFullyLocked": "Stage is not locked for all.",
   "standaloneToolsDescription": "In addition to our courses, teachers can use App Lab and Game Lab in any course to teach students how to create apps, animations, and games in JavaScript. And, we have lessons and widgets to teach encryption, text compression, and other computer science concepts.",
   "standaloneToolsHeading": "Tools for Middle and High School",
+  "standards": "Standards",
   "standardMappings": "Standard Mappings",
   "standardsAndFramework": "Curriculum Standards",
   "standardsAndFrameworkDescription": "Information about curriculum standards alignment for Code.org courses.",

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -31,6 +31,7 @@ import {
 import {stageIsAllAssessment} from '@cdo/apps/templates/progress/progressHelpers';
 import color from '../../util/color';
 import firehoseClient from '../../lib/util/firehose';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   heading: {
@@ -57,6 +58,12 @@ const styles = {
   },
   scriptLink: {
     color: color.teal
+  },
+  show: {
+    display: 'block'
+  },
+  hide: {
+    display: 'none'
   }
 };
 
@@ -164,6 +171,12 @@ class SectionProgress extends Component {
     const levelDataInitialized = scriptData && !isLoadingProgress;
     const linkToOverview = this.getLinkToOverview();
     const lessons = scriptData ? scriptData.stages : [];
+    const summaryStyle =
+      currentView === ViewType.SUMMARY ? styles.show : styles.hide;
+    const detailStyle =
+      currentView === ViewType.DETAIL ? styles.show : styles.hide;
+    const standardsStyle =
+      currentView === ViewType.STANDARDS ? styles.show : styles.hide;
 
     return (
       <div>
@@ -195,8 +208,8 @@ class SectionProgress extends Component {
               className="fa-pulse fa-3x"
             />
           )}
-          {levelDataInitialized && currentView === ViewType.SUMMARY && (
-            <div id="uitest-summary-view">
+          {levelDataInitialized && (
+            <div id="uitest-summary-view" style={summaryStyle}>
               <div
                 style={{...h3Style, ...styles.heading, ...styles.tableHeader}}
               >
@@ -219,8 +232,8 @@ class SectionProgress extends Component {
               />
             </div>
           )}
-          {levelDataInitialized && currentView === ViewType.DETAIL && (
-            <div id="uitest-detail-view">
+          {levelDataInitialized && (
+            <div id="uitest-detail-view" style={detailStyle}>
               <div
                 style={{...h3Style, ...styles.heading, ...styles.tableHeader}}
               >
@@ -246,6 +259,9 @@ class SectionProgress extends Component {
           )}
         </div>
         {levelDataInitialized && this.renderTooltips()}
+        {experiments.isEnabled(experiments.STANDARDS_REPORT) && (
+          <div style={standardsStyle}>Coming soon...</div>
+        )}
       </div>
     );
   }

--- a/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
@@ -57,19 +57,7 @@ class SectionProgressToggle extends React.Component {
       },
       {includeUserId: true}
     );
-    // Display the toggle based on the internal state so that it is
-    // more immediately responsive. Once setting internal state is
-    // complete, then update the redux currentView.
-    // Timeouts forces a render of the local state before dispatching
-    // the action.
-    this.setState(
-      {selectedToggle: selectedToggle, initialView: selectedToggle},
-      () => {
-        setTimeout(() => {
-          this.props.setCurrentView(selectedToggle);
-        }, 0);
-      }
-    );
+    this.props.setCurrentView(selectedToggle);
   };
 
   render() {

--- a/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
@@ -28,7 +28,6 @@ class SectionProgressToggle extends React.Component {
   };
 
   state = {
-    initialView: ViewType.SUMMARY,
     selectedToggle: this.props.currentView
   };
 
@@ -37,8 +36,7 @@ class SectionProgressToggle extends React.Component {
     // still need to update when that happens.
     if (this.state.selectedToggle !== nextProps.currentView) {
       this.setState({
-        selectedToggle: nextProps.currentView,
-        initialView: nextProps.currentView
+        selectedToggle: nextProps.currentView
       });
     }
   }
@@ -51,7 +49,7 @@ class SectionProgressToggle extends React.Component {
         event: 'view_change_toggle',
         data_json: JSON.stringify({
           section_id: this.props.sectionId,
-          old_view: this.state.initialView,
+          old_view: this.state.selectedToggle,
           new_view: selectedToggle
         })
       },

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -116,8 +116,9 @@ const NUM_STUDENTS_PER_PAGE = 50;
 
 // Types of views of the progress tab
 export const ViewType = {
-  SUMMARY: 'summary',
-  DETAIL: 'detail'
+  SUMMARY: 'summary', // lessons
+  DETAIL: 'detail', // levels
+  STANDARDS: 'standards'
 };
 
 /**

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -23,6 +23,7 @@ experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
   'schoolAutocompleteDropdownNewSearch';
 experiments.APPLAB_DATASETS = 'applabDatasets';
 experiments.STUDENT_LIBRARIES = 'student-libraries';
+experiments.STANDARDS_REPORT = 'standardsReport';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.


### PR DESCRIPTION
[Spec Part 1,  item 1](https://docs.google.com/document/d/1xlm_syljGXIapl72GaKxN63V7kt6syHyvWHuqZhTCfE/edit#heading=h.acp7v76y1uo0)
[LP-956](https://codedotorg.atlassian.net/browse/LP-956)

Behind the new `standardsReport` experiment flag, I added a "Standards" option to the toggle on the progress tab. 
![standards-tab](https://user-images.githubusercontent.com/12300669/70581810-546c7280-1b6d-11ea-9274-f66d4fb49f99.gif)

This change also includes an additional piece of state, `initialView` which is used to log which toggle buttons are being pressed in which order: 
<img width="665" alt="Screen Shot 2019-12-10 at 4 45 15 PM" src="https://user-images.githubusercontent.com/12300669/70581890-8f6ea600-1b6d-11ea-906f-d1dd2748d1e6.png">

