### PR TITLE
[Artist] Fix typo in level instructions 

### DIFF
--- a/dashboard/config/locales/data.en.yml
+++ b/dashboard/config/locales/data.en.yml
@@ -84,7 +84,7 @@ en:
         turtle_1_3: Make a square using only 3 blocks.
         turtle_1_4: 'Draw a triangle whose sides are all in different colors, using the "random color" option that picks a different color each time. Hint: you''ll have to figure out how far to turn by clicking on the number in the turn block.'
         turtle_1_5: Now, for practice, draw a triangle and then a square to draw an envelope.
-        turtle_1_6: 'Can you figure out how draw this triangle and square? Hint: Do the triangle first, then figure out how much to turn before drawing the square.'
+        turtle_1_6: 'Can you figure out how to draw this triangle and square? Hint: Do the triangle first, then figure out how much to turn before drawing the square.'
         turtle_1_7: Ok, let's make it a bit harder - see if you can draw these green glasses. The squares are 100 pixels on each side, and they're 50 pixels apart. Don't forget to draw in green!
         turtle_1_8: Ok, try to figure out what happens if you run this code (or press "Run" to try it). Then, repeat it enough times to complete the drawing. The colors will be different every time.
         turtle_1_9: Can you figure out what number to replace the question marks with to draw a circle?


### PR DESCRIPTION
Small typo fix in one of the old js-defined levels.
Before:
![image](https://user-images.githubusercontent.com/8787187/73208311-1adecf00-40fb-11ea-9158-8829902c46d3.png)


After:
![image](https://user-images.githubusercontent.com/8787187/73208285-0c90b300-40fb-11ea-8666-2dcfad66a62e.png)
 
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
