### PR TITLE
InstructionsWithWorkspace owns the resizer

### DIFF
--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -15,7 +15,6 @@ const styles = {
   main: {
     position: 'absolute',
     height: RESIZER_HEIGHT,
-    left: 0,
     right: 0
   },
   ellipsis: {
@@ -102,6 +101,7 @@ class HeightResizer extends React.Component {
     return (
       <div
         id="ui-test-resizer"
+        className="editor-column"
         style={mainStyle}
         onMouseDown={this.onMouseDown}
         onMouseUp={this.onMouseUp}

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -15,6 +15,7 @@ const styles = {
   main: {
     position: 'absolute',
     height: RESIZER_HEIGHT,
+    marginLeft: 15,
     right: 0
   },
   ellipsis: {

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -3,8 +3,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import CodeWorkspaceContainer from '../CodeWorkspaceContainer';
-import TopInstructions from './TopInstructions';
-import {setInstructionsMaxHeightAvailable} from '../../redux/instructions';
+import TopInstructions, {MIN_HEIGHT} from './TopInstructions';
+import {
+  setInstructionsMaxHeightAvailable,
+  setInstructionsRenderedHeight
+} from '../../redux/instructions';
+import HeightResizer from './HeightResizer';
 
 /**
  * A component representing the right side of the screen in our app. In particular
@@ -18,7 +22,10 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     children: PropTypes.node,
     // props provided via connect
     instructionsHeight: PropTypes.number.isRequired,
-    setInstructionsMaxHeightAvailable: PropTypes.func.isRequired
+    instructionsMaxHeight: PropTypes.number.isRequired,
+    isEmbedView: PropTypes.bool.isRequired,
+    setInstructionsMaxHeightAvailable: PropTypes.func.isRequired,
+    setInstructionsRenderedHeight: PropTypes.func.isRequired
   };
 
   // only used so that we can rerender when resized
@@ -102,10 +109,32 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     window.removeEventListener('resize', this.onResize);
   }
 
+  /**
+   * Given a prospective delta, determines how much we can actually change the
+   * height (accounting for min/max) and changes height by that much.
+   * @param {number} delta
+   * @returns {number} How much we actually changed
+   */
+  handleHeightResize = delta => {
+    const currentHeight = this.props.instructionsHeight;
+
+    let newHeight = Math.max(MIN_HEIGHT, currentHeight + delta);
+    newHeight = Math.min(newHeight, this.props.instructionsMaxHeight);
+
+    this.props.setInstructionsRenderedHeight(newHeight);
+    return newHeight - currentHeight;
+  };
+
   render() {
     return (
       <span>
         <TopInstructions />
+        {!this.props.isEmbedView && (
+          <HeightResizer
+            position={this.props.instructionsHeight}
+            onResize={this.handleHeightResize}
+          />
+        )}
         <CodeWorkspaceContainer
           ref={this.setCodeWorkspaceContainerRef}
           topMargin={this.props.instructionsHeight}
@@ -120,13 +149,21 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
 export default connect(
   function propsFromStore(state) {
     return {
-      instructionsHeight: state.instructions.renderedHeight
+      instructionsHeight: state.instructions.renderedHeight,
+      instructionsMaxHeight: Math.min(
+        state.instructions.maxAvailableHeight,
+        state.instructions.maxNeededHeight
+      ),
+      isEmbedView: state.pageConstants.isEmbedView
     };
   },
   function propsFromDispatch(dispatch) {
     return {
       setInstructionsMaxHeightAvailable(maxHeight) {
         dispatch(setInstructionsMaxHeightAvailable(maxHeight));
+      },
+      setInstructionsRenderedHeight(height) {
+        dispatch(setInstructionsRenderedHeight(height));
       }
     };
   }

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -36,6 +36,15 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
    * call adjustTopPaneHeight as our maxHeight may need adjusting.
    */
   onResize = () => {
+    // We have to have a reference to this component to do anything on resize anyway.
+    // Guard here because our tests aren't cleaning up nicely :(
+    if (!this.codeWorkspaceContainer) {
+      return;
+    }
+
+    // TODO (brad)
+    // See if we can achieve this effect with memoization instead of state
+    // https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization
     const {
       windowWidth: lastWindowWidth,
       windowHeight: lastWindowHeight

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -9,6 +9,7 @@ import {
   setInstructionsRenderedHeight
 } from '../../redux/instructions';
 import HeightResizer from './HeightResizer';
+import clamp from 'lodash/clamp';
 
 /**
  * A component representing the right side of the screen in our app. In particular
@@ -116,13 +117,16 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
    * @returns {number} How much we actually changed
    */
   handleHeightResize = delta => {
-    const currentHeight = this.props.instructionsHeight;
+    const {
+      instructionsHeight: oldHeight,
+      instructionsMaxHeight: maxHeight,
+      setInstructionsRenderedHeight: setHeight
+    } = this.props;
 
-    let newHeight = Math.max(MIN_HEIGHT, currentHeight + delta);
-    newHeight = Math.min(newHeight, this.props.instructionsMaxHeight);
+    const newHeight = clamp(oldHeight + delta, MIN_HEIGHT, maxHeight);
+    setHeight(newHeight);
 
-    this.props.setInstructionsRenderedHeight(newHeight);
-    return newHeight - currentHeight;
+    return newHeight - oldHeight;
   };
 
   render() {

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -23,7 +23,6 @@ import styleConstants from '../../styleConstants';
 import commonStyles from '../../commonStyles';
 import Instructions from './Instructions';
 import CollapserIcon from './CollapserIcon';
-import HeightResizer from './HeightResizer';
 import i18n from '@cdo/locale';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import queryString from 'query-string';
@@ -34,7 +33,7 @@ import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
 
-const MIN_HEIGHT = RESIZER_HEIGHT + 60;
+export const MIN_HEIGHT = RESIZER_HEIGHT + 60;
 
 const TabType = {
   INSTRUCTIONS: 'instructions',
@@ -323,22 +322,6 @@ class TopInstructions extends Component {
     if (this.state.tabSelected === TabType.COMMENTS) {
       this.props.setInstructionsRenderedHeight(this.adjustMaxNeededHeight());
     }
-  };
-
-  /**
-   * Given a prospective delta, determines how much we can actually change the
-   * height (accounting for min/max) and changes height by that much.
-   * @param {number} delta
-   * @returns {number} How much we actually changed
-   */
-  handleHeightResize = delta => {
-    const currentHeight = this.props.height;
-
-    let newHeight = Math.max(MIN_HEIGHT, currentHeight + delta);
-    newHeight = Math.min(newHeight, this.props.maxHeight);
-
-    this.props.setInstructionsRenderedHeight(newHeight);
-    return newHeight - currentHeight;
   };
 
   /**
@@ -775,12 +758,6 @@ class TopInstructions extends Component {
                 </div>
               )}
           </div>
-          {!this.props.isEmbedView && (
-            <HeightResizer
-              position={this.props.height}
-              onResize={this.handleHeightResize}
-            />
-          )}
         </div>
       </div>
     );

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -22,12 +22,17 @@ import InstructionsWithWorkspace, {
 } from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
 
 describe('InstructionsWithWorkspace', () => {
+  const DEFAULT_PROPS = {
+    instructionsHeight: 400,
+    instructionsMaxHeight: 400,
+    isEmbedView: false,
+    setInstructionsMaxHeightAvailable: () => {},
+    setInstructionsRenderedHeight: () => {}
+  };
+
   it('renders instructions and code workspace', () => {
     const wrapper = shallow(
-      <UnwrappedInstructionsWithWorkspace
-        instructionsHeight={400}
-        setInstructionsMaxHeightAvailable={() => {}}
-      />
+      <UnwrappedInstructionsWithWorkspace {...DEFAULT_PROPS} />
     );
 
     expect(wrapper.find('Connect(TopInstructions)')).to.have.lengthOf(1);
@@ -36,10 +41,7 @@ describe('InstructionsWithWorkspace', () => {
 
   it('initially does not know window width or height', () => {
     const wrapper = shallow(
-      <UnwrappedInstructionsWithWorkspace
-        instructionsHeight={400}
-        setInstructionsMaxHeightAvailable={() => {}}
-      />
+      <UnwrappedInstructionsWithWorkspace {...DEFAULT_PROPS} />
     );
     expect(wrapper.state()).to.deep.equal({
       windowWidth: undefined,
@@ -68,6 +70,7 @@ describe('InstructionsWithWorkspace', () => {
     } = {}) {
       const wrapper = shallow(
         <UnwrappedInstructionsWithWorkspace
+          {...DEFAULT_PROPS}
           instructionsHeight={instructionsHeight}
           setInstructionsMaxHeightAvailable={setInstructionsMaxHeightAvailable}
         />

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -204,7 +204,6 @@ describe('InstructionsWithWorkspace', () => {
           </InstructionsWithWorkspace>
         </Provider>
       );
-      // utils.fireResizeEvent();
 
       const resizer = () => wrapper.find('HeightResizer');
       const instructionsHeight = () =>
@@ -217,7 +216,6 @@ describe('InstructionsWithWorkspace', () => {
       // Instructions content height is stubbed to 500.
       // Initial render height is 300.
       // Real 'height' style on relevant element is 287 due to 13px resize bar adjustment.
-
       assert.equal(287, instructionsHeight());
       assert.include(store.getState().instructions, {
         renderedHeight: 300,
@@ -227,13 +225,7 @@ describe('InstructionsWithWorkspace', () => {
       });
 
       // Drag the resize bar to make the instructions bigger by 100px
-
-      resizer().simulate('mousedown', {button: 0, pageY: 0});
-      resizer().simulate('mousemove', {pageY: 100});
-      resizer().simulate('mouseup', {});
-
-      // Check updated instructions size
-
+      drag(resizer(), 100);
       assert.equal(387, instructionsHeight());
       assert.include(store.getState().instructions, {
         renderedHeight: 400,
@@ -243,13 +235,7 @@ describe('InstructionsWithWorkspace', () => {
       });
 
       // Drag the resize bar to make the instructions smaller by 100px
-
-      resizer().simulate('mousedown', {button: 0, pageY: 100});
-      resizer().simulate('mousemove', {pageY: 0});
-      resizer().simulate('mouseup', {});
-
-      // Check updated instructions size
-
+      drag(resizer(), -100);
       assert.equal(287, instructionsHeight());
       assert.include(store.getState().instructions, {
         renderedHeight: 300,
@@ -259,13 +245,7 @@ describe('InstructionsWithWorkspace', () => {
       });
 
       // Drag the resize bar to make the instructions as large as possible
-
-      resizer().simulate('mousedown', {button: 0, pageY: 0});
-      resizer().simulate('mousemove', {pageY: 1000});
-      resizer().simulate('mouseup', {});
-
-      // Check the instructions stopped at their max needed height
-
+      drag(resizer(), 1000);
       assert.equal(530, instructionsHeight());
       assert.include(store.getState().instructions, {
         renderedHeight: 543,
@@ -275,13 +255,7 @@ describe('InstructionsWithWorkspace', () => {
       });
 
       // Drag the resize bar to make the instructions as small as possible
-
-      resizer().simulate('mousedown', {button: 0, pageY: 1000});
-      resizer().simulate('mousemove', {pageY: 0});
-      resizer().simulate('mouseup', {});
-
-      // Check the instructions stopped at their minimum height
-
+      drag(resizer(), -1000);
       assert.equal(60, instructionsHeight());
       assert.include(store.getState().instructions, {
         renderedHeight: 73,
@@ -290,5 +264,11 @@ describe('InstructionsWithWorkspace', () => {
         maxAvailableHeight: Infinity
       });
     });
+
+    function drag(element, distance) {
+      element.simulate('mousedown', {button: 0, pageY: 1000});
+      element.simulate('mousemove', {pageY: 1000 + distance});
+      element.simulate('mouseup', {});
+    }
   });
 });


### PR DESCRIPTION
[LP-838](https://codedotorg.atlassian.net/browse/LP-838): As a first step towards simplifying our instructions resize code, moves ownership of the `HeightResizer` component up out of `TopInstructions` into the `InstructionsWithWorkspace` component.

I believe this makes more sense - `TopInstructions` and `CodeWorkspace` are both rendered by `InstructionsWithWorkspace`, both respecting the instructions size currently stored in redux. At the moment, `TopInstructions` also owns the resizer control that sits between these two resizable areas, but it's unclear why `TopInstructions` should be concerned with this resize bar, rather than simply rendering in the space it's given. (There are circumstances where content changes inside the instructions will trigger a container resize, but that seems like a side-effect, not a primary concern).

In the new setup, `TopInstructions`, `HeightResizer` and `CodeWorkspace` are siblings, and their parent `InstructionsWithWorkspace` owns the resize logic that governs these three components.

This is _nearly_ a pure refactor - from a behavior point of view everything should be exactly the same.  The structure of the DOM changes a bit, with the resizer moving out a few layers.

## Testing story

My approach to this change:

1. Pin existing resize behavior with an integration test on `InstructionsWithWorkspace`.
2. Move `HeightResizer`, keeping tests passing.
3. Do a little code cleanup to make things read nicely.

Also manual testing on CSF and non-CSF levels to sanity check that the resizer still looks and feels the same.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
