### PR TITLE
Deflake ProxyHelperTest

### DIFF
--- a/dashboard/test/helpers/proxy_helper_test.rb
+++ b/dashboard/test/helpers/proxy_helper_test.rb
@@ -43,7 +43,7 @@ class ProxyHelperTest < ActionView::TestCase
     hostname = 'resolves.to.private.ip.example.net'
 
     IPSocket.expects(:getaddress).with(hostname).returns('169.254.0.0')
-    IPSocket.expects(:getaddress).with(CDO.dashboard_hostname).returns('127.0.0.1')
+    ProxyHelper.stubs(:dashboard_ip_address).returns('127.0.0.1')
     refute allowed_ip_address?('resolves.to.private.ip.example.net')
   end
 


### PR DESCRIPTION
Stabilizes a test `ProxyHelperTest#test_disallows_hostname_resolving_to_private_IP_address` that has been causing intermittent CI failures ([example](https://drone.cdn-code.org/code-dot-org/code-dot-org/8768/1/4)).

## Root cause

The failing test used to look like this:

https://github.com/code-dot-org/code-dot-org/blob/3adda3c1aee1d7b2eaabe13016d305f74601471f/dashboard/test/helpers/proxy_helper_test.rb#L42-L48

It sets up two expectations, with corresponding stub return values.  If `IPSocket.getaddress` is not called twice, this test will fail.  In fact, this is exactly the failure we're getting:

```
unsatisfied expectations:
- expected exactly once, not yet invoked: IPSocket.getaddress('test-studio.code.org')
satisfied expectations:
- expected exactly once, invoked once: IPSocket.getaddress('resolves.to.private.ip.example.net')
```

So we can see that the first expectation is met, but the second is failing our test.  Why?

Digging into the happy path for this test, we start in `allowed_ip_address?`:

https://github.com/code-dot-org/code-dot-org/blob/3adda3c1aee1d7b2eaabe13016d305f74601471f/dashboard/app/helpers/proxy_helper.rb#L163-L166

Let's fill in values for the particular test to understand what's happening.

```rb
host_ip_address = IPAddr.new(IPSocket.getaddress('resolves.to.private.ip.example.net')) 
public_ip_address?(host_ip_address) || host_ip_address == ProxyHelper.dashboard_ip_address 
```

There's our first expectation satisfied, right on the first line.  Let's swap in the stub return value.

```rb
host_ip_address = IPAddr.new('169.254.0.0') 
public_ip_address?(host_ip_address) || host_ip_address == ProxyHelper.dashboard_ip_address 
```

What does `public_ip_address?` return in this case? Intuitively, `false`.  Here's the method if you'd like to check:

https://github.com/code-dot-org/code-dot-org/blob/3adda3c1aee1d7b2eaabe13016d305f74601471f/dashboard/app/helpers/proxy_helper.rb#L168-L175

(Yes, we should be using an implicit return there.)  Still haven't seen a second invocation of `IPSocket.getaddress`. Anyway, that gives us a `false || ...` scenario.  Let's collapse the expression again.

```rb
host_ip_address = IPAddr.new('169.254.0.0') 
host_ip_address == ProxyHelper.dashboard_ip_address 
```

Time to look at `ProxyHelper.dashboard_ip_address`:

https://github.com/code-dot-org/code-dot-org/blob/3adda3c1aee1d7b2eaabe13016d305f74601471f/dashboard/app/helpers/proxy_helper.rb#L136-L139

A-HA! There's our second `IPSocket.getaddress` invocation.  But it's inside a _memoized module method_.  That is, we're only going to call `getaddress` the _first_ time we call `dashboard_ip_address`. On subsequent calls `@@dashboard_ip_address` will already be set, and the right side of the expression isn't evaluated.  If another test happens to call `ProxyHelper.dashboard_ip_address` before the test `disallows hostname resolving to private IP address` does, our expectation will fail.

This failure feels flaky and hard to repro for several reasons.

1. Drone only runs dashboard tests if relevant source files were changed in in the PR.
2. If you ran just the failing test in isolation, it always passes, because no other test triggered the memoization.
3. On our `test` environment we split dashboard tests into many parallel processes, so it's likely that the test that trips memoization early might be isolated to a different process and not cause a problem.
4. Our dashboard unit test cases run in randomized order, so even in correct conditions, some test orderings would pass.

A minimum repro would look something like this:

```rb
test 'a' do
  IPSocket.expects(:getaddress)
  ProxyHelper.dashboard_ip_address
end

test 'b' do
  IPSocket.expects(:getaddress)
  ProxyHelper.dashboard_ip_address
end
```

Whichever order we run these in, the second one to run will fail.

Last question: Why did this _just_ start failing?

https://github.com/code-dot-org/code-dot-org/pull/32392 made a subtle change that calls `allowed_ip_address?` in some cases where it wasn't called before, causing existing test cases that used to never touch `dashboard_ip_address` to now run that code and trigger its memoization.

## Chosen fix

I've decided this test should expect and stub `dashboard_ip_address` itself, instead of a method inside its memoized body.  I believe the spirit of the test remains intact.