### PR TITLE
Standards Report: adjust spacing of standards header buttons

### DIFF
--- a/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
+++ b/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
@@ -22,7 +22,8 @@ const styles = {
     marginBottom: 10,
     display: 'flex',
     flexDirection: 'row',
-    alignItems: 'flex-end'
+    alignItems: 'flex-end',
+    justifyContent: 'space-between'
   },
   scriptLink: {
     color: color.teal


### PR DESCRIPTION
A little style polish to right align the standards header buttons to be more consistent with the layout in the Standards Report [spec](https://docs.google.com/document/d/1xlm_syljGXIapl72GaKxN63V7kt6syHyvWHuqZhTCfE/edit#).

SPEC

<img width="745" alt="Screen Shot 2020-01-08 at 4 00 40 PM" src="https://user-images.githubusercontent.com/12300669/72026448-57bc5200-3230-11ea-9c67-b4da0e43b891.png">

BEFORE

<img width="1029" alt="Screen Shot 2020-01-08 at 3 48 48 PM" src="https://user-images.githubusercontent.com/12300669/72026473-6a368b80-3230-11ea-8c05-005446153108.png">

AFTER

<img width="1054" alt="Screen Shot 2020-01-08 at 3 57 35 PM" src="https://user-images.githubusercontent.com/12300669/72026467-660a6e00-3230-11ea-9fca-9a89ea56b44c.png">


