### PR TITLE
Standards Import: use curriculum.code.org instead of codecurricula 

### DIFF
--- a/apps/src/sites/studio/pages/admin_standards/index.js
+++ b/apps/src/sites/studio/pages/admin_standards/index.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
   $('#import-standards').click(function(e) {
     var script = $('#select option:selected').val();
     var url =
-      'http://www.codecurricula.com/metadata/' + script + '/standards.json';
+      'https://www.curriculum.code.org/metadata/' + script + '/standards.json';
     $.ajax({
       url: url,
       type: 'get'

--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -50,7 +50,7 @@ module Rack
             "style-src 'self' https: 'unsafe-inline'",
             "img-src 'self' https: data: blob:",
             "font-src 'self' https: data:",
-            "connect-src 'self' https: https://api.pusherapp.com wss://ws.pusherapp.com wss://*.firebaseio.com http://localhost:8080 http://www.codecurricula.com",
+            "connect-src 'self' https: https://api.pusherapp.com wss://ws.pusherapp.com wss://*.firebaseio.com http://localhost:8080 https://curriculum.code.org/",
             "media-src 'self' https: http://vaas.acapela-group.com",
             "report-uri #{CDO.code_org_url('https/mixed-content')}"
           ]

--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -50,7 +50,7 @@ module Rack
             "style-src 'self' https: 'unsafe-inline'",
             "img-src 'self' https: data: blob:",
             "font-src 'self' https: data:",
-            "connect-src 'self' https: https://api.pusherapp.com wss://ws.pusherapp.com wss://*.firebaseio.com http://localhost:8080 https://www.codecurricula.com",
+            "connect-src 'self' https: https://api.pusherapp.com wss://ws.pusherapp.com wss://*.firebaseio.com http://localhost:8080 http://www.codecurricula.com",
             "media-src 'self' https: http://vaas.acapela-group.com",
             "report-uri #{CDO.code_org_url('https/mixed-content')}"
           ]


### PR DESCRIPTION
Follow up to #33123. 

I tried to import the standards on production and still hit this error: 
<img width="1000" alt="Screen Shot 2020-02-13 at 4 52 44 PM" src="https://user-images.githubusercontent.com/12300669/74559068-5f9aa080-4f18-11ea-906b-e3fcce52e762.png">

Because I allowed https: codecurricula  NOT http: codecurricula 🤦‍♀️

Update: Switching to curriculum.code.org.  I think this would've worked if I'd changed the ajax url to be https for codecurricula, but curriculum.code.org makes more sense regardless since it's the published up-to-date content that we'd want to be referencing. 