### PR TITLE
Revert "InstructionsWithWorkspace owns the resizer (attempt 2)"

### DIFF
--- a/apps/src/templates/ContainedLevel.jsx
+++ b/apps/src/templates/ContainedLevel.jsx
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -15,7 +15,7 @@ const styles = {
   main: {
     position: 'absolute',
     height: RESIZER_HEIGHT,
-    marginLeft: 15,
+    left: 0,
     right: 0
   },
   ellipsis: {
@@ -102,7 +102,6 @@ class HeightResizer extends React.Component {
     return (
       <div
         id="ui-test-resizer"
-        className="editor-column"
         style={mainStyle}
         onMouseDown={this.onMouseDown}
         onMouseUp={this.onMouseUp}

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -23,6 +23,7 @@ import styleConstants from '../../styleConstants';
 import commonStyles from '../../commonStyles';
 import Instructions from './Instructions';
 import CollapserIcon from './CollapserIcon';
+import HeightResizer from './HeightResizer';
 import i18n from '@cdo/locale';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import queryString from 'query-string';
@@ -33,7 +34,7 @@ import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
 
-export const MIN_HEIGHT = RESIZER_HEIGHT + 60;
+const MIN_HEIGHT = RESIZER_HEIGHT + 60;
 
 const TabType = {
   INSTRUCTIONS: 'instructions',
@@ -325,6 +326,22 @@ class TopInstructions extends Component {
   };
 
   /**
+   * Given a prospective delta, determines how much we can actually change the
+   * height (accounting for min/max) and changes height by that much.
+   * @param {number} delta
+   * @returns {number} How much we actually changed
+   */
+  handleHeightResize = delta => {
+    const currentHeight = this.props.height;
+
+    let newHeight = Math.max(MIN_HEIGHT, currentHeight + delta);
+    newHeight = Math.min(newHeight, this.props.maxHeight);
+
+    this.props.setInstructionsRenderedHeight(newHeight);
+    return newHeight - currentHeight;
+  };
+
+  /**
    * Calculate how much height it would take to show top instructions with our
    * entire instructions visible and update store with this value.
    * @returns {number}
@@ -489,6 +506,13 @@ class TopInstructions extends Component {
   );
 
   render() {
+    const {
+      hidden,
+      shortInstructions,
+      longInstructions,
+      hasContainedLevels
+    } = this.props;
+
     const isCSF = !this.props.noInstructionsWhenCollapsed;
     const isCSDorCSP = this.props.noInstructionsWhenCollapsed;
     const widgetWidth = WIDGET_WIDTH + 'px';
@@ -546,6 +570,13 @@ class TopInstructions extends Component {
     const teacherOnly =
       this.state.tabSelected === TabType.COMMENTS &&
       this.state.teacherViewingStudentWork;
+
+    if (
+      hidden ||
+      (!shortInstructions && !longInstructions && !hasContainedLevels)
+    ) {
+      return <div />;
+    }
 
     /* TODO: When we move CSD and CSP to the Teacher Only tab remove CSF restriction here*/
     const showContainedLevelAnswer =
@@ -744,6 +775,12 @@ class TopInstructions extends Component {
                 </div>
               )}
           </div>
+          {!this.props.isEmbedView && (
+            <HeightResizer
+              position={this.props.height}
+              onResize={this.handleHeightResize}
+            />
+          )}
         </div>
       </div>
     );

--- a/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsWithWorkspaceTest.jsx
@@ -1,39 +1,17 @@
 import $ from 'jquery';
 import React from 'react';
 import sinon from 'sinon';
-import {Provider} from 'react-redux';
-import {shallow, mount} from 'enzyme';
-import {assert, expect} from '../../../util/reconfiguredChai';
-import {
-  getStore,
-  registerReducers,
-  stubRedux,
-  restoreRedux
-} from '@cdo/apps/redux';
-import instructionsReducer, {
-  setInstructionsConstants
-} from '@cdo/apps/redux/instructions';
-import pageConstantsReducer, {
-  setPageConstants
-} from '@cdo/apps/redux/pageConstants';
-import isRtlReducer, {setRtl} from '@cdo/apps/code-studio/isRtlRedux';
-import InstructionsWithWorkspace, {
-  UnwrappedInstructionsWithWorkspace
-} from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import {UnwrappedInstructionsWithWorkspace as InstructionsWithWorkspace} from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
 
 describe('InstructionsWithWorkspace', () => {
-  const DEFAULT_PROPS = {
-    instructionsHeight: 400,
-    instructionsMaxHeight: 400,
-    showInstructions: true,
-    showResizer: true,
-    setInstructionsMaxHeightAvailable: () => {},
-    setInstructionsRenderedHeight: () => {}
-  };
-
   it('renders instructions and code workspace', () => {
     const wrapper = shallow(
-      <UnwrappedInstructionsWithWorkspace {...DEFAULT_PROPS} />
+      <InstructionsWithWorkspace
+        instructionsHeight={400}
+        setInstructionsMaxHeightAvailable={() => {}}
+      />
     );
 
     expect(wrapper.find('Connect(TopInstructions)')).to.have.lengthOf(1);
@@ -42,7 +20,10 @@ describe('InstructionsWithWorkspace', () => {
 
   it('initially does not know window width or height', () => {
     const wrapper = shallow(
-      <UnwrappedInstructionsWithWorkspace {...DEFAULT_PROPS} />
+      <InstructionsWithWorkspace
+        instructionsHeight={400}
+        setInstructionsMaxHeightAvailable={() => {}}
+      />
     );
     expect(wrapper.state()).to.deep.equal({
       windowWidth: undefined,
@@ -70,8 +51,7 @@ describe('InstructionsWithWorkspace', () => {
       codeWorkspaceHeight = 100
     } = {}) {
       const wrapper = shallow(
-        <UnwrappedInstructionsWithWorkspace
-          {...DEFAULT_PROPS}
+        <InstructionsWithWorkspace
           instructionsHeight={instructionsHeight}
           setInstructionsMaxHeightAvailable={setInstructionsMaxHeightAvailable}
         />
@@ -153,251 +133,6 @@ describe('InstructionsWithWorkspace', () => {
       const wrapper = setupComponent({codeWorkspaceHeight: 0});
       wrapper.instance().onResize();
       expect(setInstructionsMaxHeightAvailable).not.to.have.been.called;
-    });
-  });
-
-  // This is a collection of tests that deep-render InstructionsWithWorkspace and its children,
-  // to check interactions between them.
-  describe('integration tests', () => {
-    beforeEach(() => {
-      stubRedux();
-      // Setup minimum redux config for these integration tests
-      registerReducers({
-        instructions: instructionsReducer,
-        isRtl: isRtlReducer,
-        pageConstants: pageConstantsReducer
-      });
-    });
-
-    afterEach(() => {
-      restoreRedux();
-    });
-
-    // This set of integration tests checks that we don't render the instructions when they
-    // are not available or not needed.
-    // These were originally written as integration tests to cover moving this logic from
-    // TopInstructions up to InstructionsWithWorkspace, but could be changed to unit tests
-    // later on.
-    describe('hiding the instructions', () => {
-      let store;
-
-      beforeEach(() => {
-        store = getStore();
-        store.dispatch(setRtl(false));
-        store.dispatch(
-          setPageConstants({
-            hideSource: false,
-            isEmbedView: false,
-            noVisualization: false
-          })
-        );
-      });
-
-      it('renders instructions in normal circumstances', () => {
-        store.dispatch(
-          setPageConstants({
-            isShareView: false
-          })
-        );
-        store.dispatch(
-          setInstructionsConstants({
-            longInstructions: `Fake instructions`,
-            noInstructionsWhenCollapsed: true
-          })
-        );
-
-        assertRendersInstructions();
-      });
-
-      it('does not render instructions in share view', () => {
-        store.dispatch(
-          setPageConstants({
-            isShareView: true
-          })
-        );
-        store.dispatch(
-          setInstructionsConstants({
-            longInstructions: `Fake instructions`,
-            noInstructionsWhenCollapsed: true
-          })
-        );
-
-        refuteRendersInstructions();
-      });
-
-      it('does not render instructions when there are no instructions', () => {
-        store.dispatch(
-          setPageConstants({
-            isShareView: false
-          })
-        );
-        store.dispatch(
-          setInstructionsConstants({
-            shortInstructions: null,
-            longInstructions: null,
-            noInstructionsWhenCollapsed: true
-          })
-        );
-
-        refuteRendersInstructions();
-      });
-
-      it('renders instructions when contained levels are present', () => {
-        store.dispatch(
-          setPageConstants({
-            isShareView: false,
-            hasContainedLevels: true
-          })
-        );
-        store.dispatch(
-          setInstructionsConstants({
-            shortInstructions: null,
-            longInstructions: null,
-            noInstructionsWhenCollapsed: true
-          })
-        );
-
-        assertRendersInstructions();
-      });
-
-      function assertRendersInstructions() {
-        const wrapper = mountWithFakeWorkspace();
-        assert(
-          wrapper.find('TopInstructions').exists() &&
-            wrapper.find('HeightResizer').exists(),
-          'Rendered instructions and height resizer'
-        );
-      }
-
-      function refuteRendersInstructions() {
-        const wrapper = mountWithFakeWorkspace();
-        assert.isFalse(
-          wrapper.find('TopInstructions').exists() ||
-            wrapper.find('HeightResizer').exists(),
-          'Did not render instructions or height resizer'
-        );
-      }
-
-      function mountWithFakeWorkspace() {
-        return mount(
-          <Provider store={store}>
-            <InstructionsWithWorkspace>
-              <div>Fake workspace.</div>
-            </InstructionsWithWorkspace>
-          </Provider>
-        );
-      }
-    });
-
-    // This is a set of integration tests over the draggable resize grippy's behavior,
-    // which lives between the instructions area and the code workspace.
-    // As a result, these tests use much heavier setup than the rest of the file.
-    describe('resize bar behavior', () => {
-      beforeEach(() => {
-        const store = getStore();
-        store.dispatch(setRtl(false));
-        store.dispatch(
-          setPageConstants({
-            hideSource: false,
-            isEmbedView: false,
-            isShareView: false,
-            noVisualization: false
-          })
-        );
-        store.dispatch(
-          setInstructionsConstants({
-            longInstructions: `Fake instructions`,
-            noInstructionsWhenCollapsed: true
-          })
-        );
-
-        // Stub $().outerHeight, which is used to find the height of the instructions content
-        // in the DOM but doesn't return anything in tests, to always give 500px as the height
-        // of the instructions content since it gives us something to resize.
-        sinon.stub($.fn, 'outerHeight').returns(500);
-      });
-
-      afterEach(() => {
-        $.fn.outerHeight.restore();
-      });
-
-      it('can resize instructions by dragging the resize bar', () => {
-        const store = getStore();
-        const wrapper = mount(
-          <Provider store={store}>
-            <InstructionsWithWorkspace>
-              <div style={{height: 400}}>
-                Fake workspace to give the workspace container a height.
-              </div>
-            </InstructionsWithWorkspace>
-          </Provider>
-        );
-
-        const resizer = () => wrapper.find('HeightResizer');
-        const instructionsHeight = () =>
-          wrapper
-            .find('TopInstructions')
-            .find('.editor-column')
-            .prop('style').height;
-
-        // Initial state
-        // Instructions content height is stubbed to 500.
-        // Initial render height is 300.
-        // Real 'height' style on relevant element is 287 due to 13px resize bar adjustment.
-        assert.equal(287, instructionsHeight());
-        assert.include(store.getState().instructions, {
-          renderedHeight: 300,
-          expandedHeight: 300,
-          maxNeededHeight: 543,
-          maxAvailableHeight: Infinity
-        });
-
-        // Drag the resize bar to make the instructions bigger by 100px
-        drag(resizer(), 100);
-        assert.equal(387, instructionsHeight());
-        assert.include(store.getState().instructions, {
-          renderedHeight: 400,
-          expandedHeight: 400,
-          maxNeededHeight: 543,
-          maxAvailableHeight: Infinity
-        });
-
-        // Drag the resize bar to make the instructions smaller by 100px
-        drag(resizer(), -100);
-        assert.equal(287, instructionsHeight());
-        assert.include(store.getState().instructions, {
-          renderedHeight: 300,
-          expandedHeight: 300,
-          maxNeededHeight: 543,
-          maxAvailableHeight: Infinity
-        });
-
-        // Drag the resize bar to make the instructions as large as possible
-        drag(resizer(), 1000);
-        assert.equal(530, instructionsHeight());
-        assert.include(store.getState().instructions, {
-          renderedHeight: 543,
-          expandedHeight: 543,
-          maxNeededHeight: 543,
-          maxAvailableHeight: Infinity
-        });
-
-        // Drag the resize bar to make the instructions as small as possible
-        drag(resizer(), -1000);
-        assert.equal(60, instructionsHeight());
-        assert.include(store.getState().instructions, {
-          renderedHeight: 73,
-          expandedHeight: 73,
-          maxNeededHeight: 543,
-          maxAvailableHeight: Infinity
-        });
-      });
-
-      function drag(element, distance) {
-        element.simulate('mousedown', {button: 0, pageY: 1000});
-        element.simulate('mousemove', {pageY: 1000 + distance});
-        element.simulate('mouseup', {});
-      }
     });
   });
 });

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -29,6 +29,25 @@ const DEFAULT_PROPS = {
 };
 
 describe('TopInstructions', () => {
+  it('is an empty div if passed the "hidden" property', () => {
+    const wrapper = shallow(
+      <TopInstructions {...DEFAULT_PROPS} hidden={true} />
+    );
+    expect(wrapper.find('div')).to.have.lengthOf(1);
+  });
+
+  it('is an empty div if there are no instructions to display', () => {
+    const wrapper = shallow(
+      <TopInstructions
+        {...DEFAULT_PROPS}
+        shortInstructions={null}
+        longInstructions={null}
+        hasContainedLevels={false}
+      />
+    );
+    expect(wrapper.find('div')).to.have.lengthOf(1);
+  });
+
   describe('viewing the Feedback Tab', () => {
     describe('as a teacher', () => {
       it('does not show the feedback tab on a level with no rubric where the teacher is not giving feedback', () => {


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#32538.  Eyes tests caught a regression in the position of the resizer handles in RTL, full-width instructions, and maybe other cases.

![Screen Shot 2020-01-14 at 1 46 23 PM](https://user-images.githubusercontent.com/1615761/72385798-0d761d80-36d5-11ea-932a-b7e72f55b121.png)

![image](https://user-images.githubusercontent.com/1615761/72385943-5c23b780-36d5-11ea-92a8-08b5098c817e.png)

![image](https://user-images.githubusercontent.com/1615761/72386023-7fe6fd80-36d5-11ea-9916-3548ab0ac34a.png)
