### PR TITLE
Fix test paths for progress views

### DIFF
--- a/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import {expect} from '../../../util/deprecatedChai';
-import {UnconnectedVirtualizedDetailView} from '@cdo/apps/templates/sectionProgress/VirtualizedDetailView';
+import {UnconnectedVirtualizedDetailView} from '@cdo/apps/templates/sectionProgress/detail/VirtualizedDetailView';
 import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import scriptSelection from '@cdo/apps/redux/scriptSelectionRedux';
 import {

--- a/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import {expect} from '../../../util/deprecatedChai';
-import {UnconnectedVirtualizedSummaryView} from '@cdo/apps/templates/sectionProgress/VirtualizedSummaryView';
+import {UnconnectedVirtualizedSummaryView} from '@cdo/apps/templates/sectionProgress/summary/VirtualizedSummaryView';
 import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import scriptSelection from '@cdo/apps/redux/scriptSelectionRedux';
 import {


### PR DESCRIPTION
I reorganized components in #32406 and missed two paths used in tests.  I updated the paths to the correct location and both of these tests now pass locally. 