### PR TITLE
Change time window, fix pagination on `Honeybadger.get_recent_issues` script

### DIFF
--- a/lib/cdo/honeybadger.rb
+++ b/lib/cdo/honeybadger.rb
@@ -103,10 +103,10 @@ module Honeybadger
     issues = []
 
     {cronjobs: 45435, dashboard: 3240, pegasus: 34365}.each do |project, project_id|
-      next_url = "https://app.honeybadger.io/v2/projects/#{project_id}/faults" \
+      next_url = "/v2/projects/#{project_id}/faults" \
         "?occurred_after=#{1.day.ago.to_i}&q=-is:resolved%20-is:paused%20-is:ignored"
       while next_url
-        response = `curl -u #{CDO.honeybadger_api_token}: #{next_url}`
+        response = `curl -u #{CDO.honeybadger_api_token}: "https://app.honeybadger.io#{next_url}"`
         parsed_response = JSON.parse response
         parsed_response['results'].each do |issue|
           issues << {

--- a/lib/cdo/honeybadger.rb
+++ b/lib/cdo/honeybadger.rb
@@ -101,11 +101,10 @@ module Honeybadger
   def self.get_recent_issues
     raise 'CDO.honeybadger_api_token undefined' unless CDO.honeybadger_api_token
     issues = []
-    midnight_epoch = Time.now.to_i / 86400 * 86400
 
     {cronjobs: 45435, dashboard: 3240, pegasus: 34365}.each do |project, project_id|
       next_url = "https://app.honeybadger.io/v2/projects/#{project_id}/faults" \
-        "?occurred_after=#{midnight_epoch}&q=-is:resolved%20-is:paused%20-is:ignored"
+        "?occurred_after=#{1.day.ago.to_i}&q=-is:resolved%20-is:paused%20-is:ignored"
       while next_url
         response = `curl -u #{CDO.honeybadger_api_token}: #{next_url}`
         parsed_response = JSON.parse response


### PR DESCRIPTION
I'm hoping to reuse the existing `Honeybadger.get_recent_issues` method to auto-notify users on Slack that are assigned to open issues. In the process, I discovered that the timing of the query wasn't super useful.

Before, running `bin/dotd` and choosing the "H" option at ~4:15pm. Only one issue reported:

![image](https://user-images.githubusercontent.com/413693/70760834-d68ca080-1cff-11ea-8c36-cc5af9023194.png)

After, many results from the past 24 hours:

![image](https://user-images.githubusercontent.com/413693/70760810-bf4db300-1cff-11ea-9eaf-5d8df29cfc1b.png)

This PR also fixes an issue with pagination, where the API now returns paths instead of full URLs.