### PR TITLE
Don't require secrets for Rack-based integration tests

### DIFF
--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -50,6 +50,7 @@ module Cdo
     # Asynchronously fetch keys in parallel.
     # @return [Concurrent::Promises::Future<Hash>] All keys and their resolved values
     def get_multi(*keys)
+      return Concurrent::Promises.fulfilled_future({}, @pool) if keys.empty?
       client.then do
         promises = keys.map {|key| get(key).then {|value| [key, value]}}
         Concurrent::Promises.zip_futures_on(@pool, *promises).

--- a/lib/test/cdo/test_secrets.rb
+++ b/lib/test/cdo/test_secrets.rb
@@ -61,6 +61,12 @@ class SecretsTest < Minitest::Test
     assert_match /Key: missing_key/, e.message
   end
 
+  def test_required_no_keys
+    secrets = Cdo::Secrets.new
+    secrets.expects(:client).never
+    assert_equal({}, secrets.required!)
+  end
+
   def test_create
     @secrets.put('test_create', 123)
     assert_equal '123', @secrets.get!('test_create')

--- a/pegasus/config.ru
+++ b/pegasus/config.ru
@@ -1,6 +1,6 @@
 require_relative '../deployment'
 # Ensure all application secrets are loaded.
-CDO.cdo_secrets&.required! unless rack_env?(:development)
+CDO.cdo_secrets&.required! unless rack_env?(:development) || CDO.unit_test
 
 require File.expand_path('../router', __FILE__)
 


### PR DESCRIPTION
Fixes an issue running `test_hourofcode_helpers` by itself, by ensuring that secrets aren't required when loading from a unit-test environment.

Also fixes the more general underlying issue by not loading `SecretsManager` client when no secrets are actually required within the environment.
