### PR TITLE
Remove unused version_year from script cache key

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -78,7 +78,7 @@ class ScriptLevelsController < ApplicationController
   def show
     @current_user = current_user && User.includes(:teachers).where(id: current_user.id).first
     authorize! :read, ScriptLevel
-    @script = ScriptLevelsController.get_script(request, version_year: DEFAULT_VERSION_YEAR)
+    @script = ScriptLevelsController.get_script(request)
 
     # Redirect to the same script level within @script.redirect_to.
     # There are too many variations of the script level path to use
@@ -246,11 +246,11 @@ class ScriptLevelsController < ApplicationController
     render json: stage.summary_for_lesson_plans
   end
 
-  def self.get_script(request, version_year: nil)
+  def self.get_script(request)
     script_id = request.params[:script_id]
     script = ScriptConstants::FAMILY_NAMES.include?(script_id) ?
       Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale) :
-      Script.get_from_cache(script_id, version_year: version_year)
+      Script.get_from_cache(script_id)
 
     raise ActiveRecord::RecordNotFound unless script
     script

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -502,18 +502,6 @@ class Script < ActiveRecord::Base
     script_name ? Script.new(redirect_to: script_name) : nil
   end
 
-  # Given a script family name, return a dummy Script with redirect_to field
-  # pointing toward the latest stable script in that family, or to a specific
-  # version_year if one is specified.
-  # @param family_name [String] The name of the script family to search in.
-  # @param version_year [String] Version year to return. Optional.
-  # @return [Script|nil] A dummy script object, not persisted to the database,
-  #   with only the redirect_to field set.
-  def self.get_script_family_redirect(family_name, version_year: nil)
-    script_name = Script.latest_stable_version(family_name, version_year: version_year).try(:name)
-    script_name ? Script.new(redirect_to: script_name) : nil
-  end
-
   # @param user [User]
   # @param locale [String] User or request locale. Optional.
   # @return [String|nil] URL to the script overview page the user should be redirected to (if any).

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -416,7 +416,7 @@ class Script < ActiveRecord::Base
     self.class.get_from_cache(id)
   end
 
-  def self.get_without_cache(id_or_name, version_year: nil, with_associated_models: true)
+  def self.get_without_cache(id_or_name, with_associated_models: true)
     # Also serve any script by its new_name, if it has one.
     script = id_or_name && Script.find_by(new_name: id_or_name)
     return script if script
@@ -433,28 +433,22 @@ class Script < ActiveRecord::Base
   end
 
   # Returns the script with the specified id, or a script with the specified
-  # name, or a redirect to the latest version of the script within the specified
-  # family. Also populates the script cache so that future responses will be cached.
+  # name. Also populates the script cache so that future responses will be cached.
   # For example:
   #   get_from_cache('11') --> script_cache['11'] = <Script id=11, name=...>
   #   get_from_cache('frozen') --> script_cache['frozen'] = <Script name="frozen", id=...>
-  #   get_from_cache('csp1') --> script_cache['csp1'] = <Script redirect_to="csp1-2018">
-  #   get_from_cache('csp1', version_year: '2017') --> script_cache['csp1/2017'] = <Script redirect_to="csp1-2017">
   #
   # @param id_or_name [String|Integer] script id, script name, or script family name.
-  # @param version_year [String] If specified, when looking for a script to redirect
-  #   to within a script family, redirect to this version rather than the latest.
-  def self.get_from_cache(id_or_name, version_year: nil)
+  def self.get_from_cache(id_or_name)
     if ScriptConstants::FAMILY_NAMES.include?(id_or_name)
       raise "Do not call Script.get_from_cache with a family_name. Call Script.get_script_family_redirect_for_user instead.  Family: #{id_or_name}"
     end
 
