### PR TITLE
Dockerfile - Ubuntu 18.04

### DIFF
--- a/docker/dockerfiles/Dockerfile
+++ b/docker/dockerfiles/Dockerfile
@@ -1,6 +1,6 @@
 # Based on Code.org CircleCI-dependencies Dockerfile in .circle directory
 # Pushed to Docker Hub at wintercdo/code-dot-org:0.7
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 USER root
 


### PR DESCRIPTION
# Summary

Proposing using Ubuntu 18 in the Dockerfile here as [Ubuntu 14 reached end-of-life in April 2019](https://help.ubuntu.com/community/EOL#Ubuntu_14.04_Trusty_Tahr) and is no longer supported!