### PR TITLE
Import Curriculum Builder Standards Associations via Standards Admin Page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -581,6 +581,8 @@ describe('entry tests', () => {
   };
 
   var internalEntries = {
+    'admin_standards/import_standards':
+      './src/sites/studio/pages/admin_standards/import_standards.js',
     'blocks/edit': './src/sites/studio/pages/blocks/edit.js',
     'blocks/index': './src/sites/studio/pages/blocks/index.js',
     'courses/edit': './src/sites/studio/pages/courses/edit.js',

--- a/apps/src/sites/studio/pages/admin_standards/import_standards.js
+++ b/apps/src/sites/studio/pages/admin_standards/import_standards.js
@@ -1,0 +1,25 @@
+$(document).ready(function() {
+  $('#import-standards').click(function(e) {
+    var courseCode = $('#select option:selected').val();
+    var url =
+      'http://curriculumbuilder.herokuapp.com/metadata/' +
+      courseCode +
+      '/standards.json';
+    $.ajax({
+      url: url,
+      type: 'get'
+    })
+      .done(function(data) {
+        $('#data-spew').text(JSON.stringify(data));
+        $.ajax({
+          url: '/admin/standards',
+          method: 'POST',
+          contentType: 'application/json',
+          data: JSON.stringify(data)
+        });
+      })
+      .fail(function() {
+        alert('Whoops! There was a problem with the import.');
+      });
+  });
+});

--- a/dashboard/app/controllers/admin_standards_controller.rb
+++ b/dashboard/app/controllers/admin_standards_controller.rb
@@ -1,0 +1,6 @@
+class AdminStandardsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin
+  def import_standards
+  end
+end

--- a/dashboard/app/controllers/admin_standards_controller.rb
+++ b/dashboard/app/controllers/admin_standards_controller.rb
@@ -6,6 +6,5 @@ class AdminStandardsController < ApplicationController
   end
 
   def update_standards
-    JSON.parse params[:cb_standards_data]
   end
 end

--- a/dashboard/app/controllers/admin_standards_controller.rb
+++ b/dashboard/app/controllers/admin_standards_controller.rb
@@ -3,6 +3,7 @@ class AdminStandardsController < ApplicationController
   before_action :require_admin
 
   def import_standards
+    @scripts_for_standards = Script.scripts_for_standards
   end
 
   def update_standards

--- a/dashboard/app/controllers/admin_standards_controller.rb
+++ b/dashboard/app/controllers/admin_standards_controller.rb
@@ -1,6 +1,11 @@
 class AdminStandardsController < ApplicationController
   before_action :authenticate_user!
   before_action :require_admin
+
   def import_standards
+  end
+
+  def update_standards
+    JSON.parse params[:cb_standards_data]
   end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -685,6 +685,13 @@ class Script < ActiveRecord::Base
     Script.where("properties -> '$.curriculum_umbrella' = ?", curriculum_umbrella).pluck(:name)
   end
 
+  def self.scripts_for_standards
+    Script.
+      where("properties -> '$.curriculum_umbrella' = 'CSF'").
+      where("properties -> '$.version_year' >= '2019'").
+      map {|script| [script.localized_title, script.name]}
+  end
+
   def under_curriculum_umbrella?(specific_curriculum_umbrella)
     curriculum_umbrella == specific_curriculum_umbrella
   end

--- a/dashboard/app/views/admin_reports/directory.html.haml
+++ b/dashboard/app/views/admin_reports/directory.html.haml
@@ -25,3 +25,6 @@
 - Experiment::PILOT_EXPERIMENTS.each do |pilot|
   %p
     = link_to pilot[:label], show_pilot_path(pilot_name: pilot[:name])
+
+%h3 Standards
+= link_to "Import Standards", admin_standards_import_path

--- a/dashboard/app/views/admin_standards/import_standards.html.haml
+++ b/dashboard/app/views/admin_standards/import_standards.html.haml
@@ -24,6 +24,7 @@
             type: "get",
           }).done(function(data) {
             console.log(data)
+            // Put the data into rails?
           }).fail(function () {
 
           });

--- a/dashboard/app/views/admin_standards/import_standards.html.haml
+++ b/dashboard/app/views/admin_standards/import_standards.html.haml
@@ -1,0 +1,31 @@
+%h2
+  Import Standards from Curriculum Builder
+
+%p
+  Standards and their associations with lessons are stored in Curriculum Builder and used to show standards alignment by course. For example:
+%a{href: 'curriculum.code.org/csf-19/standards/'}
+  CSF Standards Alignment
+
+%br
+%br
+
+%p
+  Information about standards alignment is also used on the standards view of the progress tab of the Teacher Dashboard on Code Studio.
+  Click the button to sync the standards and their associations with lessons to Code Studio.
+
+%button.primary.padded-button#import-standards="Import Standards"
+
+:javascript
+  $(document).ready(function() {
+    $('#import-standards').click(function (e) {
+      console.log("import button was clicked!")
+      $.ajax({
+            url: 'http://curriculumbuilder.herokuapp.com/metadata/coursef/standards.json',
+            type: "get",
+          }).done(function(data) {
+            console.log(data)
+          }).fail(function () {
+
+          });
+      });
+    })

