### PR TITLE
refuse to sync in duplicates of existing script files

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -89,12 +89,12 @@ def localize_level_content
   puts "Preparing level content"
 
   block_category_strings = {}
+  level_content_directory = "../#{I18N_SOURCE_DIR}/course_content"
 
   # We have to run this specifically from the Rails directory because
   # get_i18n_strings relies on level.dsl_text which relies on level.filename
   # which relies on running a shell command
   Dir.chdir(Rails.root) do
-    base_directory = "../#{I18N_SOURCE_DIR}/course_content"
 
     Script.all.each do |script|
       next unless ScriptConstants.i18n? script.name
@@ -118,11 +118,11 @@ def localize_level_content
       # they have a version year, so this ordering is important
       script_i18n_directory =
         if ScriptConstants.script_in_category?(:hoc, script.name)
-          File.join(base_directory, "Hour of Code")
+          File.join(level_content_directory, "Hour of Code")
         elsif script.version_year
-          File.join(base_directory, script.version_year)
+          File.join(level_content_directory, script.version_year)
         else
-          File.join(base_directory, "other")
+          File.join(level_content_directory, "other")
         end
 
       FileUtils.mkdir_p script_i18n_directory
@@ -144,12 +144,12 @@ def localize_level_content
       # Note we could try here to remove the old version of the file both from
       # the filesystem and from github, but it would be significantly harder to
       # also remove it from Crowdin.
-      matching_files = Dir.glob(File.join(base_directory, "**", script_i18n_name)).reject do |other_filename|
+      matching_files = Dir.glob(File.join(level_content_directory, "**", script_i18n_name)).reject do |other_filename|
         other_filename == script_i18n_filename
       end
       unless matching_files.empty?
         # Clean up the file paths, just to make our output a little nicer
-        base = Pathname.new(base_directory)
+        base = Pathname.new(level_content_directory)
         relative_matching = matching_files.map {|filename| Pathname.new(filename).relative_path_from(base) }
         relative_new = Pathname.new(script_i18n_filename).relative_path_from(base)
         STDERR.puts "Script #{script.name.inspect} wants to output strings to #{relative_new}, but #{relative_matching.join(" and ")} already exists"

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -94,6 +94,8 @@ def localize_level_content
   # get_i18n_strings relies on level.dsl_text which relies on level.filename
   # which relies on running a shell command
   Dir.chdir(Rails.root) do
+    base_directory = "../#{I18N_SOURCE_DIR}/course_content"
+
     Script.all.each do |script|
       next unless ScriptConstants.i18n? script.name
       script_strings = {}
@@ -112,23 +114,49 @@ def localize_level_content
       end
       script_strings.delete_if {|_, value| value.blank?}
 
-      script_i18n_directory = "../#{I18N_SOURCE_DIR}/course_content"
-
       # We want to make sure to categorize HoC scripts as HoC scripts even if
       # they have a version year, so this ordering is important
       script_i18n_directory =
         if ScriptConstants.script_in_category?(:hoc, script.name)
-          File.join(script_i18n_directory, "Hour of Code")
+          File.join(base_directory, "Hour of Code")
         elsif script.version_year
-          File.join(script_i18n_directory, script.version_year)
+          File.join(base_directory, script.version_year)
         else
-          File.join(script_i18n_directory, "other")
+          File.join(base_directory, "other")
         end
+
       FileUtils.mkdir_p script_i18n_directory
-      script_i18n_filename = File.join(script_i18n_directory, "#{script.name}.json")
-      File.open(script_i18n_filename, 'w') do |file|
-        file.write(JSON.pretty_generate(script_strings))
+      script_i18n_name = "#{script.name}.json"
+      script_i18n_filename = File.join(script_i18n_directory, script_i18n_name)
+
+
+      # If a script is updated such that its destination directory changes
+      # after creation, we can end up in a situation in which we have multiple
+      # copies of the script file in the repo, which makes it difficult for the
+      # sync out to know which is the canonical version.
+      #
+      # To prevent that, here we proactively check for existing files in the
+      # filesystem with the same filename as our target script file, but a
+      # different directory. If found, we refuse to create the second such
+      # script file and notify of the attempt, so the issue can be manually
+      # resolved.
+      #
+      # Note we could try here to remove the old version of the file both from
+      # the filesystem and from github, but it would be significantly harder to
+      # also remove it from Crowdin.
+      matching_files = Dir.glob(File.join(base_directory, "**", script_i18n_name)).reject do |other_filename|
+        other_filename == script_i18n_filename
       end
+      unless matching_files.empty?
+        # Clean up the file paths, just to make our output a little nicer
+        base = Pathname.new(base_directory)
+        relative_matching = matching_files.map {|filename| Pathname.new(filename).relative_path_from(base) }
+        relative_new = Pathname.new(script_i18n_filename).relative_path_from(base)
+        STDERR.puts "Script #{script.name.inspect} wants to output strings to #{relative_new}, but #{relative_matching.join(" and ")} already exists"
+        next
+      end
+
+      File.write(script_i18n_filename, JSON.pretty_generate(script_strings))
     end
   end
 


### PR DESCRIPTION
otherwise, if a script is updated such that its strings move to a different path in crowdin, we'll end up with both copies of the script getting synced to crowdin. This can cause conflicts down the line when we try to sync out.

We have a couple options for what to do in this situation:

1. Clear the entire directory before regenerating script files, to ensure that everything is an exact match
2. Detect when we're about to create a conflict and remove the old versions of the file
3. Detect when we're about to create a conflict and warn about it, so the problem can be resolved manually.

The problem with 1 and 2 is that although our scripts have lots of ability to manipulate the filesystem and make git commits, mirroring those changes onto crowdin is more complicated. We could use [the crowdin API](https://support.crowdin.com/api/delete-file/) to do this, but that's a significant dependency that I don't think is worth adding for just this issue.

I propose we move forward with solution 3 for now, and if it becomes a significant pain to manage duplicates manually we can reconsider.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-928)

## Testing story

Manually tested by simulating an extra file:

```bash
[~/cdo (dont-sync-duplicate-script-files)]$ cp i18n/locales/source/course_content/2017/coursea-2017.json i18n/locales/source/course_content/2018
[~/cdo (dont-sync-duplicate-script-files)]$ bin/i18n/sync-in.rb
Preparing level content
Script "coursea-2017" wants to output strings to 2017/coursea-2017.json, but 2018/coursea-2017.json already exists
```

And then a second extra file:

```bash
[~/cdo (dont-sync-duplicate-script-files)]$ cp i18n/locales/source/course_content/2017/coursea-2017.json i18n/locales/source/course_content/2019
[~/cdo (dont-sync-duplicate-script-files)]$ bin/i18n/sync-in.rb
Preparing level content
Script "coursea-2017" wants to output strings to 2017/coursea-2017.json, but 2019/coursea-2017.json and 2018/coursea-2017.json already exists
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
