### PR TITLE
Fix flaky TeacherAttendanceReportControllerTest

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -42,20 +42,34 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
     @program_manager = create :program_manager
 
     # CSF workshop from this program manager with 10 teachers.
-    @pm_workshop = create :workshop, :ended, organizer: @program_manager, course: Pd::Workshop::COURSE_CSF
+    @pm_workshop = create :workshop, :ended,
+      organizer: @program_manager,
+      course: Pd::Workshop::COURSE_CSF,
+      started_at: 1.day.ago,
+      ended_at: 1.day.ago,
+      sessions_from: 1.day.ago
     10.times do
       create :pd_workshop_participant, workshop: @pm_workshop, enrolled: true, attended: true
     end
 
     # CSF workshop from this organizer with 10 teachers.
-    @workshop = create :workshop, :ended, organizer: @organizer, course: Pd::Workshop::COURSE_CSF
+    @workshop = create :workshop, :ended,
+      organizer: @organizer,
+      course: Pd::Workshop::COURSE_CSF,
+      started_at: 1.day.ago,
+      ended_at: 1.day.ago,
+      sessions_from: 1.day.ago
     10.times do
       create :pd_workshop_participant, workshop: @workshop, enrolled: true, attended: true
     end
 
     # Non-CSF workshop from a different organizer, with 1 teacher.
-    @other_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_ECS,
-      subject: Pd::Workshop::SUBJECT_ECS_PHASE_2
+    @other_workshop = create :workshop, :ended,
+      course: Pd::Workshop::COURSE_ECS,
+      subject: Pd::Workshop::SUBJECT_ECS_PHASE_2,
+      started_at: 1.day.ago,
+      ended_at: 1.day.ago,
+      sessions_from: 1.day.ago
     create :pd_workshop_participant, workshop: @other_workshop, enrolled: true, attended: true
   end
 


### PR DESCRIPTION
Several of the test cases in `TeacherAttendanceReportControllerTest` are failing at certain times of day, due to two things:

1. Timezone issues (fails from 4pm-midnight PST)
2. [This factory](https://github.com/code-dot-org/code-dot-org/blob/1e9abb2139d90ba5663c2a35a641f8a32f66fc99/dashboard/test/factories/workshop_factories.rb#L18) that sets the first session start date for a workshop ahead nine hours.

Put another way: We're using `Date.current` to set up our test data and `Date.today` for our workshop session query, and then this happens at certain times of day:

```rb
[development] dashboard > Date.today
=> Wed, 18 Dec 2019
[development] dashboard > Date.current
=> Thu, 19 Dec 2019
```

The tests in this file aren't really testing these boundaries at a timezone granularity anyway, so to get tests passing I'm setting all the generated workshops back a day (the controller being tested looks back seven days by default).

Taking a deeper look at this issue, and possible rewriting this test to check boundary conditions well, tracked as [PLC-679](https://codedotorg.atlassian.net/browse/PLC-679).