### PR TITLE
Stopped assuming that vendorId always exists when connecting to microbit

### DIFF
--- a/apps/src/third-party/maker/MBFirmataClient.js
+++ b/apps/src/third-party/maker/MBFirmataClient.js
@@ -139,7 +139,7 @@ class MicrobitFirmataClient {
     .then((ports) => {
       for (var i = 0; i < ports.length; i++) {
         var p = ports[i];
-        if ((p.vendorId.toLowerCase() == '0d28') && (p.productId == '0204')) {
+        if ((p.vendorId && p.vendorId.toLowerCase() == '0d28') && (p.productId == '0204')) {
           return p.comName;
         }
       }


### PR DESCRIPTION
# Description
On windows and linux, the usb port was either the only port returned or was always the first in the list. On OSX, this turns out to not be the case. We were seeing vendorId undefined on OSX because different ports show up earlier in the list and do not necessarily have something connected.
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
