### PR TITLE
PL: handle empty zip code lookup

### DIFF
--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -187,7 +187,7 @@ class RegionalPartner < ActiveRecord::Base
 
     # Force to be a string, ignore "-" and anything after it,
     # and only allow digits 0-9.
-    zip_code = zip_code_raw.to_s.split("-")[0].tr('^0-9', '')
+    zip_code = zip_code_raw.to_s.split("-")[0]&.tr('^0-9', '')
 
     if RegexpUtils.us_zip_code?(zip_code)
       # Try to find the matching partner using the ZIP code.

--- a/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
+++ b/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
@@ -152,8 +152,4 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
     assert_equal ['noreply@code.org'], mail.from
     assert_sendable mail
   end
-
-  test 'Fails lookup with nil zip' do
-    assert_equal RegionalPartner.find_by_zip(nil), [nil, nil]
-  end
 end

--- a/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
+++ b/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
@@ -152,4 +152,8 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
     assert_equal ['noreply@code.org'], mail.from
     assert_sendable mail
   end
+
+  test 'Fails lookup with nil zip' do
+    assert_equal RegionalPartner.find_by_zip(nil), [nil, nil]
+  end
 end

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -46,6 +46,10 @@ class RegionalPartnerTest < ActiveSupport::TestCase
     assert_equal ['Zip code is invalid'], regional_partner.errors.full_messages
   end
 
+  test 'Fails lookup with nil zip' do
+    assert_equal RegionalPartner.find_by_zip(nil), [nil, nil]
+  end
+
   test 'assign program manager to regional partner assigns program manager' do
     regional_partner = create :regional_partner
     program_manager = create :teacher


### PR DESCRIPTION
This prevents a server error when the user submits an empty ZIP code at https://code.org/educate/professional-learning/program-information

Followup to https://github.com/code-dot-org/code-dot-org/pull/32855