### PR TITLE
FreeResponse levels have translated instructions.

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -409,6 +409,7 @@ class Blockly < Level
     options.freeze
   end
 
+  # FND-985 Create shared API to get localized level properties.
   def get_localized_property(property_name)
     if should_localize? && try(property_name)
       I18n.t(

--- a/dashboard/app/models/levels/free_response.rb
+++ b/dashboard/app/models/levels/free_response.rb
@@ -53,4 +53,23 @@ class FreeResponse < Level
   def icon
     'fa fa-list-ul'
   end
+
+  # FND-985 Create shared API to get localized level properties.
+  # get_property takes a given level property_name and returns the localized
+  # version of it.
+  def get_property(property_name)
+    # Return the default English string from the database model if we shouldn't
+    # localize this property or we couldn't find a localized value.
+    default = try(property_name)
+    if should_localize?
+      I18n.t(
+        name,
+        scope: [:data, property_name],
+        default: nil,
+        smart: true
+      ) || default
+    else
+      default
+    end
+  end
 end

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -29,10 +29,12 @@
     );
 
 .free-response{:class => ('left-aligned' if left_align)}
+  -# FND-984 title needs to be localized level property.
   - if level.title.present? && (!in_level_group || is_contained_level)
     %h1= level.title
-  - if level.long_instructions
-    %div= render(inline: level.long_instructions, type: :md)
+  - long_instructions = level.get_property("long_instructions")
+  - if long_instructions
+    %div= render(inline: long_instructions, type: :md)
 
   - if level.allow_user_uploads?
     %script{src: webpack_asset_path('js/fileupload/jquery.iframe-transport.js')}
@@ -46,7 +48,9 @@
       ReactDOM.render(React.createElement(dashboard.Attachments, {showUnderageWarning: !appOptions.is13Plus, readonly: #{!!@view_options.readonly_workspace}}), document.querySelector('#free-response-upload'));
 
   - height = level.height || '80'
-  %textarea.response{id: "level_#{level.id}", placeholder: level.placeholder || 'Enter your answer here', style: "height: #{height}px;", readonly: @view_options.readonly_workspace}= last_attempt
+  -# FND-984 placeholder needs to be localized level property.
+  - placeholder = level.placeholder || I18n.t('free_response.placeholder')
+  %textarea.response{id: "level_#{level.id}", placeholder: placeholder, style: "height: #{height}px;", readonly: @view_options.readonly_workspace}= last_attempt
 
   -# Don't render the dialog partial if we're inside a LevelGroup.
   = render partial: 'levels/dialog', locals: {app: 'free_response'} unless in_level_group

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -718,6 +718,8 @@ en:
     help_support: "Help and support"
     documentation: "Documentation"
     tutorials: "Tutorials"
+  free_response:
+    placeholder: "Enter your answer here"
   multi:
     wrong_title: "Incorrect answer"
     wrong_body: "The answer you've entered is not correct.  Please try again!"


### PR DESCRIPTION
# Description
**Issue**: FreeResponse levels were not showing translated
instructions even though translations existed.
**Cause**: FreeResponse levels not using the I18n API for content.
**Fix**: Update the `long_instructions` to be grabbed using the I18n API.

* Added new `free_response.placeholder` string so we can translate the default placeholder text "Enter your answer here"
## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-772)

## Follow-up work
- https://codedotorg.atlassian.net/browse/FND-984
- https://codedotorg.atlassian.net/browse/FND-985

## Screenshots
### Before
Note that the "Make a prediction..." text is not translated to Japanese.
![image](https://user-images.githubusercontent.com/1372238/72297499-f80cdf00-3653-11ea-8403-228040a77214.png)

### After
![image](https://user-images.githubusercontent.com/1372238/72297400-bed46f00-3653-11ea-8290-50f8f0345e75.png)

## Testing story
* `./bin/dashboard-server`
  * Visit http://localhost-studio.code.org:3000/levels/5559/lang/ja-JP and verify the make a prediction text is translated
  * Made a local change to the new free_response.placeholder string to verify it works.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
