### PR TITLE
PL: Improve ZIP lookups for regional partners

### DIFF
--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -181,9 +181,13 @@ class RegionalPartner < ActiveRecord::Base
   # and we don't find a partner with that ZIP, we geocode that ZIP to get a state and try with that
   # state.
   # @param [String] zip_code
-  def self.find_by_zip(zip_code)
+  def self.find_by_zip(zip_code_raw)
     partner = nil
     state = nil
+
+    # Force to be a string, ignore "-" and anything after it,
+    # and only allow digits 0-9.
+    zip_code = zip_code_raw.to_s.split("-")[0].tr('^0-9', '')
 
     if RegexpUtils.us_zip_code?(zip_code)
       # Try to find the matching partner using the ZIP code.

--- a/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
+++ b/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
@@ -49,6 +49,36 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
     assert_equal regional_partner.id, regional_partner_mini_contact.regional_partner_id
   end
 
+  test 'Matches regional partner with integer zip' do
+    # Use the same state & zip as the mini-contact factory's defaults.
+    state = 'OH'
+    zip = '45242'
+
+    regional_partner = create :regional_partner, name: "partner_OH_45242"
+    regional_partner.mappings.find_or_create_by!(state: state)
+    regional_partner.mappings.find_or_create_by!(zip_code: zip)
+
+    regional_partner_mini_contact = create :pd_regional_partner_mini_contact,
+      form_data: build(:pd_regional_partner_mini_contact_hash).merge("zip" => 45242).to_json
+
+    assert_equal regional_partner.id, regional_partner_mini_contact.regional_partner_id
+  end
+
+  test 'Matches regional partner with messy zip' do
+    # Use the same state & zip as the mini-contact factory's defaults.
+    state = 'OH'
+    zip = '45242'
+
+    regional_partner = create :regional_partner, name: "partner_OH_45242"
+    regional_partner.mappings.find_or_create_by!(state: state)
+    regional_partner.mappings.find_or_create_by!(zip_code: zip)
+
+    regional_partner_mini_contact = create :pd_regional_partner_mini_contact,
+      form_data: build(:pd_regional_partner_mini_contact_hash).merge("zip" => " \n 45242-1234 \n ").to_json
+
+    assert_equal regional_partner.id, regional_partner_mini_contact.regional_partner_id
+  end
+
   # If matched and regional partner has one pm, send matched email to pm
   test 'Matched with one regional partner pm' do
     regional_partner = create :regional_partner, name: "partner_OH_45242"


### PR DESCRIPTION
After reviewing some `RegionalPartnerMiniContact` submissions that didn't resolve to a specific regional partner when sending email, the ZIP lookup code has been improved:

- It now converts the ZIP to a string, since the submitted forms occasionally had the ZIP stored in the JSON blob as an integer rather than a string.  (Not sure why this is, but possibly browser-specific.)
- It now ignores anything after an optional "-" (including the "-"), which should be okay since the extra digits in a ZIP code shouldn't be necessary for a geocode, but this will enable us to better match regional partners that cover specific ZIP codes.
- It only allows digits 0-9, which should filter out other characters such as spaces and newlines, which we saw in some submissions.

This should also improve ZIP lookups done at https://code.org/educate/professional-learning/program-information.