### PR TITLE
Add codecurricula to the allow list for CSP

### DIFF
--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -50,7 +50,7 @@ module Rack
             "style-src 'self' https: 'unsafe-inline'",
             "img-src 'self' https: data: blob:",
             "font-src 'self' https: data:",
-            "connect-src 'self' https: https://api.pusherapp.com wss://ws.pusherapp.com wss://*.firebaseio.com http://localhost:8080",
+            "connect-src 'self' https: https://api.pusherapp.com wss://ws.pusherapp.com wss://*.firebaseio.com http://localhost:8080 https://www.codecurricula.com",
             "media-src 'self' https: http://vaas.acapela-group.com",
             "report-uri #{CDO.code_org_url('https/mixed-content')}"
           ]


### PR DESCRIPTION
Unblocks [LP-1179](https://codedotorg.atlassian.net/browse/LP-1179)
For the standards view of the progress tab, I've set up https://studio.code.org/admin/standards where admins can import standards-lesson associations from CurriculumBuilder. This works beautifully locally, but I got an error on production:
<img width="749" alt="Screen Shot 2020-02-12 at 2 50 57 PM" src="https://user-images.githubusercontent.com/12300669/74388746-0cf2a480-4db1-11ea-953e-e1371b393ec0.png">
To resolve the issue, I added codecurricula to the allow list for our Content Security Policy directives. Since we control all of the content for codecurricula internally, this doesn't pose any new security risk. I confirmed locally that this will solve the issue. 