### PR TITLE
Donors: fix sponsor selection

### DIFF
--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -126,7 +126,7 @@ def create_course_certificate_image(name, course=nil, sponsor=nil, course_title=
 
   unless sponsor
     weight = SecureRandom.random_number
-    donor = DB[:cdo_donors].all.find {|d| d[:twitter_weight_f] - weight >= 0}
+    donor = DB[:cdo_donors].all.find {|d| d[:weight_f] - weight >= 0}
     sponsor = donor[:name_s]
   end
 

--- a/lib/cdo/user_helpers.rb
+++ b/lib/cdo/user_helpers.rb
@@ -62,7 +62,7 @@ SQL
 
   def self.random_donor
     weight = SecureRandom.random_number
-    PEGASUS_DB[:cdo_donors].all.find {|d| d[:twitter_weight_f] - weight >= 0}
+    PEGASUS_DB[:cdo_donors].all.find {|d| d[:weight_f] - weight >= 0}
   end
 
   def self.sponsor_message(user)


### PR DESCRIPTION
In https://github.com/code-dot-org/code-dot-org/pull/24613, a couple places were changed to only generate sponsor messages for donors with Twitter handles.  This changes them back to cover all donors.
