### PR TITLE
 Adding support for longer names on certificates

### DIFF
--- a/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
@@ -129,6 +129,9 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     # :trim is called in order to make sure excess empty space is removed around
     # the text.
     mock_text_image.expects(:trim!).returns(mock_text_image)
+    # :columns is the width of the image in pixels. This is checked to see if the
+    # text needs to be resized.
+    mock_text_image.expects(:columns).returns(325)
     # :read with a "pango:..." string is what generates an image with the given
     # text in it.
     Magick::Image.expects(:read).with("pango:#{string}").returns([mock_text_image])

--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -5,6 +5,10 @@ require 'honeybadger/ruby'
 require 'rmagick'
 require_relative '../script_constants'
 
+# The area in pixels under the "Certificate of Completion" on the certificate reserved for the name.
+CERT_NAME_AREA_WIDTH = 800
+CERT_NAME_AREA_HEIGHT = 80
+
 # This method returns a newly-allocated Magick::Image object.
 # NOTE: the caller MUST ensure image#destroy! is called on the returned image object to avoid memory leaks.
 def create_certificate_image2(image_path, name, params={})
@@ -15,31 +19,70 @@ def create_certificate_image2(image_path, name, params={})
   pointsize = 68
   x_offset = params[:x] || 0
   y_offset = params[:y] || 0
-  apply_text(background, name, pointsize, font, color, x_offset, y_offset)
+
+  apply_text(background, name, pointsize, font, color, x_offset, y_offset, CERT_NAME_AREA_WIDTH, CERT_NAME_AREA_HEIGHT)
   background
 end
 
-# applies the given text to the given image object.
-def apply_text(image, text, pointsize, font, color, x_offset, y_offset)
+# Applies the given text to the given image object.
+# The text is shrunk to fit the given width and height.
+#
+# @param [Magick::Image] image is the background to put text on.
+# @param [String] text is the string to add to the image.
+# @param [Integer] pointsize is the max size to display the text at.
+# @param [String] font to use e.g. 'Helvetica bold'
+# @param [String] color of the text e.g. 'rgb(118,101,160)'
+# @param [Integer] x_offset of the position to center the text at.
+# @param [Integer] y_offset of the position to center the text at.
+# @param [Integer] width in pixels of the bounding box for the text.
+# If no width is given, then the text is bound to the width of the background image.
+# @param [Integer] height in pixels of the bounding box for the text.
+# If no height is given, then the text is bound to the height of the background image.
+def apply_text(image, text, pointsize, font, color, x_offset, y_offset, width=nil, height=nil)
   # If there is no text, don't try to render it.
   return if text.nil? || text.strip.empty?
+  # If there is no background image, there is nothing to do.
+  return if image.nil?
+
   text = escape_image_magick_string(text)
+  # If no bounding box given, default to the background image width & height.
+  width ||= image.columns
+  height ||= image.rows
 
   begin
     # The text will be put into an image with a transparent background.  This
     # uses 'pango', the OS's text layout engine, in order to dynamically select
     # the correct font. This is important for handling non-latin languages.
+    # The text_overlay is first generated at full size and then resized to fit
+    # the given bounding box width & height.
     text_overlay = Magick::Image.read("pango:#{text}") do
       # pango:markup is set to false in order to easily prevent pango markup
       # injection from user input.
       define('pango', 'markup', false)
+      # If the text doesn't fit the bounding box, then put a '...' at the end.
+      define('pango', 'ellipsize', 'end')
       self.background_color = 'none'
       self.pointsize = pointsize
       self.font = font
       self.fill = color
-      # Limit the size of the text_overlay to the size of the background image.
-      self.size = "#{image.columns}x#{image.rows}"
+      # Limit the maximum size of content to protect ourselves against extremely large strings.
+      # The multiplier represents the max amount the text can be shrunk to fit the given bounds.
+      self.size = "#{width * 3}x#{height * 3}"
+      # Center the text in the box.
+      self.gravity = Magick::CenterGravity
     end.first
