### PR TITLE
Add deleted_at column to regional_partner_mappings

### DIFF
--- a/dashboard/app/models/pd/regional_partner_mapping.rb
+++ b/dashboard/app/models/pd/regional_partner_mapping.rb
@@ -8,6 +8,7 @@
 #  zip_code            :string(255)
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  deleted_at          :datetime
 #
 # Indexes
 #

--- a/dashboard/app/models/pd/regional_partner_mapping.rb
+++ b/dashboard/app/models/pd/regional_partner_mapping.rb
@@ -18,6 +18,7 @@
 require 'state_abbr'
 
 class Pd::RegionalPartnerMapping < ActiveRecord::Base
+  acts_as_paranoid # use deleted_at column instead of deleting rows
   belongs_to :regional_partner
 
   validates_inclusion_of :state, in: STATE_ABBR_WITH_DC_HASH.keys.map(&:to_s), if: :state?

--- a/dashboard/app/models/pd/regional_partner_mapping.rb
+++ b/dashboard/app/models/pd/regional_partner_mapping.rb
@@ -18,7 +18,6 @@
 require 'state_abbr'
 
 class Pd::RegionalPartnerMapping < ActiveRecord::Base
-  acts_as_paranoid # use deleted_at column instead of deleting rows
   belongs_to :regional_partner
 
   validates_inclusion_of :state, in: STATE_ABBR_WITH_DC_HASH.keys.map(&:to_s), if: :state?

--- a/dashboard/db/migrate/20200206194012_add_deleted_at_to_pd_regional_partner_mapping.rb
+++ b/dashboard/db/migrate/20200206194012_add_deleted_at_to_pd_regional_partner_mapping.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToPdRegionalPartnerMapping < ActiveRecord::Migration[5.0]
+  def change
+    add_column :pd_regional_partner_mappings, :deleted_at, :datetime
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200115225048) do
+ActiveRecord::Schema.define(version: 20200206194012) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -801,6 +801,7 @@ ActiveRecord::Schema.define(version: 20200115225048) do
     t.string   "zip_code"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
+    t.datetime "deleted_at"
     t.index ["regional_partner_id", "state", "zip_code"], name: "index_pd_regional_partner_mappings_on_id_and_state_and_zip_code", unique: true, using: :btree
     t.index ["regional_partner_id"], name: "index_pd_regional_partner_mappings_on_regional_partner_id", using: :btree
   end


### PR DESCRIPTION
Pre-work for [PLC-730](https://codedotorg.atlassian.net/browse/PLC-730)
Add deleted_at column to pd_regional_partner_mappings table. This enables soft-delete on pd_regional_partner_mappings, which will make future bulk update for mappings safer, as we will be able to undo bad deletions. Will add acts_as_paranoid to pd_regional_partner_mappings in a follow-up PR.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-730)

## Testing story
Validated functionality of mappings (zip code search, view zip codes) still works with new column, and does not show any deleted items.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
