### PR TITLE
only send build email notification on failure

### DIFF
--- a/bin/cronjob
+++ b/bin/cronjob
@@ -31,7 +31,7 @@ require 'open3'
 #
 def email_notify(command, status, content, recipient)
   return if recipient.nil? || recipient.empty?
-  return if content.empty? && status == 0
+  return if content.empty? || status == 0
 
   Mail.new do |mail|
     mail.to recipient


### PR DESCRIPTION
# Description

Never send build notification emails when ci_build returns with status code `0` (success).

For background, see https://codedotorg.slack.com/archives/C0T0PNTM3/p1576704653047400

For a tiny bit more background, per-environment crontabs get generated here:
https://github.com/code-dot-org/code-dot-org/blob/a0dd0196c14fbdaa368e775426fa0ba8c4354486/cookbooks/cdo-apps/templates/default/crontab.erb#L108

On the staging machine, this line appears as follows:
```
*/1 * * * * BUNDLE_GEMFILE=/home/ubuntu/staging/Gemfile bundle exec /home/ubuntu/staging/bin/cronjob /home/ubuntu/staging/aws/ci_build dev+build@code.org
```

Once its working, a separate step will try to move this build output to dev-build@code.org.

## Testing story

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
