### PR TITLE
explicitly unescape several more strings

### DIFF
--- a/pegasus/sites.v3/code.org/public/curriculum/concepts/index.md.erb
+++ b/pegasus/sites.v3/code.org/public/curriculum/concepts/index.md.erb
@@ -86,7 +86,7 @@ Each of these activities can either be used alone or with other computer science
     <tr>
       <td rowspan="2" style="color: white; border:1px solid white; text-align: center;"><%= lesson[:mainConcept_s] %></td>
       <td style="border:1px solid #999999;"> <h3><a href="<%= lesson[:lessonURL_t] %>" target="_new"><%= lesson[:name_t] %></a></h3>
-        <div style="font-size: 11px; line-height: 120%;"><b><%= theCourse %><br/> <%= "(age #{lesson[:age_s]}) " %> </b><br/><br/></div>
+        <div style="font-size: 11px; line-height: 120%;"><b><%= theCourse %><br/> <%= "(age #{lesson[:age_s]})" %> </b><br/><br/></div>
      	<div style="font-size: 12px; line-height: 110%;"><%= lesson[:overview_t] %><br/><br/></div>
         <a href="<%= lesson[:lessonPlan_t] %>" target="_new">Lesson Plan</a>
         <%	if lesson[:teacherVid_t].present? %>

--- a/pegasus/sites.v3/code.org/views/index_hoc.haml
+++ b/pegasus/sites.v3/code.org/views/index_hoc.haml
@@ -1,5 +1,5 @@
 .lines_of_code_header{style: "background-color: #d43f3a"}
-  =I18n.t(:csedweek_banner_teachers)
+  !=I18n.t(:csedweek_banner_teachers)
 %br/
 
 :css

--- a/pegasus/sites.v3/code.org/views/unsupported_browser.haml
+++ b/pegasus/sites.v3/code.org/views/unsupported_browser.haml
@@ -1,4 +1,4 @@
 #warning-banner{style: 'display: none;'}
   %i.fa.fa-warning.warning-sign
   &nbsp;
-  = TextRender.safe_markdown I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743')
+  = I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true)

--- a/pegasus/sites.v3/csedweek.org/public/index.haml
+++ b/pegasus/sites.v3/csedweek.org/public/index.haml
@@ -32,11 +32,11 @@ video_player: true
           -count_string = I18n.t(:n_have_learned_an_hoc).gsub("#", format_integer_with_commas(fetch_hoc_metrics['started']).to_s)
           -if request.locale == 'en-US'
             %a{:href=>'/leaderboards', :style=>'text-decoration:none'}
-              =count_string
+              !=count_string
             %h4
               =I18n.t :anybody_can_learn
           -else
-            =count_string
+            !=count_string
 
         %div{:style=>'margin-bottom: 8px'}
           = view :csedweek_action_buttons, hoc_mode: hoc_mode

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -122,11 +122,11 @@ social:
       -# Show a picture of the map unless it is currently the week of HOC.
       -if hoc_mode != "actual-hoc"
         = view :hoc_events_map
-        .footnote=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))
+        .footnote!=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))
       -else
         %a{href: resolve_url('/map')}
           %img{src: '/images/fit-1000/map.jpg', style: 'width: 100%;'}
-        .footnote=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))
+        .footnote!=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))
 
   -# Signup and Highlights
 
@@ -161,9 +161,9 @@ social:
       -if @language == "en"
         %p=hoc_s(:stats_females)
         %img{src: "/images/fit-300/stats-females.jpg", style: "width: 100%;"}
-        %p=hoc_s(:stats_females_more)
+        %p!=hoc_s(:stats_females_more)
       -else
-        %p=hoc_s(:stats_girls_more)
+        %p!=hoc_s(:stats_girls_more)
         %img{src: "/images/fit-300/stats-info3.jpg", style: "width: 100%;"}
 
   -# FAQ

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -83,10 +83,10 @@ social:
       .bannerHeading= hoc_s(:learn_banner_heading)
       = hoc_s(:learn_banner_blurb)
       .bannerBeyond
