### PR TITLE
Teacher Application Export: Use a service account to write to Google Sheets

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -5,6 +5,12 @@ exit unless only_one_running?(__FILE__)
 require_relative '../../dashboard/config/environment'
 require 'cdo/google_drive'
 
+#
+# Uses a Google Cloud service account to write teacher application data for this year into
+# a spreadsheet in Google Drive (with permissions locked down to our organization) for exploration
+# by our programs team.
+#
+
 applications = [%w(course regional_partner status scholarship_status school_type pay_fee email created_at)]
 
 Pd::Application::Teacher2021Application.find_each do |app|
@@ -20,4 +26,5 @@ Pd::Application::Teacher2021Application.find_each do |app|
   ]
 end
 
-Google::Drive.new.add_sheet_to_spreadsheet(applications, "2020-21 Teacher Applications", "all_apps (auto)")
+drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
+drive.update_sheet applications, CDO.applications_2020_2021_gsheet_key, 'all_apps (auto)'

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -170,6 +170,7 @@ google_maps_secret:       !Secret
 ga_account:               !Secret
 ga_profile_id:            !Secret
 google_safe_browsing_key: !Secret
+gdrive_export_secret:     !Secret
 
 # Mapbox
 mapbox_upload_token:
@@ -450,6 +451,9 @@ bundler_use_sudo: <%=chef_managed%>
 
 daemon: <%=name == 'production-daemon'%>
 image_optim: <%=chef_managed && !ci_test%>
+
+# Used for the teacher application data export
+applications_2020_2021_gsheet_key: !Secret
 
 # Referenced in Chef config, but not sure if they are still used anywhere?
 # TODO: verify these are intentionally no longer used and remove references from Chef config.

--- a/lib/cdo/google_drive.rb
+++ b/lib/cdo/google_drive.rb
@@ -111,7 +111,7 @@ module Google
       document = @session.spreadsheet_by_key(document_key)
       raise "Could not find document #{document_key}" unless document
       worksheet = document.worksheet_by_title(sheet_name)
-      raise "Could not find worksheet '#{sheet_name}'" unless worksheet
+      worksheet ||= document.add_worksheet(sheet_name, 500)
       worksheet.delete_rows(1, worksheet.num_rows)
       worksheet.update_cells(1, 1, data)
       worksheet.save

--- a/lib/cdo/google_drive.rb
+++ b/lib/cdo/google_drive.rb
@@ -37,7 +37,11 @@ module Google
 
     def initialize(params={})
       $log.debug 'Establishing Google Drive session'
-      @session = GoogleDrive.saved_session(deploy_dir('.gdrive_session'))
+      @session = if params[:service_account_key]
+                   GoogleDrive::Session.from_service_account_key params[:service_account_key]
+                 else
+                   GoogleDrive.saved_session(deploy_dir('.gdrive_session'))
+                 end
     end
 
     def file(path)
@@ -89,6 +93,25 @@ module Google
       end
       worksheet = spreadsheet.worksheet_by_title(sheet_name)
       worksheet ||= spreadsheet.add_worksheet(sheet_name, 500)
+      worksheet.delete_rows(1, worksheet.num_rows)
+      worksheet.update_cells(1, 1, data)
+      worksheet.save
+    end
+
+    # Update a sheet (tab) in an _existing_ Google Sheets document, completely overwriting
+    # its contents, and creating it if needed.
+    #
+    # @param [Array.<Array>] data The rows to write into the document
+    # @param [String] document_key The identifier for the google sheet to be updated, as found
+    #   in its share URL.
+    #   e.g. "f0SdU35KaAv3LE7IYhHkFCb0Y6fZTGgk1GIa1LtO8uYx"
+    # @param [String] sheet_name The full name of the sheet/tab within the document to be
+    #   created/updated.
+    def update_sheet(data, document_key, sheet_name)
+      document = @session.spreadsheet_by_key(document_key)
+      raise "Could not find document #{document_key}" unless document
+      worksheet = document.worksheet_by_title(sheet_name)
+      raise "Could not find worksheet '#{sheet_name}'" unless worksheet
       worksheet.delete_rows(1, worksheet.num_rows)
       worksheet.update_cells(1, 1, data)
       worksheet.save


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/32383: Updates the `teacher_applications_to_gdrive` script to use a Google Cloud service account with limited credentials to update the target spreadsheet.  The key(s) for the service account, as well as the ID of the target spreadsheet, are stored in AWS secrets manager.  Note, we're still using [`google-drive-ruby`](https://github.com/gimite/google-drive-ruby), just with a different recommended configuration.

## Process

I've set up two new [Google Cloud projects](https://cloud.google.com/storage/docs/projects) under our organization, one [for production GDrive exports](https://console.cloud.google.com/home/dashboard?folder=&organizationId=&project=cdo-gdrive-export-prod&supportedpurview=project) and one [for other environments](https://console.cloud.google.com/home/dashboard?folder=&organizationId=&project=cdo-gdrive-export-staging&supportedpurview=project). Each of these projects has ownership and billing configured per our organization's policy, has the [Google Drive API](https://developers.google.com/drive) and [Google Sheets API](https://developers.google.com/sheets/api) enabled per the [instructions from the Ruby gem](https://github.com/gimite/google-drive-ruby/blob/master/doc/authorization.md#service-account), and has one [service account](https://cloud.google.com/iam/docs/service-accounts) configured to act on behalf of our application through those APIs.

I downloaded new credentials for the service account, which take the form of a json file and look something like this:

```json
{
  "type": "service_account",
  "project_id": "cdo-gdrive-export-prod",
  "private_key_id": "<redacted>",
  "private_key": "<redacted>",
  "client_email": "<redacted>@cdo-gdrive-export-prod.iam.gserviceaccount.com",
  "client_id": "<redacted>",
  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
  "token_uri": "https://oauth2.googleapis.com/token",
  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<redacted>%40cdo-gdrive-export-prod.iam.gserviceaccount.com"
}
```

In order to store and use this credential securely, I uploaded it as structured data to [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/), following the instructions in [our secrets documentation](https://github.com/code-dot-org/code-dot-org/blob/staging/config/secrets.md).  I then updated our configuration to retrieve these secrets from secret manager as needed, convert it back to JSON, and wrap it in a [StringIO](https://ruby-doc.org/stdlib-2.6.3/libdoc/stringio/rdoc/StringIO.html) which our Google Drive library can read like a file.

The service account is not considered "part of our organization" and does not have access to any Google Drive documents except for those that are shared with its `client_email` as given in the credentials above.  As such, I shared the gsheet in question with the non-prod service account while I was testing, and have now shared it with the production service account.

## Testing story

Tested end-to-end locally with development secrets configured in Secret Manager.

Note that the configuration added in this PR does not configure _development_ environments to pull anything from Secrets Manager; to do that for local testing, you have to add the following lines to your `config/develoment.yml.erb` file:

```yml
gdrive_export_secret: !Secret
applications_2020_2021_gsheet_key: !Secret
```

## Future work

I'd like to update this script to check that the document in question is _only_ shared with the appropriate service account and `@code.org` accounts, and wipe the PII if it finds a policy violation.  Not making that change as part of this initial commit because I'm under increasing time pressure to get a working version of this out the door.  Tracked as [PLC-691](https://codedotorg.atlassian.net/browse/PLC-691) and starting right away.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
