### PR TITLE
Revert updates to workshop summary report

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
@@ -117,6 +117,10 @@ export class WorkshopSummaryReport extends React.Component {
         header: {label: 'Organizer Name'}
       },
       {
+        property: 'organizer_id',
+        header: {label: 'Organizer Id'}
+      },
+      {
         property: 'organizer_email',
         header: {label: 'Organizer Email'}
       },
@@ -125,55 +129,20 @@ export class WorkshopSummaryReport extends React.Component {
         header: {label: 'Regional Partner'}
       },
       {
-        property: 'workshop_dates',
-        header: {label: 'Dates'}
-      },
-      {
-        property: 'num_hours',
-        header: {label: 'Workshop Total Hours'}
-      },
-      {
-        property: 'funded',
-        header: {label: 'Funded'}
-      },
-      {
-        property: 'attendance_url',
-        header: {label: 'Attendance URL'},
-        cell: {format: this.formatUrl}
-      },
-      {
-        property: 'num_facilitators',
-        header: {label: 'Num Facilitators'}
-      },
-      {
-        property: 'num_registered',
-        header: {label: 'Num Registered'}
-      },
-      {
-        property: 'num_scholarship_teachers_attending_all_sessions',
-        header: {label: 'Num Scholarship Attending'}
-      }
-    ];
-
-    for (let i = 1; i <= ATTENDANCE_DAYS_COUNT; i++) {
-      columns.push({
-        property: `attendance_day_${i}`,
-        header: {label: `Attendance Day ${i}`}
-      });
-    }
-
-    columns.push(
-      {
-        property: 'organizer_id',
-        header: {label: 'Organizer Id'}
-      },
-      {
         property: 'workshop_name',
         header: {label: 'Workshop Name'}
       },
       {
         property: 'on_map',
         header: {label: 'Shown on Map'}
+      },
+      {
+        property: 'funded',
+        header: {label: 'Funded'}
+      },
+      {
+        property: 'workshop_dates',
+        header: {label: 'Dates'}
       },
       {
         property: 'workshop_id',
@@ -189,10 +158,19 @@ export class WorkshopSummaryReport extends React.Component {
         header: {label: 'Subject'}
       },
       {
+        property: 'attendance_url',
+        header: {label: 'Attendance URL'},
+        cell: {format: this.formatUrl}
+      },
+      {
         property: 'facilitators',
         header: {label: 'Facilitators'}
+      },
+      {
+        property: 'num_facilitators',
+        header: {label: 'Num Facilitators'}
       }
-    );
+    ];
 
     if (this.state.showFacilitatorDetails) {
       for (let i = 1; i <= FACILITATOR_DETAILS_COUNT; i++) {
@@ -211,6 +189,10 @@ export class WorkshopSummaryReport extends React.Component {
 
     columns.push(
       {
+        property: 'num_registered',
+        header: {label: 'Num Registered'}
+      },
+      {
         property: 'num_qualified_teachers',
         header: {label: 'Num Qualified Teachers'}
       },
@@ -219,6 +201,13 @@ export class WorkshopSummaryReport extends React.Component {
         header: {label: 'Days'}
       }
     );
+
+    for (let i = 1; i <= ATTENDANCE_DAYS_COUNT; i++) {
+      columns.push({
+        property: `attendance_day_${i}`,
+        header: {label: `Attendance Day ${i}`}
+      });
+    }
 
     if (this.props.permission.has(WorkshopAdmin)) {
       columns.push(

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -580,33 +580,6 @@ class Pd::Workshop < ActiveRecord::Base
     sessions.flat_map(&:attendances).flat_map(&:teacher).uniq
   end
 
-  # Get all teachers who have attended all sessions of this workshop.
-  def teachers_attending_all_sessions(filter_by_cdo_scholarship=false)
-    teachers_attending = sessions.flat_map(&:attendances).flat_map(&:teacher)
-
-    # Filter attendances to only scholarship teachers
-    if filter_by_cdo_scholarship
-      scholarship_teachers = Pd::ScholarshipInfo.where(
-        {
-          application_year: school_year,
-          course: course_key,
-          scholarship_status: Pd::ScholarshipInfoConstants::YES_CDO
-        }
-      ).pluck(:user_id)
-      teachers_attending.select! {|teacher| scholarship_teachers.include? teacher.id}
-    end
-
-    # Get number of sessions attended by teacher
-    attendance_count_by_teacher = Hash[
-      teachers_attending.uniq.map do |teacher|
-        [teacher, teachers_attending.count(teacher)]
-      end
-    ]
-
-    # Return only teachers who attended all sessions
-    attendance_count_by_teacher.select {|_, attendances| attendances == sessions.count}.keys
-  end
-
   def local_summer?
     subject == SUBJECT_SUMMER_WORKSHOP
   end

--- a/dashboard/lib/pd/payment/workshop_summary.rb
+++ b/dashboard/lib/pd/payment/workshop_summary.rb
@@ -75,42 +75,34 @@ module Pd::Payment
     def generate_organizer_report_line_item(with_payment = false)
       line_item = {
         organizer_name: workshop.organizer&.name,
+        organizer_id: workshop.organizer&.id,
         organizer_email: workshop.organizer&.email,
         regional_partner_name: workshop.regional_partner.try(:name),
         workshop_dates: workshop.sessions.map(&:formatted_date).join(' '),
-        num_hours: num_hours,
+        on_map: workshop.on_map,
         funded: workshop.funding_summary,
         attendance_url: attendance_url,
+        facilitators: workshop.facilitators.pluck(:name).join(', '),
         num_facilitators: workshop.facilitators.count,
+        workshop_id: workshop.id,
+        workshop_name: workshop.friendly_name,
+        course: workshop.course,
+        subject: workshop.subject,
         num_registered: workshop.enrollments.count,
-        num_scholarship_teachers_attending_all_sessions: workshop.teachers_attending_all_sessions(true).count,
+        num_qualified_teachers: num_qualified_teachers,
+        days: num_days,
       }
-
-      # Attendance days 1-5
-      session_attendance_counts = attendance_count_per_session
-      (1..REPORT_ATTENDANCE_DAY_COUNT).each do |n|
-        line_item["attendance_day_#{n}".to_sym] = session_attendance_counts[n - 1]
-      end
-
-      # Waiting to add some columns until after attendance to make payment processing easier
-      line_item.merge!(
-        {
-          organizer_id: workshop.organizer&.id,
-          on_map: workshop.on_map,
-          facilitators: workshop.facilitators.pluck(:name).join(', '),
-          workshop_id: workshop.id,
-          workshop_name: workshop.friendly_name,
-          course: workshop.course,
-          subject: workshop.subject,
-          num_qualified_teachers: num_qualified_teachers,
-          days: num_days,
-        }
-      )
 
       # Facilitator names and emails, 1-6
       (1..REPORT_FACILITATOR_DETAILS_COUNT).each do |n|
         line_item["facilitator_name_#{n}".to_sym] = workshop.facilitators[n - 1].try(&:name)
         line_item["facilitator_email_#{n}".to_sym] = workshop.facilitators[n - 1].try(&:email)
+      end
+
+      # Attendance days 1-5
+      session_attendance_counts = attendance_count_per_session
+      (1..REPORT_ATTENDANCE_DAY_COUNT).each do |n|
+        line_item["attendance_day_#{n}".to_sym] = session_attendance_counts[n - 1]
       end
 
       if with_payment

--- a/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
@@ -21,8 +21,6 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ::ActionController::Tes
     num_registered
     num_qualified_teachers
     days
-    num_hours
-    num_scholarship_teachers_attending_all_sessions
   ).tap do |fields|
     (1..Pd::Payment::WorkshopSummary::REPORT_FACILITATOR_DETAILS_COUNT).each do |n|
       fields << "facilitator_name_#{n}"

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -416,14 +416,6 @@ FactoryGirl.define do
     end
   end
 
-  factory :pd_scholarship_info, class: 'Pd::ScholarshipInfo' do
-    association :user, factory: :teacher
-
-    course Pd::Workshop::COURSE_KEY_MAP[Pd::Workshop::COURSE_CSP]
-    application_year Pd::Application::ApplicationConstants::YEAR_19_20
-    scholarship_status Pd::ScholarshipInfoConstants::YES_CDO
-  end
-
   factory :pd_attendance, class: 'Pd::Attendance' do
     association :session, factory: :pd_session
     association :teacher

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -842,21 +842,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert_equal enrollments.pluck(:id).sort, @workshop.unattended_enrollments.pluck(:id).sort
   end
 
-  test 'teachers_attending_all_sessions' do
-    workshop = create :workshop,
-      course: Pd::Workshop::COURSE_CSP,
-      sessions_from: Date.new(2019, 7, 1)
-
-    2.times do
-      create :pd_workshop_participant, enrolled: true, workshop: workshop
-      create :pd_workshop_participant, enrolled: true, attended: true, workshop: workshop
-      create :pd_workshop_participant, enrolled: true, attended: true, cdo_scholarship_recipient: true, workshop: workshop
-    end
-
-    assert_equal 4, workshop.teachers_attending_all_sessions.count
-    assert_equal 2, workshop.teachers_attending_all_sessions(true).count
-  end
-
   # TODO: remove this test when workshop_organizer is deprecated
   test 'organizer_or_facilitator?' do
     facilitator = create :facilitator


### PR DESCRIPTION
Changes requested to the workshop summary spreadsheet broke some payments processing. Reverting until further notice. Couldn't revert through the GitHub UI because I had made some adjacent changes in https://github.com/code-dot-org/code-dot-org/pull/32800 to move a PD factory into the PD factories file, but I think I resolved the conflict.