+
+    return unless text_overlay
+    # remove empty space around the text
+    text_overlay.trim!
+    # resize the text to fit the given bounding box unless it is already smaller.
+    text_overlay.resize_to_fit!(width, height) if text_overlay.columns > width
+    # Combine the text image on top of the certificate template image
+    image.composite!(text_overlay, Magick::CenterGravity, x_offset, y_offset, Magick::OverCompositeOp)
+
+    # Free the memory in order to avoid memory leaks (images are stored in /tmp
+    # until destroyed)
+    text_overlay.destroy!
   rescue Magick::ImageMagickError => exception
     # We want to know what kinds of text we are failing to render.
     Honeybadger.notify(
@@ -51,16 +94,6 @@ def apply_text(image, text, pointsize, font, color, x_offset, y_offset)
     # We can't render the text, so return without applying a transformation.
     return
   end
-
-  return unless text_overlay
-  text_overlay.trim!
-
-  # Combine the text image on top of the certificate template image
-  image.composite!(text_overlay, Magick::CenterGravity, x_offset, y_offset, Magick::OverCompositeOp)
-
-  # Free the memory in order to avoid memory leaks (images are stored in /tmp
-  # until destroyed)
-  text_overlay.destroy!
 end
 
 # This method returns a newly-allocated Magick::Image object.
@@ -75,8 +108,7 @@ def create_workshop_certificate_image(image_path, fields)
     y = field[:y] || 0
     x = field[:x] || 0
     pointsize = field[:pointsize] || 70
-
-    apply_text(background, string, pointsize, 'Times bold', 'rgb(87,87,87)', x, y)
+    apply_text(background, string, pointsize, 'Times bold', 'rgb(87,87,87)', x, y, CERT_NAME_AREA_WIDTH, CERT_NAME_AREA_HEIGHT)
   end
 
   background
@@ -114,14 +146,14 @@ def create_course_certificate_image(name, course=nil, sponsor=nil, course_title=
   path = pegasus_dir('sites.v3', 'code.org', 'public', 'images', template_file)
   if prefilled_title_course?(course)
     # only need to fill in student name
-    vertical_offset = course == '20-hour' ? -115 : -110
+    vertical_offset = course == '20-hour' ? -125 : -120
     image = create_certificate_image2(path, name, y: vertical_offset)
   else # all other courses use a certificate image where the course name is also blank
     course_title ||= fallback_course_title_for(course)
 
     image = Magick::Image.read(path).first
-    apply_text(image, name, 75, 'Helvetica bold', 'rgb(118,101,160)', 0, -141)
-    apply_text(image, course_title, 47, 'Helvetica bold', 'rgb(29,173,186)', 0, 11)
+    apply_text(image, name, 75, 'Helvetica bold', 'rgb(118,101,160)', 0, -135, CERT_NAME_AREA_WIDTH, CERT_NAME_AREA_HEIGHT)
+    apply_text(image, course_title, 47, 'Helvetica bold', 'rgb(29,173,186)', 0, 15)
   end
 
   unless sponsor
@@ -132,7 +164,10 @@ def create_course_certificate_image(name, course=nil, sponsor=nil, course_title=
 
   # Note certificate_sponsor_message is in both the Dashboard and Pegasus string files.
   sponsor_message = I18n.t('certificate_sponsor_message', sponsor_name: sponsor)
-  apply_text(image, sponsor_message, 18, 'Times bold', 'rgb(87,87,87)', 0, 447)
+  # The area in pixels which will display the sponsor message.
+  sponsor_area_width = 1400
+  sponsor_area_height = 35
+  apply_text(image, sponsor_message, 18, 'Times bold', 'rgb(87,87,87)', 0, 447, sponsor_area_width, sponsor_area_height)
   image
 end
 


### PR DESCRIPTION
If a student has a particularly long name, the name on their completion
certificate will now shrink to fit the space below the "Certificate of
Completion" arch.
* Added the option of defining a bounding box for text rendered on
course completion certificates. Text which is too long for these boxes
will shrink to fit the box.
* Minor adjustments to text placement on the certificates.
## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1012)
## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1372238/74362544-c86f0500-4dc0-11ea-8c31-a3d28cd2cf55.png)
*Note* You can ignore the "translation missing..." message. This is a separate issue which will be fixed in the content grab.
### After
![image](https://user-images.githubusercontent.com/1372238/74362623-ee94a500-4dc0-11ea-807d-61f7c508c7c4.png)

## Testing story
### Test input
```
Bartholomew
Bartholomew Bartholomew Bartholomew
内閣総理大臣
グーリンダイのポンポコピーのポンポコナーの
A B C D E F G H I J K L M N O P Q R S T U V W X Y Z AA BB CC DD EE FF GG HH II JJ KK LL MM NN OO PP QQ RR SS TT UU VV WW XX YY ZZ 
```

### Hour of Code Certificate
https://ec2-3-84-55-200.compute-1.amazonaws.com/certificates

### 20-Hour Certificate
https://ec2-3-84-55-200.compute-1.amazonaws.com/certificates?course=20-hour

### Course Certificate
https://ec2-3-84-55-200.compute-1.amazonaws.com/certificates?course=course1


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
