### PR TITLE
Return summer workshops in order of start date

### DIFF
--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -119,6 +119,7 @@ class RegionalPartner < ActiveRecord::Base
     pd_workshops.
       future.
       where(subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP).
+      order_by_scheduled_start.
       map {|w| w.slice(:location_name, :location_address, :workshop_date_range_string, :course)}
   end
 


### PR DESCRIPTION
# Description

Updates list of summer workshops shown to teachers using the "[search for your regional partner by zip](https://code.org/educate/professional-learning/program-information?zip=48001)" page to sort by the start date of the workshop, not the date the workshop was created. There was already a method that does exactly what I wanted, so nothing new!

## Testing story

Tested locally. Also looked to see if there's anywhere else that we call `upcoming_summer_workshops` and didn't find anything -- that said, a search for `upcoming_summer_workshops` didn't return its use in the [serializer](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/serializers/api/v1/pd/regional_partner_serializer.rb) that is responsible for its behavior on this page, which I don't understand.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
