### PR TITLE
Show workshop created_at date on workshop dashboard

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
@@ -125,7 +125,8 @@ export class Workshop extends React.Component {
             'regional_partner_name',
             'regional_partner_id',
             'scholarship_workshop?',
-            'potential_organizers'
+            'potential_organizers',
+            'created_at'
           ])
         });
       })
@@ -903,6 +904,7 @@ export class Workshop extends React.Component {
         {this.renderEndWorkshopPanel()}
         {this.renderEnrollmentsPanel()}
         {this.renderDetailsPanel()}
+        <MetadataFooter createdAt={this.state.workshop.created_at} />
       </Grid>
     );
   }
@@ -911,3 +913,28 @@ export class Workshop extends React.Component {
 export default connect(state => ({
   permission: state.workshopDashboard.permission
 }))(Workshop);
+
+/**
+ * A small, right-aligned section at the end of the workshop dashboard showing
+ * metadata we want to be able to check occasionally, like the workshop created_at date.
+ * @param {string} createdAt - and ISO 8601 date string
+ * @returns {Component}
+ * @constructor
+ */
+const MetadataFooter = ({createdAt}) => (
+  <Row>
+    <Col sm={12}>
+      <div style={METADATA_FOOTER_STYLE}>
+        Workshop created {new Date(createdAt).toLocaleDateString('en-US')}.
+      </div>
+    </Col>
+  </Row>
+);
+MetadataFooter.propTypes = {
+  createdAt: PropTypes.string.isRequired // An ISO 8601 date string
+};
+const METADATA_FOOTER_STYLE = {
+  textAlign: 'right',
+  fontSize: 'smaller',
+  fontStyle: 'italic'
+};

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -34,7 +34,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
     :enrollment_code, :on_map, :funded, :funding_type, :ready_to_close?,
     :date_and_location_name, :regional_partner_name, :regional_partner_id,
-    :scholarship_workshop?, :can_delete
+    :scholarship_workshop?, :can_delete, :created_at
 
   def sessions
     object.sessions.map do |session|

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -405,6 +405,13 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     assert_response :forbidden
   end
 
+  test 'created_at is included in a serialized workshop response' do
+    sign_in @organizer
+    get :show, params: {id: @workshop.id}
+    refute_nil JSON.parse(response.body)['created_at']
+    assert_equal @workshop.created_at, JSON.parse(response.body)['created_at']
+  end
+
   # Action: Create
 
   test 'admins can create workshops' do


### PR DESCRIPTION
Megan mentioned that she needs to look up the `created_at` field for a workshop a handful of times a year.  Rather than handle these requests manually, it seems reasonable to add this metadata in an understated style to the end of the workshop view.

![Screenshot from 2019-12-17 14-31-16](https://user-images.githubusercontent.com/1615761/71039876-137add80-20da-11ea-8b55-fc3d4ebf45c4.png)

## Testing story

Unit tests for the update to the workshop serializer.  Manually tested the client change.  The only reason I'm not adding unit tests here is that there are no unit tests for the workshop view right now but I'm adding a bunch of them in https://github.com/code-dot-org/code-dot-org/pull/31990 and they'll cover this new code path.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
