### PR TITLE
[⭐️Josh S. Wish ⭐️] Section edit option ordering and icon update 

### DIFF
--- a/apps/src/templates/tables/QuickActionsCell.jsx
+++ b/apps/src/templates/tables/QuickActionsCell.jsx
@@ -127,13 +127,14 @@ export default class QuickActionsCell extends Component {
     const styleByType =
       type === QuickActionsCellType.header
         ? styles.actionButton['header']
-        : this.state.open
-        ? styles.hoverFocus['body']
         : styles.actionButton['body'];
+
+    const hoverStyle = this.state.open ? styles.hoverFocus['body'] : null;
 
     const iconStyle = {
       ...styles.icon,
-      ...styleByType
+      ...styleByType,
+      ...hoverStyle
     };
 
     return (

--- a/apps/src/templates/tables/QuickActionsCell.jsx
+++ b/apps/src/templates/tables/QuickActionsCell.jsx
@@ -30,7 +30,7 @@ const styles = {
     [QuickActionsCellType.header]: {
       fontSize: 20,
       lineHeight: '15px',
-      color: color.darker_gray
+      color: color.charcoal
     }
   },
   hoverFocus: {

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import color from '../../util/color';
 import {sortableSectionShape, OAuthSectionTypes} from './shapes.jsx';
-import PopUpMenu, {MenuBreak} from '@cdo/apps/lib/ui/PopUpMenu';
+import PopUpMenu from '@cdo/apps/lib/ui/PopUpMenu';
 import i18n from '@cdo/locale';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import {
@@ -115,6 +115,12 @@ class SectionActionDropdown extends Component {
       <span>
         <QuickActionsCell>
           <PopUpMenu.Item
+            onClick={this.onClickEdit}
+            className="edit-section-details-link"
+          >
+            {i18n.editSectionDetails()}
+          </PopUpMenu.Item>
+          <PopUpMenu.Item
             href={teacherDashboardUrl(sectionData.id, '/progress')}
           >
             {i18n.sectionViewProgress()}
@@ -134,13 +140,6 @@ class SectionActionDropdown extends Component {
                   : i18n.printLoginCards()}
               </PopUpMenu.Item>
             )}
-          <MenuBreak />
-          <PopUpMenu.Item
-            onClick={this.onClickEdit}
-            className="edit-section-details-link"
-          >
-            {i18n.editSectionDetails()}
-          </PopUpMenu.Item>
           <PrintCertificates
             sectionId={sectionData.id}
             assignmentName={sectionData.assignmentNames[0]}

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -122,11 +122,13 @@ class SectionActionDropdown extends Component {
           </PopUpMenu.Item>
           <PopUpMenu.Item
             href={teacherDashboardUrl(sectionData.id, '/progress')}
+            className="view-progress-link"
           >
             {i18n.sectionViewProgress()}
           </PopUpMenu.Item>
           <PopUpMenu.Item
             href={teacherDashboardUrl(sectionData.id, '/manage_students')}
+            className="manage-students-link"
           >
             {i18n.manageStudents()}
           </PopUpMenu.Item>
@@ -134,6 +136,7 @@ class SectionActionDropdown extends Component {
             sectionData.loginType !== OAuthSectionTypes.clever && (
               <PopUpMenu.Item
                 href={teacherDashboardUrl(sectionData.id, '/login_info')}
+                className="print-login-link"
               >
                 {sectionData.loginType === SectionLoginType.email
                   ? i18n.joinInstructions()

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -113,7 +113,7 @@ class SectionActionDropdown extends Component {
 
     return (
       <span>
-        <QuickActionsCell>
+        <QuickActionsCell type={'header'}>
           <PopUpMenu.Item
             onClick={this.onClickEdit}
             className="edit-section-details-link"

--- a/dashboard/test/ui/features/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/section_action_dropdown.feature
@@ -12,7 +12,7 @@ Feature: Using the SectionActionDropdown
 
     When I sign in as "Teacher_Sally" and go home
     And I open the section action dropdown
-    And I press the child number 0 of class ".pop-up-menu-item"
+    And I click selector ".view-progress-link"
     And I wait until current URL contains "/progress"
 
   # * Check that we get redirected to the right page
@@ -20,7 +20,7 @@ Feature: Using the SectionActionDropdown
     Given I am a teacher
     And I create a new section and go home
     And I open the section action dropdown
-    And I press the child number 1 of class ".pop-up-menu-item"
+    And I click selector ".manage-students-link"
     And I wait until current URL contains "/manage"
 
   # * Check that we get redirected to the right page
@@ -28,7 +28,7 @@ Feature: Using the SectionActionDropdown
     Given I am a teacher
     And I create a new section and go home
     And I open the section action dropdown
-    And I press the child number 2 of class ".pop-up-menu-item"
+    And I click selector ".print-login-link"
     And I wait until current URL contains "/login_info"
 
   # * Add a section and then opens the edit dialog.
@@ -38,7 +38,7 @@ Feature: Using the SectionActionDropdown
     Given I am a teacher
     And I create a new section and go home
     And I open the section action dropdown
-    And I press the child number 3 of class ".pop-up-menu-item"
+    And I click selector ".edit-section-details-link"
     And I press the first ".uitest-saveButton" element
 
   # * Checks that section can be hidden and shown


### PR DESCRIPTION
It's not immediately obvious to teachers how to manage section settings, such as editing section details, which includes changing course assignment. Currently this is done via a dropdown opened by clicking on a chevron.  

BEFORE:

<img width="280" alt="Screen Shot 2020-02-06 at 3 46 07 PM" src="https://user-images.githubusercontent.com/12300669/73988560-e687c180-48f7-11ea-95d7-0d8963658d7f.png">


To be more consistent with our own site and externally, we're switching to use a gear icon here as that more clearly indicates settings controls.  Additionally,  I re-ordered the options to bump "Edit Section Details" to the first option. 

AFTER:
<img width="375" alt="Screen Shot 2020-02-06 at 3 41 49 PM" src="https://user-images.githubusercontent.com/12300669/73988562-e8518500-48f7-11ea-91f8-4c8b6b2c75bc.png">

