### PR TITLE
Check for elements lower on the page in courses eyes test

### DIFF
--- a/apps/src/templates/studioHomepages/CourseBlocksTools.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocksTools.jsx
@@ -53,22 +53,24 @@ class CourseBlocksTools extends Component {
       : i18n.courseBlocksToolsTitleNonEn();
 
     return (
-      <ContentContainer
-        heading={headingText}
-        description={i18n.standaloneToolsDescription()}
-      >
-        <ResourceCardResponsiveContainer>
-          {this.cards.map((card, cardIndex) => (
-            <ResourceCard
-              key={cardIndex}
-              title={card.heading}
-              description={card.description}
-              buttonText={i18n.learnMore()}
-              link={pegasus(`/${card.path}`)}
-            />
-          ))}
-        </ResourceCardResponsiveContainer>
-      </ContentContainer>
+      <div id="uitest-course-blocks-tools">
+        <ContentContainer
+          heading={headingText}
+          description={i18n.standaloneToolsDescription()}
+        >
+          <ResourceCardResponsiveContainer>
+            {this.cards.map((card, cardIndex) => (
+              <ResourceCard
+                key={cardIndex}
+                title={card.heading}
+                description={card.description}
+                buttonText={i18n.learnMore()}
+                link={pegasus(`/${card.path}`)}
+              />
+            ))}
+          </ResourceCardResponsiveContainer>
+        </ContentContainer>
+      </div>
     );
   }
 }

--- a/dashboard/test/ui/features/courses_eyes.feature
+++ b/dashboard/test/ui/features/courses_eyes.feature
@@ -33,6 +33,7 @@ Scenario: Student courses, non-english
   And I see "#header-student-courses"
   And I press "header-student-courses"
   And I wait to see "#hero"
+  And I wait to see "#uitest-course-blocks-tools"
   And I see no difference for "student non-english courses page"
   And I close my eyes
 
@@ -66,5 +67,6 @@ Scenario: Signed out courses, non-english
   And I see "#header-non-en-courses"
   And I press "header-non-en-courses"
   Then I am on "http://studio.code.org/courses"
+  And I wait to see "#uitest-course-blocks-tools"
   And I see no difference for "signed-out courses page, non-english"
   And I close my eyes


### PR DESCRIPTION
During a Dotd shift, @hacodeorg [noticed that the studio.code.org/courses eyes tests, particularly in non-English, can be flaky](https://codedotorg.slack.com/archives/C0T0PNTM3/p1576865740055000) if the screenshot is taken before the page has fully loaded.  To prevent this, we added a quick check for an element at the bottom of the page. 