### PR TITLE
don't create test user with google authentication option for test that is testing the lack of a google authentication option

### DIFF
--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4181,7 +4181,7 @@ class UserTest < ActiveSupport::TestCase
 
   test 'cannot grant admin role when google authentication option is not present' do
     email = 'annieeasley@code.org'
-    migrated_teacher = create(:teacher, :google_sso_provider, email: email)
+    migrated_teacher = create(:teacher, email: email)
 
     assert_raises(ActiveRecord::RecordInvalid) do
       migrated_teacher.update!(admin: true)


### PR DESCRIPTION
# Description

Originally regressed in https://github.com/code-dot-org/code-dot-org/pull/32237, was not immediately caught because the drone logic to check which unit tests to run isn't working.