### PR TITLE
[Applab Datasets] Render links in table description

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -398,6 +398,7 @@
   "dataTableNamePlaceholder": "Table name",
   "dataLibraryHeader": "Data Library",
   "dataLibraryDescription": "Find and import tables of real data from the Code.org library.",
+  "dataSource": "Data Source",
   "dataVisualizerPlaceholderText": "Select values to generate a visualization",
   "dataVisualizerBucketSize": "Bucket Size",
   "dataVisualizerCreateChart": "Create chart on screen",

--- a/apps/src/storage/dataBrowser/LibraryTable.jsx
+++ b/apps/src/storage/dataBrowser/LibraryTable.jsx
@@ -13,6 +13,11 @@ const styles = {
     cursor: 'pointer',
     color: color.dark_charcoal
   },
+  tableDescription: {
+    fontFamily: '"Gotham 4r", sans-serif',
+    color: color.dark_charcoal,
+    wordBreak: 'break-word'
+  },
   preview: {
     backgroundColor: color.background_gray,
     borderColor: color.lighter_gray,
@@ -64,8 +69,6 @@ class LibraryTable extends React.Component {
     collapsed: true
   };
 
-  datasetInfo = getDatasetInfo(this.props.name);
-
   toggleCollapsed = () =>
     this.setState({
       collapsed: !this.state.collapsed
@@ -73,6 +76,7 @@ class LibraryTable extends React.Component {
 
   render() {
     const icon = this.state.collapsed ? 'caret-right' : 'caret-down';
+    const datasetInfo = getDatasetInfo(this.props.name);
 
     return (
       <div>
@@ -83,7 +87,17 @@ class LibraryTable extends React.Component {
         {!this.state.collapsed && (
           <div style={styles.collapsibleContainer}>
             {/* TODO: Add last updated time */}
-            <div>{this.datasetInfo.description}</div>
+            <div style={styles.tableDescription}>
+              {datasetInfo.description}
+              {datasetInfo.sourceUrl && (
+                <span style={{display: 'inline-block'}}>
+                  {msg.dataSource() + ': '}
+                  <a href={datasetInfo.sourceUrl}>
+                    {datasetInfo.sourceText || datasetInfo.sourceUrl}
+                  </a>
+                </span>
+              )}
+            </div>
             <div>
               <button
                 style={styles.preview}
@@ -95,7 +109,7 @@ class LibraryTable extends React.Component {
               <button
                 style={styles.import}
                 type="button"
-                onClick={() => this.props.importTable(this.datasetInfo)}
+                onClick={() => this.props.importTable(datasetInfo)}
               >
                 {msg.import()}
               </button>

--- a/apps/src/storage/dataBrowser/datasetManifest.json
+++ b/apps/src/storage/dataBrowser/datasetManifest.json
@@ -28,21 +28,29 @@
     {
       "name": "Top 200 USA",
       "description": "Top 200 Songs on Spotify for the United States, updated daily.",
+      "sourceUrl": "https://spotifycharts.com/regional/us/daily/latest",
+      "sourceText": "Spotify",
       "current": true
     },
     {
       "name": "Viral 50 USA",
       "description": "Spotify's most viral 50 songs in the United States, updated daily.",
+      "sourceUrl": "https://spotifycharts.com/viral/us/daily/latest",
+      "sourceText": "Spotify",
       "current": true
     },
     {
       "name": "Top 200 Worldwide",
       "description": "The top 200 Songs in the world on Spotify, updated daily.",
+      "sourceUrl": "https://spotifycharts.com/regional/global/daily/latest",
+      "sourceText": "Spotify",
       "current": true
     },
     {
       "name": "Viral 50 Worldwide",
       "description": "Spotify's most viral 50 songs in the world, updated daily.",
+      "sourceUrl": "https://spotifycharts.com/viral/global/daily/latest",
+      "sourceText": "Spotify",
       "current": true
     }
   ],


### PR DESCRIPTION
Add support for showing data source for each table. I'm also adding the spotify source URLs as an example, but very soon this whole json file will be owned by Levelbuilders, so they can change/update as they see fit.

If you provide `sourceUrl` and `sourceText`, makes a link with the provided text:
![image](https://user-images.githubusercontent.com/8787187/73030518-acde9300-3dee-11ea-939a-3363e3414bab.png)
If you provide just `sourceUrl`, makes a link with the URL as the link text:
![image](https://user-images.githubusercontent.com/8787187/73030545-bc5ddc00-3dee-11ea-92d8-257273cc914a.png)
And if there's no `sourceUrl`, doesn't show anything about data source:
![image](https://user-images.githubusercontent.com/8787187/73030576-ce3f7f00-3dee-11ea-93eb-a068c696a3e1.png)



<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
