### PR TITLE
[Data Viz] Populate filter dropdowns

### DIFF
--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -101,6 +101,14 @@ class VisualizerModal extends React.Component {
     return columns.filter(column => isColumnNumeric(records, column));
   });
 
+  getValuesForFilterColumn = memoize((records, column) => {
+    let values = [];
+    values = Array.from(new Set(records.map(record => record[column])));
+    values = values.map(x => (typeof x === 'string' ? `"${x}"` : `${x}`));
+
+    return values;
+  });
+
   getDisplayNameForChartType(chartType) {
     switch (chartType) {
       case ChartType.BAR_CHART:
@@ -258,7 +266,7 @@ class VisualizerModal extends React.Component {
           <div style={{paddingTop: 20}}>
             <DropdownField
               displayName={msg.filter()}
-              options={[1, 2, 3]}
+              options={this.props.tableColumns}
               disabledOptions={[]}
               value={this.state.filterColumn}
               onChange={event =>
@@ -271,7 +279,10 @@ class VisualizerModal extends React.Component {
             />
             <DropdownField
               displayName={msg.by()}
-              options={[]}
+              options={this.getValuesForFilterColumn(
+                parsedRecords,
+                this.state.filterColumn
+              )}
               disabledOptions={[]}
               value={this.state.filterValue}
               onChange={event =>

--- a/apps/test/unit/storage/dataBrowser/dataVisualizer/VisualizerModalTest.js
+++ b/apps/test/unit/storage/dataBrowser/dataVisualizer/VisualizerModalTest.js
@@ -151,15 +151,10 @@ describe('VisualizerModal', () => {
     });
 
     it('shows quotes around strings', () => {
-      let records = [
-        {id: 1, col: 'xyz'},
-        {id: 2, col: 'def'},
-        {id: 3, col: '123'},
-        {id: 4, col: 'abc'}
-      ];
+      let records = [{id: 3, col: '123'}, {id: 4, col: 'abc'}];
       expect(
         wrapper.instance().getValuesForFilterColumn(records, 'col')
-      ).to.deep.equal(['"xyz"', '"def"', '"123"', '"abc"']);
+      ).to.deep.equal(['"123"', '"abc"']);
     });
 
     it('shows numbers and booleans without quotes', () => {

--- a/apps/test/unit/storage/dataBrowser/dataVisualizer/VisualizerModalTest.js
+++ b/apps/test/unit/storage/dataBrowser/dataVisualizer/VisualizerModalTest.js
@@ -143,4 +143,64 @@ describe('VisualizerModal', () => {
       ).to.deep.equal(expectedNumericColumns);
     });
   });
+
+  describe('getValuesForFilterColumn', () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = shallow(<VisualizerModal {...DEFAULT_PROPS} />);
+    });
+
+    it('shows quotes around strings', () => {
+      let records = [
+        {id: 1, col: 'xyz'},
+        {id: 2, col: 'def'},
+        {id: 3, col: '123'},
+        {id: 4, col: 'abc'}
+      ];
+      expect(
+        wrapper.instance().getValuesForFilterColumn(records, 'col')
+      ).to.deep.equal(['"xyz"', '"def"', '"123"', '"abc"']);
+    });
+
+    it('shows numbers and booleans without quotes', () => {
+      let records = [
+        {id: 1, col: true},
+        {id: 2, col: 'false'},
+        {id: 3, col: 123},
+        {id: 4, col: '456'}
+      ];
+      expect(
+        wrapper.instance().getValuesForFilterColumn(records, 'col')
+      ).to.deep.equal(['true', '"false"', '123', '"456"']);
+    });
+
+    it('shows null, undefined, and "" separately', () => {
+      let records = [
+        {id: 1, col: null},
+        {id: 2, col: undefined},
+        {id: 3, col: ''}
+      ];
+      expect(
+        wrapper.instance().getValuesForFilterColumn(records, 'col')
+      ).to.deep.equal(['null', 'undefined', '""']);
+    });
+
+    it('returns a list of unique values in the column', () => {
+      let records = [
+        {id: 1, col: 'xyz'},
+        {id: 2, col: 'def'},
+        {id: 3, col: '123'},
+        {id: 4, col: 'xyz'}, // duplicate 'xyz'
+        {id: 5, col: undefined},
+        {id: 6}, // duplicate undefined
+        {id: 7, col: 123}, // not a duplicate because this is a number and above is a string
+        {id: 8, col: true},
+        {id: 9, col: true} // duplicate true
+      ];
+
+      expect(
+        wrapper.instance().getValuesForFilterColumn(records, 'col')
+      ).to.deep.equal(['"xyz"', '"def"', '"123"', 'undefined', '123', 'true']);
+    });
+  });
 });


### PR DESCRIPTION
# Description
Populate the dropdowns for filtering (This PR does not actually implement filtering)
Strings are shown in quotes
`null` and `undefined` are shown as two separate values
booleans and numbers are shown without quotes

Screenshots show what the dropdowns look like for the same data as the unit tests:
![image](https://user-images.githubusercontent.com/8787187/72462470-fd6a4680-3785-11ea-8442-61cd2cacb6ce.png)

![image](https://user-images.githubusercontent.com/8787187/72462539-212d8c80-3786-11ea-8e77-6eb4d473607a.png)

![image](https://user-images.githubusercontent.com/8787187/72462703-86817d80-3786-11ea-9954-1af6f65372bc.png)

![image](https://user-images.githubusercontent.com/8787187/72462814-d5c7ae00-3786-11ea-8200-910e76e2eb5c.png)

<!--
  A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1s1CQ4SSrpwJtLwI5gJoFzJEbcEXZHQIQ6ikAxB9H3j4/edit?usp=drive_web&ouid=106447758460192126987)
- [jira](https://codedotorg.atlassian.net/browse/STAR-933)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
