### PR TITLE
Rename voilin to violin in GameLab Animation Library

### DIFF
--- a/apps/src/p5lab/gamelab/animationLibrary.json
+++ b/apps/src/p5lab/gamelab/animationLibrary.json
@@ -13631,8 +13631,8 @@
         "y": 300
       }
     },
-    "category_music/voilin": {
-      "name": "voilin",
+    "category_music/violin": {
+      "name": "violin",
       "frameCount": 1,
       "frameSize": {
         "x": 300,
@@ -13640,10 +13640,10 @@
       },
       "looping": true,
       "frameDelay": 2,
-      "jsonLastModified": "2017-04-18 06:08:31 UTC",
-      "pngLastModified": "2017-04-18 06:08:31 UTC",
-      "version": "ohpdIblnFiwNTsPhvoUBrEBgpI4LxYe1",
-      "sourceUrl": "/api/v1/animation-library/ohpdIblnFiwNTsPhvoUBrEBgpI4LxYe1/category_music/voilin.png",
+      "jsonLastModified": "2020-01-15 17:31:01 UTC",
+      "pngLastModified": "2020-01-15 17:31:02 UTC",
+      "version": "ddgOYDgUtjQEM.M1ll7CUEGE1M8tk1Jm",
+      "sourceUrl": "/api/v1/animation-library/ddgOYDgUtjQEM.M1ll7CUEGE1M8tk1Jm/category_music/violin.png",
       "sourceSize": {
         "x": 300,
         "y": 145
@@ -18293,7 +18293,7 @@
       "category_music/sixteenth_note_down",
       "category_music/treble-clef",
       "category_music/ukulele",
-      "category_music/voilin"
+      "category_music/violin"
     ],
     "category_obstacles": [
       "category_obstacles/cactus",
@@ -20445,7 +20445,7 @@
       "category_music/recorder",
       "category_music/saxophone",
       "category_music/ukulele",
-      "category_music/voilin"
+      "category_music/violin"
     ],
     "items": [
       "category_generic_items/bandage",
@@ -23521,8 +23521,8 @@
     "video_game_controller": [
       "category_generic_items/video_game_controller"
     ],
-    "voilin": [
-      "category_music/voilin"
+    "violin": [
+      "category_music/violin"
     ],
     "wallet": [
       "category_generic_items/wallet"

--- a/tools/scripts/rebuildAnimationLibraryManifest.rb
+++ b/tools/scripts/rebuildAnimationLibraryManifest.rb
@@ -26,8 +26,8 @@ require_relative './constants'
 include CdoCli
 
 DEFAULT_S3_BUCKET = 'cdo-animation-library'.freeze
-DEFAULT_OUTPUT_FILE = "#{`git rev-parse --show-toplevel`.strip}/apps/src/gamelab/animationLibrary.json".freeze
-SPRITELAB_OUTPUT_FILE = "#{`git rev-parse --show-toplevel`.strip}/apps/src/gamelab/spriteCostumeLibrary.json".freeze
+DEFAULT_OUTPUT_FILE = "#{`git rev-parse --show-toplevel`.strip}/apps/src/p5lab/gamelab/animationLibrary.json".freeze
+SPRITELAB_OUTPUT_FILE = "#{`git rev-parse --show-toplevel`.strip}/apps/src/p5lab/spritelab/spriteCostumeLibrary.json".freeze
 DOWNLOAD_DESTINATION = '~/cdo-animation-library'.freeze
 SPRITE_COSTUME_LIST = SPRITE_LAB_ANIMATION_LIST
 


### PR DESCRIPTION
# Description
Simple typo fix.
Not included in PR: delete voilin.png and voilin.json from S3 bucket, upload violin.png and violin.json: 
![image](https://user-images.githubusercontent.com/8787187/72456990-91ceac00-377a-11ea-8abb-7b197ecdde1e.png)

New asset:
![image](https://user-images.githubusercontent.com/8787187/72457065-a743d600-377a-11ea-85ba-e4721ee1e657.png)

Old asset:
![image](https://user-images.githubusercontent.com/8787187/72457109-bcb90000-377a-11ea-87e9-f4789e3e3c81.png)


Note: this asset is not in the Sprite Lab costume library, so no change needed there.


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
