### PR TITLE
Video players: allow force-YouTube URL parameter

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -343,9 +343,13 @@ videos.onYouTubeBlocked = function(youTubeBlockedCallback, videoInfo) {
 };
 
 function youTubeAvailabilityEndpointURL(noCookie) {
-  if (window.document.URL.toString().indexOf('force_youtube_fallback') >= 0) {
+  const url = window.document.URL.toString();
+  if (url.indexOf('force_youtube_fallback') >= 0) {
     return 'https://unreachable-test-subdomain.example.com/favicon.ico';
+  } else if (url.indexOf('force_youtube_player') >= 0) {
+    return 'https://code.org/images/favicon.ico';
   }
+
   if (noCookie) {
     return 'https://www.youtube-nocookie.com/favicon.ico';
   } else {

--- a/apps/src/sites/code.org/pages/views/theme_common_head_after.js
+++ b/apps/src/sites/code.org/pages/views/theme_common_head_after.js
@@ -24,7 +24,14 @@ initHamburger();
 
 $(window).load(function() {
   if (document.getElementsByClassName('insert_video_player').length > 0) {
-    loadVideos(window.location.search.indexOf('force_youtube_fallback') !== -1);
+    const urlParams = window.location.search;
+    let forcePlayer = false;
+    if (urlParams.indexOf('force_youtube_fallback') !== -1) {
+      forcePlayer = 'fallback';
+    } else if (urlParams.indexOf('force_youtube_player') !== -1) {
+      forcePlayer = 'youtube';
+    }
+    loadVideos(forcePlayer);
   }
 
   // This code works for both the congrats_share and the more general

--- a/apps/src/util/loadVideos.js
+++ b/apps/src/util/loadVideos.js
@@ -1,8 +1,10 @@
 import testImageAccess from '../code-studio/url_test';
 
-export function loadVideos(force_fallback) {
-  if (force_fallback) {
-    setupVideos('fallback');
+// forcePlayer can be "youtube", "fallback", or false if we just want to
+// detect the appropriate player.
+export function loadVideos(forcePlayer) {
+  if (forcePlayer) {
+    setupVideos(forcePlayer);
   } else {
     testImageAccess(
       'https://www.youtube-nocookie.com/favicon.ico?' + Math.random(),


### PR DESCRIPTION
The dashboard and pegasus video players already support a `force_youtube_fallback` URL parameter to force the fallback player to run.

Now, they also support a `force_youtube_player` URL parameter to force YouTube to run.

This might be useful for diagnosing video player issues in the future, for example if the fallback detection kicks in too aggressively because the user is on a particularly slow connection.
