### PR TITLE
PL: UI improvements for CSF workshop optional fee text

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -50,8 +50,7 @@ const styles = {
     border: 'none'
   },
   noFeeContainer: {
-    paddingTop: 7,
-    paddingBottom: 12
+    paddingBottom: 7
   },
   yesFeeRadio: {
     width: '100%'
@@ -454,6 +453,7 @@ export class WorkshopForm extends React.Component {
 
   renderWorkshopTypeOptions(validation) {
     const isCsf = this.state.course === 'CS Fundamentals';
+    const showFeeInput = isCsf;
     const showMapChoice = isCsf;
 
     return (
@@ -462,6 +462,7 @@ export class WorkshopForm extends React.Component {
           Workshop Type Options&nbsp;
           {isCsf && <a onClick={this.toggleTypeOptionsHelpDisplay}>(help)</a>}
         </ControlLabel>
+        <div style={{height: 7}}>&nbsp;</div>
         {this.state.showTypeOptionsHelpDisplay && isCsf && (
           <FormGroup>
             <p>
@@ -478,7 +479,14 @@ export class WorkshopForm extends React.Component {
         )}
         <Row>
           <Col smOffset={1}>
+            <Row>
+              {showFeeInput && (
+                <Col sm={6}>{this.renderFeeInput(validation)}</Col>
+              )}
+            </Row>
             {showMapChoice && this.renderOnMapRadios(validation)}
+            {/* A small gap to resemble the gap below the fee input. */}
+            {showFeeInput && <div style={{height: 7}}>&nbsp;</div>}
             {this.renderFundedSelect(validation)}
           </Col>
         </Row>
@@ -594,7 +602,7 @@ export class WorkshopForm extends React.Component {
 
     return (
       <FormGroup validationState={validation.style.fee}>
-        <ControlLabel>Fee</ControlLabel>
+        <ControlLabel>Fee information for participants</ControlLabel>
 
         <div style={styles.noFeeContainer}>
           <Radio
@@ -943,7 +951,6 @@ export class WorkshopForm extends React.Component {
 
   renderForm() {
     const validation = this.validate(this.state.shouldValidate);
-    const showFeeInput = this.state.course === 'CS Fundamentals';
 
     return (
       <Grid>
@@ -998,7 +1005,7 @@ export class WorkshopForm extends React.Component {
             </Col>
           </Row>
           <Row>
-            <Col sm={1}>
+            <Col sm={2}>
               <FormGroup validationState={validation.style.capacity}>
                 <ControlLabel>Capacity</ControlLabel>
                 <FormControl
@@ -1016,9 +1023,6 @@ export class WorkshopForm extends React.Component {
             </Col>
             <Col sm={3}>{this.renderCourseSelect(validation)}</Col>
             <Col sm={3}>{this.renderSubjectSelect(validation)}</Col>
-            {showFeeInput && (
-              <Col sm={4}>{this.renderFeeInput(validation)}</Col>
-            )}
           </Row>
           <Row>
             <Col sm={10}>


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/33026 with some UI improvements.  (See that PR for previous screenshots.)

![Screenshot 2020-02-12 15 10 08](https://user-images.githubusercontent.com/2205926/74386489-ed587d80-4daa-11ea-8c2d-7730694ad9d9.png)

![Screenshot 2020-02-12 15 15 11](https://user-images.githubusercontent.com/2205926/74386472-e3367f00-4daa-11ea-9ec9-8363924a4e4c.png)

![Screenshot 2020-02-12 15 19 06](https://user-images.githubusercontent.com/2205926/74386523-06612e80-4dab-11ea-984c-847bd39817d0.png)
