### PR TITLE
Fix map syntax for getting potential organizers

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -197,9 +197,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
 
   # Users who could be re-assigned to be the organizer of this workshop
   def potential_organizers
-    render json: @workshop.potential_organizers.pluck(:name, :id).map do |name, id|
-      {label: name, value: id}
-    end
+    render json: @workshop.potential_organizers.pluck(:name, :id).map {|name, id| {label: name, value: id}}
   end
 
   private


### PR DESCRIPTION
[PLC-718](https://codedotorg.atlassian.net/browse/PLC-718)

Fixes bug in dropdown for selecting a workshop organizer when editing a workshop. I think relates to this bit of [Ruby syntax trivia](https://stackoverflow.com/questions/5513531/ruby-do-end-vs-braces). Maybe a good teachable moment!

Before:

![image](https://user-images.githubusercontent.com/25372625/73030413-7274f600-3dee-11ea-818e-e0aa6131cd44.png)


After:

![image](https://user-images.githubusercontent.com/25372625/73030245-127e4f80-3dee-11ea-8dab-3f4c96ff9104.png)

## Testing story

There are no tests for this (probably why it wasn't caught), may be worth follow up work to add them.