### PR TITLE
Add trailing slash for documentation

### DIFF
--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -92,7 +92,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "documentation"
+      replace_key_prefix_with: "documentation/"
     }
   },
 ]


### PR DESCRIPTION
# Description

The trailing slash was missing on documentation in the redirection rules so things that went to /docs/concepts kept getting redirected to /documentationconcepts/.