### PR TITLE
Adding new strings for signup page

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -795,6 +795,7 @@ en:
     privacy_notice: "Privacy Notice"
     accept_label: 'I agree to the <a href="%{tos_url}" target="_blank">Terms of Service</a> and <a href="%{privacy_url}" target="_blank">Privacy Policy</a>.'
     accept_label_markdown: I agree to the [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}).
+    accept_tos: By signing up for Code.org, you agree to our [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}).
     accept: "Accept"
     print: "Print"
     reminder_desc: 'We have updated our <a href="%{tos_url}" target="_blank">Terms of Service</a> and <a href="%{privacy_url}" target="_blank">Privacy Policy</a>. Please read these carefully before accepting them. Note that our tools teaching JavaScript may be unavailable to your students before explicitly accepting the updated terms.'


### PR DESCRIPTION
# Description
We want to remove the unnecessary check boxes from our signup experience
to make it more user friendly. Here we add the new strings so we can get
translations before we commit the changes to update the UI.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-924)

## Testing story
* `./bin/dashboard-server`
  * verified the sign-up page still loads.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] New features are translatable or updates will not break translations
- [ ] Pull Request is labeled appropriately
