### PR TITLE
Point gdrive script at new doc

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -20,4 +20,4 @@ Pd::Application::Teacher2021Application.find_each do |app|
   ]
 end
 
-Google::Drive.new.add_sheet_to_spreadsheet(applications, "2019-20 Teacher Applications", "all_apps (auto)")
+Google::Drive.new.add_sheet_to_spreadsheet(applications, "2020-21 Teacher Applications", "all_apps (auto)")


### PR DESCRIPTION
[PLC-578](https://codedotorg.atlassian.net/browse/PLC-578): A tiny follow-up to https://github.com/code-dot-org/code-dot-org/pull/32383: I misunderstood the spec and there's a [_new_ Google doc](https://docs.google.com/spreadsheets/d/1g40lnTMRnweN8e4By7XaYQa1W8FWZa2OTiRgHXczSyM/edit?ts=5df97cf8#gid=0) that we should be updating.  This change updates the script to point at the new doc.

## Testing story

Tested by uploading sample application records to the new doc from my local machine.  Follow-up steps documented in the previous PR still apply - we'll need to work out details of credentials once this is deployed.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
