### PR TITLE
Simplify blocks edit page

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -17,7 +17,6 @@ import 'codemirror/addon/lint/javascript-lint';
 import 'codemirror/mode/xml/xml';
 import 'codemirror/mode/javascript/javascript';
 import './vendor/codemirror.inline-attach';
-import jsonic from 'jsonic';
 import {JSHINT} from 'jshint';
 
 import React from 'react';
@@ -29,9 +28,6 @@ window.JSHINT = JSHINT;
 CodeMirrorSpellChecker({
   codeMirrorInstance: CodeMirror
 });
-
-const VALID_COLOR = 'black';
-const INVALID_COLOR = '#d00';
 
 /**
  * initializeCodeMirror replaces a textarea on the page with a full-featured
@@ -135,56 +131,3 @@ function initializeCodeMirror(target, mode, options = {}) {
   return editor;
 }
 module.exports = initializeCodeMirror;
-
-module.exports.initializeCodeMirrorForJson = function(
-  textAreaId,
-  {validationDivId, onBlur, onChange}
-) {
-  // Leniently validate and fix up custom block JSON using jsonic
-  const textAreaEl = document.getElementById(textAreaId);
-  if (textAreaEl) {
-    const jsonValidationDiv = validationDivId
-      ? $(`#${validationDivId}`)
-      : $(
-          textAreaEl.parentNode.insertBefore(
-            document.createElement('div'),
-            textAreaEl.nextSibling
-          )
-        );
-    const showErrors = fn => arg => {
-      try {
-        if (fn) {
-          fn(arg);
-        }
-        jsonValidationDiv.text('JSON appears valid.');
-        jsonValidationDiv.css('color', VALID_COLOR);
-      } catch (err) {
-        jsonValidationDiv.text(err.toString());
-        jsonValidationDiv.css('color', INVALID_COLOR);
-      }
-    };
-    const fixupJson = showErrors(() => {
-      if (jsonEditor.getValue().trim()) {
-        let blocks = jsonic(jsonEditor.getValue().trim());
-        if (onBlur) {
-          blocks = onBlur(blocks);
-        }
-        if (onChange) {
-          onChange(jsonEditor);
-        }
-        jsonEditor.setValue(JSON.stringify(blocks, null, 2));
-      } else {
-        jsonEditor.setValue('');
-      }
-    });
-
-    const jsonEditor = initializeCodeMirror(
-      textAreaId,
-      'application/json',
-      showErrors(onChange)
-    );
-    jsonEditor.on('blur', fixupJson);
-    fixupJson();
-    return fixupJson;
-  }
-};

--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -1,9 +1,7 @@
 import * as codegen from '@cdo/apps/lib/tools/jsinterpreter/codegen';
 import $ from 'jquery';
 import assetUrl from '@cdo/apps/code-studio/assetUrl';
-import initializeCodeMirror, {
-  initializeCodeMirrorForJson
-} from '@cdo/apps/code-studio/initializeCodeMirror';
+import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
 import jsonic from 'jsonic';
 import {parseElement} from '@cdo/apps/xml';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
@@ -16,7 +14,10 @@ import animationListModule, {
 import defaultSprites from '@cdo/apps/p5lab/spritelab/defaultSprites.json';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 
-let poolField, nameField, helperEditor;
+const VALID_COLOR = 'black';
+const INVALID_COLOR = '#d00';
+
+let poolField, nameField, helperEditor, configEditor, validationDiv;
 
 $(document).ready(() => {
   registerReducers({animationList: animationListModule});
@@ -30,30 +31,65 @@ $(document).ready(() => {
     typeHints: true
   });
 
-  let submitButton = document.querySelector('#block_submit');
-  const fixupJson = initializeCodeMirrorForJson('block_config', {onChange});
-  helperEditor = initializeCodeMirror('block_helper_code', 'javascript', {
-    callback: fixupJson,
-    onUpdateLinting: (_, errors) => {
-      if (errors.length) {
-        submitButton.setAttribute('disabled', 'disabled');
-      } else {
-        submitButton.removeAttribute('disabled');
-      }
-    }
+  const blockConfigElement = document.getElementById('block_config');
+  validationDiv = $(
+    blockConfigElement.parentNode.insertBefore(
+      document.createElement('div'),
+      blockConfigElement.nextSibling
+    )
+  );
+
+  const helperCodeElement = document.getElementById('block_helper_code');
+  configEditor = initializeCodeMirror(blockConfigElement, 'application/json', {
+    callback: validateBlockConfig,
+    onUpdateLinting: onUpdateLinting
   });
-  poolField.addEventListener('change', fixupJson);
+
+  helperEditor = initializeCodeMirror(helperCodeElement, 'javascript', {
+    callback: _ => validateBlockConfig(),
+    onUpdateLinting: onUpdateLinting
+  });
+  poolField.addEventListener('change', updateBlockPreview);
+
+  updateBlockPreview();
 
   $('.alert.alert-success')
     .delay(5000)
     .fadeOut(1000);
 });
 
-let config;
-function onChange(editor) {
-  config = editor.getValue();
+function onUpdateLinting(_, errors) {
+  const submitButton = document.querySelector('#block_submit');
+  if (errors.length) {
+    submitButton.setAttribute('disabled', 'disabled');
+  } else {
+    submitButton.removeAttribute('disabled');
+  }
+}
 
-  const parsedConfig = jsonic(config);
+function validateBlockConfig(editor) {
+  try {
+    if (editor) {
+      JSON.parse(editor.getValue());
+    }
+    updateBlockPreview();
+    validationDiv.text('Config and helper code appear valid.');
+    validationDiv.css('color', VALID_COLOR);
+  } catch (err) {
+    validationDiv.text(err.toString());
+    validationDiv.css('color', INVALID_COLOR);
+  }
+}
+
+function getBlockName(funcName, pool) {
+  if (!pool || pool === 'GamelabJr') {
+    pool = 'gamelab';
+  }
+  return `${pool}_${funcName}`;
+}
+
+function updateBlockPreview() {
+  const parsedConfig = jsonic(configEditor.getValue());
 
   // Only Dancelab and Spritelab use customInputTypes.
   const customInputTypes =
@@ -61,7 +97,10 @@ function onChange(editor) {
       ? dancelabCustomInputTypes
       : spritelabCustomInputTypes;
 
-  const blocksInstalled = installCustomBlocks({
+  const blockName = getBlockName(parsedConfig.func, poolField.value);
+  nameField.value = blockName;
+  // Calling this function just so that we can catch and show errors (if any)
+  installCustomBlocks({
     blockly: Blockly,
     blockDefinitions: [
       {
@@ -74,8 +113,6 @@ function onChange(editor) {
     ],
     customInputTypes
   });
-  const blockName = Object.values(blocksInstalled)[0][0];
-  nameField.value = blockName;
   const blocksDom = parseElement(`<block type="${blockName}" />`);
   Blockly.mainBlockSpace.clear();
   Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, blocksDom);

--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -58,7 +58,9 @@ $(document).ready(() => {
   });
   poolField.addEventListener('change', updateBlockPreview);
 
-  updateBlockPreview();
+  if (blocks) {
+    updateBlockPreview();
+  }
 
   $('.alert.alert-success')
     .delay(5000)

--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -32,6 +32,13 @@ $(document).ready(() => {
   });
 
   const blockConfigElement = document.getElementById('block_config');
+
+  // Pretty print the config
+  let blocks = blockConfigElement.value;
+  if (blocks) {
+    blockConfigElement.value = JSON.stringify(JSON.parse(blocks), null, 2);
+  }
+
   validationDiv = $(
     blockConfigElement.parentNode.insertBefore(
       document.createElement('div'),
@@ -81,11 +88,11 @@ function validateBlockConfig(editor) {
   }
 }
 
-function getBlockName(funcName, pool) {
+function getBlockName(name, pool) {
   if (!pool || pool === 'GamelabJr') {
     pool = 'gamelab';
   }
-  return `${pool}_${funcName}`;
+  return `${pool}_${name}`;
 }
 
 function updateBlockPreview() {
@@ -97,7 +104,10 @@ function updateBlockPreview() {
       ? dancelabCustomInputTypes
       : spritelabCustomInputTypes;
 
-  const blockName = getBlockName(parsedConfig.func, poolField.value);
+  const blockName = getBlockName(
+    parsedConfig.func || parsedConfig.name,
+    poolField.value
+  );
   nameField.value = blockName;
   // Calling this function just so that we can catch and show errors (if any)
   installCustomBlocks({

--- a/apps/src/sites/studio/pages/levels/editors/_gamelab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_gamelab.js
@@ -1,8 +1,6 @@
 /** @file JavaScript run only on the gamelab level edit page. */
 import $ from 'jquery';
