### PR TITLE
Add script id to metrics for view toggle in progress tab

### DIFF
--- a/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
@@ -26,7 +26,8 @@ class SectionProgressToggle extends React.Component {
     // Redux provided
     currentView: PropTypes.string.isRequired,
     setCurrentView: PropTypes.func.isRequired,
-    sectionId: PropTypes.number
+    sectionId: PropTypes.number,
+    scriptId: PropTypes.number
   };
 
   onChange = selectedToggle => {
@@ -38,7 +39,8 @@ class SectionProgressToggle extends React.Component {
         data_json: JSON.stringify({
           section_id: this.props.sectionId,
           old_view: this.props.currentView,
-          new_view: selectedToggle
+          new_view: selectedToggle,
+          script_id: this.props.scriptId
         })
       },
       {includeUserId: true}
@@ -90,7 +92,8 @@ export const UnconnectedSectionProgressToggle = SectionProgressToggle;
 export default connect(
   state => ({
     currentView: state.sectionProgress.currentView,
-    sectionId: state.sectionProgress.section.id
+    sectionId: state.sectionProgress.section.id,
+    scriptId: state.scriptSelection.scriptId
   }),
   dispatch => ({
     setCurrentView(viewType) {

--- a/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
@@ -92,7 +92,7 @@ export const UnconnectedSectionProgressToggle = SectionProgressToggle;
 export default connect(
   state => ({
     currentView: state.sectionProgress.currentView,
-    sectionId: state.sectionProgress.section.id,
+    sectionId: state.sectionData.section.id,
     scriptId: state.scriptSelection.scriptId
   }),
   dispatch => ({

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -82,7 +82,7 @@ export const jumpToLessonDetails = lessonOfInterest => {
         study_group: 'progress',
         event: 'view_change_toggle',
         data_json: JSON.stringify({
-          section_id: state.sectionProgress.section.id,
+          section_id: state.sectionData.section.id,
           old_view: ViewType.SUMMARY,
           new_view: ViewType.DETAIL,
           script_id: state.scriptSelection.scriptId

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -73,7 +73,7 @@ export const addStudentLevelPairing = (scriptId, studentLevelPairing) => {
 
 export const jumpToLessonDetails = lessonOfInterest => {
   return (dispatch, getState) => {
-    const state = getState().sectionProgress;
+    const state = getState();
     dispatch(setLessonOfInterest(lessonOfInterest));
     dispatch(setCurrentView(ViewType.DETAIL));
     firehoseClient.putRecord(
@@ -82,9 +82,10 @@ export const jumpToLessonDetails = lessonOfInterest => {
         study_group: 'progress',
         event: 'view_change_toggle',
         data_json: JSON.stringify({
-          section_id: state.section.id,
+          section_id: state.sectionProgress.section.id,
           old_view: ViewType.SUMMARY,
-          new_view: ViewType.DETAIL
+          new_view: ViewType.DETAIL,
+          script_id: state.scriptSelection.scriptId
         })
       },
       {includeUserId: true}


### PR DESCRIPTION
# Description

Record scriptId when we toggle the view on the progress tab. Also change the way we getting sectionId because it was not getting the section information before so pointing it at a different part of the redux store which has the information when you are in the progress tab.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1120)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Checked that the console output for the firehose event locally contained the information we were looking for.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
