### PR TITLE
Update principal approval and reminder emails

### DIFF
--- a/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval.html.haml
@@ -47,8 +47,7 @@
   and refer to this
   = link_to('brochure', 'https://code.org/files/programs/codeorg-program-brochure.pdf')
   that highlights how to bring computer science to your school.
-  Please send any additional questions to
-  = link_to('teacher@code.org', 'mailto:teacher@code.org') + '.'
+  Please send any additional questions to your regional partner below.
   Thank you very much for your support of computer science for all!
 
 %p

--- a/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval_teacher_reminder.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval_teacher_reminder.html.haml
@@ -29,8 +29,7 @@
   and refer to this
   = link_to('brochure', 'https://code.org/files/programs/codeorg-program-brochure.pdf')
   that highlights how to bring computer science to your school.
-  Please send any additional questions to
-  = link_to('teacher@code.org', 'mailto:teacher@code.org') + '.'
+  Please send any additional questions to your regional partner below.
   Thank you very much for your support of computer science for all!
 
 %p


### PR DESCRIPTION
[PLC-642](https://codedotorg.atlassian.net/browse/PLC-642): Updates the
`principal_approval` and `principal_approval_teacher_reminder` emails to
remove references to the email address `teacher@code.org` and recommend
that the principal contact their local regional partner instead.

## Testing story

Content change, checked with local mailers test feature.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
