### PR TITLE
add z-index to watcher dropdown

### DIFF
--- a/apps/src/templates/watchers/Watchers.jsx
+++ b/apps/src/templates/watchers/Watchers.jsx
@@ -28,6 +28,9 @@ const valueAndInputWidth = 'calc(100% - 41px)';
 const inputElementHeight = 29;
 
 const styles = {
+  autocompleteDropdown: {
+    zIndex: 2 // Needed so the dropdown appears over the coding space (z-index 1)
+  },
   watchContainer: {
     width: '100%',
     height: '100%'
@@ -411,7 +414,7 @@ class Watchers extends React.Component {
                   attachment: 'together'
                 }
               ]}
-              className="debug-watch-autocomplete-dropdown"
+              style={styles.autocompleteDropdown}
             >
               <input
                 placeholder="Variable / Property"

--- a/apps/src/templates/watchers/Watchers.jsx
+++ b/apps/src/templates/watchers/Watchers.jsx
@@ -411,7 +411,7 @@ class Watchers extends React.Component {
                   attachment: 'together'
                 }
               ]}
-              style={{zIndex: 2}}
+              className="debug-watch-autocomplete-dropdown"
             >
               <input
                 placeholder="Variable / Property"

--- a/apps/src/templates/watchers/Watchers.jsx
+++ b/apps/src/templates/watchers/Watchers.jsx
@@ -411,6 +411,7 @@ class Watchers extends React.Component {
                   attachment: 'together'
                 }
               ]}
+              style={{zIndex: 2}}
             >
               <input
                 placeholder="Variable / Property"

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -291,11 +291,6 @@ button.arrow:disabled {
   z-index: 1;
 }
 
-/* Set z-index to 2 so this appears over the codeTextbox */
-.debug-watch-autocomplete-dropdown {
-  z-index: 2;
-}
-
 #codeTextbox.pin_bottom {
   border: 1px solid #ddd;
 }

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -291,6 +291,11 @@ button.arrow:disabled {
   z-index: 1;
 }
 
+/* Set z-index to 2 so this appears over the codeTextbox */
+.debug-watch-autocomplete-dropdown {
+  z-index: 2;
+}
+
 #codeTextbox.pin_bottom {
   border: 1px solid #ddd;
 }


### PR DESCRIPTION
# Description
`z-index` property is needed here because the coding space already has `z-index: 1` https://github.com/code-dot-org/code-dot-org/blob/staging/apps/style/common.scss#L291

Before:
![image](https://user-images.githubusercontent.com/8787187/70670628-6bbf6480-1c2e-11ea-8a8d-405209876f75.png)
![image](https://user-images.githubusercontent.com/8787187/70670645-7b3ead80-1c2e-11ea-9245-723de0759f54.png)


After:
![image](https://user-images.githubusercontent.com/8787187/70670571-3286f480-1c2e-11ea-8b24-baeef552f3d5.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-881)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
