### PR TITLE
[student-libraries] Refactor the library creation dialog in preparation for adding 'unpublish' functionality

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -831,7 +831,7 @@
   "libraryExportTitle": "Export Functions as a Library",
   "libraryName": "Library Name",
   "libraryNameRequirements": "Your library's name must start with a capital letter and use only letters, numbers, and underscores.",
-  "libraryNoFunctonsError": "We can't publish your library because it doesn't have any functions. Try writing a function to include in your library.",
+  "libraryNoFunctionsError": "We can't publish your library because it doesn't have any functions. Try writing a function to include in your library.",
   "libraryPublishExplanation": "Share this ID with others so they can use your library in their project:",
   "libraryPublishInvalid": "Your library must include a description and at least one function.",
   "libraryPublishFail": "There was an error publishing your library. Please check your internet connection and try again.",

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -500,7 +500,7 @@ class ShareAllowedDialog extends React.Component {
           )}
         </BaseDialog>
         <PublishDialog />
-        <LibraryCreationDialog clientApi={libraryClientAPI} />
+        <LibraryCreationDialog libraryClientApi={libraryClientAPI} />
       </div>
     );
   }

--- a/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
@@ -150,7 +150,7 @@ class LibraryCreationDialog extends React.Component {
   }
 }
 
-class ErrorDisplay extends React.Component {
+export class ErrorDisplay extends React.Component {
   static propTypes = {message: PropTypes.string.isRequired};
 
   render() {
@@ -159,7 +159,7 @@ class ErrorDisplay extends React.Component {
   }
 }
 
-class LoadingDisplay extends React.Component {
+export class LoadingDisplay extends React.Component {
   render() {
     return (
       <div style={styles.centerContent}>
@@ -169,7 +169,7 @@ class LoadingDisplay extends React.Component {
   }
 }
 
-class SuccessDisplay extends React.Component {
+export class SuccessDisplay extends React.Component {
   static propTypes = {libraryName: PropTypes.string.isRequired};
 
   copyChannelId = () => {

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -94,7 +94,6 @@ export default class LibraryPublisher extends React.Component {
       libraryDescription
     );
 
-    // TODO: Display final version of error and success messages to the user.
     libraryClientApi.publish(
       libraryJson,
       error => {
@@ -197,9 +196,11 @@ export default class LibraryPublisher extends React.Component {
       errorMessage = i18n.libraryPublishFail();
     }
     return (
-      <div>
-        <p style={styles.alert}>{errorMessage}</p>
-      </div>
+      errorMessage && (
+        <div>
+          <p style={styles.alert}>{errorMessage}</p>
+        </div>
+      )
     );
   };
 

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -1,0 +1,217 @@
+/*global dashboard*/
+import React from 'react';
+import PropTypes from 'prop-types';
+import libraryParser from './libraryParser';
+import i18n from '@cdo/locale';
+import color from '@cdo/apps/util/color';
+import {Heading2} from '@cdo/apps/lib/ui/Headings';
+import Button from '@cdo/apps/templates/Button';
+
+const styles = {
+  alert: {
+    color: color.red,
+    width: '90%',
+    paddingTop: 8
+  },
+  largerCheckbox: {
+    width: 20,
+    height: 20,
+    marginLeft: 0,
+    marginRight: 10,
+    marginTop: 10,
+    marginBottom: 10
+  },
+  info: {
+    fontSize: 12,
+    fontStyle: 'italic'
+  },
+  textInput: {
+    fontSize: 14,
+    padding: 6,
+    color: color.dimgray
+  },
+  description: {
+    width: '98%',
+    resize: 'vertical'
+  }
+};
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const PublishState = {
+  DEFAULT: 'default',
+  ERROR_PUBLISH: 'error_publish',
+  INVALID_INPUT: 'invalid_input'
+};
+
+export default class LibraryPublisher extends React.Component {
+  static propTypes = {
+    onPublishSuccess: PropTypes.func.isRequired,
+    libraryDetails: PropTypes.object.isRequired,
+    clientApi: PropTypes.object.isRequired
+  };
+
+  state = {
+    publishState: PublishState.DEFAULT,
+    libraryName: libraryParser.suggestName(
+      this.props.libraryDetails.libraryName
+    ),
+    libraryDescription: '',
+    selectedFunctions: {}
+  };
+
+  setLibraryName = event => {
+    let sanitizedName = libraryParser.sanitizeName(event.target.value);
+    if (sanitizedName === this.state.libraryName) {
+      return;
+    }
+    this.setState({libraryName: sanitizedName});
+  };
+
+  publish = () => {
+    let {libraryDescription, libraryName, selectedFunctions} = this.state;
+    let {librarySource, sourceFunctionList} = this.props.libraryDetails;
+    let functionsToPublish = sourceFunctionList.filter(sourceFunction => {
+      return selectedFunctions[sourceFunction.functionName];
+    });
+
+    if (!(libraryDescription && functionsToPublish.length > 0)) {
+      this.setState({publishState: PublishState.INVALID_INPUT});
+      return;
+    }
+
+    let libraryJson = libraryParser.createLibraryJson(
+      librarySource,
+      functionsToPublish,
+      libraryName,
+      libraryDescription
+    );
+
+    // TODO: Display final version of error and success messages to the user.
+    this.props.clientApi.publish(
+      libraryJson,
+      error => {
+        console.warn(`Error publishing library: ${error}`);
+        this.setState({publishState: PublishState.ERROR_PUBLISH});
+      },
+      () => {
+        this.props.onPublishSuccess(this.state.libraryName);
+      }
+    );
+    dashboard.project.setLibraryName(this.state.libraryName);
+    dashboard.project.setLibraryDescription(libraryDescription);
+  };
+
+  displayNameInput = () => {
+    return (
+      <div>
+        <input
+          style={styles.textInput}
+          type="text"
+          value={this.state.libraryName}
+          onChange={this.setLibraryName}
+          onBlur={event =>
+            this.setState({
+              libraryName: libraryParser.suggestName(event.target.value)
+            })
+          }
+        />
+        <div style={styles.info}>{i18n.libraryNameRequirements()}</div>
+      </div>
+    );
+  };
+
+  resetErrorMessage = () => {
+    if (
+      this.state.libraryDescription &&
+      Object.values(this.state.selectedFunctions).find(value => value) &&
+      this.state.publishState === PublishState.INVALID_INPUT
+    ) {
+      this.setState({publishState: PublishState.DEFAULT});
+    }
+  };
+
+  displayDescription = () => {
+    return (
+      <textarea
+        rows="2"
+        cols="200"
+        style={{...styles.textInput, ...styles.description}}
+        placeholder={i18n.libraryDescriptionPlaceholder()}
+        value={this.state.libraryDescription}
+        onChange={event =>
+          this.setState({libraryDescription: event.target.value})
+        }
+        onBlur={this.resetErrorMessage}
+      />
+    );
+  };
+
+  boxChecked = name => () => {
+    this.setState(state => {
+      state.selectedFunctions[name] = !state.selectedFunctions[name];
+      return state;
+    }, this.resetErrorMessage);
+  };
+
+  displayFunctions = () => {
+    return this.props.libraryDetails.sourceFunctionList.map(sourceFunction => {
+      let name = sourceFunction.functionName;
+      let comment = sourceFunction.comment;
+      return (
+        <div key={name}>
+          <input
+            style={styles.largerCheckbox}
+            type="checkbox"
+            disabled={comment.length === 0}
+            name={name}
+            checked={this.state.selectedFunctions[name] || false}
+            onChange={this.boxChecked(name)}
+          />
+          <span>{name}</span>
+          <br />
+          {comment.length === 0 && (
+            <p style={styles.alert}>{i18n.libraryExportNoCommentError()}</p>
+          )}
+          <pre style={styles.textInput}>{comment}</pre>
+        </div>
+      );
+    });
+  };
+
+  displayError = () => {
+    let errorMessage;
+    if (this.state.publishState === PublishState.INVALID_INPUT) {
+      errorMessage = i18n.libraryPublishInvalid();
+    }
+    if (this.state.publishState === PublishState.ERROR_PUBLISH) {
+      errorMessage = i18n.libraryPublishFail();
+    }
+    return (
+      <div>
+        <p style={styles.alert}>{errorMessage}</p>
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <div>
+        <Heading2>{i18n.libraryName()}</Heading2>
+        {this.displayNameInput()}
+        <Heading2>{i18n.description()}</Heading2>
+        {this.displayDescription()}
+        <Heading2>{i18n.catProcedures()}</Heading2>
+        {this.displayFunctions()}
+        <Button
+          style={{marginLeft: 0, marginTop: 20}}
+          onClick={this.publish}
+          text={i18n.publish()}
+        />
+        {this.displayError()}
+      </div>
+    );
+  }
+}

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -46,11 +46,15 @@ export const PublishState = {
   INVALID_INPUT: 'invalid_input'
 };
 
+/**
+ * An interactive page for a dialog that can be used to publish or unpublish
+ * a library from a source project.
+ */
 export default class LibraryPublisher extends React.Component {
   static propTypes = {
     onPublishSuccess: PropTypes.func.isRequired,
     libraryDetails: PropTypes.object.isRequired,
-    clientApi: PropTypes.object.isRequired
+    libraryClientApi: PropTypes.object.isRequired
   };
 
   state = {
@@ -71,8 +75,9 @@ export default class LibraryPublisher extends React.Component {
   };
 
   publish = () => {
-    let {libraryDescription, libraryName, selectedFunctions} = this.state;
-    let {librarySource, sourceFunctionList} = this.props.libraryDetails;
+    const {libraryDescription, libraryName, selectedFunctions} = this.state;
+    const {librarySource, sourceFunctionList} = this.props.libraryDetails;
+    const {libraryClientApi, onPublishSuccess} = this.props;
     let functionsToPublish = sourceFunctionList.filter(sourceFunction => {
       return selectedFunctions[sourceFunction.functionName];
     });
@@ -90,17 +95,17 @@ export default class LibraryPublisher extends React.Component {
     );
 
     // TODO: Display final version of error and success messages to the user.
-    this.props.clientApi.publish(
+    libraryClientApi.publish(
       libraryJson,
       error => {
         console.warn(`Error publishing library: ${error}`);
         this.setState({publishState: PublishState.ERROR_PUBLISH});
       },
       () => {
-        this.props.onPublishSuccess(this.state.libraryName);
+        onPublishSuccess(libraryName);
       }
     );
-    dashboard.project.setLibraryName(this.state.libraryName);
+    dashboard.project.setLibraryName(libraryName);
     dashboard.project.setLibraryDescription(libraryDescription);
   };
 
@@ -141,10 +146,12 @@ export default class LibraryPublisher extends React.Component {
         style={{...styles.textInput, ...styles.description}}
         placeholder={i18n.libraryDescriptionPlaceholder()}
         value={this.state.libraryDescription}
-        onChange={event =>
-          this.setState({libraryDescription: event.target.value})
-        }
-        onBlur={this.resetErrorMessage}
+        onChange={event => {
+          this.setState(
+            {libraryDescription: event.target.value},
+            this.resetErrorMessage
+          );
+        }}
       />
     );
   };

--- a/apps/src/code-studio/components/libraries/libraryLoader.js
+++ b/apps/src/code-studio/components/libraries/libraryLoader.js
@@ -2,7 +2,19 @@
 import libraryParser from './libraryParser';
 import annotationList from '@cdo/apps/acemode/annotationList';
 
-export function load(onCodeError, onMissingFunctions, onSuccess) {
+/**
+ * Gathers all known metadata about a user-created library and passes that data
+ * into the given callbacks. This metadata is gathered from the code in the
+ * library's source project.
+ * @param {function} onCodeError the callback used when there is a bug detected
+ *                   in the library's code.
+ * @param {function} onMissingFunctions the callback used when no functions are
+ *                   detected in the library's code.
+ * @param {function} onSuccess the callback used when a library has been
+ *                   successfully loaded. All details about the library are
+ *                   passed to this callback.
+ */
+export default function load(onCodeError, onMissingFunctions, onSuccess) {
   var error = annotationList.getJSLintAnnotations().find(annotation => {
     return annotation.type === 'error';
   });
@@ -31,7 +43,3 @@ export function load(onCodeError, onMissingFunctions, onSuccess) {
     });
   });
 }
-
-export default {
-  load
-};

--- a/apps/src/code-studio/components/libraries/libraryLoader.js
+++ b/apps/src/code-studio/components/libraries/libraryLoader.js
@@ -1,0 +1,37 @@
+/*global dashboard*/
+import libraryParser from './libraryParser';
+import annotationList from '@cdo/apps/acemode/annotationList';
+
+export function load(onCodeError, onMissingFunctions, onSuccess) {
+  var error = annotationList.getJSLintAnnotations().find(annotation => {
+    return annotation.type === 'error';
+  });
+  if (error) {
+    onCodeError();
+    return;
+  }
+
+  dashboard.project.getUpdatedSourceAndHtml_(response => {
+    let functionsList = libraryParser.getFunctions(response.source);
+    if (!functionsList || functionsList.length === 0) {
+      onMissingFunctions();
+      return;
+    }
+    let librarySource = response.source;
+    if (response.libraries) {
+      response.libraries.forEach(library => {
+        librarySource =
+          libraryParser.createLibraryClosure(library) + librarySource;
+      });
+    }
+    onSuccess({
+      libraryName: dashboard.project.getLevelName(),
+      librarySource: librarySource,
+      sourceFunctionList: functionsList
+    });
+  });
+}
+
+export default {
+  load
+};

--- a/apps/test/unit/code-studio/components/libraries/LibraryCreationDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryCreationDialogTest.js
@@ -1,22 +1,22 @@
 import {expect} from '../../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow} from 'enzyme';
-import sinon from 'sinon';
-import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
 import {
   UnconnectedLibraryCreationDialog as LibraryCreationDialog,
-  DialogState
+  DialogState,
+  LoadingDisplay,
+  ErrorDisplay,
+  SuccessDisplay
 } from '@cdo/apps/code-studio/components/libraries/LibraryCreationDialog.jsx';
-import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
+import LibraryPublisher from '@cdo/apps/code-studio/components/libraries/LibraryPublisher.jsx';
 
 describe('LibraryCreationDialog', () => {
   let wrapper;
-  const CHANNEL_ID_SELECTOR = 'input[type="text"]';
 
   beforeEach(() => {
     wrapper = shallow(
       <LibraryCreationDialog
-        clientApi={{}}
+        libraryClientApi={{}}
         dialogIsOpen={true}
         onClose={() => {}}
       />
@@ -29,24 +29,27 @@ describe('LibraryCreationDialog', () => {
 
   describe('UI', () => {
     it('displays loading while in the loading state', () => {
-      expect(wrapper.find(Spinner).exists()).to.be.true;
+      expect(wrapper.find(LoadingDisplay).exists()).to.be.true;
     });
 
-    it('displays channel id when in published state', () => {
-      replaceOnWindow('dashboard', {
-        project: {
-          getCurrentId: () => {}
-        }
-      });
-      sinon.stub(window.dashboard.project, 'getCurrentId').returns('123');
-      wrapper.setState({
-        libraryName: 'name',
-        dialogState: DialogState.PUBLISHED
-      });
+    it('displays success while in the published state', () => {
+      wrapper.setState({dialogState: DialogState.PUBLISHED});
+      expect(wrapper.find(SuccessDisplay).exists()).to.be.true;
+    });
 
-      expect(wrapper.find(CHANNEL_ID_SELECTOR).props().value).to.equal('123');
+    it('displays error while in the code error state', () => {
+      wrapper.setState({dialogState: DialogState.CODE_ERROR});
+      expect(wrapper.find(ErrorDisplay).exists()).to.be.true;
+    });
 
-      restoreOnWindow('dashboard');
+    it('displays error while in the no functions state', () => {
+      wrapper.setState({dialogState: DialogState.NO_FUNCTIONS});
+      expect(wrapper.find(ErrorDisplay).exists()).to.be.true;
+    });
+
+    it('displays publisher dialog while in the done loading state', () => {
+      wrapper.setState({dialogState: DialogState.DONE_LOADING});
+      expect(wrapper.find(LibraryPublisher).exists()).to.be.true;
     });
   });
 });

--- a/apps/test/unit/code-studio/components/libraries/LibraryCreationDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryCreationDialogTest.js
@@ -1,74 +1,22 @@
-import {expect, assert} from '../../../../util/reconfiguredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow} from 'enzyme';
+import sinon from 'sinon';
+import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
 import {
   UnconnectedLibraryCreationDialog as LibraryCreationDialog,
-  PublishState
+  DialogState
 } from '@cdo/apps/code-studio/components/libraries/LibraryCreationDialog.jsx';
-import libraryParser from '@cdo/apps/code-studio/components/libraries/libraryParser';
-import LibraryClientApi from '@cdo/apps/code-studio/components/libraries/LibraryClientApi';
-import sinon from 'sinon';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
-import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
-import annotationList from '@cdo/apps/acemode/annotationList';
-
-const LIBRARY_SOURCE =
-  '/*\n' +
-  'Everything in this block comment\n' +
-  'will be included as-is\n' +
-  '\n' +
-  'including the whitespace above it\n' +
-  '*/\n' +
-  'function myFunc2(n) {\n' +
-  '}\n' +
-  '\n' +
-  '// This comment will not be included\n' +
-  '/* \n' +
-  'This comment will be included.\n' +
-  '*/\n' +
-  'function myFunc3() {\n' +
-  '}\n' +
-  '\n' +
-  '/**/\n' +
-  'function theAboveCommentWillNotBreakThings() {\n' +
-  '}';
 
 describe('LibraryCreationDialog', () => {
   let wrapper;
-  let clientApi;
-  let publishSpy;
-
-  const SUBMIT_SELECTOR = 'input[type="submit"]';
-  const CHECKBOX_SELECTOR = 'input[type="checkbox"]';
   const CHANNEL_ID_SELECTOR = 'input[type="text"]';
-
-  before(() => {
-    replaceOnWindow('dashboard', {
-      project: {
-        setLibraryName: () => {},
-        setLibraryDescription: () => {},
-        getCurrentId: () => {},
-        getUpdatedSourceAndHtml_: () => {},
-        getLevelName: () => {}
-      }
-    });
-    sinon.stub(window.dashboard.project, 'setLibraryName').returns(undefined);
-    sinon
-      .stub(window.dashboard.project, 'setLibraryDescription')
-      .returns(undefined);
-    sinon.stub(window.dashboard.project, 'getCurrentId').returns('123');
-    clientApi = new LibraryClientApi('123');
-    publishSpy = sinon.stub(clientApi, 'publish');
-  });
-
-  after(() => {
-    restoreOnWindow('dashboard');
-  });
 
   beforeEach(() => {
     wrapper = shallow(
       <LibraryCreationDialog
-        clientApi={clientApi}
+        clientApi={{}}
         dialogIsOpen={true}
         onClose={() => {}}
       />
@@ -79,245 +27,26 @@ describe('LibraryCreationDialog', () => {
     wrapper = null;
   });
 
-  describe('onOpen', () => {
-    let getJSLintAnnotationsStub, sourceStub, functionStub;
-    let libraryName = 'Name';
-    let source = 'function foo() {}';
-    beforeEach(() => {
-      getJSLintAnnotationsStub = sinon.stub(
-        annotationList,
-        'getJSLintAnnotations'
-      );
-      sourceStub = sinon.stub(
-        window.dashboard.project,
-        'getUpdatedSourceAndHtml_'
-      );
-      functionStub = sinon.stub(libraryParser, 'getFunctions');
-      sinon.stub(libraryParser, 'sanitizeName').returns(libraryName);
-      sinon.stub(libraryParser, 'suggestName').returns(libraryName);
-      sinon.stub(window.dashboard.project, 'getLevelName').returns(libraryName);
-    });
-
-    afterEach(() => {
-      annotationList.getJSLintAnnotations.restore();
-      window.dashboard.project.getUpdatedSourceAndHtml_.restore();
-      libraryParser.getFunctions.restore();
-      libraryParser.sanitizeName.restore();
-      libraryParser.suggestName.restore();
-      window.dashboard.project.getLevelName.restore();
-    });
-
-    it('sets the loading state to CODE_ERROR when a code error exists', () => {
-      getJSLintAnnotationsStub.returns([{type: 'error'}]);
-      wrapper.instance().onOpen();
-      wrapper.update();
-      expect(wrapper.state().publishState).to.equal(PublishState.CODE_ERROR);
-    });
-
-    it('sets loading state to NO_FUNCTIONS when there are no functions', () => {
-      getJSLintAnnotationsStub.returns([]);
-      sourceStub.yields({source: ''});
-      functionStub.returns([]);
-
-      wrapper.instance().onOpen();
-      wrapper.update();
-      expect(wrapper.state().publishState).to.equal(PublishState.NO_FUNCTIONS);
-    });
-
-    it('sets loading state to DONE_LOADING on success', () => {
-      getJSLintAnnotationsStub.returns([]);
-      functionStub.returns([{functionName: 'foo', comment: ''}]);
-      sourceStub.yields({source: source});
-
-      wrapper.instance().onOpen();
-      wrapper.update();
-      expect(wrapper.state().publishState).to.equal(PublishState.DONE_LOADING);
-      expect(wrapper.state().librarySource).to.equal(source);
-      expect(wrapper.state().libraryName).to.equal(libraryName);
-    });
-
-    it('prepends imported libraries to the exported source', () => {
-      let library = 'function bar() {}';
-      getJSLintAnnotationsStub.returns([]);
-      functionStub.returns([{functionName: 'foo', comment: ''}]);
-      sourceStub.yields({source: source, libraries: [library]});
-      sinon.stub(libraryParser, 'createLibraryClosure').returns(library);
-
-      wrapper.instance().onOpen();
-      wrapper.update();
-      expect(wrapper.state().publishState).to.equal(PublishState.DONE_LOADING);
-      expect(wrapper.state().librarySource).to.equal(library + source);
-      expect(wrapper.state().libraryName).to.equal(libraryName);
-
-      libraryParser.createLibraryClosure.restore();
-    });
-  });
-
   describe('UI', () => {
-    let libraryName = 'testLibrary';
-    it('checkbox is disabled for items without comments', () => {
-      wrapper.setState({
-        libraryName: libraryName,
-        librarySource: LIBRARY_SOURCE,
-        publishState: PublishState.DONE_LOADING,
-        sourceFunctionList: libraryParser.getFunctions(LIBRARY_SOURCE)
-      });
-
-      assert.isTrue(
-        wrapper
-          .find(CHECKBOX_SELECTOR)
-          .last()
-          .prop('disabled')
-      );
-    });
-
     it('displays loading while in the loading state', () => {
-      expect(wrapper.find(SUBMIT_SELECTOR).exists()).to.be.false;
       expect(wrapper.find(Spinner).exists()).to.be.true;
     });
 
     it('displays channel id when in published state', () => {
+      replaceOnWindow('dashboard', {
+        project: {
+          getCurrentId: () => {}
+        }
+      });
+      sinon.stub(window.dashboard.project, 'getCurrentId').returns('123');
       wrapper.setState({
-        libraryName: libraryName,
-        librarySource: LIBRARY_SOURCE,
-        publishState: PublishState.PUBLISHED,
-        sourceFunctionList: libraryParser.getFunctions(LIBRARY_SOURCE)
+        libraryName: 'name',
+        dialogState: DialogState.PUBLISHED
       });
 
       expect(wrapper.find(CHANNEL_ID_SELECTOR).props().value).to.equal('123');
-    });
-  });
 
-  describe('publish', () => {
-    let libraryName = 'testLibrary';
-    let description = 'description';
-    let selectedFunctions = {myFunc2: true};
-    it('is disabled when no functions are checked', () => {
-      wrapper.setState({
-        libraryName: libraryName,
-        libraryDescription: description,
-        librarySource: LIBRARY_SOURCE,
-        publishState: PublishState.DONE_LOADING,
-        sourceFunctionList: libraryParser.getFunctions(LIBRARY_SOURCE)
-      });
-
-      wrapper.instance().publish();
-      wrapper.update();
-
-      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
-    });
-
-    it('is disabled when description is unset', () => {
-      wrapper.setState({
-        libraryName: libraryName,
-        librarySource: LIBRARY_SOURCE,
-        publishState: PublishState.DONE_LOADING,
-        sourceFunctionList: libraryParser.getFunctions(LIBRARY_SOURCE),
-        selectedFunctions: selectedFunctions
-      });
-
-      wrapper.instance().publish();
-      wrapper.update();
-
-      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
-    });
-
-    it('is enabled once description and functions are set', () => {
-      wrapper.setState({
-        libraryName: libraryName,
-        librarySource: LIBRARY_SOURCE,
-        publishState: PublishState.DONE_LOADING,
-        sourceFunctionList: libraryParser.getFunctions(LIBRARY_SOURCE)
-      });
-
-      wrapper.instance().publish();
-      wrapper.update();
-      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
-
-      wrapper.instance().resetErrorMessage();
-      wrapper.update();
-      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
-
-      wrapper.setState({
-        selectedFunctions: selectedFunctions,
-        libraryDescription: description
-      });
-      wrapper.instance().resetErrorMessage();
-      wrapper.update();
-
-      expect(wrapper.state().publishState).to.equal(PublishState.DONE_LOADING);
-    });
-
-    describe('with valid input', () => {
-      let libraryJsonSpy;
-      beforeEach(() => {
-        libraryJsonSpy = sinon.stub(libraryParser, 'createLibraryJson');
-      });
-
-      afterEach(() => {
-        libraryParser.createLibraryJson.restore();
-      });
-
-      it('sets error state when publish fails', () => {
-        publishSpy.callsArg(1);
-        sinon.stub(console, 'warn');
-        wrapper.setState({
-          libraryName: libraryName,
-          librarySource: LIBRARY_SOURCE,
-          publishState: PublishState.DONE_LOADING,
-          sourceFunctionList: libraryParser.getFunctions(LIBRARY_SOURCE),
-          libraryDescription: description,
-          selectedFunctions: selectedFunctions
-        });
-
-        wrapper.instance().publish();
-        wrapper.update();
-
-        expect(wrapper.state().publishState).to.equal(
-          PublishState.ERROR_PUBLISH
-        );
-
-        console.warn.restore();
-      });
-
-      it('sets PUBLISHED state when it succeeds', () => {
-        publishSpy.callsArg(2);
-        wrapper.setState({
-          libraryName: libraryName,
-          librarySource: LIBRARY_SOURCE,
-          publishState: PublishState.DONE_LOADING,
-          sourceFunctionList: libraryParser.getFunctions(LIBRARY_SOURCE),
-          libraryDescription: description,
-          selectedFunctions: selectedFunctions
-        });
-
-        wrapper.instance().publish();
-        wrapper.update();
-
-        expect(wrapper.state().publishState).to.equal(PublishState.PUBLISHED);
-      });
-
-      it('publishes only the selected functions and description', () => {
-        let functionList = libraryParser.getFunctions(LIBRARY_SOURCE);
-        wrapper.setState({
-          libraryName: libraryName,
-          librarySource: LIBRARY_SOURCE,
-          publishState: PublishState.DONE_LOADING,
-          sourceFunctionList: functionList,
-          libraryDescription: description,
-          selectedFunctions: selectedFunctions
-        });
-
-        wrapper.instance().publish();
-        wrapper.update();
-
-        expect(libraryJsonSpy).to.have.been.calledOnceWith(
-          LIBRARY_SOURCE,
-          [functionList[0]],
-          libraryName,
-          description
-        );
-      });
+      restoreOnWindow('dashboard');
     });
   });
 });

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -1,0 +1,220 @@
+import {expect} from '../../../../util/reconfiguredChai';
+import React from 'react';
+import {shallow} from 'enzyme';
+import LibraryPublisher, {
+  PublishState
+} from '@cdo/apps/code-studio/components/libraries/LibraryPublisher';
+import LibraryClientApi from '@cdo/apps/code-studio/components/libraries/LibraryClientApi';
+import libraryParser from '@cdo/apps/code-studio/components/libraries/libraryParser';
+import sinon from 'sinon';
+import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
+
+describe('LibraryPublisher', () => {
+  let publishSpy, clientApi, libraryDetails;
+  let defaultSelectedFunctions, sourceFunctionList;
+  const defaultDescription = '';
+  const librarySource = '//comment\nfunction foo(){}';
+  const libraryName = 'libraryName';
+  const CHECKBOX_SELECTOR = 'input[type="checkbox"]';
+
+  before(() => {
+    replaceOnWindow('dashboard', {
+      project: {
+        setLibraryName: () => {},
+        setLibraryDescription: () => {}
+      }
+    });
+    sinon.stub(window.dashboard.project, 'setLibraryName').returns(undefined);
+    sinon
+      .stub(window.dashboard.project, 'setLibraryDescription')
+      .returns(undefined);
+    sinon.stub(libraryParser, 'suggestName').returns(libraryName);
+    sinon.stub(libraryParser, 'sanitizeName').returns(libraryName);
+    clientApi = new LibraryClientApi('123');
+    publishSpy = sinon.stub(clientApi, 'publish');
+  });
+
+  after(() => {
+    libraryParser.suggestName.restore();
+    libraryParser.sanitizeName.restore();
+    restoreOnWindow('dashboard');
+  });
+
+  let onPublishSuccess, onUnpublishSuccess;
+  beforeEach(() => {
+    defaultSelectedFunctions = {};
+    sourceFunctionList = [{functionName: 'foo', comment: 'comment'}];
+    libraryDetails = {
+      libraryName: libraryName,
+      libraryDescription: defaultDescription,
+      selectedFunctions: defaultSelectedFunctions,
+      sourceFunctionList: sourceFunctionList,
+      librarySource: librarySource
+    };
+    onPublishSuccess = sinon.stub();
+    onUnpublishSuccess = sinon.stub();
+  });
+
+  afterEach(() => {
+    onPublishSuccess.resetHistory();
+    onUnpublishSuccess.resetHistory();
+  });
+
+  describe('On Load', () => {
+    it('suggests a default library name', () => {
+      libraryDetails.libraryName = 'foo';
+      let wrapper = shallow(
+        <LibraryPublisher
+          onPublishSuccess={onPublishSuccess}
+          onUnpublishSuccess={onUnpublishSuccess}
+          libraryDetails={libraryDetails}
+          clientApi={clientApi}
+        />
+      );
+
+      expect(wrapper.state().libraryName).to.equal(libraryName);
+    });
+
+    it('disables checkbox for items without comments', () => {
+      libraryDetails.sourceFunctionList.push({
+        functionName: 'bar',
+        comment: ''
+      });
+      let wrapper = shallow(
+        <LibraryPublisher
+          onPublishSuccess={onPublishSuccess}
+          onUnpublishSuccess={onUnpublishSuccess}
+          libraryDetails={libraryDetails}
+          clientApi={clientApi}
+        />
+      );
+
+      let checkboxes = wrapper.find(CHECKBOX_SELECTOR);
+      expect(checkboxes.first().prop('disabled')).to.be.false;
+      expect(checkboxes.last().prop('disabled')).to.be.true;
+    });
+  });
+
+  describe('publish', () => {
+    let wrapper;
+    const description = 'description';
+    const selectedFunctions = {foo: true};
+    beforeEach(() => {
+      wrapper = shallow(
+        <LibraryPublisher
+          onPublishSuccess={onPublishSuccess}
+          onUnpublishSuccess={onUnpublishSuccess}
+          libraryDetails={libraryDetails}
+          clientApi={clientApi}
+        />
+      );
+    });
+
+    it('is disabled when no functions are checked', () => {
+      wrapper.setState({
+        libraryDescription: description
+      });
+
+      wrapper.instance().publish();
+      wrapper.update();
+
+      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
+    });
+
+    it('is disabled when description is unset', () => {
+      wrapper.setState({
+        selectedFunctions: selectedFunctions
+      });
+
+      wrapper.instance().publish();
+      wrapper.update();
+
+      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
+    });
+
+    it('is enabled once description and functions are set', () => {
+      wrapper.instance().publish();
+      wrapper.update();
+      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
+
+      wrapper.instance().resetErrorMessage();
+      wrapper.update();
+      expect(wrapper.state().publishState).to.equal(PublishState.INVALID_INPUT);
+
+      wrapper.setState({
+        selectedFunctions: selectedFunctions,
+        libraryDescription: description
+      });
+      wrapper.instance().resetErrorMessage();
+      wrapper.update();
+
+      expect(wrapper.state().publishState).to.equal(PublishState.DEFAULT);
+    });
+
+    describe('with valid input', () => {
+      it('sets error state when publish fails', () => {
+        publishSpy.callsArg(1);
+        sinon.stub(console, 'warn');
+        wrapper.setState({
+          libraryDescription: description,
+          selectedFunctions: selectedFunctions
+        });
+
+        wrapper.instance().publish();
+        wrapper.update();
+
+        expect(wrapper.state().publishState).to.equal(
+          PublishState.ERROR_PUBLISH
+        );
+
+        console.warn.restore();
+      });
+
+      it('calls onPublishSuccess when it succeeds', () => {
+        publishSpy.callsArg(2);
+        wrapper.setState({
+          libraryDescription: description,
+          selectedFunctions: selectedFunctions
+        });
+
+        wrapper.instance().publish();
+        wrapper.update();
+
+        expect(onPublishSuccess.called).to.be.true;
+      });
+    });
+  });
+
+  it('publishes only the selected functions and description', () => {
+    let libraryJsonSpy = sinon.stub(libraryParser, 'createLibraryJson');
+    let description = 'description';
+    let selectedFunctions = {bar: true};
+    let newFunction = {functionName: 'bar', comment: 'comment'};
+    libraryDetails.sourceFunctionList.push(newFunction);
+    let wrapper = shallow(
+      <LibraryPublisher
+        onPublishSuccess={onPublishSuccess}
+        onUnpublishSuccess={onUnpublishSuccess}
+        libraryDetails={libraryDetails}
+        clientApi={clientApi}
+      />
+    );
+
+    wrapper.setState({
+      libraryDescription: description,
+      selectedFunctions: selectedFunctions
+    });
+
+    wrapper.instance().publish();
+    wrapper.update();
+
+    expect(libraryJsonSpy).to.have.been.calledWith(
+      librarySource,
+      [newFunction],
+      libraryName,
+      description
+    );
+
+    libraryParser.createLibraryJson.restore();
+  });
+});

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -10,7 +10,7 @@ import sinon from 'sinon';
 import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
 
 describe('LibraryPublisher', () => {
-  let publishSpy, clientApi, libraryDetails;
+  let publishSpy, libraryClientApi, libraryDetails;
   let defaultSelectedFunctions, sourceFunctionList;
   const defaultDescription = '';
   const librarySource = '//comment\nfunction foo(){}';
@@ -30,8 +30,8 @@ describe('LibraryPublisher', () => {
       .returns(undefined);
     sinon.stub(libraryParser, 'suggestName').returns(libraryName);
     sinon.stub(libraryParser, 'sanitizeName').returns(libraryName);
-    clientApi = new LibraryClientApi('123');
-    publishSpy = sinon.stub(clientApi, 'publish');
+    libraryClientApi = new LibraryClientApi('123');
+    publishSpy = sinon.stub(libraryClientApi, 'publish');
   });
 
   after(() => {
@@ -68,7 +68,7 @@ describe('LibraryPublisher', () => {
           onPublishSuccess={onPublishSuccess}
           onUnpublishSuccess={onUnpublishSuccess}
           libraryDetails={libraryDetails}
-          clientApi={clientApi}
+          libraryClientApi={libraryClientApi}
         />
       );
 
@@ -85,7 +85,7 @@ describe('LibraryPublisher', () => {
           onPublishSuccess={onPublishSuccess}
           onUnpublishSuccess={onUnpublishSuccess}
           libraryDetails={libraryDetails}
-          clientApi={clientApi}
+          libraryClientApi={libraryClientApi}
         />
       );
 
@@ -105,7 +105,7 @@ describe('LibraryPublisher', () => {
           onPublishSuccess={onPublishSuccess}
           onUnpublishSuccess={onUnpublishSuccess}
           libraryDetails={libraryDetails}
-          clientApi={clientApi}
+          libraryClientApi={libraryClientApi}
         />
       );
     });
@@ -196,7 +196,7 @@ describe('LibraryPublisher', () => {
         onPublishSuccess={onPublishSuccess}
         onUnpublishSuccess={onUnpublishSuccess}
         libraryDetails={libraryDetails}
-        clientApi={clientApi}
+        libraryClientApi={libraryClientApi}
       />
     );
 

--- a/apps/test/unit/code-studio/components/libraries/libraryLoaderTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryLoaderTest.js
@@ -2,7 +2,7 @@ import {expect} from '../../../../util/reconfiguredChai';
 import annotationList from '@cdo/apps/acemode/annotationList';
 import sinon from 'sinon';
 import libraryParser from '@cdo/apps/code-studio/components/libraries/libraryParser';
-import libraryLoader from '@cdo/apps/code-studio/components/libraries/libraryLoader';
+import loadLibrary from '@cdo/apps/code-studio/components/libraries/libraryLoader';
 import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
 
 describe('libraryLoader.load', () => {
@@ -52,7 +52,7 @@ describe('libraryLoader.load', () => {
   it('calls onCodeError when an error exists in the code', () => {
     getJSLintAnnotationsStub.returns([{type: 'error'}]);
 
-    libraryLoader.load(onCodeErrorStub, onMissingFunctionsStub, onSuccessStub);
+    loadLibrary(onCodeErrorStub, onMissingFunctionsStub, onSuccessStub);
 
     expect(onCodeErrorStub.called).to.be.true;
     expect(onMissingFunctionsStub.called).to.be.false;
@@ -64,7 +64,7 @@ describe('libraryLoader.load', () => {
     sourceStub.yields({source: ''});
     functionStub.returns([]);
 
-    libraryLoader.load(onCodeErrorStub, onMissingFunctionsStub, onSuccessStub);
+    loadLibrary(onCodeErrorStub, onMissingFunctionsStub, onSuccessStub);
 
     expect(onCodeErrorStub.called).to.be.false;
     expect(onMissingFunctionsStub.called).to.be.true;
@@ -79,7 +79,7 @@ describe('libraryLoader.load', () => {
     sourceStub.yields({source: source, libraries: [library]});
     sinon.stub(libraryParser, 'createLibraryClosure').returns(library);
 
-    libraryLoader.load(onCodeErrorStub, onMissingFunctionsStub, onSuccessStub);
+    loadLibrary(onCodeErrorStub, onMissingFunctionsStub, onSuccessStub);
 
     expect(onCodeErrorStub.called).to.be.false;
     expect(onMissingFunctionsStub.called).to.be.false;

--- a/apps/test/unit/code-studio/components/libraries/libraryLoaderTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryLoaderTest.js
@@ -1,0 +1,94 @@
+import {expect} from '../../../../util/reconfiguredChai';
+import annotationList from '@cdo/apps/acemode/annotationList';
+import sinon from 'sinon';
+import libraryParser from '@cdo/apps/code-studio/components/libraries/libraryParser';
+import libraryLoader from '@cdo/apps/code-studio/components/libraries/libraryLoader';
+import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
+
+describe('libraryLoader.load', () => {
+  let getJSLintAnnotationsStub, sourceStub, functionStub;
+  let onCodeErrorStub, onMissingFunctionsStub, onSuccessStub;
+  let libraryName = 'Name';
+  let source = 'function foo() {}';
+  before(() => {
+    replaceOnWindow('dashboard', {
+      project: {
+        getUpdatedSourceAndHtml_: () => {},
+        getLevelName: () => {}
+      }
+    });
+  });
+
+  after(() => {
+    restoreOnWindow('dashboard');
+  });
+
+  beforeEach(() => {
+    getJSLintAnnotationsStub = sinon.stub(
+      annotationList,
+      'getJSLintAnnotations'
+    );
+    sourceStub = sinon.stub(
+      window.dashboard.project,
+      'getUpdatedSourceAndHtml_'
+    );
+    functionStub = sinon.stub(libraryParser, 'getFunctions');
+    sinon.stub(window.dashboard.project, 'getLevelName').returns(libraryName);
+    onCodeErrorStub = sinon.stub();
+    onMissingFunctionsStub = sinon.stub();
+    onSuccessStub = sinon.stub();
+  });
+
+  afterEach(() => {
+    annotationList.getJSLintAnnotations.restore();
+    window.dashboard.project.getUpdatedSourceAndHtml_.restore();
+    libraryParser.getFunctions.restore();
+    window.dashboard.project.getLevelName.restore();
+    onCodeErrorStub.resetHistory();
+    onMissingFunctionsStub.resetHistory();
+    onSuccessStub.resetHistory();
+  });
+
+  it('calls onCodeError when an error exists in the code', () => {
+    getJSLintAnnotationsStub.returns([{type: 'error'}]);
+
+    libraryLoader.load(onCodeErrorStub, onMissingFunctionsStub, onSuccessStub);
+
+    expect(onCodeErrorStub.called).to.be.true;
+    expect(onMissingFunctionsStub.called).to.be.false;
+    expect(onSuccessStub.called).to.be.false;
+  });
+
+  it('calls onMissingFunctions when there are no functions', () => {
+    getJSLintAnnotationsStub.returns([]);
+    sourceStub.yields({source: ''});
+    functionStub.returns([]);
+
+    libraryLoader.load(onCodeErrorStub, onMissingFunctionsStub, onSuccessStub);
+
+    expect(onCodeErrorStub.called).to.be.false;
+    expect(onMissingFunctionsStub.called).to.be.true;
+    expect(onSuccessStub.called).to.be.false;
+  });
+
+  it('prepends imported libraries to the exported source', () => {
+    let library = 'function bar() {}';
+    let sourceFunctionList = [{functionName: 'foo', comment: ''}];
+    getJSLintAnnotationsStub.returns([]);
+    functionStub.returns(sourceFunctionList);
+    sourceStub.yields({source: source, libraries: [library]});
+    sinon.stub(libraryParser, 'createLibraryClosure').returns(library);
+
+    libraryLoader.load(onCodeErrorStub, onMissingFunctionsStub, onSuccessStub);
+
+    expect(onCodeErrorStub.called).to.be.false;
+    expect(onMissingFunctionsStub.called).to.be.false;
+    expect(onSuccessStub).to.have.been.calledWith({
+      libraryName: libraryName,
+      librarySource: library + source,
+      sourceFunctionList: sourceFunctionList
+    });
+
+    libraryParser.createLibraryClosure.restore();
+  });
+});


### PR DESCRIPTION
This splits the LibraryCreationDialog into three parts

1. LibraryCreationDialog - This is now a parent container for various success, loading, and error dialogs that are associated with library creation.
2. libraryLoader - this is a util function that loads and does initial error checking for source code and metadata of the library (in the future, this will also merge the source and S3 versions of the library)
3. LibraryPublisher - this handles the UX for selecting metadata to include in a library as well as the logic to publish a library. (in the future this will also handle unpublishing a library)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

### Background
Unpublish will add significant functionality to the library creation dialog. It will allow users to unpublish their library. It will also allow us to detect if a library has already been created, and, if it has, to merge the existing metadata into the library.

<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story
Updated old tests
<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
