### PR TITLE
Updated api allowlist for applab

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -26,9 +26,7 @@ class XhrProxyController < ApplicationController
 
   # 'code.org' is included so applab apps can access the tables and properties of other applab apps.
   ALLOWED_HOSTNAME_SUFFIXES = %w(
-    accuweather.com
     apex.oracle.com
-    api.coinmarketcap.com
     api.data.gov
     api.datamuse.com
     api.energidataservice.dk
@@ -44,7 +42,6 @@ class XhrProxyController < ApplicationController
     api.spacexdata.com
     api.spotify.com
     api.themoviedb.org
-    api.thingspeak.com
     api.zippopotam.us
     atlas.media.mit.edu
     bible-api.com
@@ -54,12 +51,12 @@ class XhrProxyController < ApplicationController
     data.cityofchicago.org
     data.gv.at
     data.nasa.gov
+    developer.accuweather.com
     developers.zomato.com
     donordrive.com
     dweet.io
     enclout.com
     githubusercontent.com
-    googleapis.com
     hamlin.myschoolapp.com
     herokuapp.com
     hubblesite.org

--- a/dashboard/test/controllers/xhr_proxy_controller_test.rb
+++ b/dashboard/test/controllers/xhr_proxy_controller_test.rb
@@ -30,7 +30,7 @@ class XhrProxyControllerTest < ActionController::TestCase
   end
 
   test "should handle query parameters" do
-    url = 'https://www.googleapis.com/freebase/v1/search?query=ada&filter=(any%20type:/people/person%20type:/location/citytown)'
+    url = 'https://api.data.gov/ed/collegescorecard/v1/schools?api_key=test'
     stub_request(:get, url).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
     get :get, params: {u: url, c: @channel_id}
     assert_response :success


### PR DESCRIPTION
Got a report of some apis that are no longer supported. Removing/updating those
https://forum.code.org/t/is-there-a-method-in-applab-to-check-internet-connection/32217/2

api.coinmarketcap.com <- removed
query.yahooapis.com <- removed
googleapis.com <- removed
api.thingspeak.com <- removed

accuweather.com -> updated to -> developer.accuweather.com

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
