### PR TITLE
BugFix STAR-959: Libraries are duplicated for each section by /api/v1/section_libraries

### DIFF
--- a/dashboard/app/controllers/api/v1/section_libraries_controller.rb
+++ b/dashboard/app/controllers/api/v1/section_libraries_controller.rb
@@ -11,6 +11,6 @@ class Api::V1::SectionLibrariesController < Api::V1::JsonApiController
       authorize! :list_projects, section
       libraries += ProjectsList.fetch_section_libraries(section)
     end
-    render json: libraries
+    render json: libraries.uniq
   end
 end


### PR DESCRIPTION
In the past, if a student was enrolled in more than one section, the libraries controller would return any libraries they had created once for each section they are in. That caused errors on some UI elements that expected unique library IDs. This PR ensures the library controller returns only unique libraries.

Sample error message:
![image](https://user-images.githubusercontent.com/8324574/73225857-f1d23480-4122-11ea-9502-7582c35675fb.png)

Old server response:
![image](https://user-images.githubusercontent.com/8324574/73225886-07dff500-4123-11ea-9af3-294c451df731.png)

New server response:
![image](https://user-images.githubusercontent.com/8324574/73225898-15957a80-4123-11ea-95f5-bd9be3664827.png)

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-959)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
