### PR TITLE
Add workshop length overrides for CSD and 2-day workshops

### DIFF
--- a/dashboard/app/models/pd/workshop_constants.rb
+++ b/dashboard/app/models/pd/workshop_constants.rb
@@ -61,10 +61,18 @@ module Pd
         SUBJECT_CSP_WORKSHOP_2 => {min_days: 1, max_days: 1, max_hours: 6},
         SUBJECT_CSP_WORKSHOP_3 => {min_days: 1, max_days: 1, max_hours: 6},
         SUBJECT_CSP_WORKSHOP_4 => {min_days: 1, max_days: 1, max_hours: 6},
+        SUBJECT_CSP_WORKSHOP_5 => {min_days: 2, max_days: 2, max_hours: 12},
+        SUBJECT_CSP_WORKSHOP_6 => {min_days: 2, max_days: 2, max_hours: 12},
         SUBJECT_CSP_TEACHER_CON => {max_hours: 33.5}
       },
       COURSE_CSD => {
         SUBJECT_CSD_SUMMER_WORKSHOP => {max_hours: 33.5},
+        SUBJECT_CSD_WORKSHOP_1 => {min_days: 1, max_days: 1, max_hours: 6},
+        SUBJECT_CSD_WORKSHOP_2 => {min_days: 1, max_days: 1, max_hours: 6},
+        SUBJECT_CSD_WORKSHOP_3 => {min_days: 1, max_days: 1, max_hours: 6},
+        SUBJECT_CSD_WORKSHOP_4 => {min_days: 1, max_days: 1, max_hours: 6},
+        SUBJECT_CSD_WORKSHOP_5 => {min_days: 2, max_days: 2, max_hours: 12},
+        SUBJECT_CSD_WORKSHOP_6 => {min_days: 2, max_days: 2, max_hours: 12},
         SUBJECT_CSD_TEACHER_CON => {max_hours: 33.5}
       },
       COURSE_CSF => {


### PR DESCRIPTION
[PLC-720](https://codedotorg.atlassian.net/browse/PLC-720)

Add workshop length overrides for CSD academic year workshops (to match CSP), as well as overrides for 2-day workshops for both CSD and CSP. These overrides are used primarily to generate workshop summary spreadsheets used for payments, with the `max_hours` attribute also used for workshop certificates.

## Testing story

I didn't do much in the way of testing -- I did search through of our code base to better understand where these constants are used (as mentioned above, used almost exclusively in workshop summaries). There are [tests that test that the functionality of being able to override min/max hours/days values](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/models/pd/workshop_test.rb#L636-L680) that are still in place, but not much to test anything about the constants themselves.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
