### PR TITLE
Patch Turkish string trigging false alarms.

### DIFF
--- a/dashboard/config/locales/blocks.tr-TR.yml
+++ b/dashboard/config/locales/blocks.tr-TR.yml
@@ -1138,7 +1138,7 @@ tr:
             '"y"': y konumu
             '"direction"': hareket yönü
       gamelab_setSizes:
-        text: "{SPRITE} {PROPERTY}‘yi %{N} olarak ayarla"
+        text: "{SPRITE} {PROPERTY}‘yi % {N} olarak ayarla"
         options:
           PROPERTY:
             '"scale"': boyut


### PR DESCRIPTION
We are adding a space between the `%{N}` because our I18n API falsely
thinks it failed to substitute the variable `N`. Some system downstream is
responsible for substituting the `{N}` for an actual value and creating
something like `%2`.

This is just a temporary fix and a JIRA item for the long term fix has
been filed: https://codedotorg.atlassian.net/browse/FND-993

*Manually added space between `%` and `{N}` in the `yml` file. This way we don't need to wait for the next Crowdin sync.
*Updated Crowdin value as well.

### Future work
* [long term fix](https://codedotorg.atlassian.net/browse/FND-993)

## Links
- [Honeybadger](https://app.honeybadger.io/projects/3240/faults/59959138)

## Testing story
* `./bin/dasboard-server`
  * http://localhost-studio.code.org:3000/s/coursee-2019/stage/7/puzzle/7/lang/tr-TR
  * Verified no Honeybadger event created.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
