### PR TITLE
Add rbspy recipe [ci skip]

### DIFF
--- a/aws/cloudformation/bootstrap_frontend.sh.erb
+++ b/aws/cloudformation/bootstrap_frontend.sh.erb
@@ -20,6 +20,11 @@ pushd $CHEF_CACHE
   /opt/chef/bin/chef-client -z -N <%=node_name%> -o 'recipe[cdo-apps::hostname]'
 popd
 
+# Run rbspy for 2 minutes on 3 dashboard worker processes at startup.
+# We're doing this temporarily to help debug our deployment unavailability issue.
+# Find 3 dashboard worker process IDs and feed them to 3 rbspy invocations, in parallel using xargs.
+ps aux | grep "cluster worker" | grep dashboard | head -n 3 | tr --squeeze-repeats ' ' | cut -d ' ' -f 2 | xargs -P 3 -I {} sudo rbspy record --silent --duration 120 --pid {} &
+
 # Increase EC2 instance metadata service retries/timeouts.
 export AWS_METADATA_SERVICE_TIMEOUT=30
 export AWS_METADATA_SERVICE_NUM_ATTEMPTS=30

--- a/cookbooks/Berksfile
+++ b/cookbooks/Berksfile
@@ -9,6 +9,7 @@ cookbook 'chef-client'
 cookbook 'ntp'
 cookbook 'seven_zip'
 cookbook 'chef_client_updater'
+cookbook 'tar'
 
 # List all local cookbooks using local-mode Chef.
 require 'chef/local_mode'

--- a/cookbooks/Berksfile
+++ b/cookbooks/Berksfile
@@ -9,7 +9,6 @@ cookbook 'chef-client'
 cookbook 'ntp'
 cookbook 'seven_zip'
 cookbook 'chef_client_updater'
-cookbook 'tar'
 
 # List all local cookbooks using local-mode Chef.
 require 'chef/local_mode'

--- a/cookbooks/cdo-apps/metadata.rb
+++ b/cookbooks/cdo-apps/metadata.rb
@@ -8,6 +8,7 @@ version          '0.2.414'
 
 depends 'apt'
 depends 'build-essential'
+depends 'tar'
 depends 'yarn'
 
 depends 'cdo-cloudwatch-extra-metrics'

--- a/cookbooks/cdo-apps/metadata.rb
+++ b/cookbooks/cdo-apps/metadata.rb
@@ -8,7 +8,6 @@ version          '0.2.414'
 
 depends 'apt'
 depends 'build-essential'
-depends 'tar'
 depends 'yarn'
 
 depends 'cdo-cloudwatch-extra-metrics'

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -132,3 +132,5 @@ include_recipe 'cdo-tippecanoe' if node['cdo-apps']['daemon']
 
 # Patch to fix issue with systemd-resolved: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1805183
 include_recipe 'cdo-apps::resolved'
+
+include_recipe 'cdo-apps::rbspy'

--- a/cookbooks/cdo-apps/recipes/rbspy.rb
+++ b/cookbooks/cdo-apps/recipes/rbspy.rb
@@ -1,3 +1,5 @@
+# Install https://rbspy.github.io/ to allow manual debugging of ruby performance issues.
+
 tar_extract 'https://github.com/rbspy/rbspy/releases/download/v0.3.8/rbspy-v0.3.8-x86_64-unknown-linux-musl.tar.gz' do
   target_dir '/usr/local/bin'
   creates '/usr/local/bin/rbspy'

--- a/cookbooks/cdo-apps/recipes/rbspy.rb
+++ b/cookbooks/cdo-apps/recipes/rbspy.rb
@@ -1,0 +1,4 @@
+tar_extract 'https://github.com/rbspy/rbspy/releases/download/v0.3.8/rbspy-v0.3.8-x86_64-unknown-linux-musl.tar.gz' do
+  target_dir '/usr/local/bin'
+  creates '/usr/local/bin/rbspy'
+end

--- a/cookbooks/cdo-apps/recipes/rbspy.rb
+++ b/cookbooks/cdo-apps/recipes/rbspy.rb
@@ -1,6 +1,7 @@
 # Install https://rbspy.github.io/ to allow manual debugging of ruby performance issues.
 
-tar_extract 'https://github.com/rbspy/rbspy/releases/download/v0.3.8/rbspy-v0.3.8-x86_64-unknown-linux-musl.tar.gz' do
-  target_dir '/usr/local/bin'
-  creates '/usr/local/bin/rbspy'
+ark 'rbspy' do
+  url "https://github.com/rbspy/rbspy/releases/download/v0.3.8/#{name}-v0.3.8-x86_64-unknown-linux-musl.tar.gz"
+  strip_components 0
+  has_binaries ['rbspy']
 end


### PR DESCRIPTION
Install https://rbspy.github.io/ so it's available by default on frontend instances. Right now I'm running these install steps manually on a frontend each time I need to use it. We're currently using it to investigate the ongoing deployment unavailability issue.

## Testing story

Temporarily changed `run_list` in `.kitchen.yml` to `recipe[cdo-apps::rbspy]`, ran `bundle exec kitchen converge default-ubuntu-1804`, and confirmed `rbspy` is runnable from any directory.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
