### PR TITLE
loadAppTest passes on ChromeHeadless

### DIFF
--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -186,7 +186,10 @@ describe('loadApp.js', () => {
         expect(writtenLevelId).to.be.undefined;
         expect(name).to.equal('_share_image.png');
         expect(blob).to.have.property('type', 'image/png');
-        expect(blob).to.have.property('size', 523181);
+        const expectedPngSize = /PhantomJS/.test(window.navigator.userAgent)
+          ? 523181 // PhantomJS
+          : 38961; // ChromeHeadless
+        expect(blob).to.have.property('size', expectedPngSize);
         done();
       });
 


### PR DESCRIPTION
I've been trying to run tests in ChromeHeadless on my local machine, since PhantomJS isn't working properly on recent versions of Ubuntu. Eventually, I'd like us to use ChromeHeadless in our CI builds too, but to do that, we need to fix up all the tests that fail on this browser.

One of the tests that fails is `loadAppTest project level share images uploads a share image for a non-droplet project (instead of writing the level)`. I believe this fixes that test under both ChromeHeadless and PhantomJS.

## See also

- SoundsTest passes in ChromeHeadless https://github.com/code-dot-org/code-dot-org/pull/32518
- ProjectHeaderTest passes in ChromeHeadless https://github.com/code-dot-org/code-dot-org/pull/32519
- ProjectRemixTest passes on ChromeHeadless https://github.com/code-dot-org/code-dot-org/pull/32520

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
