### PR TITLE
Application Dashboard: Show total application count

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
@@ -7,6 +7,7 @@ import {connect} from 'react-redux';
 import {Table, Button} from 'react-bootstrap';
 import {StatusColors, ApplicationStatuses} from './constants';
 import _ from 'lodash';
+import color from '@cdo/apps/util/color';
 
 const styles = {
   table: {
@@ -15,6 +16,12 @@ const styles = {
   },
   tableWrapper: {
     paddingBottom: '30px'
+  },
+  totalsRow: {
+    fontWeight: 'bold',
+    borderTopStyle: 'solid',
+    borderTopWidth: 2,
+    borderTopColor: color.charcoal
   },
   statusCell: StatusColors,
   viewApplicationsButton: {
@@ -47,8 +54,14 @@ export class SummaryTable extends React.Component {
     this.props.canSeeLocked && this.props.applicationType === 'facilitator';
 
   tableBody() {
-    return Object.keys(this.props.data).map((status, i) => {
+    const totals = {
+      locked: 0,
+      all: 0
+    };
+    const categoryRows = Object.keys(this.props.data).map((status, i) => {
       const statusData = this.props.data[status];
+      totals.locked += statusData.locked;
+      totals.all += statusData.total;
       return (
         <tr key={i}>
           <td style={{...styles.statusCell[status]}}>
@@ -61,6 +74,16 @@ export class SummaryTable extends React.Component {
         </tr>
       );
     });
+
+    return [
+      ...categoryRows,
+      <tr key="totals-row" style={styles.totalsRow}>
+        <td style={{textAlign: 'right'}}>Total</td>
+        {this.showLocked && <td>{totals.locked}</td>}
+        {this.showLocked && <td>{totals.all - totals.locked}</td>}
+        <td>{totals.all}</td>
+      </tr>
+    ];
   }
 
   handleViewClick = event => {
@@ -83,7 +106,7 @@ export class SummaryTable extends React.Component {
               <th>Status</th>
               {this.showLocked && <th>Locked</th>}
               {this.showLocked && <th>Unlocked</th>}
-              <th>Total</th>
+              <th>Count</th>
             </tr>
           </thead>
           <tbody>{this.tableBody()}</tbody>

--- a/apps/test/unit/code-studio/pd/application_dashboard/summary_table_test.jsx
+++ b/apps/test/unit/code-studio/pd/application_dashboard/summary_table_test.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import {SummaryTable} from '../../../../../src/code-studio/pd/application_dashboard/summary_table';
+
+describe('SummaryTable', () => {
+  it('computes total applications', () => {
+    const wrapper = customShallow(<SummaryTable {...DEFAULT_PROPS} />);
+
+    assert(
+      wrapper.containsMatchingElement(
+        <tr>
+          <td>Unreviewed</td>
+          <td>{10}</td>
+        </tr>
+      ),
+      'Unreviewed row matches data'
+    );
+
+    assert(
+      wrapper.containsMatchingElement(
+        <tr>
+          <td>Accepted</td>
+          <td>{9}</td>
+        </tr>
+      ),
+      'Accepted row matches data'
+    );
+
+    assert(
+      wrapper.containsMatchingElement(
+        <tr>
+          <td>Total</td>
+          <td>{19}</td>
+        </tr>
+      ),
+      'Totals row computes correct sum'
+    );
+  });
+
+  it('computes total applications with locked counts', () => {
+    const wrapper = customShallow(
+      <SummaryTable
+        {...DEFAULT_PROPS}
+        canSeeLocked
+        applicationType="facilitator"
+      />
+    );
+
+    assert(
+      wrapper.containsMatchingElement(
+        <tr>
+          <td>Unreviewed</td>
+          <td>{1}</td>
+          <td>{9}</td>
+          <td>{10}</td>
+        </tr>
+      ),
+      'Unreviewed row matches data'
+    );
+
+    assert(
+      wrapper.containsMatchingElement(
+        <tr>
+          <td>Accepted</td>
+          <td>{2}</td>
+          <td>{7}</td>
+          <td>{9}</td>
+        </tr>
+      ),
+      'Accepted row matches data'
+    );
+
+    assert(
+      wrapper.containsMatchingElement(
+        <tr>
+          <td>Total</td>
+          <td>{3}</td>
+          <td>{16}</td>
+          <td>{19}</td>
+        </tr>
+      ),
+      'Totals row computes correct sum'
+    );
+  });
+});
+
+const DEFAULT_PROPS = {
+  caption: 'Test summary table',
+  path: 'foo',
+  applicationType: 'teacher',
+  data: {
+    unreviewed: {
+      total: 10,
+      locked: 1
+    },
+    accepted: {
+      total: 9,
+      locked: 2
+    }
+  }
+};
+
+/** Shallow-render the component and stub react-router. */
+function customShallow(component) {
+  return shallow(component, {
+    context: {router: {createHref: () => {}}}
+  });
+}


### PR DESCRIPTION
Adds a row for the total application count (per-course) to the [Teacher Application Dashboard summary view](https://studio.code.org/pd/application_dashboard/summary), since partners occasionally check this total.

Suggested this change myself after answering a question for a partner and realizing our UI could do more to minimize confusion.

The total given here is a simple sum of the rows above, computed on the client.  Note that we'll have issues later if the statuses given here aren't mutually exclusive (right now, it looks like they are).

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/1615761/72293714-f669f980-3608-11ea-971d-fb5b06585819.png) | ![Screenshot from 2020-01-13 13-17-43](https://user-images.githubusercontent.com/1615761/72293721-f8cc5380-3608-11ea-99be-4b55e4a17efa.png) |

## Testing story

Checked locally.  I haven't written an automated test for this yet... I probably should.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
