### PR TITLE
Add second set of PD Application Banners

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
@@ -17,6 +17,7 @@ Our curriculum is available at [no cost](/commitment) for anyone, anywhere to te
 <br>
 <br>
 <%= view :professional_learning_apply_banner, :use_sign_up_text => true %>
+
 <hr>
 
 <a name="csd"></a>

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
@@ -12,9 +12,11 @@ High School
 
 For high schools, we offer two years computer science courses for beginners:  Computer Science Discoveries, and Computer Science Principles. If you want to go even further with your students, check out our recommended third party resources for teaching AP Computer Science A and additional courses in programming, game design, and more! 
 
-Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values). 
+Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values).
 
 <br>
+<br>
+<%= view :professional_learning_apply_banner, :use_sign_up_text => true %>
 <hr>
 
 <a name="csd"></a>

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
@@ -15,7 +15,6 @@ For high schools, we offer two years computer science courses for beginners:  Co
 Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values).
 
 <br>
-<br>
 <%= view :professional_learning_apply_banner, :use_sign_up_text => true %>
 
 <hr>

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
@@ -13,7 +13,6 @@ Middle School
 Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values).
 
 <br>
-<br>
 <%= view :professional_learning_apply_banner, :use_sign_up_text => true %>
 
 <hr>

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
@@ -10,9 +10,12 @@ Middle School
 
 [/solid-block-header]
 
-Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values). 
+Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values).
 
 <br>
+<br>
+<%= view :professional_learning_apply_banner, :use_sign_up_text => true %>
+
 <hr>
 
 <a name="csd"></a>

--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -25,6 +25,11 @@ social:
 
 = I18n.t(:hoc_overview_subtitle)
 
+%br/
+%br/
+= view :professional_learning_apply_banner, use_sign_up_text: true
+%br/
+
 - if request.language == 'en'
   .tile-container-responsive{style: "margin-top: 20px;"}
     .col-50

--- a/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
@@ -8,7 +8,7 @@
           .banner
             %img{src: "/images/homepage/professional-learning-2018-banner.png"}
             .text
-              Sign up for Professional Learning! Applications
+              Sign up for Professional Learning! Applications are
               %br/
               now open for Middle and High School teachers.
         .right.col-20
@@ -16,7 +16,7 @@
             Join us
       .phone.phone-feature
         .text
-          Sign up for Professional Learning! Applications
+          Sign up for Professional Learning! Applications are
           now open for Middle and High School teachers.
         %button
           Join us

--- a/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
@@ -1,5 +1,8 @@
 - link = "/educate/professional-learning/program-information"
 - link += "?nominated=true" if params[:nominated]
+- use_sign_up_text ||= false
+- font_size = use_sign_up_text ? '16px' : '18px'
+- padding = use_sign_up_text ? '25px 10px' : '20px 10px'
 
 - buttons = capture_haml do
   %div
@@ -16,8 +19,10 @@
         .arrowcontainer.desktop-feature{style: "float:left; width: 7%"}
           .arrow{style: "width: 0; height: 0; border-style: solid; border-width: 50px 0 50px 25px; border-color: transparent transparent transparent #ebe8f1"}
         .textcontainer{style: "float:left; width: 93%"}
-          .text{style: "color: white;  font-size: 18px; padding: 20px 10px 20px 10px; text-align: center; line-height: 1.5"}
-            - if params[:nominated]
+          .text{style: "color: white;  font-size: #{font_size}; padding: #{padding}; text-align: center; line-height: 1.5"}
+            - if use_sign_up_text
+              Sign up for Professional Learning! Applications now open for Middle and High School teachers.
+            - elsif params[:nominated]
               CONGRATULATIONS! You’ve been nominated for a scholarship!
             - else
               SEATS OPEN - 2020 Professional Learning for Middle and High School Teachers

--- a/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
@@ -21,7 +21,7 @@
         .textcontainer{style: "float:left; width: 93%"}
           .text{style: "color: white;  font-size: #{font_size}; padding: #{padding}; text-align: center; line-height: 1.5"}
             - if use_sign_up_text
-              Sign up for Professional Learning! Applications now open for Middle and High School teachers.
+              Sign up for Professional Learning! Applications are now open for Middle and High School teachers.
             - elsif params[:nominated]
               CONGRATULATIONS! You’ve been nominated for a scholarship!
             - else


### PR DESCRIPTION
# Description
Add P2 set of professional development application banners as specified in [Jira](https://codedotorg.atlassian.net/browse/PLC-656). The banners use the same banner element from https://code.org/educate/professional-learning/middle-high, with different text and a slightly smaller font (to fix the text). Also updated previous home banner to say "...Applications **are** now open..." instead of "...Applications now open..."

New banners are on the following pages:
 https://code.org/educate/curriculum/middle-school
<img width="994" alt="Screen Shot 2020-01-13 at 4 19 15 PM" src="https://user-images.githubusercontent.com/33666587/72303035-c3cbfb00-3620-11ea-9e52-1ae562b6d337.png">


 https://code.org/educate/curriculum/high-school
<img width="994" alt="Screen Shot 2020-01-13 at 4 18 56 PM" src="https://user-images.githubusercontent.com/33666587/72303039-c6c6eb80-3620-11ea-97ee-f155036a656f.png">


https://code.org/hourofcode/overview 
<img width="994" alt="Screen Shot 2020-01-13 at 4 21 56 PM" src="https://user-images.githubusercontent.com/33666587/72303055-d80ff800-3620-11ea-999d-c19cedc7b1ef.png">



## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-656)
- [P1 banners PR](https://github.com/code-dot-org/code-dot-org/pull/32629)

## Testing story
Validated banners look as spec'd in Jira on multiple browsers, and that banners still look reasonable when window is resized.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
