### PR TITLE
Allow editing blocks on view-only spritelab levels.

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -380,9 +380,14 @@ export default {
 
         let allowBehaviorEditing = Blockly.useModalFunctionEditor;
 
-        // If there is a toolbox with no categories, disallow editing the behavior,
-        // because renaming the behavior can break things.
-        if (appOptions.level.toolbox && !Blockly.hasCategories) {
+        // If there is a toolbox with no categories and the level allows editing
+        // blocks, disallow editing the behavior, because renaming the behavior
+        // can break things.
+        if (
+          appOptions.level.toolbox &&
+          !appOptions.readonlyWorkspace &&
+          !Blockly.hasCategories
+        ) {
           allowBehaviorEditing = false;
         }
 


### PR DESCRIPTION
# Description
This is in response to a Zendesk ticket regarding: https://studio.code.org/s/express-2019/stage/26/puzzle/1 

OLD:
![image](https://user-images.githubusercontent.com/8324574/72188565-7c8b0380-33af-11ea-8cc9-dec84119575e.png)


NEW:
![image](https://user-images.githubusercontent.com/8324574/72188487-4e0d2880-33af-11ea-9b9d-8f698c4b8189.png)

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
