### PR TITLE
Add /api/v1/animation-library/(spritelab|gamelab)/<version_id>/<filename>

### DIFF
--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -20,6 +20,27 @@ class AnimationLibraryApi < Sinatra::Base
   end
 
   #
+  # GET /api/v1/animation-library/(spritelab|gamelab)/<version-id>/<filename>
+  #
+  # Retrieve a file from the animation library for the given app type
+  #
+  get %r{/api/v1/animation-library/(spritelab|gamelab)/([^/]+)/(.+)} do |app_type, version_id, animation_name|
+    not_found if version_id.empty? || animation_name.empty?
+
+    begin
+      result = Aws::S3::Bucket.
+        new(ANIMATION_LIBRARY_BUCKET, client: AWS::S3.create_client).
+        object("#{app_type}/#{animation_name}").
+        get(version_id: version_id)
+      content_type result.content_type
+      cache_for 3600
+      result.body
+    rescue
+      not_found
+    end
+  end
+
+  #
   # GET /api/v1/animation-library/<version-id>/<filename>
   #
   # Retrieve a file from the animation library

--- a/shared/test/fixtures/vcr/animationlibrary/animation_not_found.yml
+++ b/shared/test/fixtures/vcr/animationlibrary/animation_not_found.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cdo-animation-library.s3.amazonaws.com/spritelab/animation_not_found.png?versionId=version
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 14 Jan 2020 21:34:09 GMT
+      Connection:
+      - close
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Error><Code>InvalidArgument</Code><Message>Invalid version id specified</Message><ArgumentName>versionId</ArgumentName><ArgumentValue>version</ArgumentValue><RequestId>A24F36AA539E4E8C</RequestId><HostId>K3N/k3jrbjQDxkR+ferC99e8P3Np6ii6OkVKpQn3WiUywEe1Q0EziskbwJAO/oMoxQzA/WDO6pE=</HostId></Error>
+    http_version: 
+  recorded_at: Tue, 14 Jan 2020 21:34:09 GMT
+recorded_with: VCR 3.0.3

--- a/shared/test/test_animation_library_api.rb
+++ b/shared/test/test_animation_library_api.rb
@@ -9,6 +9,41 @@ class AnimationLibraryTest < Minitest::Test
     @session = Rack::MockSession.new(AnimationLibraryApi, 'studio.code.org')
   end
 
+  def test_animation_not_found
+    get '/api/v1/animation-library/spritelab/version/animation_not_found.png'
+    assert last_response.not_found?
+  end
+
+  def test_get_spritelab_animation
+    contents = 'TEST_ANIMATION'
+    # Ensure the shared S3 client is used by stubbing the client with the expected response.
+    AWS::S3.s3 = Aws::S3::Client.new(
+      stub_responses: {
+        get_object: {body: contents, content_type: 'image/png'}
+      }
+    )
+    get '/api/v1/animation-library/spritelab/version/test_animation.png'
+    assert last_response.ok?
+    assert_equal contents, last_response.body
+  ensure
+    AWS::S3.s3 = nil
+  end
+
+  def test_get_gamelab_animation
+    contents = 'TEST_ANIMATION'
+    # Ensure the shared S3 client is used by stubbing the client with the expected response.
+    AWS::S3.s3 = Aws::S3::Client.new(
+      stub_responses: {
+        get_object: {body: contents, content_type: 'image/png'}
+      }
+    )
+    get '/api/v1/animation-library/gamelab/version/test_animation.png'
+    assert last_response.ok?
+    assert_equal contents, last_response.body
+  ensure
+    AWS::S3.s3 = nil
+  end
+
   def test_not_found
     get '/api/v1/animation-library/animation_not_found.png'
     assert last_response.not_found?


### PR DESCRIPTION
# Description

Adds a new endpoint to the animation library: `/api/v1/animation-library/(spritelab|gamelab)/<version_id>/<filename>`

Old endpoint: `/api/v1/animation-library/<version_id>/<filename>`
New endpoint: `/api/v1/animation-library/(spritelab|gamelab)/<version_id>/<filename>`

Rather than storing/retrieving all animations from the `cdo-animation-library` bucket directly, we will now store/query from separate `gamelab/` and `spritelab/` directories within that bucket:

![Screen Shot 2020-01-14 at 4 48 56 PM](https://user-images.githubusercontent.com/9812299/72395306-e8da6f80-36ed-11ea-80cc-6f08804e23e4.png)

## Links

- [spec](https://docs.google.com/document/d/10y0ukMPHDeaCW1lBCZK3LhNnZEKFqReDA6bna2Lx5q4/edit?usp=sharing)
- [jira](https://codedotorg.atlassian.net/browse/STAR-934)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
