### PR TITLE
HAML page for inputting secret login code

### DIFF
--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -108,6 +108,11 @@ class MakerController < ApplicationController
     render json: {school_high_needs_eligible: school.try(:maker_high_needs?)}
   end
 
+  # GET /maker/login_code
+  # renders a page for users to enter a login key
+  def login_code
+  end
+
   # POST /maker/complete
   # Called when eligible teacher clicks "Get Code."
   # Assigns a discount code and sends it back.

--- a/dashboard/app/views/maker/login_code.html.haml
+++ b/dashboard/app/views/maker/login_code.html.haml
@@ -1,6 +1,6 @@
 %h1= 'Login to the Maker App with Google'
 
-%p= 'Please enter the code provided when you logged in via Google on your default browser'
+%p Please enter the code provided when you logged in via Google on your default browser
 
 %input#input-text{:type=>"text"}
 

--- a/dashboard/app/views/maker/login_code.html.haml
+++ b/dashboard/app/views/maker/login_code.html.haml
@@ -1,0 +1,15 @@
+%h1= 'Login to the Maker App with Google'
+
+%p= 'Please enter the code provided when you logged in via Google on your default browser'
+
+%input#input-text{:type=>"text"}
+
+%button#btn-submit{ type: 'submit' } Submit
+
+:javascript
+  $(document).ready(function() {
+    $('#btn-submit').click(function() {
+      // ToDo: send submitted value to endpoint to validate login
+      console.log("Submitted: " + $('#input-text').val());
+    });
+  });

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -55,6 +55,7 @@ Dashboard::Application.routes.draw do
   post 'maker/complete', to: 'maker#complete'
   get 'maker/application_status', to: 'maker#application_status'
   post 'maker/override', to: 'maker#override'
+  get 'maker/login_code', to: 'maker#login_code'
 
   # Media proxying
   get 'media', to: 'media_proxy#get', format: false


### PR DESCRIPTION
Adds a haml page where user can input their secret code

I'd like to merge this now and then add the endpoint to login_code.html.haml page when it exists.
## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-985)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked

cc: @madelynkasula 