### PR TITLE
Removed unused shared functions checkbox from dance edit page on levelbuilder

### DIFF
--- a/dashboard/app/views/levels/editors/_dance.html.haml
+++ b/dashboard/app/views/levels/editors/_dance.html.haml
@@ -19,9 +19,6 @@
 
 = render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: 'dance'}
 
-.field
-  = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :include_shared_functions, description: "Make shared functions and behaviors available"}
-
 = render partial: 'levels/editors/fields/custom_block', locals: {f: f}
 
 = render partial: 'levels/editors/fields/custom_helper_library', locals: {f: f}


### PR DESCRIPTION
# Description
Shared functions are not used in dance levels. Only in Spritelab levels. 

**Dance Before:**

-----------------------------------------------------------
<img src="https://user-images.githubusercontent.com/8324574/71300783-0154a580-234d-11ea-8edb-f278063ab186.png" height="300" />

-----------------------------------------------------------

**Dance After:**

-----------------------------------------------------------
<img src="https://user-images.githubusercontent.com/8324574/71300803-2517eb80-234d-11ea-8819-068b9feedd50.png" height="300" />

-----------------------------------------------------------

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