--- a/dashboard/app/views/admin_standards/import_standards.html.haml
+++ b/dashboard/app/views/admin_standards/import_standards.html.haml
@@ -15,18 +15,22 @@
 
 %button.primary.padded-button#import-standards="Import Standards"
 
+= form_tag url_for(action: 'update_standards'), id: 'standards-form', method: 'post', class: 'form-inline', enforce_utf8: false do
+  %input#cb-response{type: "hidden", name: "cb_standards_data"}
+  #update-standards{style: 'display: none'}
+    = submit_tag
+
 :javascript
   $(document).ready(function() {
     $('#import-standards').click(function (e) {
-      console.log("import button was clicked!")
       $.ajax({
             url: 'http://curriculumbuilder.herokuapp.com/metadata/coursef/standards.json',
             type: "get",
           }).done(function(data) {
-            console.log(data)
-            // Put the data into rails?
+            $('#cb-response').val(JSON.stringify(data))
+            $("#standards-form").submit();
           }).fail(function () {
-
+            alert("Whoops! There was a problem with the import.");
           });
       });
     })

--- a/dashboard/app/views/admin_standards/import_standards.html.haml
+++ b/dashboard/app/views/admin_standards/import_standards.html.haml
@@ -15,11 +15,6 @@
 
 %button.primary.padded-button#import-standards="Import Standards"
 
