### PR TITLE
Add missing table abbreviation to csf stats view [ci skip]

### DIFF
--- a/aws/redshift/views/regional_partner_stats_csf_view.sql
+++ b/aws/redshift/views/regional_partner_stats_csf_view.sql
@@ -61,7 +61,7 @@ pd_enrollments_with_year as
     email, 
     user_id, 
     school_year,
-    json_extract_path_text(properties, 'role') as role
+    pde.json_extract_path_text(properties, 'role') as role
   from dashboard_production_pii.pd_enrollments pde
     join dashboard_production_pii.pd_workshops pw
         on pde.pd_workshop_id = pw.id

--- a/aws/redshift/views/regional_partner_stats_csf_view.sql
+++ b/aws/redshift/views/regional_partner_stats_csf_view.sql
@@ -61,7 +61,7 @@ pd_enrollments_with_year as
     email, 
     user_id, 
     school_year,
-    pde.json_extract_path_text(properties, 'role') as role
+    json_extract_path_text(pde.properties, 'role') as role
   from dashboard_production_pii.pd_enrollments pde
     join dashboard_production_pii.pd_workshops pw
         on pde.pd_workshop_id = pw.id


### PR DESCRIPTION
A `properties` column was added to the `pd_workshop` table, which resulted in an error when querying this view. Adding table abbreviation resolved.