### PR TITLE
Move PD Apply banner to React and add to /yourschool

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -653,6 +653,8 @@ describe('entry tests', () => {
       './src/sites/code.org/pages/public/pd-workshop-survey/splat.js',
     'code.org/public/learn/local':
       './src/sites/code.org/pages/public/learn/local.js',
+    'code.org/views/professional_learning_apply_banner':
+      './src/sites/code.org/pages/views/professional_learning_apply_banner.js',
 
     'pd/_jotform_loader': './src/sites/studio/pages/pd/_jotform_loader.js',
     'pd/_jotform_embed': './src/sites/studio/pages/pd/_jotform_embed.js',

--- a/apps/src/sites/code.org/pages/public/professional-learning-apply-banner.js
+++ b/apps/src/sites/code.org/pages/public/professional-learning-apply-banner.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ProfessionalLearningApplyBanner from '@cdo/apps/templates/templates/ProfessionalLearningApplyBanner';
+import getScriptData from '@cdo/apps/util/getScriptData';
+
+document.addEventListener('DOMContentLoaded', function(event) {
+  ReactDOM.render(
+    <ProfessionalLearningApplyBanner {...getScriptData('props')} />,
+    document.getElementById('apply-banner-container')
+  );
+});

--- a/apps/src/sites/code.org/pages/views/professional_learning_apply_banner.js
+++ b/apps/src/sites/code.org/pages/views/professional_learning_apply_banner.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ProfessionalLearningApplyBanner from '@cdo/apps/templates/templates/ProfessionalLearningApplyBanner';
+import ProfessionalLearningApplyBanner from '@cdo/apps/templates/ProfessionalLearningApplyBanner';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 document.addEventListener('DOMContentLoaded', function(event) {

--- a/apps/src/templates/ProfessionalLearningApplyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.jsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 class ProfessionalLearningApplyBanner extends React.Component {
   static propTypes = {
     useSignUpText: PropTypes.bool,
-    nominated: PropTypes.bool
+    nominated: PropTypes.bool,
+    style: PropTypes.object
   };
 
   state = {
@@ -135,7 +136,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
 
   render() {
     return (
-      <div>
+      <div style={this.props.style}>
         <a className="linktag" href={this.state.link} id="pl-apply-banner">
           <div style={this.styles.bigBanner}>
             <div className="col-50" style={this.styles.textWrapper}>
@@ -178,7 +179,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
               </div>
               <div
                 className="desktop-feature"
-                style={this.styles.desktopFeature}
+                style={this.styles.desktopBtnContainer}
               >
                 <div>
                   <button type="button" style={this.styles.button}>

--- a/apps/src/templates/ProfessionalLearningApplyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.jsx
@@ -137,18 +137,17 @@ class ProfessionalLearningApplyBanner extends React.Component {
   render() {
     return (
       <div style={this.props.style}>
-        <a className="linktag" href={this.state.link} id="pl-apply-banner">
+        <a href={this.state.link} id="pl-apply-banner">
           <div style={this.styles.bigBanner}>
             <div className="col-50" style={this.styles.textWrapper}>
               <div
-                className="arrowcontainer desktop-feature"
+                className="desktop-feature"
                 style={this.styles.leftArrowContainer}
               >
-                <div className="arrow" style={this.styles.leftArrow} />
+                <div style={this.styles.leftArrow} />
               </div>
-              <div className="textcontainer" style={this.styles.textContainer}>
+              <div style={this.styles.textContainer}>
                 <div
-                  className="text"
                   style={
                     this.props.useSignUpText
                       ? this.styles.text
@@ -164,13 +163,10 @@ class ProfessionalLearningApplyBanner extends React.Component {
                 className="desktop-feature"
                 style={this.styles.desktopFeature}
               >
-                <div
-                  className="arrowcontainer"
-                  style={this.styles.rightArrowContainer}
-                >
-                  <div className="arrow" style={this.styles.rightArrow} />
+                <div style={this.styles.rightArrowContainer}>
+                  <div style={this.styles.rightArrow} />
                 </div>
-                <div className="plane" style={this.styles.plane}>
+                <div style={this.styles.plane}>
                   <img
                     src="/images/professional-learning/plane.png"
                     style={this.styles.image}

--- a/apps/src/templates/ProfessionalLearningApplyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.jsx
@@ -136,11 +136,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
   render() {
     return (
       <div>
-        <a
-          className="linktag"
-          href="/educate/professional-learning/program-information"
-          id="pl-apply-banner"
-        >
+        <a className="linktag" href={this.state.link} id="pl-apply-banner">
           <div style={this.styles.bigBanner}>
             <div className="col-50" style={this.styles.textWrapper}>
               <div
@@ -209,44 +205,4 @@ class ProfessionalLearningApplyBanner extends React.Component {
   }
 }
 
-/**- link = "/educate/professional-learning/program-information"
-- link += "?nominated=true" if params[:nominated]
-- use_sign_up_text ||= false
-- font_size = use_sign_up_text ? '16px' : '18px'
-- padding = use_sign_up_text ? '25px 10px' : '20px 10px'
-
-- buttons = capture_haml do
-  %div
-    %button{style: "margin-top: 29px; padding: 10px 40px 10px 40px; height: initial; margin-right: 30px; font-size: 18px;"}
-      Apply Now
-
-:css
-  .bigbanner p { margin: 0px }
-
-%div
-  %a.linktag#pl-apply-banner{href: link}
-    .bigbanner{style: "width: 100%; padding: 5px; background-color: #ebe8f1"}
-      .col-50{style: "background-color: #7665a0; min-height: 100px;"}
-        .arrowcontainer.desktop-feature{style: "float:left; width: 7%"}
-          .arrow{style: "width: 0; height: 0; border-style: solid; border-width: 50px 0 50px 25px; border-color: transparent transparent transparent #ebe8f1"}
-        .textcontainer{style: "float:left; width: 93%"}
-          .text{style: "color: white;  font-size: #{font_size}; padding: #{padding}; text-align: center; line-height: 1.5"}
-            - if use_sign_up_text
-              Sign up for Professional Learning! Applications are now open for Middle and High School teachers.
-            - elsif params[:nominated]
-              CONGRATULATIONS! You’ve been nominated for a scholarship!
-            - else
-              SEATS OPEN - 2020 Professional Learning for Middle and High School Teachers
-      .col-50{style: "background-color: #ebe8f1; color: white; height: 100px; font-size: 18px; text-align: center"}
-        .desktop-feature{style: "float:left; width: 30%"}
-          .arrowcontainer{style: "float:left"}
-            .arrow{style: "width: 0; height: 0; border-style: solid; border-width: 50px 0 50px 25px; border-color: transparent transparent transparent #7665a0;"}
-          .plane{style: "float:left; padding-top: 14px;"}
-            %img{src: "/images/professional-learning/plane.png", style: "width:100px"}
-        .desktop-feature{style: "float:left; width: 70%"}
-          = buttons
-        .mobile-feature{style: "float:left; width: 100%"}
-          = buttons
-
-      .clear{style: "clear: both"} */
 export default ProfessionalLearningApplyBanner;

--- a/apps/src/templates/ProfessionalLearningApplyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.jsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class ProfessionalLearningApplyBanner extends React.Component {
+  static propTypes = {
+    useSignUpText: PropTypes.bool,
+    nominated: PropTypes.bool
+  };
+
+  state = {
+    link: this.generateLink()
+  };
+
+  styles = {
+    bigBanner: {
+      width: '100%',
+      padding: 5,
+      backgroundColor: '#ebe8f1'
+    },
+
+    textWrapper: {
+      backgroundColor: '#7665a0',
+      minHeight: 100
+    },
+
+    leftArrowContainer: {
+      float: 'left',
+      width: '7%'
+    },
+
+    leftArrow: {
+      width: 0,
+      height: 0,
+      borderStyle: 'solid',
+      borderWidth: '50px 0 50px 25px',
+      borderColor: 'transparent transparent transparent #ebe8f1'
+    },
+
+    textContainer: {
+      float: 'left',
+      width: '93%'
+    },
+
+    text: {
+      color: 'white',
+      fontSize: 16,
+      padding: '25px 10px',
+      textAlign: 'center',
+      lineHeight: 1.5
+    },
+
+    text18Font: {
+      color: 'white',
+      fontSize: 18,
+      padding: '20px 10px',
+      textAlign: 'center',
+      lineHeight: 1.5
+    },
+
+    imageButtonWrapper: {
+      backgroundColor: '#ebe8f1',
+      color: 'white',
+      height: 100,
+      fontSize: 18,
+      textAlign: 'center'
+    },
+
+    desktopFeature: {
+      float: 'left',
+      width: '30%'
+    },
+
+    rightArrowContainer: {
+      float: 'left'
+    },
+
+    rightArrow: {
+      width: 0,
+      height: 0,
+      borderStyle: 'solid',
+      borderWidth: '50px 0 50px 25px',
+      borderColor: 'transparent transparent transparent #7665a0'
+    },
+
+    plane: {
+      float: 'left',
+      paddingTop: 14
+    },
+
+    button: {
+      marginTop: 29,
+      padding: '10px 40px 10px 40px',
+      height: 'initial',
+      marginRight: 30,
+      fontSize: 18
+    },
+
+    image: {
+      width: 100
+    },
+
+    desktopBtnContainer: {
+      float: 'left',
+      width: '70%'
+    },
+
+    mobileBtnContainer: {
+      float: 'left',
+      width: '100%'
+    },
+
+    clear: {
+      clear: 'both'
+    }
+  };
+
+  generateLink() {
+    const link = '/educate/professional-learning/program-information';
+    if (this.props.nominated) {
+      return link + '?nominated=true';
+    } else {
+      return link;
+    }
+  }
+
+  getText() {
+    if (this.props.useSignUpText) {
+      return 'Sign up for Professional Learning! Applications are now open for Middle and High School teachers.';
+    } else if (this.props.nominated) {
+      return 'CONGRATULATIONS! You’ve been nominated for a scholarship!';
+    } else {
+      return 'SEATS OPEN - 2020 Professional Learning for Middle and High School Teachers';
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <a
+          className="linktag"
+          href="/educate/professional-learning/program-information"
+          id="pl-apply-banner"
+        >
+          <div style={this.styles.bigBanner}>
+            <div className="col-50" style={this.styles.textWrapper}>
+              <div
+                className="arrowcontainer desktop-feature"
+                style={this.styles.leftArrowContainer}
+              >
+                <div className="arrow" style={this.styles.leftArrow} />
+              </div>
+              <div className="textcontainer" style={this.styles.textContainer}>
+                <div
+                  className="text"
+                  style={
+                    this.props.useSignUpText
+                      ? this.styles.text
+                      : this.styles.text18Font
+                  }
+                >
+                  {this.getText()}
+                </div>
+              </div>
+            </div>
+            <div className="col-50" style={this.styles.imageButtonWrapper}>
+              <div
+                className="desktop-feature"
+                style={this.styles.desktopFeature}
+              >
+                <div
+                  className="arrowcontainer"
+                  style={this.styles.rightArrowContainer}
+                >
+                  <div className="arrow" style={this.styles.rightArrow} />
+                </div>
+                <div className="plane" style={this.styles.plane}>
+                  <img
+                    src="/images/professional-learning/plane.png"
+                    style={this.styles.image}
+                  />
+                </div>
+              </div>
+              <div
+                className="desktop-feature"
+                style={this.styles.desktopFeature}
+              >
+                <div>
+                  <button type="button" style={this.styles.button}>
+                    Apply Now
+                  </button>
+                </div>
+              </div>
+              <div
+                className="mobile-feature"
+                style={this.styles.mobileBtnContainer}
+              >
+                <div>
+                  <button type="button" style={this.styles.button}>
+                    Apply Now
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div className="clear" style={this.styles.clear} />
+          </div>
+        </a>
+      </div>
+    );
+  }
+}
+
+/**- link = "/educate/professional-learning/program-information"
+- link += "?nominated=true" if params[:nominated]
+- use_sign_up_text ||= false
+- font_size = use_sign_up_text ? '16px' : '18px'
+- padding = use_sign_up_text ? '25px 10px' : '20px 10px'
+
+- buttons = capture_haml do
+  %div
+    %button{style: "margin-top: 29px; padding: 10px 40px 10px 40px; height: initial; margin-right: 30px; font-size: 18px;"}
+      Apply Now
+
+:css
+  .bigbanner p { margin: 0px }
+
+%div
+  %a.linktag#pl-apply-banner{href: link}
+    .bigbanner{style: "width: 100%; padding: 5px; background-color: #ebe8f1"}
+      .col-50{style: "background-color: #7665a0; min-height: 100px;"}
+        .arrowcontainer.desktop-feature{style: "float:left; width: 7%"}
+          .arrow{style: "width: 0; height: 0; border-style: solid; border-width: 50px 0 50px 25px; border-color: transparent transparent transparent #ebe8f1"}
+        .textcontainer{style: "float:left; width: 93%"}
+          .text{style: "color: white;  font-size: #{font_size}; padding: #{padding}; text-align: center; line-height: 1.5"}
+            - if use_sign_up_text
+              Sign up for Professional Learning! Applications are now open for Middle and High School teachers.
+            - elsif params[:nominated]
+              CONGRATULATIONS! You’ve been nominated for a scholarship!
+            - else
+              SEATS OPEN - 2020 Professional Learning for Middle and High School Teachers
+      .col-50{style: "background-color: #ebe8f1; color: white; height: 100px; font-size: 18px; text-align: center"}
+        .desktop-feature{style: "float:left; width: 30%"}
+          .arrowcontainer{style: "float:left"}
+            .arrow{style: "width: 0; height: 0; border-style: solid; border-width: 50px 0 50px 25px; border-color: transparent transparent transparent #7665a0;"}
+          .plane{style: "float:left; padding-top: 14px;"}
+            %img{src: "/images/professional-learning/plane.png", style: "width:100px"}
+        .desktop-feature{style: "float:left; width: 70%"}
+          = buttons
+        .mobile-feature{style: "float:left; width: 100%"}
+          = buttons
+
+      .clear{style: "clear: both"} */
+export default ProfessionalLearningApplyBanner;

--- a/apps/src/templates/census2017/YourSchool.jsx
+++ b/apps/src/templates/census2017/YourSchool.jsx
@@ -13,6 +13,7 @@ import {SpecialAnnouncementActionBlock} from '../studioHomepages/TwoColumnAction
 import i18n from '@cdo/locale';
 import SchoolAutocompleteDropdown from '../SchoolAutocompleteDropdown';
 import CensusMapReplacement from './CensusMapReplacement';
+import ProfessionalLearningApplyBanner from '../ProfessionalLearningApplyBanner';
 
 const styles = {
   heading: {
@@ -119,6 +120,11 @@ class YourSchool extends Component {
           )}
         <h1 style={styles.heading}>{i18n.yourSchoolHeading()}</h1>
         <h3 style={styles.description}>{i18n.yourSchoolDescription()}</h3>
+        <ProfessionalLearningApplyBanner
+          nominated={false}
+          useSignUpText={true}
+        />
+        <br />
         <YourSchoolResources />
         {!this.props.hideMap && (
           <div id="map">

--- a/apps/src/templates/census2017/YourSchool.jsx
+++ b/apps/src/templates/census2017/YourSchool.jsx
@@ -32,6 +32,10 @@ const styles = {
     fontSize: 20,
     marginLeft: 25,
     marginRight: 25
+  },
+
+  banner: {
+    marginBottom: 35
   }
 };
 
@@ -123,8 +127,8 @@ class YourSchool extends Component {
         <ProfessionalLearningApplyBanner
           nominated={false}
           useSignUpText={true}
+          style={styles.banner}
         />
-        <br />
         <YourSchoolResources />
         {!this.props.hideMap && (
           <div id="map">

--- a/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
@@ -1,40 +1,8 @@
-- link = "/educate/professional-learning/program-information"
-- link += "?nominated=true" if params[:nominated]
 - use_sign_up_text ||= false
-- font_size = use_sign_up_text ? '16px' : '18px'
-- padding = use_sign_up_text ? '25px 10px' : '20px 10px'
+- data = {}
+- data[:useSignUpText] = use_sign_up_text
+- data[:nominated] = params[:nominated]
 
-- buttons = capture_haml do
-  %div
-    %button{style: "margin-top: 29px; padding: 10px 40px 10px 40px; height: initial; margin-right: 30px; font-size: 18px;"}
-      Apply Now
+%script{src: webpack_asset_path('js/code.org/views/professional_learning_apply_banner.js'), data: {props: data.to_json}}
 
-:css
-  .bigbanner p { margin: 0px }
-
-%div
-  %a.linktag#pl-apply-banner{href: link}
-    .bigbanner{style: "width: 100%; padding: 5px; background-color: #ebe8f1"}
-      .col-50{style: "background-color: #7665a0; min-height: 100px;"}
-        .arrowcontainer.desktop-feature{style: "float:left; width: 7%"}
-          .arrow{style: "width: 0; height: 0; border-style: solid; border-width: 50px 0 50px 25px; border-color: transparent transparent transparent #ebe8f1"}
-        .textcontainer{style: "float:left; width: 93%"}
-          .text{style: "color: white;  font-size: #{font_size}; padding: #{padding}; text-align: center; line-height: 1.5"}
-            - if use_sign_up_text
-              Sign up for Professional Learning! Applications are now open for Middle and High School teachers.
-            - elsif params[:nominated]
-              CONGRATULATIONS! You’ve been nominated for a scholarship!
-            - else
-              SEATS OPEN - 2020 Professional Learning for Middle and High School Teachers
-      .col-50{style: "background-color: #ebe8f1; color: white; height: 100px; font-size: 18px; text-align: center"}
-        .desktop-feature{style: "float:left; width: 30%"}
-          .arrowcontainer{style: "float:left"}
-            .arrow{style: "width: 0; height: 0; border-style: solid; border-width: 50px 0 50px 25px; border-color: transparent transparent transparent #7665a0;"}
-          .plane{style: "float:left; padding-top: 14px;"}
-            %img{src: "/images/professional-learning/plane.png", style: "width:100px"}
-        .desktop-feature{style: "float:left; width: 70%"}
-          = buttons
-        .mobile-feature{style: "float:left; width: 100%"}
-          = buttons
-
-      .clear{style: "clear: both"}
+#apply-banner-container


### PR DESCRIPTION
# Description
In order to put the Professional Development Apply banner on the /yourschool page we needed to write the banner in React. This PR covers moving the banner implementation to React and adding it to the /yourschool page. This is the last banner specified in this [jira ticket](https://codedotorg.atlassian.net/browse/PLC-656).
The /yourschool page now looks like:
<img width="997" alt="Screen Shot 2020-01-15 at 10 58 07 AM" src="https://user-images.githubusercontent.com/33666587/72463501-39061000-3788-11ea-844d-ebfb491136d6.png">

The other banners have not changed, ex educate/professional-learning/middle-high still looks like:
<img width="1003" alt="Screen Shot 2020-01-15 at 11 15 35 AM" src="https://user-images.githubusercontent.com/33666587/72463569-605cdd00-3788-11ea-991d-b91ae40cba11.png">


## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-656)
- Previous PRs for PD banners: 
    - [32629](https://github.com/code-dot-org/code-dot-org/pull/32629)
    - [32651](https://github.com/code-dot-org/code-dot-org/pull/32651)
    - [32675](https://github.com/code-dot-org/code-dot-org/pull/32675)

## Testing story
Validated new banner looks as expected and existing banners using the same code still look the same (all purple banners). Validated banners at:
- educate/professional-learning/middle-high
- educate/professional-learning/middle-high?nominated=true
- /hourofcode/overview
- educate/curriculum/middle-school
- educate/curriculum/high-school

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
