### PR TITLE
Allow maker discount admin overrides for no shipping discount recipients

### DIFF
--- a/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
@@ -26,7 +26,6 @@ export default class EligibilityChecklist extends React.Component {
     schoolName: PropTypes.string,
     schoolHighNeedsEligible: PropTypes.bool,
     hasConfirmedSchool: PropTypes.bool,
-    getsFullDiscount: PropTypes.bool,
     initialDiscountCode: PropTypes.string,
     initialExpiration: PropTypes.string,
     adminSetStatus: PropTypes.bool.isRequired,
@@ -62,7 +61,7 @@ export default class EligibilityChecklist extends React.Component {
     if (props.adminSetStatus) {
       this.state = {
         ...this.state,
-        statusYear: props.getsFullDiscount ? Status.SUCCEEDED : Status.FAILED
+        statusYear: Status.SUCCEEDED
       };
     }
 

--- a/apps/src/sites/studio/pages/maker/discountcode.js
+++ b/apps/src/sites/studio/pages/maker/discountcode.js
@@ -14,8 +14,6 @@ $(document).ready(() => {
     currently_distributing_discount_codes
   } = scriptData;
 
-  currently_distributing_discount_codes = true;
-
   ReactDOM.render(
     <div>
       {is_admin && <DiscountAdminOverride />}

--- a/apps/src/sites/studio/pages/maker/discountcode.js
+++ b/apps/src/sites/studio/pages/maker/discountcode.js
@@ -14,6 +14,8 @@ $(document).ready(() => {
     currently_distributing_discount_codes
   } = scriptData;
 
+  currently_distributing_discount_codes = true;
+
   ReactDOM.render(
     <div>
       {is_admin && <DiscountAdminOverride />}
@@ -30,7 +32,6 @@ $(document).ready(() => {
           schoolName={application.school_name}
           schoolHighNeedsEligible={application.school_high_needs_eligible}
           hasConfirmedSchool={application.has_confirmed_school}
-          getsFullDiscount={application.gets_full_discount}
           initialDiscountCode={application.discount_code}
           initialExpiration={application.expiration}
           adminSetStatus={application.admin_set_status}

--- a/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
@@ -62,7 +62,6 @@ describe('EligibilityChecklist', () => {
         schoolId="12345"
         schoolName="Code.org Junior Academy"
         hasConfirmedSchool={true}
-        getsFullDiscount={false}
       />
     );
     assert.equal(wrapper.find('Button').length, 1);
@@ -76,7 +75,6 @@ describe('EligibilityChecklist', () => {
         schoolId="12345"
         schoolName="Code.org Junior Academy"
         hasConfirmedSchool={true}
-        getsFullDiscount={false}
       />
     );
     assert.equal(wrapper.find('EligibilityConfirmDialog').length, 0);
@@ -93,7 +91,6 @@ describe('EligibilityChecklist', () => {
         schoolId="12345"
         schoolName="Code.org Junior Academy"
         hasConfirmedSchool={true}
-        getsFullDiscount={false}
       />
     );
     wrapper.find('Button').simulate('click');
@@ -103,14 +100,13 @@ describe('EligibilityChecklist', () => {
     assert(wrapper.is('DiscountCodeInstructions'));
   });
 
-  it('renders DiscountCodeInstructions if we previoulsy received a discountCode', () => {
+  it('renders DiscountCodeInstructions if we previously received a discountCode', () => {
     const wrapper = shallow(
       <EligibilityChecklist
         {...defaultProps}
         unit6Intention={Unit6Intention.YES_SPRING_2020}
         initialDiscountCode="MYCODE"
         initialExpiration="2018-12-31T00:00:00.000Z"
-        getsFullDiscount={false}
       />
     );
     assert(wrapper.is('DiscountCodeInstructions'));
@@ -122,7 +118,6 @@ describe('EligibilityChecklist', () => {
         {...defaultProps}
         unit6Intention={Unit6Intention.YES_SPRING_2020}
         adminSetStatus={true}
-        getsFullDiscount={true}
       />
     );
     assert.equal(wrapper.find('Unit6ValidationStep').length, 0);
@@ -134,7 +129,6 @@ describe('EligibilityChecklist', () => {
         {...defaultProps}
         unit6Intention={Unit6Intention.NO}
         adminSetStatus={true}
-        getsFullDiscount={true}
       />
     );
     assert.equal(wrapper.state().statusYear, Status.SUCCEEDED);
@@ -146,7 +140,6 @@ describe('EligibilityChecklist', () => {
         {...defaultProps}
         unit6Intention={Unit6Intention.NO}
         adminSetStatus={true}
-        getsFullDiscount={true}
       />
     );
     assert.equal(wrapper.find('Button').props().text, 'Get Code');


### PR DESCRIPTION
## Description

Noticed an issue where an admin override will result in no "Get Code" button being displayed if they've given a user a discount without shipping (ie, the case for any override for teachers not in Alaska or Hawaii -- this is represented as `full_discount` = 0 in our database). This is what currently appears if a teacher didn't meet all eligibility criteria, then an admin overrode their application and gave them a full discount without shipping:

![image](https://user-images.githubusercontent.com/25372625/71925433-e2745280-3145-11ea-8707-de9db0f04675.png)

Here's what happens in the same situation now:

![image](https://user-images.githubusercontent.com/25372625/71925635-56165f80-3146-11ea-87d7-17fc6efaeec7.png)

I removed references to whether a user is eligible for a full discount in the `EligibilityChecklist` component entirely, as I don't think it is necessary.

I am not 100% sure of whether my approach here (make `statusYear` = success if any admin override) is the correct one, or if I should change the display "Get Code" button logic to just check whether the teacher has an admin override.

## Testing

See standalone comment below -- there's a test for this situation that I've updated.

I did manually look at a few scenarios:
- Teacher in Alabama meets all criteria -> "Get Code" appears and returns non-shipping included b
- Teacher in Alabama doesn't meet all criteria and no admin override -> no "Get Code" button appears.
- Teacher in Alabama doesn't meet all criteria, and admin overrides with a no shipping code  -> "Get Code"button appears and returns an no shipping code.
- Teacher in Alabama doesn't meet all criteria, and admin overrides with a shipping included code  -> "Get Code"button appears and returns a shipping included code.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
