### PR TITLE
Export MySQL dashboard tables to Redshift staging tables

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -110,7 +110,6 @@ cron-user-hierarchy-pii:
 - dashboard.user_geos
 - dashboard.user_school_infos
 cron-user-levels:
-- dashboard.user_levels:
-    export_to_staging_table: true
+- dashboard.user_levels
 cron-level-sources-pii:
 - dashboard.level_sources

--- a/lib/cdo/aws/dms.rb
+++ b/lib/cdo/aws/dms.rb
@@ -26,8 +26,8 @@ module Cdo
 
           # Conditionally add transformation rule to prefix target table name with '_import_', so we can
           # prototype exporting an Aurora table to a staging Redshift table, which is later swapped into the target table.
-          # TODO: (suresh) Replace this with a transformation rule to prefix all tables once prototyping completes.
-          if properties && properties['export_to_staging_table']
+          # TODO: (suresh) Replace this with a transformation rule to prefix ALL tables once prototyping is complete.
+          if schema == 'dashboard_production'
             rules << {
               'rule-type': 'transformation',
               'rule-action': 'add-prefix',


### PR DESCRIPTION
Modify Database Migration Service Replication Tasks to export any table in the Aurora MySQL dashboard schema to a temporary Redshift table with a prefix (_import_user_levels, _import_courses, etc.). This is phase 2 prototyping of logic to carry out daily full load export to Redshift while minimizing downtime for the Reporting/Analytics solution.

https://codedotorg.atlassian.net/browse/INF-279



### Background

This change is part of an Epic https://codedotorg.atlassian.net/browse/INF-242

## Testing story

```
$ bundle exec rake stack:data:validate RAILS_ENV=production

Listing changes to existing stack `DATA-production`:
Modify DMSCronFullLoad [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCronLevelSourcesPiiFullLoad [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCronPiiFullLoad [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCronUserHierarchyFullLoad [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCronUserHierarchyPiiFullLoad [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
