### PR TITLE
Notify engineers if sensitive data is shared externally

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -71,7 +71,7 @@ def notify_of_external_sharing(drive)
 
   if external_emails.present?
     email_domains = external_emails.map {|email| email.slice(/@.*/)}
-    error_msg = "Document contains PII information is shared to "\
+    error_msg = "Document containing PII information is shared to "\
       "#{external_emails.length} external account(s) at the following domain(s): #{email_domains.join(', ')}. "\
       "Please check with PLC team that this is intentional!"
 

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -58,11 +58,15 @@ def update_sheets(drive)
 end
 
 def notify_of_external_sharing(drive)
+  # List of external emails that we can share this document with
+  allowed_list = []
+
   acl = drive.get_spreadsheet_acl CDO.applications_2020_2021_gsheet_key
 
   external_emails = []
   acl.each do |entry|
-    external_emails << entry.email_address unless entry.email_address.end_with?('@code.org')
+    next if entry.email_address.end_with?('@code.org') || allowed_list.include?(entry.email_address)
+    external_emails << entry.email_address
   end
 
   if external_emails.present?
@@ -80,7 +84,7 @@ def main
   # Uses a Google Cloud service account to access Google Drive
   drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
 
-  update_sheets(drive)
+  # update_sheets(drive)
   notify_of_external_sharing(drive)
 end
 

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -59,7 +59,7 @@ end
 
 def notify_of_external_sharing(drive)
   # List of external emails that we can share this document with
-  allowed_list = []
+  allowed_list = [CDO.gdrive_export_secret.client_email]
 
   acl = drive.get_spreadsheet_acl CDO.applications_2020_2021_gsheet_key
 

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -4,6 +4,7 @@ exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require 'cdo/google_drive'
+require 'honeybadger/ruby'
 
 # Squash an unhelpful warning that's causing a Honeybadger error
 # see https://github.com/nahi/httpclient/issues/252#issuecomment-302427338
@@ -15,43 +16,72 @@ class WebAgent
   end
 end
 
-#
-# Uses a Google Cloud service account to write teacher application data for this year into
+# Writes teacher application data for this year into
 # a spreadsheet in Google Drive (with permissions locked down to our organization) for exploration
 # by our programs team.
-#
+def update_sheets(drive)
+  # Update application sheet
+  applications = [%w(course regional_partner status scholarship_status school_type pay_fee email created_at)]
+  Pd::Application::Teacher2021Application.find_each do |app|
+    applications << [
+      app.course,
+      app.regional_partner.try(:name),
+      app.status,
+      app.scholarship_status,
+      app.school_type,
+      app.sanitize_form_data_hash[:principal_pay_fee],
+      app.email,
+      app.created_at
+    ]
+  end
 
-applications = [%w(course regional_partner status scholarship_status school_type pay_fee email created_at)]
+  drive.update_sheet applications, CDO.applications_2020_2021_gsheet_key, 'all_apps (auto)'
 
