### PR TITLE
Teacher Application Export: Squash Honeybadger error

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -5,6 +5,16 @@ exit unless only_one_running?(__FILE__)
 require_relative '../../dashboard/config/environment'
 require 'cdo/google_drive'
 
+# Squash an unhelpful warning that's causing a Honeybadger error
+# see https://github.com/nahi/httpclient/issues/252#issuecomment-302427338
+class WebAgent
+  class Cookie < HTTP::Cookie
+    def domain
+      original_domain
+    end
+  end
+end
+
 #
 # Uses a Google Cloud service account to write teacher application data for this year into
 # a spreadsheet in Google Drive (with permissions locked down to our organization) for exploration


### PR DESCRIPTION
The [`teacher_application_to_gdrive` task](https://github.com/code-dot-org/code-dot-org/pull/32383) is generating [a Honeybadger error](https://app.honeybadger.io/projects/45435/faults/59452084) when it runs successfully:

```
Cookie#domain returns dot-less domain name now. Use Cookie#dot_domain if you need "." at the beginning.
```

This warning is being generated by the [`httpclient`](https://github.com/nahi/httpclient) library used by [`google-drive-ruby`](https://github.com/gimite/google-drive-ruby) and has [annoyed other people](https://github.com/nahi/httpclient/issues/252#issuecomment-302427338).  The suggested fix (monkeypatch the method generating the warning) was found in the linked thread.

## Testing story

Tested using local configuration, as documented in https://github.com/code-dot-org/code-dot-org/pull/32609.  Before and after:

![image](https://user-images.githubusercontent.com/1615761/72635391-9bd6e300-3911-11ea-8039-fc3fffa9b622.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
