### PR TITLE
Fix "NoMethodError: undefined method `join' for nil:NilClass" in HoneyBadger

### DIFF
--- a/dashboard/app/helpers/proxy_helper.rb
+++ b/dashboard/app/helpers/proxy_helper.rb
@@ -25,7 +25,11 @@ module ProxyHelper
     url = URI.parse(location)
 
     raise URI::InvalidURIError.new if url.host.nil? || url.port.nil?
-    unless allowed_hostname?(url, allowed_hostname_suffixes) && allowed_ip_address?(url.host)
+    unless allowed_ip_address?(url.host)
+      render_error_response 400, "Target IP address is restricted"
+      return
+    end
+    unless allowed_hostname?(url, allowed_hostname_suffixes)
       render_error_response 400, "Hostname '#{url.host}' is not in the list of allowed hostnames. " \
           "The list of allowed hostname suffixes is: #{allowed_hostname_suffixes.join(', ')}. " \
           "If you wish to access a URL which is not currently allowed, please email support@code.org."

--- a/dashboard/test/controllers/media_proxy_controller_test.rb
+++ b/dashboard/test/controllers/media_proxy_controller_test.rb
@@ -53,7 +53,6 @@ class MediaProxyControllerTest < ActionController::TestCase
   end
 
   test "can't access loopback IP addresses" do
-    stub_request(:get, IMAGE_URI).to_return(body: IMAGE_DATA, headers: {content_type: 'image/jpeg'})
     get :get, params: {u: 'http://0.0.0.0'}
     assert_response 400
   end

--- a/dashboard/test/controllers/media_proxy_controller_test.rb
+++ b/dashboard/test/controllers/media_proxy_controller_test.rb
@@ -52,6 +52,12 @@ class MediaProxyControllerTest < ActionController::TestCase
     assert_response 400
   end
 
+  test "can't access loopback IP addresses" do
+    stub_request(:get, IMAGE_URI).to_return(body: IMAGE_DATA, headers: {content_type: 'image/jpeg'})
+    get :get, params: {u: 'http://0.0.0.0'}
+    assert_response 400
+  end
+
   test "should fail if too many redirects" do
     response = {body: 'Redirect', status: 302, headers: {location: IMAGE_URI}}
     stub_request(:get, IMAGE_URI).to_return(


### PR DESCRIPTION
PR https://github.com/code-dot-org/code-dot-org/pull/28439 prevented the media proxy from resolving certain IP address ranges. But the response would sometimes fail with [this HoneyBadger error](https://app.honeybadger.io/projects/3240/faults/55934507) when called via this code path, where `allowed_hostname_suffixes` is nil:

https://github.com/code-dot-org/code-dot-org/blob/f59afc267ae6a130b735f8308ee86685619b9a11/dashboard/app/controllers/media_proxy_controller.rb#L38-L48