### PR TITLE
Add curriculum.code.org to allowed hostnames for doc proxy

### DIFF
--- a/dashboard/app/controllers/curriculum_proxy_controller.rb
+++ b/dashboard/app/controllers/curriculum_proxy_controller.rb
@@ -14,7 +14,7 @@ class CurriculumProxyController < ApplicationController
     render_proxied_url(
       URI.parse(request.original_url).path.sub(/^\/docs/, 'https://docs.code.org'),
       allowed_content_types: nil,
-      allowed_hostname_suffixes: %w(docs.code.org),
+      allowed_hostname_suffixes: %w(curriculum.code.org docs.code.org),
       expiry_time: EXPIRY_TIME,
       infer_content_type: true
     )


### PR DESCRIPTION
# Description
We got several reports of issues showing docs on levels
![image](https://user-images.githubusercontent.com/8787187/72364816-fc64e680-36ab-11ea-84ae-31e65216a473.png)
The issue seems to be how we proxy between studio.code.org, docs.code.org, and curriculum.code.org.
Targeted fix for now to just allow curriculum.code.org as a hostname, with a more comprehensive fix coming later.
See also: https://codedotorg.slack.com/archives/C0T0PNTM3/p1579018531110000

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
