### PR TITLE
add curriculum.code.org to allowed hostnames

### DIFF
--- a/dashboard/app/controllers/curriculum_proxy_controller.rb
+++ b/dashboard/app/controllers/curriculum_proxy_controller.rb
@@ -14,7 +14,7 @@ class CurriculumProxyController < ApplicationController
     render_proxied_url(
       URI.parse(request.original_url).path.sub(/^\/docs/, 'https://docs.code.org'),
       allowed_content_types: nil,
-      allowed_hostname_suffixes: %w(docs.code.org),
+      allowed_hostname_suffixes: %w(curriculum.code.org docs.code.org),
       expiry_time: EXPIRY_TIME,
       infer_content_type: true
     )


### PR DESCRIPTION
# Description
Hotfix of https://github.com/code-dot-org/code-dot-org/pull/32658

We got several reports of issues showing docs on levels

![image](https://user-images.githubusercontent.com/8324574/72368087-3a650900-36b2-11ea-853b-b9a2c280b071.png)

The issue seems to be how we proxy between studio.code.org, docs.code.org, and curriculum.code.org.
Targeted fix for now to just allow curriculum.code.org as a hostname, with a more comprehensive fix coming later.
See also: https://codedotorg.slack.com/archives/C0T0PNTM3/p1579018531110000
<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
