### PR TITLE
Video player: fix fallback issues

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -8,6 +8,7 @@ import FallbackPlayerCaptionDialogLink from '../templates/FallbackPlayerCaptionD
 var videojs = require('video.js');
 var testImageAccess = require('./url_test');
 var clientState = require('./clientState');
+import i18n from '@cdo/locale';
 
 var videos = (module.exports = {});
 
@@ -64,13 +65,19 @@ function onYouTubeIframeAPIReady() {
 }
 
 function createVideo(options) {
-  return $('<iframe id="video"/>')
+  const videoDiv = $('<iframe id="video"/>')
     .addClass('video-player')
     .attr({
       src: options.src,
       allowfullscreen: 'true',
       scrolling: 'no'
     });
+
+  const videoTabContainerDiv = $("<div id='videoTabContainer'></div>").append(
+    videoDiv
+  );
+
+  return videoTabContainerDiv;
 }
 
 /**
@@ -202,8 +209,13 @@ videos.showVideoDialog = function(options, forceShowVideo) {
   var nav = $div.find('.ui-tabs-nav');
   nav.append(download);
 
+  // Even though some React code will mount to this div and clear its
+  // contents, include the same link string as the React code will use, so that
+  // our calculations for the modal dimensions will account for its presence.
   var fallbackPlayerLinkDiv = $(
-    '<div id="fallback-player-caption-dialog-link"/>'
+    '<div id="fallback-player-caption-dialog-link"><a>' +
+      i18n.fallbackVideoClosedCaptioningLink() +
+      '</a></div>'
   ).css({
     'padding-right': '40px',
     'padding-top': '9px',
@@ -379,8 +391,8 @@ function addFallbackVideoPlayer(videoInfo, playerWidth, playerHeight) {
     '" type="video/mp4"/>' +
     '</video></div>';
 
-  // Swap current #video with new code
-  $('#video').replaceWith(playerCode);
+  $('#videoTabContainer').empty();
+  $('#videoTabContainer').append(playerCode);
 
   videojs.options.flash.swf = '/blockly/video-js/video-js.swf';
   videojs.options.techOrder = ['flash', 'html5'];
@@ -417,7 +429,7 @@ function openNotesTab() {
 }
 
 function openVideoTab() {
-  var notesTabIndex = $('.dash_modal_body a[href="#video"]')
+  var notesTabIndex = $('.dash_modal_body a[href="#videoTabContainer"]')
     .parent()
     .index();
   $('.ui-tabs').tabs('option', 'active', notesTabIndex);

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -213,7 +213,8 @@ videos.showVideoDialog = function(options, forceShowVideo) {
   // contents, include the same link string as the React code will use, so that
   // our calculations for the modal dimensions will account for its presence.
   var fallbackPlayerLinkDiv = $(
-    '<div id="fallback-player-caption-dialog-link"><a>' +
+    '<div id="fallback-player-caption-dialog-link">' +
+      '<a style="opacity: 0; pointer-events: none">' +
       i18n.fallbackVideoClosedCaptioningLink() +
       '</a></div>'
   ).css({

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -754,6 +754,10 @@ $default-modal-width: 640px;
   padding: 0;
 }
 
+#video {
+  border-width: 0;
+}
+
 .video-player {
   width: 100%;
   height: 100%;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -750,7 +750,7 @@ $default-modal-width: 640px;
   background-color: $orange;
 }
 
-#video {
+#videoTabContainer {
   padding: 0;
 }
 

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -8,7 +8,7 @@
 #notes-content{style: 'display: none;'}
   %ul
     %li
-      %a{href: '#video'}
+      %a{href: '#videoTabContainer'}
         = I18n.t('video.tab')
         %span.video-name
     %li


### PR DESCRIPTION
This fixes two issues when using fallback video in the popup video player on dashboard:

- Notes were showing below the dialog, not inside it, because we weren't hiding the fallback video when changing to the notes tab.  This was because the tab manager expected a div with ID `video` to be available to show/hide when the user entered/exited its tab, but when we were attaching the fallback player to the DOM we were replacing the only div with that ID, and so the video was never hidden when attempting to view the notes.  Now, the tab manager works with a container div that doesn't go away.
- The fallback video was extending below the bottom of the dialog at some screen widths, because the caption link was being added using React, but wasn't yet visible when we calculated the dialog dimensions.

## before

![Screenshot 2020-01-21 13 47 03](https://user-images.githubusercontent.com/2205926/72846060-ac11f980-3c54-11ea-8615-41da2f3fc2fb.png)

## after

![Screenshot 2020-01-21 13 47 21](https://user-images.githubusercontent.com/2205926/72846085-b633f800-3c54-11ea-98a9-d67a753d09ef.png)
![Screenshot 2020-01-21 13 47 37](https://user-images.githubusercontent.com/2205926/72846086-b633f800-3c54-11ea-8692-6b68a1d964b6.png)
