### PR TITLE
Use CDO module for link helper

### DIFF
--- a/dashboard/app/controllers/pd/regional_partner_contact_controller.rb
+++ b/dashboard/app/controllers/pd/regional_partner_contact_controller.rb
@@ -22,6 +22,6 @@ class Pd::RegionalPartnerContactController < ApplicationController
         referer: request.referer
       }
     )
-    redirect_to code_org_url('educate/professional-learning/contact-regional-partner')
+    redirect_to CDO.code_org_url('educate/professional-learning/contact-regional-partner')
   end
 end

--- a/dashboard/app/views/pd/regional_partner_contact_mailer/unmatched.html.haml
+++ b/dashboard/app/views/pd/regional_partner_contact_mailer/unmatched.html.haml
@@ -1,6 +1,6 @@
 %p
   The following person has requested to connect with their local Code.org Regional Partner
-  = link_to('through this form,', 'https://code.org/educate/professional-learning/contact-regional-partner')
+  = link_to('through this form,', CDO.code_org_url('educate/professional-learning/contact-regional-partner', CDO.default_scheme))
   - if @matched_but_no_pms
     but the Regional Partner does not have any program managers.
   - else


### PR DESCRIPTION
Fixes a link that caused this [Honeybadger error ](https://app.honeybadger.io/projects/324/faults/60633192) (albeit from staging) -- we think the link worked locally because we load both pegasus and dashboard into a single Ruby instance, whereas we do not do this in other environments. As a result, I was originally using this [global pegasus method ](https://github.com/code-dot-org/code-dot-org/blob/staging/pegasus/helpers.rb#L48), instead of the one in the CDO module.

Also improves a hard coded link to use the same approach per suggestion from @breville.

## Testing story

Tested manually on my machine.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
