### PR TITLE
Add two questions to the CSF Intro enrollment form

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -18,6 +18,7 @@ const NOT_TEACHING = "I'm not teaching this year";
 const EXPLAIN = '(Please Explain):';
 
 const CSF = 'CS Fundamentals';
+const INTRO = SubjectNames.SUBJECT_CSF_101;
 const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
 
 const VALIDATION_STATE_ERROR = 'error';
@@ -261,7 +262,8 @@ export default class EnrollForm extends React.Component {
           this.state.csf_has_physical_curriculum_guide
         ],
       previous_courses: this.state.previous_courses,
-      replace_existing: this.state.replace_existing
+      replace_existing: this.state.replace_existing,
+      csf_intro_intent: this.state.csf_intro_intent
     };
     this.submitRequest = $.ajax({
       method: 'POST',
@@ -324,6 +326,11 @@ export default class EnrollForm extends React.Component {
         onInputChange: this.handleTeachingOtherChange
       }
     ]);
+    const csfIntroIntentLabel =
+      `Most teachers register for the Intro workshop in order to learn how to ` +
+      `teach a CS Fundamentals course during the current or upcoming academic year. Is this also ` +
+      `true of your interest in registering for this workshop?`;
+    const csfIntroIntentAnswers = ['Yes', 'No', 'Unsure'];
     const csfCourses = Object.keys(CSF_COURSES)
       .filter(key => key !== 'courses14_accelerated')
       .map(key => CSF_COURSES[key])
@@ -460,6 +467,24 @@ export default class EnrollForm extends React.Component {
             />
           </FormGroup>
         )}
