### PR TITLE
Remove Description heading from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
-# Description
-
 <!--
-  A summary of the change, including any relevant motivation and context.
+  Your description goes here: A summary of the change, including any relevant motivation and context.
 
   If relevant, include a description both of the existing behavior and of the new behavior.
 -->


### PR DESCRIPTION
Removes the `# Description` heading from the top of the PR template. I find myself always deleting this heading. I believe it's redundant - the top of your PR description should _implicitly_ be a description of the change (and I've left a comment in to that effect).

It also leads to situations like this (not meaning to pick on @mvkski in particular - I've seen a few of these):

| Example |
| --- |
| ![image](https://user-images.githubusercontent.com/1615761/72825821-97217000-3c2c-11ea-947c-2af09f0406c5.png) |
