### PR TITLE
do not expire pilot experiments after 100 days

### DIFF
--- a/dashboard/app/controllers/experiments_controller.rb
+++ b/dashboard/app/controllers/experiments_controller.rb
@@ -38,12 +38,9 @@ class ExperimentsController < ApplicationController
       return
     end
 
-    # Default to being active for 100 days
-    now = DateTime.now
     SingleUserExperiment.find_or_create_by!(
       min_user_id: current_user.id,
-      name: experiment_name,
-      end_at: now + 100.days
+      name: experiment_name
     )
     redirect_to '/', flash: {notice: "You have successfully joined the experiment '#{params[:experiment_name]}'."}
   end

--- a/dashboard/test/controllers/experiments_controller_test.rb
+++ b/dashboard/test/controllers/experiments_controller_test.rb
@@ -73,7 +73,12 @@ class ExperimentsControllerTest < ActionController::TestCase
   ) do
     assert_nil flash[:alert]
     assert_includes flash[:notice], "You have successfully joined the experiment"
-    assert SingleUserExperiment.where(name: "2018-teacher-experience", min_user_id: @teacher.id)
+    assert SingleUserExperiment.where(
+      name: "2018-teacher-experience",
+      min_user_id: @teacher.id,
+      start_at: nil,
+      end_at: nil
+    )
   end
 
   test_user_gets_response_for(


### PR DESCRIPTION
# Description

Several CSD piloters reported losing access to their pilot scripts. The problem turned out to be that we were setting an expiration date on their pilot experiment if they joined the pilot via URL. The short-term solution was to clear the expiration date `end_at` from all experiments named `'csd-piloters'`. This PR will make it so that we do not accidentally create any pilot experiments with expiration dates again.

## Testing story

Updated unit tests to validate start_at and end_at fields are nil.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
