### PR TITLE
Fixing strings with missing interpolation args

### DIFF
--- a/pegasus/sites.v3/code.org/public/congrats.haml
+++ b/pegasus/sites.v3/code.org/public/congrats.haml
@@ -30,8 +30,9 @@ max_age: 60
   end
 
   facebook = {:u=>share_url}
-  twitter = {:url=>share_url, :related=>'codeorg', :text=>I18n.t('just_did_hoc_donor', donor_twitter: get_random_donor_twitter)}
-  twitter[:hashtags] = 'HourOfCode' unless I18n.t(:just_did_hoc_donor).include? '#HourOfCode'
+  twitter_message = I18n.t('just_did_hoc_donor', donor_twitter: get_random_donor_twitter)
+  twitter = {:url=>share_url, :related=>'codeorg', :text=>twitter_message}
+  twitter[:hashtags] = 'HourOfCode' unless twitter_message.include? '#HourOfCode'
 
   company_param = params[:co]
   form = DB[:forms].where(kind:'CompanyProfile', name:company_param).first if company_param

--- a/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
@@ -130,7 +130,7 @@
 
 #volunteer-engineer-thanks{:style=>"display: none;"}
   .alert.alert-success{role:"alert"}
-    %p= I18n.t(:volunteer_engineer_submission_thankyou).gsub('%{url}', '/volunteer/local')
+    %p= I18n.t(:volunteer_engineer_submission_thankyou, url: '/volunteer/local')
   - if !form.secret
     #edit-information
       You can update your volunteer information or email subscription preferences anytime

--- a/pegasus/sites.v3/code.org/views/volunteer_engineer_form_intro.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_engineer_form_intro.haml
@@ -2,6 +2,6 @@
 %p
   = I18n.t(:volunteer_engineer_submission_intro_recruit)
   = I18n.t(:volunteer_engineer_submission_intro_guide, volunteer_guide: '/volunteer/guide')
-%p= I18n.t(:volunteer_engineer_submission_intro_links).gsub('%{learn_more}', 'https://hourofcode.com').gsub('%{volunteer_local}', '/volunteer/local')
+%p= I18n.t(:volunteer_engineer_submission_intro_links, learn_more: 'https://hourofcode.com', volunteer_local: '/volunteer/local')
 %img{src: "/images/fill-300x150/homepage/kids3_2x.jpg", style: "margin: 10px 0 20px 0; max-width: 100%;"}
 %p= I18n.t(:volunteer_engineer_submission_intro_signup)

--- a/pegasus/sites.v3/hourofcode.com/views/unsupported_browser.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/unsupported_browser.haml
@@ -1,4 +1,4 @@
 #warning-banner{style: 'display: none;'}
   %i.fa.fa-warning.warning-sign
   &nbsp;
-  = TextRender.safe_markdown I18n.t("compatibility_unsupported_browser_markdown").gsub(/%{supported_browsers_url}/, 'https://support.code.org/hc/en-us/articles/202591743')
+  = TextRender.safe_markdown I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743')


### PR DESCRIPTION
# Description
We recently added logging for our translated strings which reports when
the strings are missing arguments being passed to them. This PR fixes
many of the offending strings.

## Links
### HoneyBadger reports
* https://app.honeybadger.io/projects/34365/faults/59957999
* https://app.honeybadger.io/projects/34365/faults/59958279
* https://app.honeybadger.io/projects/34365/faults/59958439
* https://app.honeybadger.io/projects/34365/faults/59958440

## Testing story
* Visited http://localhost.hourofcode.com:3000/us/learn and verified the #warning-banner looked correct. 
* Visit http://localhost.code.org:3000/congrats and verify `share-twitter` element has donor in the message.
* Visit http://localhost.code.org:3000/volunteer and verify "Thank you!" element still has a working link in it.

## Follow-up
Found some other weird string substitutions: https://codedotorg.atlassian.net/browse/FND-992

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
