### PR TITLE
Log thread backtraces and GC stats for app debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,7 @@ gem 'gctools', github: 'wjordan/gctools', ref: 'ruby-2.5'
 # Optimizes copy-on-write memory usage with GC before web-application fork.
 gem 'nakayoshi_fork'
 # Ref: https://github.com/puma/puma/pull/1646
-gem 'puma', github: 'wjordan/puma', ref: 'out_of_band'
+gem 'puma', github: 'wjordan/puma', branch: 'debugging'
 gem 'puma_worker_killer'
 gem 'unicorn', '~> 5.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,8 +166,8 @@ GIT
 
 GIT
   remote: https://github.com/wjordan/puma.git
-  revision: 2ab96d67341a0ae1a4baf6bf80790389abc159ac
-  ref: out_of_band
+  revision: c0f187bc4eba3b1391b9e7c4c4ce39e3cc03fbac
+  branch: debugging
   specs:
     puma (3.12.0)
 

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -33,3 +33,12 @@ end
 
 require 'gctools/oobgc'
 out_of_band {GC::OOB.run}
+
+# Log thread backtraces and GC stats from all worker processes every second when enabled.
+require 'dynamic_config/gatekeeper'
+require 'puma/plugin/log_app_stats'
+LogAppStats.stats_proc = -> {Gatekeeper.allows('logAppStatsDashboard')}
+plugin :log_app_stats
+worker_check_interval 1
+thread_backtraces
+gc_stats

--- a/lib/cdo/app_server_hooks.rb
+++ b/lib/cdo/app_server_hooks.rb
@@ -13,6 +13,9 @@ module Cdo
       #   sudo service dashboard upgrade && sudo service pegasus upgrade
       require 'dynamic_config/gatekeeper'
       require 'dynamic_config/dcdo'
+      Gatekeeper.after_fork
+      DCDO.after_fork
+
       if Gatekeeper.allows('enableWebServiceProcessRollingRestart')
         require 'puma_worker_killer'
 

--- a/lib/puma/plugin/log_app_stats.rb
+++ b/lib/puma/plugin/log_app_stats.rb
@@ -1,0 +1,29 @@
+require 'puma'
+require 'puma/plugin'
+require 'active_support/core_ext/module/attribute_accessors'
+
+# Puma plugin to log app stats every second.
+module LogAppStats
+  mattr_accessor(:stats_proc) {-> {true}}
+
+  Puma::Plugin.create do
+    def start(launcher)
+      @launcher = launcher
+      in_background(&method(:stats))
+    end
+
+    private
+
+    def stats
+      loop do
+        if LogAppStats.stats_proc.call
+          @launcher.events.log @launcher.stats
+        end
+      rescue StandardError => e
+        @launcher.events.error "LogAppStats failed:\n  #{e}\n  #{e.backtrace.join("\n    ")}"
+      ensure
+        sleep 1
+      end
+    end
+  end
+end

--- a/pegasus/config/puma.rb
+++ b/pegasus/config/puma.rb
@@ -34,7 +34,6 @@ require 'gctools/oobgc'
 out_of_band {GC::OOB.run}
 
 # Log thread backtraces and GC stats from all worker processes every second when enabled.
-require 'dynamic_config/gatekeeper'
 require 'puma/plugin/log_app_stats'
 LogAppStats.stats_proc = -> {Gatekeeper.allows('logAppStatsPegasus')}
 plugin :log_app_stats

--- a/pegasus/config/puma.rb
+++ b/pegasus/config/puma.rb
@@ -32,3 +32,12 @@ end
 
 require 'gctools/oobgc'
 out_of_band {GC::OOB.run}
+
+# Log thread backtraces and GC stats from all worker processes every second when enabled.
+require 'dynamic_config/gatekeeper'
+require 'puma/plugin/log_app_stats'
+LogAppStats.stats_proc = -> {Gatekeeper.allows('logAppStatsPegasus')}
+plugin :log_app_stats
+worker_check_interval 1
+thread_backtraces
+gc_stats


### PR DESCRIPTION
## Description
Three changes in this PR:

1. Update our Puma fork to the latest upstream version (4.3.1), with a [slightly different approach to request-balancing](https://github.com/wjordan/puma/commit/68cc97208a59937fb0d7ef5e8e8cd5e1ba6862b4) and some [extra debugging hooks for thread backtrace](https://github.com/wjordan/puma/commit/be78a1c500dfb4d1cb09dee10501b698d6d54c5b) and [gc stats](https://github.com/wjordan/puma/commit/fee32c3fa4a3177559e0f580a2b48f4998f899de);
2. Add a plugin ([`LogAppStats`](https://github.com/code-dot-org/code-dot-org/compare/log_app_stats?expand=1#diff-d1ffd7d95b42fb7cd92d2d57b08918a0)) to log app stats every second across all worker processes for debugging purposes, that can be dynamically switched on/off by a flag.
3. Add `before_fork` code to (re-)launch DCDO and Gatekeeper update-threads in the parent. This fixes a bug where DCDO/Gatekeeper entries were not getting updated in the daemonized parent process in cluster (`workers` > 0) + daemon (`-d`) mode.

### Testing Story
Manual testing on an adhoc to confirm the logging and dynamic configuration work as expected. No automated testing at this point since the instrumentation was developed quickly, and intended to be enabled only for temporary/debugging purposes.