### PR TITLE
Use content_tag rather than string interpolation to safely build HTML element

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -606,7 +606,9 @@ module LevelsHelper
   end
 
   def match_answer_as_image(path, width)
-    "<img src='#{path.strip}' #{"width='#{width.strip}'" if width}></img>"
+    attrs = {src: path.strip}
+    attrs[:width] = width.strip if width
+    content_tag(:img, '', attrs)
   end
 
   def match_answer_as_embedded_blockly(path)

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -713,7 +713,7 @@ class LevelsHelperTest < ActionView::TestCase
   end
 
   test 'render_multi_or_match_content can generate images' do
-    assert_equal render_multi_or_match_content("example.png"), "<img src='example.png' ></img>"
+    assert_equal render_multi_or_match_content("example.png"), "<img src=\"example.png\"></img>"
   end
 
   test 'render_multi_or_match_content can generate embedded blockly' do


### PR DESCRIPTION


# Description

Updates `match_answer_as_image` to work the same as `match_answer_as_embedded_blockly` and `match_answer_as_iframe`

Prereq for https://codedotorg.atlassian.net/browse/FND-904

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
