### PR TITLE
Updates to Fast Snapshot Restore

### DIFF
--- a/aws/cloudformation/test/test_fast_snapshot_restore.rb
+++ b/aws/cloudformation/test/test_fast_snapshot_restore.rb
@@ -21,7 +21,7 @@ class TestFastSnapshotRestore < Minitest::Test
     EC2.api_requests.clear
   end
 
-  def handle(request_type, physical_resource_id, properties = {})
+  def handle(request_type, physical_resource_id, properties = {}, old_properties: nil)
     response_url = 'http://example.com/response'
     stub_request(:put, response_url)
     handler(
@@ -29,38 +29,42 @@ class TestFastSnapshotRestore < Minitest::Test
         'RequestType' => request_type,
         'ResponseURL' => response_url,
         'PhysicalResourceId' => physical_resource_id,
-        'ResourceProperties' => properties
+        'ResourceProperties' => properties,
+        'OldResourceProperties' => old_properties
       },
       context: OpenStruct.new(log_stream_name: 'log')
     )
   end
 
-  def expect_api(requests)
-    assert_equal requests.map {|op, params| {operation_name: op, params: params}},
+  def expect_api(*requests)
+    assert_equal requests.map(&:first).map {|(op, params)| {operation_name: op, params: params}},
       EC2.api_requests.map {|req| req.slice(:operation_name, :params)}
   end
 
   def test_create
     handle 'Create', nil, {'AvailabilityZones' => ['az'], 'ImageIds' => ['ami']}
     expect_api(
-      describe_images: {image_ids: ['ami']},
-      enable_fast_snapshot_restores: {availability_zones: ['az'], source_snapshot_ids: ['snap']}
+      {describe_images: {image_ids: ['ami']}},
+      {enable_fast_snapshot_restores: {availability_zones: ['az'], source_snapshot_ids: ['snap']}}
     )
   end
 
   def test_update
-    handle 'Update', [['az'], ['old_snap']].to_json, {'AvailabilityZones' => ['az'], 'ImageIds' => ['ami2']}
+    handle 'Update', '12345', {'AvailabilityZones' => ['az'], 'ImageIds' => ['ami2']},
+      old_properties: {'AvailabilityZones' => ['az'], 'ImageIds' => ['oldAmi']}
     expect_api(
-      disable_fast_snapshot_restores: {availability_zones: ['az'], source_snapshot_ids: ['old_snap']},
-      describe_images: {image_ids: ['ami2']},
-      enable_fast_snapshot_restores: {availability_zones: ['az'], source_snapshot_ids: ['snap']}
+      {describe_images: {image_ids: ['oldAmi']}},
+      {disable_fast_snapshot_restores: {availability_zones: ['az'], source_snapshot_ids: ['snap']}},
+      {describe_images: {image_ids: ['ami2']}},
+      {enable_fast_snapshot_restores: {availability_zones: ['az'], source_snapshot_ids: ['snap']}}
     )
   end
 
   def test_delete
-    handle 'Delete', [['az'], ['old_snap']].to_json
+    handle 'Delete', '12345', {'AvailabilityZones' => ['az'], 'ImageIds' => ['ami']}
     expect_api(
-      disable_fast_snapshot_restores: {availability_zones: ['az'], source_snapshot_ids: ['old_snap']}
+      {describe_images: {image_ids: ['ami']}},
+      {disable_fast_snapshot_restores: {availability_zones: ['az'], source_snapshot_ids: ['snap']}}
     )
   end
 end


### PR DESCRIPTION
Followup to #32747.
Slight improvements to custom resource to handle updates without issues deleting the previous resource.

#### Details

Instead of changing the `PhysicalResourceId` with JSON-encoded values of `availability_zones` and `source_snapshot_ids`, causing a new resource to be created (and the old one deleted) on every stack update, the updated version uses a constant UUID-based `PhysicalResourceId` and disables/enables fast snapshot restore by looking up the snapshot each time from the resource properties.

Unit tests updated to reflect the updated behavior, and the change has been tested/verified on the integration-test stack.