### PR TITLE
Fixing error handling of certificate creation.

### DIFF
--- a/pegasus/test/test_certificate_image.rb
+++ b/pegasus/test/test_certificate_image.rb
@@ -62,6 +62,20 @@ class CertificateImageTest < Minitest::Test
     twenty_hour_certificate_image = create_course_certificate_image('Robot Tester', '20-hour')
     assert_image twenty_hour_certificate_image, 1754, 1240, 'JPEG'
 
+    # Create course certificates with nil and empty values
+    nil_name_course_certificate_image = create_course_certificate_image(nil, 'course1', 'sponsor', 'Course 1')
+    assert_image nil_name_course_certificate_image, 1754, 1240, 'PNG'
+    nil_sponsor_course_certificate_image = create_course_certificate_image('Robot Tester', 'course1', nil, 'Course 1')
+    assert_image nil_sponsor_course_certificate_image, 1754, 1240, 'PNG'
+    nil_title_course_certificate_image = create_course_certificate_image('Robot Tester', 'course1', 'sponsor', nil)
+    assert_image nil_title_course_certificate_image, 1754, 1240, 'PNG'
+    empty_name_course_certificate_image = create_course_certificate_image('', 'course1', 'sponsor', 'Course 1')
+    assert_image empty_name_course_certificate_image, 1754, 1240, 'PNG'
+    empty_sponsor_course_certificate_image = create_course_certificate_image('Robot Tester', 'course1', '', 'Course 1')
+    assert_image empty_sponsor_course_certificate_image, 1754, 1240, 'PNG'
+    empty_title_course_certificate_image = create_course_certificate_image('Robot Tester', 'course1', 'sponsor', '')
+    assert_image empty_title_course_certificate_image, 1754, 1240, 'PNG'
+
     # Entered name "à Test Namé" on /congrats/course1
     # JS btoa(JSON.stringified(config)) becomes:
     #   "eyJuYW1lIjoi4CBUZXN0IE5hbekiLCJjb3Vyc2UiOiJDb3Vyc2UgMSJ9"


### PR DESCRIPTION
A recent refactoring of the certificate creation code resulted in the
usage of a variable which no longer exists. 

Also added better handling of bad input for certificate creation, such
as very long name and empty names.

* The offending variableis `image_path`. It no longer exists in the context where the 
HoneyBadger reports are generated. This has been removed.
* The reason that line of code was getting hit in the first place is because there are empty strings which are trying to be generated in to images. I also added handling of empty strings to prevent further reports.

## Links
- [previous PR](https://github.com/code-dot-org/code-dot-org/pull/32801)
- [honeybadger](https://app.honeybadger.io/projects/34365/faults/59910555)

## Testing story
- Replicated issue with unit tests and then added code to handle the bug.
- Manually generated a certificate.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
