### PR TITLE
Bump ml-activities to 0.0.24

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -57,7 +57,7 @@
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "1.1.0",
-    "@code-dot-org/ml-activities": "0.0.23",
+    "@code-dot-org/ml-activities": "0.0.24",
     "@code-dot-org/p5.play": "^1.3.12-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1616,10 +1616,10 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-1.1.0.tgz#7c8185adf06a9172e3bde4ccd6f6738a787b2a7c"
 
-"@code-dot-org/ml-activities@0.0.23":
-  version "0.0.23"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.23.tgz#251d714ef2374872ab20038e3221fbd3fc4210b0"
-  integrity sha512-dlb+foyp09Qcqomlztn2AKAt9JoMZ1MPY8fvbKGMantYfdL1HSsv3l6IRyzan5fN+jbKchnOqwov8KGnC3WUlw==
+"@code-dot-org/ml-activities@0.0.24":
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.24.tgz#c9303711a8924ce9eb27f375cd5c14ca9adb570d"
+  integrity sha512-MINYiyW41LsVukCUxw+o00VLlS3OnMkhOd17dEc/hjYAtVApfbGrC1xhxDuU2fqOr0fxOCaRoWEucU5HGXrsdg==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"


### PR DESCRIPTION
# Description

Needed to get https://github.com/code-dot-org/ml-activities/pull/353 in for the i18n pipeline. Other than that PR, the only other commit since v 0.0.23 was documentation.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
