### PR TITLE
Revert "Hide facilitator summary tables in Application Dashboard"

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/application_dashboard.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/application_dashboard.jsx
@@ -44,6 +44,21 @@ const ApplicationDashboardHeader = props => (
 );
 
 const paths = {
+  csf_facilitators: {
+    type: 'facilitator',
+    name: 'CS Fundamentals Facilitator Applications',
+    course: 'csf'
+  },
+  csd_facilitators: {
+    type: 'facilitator',
+    name: 'CS Discoveries Facilitator Applications',
+    course: 'csd'
+  },
+  csp_facilitators: {
+    type: 'facilitator',
+    name: 'CS Principles Facilitator Applications',
+    course: 'csp'
+  },
   csd_teachers: {
     type: 'teacher',
     name: 'CS Discoveries Teacher Applications',

--- a/apps/src/code-studio/pd/application_dashboard/summary.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary.jsx
@@ -85,6 +85,35 @@ export class Summary extends React.Component {
         {this.props.showRegionalPartnerDropdown && <RegionalPartnerDropdown />}
         <h1>{this.props.regionalPartnerFilter.label}</h1>
         <Row>
+          <Col sm={4}>
+            <SummaryTable
+              id="summary-csf-facilitators"
+              caption="CS Fundamentals Facilitators"
+              data={this.state.applications['csf_facilitators']}
+              path="csf_facilitators"
+              applicationType="facilitator"
+            />
+          </Col>
+          <Col sm={4}>
+            <SummaryTable
+              id="summary-csd-facilitators"
+              caption="CS Discoveries Facilitators"
+              data={this.state.applications['csd_facilitators']}
+              path="csd_facilitators"
+              applicationType="facilitator"
+            />
+          </Col>
+          <Col sm={4}>
+            <SummaryTable
+              id="summary-csp-facilitators"
+              caption="CS Principles Facilitators"
+              data={this.state.applications['csp_facilitators']}
+              path="csp_facilitators"
+              applicationType="facilitator"
+            />
+          </Col>
+        </Row>
+        <Row>
           <Col sm={6}>
             <SummaryTable
               id="summary-csd-teachers"

--- a/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
@@ -26,13 +26,34 @@ describe('Summary', () => {
     expect(summary.find('Spinner')).to.have.length(1);
   });
 
-  it('Generates 2 tables in 1 rows after hearing from server', () => {
+  it('Generates 5 tables in 2 rows after hearing from server', () => {
     let server = sinon.fakeServer.create();
 
     server.respondWith('GET', '/api/v1/pd/applications', [
       200,
       {'Content-Type': 'application/json'},
       JSON.stringify({
+        csf_facilitators: {
+          unreviewed: {locked: 0, total: 1},
+          pending: {locked: 0, total: 0},
+          accepted: {locked: 0, total: 0},
+          declined: {locked: 0, total: 0},
+          waitlisted: {locked: 0, total: 0}
+        },
+        csd_facilitators: {
+          unreviewed: {locked: 0, total: 0},
+          pending: {locked: 0, total: 0},
+          accepted: {locked: 0, total: 0},
+          declined: {locked: 0, total: 0},
+          waitlisted: {locked: 0, total: 0}
+        },
+        csp_facilitators: {
+          unreviewed: {locked: 0, total: 0},
+          pending: {locked: 0, total: 0},
+          accepted: {locked: 0, total: 0},
+          declined: {locked: 0, total: 0},
+          waitlisted: {locked: 0, total: 0}
+        },
         csd_teachers: {
           unreviewed: {locked: 0, total: 1},
           pending: {locked: 0, total: 0},
@@ -63,8 +84,9 @@ describe('Summary', () => {
     server.respond();
     summary.update();
     const rows = summary.find(Row);
-    expect(rows).to.have.length(1);
-    expect(rows.at(0).children()).to.have.length(2);
+    expect(rows).to.have.length(2);
+    expect(rows.at(0).children()).to.have.length(3);
+    expect(rows.at(1).children()).to.have.length(2);
 
     expect(summary.find('Spinner')).to.have.length(0);
   });


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#32377 to investigate an UI test failure and to unblock merging staging-next to staging.

- [Discussion thread](https://codedotorg.slack.com/archives/DGJJ7D7B5/p1576526024000500)
- [UI Test failure](https://eyes.applitools.com/app/test-results/00000251825785414198/00000251825785322287/steps/2?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor)
