### PR TITLE
Upgrade to Expo SDK 36, fix WebView usage with iOS devices and file URLs

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -246,7 +246,7 @@
     "rosie": "^2.0.1",
     "selectize": "^0.12.4",
     "snack-build": "0.0.1",
-    "snack-sdk": "2.3.4",
+    "snack-sdk": "2.3.6",
     "wgxpath": "^1.2.0",
     "whatwg-fetch": "^2.0.3"
   }

--- a/apps/src/templates/export/expo/App.js.ejs
+++ b/apps/src/templates/export/expo/App.js.ejs
@@ -115,6 +115,11 @@ export default class App extends React.Component {
       this.setState({needsEmptyRender: false});
     }
 
+    let readAccessToURL;
+    if (Platform.OS === 'ios' && indexUri) {
+      readAccessToURL = indexUri.substring(0, indexUri.lastIndexOf('/') + 1);
+    }
+
     return (
       <View onLayout={this.onLayout} style={styles.container}>
         {showWebView && <View style={this.webViewContainerStyle()}>
@@ -122,6 +127,8 @@ export default class App extends React.Component {
             allowUniversalAccessFromFileURLs
             originWhitelist={['*']}
             allowFileAccess
+            allowFileAccessFromFileURLs
+            allowingReadAccessToURL={readAccessToURL}
             source={needsEmptyRender ? undefined : {uri: indexUri}}
             style={Platform.OS === 'ios' ? styles.webViewIOS : styles.webViewAndroid}
             javaScriptEnabled
@@ -129,6 +136,7 @@ export default class App extends React.Component {
             scrollEnabled={false}
             bounces={false}
             onLoad={this.onLoad}
+            useWebkit
           />
         </View>}
         {!loaded && <View style={styles.cover} />}

--- a/apps/src/templates/export/expo/package.exported_json
+++ b/apps/src/templates/export/expo/package.exported_json
@@ -1,6 +1,5 @@
 {
   "main": "node_modules/expo/AppEntry.js",
-  "private": true,
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
@@ -8,9 +7,15 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^34.0.0",
-    "expo-cli": "^3.1.1",
+    "expo": "^35.0.0",
+    "expo-cli": "^3.9.1",
     "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-34.0.0.tar.gz"
-  }
+    "react-dom": "16.8.3",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
+    "react-native-web": "^0.11.7"
+  },
+  "devDependencies": {
+    "babel-preset-expo": "^7.1.0"
+  },
+  "private": true
 }

--- a/apps/src/templates/export/expo/package.exported_json
+++ b/apps/src/templates/export/expo/package.exported_json
@@ -7,15 +7,16 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^35.0.0",
-    "expo-cli": "^3.9.1",
-    "react": "16.8.3",
-    "react-dom": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
-    "react-native-web": "^0.11.7"
+    "expo": "~36.0.0",
+    "expo-cli": "3.11.1",
+    "react": "~16.9.0",
+    "react-dom": "~16.9.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
+    "react-native-web": "~0.11.7",
+    "react-native-webview": "7.4.3"
   },
   "devDependencies": {
-    "babel-preset-expo": "^7.1.0"
+    "babel-preset-expo": "~8.0.0"
   },
   "private": true
 }

--- a/apps/src/util/exporter.js
+++ b/apps/src/util/exporter.js
@@ -14,7 +14,7 @@ import exportExpoPackagedFilesEjs from '../templates/export/expo/packagedFiles.j
 import exportExpoPackagedFilesEntryEjs from '../templates/export/expo/packagedFilesEntry.js.ejs';
 import {EXPO_SDK_VERSION, PLATFORM_ANDROID} from './exporterConstants';
 
-const EXPO_REACT_NATIVE_WEBVIEW_VERSION = '7.2.4';
+const EXPO_REACT_NATIVE_WEBVIEW_VERSION = '7.0.5';
 
 export function createPackageFilesFromZip(zip, appName) {
   const moduleList = [];

--- a/apps/src/util/exporter.js
+++ b/apps/src/util/exporter.js
@@ -14,7 +14,7 @@ import exportExpoPackagedFilesEjs from '../templates/export/expo/packagedFiles.j
 import exportExpoPackagedFilesEntryEjs from '../templates/export/expo/packagedFilesEntry.js.ejs';
 import {EXPO_SDK_VERSION, PLATFORM_ANDROID} from './exporterConstants';
 
-const EXPO_REACT_NATIVE_WEBVIEW_VERSION = '7.0.5';
+const EXPO_REACT_NATIVE_WEBVIEW_VERSION = '7.4.3';
 
 export function createPackageFilesFromZip(zip, appName) {
   const moduleList = [];

--- a/apps/src/util/exporterConstants.js
+++ b/apps/src/util/exporterConstants.js
@@ -4,7 +4,7 @@
  * and its dependencies (167KB).
  */
 
-export const EXPO_SDK_VERSION = '34.0.0';
+export const EXPO_SDK_VERSION = '35.0.0';
 
 export const PLATFORM_ANDROID = 'android';
 export const PLATFORM_IOS = 'ios';

--- a/apps/src/util/exporterConstants.js
+++ b/apps/src/util/exporterConstants.js
@@ -4,7 +4,7 @@
  * and its dependencies (167KB).
  */
 
-export const EXPO_SDK_VERSION = '35.0.0';
+export const EXPO_SDK_VERSION = '36.0.0';
 
 export const PLATFORM_ANDROID = 'android';
 export const PLATFORM_IOS = 'ios';

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -14451,10 +14451,10 @@ snack-build@0.0.1:
     babel-runtime "^6.23.0"
     graphql-request "^1.8.2"
 
-snack-sdk@2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/snack-sdk/-/snack-sdk-2.3.4.tgz#a1c1492292052e91d7d9a65cf994dfba5b2b4c05"
-  integrity sha512-po6BghsYZZQ9Y9zeyWXynWJySIF6HBuM9jEVEuf/z/50DPyzuYupNHxz7p6WCcFwOSJowWFwzkG7uZ4SSn9HCA==
+snack-sdk@2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/snack-sdk/-/snack-sdk-2.3.6.tgz#750d8eec557a8a5dc125337e4fac8ee1226c6941"
+  integrity sha512-eFq9S99RX7aLdTXckqIGhAw7s81SNGOnuWrKiLV2kaZEGEgruFWjDyD1SsIt5MlhHztIrPWTkGwuwctdKR3AZA==
   dependencies:
     babel-runtime "^6.23.0"
     diff "^3.2.0"


### PR DESCRIPTION
# Description
- Upgrade Expo projects to use SDK v36 ([just released this week](https://blog.expo.io/expo-sdk-36-is-now-available-b91897b437fe))
- Fix the use of the `WebView` component on iOS, which has new stringent requirements around hosting content from `file:` URLs and that content's ability to load other content via `file:` URLs
  - We populate the `allowingReadAccessToURL` property with the directory that contains our `index.html` so it can load anything relative to that directory

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- https://github.com/react-native-community/react-native-webview/blob/master/docs/Reference.md
- https://blog.expo.io/expo-sdk-36-is-now-available-b91897b437fe

## Testing story
- Verified APK builds on Google Pixel 3 hardware
- Verified iOS work Expo using iPhone 7 Plus hardware

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
