### PR TITLE
Logging unused string interpolation args

### DIFF
--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -113,33 +113,26 @@ module Cdo
         end
       end
 
-      # TODO: FND-974
-      # We currently have some strings that are _intentionally_ rendering
-      # without using all their interpolation patterns. (see
-      # _javascript_strings.haml for one example)
-      #
-      # Once all those intentional violations have been removed, we can
-      # uncomment this method override to add logging
-      #def translate(locale, key, options = ::I18n::EMPTY_HASH)
-      #  result = super(locale, key, options)
-      #  # Log unused interpolation arguments to honeybadger; these are likely
-      #  # the result of translations mistakenly including interpolation syntax
-      #  # that was removed in the source string and we want to be notified so
-      #  # we can update the translation.
-      #  if result.is_a?(String) && ::I18n::INTERPOLATION_PATTERN.match?(result)
-      #    Honeybadger.notify(
-      #      error_class: 'Interpolation Pattern present in translation',
-      #      error_message: "String #{result.inspect} has unused interpolation patterns after translation",
-      #      context: {
-      #        key: key,
-      #        locale: locale,
-      #        options: options,
-      #        result: result,
-      #      }
-      #    )
-      #  end
-      #  result
-      #end
+      def translate(locale, key, options = ::I18n::EMPTY_HASH)
+        result = super(locale, key, options)
+        # Log unused interpolation arguments to honeybadger; these are likely
+        # the result of translations mistakenly including interpolation syntax
+        # that was removed in the source string and we want to be notified so
+        # we can update the translation.
+        if result.is_a?(String) && ::I18n::INTERPOLATION_PATTERN.match?(result)
+          Honeybadger.notify(
+            error_class: 'Interpolation Pattern present in translation',
+            error_message: "String #{result.inspect} has unused interpolation patterns after translation",
+            context: {
+              key: key,
+              locale: locale,
+              options: options,
+              result: result,
+            }
+          )
+        end
+        result
+      end
     end
 
     class SimpleBackend < ::I18n::Backend::Simple

--- a/lib/test/cdo/test_i18n_backend.rb
+++ b/lib/test/cdo/test_i18n_backend.rb
@@ -153,15 +153,13 @@ class I18nSafeInterpolationTest < Minitest::Test
     assert_equal "%{hello} World", @backend.translate(@locale, 'test_missing_interpolation_argument', world: "World")
   end
 
-  # TODO: FND-974
-  # make this not be true
-  def test_missing_interpolation_arguments_are_not_logged
+  def test_missing_interpolation_arguments_are_logged
     @backend.store_translations(
       @locale,
       test_missing_interpolation_argument: "Hello %{world}"
     )
 
-    Honeybadger.expects(:notify).never
+    Honeybadger.expects(:notify)
     @backend.translate(@locale, 'test_missing_interpolation_argument')
   end
 end


### PR DESCRIPTION
# Description
HoneyBadger reports will now be generated whenever we try to translate a
string but the result still has undefined values.

For example: If the translation system returns "Hallo, Dayne #{last_name}"
then a HoneyBadger report will be generated. Now we know
the German translation of this string should no longer rely on
"last_name" being defined.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-974)

## Testing story
* Unit test
* localhost-studio.code.org:3000/home/lang/ja-jp and verified string translation is still working.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
