### PR TITLE
Standards import url: remove www

### DIFF
--- a/apps/src/sites/studio/pages/admin_standards/index.js
+++ b/apps/src/sites/studio/pages/admin_standards/index.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
   $('#import-standards').click(function(e) {
     var script = $('#select option:selected').val();
     var url =
-      'https://www.curriculum.code.org/metadata/' + script + '/standards.json';
+      'https://curriculum.code.org/metadata/' + script + '/standards.json';
     $.ajax({
       url: url,
       type: 'get'


### PR DESCRIPTION
Follow up to #33149 

I don't know why or how to figure out why, but the link for standards metadata from curriculum builder without www works (e.g. https://curriculum.code.org/metadata/coursea-2019/standards.json), but the link with it does not (e.g.  https://www.curriculum.code.org/metadata/coursea-2019/standards.json). I removed www so that I can import standards from curriculum builder.