### PR TITLE
Get friendly names for course-specific scholarship statuses

### DIFF
--- a/dashboard/app/models/pd/scholarship_info.rb
+++ b/dashboard/app/models/pd/scholarship_info.rb
@@ -46,12 +46,12 @@ class Pd::ScholarshipInfo < ActiveRecord::Base
 
   # Display string for the scholarship status, like "Yes, Code.org"
   def friendly_status_name
-    self.class.get_scholarship_label(scholarship_status)
+    self.class.get_scholarship_label(scholarship_status, course)
   end
 
   # Translate a SCHOLARSHIP_STATUSES value to a more friendly label
-  def self.get_scholarship_label(value)
-    SCHOLARSHIP_DROPDOWN_OPTIONS.find {|option| option[:value] == value}[:label]
+  def self.get_scholarship_label(value, course)
+    COURSE_SPECIFIC_SCHOLARSHIP_DROPDOWN_OPTIONS[course].find {|option| option[:value] == value}[:label]
   end
 
   # Confirm scholarship status is valid (course-specific)

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -833,7 +833,7 @@ module Api::V1::Pd
             notes_4: nil,
             notes_5: nil,
             friendly_scholarship_status:
-              Pd::ScholarshipInfo.get_scholarship_label(Pd::ScholarshipInfoConstants::NO)
+              Pd::ScholarshipInfo.get_scholarship_label(Pd::ScholarshipInfoConstants::NO, 'csp')
           }.stringify_keys, JSON.parse(@response.body).first
         )
       end

--- a/dashboard/test/models/pd/scholarship_info_test.rb
+++ b/dashboard/test/models/pd/scholarship_info_test.rb
@@ -52,4 +52,16 @@ class Pd::ScholarshipInfoTest < ActiveSupport::TestCase
     csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfo::YES_EIR
     assert csp_scholarship_info.valid?
   end
+
+  # Test confirms that we can get a friendly scholarship status (without error)
+  test 'can get friendly scholarship name with CSP-specific scholarship status' do
+    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfo::YES_EIR
+    csp_scholarship_info.friendly_status_name
+  end
+
+  # Test confirms that we can get a friendly scholarship status (without error)
+  test 'can get friendly scholarship name with non-course specific scholarship status' do
+    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfo::NO
+    csp_scholarship_info.friendly_status_name
+  end
 end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -454,8 +454,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop.reload.destroy!
 
     assert workshop.reload.deleted?
-    refute Pd::Workshop.exists? workshop.attributes
-    assert Pd::Workshop.with_deleted.exists? workshop.attributes
+    refute Pd::Workshop.exists? id: workshop.id
+    assert Pd::Workshop.with_deleted.exists? id: workshop.id
 
     # Make sure dependent sessions and enrollments are also soft-deleted.
     assert session.reload.deleted?


### PR DESCRIPTION
Fixes this [Honeybadger error](https://app.honeybadger.io/projects/3240/faults/60739405) -- we display human friendly versions of scholarship statuses in our application and workshop dashboard UI, which were addressed in the [PR that introduced this bug](https://github.com/code-dot-org/code-dot-org/pull/32946) -- however, we also use human friendly scholarship statuses in our teacher application and enrollment models, which this fix addresses.

## Testing story

Adds new tests to confirm that this method works with both course-specific and non-course-specific cases -- was encouraged by [this blogger to not use `assert_nothing_raised`](http://www.thagomizer.com/blog/2013/06/11/assert-nothing-raised.html).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
