### PR TITLE
Don't parse columns from records

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -19,11 +19,7 @@ import * as utils from '../utils';
 import * as dropletConfig from './dropletConfig';
 import {getDatasetInfo} from '../storage/dataBrowser/dataUtils';
 import {initFirebaseStorage} from '../storage/firebaseStorage';
-import {
-  getColumnsRef,
-  onColumnsChange,
-  addMissingColumns
-} from '../storage/firebaseMetadata';
+import {getColumnsRef, onColumnsChange} from '../storage/firebaseMetadata';
 import {getProjectDatabase, getSharedDatabase} from '../storage/firebaseUtils';
 import * as apiTimeoutList from '../lib/util/timeoutList';
 import designMode from './designMode';
@@ -1392,9 +1388,6 @@ function onDataViewChange(view, oldTableName, newTableName) {
         storageRef = sharedStorageRef.child(`tables/${newTableName}/records`);
       } else {
         storageRef = projectStorageRef.child(`tables/${newTableName}/records`);
-      }
-      if (newTableType === tableType.PROJECT) {
-        addMissingColumns(newTableName);
       }
       onColumnsChange(
         newTableType === tableType.PROJECT

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -57,7 +57,6 @@ const INITIAL_STATE = {
 
 class DataTable extends React.Component {
   static propTypes = {
-    getColumnNames: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     rowsPerPage: PropTypes.number,
     // from redux state
@@ -162,12 +161,8 @@ class DataTable extends React.Component {
   };
 
   getNextColumnName() {
-    const names = this.props.getColumnNames(
-      this.props.tableRecords,
-      this.props.tableColumns
-    );
-    let i = names.length;
-    while (names.includes(`column${i}`)) {
+    let i = this.props.tableColumns.length;
+    while (this.props.tableColumns.includes(`column${i}`)) {
       i++;
     }
     return `column${i}`;
@@ -211,10 +206,7 @@ class DataTable extends React.Component {
   }
 
   render() {
-    let columnNames = this.props.getColumnNames(
-      this.props.tableRecords,
-      this.props.tableColumns
-    );
+    let columnNames = [...this.props.tableColumns];
     let editingColumn = this.state.editingColumn;
 
     let rowsPerPage = this.props.rowsPerPage || MAX_ROWS_PER_PAGE;

--- a/apps/src/storage/dataBrowser/DataTableView.jsx
+++ b/apps/src/storage/dataBrowser/DataTableView.jsx
@@ -142,9 +142,13 @@ class DataTableView extends React.Component {
   }
 
   render() {
-    if (this.props.view !== DataView.TABLE) {
-      return null;
-    }
+    const visible = DataView.TABLE === this.props.view;
+    const containerStyle = [
+      styles.container,
+      {
+        display: visible ? '' : 'none'
+      }
+    ];
     const debugDataStyle = [
       dataStyles.debugData,
       {
@@ -155,7 +159,7 @@ class DataTableView extends React.Component {
       this.props.tableListMap[this.props.tableName] === tableType.SHARED;
 
     return (
-      <div id="dataTable" style={styles.container} className="inline-flex">
+      <div id="dataTable" style={containerStyle} className="inline-flex">
         <div style={dataStyles.viewHeader}>
           <span style={dataStyles.backLink}>
             <a

--- a/apps/src/storage/dataBrowser/DataTableView.jsx
+++ b/apps/src/storage/dataBrowser/DataTableView.jsx
@@ -13,7 +13,6 @@ import {changeView, showWarning, tableType} from '../redux/data';
 import * as dataStyles from './dataStyles';
 import color from '../../util/color';
 import {connect} from 'react-redux';
-import {getColumnNamesFromRecords} from '../firebaseMetadata';
 import experiments from '../../util/experiments';
 
 const MIN_TABLE_WIDTH = 600;
@@ -91,23 +90,6 @@ class DataTableView extends React.Component {
     }
   }
 
-  /**
-   * @param {Array} records Array of JSON-encoded records.
-   * @param {string} columns Array of column names.
-   */
-  getColumnNames(records, columns) {
-    // Make sure 'id' is the first column.
-    const columnNames = getColumnNamesFromRecords(records);
-
-    columns.forEach(columnName => {
-      if (columnNames.indexOf(columnName) === -1) {
-        columnNames.push(columnName);
-      }
-    });
-
-    return columnNames;
-  }
-
   importCsv = (csvData, onComplete) => {
     FirebaseStorage.importCsv(
       this.props.tableName,
@@ -160,17 +142,9 @@ class DataTableView extends React.Component {
   }
 
   render() {
-    let columnNames = this.getColumnNames(
-      this.props.tableRecords,
-      this.props.tableColumns
-    );
-    const visible = DataView.TABLE === this.props.view;
-    const containerStyle = [
-      styles.container,
-      {
-        display: visible ? '' : 'none'
-      }
-    ];
+    if (this.props.view !== DataView.TABLE) {
+      return null;
+    }
     const debugDataStyle = [
       dataStyles.debugData,
       {
@@ -181,7 +155,7 @@ class DataTableView extends React.Component {
       this.props.tableListMap[this.props.tableName] === tableType.SHARED;
 
     return (
-      <div id="dataTable" style={containerStyle} className="inline-flex">
+      <div id="dataTable" style={styles.container} className="inline-flex">
         <div style={dataStyles.viewHeader}>
           <span style={dataStyles.backLink}>
             <a
@@ -204,7 +178,6 @@ class DataTableView extends React.Component {
           </span>
         </div>
         <TableControls
-          columns={columnNames}
           clearTable={this.clearTable}
           importCsv={this.importCsv}
           exportCsv={this.exportCsv}
@@ -212,9 +185,7 @@ class DataTableView extends React.Component {
           readOnly={readOnly}
         />
         <div style={debugDataStyle}>{this.getTableJson()}</div>
-        {!this.state.showDebugView && (
-          <DataTable getColumnNames={this.getColumnNames} readOnly={readOnly} />
-        )}
+        {!this.state.showDebugView && <DataTable readOnly={readOnly} />}
       </div>
     );
   }

--- a/apps/src/storage/dataBrowser/PreviewModal.jsx
+++ b/apps/src/storage/dataBrowser/PreviewModal.jsx
@@ -5,7 +5,6 @@ import {hidePreview} from '../redux/data';
 import {getDatasetInfo} from './dataUtils';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import DataTable from './DataTable';
-import {parseColumnsFromRecords} from '../firebaseMetadata';
 import msg from '@cdo/locale';
 
 class PreviewModal extends React.Component {
@@ -32,13 +31,7 @@ class PreviewModal extends React.Component {
         <h1>{this.props.tableName}</h1>
         <p>{datasetInfo.description}</p>
         <div style={{overflow: 'scroll', maxHeight: '70%'}}>
-          <DataTable
-            getColumnNames={(records, columns) =>
-              parseColumnsFromRecords(records)
-            }
-            readOnly
-            rowsPerPage={100}
-          />
+          <DataTable readOnly rowsPerPage={100} />
         </div>
         <button type="button" onClick={() => this.importTable(datasetInfo)}>
           {msg.import()}

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -27,7 +27,7 @@ export function getColumnRefByName(tableName, columnName) {
     });
 }
 
-function getColumnNamesFromRecords(records) {
+export function getColumnNamesFromRecords(records) {
   const columnNames = [];
   Object.keys(records).forEach(id => {
     const record = JSON.parse(records[id]);
@@ -109,23 +109,16 @@ export function onColumnsChange(database, tableName, callback) {
 /**
  *
  * @param {string} tableName
- * @param {Array.<string>} existingColumnNames
+ * @param {Array.<string>} columns
  * @returns {*}
  */
-export function addMissingColumns(tableName) {
+export function addMissingColumns(tableName, columns) {
   return getColumnNamesSnapshot(tableName).then(existingColumnNames => {
-    const recordsRef = getProjectDatabase().child(
-      `storage/tables/${tableName}/records`
-    );
-    return recordsRef.once('value').then(snapshot => {
-      const recordsData = snapshot.val() || {};
-      getColumnNamesFromRecords(recordsData).forEach(columnName => {
-        if (!existingColumnNames.includes(columnName)) {
-          getColumnsRef(getProjectDatabase(), tableName)
-            .push()
-            .set({columnName});
-        }
-      });
+    let columnsRef = getColumnsRef(getProjectDatabase(), tableName);
+    columns.forEach(columnName => {
+      if (!existingColumnNames.includes(columnName)) {
+        columnsRef.push().set({columnName});
+      }
     });
   });
 }

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -33,7 +33,12 @@ function getColumnNamesFromRecords(records) {
     const record = JSON.parse(records[id]);
     Object.keys(record).forEach(columnName => {
       if (columnNames.indexOf(columnName) === -1) {
-        columnNames.push(columnName);
+        if (columnName === 'id') {
+          // Make sure 'id' is first column
+          columnNames.unshift(columnName);
+        } else {
+          columnNames.push(columnName);
+        }
       }
     });
   });

--- a/apps/src/storage/firebaseMetadata.js
+++ b/apps/src/storage/firebaseMetadata.js
@@ -27,22 +27,8 @@ export function getColumnRefByName(tableName, columnName) {
     });
 }
 
-// TODO: De-dupe this function with getColumnNamesFromRecords() below
-export function parseColumnsFromRecords(records) {
+function getColumnNamesFromRecords(records) {
   const columnNames = [];
-  Object.keys(records).forEach(id => {
-    const record = JSON.parse(records[id]);
-    Object.keys(record).forEach(column => {
-      if (columnNames.indexOf(column) === -1) {
-        columnNames.push(column);
-      }
-    });
-  });
-  return columnNames;
-}
-
-export function getColumnNamesFromRecords(records) {
-  const columnNames = ['id'];
   Object.keys(records).forEach(id => {
     const record = JSON.parse(records[id]);
     Object.keys(record).forEach(columnName => {

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -221,7 +221,12 @@ FirebaseStorage.createRecord = function(tableName, record, onSuccess, onError) {
       );
       return recordRef.set(JSON.stringify(record));
     })
-    .then(() => addMissingColumns(tableName, Object.keys(record)))
+    .then(() =>
+      addMissingColumns(
+        tableName,
+        getColumnNamesFromRecords([JSON.stringify(record)])
+      )
+    )
     .then(() => onSuccess(record), onError);
 };
 
@@ -379,7 +384,12 @@ FirebaseStorage.updateRecord = function(
         incrementRateLimitCounters()
           .then(() => updateTableCounters(tableName, 0))
           .then(() => recordRef.set(recordJson))
-          .then(() => addMissingColumns(tableName, Object.keys(record)))
+          .then(() =>
+            addMissingColumns(
+              tableName,
+              getColumnNamesFromRecords([recordJson])
+            )
+          )
           .then(() => onComplete(record, true), onError);
       }
     });

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -220,6 +220,7 @@ FirebaseStorage.createRecord = function(tableName, record, onSuccess, onError) {
       );
       return recordRef.set(JSON.stringify(record));
     })
+    .then(() => addMissingColumns(tableName))
     .then(() => onSuccess(record), onError);
 };
 
@@ -377,6 +378,7 @@ FirebaseStorage.updateRecord = function(
         incrementRateLimitCounters()
           .then(() => updateTableCounters(tableName, 0))
           .then(() => recordRef.set(recordJson))
+          .then(() => addMissingColumns(tableName))
           .then(() => onComplete(record, true), onError);
       }
     });
@@ -547,6 +549,7 @@ FirebaseStorage.copyStaticTable = function(tableName, onSuccess, onError) {
     .then(snapshot => {
       getRecordsRef(tableName).set(snapshot.val());
     })
+    .then(() => addMissingColumns(tableName))
     .then(onSuccess, onError);
 };
 
@@ -605,6 +608,7 @@ FirebaseStorage.createTable = function(tableName, onSuccess, onError) {
           return Promise.resolve();
         });
     })
+    .then(() => addColumnName(tableName, 'id'))
     .then(onSuccess, onError);
 };
 


### PR DESCRIPTION
# Description
#32200 was reverted by #32413

This PR reintroduces that change, but without the change to return `null` when the `DataTableView` wasn't visible. Turns out, this broke tests.

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
