### PR TITLE
Fix test username overflow

### DIFF
--- a/dashboard/test/ui/features/weblab/too_young.feature
+++ b/dashboard/test/ui/features/weblab/too_young.feature
@@ -7,7 +7,7 @@ Feature: Weblab Too Young
     And element ".alert-danger" contains text "This content has age restrictions in place"
 
   Scenario: Weblab Allowed for Student in Teacher's Section
-    Given I create a teacher-associated under-13 student named "Hermione"
+    Given I create a teacher-associated under-13 student named "Luna"
     And I am on "http://studio.code.org/projects/weblab/new"
     And I wait until element "#workspace-header" is visible
     And I am on "http://studio.code.org/projects/weblab/new"


### PR DESCRIPTION
@wjordan figured out why this was failing on our test machine: max username is 20 characters, "hermione" is 8, "teacher_" is another 8, leaving only 4 digits for the generated username.  It failed when trying to generate "teacher_hermione10000".

Thanks to a Polyjuice Potion, Hermione is now Luna!
