### PR TITLE
hoc mode: change test environment to post-hoc

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -416,7 +416,7 @@ proxy: false # If true, generated URLs will not include explicit port numbers in
 # Run dashboard-server with the level editing interface enabled (for admins)
 levelbuilder_mode:
 
-default_hoc_mode:   soon-hoc # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode:   post-hoc # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''       # overridden by 'hoc_launch' DCDO param, except in :test
 
 localize_apps: false


### PR DESCRIPTION
Now that hoc2019 is finished, and we are switching our various environments to `hoc_mode` of `"post-hoc"`, make sure the test environment also gets this new value.