### PR TITLE
Disabled flaky TeacherAttendanceReportControllerTest

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -37,6 +37,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
 
   self.use_transactional_test_case = true
   setup_all do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     @workshop_admin = create :workshop_admin
     @organizer = create :workshop_organizer
     @program_manager = create :program_manager
@@ -73,12 +74,14 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
     create :pd_workshop_participant, workshop: @other_workshop, enrolled: true, attended: true
   end
 
-  test_user_gets_response_for :index, user: :workshop_admin
-  test_user_gets_response_for :index, user: :workshop_organizer
-  test_user_gets_response_for :index, user: :program_manager
-  test_user_gets_response_for :index, response: :forbidden, user: :teacher
+  # -- SKIP -- Setup method fails 6 hours per day due to time zone differences
+  # test_user_gets_response_for :index, user: :workshop_admin
+  # test_user_gets_response_for :index, user: :workshop_organizer
+  # test_user_gets_response_for :index, user: :program_manager
+  # test_user_gets_response_for :index, response: :forbidden, user: :teacher
 
   test 'workshop admins get payment info' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @workshop_admin
 
     get :index
@@ -91,6 +94,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
 
   # TODO: remove this test when workshop_organizer is deprecated
   test 'organizers do not get payment info' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @organizer
 
     get :index
@@ -102,6 +106,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   end
 
   test 'program managers do not get payment info' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @program_manager
 
     get :index
@@ -148,6 +153,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   end
 
   test 'Returns only workshops that have ended and have teachers' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     # Workshop, not ended, with teachers
     # This workshop should not be returned
     workshop_in_progress = create :workshop
@@ -177,6 +183,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   end
 
   test 'filter by schedule' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
@@ -201,6 +208,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   end
 
   test 'filter by end date' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     start_date = Date.today - 6.months
     end_date = start_date + 1.month
 
@@ -225,6 +233,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   end
 
   test 'filter by course' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @workshop_admin
 
     # @pm_workshop and @workshop are CSF; @other_workshop is not
@@ -241,6 +250,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   end
 
   test 'csv' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @workshop_admin
     get :index, format: :csv
     assert_response :success

--- a/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/teacher_attendance_report_controller_test.rb
@@ -113,6 +113,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   end
 
   test 'workshop admins see all workshops' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @workshop_admin
 
     get :index
@@ -125,6 +126,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
 
   # TODO: remove this test when workshop_organizer is deprecated
   test 'organizers only see their own workshops' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @organizer
 
     get :index
@@ -135,6 +137,7 @@ class Api::V1::Pd::TeacherAttendanceReportControllerTest < ::ActionController::T
   end
 
   test 'program managers only see their own workshops' do
+    skip 'test is flaky for 6 hours per day due to time zone differences'
     sign_in @program_manager
 
     get :index


### PR DESCRIPTION
# Description
These tests were consistently failing from 10AM to 4PM PDT due to a timezone issue. It is a consistent repro, but does not affect some environments (we think this is because of differences in timezone settings). This issue was attempted to be fixed by this PR https://github.com/code-dot-org/code-dot-org/pull/32481, but did not completely fix the issue. This PR disables the failing test.
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack thread](https://codedotorg.slack.com/archives/CC4U03GA0/p1576784550004100)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