-import initializeCodeMirror, {
-  initializeCodeMirrorForJson
-} from '@cdo/apps/code-studio/initializeCodeMirror';
+import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
 import {throwIfSerializedAnimationListIsInvalid} from '@cdo/apps/p5lab/shapes';
 
 const VALID_COLOR = 'black';
@@ -37,18 +35,6 @@ $(document).ready(function() {
     }
   });
 
-  // Leniently validate and fix up custom block JSON using jsonic
-  if (document.getElementById('level_custom_blocks')) {
-    initializeCodeMirrorForJson('level_custom_blocks', {
-      validationDiv: 'custom-blocks-validation',
-      onBlur(blocks) {
-        if (!Array.isArray(blocks)) {
-          return [blocks];
-        }
-        return blocks;
-      }
-    });
-  }
   if (document.getElementById('level_custom_helper_library')) {
     initializeCodeMirror('level_custom_helper_library', 'javascript');
   }


### PR DESCRIPTION
This is a mostly-no-op change with a small bug fix.
It seems like the intention was to have `initializeCodeMirrorForJson` be a general purpose function, but at the same time, its code was really intertwined with the specific blocks edit page use case. I decided it would be cleaner to have the blocks edit page own all of its own logic, and just call `initializeCodeMirror` directly. 

Along the way, I found that the onChange callback was not being called, since https://github.com/code-dot-org/code-dot-org/pull/27138 changed `initializeCodeMirror` to accept an options object, and the call in `intializeCodeMirrorForJson` was not changed. This didn't seem to really cause any issues, since the callback was still called on blur, but this PR fixes that so the preview and generated code live-update as you change the config.

![Feb-12-2020 09-46-21](https://user-images.githubusercontent.com/8787187/74361949-a05db280-4d7c-11ea-87ec-8960adf8f5fe.gif)


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
