### PR TITLE
Fixing unused string interpolation

### DIFF
--- a/pegasus/sites.v3/code.org/public/leaderboards.haml
+++ b/pegasus/sites.v3/code.org/public/leaderboards.haml
@@ -13,9 +13,10 @@ social:
   "twitter:image:width" : 759
   "twitter:image:height" : 208
 ---
+-twitter_message = I18n.t('who_has_done_hoc_donor', donor_twitter: get_random_donor_twitter)
 -facebook = {:u=>"https://www.facebook.com/photo.php?fbid=521364791293162"}
--twitter = {:url=>"http://#{request.site}/leaderboards", :related=>'codeorg', :hashtags=>'', :text=>I18n.t('who_has_done_hoc_donor', donor_twitter: get_random_donor_twitter)}
--twitter[:hashtags] = 'HourOfCode' unless I18n.t(:who_has_done_hoc_donor).include? '#HourOfCode'
+-twitter = {:url=>"http://#{request.site}/leaderboards", :related=>'codeorg', :hashtags=>'', :text=>twitter_message}
+-twitter[:hashtags] = 'HourOfCode' unless twitter_message.include? '#HourOfCode'
 
 -hoc_metrics = fetch_hoc_metrics
 -started = format_integer_with_commas(hoc_metrics['started'])


### PR DESCRIPTION
We were getting reports that a string was being requested from the I18n API but the proper arguments were not being sent. This request fixes that.

This issue was NOT actually causing a user facing issue. However, it is a redundant call to the I18n API so I have refactored the code to make it a single call.

* Calls `I18n.t('who_has_done_hoc_donor', donor_twitter: get_random_donor_twitter)` only once.
* Did a quick check to see if I could find any other parts of the code which follow this pattern and would have this same issue but didn't find anything.

## Links
- [Honeybadger](https://app.honeybadger.io/projects/34365/faults/59958279?at=2020-01-30T20:00:00+00:00)

## Testing
- Manually verified string still works at http://localhost.code.org:3000/leaderboards

# Reviewer Checklist:
- [ ] New features are translatable or updates will not break translations
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
