### PR TITLE
Fix the location of video download icon for games when the language bidi is rtl

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -192,7 +192,7 @@ videos.showVideoDialog = function(options, forceShowVideo) {
   var download = $('<a/>')
     .append($('<img src="/shared/images/download_button.png"/>'))
     .addClass('download-video')
-    .css('float', 'left')
+    .css('float', 'inherit')
     .attr('href', options.download)
     .click(function() {
       // track download in Google Analytics

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -192,13 +192,16 @@ videos.showVideoDialog = function(options, forceShowVideo) {
   var download = $('<a/>')
     .append($('<img src="/shared/images/download_button.png"/>'))
     .addClass('download-video')
-    .css('float', 'inherit')
+    .css('float', 'left')
     .attr('href', options.download)
     .click(function() {
       // track download in Google Analytics
       trackEvent('downloadvideo', 'startdownloadvideo', options.key);
       return true;
     });
+  if (document.dir === 'rtl') {
+    download.css('float', 'right');
+  }
   var nav = $div.find('.ui-tabs-nav');
   nav.append(download);
 


### PR DESCRIPTION
This fix will resolve the issue with the location of the download icon for the games' intro video. Before this change the download arrow was almost hiding behind the close icon. As an example you can see this for dance party video:
<img width="590" alt="Screen Shot 2020-01-26 at 4 03 21 PM" src="https://user-images.githubusercontent.com/20547172/73144443-976da100-405a-11ea-92c1-f53752823d32.png">
The same issue exists for mine craft as well.
After this fix the download arrow will be shown to the right of the gray bar as you can see here:
<img width="594" alt="Screen Shot 2020-01-26 at 4 17 36 PM" src="https://user-images.githubusercontent.com/20547172/73144459-c7b53f80-405a-11ea-8f96-587060562059.png">
I checked for a few games and verified that the issue is fixed for those after applying this change.