### PR TITLE
display null, undefined, "" in Applab Data Table

### DIFF
--- a/apps/src/storage/dataBrowser/dataUtils.js
+++ b/apps/src/storage/dataBrowser/dataUtils.js
@@ -118,8 +118,11 @@ export function editableValue(val) {
  * @returns {string}
  */
 export function displayableValue(val) {
-  if (val === null || val === undefined || val === '') {
-    return '';
+  if (val === null) {
+    return 'null';
+  } else if (val === undefined) {
+    return 'undefined';
+  } else {
+    return JSON.stringify(val);
   }
-  return JSON.stringify(val);
 }


### PR DESCRIPTION
# Description
Currently all these values display as blank, but we want to show them separately so that students can tell what's actually in their table. This will also be important for the data visualizer work, which allows students to filter by specific value. For this, they will be able to be filter separately by `""`, `null`, or `undefined`, so it's important that they be able to tell what the actual value is in the table view.

Before:
![image](https://user-images.githubusercontent.com/8787187/72370789-d3e2e980-36b7-11ea-858c-f8519a167c9a.png)

After:
![image](https://user-images.githubusercontent.com/8787187/72370844-eeb55e00-36b7-11ea-9c74-98cc1820de93.png)

This change also applies to key/value pairs (`undefined` is not possible here)
![image](https://user-images.githubusercontent.com/8787187/72371313-fa555480-36b8-11ea-9c4b-bc187b64763c.png)
![image](https://user-images.githubusercontent.com/8787187/72371326-03462600-36b9-11ea-98c9-d57fcc2bd2d1.png)


<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
