### PR TITLE
Enable access to shared firebase environment

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -432,6 +432,7 @@ Applab.init = function(config) {
     channelId: config.channel,
     firebaseName: config.firebaseName,
     firebaseAuthToken: config.firebaseAuthToken,
+    firebaseSharedAuthToken: config.firebaseSharedAuthToken,
     firebaseChannelIdSuffix: config.firebaseChannelIdSuffix || '',
     showRateLimitAlert: studioApp().showRateLimitAlert
   });

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -49,6 +49,7 @@
  * @property {string} share
  * @property {string} labUserId
  * @property {string} firebaseName
+ * @property {string} firebaseSharedAuthToken
  * @property {string} firebaseAuthToken
  * @property {string} firebaseChannelIdSuffix
  * @property {boolean} isSignedIn

--- a/apps/src/storage/firebaseUtils.js
+++ b/apps/src/storage/firebaseUtils.js
@@ -1,6 +1,7 @@
 import Firebase from 'firebase';
 let config;
 let firebaseCache;
+let sharedFirebaseCache;
 let firebaseConfig;
 
 export function init(setupConfig) {
@@ -84,7 +85,7 @@ export function getProjectCountersRef(tableName) {
 }
 
 export function getSharedDatabase() {
-  return getFirebase().child('v3/channels/shared');
+  return getSharedFirebase().child('v3/channels/shared');
 }
 
 export function getProjectDatabase() {
@@ -92,6 +93,28 @@ export function getProjectDatabase() {
     config.firebaseChannelIdSuffix
   }`;
   return getFirebase().child(path);
+}
+
+function getSharedFirebase() {
+  let sharedFb = sharedFirebaseCache;
+  if (!sharedFb) {
+    if (!config.firebaseSharedAuthToken) {
+      throw new Error(
+        'Error connecting to Firebase: Shared token not specified'
+      );
+    }
+    sharedFb = new Firebase('https://cdo-v3-shared.firebaseio.com');
+    sharedFb.authWithCustomToken(
+      config.firebaseSharedAuthToken,
+      (err, user) => {
+        if (err) {
+          throw new Error(`error authenticating to shared Firebase: ${err}`);
+        }
+      }
+    );
+    sharedFirebaseCache = sharedFb;
+  }
+  return sharedFb;
 }
 
 function getFirebase() {

--- a/apps/src/storage/firebaseUtils.js
+++ b/apps/src/storage/firebaseUtils.js
@@ -100,7 +100,7 @@ function getSharedFirebase() {
   if (!sharedFb) {
     if (!config.firebaseSharedAuthToken) {
       throw new Error(
-        'Error connecting to Firebase: Shared token not specified'
+        'Error connecting to Firebase: CDO.firebase_shared_secret not specified'
       );
     }
     sharedFb = new Firebase('https://cdo-v3-shared.firebaseio.com');

--- a/apps/src/storage/firebaseUtils.js
+++ b/apps/src/storage/firebaseUtils.js
@@ -1,6 +1,7 @@
 import Firebase from 'firebase';
+const SHARED_ENV = 'cdo-v3-shared';
 let config;
-let firebaseCache;
+let projectFirebaseCache;
 let sharedFirebaseCache;
 let firebaseConfig;
 
@@ -73,7 +74,7 @@ export function resetConfigForTesting() {
 }
 
 export function getConfigRef() {
-  return getFirebase().child('v3/config/channels');
+  return getFirebase(config.firebaseName).child('v3/config/channels');
 }
 
 export function getRecordsRef(tableName) {
@@ -85,74 +86,54 @@ export function getProjectCountersRef(tableName) {
 }
 
 export function getSharedDatabase() {
-  return getSharedFirebase().child('v3/channels/shared');
+  return getFirebase(SHARED_ENV).child('v3/channels/shared');
 }
 
 export function getProjectDatabase() {
   const path = `v3/channels/${config.channelId}${
     config.firebaseChannelIdSuffix
   }`;
-  return getFirebase().child(path);
+  return getFirebase(config.firebaseName).child(path);
 }
 
-function getSharedFirebase() {
-  let sharedFb = sharedFirebaseCache;
-  if (!sharedFb) {
-    if (!config.firebaseSharedAuthToken) {
-      throw new Error(
-        'Error connecting to Firebase: CDO.firebase_shared_secret not specified'
-      );
-    }
-    sharedFb = new Firebase('https://cdo-v3-shared.firebaseio.com');
-    sharedFb.authWithCustomToken(
-      config.firebaseSharedAuthToken,
-      (err, user) => {
-        if (err) {
-          throw new Error(`error authenticating to shared Firebase: ${err}`);
-        }
-      }
-    );
-    sharedFirebaseCache = sharedFb;
-  }
-  return sharedFb;
-}
-
-function getFirebase() {
-  let fb = firebaseCache;
+function getFirebase(environment) {
+  let fb =
+    environment === SHARED_ENV ? sharedFirebaseCache : projectFirebaseCache;
   if (!fb) {
-    if (!config.firebaseName) {
+    if (!environment) {
       throw new Error(
         'Error connecting to Firebase: Firebase name not specified'
       );
     }
-    if (!config.firebaseAuthToken) {
-      let msg =
-        'Error connecting to Firebase: Firebase auth token not specified. ';
-      if (config.firebaseName === 'cdo-v3-dev') {
-        msg +=
-          'To use data blocks or data browser in development, you must ' +
-          'set "firebase_secret" in locals.yml to the value at ' +
-          'https://manage.chef.io/organizations/code-dot-org/environments/development/attributes ' +
-          '-> cdo-secrets';
-      }
-      throw new Error(msg);
+    const authToken =
+      environment === SHARED_ENV
+        ? config.firebaseSharedAuthToken
+        : config.firebaseAuthToken;
+    if (!authToken) {
+      throw new Error(
+        'Error connecting to Firebase: CDO.firebase_shared_secret and/or CDO.firebase_secret not specified'
+      );
     }
-    let base_url = `https://${config.firebaseName}.firebaseio.com`;
+    let base_url = `https://${environment}.firebaseio.com`;
     fb = new Firebase(base_url);
-    if (config.firebaseAuthToken) {
-      fb.authWithCustomToken(config.firebaseAuthToken, (err, user) => {
+    if (authToken) {
+      fb.authWithCustomToken(authToken, (err, user) => {
         if (err) {
           throw new Error(`error authenticating to Firebase: ${err}`);
         }
       });
     }
-    firebaseCache = fb;
+    if (environment === SHARED_ENV) {
+      sharedFirebaseCache = fb;
+    } else {
+      projectFirebaseCache = fb;
+    }
   }
   return fb;
 }
 
 export function isInitialized() {
-  return !!firebaseCache;
+  return !!projectFirebaseCache;
 }
 
 // The following characters are illegal in firebase paths: .#$[]/

--- a/apps/test/integration/util/runLevelTest.js
+++ b/apps/test/integration/util/runLevelTest.js
@@ -145,6 +145,7 @@ function runLevel(app, skinId, level, onAttempt, finished, testData) {
     containerId: 'app',
     embed: testData.embed,
     firebaseName: 'test-firebase-name',
+    firebaseSharedAuthToken: 'test-firebase-shared-auth-token',
     firebaseAuthToken: 'test-firebase-auth-token',
     isSignedIn: true,
     onFeedback: finished,

--- a/apps/test/unit/storage/FirebaseStorageTest.js
+++ b/apps/test/unit/storage/FirebaseStorageTest.js
@@ -15,10 +15,12 @@ describe('FirebaseStorage', () => {
     FirebaseStorage = initFirebaseStorage({
       channelId: 'test-firebase-channel-id',
       firebaseName: 'test-firebase-name',
+      firebaseSharedAuthToken: 'test-firebase-shared-auth-token',
       firebaseAuthToken: 'test-firebase-auth-token',
       showRateLimitAlert: () => {}
     });
     getProjectDatabase().autoFlush();
+    getSharedDatabase().autoFlush();
     return getConfigRef()
       .set({
         limits: {
@@ -32,6 +34,7 @@ describe('FirebaseStorage', () => {
       })
       .then(() => {
         getProjectDatabase().set(null);
+        getSharedDatabase().set(null);
       });
   });
 

--- a/apps/test/unit/storage/MockFirebaseTest.js
+++ b/apps/test/unit/storage/MockFirebaseTest.js
@@ -162,6 +162,7 @@ describe('MockFirebase', () => {
       init({
         channelId: 'test-firebase-channel-id',
         firebaseName: 'test-firebase-name',
+        firebaseSharedAuthToken: 'test-firebase-shared-auth-token',
         firebaseAuthToken: 'test-firebase-auth-token',
         showRateLimitAlert: () => {}
       });

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -205,6 +205,7 @@ slack_endpoint_broken_links:
 # in Applab.
 firebase_name: cdo-v3-<%=env%>
 firebase_secret: !Secret
+firebase_shared_secret: !Secret
 firebase_channel_id_suffix: ''
 firebase_max_channel_writes_per_15_sec: 300
 firebase_max_channel_writes_per_60_sec: 600

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -5,6 +5,7 @@ dashboard_enable_pegasus: true
 
 firebase_name: cdo-v3-dev
 # provide a unique path for firebase channels data for development, to avoid conflicts in channel ids.
+firebase_shared_secret: !Secret
 firebase_channel_id_suffix: -DEVELOPMENT-<%=ENV['USER']%>
 
 lint: true

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -5,6 +5,7 @@ dashboard_enable_pegasus: true
 
 firebase_name: cdo-v3-dev
 # provide a unique path for firebase channels data for development, to avoid conflicts in channel ids.
+firebase_secret: !Secret
 firebase_shared_secret: !Secret
 firebase_channel_id_suffix: -DEVELOPMENT-<%=ENV['USER']%>
 

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -21,6 +21,7 @@ dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
 google_maps_api_key: boguskey
 db_writer: 'mysql://root@localhost/'
+firebase_shared_secret: fake_firebase_shared_secret
 <% end -%>
 
 db_cluster_id: test-cluster

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -463,6 +463,7 @@ module LevelsHelper
     if @level.game.use_firebase?
       fb_options[:firebaseName] = CDO.firebase_name
       fb_options[:firebaseAuthToken] = firebase_auth_token
+      fb_options[:firebaseSharedAuthToken] = CDO.firebase_shared_secret
       fb_options[:firebaseChannelIdSuffix] = CDO.firebase_channel_id_suffix
     end
 

--- a/shared/middleware/helpers/firebase_helper.rb
+++ b/shared/middleware/helpers/firebase_helper.rb
@@ -6,8 +6,8 @@ require 'firebase'
 class FirebaseHelper
   def initialize(channel_id)
     raise "channel_id must be non-empty" if channel_id.nil? || channel_id.empty?
-    @firebase = FirebaseHelper.create_client
-    @channel_id = channel_id == 'shared' ? channel_id : channel_id + CDO.firebase_channel_id_suffix
+    @firebase = channel_id == 'shared' ? FirebaseHelper.create_shared_client : FirebaseHelper.create_client
+    @channel_id = channel_id + CDO.firebase_channel_id_suffix
   end
 
   # @param [String] table_name The name of the table to query.
@@ -44,6 +44,13 @@ class FirebaseHelper
   def self.delete_channel(encrypted_channel_id)
     raise "channel_id must be non-empty" if encrypted_channel_id.nil? || encrypted_channel_id.empty?
     create_client.delete "/v3/channels/#{encrypted_channel_id}/"
+  end
+
+  def self.create_shared_client
+    raise "CDO.firebase_shared_secret not defined" unless CDO.firebase_shared_secret
+    Firebase::Client.new \
+      'https://cdo-v3-shared.firebaseio.com/',
+      CDO.firebase_shared_secret
   end
 
   def self.create_client


### PR DESCRIPTION
While I was first building the shared datasets feature, we had decided that adding a shared channel to each firebase environment would be the simplest approach. 
That looked something like this:
![image](https://user-images.githubusercontent.com/8787187/73477483-3212fc00-4349-11ea-9dc2-8db82587a8a3.png)
That worked pretty seamlessly with the rest of the existing data features, but we're now running into issues with keeping things in sync across environments. Currently, there is *no synchronization* between or across firebase environments. However, we want to build a tool to allow Levelbuilders to upload static datasets. The most straight-forward approach with the existing architecture would result in the dataset being uploaded to the Levelbuilder firebase environment without a clear way to get the data to the production firebase environment. There were two options:
1. Give the levelbuilder environment access to the production firebase environment so that levelbuilders could upload data to the right place. (Not ideal).
2. Allow levels in production to rely on the levelbuilder firebase environment, so that levelbuilders could upload data to the levelbuilder firebase environment, but the levels would work in production also. (Also not ideal).

Because neither of these options seemed like a good idea, we decided to create a new firebase database that will be shared across all of our environments. That looks like this:
![image](https://user-images.githubusercontent.com/8787187/73477925-fa588400-4349-11ea-82a4-f80ef0d9c0a4.png)

Old: `https://cdo-v3-<environment>.firebaseio.com/v3/channels/shared/storage/tables/<tableName>/records` 
New: `https://cdo-v3-shared.firebaseio.com/v3/channels/shared/storage/tables/<tableName>/records`

This PR sets up the access path to the shared firebase database instead of the shared node in the environment's firebase database.

This change only affects the shared datasets in the App Lab Dataset Library. 
## Testing story
I'm working on an integration test for this.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
