### PR TITLE
Standards link in admin box

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -674,7 +674,7 @@ class Script < ActiveRecord::Base
   end
 
   def has_standards_associations?
-    curriculum_umbrella == 'CSF' && version_year >= 2019
+    curriculum_umbrella == 'CSF' && version_year && version_year >= '2019'
   end
 
   def under_curriculum_umbrella?(specific_curriculum_umbrella)

--- a/dashboard/app/views/home/_admin.html.haml
+++ b/dashboard/app/views/home/_admin.html.haml
@@ -19,6 +19,8 @@
           %li
             = link_to("(#{t 'crud.edit'})", edit_script_path(script))
             = link_to(data_t_suffix('script.name', script.name, 'title'), script_next_path(script))
+            - if script.has_standards_associations?
+              = link_to "(Import Standards)", admin_standards_import_path
     %li= link_to t('builder.manage'), new_level_path
     %li= link_to 'Admin Page Directory', admin_directory_path
     %li= link_to 'Gallery', 'projects/public'


### PR DESCRIPTION
[LP-1162](https://codedotorg.atlassian.net/browse/LP-1162)

If a script has standards associations we're interested in for the progress tab in Code Studio (currently CSF scripts with version year 2019+) there will be a shortcut link to import standards for that script in the admin box. The link will take the admin user to studio.code.org/admin/standards where they can import standards from CurriculumBuilder. 

<img width="535" alt="Screen Shot 2020-01-24 at 1 41 38 PM" src="https://user-images.githubusercontent.com/12300669/73106156-94827d00-3eaf-11ea-82ad-c6a7f75eeb91.png">
