### PR TITLE
use syncronous stdout to _actually_ stream the output of the sync as it happens

### DIFF
--- a/bin/i18n/hoc_sync_utils.rb
+++ b/bin/i18n/hoc_sync_utils.rb
@@ -86,8 +86,6 @@ class HocSyncUtils
         FileUtils.mkdir_p(dest_dir)
         FileUtils.cp(source_path, File.join(dest_dir, dest_name))
       end
-
-      puts "Copied locale #{prop[:unique_language_s]}"
     end
   end
 

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -23,6 +23,18 @@ CROWDIN_PROJECTS = {
 }
 
 class I18nScriptUtils
+  # Because we log many of the i18n operations to slack, we often want to
+  # explicitly force stdout to operate syncronously, rather than buffering
+  # output and dumping a whole lot of output into slack all at once.
+  #
+  # See the sync_up and sync_down methods in particular for usage.
+  def self.with_syncronous_stdout
+    old_sync = $stdout.sync
+    $stdout.sync = true
+    yield
+    $stdout.sync = old_sync
+  end
+
   # Output the given data to YAML that will be consumed by Crowdin. Includes a
   # couple changes to the default `data.to_yaml` serialization:
   #

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -8,38 +8,40 @@ require_relative 'i18n_script_utils'
 require 'open3'
 
 def sync_down
-  puts "Beginning sync down"
+  I18nScriptUtils.with_syncronous_stdout do
+    puts "Beginning sync down"
 
-  CROWDIN_PROJECTS.each do |name, options|
-    puts "Downloading translations from #{name} project"
-    command = "crowdin --config #{options[:config_file]} --identity #{options[:identity_file]} download translations"
+    CROWDIN_PROJECTS.each do |name, options|
+      puts "Downloading translations from #{name} project"
+      command = "crowdin --config #{options[:config_file]} --identity #{options[:identity_file]} download translations"
 
-    # Filter the output because the crowdin translation download is _super_
-    # verbose; it includes not only a progress spinner, but also information
-    # about each individual file downloaded in each individual language.
-    #
-    # We really only care about general progress monitoring, so we remove or
-    # ignore any things we identify as "noise" in the output.
-    Open3.popen2(command) do |_stdin, stdout, status_thread|
-      while line = stdout.gets
-        # strip out the progress spinner, which is implemented as the sequence
-        # \-/| followed by a backspace character
-        line.gsub!(/[\|\/\-\\][\b]/, '')
+      # Filter the output because the crowdin translation download is _super_
+      # verbose; it includes not only a progress spinner, but also information
+      # about each individual file downloaded in each individual language.
+      #
+      # We really only care about general progress monitoring, so we remove or
+      # ignore any things we identify as "noise" in the output.
+      Open3.popen2(command) do |_stdin, stdout, status_thread|
+        while line = stdout.gets
+          # strip out the progress spinner, which is implemented as the sequence
+          # \-/| followed by a backspace character
+          line.gsub!(/[\|\/\-\\][\b]/, '')
 
-        # skip lines detailing individual file extraction
-        next if line.start_with?("Extracting: ")
+          # skip lines detailing individual file extraction
+          next if line.start_with?("Extracting: ")
 
-        # skip warning that happens if the sync is run multiple times in succession
-        next if line == "Warning: Export was skipped. Please note that this method can be invoked only once per 30 minutes.\n"
+          # skip warning that happens if the sync is run multiple times in succession
+          next if line == "Warning: Export was skipped. Please note that this method can be invoked only once per 30 minutes.\n"
 
-        puts line
+          puts line
+        end
+
+        raise "Sync down failed"  unless status_thread.value.success?
       end
-
-      raise "Sync down failed"  unless status_thread.value.success?
     end
-  end
 
-  puts "Sync down complete"
+    puts "Sync down complete"
+  end
 end
 
 sync_down if __FILE__ == $0

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -23,7 +23,9 @@ def sync_out
   rebuild_blockly_js_files
   HocSyncUtils.sync_out
   puts "updating TTS I18n (should usually take 2-3 minutes, may take up to 15 if there are a whole lot of translation updates)"
-  I18nScriptUtils.run_standalone_script "dashboard/scripts/update_tts_i18n.rb"
+  I18nScriptUtils.with_syncronous_stdout do
+    I18nScriptUtils.run_standalone_script "dashboard/scripts/update_tts_i18n.rb"
+  end
 end
 
 # Files downloaded from Crowdin are organized by language name; rename folders

--- a/bin/i18n/sync-up.rb
+++ b/bin/i18n/sync-up.rb
@@ -8,25 +8,27 @@
 require_relative 'i18n_script_utils'
 
 def sync_up
-  puts "Beginning sync up"
+  I18nScriptUtils.with_syncronous_stdout do
+    puts "Beginning sync up"
 
-  CROWDIN_PROJECTS.each do |name, options|
-    puts "Uploading source strings to #{name} project"
-    command = "crowdin --config #{options[:config_file]} --identity #{options[:identity_file]} upload sources"
-    Open3.popen2(command) do |_stdin, stdout, status_thread|
-      while line = stdout.gets
-        # skip lines detailing individual file upload, unless that file
-        # resulted in an unexpected response
-        next if line.start_with?("File ") && line.end_with?("OK\n", "SKIPPED\n")
+    CROWDIN_PROJECTS.each do |name, options|
+      puts "Uploading source strings to #{name} project"
+      command = "crowdin --config #{options[:config_file]} --identity #{options[:identity_file]} upload sources"
+      Open3.popen2(command) do |_stdin, stdout, status_thread|
+        while line = stdout.gets
+          # skip lines detailing individual file upload, unless that file
+          # resulted in an unexpected response
+          next if line.start_with?("File ") && line.end_with?("OK\n", "SKIPPED\n")
 
-        puts line
+          puts line
+        end
+
+        raise "Sync up failed" unless status_thread.value.success?
       end
-
-      raise "Sync up failed" unless status_thread.value.success?
     end
-  end
 
-  puts "Sync up complete"
+    puts "Sync up complete"
+  end
 end
 
 sync_up if __FILE__ == $0


### PR DESCRIPTION
follow-up to https://github.com/code-dot-org/code-dot-org/pull/33142

also removed the "copied locale" output form the hoc sync out; that part of the sync happens so quickly, it's not necessary to get a fine-grained progress report

I recommend reviewing the diff [with whitespace changes disabled](https://github.com/code-dot-org/code-dot-org/pull/33171/files?w=1)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
