### PR TITLE
Restore created_at on workshop dashboard

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
@@ -160,7 +160,7 @@ export class Workshop extends React.Component {
     const {workshopId} = params;
     const isWorkshopAdmin = permission.has(WorkshopAdmin);
     const {workshop, enrollments, loadingEnrollments} = this.state;
-    const {sessions, state: workshopState} = workshop;
+    const {created_at, sessions, state: workshopState} = workshop;
 
     return (
       <Grid>
@@ -203,6 +203,7 @@ export class Workshop extends React.Component {
           isWorkshopAdmin={isWorkshopAdmin}
           onWorkshopSaved={this.handleWorkshopSaved}
         />
+        <MetadataFooter createdAt={created_at} />
       </Grid>
     );
   }

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/fakeWorkshopServer.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/fakeWorkshopServer.js
@@ -1,0 +1,28 @@
+import sinon from 'sinon';
+
+/**
+ * Creates a sinon fake server that can respond to API requests about
+ * a given workshop.
+ * @param {workshopShape} workshop
+ * @returns A sinon fake server
+ * @see https://sinonjs.org/releases/latest/fake-xhr-and-server/
+ */
+export default function fakeWorkshopServer(workshop) {
+  const server = sinon.createFakeServer();
+
+  // Workshop load request
+  server.respondWith('GET', `/api/v1/pd/workshops/${workshop.id}`, [
+    200,
+    {'Content-Type': 'application/json'},
+    JSON.stringify(workshop)
+  ]);
+
+  // Enrollments load request
+  server.respondWith('GET', `/api/v1/pd/workshops/${workshop.id}/enrollments`, [
+    200,
+    {'Content-Type': 'application/json'},
+    JSON.stringify([])
+  ]);
+
+  return server;
+}

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
@@ -7,13 +7,14 @@ import {States} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
  * @see also `workshopShape` and `enrollmentShape` in types.js
  */
 Factory.define('workshop')
-  .sequence('id')
+  .sequence('id', n => n.toString())
   .attr('course', 'CS Fundamentals')
   .attr('subject', 'Intro')
   .attr('sessions', () => Factory.buildList('session', 1))
   .attr('state', States[0])
   .attr('account_required_for_attendance?', false)
-  .attr('scholarship_workshop?', false);
+  .attr('scholarship_workshop?', false)
+  .attr('created_at', () => new Date().toISOString());
 
 Factory.define('session')
   .sequence('id')

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshopTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshopTest.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import {Factory} from 'rosie';
+import {Workshop} from '@cdo/apps/code-studio/pd/workshop_dashboard/workshop';
+import Permission from '@cdo/apps/code-studio/pd/workshop_dashboard/permission';
+import fakeWorkshopServer from './fakeWorkshopServer';
+import './workshopFactory';
+
+describe('Workshop', () => {
+  let fakeServer, fakeWorkshop;
+
+  beforeEach(() => {
+    fakeWorkshop = Factory.build('workshop');
+    fakeServer = fakeWorkshopServer(fakeWorkshop);
+  });
+
+  afterEach(() => {
+    fakeServer.restore();
+  });
+
+  it('renders', () => {
+    const wrapper = shallow(
+      <Workshop
+        params={{workshopId: fakeWorkshop.id}}
+        route={{}}
+        permission={new Permission()}
+      />,
+      {context: {router: {}}}
+    );
+    fakeServer.respond();
+
+    const metadata = wrapper.find('MetadataFooter');
+    assert(metadata.exists(), 'The created_at footer exists');
+    assert.equal(
+      Date.parse(fakeWorkshop.created_at),
+      Date.parse(metadata.prop('createdAt')),
+      'The created_at footer contains the correct date'
+    );
+  });
+});


### PR DESCRIPTION
Restores behavior introduced in https://github.com/code-dot-org/code-dot-org/pull/32453 and regressed during a complicated rebase in https://github.com/code-dot-org/code-dot-org/pull/31990.  Most of the change was preserved, but the JSX that actually renders the new component was accidentally dropped.  Caught by an eyes diff today:

![image](https://user-images.githubusercontent.com/1615761/71220064-1ad9ec80-227c-11ea-8221-81579c30ff15.png)


## Testing story

I mentioned in the previous PR that I wasn't adding a test for the UI because I was adding so many tests in the other PR (that regressed this!) and it would be covered.  Turns out I was wrong!  So now I'm adding a unit test for the Workshop component that verifies that we show the `created_at` date as expected.

I was able to reuse the Rosie workshop factory that I created for other workshop dashboard component tests, and broke out a fake server helper into its own file for potential future reuse as well.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
