### PR TITLE
Fixing the donor message on certificates

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -515,8 +515,7 @@ en:
     no_primary_course: "Try a Code Studio course"
     choose_next_course: "Try a Code Studio course by choosing one below"
     print_certificate: "Print Certificate"
-  certificate:
-    sponsor_message: "%{sponsor_name} made the generous gift to sponsor your learning."
+  certificate_sponsor_message: "%{sponsor_name} made the generous gift to sponsor your learning."
   move_students:
     new_section_dne: "Sorry, but section %{new_section_code} does not exist. Please enter a different section code."
     section_code_cant_be_current_section: "The current section cannot be the same as the new section."

--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -23,13 +23,7 @@ end
 def apply_text(image, text, pointsize, font, color, x_offset, y_offset)
   # If there is no text, don't try to render it.
   return if text.nil? || text.strip.empty?
-
   text = escape_image_magick_string(text)
-
-  # Limit the text length to prevent attacks where students send names hundreds
-  # of characters long and our system wastes memory trying to render a huge
-  # image.
-  text = text[0, 50] if text.size > 50
 
   begin
     # The text will be put into an image with a transparent background.  This
@@ -43,6 +37,8 @@ def apply_text(image, text, pointsize, font, color, x_offset, y_offset)
       self.pointsize = pointsize
       self.font = font
       self.fill = color
+      # Limit the size of the text_overlay to the size of the background image.
+      self.size = "#{image.columns}x#{image.rows}"
     end.first
   rescue Magick::ImageMagickError => exception
     # We want to know what kinds of text we are failing to render.
@@ -134,7 +130,8 @@ def create_course_certificate_image(name, course=nil, sponsor=nil, course_title=
     sponsor = donor[:name_s]
   end
 
-  sponsor_message = I18n.t('certificate.sponsor_message', sponsor_name: sponsor)
+  # Note certificate_sponsor_message is in both the Dashboard and Pegasus string files.
+  sponsor_message = I18n.t('certificate_sponsor_message', sponsor_name: sponsor)
   apply_text(image, sponsor_message, 18, 'Times bold', 'rgb(87,87,87)', 0, 447)
   image
 end

--- a/pegasus/cache/i18n/en-US.yml
+++ b/pegasus/cache/i18n/en-US.yml
@@ -155,6 +155,7 @@
   landscape_recommended_certificates: "It is recommended that you choose **Landscape** when you print the certificates."
   print_one_here_certificates: "Print one here."
   enter_certificate_names: "Enter up to 30 names, **one per line**. A printable page with personalized %{script_name} certificates will be generated."
+  certificate_sponsor_message: "%{sponsor_name} made the generous gift to sponsor your learning."
   share_achievement: "Share your achievement"
   beyond_hour_message: "Keep going with our <a href='http://studio.code.org'>other courses</a>, or see more options to <a href='/learn/beyond'>Learn beyond an Hour</a>."
   leaderboards_for_hoc: "Leaderboards for the Hour of Code."


### PR DESCRIPTION
*Bug*: "Missing translation" was being shown at the bottom of certificates instead of a random message talking about a Code.org donor. Also, there is the issue of the string being truncated.

*Cause*: The string exists in en.yml, however those are dashboard strings. These certificates are in pegasus and  dashboard. The string also needed to be added to the list of Pegasus strings. The cause of the truncated donor message is because we were limiting the number of characters to 20 in order to prevent students putting in names with hundreds of characters and breaking imagemagick.

*Fix*: Add the new sponsor string to the Pegasus strings as well. Remove the 20 character limit and instead limit the text labels to the size of the certificate.

## Before
![image](https://user-images.githubusercontent.com/1372238/74194372-00573a80-4c51-11ea-8e65-a9a8f31ac549.png)
## After
![image](https://user-images.githubusercontent.com/1372238/74194398-0baa6600-4c51-11ea-9ca8-6957b49ce5f5.png)

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1010)

## Testing story
* `bin/pegasus-server`
  * http://localhost.code.org:3000/certificates
  * Tried imputing names which previously resulted in Honeybadger errors.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
