### PR TITLE
add a Component for rendering the subset of markdown syntax that is inline-only

### DIFF
--- a/apps/src/templates/InlineMarkdown.jsx
+++ b/apps/src/templates/InlineMarkdown.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import rehypeReact from 'rehype-react';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import unified from 'unified';
+
+function inlineOnly() {
+  // remove ability to parse all block methods except paragraphs; some inner
+  // functionality of remark depends on paragraphs being present, and we'll
+  // just strip them out at the end.
+  this.Parser.prototype.blockMethods = ['paragraph'];
+}
+
+const markdownToReact = unified()
+  .use(remarkParse)
+  .use(inlineOnly)
+  .use(remarkRehype)
+  .use(rehypeReact, {
+    createElement: React.createElement
+  });
+
+export default class InlineMarkdown extends React.Component {
+  static propTypes = {
+    markdown: PropTypes.string.isRequired
+  };
+
+  render() {
+    const rendered = markdownToReact.processSync(this.props.markdown).contents;
+    // rendered will be a paragraph element because we kept the 'paragraph'
+    // block method enabled in the parser above for structural reasons; we want
+    // to simply swap that out for a span element.
+    return <span>{rendered.props.children}</span>;
+  }
+}

--- a/apps/test/unit/templates/InlineMarkdownTest.js
+++ b/apps/test/unit/templates/InlineMarkdownTest.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../util/deprecatedChai';
+import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
+
+describe('InlineMarkdown', () => {
+  it('will render basic inline markdown', () => {
+    const wrapper = shallow(
+      <InlineMarkdown markdown="**some** _basic_ [inline](markdown)" />
+    );
+
+    expect(
+      wrapper.equals(
+        <span>
+          <strong>some</strong> <em>basic</em> <a href="markdown">inline</a>
+        </span>
+      )
+    ).to.equal(true);
+  });
+
+  it('will refuse to render block elements', () => {
+    const wrapper = shallow(
+      <InlineMarkdown markdown="markdown which contains\n\n- some\n - basic\n\n> block elements" />
+    );
+
+    expect(
+      wrapper.equals(
+        <span>
+          markdown which contains\n\n- some\n - basic\n\n&gt; block elements
+        </span>
+      )
+    ).to.equal(true);
+  });
+
+  it('will ignore what would normally be a paragraph break', () => {
+    const wrapper = shallow(
+      <InlineMarkdown markdown="**some** _basic_ [inline](markdown)\n\nand **yet more** markdown in a _second_ paragraph" />
+    );
+
+    expect(
+      wrapper.equals(
+        <span>
+          <strong>some</strong> <em>basic</em> <a href="markdown">inline</a>
+          \n\nand <strong>yet more</strong> markdown in a <em>second</em>{' '}
+          paragraph
+        </span>
+      )
+    ).to.equal(true);
+  });
+
+  it('will ignore raw html', () => {
+    // Note that we _could_ add to this the ability to render raw HTML; we
+    // would just need to add rehypeRaw and rehypeSanitize like we do for
+    // SafeMarkdown, and curate the list of allowed tags. For now - until we
+    // have a specific use case that demands this work - we simply ignore all
+    // raw html.
+
+    const basicWrapper = shallow(
+      <InlineMarkdown markdown='<strong>some</strong> <em>basic</em> <a href="markdown">inline</a>' />
+    );
+
+    expect(
+      basicWrapper.equals(<span>some basic inline</span>),
+      'inline html is ignored'
+    ).to.equal(true);
+
+    const advancedWrapper = shallow(
+      <InlineMarkdown markdown="<table><thead><th>Some advanced html</th><th><strong>not</strong> usually supported by markdown</th></thead></table>" />
+    );
+
+    expect(
+      advancedWrapper.equals(
+        <span>Some advanced htmlnot usually supported by markdown</span>
+      ),
+      'block html is ignored'
+    ).to.equal(true);
+  });
+});


### PR DESCRIPTION
# Description

Standard markdown will by definition always render block elements, and our SafeMarkdown component reflects that. However, there are times when we want to be able to consume a subset of markdown syntax and still output an inline element; formatting within a label tag, for example.

For those situations, we now have the InlineMarkdown component; you give it a markdown string and it will consume only those parts of markdown syntax that output inline elements, ultimately returning a `span`. All other syntax will be ignored, and returned raw (see tests for examples).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
