### PR TITLE
Only show PD banner for English /hourofcode/overview

### DIFF
--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -25,12 +25,11 @@ social:
 
 = I18n.t(:hoc_overview_subtitle)
 
-%br/
-%br/
-= view :professional_learning_apply_banner, use_sign_up_text: true
-%br/
-
 - if request.language == 'en'
+  %br/
+  %br/
+  = view :professional_learning_apply_banner, use_sign_up_text: true
+  %br/
   .tile-container-responsive{style: "margin-top: 20px;"}
     .col-50
       .tutorial-tile


### PR DESCRIPTION
# Description
Follow up to [ #32651](https://github.com/code-dot-org/code-dot-org/pull/32651), the https://code.org/hourofcode/overview page was showing the banner for all languages when it should only show for English. Update to only show this banner for English version of page. The other pages in the PR only had English versions so leaving as is.

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-656)

## Testing story
Validated banner shows up on English language and does not show up for non-English languages.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
