### PR TITLE
Stage completion by section PolicyObject

### DIFF
--- a/dashboard/lib/policies/stage_activity.rb
+++ b/dashboard/lib/policies/stage_activity.rb
@@ -1,0 +1,19 @@
+class Policies::StageActivity
+  # A user has "completed" a stage if they have completed at least 60% of the levels within the stage.
+  def self.completed_by_user?(user, stage)
+    return false unless user
+    return false unless stage
+
+    number_of_levels_in_stage = stage.script_levels.count
+
+    stage_level_ids = stage.script_levels.map(&:level).pluck(:id)
+
+    number_of_completed_levels_in_stage = user.user_levels.where(level_id: stage_level_ids).select(&:passing?).count
+
+    (number_of_completed_levels_in_stage.to_f / number_of_levels_in_stage) >= 0.6
+  end
+
+  # A section has "completed" a stage if 80% of the users in the section have completed 60% of level within the stage.
+  def self.completed_by_section?(section, stage)
+  end
+end

--- a/dashboard/lib/policies/stage_activity.rb
+++ b/dashboard/lib/policies/stage_activity.rb
@@ -13,7 +13,20 @@ class Policies::StageActivity
     (number_of_completed_levels_in_stage.to_f / number_of_levels_in_stage) >= 0.6
   end
 
-  # A section has "completed" a stage if 80% of the users in the section have completed 60% of level within the stage.
+  # A section has "completed" a stage if 80% of the users in the section have completed 60% of levels within the stage.
   def self.completed_by_section?(section, stage)
+    return false unless section
+    return false unless stage
+
+    number_of_students_in_section = section.students.count
+
+    number_of_students_who_completed_stage = 0
+    section.students.each do |student|
+      if completed_by_user?(student, stage)
+        number_of_students_who_completed_stage += 1
+      end
+    end
+
+    (number_of_students_who_completed_stage.to_f / number_of_students_in_section) >= 0.8
   end
 end

--- a/dashboard/test/lib/policies/stage_activity_test.rb
+++ b/dashboard/test/lib/policies/stage_activity_test.rb
@@ -2,10 +2,13 @@ require 'test_helper'
 
 class Policies::StageActivityTest < ActiveSupport::TestCase
   setup_all do
-    @user = create :user
+    @user_1 = create :user
+    @user_2 = create :user
+    @user_3 = create :user
+    @user_4 = create :user
     @script = create :script
     @stage = create :stage
-    @script_level = create(
+    @script_level_1 = create(
       :script_level,
       script: @script,
       stage: @stage,
@@ -29,38 +32,65 @@ class Policies::StageActivityTest < ActiveSupport::TestCase
         create(:maze, name: 'ScriptActivity test level 3')
       ]
     )
+    @section = create(:section, user: create(:teacher))
+    create(:follower, section: @section, student_user: @user_1)
+    create(:follower, section: @section, student_user: @user_2)
+    create(:follower, section: @section, student_user: @user_3)
+    create(:follower, section: @section, student_user: @user_4)
   end
 
-  test 'stage is incomplete for a user if no levels within stage are complete' do
-    refute Policies::StageActivity.completed_by_user?(@user, @stage)
-  end
-
-  test 'stage is incomplete for a user if less than 60% of levels within stage are complete' do
+  def complete_stage(student)
     UserLevel.create(
-      user: @user,
-      level: @script_level.levels[0],
-      script: @script,
-      attempts: 1,
-      best_result: Activity::MINIMUM_PASS_RESULT
-    )
-    refute Policies::StageActivity.completed_by_user?(@user, @stage)
-  end
-
-  test 'stage is complete for a user if more than 60% of levels within stage are complete' do
-    UserLevel.create(
-      user: @user,
-      level: @script_level.levels[0],
+      user: student,
+      level: @script_level_1.levels[0],
       script: @script,
       attempts: 1,
       best_result: Activity::MINIMUM_PASS_RESULT
     )
     UserLevel.create(
-      user: @user,
+      user: student,
       level: @script_level_2.levels[0],
       script: @script,
       attempts: 1,
       best_result: Activity::MINIMUM_PASS_RESULT
     )
