### PR TITLE
Avoid pixelation data loss

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1230,6 +1230,9 @@ var projects = (module.exports = {
     this.logError_(errorType, errorCount, errorText);
   },
   logError_: function(errorType, errorCount, errorText) {
+    // Share URLs only make sense for standalone app types.
+    const shareUrl = this.getStandaloneApp() ? this.getShareUrl() : '';
+
     firehoseClient.putRecord(
       {
         study: 'project-data-integrity',
@@ -1246,7 +1249,7 @@ var projects = (module.exports = {
           errorText: errorText,
           isOwner: this.isOwner(),
           currentUrl: window.location.href,
-          shareUrl: this.getShareUrl(),
+          shareUrl: shareUrl,
           currentSourceVersionId: currentSourceVersionId
         })
       },

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1527,13 +1527,17 @@ var projects = (module.exports = {
           } else {
             this.fetchSource(
               data,
-              () => {
-                if (current.isOwner && pathInfo.action === 'view') {
-                  isEditing = true;
+              err => {
+                if (err) {
+                  deferred.reject();
+                } else {
+                  if (current.isOwner && pathInfo.action === 'view') {
+                    isEditing = true;
+                  }
+                  fetchAbuseScoreAndPrivacyViolations(this, function() {
+                    deferred.resolve();
+                  });
                 }
-                fetchAbuseScoreAndPrivacyViolations(this, function() {
-                  deferred.resolve();
-                });
               },
               queryParams('version'),
               sourcesApi
@@ -1552,11 +1556,15 @@ var projects = (module.exports = {
         } else {
           this.fetchSource(
             data,
-            () => {
-              projects.showHeaderForProjectBacked();
-              fetchAbuseScoreAndPrivacyViolations(this, function() {
-                deferred.resolve();
-              });
+            err => {
+              if (err) {
+                deferred.reject();
+              } else {
+                projects.showHeaderForProjectBacked();
+                fetchAbuseScoreAndPrivacyViolations(this, function() {
+                  deferred.resolve();
+                });
+              }
             },
             queryParams('version'),
             sourcesApi
@@ -1684,12 +1692,9 @@ var projects = (module.exports = {
             null,
             `unable to fetch project source file: ${err}`
           );
-          console.warn();
-          data = {
-            source: '',
-            html: '',
-            animations: ''
-          };
+          console.warn(err);
+          callback(err);
+          return;
         }
         currentSourceVersionId =
           jqXHR && jqXHR.getResponseHeader('S3-Version-Id');

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1231,6 +1231,7 @@ var projects = (module.exports = {
   },
   logError_: function(errorType, errorCount, errorText) {
     // Share URLs only make sense for standalone app types.
+    // This includes most app types, but excludes pixelation.
     const shareUrl = this.getStandaloneApp() ? this.getShareUrl() : '';
 
     firehoseClient.putRecord(

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1018,14 +1018,14 @@ var projects = (module.exports = {
                 saveSourcesErrorCount,
                 err.message
               );
-              window.location.reload();
+              utils.reload();
             } else if (err.message.includes('httpStatusCode: 409')) {
               this.showSaveError_(
                 'conflict-save-sources-reload',
                 saveSourcesErrorCount,
                 err.message
               );
-              window.location.reload();
+              utils.reload();
             } else {
               saveSourcesErrorCount++;
               this.showSaveError_(
@@ -1522,11 +1522,22 @@ var projects = (module.exports = {
         // Load the project ID, if one exists
         channels.fetch(pathInfo.channelId, (err, data) => {
           if (err) {
-            // Project not found, redirect to the new project experience.
-            location.href = location.pathname
-              .split('/')
-              .slice(PathPart.START, PathPart.APP + 1)
-              .join('/');
+            if (err.message.includes('error: Not Found')) {
+              // Project not found. Redirect to the most recent project of this
+              // type, or a new project of this type if none exists.
+              const newPath = utils
+                .currentLocation()
+                .pathname.split('/')
+                .slice(PathPart.START, PathPart.APP + 1)
+                .join('/');
+              utils.navigateToHref(newPath);
+              if (IN_UNIT_TEST) {
+                // Allow unit test to confirm that navigation has happened.
+                deferred.resolve();
+              }
+            } else {
+              deferred.reject();
+            }
           } else {
             this.fetchSource(
               data,
@@ -1897,12 +1908,12 @@ function redirectFromHashUrl() {
  * that we may have hash based route or not
  */
 function parsePath() {
-  var pathname = location.pathname;
+  var pathname = utils.currentLocation().pathname;
 
   // We have a hash based route. Replace the hash with a slash, and append to
   // our existing path
-  if (location.hash) {
-    pathname += location.hash.replace('#', '/');
+  if (utils.currentLocation().hash) {
+    pathname += utils.currentLocation().hash.replace('#', '/');
   }
 
   var tokens = pathname.split('/');
@@ -1926,7 +1937,7 @@ function parsePath() {
   // embed url. Since a lot of our javascript depends on having the decoded channel
   // id, we do that here when parsing the page's path.
   let channelId = tokens[PathPart.CHANNEL_ID];
-  if (location.search.indexOf('nosource') >= 0) {
+  if (utils.currentLocation().search.indexOf('nosource') >= 0) {
     channelId = channelId
       .split('')
       .map(char => ALPHABET[CIPHER.indexOf(char)] || char)

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -17,12 +17,14 @@ describe('project.js', () => {
     sourceHandler = createStubSourceHandler();
     replaceAppOptions();
     sinon.stub(utils, 'reload');
+    sinon.stub(header, 'showProjectHeader');
     sinon.stub(header, 'showMinimalProjectHeader');
     sinon.stub(header, 'updateTimestamp');
   });
 
   afterEach(() => {
     utils.reload.restore();
+    header.showProjectHeader.restore();
     header.showMinimalProjectHeader.restore();
     header.updateTimestamp.restore();
     restoreAppOptions();
@@ -663,8 +665,6 @@ describe('project.js', () => {
 
     beforeEach(() => {
       window.appOptions.channel = 'mychannel';
-      window.dashboard = window.dashboard || {};
-      window.dashboard = {project};
       sinon.stub(utils, 'currentLocation').returns({
         pathname: '/projects/artist/mychannel',
         search: ''

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -658,6 +658,103 @@ describe('project.js', () => {
     });
   });
 
+  describe('load', () => {
+    let server;
+
+    beforeEach(() => {
+      window.appOptions.channel = 'mychannel';
+      window.dashboard = window.dashboard || {};
+      window.dashboard = {project};
+      sinon.stub(utils, 'currentLocation').returns({
+        pathname: '/projects/artist/mychannel',
+        search: ''
+      });
+      sinon.stub(project, 'getStandaloneApp').returns('artist');
+      server = sinon.createFakeServer({autoRespond: true});
+      project.init(sourceHandler);
+      sinon.stub(console, 'warn');
+    });
+
+    afterEach(() => {
+      server.restore();
+      project.getStandaloneApp.restore();
+      utils.currentLocation.restore();
+      console.warn.restore();
+    });
+
+    describe('standalone project', () => {
+      beforeEach(() => {
+        sinon.stub(utils, 'navigateToHref');
+      });
+
+      afterEach(() => {
+        utils.navigateToHref.restore();
+      });
+
+      it('succeeds when ajax requests succeed', done => {
+        stubGetChannels(server);
+        stubGetMainJson(server);
+        project.load().then(() => {
+          expect(utils.navigateToHref).not.to.have.been.called;
+          done();
+        });
+      });
+
+      it('redirects to new project when channel not found', done => {
+        project.load().then(() => {
+          expect(utils.navigateToHref).to.have.been.calledOnce;
+          expect(utils.navigateToHref.firstCall.args[0]).to.equal(
+            '/projects/artist'
+          );
+          done();
+        });
+      });
+
+      it('fails when channels request fails', done => {
+        stubGetChannelsWithError(server);
+        project.load().fail(done);
+      });
+
+      it('fails when sources request fails', done => {
+        stubGetChannels(server);
+        stubGetMainJsonWithError(server);
+        project.load().fail(done);
+      });
+    });
+
+    describe('project-backed level', () => {
+      beforeEach(() => {
+        // This was stubbed at the top level in this file, so unstub it here
+        window.appOptions.level.isProjectLevel = false;
+      });
+
+      it('succeeds when ajax requests succeed', done => {
+        stubGetChannels(server);
+        stubGetMainJson(server);
+        project.load().then(done);
+      });
+
+      it('fails when channels request fails', done => {
+        stubGetChannelsWithError(server);
+        project.load().fail(done);
+      });
+
+      it('fails when sources request fails', done => {
+        stubGetChannels(server);
+        stubGetMainJsonWithError(server);
+        project.load().fail(done);
+      });
+    });
+
+    describe('no channel', () => {
+      it('always succeeds', done => {
+        window.appOptions.level.isProjectLevel = false;
+        window.appOptions.channel = null;
+        project.load().then(done);
+      });
+    });
+  });
+
   describe('serverSideRemix()', () => {
     let server;
 
@@ -821,6 +918,34 @@ function restoreAppOptions() {
   restoreOnWindow('appOptions');
 }
 
+function stubGetChannelsWithError(server) {
+  server.respondWith('GET', /\/v3\/channels\/.*/, xhr => {
+    xhr.error();
+  });
+}
+
+function stubGetChannels(server) {
+  server.respondWith('GET', /\/v3\/channels\/.*/, xhr => {
+    xhr.respond(
+      200,
+      {
+        'Content-Type': 'application/json'
+      },
+      JSON.stringify({
+        createdAt: '2018-10-22T21:59:43.000-07:00',
+        updatedAt: '2018-10-22T21:59:45.000-07:00',
+        isOwner: true,
+        publishedAt: null,
+        level: '/projects/artist',
+        migratedToS3: true,
+        name: 'artist project',
+        id: 'kmz3weHzTpZTbRWrHRzMJA',
+        projectType: 'artist'
+      })
+    );
+  });
+}
+
 function stubPostChannels(server) {
   server.respondWith('POST', /\/v3\/channels/, xhr => {
     xhr.respond(
@@ -841,6 +966,30 @@ function stubPostChannels(server) {
       })
     );
   });
+}
+
+function stubGetMainJson(server) {
+  server.respondWith('GET', /\/v3\/sources\/.*\/main\.json/, xhr => {
+    xhr.respond(
+      200,
+      {
+        'Content-Type': 'application/json'
+      },
+      JSON.stringify({
+        filename: 'main.json',
+        category: 'json',
+        size: 0,
+        versionId: 12345,
+        timestamp: Date.now()
+      })
+    );
+  });
+}
+
+function stubGetMainJsonWithError(server) {
+  server.respondWith('GET', /\/v3\/sources\/.*\/main\.json/, xhr =>
+    xhr.error()
+  );
 }
 
 function stubPutMainJson(server) {

--- a/dashboard/public/pixelation/pixelation.html
+++ b/dashboard/public/pixelation/pixelation.html
@@ -22,25 +22,25 @@
       <td>
         <label for="width">Image width:</label>
       </td><td>
-      <input type="number" min="1" max="255" value="10" id="width" oninput="setSliders();" onchange="setMinTextValues();">
+      <input type="number" min="1" max="255" value="10" id="width" oninput="setSliders();" onchange="setMinTextValues();" disabled>
     </td><td class="hide_on_v2">
-      <input type="range" min="1" max="255" value="10" id="widthRange" oninput="changeVal('width');" onchange="changeVal('width');" class="rangeInput">
+      <input type="range" min="1" max="255" value="10" id="widthRange" oninput="changeVal('width');" onchange="changeVal('width');" class="rangeInput" disabled>
     </td>
     </tr><tr>
     <td>
       <label for="height">Image height:</label>
     </td><td>
-    <input type="number" min="1" max="255" value="10" id="height" oninput="setSliders();" onchange="setMinTextValues();">
+    <input type="number" min="1" max="255" value="10" id="height" oninput="setSliders();" onchange="setMinTextValues();" disabled>
   </td><td class="hide_on_v2">
-    <input type="range" min="1" max="255" value="10" id="heightRange" oninput="changeVal('height');" onchange="changeVal('width');" class="rangeInput">
+    <input type="range" min="1" max="255" value="10" id="heightRange" oninput="changeVal('height');" onchange="changeVal('width');" class="rangeInput" disabled>
   </td>
   </tr><tr class="hide_on_v1 hide_on_v2">
     <td>
       <label for="bitsPerPixel">Bits per pixel:</label>
     </td><td>
-    <input type="number" min="1" max="24" id="bitsPerPixel" value="1" oninput="setSliders();" onchange="setMinTextValues();">
+    <input type="number" min="1" max="24" id="bitsPerPixel" value="1" oninput="setSliders();" onchange="setMinTextValues();" disabled>
   </td><td>
-    <input type=range id="bitsPerPixelSlider" min="1" max="24" oninput="changeVal('bitsPerPixel')" onchange="changeVal('width');" class="rangeInput">
+    <input type=range id="bitsPerPixelSlider" min="1" max="24" oninput="changeVal('bitsPerPixel')" onchange="changeVal('width');" class="rangeInput" disabled>
   </td>
   </tr>
   </table>
@@ -49,10 +49,10 @@
   </label>
   <div class="label_group encoding_controls">
     <label>Binary:
-      <input type="radio" name="binHex" value="bin" checked="checked" onchange="hexToBin(); drawGraph();">
+      <input id="hex_to_bin" type="radio" name="binHex" value="bin" checked="checked" onchange="hexToBin(); drawGraph();" disabled>
     </label>
     <label>Hexadecimal:
-      <input type="radio" name="binHex" value="hex" onchange="binToHex(); drawGraph();">
+      <input id="bin_to_hex" type="radio" name="binHex" value="hex" onchange="binToHex(); drawGraph();" disabled>
     </label>
   </div>
 </div>
@@ -63,9 +63,9 @@
   </div>
   <div id="belowVisualization">
     <label id="actual_size_label" class="right">Actual size:
-      <input type="checkbox" id="actual_size" onchange="drawGraph();">
+      <input type="checkbox" id="actual_size" onchange="drawGraph();" disabled>
     </label>
-    <button id="save_image" class="btn" onclick="showPNG();">Save Image</button>
+    <button id="save_image" class="btn" onclick="showPNG();" disabled>Save Image</button>
     <div id="bubble">
       <p id="below_viz_instructions" style="display: none;"></p>
     </div>
@@ -73,15 +73,15 @@
   <div id="reference_area_target"></div>
 </div>
 <div id="visualizationEditor" class="responsive">
-  <textarea id="pixel_data" oninput="drawGraph(null, false, true);" autocapitalize="false" autocorrect="false" autocomplete="false" spellcheck="false"></textarea>
+  <textarea id="pixel_data" oninput="drawGraph(null, false, true);" autocapitalize="false" autocorrect="false" autocomplete="false" spellcheck="false" disabled></textarea>
   <!--[if IE 9]>
   <script>
     document.getElementById('pixel_data').onkeyup = drawGraph.bind(null, null, false, true);
   </script>
   <![endif]-->
-  <button class="btn" onclick="formatBitDisplay();" title="View bits separated by pixel">Readable format</button>
-  <button class="btn" onclick="unformatBits();"  title="View bits without any formatting">Raw format</button>
-  <button id="start_over" class="btn btn-danger" onclick="startOverClicked();">Start Over</button>
-  <button id="finished" class="btn btn-primary right" onclick="onFinishedButtonClick();">Finished! Continue to next stage</button>
+  <button id="readable_format" class="btn" onclick="formatBitDisplay();" title="View bits separated by pixel" disabled>Readable format</button>
+  <button id="raw_format" class="btn" onclick="unformatBits();"  title="View bits without any formatting" disabled>Raw format</button>
+  <button id="start_over" class="btn btn-danger" onclick="startOverClicked();" disabled>Start Over</button>
+  <button id="finished" class="btn btn-primary right" onclick="onFinishedButtonClick();" disabled>Finished! Continue to next stage</button>
 </div>
 <script type="text/javascript" src="/pixelation/pixelation.js"></script>

--- a/dashboard/public/pixelation/pixelation.js
+++ b/dashboard/public/pixelation/pixelation.js
@@ -69,8 +69,8 @@ function customizeStyles() {
     $(".hide_on_v1").hide();
 
     // Default initial width and height (only available to widget v1)
-    const initialWidth = parseInt(options.v1InitialWidth, 10);
-    const initialHeight = parseInt(options.v1InitialHeight, 10);
+    var initialWidth = parseInt(options.v1InitialWidth, 10);
+    var initialHeight = parseInt(options.v1InitialHeight, 10);
     if (!isNaN(initialWidth)) {
       $("#width").val(initialWidth);
     }
@@ -178,18 +178,26 @@ function initProjects() {
     dashboard.project
       .load()
       .then(function() {
-        // Only enable saving if the initial load succeeds. This means new work
-        // will not be saved, but old work will not be erased and may become
-        // available by refreshing the page.
+        // Only enable saving if the initial load succeeds. This ensures that
+        // any previous work will not be erased if the initial load fails.
         options.saveProject = dashboard.project.save.bind(dashboard.project);
         options.projectChanged = dashboard.project.projectChanged;
         window.dashboard.project.init(sourceHandler);
 
         // Complete project initialization sequence.
         $(document).trigger("appInitialized");
-      })
-      .always(function() {
+
+        // Only enable UI controls if the initial load succeeds. This ensures
+        // the user cannot create any work which we are then unable to save if
+        // the initial load fails.
+        enableUiControls();
+
         pixelationDisplay();
+      })
+      .fail(function() {
+        window.alert(
+          "the pixelation level failed to load. Please reload the page to try again."
+        );
       });
   } else {
     pixelationDisplay();
@@ -703,6 +711,31 @@ function startOverConfirmed() {
   pixel_data.value = options.data;
   drawGraph(null, false, true);
   formatBitDisplay();
+}
+
+var UI_CONTROL_IDS = [
+  "width",
+  "widthRange",
+  "height",
+  "heightRange",
+  "bitsPerPixel",
+  "bitsPerPixelSlider",
+  "hex_to_bin",
+  "bin_to_hex",
+  "actual_size",
+  "save_image",
+  "pixel_data",
+  "readable_format",
+  "raw_format",
+  "start_over",
+  "finished"
+];
+
+function enableUiControls() {
+  UI_CONTROL_IDS.forEach(function(id) {
+    var el = document.getElementById(id);
+    el.removeAttribute("disabled");
+  });
 }
 
 pixelationInit();


### PR DESCRIPTION
## Background

Finishes https://codedotorg.atlassian.net/browse/LP-1119 . The problem is summarized in the following comment: https://github.com/code-dot-org/code-dot-org/blob/1b99af282ef6089b68f3ddd45fadbc6c09dde9f3/dashboard/public/pixelation/pixelation.js#L181-L183

There were two parts to the problem:
1. when project.load() fails, we let the user keep working on their pixelation level even though we won't be able to save it
2. when we fail to load source code, project.load() sometimes reports success anyway

It is possible that the second part of the problem may cause data loss on other app types, although in that scenario, the user should be able to recover any lost work using version history.

## Description

This PR does the following:

1. disable pixelation UI controls if project load fails

| enabled | disabled |
|---|---|
| ![Screen Shot 2020-01-22 at 11 58 55 PM](https://user-images.githubusercontent.com/8001765/72966357-9ba47080-3d73-11ea-861c-3aa145c8b839.png) | ![Screen Shot 2020-01-23 at 12 01 11 AM](https://user-images.githubusercontent.com/8001765/72966379-a6f79c00-3d73-11ea-9ff1-f2a0fa19a2a1.png) |

2. make sure `project.load()` resolves, rejects, or redirects correctly based on the responses of the ajax requests for the channel info and source code

## Side effects
1. when channels or source code fails to load for a non-pixelation level, we'll now show the loading spinner forever. this isn't ideal, but it's better than the previous behavior where we silently dropped the source code, forcing the user to find it in version history if they want to recover it.
![Screen Shot 2020-01-23 at 12 03 35 AM](https://user-images.githubusercontent.com/8001765/72966459-e3c39300-3d73-11ea-99e2-87acbaf9acf9.png)

2. we now fail `project.load()` when channel fails to load for a standalone project, when the error code is anything besides a 404

## Testing story
* added unit tests for project.load()
* manually verified that pixelation UI controls are disabled when either channels or sources fail to load
* manually verified the loading spinner shows forever when loading a standalone applab project and either channels or sources fails to load

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
