### PR TITLE
Fix nonexistent-email bug in teacher application export

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -75,7 +75,7 @@ def notify_of_external_sharing(drive)
   end
 
   if external_emails.present?
-    email_domains = external_emails.map {|email| email.slice(/@.*/)}
+    email_domains = external_emails.map {|email| email.slice(/@.*/)}.uniq
     error_msg = "Document containing PII information is shared to "\
       "#{external_emails.length} external account(s) at the following domain(s): #{email_domains.join(', ')}. "\
       "Please check with PLC team that this is intentional!"

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -67,7 +67,10 @@ def notify_of_external_sharing(drive)
 
   external_emails = []
   acl.each do |entry|
-    next if entry.email_address.end_with?('@code.org') || allowed_list.include?(entry.email_address)
+    next if entry.email_address.blank? ||
+      entry.email_address.end_with?('@code.org') ||
+      allowed_list.include?(entry.email_address)
+
     external_emails << entry.email_address
   end
 


### PR DESCRIPTION
Fixing a bug in https://github.com/code-dot-org/code-dot-org/pull/33091, which is reported in this [Honeybadger error](https://app.honeybadger.io/projects/45435/faults/60828020).

The script extracts email addresses from all ACL entries of a Google spreadsheet. However, some entries don't have email addresses. For example, this one `#<GoogleDrive::AclEntry type="domain", domain="code.org", role="writer">` gives a broad access to accounts under Code.org domain. This problem was not exposed when testing using a private spreadsheet.

## Testing story
Tested the script manually in `product-daemon` machine.