### PR TITLE
Add logging of feature impressions for TeacherDashboardHeader A/B Test

### DIFF
--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -21,6 +21,7 @@ import EditSectionDialog from './EditSectionDialog';
 import SetUpSections from '../studioHomepages/SetUpSections';
 import {recordOpenEditSectionDetails} from './sectionHelpers';
 import experiments from '@cdo/apps/util/experiments';
+import {recordImpression} from './impressionHelpers';
 
 const styles = {
   button: {
@@ -61,6 +62,11 @@ class OwnedSections extends React.Component {
   constructor(props) {
     super(props);
     this.onEditSection = this.onEditSection.bind(this);
+    if (experiments.isEnabled(experiments.TEACHER_DASHBOARD_SECTION_BUTTONS)) {
+      recordImpression('OwnedSectionsTableTeacherHeaderWithButtons');
+    } else {
+      recordImpression('OwnedSectionsTableTeacherHeaderWithoutButtons');
+    }
   }
 
   componentDidMount() {

--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -63,9 +63,9 @@ class OwnedSections extends React.Component {
     super(props);
     this.onEditSection = this.onEditSection.bind(this);
     if (experiments.isEnabled(experiments.TEACHER_DASHBOARD_SECTION_BUTTONS)) {
-      recordImpression('OwnedSectionsTableTeacherHeaderWithButtons');
+      recordImpression('owned_sections_table_with_dashboard_header_buttons');
     } else {
-      recordImpression('OwnedSectionsTableTeacherHeaderWithoutButtons');
+      recordImpression('owned_sections_table_without_dashboard_header_buttons');
     }
   }
 

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -18,9 +18,11 @@ import EmptySection from './EmptySection';
 import _ from 'lodash';
 import firehoseClient from '../../lib/util/firehose';
 import StandardsReport from '../sectionProgress/standards/StandardsReport';
+import {recordImpression} from './impressionHelpers';
 
 function Header(props) {
   if (experiments.isEnabled(experiments.TEACHER_DASHBOARD_SECTION_BUTTONS)) {
+    recordImpression('teacher_dashboard_header_with_buttons');
     return (
       <div>
         {/* TeacherDashboardNavigation must be outside of
@@ -32,6 +34,7 @@ function Header(props) {
       </div>
     );
   } else {
+    recordImpression('teacher_dashboard_header_no_buttons');
     return <TeacherDashboardHeader sectionName={props.sectionName} />;
   }
 }

--- a/apps/src/templates/teacherDashboard/impressionHelpers.js
+++ b/apps/src/templates/teacherDashboard/impressionHelpers.js
@@ -1,0 +1,10 @@
+import firehoseClient from '../../lib/util/firehose';
+
+export function recordImpression(study_group) {
+  firehoseClient.putRecord({
+    study: 'teacher_dashboard_actions',
+    study_group: study_group,
+    event: 'load_feature',
+    data_json: '{}'
+  });
+}


### PR DESCRIPTION
This is needed to be able to interpret A/B test results. Impressions serve as the denominator over which the number of interactions with a feature are divided to calculate usage rates of features.