+        {this.props.workshop_course === CSF &&
+          this.props.workshop_subject === INTRO && (
+            <ButtonList
+              groupName="csf_intro_intent"
+              type="radio"
+              required
+              label={csfIntroIntentLabel}
+              answers={csfIntroIntentAnswers}
+              onChange={this.handleChange}
+              selectedItems={this.state.csf_intro_intent}
+              validationState={
+                this.state.errors.hasOwnProperty('csf_intro_intent')
+                  ? VALIDATION_STATE_ERROR
+                  : null
+              }
+              errorText={this.state.errors.csf_intro_intent}
+            />
+          )}
         {this.props.workshop_course === CSF &&
           this.props.workshop_subject === DEEP_DIVE && (
             <FormGroup>
@@ -614,7 +639,9 @@ export default class EnrollForm extends React.Component {
     if (this.props.workshop_course === CSF) {
       requiredFields.push('role');
       requiredFields.push('grades_teaching');
-      if (this.props.workshop_subject === DEEP_DIVE) {
+      if (this.props.workshop_subject === INTRO) {
+        requiredFields.push('csf_intro_intent');
+      } else if (this.props.workshop_subject === DEEP_DIVE) {
         requiredFields.push('attended_csf_intro_workshop');
         requiredFields.push('csf_has_physical_curriculum_guide');
       }

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -263,7 +263,8 @@ export default class EnrollForm extends React.Component {
         ],
       previous_courses: this.state.previous_courses,
       replace_existing: this.state.replace_existing,
-      csf_intro_intent: this.state.csf_intro_intent
+      csf_intro_intent: this.state.csf_intro_intent,
+      csf_intro_other_factors: this.state.csf_intro_other_factors
     };
     this.submitRequest = $.ajax({
       method: 'POST',
@@ -326,11 +327,25 @@ export default class EnrollForm extends React.Component {
         onInputChange: this.handleTeachingOtherChange
       }
     ]);
+
     const csfIntroIntentLabel =
       `Most teachers register for the Intro workshop in order to learn how to ` +
       `teach a CS Fundamentals course during the current or upcoming academic year. Is this also ` +
       `true of your interest in registering for this workshop?`;
     const csfIntroIntentAnswers = ['Yes', 'No', 'Unsure'];
+
+    const csfIntroOtherFactorsLabel = `What other factors might influence your registration? Check all that apply.`;
+    const csfIntroOtherFactorsAnswers = [
+      'I am newly assigned to teach computer science and want help getting started.',
+      'Teaching computer science is one of my teaching duties.',
+      'I am interested in teaching CS Fundamentals.',
+      'I have administrator support to teach CS Fundamentals.',
+      'I have available time on my schedule for teaching computer science.',
+      'I want to learn computer science concepts.',
+      'Computer science is a required subject in my region.',
+      'I am here to bring information back to my school or district.'
+    ];
+
     const csfCourses = Object.keys(CSF_COURSES)
       .filter(key => key !== 'courses14_accelerated')
       .map(key => CSF_COURSES[key])
@@ -483,6 +498,23 @@ export default class EnrollForm extends React.Component {
                   : null
               }
               errorText={this.state.errors.csf_intro_intent}
+            />
+          )}
+        {this.props.workshop_course === CSF &&
+          this.props.workshop_subject === INTRO && (
+            <ButtonList
+              groupName="csf_intro_other_factors"
+              type="check"
+              label={csfIntroOtherFactorsLabel}
+              answers={csfIntroOtherFactorsAnswers}
+              onChange={this.handleChange}
+              selectedItems={this.state.csf_intro_other_factors}
+              validationState={
+                this.state.errors.hasOwnProperty('csf_intro_other_factors')
+                  ? VALIDATION_STATE_ERROR
+                  : null
+              }
+              errorText={this.state.errors.csf_intro_other_factors}
             />
           )}
         {this.props.workshop_course === CSF &&

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import EnrollForm from '@cdo/apps/code-studio/pd/workshop_enrollment/enroll_form';
-import {expect} from 'chai';
+import {assert, expect} from 'chai';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
 import jQuery from 'jquery';
+import EnrollForm from '@cdo/apps/code-studio/pd/workshop_enrollment/enroll_form';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 describe('Enroll Form', () => {
   // We aren't testing server responses, but have a fake server to handle calls and suppress warnings
@@ -48,6 +49,56 @@ describe('Enroll Form', () => {
     });
   });
 
+  describe('CSF Intro Enroll Form', () => {
+    let enrollForm;
+    before(() => {
+      enrollForm = shallow(
+        <EnrollForm
+          workshop_id={props.workshop_id}
+          workshop_course="CS Fundamentals"
+          workshop_subject={SubjectNames.SUBJECT_CSF_101}
+          first_name={props.first_name}
+          email={props.email}
+          previous_courses={props.previous_courses}
+          onSubmissionComplete={props.onSubmissionComplete}
+        />
+      );
+    });
+
+    it('displays intent question', () => {
+      assert(enrollForm.exists({groupName: 'csf_intro_intent'}));
+    });
+
+    it('displays other factors question', () => {
+      assert(enrollForm.exists({groupName: 'csf_intro_other_factors'}));
+    });
+  });
+
+  describe('CSF Deep Dive Enroll Form', () => {
+    let enrollForm;
+    before(() => {
+      enrollForm = shallow(
+        <EnrollForm
+          workshop_id={props.workshop_id}
+          workshop_course="CS Fundamentals"
+          workshop_subject={SubjectNames.SUBJECT_CSF_201}
+          first_name={props.first_name}
+          email={props.email}
+          previous_courses={props.previous_courses}
+          onSubmissionComplete={props.onSubmissionComplete}
+        />
+      );
+    });
+
+    it('does not display intent question', () => {
+      assert.isFalse(enrollForm.exists({groupName: 'csf_intro_intent'}));
+    });
+
+    it('does not display other factors question', () => {
+      assert.isFalse(enrollForm.exists({groupName: 'csf_intro_other_factors'}));
+    });
+  });
+
   describe('CSP Enroll Form', () => {
     let enrollForm;
     before(() => {
@@ -74,6 +125,14 @@ describe('Enroll Form', () => {
 
     it('does not display replace existing question', () => {
       expect(enrollForm.find('#replace_existing')).to.have.length(0);
+    });
+
+    it('does not display intent question', () => {
+      assert.isFalse(enrollForm.exists({groupName: 'csf_intro_intent'}));
+    });
+
+    it('does not display other factors question', () => {
+      assert.isFalse(enrollForm.exists({groupName: 'csf_intro_other_factors'}));
     });
   });
 

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -6,6 +6,8 @@ import jQuery from 'jquery';
 import EnrollForm from '@cdo/apps/code-studio/pd/workshop_enrollment/enroll_form';
 import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
+const refute = p => assert.isNotOk(p);
+
 describe('Enroll Form', () => {
   // We aren't testing server responses, but have a fake server to handle calls and suppress warnings
   sinon.fakeServer.create();
@@ -34,18 +36,18 @@ describe('Enroll Form', () => {
     });
 
     it('displays role question and grade question', () => {
-      expect(enrollForm.find('#role')).to.have.length(1);
-      expect(enrollForm.find('#grades_teaching')).to.have.length(1);
+      assert(enrollForm.exists('#role'));
+      assert(enrollForm.exists('#grades_teaching'));
     });
 
     it('displays describe role question after other/admin role answer', () => {
       enrollForm.setState({role: 'Other'});
-      expect(enrollForm.find('#describe_role')).to.have.length(1);
+      assert(enrollForm.exists('#describe_role'));
     });
 
     it("doesn't display describe role question after normal teaching role answer", () => {
       enrollForm.setState({role: 'Librarian'});
-      expect(enrollForm.find('#describe_role')).to.have.length(0);
+      refute(enrollForm.exists('#describe_role'));
     });
   });
 
@@ -91,11 +93,11 @@ describe('Enroll Form', () => {
     });
 
     it('does not display intent question', () => {
-      assert.isFalse(enrollForm.exists({groupName: 'csf_intro_intent'}));
+      refute(enrollForm.exists({groupName: 'csf_intro_intent'}));
     });
 
     it('does not display other factors question', () => {
-      assert.isFalse(enrollForm.exists({groupName: 'csf_intro_other_factors'}));
+      refute(enrollForm.exists({groupName: 'csf_intro_other_factors'}));
     });
   });
 
@@ -116,23 +118,23 @@ describe('Enroll Form', () => {
     });
 
     it('does not display role question', () => {
-      expect(enrollForm.find('#role')).to.have.length(0);
+      refute(enrollForm.exists('#role'));
     });
 
     it('does not display previous courses question', () => {
-      expect(enrollForm.find('#previous_courses')).to.have.length(0);
+      refute(enrollForm.exists('#previous_courses'));
     });
 
     it('does not display replace existing question', () => {
-      expect(enrollForm.find('#replace_existing')).to.have.length(0);
+      refute(enrollForm.exists('#replace_existing'));
     });
 
     it('does not display intent question', () => {
-      assert.isFalse(enrollForm.exists({groupName: 'csf_intro_intent'}));
+      refute(enrollForm.exists({groupName: 'csf_intro_intent'}));
     });
 
     it('does not display other factors question', () => {
-      assert.isFalse(enrollForm.exists({groupName: 'csf_intro_other_factors'}));
+      refute(enrollForm.exists({groupName: 'csf_intro_other_factors'}));
     });
   });
 
@@ -153,11 +155,11 @@ describe('Enroll Form', () => {
     });
 
     it('does display previous courses question', () => {
-      expect(enrollForm.find('#previous_courses')).to.have.length(1);
+      assert(enrollForm.exists('#previous_courses'));
     });
 
     it('does display replace existing question', () => {
-      expect(enrollForm.find('#replace_existing')).to.have.length(1);
+      assert(enrollForm.exists('#replace_existing'));
     });
   });
 

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -126,7 +126,9 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
       csf_courses_planned: params[:csf_courses_planned],
       csf_has_physical_curriculum_guide: params[:csf_has_physical_curriculum_guide],
       previous_courses: params[:previous_courses],
-      replace_existing: params[:replace_existing]
+      replace_existing: params[:replace_existing],
+      csf_intro_intent: params[:csf_intro_intent],
+      csf_intro_other_factors: params[:csf_intro_other_factors]
     }
   end
 

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -77,6 +77,8 @@ class Pd::Enrollment < ActiveRecord::Base
     csf_has_physical_curriculum_guide
     previous_courses
     replace_existing
