### PR TITLE
Fix minimum requirement logic in teacher application

### DIFF
--- a/dashboard/app/models/pd/application/principal_approval2021_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval2021_application.rb
@@ -82,7 +82,7 @@ module Pd::Application
           TEXT_FIELDS[:other_with_text]
         ],
         replace_course: [
-          'Yes',
+          YES,
           'No, this course will be added to the schedule in addition to an existing computer science course',
           'No, computer science is new to my school',
           TEXT_FIELDS[:dont_know_explain]

--- a/dashboard/app/models/pd/application/teacher2021_application.rb
+++ b/dashboard/app/models/pd/application/teacher2021_application.rb
@@ -797,12 +797,12 @@ module Pd::Application
           end
 
         meets_minimum_criteria_scores[:replace_existing] =
-          if responses[:principal_wont_replace_existing_course] == principal_options[:replace_course][1]
-            YES
+          if responses[:principal_wont_replace_existing_course] == YES
+            NO
           elsif responses[:principal_wont_replace_existing_course] == TEXT_FIELDS[:i_dont_know_explain]
             nil
           else
-            NO
+            YES
           end
 
         school_stats = get_latest_school_stats(school_id)

--- a/dashboard/app/models/pd/application/teacher2021_application.rb
+++ b/dashboard/app/models/pd/application/teacher2021_application.rb
@@ -797,7 +797,7 @@ module Pd::Application
           end
 
         meets_minimum_criteria_scores[:replace_existing] =
-          if responses[:principal_wont_replace_existing_course] == YES
+          if responses[:principal_wont_replace_existing_course].start_with?(YES)
             NO
           elsif responses[:principal_wont_replace_existing_course] == TEXT_FIELDS[:i_dont_know_explain]
             nil


### PR DESCRIPTION
There is a bug in deciding if an application meets minimum requirements using responses from a principal approval form. The issue is reported [here](https://codedotorg.slack.com/archives/G9DF14A56/p1578337769002000). 

The specific question is this one
https://github.com/code-dot-org/code-dot-org/blob/781c8022acc55e6d8ee0ecba1163bd0d5bd5233d/lib/cdo/shared_constants/pd/principal_approval2021_application_constants.rb#L19

which has 4 possible answers.
https://github.com/code-dot-org/code-dot-org/blob/f548aa8d16fe29b835ad83cd922dc6a8d3028fdb/dashboard/app/models/pd/application/principal_approval2021_application.rb#L84-L88

The fix is simple. 
* If the principal answers _Yes_ -> a new course will replaces an existing one -> the application does not meet minimum requirement.
* If the answer is _I don't know_ -> undecided
* All other answers are _No..._ -> the application meets minimum requirement.

## Links
- [Slack discussion](https://codedotorg.slack.com/archives/G9DF14A56/p1578337769002000)
- [Teacher application spec](https://docs.google.com/document/d/1CHjjb7AUUgtX0_deNoxJKeyMjD6DYHjqfQMCjKS1quQ/edit#)

## Testing story
- Adds unit tests to `teacher2021_application_test.rb`.
- Runs `principal_approval2021_application_test.rb`.

## TODO
- [x] Re-score all applications by running `Pd::Application::Teacher2021Application.all.each {|a| a.auto_score!}`