### PR TITLE
Sort hour of code tutorials by popularity

### DIFF
--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -120,9 +120,6 @@ style_min: false
   - tutorial[:string_detail_platforms]              = hoc_s(prefix + "string_detail_platforms")
   - tutorial[:string_detail_programming_languages]  = hoc_s(prefix + "string_detail_programming_languages")
 
-- hoc_mode = DCDO.get("hoc_mode", CDO.default_hoc_mode)
-- sort_by_popularity = [false, "post-hoc"].include?(hoc_mode) || (request.site == 'code.org' && hoc_mode == 'pre-hoc')
-
 #tutorials
 
 :javascript
@@ -135,7 +132,7 @@ style_min: false
       roboticsButtonUrl: "/learn/robotics",
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},
       disabledTutorials: #{DCDO.get('learn_hide_tutorials', [])},
-      defaultSortByPopularity: #{sort_by_popularity}
+      defaultSortByPopularity: #{Tutorials.sort_by_popularity?(request.site, DCDO.get("hoc_mode", CDO.default_hoc_mode))}
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));
 

--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -120,8 +120,8 @@ style_min: false
   - tutorial[:string_detail_platforms]              = hoc_s(prefix + "string_detail_platforms")
   - tutorial[:string_detail_programming_languages]  = hoc_s(prefix + "string_detail_programming_languages")
 
-- sort_by_popularity = request.site == 'code.org'
-- sort_by_popularity &&= [false, "pre-hoc"].include?(DCDO.get("hoc_mode", CDO.default_hoc_mode))
+- hoc_mode = DCDO.get("hoc_mode", CDO.default_hoc_mode)
+- sort_by_popularity = [false, "post-hoc"].include?(hoc_mode) || (request.site == 'code.org' && hoc_mode == 'pre-hoc')
 
 #tutorials
 

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -112,8 +112,6 @@ social:
   - tutorial[:string_detail_platforms]              = hoc_s(prefix + "string_detail_platforms")
   - tutorial[:string_detail_programming_languages]  = hoc_s(prefix + "string_detail_programming_languages")
 
-- sort_by_popularity = [false, "post-hoc"].include?(DCDO.get("hoc_mode", CDO.default_hoc_mode))
-
 #tutorials
 
 .clear{style: "clear: both"}
@@ -128,7 +126,7 @@ social:
       roboticsButtonUrl: "#{resolve_url('/learn/robotics')}",
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},
       disabledTutorials: #{DCDO.get('learn_hide_tutorials', [])},
-      defaultSortByPopularity: #{sort_by_popularity}
+      defaultSortByPopularity: #{Tutorials.sort_by_popularity?(request.site, DCDO.get("hoc_mode", CDO.default_hoc_mode))}
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));
 

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -112,6 +112,8 @@ social:
   - tutorial[:string_detail_platforms]              = hoc_s(prefix + "string_detail_platforms")
   - tutorial[:string_detail_programming_languages]  = hoc_s(prefix + "string_detail_programming_languages")
 
+- sort_by_popularity = [false, "post-hoc"].include?(DCDO.get("hoc_mode", CDO.default_hoc_mode))
+
 #tutorials
 
 .clear{style: "clear: both"}
@@ -125,7 +127,8 @@ social:
       locale: "#{locale_code}",
       roboticsButtonUrl: "#{resolve_url('/learn/robotics')}",
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},
-      disabledTutorials: #{DCDO.get('learn_hide_tutorials', [])}
+      disabledTutorials: #{DCDO.get('learn_hide_tutorials', [])},
+      defaultSortByPopularity: #{sort_by_popularity}
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));
 

--- a/pegasus/src/database.rb
+++ b/pegasus/src/database.rb
@@ -82,6 +82,10 @@ class Tutorials
     by_short_code = CDO.cache.fetch("Tutorials/#{@table}/by_short_code") {@contents.index_by {|row| row[:short_code]}}
     by_short_code[short_code]
   end
+
+  def self.sort_by_popularity?(site, hoc_mode)
+    ("post-hoc" == hoc_mode) || (site == 'code.org' && [false, 'pre-hoc'].include?(hoc_mode))
+  end
 end
 
 def no_credit_count

