### PR TITLE
Only allow teachers who attend workshops to print workshop certificates

### DIFF
--- a/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.jsx
@@ -78,6 +78,7 @@ class EnrolledWorkshopsTable extends React.Component {
           <Button
             onClick={() => this.openCertificate(workshop)}
             style={styles.button}
+            disabled={!workshop.attended}
           >
             Print certificate
           </Button>

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/EnrolledWorkshopsTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/EnrolledWorkshopsTest.jsx
@@ -138,12 +138,12 @@ describe('EnrolledWorkshops', () => {
     );
   });
 
-  it('Clicking "Print Certificate" does not open the certificate if user did not attend workshop', function() {
+  it('"Print Certificate" button is disabled if user did not attend workshop', function() {
     const enrolledWorkshopsTable = shallow(
       <EnrolledWorkshopsTable workshops={workshops} />
     );
 
-    // Click the "Print Certificate" button
+    // Get disabled "Print Certificate" React Button component
     const printCertificateButton = enrolledWorkshopsTable
       .find('tbody tr')
       .at(3)

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/EnrolledWorkshopsTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/EnrolledWorkshopsTest.jsx
@@ -22,7 +22,9 @@ describe('EnrolledWorkshops', () => {
       facilitators: [],
       organizer: {name: 'organizer_name', email: 'organizer_email'},
       enrollment_code: 'code1',
-      state: 'Not Started'
+      state: 'Not Started',
+      user_id: 123,
+      attended: false
     },
     {
       id: 2,
@@ -39,7 +41,9 @@ describe('EnrolledWorkshops', () => {
       facilitators: [],
       organizer: {name: 'organizer_name', email: 'organizer_email'},
       enrollment_code: 'code2',
-      state: 'In Progress'
+      state: 'In Progress',
+      user_id: 123,
+      attended: false
     },
     {
       id: 3,
@@ -56,7 +60,28 @@ describe('EnrolledWorkshops', () => {
       facilitators: [],
       organizer: {name: null, email: null},
       enrollment_code: 'code3',
-      state: 'Ended'
+      state: 'Ended',
+      user_id: 123,
+      attended: true
+    },
+    {
+      id: 4,
+      sessions: [],
+      location_name: 'My house',
+      location_address: '123 Fake Street',
+      on_map: false,
+      funded: false,
+      workshop_type: 'workshopType',
+      course: 'course',
+      subject: 'subject',
+      enrolled_teacher_count: 10,
+      capacity: 15,
+      facilitators: [],
+      organizer: {name: null, email: null},
+      enrollment_code: 'code4',
+      state: 'Ended',
+      user_id: 123,
+      attended: false
     }
   ];
 
@@ -73,9 +98,9 @@ describe('EnrolledWorkshops', () => {
       <EnrolledWorkshopsTable workshops={workshops} />
     );
 
-    // We expect there to be a table with 3 rows in the body, two of which have two buttons
-    expect(enrolledWorkshopsTable.find('tbody tr')).to.have.length(3);
-    expect(enrolledWorkshopsTable.find('tbody tr Button')).to.have.length(5);
+    // We expect there to be a table with 4 rows in the body, three of which have two buttons
+    expect(enrolledWorkshopsTable.find('tbody tr')).to.have.length(4);
+    expect(enrolledWorkshopsTable.find('tbody tr Button')).to.have.length(7);
     expect(enrolledWorkshopsTable.state('showCancelModal')).to.be.false;
     expect(enrolledWorkshopsTable.state('enrollmentCodeToCancel')).to.equal(
       undefined
@@ -92,15 +117,15 @@ describe('EnrolledWorkshops', () => {
     );
   });
 
-  it('Clicking "Print Certificate" opens the certificate in a new tab', function() {
+  it('Clicking "Print Certificate" opens the certificate in a new tab if user attended workshop', function() {
     const enrolledWorkshopsTable = shallow(
       <EnrolledWorkshopsTable workshops={workshops} />
     );
 
     // Click the "Print Certificate" button
     enrolledWorkshopsTable
-      .find('tr')
-      .last()
+      .find('tbody tr')
+      .at(2)
       .find('Button')
       .first()
       .simulate('click');
@@ -111,5 +136,20 @@ describe('EnrolledWorkshops', () => {
         `/pd/generate_workshop_certificate/${workshops[2].enrollment_code}`
       )
     );
+  });
+
+  it('Clicking "Print Certificate" does not open the certificate if user did not attend workshop', function() {
+    const enrolledWorkshopsTable = shallow(
+      <EnrolledWorkshopsTable workshops={workshops} />
+    );
+
+    // Click the "Print Certificate" button
+    const printCertificateButton = enrolledWorkshopsTable
+      .find('tbody tr')
+      .at(3)
+      .find('Button')
+      .first();
+
+    expect(printCertificateButton.prop('disabled')).to.be.true;
   });
 });

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -40,16 +40,11 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
       enrollment.workshop&.future_or_current_teachercon_or_fit?
     end
 
-    # Adds information about whether the user actually attended the workshop in question
-    serialized_workshops = []
-    enrollments.each do |enrollment|
-      workshop = Api::V1::Pd::WorkshopSerializer.new(enrollment.workshop, scope: {enrollment_code: enrollment.try(:code)}).attributes
-      workshop[:user_id] = enrollment.user_id
-      workshop[:attended] = enrollment.attendances.exists?
-      serialized_workshops << workshop
+    workshops = enrollments.map do |enrollment|
+      Api::V1::Pd::WorkshopSerializer.new(enrollment.workshop, scope: {enrollment_code: enrollment.try(:code)}).attributes
     end
 
-    render json: serialized_workshops
+    render json: workshops
   end
 
   # GET /api/v1/pd/workshops/filter

--- a/dashboard/app/controllers/pd/workshop_certificate_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_certificate_controller.rb
@@ -6,7 +6,7 @@ class Pd::WorkshopCertificateController < ApplicationController
     find_by: :code, id_param: :enrollment_code
 
   def generate_certificate
-    return render_404 unless @enrollment&.attendances&.any?
+    return render_404 unless @enrollment.attendances.any?
 
     image = Pd::CertificateRenderer.render_workshop_certificate @enrollment
     send_data image.to_blob, type: 'image/png', disposition: 'inline'

--- a/dashboard/app/controllers/pd/workshop_certificate_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_certificate_controller.rb
@@ -6,6 +6,8 @@ class Pd::WorkshopCertificateController < ApplicationController
     find_by: :code, id_param: :enrollment_code
 
   def generate_certificate
+    return render_404 unless @enrollment&.attendances&.any?
+
     image = Pd::CertificateRenderer.render_workshop_certificate @enrollment
     send_data image.to_blob, type: 'image/png', disposition: 'inline'
   ensure

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -32,7 +32,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
   attributes :id, :organizer, :location_name, :location_address, :course,
     :subject, :capacity, :notes, :state, :facilitators,
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
-    :enrollment_code, :on_map, :funded, :funding_type, :ready_to_close?,
+    :enrollment_code, :attended, :on_map, :funded, :funding_type, :ready_to_close?,
     :date_and_location_name, :regional_partner_name, :regional_partner_id,
     :scholarship_workshop?, :can_delete, :created_at
 
@@ -61,6 +61,10 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
 
   def enrollment_code
     @scope.try(:[], :enrollment_code)
+  end
+
+  def attended
+    object.enrollments.find_by(code: @scope.try(:[], :enrollment_code))&.attendances&.any?
   end
 
   def regional_partner_name

--- a/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
@@ -5,7 +5,7 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     @user = create :teacher
     sign_in(@user)
     @workshop = create :workshop, num_sessions: 1, course: Pd::Workshop::COURSE_CSD
-    @enrollment = create :pd_enrollment, workshop: @workshop
+    @enrollment = create :pd_enrollment, :with_attendance, workshop: @workshop
 
     facilitator_1 = create :facilitator, name: 'Facilitator 1'
     facilitator_2 = create :facilitator, name: 'Facilitator 2'
@@ -30,12 +30,19 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     end
   end
 
+  test 'Generates no certificates if teacher did not attend workshop' do
+    @enrollment = create :pd_enrollment, workshop: @workshop
+
+    get :generate_certificate, params: {enrollment_code: @enrollment.code}
+    assert_response :missing
+  end
+
   # Disable this lint rule because it's very useful to use _ as shorthand for 'anything' matchers
   # rubocop:disable Lint/UnderscorePrefixedVariableName
 
   test 'Generates certificate for CSF 101 workshop' do
     workshop = create :csf_intro_workshop
-    enrollment = create :pd_enrollment, workshop: workshop
+    enrollment = create :pd_enrollment, :with_attendance, workshop: workshop
 
     _ = anything
     mock_draw = expect_renders_certificate
@@ -49,7 +56,7 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
   end
 
   test 'Generates certificate for regular CSD event' do
-    enrollment = create :pd_enrollment, workshop: @workshop
+    enrollment = create :pd_enrollment, :with_attendance, workshop: @workshop
     assert_equal Pd::Workshop::COURSE_CSD, @workshop.course
 
     _ = anything
@@ -69,7 +76,7 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
       num_sessions: 1,
       course: Pd::Workshop::COURSE_CSD,
       subject: Pd::Workshop::SUBJECT_CSD_TEACHER_CON
-    enrollment = create :pd_enrollment, workshop: workshop
+    enrollment = create :pd_enrollment, :with_attendance, workshop: workshop
 
     _ = anything
     mock_draw = expect_renders_certificate
@@ -87,7 +94,7 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
       num_sessions: 1,
       course: Pd::Workshop::COURSE_CSP,
       subject: Pd::Workshop::SUBJECT_CSP_TEACHER_CON
-    enrollment = create :pd_enrollment, workshop: workshop
+    enrollment = create :pd_enrollment, :with_attendance, workshop: workshop
 
     _ = anything
     mock_draw = expect_renders_certificate

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -408,6 +408,12 @@ FactoryGirl.define do
       full_name {user.name} # sets first_name and last_name
       email {user.email}
     end
+
+    trait :with_attendance do
+      after(:create) do |enrollment|
+        create_list(:pd_attendance, 1, enrollment: enrollment)
+      end
+    end
   end
 
   factory :pd_attendance, class: 'Pd::Attendance' do


### PR DESCRIPTION
[PLC-687](https://codedotorg.atlassian.net/browse/PLC-687): Prevents teachers who did not attend workshops from printing certificates of completion.

## Testing story

Added a test for the new behavior. I was trying to test by actually generating a click event, but I ran into [this bug](https://github.com/airbnb/enzyme/issues/386) (I think). In order to get feedback I added a less great test, but happy to adjust if there are ideas about how to work around this issue.

Also added/modified testing related to new server side logic to prevent rendering workshop certificates for teaches who haven't attended a workshop.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
