### PR TITLE
[student-libraries] Migrated library 'View Code' modal to droplet view rather than basic <pre> view

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryViewCode.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryViewCode.jsx
@@ -1,13 +1,25 @@
+/* globals droplet */
 import PropTypes from 'prop-types';
 import React from 'react';
-import GeneratedCode from '@cdo/apps/templates/feedback/GeneratedCode';
 import Dialog, {Body, Title} from '@cdo/apps/templates/Dialog';
+import color from '@cdo/apps/util/color';
 
 const DEFAULT_MARGIN = 7;
 
 const styles = {
-  generatedCode: {
-    textAlign: 'left',
+  message: {
+    color: color.dark_charcoal,
+    margin: DEFAULT_MARGIN,
+    overflow: 'auto',
+    whiteSpace: 'pre-wrap',
+    fontSize: 14,
+    maxHeight: 95
+  },
+  code: {
+    position: 'relative',
+    // Our droplet editor requires a specific height to display correctly.
+    // Therefore, we use `height` rather than `maxHeight` here.
+    height: 390,
     margin: DEFAULT_MARGIN
   }
 };
@@ -19,19 +31,40 @@ export default class LibraryViewCode extends React.Component {
     library: PropTypes.object.isRequired
   };
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.isOpen === false && this.props.isOpen === true) {
+      this.onOpen();
+    }
+  }
+
+  onOpen = () => {
+    const {library} = this.props;
+    this.editor = new droplet.Editor(this.refs.libraryCodeViewer, {
+      mode: 'javascript',
+      allowFloatingBlocks: false,
+      enablePaletteAtStart: false,
+      textModeAtStart: true,
+      palette: []
+    });
+
+    this.editor.setValue(library.source);
+    this.editor.setReadOnly(true);
+  };
+
   render() {
-    let {isOpen, onClose, library} = this.props;
+    const {isOpen, onClose, library} = this.props;
     return (
       <Dialog isOpen={isOpen} handleClose={onClose} useUpdatedStyles>
         <Title>
           <div>{library.name}</div>
         </Title>
         <Body>
-          <GeneratedCode
-            message={library.description || ''}
-            code={library.source || ''}
-            style={styles.generatedCode}
-          />
+          <div style={{textAlign: 'left'}}>
+            <div style={styles.message}>{library.description}</div>
+            <div className="libraryCodeViewerContainer" style={styles.code}>
+              <div ref="libraryCodeViewer" />
+            </div>
+          </div>
         </Body>
       </Dialog>
     );

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -310,7 +310,7 @@ html[dir='rtl'] .editor-column {
 
 // #codeWorkspace.readonly is used when we are displaying a workspace but it
 // is not editable (like someone else project), or when app is running
-#codeWorkspace.readonly, #codeWorkspace.dimmed {
+#codeWorkspace.readonly, #codeWorkspace.dimmed, .libraryCodeViewerContainer {
   // special cases for:
   .blocklySvg, // blockly
   .droplet-main-scroller, // droplet block view


### PR DESCRIPTION
Added droplet syntax highlighting to the 'View Code' modal in the library manager. 

### Before:
![image](https://user-images.githubusercontent.com/8324574/73205506-f502fb80-40f5-11ea-8f3b-cd23f2208037.png)

### After:
![image](https://user-images.githubusercontent.com/8324574/73205536-064c0800-40f6-11ea-84a3-e3993d15497d.png)

Note: The droplet editor requires explicit height and width values. Because of this, we set the 'height' value to what would normally be the 'maxHeight' value. This may seem odd for very small libraries.

Example:
![image](https://user-images.githubusercontent.com/8324574/73205688-6478eb00-40f6-11ea-8b03-788f03cc6a12.png)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-882)
- [spec](https://docs.google.com/document/d/1VxMmdHdIeBWCXKofkjEy9MuWcrzeEW3Zt-Ir8pINYdA/edit)
- [all relevant PRs](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Ajmkulwik+archived%3Afalse+student+libraries)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
