### PR TITLE
bundle update kgio

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,7 +507,7 @@ GEM
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    kgio (2.11.1)
+    kgio (2.11.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     le (2.7.2)


### PR DESCRIPTION
# Description
Updating the kgio gem in order to pull in a fix. `bundle install` was
failing for kgio-2.11.1 because it failed to compile. The kgio gem
website referenced the same compilation issue for this version and has a
fix for it in v2.11.2.

I haven't figured out why other CDO developer's aren't running into this issue, but it does affect me everyday and is a pain because I have to keep managing a separate Gemfile.lock. I would like to try updating this dependency to see if

## Fix reference
https://yhbt.net/kgio/NEWS.html
> kgio 2.11.2 - fix Ruby 2.5 compatibility for accept_class / 2018-01-30 21:11 UTC

## Testing story
* https://adhoc-bundle-update-kgio-studio.cdn-code.org/courses

# Reviewer Checklist:
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
