### PR TITLE
Make pin size for CSF workshop map smaller

### DIFF
--- a/apps/src/sites/code.org/pages/views/workshop_search.js
+++ b/apps/src/sites/code.org/pages/views/workshop_search.js
@@ -82,7 +82,10 @@ function createNewMarker(latLng, title, infoWindowContent, subject) {
     map: gmap,
     title: title,
     infoWindowContent: infoWindowContent,
-    icon: {url: iconForSubject(subject)}
+    icon: {
+      url: iconForSubject(subject),
+      scaledSize: new google.maps.Size(40, 40)
+    }
   });
   google.maps.event.addListener(marker, 'click', function() {
     infoWindow.setContent(this.get('infoWindowContent'));


### PR DESCRIPTION
[PLC-674](https://codedotorg.atlassian.net/browse/PLC-674)

Makes pins on CSF workshop map smaller. Map is visible at https://code.org/professional-development-workshops.

I originally thought the `scaledSize` property worked in percentages, but turns out I was wrong ([docs here](https://developers.google.com/maps/documentation/javascript/reference/marker)) -- these icons are 64x64 by default ([image source here](https://maps.google.com/mapfiles/kml/paddle/red-blank.png)), so the icons are now about two thirds of what they were previously (40x40 now).

Before:

National view
![image](https://user-images.githubusercontent.com/25372625/73090689-af43fa00-3e8d-11ea-87c9-a904b3339d5b.png)

City view
![image](https://user-images.githubusercontent.com/25372625/73090724-c1259d00-3e8d-11ea-9b0e-f510e4bfb1ac.png)

After:

National view
![image](https://user-images.githubusercontent.com/25372625/73092840-2f6c5e80-3e92-11ea-84b7-f22c7e3d5f0a.png)

City view
![image](https://user-images.githubusercontent.com/25372625/73092805-211e4280-3e92-11ea-98ac-60ed6f1dfa86.png)

## Testing story

Tested manually and compared to the [volunteer page](https://code.org/volunteer/local) to get something of a similar size.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
