### PR TITLE
Fix PD banner URLs

### DIFF
--- a/apps/src/templates/ProfessionalLearningApplyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.jsx
@@ -5,11 +5,8 @@ class ProfessionalLearningApplyBanner extends React.Component {
   static propTypes = {
     useSignUpText: PropTypes.bool,
     nominated: PropTypes.bool,
-    style: PropTypes.object
-  };
-
-  state = {
-    link: this.generateLink()
+    style: PropTypes.object,
+    linkSuffix: PropTypes.string
   };
 
   styles = {
@@ -116,7 +113,10 @@ class ProfessionalLearningApplyBanner extends React.Component {
   };
 
   generateLink() {
-    const link = '/educate/professional-learning/program-information';
+    let link = '/educate/professional-learning';
+    if (this.props.linkSuffix) {
+      link = `${link}/${this.props.linkSuffix}`;
+    }
     if (this.props.nominated) {
       return link + '?nominated=true';
     } else {
@@ -137,7 +137,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
   render() {
     return (
       <div style={this.props.style}>
-        <a href={this.state.link} id="pl-apply-banner">
+        <a href={this.generateLink()} id="pl-apply-banner">
           <div style={this.styles.bigBanner}>
             <div className="col-50" style={this.styles.textWrapper}>
               <div

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
@@ -15,7 +15,7 @@ For high schools, we offer two years computer science courses for beginners:  Co
 Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values).
 
 <br>
-<%= view :professional_learning_apply_banner, :use_sign_up_text => true %>
+<%= view :professional_learning_apply_banner, :use_sign_up_text => true, :link_suffix => "middle-high" %>
 
 <hr>
 

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
@@ -13,7 +13,7 @@ Middle School
 Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values).
 
 <br>
-<%= view :professional_learning_apply_banner, :use_sign_up_text => true %>
+<%= view :professional_learning_apply_banner, :use_sign_up_text => true, :link_suffix => "middle-high" %>
 
 <hr>
 

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md.erb
@@ -32,7 +32,7 @@ theme: responsive
 [optimizely-original]
 
 # Professional Learning for Middle and High School
-<%= view :professional_learning_apply_banner %>
+<%= view :professional_learning_apply_banner, :link_suffix => "program-information" %>
 <br/>
 
 <a name="scholarships"></a>

--- a/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
@@ -2,7 +2,7 @@
   = inline_css 'homepage_below_hero_plane_banner.css'
 
   .homepage-professional-learning-banner
-    %a.linktag#pl-2019{href: "/educate/professional-learning/middle-high"}
+    %a.linktag#pl-2019{href: "/educate/professional-learning"}
       .nonphone.col-80.tablet-feature
         .left.col-80.animateSlideInFromLeft
           .banner

--- a/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
@@ -1,7 +1,9 @@
 - use_sign_up_text ||= false
+- link_suffix ||= nil
 - data = {}
 - data[:useSignUpText] = use_sign_up_text
 - data[:nominated] = params[:nominated]
+- data[:linkSuffix] = link_suffix
 
 %script{src: webpack_asset_path('js/code.org/views/professional_learning_apply_banner.js'), data: {props: data.to_json}}
 


### PR DESCRIPTION
# Description
Professional Development recruitment banners had incorrect URLs. Added a field to specify the suffix after https://code.org/educate/professional-learning for all purple banners to make generic banner more flexible.
Banners now link to:
- homepage: /educate/professional-learning
- middle-high: /educate/professional-learning/program-information (no change)
- /curriculum/middle-school: /educate/professional-learning/middle-high
- /curriculum/high-school:/educate/professional-learning/middle-high
- /hourofcode/overview: /educate/professional-learning
- /yourschool: /educate/professional-learning

## Links

- [spec](https://docs.google.com/document/d/1QUcJ_5rfybmM3l641bklBUUdJZ5wAQU--r8smq9ar1Y/edit?ts=5e1f6bcc#heading=h.bhpsamr7j01m)
- [jira for bug](https://codedotorg.atlassian.net/browse/PLC-700)
- [initial jira ticket](https://codedotorg.atlassian.net/browse/PLC-656)

## Testing story
Validated all banners now link to the correct pages.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
