### PR TITLE
Fix error handling on library export

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
@@ -256,7 +256,7 @@ class LibraryCreationDialog extends React.Component {
     if (
       this.state.libraryDescription &&
       Object.values(this.state.selectedFunctions).find(value => value) &&
-      this.publishState === PublishState.INVALID_INPUT
+      this.state.publishState === PublishState.INVALID_INPUT
     ) {
       this.setState({publishState: PublishState.DONE_LOADING});
     }
@@ -310,7 +310,7 @@ class LibraryCreationDialog extends React.Component {
     });
   };
 
-  displayError = () => {
+  displayAlert = () => {
     let errorMessage;
     if (this.state.publishState === PublishState.INVALID_INPUT) {
       errorMessage = i18n.libraryPublishInvalid();
@@ -339,7 +339,7 @@ class LibraryCreationDialog extends React.Component {
           onClick={this.publish}
           text={i18n.publish()}
         />
-        {this.displayError()}
+        {this.displayAlert()}
       </div>
     );
   };

--- a/apps/test/unit/code-studio/components/libraries/LibraryCreationDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryCreationDialogTest.js
@@ -222,6 +222,32 @@ describe('LibraryCreationDialog', () => {
       expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
     });
 
+    it('is enabled once description and functions are set', () => {
+      wrapper.setState({
+        libraryName: libraryName,
+        librarySource: LIBRARY_SOURCE,
+        publishState: PublishState.DONE_LOADING,
+        sourceFunctionList: libraryParser.getFunctions(LIBRARY_SOURCE)
+      });
+
+      wrapper.instance().publish();
+      wrapper.update();
+      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
+
+      wrapper.instance().resetErrorMessage();
+      wrapper.update();
+      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
+
+      wrapper.setState({
+        selectedFunctions: selectedFunctions,
+        libraryDescription: description
+      });
+      wrapper.instance().resetErrorMessage();
+      wrapper.update();
+
+      expect(wrapper.state().publishState).to.equal(PublishState.DONE_LOADING);
+    });
+
     describe('with valid input', () => {
       let libraryJsonSpy;
       beforeEach(() => {


### PR DESCRIPTION
# Description
Updates and refactors to library export were implemented as part of this PR: https://github.com/code-dot-org/code-dot-org/pull/32599. They broke some error handling.

This PR fixes the error handling and adds unit tests for the parts where unit tests make sense.

Buggy error messages:
![image](https://user-images.githubusercontent.com/8324574/72405759-d6bcf900-370e-11ea-9d6a-04bc2b35ce7d.png)

Fixed error messages: 
![image](https://user-images.githubusercontent.com/8324574/72405800-f522f480-370e-11ea-94cc-f93f04b231a1.png)

![image](https://user-images.githubusercontent.com/8324574/72405817-053ad400-370f-11ea-8339-b74826e42a88.png)

Auto-removal of error message works again:
![newExportLibrary](https://user-images.githubusercontent.com/8324574/72405912-62368a00-370f-11ea-8450-7e97c8755d38.gif)


## Links


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
