### PR TITLE
Homepage: Simple homepage update for post-hoc 2019

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/homepage.css
+++ b/pegasus/sites.v3/code.org/public/css/homepage.css
@@ -161,7 +161,7 @@ body.modal-open .supreme-container{
 
 .curriculum-banner {
   width: 100%;
-  background-color: black;
+  background-color: rgb(118,101,160);
   text-align: center;
   color: white;
   padding: 14px;

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -5,6 +5,11 @@
   actions = Homepage.get_actions(request)
 
 - main_actions = capture_haml do
+  - if show_single_hero == "changeworld"
+    .hero-message-line1{style: "color: white; font-size: 28px; line-height: 28px; padding-top: 20px; padding-bottom: 20px; font-family: 'Gotham 5r', sans-serif"}
+      = hoc_s(:hoc2019_header_line1_mobile)
+    .hero-message-line2{style: "color: white; font-size: 28px; line-height: 28px; padding-bottom: 80px; font-family: 'Gotham 5r', sans-serif"}
+      = hoc_s(:hoc2019_header_line2_mobile)
   - if show_single_hero == "dance2019"
     -# Two lines of text
     .hero-message-line1{style: "font-size: 28px; line-height: 28px; padding-bottom: 10px; color: white"}
@@ -50,11 +55,9 @@
         Two headers with inverse media queries conditionally load the correctly-sized image.
       - response.add_header 'Link', "<#{entry[:image]}>; rel=preload; as=image; media=\"#{css_retina?(false)}\";"
       - response.add_header 'Link', "<#{entry[:image].gsub('.jpg', '_2x.jpg')}>; rel=preload; as=image; media=\"#{css_retina?}\";"
-      -# Temp: for dance2019, heroes will show/hide resposively, so use widehero_do_not_hide
-      .widehero_do_not_hide#fullwidth0{style: "background-position: #{entry[:centering]}; background-image: url(#{entry[:image]});", class: entry[:classname]}
+      .widehero#fullwidth0{style: "background-position: #{entry[:centering]}; background-image: url(#{entry[:image]});"}
     - else
-      -# Temp: for dance2019, heroes will show/hide responsively, so use widehero_do_not_hide
-      .widehero_do_not_hide.lazyload{id: "fullwidth#{index}", "data-bg"=> "#{entry[:image]}", style: "background-position: #{entry[:centering]}", class: entry[:classname]}
+      .widehero.lazyload{id: "fullwidth#{index}", "data-bg"=> "#{entry[:image]}", style: "background-position: #{entry[:centering]}"}
 
   #fullwidth
     - if request.site == 'code.org'
@@ -108,7 +111,6 @@
   - elsif show_single_hero
     #actions
       = main_actions
-
 
   #caption_container.container_responsive
     - unless show_single_hero
@@ -229,8 +231,6 @@
     var numWideHeroes = $(".widehero").length;
 
     if (numWideHeroes > 1) {
-      // Temporary for dance2019: don't cycle, even though we have multiple
-      // hero backgrounds, because we're using them responsively.
-      //timerId = setInterval(cycleImage, #{hero_display_time});
+      timerId = setInterval(cycleImage, #{hero_display_time});
     }
   });

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -351,11 +351,11 @@ class Homepage
   end
 
   def self.show_single_hero(request)
-    launch_ai = DCDO.get('launch_ai', nil)
-    (launch_ai && request.language == "en") ? "oceans2019" : "dance2019"
+    "changeworld"
   end
 
   def self.get_heroes_arranged(request)
+    hero_changeworld = [{centering: "50% 30%", type: "stat", textposition: "bottom", image: "/images/homepage/announcement.jpg"}]
     hero_create = [{text: "homepage_hero_text_stat_students", centering: "50% 30%", type: "stat", textposition: "bottom", image: "/images/homepage/announcement.jpg"}]
     hero_hoc2019 = [{text: "homepage_hero_text_stat_students", centering: "50% 30%", type: "stat", textposition: "bottom", image: "/images/homepage/hoc2019.jpg"}]
     hero_dance2019 = [
@@ -372,6 +372,8 @@ class Homepage
       heroes_arranged = hero_hoc2019
     elsif show_single_hero(request) == "create"
       heroes_arranged = hero_create
+    elsif show_single_hero(request) == "changeworld"
+      heroes_arranged = hero_changeworld
     elsif show_single_hero(request) == "dance2019"
       heroes_arranged = hero_dance2019
     elsif show_single_hero(request) == "oceans2019"


### PR DESCRIPTION
A simple homepage update for post-hoc 2019.  This will just take over the en & non-en `code.org/` homepage after merge; it doesn't actually rely on the `hoc_mode` value, though that does affect which actions we show.  The screenshots here are for the actions with `hoc_mode` being `post-hoc`.

Cleans up some temporary changes from https://github.com/code-dot-org/code-dot-org/pull/31898.

## desktop
![Screenshot 2019-12-16 12 50 45](https://user-images.githubusercontent.com/2205926/70942335-4e5e1200-2003-11ea-874d-f4b29d4f4401.png)

## tablet
![Screenshot 2019-12-16 12 51 47](https://user-images.githubusercontent.com/2205926/70942336-4ef6a880-2003-11ea-974b-daedddc77305.png)

## mobile
![Screenshot 2019-12-16 12 52 11](https://user-images.githubusercontent.com/2205926/70942337-4ef6a880-2003-11ea-8e82-026987f369fb.png)
