### PR TITLE
Use Rails URL building logic to construct i18n URLs

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -108,14 +108,9 @@ class I18nScriptUtils
   end
 
   def self.get_level_url_key(script, level)
-    script_name = script.name
     script_level = level.script_levels.find_by_script_id(script.id)
-    if script_level.bonus
-      escaped_level_name = CGI.escape(level.name)
-      "https://studio.code.org/s/#{script_name}/stage/#{script_level.stage.relative_position}/extras?level_name=#{escaped_level_name}"
-    else
-      "https://studio.code.org/s/#{script_name}/stage/#{script_level.stage.relative_position}/puzzle/#{script_level.position}"
-    end
+    path = script_level.build_script_level_path(script_level)
+    URI.join("https://studio.code.org", path)
   end
 
   def self.get_level_from_url(url)

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -25,7 +25,7 @@ module LevelsHelper
     elsif script_level.stage.lockable?
       script_lockable_stage_script_level_path(script_level.script, script_level.stage, script_level, params)
     elsif script_level.bonus
-      query_params = params.merge(id: script_level.id)
+      query_params = params.merge(level_name: script_level.level.name)
       script_stage_extras_path(script_level.script.name, script_level.stage.relative_position, query_params)
     else
       script_stage_script_level_path(script_level.script, script_level.stage, script_level, params)

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -546,13 +546,14 @@ class LevelsHelperTest < ActionView::TestCase
     uri = URI(build_script_level_path(sl, {}))
     query_params = CGI.parse(uri.query)
     assert_equal '/s/my_cool_script/stage/1/extras', uri.path
-    assert_equal sl.id.to_s, query_params['id'].first
+    assert_equal sl.level.name, query_params['level_name'].first
+    assert_nil query_params['solution'].first
 
     sl = stage.script_levels[3]
     uri = URI(build_script_level_path(sl, {solution: true}))
     query_params = CGI.parse(uri.query)
     assert_equal '/s/my_cool_script/stage/1/extras', uri.path
-    assert_equal sl.id.to_s, query_params['id'].first
+    assert_equal sl.level.name, query_params['level_name'].first
     assert_equal 'true', query_params['solution'].first
   end
 

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -430,7 +430,7 @@ class LevelsHelperTest < ActionView::TestCase
     # (position 4) Lockable 3
     # (position 5) Non-Lockable 2
 
-    input_dsl = <<-DSL.gsub(/^\s+/, '')
+    input_dsl = <<~DSL
       stage 'Lockable1',
         lockable: true;
       assessment 'LockableAssessment1';
@@ -495,7 +495,7 @@ class LevelsHelperTest < ActionView::TestCase
   end
 
   test 'build_script_level_path uses names for bonus levels to support cross-environment links' do
-    input_dsl = <<-DSL.gsub(/^\s+/, '')
+    input_dsl = <<~DSL
       stage 'Test bonus level links'
       level 'Level1'
       level 'BonusLevel1', bonus: true
@@ -520,7 +520,7 @@ class LevelsHelperTest < ActionView::TestCase
   end
 
   test 'build_script_level_path handles bonus levels with or without solutions' do
-    input_dsl = <<-DSL.gsub(/^\s+/, '')
+    input_dsl = <<~DSL
       stage 'My cool stage'
       level 'Level1'
       level 'Level2'


### PR DESCRIPTION
# Description

rather than trying to do it manually; there are a ton of exceptions to the standard level url pattern that we don't want to have to duplicate; see for example https://studio.code.org/s/csd1-2019/stage/2/puzzle/1 and https://studio.code.org/s/csd1-2019/lockable/2/puzzle/1/page/1, which currently both get identified by the single key `https://studio.code.org/s/csd1-2019/stage/2/puzzle/1`