### PR TITLE
Eager-load classes in Queries module

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 require 'census_helper'
+require_dependency 'queries/school_info'
+require_dependency 'queries/script_activity'
 
 class HomeController < ApplicationController
   include UsersHelper

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -74,6 +74,8 @@ require 'cdo/aws/metrics'
 require 'cdo/user_helpers'
 require 'school_info_interstitial_helper'
 require 'sign_up_tracking'
+require_dependency 'queries/school_info'
+require_dependency 'queries/script_activity'
 
 class User < ActiveRecord::Base
   include SerializedProperties

--- a/dashboard/lib/queries/school_info.rb
+++ b/dashboard/lib/queries/school_info.rb
@@ -1,3 +1,5 @@
+require_relative 'user_school_info'
+
 class Queries::SchoolInfo
   def self.last_complete(user)
     Queries::UserSchoolInfo.last_complete(user)&.school_info


### PR DESCRIPTION
# Description

Fix for the "Circular dependency when autoloading constant" errors we are seeing after some deployments. We think there's a chance these errors are linked to the recurring post-deployment downtime issue we've been having, though we haven't been able to prove / reproduce this.

Ideally we would fix `eager_load_paths` such that all relevant lib files used at runtime are eager-loaded, but we ran into some issues around the fact that the nested `SchoolInfo` and `UserSchoolInfo` classes under the `Queries` module have the same name as classes in `app/models`. Upgrading to Rails 6 may also change all of this, so I want to try out this less invasive fix.

## Links

Context and discussion:
- https://codedotorg.slack.com/archives/C03CK49G9/p1579026982058200
- https://codedotorg.slack.com/archives/C03CK49G9/p1579284058007700
- https://blog.arkency.com/2014/11/dont-forget-about-eager-load-when-extending-autoload/

## Testing story

Manually confirmed using an adhoc and console that `Queries::SchoolInfo`, `Queries::UserSchoolInfo`, and `Queries::ScriptActivity` are `defined?` at startup.

There should be no functional changes, so hopefully existing unit and UI tests are enough.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