--- a/pegasus/test/test_tutorials.rb
+++ b/pegasus/test/test_tutorials.rb
@@ -26,4 +26,34 @@ class TutorialsTest < Minitest::Test
     tutorial[:image] = 'xyz'
     refute_equal Tutorials.new(:tutorials).contents('code.org').first[:image], tutorial[:image]
   end
+
+  def test_sort_by_popularity_code_org
+    code_org = "code.org"
+
+    assert Tutorials.sort_by_popularity?(code_org, "post-hoc")
+    assert Tutorials.sort_by_popularity?(code_org, "pre-hoc")
+    assert Tutorials.sort_by_popularity?(code_org, false)
+
+    refute Tutorials.sort_by_popularity?(code_org, "bad data")
+  end
+
+  def test_sort_by_popularity_hour_of_code_com
+    hour_of_code = "hourofcode.com"
+
+    assert Tutorials.sort_by_popularity?(hour_of_code, "post-hoc")
+
+    refute Tutorials.sort_by_popularity?(hour_of_code, "pre-hoc")
+    refute Tutorials.sort_by_popularity?(hour_of_code, false)
+    refute Tutorials.sort_by_popularity?(hour_of_code, "not a value")
+  end
+
+  def test_sort_by_popularity_cs_ed_week_org
+    cs_ed_week = "csedweek.org"
+
+    assert Tutorials.sort_by_popularity?(cs_ed_week, "post-hoc")
+
+    refute Tutorials.sort_by_popularity?(cs_ed_week, "pre-hoc")
+    refute Tutorials.sort_by_popularity?(cs_ed_week, false)
+    refute Tutorials.sort_by_popularity?(cs_ed_week, "unexpected")
+  end
 end

--- a/pegasus/test/test_tutorials.rb
+++ b/pegasus/test/test_tutorials.rb
@@ -35,6 +35,8 @@ class TutorialsTest < Minitest::Test
     assert Tutorials.sort_by_popularity?(code_org, false)
 
     refute Tutorials.sort_by_popularity?(code_org, "bad data")
+    refute Tutorials.sort_by_popularity?(code_org, "soon-hoc")
+    refute Tutorials.sort_by_popularity?(code_org, "actual-hoc")
   end
 
   def test_sort_by_popularity_hour_of_code_com
@@ -43,6 +45,7 @@ class TutorialsTest < Minitest::Test
     assert Tutorials.sort_by_popularity?(hour_of_code, "post-hoc")
 
     refute Tutorials.sort_by_popularity?(hour_of_code, "pre-hoc")
+    refute Tutorials.sort_by_popularity?(hour_of_code, "actual-hoc")
     refute Tutorials.sort_by_popularity?(hour_of_code, false)
     refute Tutorials.sort_by_popularity?(hour_of_code, "not a value")
   end
@@ -53,6 +56,7 @@ class TutorialsTest < Minitest::Test
     assert Tutorials.sort_by_popularity?(cs_ed_week, "post-hoc")
 
     refute Tutorials.sort_by_popularity?(cs_ed_week, "pre-hoc")
+    refute Tutorials.sort_by_popularity?(cs_ed_week, "soon-hoc")
     refute Tutorials.sort_by_popularity?(cs_ed_week, false)
     refute Tutorials.sort_by_popularity?(cs_ed_week, "unexpected")
   end


### PR DESCRIPTION
# Description
Update hourofcode.com/learn, code.org/learn, and csedweek.org/learn to sort tutorials by popularity when in the "post-hoc" mode. Current mode for production is "post-hoc".
<img width="253" alt="Screen Shot 2020-01-08 at 10 57 30 AM" src="https://user-images.githubusercontent.com/33666587/72007292-38a8ca80-3206-11ea-8d92-7e1f4ff85e76.png">

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-684)

## Testing story
Validated all pages sort as expected during "post-hoc" mode. During "pre-hoc" mode only code.org/learn will sort by popularity as was the behavior previously.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
