### PR TITLE
stub CDO vars for asset_helper in pegasus rendering tests

### DIFF
--- a/pegasus/test/test_congrats_routes.rb
+++ b/pegasus/test/test_congrats_routes.rb
@@ -9,11 +9,6 @@ class CongratsRoutesTest < Minitest::Test
       $log.level = Logger::ERROR # Pegasus spams debug logging otherwise
       @mock_session = Rack::MockSession.new(MockPegasus.new, 'code.org')
       @pegasus = Rack::Test::Session.new(@mock_session)
-
-      # Ensure that AssetHelper#webpack_asset_path does not raise an exception
-      # when called from unit tests. See comments on that method for details.
-      CDO.stubs(optimize_webpack_assets: false)
-      CDO.stubs(use_my_apps: true)
     end
 
     it 'shows a course-specific congrats page for appropriate courses' do

--- a/pegasus/test/test_congrats_routes.rb
+++ b/pegasus/test/test_congrats_routes.rb
@@ -9,6 +9,11 @@ class CongratsRoutesTest < Minitest::Test
       $log.level = Logger::ERROR # Pegasus spams debug logging otherwise
       @mock_session = Rack::MockSession.new(MockPegasus.new, 'code.org')
       @pegasus = Rack::Test::Session.new(@mock_session)
+
+      # Ensure that AssetHelper#webpack_asset_path does not raise an exception
+      # when called from unit tests. See comments on that method for details.
+      CDO.stubs(optimize_webpack_assets: false)
+      CDO.stubs(use_my_apps: true)
     end
 
     it 'shows a course-specific congrats page for appropriate courses' do

--- a/pegasus/test/test_haml.rb
+++ b/pegasus/test/test_haml.rb
@@ -10,13 +10,6 @@ class HamlTest < Minitest::Test
     Documents.new
   end
 
-  def setup
-    # Ensure that AssetHelper#webpack_asset_path does not raise an exception
-    # when called from unit tests. See comments on that method for details.
-    CDO.stubs(optimize_webpack_assets: false)
-    CDO.stubs(use_my_apps: true)
-  end
-
   def test_resources_videos
     path = '/educate/resources/videos'
     resp = get(path)

--- a/pegasus/test/test_haml.rb
+++ b/pegasus/test/test_haml.rb
@@ -10,6 +10,13 @@ class HamlTest < Minitest::Test
     Documents.new
   end
 
+  def setup
+    # Ensure that AssetHelper#webpack_asset_path does not raise an exception
+    # when called from unit tests. See comments on that method for details.
+    CDO.stubs(optimize_webpack_assets: false)
+    CDO.stubs(use_my_apps: true)
+  end
+
   def test_resources_videos
     path = '/educate/resources/videos'
     resp = get(path)

--- a/pegasus/test/test_helper.rb
+++ b/pegasus/test/test_helper.rb
@@ -7,3 +7,12 @@ if ENV['CIRCLECI']
   reporters << Minitest::Reporters::JUnitReporter.new("#{ENV['CIRCLE_TEST_REPORTS']}/pegasus")
 end
 Minitest::Reporters.use! reporters
+
+class Minitest::Test
+  def before_setup
+    # Ensure that AssetHelper#webpack_asset_path does not raise an exception
+    # when called from unit tests. See comments on that method for details.
+    CDO.stubs(optimize_webpack_assets: false)
+    CDO.stubs(use_my_apps: true)
+  end
+end

--- a/pegasus/test/test_hoc_routes.rb
+++ b/pegasus/test/test_hoc_routes.rb
@@ -21,6 +21,11 @@ class HocRoutesTest < Minitest::Test
       @pegasus = Rack::Test::Session.new(@mock_session)
       DCDO.clear
       Gatekeeper.clear
+
+      # Ensure that AssetHelper#webpack_asset_path does not raise an exception
+      # when called from unit tests. See comments on that method for details.
+      CDO.stubs(optimize_webpack_assets: false)
+      CDO.stubs(use_my_apps: true)
     end
 
     it 'redirects to tutorial via shortcode' do

--- a/pegasus/test/test_hoc_routes.rb
+++ b/pegasus/test/test_hoc_routes.rb
@@ -21,11 +21,6 @@ class HocRoutesTest < Minitest::Test
       @pegasus = Rack::Test::Session.new(@mock_session)
       DCDO.clear
       Gatekeeper.clear
-
-      # Ensure that AssetHelper#webpack_asset_path does not raise an exception
-      # when called from unit tests. See comments on that method for details.
-      CDO.stubs(optimize_webpack_assets: false)
-      CDO.stubs(use_my_apps: true)
     end
 
     it 'redirects to tutorial via shortcode' do

