### PR TITLE
Update the name of the flag we use for specificity

### DIFF
--- a/apps/src/lib/kits/maker/toolkit.js
+++ b/apps/src/lib/kits/maker/toolkit.js
@@ -159,7 +159,7 @@ function getBoard() {
   if (shouldRunWithFakeBoard()) {
     return Promise.resolve(new FakeBoard());
   } else {
-    if (experiments.isEnabled('bett-demo')) {
+    if (experiments.isEnabled(experiments.BETT_DEMO)) {
       //TODO - break out the applicable parts of findPortWithViableDevice
       return findPortWithViableDevice().then(() => new MicroBitBoard());
     } else {

--- a/apps/src/lib/kits/maker/toolkit.js
+++ b/apps/src/lib/kits/maker/toolkit.js
@@ -159,7 +159,7 @@ function getBoard() {
   if (shouldRunWithFakeBoard()) {
     return Promise.resolve(new FakeBoard());
   } else {
-    if (experiments.isEnabled('microbit')) {
+    if (experiments.isEnabled('bett-demo')) {
       //TODO - break out the applicable parts of findPortWithViableDevice
       return findPortWithViableDevice().then(() => new MicroBitBoard());
     } else {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -24,6 +24,7 @@ experiments.SCHOOL_AUTOCOMPLETE_DROPDOWN_NEW_SEARCH =
 experiments.APPLAB_DATASETS = 'applabDatasets';
 experiments.STUDENT_LIBRARIES = 'student-libraries';
 experiments.STANDARDS_REPORT = 'standardsReport';
+experiments.BETT_DEMO = 'bett-demo';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.


### PR DESCRIPTION
# Description
To prep for the BETT Demo, I'm swapping out the name of the experiment flag from 'microbit' to 'bett-demo'. Being more specific with the flag string will make it easier to scope the changes that are behind this flag and easily deprecate the flag after the demo (useful as we move our changes from 'demo-ready' to 'release-ready').
 
## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
