### PR TITLE
Fix pin size for locations with multiple workshops

### DIFF
--- a/apps/src/sites/code.org/pages/views/workshop_search.js
+++ b/apps/src/sites/code.org/pages/views/workshop_search.js
@@ -70,7 +70,7 @@ function processPdWorkshops(workshops) {
       markersByLocation[hash].infoWindowContent += infoWindowContent;
       // Upgrade any marker containing a deep dive workshop to the deep dive icon
       if (workshop.subject === SubjectNames.SUBJECT_CSF_201) {
-        markersByLocation[hash].icon = {url: iconForSubject(workshop.subject)};
+        markersByLocation[hash].icon = iconForSubject(workshop.subject);
       }
     }
   });
@@ -82,10 +82,7 @@ function createNewMarker(latLng, title, infoWindowContent, subject) {
     map: gmap,
     title: title,
     infoWindowContent: infoWindowContent,
-    icon: {
-      url: iconForSubject(subject),
-      scaledSize: new google.maps.Size(40, 40)
-    }
+    icon: iconForSubject(subject)
   });
   google.maps.event.addListener(marker, 'click', function() {
     infoWindow.setContent(this.get('infoWindowContent'));
@@ -95,12 +92,13 @@ function createNewMarker(latLng, title, infoWindowContent, subject) {
   return marker;
 }
 
-function iconForSubject(subject) {
-  if (subject === SubjectNames.SUBJECT_CSF_201) {
-    return 'https://maps.google.com/mapfiles/kml/paddle/red-stars.png';
-  }
-  return 'https://maps.google.com/mapfiles/kml/paddle/red-blank.png';
-}
+const iconForSubject = subject => ({
+  url:
+    subject === SubjectNames.SUBJECT_CSF_201
+      ? 'https://maps.google.com/mapfiles/kml/paddle/red-stars.png'
+      : 'https://maps.google.com/mapfiles/kml/paddle/red-blank.png',
+  scaledSize: new google.maps.Size(40, 40)
+});
 
 function completeProcessingPdWorkshops() {
   addGeocomplete();


### PR DESCRIPTION
My [recent change](https://github.com/code-dot-org/code-dot-org/pull/32861) to pin sizes on the CSF workshop map resulted in locations with multiple workshops that included a deep dive workshop remaining in the original size:

![image](https://user-images.githubusercontent.com/25372625/73400665-772e2400-429e-11ea-8b2e-e3c7b0f7ca58.png)

Now, pins are all the same size (intro, deep dive, combination of workshops):

![image](https://user-images.githubusercontent.com/25372625/73401056-43073300-429f-11ea-9000-dd1d1984d689.png)

## Testing story

Tested locally per screenshot above, but no automated tests for this. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
