### PR TITLE
[Sprite Lab] Fix syntax error with location generated code

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -90,7 +90,7 @@ const customInputTypes = {
       currentInputRow.appendTitle(button, inputConfig.name);
     },
     generateCode(block, arg) {
-      return block.getTitleValue(arg.name);
+      return `(${block.getTitleValue(arg.name)})`;
     }
   },
   locationVariableDropdown: {


### PR DESCRIPTION
# Description
The location picker block generates a JSON object of the form `"{"x": 200, "y": 200}"`, which is fine if it's connected to something, so you get like `makeNewSprite("purple bunny", {"x": 200, "y": 200})`
However, if the block is on its own and *not* inactive, it causes a syntax error. Usually, disconnected blocks are commented out in the generated code. However, there's an existing [Blockly Issue](https://github.com/code-dot-org/blockly/issues/132) where blocks that are bumped out are not marked inactive. 
By wrapping the generated code in parentheses, we avoid this issue, because `({"x": 200, "y": 200});` is a valid JS statement while `{"x": 200, "y": 200};` is not
![image](https://user-images.githubusercontent.com/8787187/72483006-6963a380-37b4-11ea-8e95-294e1da325ca.png)


Before:
![image](https://user-images.githubusercontent.com/8787187/72482918-2275ae00-37b4-11ea-8dc7-7c0644de9999.png)
![image](https://user-images.githubusercontent.com/8787187/72482952-37524180-37b4-11ea-8e6b-e6e0bda43ad9.png)


After:
![image](https://user-images.githubusercontent.com/8787187/72482933-2dc8d980-37b4-11ea-9ec7-d1eb1c414fa9.png)
(No syntax error)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/STAR-401)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
