### PR TITLE
Add unit test for datasets_controller

### DIFF
--- a/apps/src/storage/levelbuilder/ManifestEditor.jsx
+++ b/apps/src/storage/levelbuilder/ManifestEditor.jsx
@@ -56,8 +56,8 @@ class ManifestEditor extends React.Component {
       contentType: 'application/json',
       data: JSON.stringify({manifest: this.refs.content.value})
     })
-      .done(data => this.displayNotice('Manifest Saved', false))
-      .fail(() => this.displayNotice('Error', true));
+      .done(() => this.displayNotice('Manifest Saved', false))
+      .fail(err => this.displayNotice(`Error: ${err.statusText}`, true));
   };
 
   componentDidMount() {

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -14,9 +14,7 @@ class DatasetsController < ApplicationController
   def update_manifest
     parsed_manifest = JSON.parse(params['manifest'])
     response = @firebase.set_library_manifest parsed_manifest
-    data = {status: response.code}
-    data[:msg] = response.body unless response.success?
-    render json: data
+    return head response.code
   rescue JSON::ParserError
     render json: {msg: 'Invalid JSON'}
   end

--- a/dashboard/test/controllers/datasets_controller_test.rb
+++ b/dashboard/test/controllers/datasets_controller_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+require 'firebase'
+
+class DatasetsControllerTest < ActionController::TestCase
+  setup do
+    @levelbuilder = create(:levelbuilder)
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    sign_in @levelbuilder
+    @test_manifest = {
+      tables: [
+        {
+          "current": false,
+          "description": "Information about different cat breeds",
+          "name": "cats",
+          "published": true
+        }
+      ],
+      categories: [
+        {
+          "datasets": [
+            "cats"
+          ],
+          "description": "description",
+          "name": "Animals",
+          "published": true
+        }
+      ]
+    }
+  end
+
+  test 'update_manifest: can update manifest' do
+    test_response = mock
+    test_response.expects(:code).returns(200)
+    FirebaseHelper.any_instance.stubs(:set_library_manifest).returns(test_response)
+    post :update_manifest, params: {manifest: @test_manifest.to_json}
+    assert_response :success
+  end
+
+  test 'update_manifest: passes through the error code' do
+    test_response = mock
+    test_response.expects(:code).returns(401)
+    FirebaseHelper.any_instance.stubs(:set_library_manifest).returns(test_response)
+    post :update_manifest, params: {manifest: @test_manifest.to_json}
+    assert_response :unauthorized
+  end
+end


### PR DESCRIPTION
Simple unit test just to sanity check the request and response for updating the manifest

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
