### PR TITLE
InstructionsWithWorkspace owns the resizer (attempt 3)

### DIFF
--- a/apps/src/templates/ContainedLevel.jsx
+++ b/apps/src/templates/ContainedLevel.jsx
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -15,7 +15,7 @@ const styles = {
   main: {
     position: 'absolute',
     height: RESIZER_HEIGHT,
-    left: 0,
+    marginLeft: 15,
     right: 0
   },
   ellipsis: {
@@ -102,6 +102,7 @@ class HeightResizer extends React.Component {
     return (
       <div
         id="ui-test-resizer"
+        className="editor-column"
         style={mainStyle}
         onMouseDown={this.onMouseDown}
         onMouseUp={this.onMouseUp}

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -3,8 +3,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import CodeWorkspaceContainer from '../CodeWorkspaceContainer';
-import TopInstructions from './TopInstructions';
-import {setInstructionsMaxHeightAvailable} from '../../redux/instructions';
+import TopInstructions, {MIN_HEIGHT} from './TopInstructions';
+import {
+  setInstructionsMaxHeightAvailable,
+  setInstructionsRenderedHeight
+} from '../../redux/instructions';
+import HeightResizer from './HeightResizer';
+import clamp from 'lodash/clamp';
 
 /**
  * A component representing the right side of the screen in our app. In particular
@@ -18,7 +23,11 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     children: PropTypes.node,
     // props provided via connect
     instructionsHeight: PropTypes.number.isRequired,
-    setInstructionsMaxHeightAvailable: PropTypes.func.isRequired
+    instructionsMaxHeight: PropTypes.number.isRequired,
+    showInstructions: PropTypes.bool.isRequired,
+    showResizer: PropTypes.bool.isRequired,
+    setInstructionsMaxHeightAvailable: PropTypes.func.isRequired,
+    setInstructionsRenderedHeight: PropTypes.func.isRequired
   };
 
   // only used so that we can rerender when resized
@@ -36,6 +45,15 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
    * call adjustTopPaneHeight as our maxHeight may need adjusting.
    */
   onResize = () => {
+    // We have to have a reference to this component to do anything on resize anyway.
+    // Guard here because our tests aren't cleaning up nicely :(
+    if (!this.codeWorkspaceContainer) {
+      return;
+    }
+
+    // TODO (brad)
+    // See if we can achieve this effect with memoization instead of state
+    // https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization
     const {
       windowWidth: lastWindowWidth,
       windowHeight: lastWindowHeight
@@ -93,10 +111,35 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
     window.removeEventListener('resize', this.onResize);
   }
 
+  /**
+   * Given a prospective delta, determines how much we can actually change the
+   * height (accounting for min/max) and changes height by that much.
+   * @param {number} delta
+   * @returns {number} How much we actually changed
+   */
+  handleHeightResize = delta => {
+    const {
+      instructionsHeight: oldHeight,
+      instructionsMaxHeight: maxHeight,
+      setInstructionsRenderedHeight: setHeight
+    } = this.props;
+
+    const newHeight = clamp(oldHeight + delta, MIN_HEIGHT, maxHeight);
+    setHeight(newHeight);
+
+    return newHeight - oldHeight;
+  };
+
   render() {
     return (
       <span>
-        <TopInstructions />
+        {this.props.showInstructions && <TopInstructions />}
+        {this.props.showResizer && (
+          <HeightResizer
+            position={this.props.instructionsHeight}
+            onResize={this.handleHeightResize}
+          />
+        )}
         <CodeWorkspaceContainer
           ref={this.setCodeWorkspaceContainerRef}
           topMargin={this.props.instructionsHeight}
@@ -110,14 +153,30 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
 
 export default connect(
   function propsFromStore(state) {
+    const {hasContainedLevels, isEmbedView, isShareView} = state.pageConstants;
+    const {shortInstructions, longInstructions} = state.instructions;
+    const showInstructions = !!(
+      !isShareView &&
+      (shortInstructions || longInstructions || hasContainedLevels)
+    );
+    const showResizer = showInstructions && !isEmbedView;
     return {
-      instructionsHeight: state.instructions.renderedHeight
+      instructionsHeight: state.instructions.renderedHeight,
+      instructionsMaxHeight: Math.min(
+        state.instructions.maxAvailableHeight,
+        state.instructions.maxNeededHeight
+      ),
+      showInstructions,
+      showResizer
     };
   },
   function propsFromDispatch(dispatch) {
     return {
       setInstructionsMaxHeightAvailable(maxHeight) {
         dispatch(setInstructionsMaxHeightAvailable(maxHeight));
+      },
+      setInstructionsRenderedHeight(height) {
+        dispatch(setInstructionsRenderedHeight(height));
       }
     };
   }

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -23,7 +23,6 @@ import styleConstants from '../../styleConstants';
 import commonStyles from '../../commonStyles';
 import Instructions from './Instructions';
 import CollapserIcon from './CollapserIcon';
-import HeightResizer from './HeightResizer';
 import i18n from '@cdo/locale';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import queryString from 'query-string';
@@ -34,7 +33,7 @@ import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
 
-const MIN_HEIGHT = RESIZER_HEIGHT + 60;
+export const MIN_HEIGHT = RESIZER_HEIGHT + 60;
 
 const TabType = {
   INSTRUCTIONS: 'instructions',
@@ -326,22 +325,6 @@ class TopInstructions extends Component {
   };
 
   /**
-   * Given a prospective delta, determines how much we can actually change the
-   * height (accounting for min/max) and changes height by that much.
-   * @param {number} delta
-   * @returns {number} How much we actually changed
-   */
-  handleHeightResize = delta => {
-    const currentHeight = this.props.height;
-
-    let newHeight = Math.max(MIN_HEIGHT, currentHeight + delta);
-    newHeight = Math.min(newHeight, this.props.maxHeight);
-
-    this.props.setInstructionsRenderedHeight(newHeight);
-    return newHeight - currentHeight;
-  };
-
-  /**
    * Calculate how much height it would take to show top instructions with our
    * entire instructions visible and update store with this value.
    * @returns {number}
@@ -506,13 +489,6 @@ class TopInstructions extends Component {
   );
 
   render() {
-    const {
-      hidden,
-      shortInstructions,
-      longInstructions,
-      hasContainedLevels
-    } = this.props;
-
     const isCSF = !this.props.noInstructionsWhenCollapsed;
     const isCSDorCSP = this.props.noInstructionsWhenCollapsed;
     const widgetWidth = WIDGET_WIDTH + 'px';
@@ -570,13 +546,6 @@ class TopInstructions extends Component {
     const teacherOnly =
       this.state.tabSelected === TabType.COMMENTS &&
       this.state.teacherViewingStudentWork;
-
-    if (
-      hidden ||
-      (!shortInstructions && !longInstructions && !hasContainedLevels)
-    ) {
-      return <div />;
-    }
 
     /* TODO: When we move CSD and CSP to the Teacher Only tab remove CSF restriction here*/
     const showContainedLevelAnswer =
@@ -775,12 +744,6 @@ class TopInstructions extends Component {
                 </div>
               )}
           </div>
-          {!this.props.isEmbedView && (
-            <HeightResizer
-              position={this.props.height}
-              onResize={this.handleHeightResize}
-            />
-          )}
         </div>
       </div>
     );

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -29,25 +29,6 @@ const DEFAULT_PROPS = {
 };
 
 describe('TopInstructions', () => {
-  it('is an empty div if passed the "hidden" property', () => {
-    const wrapper = shallow(
-      <TopInstructions {...DEFAULT_PROPS} hidden={true} />
-    );
-    expect(wrapper.find('div')).to.have.lengthOf(1);
-  });
-
-  it('is an empty div if there are no instructions to display', () => {
-    const wrapper = shallow(
-      <TopInstructions
-        {...DEFAULT_PROPS}
-        shortInstructions={null}
-        longInstructions={null}
-        hasContainedLevels={false}
-      />
-    );
-    expect(wrapper.find('div')).to.have.lengthOf(1);
-  });
-
   describe('viewing the Feedback Tab', () => {
     describe('as a teacher', () => {
       it('does not show the feedback tab on a level with no rubric where the teacher is not giving feedback', () => {


### PR DESCRIPTION
This reverts https://github.com/code-dot-org/code-dot-org/pull/32670, restoring https://github.com/code-dot-org/code-dot-org/pull/32538 and https://github.com/code-dot-org/code-dot-org/pull/32417.

Feeling a bit embarrassed at the number of regressions I've caused while trying to push this refactor through.

## Regressions addressed

Please review the description of https://github.com/code-dot-org/code-dot-org/pull/32417 to understand the original intent of this change.  Beyond that, this PR includes the following fixes for regressions caused in past attempts:

- Resize bar is correctly hidden when instructions are not rendered at all:
  ![image (22)](https://user-images.githubusercontent.com/1615761/72380209-c6365f80-36c9-11ea-8d5a-c8575b85bab3.png)
- Grippy is positioned correctly when page layout is RTL:
  ![Screen Shot 2020-01-14 at 1 46 23 PM](https://user-images.githubusercontent.com/1615761/72385798-0d761d80-36d5-11ea-932a-b7e72f55b121.png)
- Grippy is positioned correctly when there is no visualization column:
  ![image](https://user-images.githubusercontent.com/1615761/72385943-5c23b780-36d5-11ea-92a8-08b5098c817e.png)
  ![image](https://user-images.githubusercontent.com/1615761/72386023-7fe6fd80-36d5-11ea-9916-3548ab0ac34a.png)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
