### PR TITLE
Title logging

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -1,5 +1,6 @@
 require 'cdo/activity_constants'
 require 'cdo/share_filtering'
+require 'cdo/firehose'
 
 class ActivitiesController < ApplicationController
   include LevelsHelper
@@ -65,10 +66,14 @@ class ActivitiesController < ApplicationController
           params[:program].strip_utf8mb4
         )
         if share_checking_error
-          slog(
-            tag: 'share_checking_error',
-            error: "#{share_checking_error.class.name}: #{share_checking_error}",
-            level_source_id: @level_source.id
+          FirehoseClient.instance.put_record(
+            study: 'share_filtering',
+            study_group: 'v0',
+            event: 'share_filtering_error',
+            data_string: "#{share_checking_error.class.name}: #{share_checking_error}",
+            data_json: {
+              level_source_id: @level_source.id
+            }.to_json
           )
         end
       end

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -53,9 +53,9 @@ class ActivitiesController < ApplicationController
       if @level.game.sharing_filtered?
         begin
           share_failure = ShareFiltering.find_share_failure(params[:program], locale)
-        rescue OpenURI::HTTPError, IO::EAGAINWaitReadable => share_checking_error
+        rescue OpenURI::HTTPError, IO::EAGAINWaitReadable => share_filtering_error
           # If WebPurify or Geocoder fail, the program will be allowed, and we
-          # retain the share_checking_error to log it alongside the level_source
+          # retain the share_filtering_error to log it alongside the level_source
           # ID below.
         end
       end
@@ -65,12 +65,12 @@ class ActivitiesController < ApplicationController
           @level,
           params[:program].strip_utf8mb4
         )
-        if share_checking_error
+        if share_filtering_error
           FirehoseClient.instance.put_record(
             study: 'share_filtering',
             study_group: 'v0',
             event: 'share_filtering_error',
-            data_string: "#{share_checking_error.class.name}: #{share_checking_error}",
+            data_string: "#{share_filtering_error.class.name}: #{share_filtering_error}",
             data_json: {
               level_source_id: @level_source.id
             }.to_json


### PR DESCRIPTION
# Description

As a followup to https://github.com/code-dot-org/code-dot-org/pull/32269, move the logging for WebPurify/Geocoder errors in our profanity/privacy filtering to Firehose. We've been using `slog`, which is not the current preferred place for logging.

More info on `slog`:

- https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/deployment.rb#L3
- https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo.rb#L153
- https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/slog.rb#L14

**Open Question:** Should I move the other "slogging" in this file to Firehose as well? https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/activities_controller.rb#L128

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/LP-1059?atlOrigin=eyJpIjoiMmIwNDVkNjg0ZmY0NDllODllZDE2ZDE3YWM0ZTI5MDIiLCJwIjoiaiJ9)

## Testing story

Updated activities_controller.rb unit tests to reflect the new logging.
<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
