### PR TITLE
Update bubble choice ux

### DIFF
--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -43,6 +43,11 @@ const styles = {
     flexDirection: 'column',
     alignItems: 'flex-start'
   },
+  bubbleAndTitle: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
   title: {
     fontSize: 20,
     fontFamily: '"Gotham 5r"',

--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import {navigateToHref} from '@cdo/apps/utils';
+import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
+import {getIconForLevel} from '@cdo/apps/templates/progress/progressHelpers';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
@@ -25,26 +27,27 @@ const styles = {
   placeholderThumbnail: {
     width: THUMBNAIL_IMAGE_SIZE,
     height: THUMBNAIL_IMAGE_SIZE,
-    backgroundColor: color.lighter_gray
+    backgroundColor: color.lighter_gray,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
   },
-  thumbnailOverlay: {
-    position: 'absolute',
-    width: THUMBNAIL_IMAGE_SIZE,
-    height: THUMBNAIL_IMAGE_SIZE,
-    backgroundColor: 'rgba(0, 255, 0, 0.3)'
-  },
-  check: {
-    fontSize: THUMBNAIL_IMAGE_SIZE,
+  icon: {
+    fontSize: THUMBNAIL_IMAGE_SIZE - 50,
     color: color.white,
     opacity: 0.8
   },
   column: {
-    marginLeft: MARGIN * 2
+    marginLeft: MARGIN * 2,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start'
   },
   title: {
     fontSize: 20,
     fontFamily: '"Gotham 5r"',
-    color: color.teal
+    color: color.teal,
+    marginLeft: 10
   },
   description: {
     marginTop: MARGIN
@@ -75,6 +78,8 @@ export default class BubbleChoice extends React.Component {
           description: PropTypes.string,
           thumbnail_url: PropTypes.string,
           url: PropTypes.string.isRequired,
+          position: PropTypes.number,
+          letter: PropTypes.string,
           perfect: PropTypes.bool
         })
       )
@@ -129,24 +134,25 @@ export default class BubbleChoice extends React.Component {
             style={styles.row}
             className="uitest-bubble-choice"
           >
-            {sublevel.perfect && (
-              <div style={styles.thumbnailOverlay}>
-                <FontAwesome icon="check" style={styles.check} />
-              </div>
-            )}
             {/* Render a square-shaped placeholder if we don't have a thumbnail. */}
             {sublevel.thumbnail_url ? (
               <img src={sublevel.thumbnail_url} style={styles.thumbnail} />
             ) : (
-              <div
-                style={styles.placeholderThumbnail}
-                className="placeholder"
-              />
+              <div style={styles.placeholderThumbnail} className="placeholder">
+                <FontAwesome
+                  icon={getIconForLevel(sublevel)}
+                  style={styles.icon}
+                  key={sublevel.id}
+                />
+              </div>
             )}
             <div style={styles.column}>
-              <a href={sublevel.url + location.search} style={styles.title}>
-                {sublevel.display_name}
-              </a>
+              <div style={styles.bubbleAndTitle}>
+                <ProgressBubble level={sublevel} disabled={false} />
+                <a href={sublevel.url + location.search} style={styles.title}>
+                  {sublevel.display_name}
+                </a>
+              </div>
               {sublevel.description && (
                 <div style={styles.description}>{sublevel.description}</div>
               )}

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -148,7 +148,8 @@ class ProgressBubble extends React.Component {
     const levelIcon = getIconForLevel(level);
 
     const disabled = this.props.disabled || levelIcon === 'lock';
-    const hideNumber = levelIcon === 'lock' || level.paired || level.bonus;
+    const hideNumber =
+      level.letter || levelIcon === 'lock' || level.paired || level.bonus;
 
     const style = {
       ...styles.main,
@@ -232,6 +233,9 @@ class ProgressBubble extends React.Component {
                 ...(level.isConceptLevel && styles.diamondContents)
               }}
             >
+              {level.letter && (
+                <span id="test-bubble-letter"> {level.letter} </span>
+              )}
               {levelIcon === 'lock' && <FontAwesome icon="lock" />}
               {pairingIconEnabled && level.paired && (
                 <FontAwesome icon="users" />

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -68,8 +68,8 @@ describe('BubbleChoice', () => {
     const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} />);
     const bubbles = wrapper.find('ProgressBubble');
     assert.equal(2, bubbles.length);
-    assert.equal('perfect', bubbles.at(0).props().status);
-    assert.equal('not_tried', bubbles.at(1).props().status);
+    assert.equal('perfect', bubbles.at(0).props().level.status);
+    assert.equal('not_tried', bubbles.at(1).props().level.status);
   });
 
   it('renders a placeholder div if sublevel thumbnail is not present', () => {

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -10,13 +10,21 @@ const fakeSublevels = [
     id: 1,
     display_name: 'Choice 1',
     thumbnail_url: 'some-fake.url/kittens.png',
-    url: '/s/script/stage/1/puzzle/2/sublevel/1'
+    url: '/s/script/stage/1/puzzle/2/sublevel/1',
+    description: 'Sublevel 1 is lots of fun',
+    position: 1,
+    letter: 'a',
+    status: 'perfect'
   },
   {
     id: 2,
     display_name: 'Choice 2',
     thumbnail_url: null,
-    url: '/s/script/stage/1/puzzle/2/sublevel/2'
+    url: '/s/script/stage/1/puzzle/2/sublevel/2',
+    description: 'Sublevel 2 has cool stuff to do',
+    position: 2,
+    letter: 'b',
+    status: 'not_tried'
   }
 ];
 
@@ -27,7 +35,10 @@ const DEFAULT_PROPS = {
     sublevels: fakeSublevels,
     previous_level_url: '/s/script/stage/1/puzzle/1',
     next_level_url: '/s/script/stage/1/puzzle/3',
-    script_url: '/s/script'
+    script_url: '/s/script',
+    name: 'Bubble Choice',
+    type: 'BubbleChoice',
+    teacher_markdown: 'Students should work on which ever bubble they like'
   }
 };
 
@@ -51,6 +62,14 @@ describe('BubbleChoice', () => {
         .getDOMNode()
         .src.includes(fakeSublevels[0].thumbnail_url)
     );
+  });
+
+  it('renders progress bubbles for sublevels', () => {
+    const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} />);
+    const bubbles = wrapper.find('ProgressBubble');
+    assert.equal(2, bubbles.length);
+    assert.equal('perfect', bubbles.at(0).props().status);
+    assert.equal('not_tried', bubbles.at(1).props().status);
   });
 
   it('renders a placeholder div if sublevel thumbnail is not present', () => {

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -45,6 +45,20 @@ describe('ProgressBubble', () => {
     assert(wrapper.is('div'));
   });
 
+  it('shows letter in bubble when level has a letter', () => {
+    const wrapper = shallow(
+      <ProgressBubble
+        {...defaultProps}
+        level={{
+          ...defaultProps.level,
+          letter: 'a'
+        }}
+      />
+    );
+
+    expect(wrapper.find('#test-bubble-letter')).to.have.lengthOf(1);
+  });
+
   it('has a green background when we have perfect status and not assessment', () => {
     const wrapper = shallow(<ProgressBubble {...defaultProps} />);
 

--- a/dashboard/test/ui/features/bubble_choice.feature
+++ b/dashboard/test/ui/features/bubble_choice.feature
@@ -12,8 +12,11 @@ Feature: BubbleChoice
 
     # Make sure you are taken back to the BubbleChoice activity page with progress
     And I wait until element ".uitest-bubble-choice:eq(0)" is visible
+    And element ".uitest-bubble-choice:eq(0) .uitest-ProgressBubble:first" is visible
+      #.uitest-ProgressBubble:first
     And check that the url contains "/s/allthethings/stage/40/puzzle/1"
-    And element ".uitest-bubble-choice:eq(0) i.fa-check" is visible
+    And element ".uitest-bubble-choice:eq(0) .uitest-ProgressBubble:first" is visible
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .uitest-ProgressBubble:first .uitest-bubble" is "perfect"
 
     And I sign out
 
@@ -32,8 +35,8 @@ Feature: BubbleChoice
     Given I am on "http://studio.code.org/s/allthethings/stage/40/puzzle/1"
     And I wait until element ".teacher-panel" is visible
     # Teacher has not completed level, so make sure it is not shown as complete
-    And element ".uitest-bubble-choice:eq(0) i.fa-check" is not visible
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .uitest-ProgressBubble:first .uitest-bubble" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it
     And I wait until element ".uitest-bubble-choice:eq(0)" is visible
     And I wait for 2 seconds
-    And element ".uitest-bubble-choice:eq(0) i.fa-check" is visible
+    Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .uitest-ProgressBubble:first .uitest-bubble" is "perfect"

--- a/dashboard/test/ui/features/level_group_multi_page_dots.feature
+++ b/dashboard/test/ui/features/level_group_multi_page_dots.feature
@@ -139,7 +139,6 @@ Scenario: optional free play level
   And check that the URL contains "/page/3"
 
   # Verify the bubble status and submit dialog contents are now complete
-
   Then I verify progress in the header of the current page is "perfect_assessment" for level 2
   Then I verify progress in the header of the current page is "perfect_assessment" for level 3
   Then I verify progress in the header of the current page is "perfect_assessment" for level 4

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -80,6 +80,12 @@ Then /^I verify progress for stage (\d+) level (\d+) is "([^"]*)"/ do |stage, le
   verify_progress(selector, test_result)
 end
 
+Then /^I verify progress for the sublevel with selector "([^"]*)" is "([^"]*)"/ do |selector, test_result|
+  wait_short_until do
+    verify_progress(selector, test_result)
+  end
+end
+
 # PLC Progress
 Then /^I verify progress for the selector "([^"]*)" is "([^"]*)"/ do |selector, progress|
   element_has_css(selector, 'background-color', MODULE_PROGRESS_COLOR_MAP[progress.to_sym])


### PR DESCRIPTION

Update the UX of a parent bubble choice level
- Use bubble instead of overlay
- If no thumbnail put icon in the box so it doesn't look broken

## Before

 <img width="1440" alt="Screen Shot 2020-02-14 at 1 22 42 PM" src="https://user-images.githubusercontent.com/208083/74556955-19037100-4f2d-11ea-97c3-9762d81fb20f.png">


## After
<img width="1440" alt="Screen Shot 2020-02-14 at 1 18 46 PM" src="https://user-images.githubusercontent.com/208083/74556737-b01bf900-4f2c-11ea-9cd5-0f87cf3a1205.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1V659BsDBGeQgBZziz3wfEA--XLOKl7ZWt2WFkWfA7Ik/edit#)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Added new tests for BubbleChoice and ProgressBubble.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
