### PR TITLE
Clean up unused about_stats

### DIFF
--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -161,7 +161,6 @@ def main
   total_with_gender = [1, total_females + total_males].max
 
   Properties.set :about_stats, {
-    number_served: total_started,
     number_students: DASHBOARD_REPORTING_DB_READONLY[:users].where(user_type: 'student').exclude(last_sign_in_at: nil).count,
     number_teachers: DASHBOARD_REPORTING_DB_READONLY[:users].where(user_type: 'teacher').exclude(last_sign_in_at: nil).count,
     percent_female: ((100 * total_females) / total_with_gender).to_i,

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -156,14 +156,9 @@ def main
     project_count:            existing_project_count,
   }
 
-  total_females = DASHBOARD_REPORTING_DB_READONLY[:users].where(gender: 'f').exclude(last_sign_in_at: nil).count
-  total_males = DASHBOARD_REPORTING_DB_READONLY[:users].where(gender: 'm').exclude(last_sign_in_at: nil).count
-  total_with_gender = [1, total_females + total_males].max
-
   Properties.set :about_stats, {
     number_students: DASHBOARD_REPORTING_DB_READONLY[:users].where(user_type: 'student').exclude(last_sign_in_at: nil).count,
     number_teachers: DASHBOARD_REPORTING_DB_READONLY[:users].where(user_type: 'teacher').exclude(last_sign_in_at: nil).count,
-    percent_female: ((100 * total_females) / total_with_gender).to_i,
   }
 end
 

--- a/lib/cdo/properties.rb
+++ b/lib/cdo/properties.rb
@@ -45,7 +45,6 @@ class Properties
     # would be used, for example, if the DB is unavailable or the cron failed to
     # run properly.
     get(:about_stats) || {
-      'percent_female' => 44,
       'number_students' => 19_177_297,
       'number_teachers' => 591_636
     }

--- a/lib/cdo/properties.rb
+++ b/lib/cdo/properties.rb
@@ -46,7 +46,6 @@ class Properties
     # run properly.
     get(:about_stats) || {
       'percent_female' => 44,
-      'number_served' => 426_346_094,
       'number_students' => 19_177_297,
       'number_teachers' => 591_636
     }

--- a/pegasus/sites.v3/code.org/public/diversity.md.erb
+++ b/pegasus/sites.v3/code.org/public/diversity.md.erb
@@ -12,9 +12,6 @@ social:
   "og:video:height": ""
   "og:video:type": ""
 ---
-<%
-  stats = Properties.get_user_metrics
-%>
 
 # Code.org and Diversity in Computer Science
 

--- a/pegasus/sites.v3/code.org/public/equityDocs/index.md.erb
+++ b/pegasus/sites.v3/code.org/public/equityDocs/index.md.erb
@@ -12,9 +12,6 @@ social:
   "og:video:height": ""
   "og:video:type": ""
 ---
-<%
-  stats = Properties.get_user_metrics
-%>
 
 # Code.org and Diversity in Computer Science
 
@@ -54,7 +51,7 @@ In 2014 we offered incentives to teachers (via [DonorsChoose.org](http://www.don
 
 Instead, all of our professional development workshops include a session on equity and access, to help teachers build awareness of their own stereotypes, and to give them tools to recruit or retain a diverse CS student population.  In particular, we host professional development workshops with district administrators and counselors, who play a critical role in helping high school students choose their fields of study, in order to guide them to help recruit diverse students to the new computer sciences we help them establish in their schools.
 
-**The results:** among our school district partnerships, the students in our high school computer science classes are 37% female, and 56% black or Hispanic.  
+**The results:** among our school district partnerships, the students in our high school computer science classes are 37% female, and 56% black or Hispanic.
 
 <center><img style="max-width: 100%" src="/images/2015AR/diversity.jpg" /></center>
 


### PR DESCRIPTION
While working on https://github.com/code-dot-org/code-dot-org/pull/32493 I found that two of the "about stats" served by our Properties system are not used anywhere on our site, and in turn some calls for those stats are unnecessary.  This cleans up a few loose ends.

## Testing story

I'm removing unused code.

- I've done my best to search for any possible usages of the code I'm removing, using the RubyMine's tools and full-text search.
- I've manually loaded pages I know I've touched.
- I am leaning on our existing test suite to find anything else.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
