### PR TITLE
Video player: redirect deprecated test page

### DIFF
--- a/dashboard/app/controllers/videos_controller.rb
+++ b/dashboard/app/controllers/videos_controller.rb
@@ -7,8 +7,9 @@ class VideosController < ApplicationController
 
   before_action :set_video, only: [:edit, :update]
 
+  # This page is currently deprecated, so let's redirect to related content.
   def test
-    @video = Video.first
+    redirect_to CDO.code_org_url('/educate/it')
   end
 
   def embed


### PR DESCRIPTION
Now that the test page is removed from https://studio.code.org/videos/test, it can redirect to https://code.org/educate/it, rather than erroring.

Followup to https://github.com/code-dot-org/code-dot-org/pull/32816
