### PR TITLE
Homepage: Fix dropdown menu cropping

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -46,7 +46,7 @@
 
   .clear{style: "clear: both"}
 
-#hero{style: "position: relative; overflow: hidden"}
+#hero{style: "position: relative"}
   - heroes_arranged.each_with_index do |entry, index|
     -# Preload the first hero image to render immediately, lazy-load the rest to conserve bandwidth.
     - if index == 0


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/32284 inadvertently caused the dropdown menu in the header to be cropped below the bottom of the hero.  This fixes that.

### before
![Screenshot 2020-01-23 21 19 09](https://user-images.githubusercontent.com/2205926/73046212-06ae7f80-3e26-11ea-95c8-72f91c6fe4fe.png)

### after
![Screenshot 2020-01-23 21 18 58](https://user-images.githubusercontent.com/2205926/73046215-0b733380-3e26-11ea-9917-5c62af93eae4.png)

Thank you to an observant ex-colleague who was browsing the site this evening.
