### PR TITLE
Add environment tag to data stack

### DIFF
--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -204,7 +204,7 @@ module AWS
             CAPABILITY_IAM
             CAPABILITY_NAMED_IAM
           ]
-          if TEMPLATE == 'cloud_formation_stack.yml.erb'
+          if %w[cloud_formation_stack.yml.erb data.yml.erb].include?(TEMPLATE)
             options[:tags].push(
               key: 'environment',
               value: rack_env


### PR DESCRIPTION
Followup to #32732. Data stack should continue to have environment-specific tags on its resources just like the application stacks, since its resources are unique to a specific environment.
