### PR TITLE
If tableRecords is an object, convert it to an array before parsing

### DIFF
--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -85,17 +85,13 @@ class VisualizerModal extends React.Component {
   };
 
   parseRecords = memoize(rawRecords => {
-    if (Object.keys(rawRecords).length === 0) {
-      return [];
-    } else {
-      let parsedRecords = [];
-      rawRecords.forEach(record => {
-        if (record) {
-          parsedRecords.push(JSON.parse(record));
-        }
-      });
-      return parsedRecords;
-    }
+    let parsedRecords = [];
+    rawRecords.forEach(record => {
+      if (record) {
+        parsedRecords.push(JSON.parse(record));
+      }
+    });
+    return parsedRecords;
   });
 
   findNumericColumns = memoize((records, columns) => {
@@ -121,7 +117,13 @@ class VisualizerModal extends React.Component {
   }
 
   render() {
-    const parsedRecords = this.parseRecords(this.props.tableRecords);
+    // this.props.tableRecords is either an object or an array (see propTypes comment). If it's an object, we want to
+    // convert it to an array before trying to parse the records.
+    const parsedRecords = this.parseRecords(
+      Array.isArray(this.props.tableRecords)
+        ? this.props.tableRecords
+        : Object.values(this.props.tableRecords)
+    );
     const numericColumns = this.findNumericColumns(
       parsedRecords,
       this.props.tableColumns


### PR DESCRIPTION
# Description
`this.props.tableRecords` is sometimes an object and sometimes an array. See:
https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html

If it's an object, `rawRecords.forEach` throws an error, so we should convert it to be an array before trying to parse the records.
Before:
![image](https://user-images.githubusercontent.com/8787187/72298256-82345380-3612-11ea-8c59-8045b2f076f5.png)

After:
![image](https://user-images.githubusercontent.com/8787187/72298021-063a0b80-3612-11ea-8bd5-e2b711963152.png)

!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->
## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
