### PR TITLE
disable use of HTML in multi_or_match_content

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -673,7 +673,7 @@ module LevelsHelper
     return match_answer_as_embedded_blockly(path) if File.extname(path).ends_with? '_blocks'
     return match_answer_as_iframe(path, width) if File.extname(path) == '.level'
 
-    @@markdown_renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::Inline)
+    @@markdown_renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::Inline.new(filter_html: true))
     @@markdown_renderer.render(text).html_safe
   end
 


### PR DESCRIPTION
Final part of the process of removing HTML from DSL fields:

1. Enable support for markdown in relevant DSL fields (https://github.com/code-dot-org/code-dot-org/pull/32750)
2. Update all DSL levels to use markdown rather than HTML
   1. levels whose HTML can be directly converted to markdown (links, bold, italic, etc) (https://github.com/code-dot-org/code-dot-org/pull/32761)
   2. levels whose HTML is already close to markdown (manually-styled code blocks, etc) (https://github.com/code-dot-org/code-dot-org/pull/32802)
   3. levels that will need to be manually refactored (updated on levelbuilder)
3. Disable HTML **<- this PR**

Now that all affected DSL levels have been updated to use markdown rather than HTML, we can safely disable the parsing of HTML for this helper and then safely reenable the i18n sync.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-904)
- [level tracking gsheet](https://docs.google.com/spreadsheets/d/1OT6VpCgRuHXphNjyac5xsNJPjktIcp8rAQ7YkbhzjOo/edit#gid=539558419)
- [scripts used to validate changes](https://gist.github.com/Hamms/b8e391b9f5e24784fb38a5de6f972639)

## Testing story

I wrote [a script to render all affected levels to HTML](https://gist.github.com/Hamms/b8e391b9f5e24784fb38a5de6f972639#file-render_to_html-rb) and stored the results of running the script both before and after this change.

I then wrote [another script to compare differences between HTML](https://gist.github.com/Hamms/b8e391b9f5e24784fb38a5de6f972639#file-html-diff-js) and ran it against the results of the previous script.

The only levels remaining for which there are differences are:

```CSD U2 RGB match
CSD: Variables Matching
Choose 2 Test
Choose 2 Test tight
CSD Headers Prediction
ECSPD Online U1D10 Assessment 2
K-1 multi 4
K-1 multi 5
PS U3-bakertest
U2L06 - MC: Which is an MST?
U3L13 - Making Predications MC
brendan test survey
RQB test levelgroup
Test longassessment levelgroup new
Test longassessment levelgroup split new
AP_practice_Qs_rqb_36_CSP_4_1_2
CSD U3 Sprites intro predict multi_2018_2019
csp-20-21-u5-mini-assessment-3
CSP 20-21 Unit 5 Pilot Mini Assessment
CSD U3 Sprites intro predict multi_2018_2019_pilot
contained_Choose_2_Test
testing abcdefg
```

I will confirm with the curriculum team that these are all unused or unimportant levels before merging.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
