### PR TITLE
Remove check for attendance at academic year workshop for maker discount codes

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -584,7 +584,6 @@
   "editable": "Editable",
   "eligibilityExplanation": "In order to be eligible to receive a code for a subsidized Circuit Playground kit, you must meet the following requirements:",
   "eligibilityReqPD": "You attended a 5-day summer workshop for CS Discoveries in 2019 or are participating in the 2019-20 Facilitator Development Program as a new CS Discoveries facilitator.",
-  "eligibilityReqAcademicYearPD": "You have attended the fourth academic year workshop in the 2019-20 school year or are participating in the 2019-20 Facilitator Development Program as a new CS Discoveries facilitator.",
   "eligibilityReqStudentCount": "Ten students in one of your sections have completed the first three units of CS Discoveries.",
   "eligibilityReqStudentCountFail": "Sorry, it doesn't look like you have enough students in your sections that have made progress in Units 2 and 3. Please check back here once your students have finished the first semester of CS Discoveries. If you are using a different account to track the progress of students or if you think there has been an error in detecting how much progress your students have made in Units 2 and 3, please contact us at teacher@code.org.",
   "eligibilityReqYear": "You plan to teach Unit 6 by the end of the 2020-21 school year.",

--- a/apps/src/lib/kits/maker/ui/DiscountAdminOverride.jsx
+++ b/apps/src/lib/kits/maker/ui/DiscountAdminOverride.jsx
@@ -78,9 +78,6 @@ export default class DiscountAdminOverride extends Component {
       teacherID,
       submitting: false,
       statusPD: application.is_pd_eligible ? Status.SUCCEEDED : Status.FAILED,
-      statusAcademicYearPD: application.is_quarterly_workshop_pd_eligible
-        ? Status.SUCCEEDED
-        : Status.FAILED,
       statusStudentCount: application.is_progress_eligible
         ? Status.SUCCEEDED
         : Status.FAILED,
@@ -158,10 +155,6 @@ export default class DiscountAdminOverride extends Component {
             <ValidationStep
               stepName={i18n.eligibilityReqPD()}
               stepStatus={this.state.statusPD}
-            />
-            <ValidationStep
-              stepName={i18n.eligibilityReqAcademicYearPD()}
-              stepStatus={this.state.statusAcademicYearPD}
             />
             <ValidationStep
               stepName={i18n.eligibilityReqStudentCount()}

--- a/apps/src/lib/kits/maker/ui/DiscountAdminOverride.story.jsx
+++ b/apps/src/lib/kits/maker/ui/DiscountAdminOverride.story.jsx
@@ -12,7 +12,6 @@ export default storybook => {
         story: () => (
           <DiscountAdminOverride
             statusPD={Status.SUCCEEDED}
-            statusAcademicYearPD={Status.SUCCEEDED}
             statusStudentCount={Status.FAILED}
           />
         )

--- a/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
@@ -20,7 +20,6 @@ const styles = {
 export default class EligibilityChecklist extends React.Component {
   static propTypes = {
     statusPD: PropTypes.oneOf(Object.values(Status)).isRequired,
-    statusAcademicYearPD: PropTypes.oneOf(Object.values(Status)).isRequired,
     statusStudentCount: PropTypes.oneOf(Object.values(Status)).isRequired,
     unit6Intention: PropTypes.string,
     schoolId: PropTypes.string,
@@ -152,12 +151,6 @@ export default class EligibilityChecklist extends React.Component {
               <SafeMarkdown markdown={eligibilityReqPDFail} />
             </ValidationStep>
             <ValidationStep
-              stepName={i18n.eligibilityReqAcademicYearPD()}
-              stepStatus={this.props.statusAcademicYearPD}
-            >
-              <SafeMarkdown markdown={eligibilityReqPDFail} />
-            </ValidationStep>
-            <ValidationStep
               stepName={i18n.eligibilityReqStudentCount()}
               stepStatus={this.props.statusStudentCount}
             >
@@ -167,7 +160,6 @@ export default class EligibilityChecklist extends React.Component {
               showRadioButtons={
                 this.props.statusStudentCount === Status.SUCCEEDED &&
                 this.props.statusPD === Status.SUCCEEDED &&
-                this.props.statusAcademicYearPD === Status.SUCCEEDED &&
                 !this.props.adminSetStatus
               }
               stepStatus={this.state.statusYear}

--- a/apps/src/lib/kits/maker/ui/EligibilityChecklist.story.jsx
+++ b/apps/src/lib/kits/maker/ui/EligibilityChecklist.story.jsx
@@ -5,7 +5,6 @@ import {Unit6Intention} from '../util/discountLogic';
 
 const defaultProps = {
   statusPD: Status.SUCCEEDED,
-  statusAcademicYearPD: Status.SUCCEEDED,
   statusStudentCount: Status.SUCCEEDED,
   hasConfirmedSchool: false,
   adminSetStatus: false,
@@ -69,22 +68,6 @@ export default storybook => {
               schoolName="Code.org Junior Academy"
               hasConfirmedSchool={true}
               schoolHighNeedsEligible={true}
-            />
-          </div>
-        )
-      },
-      {
-        name: '2020: Failed academic year PD attendance requirement',
-        description: 'When a teacher did not attend quarterly PD',
-        story: () => (
-          <div style={{margin: '2em'}}>
-            <EligibilityChecklist
-              {...defaultProps}
-              schoolId="1234"
-              schoolName="Code.org Junior Academy"
-              hasConfirmedSchool={true}
-              schoolHighNeedsEligible={true}
-              statusAcademicYearPD={Status.FAILED}
             />
           </div>
         )

--- a/apps/src/sites/studio/pages/maker/discountcode.js
+++ b/apps/src/sites/studio/pages/maker/discountcode.js
@@ -22,11 +22,6 @@ $(document).ready(() => {
           statusPD={
             application.is_pd_eligible ? Status.SUCCEEDED : Status.FAILED
           }
-          statusAcademicYearPD={
-            application.is_quarterly_workshop_pd_eligible
-              ? Status.SUCCEEDED
-              : Status.FAILED
-          }
           statusStudentCount={
             application.is_progress_eligible ? Status.SUCCEEDED : Status.FAILED
           }

--- a/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
@@ -8,7 +8,6 @@ import {Unit6Intention} from '@cdo/apps/lib/kits/maker/util/discountLogic';
 describe('EligibilityChecklist', () => {
   const defaultProps = {
     statusPD: Status.SUCCEEDED,
-    statusAcademicYearPD: Status.SUCCEEDED,
     statusStudentCount: Status.SUCCEEDED,
     hasConfirmedSchool: false,
     adminSetStatus: false,

--- a/dashboard/app/models/circuit_playground_discount_application.rb
+++ b/dashboard/app/models/circuit_playground_discount_application.rb
@@ -131,13 +131,6 @@ class CircuitPlaygroundDiscountApplication < ApplicationRecord
           Pd::Workshop::SUBJECT_SUMMER_WORKSHOP,
         ]
       ),
-      is_quarterly_workshop_pd_eligible: studio_person_pd_eligible?(user,
-        [
-          Pd::Workshop::SUBJECT_CSD_WORKSHOP_4,
-          Pd::Workshop::SUBJECT_CSD_WORKSHOP_6,
-          Pd::Workshop::SUBJECT_CSD_VIRTUAL_8
-        ]
-      ),
       is_progress_eligible: student_progress_eligible?(user)
     }
   end
@@ -159,13 +152,6 @@ class CircuitPlaygroundDiscountApplication < ApplicationRecord
       is_pd_eligible: studio_person_pd_eligible?(user,
         [
           Pd::Workshop::SUBJECT_SUMMER_WORKSHOP,
-        ]
-      ),
-      is_quarterly_workshop_pd_eligible: studio_person_pd_eligible?(user,
-        [
-          Pd::Workshop::SUBJECT_CSD_WORKSHOP_4,
-          Pd::Workshop::SUBJECT_CSD_WORKSHOP_6,
-          Pd::Workshop::SUBJECT_CSD_VIRTUAL_8
         ]
       ),
       is_progress_eligible: student_progress_eligible?(user),

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -414,7 +414,6 @@ class MakerControllerTest < ActionController::TestCase
     expected = {
       "application" => {
         "is_pd_eligible" => false,
-        "is_quarterly_workshop_pd_eligible" => false,
         "is_progress_eligible" => false,
         "user_school" => {
           "id" => nil,
@@ -450,7 +449,6 @@ class MakerControllerTest < ActionController::TestCase
     expected = {
       "application" => {
         "is_pd_eligible" => false,
-        "is_quarterly_workshop_pd_eligible" => false,
         "is_progress_eligible" => false,
         "user_school" => {
           "id" => nil,

--- a/dashboard/test/models/circuit_playground_discount_application_test.rb
+++ b/dashboard/test/models/circuit_playground_discount_application_test.rb
@@ -194,7 +194,6 @@ class CircuitPlaygroundDiscountApplicationTest < ActiveSupport::TestCase
       discount_code: nil,
       expiration: nil,
       is_pd_eligible: true,
-      is_quarterly_workshop_pd_eligible: true,
       is_progress_eligible: false,
       admin_set_status: false,
     }
@@ -215,7 +214,6 @@ class CircuitPlaygroundDiscountApplicationTest < ActiveSupport::TestCase
       discount_code: nil,
       expiration: nil,
       is_pd_eligible: false,
-      is_quarterly_workshop_pd_eligible: false,
       is_progress_eligible: false,
       admin_set_status: false,
     }
@@ -237,7 +235,6 @@ class CircuitPlaygroundDiscountApplicationTest < ActiveSupport::TestCase
       discount_code: nil,
       expiration: nil,
       is_pd_eligible: false,
-      is_quarterly_workshop_pd_eligible: false,
       is_progress_eligible: false,
       admin_set_status: true,
     }
@@ -252,7 +249,6 @@ class CircuitPlaygroundDiscountApplicationTest < ActiveSupport::TestCase
 
     expected = {
       is_pd_eligible: false,
-      is_quarterly_workshop_pd_eligible: false,
       is_progress_eligible: true,
       user_school: {
         id: nil,


### PR DESCRIPTION
## Description

We built a check for whether a teacher had attended the fourth academic year workshop before being able to redeem a maker discount code. We've decided not to do that check, so I've removed all references to that check.

## Testing story

This feature has storybook, JS, and Ruby tests in place that 🤞 passed after these changes. 

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
