### PR TITLE
Update middle-high page to reflect control in Optimizely

### DIFF
--- a/pegasus/sites.v3/code.org/views/course_wide_block.haml
+++ b/pegasus/sites.v3/code.org/views/course_wide_block.haml
@@ -1,12 +1,15 @@
 - lesson_plans ||= nil
 - ages ||= nil
 - cta_text ||= nil
+- heading_style = 'position: absolute; color: white; margin-top: 20px; margin-left: 30px;'
+- heading_font_size ||= nil
+- heading_style = heading_font_size ? "#{heading_style} font-size: #{heading_font_size};": heading_style
 
 .courseblock-span6.courseblock-wide-large{style: "height: 100%; max-width: 100%; padding-bottom: 20px; margin-bottom: 10px;"}
   #courseblock-header{style: 'position: relative; height: 80px;'}
     %a{:href=>cta_link, style: 'position: absolute;'}
       %img{src: img, style: "width: 100%;"}
-    %h3{style: 'position: absolute; color: white; margin-top: 20px; margin-left: 30px;'}= title
+    %h3{style: heading_style}= title
   #courseblock-content{style: 'padding-left: 20px; padding-right: 20px;'}
     - unless ages.nil?
       %h4= ages

--- a/pegasus/sites.v3/code.org/views/regional_partner_zip_form.haml
+++ b/pegasus/sites.v3/code.org/views/regional_partner_zip_form.haml
@@ -2,9 +2,13 @@
 - link += "?nominated=true" if params[:nominated]
 
 - body = capture_haml do
-  %p For most schools, attending Code.org professional learning is free of charge. Apply and see if you and your school qualify.
   %p
-    %b Enter your school’s zip code to learn more.
+    Professional learning programs are hosted by over 60 Regional Partners
+    throughout the U.S. See what scholarships and discounts are available
+    in your region.
+    %p
+      %strong
+        5-day summer workshop + 4 full-day school year sessions
   %form.linktag#pl-zip-form{action: "/educate/professional-learning/program-information", method: "get"}
     %span{style: "font-size:1.2em"} Zip:
     %input{type: "text", name: "zip", style: "padding:10px"}
@@ -12,4 +16,4 @@
       %input{type: "text", name: "nominated", value: params[:nominated], hidden: "true"}
     %input{type: "submit", value: "Submit", style: "color:white; background-color:orange; padding:10px; font-size:1.2em"}
 
-= view :course_wide_block, cta_link: link, img: CDO.code_org_url('/shared/images/banners/small-teal-icons.png'), title: 'Attend at no cost!', description: body
+= view :course_wide_block, cta_link: link, img: CDO.code_org_url('/shared/images/banners/small-teal-icons.png'), title: 'Find a Program (Scholarships Limited)', description: body, heading_font_size: '20px'


### PR DESCRIPTION
# Description
We are ending an experiment in Optimizely and need to update the middle-high page to reflect the control in Optimizely. This amounts to updating the regional partner search box to this:
<img width="481" alt="Screen Shot 2020-01-21 at 10 33 15 AM" src="https://user-images.githubusercontent.com/33666587/72833261-4cf3bb00-3c3b-11ea-90f9-a324762c6d01.png">

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-698)

## Testing story
Validated on private Firefox browser (where Optimizely does not apply changes) that new version looks the same as Optimizely version.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
