### PR TITLE
Don't check all map options if there's an infinite loop

### DIFF
--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -615,7 +615,7 @@ module.exports = class Maze {
    */
   prepareForExecution_() {
     this.executionInfo = new ExecutionInfo({
-      ticks: 1e4
+      ticks: 1000
     });
     this.resultsHandler.executionInfo = this.executionInfo;
     this.result = ResultType.UNSET;

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -357,8 +357,9 @@ module.exports = class Maze {
           // and failures
           var successes = [];
           var failures = [];
+          const numGrids = this.controller.map.staticGrids.length;
 
-          this.controller.map.staticGrids.forEach((grid, i) => {
+          for (let i = 0; i < numGrids; i++) {
             this.controller.map.useGridWithId(i);
             this.controller.subtype.reset();
 
@@ -372,6 +373,9 @@ module.exports = class Maze {
             this.onExecutionFinish_();
             if (this.executionInfo.terminationValue() === true) {
               successes.push(i);
+            } else if (this.executionInfo.terminationValue() === Infinity) {
+              failures.push(i);
+              break;
             } else {
               failures.push(i);
             }
@@ -380,7 +384,7 @@ module.exports = class Maze {
             this.controller.subtype.drawer.reset();
             this.prepareForExecution_();
             studioApp().reset(false);
-          });
+          }
 
           // The user's code needs to succeed against all possible grids
           // to be considered actually successful; if there are any

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -374,7 +374,14 @@ module.exports = class Maze {
             if (this.executionInfo.terminationValue() === true) {
               successes.push(i);
             } else if (this.executionInfo.terminationValue() === Infinity) {
-              failures.push(i);
+              // terminationValue Infinity means executing took more than the maximum number of steps
+              // so we have declared it to be an infinite loop. If there are a lot of map configurations that result
+              // in infinite loops, the time required to check each one is perceived as buggy/glitchy. To prevent this
+              // perceived lag,  we should stop checking map configurations as soon as we detect an infinite loop
+              // and immediately show the result. It is possible that there is an infinite loop
+              // on only some map configurations. In these cases, we should always show the map configuration
+              // with first infinite loop we detect.
+              failures = [i];
               break;
             } else {
               failures.push(i);


### PR DESCRIPTION
If there are a lot of map configurations and there's an infinite loop, the code hangs for quite a while before animating the result. The reason for this is that we check every possible configuration prior to showing any results. As soon as we detect an infinite loop, we should break out of checking the possible grid configurations and immediately show the result.

See for example https://studio.code.org/s/express-2019/stage/17/puzzle/5, which has 144 possible configurations.

Also reduce the max number of ticks to 1000. This should be a high enough upper bound for maze.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
