### PR TITLE
ProjectHeaderTest passes in ChromeHeadless

### DIFF
--- a/apps/test/unit/templates/projects/ProjectHeaderTest.js
+++ b/apps/test/unit/templates/projects/ProjectHeaderTest.js
@@ -10,11 +10,13 @@ describe('ProjectHeader', () => {
       <ProjectHeader canViewAdvancedTools={true} projectCount={10000000} />
     );
 
-    // Note because we don't have a locale in the test we get an unformatted number
-    // Example 10000000 instead of 10,000,000
+    // Expect the number to be formatted to the appropriate client locale
+    // (which can change depending on the browser running this test)
+    const localeFormattedCount = Number(10000000).toLocaleString();
+
     assert.equal(
       wrapper.find(HeaderBanner).props().subHeadingText,
-      '10000000 projects created'
+      `${localeFormattedCount} projects created`
     );
   });
 });


### PR DESCRIPTION
I've been trying to run tests in ChromeHeadless on my local machine, since PhantomJS isn't working properly on recent versions of Ubuntu. Eventually, I'd like us to use ChromeHeadless in our CI builds too, but to do that, we need to fix up all the tests that fail on this browser.

One of the tests that fails is `ProjectsHeaderTest#Project count data renders properly in subheading`. I believe this fixes that test under both ChromeHeadless and PhantomJS.

## See also

- SoundsTest passes in ChromeHeadless https://github.com/code-dot-org/code-dot-org/pull/32518

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
