### PR TITLE
[Data Viz] Fix dropdown display bug

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -385,6 +385,7 @@
   "dataLibraryHeader": "Data Library",
   "dataLibraryDescription": "Find and import tables of real data from the Code.org library.",
   "dataVisualizerPlaceholderText": "Select values to generate a visualization",
+  "dataVisualizerBucketSize": "Bucket Size",
   "dataVisualizerCreateChart": "Create chart on screen",
   "dataVisualizerChartTitle": "Chart Title",
   "dataVisualizerChartType": "Chart Type",

--- a/apps/src/storage/dataBrowser/dataVisualizer/DropdownField.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/DropdownField.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Radium from 'radium';
 import PropTypes from 'prop-types';
 import msg from '@cdo/locale';
-import {ChartType} from '../dataUtils';
 import * as rowStyle from '@cdo/apps/applab/designElements/rowStyle';
 
 class DropdownField extends React.Component {
@@ -11,24 +10,10 @@ class DropdownField extends React.Component {
     onChange: PropTypes.func.isRequired,
     options: PropTypes.array.isRequired,
     disabledOptions: PropTypes.array,
+    getDisplayNameForOption: PropTypes.func,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     inlineLabel: PropTypes.bool
   };
-
-  getDisplayNameForChartType(chartType) {
-    switch (chartType) {
-      case ChartType.BAR_CHART:
-        return msg.barChart();
-      case ChartType.HISTOGRAM:
-        return msg.histogram();
-      case ChartType.SCATTER_PLOT:
-        return msg.scatterPlot();
-      case ChartType.CROSS_TAB:
-        return msg.crossTab();
-      default:
-        return chartType;
-    }
-  }
 
   render() {
     const labelStyle = this.props.inlineLabel
@@ -60,7 +45,9 @@ class DropdownField extends React.Component {
               }
               value={option}
             >
-              {this.getDisplayNameForChartType(option)}
+              {this.props.getDisplayNameForOption
+                ? this.props.getDisplayNameForOption(option)
+                : option}
             </option>
           ))}
         </select>

--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -196,7 +196,9 @@ class VisualizerModal extends React.Component {
 
             {this.state.chartType === ChartType.HISTOGRAM && (
               <div style={styles.input}>
-                <label style={rowStyle.description}>Bucket Size</label>
+                <label style={rowStyle.description}>
+                  {msg.dataVisualizerBucketSize()}
+                </label>
                 <input
                   style={rowStyle.input}
                   value={this.state.bucketSize}

--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -105,6 +105,21 @@ class VisualizerModal extends React.Component {
     return columns.filter(column => isColumnNumeric(records, column));
   });
 
+  getDisplayNameForChartType(chartType) {
+    switch (chartType) {
+      case ChartType.BAR_CHART:
+        return msg.barChart();
+      case ChartType.HISTOGRAM:
+        return msg.histogram();
+      case ChartType.SCATTER_PLOT:
+        return msg.scatterPlot();
+      case ChartType.CROSS_TAB:
+        return msg.crossTab();
+      default:
+        return chartType;
+    }
+  }
+
   render() {
     const parsedRecords = this.parseRecords(this.props.tableRecords);
     const numericColumns = this.findNumericColumns(
@@ -168,6 +183,7 @@ class VisualizerModal extends React.Component {
                 ChartType.SCATTER_PLOT,
                 ChartType.CROSS_TAB
               ]}
+              getDisplayNameForOption={this.getDisplayNameForChartType}
               value={this.state.chartType}
               onChange={event =>
                 this.setState({


### PR DESCRIPTION
# Description
#32420 added some logic to be able to translate the chart type options in the dropdown. However, it incorrectly applied this logic to all dropdowns, not just the chart type one. This changes that so that mapping option value -> displayable value is a prop on `DropdownField`. Right now, the chart type dropdown is the only one that provides that prop.

Also while I'm here, adds i18n for "Bucket Size" (also a follow up to #32420) 

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