+    csf_intro_intent
+    csf_intro_other_factors
   )
 
   def set_default_scholarship_info

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -237,6 +237,24 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ::ActionController::TestC
     refute_nil enrollment.code
   end
 
+  test 'CSF Intro enrollments can be created' do
+    assert_creates(Pd::Enrollment) do
+      post :create, params: {
+        workshop_id: @workshop.id,
+        school_info: school_info_params,
+        csf_intro_intent: 'Yes',
+        csf_intro_other_factors: [
+          "I want to learn computer science concepts.",
+          "I have available time on my schedule for teaching computer science."
+        ]
+      }.merge(enrollment_test_params)
+      assert_response :success
+      assert_equal RESPONSE_MESSAGES[:SUCCESS], JSON.parse(@response.body)["workshop_enrollment_status"]
+    end
+    enrollment = Pd::Enrollment.last
+    refute_nil enrollment.code
+  end
+
   test 'creating a duplicate enrollment sends \'duplicate\' workshop enrollment status' do
     params = enrollment_test_params.merge(
       {


### PR DESCRIPTION
[PLC-608](https://codedotorg.atlassian.net/browse/PLC-608): Adds two new questions below the last visible question on the enrollment form for a CSF Intro workshop:

![Screenshot from 2019-12-11 14-38-59](https://user-images.githubusercontent.com/1615761/70668558-d1105700-1c28-11ea-82d7-6b76a48c8949.png)

We're intentionally not surfacing these results anywhere - they are only being captured for review through internal data tools later.

## Testing story

Simple unit tests on the client showing that these fields only show up for CSF Intro workshops, and for the server showing that these new parameters are accepted by the enrollment API.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
