### PR TITLE
Import maker discount codes

### DIFF
--- a/bin/oneoff/populate_discount_codes.rb
+++ b/bin/oneoff/populate_discount_codes.rb
@@ -11,12 +11,10 @@ require src_dir 'database'
 
 def populate_csv_data(filename, full_discount, expiration)
   csv_contents = CSV.read(filename)
-  # skip header row
-  csv_contents.shift
   csv_contents.each do |line|
-    prefix, code = line
+    code = line[0]
     CircuitPlaygroundDiscountCode.create!(
-      code: prefix + code,
+      code: code,
       full_discount: full_discount,
       expiration: expiration
     )
@@ -41,7 +39,7 @@ else
   exit(-1)
 end
 
-populate_csv_data(filename, full_discount, Date.new(2018, 12, 31))
+populate_csv_data(filename, full_discount, Date.new(2021, 12, 31))
 
 puts 'Complete'
 

--- a/bin/oneoff/populate_discount_codes.rb
+++ b/bin/oneoff/populate_discount_codes.rb
@@ -39,7 +39,7 @@ else
   exit(-1)
 end
 
-populate_csv_data(filename, full_discount, Date.new(2021, 12, 31))
+populate_csv_data(filename, full_discount, Date.new(2021, 4, 30))
 
 puts 'Complete'
 

--- a/dashboard/app/models/circuit_playground_discount_code.rb
+++ b/dashboard/app/models/circuit_playground_discount_code.rb
@@ -15,7 +15,7 @@
 class CircuitPlaygroundDiscountCode < ApplicationRecord
   # We'll notify honeybadger when we request a full/partial discount and there
   # are fewer than this many available (so that we can add more).
-  WARN_COUNT = 50
+  WARN_COUNT = 25
 
   # Claims the next available code of the given discount amount (full/partial)
   # and returns the code.


### PR DESCRIPTION
## Description

Updates script to import maker discount codes for 2020-2021. There are two types of discount codes: codes that include shipping for teachers in Alaska and Hawaii (full discount codes), and codes that do not.

Codes are in two different CSVs, each without a header row. Previous imports have had separate columns for a "prefix" and a "code" -- in this iteration, prefixes and codes are already combined into a single column in the CSV.

I set these to expire at the end of 2021 -- @agealy, I can change to a different date that's aligned with the last redemption window if that is more sensible.

There are a total of 50 discount codes with shipping, and 800 without shipping -- I moved the threshold for Honeybadger alerting down to 25 (from 50) so that we don't get a Honeybadger warning every time a "with shipping" discount code is used. 

The rub here is that we wouldn't get an alert until very late for the non-shipping discount codes, but we've only used ~800 over the last two years so I'd be surprised if we actually reached that point.

Will need to execute this script twice on production (once for full discount codes, and once for the other discount codes).

## Testing story

Ran the following locally:
`bundle exec ruby ./populate_discount_codes.rb true <filename with discount codes with shipping>`
`bundle exec ruby ./populate_discount_codes.rb false <filename with discount codes without shipping>`

Confirmed that what was imported was as we'd expect.