-    return get_without_cache(id_or_name, version_year: version_year, with_associated_models: false) unless should_cache?
-    cache_key_suffix = version_year ? "/#{version_year}" : ''
-    cache_key = "#{id_or_name}#{cache_key_suffix}"
+    return get_without_cache(id_or_name, with_associated_models: false) unless should_cache?
+    cache_key = id_or_name.to_s
     script_cache.fetch(cache_key) do
       # Populate cache on miss.
-      script_cache[cache_key] = get_without_cache(id_or_name, version_year: version_year)
+      script_cache[cache_key] = get_without_cache(id_or_name)
     end
   end
 

--- a/dashboard/test/integration/caching_test.rb
+++ b/dashboard/test/integration/caching_test.rb
@@ -101,4 +101,11 @@ class CachingTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
   end
+
+  test 'should cache script after initialization' do
+    Script.script_cache_to_cache
+    assert_queries(0, ignore_filters: [], capture_filters: [/script\.rb.*get_from_cache/]) do
+      get '/s/course1/stage/3/puzzle/1'
+    end
+  end
 end

--- a/dashboard/test/testing/capture_queries.rb
+++ b/dashboard/test/testing/capture_queries.rb
@@ -23,19 +23,30 @@ module CaptureQueries
     end
   end
 
-  def assert_queries(num, &block)
+  def assert_queries(num, *args, &block)
     return yield if num.nil?
-    queries = capture_queries(&block)
+    queries = capture_queries(*args, &block)
     assert_equal num, queries.count, "Wrong query count:\n#{queries.join("\n")}\n"
   end
 
-  def assert_cached_queries(num, &block)
+  def assert_cached_queries(num, *args, &block)
     Retryable.retryable(on: Minitest::Assertion, tries: 2, sleep: 0) do
-      assert_queries(num, &block)
+      assert_queries(num, *args, &block)
     end
   end
 
-  def capture_queries(&block)
+  IGNORE_FILTERS = [
+    # Script/course-cache related queries don't count.
+    /(script|course)\.rb.*get_from_cache/,
+    # Level-cache queries don't count.
+    /script\.rb.*cache_find_(script_level|level)/,
+    # Ignore cached script id lookup
+    /stage_extras_script_ids/,
+    # Ignore random updates to experiment cache.
+    /experiment\.rb.*update_cache/
+  ]
+
+  def capture_queries(ignore_filters: IGNORE_FILTERS, capture_filters: [], &block)
     queries = []
     query = lambda do |_name, start, finish, _id, payload|
       duration = finish - start
@@ -45,14 +56,8 @@ module CaptureQueries
       cleaner.add_silencer {|line| line =~ /application_controller.*with_locale/}
       backtrace = cleaner.clean(caller)
 
-      # Script/course-cache related queries don't count.
-      next if backtrace.any? {|line| line =~ /(script|course)\.rb.*get_from_cache/}
-      # Level-cache queries don't count.
-      next if backtrace.any? {|line| line =~ /script\.rb.*cache_find_(script_level|level)/}
-      # Ignore cached script id lookup
-      next if backtrace.any? {|line| line =~ /stage_extras_script_ids/}
-      # Ignore random updates to experiment cache.
-      next if backtrace.any? {|line| line =~ /experiment\.rb.*update_cache/}
+      next if ignore_filters.any? {|filter| backtrace.any? {|line| line =~ filter}}
+      next unless capture_filters.all? {|filter| backtrace.any? {|line| line =~ filter}}
 
       queries << "#{QueryLogger.log(duration, payload)}\n#{backtrace.join("\n")}"
     end


### PR DESCRIPTION
Fixes a bug introduced in #22887 where scripts fetched for a non-nil `version_year` (which included all fetches from `ScriptLevelsController#show`) were not pre-loaded during application initialization. This caused the first request (within each process) to `ScriptLevelsController#show` for each script to be slower than expected on startup.

Since #28683, `version_year` is no longer used by the script-cache fetch anyway, so all of the logic extending the cache key by this variable can be removed for simplicity.