### PR TITLE
Teacher Application Export: Enable cronjob

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -92,8 +92,7 @@
       cronjob at:'*/10 * * * *', do:deploy_dir('bin', 'cron', 'delete_twilio_data')
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'confirm_usage')
       cronjob at:'5 16 * * *', do:deploy_dir('bin', 'cron', 'calculate_workshop_survey_results')
-      # [Brad] Disabled so that we can do the first run manually on production-daemon, to update credentials.
-      # cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
+      cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
       cronjob at:'0 11 * * *', do:deploy_dir('bin', 'cron', 'workshops_to_s3')
       cronjob at:'00 17 * * *', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
       cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')


### PR DESCRIPTION
[PLC-578](https://codedotorg.atlassian.net/browse/PLC-578): Automates work started in https://github.com/code-dot-org/code-dot-org/pull/32383 and solved in https://github.com/code-dot-org/code-dot-org/pull/32597.  This sets the `teacher_applications_to_gdrive` script to run every two hours, keeping the data in that document (relatively) fresh.

## Follow-up work

- [PLC-692](https://codedotorg.atlassian.net/browse/PLC-692): Also publish metadata to the spreadsheet, in a separate tab
- [PLC-691](https://codedotorg.atlassian.net/browse/PLC-691): Make the script enforce our data-sharing policy for this document

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
