### PR TITLE
PLC--Standardize location of ActiveRecord callback functions

### DIFF
--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -103,14 +103,15 @@ module Pd::Application
       ]
     }
 
+    has_many :emails, class_name: 'Pd::Application::Email'
+    has_and_belongs_to_many :tags, class_name: 'Pd::Application::Tag', foreign_key: 'pd_application_id', association_foreign_key: 'pd_application_tag_id'
+
     after_initialize -> {self.status = :unreviewed}, if: :new_record?
     before_create -> {self.status = :unreviewed}
     after_initialize :set_type_and_year
     before_validation :set_type_and_year
     before_save :update_accepted_date, if: :status_changed?
     before_create :generate_application_guid, if: -> {application_guid.blank?}
-    has_many :emails, class_name: 'Pd::Application::Email'
-    has_and_belongs_to_many :tags, class_name: 'Pd::Application::Tag', foreign_key: 'pd_application_id', association_foreign_key: 'pd_application_tag_id'
 
     serialized_attrs %w(
       notes_2

--- a/dashboard/app/models/pd/application/facilitator1819_application.rb
+++ b/dashboard/app/models/pd/application/facilitator1819_application.rb
@@ -40,11 +40,11 @@ module Pd::Application
   class Facilitator1819Application < FacilitatorApplicationBase
     include Pd::Facilitator1819ApplicationConstants
 
-    validates_uniqueness_of :user_id
-
     has_one :pd_fit_weekend1819_registration,
       class_name: 'Pd::FitWeekend1819Registration',
       foreign_key: 'pd_application_id'
+
+    validates_uniqueness_of :user_id
 
     serialized_attrs %w(
       auto_assigned_enrollment_id

--- a/dashboard/app/models/pd/application/facilitator1920_application.rb
+++ b/dashboard/app/models/pd/application/facilitator1920_application.rb
@@ -38,19 +38,19 @@ module Pd::Application
   class Facilitator1920Application < FacilitatorApplicationBase
     include Pd::Facilitator1920ApplicationConstants
 
-    validates_uniqueness_of :user_id
-
     has_one :pd_fit_weekend1920_registration,
       class_name: 'Pd::FitWeekend1920Registration',
       foreign_key: 'pd_application_id'
 
-    serialized_attrs %w(
-      status_log
-    )
+    validates_uniqueness_of :user_id
 
     before_save :log_status, if: -> {status_changed?}
 
     after_create :clear_extraneous_answers
+
+    serialized_attrs %w(
+      status_log
+    )
 
     #override
     def year

--- a/dashboard/app/models/pd/application/principal_approval1819_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval1819_application.rb
@@ -38,14 +38,17 @@ module Pd::Application
   class PrincipalApproval1819Application < PrincipalApprovalApplicationBase
     include Pd::PrincipalApproval1819ApplicationConstants
 
+    REPLACE_COURSE_NO = "No, this course will be added to the schedule, but it won't replace an existing computer science course"
+
+    belongs_to :teacher_application, class_name: 'Pd::Application::Teacher1819Application',
+               primary_key: :application_guid, foreign_key: :application_guid
+
+    validates_presence_of :teacher_application
+
     # @override
     def year
       YEAR_18_19
     end
-
-    validates_presence_of :teacher_application
-    belongs_to :teacher_application, class_name: 'Pd::Application::Teacher1819Application',
-      primary_key: :application_guid, foreign_key: :application_guid
 
     def self.create_placeholder_and_send_mail(teacher_application)
       ::Pd::Application::TeacherApplicationMailer.principal_approval(teacher_application).deliver_now
@@ -63,7 +66,6 @@ module Pd::Application
       (!existing_application || existing_application.placeholder?) ? nil : existing_application
     end
 
-    REPLACE_COURSE_NO = "No, this course will be added to the schedule, but it won't replace an existing computer science course"
     def self.options
       {
         title: COMMON_OPTIONS[:title],

--- a/dashboard/app/models/pd/application/principal_approval1920_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval1920_application.rb
@@ -38,14 +38,15 @@ module Pd::Application
   class PrincipalApproval1920Application < PrincipalApprovalApplicationBase
     include Pd::PrincipalApproval1920ApplicationConstants
 
+    belongs_to :teacher_application, class_name: 'Pd::Application::Teacher1920Application',
+               primary_key: :application_guid, foreign_key: :application_guid
+
+    validates_presence_of :teacher_application
+
     # @override
     def year
       YEAR_19_20
     end
-
-    validates_presence_of :teacher_application
-    belongs_to :teacher_application, class_name: 'Pd::Application::Teacher1920Application',
-      primary_key: :application_guid, foreign_key: :application_guid
 
     def self.create_placeholder_and_send_mail(teacher_application)
       teacher_application.queue_email :principal_approval, deliver_now: true

--- a/dashboard/app/models/pd/application/principal_approval2021_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval2021_application.rb
@@ -38,6 +38,11 @@ module Pd::Application
   class PrincipalApproval2021Application < PrincipalApprovalApplicationBase
     include Pd::PrincipalApproval2021ApplicationConstants
 
+    belongs_to :teacher_application, class_name: 'Pd::Application::Teacher2021Application',
+               primary_key: :application_guid, foreign_key: :application_guid
+
+    validates_presence_of :teacher_application
+
     # @override
     def year
       self.class.year
@@ -46,10 +51,6 @@ module Pd::Application
     def self.year
       YEAR_20_21
     end
-
-    validates_presence_of :teacher_application
-    belongs_to :teacher_application, class_name: 'Pd::Application::Teacher2021Application',
-      primary_key: :application_guid, foreign_key: :application_guid
 
     def self.create_placeholder_and_send_mail(teacher_application)
       teacher_application.queue_email :principal_approval, deliver_now: true

--- a/dashboard/app/models/pd/application/teacher1819_application.rb
+++ b/dashboard/app/models/pd/application/teacher1819_application.rb
@@ -38,11 +38,11 @@ module Pd::Application
   class Teacher1819Application < TeacherApplicationBase
     include ::Pd::Teacher1819ApplicationConstants
 
-    validates_uniqueness_of :user_id
-
     has_one :pd_teachercon1819_registration,
       class_name: 'Pd::Teachercon1819Registration',
       foreign_key: 'pd_application_id'
+
+    validates_uniqueness_of :user_id
 
     serialized_attrs %w(
       auto_assigned_enrollment_id

--- a/dashboard/app/models/pd/application/teacher2021_application.rb
+++ b/dashboard/app/models/pd/application/teacher2021_application.rb
@@ -38,8 +38,6 @@ module Pd::Application
   class Teacher2021Application < TeacherApplicationBase
     include Pd::Teacher2021ApplicationConstants
 
-    validates_uniqueness_of :user_id
-
     PRINCIPAL_APPROVAL_STATE = [
       NOT_REQUIRED = 'Not required',
       IN_PROGRESS = 'Incomplete - Principal email sent on ',
@@ -47,6 +45,30 @@ module Pd::Application
     ]
 
     REVIEWING_INCOMPLETE = 'Reviewing Incomplete'
+
+    # These statuses are considered "decisions", and will queue an email that will be sent by cronjob the next morning
+    # In these decision emails, status and email_type are the same.
+    AUTO_EMAIL_STATUSES = %w(
+      accepted_no_cost_registration
+      declined
+      waitlisted
+      registration_sent
+    )
+
+    # If the regional partner's emails are SENT_BY_SYSTEM, the application must
+    # have an assigned workshop to be set to one of these statuses because they
+    # trigger emails with a link to the workshop registration form
+    WORKSHOP_REQUIRED_STATUSES = %w(
+      accepted_no_cost_registration
+      registration_sent
+    )
+
+    has_many :emails, class_name: 'Pd::Application::Email', foreign_key: 'pd_application_id'
+
+    validates_uniqueness_of :user_id
+    validate :workshop_present_if_required_for_status, if: -> {status_changed?}
+
+    before_save :log_status, if: -> {status_changed?}
 
     serialized_attrs %w(
       status_log
@@ -68,29 +90,6 @@ module Pd::Application
         withdrawn
       )
     end
-
-    # These statuses are considered "decisions", and will queue an email that will be sent by cronjob the next morning
-    # In these decision emails, status and email_type are the same.
-    AUTO_EMAIL_STATUSES = %w(
-      accepted_no_cost_registration
-      declined
-      waitlisted
-      registration_sent
-    )
-
-    # If the regional partner's emails are SENT_BY_SYSTEM, the application must
-    # have an assigned workshop to be set to one of these statuses because they
-    # trigger emails with a link to the workshop registration form
-    WORKSHOP_REQUIRED_STATUSES = %w(
-      accepted_no_cost_registration
-      registration_sent
-    )
-
-    has_many :emails, class_name: 'Pd::Application::Email', foreign_key: 'pd_application_id'
-
-    before_save :log_status, if: -> {status_changed?}
-
-    validate :workshop_present_if_required_for_status, if: -> {status_changed?}
 
     def workshop_present_if_required_for_status
       if regional_partner&.applications_decision_emails == RegionalPartner::SENT_BY_SYSTEM &&

--- a/dashboard/app/models/pd/application/teacher_application_base.rb
+++ b/dashboard/app/models/pd/application/teacher_application_base.rb
@@ -40,11 +40,30 @@ module Pd::Application
     include Rails.application.routes.url_helpers
     include SchoolInfoDeduplicator
 
+    VALID_COURSES = COURSE_NAME_MAP.keys.map(&:to_s)
+
+    PROGRAMS = {
+      csd: 'Computer Science Discoveries (appropriate for 6th - 10th grade)',
+      csp: 'Computer Science Principles (appropriate for 9th - 12th grade, and can be implemented as an AP or introductory course)',
+    }.freeze
+    PROGRAM_OPTIONS = PROGRAMS.values
+
+    GRADES = [
+      'Pre-K'.freeze,
+      'Kindergarten'.freeze,
+      *(1..12).map {|n| "Grade #{n}".freeze}
+    ].freeze
+
+    validate :scholarship_status_valid
+    validates :status, exclusion: {in: ['interview'], message: '%{value} is reserved for facilitator applications.'}
+    validates :course, presence: true, inclusion: {in: VALID_COURSES}
+
+    before_validation :set_course_from_program
+    before_save :save_partner, if: -> {form_data_changed? && regional_partner_id.nil? && !deleted?}
+
     serialized_attrs %w(
       pd_workshop_id
     )
-
-    validate :scholarship_status_valid
 
     def scholarship_status_valid
       unless scholarship_status.nil? || Pd::ScholarshipInfoConstants::SCHOLARSHIP_STATUSES.include?(scholarship_status)
@@ -85,32 +104,13 @@ module Pd::Application
       self.application_year = year
     end
 
-    validates :status, exclusion: {in: ['interview'], message: '%{value} is reserved for facilitator applications.'}
-
-    VALID_COURSES = COURSE_NAME_MAP.keys.map(&:to_s)
-
-    validates :course, presence: true, inclusion: {in: VALID_COURSES}
-    before_validation :set_course_from_program
     def set_course_from_program
       self.course = PROGRAMS.key(program)
     end
 
-    before_save :save_partner, if: -> {form_data_changed? && regional_partner_id.nil? && !deleted?}
     def save_partner
       self.regional_partner_id = sanitize_form_data_hash[:regional_partner_id]
     end
-
-    PROGRAMS = {
-      csd: 'Computer Science Discoveries (appropriate for 6th - 10th grade)',
-      csp: 'Computer Science Principles (appropriate for 9th - 12th grade, and can be implemented as an AP or introductory course)',
-    }.freeze
-    PROGRAM_OPTIONS = PROGRAMS.values
-
-    GRADES = [
-      'Pre-K'.freeze,
-      'Kindergarten'.freeze,
-      *(1..12).map {|n| "Grade #{n}".freeze}
-    ].freeze
 
     def self.options
       raise 'Abstract method must be overridden by inheriting class'

--- a/dashboard/app/models/pd/attendance.rb
+++ b/dashboard/app/models/pd/attendance.rb
@@ -24,20 +24,23 @@ class Pd::Attendance < ActiveRecord::Base
 
   belongs_to :session, class_name: 'Pd::Session', foreign_key: :pd_session_id
   belongs_to :teacher, class_name: 'User', foreign_key: :teacher_id
-  alias_method :user, :teacher
   belongs_to :enrollment, class_name: 'Pd::Enrollment', foreign_key: :pd_enrollment_id
   belongs_to :marked_by_user, class_name: 'User', foreign_key: :marked_by_user_id
 
   has_one :workshop, class_name: 'Pd::Workshop', through: :session
 
   validate :teacher_or_enrollment_must_be_present, unless: :deleted?
+
+  before_save :save_matching_enrollment_association, :update_enrollment_user
+
+  alias_method :user, :teacher
+
   def teacher_or_enrollment_must_be_present
     if teacher.nil? && enrollment.nil?
       errors.add(:base, 'Teacher or enrollment must be present.')
     end
   end
 
-  before_save :save_matching_enrollment_association, :update_enrollment_user
   def save_matching_enrollment_association
     self.enrollment = resolve_enrollment
   end

--- a/dashboard/app/models/pd/course_facilitator.rb
+++ b/dashboard/app/models/pd/course_facilitator.rb
@@ -13,10 +13,10 @@
 #
 
 class Pd::CourseFacilitator < ActiveRecord::Base
+  belongs_to :facilitator, class_name: 'User'
+
   validates_inclusion_of :course, in: Pd::Workshop::COURSES
   validates_uniqueness_of :course, scope: :facilitator_id
-
-  belongs_to :facilitator, class_name: 'User'
 
   def self.facilitators_for_course(course)
     User.joins(:courses_as_facilitator).

--- a/dashboard/app/models/pd/district_payment_term.rb
+++ b/dashboard/app/models/pd/district_payment_term.rb
@@ -19,6 +19,7 @@ class Pd::DistrictPaymentTerm < ActiveRecord::Base
     RATE_DAILY = 'daily'.freeze
   ].freeze
 
-  validates_inclusion_of :rate_type, in: RATE_TYPES
   belongs_to :school_district
+
+  validates_inclusion_of :rate_type, in: RATE_TYPES
 end

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -64,9 +64,9 @@ class Pd::Enrollment < ActiveRecord::Base
   validate :school_info_country_required, if: -> {!deleted? && (new_record? || school_info_id_changed?)}
 
   before_validation :autoupdate_user_field
+  after_create :set_default_scholarship_info
   after_save :enroll_in_corresponding_online_learning, if: -> {!deleted? && (user_id_changed? || email_changed?)}
   after_save :authorize_teacher_account
-  after_create :set_default_scholarship_info
 
   serialized_attrs %w(
     role

--- a/dashboard/app/models/pd/facilitator_program_registration.rb
+++ b/dashboard/app/models/pd/facilitator_program_registration.rb
@@ -23,6 +23,12 @@
 class Pd::FacilitatorProgramRegistration < ActiveRecord::Base
   include Pd::ProgramRegistrationForm
 
+  TEACHERCON_DECLINE = 'No - I\'m no longer interested'.freeze
+  TEACHERCON_ALTERNATE = 'No - but I need to attend a different date.'.freeze
+  TRAINING_DECLINE = 'No'.freeze
+  TRAINING_ALTERNATE = 'I want to participate in the program, but I\'m no longer able to attend these dates.'.freeze
+  TRAINING_ALTERNATE_DECLINE = 'I am no longer interested in the Code.org Facilitator Development Program.'.freeze
+
   def self.required_fields
     [
       :address_street,
@@ -47,12 +53,6 @@ class Pd::FacilitatorProgramRegistration < ActiveRecord::Base
       :subjects_taught,
     ].freeze
   end
-
-  TEACHERCON_DECLINE = 'No - I\'m no longer interested'.freeze
-  TEACHERCON_ALTERNATE = 'No - but I need to attend a different date.'.freeze
-  TRAINING_DECLINE = 'No'.freeze
-  TRAINING_ALTERNATE = 'I want to participate in the program, but I\'m no longer able to attend these dates.'.freeze
-  TRAINING_ALTERNATE_DECLINE = 'I am no longer interested in the Code.org Facilitator Development Program.'.freeze
 
   def self.options
     super.merge(

--- a/dashboard/app/models/pd/facilitator_teachercon_attendance.rb
+++ b/dashboard/app/models/pd/facilitator_teachercon_attendance.rb
@@ -26,9 +26,9 @@
 #
 
 class Pd::FacilitatorTeacherconAttendance < ActiveRecord::Base
-  belongs_to :user
-
   DATE_FORMAT = "%B %e".freeze
+
+  belongs_to :user
 
   def attendance_dates(teachercon)
     dates = {}

--- a/dashboard/app/models/pd/fit_weekend1819_registration.rb
+++ b/dashboard/app/models/pd/fit_weekend1819_registration.rb
@@ -18,21 +18,22 @@
 class Pd::FitWeekend1819Registration < ActiveRecord::Base
   include Pd::Form
 
+  YES = 'Yes'.freeze
+  NO = 'No'.freeze
+  YES_OR_NO = [YES, NO].freeze
+
   belongs_to :pd_application, class_name: 'Pd::Application::ApplicationBase'
 
   after_create :update_application_status
+  after_create :send_fit_weekend_confirmation_email
+
   def update_application_status
     pd_application.update!(status: 'withdrawn') unless accepted?
   end
 
-  after_create :send_fit_weekend_confirmation_email
   def send_fit_weekend_confirmation_email
     Pd::FitWeekendRegistrationMailer.confirmation(self).deliver_now
   end
-
-  YES = 'Yes'.freeze
-  NO = 'No'.freeze
-  YES_OR_NO = [YES, NO].freeze
 
   def self.options
     {

--- a/dashboard/app/models/pd/fit_weekend_registration_base.rb
+++ b/dashboard/app/models/pd/fit_weekend_registration_base.rb
@@ -20,6 +20,10 @@ class Pd::FitWeekendRegistrationBase < ActiveRecord::Base
 
   self.table_name = 'pd_fit_weekend_registrations'
 
+  YES = 'Yes'.freeze
+  NO = 'No'.freeze
+  YES_OR_NO = [YES, NO].freeze
+
   belongs_to :pd_application, class_name: 'Pd::Application::ApplicationBase'
 
   after_initialize :set_registration_year
@@ -35,10 +39,6 @@ class Pd::FitWeekendRegistrationBase < ActiveRecord::Base
   def set_registration_year
     self.registration_year = nil
   end
-
-  YES = 'Yes'.freeze
-  NO = 'No'.freeze
-  YES_OR_NO = [YES, NO].freeze
 
   def self.options
     {

--- a/dashboard/app/models/pd/post_course_survey.rb
+++ b/dashboard/app/models/pd/post_course_survey.rb
@@ -37,16 +37,8 @@ module Pd
 
     belongs_to :user
 
-    # @override
-    def self.attribute_mapping
-      {
-        user_id: 'userId',
-        course: 'csp_or_csd'
-      }
-    end
-
     validates_uniqueness_of :user_id, scope: [:form_id, :year, :course],
-      message: 'already has a submission for this form, year, and course'
+                            message: 'already has a submission for this form, year, and course'
 
     validates_presence_of(
       :user_id,
@@ -54,6 +46,14 @@ module Pd
     )
     validates_inclusion_of :year, in: VALID_YEARS
     validates_inclusion_of :course, in: VALID_COURSES
+
+    # @override
+    def self.attribute_mapping
+      {
+        user_id: 'userId',
+        course: 'csp_or_csd'
+      }
+    end
 
     def self.form_id
       get_form_id 'post_course', CURRENT_YEAR

--- a/dashboard/app/models/pd/pre_workshop_survey.rb
+++ b/dashboard/app/models/pd/pre_workshop_survey.rb
@@ -19,8 +19,9 @@ class Pd::PreWorkshopSurvey < ActiveRecord::Base
   UNIT_NOT_STARTED = 'I have not started teaching the course yet'
 
   belongs_to :pd_enrollment, class_name: 'Pd::Enrollment'
-  validates_presence_of :pd_enrollment
   has_one :workshop, through: :pd_enrollment
+
+  validates_presence_of :pd_enrollment
 
   # PreWorkshopSurvey has dynamic options based on the workshop
   def dynamic_options

--- a/dashboard/app/models/pd/regional_partner_cohort.rb
+++ b/dashboard/app/models/pd/regional_partner_cohort.rb
@@ -20,6 +20,14 @@
 #
 
 class Pd::RegionalPartnerCohort < ActiveRecord::Base
+  ALLOWED_COURSES = [
+    Pd::Workshop::COURSE_CSP,
+    Pd::Workshop::COURSE_CSD,
+    Pd::Workshop::COURSE_ECS,
+    Pd::Workshop::COURSE_CS_IN_A,
+    Pd::Workshop::COURSE_CS_IN_S
+  ]
+
   enum role: {
     teacher: 0,
     facilitator: 1
@@ -33,13 +41,6 @@ class Pd::RegionalPartnerCohort < ActiveRecord::Base
   belongs_to :regional_partner
   belongs_to :summer_workshop, class_name: 'Pd::Workshop'
 
-  ALLOWED_COURSES = [
-    Pd::Workshop::COURSE_CSP,
-    Pd::Workshop::COURSE_CSD,
-    Pd::Workshop::COURSE_ECS,
-    Pd::Workshop::COURSE_CS_IN_A,
-    Pd::Workshop::COURSE_CS_IN_S
-  ]
   validates :course, presence: true, inclusion: {in: ALLOWED_COURSES, allow_blank: true}
 
   # Year format: YYYY-YYYY, e.g. "2016-2017"

--- a/dashboard/app/models/pd/teachercon1819_registration.rb
+++ b/dashboard/app/models/pd/teachercon1819_registration.rb
@@ -21,13 +21,13 @@ class Pd::Teachercon1819Registration < ActiveRecord::Base
   include Pd::Form
   include Pd::Teachercon1819RegistrationConstants
 
-  belongs_to :pd_application, class_name: 'Pd::Application::ApplicationBase'
-  belongs_to :regional_partner, class_name: 'RegionalPartner'
-  belongs_to :user
-
   YES = 'Yes'.freeze
   NO = 'No'.freeze
   YES_OR_NO = [YES, NO].freeze
+
+  belongs_to :pd_application, class_name: 'Pd::Application::ApplicationBase'
+  belongs_to :regional_partner, class_name: 'RegionalPartner'
+  belongs_to :user
 
   after_create :update_application_status
   def update_application_status

--- a/dashboard/app/models/pd/teachercon_survey.rb
+++ b/dashboard/app/models/pd/teachercon_survey.rb
@@ -16,9 +16,6 @@
 class Pd::TeacherconSurvey < ActiveRecord::Base
   include Pd::FacilitatorSpecificForm
 
-  belongs_to :pd_enrollment, class_name: "Pd::Enrollment"
-  validates_presence_of :pd_enrollment
-
   DISAGREES = [
     'Strongly Disagree',
     'Disagree',
@@ -40,6 +37,9 @@ class Pd::TeacherconSurvey < ActiveRecord::Base
     "Leaning toward B",
     "Strongly aligned with B",
   ].freeze
+
+  belongs_to :pd_enrollment, class_name: "Pd::Enrollment"
+  validates_presence_of :pd_enrollment
 
   def self.public_fields
     (

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -34,6 +34,17 @@ class Pd::Workshop < ActiveRecord::Base
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 
+  belongs_to :organizer, class_name: 'User'
+  has_and_belongs_to_many :facilitators, class_name: 'User', join_table: 'pd_workshops_facilitators', foreign_key: 'pd_workshop_id', association_foreign_key: 'user_id'
+
+  has_many :sessions, -> {order :start}, class_name: 'Pd::Session', dependent: :destroy, foreign_key: 'pd_workshop_id'
+  accepts_nested_attributes_for :sessions, allow_destroy: true
+
+  has_many :enrollments, class_name: 'Pd::Enrollment', dependent: :destroy, foreign_key: 'pd_workshop_id'
+  belongs_to :regional_partner
+
+  has_many :regional_partner_program_managers, source: :program_managers, through: :regional_partner
+
   validates_inclusion_of :course, in: COURSES
   validates :capacity, numericality: {only_integer: true, greater_than: 0, less_than: 10000}
   validates_length_of :notes, maximum: 65535
@@ -46,17 +57,6 @@ class Pd::Workshop < ActiveRecord::Base
   validates :funding_type,
     inclusion: {in: FUNDING_TYPES, if: :funded_csf?},
     absence: {unless: :funded_csf?}
-
-  belongs_to :organizer, class_name: 'User'
-  has_and_belongs_to_many :facilitators, class_name: 'User', join_table: 'pd_workshops_facilitators', foreign_key: 'pd_workshop_id', association_foreign_key: 'user_id'
-
-  has_many :sessions, -> {order :start}, class_name: 'Pd::Session', dependent: :destroy, foreign_key: 'pd_workshop_id'
-  accepts_nested_attributes_for :sessions, allow_destroy: true
-
-  has_many :enrollments, class_name: 'Pd::Enrollment', dependent: :destroy, foreign_key: 'pd_workshop_id'
-  belongs_to :regional_partner
-
-  has_many :regional_partner_program_managers, source: :program_managers, through: :regional_partner
 
   before_save :process_location, if: -> {location_address_changed?}
   auto_strip_attributes :location_name, :location_address

--- a/dashboard/app/models/pd/workshop_daily_survey.rb
+++ b/dashboard/app/models/pd/workshop_daily_survey.rb
@@ -29,9 +29,38 @@ module Pd
     include SharedWorkshopConstants
     include Pd::WorkshopSurveyConstants
 
+    # Different categories have different valid days
+    VALID_DAYS = {
+      LOCAL_CATEGORY => (0..5).to_a.freeze,
+      ACADEMIC_YEAR_1_CATEGORY => [1].freeze,
+      ACADEMIC_YEAR_2_CATEGORY => [1].freeze,
+      ACADEMIC_YEAR_3_CATEGORY => [1].freeze,
+      ACADEMIC_YEAR_4_CATEGORY => [1].freeze,
+      ACADEMIC_YEAR_1_2_CATEGORY => [1, 2].freeze,
+      ACADEMIC_YEAR_3_4_CATEGORY => [1, 2].freeze,
+      VIRTUAL_1_CATEGORY => [1].freeze,
+      VIRTUAL_2_CATEGORY => [1].freeze,
+      VIRTUAL_3_CATEGORY => [1].freeze,
+      VIRTUAL_4_CATEGORY => [1].freeze,
+      VIRTUAL_5_CATEGORY => [1].freeze,
+      VIRTUAL_6_CATEGORY => [1].freeze,
+      VIRTUAL_7_CATEGORY => [1].freeze,
+      VIRTUAL_8_CATEGORY => [1].freeze,
+      CSF_CATEGORY => CSF_SURVEY_INDEXES.values.freeze
+    }
+
     belongs_to :user
     belongs_to :pd_session, class_name: 'Pd::Session'
     belongs_to :pd_workshop, class_name: 'Pd::Workshop'
+
+    validates_uniqueness_of :user_id, scope: [:pd_workshop_id, :day, :form_id],
+                            message: 'already has a submission for this workshop, day, and form'
+    validates_presence_of(
+      :user_id,
+      :pd_workshop_id,
+      :day
+    )
+    validate :day_for_subject
 
     # @override
     def self.attribute_mapping
@@ -54,37 +83,6 @@ module Pd
     def set_day_from_form_id
       self.day = self.class.get_day_for_subject_and_form_id(pd_workshop.subject, form_id)
     end
-
-    validates_uniqueness_of :user_id, scope: [:pd_workshop_id, :day, :form_id],
-      message: 'already has a submission for this workshop, day, and form'
-
-    validates_presence_of(
-      :user_id,
-      :pd_workshop_id,
-      :day
-    )
-
-    # Different categories have different valid days
-    VALID_DAYS = {
-      LOCAL_CATEGORY => (0..5).to_a.freeze,
-      ACADEMIC_YEAR_1_CATEGORY => [1].freeze,
-      ACADEMIC_YEAR_2_CATEGORY => [1].freeze,
-      ACADEMIC_YEAR_3_CATEGORY => [1].freeze,
-      ACADEMIC_YEAR_4_CATEGORY => [1].freeze,
-      ACADEMIC_YEAR_1_2_CATEGORY => [1, 2].freeze,
-      ACADEMIC_YEAR_3_4_CATEGORY => [1, 2].freeze,
-      VIRTUAL_1_CATEGORY => [1].freeze,
-      VIRTUAL_2_CATEGORY => [1].freeze,
-      VIRTUAL_3_CATEGORY => [1].freeze,
-      VIRTUAL_4_CATEGORY => [1].freeze,
-      VIRTUAL_5_CATEGORY => [1].freeze,
-      VIRTUAL_6_CATEGORY => [1].freeze,
-      VIRTUAL_7_CATEGORY => [1].freeze,
-      VIRTUAL_8_CATEGORY => [1].freeze,
-      CSF_CATEGORY => CSF_SURVEY_INDEXES.values.freeze
-    }
-
-    validate :day_for_subject
 
     def self.get_form_id_for_subjects_and_day(subjects, day)
       subjects.map do |subject|

--- a/dashboard/app/models/pd/workshop_facilitator_daily_survey.rb
+++ b/dashboard/app/models/pd/workshop_facilitator_daily_survey.rb
@@ -30,38 +30,6 @@ module Pd
     include JotFormBackedForm
     include Pd::WorkshopSurveyConstants
 
-    belongs_to :user
-    belongs_to :pd_session, class_name: 'Pd::Session'
-    belongs_to :pd_workshop, class_name: 'Pd::Workshop'
-    belongs_to :facilitator, class_name: 'User', foreign_key: 'facilitator_id'
-
-    validates_uniqueness_of :user_id, scope: [:pd_workshop_id, :pd_session_id, :facilitator_id, :form_id],
-      message: 'already has a submission for this workshop, session, facilitator, and form'
-
-    before_validation :set_workshop_from_session, if: -> {pd_session_id_changed? && !pd_workshop_id_changed?}
-    def set_workshop_from_session
-      self.pd_workshop_id = pd_session&.pd_workshop_id
-    end
-
-    # @override
-    def self.attribute_mapping
-      {
-        user_id: 'userId',
-        pd_session_id: 'sessionId',
-        pd_workshop_id: 'workshopId',
-        facilitator_id: 'facilitatorId',
-        day: 'day'
-      }
-    end
-
-    validates_presence_of(
-      :user_id,
-      :pd_workshop_id,
-      :pd_session_id,
-      :facilitator_id,
-      :day
-    )
-
     # Different categories have different valid days
     # Not identical to the one in WorkshopDailySurvey
     VALID_DAYS = {
@@ -83,7 +51,38 @@ module Pd
       CSF_CATEGORY => CSF_SURVEY_INDEXES.values.freeze
     }
 
+    belongs_to :user
+    belongs_to :pd_session, class_name: 'Pd::Session'
+    belongs_to :pd_workshop, class_name: 'Pd::Workshop'
+    belongs_to :facilitator, class_name: 'User', foreign_key: 'facilitator_id'
+
+    validates_uniqueness_of :user_id, scope: [:pd_workshop_id, :pd_session_id, :facilitator_id, :form_id],
+      message: 'already has a submission for this workshop, session, facilitator, and form'
+
+    validates_presence_of(
+      :user_id,
+      :pd_workshop_id,
+      :pd_session_id,
+      :facilitator_id,
+      :day
+    )
     validate :day_for_subject
+
+    before_validation :set_workshop_from_session, if: -> {pd_session_id_changed? && !pd_workshop_id_changed?}
+    def set_workshop_from_session
+      self.pd_workshop_id = pd_session&.pd_workshop_id
+    end
+
+    # @override
+    def self.attribute_mapping
+      {
+        user_id: 'userId',
+        pd_session_id: 'sessionId',
+        pd_workshop_id: 'workshopId',
+        facilitator_id: 'facilitatorId',
+        day: 'day'
+      }
+    end
 
     def self.form_ids_for_subjects(subjects)
       subjects.map do |subject|

--- a/dashboard/app/models/pd/workshop_survey.rb
+++ b/dashboard/app/models/pd/workshop_survey.rb
@@ -17,9 +17,6 @@
 class Pd::WorkshopSurvey < ActiveRecord::Base
   include Pd::FacilitatorSpecificForm
 
-  belongs_to :pd_enrollment, class_name: "Pd::Enrollment"
-  validates_presence_of :pd_enrollment
-
   STRONGLY_DISAGREE_TO_STRONGLY_AGREE = [
     'Strongly Disagree',
     'Disagree',
@@ -32,6 +29,9 @@ class Pd::WorkshopSurvey < ActiveRecord::Base
   OTHER = 'Other'.freeze
   YES = 'Yes'.freeze
   NO = 'No'.freeze
+
+  belongs_to :pd_enrollment, class_name: "Pd::Enrollment"
+  validates_presence_of :pd_enrollment
 
   def self.required_fields
     [

--- a/dashboard/app/models/pd/workshop_survey.rb
+++ b/dashboard/app/models/pd/workshop_survey.rb
@@ -31,6 +31,7 @@ class Pd::WorkshopSurvey < ActiveRecord::Base
   NO = 'No'.freeze
 
   belongs_to :pd_enrollment, class_name: "Pd::Enrollment"
+
   validates_presence_of :pd_enrollment
 
   def self.required_fields

--- a/dashboard/app/models/plc/enrollment_unit_assignment.rb
+++ b/dashboard/app/models/plc/enrollment_unit_assignment.rb
@@ -23,20 +23,20 @@
 #
 # Normally created when a teacher enrolls in a workshop with a corresponding PLC course.
 class Plc::EnrollmentUnitAssignment < ActiveRecord::Base
-  belongs_to :plc_user_course_enrollment, class_name: '::Plc::UserCourseEnrollment'
-  belongs_to :plc_course_unit, class_name: '::Plc::CourseUnit'
-  has_many :plc_module_assignments, class_name: '::Plc::EnrollmentModuleAssignment', foreign_key: 'plc_enrollment_unit_assignment_id', dependent: :destroy
-  belongs_to :user, class_name: 'User'
-
   UNIT_STATUS_STATES = [
     START_BLOCKED = 'start_blocked'.freeze,
     IN_PROGRESS = 'in_progress'.freeze,
     COMPLETED = 'completed'.freeze
   ].freeze
 
-  after_save :enroll_user_in_required_modules
+  belongs_to :plc_user_course_enrollment, class_name: '::Plc::UserCourseEnrollment'
+  belongs_to :plc_course_unit, class_name: '::Plc::CourseUnit'
+  has_many :plc_module_assignments, class_name: '::Plc::EnrollmentModuleAssignment', foreign_key: 'plc_enrollment_unit_assignment_id', dependent: :destroy
+  belongs_to :user, class_name: 'User'
 
   validates :status, inclusion: {in: UNIT_STATUS_STATES}
+
+  after_save :enroll_user_in_required_modules
 
   def module_assignment_for_type(module_type)
     plc_module_assignments.joins(:plc_learning_module).find_by('plc_learning_modules.module_type': module_type)

--- a/dashboard/app/models/plc/learning_module.rb
+++ b/dashboard/app/models/plc/learning_module.rb
@@ -22,11 +22,6 @@
 # part of modules, and modules are not part of courses.
 # Learning Modules correspond to Stages in our regular curriculum hierarchy.
 class Plc::LearningModule < ActiveRecord::Base
-  belongs_to :stage
-  belongs_to :plc_course_unit, class_name: '::Plc::CourseUnit', foreign_key: 'plc_course_unit_id'
-  has_and_belongs_to_many :plc_tasks, class_name: '::Plc::Task', foreign_key: 'plc_learning_module_id', association_foreign_key: 'plc_task_id'
-  has_many :plc_module_assignments, class_name: '::Plc::EnrollmentModuleAssignment', foreign_key: 'plc_learning_module_id', dependent: :destroy
-
   MODULE_TYPES = [
     REQUIRED_MODULE = 'required'.freeze,
     CONTENT_MODULE = 'content'.freeze,
@@ -35,10 +30,15 @@ class Plc::LearningModule < ActiveRecord::Base
 
   NONREQUIRED_MODULE_TYPES = (MODULE_TYPES - [REQUIRED_MODULE]).freeze
 
+  attr_readonly :plc_course_unit_id
+
+  belongs_to :stage
+  belongs_to :plc_course_unit, class_name: '::Plc::CourseUnit', foreign_key: 'plc_course_unit_id'
+  has_and_belongs_to_many :plc_tasks, class_name: '::Plc::Task', foreign_key: 'plc_learning_module_id', association_foreign_key: 'plc_task_id'
+  has_many :plc_module_assignments, class_name: '::Plc::EnrollmentModuleAssignment', foreign_key: 'plc_learning_module_id', dependent: :destroy
+
   validates_presence_of :plc_course_unit_id
   validates_inclusion_of :module_type, in: MODULE_TYPES
-
-  attr_readonly :plc_course_unit_id
 
   scope :required, -> {where(module_type: REQUIRED_MODULE)}
   scope :content, -> {where(module_type: CONTENT_MODULE)}

--- a/dashboard/app/models/plc/task.rb
+++ b/dashboard/app/models/plc/task.rb
@@ -29,8 +29,8 @@
 #
 # Tasks correspond to ScriptLevels in our regular curriculum hierarchy.
 class Plc::Task < ActiveRecord::Base
+  attr_readonly :type
+
   belongs_to :script_level
   has_and_belongs_to_many :plc_learning_modules, class_name: '::Plc::LearningModule', foreign_key: 'plc_task_id', association_foreign_key: 'plc_learning_module_id'
-
-  attr_readonly :type
 end


### PR DESCRIPTION
# Description
Standardized ActiveRecord callback locations and other macros in pd/plc models. Followed the [Rails style guide](https://rails.rubystyle.guide/#macro-style-methods) to determine order of macros in the classes. The recommended order is:
1. default scope
1. constants
1. attrs
1. enums
1. association macros (belongs, has_one, etc.)
1. validations
1. callbacks
1. other macros

The [style guide](https://rails.rubystyle.guide/#callbacks-order) also recommends putting callbacks in the order they will be called, so some callbacks were re-ordered for that reason.

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-413)

## Testing story
Validated that tests still passed after change, and that tests covered lines that were changed. This change is entirely copy/paste so no functionality was changed. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
