### PR TITLE
standardize use of header in pegasus

### DIFF
--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -161,8 +161,6 @@ class Documents < Sinatra::Base
         base = settings.configs[base][:base]
       end
     end
-
-    @locals = {header: @header}
   end
 
   # Language selection
@@ -243,27 +241,27 @@ class Documents < Sinatra::Base
     return unless response.headers['X-Pegasus-Version'] == '3'
     return unless ['', 'text/html'].include?(response.content_type.to_s.split(';', 2).first.to_s.downcase)
 
-    if params.key?('embedded') && @locals[:header]['embedded_layout']
-      @locals[:header]['layout'] = @locals[:header]['embedded_layout']
-      @locals[:header]['theme'] ||= 'none'
+    if params.key?('embedded') && @header['embedded_layout']
+      @header['layout'] = @header['embedded_layout']
+      @header['theme'] ||= 'none'
       response.headers['X-Frame-Options'] = 'ALLOWALL'
     end
 
-    if @locals[:header]['content-type']
-      response.headers['Content-Type'] = @locals[:header]['content-type']
+    if @header['content-type']
+      response.headers['Content-Type'] = @header['content-type']
     end
-    layout = @locals[:header]['layout'] || 'default'
+    layout = @header['layout'] || 'default'
     unless ['', 'none'].include?(layout)
       template = resolve_template('layouts', settings.template_extnames, layout)
       raise Exception, "'#{layout}' layout not found." unless template
-      body render_template(template, @locals.merge({body: body.join('')}))
+      body render_template(template, {body: body.join('')})
     end
 
-    theme = @locals[:header]['theme'] || 'default'
+    theme = @header['theme'] || 'default'
     unless ['', 'none'].include?(theme)
       template = resolve_template('themes', settings.template_extnames, theme)
       raise Exception, "'#{theme}' theme not found." unless template
-      body render_template(template, @locals.merge({body: body.join('')}))
+      body render_template(template, {body: body.join('')})
     end
   end
 
@@ -483,7 +481,6 @@ class Documents < Sinatra::Base
     end
 
     def render_(body, path=nil, line=0, locals={})
-      locals = @locals.merge(locals).symbolize_keys
       options = {locals: locals, line: line, path: path}
 
       extensions = MultipleExtnameFileUtils.all_extnames(path)

--- a/pegasus/sites.v3/code.org/layouts/default.haml
+++ b/pegasus/sites.v3/code.org/layouts/default.haml
@@ -4,7 +4,7 @@
   = view :unsupported_browser
   -if request.site == 'code.org'
     = view :header
-  -elsif header['theme'] == 'responsive'
+  -elsif @header['theme'] == 'responsive'
     #desktop-header.desktop-feature
       = view :header
     #mobile-header.mobile-headers.mobile-feature
@@ -12,29 +12,29 @@
   -else
     = view :header
 
-  -if header['theme'] == 'responsive'
-    -if header['responsivePadMobile']
+  -if @header['theme'] == 'responsive'
+    -if @header['responsivePadMobile']
       -containerClass = "container_responsive mobile-pad-edge"
     -else
       -containerClass = "container_responsive"
   -else
     -containerClass = "container_nonresponsive"
 
-  - if header['state-facts']
+  - if @header['state-facts']
     %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/state-facts.css'}
 
   %div{:class=>containerClass}
 
-    -if header['theme'] == 'responsive'
-      -if header['nav']
+    -if @header['theme'] == 'responsive'
+      -if @header['nav']
         %div
           .col-80-right
             =body
           .left-nav.desktop-feature
-            -if header['nav'].nil? || header['nav'] == 'blank'
+            -if @header['nav'].nil? || @header['nav'] == 'blank'
               &nbsp;
             -else
-              = view(header['nav'])
+              = view(@header['nav'])
       -else
         =body
 
@@ -48,26 +48,26 @@
       -contentWidth = 970
       %div{:style=>"width: #{contentWidth}px;"}
 
