### PR TITLE
Fix the dir problem in homepage hero-message text

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -6,9 +6,9 @@
 
 - main_actions = capture_haml do
   - if show_single_hero == "changeworld"
-    .hero-message-line1{style: "color: white; font-size: 28px; line-height: 28px; padding-top: 20px; padding-bottom: 20px; font-family: 'Gotham 5r', sans-serif"}
+    .hero-message-line1{style: "color: white; font-size: 28px; line-height: 28px; padding-top: 20px; padding-bottom: 20px; font-family: 'Gotham 5r', sans-serif", dir: "auto"}
       = hoc_s(:hoc2019_header_line1_mobile)
-    .hero-message-line2{style: "color: white; font-size: 28px; line-height: 28px; padding-bottom: 80px; font-family: 'Gotham 5r', sans-serif"}
+    .hero-message-line2{style: "color: white; font-size: 28px; line-height: 28px; padding-bottom: 80px; font-family: 'Gotham 5r', sans-serif", dir: "auto"}
       = hoc_s(:hoc2019_header_line2_mobile)
   - if show_single_hero == "dance2019"
     -# Two lines of text


### PR DESCRIPTION
This change fixes an issue in the hero message when the page locale has the rtl direction. The note looks like the following picture before the change:
<img width="635" alt="Screen Shot 2020-01-20 at 12 24 00 PM" src="https://user-images.githubusercontent.com/20547172/72756401-f24a5880-3b81-11ea-9883-46a7bcb76fda.png">
As you can see the location of dot in the non-english rtl text is wrong.
After applying this fix, the rtl text looks like the following:
<img width="521" alt="Screen Shot 2020-01-20 at 12 27 09 PM" src="https://user-images.githubusercontent.com/20547172/72756460-245bba80-3b82-11ea-8659-cb03a109cae9.png">