### PR TITLE
Removing references to "under 13".

### DIFF
--- a/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
+++ b/dashboard/app/views/devise/registrations/_old_sign_up_form.html.haml
@@ -127,8 +127,6 @@
             -# Student text.
             %div.student-options
               = t('terms_interstitial.accept_label_markdown', tos_url: CDO.code_org_url('/tos'), privacy_url: CDO.code_org_url('/privacy'), markdown: true).html_safe
-              %p
-                = t('signup_form.under_13_consent')
 
       -# If GDPR applies, show an additional checkbox.
       #data_transfer_agreement_accepted-block.itemblock

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -166,7 +166,6 @@ en:
     valid_password: "Valid password!"
     invalid_password: "Password must be at least 6 characters"
     mismatch_password: "The two passwords you entered do not match"
-    under_13_consent: "If I am under 13 years of age, I confirm that I have my parent or legal guardian's permission to use the Code.org services."
     student_consent: "I confirm that I have my parent or legal guardian's permission to use the Code.org services."
     agree_us_website: "I agree to using a website based in the United States."
     my_data_to_us: "Data from my use of this site may be sent to and stored or processed in the United States."


### PR DESCRIPTION
# Description
We have determined that we don't need the under 13 consent from guardians according to the COPPA guidelines so we should remove them in order to clean up the sign-up page.
* Remove string usage on old sign-in page.
* Remove string from source string list.

## Before
![image](https://user-images.githubusercontent.com/1372238/73799636-60139880-47ae-11ea-8def-9f18ec7d49ec.png)

## After
![image](https://user-images.githubusercontent.com/1372238/73799599-4a05d800-47ae-11ea-9dd3-6663faa676cb.png)

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-994)

## Testing story
* `./bin/dashboard-server`
  * http://localhost-studio.code.org:3000/users/sign_up

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
