### PR TITLE
Account Purger: Make Net::ReadTimeout a reason to retry a QueuedAccountPurge

### DIFF
--- a/dashboard/app/models/queued_account_purge.rb
+++ b/dashboard/app/models/queued_account_purge.rb
@@ -37,7 +37,7 @@ class QueuedAccountPurge < ApplicationRecord
   # Some errors are known to be intermittent, such as external services being temporarily
   # unavailable. If an account purge was queued for one of these reasons, our system can
   # automatically retry it on the next run without developer intervention.
-  AUTO_RETRYABLE_REASONS = %w{Pardot::InvalidApiKeyException}
+  AUTO_RETRYABLE_REASONS = %w{Net::ReadTimeout Pardot::InvalidApiKeyException}
   scope :needing_manual_review, -> {where.not(reason_for_review: AUTO_RETRYABLE_REASONS)}
 
   # Used by developers to resolve an account purge queued for manual review,

--- a/dashboard/test/models/queued_account_purge_test.rb
+++ b/dashboard/test/models/queued_account_purge_test.rb
@@ -61,6 +61,13 @@ class QueuedAccountPurgeTest < ActiveSupport::TestCase
     refute_includes QueuedAccountPurge.needing_manual_review, q2
   end
 
+  test "needing_manual_review omits Net::ReadTimeout" do
+    q1 = create :queued_account_purge
+    q2 = create :queued_account_purge, reason_for_review: 'Net::ReadTimeout'
+    assert_includes QueuedAccountPurge.needing_manual_review, q1
+    refute_includes QueuedAccountPurge.needing_manual_review, q2
+  end
+
   test "clean_up_resolved_purges drops records for purged users" do
     # This one should get cleaned up
     q1 = create(:queued_account_purge, user: create(:student, deleted_at: Time.now, purged_at: Time.now))


### PR DESCRIPTION
[This past Saturday](https://codedotorg.slack.com/archives/C6B838SB0/p1579593818000400), two automated account purges failed with a `Net::ReadTImeout` error.  This seems like an intermittent failure and one that we ought to be able to auto-retry, so I'm adding it to the list of retryable errors.  See https://github.com/code-dot-org/code-dot-org/pull/30909 for details on the QueuedAccountPurge auto-retry system.

## Testing story

Unit test added for new behavior.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
