### PR TITLE
Conditionally show (auto-email) text for teacher application status

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/cohort_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_view_table.jsx
@@ -10,7 +10,7 @@ import _, {orderBy} from 'lodash';
 import moment from 'moment';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
 import {WorkshopTypes} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
-import {StatusColors, ApplicationStatuses} from './constants';
+import {StatusColors, getApplicationStatuses} from './constants';
 import {
   UNMATCHED_PARTNER_VALUE,
   ALL_PARTNERS_VALUE,
@@ -158,7 +158,7 @@ export class CohortViewTable extends React.Component {
         cell: {
           formatters: [
             status =>
-              ApplicationStatuses[this.props.viewType][status] ||
+              getApplicationStatuses(this.props.viewType)[status] ||
               _.upperFirst(status)
           ],
           transforms: [

--- a/apps/src/code-studio/pd/application_dashboard/constants.js
+++ b/apps/src/code-studio/pd/application_dashboard/constants.js
@@ -46,35 +46,6 @@ export const StatusColors = {
 };
 
 /**
- * Valid statuses for this year's applications.
- * Format per application type is {value: label}
- */
-export const ApplicationStatuses = {
-  teacher: {
-    unreviewed: 'Unreviewed',
-    pending: 'Pending',
-    waitlisted: 'Waitlisted (auto-email)',
-    declined: 'Declined (auto-email)',
-    accepted_not_notified: 'Accepted - Not notified',
-    accepted_notified_by_partner: 'Accepted - Notified by partner',
-    accepted_no_cost_registration:
-      'Accepted - No cost registration (auto-email)',
-    registration_sent: 'Registration Sent (auto-email)',
-    paid: 'Paid',
-    withdrawn: 'Withdrawn'
-  },
-  facilitator: {
-    unreviewed: 'Unreviewed',
-    pending: 'Pending',
-    interview: 'Interview',
-    waitlisted: 'Waitlisted',
-    accepted: 'Accepted',
-    declined: 'Declined',
-    withdrawn: 'Withdrawn'
-  }
-};
-
-/**
  * Statuses that represent "finalized" applications
  */
 export const ApplicationFinalStatuses = [
@@ -99,3 +70,43 @@ export const ScholarshipStatusRequiredStatuses = [
   'registration_sent',
   'paid'
 ];
+
+/**
+ * Valid statuses for this year's applications.
+ * Format per application type is {value: label}
+ */
+export function getApplicationStatuses(type, addAutoEmail = true) {
+  if (type === 'teacher') {
+    return {
+      unreviewed: 'Unreviewed',
+      pending: 'Pending',
+      waitlisted: `Waitlisted${autoEmailText(addAutoEmail)}`,
+      declined: `Declined${autoEmailText(addAutoEmail)}`,
+      accepted_not_notified: 'Accepted - Not notified',
+      accepted_notified_by_partner: 'Accepted - Notified by partner',
+      accepted_no_cost_registration: `Accepted - No cost registration${autoEmailText(
+        addAutoEmail
+      )}`,
+      registration_sent: `Registration Sent${autoEmailText(addAutoEmail)}`,
+      paid: 'Paid',
+      withdrawn: 'Withdrawn'
+    };
+  } else if (type === 'facilitator') {
+    return {
+      unreviewed: 'Unreviewed',
+      pending: 'Pending',
+      interview: 'Interview',
+      waitlisted: 'Waitlisted',
+      accepted: 'Accepted',
+      declined: 'Declined',
+      withdrawn: 'Withdrawn'
+    };
+  }
+}
+
+function autoEmailText(addAutoEmail) {
+  if (addAutoEmail) {
+    return ' (auto-email)';
+  }
+  return '';
+}

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -243,11 +243,7 @@ export class DetailViewContents extends React.Component {
       fit_workshop_id: this.props.applicationData.fit_workshop_id,
       scholarship_status: this.props.applicationData.scholarship_status,
       bonus_point_questions: this.scoreableQuestions['bonusPoints'],
-      cantSaveStatusReason: '',
-      statuses: getApplicationStatuses(
-        this.props.viewType,
-        this.props.applicationData.update_emails_sent_by_system
-      )
+      cantSaveStatusReason: ''
     };
   }
 
@@ -258,20 +254,6 @@ export class DetailViewContents extends React.Component {
       !this.props.applicationData.notes
     ) {
       this.setState({notes: DEFAULT_NOTES});
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    if (
-      prevProps.applicationData.update_emails_sent_by_system !==
-      this.props.applicationData.update_emails_sent_by_system
-    ) {
-      this.setState({
-        statuses: getApplicationStatuses(
-          this.props.viewType,
-          this.props.applicationData.update_emails_sent_by_system
-        )
-      });
     }
   }
 
@@ -308,7 +290,11 @@ export class DetailViewContents extends React.Component {
       this.setState({
         cantSaveStatusReason: `Please assign a scholarship status to this applicant before setting this
                               applicant's status to ${
-                                this.state.statuses[event.target.value]
+                                getApplicationStatuses(
+                                  this.props.viewType,
+                                  this.props.applicationData
+                                    .update_emails_sent_by_system
+                                )[event.target.value]
                               }.`,
         showCantSaveStatusDialog: true
       });
@@ -664,6 +650,10 @@ export class DetailViewContents extends React.Component {
   };
 
   renderStatusSelect = () => {
+    const statuses = getApplicationStatuses(
+      this.props.viewType,
+      this.props.applicationData.update_emails_sent_by_system
+    );
     const selectControl = (
       <div>
         <FormControl
@@ -677,9 +667,9 @@ export class DetailViewContents extends React.Component {
           onChange={this.handleStatusChange}
           style={styles.statusSelect}
         >
-          {Object.keys(this.state.statuses).map((status, i) => (
+          {Object.keys(statuses).map((status, i) => (
             <option value={status} key={i}>
-              {this.state.statuses[status]}
+              {statuses[status]}
             </option>
           ))}
         </FormControl>

--- a/apps/src/code-studio/pd/application_dashboard/quick_view.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view.jsx
@@ -19,7 +19,7 @@ import RegionalPartnerDropdown, {
 import QuickViewTable from './quick_view_table';
 import Spinner from '../components/spinner';
 import $ from 'jquery';
-import {ApplicationStatuses} from './constants';
+import {getApplicationStatuses} from './constants';
 import {Button, FormGroup, ControlLabel, Row, Col} from 'react-bootstrap';
 
 const styles = {
@@ -65,7 +65,7 @@ export class QuickView extends React.Component {
   }
 
   componentWillMount() {
-    const statusList = ApplicationStatuses[this.props.route.viewType];
+    const statusList = getApplicationStatuses(this.props.route.viewType);
     this.statuses = Object.keys(statusList).map(v => ({
       value: v,
       label: statusList[v]

--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -7,7 +7,7 @@ import * as sort from 'sortabular';
 import color from '@cdo/apps/util/color';
 import {Button} from 'react-bootstrap';
 import _, {orderBy} from 'lodash';
-import {StatusColors, ApplicationStatuses} from './constants';
+import {StatusColors, getApplicationStatuses} from './constants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
 import PrincipalApprovalButtons from './principal_approval_buttons';
 
@@ -150,7 +150,7 @@ export class QuickViewTable extends React.Component {
         cell: {
           formatters: [
             status =>
-              ApplicationStatuses[this.props.viewType][status] ||
+              getApplicationStatuses(this.props.viewType)[status] ||
               _.upperFirst(status)
           ],
           transforms: [

--- a/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import {Table, Button} from 'react-bootstrap';
-import {StatusColors, ApplicationStatuses} from './constants';
+import {StatusColors, getApplicationStatuses} from './constants';
 import _ from 'lodash';
 import color from '@cdo/apps/util/color';
 
@@ -65,7 +65,7 @@ export class SummaryTable extends React.Component {
       return (
         <tr key={i}>
           <td style={{...styles.statusCell[status]}}>
-            {ApplicationStatuses[this.props.applicationType][status] ||
+            {getApplicationStatuses(this.props.applicationType)[status] ||
               _.upperFirst(status)}
           </td>
           {this.showLocked && <td>{statusData.locked}</td>}

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -1,6 +1,6 @@
 import {DetailViewContents} from '@cdo/apps/code-studio/pd/application_dashboard/detail_view_contents';
 import {
-  ApplicationStatuses,
+  getApplicationStatuses,
   ApplicationFinalStatuses,
   ScholarshipStatusRequiredStatuses
 } from '@cdo/apps/code-studio/pd/application_dashboard/constants';
@@ -125,20 +125,20 @@ describe('DetailViewContents', () => {
 
       // lock button is disabled for all statuses except "finalized"
       // statuses in the constant are an object {value: label}
-      Object.keys(ApplicationStatuses[applicationType.toLowerCase()]).forEach(
-        status => {
-          const statusIsFinal = ApplicationFinalStatuses.includes(status);
+      Object.keys(
+        getApplicationStatuses(applicationType.toLowerCase())
+      ).forEach(status => {
+        const statusIsFinal = ApplicationFinalStatuses.includes(status);
+        detailView
+          .find('#DetailViewHeader select')
+          .simulate('change', {target: {value: status}});
+        expect(
           detailView
-            .find('#DetailViewHeader select')
-            .simulate('change', {target: {value: status}});
-          expect(
-            detailView
-              .find('#DetailViewHeader Button')
-              .first()
-              .prop('disabled')
-          ).to.equal(!statusIsFinal);
-        }
-      );
+            .find('#DetailViewHeader Button')
+            .first()
+            .prop('disabled')
+        ).to.equal(!statusIsFinal);
+      });
     });
 
     it(`disables status dropdown when locked`, () => {
@@ -381,22 +381,20 @@ describe('DetailViewContents', () => {
   describe('Teacher application scholarship status', () => {
     let detailView;
 
-    beforeEach(() => {
-      detailView = mountDetailView('Teacher', {
-        applicationData: {
-          ...DEFAULT_APPLICATION_DATA,
-          status: 'unreviewed',
-          scholarship_status: null
-        }
-      });
-    });
-
     afterEach(() => {
       detailView.unmount();
     });
 
     for (const applicationStatus of ScholarshipStatusRequiredStatuses) {
       it(`is required in order to set application status to ${applicationStatus}`, () => {
+        detailView = mountDetailView('Teacher', {
+          applicationData: {
+            ...DEFAULT_APPLICATION_DATA,
+            status: 'unreviewed',
+            scholarship_status: null,
+            update_emails_sent_by_system: false
+          }
+        });
         expect(isModalShowing()).to.be.false;
         expect(getScholarshipStatus()).to.be.null;
         expect(getApplicationStatus()).to.equal('unreviewed');
@@ -427,6 +425,14 @@ describe('DetailViewContents', () => {
       'withdrawn'
     ]) {
       it(`is not required to set application status to ${applicationStatus}`, () => {
+        detailView = mountDetailView('Teacher', {
+          applicationData: {
+            ...DEFAULT_APPLICATION_DATA,
+            status: 'unreviewed',
+            scholarship_status: null,
+            update_emails_sent_by_system: false
+          }
+        });
         expect(isModalShowing()).to.be.false;
         expect(getScholarshipStatus()).to.be.null;
 
@@ -435,6 +441,48 @@ describe('DetailViewContents', () => {
         expect(getApplicationStatus()).to.equal(applicationStatus);
       });
     }
+
+    it('appends auto email text if set to true', () => {
+      detailView = mountDetailView('Teacher', {
+        applicationData: {
+          ...DEFAULT_APPLICATION_DATA,
+          status: 'unreviewed',
+          scholarship_status: null,
+          update_emails_sent_by_system: true
+        },
+        viewType: 'teacher'
+      });
+      let options = detailView.find('#DetailViewHeader select').find('option');
+      let applicationStatuses = Object.values(
+        getApplicationStatuses('teacher', true)
+      );
+      var i = 0;
+      options.forEach(option => {
+        expect(option.text()).to.equal(applicationStatuses[i]);
+        i++;
+      });
+    });
+
+    it('does not appends auto email text if set to false', () => {
+      detailView = mountDetailView('Teacher', {
+        applicationData: {
+          ...DEFAULT_APPLICATION_DATA,
+          status: 'unreviewed',
+          scholarship_status: null,
+          update_emails_sent_by_system: false
+        },
+        viewType: 'teacher'
+      });
+      let options = detailView.find('#DetailViewHeader select').find('option');
+      let applicationStatuses = Object.values(
+        getApplicationStatuses('teacher', false)
+      );
+      var i = 0;
+      options.forEach(option => {
+        expect(option.text()).to.equal(applicationStatuses[i]);
+        i++;
+      });
+    });
 
     function clickEditButton() {
       detailView

--- a/dashboard/app/serializers/api/v1/pd/application_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_serializer.rb
@@ -4,7 +4,7 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
   attributes(
     :regional_partner_name,
     :regional_partner_id,
-    :regional_partner_emails_sent_by_system,
+    :update_emails_sent_by_system,
     :locked,
     :notes,
     :notes_2,
@@ -153,8 +153,10 @@ class Api::V1::Pd::ApplicationSerializer < ActiveModel::Serializer
     object.try(:principal_approval_state)
   end
 
-  def regional_partner_emails_sent_by_system
-    object&.regional_partner&.applications_decision_emails == RegionalPartner::SENT_BY_SYSTEM
+  # update emails are sent by the system if there is no regional partner or if the regional partner
+  # has not set the decision email flag to SENT_BY_PARTNER
+  def update_emails_sent_by_system
+    !(object&.regional_partner&.applications_decision_emails == RegionalPartner::SENT_BY_PARTNER)
   end
 
   def meets_scholarship_criteria


### PR DESCRIPTION
[PLC-697](https://codedotorg.atlassian.net/browse/PLC-697)
On the application dashboard, our application status dropdowns include "(auto-email)" in some of the status descriptions as a reminder that changing the application to that status will send an email. However, some regional partners opt out of our auto-email system and for them this annotation can be misleading.

This PR updates the logic to omit (auto-email) if we know the regional partner will send their own emails. We only have this data on the individual application page, so on the summary pages we will continue to show the (auto-email) annotation. 

Now if we know the partner sends their own email the dropdown looks like this:
<img width="248" alt="Screen Shot 2020-02-06 at 9 45 23 AM" src="https://user-images.githubusercontent.com/33666587/73964372-e4f1d580-48c6-11ea-9ccb-c9618b5fe2bd.png">

Instead of this:
<img width="326" alt="Screen Shot 2020-02-06 at 9 44 54 AM" src="https://user-images.githubusercontent.com/33666587/73964342-d9061380-48c6-11ea-99c3-b904d98ceb2d.png">

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-697)

## Testing story
Added unit tests on the detail view page to validate the dropdown text changes based on the value of the update_emails_sent_by_system flag. Also validated via manual UI testing, including that changing the partner will change the dropdown text if needed.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
