### PR TITLE
ProjectRemixTest passes on ChromeHeadless

### DIFF
--- a/apps/src/code-studio/components/header/ProjectRemix.jsx
+++ b/apps/src/code-studio/components/header/ProjectRemix.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
-
+import * as utils from '../../../utils';
 import {refreshProjectName} from '../../headerRedux';
 
 class ProjectRemix extends React.Component {
@@ -21,7 +21,7 @@ class ProjectRemix extends React.Component {
     ) {
       dashboard.project.serverSideRemix();
     } else if (!this.props.isSignedIn) {
-      window.location.assign(
+      utils.navigateToHref(
         `/users/sign_in?user_return_to=${window.location.pathname}`
       );
     } else {

--- a/apps/test/unit/code-studio/components/header/ProjectRemixTest.js
+++ b/apps/test/unit/code-studio/components/header/ProjectRemixTest.js
@@ -4,7 +4,7 @@ import {shallow} from 'enzyme';
 
 import {expect} from '../../../../util/reconfiguredChai';
 import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
-
+import * as utils from '@cdo/apps/utils';
 import {UnconnectedProjectRemix as ProjectRemix} from '@cdo/apps/code-studio/components/header/ProjectRemix';
 
 const defaultProps = {
@@ -54,18 +54,18 @@ describe('ProjectRemix', () => {
   });
 
   it('will redirect to sign in if necessary', () => {
-    sinon.stub(window.location, 'assign');
+    sinon.stub(utils, 'navigateToHref');
 
     const wrapper = shallow(<ProjectRemix {...defaultProps} />);
     wrapper.simulate('click');
-    expect(window.location.assign.calledOnce).to.be.true;
+    expect(utils.navigateToHref.calledOnce).to.be.true;
     expect(
-      window.location.assign.calledWith(
+      utils.navigateToHref.calledWith(
         '/users/sign_in?user_return_to=/context.html'
       )
     ).to.be.true;
 
-    window.location.assign.restore();
+    utils.navigateToHref.restore();
   });
 
   it('will copy the project', () => {


### PR DESCRIPTION
I've been trying to run tests in ChromeHeadless on my local machine, since PhantomJS isn't working properly on recent versions of Ubuntu. Eventually, I'd like us to use ChromeHeadless in our CI builds too, but to do that, we need to fix up all the tests that fail on this browser.

One of the tests that fails is `ProjectRemix#will redirect to sign in if necessary`. I believe this fixes that test under both ChromeHeadless and PhantomJS.

## See also

- SoundsTest passes in ChromeHeadless https://github.com/code-dot-org/code-dot-org/pull/32518
- ProjectHeaderTest passes in ChromeHeadless https://github.com/code-dot-org/code-dot-org/pull/32519

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