-        = hoc_s(:learn_banner_beyond)
+        != hoc_s(:learn_banner_beyond)
       .bannerTeachers
         %img.bannerTeacherIcon{src: "/images/learn/teacher_icon.png"}
-        = hoc_s(:learn_banner_teachers)
+        != hoc_s(:learn_banner_teachers)
     #studentImage.hidden-xs.col-sm-12.col-md-6
 
 -# Not ideal but we can pull the undigested files from /blockly.

--- a/pegasus/sites.v3/hourofcode.com/public/map.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/map.haml
@@ -10,4 +10,4 @@ layout: wide_index
   = view :header
 %h2.center-text= view :hoc_events_counter
 = view :hoc_events_map
-.footnote=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))
+.footnote!=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))

--- a/pegasus/sites.v3/hourofcode.com/views/faq.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/faq.haml
@@ -1,7 +1,7 @@
 %h1= hoc_s(:hoc_faq_title)
 
 %h2#about= hoc_s(:hoc_faq_what_is_hoc_q)
-%div= hoc_s(:hoc_faq_what_is_hoc_a).gsub(/%{tutorials}/, resolve_url('/learn')).gsub(/%{partners}/, resolve_url('/partners'))
+%div!= hoc_s(:hoc_faq_what_is_hoc_a).gsub(/%{tutorials}/, resolve_url('/learn')).gsub(/%{partners}/, resolve_url('/partners'))
 
 -# Hide signup buttons during Hour of Code
   %br/
@@ -10,54 +10,54 @@
     =hoc_s(:signup_host_an_hour)
 
 %h2= hoc_s(:hoc_faq_when_is_hoc_q)
-%div= hoc_s(:hoc_faq_when_is_hoc_a).gsub(/%{csedweek_url}/, 'https://csedweek.org').gsub(/%{campaign_date_year}/, campaign_date('year')).gsub(/%{campaign_date_full}/, campaign_date('full')).gsub(/%{grace_hopper}/, 'http://en.wikipedia.org/wiki/Grace_Hopper')
+%div!= hoc_s(:hoc_faq_when_is_hoc_a).gsub(/%{csedweek_url}/, 'https://csedweek.org').gsub(/%{campaign_date_year}/, campaign_date('year')).gsub(/%{campaign_date_full}/, campaign_date('full')).gsub(/%{grace_hopper}/, 'http://en.wikipedia.org/wiki/Grace_Hopper')
 
 %h2= hoc_s(:hoc_faq_why_cs_q)
-%div= hoc_s(:hoc_faq_why_cs_a).gsub(/%{stats_url}/, resolve_url('/promote/stats'))
+%div!= hoc_s(:hoc_faq_why_cs_a).gsub(/%{stats_url}/, resolve_url('/promote/stats'))
 
 %h2= hoc_s(:hoc_faq_how_participate_q)
-%div= hoc_s(:hoc_faq_how_participate_a).gsub('/how-to', resolve_url('/how-to')).gsub(/%{campaign_date}/, campaign_date('start-short'))
+%div!= hoc_s(:hoc_faq_how_participate_a).gsub('/how-to', resolve_url('/how-to')).gsub(/%{campaign_date}/, campaign_date('start-short'))
 
 %h2= hoc_s(:hoc_faq_behind_hoc_q)
-%div= hoc_s(:hoc_faq_behind_hoc_a).gsub(/%{partner_url}/, resolve_url('/partners'))
+%div!= hoc_s(:hoc_faq_behind_hoc_a).gsub(/%{partner_url}/, resolve_url('/partners'))
 
 %h2= hoc_s(:hoc_faq_host_q)
-%div= hoc_s(:hoc_faq_host_a).gsub('/how-to', resolve_url('/how-to')).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
+%div!= hoc_s(:hoc_faq_host_a).gsub('/how-to', resolve_url('/how-to')).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
 
 %h2= hoc_s(:hoc_faq_devices_q)
