### PR TITLE
Remove the version parameter from google maps

### DIFF
--- a/apps/src/templates/GoogleSchoolLocationSearchField.jsx
+++ b/apps/src/templates/GoogleSchoolLocationSearchField.jsx
@@ -7,7 +7,7 @@ import i18n from '@cdo/locale';
  * A search box that loads a Google Location Search control.
  *
  * Note: Google location search requires the following line to be present in the haml where this component is used:
- * %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.37"}
+ * %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry"}
  */
 export default class GoogleSchoolLocationSearchField extends React.Component {
   static propTypes = {

--- a/apps/src/templates/SchoolNotFound.jsx
+++ b/apps/src/templates/SchoolNotFound.jsx
@@ -69,7 +69,7 @@ export default class SchoolNotFound extends Component {
     showRequiredIndicators: PropTypes.bool,
     schoolNameLabel: PropTypes.string,
     // Note: Google location search requires the following line to be present in the haml where this component is used:
-    // %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.37"}
+    // %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry"}
     useGoogleLocationSearch: PropTypes.bool
   };
 

--- a/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
@@ -163,7 +163,7 @@
     = render "devise/shared/oauth_links"
 
 %script{src: webpack_asset_path('js/devise/registrations/_old_sign_up_form.js')}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.37"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry"}
 
 :javascript
 

--- a/dashboard/app/views/home/_homepage.html.haml
+++ b/dashboard/app/views/home/_homepage.html.haml
@@ -1,5 +1,5 @@
 - if @homepage_data[:showCensusBanner]
-  %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.37"}
+  %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry"}
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/home/_homepage.js'), data: {homepage: @homepage_data.to_json}}

--- a/dashboard/app/views/layouts/_school_info_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_school_info_interstitial.html.haml
@@ -20,7 +20,7 @@
 - script_data[:existingSchoolInfo][:country] ||= 'United States' if us_ip
 
 - content_for(:head) do
-  %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.37"}
+  %script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry"}
   %script{src: webpack_asset_path('js/layouts/_school_info_interstitial.js'), data: {schoolinfointerstitial: script_data.to_json}}
   :css
     .pac-container { z-index: 2000; }

--- a/pegasus/sites.v3/code.org/public/learn/local.haml
+++ b/pegasus/sites.v3/code.org/public/learn/local.haml
@@ -11,7 +11,7 @@ theme: responsive
 %script{type: "text/javascript", src: "/js/sifter.min.js"}
 %script{type: "text/javascript", src: "/js/microplugin.min.js"}
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.37"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry"}
 %script{type: "text/javascript", src: "/js/maplace.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.colorbox-min.js"}

--- a/pegasus/sites.v3/code.org/public/volunteer/local/index.haml
+++ b/pegasus/sites.v3/code.org/public/volunteer/local/index.haml
@@ -5,7 +5,7 @@ theme: responsive
 %script{type: "text/javascript", src: "/js/sifter.min.js"}
 %script{type: "text/javascript", src: "/js/microplugin.min.js"}
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.37"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry"}
 %script{type: "text/javascript", src: "/js/maplace.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.colorbox-min.js"}

--- a/pegasus/sites.v3/code.org/public/volunteer/remote/index.haml
+++ b/pegasus/sites.v3/code.org/public/volunteer/remote/index.haml
@@ -5,7 +5,7 @@ theme: responsive
 %script{type: "text/javascript", src: "/js/sifter.min.js"}
 %script{type: "text/javascript", src: "/js/microplugin.min.js"}
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry&v=3.37"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=true&libraries=places,geometry"}
 %script{type: "text/javascript", src: "/js/maplace.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 %script{type: "text/javascript", src: "/js/jquery.colorbox-min.js"}

--- a/pegasus/sites.v3/code.org/views/class_submission.haml
+++ b/pegasus/sites.v3/code.org/views/class_submission.haml
@@ -1,7 +1,7 @@
 %script{type: "text/javascript", src: "/js/sifter.min.js"}
 %script{type: "text/javascript", src: "/js/microplugin.min.js"}
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?sensor=true&libraries=places,geometry&v=3.37"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?sensor=true&libraries=places,geometry"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 %link{rel: "stylesheet", type: "text/css", href: "/css/selectize.bootstrap3.css"}/
 

--- a/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
@@ -5,7 +5,7 @@
 %script{type: "text/javascript", src: "/js/microplugin.min.js"}
 %script{type: "text/javascript", src: "/js/selectize.min.js"}
 %link{rel: "stylesheet", type: "text/css", href: "/css/selectize.bootstrap3.css"}/
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry&v=3.37"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry"}
 
 /[if lt IE 9]
   %script{src: "/js/es5-shim.min.js"}

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -19,7 +19,7 @@ social:
 -twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text)}
 -twitter[:hashtags] = 'HourOfCode' unless hoc_s(:front_header_banner).include? '#HourOfCode'
 
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry&v=3.37"}
+%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 - js_locale = request.locale.to_s.downcase.tr('-', '_')
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}

--- a/pegasus/sites.v3/hourofcode.com/public/map.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/map.haml
@@ -5,7 +5,6 @@ layout: wide_index
 :ruby
   @header["title"] = hoc_s(:map_title)
 
-%script{type: "text/javascript", src: "https://maps.googleapis.com/maps/api/js?client=#{CDO.google_maps_client_id}&sensor=false&libraries=places,geometry&v=3.37"}
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 
   = view :header


### PR DESCRIPTION
# Description

Undoes the pinning of our Google Maps version from #29983. Note that in that prior to that PR the version seemed to be pinned at v3.7 but Google regularly deletes older versions (screenshot from Google's versioning [documentation](https://developers.google.com/maps/documentation/javascript/versions)): 


![Screenshot 2019-12-20 at 11 53 03 AM](https://user-images.githubusercontent.com/46464143/71288262-727d6400-231f-11ea-82a1-06cdcc013d65.png)

According to Google's [documentation](https://developers.google.com/maps/documentation/javascript/versions#release-channels-and-version-numbers), if we don't specify a version we will be on their quarterly updates. Because we were specifying such an old version before pinning the API to v3.37 we were getting quarterly updates and, to my knowledge, never noticed.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
