### PR TITLE
Certificates support non-latin characters in names

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -516,6 +516,8 @@ en:
     no_primary_course: "Try a Code Studio course"
     choose_next_course: "Try a Code Studio course by choosing one below"
     print_certificate: "Print Certificate"
+  certificate:
+    sponsor_message: "%{sponsor_name} made the generous gift to sponsor your learning."
   move_students:
     new_section_dne: "Sorry, but section %{new_section_code} does not exist. Please enter a different section code."
     section_code_cant_be_current_section: "The current section cannot be the same as the new section."

--- a/dashboard/lib/pd/certificate_renderer.rb
+++ b/dashboard/lib/pd/certificate_renderer.rb
@@ -31,11 +31,9 @@ module Pd
       [
         {
           string: enrollment.try(:full_name) || '',
-          pointsize: 90,
-          height: 100,
-          width: 1200,
-          x: 570,
-          y: 570,
+          pointsize: 70,
+          x: 0,
+          y: -240,
         }
       ]
     end
@@ -45,24 +43,21 @@ module Pd
         [
           {
             string: workshop.course_name,
-            y: 780,
-            pointsize: 90,
-            height: 100,
+            y: -30,
+            pointsize: 70,
           },
           {
             string: workshop.friendly_subject,
-            y: 870,
-            pointsize: 80,
-            height: 90,
+            y: 65,
+            pointsize: 60,
           }
         ]
       else
         [
           {
             string: workshop.course_name,
-            y: 800,
-            pointsize: 90,
-            height: 100,
+            y: -10,
+            pointsize: 70,
           }
         ]
       end
@@ -72,11 +67,9 @@ module Pd
       [
         {
           string: ActiveSupport::NumberHelper.number_to_rounded(workshop.effective_num_hours, precision: 1, strip_insignificant_zeros: true),
-          y: 978,
-          x: 880,
-          height: 40,
-          width: 50,
-          pointsize: 40,
+          y: 143,
+          x: -265,
+          pointsize: 30,
         }
       ]
     end
@@ -85,9 +78,8 @@ module Pd
       [
         {
           string: workshop.workshop_date_range_string,
-          y: 1054,
-          height: 50,
-          pointsize: 45,
+          y: 228,
+          pointsize: 33,
         }
       ]
     end
@@ -96,11 +88,9 @@ module Pd
       facilitator_names(workshop).each_with_index.map do |name, i|
         {
           string: name,
-          height: 50,
-          pointsize: 40,
-          width: 420,
-          y: 1305 - (50 * i),
-          x: 1290,
+          pointsize: 30,
+          y: 475 - (50 * i),
+          x: 330,
         }
       end
     end

--- a/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
@@ -44,10 +44,14 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     workshop = create :csf_intro_workshop
     enrollment = create :pd_enrollment, :with_attendance, workshop: workshop
 
