### PR TITLE
clean up hourofcode.com layouts

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/layouts/default.haml
+++ b/pegasus/sites.v3/hourofcode.com/layouts/default.haml
@@ -1,5 +1,3 @@
-%link{rel:'stylesheet', type:'text/css', href: '/shared/css/warning-banner.css'}
-
 .wrapper
   = view :unsupported_browser
   -if @header['theme'] == 'responsive'
@@ -62,7 +60,3 @@
       %br/
       %br/
   .push
-
-= view :cookie_banner
-
-= view :footer

--- a/pegasus/sites.v3/hourofcode.com/layouts/wide.haml
+++ b/pegasus/sites.v3/hourofcode.com/layouts/wide.haml
@@ -1,4 +1,3 @@
-%link{rel:'stylesheet', type:'text/css', href: '/shared/css/warning-banner.css'}
 %link{rel:'stylesheet', type:'text/css', href:'/css/wide-layout.css'}
 
 = view :unsupported_browser
@@ -18,7 +17,3 @@
 %br/
 %br/
 %br/
-
-= view :cookie_banner
-
-= view :footer

--- a/pegasus/sites.v3/hourofcode.com/layouts/wide_index.haml
+++ b/pegasus/sites.v3/hourofcode.com/layouts/wide_index.haml
@@ -1,12 +1,6 @@
-%link{rel:'stylesheet', type:'text/css', href: '/shared/css/warning-banner.css'}
-
 = view :unsupported_browser
 = body
 
 %br/
 %br/
 %br/
-
-= view :cookie_banner
-
-= view :footer

--- a/pegasus/sites.v3/hourofcode.com/themes/default.haml
+++ b/pegasus/sites.v3/hourofcode.com/themes/default.haml
@@ -8,6 +8,8 @@
     -else
       %link{rel:'stylesheet', type:'text/css', href:'/css/common-international.css'}
 
+    %link{rel:'stylesheet', type:'text/css', href: '/shared/css/warning-banner.css'}
+
     /[if lt IE 9]
       %script{src:'/js/respond.min.js'}
 
@@ -15,7 +17,6 @@
 
     =view :theme_common_head_after
   %body
-    %link{rel:'stylesheet', type:'text/css', href: '/shared/css/warning-banner.css'}
     =body
     =view :cookie_banner
     =view :footer

--- a/pegasus/sites.v3/hourofcode.com/themes/default.haml
+++ b/pegasus/sites.v3/hourofcode.com/themes/default.haml
@@ -15,5 +15,8 @@
 
     =view :theme_common_head_after
   %body
+    %link{rel:'stylesheet', type:'text/css', href: '/shared/css/warning-banner.css'}
     =body
+    =view :cookie_banner
+    =view :footer
     =view :theme_common_body_after


### PR DESCRIPTION
Move markup shared by all layouts into the default theme, which as of https://github.com/code-dot-org/code-dot-org/pull/32990/ is also the _only_ theme.

## Testing story

Validated with https://github.com/code-dot-org/code-dot-org/pull/32977 that this change causes only minor whitespace changes. This also confirms that there are no hoc.com pages currently using `theme: none`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
