### PR TITLE
Teacher Application Export: Put timezone in Pacific time

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -29,13 +29,14 @@ end
 drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
 drive.update_sheet applications, CDO.applications_2020_2021_gsheet_key, 'all_apps (auto)'
 
+last_updated = DateTime.now.in_time_zone ActiveSupport::TimeZone.new "Pacific Time (US & Canada)"
 metadata = [
   ['AUTOMATION METADATA'],
   [''],
   ['The tabs "all_apps (auto)" and "meta (auto)" are auto-generated;'],
   ['Any edits you make to them (besides formatting) may be lost.'],
   [''],
-  ['Last updated:', DateTime.now.strftime('%Y-%m-%d %l:%M%P GMT%:::z')],
+  ['Last updated:', last_updated.strftime('%Y-%m-%d %l:%M%P GMT%:::z')],
   ['Written by:', CDO.gdrive_export_secret.client_email],
   ['Teacher applications:', applications.length - 1],
   [''],


### PR DESCRIPTION
A small improvement upon https://github.com/code-dot-org/code-dot-org/pull/32609: Our production server published the last-updated timestamp in GMT.  Coerce it to use Pacific Time, since that's the zone for HQ.

See [`DateTime#in_time_zone`](https://www.rubydoc.info/gems/activesupport/3.0.7/DateTime:in_time_zone), [`ActiveSupport::TimeZone`](https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html), and [a relevant StackOverflow answer](https://stackoverflow.com/a/2695858).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
