### PR TITLE
Silence proxy errors

### DIFF
--- a/dashboard/app/helpers/proxy_helper.rb
+++ b/dashboard/app/helpers/proxy_helper.rb
@@ -78,9 +78,10 @@ module ProxyHelper
     render_error_response 400, "Invalid URI #{location}"
   rescue SocketError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ENETUNREACH => e
     render_error_response 400, "Network error #{e.class} #{e.message}"
-  rescue OpenSSL::SSL::SSLError => e
-    raise e unless e.message =~ SSL_HOSTNAME_MISMATCH_REGEX
-    render_error_response 400, "Remote host SSL certificate error #{e.message}"
+  rescue OpenSSL::SSL::SSLError
+    render_error_response 400, "Remote host SSL certificate error"
+  rescue EOFError
+    render_error_response 400, "Remote host closed the connection before sending all data"
   end
 
   # Unlike render_proxied_url, this does not attempt to render the URL, but instead

--- a/dashboard/test/controllers/media_proxy_controller_test.rb
+++ b/dashboard/test/controllers/media_proxy_controller_test.rb
@@ -77,4 +77,25 @@ class MediaProxyControllerTest < ActionController::TestCase
     get :get, params: {u: IMAGE_URI}
     assert_response 503
   end
+
+  test "should return 400 on upstream timeouts" do
+    stub_request(:get, IMAGE_URI).to_timeout
+    get :get, params: {u: IMAGE_URI}
+    assert_response 400
+    assert_includes response.body, 'Network error'
+  end
+
+  test "should return 400 on SSL errors" do
+    stub_request(:get, IMAGE_URI).to_raise(OpenSSL::SSL::SSLError)
+    get :get, params: {u: IMAGE_URI}
+    assert_response 400
+    assert_includes response.body, 'Remote host SSL certificate error'
+  end
+
+  test "should return 400 on EOF errors" do
+    stub_request(:get, IMAGE_URI).to_raise(EOFError)
+    get :get, params: {u: IMAGE_URI}
+    assert_response 400
+    assert_includes response.body, 'Remote host closed the connection'
+  end
 end


### PR DESCRIPTION
Sample errors that we want to silence in HoneyBadger:
https://app.honeybadger.io/projects/3240/faults/43423297
https://app.honeybadger.io/projects/3240/faults/51119185

- [x] PR is opened against `staging-next`.
- [x] Includes test coverage for this behavior change.