### PR TITLE
PL: Write 2020 workshops to a gsheet

### DIFF
--- a/bin/cron/summer_workshops_to_gdrive
+++ b/bin/cron/summer_workshops_to_gdrive
@@ -33,7 +33,7 @@ workshops = []
 workshops << Api::V1::Pd::WorkshopDownloadSerializer.new(Pd::Workshop.first).attributes.keys.map(&:to_s)
 
 # Subsequent rows are for each workshop.
-Pd::Workshop.where(subject: subjects).find_each.each do |w|
+Pd::Workshop.where(subject: subjects).find_each do |w|
   if w.workshop_starting_date && w.workshop_starting_date >= Date.new(2020, 5, 15) && w.workshop_starting_date <= Date.new(2020, 8, 31)
     workshops << Api::V1::Pd::WorkshopDownloadSerializer.new(w).attributes.values
   end

--- a/bin/cron/summer_workshops_to_gdrive
+++ b/bin/cron/summer_workshops_to_gdrive
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
+require_relative '../../dashboard/config/environment'
+require 'cdo/google_drive'
+
+# Squash an unhelpful warning that's causing a Honeybadger error
+# see https://github.com/nahi/httpclient/issues/252#issuecomment-302427338
+class WebAgent
+  class Cookie < HTTP::Cookie
+    def domain
+      original_domain
+    end
+  end
+end
+
+#
+# Uses a Google Cloud service account to write summer workshop data for this year into
+# a spreadsheet in Google Drive (with permissions locked down to our organization) for exploration
+# by our programs team.
+#
+
+subjects = [
+  Pd::SharedWorkshopConstants::SUBJECT_SUMMER_WORKSHOP,
+  Pd::SharedWorkshopConstants::SUBJECT_CSF_101,
+  Pd::SharedWorkshopConstants::SUBJECT_CSF_201
+]
+
+workshops = []
+
+# The first row is an array of strings, one for each attribute name.
+workshops << Api::V1::Pd::WorkshopDownloadSerializer.new(Pd::Workshop.first).attributes.keys.map(&:to_s)
+
+# Subsequent rows are for each workshop.
+Pd::Workshop.where(subject: subjects).find_each.each do |w|
+  if w.workshop_starting_date && w.workshop_starting_date >= Date.new(2020, 5, 15) && w.workshop_starting_date <= Date.new(2020, 8, 31)
+    workshops << Api::V1::Pd::WorkshopDownloadSerializer.new(w).attributes.values
+  end
+end
+
+drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
+drive.update_sheet workshops, CDO.applications_2020_2021_gsheet_key, 'summer_workshops (auto)'
+
+# Write another tab with some information
+
+last_updated = DateTime.now.in_time_zone ActiveSupport::TimeZone.new "Pacific Time (US & Canada)"
+metadata = [
+  ['SUMMER WORKSHOPS AUTOMATION METADATA'],
+  [''],
+  ['The tabs "summer_workshops (auto)" and "summer_workshops_meta (auto)" are auto-generated;'],
+  ['Any edits you make to them (besides formatting) may be lost.'],
+  [''],
+  ['Last updated:', last_updated.strftime('%Y-%m-%d %l:%M%P GMT%:::z')],
+  ['Written by:', CDO.gdrive_export_secret.client_email],
+  ['Summer workshops:', workshops.length - 1],
+  [''],
+  ['Parts of this Google Sheet are auto-populated from our live application by an automated process.'],
+  ["The sheet is shared with a \"service account\" that updates it on the application's behalf."],
+]
+drive.update_sheet metadata, CDO.applications_2020_2021_gsheet_key, 'summer_workshops_meta (auto)'

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -93,6 +93,7 @@
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'confirm_usage')
       cronjob at:'5 16 * * *', do:deploy_dir('bin', 'cron', 'calculate_workshop_survey_results')
       cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
+      cronjob at:'30 */2 * * *', do:deploy_dir('bin', 'cron', 'summer_workshops_to_gdrive')
       cronjob at:'0 11 * * *', do:deploy_dir('bin', 'cron', 'workshops_to_s3')
       cronjob at:'00 17 * * *', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
       cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')


### PR DESCRIPTION
Write serialized information about workshops to a gsheet.  The workshops are CSD/CSP 5-day summer, CSF intro, and CSF deepdive.  The dates are May 15th 2020 through August 31st 2020.  The write is done 30 minutes after every second hour.  The destination tab is `summer_workshops (auto)`, and we also write some information to a tab called `summer_workshops_meta (auto)`.

This writes to the same gsheet as https://github.com/code-dot-org/code-dot-org/pull/32609 and works very similarly.
