### PR TITLE
Add EIR scholarship option for CSP only

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -151,8 +151,8 @@ def main
   )
 
   generate_shared_js_file(
-    generate_constants(
-      'SCHOLARSHIP_DROPDOWN_OPTIONS',
+    generate_multiple_constants(
+      %w(COURSE_SPECIFIC_SCHOLARSHIP_DROPDOWN_OPTIONS),
       source_module: Pd::ScholarshipInfoConstants,
       transform_keys: true
     ),

--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -151,8 +151,8 @@ def main
   )
 
   generate_shared_js_file(
-    generate_multiple_constants(
-      %w(COURSE_SPECIFIC_SCHOLARSHIP_DROPDOWN_OPTIONS),
+    generate_constants(
+      'COURSE_SPECIFIC_SCHOLARSHIP_DROPDOWN_OPTIONS',
       source_module: Pd::ScholarshipInfoConstants,
       transform_keys: true
     ),

--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -90,6 +90,7 @@ def main
     generate_multiple_constants(
       %w(
         COURSES
+        COURSE_KEY_MAP
         SUBJECT_NAMES
         SUBJECTS
         LEGACY_SUBJECTS

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -37,6 +37,7 @@ import {
   ScoreableQuestions as FacilitatorScoreableQuestions,
   ValidScores as FacilitatorValidScores
 } from '@cdo/apps/generated/pd/facilitatorApplicationConstants';
+import {CourseSpecificScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
 import _ from 'lodash';
 import {
   ApplicationStatuses,
@@ -574,6 +575,11 @@ export class DetailViewContents extends React.Component {
     return (
       <ScholarshipDropdown
         scholarshipStatus={this.state.scholarship_status}
+        dropdownOptions={
+          CourseSpecificScholarshipDropdownOptions[
+            this.props.applicationData.course
+          ]
+        }
         onChange={this.handleScholarshipStatusChange}
         disabled={!this.state.editing}
       />

--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormGroup} from 'react-bootstrap';
 import Select from 'react-select';
-import {ScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
 
 export class ScholarshipDropdown extends React.Component {
   static propTypes = {
     scholarshipStatus: PropTypes.string,
+    dropdownOptions: PropTypes.array,
     onChange: PropTypes.func,
     disabled: PropTypes.bool
   };
@@ -18,7 +18,7 @@ export class ScholarshipDropdown extends React.Component {
           clearable={false}
           value={this.props.scholarshipStatus}
           onChange={this.props.onChange}
-          options={ScholarshipDropdownOptions}
+          options={this.props.dropdownOptions}
           disabled={this.props.disabled}
         />
       </FormGroup>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -106,11 +106,6 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
     return strs.join(', ');
   }
 
-  // Gets
-  courseAbbreviation(course) {
-    return CourseKeyMap[course];
-  }
-
   // Gets variable containing appropriate list of dropdown options given a course
   scholarshipDropdownOptions(course) {
     return CourseSpecificScholarshipDropdownOptions[course];
@@ -121,9 +116,7 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
       return <td>{enrollment.scholarship_ineligible_reason}</td>;
     }
 
-    let workshopCourseAbbreviation = this.courseAbbreviation(
-      this.props.workshopCourse
-    );
+    let workshopCourseAbbreviation = CourseKeyMap[this.props.workshopCourse];
     let dropdownOptions = this.scholarshipDropdownOptions(
       workshopCourseAbbreviation
     );

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -116,9 +116,8 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
       return <td>{enrollment.scholarship_ineligible_reason}</td>;
     }
 
-    let workshopCourseAbbreviation = CourseKeyMap[this.props.workshopCourse];
     let dropdownOptions = this.scholarshipDropdownOptions(
-      workshopCourseAbbreviation
+      CourseKeyMap[this.props.workshopCourse]
     );
 
     if (

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -8,8 +8,11 @@ import {workshopEnrollmentStyles as styles} from '../workshop_enrollment_styles'
 import {ScholarshipDropdown} from '../../components/scholarshipDropdown';
 import Spinner from '../../components/spinner';
 import {WorkshopAdmin, ProgramManager} from '../permission';
-import {ScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
-import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {CourseSpecificScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
+import {
+  SubjectNames,
+  CourseKeyMap
+} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const CSF = 'CS Fundamentals';
 const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
@@ -103,10 +106,27 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
     return strs.join(', ');
   }
 
+  // Gets
+  courseAbbreviation(course) {
+    return CourseKeyMap[course];
+  }
+
+  // Gets variable containing appropriate list of dropdown options given a course
+  scholarshipDropdownOptions(course) {
+    return CourseSpecificScholarshipDropdownOptions[course];
+  }
+
   scholarshipInfo(enrollment) {
     if (enrollment.scholarship_ineligible_reason) {
       return <td>{enrollment.scholarship_ineligible_reason}</td>;
     }
+
+    let workshopCourseAbbreviation = this.courseAbbreviation(
+      this.props.workshopCourse
+    );
+    let dropdownOptions = this.scholarshipDropdownOptions(
+      workshopCourseAbbreviation
+    );
 
     if (
       this.props.permissionList.has(ProgramManager) ||
@@ -116,12 +136,13 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
         <td>
           <ScholarshipDropdown
             scholarshipStatus={enrollment.scholarship_status}
+            dropdownOptions={dropdownOptions}
             onChange={this.handleScholarshipStatusChange.bind(this, enrollment)}
           />
         </td>
       );
     } else {
-      let scholarshipInfo = ScholarshipDropdownOptions.find(o => {
+      let scholarshipInfo = dropdownOptions.find(o => {
         return o.value === enrollment.scholarship_status;
       });
       return <td>{scholarshipInfo ? scholarshipInfo.label : '--'}</td>;

--- a/dashboard/app/models/pd/scholarship_info.rb
+++ b/dashboard/app/models/pd/scholarship_info.rb
@@ -33,9 +33,9 @@ class Pd::ScholarshipInfo < ActiveRecord::Base
   belongs_to :enrollment, class_name: 'Pd::Enrollment', foreign_key: :pd_enrollment_id
   belongs_to :application, class_name: 'Pd::Application::TeacherApplicationBase', foreign_key: :pd_application_id
 
+  validate :course_specific_scholarship_status
   validates_presence_of :user_id
   validates_inclusion_of :application_year, in: SCHOLARSHIP_YEARS
-  validates_inclusion_of :scholarship_status, in: SCHOLARSHIP_STATUSES
   validates_inclusion_of :course, in: COURSE_KEY_MAP.values
 
   def self.update_or_create(user, application_year, course, scholarship_status)
@@ -52,5 +52,12 @@ class Pd::ScholarshipInfo < ActiveRecord::Base
   # Translate a SCHOLARSHIP_STATUSES value to a more friendly label
   def self.get_scholarship_label(value)
     SCHOLARSHIP_DROPDOWN_OPTIONS.find {|option| option[:value] == value}[:label]
+  end
+
+  # Confirm scholarship status is valid (course-specific)
+  def course_specific_scholarship_status
+    unless COURSE_SPECIFIC_SCHOLARSHIP_STATUSES[course].include? scholarship_status
+      errors.add(:scholarship_status, 'must be in list of possible statuses.')
+    end
   end
 end

--- a/dashboard/app/models/pd/scholarship_info.rb
+++ b/dashboard/app/models/pd/scholarship_info.rb
@@ -33,7 +33,7 @@ class Pd::ScholarshipInfo < ActiveRecord::Base
   belongs_to :enrollment, class_name: 'Pd::Enrollment', foreign_key: :pd_enrollment_id
   belongs_to :application, class_name: 'Pd::Application::TeacherApplicationBase', foreign_key: :pd_application_id
 
-  validate :course_specific_scholarship_status
+  validate :scholarship_must_be_valid_for_course
   validates_presence_of :user_id
   validates_inclusion_of :application_year, in: SCHOLARSHIP_YEARS
   validates_inclusion_of :course, in: COURSE_KEY_MAP.values
@@ -55,7 +55,7 @@ class Pd::ScholarshipInfo < ActiveRecord::Base
   end
 
   # Confirm scholarship status is valid (course-specific)
-  def course_specific_scholarship_status
+  def scholarship_must_be_valid_for_course
     unless COURSE_SPECIFIC_SCHOLARSHIP_STATUSES[course].include? scholarship_status
       errors.add(:scholarship_status, 'must be in list of possible statuses.')
     end

--- a/dashboard/app/models/pd/workshop_constants.rb
+++ b/dashboard/app/models/pd/workshop_constants.rb
@@ -99,11 +99,5 @@ module Pd
       COURSE_CSD => {course_name: 'csd-2019'},
       COURSE_CSP => {course_name: 'csp-2019'}
     }.freeze
-
-    COURSE_KEY_MAP = {
-      COURSE_CSF => 'csf',
-      COURSE_CSD => 'csd',
-      COURSE_CSP => 'csp'
-    }
   end
 end

--- a/dashboard/test/models/pd/scholarship_info_test.rb
+++ b/dashboard/test/models/pd/scholarship_info_test.rb
@@ -42,4 +42,9 @@ class Pd::ScholarshipInfoTest < ActiveSupport::TestCase
     scholarship_info.reload
     assert_equal Pd::ScholarshipInfoConstants::YES_OTHER, scholarship_info.scholarship_status
   end
+
+  test 'cannot create CSF scholarship info with CSP-specific scholarship status' do
+    csf_scholarship_info = build :pd_scholarship_info, course: COURSE_KEY_MAP[COURSE_CSF], scholarship_status: Pd::ScholarshipInfo::YES_EIR
+    assert_not_nil csf_scholarship_info.errors[:scholarship_status]
+  end
 end

--- a/dashboard/test/models/pd/scholarship_info_test.rb
+++ b/dashboard/test/models/pd/scholarship_info_test.rb
@@ -47,4 +47,9 @@ class Pd::ScholarshipInfoTest < ActiveSupport::TestCase
     csf_scholarship_info = build :pd_scholarship_info, course: COURSE_KEY_MAP[COURSE_CSF], scholarship_status: Pd::ScholarshipInfo::YES_EIR
     assert_not_nil csf_scholarship_info.errors[:scholarship_status]
   end
+
+  test 'can create CSP scholarship info with CSP-specific scholarship status' do
+    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfo::YES_EIR
+    assert csp_scholarship_info.valid?
+  end
 end

--- a/lib/cdo/shared_constants/pd/scholarship_info_constants.rb
+++ b/lib/cdo/shared_constants/pd/scholarship_info_constants.rb
@@ -6,10 +6,22 @@ module Pd
       YES_OTHER = 'yes_other'.freeze
     ].freeze
 
+    COURSE_SPECIFIC_SCHOLARSHIP_STATUSES = {
+      'csp' => SCHOLARSHIP_STATUSES + [YES_EIR = 'yes_eir'],
+      'csd' => SCHOLARSHIP_STATUSES,
+      'csf' => SCHOLARSHIP_STATUSES
+    }
+
     SCHOLARSHIP_DROPDOWN_OPTIONS = [
       {value: NO, label: "No, paid teacher"},
       {value: YES_CDO, label: "Yes, Code.org scholarship"},
       {value: YES_OTHER, label: "Yes, other funding (non code.org)"}
-    ]
+    ].freeze
+
+    COURSE_SPECIFIC_SCHOLARSHIP_DROPDOWN_OPTIONS = {
+      'csp' => SCHOLARSHIP_DROPDOWN_OPTIONS + [{value: YES_EIR, label: "Yes, EIR scholarship"}],
+      'csd' => SCHOLARSHIP_DROPDOWN_OPTIONS,
+      'csf' => SCHOLARSHIP_DROPDOWN_OPTIONS
+    }
   end
 end

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -133,5 +133,11 @@ module Pd
       local_summer: SUBJECT_SUMMER_WORKSHOP,
       both: 'both'
     }.freeze
+
+    COURSE_KEY_MAP = {
+      COURSE_CSF => 'csf',
+      COURSE_CSD => 'csd',
+      COURSE_CSP => 'csp'
+    }
   end
 end


### PR DESCRIPTION
[PLC-717](https://codedotorg.atlassian.net/browse/PLC-717)

Adds a new scholarship option for CSP only (scholarships funded by our federal EIR grant). Requires adding support for course-specific scholarship options, which is enforced at the model level as well as in the options presented to users in our workshop and application dashboards.

## Testing story

Added new model test to check that CSP-specific scholarship status could not be added for CSF scholarship info record.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
