### PR TITLE
Improve formatting when user is not in discount eligibility window

### DIFF
--- a/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/EligibilityChecklist.jsx
@@ -185,11 +185,11 @@ export default class EligibilityChecklist extends React.Component {
         {this.state.statusRedemptionWindow === Status.FAILED &&
           this.state.statusYear === Status.SUCCEEDED &&
           !this.props.adminSetStatus && (
-            <div>
-              {redemptionWindowFail(
+            <SafeMarkdown
+              markdown={redemptionWindowFailMd(
                 this.formattedEligibilityDate(this.state.yearChoice)
               )}
-            </div>
+            />
           )}
         {((this.state.statusYear === Status.SUCCEEDED &&
           this.state.statusRedemptionWindow === Status.SUCCEEDED) ||
@@ -266,11 +266,11 @@ think there has been an error in detecting how much progress your students have 
 2 and 3, please contact us at [teacher@code.org](mailto:teacher@code.org).
 `;
 
-const redemptionWindowFail = eligibilityDate => `
+const redemptionWindowFailMd = eligibilityDate => `
 Thanks for letting us know your plans! It appears that you qualify for the
 subsidized Circuit Playground classroom kit, but we’re not able to provide the
-hardware until the semester you plan to teach Unit 6. To receive your subsidized
-classroom kit, please visit this page again anytime after ${eligibilityDate}.
-The final date to request your subsidized kit is April 30, 2021. For any
-questions or concerns, please contact us at teacher@code.org.
+hardware until the semester you plan to teach Unit 6. **To receive your subsidized
+classroom kit, please visit this page again anytime after ${eligibilityDate}.**
+The final date to request your subsidized kit is **April 30, 2021**. For any
+questions or concerns, please contact us at [teacher@code.org](mailto:teacher@code.org).
 `;


### PR DESCRIPTION
## Description

Improves formatting of message shown to teachers who are not yet in discount eligibility window.

Before:

![image](https://user-images.githubusercontent.com/25372625/72550279-3a4a4200-3847-11ea-9f75-d2145bd74bbc.png)

After (change is in message at bottom of image):

![image](https://user-images.githubusercontent.com/25372625/72478331-91e4a100-37a6-11ea-9b0b-f6c07890bd6e.png)