### PR TITLE
Remove 'Create a Behavior/Function' buttons from the toolbox WYSIWYG levelbuilder page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -339,6 +339,7 @@
   "createAccountDesc": "Join Code.org! With an account you’ll be able to save your course progress, keep your apps and games, and share your favorites in the public gallery.",
   "createAccountToShare": "Create a Code.org account to share your project",
   "createAccountToShareDescription": "You must create a Code.org account before you can share and publish your project. Creating an account will also let you save your progress and continue to work on your project later.",
+  "createBlocklyBehavior": "Create a Behavior",
   "createNewClassroom": "Create a new classroom section to start assigning courses and seeing your student progress.",
   "createPassword": "Create a password",
   "createSection": "Create a section",

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2682,7 +2682,8 @@ StudioApp.prototype.handleUsingBlockly_ = function(config) {
       false
     ),
     useModalFunctionEditor: utils.valueOr(
-      config.level.useModalFunctionEditor,
+      config.level.edit_blocks !== 'toolbox_blocks' &&
+        config.level.useModalFunctionEditor,
       false
     ),
     useContractEditor: utils.valueOr(config.level.useContractEditor, false),
@@ -2707,7 +2708,8 @@ StudioApp.prototype.handleUsingBlockly_ = function(config) {
   // Never show unused blocks or disable autopopulate in edit mode
   if (options.editBlocks) {
     options.showUnusedBlocks = false;
-    options.disableProcedureAutopopulate = false;
+    options.disableProcedureAutopopulate =
+      options.editBlocks === 'toolbox_blocks';
   }
 
   [

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -44,7 +44,7 @@ import msg from '@cdo/locale';
 import project from './code-studio/initApp/project';
 import puzzleRatingUtils from './puzzleRatingUtils';
 import userAgentParser from './code-studio/initApp/userAgentParser';
-import {KeyCodes, TestResults} from './constants';
+import {KeyCodes, TestResults, TOOLBOX_EDIT_MODE} from './constants';
 import {assets as assetsApi} from './clientApi';
 import {blocks as makerDropletBlocks} from './lib/kits/maker/dropletConfig';
 import {closeDialog as closeInstructionsDialog} from './redux/instructionsDialog';
@@ -2034,7 +2034,7 @@ StudioApp.prototype.configureDom = function(config) {
       // If in level builder editing blocks, make workspace extra tall
       vizHeight = 3000;
       // Modify the arrangement of toolbox blocks so categories align left
-      if (config.level.edit_blocks === 'toolbox_blocks') {
+      if (config.level.edit_blocks === TOOLBOX_EDIT_MODE) {
         this.blockYCoordinateInterval = 80;
         config.blockArrangement = {category: {x: 20}};
       }
@@ -2640,7 +2640,7 @@ StudioApp.prototype.handleUsingBlockly_ = function(config) {
     this.checkForEmptyBlocks_ = false;
     if (
       config.level.edit_blocks === 'required_blocks' ||
-      config.level.edit_blocks === 'toolbox_blocks' ||
+      config.level.edit_blocks === TOOLBOX_EDIT_MODE ||
       config.level.edit_blocks === 'recommended_blocks'
     ) {
       // Don't show when run block for toolbox/required/recommended block editing
@@ -2682,7 +2682,7 @@ StudioApp.prototype.handleUsingBlockly_ = function(config) {
       false
     ),
     useModalFunctionEditor: utils.valueOr(
-      config.level.edit_blocks !== 'toolbox_blocks' &&
+      config.level.edit_blocks !== TOOLBOX_EDIT_MODE &&
         config.level.useModalFunctionEditor,
       false
     ),
@@ -2709,7 +2709,7 @@ StudioApp.prototype.handleUsingBlockly_ = function(config) {
   if (options.editBlocks) {
     options.showUnusedBlocks = false;
     options.disableProcedureAutopopulate =
-      options.editBlocks === 'toolbox_blocks';
+      options.editBlocks === TOOLBOX_EDIT_MODE;
   }
 
   [

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2681,11 +2681,9 @@ StudioApp.prototype.handleUsingBlockly_ = function(config) {
       config.level.topLevelProcedureAutopopulate,
       false
     ),
-    useModalFunctionEditor: utils.valueOr(
+    useModalFunctionEditor:
       config.level.edit_blocks !== TOOLBOX_EDIT_MODE &&
-        config.level.useModalFunctionEditor,
-      false
-    ),
+      !!config.level.useModalFunctionEditor,
     useContractEditor: utils.valueOr(config.level.useContractEditor, false),
     disableExamples: utils.valueOr(config.level.disableExamples, false),
     defaultNumExampleBlocks: utils.valueOr(
@@ -2705,7 +2703,10 @@ StudioApp.prototype.handleUsingBlockly_ = function(config) {
     typeHints: utils.valueOr(config.level.showTypeHints, false)
   };
 
-  // Never show unused blocks or disable autopopulate in edit mode
+  // Never show unused blocks in edit mode. Procedure autopopulate should always
+  // be enabled in edit mode. Except in toolbox mode where functions/behaviors
+  // should never be created (and therefore the autopopulated blocks would be
+  // confusing).
   if (options.editBlocks) {
     options.showUnusedBlocks = false;
     options.disableProcedureAutopopulate =

--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -181,3 +181,5 @@ export const EXPO_SESSION_SECRET =
   '{"id":"fakefake-67ec-4314-a438-60589b9c0fa2","version":1,"expires_at":2000000000000}';
 
 export const BASE_DIALOG_WIDTH = 700;
+
+export const TOOLBOX_EDIT_MODE = 'toolbox_blocks';

--- a/apps/src/dance/blocks.js
+++ b/apps/src/dance/blocks.js
@@ -331,7 +331,7 @@ export default {
         if (behaviorEditor && !behaviorEditor.isOpen()) {
           flyout.addButtonToFlyout_(
             cursor,
-            'Create a Behavior',
+            i18n.createBlocklyBehavior(),
             behaviorEditor.openWithNewFunction.bind(behaviorEditor)
           );
         }

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -7,6 +7,7 @@ import {changeInterfaceMode, viewAnimationJson} from './actions';
 import {startInAnimationTab} from './stateQueries';
 import {P5LabInterfaceMode, APP_WIDTH} from './constants';
 import {SpritelabReservedWords} from './spritelab/constants';
+import {TOOLBOX_EDIT_MODE} from '../constants';
 import experiments from '@cdo/apps/util/experiments';
 import {
   outputError,
@@ -834,7 +835,7 @@ P5Lab.prototype.onPuzzleComplete = function(submit, testResult, message) {
     // See StudioApp -> setStartBlocks_
     // Because of this, we need to remove the SharedFunctions when we are in
     // toolbox edit mode. Otherwise, they end up in a student's toolbox.
-    if (this.level.edit_blocks === 'toolbox_blocks') {
+    if (this.level.edit_blocks === TOOLBOX_EDIT_MODE) {
       var allBlocks = Array.from(xml.querySelectorAll('xml > block'));
       var toRemove = allBlocks.filter(element => {
         return (

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -5,6 +5,7 @@ import {SVG_NS} from '@cdo/apps/constants';
 import {getStore} from '@cdo/apps/redux';
 import {getLocation} from './locationPickerModule';
 import {APP_HEIGHT, P5LabInterfaceMode} from '../constants';
+import {TOOLBOX_EDIT_MODE} from '../../constants';
 import {animationSourceUrl} from '../animationListModule';
 import {changeInterfaceMode} from '../actions';
 import {Goal, show} from '../AnimationPicker/animationPickerModule';
@@ -515,7 +516,7 @@ export default {
       Blockly.BlockValueType.BEHAVIOR,
       'gamelab_behavior_get'
     );
-    if (blockInstallOptions.level.editBlocks !== 'toolbox_blocks') {
+    if (blockInstallOptions.level.editBlocks !== TOOLBOX_EDIT_MODE) {
       Blockly.Flyout.configure(Blockly.BlockValueType.BEHAVIOR, {
         initialize(flyout, cursor) {
           if (behaviorEditor && !behaviorEditor.isOpen()) {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -521,7 +521,7 @@ export default {
           if (behaviorEditor && !behaviorEditor.isOpen()) {
             flyout.addButtonToFlyout_(
               cursor,
-              'Create a Behavior',
+              i18n.createBlocklyBehavior(),
               behaviorEditor.openWithNewFunction.bind(behaviorEditor)
             );
           }

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -515,17 +515,19 @@ export default {
       Blockly.BlockValueType.BEHAVIOR,
       'gamelab_behavior_get'
     );
-    Blockly.Flyout.configure(Blockly.BlockValueType.BEHAVIOR, {
-      initialize(flyout, cursor) {
-        if (behaviorEditor && !behaviorEditor.isOpen()) {
-          flyout.addButtonToFlyout_(
-            cursor,
-            'Create a Behavior',
-            behaviorEditor.openWithNewFunction.bind(behaviorEditor)
-          );
-        }
-      },
-      addDefaultVar: false
-    });
+    if (blockInstallOptions.level.editBlocks !== 'toolbox_blocks') {
+      Blockly.Flyout.configure(Blockly.BlockValueType.BEHAVIOR, {
+        initialize(flyout, cursor) {
+          if (behaviorEditor && !behaviorEditor.isOpen()) {
+            flyout.addButtonToFlyout_(
+              cursor,
+              'Create a Behavior',
+              behaviorEditor.openWithNewFunction.bind(behaviorEditor)
+            );
+          }
+        },
+        addDefaultVar: false
+      });
+    }
   }
 };


### PR DESCRIPTION
# Description
Currently, the 'Create a Function/Behavior' buttons in /edit_blocks/toolbox_blocks do not work. This is intentional - levelbuilders should not be able to add a custom behavior or function in /edit_blocks/toolbox_blocks mode. This PR removes the buttons from /edit_blocks/toolbox_blocks page.


<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
This is the button removed as part of this change:
![image](https://user-images.githubusercontent.com/8324574/71843491-e1c1ba80-3078-11ea-955c-763103facc5d.png)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
