### PR TITLE
Fix i18n paths for hourofcode project

### DIFF
--- a/bin/i18n/hoc_sync_utils.rb
+++ b/bin/i18n/hoc_sync_utils.rb
@@ -43,17 +43,14 @@ class HocSyncUtils
     Languages.get_hoc_languages.each do |prop|
       # move downloaded folders to root source directory and rename from
       # language to locale
-      crowdin_dir = File.join(I18N_SOURCE_DIR, "hourofcode", prop[:crowdin_name_s])
       dest_dir = "i18n/locales/#{prop[:locale_s]}"
-      next unless File.directory?(crowdin_dir)
-
-      FileUtils.cp_r File.join(crowdin_dir, '.'), dest_dir
-      FileUtils.rm_r crowdin_dir
+      next unless File.directory?(dest_dir)
 
       # replace the crowdin code in the file itself with our own unique
       # language code
       old_path = File.join(dest_dir, "hourofcode/en.yml")
       crowdin_translation_data = YAML.load_file(old_path)
+      puts old_path
       new_translation_data = {}
       new_translation_data[prop[:unique_language_s]] = crowdin_translation_data.values.first
 
@@ -62,17 +59,6 @@ class HocSyncUtils
       File.write(new_path, new_translation_data.to_yaml)
       FileUtils.rm old_path
     end
-
-    # Now, any remaining directories named after the language name (rather than
-    # the four-letter language code) represent languages downloaded from
-    # crowdin that aren't in our system. We expect this to happen whenever a
-    # language has been enabled for our project on crowdin before it gets added
-    # to our system; we do this pretty often because that allows us to start
-    # collecting translations for a language in advance of enabling it.
-    #
-    # So although these directories are neither bad nor unexpected, they're
-    # still unwanted. So we remove them.
-    FileUtils.rm_r(Dir.glob(File.join(I18N_SOURCE_DIR, "hourofcode", "[A-Z]*")))
   end
 
   def self.copy_from_i18n_source_to_hoc

--- a/bin/i18n/hoc_sync_utils.rb
+++ b/bin/i18n/hoc_sync_utils.rb
@@ -33,12 +33,12 @@ class HocSyncUtils
   end
 
   def self.sync_out
-    rename_downloads_from_crowdin_code_to_locale
+    rename_yml_to_locale
     copy_from_i18n_source_to_hoc
     restore_sanitized_headers
   end
 
-  def self.rename_downloads_from_crowdin_code_to_locale
+  def self.rename_yml_to_locale
     puts "Updating crowdin codes to our locale codes..."
     Languages.get_hoc_languages.each do |prop|
       # move downloaded folders to root source directory and rename from
@@ -50,7 +50,7 @@ class HocSyncUtils
       # language code
       old_path = File.join(dest_dir, "hourofcode/en.yml")
       crowdin_translation_data = YAML.load_file(old_path)
-      puts old_path
+      next unless File.exist?(old_path)
       new_translation_data = {}
       new_translation_data[prop[:unique_language_s]] = crowdin_translation_data.values.first
 

--- a/bin/i18n/hourofcode_crowdin.yml
+++ b/bin/i18n/hourofcode_crowdin.yml
@@ -2,25 +2,23 @@
 # Your crowdin's credentials
 #
 "project_identifier" : "hour-of-code"
-"base_path" : "../../i18n/locales/source/hourofcode"
+"base_path" : "../../i18n/locales"
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
 "api_key" : ""
-
-"preserve_hierarchy": true
 
 #
 # Files configuration
 #
 files: [
   {
-    "source": "/en.yml",
+    "source": "/source/hourofcode/en.yml",
     "translation": "/%language%/hourofcode/%original_file_name%",
     "update_option": "update_as_unapproved"
   }, {
-    "source": "/**/*.md",
-    "translation": "/%language%/hourofcode/**/%file_name%.md",
+    "source": "/source/hourofcode/**/*.md",
+    "translation": "%language%/hourofcode/**/%file_name%.md",
     "update_option": "update_as_unapproved"
   }
 ]

--- a/bin/i18n/hourofcode_crowdin.yml
+++ b/bin/i18n/hourofcode_crowdin.yml
@@ -18,7 +18,7 @@ files: [
     "update_option": "update_as_unapproved"
   }, {
     "source": "/source/hourofcode/**/*.md",
-    "translation": "%language%/hourofcode/**/%file_name%.md",
+    "translation": "/%language%/hourofcode/**/%file_name%.md",
     "update_option": "update_as_unapproved"
   }
 ]


### PR DESCRIPTION
This PR moves the files downloaded from Crowdin into `i18n/locales/<locale>/hourofcode` and distributes them from there.

### Testing

Dry run with new config:

```ubuntu@ip-10-0-0-11:~/code-dot-org$ crowdin --config bin/i18n/hourofcode_crowdin.yml --identity bin/i18n/CROWDIN_HOUROFCODE_CREDENTIALS.yml upload sources --dryrun
Version 2.0.31 of the CLI client is available. You can download the new version here: https://downloads.crowdin.com/cli/v2/crowdin-cli.zip
activity-guidelines.md
advisory-committee.md
assistive-technology.md
en.yml
how-to/2019.md
how-to/afterschool.md
how-to/companies.md
how-to/districts.md
how-to/events.md
how-to/index.md
how-to/parents.md
how-to/public-officials.md
how-to/volunteers.md
international-partners.md
partners.md
promote/index.md
promote/official-press-release.md
promote/op-ed.md
promote/press-kit.md
promote/previous-posters.md
promote/proclamation.md
promote/resources.md
promote/stats.md
supporting-special-needs-students.md
thanks.md
whole-school.md
```
Which looks the same as the current set of files in the hour-of-code project.

I ran the sync out and after pulling all the files from the hourofcode project. 


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-902)



# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
