### PR TITLE
stream the output of the sync as it happens

### DIFF
--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -29,6 +29,9 @@ def sync_down
         # skip lines detailing individual file extraction
         next if line.start_with?("Extracting: ")
 
+        # skip warning that happens if the sync is run multiple times in succession
+        next if line == "Warning: Export was skipped. Please note that this method can be invoked only once per 30 minutes.\n"
+
         puts line
       end
 

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -29,9 +29,6 @@ def sync_down
         # skip lines detailing individual file extraction
         next if line.start_with?("Extracting: ")
 
-        # skip warning that happens if the sync is run multiple times in succession
-        next if line == "Warning: Export was skipped. Please note that this method can be invoked only once per 30 minutes.\n"
-
         puts line
       end
 

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -21,13 +21,16 @@ def sync_down
     # We really only care about general progress monitoring, so we remove or
     # ignore any things we identify as "noise" in the output.
     Open3.popen2(command) do |_stdin, stdout, status_thread|
-      stdout.each_line do |line|
+      while line = stdout.gets
         # strip out the progress spinner, which is implemented as the sequence
         # \-/| followed by a backspace character
         line.gsub!(/[\|\/\-\\][\b]/, '')
 
         # skip lines detailing individual file extraction
-        next if line.start_with?("Extracting: ", "Building ")
+        next if line.start_with?("Extracting: ")
+
+        # skip warning that happens if the sync is run multiple times in succession
+        next if line == "Warning: Export was skipped. Please note that this method can be invoked only once per 30 minutes.\n"
 
         puts line
       end

--- a/bin/i18n/sync-up.rb
+++ b/bin/i18n/sync-up.rb
@@ -14,7 +14,7 @@ def sync_up
     puts "Uploading source strings to #{name} project"
     command = "crowdin --config #{options[:config_file]} --identity #{options[:identity_file]} upload sources"
     Open3.popen2(command) do |_stdin, stdout, status_thread|
-      stdout.each_line do |line|
+      while line = stdout.gets
         # skip lines detailing individual file upload, unless that file
         # resulted in an unexpected response
         next if line.start_with?("File ") && line.end_with?("OK\n", "SKIPPED\n")


### PR DESCRIPTION
rather than waiting for it all to finish

also restore the "building" lines; now that we will (hopefully) be logging each line as it shows up rather than all once, these should both no longer be throttled by slack and provide insight into how far along the sync is.

also, skip the "Warning: Export was skipped." line that happens when no changes have come in for a language since the last time the sync was run; this will show up in the building line anyway.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-897)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
