### PR TITLE
Upload about.md.partial as about.md

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -61,5 +61,18 @@ orig_dir=pegasus/cache/i18n
 loc_dir=i18n/locales/source/pegasus
 mkdir -p $loc_dir
 
+### Markdown
+mkdir -p i18n/locales/source/markdown
+loc_dir=i18n/locales/source/markdown/public/international/
+mkdir -p $loc_dir
+orig_file=pegasus/sites.v3/code.org/public/international/about.md.partial
+loc_file=i18n/locales/source/markdown/public/international/about.md
+cp_in $orig_file $loc_file
+loc_dir=i18n/locales/source/markdown/public/educate/curriculum/
+mkdir -p $loc_dir
+orig_file=pegasus/sites.v3/code.org/public/educate/curriculum/csf-transition-guide.md
+cp_in $orig_file $loc_dir
+
+
 perl -i ./bin/i18n-codeorg/lib/fix-ruby-yml.pl $orig_dir/en-US.yml
 cp_in $orig_dir/en-US.yml $loc_dir/mobile.yml

--- a/bin/i18n/codeorg_markdown_crowdin.yml
+++ b/bin/i18n/codeorg_markdown_crowdin.yml
@@ -1,18 +1,17 @@
 "project_identifier" : "codeorg-markdown"
-"base_path" : "../../pegasus/sites.v3/code.org"
+"base_path" : "../.."
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
 "api_key" : ""
 
-"preserve_hierarchy": true
-
 files: [{
-  "source": "/public/international/about.md.partial",
+  "source": "i18n/locales/source/markdown/public/international/about.md",
   # cannot use %file_name% and %file_extension% helpers here, because crowdin
   # doesn't handle multiple extensions like we'd want
-  "translation": "/i18n/%original_path%/about.%locale%.md.partial",
-}, {
-  "source": "/public/educate/curriculum/csf-transition-guide.md",
-  "translation": "/i18n/%original_path%/%file_name%.%locale%.%file_extension%",
+  "translation": "pegasus/sites.v3/code.org/i18n/public/international/about.%locale%.md.partial",
+  },
+  {
+  "source": "18n/locales/source/markdown/public/educate/curriculum/csf-transition-guide.md",
+  "translation": "pegasus.sites.v3/code.org/i18n/public/educate/curriculum/%file_name%.%locale%.%file_extension%"
 }]

--- a/bin/i18n/codeorg_markdown_crowdin.yml
+++ b/bin/i18n/codeorg_markdown_crowdin.yml
@@ -6,12 +6,6 @@
 "api_key" : ""
 
 files: [{
-  "source": "i18n/locales/source/markdown/public/international/about.md",
-  # cannot use %file_name% and %file_extension% helpers here, because crowdin
-  # doesn't handle multiple extensions like we'd want
-  "translation": "pegasus/sites.v3/code.org/i18n/public/international/about.%locale%.md.partial",
-  },
-  {
-  "source": "18n/locales/source/markdown/public/educate/curriculum/csf-transition-guide.md",
-  "translation": "pegasus.sites.v3/code.org/i18n/public/educate/curriculum/%file_name%.%locale%.%file_extension%"
-}]
+  "source": "/i18n/locales/source/markdown/**/*.md",
+  "translation": "/pegasus/sites.v3/code.org/i18n/public/%original_path%/%file_name%.%locale%.md.partial",
+  }]


### PR DESCRIPTION
This PR introduces a number of changes:
1. Upload about.md.partial as about.md so that Crowdin treats the file as Markdown. (the goal of this task)
2. Changes the directory structure of the files uploaded to not include `public/`. The rest of the path is maintained as that seemed like useful context.
3. `csf-transition-guide.md` will now be `csf-transition-guide.md.partial` for translated files

Options I didn't take:
1. I could've kept the config specifying the two files separately. However, to do that the directory structure would either be flat (so translators would just see `about.md` and `csf-transition-guide.md` without the rest of the path) or would have extraneous path information (eg `source/public/...`). 

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/FND-684)

## Testing story

```
ubuntu@ip-10-0-0-11:~/code-dot-org$ crowdin --config bin/i18n/codeorg_markdown_crowdin.yml --identity bin/i18n/CROWDIN_CODEORG_MARKDOWN_CREDENTIALS.yml upload sources --dryrun
Version 2.0.31 of the CLI client is available. You can download the new version here: https://downloads.crowdin.com/cli/v2/crowdin-cli.zip
educate/curriculum/csf-transition-guide.md
international/about.md
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
