### PR TITLE
Fix Cohort calculator test

### DIFF
--- a/apps/test/unit/code-studio/pd/application_dashboard/cohort_calculatorTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/cohort_calculatorTest.js
@@ -8,8 +8,11 @@ import sinon from 'sinon';
 describe('Cohort Calculator', () => {
   describe('Initially', () => {
     let cohortCalculator;
+    let xhr;
     const regionalPartnerFilterValue = AllPartnersValue;
+
     before(() => {
+      xhr = sinon.useFakeXMLHttpRequest();
       cohortCalculator = shallow(
         <CohortCalculator
           regionalPartnerFilterValue={regionalPartnerFilterValue}
@@ -17,6 +20,10 @@ describe('Cohort Calculator', () => {
           accepted={0}
         />
       );
+    });
+
+    after(() => {
+      xhr.restore();
     });
 
     it('Is loading', () => {


### PR DESCRIPTION
# Description
Assures that unit test runs before component finishes loading data from server. Achieving this by using a fake XHR object to not actually send data request when component is rendered.

### Background
Cohort Calculator unit test sometime failed on staging. I suspect the flow looked like this
1. `before` hook ran, shallowly rendered `CohortCalculator` component.
2. `CohortCalculator` called `loadData` function, which first set `loadingEnrollmentCount` from `null` to `true`, then sent a request to server to load data.
3. The request completed and set `loadingEnrollmentCount` from `true` to `false`.
4. `Is loading` test ran, expecting `loadingEnrollmentCount` to be `true`, but get value `false` instead.

From [staging log](https://codedotorg.slack.com/archives/C03CK8E51/p1576879555083900):
```
SUMMARY:
âœ" 1254 tests completed
âœ– 1 test failed
FAILED TESTS:
  unit tests
    Cohort Calculator
      Initially
        âœ– Is loading
          PhantomJS 2.1.1 (Linux 0.0.0)
        expected false to be true
      + expected - actual
```

Cohort Calculator
https://studio.code.org/pd/application_dashboard/csd_teachers
<screenshot>
<img width="777" alt="Screen Shot 2019-12-20 at 3 56 39 PM" src="https://user-images.githubusercontent.com/46507039/71299607-090f4c80-2343-11ea-8b51-aa8fd6b430ed.png">

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-605)

## Testing story
- `WATCH=1 yarn test:entry --entry=test/unit/code-studio/pd/application_dashboard/cohort_calculatorTest.js`