### PR TITLE
let partners edit scripts they own which have pilot experiments

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1666,6 +1666,9 @@ class Script < ActiveRecord::Base
     return false unless pilot? && user
     return true if user.permission?(UserPermission::LEVELBUILDER)
     return true if has_pilot_experiment?(user)
+    # a platformization partner should be able to view pilot scripts which they
+    # own, even if they are not in the pilot experiment.
+    return true if has_editor_experiment?(user)
 
     # A user without the experiment has pilot script access if
     # (1) they have been assigned to or have progress in the pilot script, and
@@ -1686,6 +1689,13 @@ class Script < ActiveRecord::Base
     return false unless user&.teacher?
     return true if user.permission?(UserPermission::LEVELBUILDER)
     all_scripts.any? {|script| script.has_pilot_experiment?(user)}
+  end
+
+  # If a user is in the editor experiment of this script, that indicates that
+  # they are a platformization partner who owns this script.
+  def has_editor_experiment?(user)
+    return false unless editor_experiment
+    SingleUserExperiment.enabled?(user: user, experiment_name: editor_experiment)
   end
 
   def self.get_version_year_options

--- a/dashboard/config/scripts/time4cs-experiment-unit-2.script
+++ b/dashboard/config/scripts/time4cs-experiment-unit-2.script
@@ -1,5 +1,6 @@
 login_required true
 hideable_stages true
+pilot_experiment 'time4cs-experiment'
 editor_experiment 'broward'
 
 stage 'Introduction to the Problem', flex_category: 'time4cs_c1'

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1760,6 +1760,42 @@ endvariants
     assert Script.has_any_pilot_access?(levelbuilder)
   end
 
+  test 'platformization partner has pilot access' do
+    script = create :script
+    partner_pilot_script = create :script, pilot_experiment: 'my-experiment', editor_experiment: 'ed-experiment'
+
+    student = create :student
+    teacher = create :teacher
+    partner = create :teacher, editor_experiment: 'ed-experiment'
+
+    refute script.has_pilot_access?
+    refute script.has_pilot_access?(student)
+    refute script.has_pilot_access?(teacher)
+    refute script.has_pilot_access?(partner)
+
+    refute partner_pilot_script.has_pilot_access?
+    refute partner_pilot_script.has_pilot_access?(student)
+    refute partner_pilot_script.has_pilot_access?(teacher)
+    assert partner_pilot_script.has_pilot_access?(partner)
+  end
+
+  test 'platformization partner has editor experiment' do
+    script = create :script
+    partner_script = create :script, editor_experiment: 'ed-experiment'
+
+    student = create :student
+    teacher = create :teacher
+    partner = create :teacher, editor_experiment: 'ed-experiment'
+
+    refute script.has_editor_experiment?(student)
+    refute script.has_editor_experiment?(teacher)
+    refute script.has_editor_experiment?(partner)
+
+    refute partner_script.has_editor_experiment?(student)
+    refute partner_script.has_editor_experiment?(teacher)
+    assert partner_script.has_editor_experiment?(partner)
+  end
+
   test "script_names_by_curriculum_umbrella returns the correct script names" do
     assert_equal(
       [@csf_script.name],


### PR DESCRIPTION
# Description

Fixes https://codedotorg.atlassian.net/browse/LP-1080, which contains some explanation of the problem.

## Testing story

Manually verified that when a script has an editor experiment and a pilot experiment, that a user in that editor experiment (but not the pilot experiment) can view and edit that script. Also added unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
