### PR TITLE
Rp view updates [ci skip]

### DIFF
--- a/aws/redshift/queries/annual_master_metrics/bb_diversity_survey_2019.sql
+++ b/aws/redshift/queries/annual_master_metrics/bb_diversity_survey_2019.sql
@@ -1,0 +1,110 @@
+--Extracts # of total students and # of URM students for each response.
+--Why use each of these nested functions?  
+--COALESCE( -- If blank, replace with 0. Needed for adding together fields.  
+--NULLIF( -- If blank string, replace with null. Causes problems if you try to convert a blank string to int.  
+--REGEXP_REPLACE( -- Remove all characters from response that are non-integers (e.g., %, letters, etc.)  
+--JSON_EXTRACT_PATH_TEXT( -- Identify JSON field of interest
+
+drop table if exists #survey_results;
+create temp table #survey_results as
+SELECT user_id,
+white + black + hispanic + asian + native + american_indian + other students_survey,
+black + hispanic + native + american_indian + other urm_survey,
+farm as farm_survey
+FROM
+(
+SELECT user_id, properties,
+COALESCE(NULLIF(REGEXP_REPLACE(JSON_EXTRACT_PATH_TEXT(properties,'diversity_hispanic'),'[^0-9]'),'')::INT,0) hispanic,
+COALESCE(NULLIF(REGEXP_REPLACE(JSON_EXTRACT_PATH_TEXT(properties,'diversity_white'),'[^0-9]'),'')::INT,0) white,
+COALESCE(NULLIF(REGEXP_REPLACE(JSON_EXTRACT_PATH_TEXT(properties,'diversity_black'),'[^0-9]'),'')::INT,0) black,
+COALESCE(NULLIF(REGEXP_REPLACE(JSON_EXTRACT_PATH_TEXT(properties,'diversity_asian'),'[^0-9]'),'')::INT,0) asian,
+COALESCE(NULLIF(REGEXP_REPLACE(JSON_EXTRACT_PATH_TEXT(properties,'diversity_native'),'[^0-9]'),'')::INT,0) native,
+COALESCE(NULLIF(REGEXP_REPLACE(JSON_EXTRACT_PATH_TEXT(properties,'diversity_american_indian'),'[^0-9]'),'')::INT,0) american_indian,
+COALESCE(NULLIF(REGEXP_REPLACE(JSON_EXTRACT_PATH_TEXT(properties,'diversity_other'),'[^0-9]'),'')::INT,0) other,
+NULLIF(JSON_EXTRACT_PATH_TEXT(properties,'diversity_farm'), '')::INT as farm
+FROM dashboard_production.survey_results
+WHERE kind = 'Diversity2019'
+AND properties != '{}') as temp;
+
+-- See what percentage of each teacher's students are under 13
+drop table if exists #class_composition;
+create temp table #class_composition as
+SELECT sr.user_id,
+count(distinct f.student_user_id) students_cs,
+count(distinct case when u.birthday >= '2006-05-01' then f.student_user_id end) students_under_13_cs,
+count(distinct case when u.birthday >= '2006-05-01' then f.student_user_id end) / count(distinct f.student_user_id)::float pct_under_13_cs
+FROM dashboard_production.survey_results sr
+join dashboard_production.sections se on se.user_id = sr.user_id
+join dashboard_production.followers f on f.section_id = se.id and f.created_at >= '2018-07-01' -- new students
+join dashboard_production_pii.users u on u.id = f.student_user_id
+WHERE kind = 'Diversity2019'
+AND sr.properties != '{}'
+group by sr.user_id;
+ 
+-- Combine the two above tables.
+-- Uncomment if you actually want to replace the table that generated our results.
+drop table if exists public.bb_diversity_survey_2019;
+create table public.bb_diversity_survey_2019 as
+select sr.user_id, students_survey, urm_survey, farm_survey, students_cs, students_under_13_cs, 
+pct_under_13_cs
+from #survey_results sr
+join #class_composition cc on cc.user_id = sr.user_id;
+
+-- Calculate % URM across all classrooms with 5+ students and excluding exactly 100 student classes, as these teachers likely misunderstood the question.
+select sum(urm_survey)::float / sum(students_survey) as pct_urm
+from public.bb_diversity_survey_2019
+where students_survey >= 5 
+and students_survey != 100 
+and pct_under_13_cs >= 0.5;
+
+-- 7th category here is 70-100% -- maybe should update query to 
+-- Calculate % free and reduced lunch across all classrooms with 5+ students and excluding exactly 100 student classes, as these teachers likely misunderstood the question.
+select (
+-- Free and reduced lunch numerator
+select sum(students_survey * case farm_survey when 0 then 0 when 1 then 0.1 when 2 then 0.2 when 3 then 0.3 when 4 then 0.4 when 5 then 0.5 when 6 then 0.6 when 7 then 0.7 else 0 end)
+from public.bb_diversity_survey_2019
+where students_survey != 100
+and students_survey >= 5
+) 
+/ 
+(
+-- Free and reduced lunch denominator
+select sum(case when farm_survey <= 7 then students_survey else 0 end) 
+from public.bb_diversity_survey_2019
+where students_survey != 100
+and students_survey >= 5
+) as pct_free_and_reduced_lunch;
+
+select farm_survey, count(*)
+from public.bb_diversity_survey_2019
+group by 1
+
+--46% URM in 13+ in 2018-19
+select avg(urm::float)
+from
+(
+select distinct u.id, urm
+from users u
+join sign_ins si on si.user_id = u.id
+join user_geos ug on ug.user_id = u.id and ug.country = 'United States' -- added b/c of geolocation bug, may have shown prompt to non-US users
+where sign_in_at between '2018-07-01' and '2019-06-30'
+and user_type = 'student'
+)
+
+--29% over 13
+select avg(over_13::float)
+from
+(
+select distinct u.id, case when date_diff('year', birthday, '2019-01-01') >= 13 then 1 else 0 end over_13
+from users u
+join sign_ins si on si.user_id = u.id
+join user_geos ug on ug.user_id = u.id and ug.country = 'United States'
+where sign_in_at between '2018-07-01' and '2019-06-30'
+and user_type = 'student'
+and birthday is not null
+)
+
+--50% URM in 2018-19
+--I made a copy/paste mistake here originally, using .73 instead of .71 as the proportion of students under 13
+--This resulted in writing 51% URM in the board deck, instead of 50%. Was resolved Nov. 11, 2019.
+select (.29*.46)+(.71*.51)

--- a/aws/redshift/queries/annual_master_metrics/cs_fundamentals_pd_high_needs_rural.sql
+++ b/aws/redshift/queries/annual_master_metrics/cs_fundamentals_pd_high_needs_rural.sql
@@ -1,0 +1,47 @@
+-- % CSF PD teachers at high needs schools
+select 
+  avg(high_needs::float), 
+  count(*), 
+   '% CSF PD teachers at high needs schools' as metric, 
+   1 as sort
+from
+(
+SELECT distinct
+       pda.teacher_id,
+       high_needs
+FROM dashboard_production_pii.pd_workshops pdw
+  JOIN dashboard_production_pii.pd_sessions pds ON pds.pd_workshop_id = pdw.id
+  JOIN dashboard_production_pii.pd_enrollments pde ON pdw.id = pde.pd_workshop_id
+  JOIN dashboard_production_pii.pd_attendances pda ON pda.pd_session_id = pds.id and pda.pd_enrollment_id = pde.id
+  JOIN dashboard_production.school_infos si ON si.id = pde.school_info_id
+  JOIN school_stats ss ON ss.school_id = si.school_id
+WHERE pdw.course = 'CS Fundamentals'
+AND   DATE_PART(year,start) = date_part(year,(dateadd(year, -1, getdate())))
+and   high_needs is not null
+)
+
+union all
+-- % CSF PD teachers at rural schools
+select 
+  avg(rural::float), 
+  count(*), 
+  '% CSF PD teachers at rural schools' as metric, 
+  2 as sort
+from
+(
+SELECT distinct
+       pda.teacher_id,
+       rural
+FROM dashboard_production_pii.pd_workshops pdw
+  JOIN dashboard_production_pii.pd_sessions pds ON pds.pd_workshop_id = pdw.id
+  JOIN dashboard_production_pii.pd_enrollments pde ON pdw.id = pde.pd_workshop_id
+  JOIN dashboard_production_pii.pd_attendances pda ON pda.pd_session_id = pds.id and pda.pd_enrollment_id = pde.id
+  JOIN dashboard_production.school_infos si ON si.id = pde.school_info_id
+  JOIN school_stats ss ON ss.school_id = si.school_id
+WHERE pdw.course = 'CS Fundamentals'
+AND   DATE_PART(year,start) = date_part(year,(dateadd(year, -1, getdate())))
+and   rural is not null
+);
+
+0.5735617442286551	10916	% CSF PD teachers at high needs schools	1
+0.28091576062936446	11313	% CSF PD teachers at rural schools	2

--- a/aws/redshift/queries/annual_master_metrics/csd_csp_all.sql
+++ b/aws/redshift/queries/annual_master_metrics/csd_csp_all.sql
@@ -1,0 +1,174 @@
+select
+  'Started CSD, % high needs' metric,
+  count(distinct case when high_needs = 1 then st.user_id end)::float 
+  /
+  count(distinct st.user_id) value,
+  count(distinct st.user_id) denominator
+from csp_csd_started st
+join followers f on f.student_user_id = st.user_id
+join school_years sy on f.created_at between sy.started_at and sy.ended_at
+join sections se on se.id = f.section_id
+join users u on u.id = se.user_id
+join school_infos si on si.id = u.school_info_id
+join school_stats ss on ss.school_id = si.school_id
+where se.user_id in (select user_id from csp_csd_started_teachers where course_name = 'csd' and school_year = '2019-20')
+and st.course_name = 'csd' 
+and st.school_year = '2019-20'
+and st.started_at::date <= '2020-12-31'
+and high_needs is not null
+group by 1
+
+union all
+
+select
+  'Started CSD, % rural' metric,
+  count(distinct case when rural = 1 then st.user_id end)::float 
+  /
+  count(distinct st.user_id) value,
+  count(distinct st.user_id) denominator
+from csp_csd_started st
+join followers f on f.student_user_id = st.user_id
+join school_years sy on f.created_at between sy.started_at and sy.ended_at
+join sections se on se.id = f.section_id
+join users u on u.id = se.user_id
+join school_infos si on si.id = u.school_info_id
+join school_stats ss on ss.school_id = si.school_id
+where se.user_id in (select user_id from csp_csd_started_teachers where course_name = 'csd' and school_year = '2019-20')
+and st.course_name = 'csd' 
+and st.school_year = '2019-20'
+and st.started_at::date <= '2019-12-31'
+and rural is not null
+group by 1
+
+union all
+
+-- teachers per school, CSP
+select 
+'teachers per school, CSP' metric,
+count(distinct st.user_id)::float / count(distinct school_id) value, 
+count(distinct school_id) denominator
+from csp_csd_started_teachers st
+join users u on u.id = st.user_id
+join school_infos si on si.id = u.school_info_id
+where school_year = '2019-20'
+and course_name = 'csp'
+and school_id is not null
+and started_at::date <= '2019-12-31'
+
+union all
+
+-- teachers per school, CSD
+select
+'teachers per school, CSD' metric,
+ count(distinct st.user_id)::float / count(distinct school_id) value,
+ count(distinct school_id) denominator
+from csp_csd_started_teachers st
+join users u on u.id = st.user_id
+join school_infos si on si.id = u.school_info_id
+where school_year = '2019-20'
+and course_name = 'csd'
+and school_id is not null
+and started_at::date <= '2019-12-31'
+
+union all
+
+-- All time CSP PD'd teachers teaching
+select 
+'All time CSP PDd teachers teaching' metric,
+count(distinct tt.studio_person_id) value,
+null as denominator
+from csp_csd_started_teachers st
+join users u on u.id = st.user_id
+join csp_csd_teachers_trained tt on tt.studio_person_id = u.studio_person_id and tt.course = 'CS Principles'
+where st.school_year = '2019-20'
+and course_name = 'csp'
+and started_at::date <= '2019-12-31'
+
+union all
+
+-- All time CSD PD'd teachers teaching
+
+select 'All time CSD PDd teachers teaching' metric,
+count(distinct tt.studio_person_id) value,
+null as denominator
+from csp_csd_started_teachers st
+join users u on u.id = st.user_id
+join csp_csd_teachers_trained tt on tt.studio_person_id = u.studio_person_id and tt.course = 'CS Discoveries'
+where st.school_year = '2019-20'
+and course_name = 'csd'
+and started_at::date <= '2019-12-31'
+
+union all
+
+-- teachers per school, CSP PD
+select 
+'teachers per school, CSP PD'  metric,
+count(distinct tt.studio_person_id)::float / count(distinct tt.school_id) value,
+count(distinct tt.school_id)  denominator
+from csp_csd_started_teachers st
+join users u on u.id = st.user_id
+join csp_csd_teachers_trained tt on tt.studio_person_id = u.studio_person_id and tt.course = 'CS Principles'
+where st.school_year = '2019-20'
+and course_name = 'csp'
+and tt.school_id is not null
+and started_at::date <= '2019-12-31'
+
+union all
+
+-- teachers per school, CSD PD
+
+select 
+'teachers per school, CSD PD' metric,
+count(distinct tt.studio_person_id)::float / count(distinct tt.school_id) value,
+ count(distinct tt.school_id) denominator
+from csp_csd_started_teachers st
+join users u on u.id = st.user_id
+join csp_csd_teachers_trained tt on tt.studio_person_id = u.studio_person_id and tt.course = 'CS Discoveries' and tt.school_year = '2019-20'
+where st.school_year = '2019-20'
+and course_name = 'csd'
+and tt.school_id is not null
+and started_at::date <= '2019-12-31'
+
+union all
+
+-- # of students starting (first half of year)
+select course_name + ' # of students starting (first half of year)' as metric,
+ count(distinct user_id) value,
+null as denominator
+from csp_csd_started
+where started_at <= '2019-12-31'
+and school_year = '2019-20'
+group by course_name 
+
+union all
+
+-- % URM of students starting (first half of year)
+select course_name + '% URM of students starting (first half of year)' metric, 
+avg(urm::float) value,
+null as denominator
+from
+(
+select distinct course_name, user_id, urm
+from csp_csd_started st
+join users u on u.id = st.user_id
+where started_at <= '2019-12-31'
+and school_year = '2019-20'
+)
+group by course_name
+
+union all 
+
+-- % Female of students starting (first half of year)
+select course_name + ' % Female of students starting (first half of year)' metric, 
+ count(distinct case when gender = 'f' then user_id end)::float / 
+ count(distinct case when gender in ('m','f') then user_id end) value,
+null as denominator
+from
+(
+select distinct course_name, user_id, gender
+from csp_csd_started st
+join users u on u.id = st.user_id
+where started_at <= '2019-12-31'
+and school_year = '2019-20'
+)
+group by course_name ;

--- a/aws/redshift/queries/annual_master_metrics/csd_csp_pd_high_needs_rural.sql
+++ b/aws/redshift/queries/annual_master_metrics/csd_csp_pd_high_needs_rural.sql
@@ -1,0 +1,111 @@
+
+
+select count(distinct case when ss.high_needs = 1 then f.student_user_id end)::float /
+  count(distinct f.student_user_id) pct_high_needs,
+    count(distinct f.student_user_id) denominator
+from users u
+join sections se on se.user_id = u.id
+join followers f on f.section_id = se.id
+join user_scripts us on us.user_id = f.student_user_id
+join scripts sc on sc.id = us.script_id
+join users u_student on u_student.id = f.student_user_id
+join csp_csd_teachers_trained tt on tt.studio_person_id = u.studio_person_id and course = 'CS Principles'
+join school_stats ss on ss.school_id = tt.school_id
+where sc.family_name in ('csp1','csp2','csp3','csp4','csp5','csp-explore','csp-create','csppostap')
+and us.started_at between '2019-07-01' and '2019-12-31'
+and (u_student.deleted_at is null or u_student.deleted_at::date >= '2020-01-01')
+and u_student.user_type = 'student'
+and high_needs is not null
+and se.user_id in
+(
+  -- teachers trained by Code.org in CS Principles
+  select u.id user_id
+  from analysis.csp_csd_teachers_trained tt
+  join users u on u.studio_person_id = tt.studio_person_id 
+  where course = 'CS Principles'
+);
+
+
+select count(distinct case when ss.high_needs = 1 then f.student_user_id end)::float /
+  count(distinct f.student_user_id) pct_high_needs,
+    count(distinct f.student_user_id) denominator
+from users u
+join sections se on se.user_id = u.id
+join followers f on f.section_id = se.id
+join user_scripts us on us.user_id = f.student_user_id
+join scripts sc on sc.id = us.script_id
+join users u_student on u_student.id = f.student_user_id
+join csp_csd_teachers_trained tt on tt.studio_person_id = u.studio_person_id and course = 'CS Discoveries'
+join school_stats ss on ss.school_id = tt.school_id
+where sc.id in (select script_id from course_scripts cs join courses c on c.id = cs.course_id where c.name in ('csd-2017','csd-2018', 'csd-2019'))
+and us.started_at between '2019-07-01' and '2019-12-31'
+and (u_student.deleted_at is null or u_student.deleted_at::date >= '2020-01-01')
+and u_student.user_type = 'student'
+and high_needs is not null
+and se.user_id in
+(
+  -- teachers trained by Code.org in CS Discoveries
+  select u.id user_id
+  from analysis.csp_csd_teachers_trained tt
+  join users u on u.studio_person_id = tt.studio_person_id 
+  where course = 'CS Discoveries'
+);
+
+select ((.3937477903782872	* 73542) + (.5098155923985974 * 184808)) / (73542 + 184808);
+
+
+
+
+select count(distinct case when ss.rural = 1 then f.student_user_id end)::float /
+  count(distinct f.student_user_id) pct_rural,
+    count(distinct f.student_user_id) denominator
+from users u
+join sections se on se.user_id = u.id
+join followers f on f.section_id = se.id
+join user_scripts us on us.user_id = f.student_user_id
+join scripts sc on sc.id = us.script_id
+join users u_student on u_student.id = f.student_user_id
+join csp_csd_teachers_trained tt on tt.studio_person_id = u.studio_person_id and course = 'CS Principles'
+join school_stats ss on ss.school_id = tt.school_id
+where sc.family_name in ('csp1','csp2','csp3','csp4','csp5','csp-explore','csp-create','csppostap')
+and us.started_at between '2019-07-01' and '2019-12-31'
+and (u_student.deleted_at is null or u_student.deleted_at::date >= '2020-01-01')
+and u_student.user_type = 'student'
+and rural is not null
+and se.user_id in
+(
+  -- teachers trained by Code.org in CS Principles
+  select u.id user_id
+  from analysis.csp_csd_teachers_trained tt
+  join users u on u.studio_person_id = tt.studio_person_id 
+  where course = 'CS Principles'
+  --and school_year != '2018-19'
+);
+
+
+select count(distinct case when ss.rural = 1 then f.student_user_id end)::float /
+  count(distinct f.student_user_id) pct_rural,
+    count(distinct f.student_user_id) denominator
+from users u
+join sections se on se.user_id = u.id
+join followers f on f.section_id = se.id
+join user_scripts us on us.user_id = f.student_user_id
+join scripts sc on sc.id = us.script_id
+join users u_student on u_student.id = f.student_user_id
+join csp_csd_teachers_trained tt on tt.studio_person_id = u.studio_person_id and course = 'CS Discoveries'
+join school_stats ss on ss.school_id = tt.school_id
+where sc.id in (select script_id from course_scripts cs join courses c on c.id = cs.course_id where c.name in ('csd-2017','csd-2018', 'csd-2019'))
+and us.started_at between '2019-07-01' and '2019-12-31'
+and (u_student.deleted_at is null or u_student.deleted_at::date >= '2020-01-01')
+and u_student.user_type = 'student'
+and rural is not null
+and se.user_id in
+(
+  -- teachers trained by Code.org in CS Discoveries
+  select u.id user_id
+  from analysis.csp_csd_teachers_trained tt
+  join users u on u.studio_person_id = tt.studio_person_id 
+  where course = 'CS Discoveries'
+);
+
+select ((0.19009572332870156 *	77724) +(0.31701545244637613 *	191426)) / (191426 + 77724);

--- a/aws/redshift/queries/annual_master_metrics/l365.sql
+++ b/aws/redshift/queries/annual_master_metrics/l365.sql
@@ -1,0 +1,50 @@
+-- code studio last 365-DAY ACTIVE annual master metrics
+select
+  count(distinct case when high_needs = 1 then si.user_id end)::float 
+  /
+  count(distinct si.user_id) value,
+  count(distinct si.user_id) denominator, 
+  'L365D % students in high needs schools' metric, 
+  date_part(year,(dateadd(year, -1, getdate()))) as year,
+  1 as sort
+from sign_ins si
+join followers f on f.student_user_id = si.user_id
+join sections se on se.id = f.section_id
+join users u on u.id = se.user_id
+join school_infos sinf on sinf.id = u.school_info_id
+join school_stats ss on ss.school_id = sinf.school_id
+where high_needs is not null
+and sign_in_at between date_part(year,(dateadd(year, -1, getdate())))::varchar + '-01-01' and date_part(year,(dateadd(year, -1, getdate())))::varchar + '-12-31'
+
+union all
+
+select
+  count(distinct case when rural = 1 then si.user_id end)::float 
+  /
+  count(distinct si.user_id) value, 
+  count(distinct si.user_id) as denominator, 
+  'L365D % students in rural schools' metric, 
+  date_part(year,(dateadd(year, -1, getdate()))) as year,
+  2 as sort
+from sign_ins si
+join followers f on f.student_user_id = si.user_id
+join sections se on se.id = f.section_id
+join users u on u.id = se.user_id
+join school_infos sinf on sinf.id = u.school_info_id
+join school_stats ss on ss.school_id = sinf.school_id
+where rural is not null
+and sign_in_at::date between date_part(year,(dateadd(year, -1, getdate())))::varchar + '-01-01' and date_part(year,(dateadd(year, -1, getdate())))::varchar + '-12-31'
+
+union all
+
+SELECT 
+  COUNT(distinct case when f.id is not null then u.id end)::float / count(distinct u.id) value,
+  count(distinct u.id) denominator, 
+  'L365D % students with teachers' metric,
+  date_part(year,(dateadd(year, -1, getdate()))) as year,
+  3 as sort
+FROM users u
+left join followers f on f.student_user_id = u.id
+WHERE user_type = 'student' 
+AND u.id in (SELECT u.id FROM sign_ins si join users u on u.id = si.user_id WHERE user_type = 'student' AND sign_in_at::date 
+between date_part(year,(dateadd(year, -1, getdate())))::varchar + '-01-01' and date_part(year,(dateadd(year, -1, getdate())))::varchar + '-12-31');

--- a/aws/redshift/views/regional_partner_stats_csp_csd_view.sql
+++ b/aws/redshift/views/regional_partner_stats_csp_csd_view.sql
@@ -11,6 +11,7 @@ with completed as
   from analysis.csp_csd_completed_teachers cc
   join dashboard_production_pii.users u on u.id = cc.user_id
 ), 
+
 started as
 (
   select 
@@ -22,6 +23,42 @@ started as
   from analysis.csp_csd_started_teachers cc
   join dashboard_production_pii.users u on u.id = cc.user_id
 ),
+
+-- the following five subqueries through "all_trained_taught_combos" were added to ensure there is a distinct line for the year a teacher is trained if they go on to teach, but only after the year they were trained
+trained as 
+(select studio_person_id, school_year as school_year_trained, course, school_id, regional_partner_id, scholarship
+from analysis.csp_csd_teachers_trained), 
+
+taught as 
+(select studio_person_id, school_year as school_year_taught, course
+from started),
+
+trained_and_taught as
+(select trained.studio_person_id,  school_year_trained,  school_year_taught
+from trained 
+join taught 
+  on trained.studio_person_id = taught.studio_person_id
+  and school_year_trained <= school_year_taught
+  ),
+
+taught_only_after_year_trained as
+(select studio_person_id, school_year_trained, course, school_id, regional_partner_id, scholarship
+from trained
+where studio_person_id in (select studio_person_id from trained_and_taught where studio_person_id is not null)
+and studio_person_id not in (select studio_person_id from trained_and_taught where school_year_trained = school_year_taught and studio_person_id is not null)),
+
+all_trained_taught_combos as (
+select  distinct trained.studio_person_id,  school_year_trained,  school_year_taught, trained.course, school_id, regional_partner_id, scholarship
+from trained 
+left join taught 
+  on trained.studio_person_id = taught.studio_person_id
+  and trained.school_year_trained <= taught.school_year_taught
+
+union all 
+
+select  studio_person_id,  school_year_trained,  NULL as school_year_taught, course, school_id, regional_partner_id, scholarship
+from taught_only_after_year_trained ), 
+
 names as
 (
   select 
@@ -78,7 +115,7 @@ SELECT distinct
        e.emails as email,
        d.course, -- pd_course
        scholarship,
-       d.school_year as school_year_trained,
+       d.school_year_trained,
        coalesce(sa_csp.school_year, sa_csd.school_year) as school_year_taught,
        CASE WHEN rp.name is null THEN 'No Partner' ELSE rp.name END as regional_partner_name,
        rp.id as regional_partner_id,
@@ -131,7 +168,7 @@ SELECT distinct
        sa_csp.students_native + sa_csd.students_native as students_native,
        sa_csp.students_hawaiian + sa_csd.students_hawaiian as students_hawaiian,
        sa_csp.students_race + sa_csd.students_race as students_race
-FROM analysis.csp_csd_teachers_trained d
+FROM all_trained_taught_combos d
 LEFT JOIN names n
       ON d.studio_person_id = n.studio_person_id
 LEFT JOIN emails e
@@ -143,35 +180,35 @@ LEFT JOIN analysis.school_stats ss_summer_pd
 LEFT JOIN analysis.quarterly_workshop_attendance_view qwa 
       ON qwa.studio_person_id = d.studio_person_id
       AND qwa.course = d.course 
-      AND qwa.school_year = d.school_year
+      AND qwa.school_year = d.school_year_trained
 --pii tables (regional partner names, person names, emails, locations)
 LEFT JOIN dashboard_production_pii.regional_partners rp  
       ON d.regional_partner_id = rp.id 
 -- analysis tables
 LEFT JOIN analysis.student_activity_csp_csd_view sa_csp 
       ON sa_csp.studio_person_id = d.studio_person_id 
-      AND sa_csp.school_year >= d.school_year 
+      AND sa_csp.school_year = d.school_year_taught
       AND sa_csp.course_name_short = 'csp'
 LEFT JOIN analysis.student_activity_csp_csd_view sa_csd 
       ON sa_csd.studio_person_id = d.studio_person_id 
-      AND sa_csd.school_year >= d.school_year 
+      AND sa_csd.school_year = d.school_year_taught 
       AND sa_csd.course_name_short = 'csd'
 LEFT JOIN started s
       ON s.studio_person_id = d.studio_person_id
       AND s.course = d.course
-      AND s.school_year = coalesce(sa_csp.school_year, sa_csd.school_year)
+      AND s.school_year = d.school_year_taught
 LEFT JOIN completed c
       ON c.studio_person_id = d.studio_person_id
       AND c.course = d.course   
       AND c.school_year  = s.school_year  
 LEFT JOIN analysis.teacher_most_progress_csp_csd_view tmp_csp 
       ON tmp_csp.studio_person_id = d.studio_person_id
-      AND tmp_csp.school_year = coalesce(sa_csp.school_year, sa_csd.school_year)
+      AND tmp_csp.school_year = d.school_year_taught
       AND tmp_csp.course_name_short = 'csp'
 LEFT JOIN analysis.teacher_most_progress_csp_csd_view tmp_csd 
       ON tmp_csd.studio_person_id = d.studio_person_id
-      AND tmp_csd.school_year = coalesce(sa_csp.school_year, sa_csd.school_year)
+      AND tmp_csd.school_year =  d.school_year_taught
       AND tmp_csd.course_name_short = 'csd'
-with no schema binding
+with no schema binding;
 
 GRANT SELECT ON analysis_pii.regional_partner_stats_csp_csd_view TO reader_pii;

--- a/aws/redshift/views/school_activity_stats_view.sql
+++ b/aws/redshift/views/school_activity_stats_view.sql
@@ -72,6 +72,8 @@ csf_script_ids as
          ss.stage_el AS elementary,
          ss.stage_mi AS middle,
          ss.stage_hi AS high,
+         ss.grades_lo, 
+         ss.grades_hi,
          ss.frl_eligible as frl_eligible_count, 
          ss.frl_eligible_percent,
          ss.urm_percent * ss.students as urm_count,
@@ -131,7 +133,7 @@ csf_script_ids as
         ON hoc_event.school_id = ss.school_id
     LEFT JOIN applied_to_csd_csp_pd app
         ON app.school_id = ss.school_id
-  GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18, 19, 20, 21
+  GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18, 19, 20, 21, 22, 23
   WITH NO SCHEMA BINDING;
   
 GRANT SELECT ON analysis.school_activity_stats_view TO GROUP reader;


### PR DESCRIPTION
<!--
Liz pointed out that in the CSP CSD Overview for regional partners in tableau, there was a slight undercount of the number of teachers trained when compared with the cumulative numbers in the cumulative view. I determined that this was due to a bug in the regional_partner_stats_csp_csd_view whereby teachers who only started teaching in a year after the year they were trained (and not in that year, which is the usual behavior), weren't accounted for in the year they were trained. This update solves that problem by adding a line with a "null" in the school_year_taught column for those teachers. 
-->
