### PR TITLE
Announcements: fix image stretching

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/LandingPage.jsx
@@ -80,7 +80,7 @@ export const LastWorkshopSurveyBanner = ({
   <TwoColumnActionBlock
     isRtl={false}
     responsiveSize="lg"
-    imageUrl={pegasus('/shared/images/fill-540x289/misc/teacher.png')}
+    imageUrl={pegasus('/shared/images/fill-540x300/misc/teacher.png')}
     subHeading={subHeading}
     description={description}
     buttons={[

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -171,7 +171,7 @@ export class LocalClassActionBlock extends Component {
     return (
       <TwoColumnActionBlock
         imageUrl={pegasus(
-          '/shared/images/fill-540x289/misc/beyond-local-map.png'
+          '/shared/images/fill-540x300/misc/beyond-local-map.png'
         )}
         heading={heading}
         subHeading={i18n.findLocalClassSubheading()}
@@ -192,7 +192,7 @@ export class AdministratorResourcesActionBlock extends Component {
     return (
       <TwoColumnActionBlock
         imageUrl={pegasus(
-          '/images/fill-540x289/2015AR/newcsteacherstrained.png'
+          '/images/fill-540x300/2015AR/newcsteacherstrained.png'
         )}
         heading={i18n.administratorResourcesHeading()}
         description={i18n.administratorResourcesDescription()}


### PR DESCRIPTION
Fixes some minor stretching of images in some announcements.

Followup to https://github.com/code-dot-org/code-dot-org/pull/32360.

### After fix:

![Screenshot 2019-12-19 16 15 59](https://user-images.githubusercontent.com/2205926/71146955-54f6be80-227b-11ea-8833-1f99d0618fd7.png)

![Screenshot 2019-12-19 16 16 14](https://user-images.githubusercontent.com/2205926/71146958-558f5500-227b-11ea-821f-4aa6d0c00d45.png)

![Screenshot 2019-12-19 16 16 19](https://user-images.githubusercontent.com/2205926/71146959-558f5500-227b-11ea-8af1-eeee16413d5e.png)