-Pd::Application::Teacher2021Application.find_each do |app|
-  applications << [
-    app.course,
-    app.regional_partner.try(:name),
-    app.status,
-    app.scholarship_status,
-    app.school_type,
-    app.sanitize_form_data_hash[:principal_pay_fee],
-    app.email,
-    app.created_at
+  # Update metadata sheet
+  last_updated = DateTime.now.in_time_zone ActiveSupport::TimeZone.new "Pacific Time (US & Canada)"
+  metadata = [
+    ['AUTOMATION METADATA'],
+    [''],
+    ['The tabs "all_apps (auto)" and "meta (auto)" are auto-generated;'],
+    ['Any edits you make to them (besides formatting) may be lost.'],
+    [''],
+    ['Last updated:', last_updated.strftime('%Y-%m-%d %l:%M%P GMT%:::z')],
+    ['Written by:', CDO.gdrive_export_secret.client_email],
+    ['Teacher applications:', applications.length - 1],
+    [''],
+    ['Parts of this Google Sheet are auto-populated from our live application by an automated process.'],
+    ["The sheet is shared with a \"service account\" that updates it on the application's behalf."],
+    ["(Technical Details: https://github.com/code-dot-org/code-dot-org/pull/32597)"],
   ]
+
+  drive.update_sheet metadata, CDO.applications_2020_2021_gsheet_key, 'meta (auto)'
 end
 
-drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
-drive.update_sheet applications, CDO.applications_2020_2021_gsheet_key, 'all_apps (auto)'
+def notify_of_external_sharing(drive)
+  acl = drive.get_spreadsheet_acl CDO.applications_2020_2021_gsheet_key
 
-last_updated = DateTime.now.in_time_zone ActiveSupport::TimeZone.new "Pacific Time (US & Canada)"
-metadata = [
-  ['AUTOMATION METADATA'],
-  [''],
-  ['The tabs "all_apps (auto)" and "meta (auto)" are auto-generated;'],
-  ['Any edits you make to them (besides formatting) may be lost.'],
-  [''],
-  ['Last updated:', last_updated.strftime('%Y-%m-%d %l:%M%P GMT%:::z')],
-  ['Written by:', CDO.gdrive_export_secret.client_email],
-  ['Teacher applications:', applications.length - 1],
-  [''],
-  ['Parts of this Google Sheet are auto-populated from our live application by an automated process.'],
-  ["The sheet is shared with a \"service account\" that updates it on the application's behalf."],
-  ["(Technical Details: https://github.com/code-dot-org/code-dot-org/pull/32597)"],
-]
-drive.update_sheet metadata, CDO.applications_2020_2021_gsheet_key, 'meta (auto)'
+  external_emails = []
+  acl.each do |entry|
+    external_emails << entry.email_address unless entry.email_address.end_with?('@code.org')
+  end
+
+  if external_emails.present?
+    email_domains = external_emails.map {|email| email.slice(/@.*/)}
+    error_msg = "Document contains PII information is shared to "\
+      "#{external_emails.length} external account(s) at the following domain(s): #{email_domains.join(', ')}. "\
+      "Please check with PLC team that this is intentional!"
+
+    Honeybadger.notify error_msg
+    puts error_msg
+  end
+end
+
+def main
+  # Uses a Google Cloud service account to access Google Drive
+  drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
+
+  update_sheets(drive)
+  notify_of_external_sharing(drive)
+end
+
+main

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -58,8 +58,10 @@ def update_sheets(drive)
 end
 
 def notify_of_external_sharing(drive)
-  # List of external emails that we can share this document with
-  allowed_list = [CDO.gdrive_export_secret.client_email]
+  # List of external emails that we can share this document with.
+  # This list is saved in DCDO as an array. To append a new value to this list:
+  # DCDO.set(key_name, DCDO.get(key_name, []) << new_value)
+  allowed_list = DCDO.get('external_emails_with_application_data_access', []) << CDO.gdrive_export_secret.client_email
 
   acl = drive.get_spreadsheet_acl CDO.applications_2020_2021_gsheet_key
 

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -84,7 +84,7 @@ def main
   # Uses a Google Cloud service account to access Google Drive
   drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
 
-  # update_sheets(drive)
+  update_sheets(drive)
   notify_of_external_sharing(drive)
 end
 

--- a/lib/cdo/google_drive.rb
+++ b/lib/cdo/google_drive.rb
@@ -117,6 +117,15 @@ module Google
       worksheet.save
     end
 
+    # Returns an ACL object for a spreadsheet document
+    # @param [String] document_key
+    # @return [GoogleDrive::Acl] ACL object that contains an array of GoogleDrive::AclEntry
+    def get_spreadsheet_acl(document_key)
+      document = @session.spreadsheet_by_key(document_key)
+      raise "Could not find document #{document_key}" unless document
+      document.acl
+    end
+
     private
 
     def path_to_title_array(path)


### PR DESCRIPTION
[PLC-691](https://codedotorg.atlassian.net/browse/PLC-691). This [spreadsheet](https://docs.google.com/spreadsheets/d/1GIa1LtK35YhHTGgkaAv3LE7IO8uYxkFCb0Y5fZf0SdU/) contains application and workshop information with PII data. We want to make sure that it is not accidentally shared to non-Code.org accounts.

This change notifies engineers via Honeybadger when the file is shared to a non-Code.org account. However, to avoid unnecessary disruption to the users of this file, it doesn't stop the sharing or stop syncing new data.

If it is verified that we want to share data to an external account, we will add email of that account to the `allowed_list` in `notify_of_external_sharing` function.

_For reviewers:_ I move some existing code into a function to separate two different responsibilities. You can select "Hide whitespace changes" to ignore that change.

## To do
- [x] Run `DCDO.set('external_emails_with_application_data_access', <array of emails>)` in production console.

## Testing story
Testing manually using a private spreadsheet following the instruction in [this PR](https://github.com/code-dot-org/code-dot-org/pull/32609). The main steps are:
* Created a private spreadsheet (not in Team Drive)
* Shared it with a non-production google service account (`gdrive_export_secret` entry in AWS Secret Manager).
* Configured `development.yml.erb` and `locals.yml`.
* Added a DCDO value in local machine: `DCDO.set('external_emails_with_application_data_access', <test_email>)`
* Ran `bin/cron/teacher_applications_to_gdrive` targeting that file. 
* Verified that it threw Honeybadger error for non-Code.org account not set in the DCDO variable above. Example of an Honeybadger error https://app.honeybadger.io/projects/3240/faults/60718293.

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
