### PR TITLE
Responsive: make visualization column vertically responsive

### DIFF
--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -460,25 +460,29 @@ html[dir='rtl'] div#visualizationResizeBar {
   }
 }
 
-@media screen and (min-width: 1101px) and (max-width: 1150px) {
+@media screen and (min-width: 1101px) and (max-width: 1150px),
+       screen and (min-height: 801px) and (max-height: 900px) {
   @include visualization-width(350px);
   @include studio-dpad-container-width(350px);
   @include karel-counter(20px, 1.2px);
 }
 
-@media screen and (min-width: 1051px) and (max-width: 1100px) {
+@media screen and (min-width: 1051px) and (max-width: 1100px),
+       screen and (min-height: 701px) and (max-height: 800px) {
   @include visualization-width(300px);
   @include studio-dpad-container-width(300px);
   @include karel-counter(24px, 1.4px);
 }
 
-@media screen and (min-width: 1001px) and (max-width: 1050px) {
+@media screen and (min-width: 1001px) and (max-width: 1050px),
+       screen and (min-height: 601px) and (max-height: 700px) {
   @include visualization-width(250px);
   @include studio-dpad-container-width(250px);
   @include karel-counter(28px, 1.6px);
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1000px),
+       screen and (max-height: 600px) {
   @include visualization-width(200px);
   @include studio-dpad-container-width(200px);
   @include karel-counter(32px, 2px);


### PR DESCRIPTION
Until now the "visualization column" has only been responsive based on horizontal width.  Now it also shrinks down if the height is limited.

If we go ahead with this approach, it will need to be tested broadly, and the height values likely need tweaking too.

### before

![dance-1280x480-before](https://user-images.githubusercontent.com/2205926/70740664-792c2b80-1cce-11ea-8d4e-707c94679595.png)

### after

![dance-1280x480-after](https://user-images.githubusercontent.com/2205926/70740670-7df0df80-1cce-11ea-9c74-332f287c6488.png)