-        -if header['nav']
+        -if @header['nav']
           %div{:style=>'width: 140px; margin-right: 40px; float: left;'}
-            -if header['nav'].nil? || header['nav'] == 'blank'
+            -if @header['nav'].nil? || @header['nav'] == 'blank'
               &nbsp;
             -else
-              = view(header['nav'])
+              = view(@header['nav'])
             -contentWidth -= 180
 
-        -if header['rightbar']
+        -if @header['rightbar']
           -contentWidth -= 180
 
         %div{:style=>"width: #{contentWidth}px; float: left; margin: 0; padding: 0;"}
           = body
 
-        -if header['rightbar']
+        -if @header['rightbar']
           %div{:style=>'width: 140px; margin-left: 40px; float: left;'}
-            -if header['rightbar'].nil? || header['rightbar'] == 'blank'
+            -if @header['rightbar'].nil? || @header['rightbar'] == 'blank'
               &nbsp;
             -else
-              = view(header['rightbar']) unless header['rightbar'].nil?
+              = view(@header['rightbar']) unless @header['rightbar'].nil?
 
       #clearboth{:style=>"clear:both"}
       %br/
@@ -75,13 +75,13 @@
       %br/
   .push
 
--if header['theme'] == 'responsive'
+-if @header['theme'] == 'responsive'
   .desktop-feature
-    -if header['footer'] == 'donor_footer'
+    -if @header['footer'] == 'donor_footer'
       = view :donor_slider
     = view :footer
   .mobile-headers.mobile-feature
-    -if header['footer'] == 'donor_footer'
+    -if @header['footer'] == 'donor_footer'
       = view :donor_slider
     = view :mobile_footer_responsive
 -else

--- a/pegasus/sites.v3/code.org/layouts/page_print.haml
+++ b/pegasus/sites.v3/code.org/layouts/page_print.haml
@@ -3,9 +3,9 @@
   %head
     %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/common.css'}
     %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/font-awesome.min.css'}
-    - if header['chart']
+    - if @header['chart']
       %script{src:'https://www.google.com/jsapi'}
-    - if header['state-facts']
+    - if @header['state-facts']
       %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/state-facts-print.css'}
       %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/state-facts.css'}
   %body

--- a/pegasus/sites.v3/code.org/layouts/wide.haml
+++ b/pegasus/sites.v3/code.org/layouts/wide.haml
@@ -2,14 +2,14 @@
 
 .wrapper
   = view :unsupported_browser
-  -unless header['theme'] == 'responsive_wide'
+  -unless @header['theme'] == 'responsive_wide'
     = view :header
 
   -containerClass = "container_fullwidth"
 
   .containerClass
 
-    -if header['theme'] == 'responsive_wide'
+    -if @header['theme'] == 'responsive_wide'
       =body
 
       #clearboth{:style=>"clear:both"}
@@ -17,7 +17,7 @@
 
   .push
 
--if header['theme'] == 'responsive_wide'
+-if @header['theme'] == 'responsive_wide'
   -if page_translated? && !partner_site?
     = view :mobile_footer_responsive
   -else

--- a/pegasus/sites.v3/code.org/views/theme_common_head_after.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_head_after.haml
@@ -13,5 +13,5 @@
 %script{src: webpack_asset_path('js/vendors.js')}
 %script{:defer => "defer", src: webpack_asset_path("js/code.org/views/theme_common_head_after.js")}
 
-- if header['chart']
+- if @header['chart']
   %script{src:'https://www.google.com/jsapi'}

--- a/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
@@ -1,7 +1,7 @@
 - @header['social'].each_pair do |property, content|
   %meta{property:property, content:content}
 
-- if header['noindex']
+- if @header['noindex']
   %meta{name: "robots", content: "noindex"}
 
 %title= page_title_with_tagline

--- a/pegasus/sites.v3/codeprojects.org/layouts/default.haml
+++ b/pegasus/sites.v3/codeprojects.org/layouts/default.haml
@@ -1,2 +1,2 @@
--if header['theme'] == 'none'
+-if @header['theme'] == 'none'
   = view :footer

