### PR TITLE
Removing bonus points from teacher application

### DIFF
--- a/dashboard/app/models/pd/application/teacher2021_application.rb
+++ b/dashboard/app/models/pd/application/teacher2021_application.rb
@@ -740,16 +740,14 @@ module Pd::Application
 
       meets_minimum_criteria_scores = {}
       meets_scholarship_criteria_scores = {}
-      bonus_points_scores = {}
 
       # Section 2
       if course == 'csd'
-        meets_minimum_criteria_scores[:csd_which_grades] = (responses[:csd_which_grades] & options[:csd_which_grades].first(5)).any? ? YES : NO
-
+        meets_minimum_criteria_scores[:csd_which_grades] =
+          (responses[:csd_which_grades] & options[:csd_which_grades].first(5)).any? ? YES : NO
       elsif course == 'csp'
-        meets_minimum_criteria_scores[:csp_which_grades] = (responses[:csp_which_grades] & options[:csp_which_grades].first(4)).any? ? YES : NO
-
-        bonus_points_scores[:csp_how_offer] = responses[:csp_how_offer].in?(options[:csp_how_offer].last(2)) ? 2 : 0
+        meets_minimum_criteria_scores[:csp_which_grades] =
+          (responses[:csp_which_grades] & options[:csp_which_grades].first(4)).any? ? YES : NO
       end
 
       if responses[:plan_to_teach].in? options[:plan_to_teach].first(4)
@@ -778,9 +776,6 @@ module Pd::Application
 
       # Section 4
       meets_minimum_criteria_scores[:committed] = responses[:committed] == options[:committed].first ? YES : NO
-
-      # Section 5
-      bonus_points_scores[:race] = ((responses[:race] || []) & (options[:race].values_at(1, 2, 4, 5))).any? ? 2 : 0
 
       # Principal Approval
       if responses[:principal_approval]
@@ -836,7 +831,6 @@ module Pd::Application
           {
             meets_minimum_criteria_scores: meets_minimum_criteria_scores,
             meets_scholarship_criteria_scores: meets_scholarship_criteria_scores,
-            bonus_points_scores: bonus_points_scores
           }
         ) {|key, old, new| key == :replace_existing ? new : old}.to_json
       )
@@ -877,7 +871,7 @@ module Pd::Application
 
     # @override
     def total_score
-      (response_scores_hash[:bonus_points_scores] || {}).values.map(&:to_i).reduce(:+) || 0
+      0
     end
 
     # @override
@@ -963,7 +957,6 @@ module Pd::Application
       {
         meets_minimum_criteria_scores: {},
         meets_scholarship_criteria_scores: {},
-        bonus_points_scores: {}
       }
     end
   end

--- a/dashboard/test/models/pd/application/teacher2021_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher2021_application_test.rb
@@ -526,9 +526,6 @@ module Pd::Application
             free_lunch_percent: YES,
             underrepresented_minority_percent: YES,
           },
-          bonus_points_scores: {
-            race: 2,
-          },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
       )
@@ -572,10 +569,6 @@ module Pd::Application
             free_lunch_percent: YES,
             underrepresented_minority_percent: YES,
           },
-          bonus_points_scores: {
-            csp_how_offer: 2,
-            race: 2,
-          },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
       )
@@ -607,10 +600,6 @@ module Pd::Application
             replace_existing: YES,
           },
           meets_scholarship_criteria_scores: {},
-          bonus_points_scores: {
-            csp_how_offer: 2,
-            race: 2
-          },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
       )
@@ -653,9 +642,6 @@ module Pd::Application
             free_lunch_percent: NO,
             underrepresented_minority_percent: NO,
           },
-          bonus_points_scores: {
-            race: 0,
-          },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)
       )
@@ -697,10 +683,6 @@ module Pd::Application
           meets_scholarship_criteria_scores: {
             free_lunch_percent: NO,
             underrepresented_minority_percent: NO,
-          },
-          bonus_points_scores: {
-            csp_how_offer: 0,
-            race: 0,
           },
         }.deep_stringify_keys,
         JSON.parse(application.response_scores)

--- a/lib/cdo/shared_constants/pd/teacher2021_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher2021_application_constants.rb
@@ -264,19 +264,10 @@ module Pd
       # Scholarship requirements
       free_lunch_percent: YES_NO,
       underrepresented_minority_percent: YES_NO,
-      # Bonus Points
-      csp_how_offer: [2, 0],
-      race: [2, 0]
     }
 
     # Need to explicitly list these for the shared constant generation to work.
     SCOREABLE_QUESTIONS = {
-      bonus_points: [
-        :csp_how_offer,
-        :free_lunch_percent,
-        :underrepresented_minority_percent,
-        :race,
-      ],
       scholarship_questions: [
         :underrepresented_minority_percent,
         :free_lunch_percent,


### PR DESCRIPTION
# Description
Bonus points are no longer part of the 20-21 rubric. We had removed them from application detail view but still calculate them on the server side. This change will remove bonus points from server-side teacher 20-21 application code. 

This change doesn't remove `bonus_points` and `total_score` in [application_serializer.rb](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/serializers/api/v1/pd/application_serializer.rb) and [detail_view_content.jsx](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx) because the code are shared among multiple application years and application types (teacher or facilitator).


## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-507)

## Testing story
- Manual test
  - Creates a teacher application at `http://localhost-studio.code.org:3000/pd/application/teacher`. Then verifies that application is displayed correctly in detail view `https://studio.code.org/pd/application_dashboard/csd_teachers/<application_id>`

- Automated tests
  - Unit tests
    - bundle exec rails test test/models/pd/application/teacher2021_application_test.rb
    - bundle exec rails test test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
    - bundle exec rails test test/controllers/api/v1/pd/applications_controller_test.rb
    - bundle exec rails test test/serializers/api/v1/pd/application_serializer_test.rb
  - Eyes test
    - ./runner.rb -d localhost-studio.code.org:3000 --html --eyes -c Chrome -f features/pd/teacher_application_dashboard.feature
    - ./runner.rb -d localhost-studio.code.org:3000 --html --eyes -c Chrome -f features/pd/teacher_application.feature

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