--- a/pegasus/test/test_i18n_hoc_routes.rb
+++ b/pegasus/test/test_i18n_hoc_routes.rb
@@ -9,6 +9,13 @@ class I18nHocRoutesTest < Minitest::Test
     Rack::Builder.parse_file(File.absolute_path('../config.ru', __dir__)).first
   end
 
+  def setup
+    # Ensure that AssetHelper#webpack_asset_path does not raise an exception
+    # when called from unit tests. See comments on that method for details.
+    CDO.stubs(optimize_webpack_assets: false)
+    CDO.stubs(use_my_apps: true)
+  end
+
   def test_hoc_pages_for_all_locales
     header 'Host', 'hourofcode.com'
     languages = DB[:cdo_languages].select(:unique_language_s).where(supported_hoc_b: 1)

--- a/pegasus/test/test_i18n_hoc_routes.rb
+++ b/pegasus/test/test_i18n_hoc_routes.rb
@@ -9,13 +9,6 @@ class I18nHocRoutesTest < Minitest::Test
     Rack::Builder.parse_file(File.absolute_path('../config.ru', __dir__)).first
   end
 
-  def setup
-    # Ensure that AssetHelper#webpack_asset_path does not raise an exception
-    # when called from unit tests. See comments on that method for details.
-    CDO.stubs(optimize_webpack_assets: false)
-    CDO.stubs(use_my_apps: true)
-  end
-
   def test_hoc_pages_for_all_locales
     header 'Host', 'hourofcode.com'
     languages = DB[:cdo_languages].select(:unique_language_s).where(supported_hoc_b: 1)

--- a/pegasus/test/test_pegasus_documents.rb
+++ b/pegasus/test/test_pegasus_documents.rb
@@ -74,13 +74,6 @@ class PegasusTest < Minitest::Test
     code.org/page_mode
   ]
 
-  def setup
-    # Ensure that AssetHelper#webpack_asset_path does not raise an exception
-    # when called from unit tests. See comments on that method for details.
-    CDO.stubs(optimize_webpack_assets: false)
-    CDO.stubs(use_my_apps: true)
-  end
-
   def test_render_pegasus_documents
     all_documents = app.helpers.all_documents.reject do |page|
       # 'Splat' documents not yet handled.

--- a/pegasus/test/test_pegasus_documents.rb
+++ b/pegasus/test/test_pegasus_documents.rb
@@ -74,6 +74,13 @@ class PegasusTest < Minitest::Test
     code.org/page_mode
   ]
 
+  def setup
+    # Ensure that AssetHelper#webpack_asset_path does not raise an exception
+    # when called from unit tests. See comments on that method for details.
+    CDO.stubs(optimize_webpack_assets: false)
+    CDO.stubs(use_my_apps: true)
+  end
+
   def test_render_pegasus_documents
     all_documents = app.helpers.all_documents.reject do |page|
       # 'Splat' documents not yet handled.

--- a/pegasus/test/test_site.rb
+++ b/pegasus/test/test_site.rb
@@ -8,13 +8,6 @@ class SiteTest < Minitest::Test
     Rack::Builder.parse_file(File.absolute_path('../config.ru', __dir__)).first
   end
 
-  def setup
-    # Ensure that AssetHelper#webpack_asset_path does not raise an exception
-    # when called from unit tests. See comments on that method for details.
-    CDO.stubs(optimize_webpack_assets: false)
-    CDO.stubs(use_my_apps: true)
-  end
-
   def test_post_whitelist
     header 'host', 'code.org'
     # Ensure POST requests to Pegasus template paths return a 405 error by default.

--- a/pegasus/test/test_site.rb
+++ b/pegasus/test/test_site.rb
@@ -8,6 +8,13 @@ class SiteTest < Minitest::Test
     Rack::Builder.parse_file(File.absolute_path('../config.ru', __dir__)).first
   end
 
+  def setup
+    # Ensure that AssetHelper#webpack_asset_path does not raise an exception
+    # when called from unit tests. See comments on that method for details.
+    CDO.stubs(optimize_webpack_assets: false)
+    CDO.stubs(use_my_apps: true)
+  end
+
   def test_post_whitelist
     header 'host', 'code.org'
     # Ensure POST requests to Pegasus template paths return a 405 error by default.


### PR DESCRIPTION
pegasus tests fail due to inability to find the webpack manifest when developers have certain combinations of CDO variables set and have not built the apps package. This PR stubs those CDO variables for all pegasus unit tests so that they will pass regardless of what the developer has them set to in locals.yml.

## Testing story

Manually verified that PR fixes all of the test which were failing locally with webpack manifest errors after running `cd apps; grunt clean` and setting the following in locals.yml:
```
use_my_apps: false
optimize_webpack_assets: true
```
I did see other failures when running pegasus tests locally, but these exist regardless of the above CDO variables.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
