### PR TITLE
Video player: upgrade dashboard video.js to 7.6.6

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -197,7 +197,7 @@ describe('entry tests', () => {
         // blockly media, etc).
         {
           expand: true,
-          cwd: './node_modules/video.js/dist/video-js',
+          cwd: './node_modules/video.js/dist',
           src: ['**'],
           dest: 'build/package/video-js'
         }

--- a/apps/package.json
+++ b/apps/package.json
@@ -213,7 +213,7 @@
     "uglifyjs-webpack-plugin": "2.1.1",
     "unminified-webpack-plugin": "^2.0.0",
     "url-loader": "^0.5.7",
-    "video.js": "4.5.2",
+    "video.js": "7.6.6",
     "vmsg": "^0.3.6",
     "webpack": "^4.29.0",
     "webpack-bundle-analyzer": "^3.3.2",

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -396,22 +396,26 @@ function addFallbackVideoPlayer(videoInfo, playerWidth, playerHeight) {
   $('#videoTabContainer').empty();
   $('#videoTabContainer').append(playerCode);
 
-  var videoPlayer = videojs(fallbackPlayerID, {}, function() {
-    var $fallbackPlayer = $('#' + fallbackPlayerID);
+  var videoPlayer = videojs(
+    fallbackPlayerID,
+    {nativeControlsForTouch: true},
+    function() {
+      var $fallbackPlayer = $('#' + fallbackPlayerID);
 
-    // Handle a video.js player error.
-    this.on('error', function(e) {
-      $fallbackPlayer.addClass('fallback-video-player-failed');
-      if (hasNotesTab()) {
-        openNotesTab();
-      }
-    });
+      // Handle a video.js player error.
+      this.on('error', function(e) {
+        $fallbackPlayer.addClass('fallback-video-player-failed');
+        if (hasNotesTab()) {
+          openNotesTab();
+        }
+      });
 
-    // Properly dispose of video.js player instance when hidden.
-    $fallbackPlayer.parents('.modal').one('hidden.bs.modal', function() {
-      videoPlayer.dispose();
-    });
-  });
+      // Properly dispose of video.js player instance when hidden.
+      $fallbackPlayer.parents('.modal').one('hidden.bs.modal', function() {
+        videoPlayer.dispose();
+      });
+    }
+  );
 
   videoPlayer.on('ended', onVideoEnded);
 

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -5,7 +5,7 @@ import trackEvent from '../util/trackEvent';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FallbackPlayerCaptionDialogLink from '../templates/FallbackPlayerCaptionDialogLink';
-var videojs = require('video.js').default;
+import videojs from 'video.js';
 var testImageAccess = require('./url_test');
 var clientState = require('./clientState');
 import i18n from '@cdo/locale';

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -394,19 +394,18 @@ function addFallbackVideoPlayer(videoInfo, playerWidth, playerHeight) {
   $('#videoTabContainer').empty();
   $('#videoTabContainer').append(playerCode);
 
-  //videojs.options.flash.swf = '/blockly/video-js/video-js.swf';
-  //videojs.options.techOrder = ['flash', 'html5'];
-
   var videoPlayer = videojs(fallbackPlayerID, {}, function() {
     var $fallbackPlayer = $('#' + fallbackPlayerID);
-    var showingErrorMessage = false; // $fallbackPlayer.find('p').length > 0;
-    if (showingErrorMessage) {
+
+    // Handle a video.js player error.
+    this.on('error', function(e) {
       $fallbackPlayer.addClass('fallback-video-player-failed');
       if (hasNotesTab()) {
         openNotesTab();
       }
-    }
-    // Properly dispose of video.js player instance when hidden
+    });
+
+    // Properly dispose of video.js player instance when hidden.
     $fallbackPlayer.parents('.modal').one('hidden.bs.modal', function() {
       videoPlayer.dispose();
     });

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -362,11 +362,15 @@ function addFallbackVideoPlayer(videoInfo, playerWidth, playerHeight) {
   // to expand to its edges.  This is currently implemented by a standalone
   // video.
   let containerDivStyle;
+  let extraVideoStyle = '';
+  let dimensions = '';
   if (playerWidth === '100%' && playerHeight === '100%') {
     containerDivStyle =
       'position: absolute; top: 0; bottom: 0; left: 0; right: 0';
+    extraVideoStyle = 'vjs-fill';
   } else {
     containerDivStyle = '';
+    dimensions = 'width="' + playerWidth + '" height="' + playerHeight + '" ';
   }
 
   var playerCode =
@@ -375,13 +379,11 @@ function addFallbackVideoPlayer(videoInfo, playerWidth, playerHeight) {
     '"><video id="' +
     fallbackPlayerID +
     '" ' +
-    'width="' +
-    playerWidth +
-    '" height="' +
-    playerHeight +
-    '" ' +
+    dimensions +
     (videoInfo.autoplay ? 'autoplay ' : '') +
-    'class="video-js vjs-default-skin vjs-big-play-centered" ' +
+    'class="video-js vjs-default-skin vjs-big-play-centered ' +
+    extraVideoStyle +
+    '" ' +
     'controls preload="auto" ' +
     'poster="' +
     videoInfo.thumbnail +

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -5,7 +5,7 @@ import trackEvent from '../util/trackEvent';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FallbackPlayerCaptionDialogLink from '../templates/FallbackPlayerCaptionDialogLink';
-var videojs = require('video.js');
+var videojs = require('video.js').default;
 var testImageAccess = require('./url_test');
 var clientState = require('./clientState');
 import i18n from '@cdo/locale';
@@ -394,12 +394,12 @@ function addFallbackVideoPlayer(videoInfo, playerWidth, playerHeight) {
   $('#videoTabContainer').empty();
   $('#videoTabContainer').append(playerCode);
 
-  videojs.options.flash.swf = '/blockly/video-js/video-js.swf';
-  videojs.options.techOrder = ['flash', 'html5'];
+  //videojs.options.flash.swf = '/blockly/video-js/video-js.swf';
+  //videojs.options.techOrder = ['flash', 'html5'];
 
   var videoPlayer = videojs(fallbackPlayerID, {}, function() {
     var $fallbackPlayer = $('#' + fallbackPlayerID);
-    var showingErrorMessage = $fallbackPlayer.find('p').length > 0;
+    var showingErrorMessage = false; // $fallbackPlayer.find('p').length > 0;
     if (showingErrorMessage) {
       $fallbackPlayer.addClass('fallback-video-player-failed');
       if (hasNotesTab()) {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1448,6 +1448,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.4.5":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
+  integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
@@ -2246,6 +2253,19 @@
     "@types/unist" "*"
     "@types/vfile-message" "*"
 
+"@videojs/http-streaming@1.10.6":
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/@videojs/http-streaming/-/http-streaming-1.10.6.tgz#a9119b1828b354c5cc17b42ea051cc7bcce2dca0"
+  integrity sha512-uPBuunHnxWeFRYxRX0j6h1IIWv3+QKvSkZGmW9TvqxWBqeNGSrQymR6tm1nVjQ2HhMVxVphQTUhUTTPDVWqmQg==
+  dependencies:
+    aes-decrypter "3.0.0"
+    global "^4.3.0"
+    m3u8-parser "4.4.0"
+    mpd-parser "0.8.1"
+    mux.js "5.2.1"
+    url-toolkit "^2.1.3"
+    video.js "^6.8.0 || ^7.0.0"
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -2455,6 +2475,15 @@ address@1.0.3, address@^1.0.1:
 adm-zip@^0.4.7:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.7.tgz#8606c2cbf1c426ce8c8ec00174447fd49b6eafc1"
+
+aes-decrypter@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aes-decrypter/-/aes-decrypter-3.0.0.tgz#7848a1c145b9fdbf57ae3e2b5b1bc7cf0644a8fb"
+  integrity sha1-eEihwUW5/b9Xrj4rWxvHzwZEqPs=
+  dependencies:
+    commander "^2.9.0"
+    global "^4.3.2"
+    pkcs7 "^1.0.2"
 
 after@0.8.2:
   version "0.8.2"
@@ -7436,12 +7465,20 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
-global@^4.3.2:
+global@4.3.2, global@^4.3.2, global@~4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
   dependencies:
     min-document "^2.19.0"
     process "~0.5.1"
+
+global@^4.3.0, global@^4.3.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
+  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
+  dependencies:
+    min-document "^2.19.0"
+    process "^0.11.10"
 
 globals@^11.0.1:
   version "11.12.0"
@@ -8685,6 +8722,11 @@ indexes-of@^1.0.1:
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+
+individual@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/individual/-/individual-2.0.0.tgz#833b097dad23294e76117a98fb38e0d9ad61bb97"
+  integrity sha1-gzsJfa0jKU52EXqY+zjg2a1hu5c=
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -10128,6 +10170,13 @@ lru-queue@0.1:
   dependencies:
     es5-ext "~0.10.2"
 
+m3u8-parser@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/m3u8-parser/-/m3u8-parser-4.4.0.tgz#adf606c0af6d97f6750095a42006c2ae03dde177"
+  integrity sha512-iH2AygTFILtato+XAgnoPYzLHM4R3DjATj7Ozbk7EHdB2XoLF2oyOUguM7Kc4UVHbQHHL/QPaw98r7PbWzG0gg==
+  dependencies:
+    global "^4.3.2"
+
 macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
@@ -10678,6 +10727,14 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
+mpd-parser@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/mpd-parser/-/mpd-parser-0.8.1.tgz#db299dbec337999fbbbace989d227c7b03dc8ea7"
+  integrity sha512-WBTJ1bKk8OLUIxBh6s1ju1e2yz/5CzhPbgi6P3F3kJHKhGy1Z+ElvEnuzEbtC/dnbRcJtMXazE3f93N5LLdp9Q==
+  dependencies:
+    global "^4.3.2"
+    url-toolkit "^2.1.1"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -10721,6 +10778,11 @@ mute-stream@0.0.7:
 mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+
+mux.js@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/mux.js/-/mux.js-5.2.1.tgz#6698761fc88da5acecea0758ac25f11d3a08bee8"
+  integrity sha512-1t2payD3Y8izfZRq7tfUQlhL2fKzjeLr9v1/2qNCTkEQnd9Abtn1JgzsBgGZubEXh6lM5L8B0iLGoWQiukjtbQ==
 
 nan@2.4.x, nan@^2.3.0, nan@^2.3.5:
   version "2.4.0"
@@ -11615,6 +11677,11 @@ parse-glob@^3.0.4:
     is-extglob "^1.0.0"
     is-glob "^2.0.0"
 
+parse-headers@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.3.tgz#5e8e7512383d140ba02f0c7aa9f49b4399c92515"
+  integrity sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -11791,6 +11858,11 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkcs7@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pkcs7/-/pkcs7-1.0.2.tgz#b6dba527528c2942bfc122ce2dafcdb5e59074e7"
+  integrity sha1-ttulJ1KMKUK/wSLOLa/NteWQdOc=
 
 pkg-dir@^2.0.0:
   version "2.0.0"
@@ -13958,6 +14030,13 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rust-result@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rust-result/-/rust-result-1.0.0.tgz#34c75b2e6dc39fe5875e5bdec85b5e0f91536f72"
+  integrity sha1-NMdbLm3Dn+WHXlveyFteD5FTb3I=
+  dependencies:
+    individual "^2.0.0"
+
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
@@ -13987,6 +14066,13 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
 safe-buffer@5.1.2, safe-buffer@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+safe-json-parse@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-4.0.0.tgz#7c0f578cfccd12d33a71c0e05413e2eca171eaac"
+  integrity sha1-fA9XjPzNEtM6ccDgVBPi7KFx6qw=
+  dependencies:
+    rust-result "^1.0.0"
 
 safe-json-parse@~1.0.1:
   version "1.0.1"
@@ -15912,6 +15998,11 @@ url-parse@^1.1.8, url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url-toolkit@^2.1.1, url-toolkit@^2.1.3:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.1.6.tgz#6d03246499e519aad224c44044a4ae20544154f2"
+  integrity sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw==
+
 url@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
@@ -16054,15 +16145,31 @@ vfile@^3.0.1:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
-video.js@4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/video.js/-/video.js-4.5.2.tgz#fefe212b684e79225a6424b909b78b579e5474ea"
+video.js@7.6.6, "video.js@^6.8.0 || ^7.0.0":
+  version "7.6.6"
+  resolved "https://registry.yarnpkg.com/video.js/-/video.js-7.6.6.tgz#e7c9163d53f9b0e05ccb5ac0f79d02fa49b4d3ac"
+  integrity sha512-AXzHwymhvMpS7c7rF29u0j0/3tSs+v2gIk5UY8OkiDHSEHL7T0+t3hid4JHW7aGvTruUUgwyf4C74cX2RDL1Pw==
   dependencies:
-    videojs-swf "4.4.0"
+    "@babel/runtime" "^7.4.5"
+    "@videojs/http-streaming" "1.10.6"
+    global "4.3.2"
+    keycode "^2.2.0"
+    safe-json-parse "4.0.0"
+    videojs-font "3.2.0"
+    videojs-vtt.js "^0.14.1"
+    xhr "2.4.0"
 
-videojs-swf@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/videojs-swf/-/videojs-swf-4.4.0.tgz#062f75f971fdb8b5102185c267fb4e72cd12c54d"
+videojs-font@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/videojs-font/-/videojs-font-3.2.0.tgz#212c9d3f4e4ec3fa7345167d64316add35e92232"
+  integrity sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA==
+
+videojs-vtt.js@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/videojs-vtt.js/-/videojs-vtt.js-0.14.1.tgz#da583eb1fc9c81c826a9432b706040e8dea49911"
+  integrity sha512-YxOiywx6N9t3J5nqsE5WN2Sw4CSqVe3zV+AZm2T4syOc2buNJaD6ZoexSdeszx2sHLU/RRo2r4BJAXFDQ7Qo2Q==
+  dependencies:
+    global "^4.3.1"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -16434,6 +16541,16 @@ wtf-8@1.0.0:
 x-is-string@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+
+xhr@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.4.0.tgz#e16e66a45f869861eeefab416d5eff722dc40993"
+  integrity sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=
+  dependencies:
+    global "~4.3.0"
+    is-function "^1.0.1"
+    parse-headers "^2.0.0"
+    xtend "^4.0.0"
 
 xml2js@0.4.15, xml2js@^0.4.4:
   version "0.4.15"

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -764,6 +764,10 @@ $default-modal-width: 640px;
   margin: 0;
 }
 
+.vjs-tech:focus, .vjs-poster:focus {
+  outline: 0;
+}
+
 .video-player-rounded-corners {
   border-radius: 10px;
   border-width: 0;


### PR DESCRIPTION
This updates `Video.js`, which we use for our fallback video player, to `7.6.6`, on dashboard.

It no longer supports IE below version 11.  This PR also removes Flash support, though it is possibly to add using the `videojs-flash` plug-in.