### PR TITLE
Bump ml-activities and add needed styles

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -57,7 +57,7 @@
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "1.1.0",
-    "@code-dot-org/ml-activities": "0.0.24",
+    "@code-dot-org/ml-activities": "0.0.25",
     "@code-dot-org/p5.play": "^1.3.12-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/style/fish/style.scss
+++ b/apps/style/fish/style.scss
@@ -18,6 +18,24 @@ button {
   font-size: 18px;
 }
 
+#pondTextMarkdown p {
+  margin: 0;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+#pondTextMarkdown strong {
+  color: #eb5757;
+  font-weight: normal;
+  font-family: "Gotham 4r", arial, sans-serif;
+}
+
+#pondTextMarkdown em {
+  color: #56c568;
+  font-style: normal;
+  font-family: "Gotham 4r", arial, sans-serif;
+}
+
 /*
  * Primary aim is to fit the width up to 0.9 of the screen width.
  * Secondary aim is that the vertical fits on the screen.

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1616,10 +1616,10 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-1.1.0.tgz#7c8185adf06a9172e3bde4ccd6f6738a787b2a7c"
 
-"@code-dot-org/ml-activities@0.0.24":
-  version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.24.tgz#c9303711a8924ce9eb27f375cd5c14ca9adb570d"
-  integrity sha512-MINYiyW41LsVukCUxw+o00VLlS3OnMkhOd17dEc/hjYAtVApfbGrC1xhxDuU2fqOr0fxOCaRoWEucU5HGXrsdg==
+"@code-dot-org/ml-activities@0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-activities/-/ml-activities-0.0.25.tgz#e7308b02d7cc37e6efb970ca4596eaa459b89cc0"
+  integrity sha512-Ic8H7GnQum1PZyjToWxmM1XetBc+5aXmqdDSBmI4IMT32zeJH9CCvyMRlCLXFIGo7VVGXz+GEcYLBi1pFTzCCw==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"


### PR DESCRIPTION
This PR bumps ml-activities to version [0.0.25](https://github.com/code-dot-org/ml-activities/commit/5502fd9769f68da503bf9e91b710f2901de69c4c) in order to get an update to a string to make it more translateable.

This version contains updates from three PRS:
1. https://github.com/code-dot-org/ml-activities/pull/350 (slight risk but confident in tests)
2. https://github.com/code-dot-org/ml-activities/pull/355 (linter rule, no production risk)
3. https://github.com/code-dot-org/ml-activities/pull/354 (adding markdown support, limited risk to one string)

The styling of the new string does require code-studio changes as it involves fonts. Those styling updates are in this PR.

Updated string with styling:
![Screenshot 2020-01-23 at 9 35 57 AM](https://user-images.githubusercontent.com/46464143/73009633-c7504680-3dc5-11ea-8337-ad6493ad47f4.png)

## Testing story

I played through the whole tutorial locally and found no issues.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