--- a/pegasus/sites.v3/hourofcode.com/layouts/default.haml
+++ b/pegasus/sites.v3/hourofcode.com/layouts/default.haml
@@ -2,7 +2,7 @@
 
 .wrapper
   = view :unsupported_browser
-  -if header['theme'] == 'responsive'
+  -if @header['theme'] == 'responsive'
     #desktop-header.desktop-feature
       = view :header
     #mobile-header.mobile-headers.mobile-feature
@@ -10,12 +10,12 @@
   -else
     = view :header
 
-  -if header['theme'] == 'responsive'
+  -if @header['theme'] == 'responsive'
     -if request.path_info =~ /^\/learn/
       = view :learn_tabs
 
-  -if header['theme'] == 'responsive'
-    -if header['responsivePadMobile']
+  -if @header['theme'] == 'responsive'
+    -if @header['responsivePadMobile']
       -containerClass = "container_responsive mobile-pad-edge"
     -else
       -containerClass = "container_responsive"
@@ -24,7 +24,7 @@
 
   %div{:class=>containerClass}
 
-    -if header['theme'] == 'responsive'
+    -if @header['theme'] == 'responsive'
       =body
 
       #clearboth{:style=>"clear:both"}
@@ -37,25 +37,25 @@
       -contentWidth = 970
       %div{:style=>"width: #{contentWidth}px;"}
 
-        -if header['nav']
+        -if @header['nav']
           %div{:style=>'width: 140px; margin-right: 40px; float: left;'}
-            -if header['nav'].nil? || header['nav'] == 'blank'
+            -if @header['nav'].nil? || @header['nav'] == 'blank'
               &nbsp;
             -else
-              = view(header['nav'])
+              = view(@header['nav'])
             -contentWidth -= 180
 
-        -if header['rightbar']
+        -if @header['rightbar']
           -contentWidth -= 180
 
         %div{:style=>"width: #{contentWidth}px; float: left; margin: 0; padding: 0;"}= body
 
-        -if header['rightbar']
+        -if @header['rightbar']
           %div{:style=>'width: 140px; margin-left: 40px; float: left;'}
-            -if header['rightbar'].nil? || header['rightbar'] == 'blank'
+            -if @header['rightbar'].nil? || @header['rightbar'] == 'blank'
               &nbsp;
             -else
-              = view(header['rightbar']) unless header['rightbar'].nil?
+              = view(@header['rightbar']) unless @header['rightbar'].nil?
 
       #clearboth{:style=>"clear:both"}
       %br/

--- a/pegasus/sites.v3/hourofcode.com/layouts/wide.haml
+++ b/pegasus/sites.v3/hourofcode.com/layouts/wide.haml
@@ -6,12 +6,12 @@
 
 .container.wide-index-content
 
-  - if header['nav']
+  - if @header['nav']
     .row
       .col-sm-9
         = body
       .col-sm-3.nav-col
-        = view(header['nav'])
+        = view(@header['nav'])
   - else
     = body
 


### PR DESCRIPTION
Currently, pegasus exposes all instance variables declared in `router.rb` to all views, and also manually constructs a "locals" variable containing a reference to the specific instance variable `@header`. This means that all views are able to access header data either by directly referencing it via `@header` or by referencing the version provided by the `locals` variable via `header`.

Because the `locals` variable is _only_ used for this purpose, I move we deprecate it entirely and have all views use the same `@header` reference.

Part of the preliminary work to standardize a few things in pegasus in preparation for https://github.com/code-dot-org/code-dot-org/pull/32607

## Testing story

Manually tested a number of pegasus pages to confirm they still work as expected; I'm also counting on https://github.com/code-dot-org/code-dot-org/blob/68bfebd29bc2fefac8f0e09fa9d731c22ac88345/pegasus/test/test_pegasus_documents.rb

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
