### PR TITLE
Have pt-PT fallback to pt-BR in Rails

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -108,6 +108,7 @@ module Dashboard
       # Following examples from: https://github.com/ruby-i18n/i18n/wiki/Fallbacks
       # and http://pawelgoscicki.com/archives/2015/02/enabling-i18n-locale-fallbacks-in-rails/
       I18n.fallbacks.map(es: :'es-MX')
+      I18n.fallbacks.map(pt: :'pt-BR')
     end
 
     config.assets.gzip = false # cloudfront gzips everything for us on the fly.


### PR DESCRIPTION
# Description

Note: this only works for Dashboard strings. We do not have custom fallback behaviour implemented for Pegasus or Apps strings.

This is done the same way as the es-ES to es-MX fallback.

To my knowledge this is the only other fallback requested. If we get too many fallback requests or they become complicated, I would like to rethink how we specify these.

[jira](https://codedotorg.atlassian.net/browse/FND-672)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
