### PR TITLE
SoundsTest passes in ChromeHeadless

### DIFF
--- a/apps/test/unit/SoundsTest.js
+++ b/apps/test/unit/SoundsTest.js
@@ -1,11 +1,11 @@
 import {expect} from '../util/deprecatedChai';
 import Sounds from '@cdo/apps/Sounds';
 import sinon from 'sinon';
+import winMp3 from '!!file-loader!../audio/assets/win.mp3';
 
 describe('Sounds', () => {
   const sounds = new Sounds();
-  const sourceURL =
-    'studio.code.org/api/v1/sound-library/KyZOBksdJiQSlvoiOzFGpryJiMexdfks/category_ui/click1.mp3';
+  const sourceURL = winMp3;
   sounds.register({id: sourceURL, mp3: sourceURL});
   const sound = sounds.soundsById[sourceURL];
   let spy;


### PR DESCRIPTION
I've been trying to run tests in ChromeHeadless on my local machine, since PhantomJS isn't working properly on recent versions of Ubuntu.  Eventually, I'd like us to use ChromeHeadless in our CI builds too, but to do that, we need to fix up all the tests that fail on this browser.

One of the tests that fails is `SoundsTest#does play URLs when unmuted`.  I believe this fixes that test under both ChromeHeadless and PhantomJS.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