-= form_tag url_for(action: 'update_standards'), id: 'standards-form', method: 'post', class: 'form-inline', enforce_utf8: false do
-  %input#cb-response{type: "hidden", name: "cb_standards_data"}
-  #update-standards{style: 'display: none'}
-    = submit_tag
-
 :javascript
   $(document).ready(function() {
     $('#import-standards').click(function (e) {
@@ -27,8 +22,12 @@
             url: 'http://curriculumbuilder.herokuapp.com/metadata/coursef/standards.json',
             type: "get",
           }).done(function(data) {
-            $('#cb-response').val(JSON.stringify(data))
-            $("#standards-form").submit();
+            $.ajax({
+              url: '/admin/standards',
+              method: 'POST',
+              contentType: 'application/json',
+              data: JSON.stringify(data)
+            });
           }).fail(function () {
             alert("Whoops! There was a problem with the import.");
           });

--- a/dashboard/app/views/admin_standards/import_standards.html.haml
+++ b/dashboard/app/views/admin_standards/import_standards.html.haml
@@ -1,3 +1,6 @@
+- content_for(:head) do
+  %script{ src: webpack_asset_path('js/admin_standards/import_standards.js')}
+
 %h2
   Import Standards from Curriculum Builder
 
@@ -20,25 +23,3 @@
   %button.primary.padded-button#import-standards="Import Standards"
 
 %p#data-spew
-
-:javascript
-  $(document).ready(function() {
-    $('#import-standards').click(function (e) {
-      var courseCode = $("#select option:selected").val()
-      var url = 'http://curriculumbuilder.herokuapp.com/metadata/' + courseCode + '/standards.json'
-      $.ajax({
-            url: url,
-            type: "get",
-          }).done(function(data) {
-            $('#data-spew').text(JSON.stringify(data))
-            $.ajax({
-              url: '/admin/standards',
-              method: 'POST',
-              contentType: 'application/json',
-              data: JSON.stringify(data)
-            });
-          }).fail(function () {
-            alert("Whoops! There was a problem with the import.");
-          });
-      });
-    })

--- a/dashboard/app/views/admin_standards/import_standards.html.haml
+++ b/dashboard/app/views/admin_standards/import_standards.html.haml
@@ -1,16 +1,3 @@
-:ruby
-  courses = [
-    ["", ""],
-    ["Course A 2019", "coursea-2019"],
-    ["Course B 2019", "courseb-2019"],
-    ["Course C 2019", "coursec-2019"],
-    ["Course D 2019", "coursed-2019"],
-    ["Course E 2019", "coursee-2019"],
-    ["Course F 2019", "coursef-2019"],
-    ["Pre-Express 2019", "pre-express-2019"],
-    ["Express 2019", "express-2019"]
-  ]
-
 %h2
   Import Standards from Curriculum Builder
 
@@ -27,7 +14,7 @@
 
 %h3 Select a Course
 = form_tag url_for(action: 'import_standards'), id: 'standards-form', method: 'post', class: 'form-inline', enforce_utf8: false do
-  = select_tag(:course, options_for_select(courses), id: "select")
+  = select_tag(:course, options_for_select(@scripts_for_standards), id: "select")
   %br
   %br
   %button.primary.padded-button#import-standards="Import Standards"

--- a/dashboard/app/views/admin_standards/import_standards.html.haml
+++ b/dashboard/app/views/admin_standards/import_standards.html.haml
@@ -1,8 +1,21 @@
+:ruby
+  courses = [
+    ["", ""],
+    ["Course A 2019", "coursea-2019"],
+    ["Course B 2019", "courseb-2019"],
+    ["Course C 2019", "coursec-2019"],
+    ["Course D 2019", "coursed-2019"],
+    ["Course E 2019", "coursee-2019"],
+    ["Course F 2019", "coursef-2019"],
+    ["Pre-Express 2019", "pre-express-2019"],
+    ["Express 2019", "express-2019"]
+  ]
+
 %h2
   Import Standards from Curriculum Builder
 
 %p
-  Standards and their associations with lessons are stored in Curriculum Builder and used to show standards alignment by course. For example:
+  The associations between standards and lessons are stored in Curriculum Builder and used to show standards alignment by course. For example:
 %a{href: 'curriculum.code.org/csf-19/standards/'}
   CSF Standards Alignment
 
@@ -10,18 +23,27 @@
 %br
 
 %p
-  Information about standards alignment is also used on the standards view of the progress tab of the Teacher Dashboard on Code Studio.
-  Click the button to sync the standards and their associations with lessons to Code Studio.
+  Information about CSTA standards alignment is also used on the standards view of the progress tab of the Teacher Dashboard on Code Studio for CSF courses. Select a course to import standards associated with that course's lessons.
 
-%button.primary.padded-button#import-standards="Import Standards"
+%h3 Select a Course
+= form_tag url_for(action: 'import_standards'), id: 'standards-form', method: 'post', class: 'form-inline', enforce_utf8: false do
+  = select_tag(:course, options_for_select(courses), id: "select")
+  %br
+  %br
+  %button.primary.padded-button#import-standards="Import Standards"
+
+%p#data-spew
 
 :javascript
   $(document).ready(function() {
     $('#import-standards').click(function (e) {
+      var courseCode = $("#select option:selected").val()
+      var url = 'http://curriculumbuilder.herokuapp.com/metadata/' + courseCode + '/standards.json'
       $.ajax({
-            url: 'http://curriculumbuilder.herokuapp.com/metadata/coursef/standards.json',
+            url: url,
             type: "get",
           }).done(function(data) {
+            $('#data-spew').text(JSON.stringify(data))
             $.ajax({
               url: '/admin/standards',
               method: 'POST',

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -356,6 +356,7 @@ Dashboard::Application.routes.draw do
   get '/admin/gatekeeper', to: 'dynamic_config#gatekeeper_show', as: 'gatekeeper_show'
   post '/admin/gatekeeper/delete', to: 'dynamic_config#gatekeeper_delete', as: 'gatekeeper_delete'
   post '/admin/gatekeeper/set', to: 'dynamic_config#gatekeeper_set', as: 'gatekeeper_set'
+  get '/admin/standards', to: 'admin_standards#import_standards', as: 'admin_standards_import'
 
   get '/notes/:key', to: 'notes#index'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -357,6 +357,7 @@ Dashboard::Application.routes.draw do
   post '/admin/gatekeeper/delete', to: 'dynamic_config#gatekeeper_delete', as: 'gatekeeper_delete'
   post '/admin/gatekeeper/set', to: 'dynamic_config#gatekeeper_set', as: 'gatekeeper_set'
   get '/admin/standards', to: 'admin_standards#import_standards', as: 'admin_standards_import'
+  post '/admin/standards', to: 'admin_standards#update_standards', as: 'admin_standards_update'
 
   get '/notes/:key', to: 'notes#index'
 


### PR DESCRIPTION
[Stage + Standards Brainstorm ](https://docs.google.com/document/d/1GeuADi_3Z8cfX5hRnGU8BTeuD-5fUnFsnBsOQlDVW1Y/edit)

Standards and their associations with lessons don't update very frequently, roughly once a year as new curriculum is authored. The information about standards and their associations lives in Curriculum Builder.  We want to use it in Code Studio on the new standards view of the progress tab. This PR gives admins a landing page with a way to import standards associations by course from Curriculum Builder into Code Studio. 

![standards-admin-page](https://user-images.githubusercontent.com/12300669/72313225-85920400-363f-11ea-81c0-8654a967dedb.gif)

Right now, I'm just spewing the fetched data onto the page, but in follow up work, the standards-stage associations will be created in Code Studio based on the above linked brainstorm. 
