### PR TITLE
Remove debug flag from Filipino, Marathi, Tamil, and Telugu

### DIFF
--- a/dashboard/config/locales.yml
+++ b/dashboard/config/locales.yml
@@ -134,7 +134,6 @@
 "fil-PH":
   english: "Filipino"
   native: "Pilipino"
-  debug: true
 
 "fr": "fr-FR"
 "fr-FR":
@@ -272,7 +271,6 @@
 "mr-IN":
   english: "Marathi"
   native: "मराठी"
-  debug: true
   webfonts: false
 
 "ms": "ms-MY"
@@ -398,14 +396,12 @@
 "ta-IN":
   english: "Tamil"
   native: "தமிழ்"
-  debug: true
   webfonts: false
 
 "te": "te-IN"
 "te-IN":
   english: "Telugu"
   native: "తెలుగు"
-  debug: true
   webfonts: false
 
 "th": "th-TH"


### PR DESCRIPTION
# Description

This will add these languages to the dropdown on Dashboard in production. I will make the corresponding change in the `cdo-languages` gsheet to turn these on on Code.org (they're all enabled for hourofcode.com already).

A previous attempt to enable these languages resulted in some [Honeybadger errors](https://app.honeybadger.io/projects/3240/faults/58136091). This was fixed in #32525.

These languages don't need to be enabled in apps as the translation files have existed for a while.

I have manually tested this every way I can think of (enabling these languages in Dashboard and not Pegasus and vice versa). The only user-visible impact is that the language dropdown defaults to the first entry if the language isn't enabled. So if Filipino is enabled in Dashboard and the user selects it then goes to code.org/dance, they will see Arabic selected in the language dropdown. Ideally, the change to enable these languages in Pegasus will go out in the same DTP as this change.

## Links

- [jira](https://codedotorg.atlassian.net/browse/FND-959)



# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