-    _ = anything
-    mock_draw = expect_renders_certificate
-    mock_draw.expects(:annotate).with(_, _, _, _, _, 'CS Fundamentals')
-    mock_draw.expects(:annotate).with(_, _, _, _, _, 'Intro Workshop')
+    mock_image = expect_renders_certificate
+    expect_renders_text(mock_image, enrollment.full_name)
+    expect_renders_text(mock_image, 'CS Fundamentals')
+    expect_renders_text(mock_image, 'Intro Workshop')
+    workshop.facilitators.each {|f| expect_renders_text(mock_image, f.name)}
+    workshop_hours = Integer(workshop.effective_num_hours)
+    expect_renders_text(mock_image, workshop_hours.to_s)
+    expect_renders_text(mock_image, workshop.workshop_date_range_string)
 
     get :generate_certificate, params: {
       user: @user,
@@ -59,11 +63,13 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     enrollment = create :pd_enrollment, :with_attendance, workshop: @workshop
     assert_equal Pd::Workshop::COURSE_CSD, @workshop.course
 
-    _ = anything
-    mock_draw = expect_renders_certificate
-    mock_draw.expects(:annotate).with(_, _, _, _, _, 'CS Discoveries')
-    mock_draw.expects(:annotate).with(_, _, _, _, _, 'Facilitator 1')
-    mock_draw.expects(:annotate).with(_, _, _, _, _, 'Facilitator 2')
+    mock_image = expect_renders_certificate
+    expect_renders_text(mock_image, enrollment.full_name)
+    expect_renders_text(mock_image, 'CS Discoveries')
+    @workshop.facilitators.each {|f| expect_renders_text(mock_image, f.name)}
+    workshop_hours = Integer(@workshop.effective_num_hours)
+    expect_renders_text(mock_image, workshop_hours.to_s)
+    expect_renders_text(mock_image, @workshop.workshop_date_range_string)
 
     get :generate_certificate, params: {
       user: @user,
@@ -78,10 +84,13 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
       subject: Pd::Workshop::SUBJECT_CSD_TEACHER_CON
     enrollment = create :pd_enrollment, :with_attendance, workshop: workshop
 
-    _ = anything
-    mock_draw = expect_renders_certificate
-    mock_draw.expects(:annotate).with(_, _, _, _, _, 'CS Discoveries')
-    mock_draw.expects(:annotate).with(_, _, _, _, _, Pd::CertificateRenderer::HARDCODED_CSD_FACILITATOR)
+    mock_image = expect_renders_certificate
+    expect_renders_text(mock_image, enrollment.full_name)
+    expect_renders_text(mock_image, 'CS Discoveries')
+    expect_renders_text(mock_image, Pd::CertificateRenderer::HARDCODED_CSD_FACILITATOR)
+    workshop_hours = Integer(workshop.effective_num_hours)
+    expect_renders_text(mock_image, workshop_hours.to_s)
+    expect_renders_text(mock_image, workshop.workshop_date_range_string)
 
     get :generate_certificate, params: {
       user: @user,
@@ -96,10 +105,13 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
       subject: Pd::Workshop::SUBJECT_CSP_TEACHER_CON
     enrollment = create :pd_enrollment, :with_attendance, workshop: workshop
 
-    _ = anything
-    mock_draw = expect_renders_certificate
-    mock_draw.expects(:annotate).with(_, _, _, _, _, 'CS Principles')
-    mock_draw.expects(:annotate).with(_, _, _, _, _, Pd::CertificateRenderer::HARDCODED_CSP_FACILITATOR)
+    mock_image = expect_renders_certificate
+    expect_renders_text(mock_image, enrollment.full_name)
+    expect_renders_text(mock_image, 'CS Principles')
+    expect_renders_text(mock_image, Pd::CertificateRenderer::HARDCODED_CSP_FACILITATOR)
+    workshop_hours = Integer(workshop.effective_num_hours)
+    expect_renders_text(mock_image, workshop_hours.to_s)
+    expect_renders_text(mock_image, workshop.workshop_date_range_string)
 
     get :generate_certificate, params: {
       user: @user,
@@ -107,12 +119,31 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     }
   end
 
+  # Verifies the expected Magick::Image methods are called which are needed to
+  # put text on the certificate template image.
+  def expect_renders_text(mock_background_image, string)
+    # See create_workshop_certificate_image in certificate_image.rb for help
+    # understanding why these particular mocks and stubs work.
+    mock_text_image = mock
+    mock_text_image.stub_everything
+    # :trim is called in order to make sure excess empty space is removed around
+    # the text.
+    mock_text_image.expects(:trim!).returns(mock_text_image)
+    # :read with a "pango:..." string is what generates an image with the given
+    # text in it.
+    Magick::Image.expects(:read).with("pango:#{string}").returns([mock_text_image])
+    # :composite! puts the text_image onto the certificate.
+    _ = anything
+    mock_background_image.expects(:composite!).with(mock_text_image, _, _, _, Magick::OverCompositeOp)
+    # Important to make sure the temporary text image is destroyed; otherwise
+    # there will be a memory leak.
+    mock_text_image.expects(:destroy!)
+  end
+
   # rubocop:enable Lint/UnderscorePrefixedVariableName
-
+  # Verifies that the certificate template image is loaded by the Magick::Image
+  # methods and eventually cleaned up.
   def expect_renders_certificate
-    # Mock certificate generation at a fairly low level so that we actually run
-    # our logic for generating annotations on the certificate.
-
     # See create_workshop_certificate_image in certificate_image.rb for help
     # understanding why these particular mocks and stubs work.
 
@@ -122,21 +153,12 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     mock_image.stub_everything
     Magick::Image.expects(:read).returns([mock_image])
 
-    # We also want Magick::Draw.new to return a flexible mock Magick::Draw.
-    mock_draw = mock
-    mock_draw.stub_everything
-    Magick::Draw.expects(:new).returns(mock_draw)
-
     # The Magick::Image is returned all the way up to the WorkshopCertificateController,
     # which is responsible for cleaning it up, so we set up expectations that
     # the image will be used and then destroyed to avoid memory leaks.
     # Note: These expectations take precendence over the `stub_everything` calls above.
-    mock_image.expects(:to_blob)
     mock_image.expects(:destroy!)
-
-    # Return mock Magick::Draw to tests can add expectations about the specific annotations
-    # being generated
-    mock_draw
+    mock_image
   end
 
   test_redirect_to_sign_in_for :generate_certificate, params: -> {{enrollment_code: @enrollment.code}}

--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -8,9 +8,6 @@ require_relative '../script_constants'
 # This method returns a newly-allocated Magick::Image object.
 # NOTE: the caller MUST ensure image#destroy! is called on the returned image object to avoid memory leaks.
 def create_certificate_image2(image_path, name, params={})
-  # The unmodified user input so we can document it error logs.
-  original_name = name
-
   # Load the certificate template
   background = Magick::Image.read(image_path).first
 
@@ -24,51 +21,58 @@ def create_certificate_image2(image_path, name, params={})
   # image.
   name = name[0, 50] if name.size > 50
 
+  font = "Times bold"
+  color = "#575757"
+  pointsize = 68
+  x_offset = params[:x] || 0
+  y_offset = params[:y] || 0
+  apply_text(background, name, pointsize, font, color, x_offset, y_offset)
+  background
+end
+
+# applies the given text to the given image object.
+def apply_text(image, text, pointsize, font, color, x_offset, y_offset)
   begin
-    # The user's name will be put into an image with a transparent background.
-    # This uses 'pango', the OS's text layout engine, in order to dynamically
-    # select the correct font. This is important for handling non-latin
-    # languages.
-    name_overlay = Magick::Image.read("pango:#{name}") do
-      # pango:markup is set to false in order to easily prevent pango markup injection
-      # from student names.
+    # The text will be put into an image with a transparent background.  This
+    # uses 'pango', the OS's text layout engine, in order to dynamically select
+    # the correct font. This is important for handling non-latin languages.
+    text_overlay = Magick::Image.read("pango:#{text}") do
+      # pango:markup is set to false in order to easily prevent pango markup
+      # injection from user input.
       define('pango', 'markup', false)
       self.background_color = 'none'
-      self.pointsize = 68
-      self.font = "Times bold"
-      self.fill = "#575757"
-    end.first.trim!
+      self.pointsize = pointsize
+      self.font = font
+      self.fill = color
+    end.first
   rescue Magick::ImageMagickError => exception
-    # We want to know what kinds of names we are failing to render.
+    # We want to know what kinds of text we are failing to render.
     Honeybadger.notify(
       exception,
       context: {
         image_path: image_path,
-        name: name,
-        original_name: original_name,
+        text: text,
       }
     )
-    # The student gave us a name we can't render, so leave the name blank.
-    return background
+    # We can't render the text, so return without applying a transformation.
+    return
   end
 
-  # x,y offsets
-  y = params[:y] || 0
-  x = params[:x] || 0
-  # Combine the name image on top of the certificate template image
-  background.composite!(name_overlay, Magick::CenterGravity, x, y, Magick::OverCompositeOp)
+  return unless text_overlay
+  text_overlay.trim!
+
+  # Combine the text image on top of the certificate template image
+  image.composite!(text_overlay, Magick::CenterGravity, x_offset, y_offset, Magick::OverCompositeOp)
 
   # Free the memory in order to avoid memory leaks (images are stored in /tmp
   # until destroyed)
-  name_overlay.destroy!
-  background
+  text_overlay.destroy!
 end
 
 # This method returns a newly-allocated Magick::Image object.
 # NOTE: the caller MUST ensure image#destroy! is called on the returned image object to avoid memory leaks.
 def create_workshop_certificate_image(image_path, fields)
   background = Magick::Image.read(image_path).first
-  draw = Magick::Draw.new
 
   fields.each do |field|
     string = escape_image_magick_string(field[:string].to_s)
@@ -76,17 +80,9 @@ def create_workshop_certificate_image(image_path, fields)
 
     y = field[:y] || 0
     x = field[:x] || 0
-    width = field[:width] || background.columns
-    height = field[:height] || background.rows
+    pointsize = field[:pointsize] || 70
 
-    draw.annotate(background, width, height, x, y, string) do
-      draw.gravity = Magick::CenterGravity
-      self.pointsize = field[:pointsize] || 90
-      self.font_family = 'Times'
-      self.font_weight = Magick::BoldWeight
-      self.stroke = 'none'
-      self.fill = 'rgb(87,87,87)'
-    end
+    apply_text(background, string, pointsize, 'Times bold', 'rgb(87,87,87)', x, y)
   end
 
   background
@@ -131,27 +127,8 @@ def create_course_certificate_image(name, course=nil, sponsor=nil, course_title=
     course_title ||= fallback_course_title_for(course)
 
     image = Magick::Image.read(path).first
-
-    # student name
-    name_vertical_offset = 445
-    Magick::Draw.new.annotate(image, 0, 0, 0, name_vertical_offset, name) do
-      self.gravity = Magick::NorthGravity
-      self.pointsize = 96
-      self.font_family = 'Helvetica'
-      self.font_weight = Magick::BoldWeight
-      self.stroke = 'none'
-      self.fill = 'rgb(118,101,160)' # purple
-    end
-
-    course_vertical_offset = 610
-    Magick::Draw.new.annotate(image, 0, 0, 0, course_vertical_offset, course_title) do
-      self.gravity = Magick::NorthGravity
-      self.pointsize = 60
-      self.font_family = 'Helvetica'
-      self.font_weight = Magick::BoldWeight
-      self.stroke = 'none'
-      self.fill = 'rgb(29, 173, 186)' # teal
-    end
+    apply_text(image, name, 75, 'Helvetica bold', 'rgb(118,101,160)', 0, -141)
+    apply_text(image, course_title, 47, 'Helvetica bold', 'rgb(29,173,186)', 0, 11)
   end
 
   unless sponsor
@@ -160,14 +137,8 @@ def create_course_certificate_image(name, course=nil, sponsor=nil, course_title=
     sponsor = donor[:name_s]
   end
 
-  Magick::Draw.new.annotate(image, 0, 0, 0, 160, "#{sponsor} made the generous gift to sponsor your learning.") do
-    self.gravity = Magick::SouthGravity
-    self.pointsize = 24
-    self.font_family = 'Times'
-    self.font_weight = Magick::BoldWeight
-    self.stroke = 'none'
-    self.fill = 'rgb(87,87,87)'
-  end
+  sponsor_message = I18n.t('certificate.sponsor_message', sponsor_name: sponsor)
+  apply_text(image, sponsor_message, 18, 'Times bold', 'rgb(87,87,87)', 0, 447)
   image
 end
 


### PR DESCRIPTION
When a student or teach completes a course, we generate a little
congratulatory certificate with their name on it which they can print
out. This change enables all completion certificates to support
non-latin characters such as Korean and Japanese for the
student, teacher, facilitator, and course names.
* Created a I18n friendly function for adding text to a certificate image.
* Updated all dynamic text for course & workshop completion certificates to use the I18n friendly text function.
* Created an I18n string for the "sponsor" string displayed on certificates. 
## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-905)

## Testing story
* `./bin/dashboard-server`
  * http://localhost.code.org:3000/certificates?course=%E3%82%B3%E3%83%BC%E3%82%B91
  * `岩田 聡` as the name
* http://localhost-studio.code.org:3000/pd/generate_workshop_certificate/FSZPCWBGFS
  * This generates a workshop certificate, however I had to create my own which was onerous. If you really want to create your own, I can sit with you and help you out.
## Screenshots
### Japanese completion certificate for course 1
![image](https://user-images.githubusercontent.com/1372238/72855263-cb3d7500-3cae-11ea-957f-d269ea72c047.png)

### Professional Development workshop certificate BEFORE
![image](https://user-images.githubusercontent.com/1372238/72855270-d0022900-3cae-11ea-854c-4ab87f4600ce.png)

### Professional Development workshop certificate AFTER
Note that the numbers and dates are a little different because this is from my local test environment.
![image](https://user-images.githubusercontent.com/1372238/72855277-d42e4680-3cae-11ea-88b3-1f21e5e10463.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
