### PR TITLE
Remove some logging for each file and silence the output from yarn build

### DIFF
--- a/bin/i18n/hoc_sync_utils.rb
+++ b/bin/i18n/hoc_sync_utils.rb
@@ -41,7 +41,6 @@ class HocSyncUtils
   def self.rename_downloads_from_crowdin_code_to_locale
     puts "Updating crowdin codes to our locale codes..."
     Languages.get_hoc_languages.each do |prop|
-      puts "Renaming #{prop[:locale_s]}.yml to #{prop[:unique_language_s]}.yml"
       # move downloaded folders to root source directory and rename from
       # language to locale
       crowdin_dir = File.join(I18N_SOURCE_DIR, "hourofcode", prop[:crowdin_name_s])

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -70,7 +70,7 @@ def restore_redacted_files
     next if locale == 'en-US'
     next unless File.directory?("i18n/locales/#{locale}/")
 
-    print "Restoring #{locale} (#{locale_index}/#{total_locales})"
+    puts "Restoring #{locale} (#{locale_index}/#{total_locales})"
     original_files.each do |original_path|
       translated_path = original_path.sub("original", locale)
       next unless File.file?(translated_path)
@@ -198,7 +198,7 @@ def distribute_translations
   total_locales = Languages.get_locale.count
   Languages.get_locale.each_with_index do |prop, i|
     locale = prop[:locale_s]
-    print "Distributing #{locale} (#{i}/#{total_locales})"
+    puts "Distributing #{locale} (#{i}/#{total_locales})"
     $stdout.flush
     next if locale == 'en-US'
     next unless File.directory?("i18n/locales/#{locale}/")

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -15,8 +15,6 @@ require_relative 'i18n_script_utils'
 require_relative 'redact_restore_utils'
 require_relative 'hoc_sync_utils'
 
-CLEAR = "\r\033[K"
-
 def sync_out
   rename_from_crowdin_name_to_locale
   restore_redacted_files
@@ -72,11 +70,11 @@ def restore_redacted_files
     next if locale == 'en-US'
     next unless File.directory?("i18n/locales/#{locale}/")
 
-    original_files.each_with_index do |original_path, file_index|
+    print "Restoring #{locale} (#{locale_index}/#{total_locales})"
+    original_files.each do |original_path|
       translated_path = original_path.sub("original", locale)
       next unless File.file?(translated_path)
 
-      print "#{CLEAR}Restoring #{locale} (#{locale_index}/#{total_locales}) file #{file_index}/#{original_files.count}"
       $stdout.flush
 
       if original_path.include? "course_content"
@@ -200,7 +198,7 @@ def distribute_translations
   total_locales = Languages.get_locale.count
   Languages.get_locale.each_with_index do |prop, i|
     locale = prop[:locale_s]
-    print "#{CLEAR}Distributing #{locale} (#{i}/#{total_locales})"
+    print "Distributing #{locale} (#{i}/#{total_locales})"
     $stdout.flush
     next if locale == 'en-US'
     next unless File.directory?("i18n/locales/#{locale}/")
@@ -240,7 +238,7 @@ def distribute_translations
     sanitize_file_and_write(loc_file, destination)
   end
 
-  puts "#{CLEAR}Distribution finished!"
+  puts "Distribution finished!"
 end
 
 # For untranslated apps, copy English file for all locales
@@ -259,7 +257,11 @@ end
 def rebuild_blockly_js_files
   I18nScriptUtils.run_bash_script "apps/node_modules/@code-dot-org/blockly/i18n/codeorg-messages.sh"
   Dir.chdir('apps') do
-    puts `yarn build`
+    _stdout, stderr, status = Open3.capture3('yarn build')
+    unless status == 0
+      puts "Error building apps:"
+      puts stderr
+    end
   end
 end
 


### PR DESCRIPTION
First pass at making the i18n pipeline (in this case the out step) less verbose. For the most part, I kept the locale updates but removed anything more fine grained than that (like the file counter) and also squashed the `yarn build` output. It's still pretty verbose after this but this remove _a lot_ of logging.


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


- [jira](https://codedotorg.atlassian.net/browse/FND-874)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
