### PR TITLE
Move Students button disabled when transfer is pending

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -990,6 +990,7 @@
   "moreInfo": "More info.",
   "moveStudents": "Move students",
   "moveStudentsConfirm": "No, I want to move student(s) to be in the new section only.",
+  "movingStudents": "Moving students...",
   "moveToSection": "Move to section",
   "multipleChoiceQuestionsOverview": "Multiple choice questions overview ({numSubmissions} / {numStudents} students)",
   "multipleChoiceStudentOverview": "Multiple choice questions overview ({studentName})",

--- a/apps/src/templates/manageStudents/MoveStudents.jsx
+++ b/apps/src/templates/manageStudents/MoveStudents.jsx
@@ -348,7 +348,6 @@ class MoveStudents extends Component {
 
   render() {
     const {studentData, transferData, transferStatus} = this.props;
-
     // Define a sorting transform that can be applied to each column
     const sortable = wrappedSortable(
       this.getSortingColumns,
@@ -367,6 +366,8 @@ class MoveStudents extends Component {
       sortingColumns,
       sort: orderBy
     })(decoratedRows);
+
+    const pendingTransfer = transferStatus.status === TransferStatus.PENDING;
 
     return (
       <div>
@@ -457,7 +458,9 @@ class MoveStudents extends Component {
               text={i18n.moveStudents()}
               onClick={this.transfer}
               color={Button.ButtonColor.orange}
-              disabled={this.isButtonDisabled()}
+              disabled={pendingTransfer || this.isButtonDisabled()}
+              isPending={pendingTransfer}
+              pendingText={i18n.movingStudents()}
             />
           </DialogFooter>
         </BaseDialog>

--- a/apps/src/templates/manageStudents/manageStudentsRedux.js
+++ b/apps/src/templates/manageStudents/manageStudentsRedux.js
@@ -25,7 +25,8 @@ export const RowType = {
 // Response from server after moving student(s) to a new section
 export const TransferStatus = {
   SUCCESS: 'success',
-  FAIL: 'fail'
+  FAIL: 'fail',
+  PENDING: 'pending'
 };
 
 // Type of student transfer - whether students are being moved (and subsequently removed from current section) or copied to new section
@@ -143,6 +144,7 @@ const UPDATE_STUDENT_TRANSFER = 'manageStudents/UPDATE_STUDENT_TRANSFER';
 const CANCEL_STUDENT_TRANSFER = 'manageStudents/CANCEL_STUDENT_TRANSFER';
 const TRANSFER_STUDENTS_SUCCESS = 'manageStudents/TRANSFER_STUDENTS_SUCCESS';
 const TRANSFER_STUDENTS_FAILURE = 'manageStudents/TRANSFER_STUDENTS_FAILURE';
+const TRANSFER_STUDENTS_PENDING = 'manageStudents/TRANSFER_STUDENTS_PENDING';
 const START_LOADING_STUDENTS = 'manageStudents/START_LOADING_STUDENTS';
 const FINISH_LOADING_STUDENTS = 'manageStudents/FINISH_LOADING_STUDENTS';
 
@@ -215,6 +217,9 @@ export const transferStudentsSuccess = (
 export const transferStudentsFailure = error => ({
   type: TRANSFER_STUDENTS_FAILURE,
   error
+});
+export const transferStudentsPending = () => ({
+  type: TRANSFER_STUDENTS_PENDING
 });
 export const addStudentsSuccess = (numStudents, rowIds, studentData) => ({
   type: ADD_STUDENT_SUCCESS,
@@ -355,6 +360,7 @@ export const addMultipleAddRows = studentNames => {
 
 export const transferStudents = onComplete => {
   return (dispatch, getState) => {
+    dispatch(transferStudentsPending());
     const state = getState();
     // Get section code for current section from teacherSectionsRedux
     const currentSectionCode = sectionCode(state, state.sectionData.section.id);
@@ -713,6 +719,15 @@ export default function manageStudents(state = initialState, action) {
         ...state.transferStatus,
         status: TransferStatus.FAIL,
         error: action.error
+      }
+    };
+  }
+  if (action.type === TRANSFER_STUDENTS_PENDING) {
+    return {
+      ...state,
+      transferStatus: {
+        ...state.transferStatus,
+        status: TransferStatus.PENDING
       }
     };
   }


### PR DESCRIPTION
[LP-1132](https://codedotorg.atlassian.net/browse/LP-1132) 
See [LP-1130 ](https://codedotorg.atlassian.net/browse/LP-1130)for additional context

When a teacher has a large number of students in their section and they try to move them all to a new section there can be a database bottleneck that slows down the site. This is exacerbated when the teacher tries multiples times to move students before the process has finished. 

To prevent teachers from being able to "mash" the Move Students button multiple times while the process is still pending, I added a pending status to the button and disable it until we know whether the call to the server failed or succeeded. 

BEFORE:  the move students button remains clickable 
![pending-move-students-before](https://user-images.githubusercontent.com/12300669/73110902-ff868080-3ebc-11ea-9f2d-990059192b62.gif)

AFTER: the move students button grays out to indicate it's disabled and shows the pending text and spinner 
![pending-move-students](https://user-images.githubusercontent.com/12300669/73110903-01504400-3ebd-11ea-8a79-cb7992593b6f.gif)
