### PR TITLE
add a serverside inline markdown renderer

### DIFF
--- a/lib/cdo/redcarpet/inline.rb
+++ b/lib/cdo/redcarpet/inline.rb
@@ -1,0 +1,38 @@
+require 'redcarpet'
+
+module Redcarpet
+  module Render
+    class Inline < HTML
+      # Override block-level methods to always just return their content as a
+      # string (no markup)
+      %w(
+        block_code
+        block_quote
+        footnote_def
+        footnotes
+        header
+        hrule
+        list
+        list_item
+        paragraph
+        table
+        table_cell
+        table_row
+      ).each do |method|
+        define_method method do |*args|
+          args.first
+        end
+      end
+
+      # Disallow HTML entirely
+      %w(
+        block_html
+        raw_html
+      ).each do |method|
+        define_method method do |*_args|
+          ""
+        end
+      end
+    end
+  end
+end

--- a/lib/test/cdo/redcarpet/test_inline.rb
+++ b/lib/test/cdo/redcarpet/test_inline.rb
@@ -1,0 +1,47 @@
+require_relative '../../test_helper'
+require 'cdo/redcarpet/inline'
+
+class RedcarpetInlineRendererTest < Minitest::Test
+  def setup
+    @renderer = Redcarpet::Markdown.new(Redcarpet::Render::Inline)
+  end
+
+  def test_base
+    assert_equal "base string", @renderer.render("base string")
+  end
+
+  def test_inline_markdown
+    expected = "a <strong>string</strong> with <em>some</em> <a href=\"markdown\">basic</a>"
+    markdown = "a **string** with _some_ [basic](markdown)"
+    assert_equal expected, @renderer.render(markdown)
+  end
+
+  def test_paragraph
+    expected = "<strong>some</strong> <em>basic</em> <a href=\"markdown\">inline</a>and <strong>yet more</strong> markdown in a <em>second</em> paragraph"
+    markdown = "**some** _basic_ [inline](markdown)\n\nand **yet more** markdown in a _second_ paragraph"
+    assert_equal expected, @renderer.render(markdown)
+  end
+
+  def test_header
+    assert_equal "header", @renderer.render("# header")
+  end
+
+  def test_blockquote
+    assert_equal "blockquote", @renderer.render("> blockquote")
+  end
+
+  def test_list
+    assert_equal "an\nunordered\nlist\n", @renderer.render("- an\n- unordered\n- list")
+    assert_equal "an\nordered\nlist\n", @renderer.render("1. an\n2. ordered\n3. list")
+  end
+
+  def test_raw_html
+    assert_equal "some basic inline",
+      @renderer.render("<strong>some</strong> <em>basic</em> <a href=\"markdown\">inline</a>")
+
+    assert_equal "<strong>mixed</strong> html <em>and</em> markdown",
+      @renderer.render("**mixed** <i>html</i> _and_ <strong>markdown</strong>")
+
+    assert_equal "", @renderer.render("<table><thead><th>Some advanced html</th><th><strong>not</strong> usually supported by markdown</th></thead></table>\n")
+  end
+end


### PR DESCRIPTION
# Description

Similar to https://github.com/code-dot-org/code-dot-org/pull/32531; will be used by https://github.com/code-dot-org/code-dot-org/pull/32521 to upgrade the `render_multi_or_match_content` helper, which usually renders into headers or labels and therefore needs inline rendering support.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
