### PR TITLE
Revert "Revert "Standards legend""

### DIFF
--- a/apps/src/templates/sectionProgress/ProgressBox.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.jsx
@@ -31,7 +31,6 @@ export default class ProgressBox extends Component {
     perfect: PropTypes.number,
     style: PropTypes.object,
     stageIsAllAssessment: PropTypes.bool,
-    showLessonNumber: PropTypes.bool,
     lessonNumber: PropTypes.number
   };
 
@@ -84,7 +83,7 @@ export default class ProgressBox extends Component {
     };
     return (
       <div style={boxWithBorderStyle}>
-        {this.props.showLessonNumber && (
+        {this.props.lessonNumber && (
           <div style={lessonNumberStyle}>{this.props.lessonNumber}</div>
         )}
         <div style={incompleteLevels} />

--- a/apps/src/templates/sectionProgress/ProgressBox.story.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.story.jsx
@@ -59,7 +59,6 @@ export default storybook => {
           incomplete={0}
           imperfect={0}
           perfect={20}
-          showLessonNumber={true}
           lessonNumber={88}
         />
       )
@@ -73,7 +72,6 @@ export default storybook => {
           incomplete={0}
           imperfect={0}
           perfect={0}
-          showLessonNumber={true}
           lessonNumber={1}
         />
       )

--- a/apps/src/templates/sectionProgress/standards/StandardsLegend.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsLegend.jsx
@@ -1,0 +1,84 @@
+import React, {Component} from 'react';
+import ProgressBox from '@cdo/apps/templates/sectionProgress/ProgressBox';
+import color from '@cdo/apps/util/color';
+import i18n from '@cdo/locale';
+
+const styles = {
+  header: {
+    fontWeight: 'bold',
+    color: color.charcoal,
+    textAlign: 'center',
+    fontSize: 16,
+    lineHeight: '24px'
+  },
+  th: {
+    backgroundColor: color.lightest_gray,
+    color: color.charcoal,
+    border: `1px solid ${color.lightest_gray}`,
+    fontFamily: '"Gotham 4r", sans-serif',
+    fontSize: 14,
+    textAlign: 'center',
+    padding: 15
+  },
+  td: {
+    border: `1px solid ${color.lightest_gray}`,
+    padding: 15
+  },
+  boxStyle: {
+    margin: '0 auto'
+  },
+  completedBoxes: {
+    display: 'flex',
+    flexDirection: 'row'
+  }
+};
+
+export default class SummaryViewLegend extends Component {
+  render() {
+    return (
+      <div style={{marginTop: 60}}>
+        <table>
+          <thead>
+            <tr>
+              <td>
+                <h3 style={styles.header}>{i18n.lessonStatus()}</h3>
+              </td>
+            </tr>
+            <tr>
+              <th style={styles.th}>{i18n.notStarted()}</th>
+              <th style={styles.th}>{i18n.completed()}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style={styles.td}>
+                <ProgressBox
+                  style={styles.boxStyle}
+                  started={false}
+                  incomplete={20}
+                  imperfect={0}
+                  perfect={0}
+                  stageIsAllAssessment={false}
+                  lessonNumber={10}
+                />
+              </td>
+              <td style={styles.td}>
+                <div style={styles.completedBoxes}>
+                  <ProgressBox
+                    style={styles.boxStyle}
+                    started={true}
+                    incomplete={0}
+                    imperfect={0}
+                    perfect={20}
+                    stageIsAllAssessment={false}
+                    lessonNumber={8}
+                  />
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}

--- a/apps/src/templates/sectionProgress/standards/StandardsView.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsView.jsx
@@ -1,7 +1,13 @@
 import React, {Component} from 'react';
+import StandardsLegend from './StandardsLegend';
 
 export default class StandardsView extends Component {
   render() {
-    return <div>Coming soon...</div>;
+    return (
+      <div>
+        <p>Coming soon...</p>
+        <StandardsLegend />
+      </div>
+    );
   }
 }


### PR DESCRIPTION
Josh reported a [failure](https://codedotorg.slack.com/archives/C1HJJ7MQC/p1576529830188500) in the latest staging-next merge and the most recent merge was  #32410.  In my haste to unblock the pipeline, I erroneously reverted #32410. The problem was really in #32406 which was merged in quick succession right before #32410. 

In #32406 I reorganized components in SectionProgress and missed two path updates. I fixed those paths in #32427 to unblock the pipeline.  Given that this revert had nothing to do with the problem 🤦‍♀️it can be re-introduced. 