-%div= hoc_s(:hoc_faq_devices_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/')).gsub(/%{partner_url}/, 'code.org').gsub(/%{unplugged_url}\/?/, codeorg_url('/curriculum/unplugged'))
+%div!= hoc_s(:hoc_faq_devices_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/')).gsub(/%{partner_url}/, 'code.org').gsub(/%{unplugged_url}\/?/, codeorg_url('/curriculum/unplugged'))
 
 %h2= hoc_s(:hoc_faq_need_computers_q)
-%div= hoc_s(:hoc_faq_need_computers_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/')).gsub(/%{pair_programming_research}/, 'http://www.ncwit.org/resources/pair-programming-box-power-collaborative-learning').gsub(/%{pair_programming_video}/, 'https://www.youtube.com/watch?v=vgkahOzFH2Q').gsub(/%{unplugged_url}\/?/, codeorg_url('/curriculum/unplugged'))
+%div!= hoc_s(:hoc_faq_need_computers_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/')).gsub(/%{pair_programming_research}/, 'http://www.ncwit.org/resources/pair-programming-box-power-collaborative-learning').gsub(/%{pair_programming_video}/, 'https://www.youtube.com/watch?v=vgkahOzFH2Q').gsub(/%{unplugged_url}\/?/, codeorg_url('/curriculum/unplugged'))
 
 -if @country == 'us'
   %h2= hoc_s(:hoc_faq_logo_q)
-  %div= hoc_s(:hoc_faq_logo_a).gsub(/%{logo_url}/, "https://support.code.org/hc/en-us/articles/202518403")
+  %div!= hoc_s(:hoc_faq_logo_a).gsub(/%{logo_url}/, "https://support.code.org/hc/en-us/articles/202518403")
 
 -if @country != 'us'
   %h2= hoc_s(:hoc_faq_international_q).gsub(/<country>/, HOC_COUNTRIES[@country]['full_name'])
-  %div= hoc_s(:hoc_faq_international_a).gsub('/promote', resolve_url('/promote'))
+  %div!= hoc_s(:hoc_faq_international_a).gsub('/promote', resolve_url('/promote'))
 
 %h2= hoc_s(:hoc_faq_tutorial_q)
-%div= hoc_s(:hoc_faq_tutorial_a).gsub('/tutorial-guidelines', resolve_url('/tutorial-guidelines'))
+%div!= hoc_s(:hoc_faq_tutorial_a).gsub('/tutorial-guidelines', resolve_url('/tutorial-guidelines'))
 
 %h2= hoc_s(:hoc_faq_account_q)
-%div= hoc_s(:hoc_faq_account_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
+%div!= hoc_s(:hoc_faq_account_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
 
 %h2= hoc_s(:hoc_faq_certificates_q)
-%div= hoc_s(:hoc_faq_certificates_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
+%div!= hoc_s(:hoc_faq_certificates_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
 
 %h2= hoc_s(:hoc_faq_high_school_q)
-%div= hoc_s(:hoc_faq_high_school_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/')).gsub(/%{partner_url}/, 'code.org')
+%div!= hoc_s(:hoc_faq_high_school_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/')).gsub(/%{partner_url}/, 'code.org')
 
 %h2= hoc_s(:hoc_faq_count_hoc_q)
-%div= hoc_s(:hoc_faq_count_hoc_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
+%div!= hoc_s(:hoc_faq_count_hoc_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
 
 %h2= hoc_s(:hoc_faq_map_q)
-%div= hoc_s(:hoc_faq_map_a).gsub(/%{events_url}/, resolve_url('/events'))
+%div!= hoc_s(:hoc_faq_map_a).gsub(/%{events_url}/, resolve_url('/events'))
 
 %h2= hoc_s(:hoc_faq_one_hour_q)
-%div= hoc_s(:hoc_faq_one_hour_a)
+%div!= hoc_s(:hoc_faq_one_hour_a)
 
 %h2= hoc_s(:hoc_faq_keep_learning_q)
-%div= hoc_s(:hoc_faq_keep_learning_a).gsub('/promote', resolve_url('/promote'))
+%div!= hoc_s(:hoc_faq_keep_learning_a).gsub('/promote', resolve_url('/promote'))

--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,7 +4,7 @@
   %h1#join-us-header=hoc_s(:front_join_us_button)
   -if ["post-hoc", false].include?(hoc_mode)
     #signup-closed
-      =hoc_s(:signup_registration_not_required).gsub(/%{hoc_activities_url}/, resolve_url('/learn')).gsub(/%{howto_guide_url}/, resolve_url('/how-to'))
+      !=hoc_s(:signup_registration_not_required).gsub(/%{hoc_activities_url}/, resolve_url('/learn')).gsub(/%{howto_guide_url}/, resolve_url('/how-to'))
       =hoc_s(:signup_registration_closed)
     =view :index_video
   -else

--- a/pegasus/sites.v3/hourofcode.com/views/learn_carousel.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/learn_carousel.haml
@@ -10,10 +10,10 @@
 -if items.count > 0
   -if shuffle
     -items = items.to_a.shuffle.to_h
-  %h3{:class=>'course-carousel-title', :style=>"margin-bottom:8px"}=heading
+  %h3{:class=>'course-carousel-title', :style=>"margin-bottom:8px"}!=heading
 
   -unless subheading.nil_or_empty?
-    %p=subheading
+    %p!=subheading
 
   .learnpage{:style=>'position:relative'}
 
@@ -38,7 +38,7 @@
                     %h2= tutorial[:name]
                 %h3= tutorial[:orgname]
                 -unless international_layout
-                  %p.slide-longdescription= tutorial[:longdescription]
+                  %p.slide-longdescription!= tutorial[:longdescription]
                   %p.slide-shortdescription= tutorial[:shortdescription]
                   .slide-tags= tags
                   .slide-participants-count<

--- a/pegasus/sites.v3/hourofcode.com/views/learn_carousels.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/learn_carousels.haml
@@ -47,7 +47,7 @@
   %br
   - unless variation == "university"
     .footer-banner
-      = I18n.t(:learn_footer_all_tutorials)
+      != I18n.t(:learn_footer_all_tutorials)
 
 :javascript
 

--- a/pegasus/sites.v3/hourofcode.com/views/share_buttons.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/share_buttons.haml
@@ -2,11 +2,11 @@
   %a.window-popup{:href=>"https://www.facebook.com/sharer/sharer.php?#{facebook.to_query}"}<
     %button.button-color-share.share-button-facebook<
       %i{:class=>"fa fa-facebook"}<
-      =hoc_s(:share_on_facebook)
+      !=hoc_s(:share_on_facebook)
   %a.window-popup{:href=>"https://twitter.com/share?#{twitter.to_query}"}<
     %button.button-color-share.share-button-twitter<
       %i{:class=>"fa fa-twitter"}<
-      =hoc_s(:share_on_twitter)
+      !=hoc_s(:share_on_twitter)
   -download_url ||= nil
   -unless download_url.nil_or_empty?
     %a.desktop-feature{:href=>download_url, :style=>'padding-left:10px'}

--- a/pegasus/sites.v3/hourofcode.com/views/unsupported_browser.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/unsupported_browser.haml
@@ -1,4 +1,4 @@
 #warning-banner{style: 'display: none;'}
   %i.fa.fa-warning.warning-sign
   &nbsp;
-  = TextRender.safe_markdown I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743')
+  = I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true)


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/33081, this time including changes to all domains, not just code.org

## Testing story
Again used https://github.com/code-dot-org/code-dot-org/pull/32977 to render pegasus both before and after this change, and verified that there is no difference.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
