### PR TITLE
Revert "Revert "Don't show tts button until audio is playable""

### DIFF
--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -174,7 +174,7 @@ class InlineAudio extends React.Component {
   getAudioSrc() {
     if (this.props.src) {
       return this.props.src;
-    } else if (this.props.message) {
+    } else if (this.props.message && VOICES[this.props.locale]) {
       const voice = VOICES[this.props.locale];
       const voicePath = `${voice.VOICE}/${voice.SPEED}/${voice.SHAPE}`;
 

--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -102,8 +102,13 @@ class InlineAudio extends React.Component {
     audio: undefined,
     playing: false,
     error: false,
-    hover: false
+    hover: false,
+    loaded: false
   };
+
+  componentDidMount() {
+    this.getAudioElement();
+  }
 
   componentWillUpdate(nextProps) {
     const audioTargetWillChange =
@@ -137,6 +142,11 @@ class InlineAudio extends React.Component {
 
     const src = this.getAudioSrc();
     const audio = new Audio(src);
+
+    audio.addEventListener('canplay', () => {
+      this.setState({loaded: true});
+    });
+
     audio.addEventListener('ended', e => {
       this.setState({
         playing: false
@@ -210,6 +220,7 @@ class InlineAudio extends React.Component {
     if (
       this.props.textToSpeechEnabled &&
       !this.state.error &&
+      this.state.loaded &&
       this.isLocaleSupported() &&
       this.getAudioSrc()
     ) {

--- a/apps/src/templates/instructions/InstructionsCSF.story.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.story.jsx
@@ -110,19 +110,6 @@ const createCommonStore = function(options = {}) {
       "And then this will appear below. Used to convey information that should not be perceived as being 'spoken' by the avatar character.";
   }
 
-  if (options.tts) {
-    pageConstants.textToSpeechEnabled = true;
-    pageConstants.locale = 'en_us';
-
-    // Grab some arbitrary preexisting audio files for this test; they will not
-    // match the displayed text for this test, but that doesn't seem necessary
-    // enough to justify generating custom audio just for this storybook
-    pageConstants.ttsShortInstructionsUrl =
-      'https://tts.code.org/sharon22k/180/100/045539bb7fc9812eec4024867ac56d61/courseC_maze_programming8.mp3';
-    pageConstants.ttsLongInstructionsUrl =
-      'https://tts.code.org/sharon22k/180/100/e91c9a88c669b0aeba648353cc478452/courseC_maze_programming9.mp3';
-  }
-
   store.dispatch(setPageConstants(pageConstants));
   store.dispatch(setInstructionsConstants(instructionsConstants));
 
@@ -158,16 +145,12 @@ const STORIES = {
   'Sub-Instructions': {
     subInstructions: true
   },
-  'Text-to-Speech': {
-    tts: true
-  },
   'Full-featured example': {
     avatar: true,
     failureAvatar: true,
     feedback: true,
     hints: true,
-    longInstructions: true,
-    tts: true
+    longInstructions: true
   },
   'Full-featured Right-to-Left example': {
     avatar: true,
@@ -175,8 +158,7 @@ const STORIES = {
     feedback: true,
     hints: true,
     longInstructions: true,
-    rtl: true,
-    tts: true
+    rtl: true
   }
 };
 

--- a/apps/src/templates/instructions/TopInstructions.story.jsx
+++ b/apps/src/templates/instructions/TopInstructions.story.jsx
@@ -3,7 +3,6 @@ import {Provider} from 'react-redux';
 import {createStore, combineReducers} from 'redux';
 import * as commonReducers from '@cdo/apps/redux/commonReducers';
 import {
-  setFeedback,
   setHasAuthoredHints,
   setInstructionsConstants
 } from '@cdo/apps/redux/instructions';
@@ -54,12 +53,6 @@ const createCommonStore = function(options = {}) {
 
     pageConstants.showNextHint = () => {};
     instructionsConstants.noInstructionsWhenCollapsed = false;
-    store.dispatch(
-      setFeedback({
-        message:
-          'some simple, plaintext feedback, used to indicate that something went wrong'
-      })
-    );
     store.dispatch(setHasAuthoredHints(true));
     store.dispatch(
       enqueueHints(

--- a/apps/test/storybook/renderStoriesTest.js
+++ b/apps/test/storybook/renderStoriesTest.js
@@ -21,14 +21,18 @@ describe('react-storybook stories render without errors or warnings', function()
   throwOnConsoleWarningsEverywhere();
   clearTimeoutsBetweenTests();
 
-  //Stub jquery fileupload library function
-  let fileupload;
+  // Stub jquery fileupload library function and window.Audio class.
+  let fileupload, windowAudio;
   before(() => {
     fileupload = $.fn.fileupload;
     $.fn.fileupload = () => {};
+
+    windowAudio = window.Audio;
+    window.Audio = FakeAudio;
   });
   after(() => {
     $.fn.fileupload = fileupload;
+    window.Audio = windowAudio;
   });
 
   // Test all the *.story.jsx files that aren't blacklisted
@@ -42,3 +46,14 @@ describe('react-storybook stories render without errors or warnings', function()
       });
     });
 });
+
+class FakeAudio {
+  play() {}
+  pause() {}
+  load() {}
+  // EventTarget interface
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() {}
+  removeAttribute() {}
+}

--- a/apps/test/unit/templates/instructions/InlineAudioTest.js
+++ b/apps/test/unit/templates/instructions/InlineAudioTest.js
@@ -63,6 +63,20 @@ describe('InlineAudio', function() {
     );
   });
 
+  it('does not generate src from message text if no voice is available for locale', function() {
+    const component = mount(
+      <StatelessInlineAudio
+        assetUrl={function() {}}
+        isK1={true}
+        locale="aa_aa"
+        message={'test'}
+      />
+    );
+
+    const result = component.instance().getAudioSrc();
+    assert.equal(result, undefined);
+  });
+
   it('can handle (select) non-english locales', function() {
     const component = mount(
       <StatelessInlineAudio

--- a/apps/test/unit/templates/instructions/InlineAudioTest.js
+++ b/apps/test/unit/templates/instructions/InlineAudioTest.js
@@ -80,21 +80,14 @@ describe('InlineAudio', function() {
     );
   });
 
-  it('renders controls if text-to-speech is enabled', function() {
+  it('renders controls if text-to-speech is enabled and sound is loaded', function() {
     const component = mount(
       <StatelessInlineAudio {...DEFAULT_PROPS} textToSpeechEnabled />
     );
 
-    expect(component).to.containMatchingElement(
-      <div className="inline-audio">
-        <div id="volume">
-          <i className="fa fa-volume-up" />
-        </div>
-        <div className="playPause">
-          <i className="fa fa-play" />
-        </div>
-      </div>
-    );
+    expect(component.exists('.inline-audio')).to.be.false;
+    component.setState({loaded: true});
+    expect(component.exists('.inline-audio')).to.be.true;
   });
 
   it('can toggle audio', function() {
@@ -107,11 +100,11 @@ describe('InlineAudio', function() {
     expect(component.state().playing).to.be.false;
   });
 
-  it('only gets Audio the first time it is played', function() {
-    const component = mount(<StatelessInlineAudio {...DEFAULT_PROPS} />);
+  it('only initializes Audio once', function() {
     sinon.spy(window, 'Audio');
+    const component = mount(<StatelessInlineAudio {...DEFAULT_PROPS} />);
 
-    expect(window.Audio).not.to.have.been.called;
+    expect(window.Audio).to.have.been.calledOnce;
     component.instance().playAudio();
     expect(window.Audio).to.have.been.calledOnce;
     component.instance().pauseAudio();


### PR DESCRIPTION
Reverts #32634, re-implementing #31089

Now that we check the audio src every time the `<InlineAudio/>` component mounts, a bug was uncovered where when we receive message text as the audio source, we aren't checking if we actually have a voice for that locale before creating a src URL (relevant [New Relic error](https://rpm.newrelic.com/accounts/501463/browser/3787364/errors/details#?selectedItem=Cannot%20read%20property%20%27VOICE%27%20of%20undefined&tw_start=&tw_end=now&tw_offset=43200000&selectedTab=overview)). Bug is fixed in [0d254aa](https://github.com/code-dot-org/code-dot-org/pull/32639/commits/0d254aaa098a3dda7dbd26f66a4a53072226d1a9)