-    assert Policies::StageActivity.completed_by_user?(@user, @stage)
+  end
+
+  test 'stage is incomplete for a user if no levels within stage are complete' do
+    refute Policies::StageActivity.completed_by_user?(@user_1, @stage)
+  end
+
+  test 'stage is incomplete for a user if less than 60% of levels within stage are complete' do
+    UserLevel.create(
+      user: @user_1,
+      level: @script_level_1.levels[0],
+      script: @script,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+    refute Policies::StageActivity.completed_by_user?(@user_1, @stage)
+  end
+
+  test 'stage is complete for a user if more than 60% of levels within stage are complete' do
+    complete_stage(@user_1)
+    assert Policies::StageActivity.completed_by_user?(@user_1, @stage)
+  end
+
+  test 'stage is incomplete for a section if none of the students have completed the stage' do
+    refute Policies::StageActivity.completed_by_section?(@section, @stage)
+  end
+
+  test 'stage is incomplete for a section if less than 80% of students have completed the stage' do
+    complete_stage(@user_1)
+    complete_stage(@user_2)
+    refute Policies::StageActivity.completed_by_section?(@section, @stage)
+  end
+
+  test 'stage is complete for a section if at least 80% of students have completed the stage' do
+    students = [@user_1, @user_2, @user_3, @user_4]
+    students.each do |student|
+      complete_stage(student)
+    end
+    assert Policies::StageActivity.completed_by_section?(@section, @stage)
   end
 end

--- a/dashboard/test/lib/policies/stage_activity_test.rb
+++ b/dashboard/test/lib/policies/stage_activity_test.rb
@@ -13,7 +13,7 @@ class Policies::StageActivityTest < ActiveSupport::TestCase
       script: @script,
       stage: @stage,
       levels: [
-        create(:maze, name: 'ScriptActivity test level 1')
+        create(:maze, name: 'StageActivity test level 1')
       ]
     )
     @script_level_2 = create(
@@ -21,7 +21,7 @@ class Policies::StageActivityTest < ActiveSupport::TestCase
       script: @script,
       stage: @stage,
       levels: [
-        create(:maze, name: 'ScriptActivity test level 2')
+        create(:maze, name: 'StageActivity test level 2')
       ]
     )
     @script_level_3 = create(
@@ -29,7 +29,7 @@ class Policies::StageActivityTest < ActiveSupport::TestCase
       script: @script,
       stage: @stage,
       levels: [
-        create(:maze, name: 'ScriptActivity test level 3')
+        create(:maze, name: 'StageActivity test level 3')
       ]
     )
     @section = create(:section, user: create(:teacher))

--- a/dashboard/test/lib/policies/stage_activity_test.rb
+++ b/dashboard/test/lib/policies/stage_activity_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class Policies::StageActivityTest < ActiveSupport::TestCase
+  setup_all do
+    @user = create :user
+    @script = create :script
+    @stage = create :stage
+    @script_level = create(
+      :script_level,
+      script: @script,
+      stage: @stage,
+      levels: [
+        create(:maze, name: 'ScriptActivity test level 1')
+      ]
+    )
+    @script_level_2 = create(
+      :script_level,
+      script: @script,
+      stage: @stage,
+      levels: [
+        create(:maze, name: 'ScriptActivity test level 2')
+      ]
+    )
+    @script_level_3 = create(
+      :script_level,
+      script: @script,
+      stage: @stage,
+      levels: [
+        create(:maze, name: 'ScriptActivity test level 3')
+      ]
+    )
+  end
+
+  test 'stage is incomplete for a user if no levels within stage are complete' do
+    refute Policies::StageActivity.completed_by_user?(@user, @stage)
+  end
+
+  test 'stage is incomplete for a user if less than 60% of levels within stage are complete' do
+    UserLevel.create(
+      user: @user,
+      level: @script_level.levels[0],
+      script: @script,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+    refute Policies::StageActivity.completed_by_user?(@user, @stage)
+  end
+
+  test 'stage is complete for a user if more than 60% of levels within stage are complete' do
+    UserLevel.create(
+      user: @user,
+      level: @script_level.levels[0],
+      script: @script,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+    UserLevel.create(
+      user: @user,
+      level: @script_level_2.levels[0],
+      script: @script,
+      attempts: 1,
+      best_result: Activity::MINIMUM_PASS_RESULT
+    )
+    assert Policies::StageActivity.completed_by_user?(@user, @stage)
+  end
+end


### PR DESCRIPTION
Extraction and extension of #32963 (Thank you, Dani!) 
[LP-1129](https://codedotorg.atlassian.net/browse/LP-1129), partial, up next is getting this info to the progress tab 
CSF Standards Report [spec](https://docs.google.com/document/d/1xlm_syljGXIapl72GaKxN63V7kt6syHyvWHuqZhTCfE/edit#heading=h.ax62vxl69vcw)

For the new Standards View of the Progress Tab on the Teacher Dashboard, we'll be displaying lesson completion by section for lessons that align to a particular standard. "Completion" for these purposes is defined as at least 60% of levels passed by at least 80% of the students in a section. In this PR, I made  a StageActivity PolicyObject that can determine completion by user and completion by section for a given stage. Relevant tests are included. 