### PR TITLE
actually add new simple_embedded theme after removing old layout

### DIFF
--- a/pegasus/sites.v3/code.org/themes/simple_embedded.haml
+++ b/pegasus/sites.v3/code.org/themes/simple_embedded.haml
@@ -1,0 +1,11 @@
+!!! 5
+%html
+  %head
+    =view :fonts
+    %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/common.css'}
+    %link{rel:'stylesheet', type:'text/css', href:'/style.css'}
+    %link{rel:'stylesheet', type:'text/css', href:'/css/brstrap-nonresponsive.css'}
+    %link{rel:'stylesheet', type:'text/css', href:'/css/simple-embedded.css'}
+    %script{src:'/js/jquery.min.js'}
+  %body
+    = body


### PR DESCRIPTION
follow-up to https://github.com/code-dot-org/code-dot-org/pull/32932, which attempted to convert the simple_embedded layout to a theme, but forgot to actually add the new theme.

Opening this PR to quickly resolve the issue (which was caught by honeybadger: https://app.honeybadger.io/projects/34365/faults/60513237); a unit test that would have caught this issue is incoming.