### PR TITLE
[DataViz] Implement exact-match filter

### DIFF
--- a/apps/test/unit/storage/dataBrowser/dataVisualizer/VisualizerModalTest.js
+++ b/apps/test/unit/storage/dataBrowser/dataVisualizer/VisualizerModalTest.js
@@ -198,4 +198,155 @@ describe('VisualizerModal', () => {
       ).to.deep.equal(['"xyz"', '"def"', '"123"', 'undefined', '123', 'true']);
     });
   });
+
+  describe('filterRecords', () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = shallow(<VisualizerModal {...DEFAULT_PROPS} />);
+    });
+    it('works with numbers', () => {
+      let records = [
+        {id: 1, filterCol: 123, chartCol: 2},
+        {id: 2, filterCol: 456, chartCol: 3},
+        {id: 3, filterCol: 123, chartCol: 5},
+        {id: 4, filterCol: '456', chartCol: 7},
+        {id: 5, filterCol: 0, chartCol: 5}
+      ];
+      expect(
+        wrapper.instance().filterRecords(records, 'filterCol', '123')
+      ).to.deep.equal([
+        {id: 1, filterCol: 123, chartCol: 2},
+        {id: 3, filterCol: 123, chartCol: 5}
+      ]);
+
+      expect(
+        wrapper.instance().filterRecords(records, 'filterCol', '456')
+      ).to.deep.equal([{id: 2, filterCol: 456, chartCol: 3}]);
+
+      expect(
+        wrapper.instance().filterRecords(records, 'filterCol', '0')
+      ).to.deep.equal([{id: 5, filterCol: 0, chartCol: 5}]);
+    });
+
+    it('works with booleans', () => {
+      let records = [
+        {id: 1, filterCol: true, chartCol: 2},
+        {id: 2, filterCol: false, chartCol: 3},
+        {id: 3, filterCol: true, chartCol: 5},
+        {id: 4, filterCol: 'false', chartCol: 7}
+      ];
+      expect(
+        wrapper.instance().filterRecords(records, 'filterCol', 'true')
+      ).to.deep.equal([
+        {id: 1, filterCol: true, chartCol: 2},
+        {id: 3, filterCol: true, chartCol: 5}
+      ]);
+
+      expect(
+        wrapper.instance().filterRecords(records, 'filterCol', 'false')
+      ).to.deep.equal([{id: 2, filterCol: false, chartCol: 3}]);
+    });
+
+    it('works with null', () => {
+      let records = [
+        {id: 1, filterCol: null, chartCol: 2},
+        {id: 2, filterCol: false, chartCol: 3},
+        {id: 3, filterCol: 0, chartCol: 5},
+        {id: 4, filterCol: null, chartCol: 7}
+      ];
+
+      expect(
+        wrapper.instance().filterRecords(records, 'filterCol', 'null')
+      ).to.deep.equal([
+        {id: 1, filterCol: null, chartCol: 2},
+        {id: 4, filterCol: null, chartCol: 7}
+      ]);
+    });
+
+    it('works with undefined', () => {
+      let records = [
+        {id: 1, chartCol: 2},
+        {id: 2, filterCol: undefined, chartCol: 3},
+        {id: 3, filterCol: 0, chartCol: 5},
+        {id: 4, filterCol: null, chartCol: 7}
+      ];
+
+      expect(
+        wrapper.instance().filterRecords(records, 'filterCol', 'undefined')
+      ).to.deep.equal([
+        {id: 1, chartCol: 2},
+        {id: 2, filterCol: undefined, chartCol: 3}
+      ]);
+    });
+
+    describe('filtering with strings', () => {
+      it('works by exact match only', () => {
+        let records = [
+          {id: 1, filterCol: 'part', chartCol: 3},
+          {id: 2, filterCol: 'par', chartCol: 3},
+          {id: 3, filterCol: 'part', chartCol: 5},
+          {id: 4, filterCol: 'partial', chartCol: 7}
+        ];
+
+        expect(
+          wrapper.instance().filterRecords(records, 'filterCol', '"part"')
+        ).to.deep.equal([
+          {id: 1, filterCol: 'part', chartCol: 3},
+          {id: 3, filterCol: 'part', chartCol: 5}
+        ]);
+      });
+
+      it('works with empty string', () => {
+        let records = [
+          {id: 1, filterCol: '', chartCol: 3},
+          {id: 2, filterCol: 'a', chartCol: 3},
+          {id: 3, filterCol: 'b', chartCol: 5},
+          {id: 4, filterCol: '', chartCol: 7}
+        ];
+
+        expect(
+          wrapper.instance().filterRecords(records, 'filterCol', '""')
+        ).to.deep.equal([
+          {id: 1, filterCol: '', chartCol: 3},
+          {id: 4, filterCol: '', chartCol: 7}
+        ]);
+      });
+
+      it('works with strings that contain quotes', () => {
+        let records = [
+          {id: 1, filterCol: '"hello", he said', chartCol: 3},
+          {id: 2, filterCol: "'single quoted string'", chartCol: 3},
+          {id: 3, filterCol: "it's a contraction", chartCol: 5},
+          {id: 4, filterCol: '"hello", he said', chartCol: 'a'},
+          {id: 5, filterCol: "'single quoted string'", chartCol: 'b'},
+          {id: 6, filterCol: "it's a contraction", chartCol: 'c'}
+        ];
+
+        expect(
+          wrapper
+            .instance()
+            .filterRecords(records, 'filterCol', `'"hello", he said'`)
+        ).to.deep.equal([
+          {id: 1, filterCol: '"hello", he said', chartCol: 3},
+          {id: 4, filterCol: '"hello", he said', chartCol: 'a'}
+        ]);
+        expect(
+          wrapper
+            .instance()
+            .filterRecords(records, 'filterCol', `"'single quoted string'"`)
+        ).to.deep.equal([
+          {id: 2, filterCol: "'single quoted string'", chartCol: 3},
+          {id: 5, filterCol: "'single quoted string'", chartCol: 'b'}
+        ]);
+        expect(
+          wrapper
+            .instance()
+            .filterRecords(records, 'filterCol', `"it's a contraction"`)
+        ).to.deep.equal([
+          {id: 3, filterCol: "it's a contraction", chartCol: 5},
+          {id: 6, filterCol: "it's a contraction", chartCol: 'c'}
+        ]);
+      });
+    });
+  });
 });

