### PR TITLE
Revert "Revert "Add EIR scholarship option for CSP only""

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -90,6 +90,7 @@ def main
     generate_multiple_constants(
       %w(
         COURSES
+        COURSE_KEY_MAP
         SUBJECT_NAMES
         SUBJECTS
         LEGACY_SUBJECTS
@@ -151,7 +152,7 @@ def main
 
   generate_shared_js_file(
     generate_constants(
-      'SCHOLARSHIP_DROPDOWN_OPTIONS',
+      'COURSE_SPECIFIC_SCHOLARSHIP_DROPDOWN_OPTIONS',
       source_module: Pd::ScholarshipInfoConstants,
       transform_keys: true
     ),

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -37,6 +37,7 @@ import {
   ScoreableQuestions as FacilitatorScoreableQuestions,
   ValidScores as FacilitatorValidScores
 } from '@cdo/apps/generated/pd/facilitatorApplicationConstants';
+import {CourseSpecificScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
 import _ from 'lodash';
 import {
   ApplicationStatuses,
@@ -574,6 +575,11 @@ export class DetailViewContents extends React.Component {
     return (
       <ScholarshipDropdown
         scholarshipStatus={this.state.scholarship_status}
+        dropdownOptions={
+          CourseSpecificScholarshipDropdownOptions[
+            this.props.applicationData.course
+          ]
+        }
         onChange={this.handleScholarshipStatusChange}
         disabled={!this.state.editing}
       />

--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {FormGroup} from 'react-bootstrap';
 import Select from 'react-select';
-import {ScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
 
 export class ScholarshipDropdown extends React.Component {
   static propTypes = {
     scholarshipStatus: PropTypes.string,
+    dropdownOptions: PropTypes.array,
     onChange: PropTypes.func,
     disabled: PropTypes.bool
   };
@@ -18,7 +18,7 @@ export class ScholarshipDropdown extends React.Component {
           clearable={false}
           value={this.props.scholarshipStatus}
           onChange={this.props.onChange}
-          options={ScholarshipDropdownOptions}
+          options={this.props.dropdownOptions}
           disabled={this.props.disabled}
         />
       </FormGroup>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -8,8 +8,11 @@ import {workshopEnrollmentStyles as styles} from '../workshop_enrollment_styles'
 import {ScholarshipDropdown} from '../../components/scholarshipDropdown';
 import Spinner from '../../components/spinner';
 import {WorkshopAdmin, ProgramManager} from '../permission';
-import {ScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
-import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {CourseSpecificScholarshipDropdownOptions} from '@cdo/apps/generated/pd/scholarshipInfoConstants';
+import {
+  SubjectNames,
+  CourseKeyMap
+} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const CSF = 'CS Fundamentals';
 const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
@@ -103,10 +106,19 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
     return strs.join(', ');
   }
 
+  // Gets variable containing appropriate list of dropdown options given a course
+  scholarshipDropdownOptions(course) {
+    return CourseSpecificScholarshipDropdownOptions[course];
+  }
+
   scholarshipInfo(enrollment) {
     if (enrollment.scholarship_ineligible_reason) {
       return <td>{enrollment.scholarship_ineligible_reason}</td>;
     }
+
+    let dropdownOptions = this.scholarshipDropdownOptions(
+      CourseKeyMap[this.props.workshopCourse]
+    );
 
     if (
       this.props.permissionList.has(ProgramManager) ||
@@ -116,12 +128,13 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
         <td>
           <ScholarshipDropdown
             scholarshipStatus={enrollment.scholarship_status}
+            dropdownOptions={dropdownOptions}
             onChange={this.handleScholarshipStatusChange.bind(this, enrollment)}
           />
         </td>
       );
     } else {
-      let scholarshipInfo = ScholarshipDropdownOptions.find(o => {
+      let scholarshipInfo = dropdownOptions.find(o => {
         return o.value === enrollment.scholarship_status;
       });
       return <td>{scholarshipInfo ? scholarshipInfo.label : '--'}</td>;

--- a/dashboard/app/models/pd/scholarship_info.rb
+++ b/dashboard/app/models/pd/scholarship_info.rb
@@ -33,9 +33,9 @@ class Pd::ScholarshipInfo < ActiveRecord::Base
   belongs_to :enrollment, class_name: 'Pd::Enrollment', foreign_key: :pd_enrollment_id
   belongs_to :application, class_name: 'Pd::Application::TeacherApplicationBase', foreign_key: :pd_application_id
 
+  validate :scholarship_must_be_valid_for_course
   validates_presence_of :user_id
   validates_inclusion_of :application_year, in: SCHOLARSHIP_YEARS
-  validates_inclusion_of :scholarship_status, in: SCHOLARSHIP_STATUSES
   validates_inclusion_of :course, in: COURSE_KEY_MAP.values
 
   def self.update_or_create(user, application_year, course, scholarship_status)
@@ -52,5 +52,12 @@ class Pd::ScholarshipInfo < ActiveRecord::Base
   # Translate a SCHOLARSHIP_STATUSES value to a more friendly label
   def self.get_scholarship_label(value)
     SCHOLARSHIP_DROPDOWN_OPTIONS.find {|option| option[:value] == value}[:label]
+  end
+
+  # Confirm scholarship status is valid (course-specific)
+  def scholarship_must_be_valid_for_course
+    unless COURSE_SPECIFIC_SCHOLARSHIP_STATUSES[course].include? scholarship_status
+      errors.add(:scholarship_status, 'must be in list of possible statuses.')
+    end
   end
 end

--- a/dashboard/app/models/pd/workshop_constants.rb
+++ b/dashboard/app/models/pd/workshop_constants.rb
@@ -99,11 +99,5 @@ module Pd
       COURSE_CSD => {course_name: 'csd-2019'},
       COURSE_CSP => {course_name: 'csp-2019'}
     }.freeze
-
-    COURSE_KEY_MAP = {
-      COURSE_CSF => 'csf',
-      COURSE_CSD => 'csd',
-      COURSE_CSP => 'csp'
-    }
   end
 end

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -416,6 +416,14 @@ FactoryGirl.define do
     end
   end
 
+  factory :pd_scholarship_info, class: 'Pd::ScholarshipInfo' do
+    association :user, factory: :teacher
+
+    course Pd::Workshop::COURSE_KEY_MAP[Pd::Workshop::COURSE_CSP]
+    application_year Pd::Application::ApplicationConstants::YEAR_19_20
+    scholarship_status Pd::ScholarshipInfoConstants::YES_CDO
+  end
+
   factory :pd_attendance, class: 'Pd::Attendance' do
     association :session, factory: :pd_session
     association :teacher

--- a/dashboard/test/models/pd/scholarship_info_test.rb
+++ b/dashboard/test/models/pd/scholarship_info_test.rb
@@ -42,4 +42,14 @@ class Pd::ScholarshipInfoTest < ActiveSupport::TestCase
     scholarship_info.reload
     assert_equal Pd::ScholarshipInfoConstants::YES_OTHER, scholarship_info.scholarship_status
   end
+
+  test 'cannot create CSF scholarship info with CSP-specific scholarship status' do
+    csf_scholarship_info = build :pd_scholarship_info, course: COURSE_KEY_MAP[COURSE_CSF], scholarship_status: Pd::ScholarshipInfo::YES_EIR
+    assert_not_nil csf_scholarship_info.errors[:scholarship_status]
+  end
+
+  test 'can create CSP scholarship info with CSP-specific scholarship status' do
+    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfo::YES_EIR
+    assert csp_scholarship_info.valid?
+  end
 end

--- a/lib/cdo/shared_constants/pd/scholarship_info_constants.rb
+++ b/lib/cdo/shared_constants/pd/scholarship_info_constants.rb
@@ -6,10 +6,22 @@ module Pd
       YES_OTHER = 'yes_other'.freeze
     ].freeze
 
+    COURSE_SPECIFIC_SCHOLARSHIP_STATUSES = {
+      'csp' => SCHOLARSHIP_STATUSES + [YES_EIR = 'yes_eir'],
+      'csd' => SCHOLARSHIP_STATUSES,
+      'csf' => SCHOLARSHIP_STATUSES
+    }
+
     SCHOLARSHIP_DROPDOWN_OPTIONS = [
       {value: NO, label: "No, paid teacher"},
       {value: YES_CDO, label: "Yes, Code.org scholarship"},
       {value: YES_OTHER, label: "Yes, other funding (non code.org)"}
-    ]
+    ].freeze
+
+    COURSE_SPECIFIC_SCHOLARSHIP_DROPDOWN_OPTIONS = {
+      'csp' => SCHOLARSHIP_DROPDOWN_OPTIONS + [{value: YES_EIR, label: "Yes, EIR scholarship"}],
+      'csd' => SCHOLARSHIP_DROPDOWN_OPTIONS,
+      'csf' => SCHOLARSHIP_DROPDOWN_OPTIONS
+    }
   end
 end

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -133,5 +133,11 @@ module Pd
       local_summer: SUBJECT_SUMMER_WORKSHOP,
       both: 'both'
     }.freeze
+
+    COURSE_KEY_MAP = {
+      COURSE_CSF => 'csf',
+      COURSE_CSD => 'csd',
+      COURSE_CSP => 'csp'
+    }
   end
 end


### PR DESCRIPTION
Takes this PR (already reviewed): https://github.com/code-dot-org/code-dot-org/pull/32946

Adds `pd_scholarship_info` factory that was missing (the missing factory was removed as part of this [PR](https://github.com/code-dot-org/code-dot-org/pull/32948), which was rolled back as a result of a miscommunication with the programs team).