### PR TITLE
Homepage: Hide courses bar

### DIFF
--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -432,7 +432,7 @@ class Homepage
   end
 
   def self.show_courses_banner(request)
-    true
+    false
   end
 
   def self.get_dance_stars


### PR DESCRIPTION
Now that the post-hoc homepage hero action links to /courses, there's no need to also link to it in the bar below the hero.

Followup to https://github.com/code-dot-org/code-dot-org/pull/32425

![Screenshot 2019-12-20 08 58 34](https://user-images.githubusercontent.com/2205926/71213291-3b02bd80-2307-11ea-9cf7-ffafe590a550.png)

