### PR TITLE
Fix Continuous Integration change detection

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -116,10 +116,6 @@ steps:
   # Also fetch the target branch (which is staging or staging-next for pull requests.) We need this for determining which tests to run based on changed files.
   - git remote set-branches --add origin $DRONE_TARGET_BRANCH
   - git fetch --depth 100 origin $DRONE_TARGET_BRANCH
-  # Always fetch staging branch because the change detection logic compares against the staging branch even when the base
-  # branch is staging-next:
-  # https://github.com/code-dot-org/code-dot-org/blob/8ea6ee6b63abd36e51c69d400eefdaa87154030a/lib/cdo/git_utils.rb#L104-L113
-  - git fetch --depth 100 origin staging
   # Merge so we're up-to-date with the target before running tests. We only do this for UI tests, not unit tests,
   # since it disrupts Codecov pull request reports.
   - git config user.name "Drone"

--- a/.drone.yml
+++ b/.drone.yml
@@ -116,6 +116,10 @@ steps:
   # Also fetch the target branch (which is staging or staging-next for pull requests.) We need this for determining which tests to run based on changed files.
   - git remote set-branches --add origin $DRONE_TARGET_BRANCH
   - git fetch --depth 100 origin $DRONE_TARGET_BRANCH
+  # Always fetch staging branch because the change detection logic compares against the staging branch even when the base
+  # branch is staging-next:
+  # https://github.com/code-dot-org/code-dot-org/blob/8ea6ee6b63abd36e51c69d400eefdaa87154030a/lib/cdo/git_utils.rb#L104-L113
+  - git fetch --depth 100 origin staging
   # Merge so we're up-to-date with the target before running tests. We only do this for UI tests, not unit tests,
   # since it disrupts Codecov pull request reports.
   - git config user.name "Drone"

--- a/lib/cdo/git_utils.rb
+++ b/lib/cdo/git_utils.rb
@@ -108,7 +108,8 @@ module GitUtils
       when 'test'
         'origin/production'
       else # levelbuilder, feature branches, etc.
-        'origin/staging'
+        # In Continuous Integration (Drone) builds, use the base branch of the Pull Request, which might be staging-next.
+        CDO.ci ? "origin/#{circle_pr_branch_base_no_origin}" : 'origin/staging'
     end
   end
 


### PR DESCRIPTION
# Description

Drone Continuous Integration builds skip unit tests when the target/base branch is `staging-next` because the detection of which source code directories have changed attempts to compare to `origin/staging` which is not present in the Drone container.  The git command referencing the `origin/staging` branch raises an error because it has not been fetched.  The best solution would probably be to compare the source code changes against `origin/staging-next`, but this comparison [takes place a few layers down](https://github.com/code-dot-org/code-dot-org/blob/4aac135f692d88da0b9b52c7f30e30cb8e8226e1/lib/rake/test.rake#L342) in the Continuous Integration rake call stack where information about what the target branch of the Pull Request that invoked the build is no longer available.

This change, instead, always fetches `origin/staging`.  This assumes that most feature-branches off of the `staging-next` branch will trigger the same source code change detection when compared against `staging`.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
