### PR TITLE
[Applab Datasets] Levelbuilder manifest edit page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -586,6 +586,8 @@ describe('entry tests', () => {
     'blocks/edit': './src/sites/studio/pages/blocks/edit.js',
     'blocks/index': './src/sites/studio/pages/blocks/index.js',
     'courses/edit': './src/sites/studio/pages/courses/edit.js',
+    'datasets/show_manifest':
+      './src/sites/studio/pages/datasets/show_manifest.js',
     levelbuilder: './src/sites/studio/pages/levelbuilder.js',
     'levels/editors/_all': './src/sites/studio/pages/levels/editors/_all.js',
     'levels/editors/_applab':

--- a/apps/src/sites/studio/pages/datasets/show_manifest.js
+++ b/apps/src/sites/studio/pages/datasets/show_manifest.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Provider} from 'react-redux';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import data, {setLibraryManifest} from '@cdo/apps/storage/redux/data';
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
+import ManifestEditor from '@cdo/apps/storage/levelbuilder/ManifestEditor';
+
+$(document).ready(function() {
+  const manifest = getScriptData('libraryManifest');
+  registerReducers({data});
+  const store = getStore();
+  store.dispatch(setLibraryManifest(manifest));
+  ReactDOM.render(
+    <Provider store={store}>
+      <ManifestEditor />
+    </Provider>,
+    document.querySelector('.manifest_editor')
+  );
+  initializeCodeMirror('content', 'application/json');
+});

--- a/apps/src/storage/levelbuilder/ManifestEditor.jsx
+++ b/apps/src/storage/levelbuilder/ManifestEditor.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {connect} from 'react-redux';
+import PropTypes from 'prop-types';
+
+class ManifestEditor extends React.Component {
+  static propTypes = {
+    // Provided via Redux
+    libraryManifest: PropTypes.object.isRequired
+  };
+
+  render() {
+    return (
+      <div>
+        <h1>Edit Dataset Manifest </h1>
+        <textarea
+          id="content"
+          ref="content"
+          value={JSON.stringify(this.props.libraryManifest, null, 2)}
+          // Change handler is required for this element, but changes will be handled by the code mirror.
+          onChange={() => {}}
+        />
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({libraryManifest: state.data.libraryManifest || {}}),
+  dispatch => ({})
+)(ManifestEditor);

--- a/apps/src/storage/levelbuilder/ManifestEditor.jsx
+++ b/apps/src/storage/levelbuilder/ManifestEditor.jsx
@@ -13,8 +13,9 @@ class ManifestEditor extends React.Component {
       <div>
         <h1>Edit Dataset Manifest </h1>
         <textarea
-          id="content"
           ref="content"
+          // 3rd parameter specifies number of spaces to insert into the output JSON string for readability purposes.
+          // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
           value={JSON.stringify(this.props.libraryManifest, null, 2)}
           // Change handler is required for this element, but changes will be handled by the code mirror.
           onChange={() => {}}

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -1,6 +1,7 @@
 class DatasetsController < ApplicationController
   before_action :require_levelbuilder_mode
   before_action :initialize_firebase
+  authorize_resource class: false
 
   def show_manifest
     @dataset_library_manifest = @firebase.get_library_manifest

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -3,11 +3,13 @@ class DatasetsController < ApplicationController
   before_action :initialize_firebase
   authorize_resource class: false
 
+  # GET /datasets/manifest
   def show_manifest
     @dataset_library_manifest = @firebase.get_library_manifest
   end
 
-  def updated_manifest
+  # POST /datasets/manifest
+  def update_manifest
   end
 
   private

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -1,0 +1,17 @@
+class DatasetsController < ApplicationController
+  before_action :require_levelbuilder_mode
+  before_action :initialize_firebase
+
+  def show_manifest
+    @dataset_library_manifest = @firebase.get_library_manifest
+  end
+
+  def updated_manifest
+  end
+
+  private
+
+  def initialize_firebase
+    @firebase = FirebaseHelper.new('shared')
+  end
+end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -47,7 +47,9 @@ class Ability
       Pd::Application::Teacher1920Application,
       Pd::Application::Teacher2021Application,
       Pd::InternationalOptIn,
-      :maker_discount
+      :maker_discount,
+      :show_manifest,
+      :updated_manifest
     ]
     cannot :index, Level
 
@@ -240,6 +242,8 @@ class Ability
       # Ability for LevelStarterAssetsController. Since the controller does not have
       # a corresponding model, use lower/snake-case symbol instead of class name.
       can [:upload, :destroy], :level_starter_asset
+
+      can [:show_manifest, :updated_manifest], :dataset
     end
 
     if user.persisted?

--- a/dashboard/app/views/datasets/show_manifest.html.haml
+++ b/dashboard/app/views/datasets/show_manifest.html.haml
@@ -1,4 +1,3 @@
-- require 'json'
 - content_for(:head) do
   %script{src: webpack_asset_path('js/levelbuilder.js')}
   = stylesheet_link_tag 'css/levelbuilder', media: 'all'

--- a/dashboard/app/views/datasets/show_manifest.html.haml
+++ b/dashboard/app/views/datasets/show_manifest.html.haml
@@ -1,0 +1,9 @@
+- require 'json'
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/levelbuilder.js')}
+  = stylesheet_link_tag 'css/levelbuilder', media: 'all'
+
+.manifest_editor
+
+%script{src: webpack_asset_path('js/datasets/show_manifest.js'),
+        data: {libraryManifest: @dataset_library_manifest.to_json}}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -223,6 +223,9 @@ Dashboard::Application.routes.draw do
   resources :shared_blockly_functions, path: '/functions'
   resources :libraries
 
+  get 'datasets/manifest', to: 'datasets#show_manifest'
+  post 'datasets/manifest', to: 'datasets#updated_manifest'
+
   resources :levels do
     member do
       get 'get_rubric'


### PR DESCRIPTION
This is the first in a sequence of PRs to implement a page on levelbuilder to control the dataset manifest in Firebase. Right now, the page shows the contents at https://cdo-v3-shared.firebaseio.com/v3/channels/shared/metadata/manifest in a syntax-highlighted JSON code mirror. Changes made on this page don't do anything yet.

![image](https://user-images.githubusercontent.com/8787187/74192131-c0209980-4c09-11ea-8418-e789b0b6d115.png)
## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira](https://codedotorg.atlassian.net/browse/STAR-971)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
