### PR TITLE
add error reporting for 'get level by url' regex

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -119,13 +119,11 @@ class I18nScriptUtils
       url_regex = %r{https://studio.code.org/s/(?<script_name>[A-Za-z0-9\s\-_]+)/stage/(?<stage_pos>[0-9]+)/(?<level_info>.+)}
       matches = new_url.match(url_regex)
 
-      if matches.nil?
-        STDERR.puts "could not find level for url: #{new_url}"
-        return nil
-      end
-
       hash[new_url] =
-        if matches[:level_info].starts_with?("extras")
+        if matches.nil?
+          STDERR.puts "could not find level for url: #{new_url}"
+          nil
+        elsif matches[:level_info].starts_with?("extras")
           level_info_regex = %r{extras\?level_name=(?<level_name>.+)}
           level_name = matches[:level_info].match(level_info_regex)[:level_name]
           Level.find_by_name(CGI.unescape(level_name))

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -118,6 +118,12 @@ class I18nScriptUtils
     @levels_by_url ||= Hash.new do |hash, new_url|
       url_regex = %r{https://studio.code.org/s/(?<script_name>[A-Za-z0-9\s\-_]+)/stage/(?<stage_pos>[0-9]+)/(?<level_info>.+)}
       matches = new_url.match(url_regex)
+
+      if matches.nil?
+        STDERR.puts "could not find level for url: #{new_url}"
+        return nil
+      end
+
       hash[new_url] =
         if matches[:level_info].starts_with?("extras")
           level_info_regex = %r{extras\?level_name=(?<level_name>.+)}

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -179,6 +179,7 @@ def distribute_course_content(locale)
 
     course_strings.each do |level_url, level_strings|
       level = I18nScriptUtils.get_level_from_url(level_url)
+      next unless level.present?
       locale_strings.deep_merge! serialize_i18n_strings(level, level_strings)
     end
   end


### PR DESCRIPTION
short-term fix to allow the sync to continue when our regex fails, and to report on those urls that fail. Will give us some leeway and additional information to pursue a longer-term fix, a la https://github.com/code-dot-org/code-dot-org/pull/32901

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
