### PR TITLE
[Applab Datasets] Fix experiment check

### DIFF
--- a/apps/src/storage/dataBrowser/LibraryTable.jsx
+++ b/apps/src/storage/dataBrowser/LibraryTable.jsx
@@ -84,7 +84,8 @@ class LibraryTable extends React.Component {
     );
     const shouldShowTable =
       datasetInfo &&
-      (datasetInfo.published || experiments.SHOW_UNPUBLISHED_FIREBASE_TABLES);
+      (datasetInfo.published ||
+        experiments.isEnabled(experiments.SHOW_UNPUBLISHED_FIREBASE_TABLES));
     if (!shouldShowTable) {
       return null;
     }


### PR DESCRIPTION
Small follow up bug fix to #32973. 
`datasetInfo.published || experiments.SHOW_UNPUBLISHED_FIREBASE_TABLES` is always truthy since `experiments.SHOW_UNPUBLISHED_FIREBASE_TABLES` is a string. I need to instead be checking for `experiments.isEnabled(experiments.SHOW_UNPUBLISHED_FIREBASE_TABLES)`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