--- a/apps/test/unit/storage/dataBrowser/dataVisualizer/VisualizerModalTest.js
+++ b/apps/test/unit/storage/dataBrowser/dataVisualizer/VisualizerModalTest.js
@@ -214,18 +214,15 @@ describe('VisualizerModal', () => {
       ];
       expect(
         wrapper.instance().filterRecords(records, 'filterCol', '123')
-      ).to.deep.equal([
-        {id: 1, filterCol: 123, chartCol: 2},
-        {id: 3, filterCol: 123, chartCol: 5}
-      ]);
+      ).to.deep.equal([records[0], records[2]]);
 
       expect(
         wrapper.instance().filterRecords(records, 'filterCol', '456')
-      ).to.deep.equal([{id: 2, filterCol: 456, chartCol: 3}]);
+      ).to.deep.equal([records[1]]);
 
       expect(
         wrapper.instance().filterRecords(records, 'filterCol', '0')
-      ).to.deep.equal([{id: 5, filterCol: 0, chartCol: 5}]);
+      ).to.deep.equal([records[4]]);
     });
 
     it('works with booleans', () => {
@@ -237,14 +234,11 @@ describe('VisualizerModal', () => {
       ];
       expect(
         wrapper.instance().filterRecords(records, 'filterCol', 'true')
-      ).to.deep.equal([
-        {id: 1, filterCol: true, chartCol: 2},
-        {id: 3, filterCol: true, chartCol: 5}
-      ]);
+      ).to.deep.equal([records[0], records[2]]);
 
       expect(
         wrapper.instance().filterRecords(records, 'filterCol', 'false')
-      ).to.deep.equal([{id: 2, filterCol: false, chartCol: 3}]);
+      ).to.deep.equal([records[1]]);
     });
 
     it('works with null', () => {
@@ -257,10 +251,7 @@ describe('VisualizerModal', () => {
 
       expect(
         wrapper.instance().filterRecords(records, 'filterCol', 'null')
-      ).to.deep.equal([
-        {id: 1, filterCol: null, chartCol: 2},
-        {id: 4, filterCol: null, chartCol: 7}
-      ]);
+      ).to.deep.equal([records[0], records[3]]);
     });
 
     it('works with undefined', () => {
@@ -273,10 +264,7 @@ describe('VisualizerModal', () => {
 
       expect(
         wrapper.instance().filterRecords(records, 'filterCol', 'undefined')
-      ).to.deep.equal([
-        {id: 1, chartCol: 2},
-        {id: 2, filterCol: undefined, chartCol: 3}
-      ]);
+      ).to.deep.equal([records[0], records[1]]);
     });
 
     describe('filtering with strings', () => {
@@ -290,10 +278,7 @@ describe('VisualizerModal', () => {
 
         expect(
           wrapper.instance().filterRecords(records, 'filterCol', '"part"')
-        ).to.deep.equal([
-          {id: 1, filterCol: 'part', chartCol: 3},
-          {id: 3, filterCol: 'part', chartCol: 5}
-        ]);
+        ).to.deep.equal([records[0], records[2]]);
       });
 
       it('works with empty string', () => {
@@ -306,10 +291,7 @@ describe('VisualizerModal', () => {
 
         expect(
           wrapper.instance().filterRecords(records, 'filterCol', '""')
-        ).to.deep.equal([
-          {id: 1, filterCol: '', chartCol: 3},
-          {id: 4, filterCol: '', chartCol: 7}
-        ]);
+        ).to.deep.equal([records[0], records[3]]);
       });
 
       it('works with strings that contain quotes', () => {
@@ -326,26 +308,17 @@ describe('VisualizerModal', () => {
           wrapper
             .instance()
             .filterRecords(records, 'filterCol', `'"hello", he said'`)
-        ).to.deep.equal([
-          {id: 1, filterCol: '"hello", he said', chartCol: 3},
-          {id: 4, filterCol: '"hello", he said', chartCol: 'a'}
-        ]);
+        ).to.deep.equal([records[0], records[3]]);
         expect(
           wrapper
             .instance()
             .filterRecords(records, 'filterCol', `"'single quoted string'"`)
-        ).to.deep.equal([
-          {id: 2, filterCol: "'single quoted string'", chartCol: 3},
-          {id: 5, filterCol: "'single quoted string'", chartCol: 'b'}
-        ]);
+        ).to.deep.equal([records[1], records[4]]);
         expect(
           wrapper
             .instance()
             .filterRecords(records, 'filterCol', `"it's a contraction"`)
-        ).to.deep.equal([
-          {id: 3, filterCol: "it's a contraction", chartCol: 5},
-          {id: 6, filterCol: "it's a contraction", chartCol: 'c'}
-        ]);
+        ).to.deep.equal([records[2], records[5]]);
       });
     });
   });


### PR DESCRIPTION
Currently, exact-match filter only explicitly supports strings, numbers, booleans, `null`, and, `undefined`. It is possible to have other values (such as objects or arrays) in a data table, but filtering in those cases is currently intentionally unspecified behavior.
#32693 populates the first dropdown with the column names, and the second with all values in the selected column.

If both dropdowns have a value selected, we perform an exact match filter on the records
![image](https://user-images.githubusercontent.com/8787187/72937145-679e6080-3d1d-11ea-83f6-b22321c03418.png)

If you select filter options such that there is nothing to chart, we show a blank chart:
![image](https://user-images.githubusercontent.com/8787187/72937391-e3001200-3d1d-11ea-8424-b8427204f61a.png)


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/STAR-953)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
