### PR TITLE
Teacher Application Export: Include metadata

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -28,3 +28,19 @@ end
 
 drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
 drive.update_sheet applications, CDO.applications_2020_2021_gsheet_key, 'all_apps (auto)'
+
+metadata = [
+  ['AUTOMATION METADATA'],
+  [''],
+  ['The tabs "all_apps (auto)" and "meta (auto)" are auto-generated;'],
+  ['Any edits you make to them (besides formatting) may be lost.'],
+  [''],
+  ['Last updated:', DateTime.now.strftime('%Y-%m-%d %l:%M%P GMT%:::z')],
+  ['Written by:', CDO.gdrive_export_secret.client_email],
+  ['Teacher applications:', applications.length - 1],
+  [''],
+  ['Parts of this Google Sheet are auto-populated from our live application by an automated process.'],
+  ["The sheet is shared with a \"service account\" that updates it on the application's behalf."],
+  ["(Technical Details: https://github.com/code-dot-org/code-dot-org/pull/32597)"],
+]
+drive.update_sheet metadata, CDO.applications_2020_2021_gsheet_key, 'meta (auto)'

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -92,8 +92,7 @@
       cronjob at:'*/10 * * * *', do:deploy_dir('bin', 'cron', 'delete_twilio_data')
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'confirm_usage')
       cronjob at:'5 16 * * *', do:deploy_dir('bin', 'cron', 'calculate_workshop_survey_results')
-      # [Brad] Disabled so that we can do the first run manually on production-daemon, to update credentials.
-      # cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
+      cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
       cronjob at:'0 11 * * *', do:deploy_dir('bin', 'cron', 'workshops_to_s3')
       cronjob at:'00 17 * * *', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
       cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')


### PR DESCRIPTION
[PLC-692](https://codedotorg.atlassian.net/browse/PLC-692): An improvement on the system set up in https://github.com/code-dot-org/code-dot-org/pull/32383.  We now write a new tab "meta (auto)" with some simple metadata about the automated export task, and some documentation.

Here's what it looks like (in a test spreadsheet populated by fake data from my local machine, with the email address manually redacted after the export):

![image](https://user-images.githubusercontent.com/1615761/72117543-fadd9c00-3302-11ea-876c-23de48cf3f80.png)

I've included:

- The export date and time (with timezone) so that partners can check how stale the data in the spreadsheet is, and hopefully notice and notify us if it stops updating.
- The account that performed the update, so that we can spot-check that the correct credentials are being used to update the application data, and as an early test for using this email address when [verifying the sharing policy](https://codedotorg.atlassian.net/browse/PLC-691).
- The total number of applications, which is probably useful at a glance.

## Testing story

I tested this from my local machine against a private gsheet and with a temporary local configuration to match:

First, we need to create a gsheet for testing ([mine is here](https://docs.google.com/spreadsheets/d/1ov0ux-0idp2V4_0b_EzwikVN7CmkoX6Z3wb8gkvwQ2Y/edit#gid=1295130438)) and share it with the service account's email address.

Then, we need to load the (non-production) service account credentials from AWS Secret Manager:
```yml
# development.yml.erb
gdrive_export_secret: !Secret
```

And we point the export process at our private testing gsheet.
```yml
# locals.yml
applications_2020_2021_gsheet_key: '1ov0ux-0idp2V4_0b_EzwikVN7CmkoX6Z3wb8gkvwQ2Y'
```

(And if you happen to have no teacher applications on your local machine, you can autogenerate some from inside the Rails console like this:)

```rb
[development] dashboard > FactoryGirl.create_list(:pd_teacher2021_application, 10)
```

Then we run the local script!

```bash
> bin/cron/teacher_applications_to_gdrive
```

Running through this several times, I've verified:

- The metadata tab is created if it is needed
- Metadata is updated as expected
- Rows and columns are added if needed for content being written
- The count of teacher applications is correct
- The timestamp is correct and easy to read
- The email address of the service account is correct
- Formatting, row/column sizing, number of frozen rows/columns and deleted (unused) rows/columns are preserved across updates

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
