### PR TITLE
Fix TypeError in /teacher-dashboard/review-hociyskvuwa/all

### DIFF
--- a/pegasus/helper_modules/hoc_event_review.rb
+++ b/pegasus/helper_modules/hoc_event_review.rb
@@ -41,13 +41,15 @@ module HocEventReview
   # Get events according to given filters
   def self.events(**rest)
     events_query(rest).
-      select(:data, :secret, :processed_data).
-      limit(100).
-      map do |form|
-        JSON.parse(form[:data]).
-          merge(secret: form[:secret]).
-          merge(JSON.parse(form[:processed_data]))
-      end
+        select(:data, :secret, :processed_data).
+        limit(100).
+        map do |form|
+          next unless !!form[:processed_data]
+          JSON.parse(form[:data]).
+              merge(secret: form[:secret]).
+              merge(JSON.parse(form[:processed_data]))
+        end.
+        compact
   end
 
   private_class_method def self.events_query(

--- a/pegasus/helper_modules/hoc_event_review.rb
+++ b/pegasus/helper_modules/hoc_event_review.rb
@@ -44,7 +44,7 @@ module HocEventReview
         select(:data, :secret, :processed_data).
         limit(100).
         map do |form|
-          next unless !!form[:processed_data]
+          next unless form[:processed_data]
           JSON.parse(form[:data]).
               merge(secret: form[:secret]).
               merge(JSON.parse(form[:processed_data]))

--- a/pegasus/helper_modules/hoc_event_review.rb
+++ b/pegasus/helper_modules/hoc_event_review.rb
@@ -41,15 +41,15 @@ module HocEventReview
   # Get events according to given filters
   def self.events(**rest)
     events_query(rest).
-        select(:data, :secret, :processed_data).
-        limit(100).
-        map do |form|
-          next unless form[:processed_data]
-          JSON.parse(form[:data]).
-              merge(secret: form[:secret]).
-              merge(JSON.parse(form[:processed_data]))
-        end.
-        compact
+      select(:data, :secret, :processed_data).
+      limit(100).
+      map do |form|
+        next unless form[:processed_data]
+        JSON.parse(form[:data]).
+          merge(secret: form[:secret]).
+          merge(JSON.parse(form[:processed_data]))
+      end.
+      compact
   end
 
   private_class_method def self.events_query(

--- a/pegasus/test/test_hoc_event_review.rb
+++ b/pegasus/test/test_hoc_event_review.rb
@@ -102,13 +102,12 @@ class HocEventReviewTest < Minitest::Test
     end
 
     it 'only finds events with processed data' do
-      with_form country: 'US', state: 'CA', special_event: 1 do
-        with_form country: 'US', state: 'OR', has_processed_data: false  do
-          expected = [
-            {state_code: 'CA', count: 1},
-          ]
-          actual = HocEventReview.event_counts_by_state special_events_only: true
-          assert_equal expected, actual
+      with_form country: 'US', state: 'CA', has_processed_data: false do
+        with_form country: 'US', state: 'OR' do
+          with_form country: 'MX' do
+            actual = HocEventReview.events
+            assert_equal 2, actual.size
+          end
         end
       end
     end


### PR DESCRIPTION
# Description

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
Fix TypeError in hour of code review page. If any event in the query had not been processed yet the page would fail to load due to trying to parse a nil value.

<!--### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-657)
- [honeybadger](https://app.honeybadger.io/projects/34365/faults/58053063 )
- [event review page](https://code.org/teacher-dashboard/review-hociyskvuwa/all)
- [new event form (scroll down)](https://hourofcode.com/us)

## Testing story
Tested locally by first reproducing the issue:
- add an event
- see review page failed to load
- process event with process_forms script
- see review page loaded with event
Then:
- added check to skip events in query without processed data
- confirmed could see events even if there were events without processed data
- added unit test that tested this scenario

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
