### PR TITLE
Prevent creating StageStandards duplicates 

### DIFF
--- a/dashboard/app/controllers/admin_standards_controller.rb
+++ b/dashboard/app/controllers/admin_standards_controller.rb
@@ -37,7 +37,7 @@ class AdminStandardsController < ApplicationController
           missing_standards << standard["shortcode"]
         end
 
-        if code_studio_standard && stage
+        if code_studio_standard && stage && !stage.standards.include?(code_studio_standard)
           stage.standards << code_studio_standard
           stage.save!
         end


### PR DESCRIPTION
[LP-1156](https://codedotorg.atlassian.net/browse/LP-1156) partial, up next is enforcing uniqueness at the database level. 

When standards associations are imported from CurriculumBuilder we don't want to create duplicates if a particular Standard is already associated with a particular Stage in Code Studio.  With this change we'll now skip creating a StageStandard for an imported stage-standard association if the relevant StageStandard already exists. 

To check that this change worked, I: 
1.) Cleared my database of all StageStandards
2.) Imported standards associations for Course A and counted the resulting StageStandards. 
`ActiveRecord::Base.connection.execute('SELECT * FROM stages_standards' ).to_a.length` => 35
3.) Imported Course A standards associations again and counted the resulting StageStandards to confirm duplication was happening. 
`ActiveRecord::Base.connection.execute('SELECT * FROM stages_standards' ).to_a.length` => 70
4.) Deleted all of the StageStandards for Course A 
`stages = Stage.includes(:standards).where.not(standards: { id: nil})`
`stages.each do |stage| stage.standards.clear end`
5.) Made the code change. 
6.) Imported Course A standards associations again and counted the resulting StageStandards
`ActiveRecord::Base.connection.execute('SELECT * FROM stages_standards' ).to_a.length` => 35 
7.) Imported Course A standards associations again and counted the resulting StageStandards to confirm duplication was NOT happening. 
`ActiveRecord::Base.connection.execute('SELECT * FROM stages_standards' ).to_a.length` => 35


