### PR TITLE
Sort standards table by concept and organization_id within concept

### DIFF
--- a/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
+++ b/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
@@ -20,11 +20,22 @@ const initialState = {
   teacherComment: null
 };
 
+function sortByOrganizationId(standardsByConcept) {
+  return _.orderBy(standardsByConcept, 'organization_id', 'asc');
+}
+
 export default function sectionStandardsProgress(state = initialState, action) {
   if (action.type === ADD_STANDARDS_DATA) {
+    const sortedByConcept = _.orderBy(action.standardsData, 'concept', 'asc');
+    const groupedStandards = _.orderBy(
+      _.groupBy(sortedByConcept, 'concept'),
+      'concept',
+      'asc'
+    );
+    const sortedStandards = _.map(groupedStandards, sortByOrganizationId);
     return {
       ...state,
-      standardsData: _.orderBy(action.standardsData, 'concept', 'asc')
+      standardsData: _.flatten(sortedStandards)
     };
   }
   if (action.type === SET_TEACHER_COMMENT_FOR_REPORT) {

--- a/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
+++ b/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
@@ -24,7 +24,7 @@ export default function sectionStandardsProgress(state = initialState, action) {
   if (action.type === ADD_STANDARDS_DATA) {
     return {
       ...state,
-      standardsData: action.standardsData
+      standardsData: _.orderBy(action.standardsData, 'concept', 'asc')
     };
   }
   if (action.type === SET_TEACHER_COMMENT_FOR_REPORT) {


### PR DESCRIPTION
[LP-1172](https://codedotorg.atlassian.net/browse/LP-1172)
Based on the [spec](https://docs.google.com/document/d/1xlm_syljGXIapl72GaKxN63V7kt6syHyvWHuqZhTCfE/edit#) for the standards table, we want the table to be organized based on the following rules:

Grouping: The Standards will be grouped by Standard Family (EX: All the Algorithms and Programming standards will be grouped together)
Sorting: The Standard groups will be sorted in order of Standard Family name, alphabetically, descending. The standards will be sorted within each group alphabetically, descending, by standard code (ex: 1B-AP-11)

This PR implements the needed grouping and sorting for the table. 

BEFORE:
![unsorted-standards](https://user-images.githubusercontent.com/12300669/74562889-72b16e80-4f20-11ea-97d0-d641b32275f9.gif)

AFTER:
![sorted_standards](https://user-images.githubusercontent.com/12300669/74562521-db4c1b80-4f1f-11ea-89af-db2bdd24b223.gif)


