### PR TITLE
Add temporary 'wait' step to ensure tables have loaded before running

### DIFF
--- a/dashboard/test/ui/features/applab/data_blocks.feature
+++ b/dashboard/test/ui/features/applab/data_blocks.feature
@@ -22,5 +22,10 @@ Feature: App Lab Data Blocks
     And I wait for the page to fully load
     And element "#runButton" is visible
     And I open the debug console
+
+    # TODO: Remove race condition where table does not yet exist when "#runButton" is clicked.
+    # Related ticket to fix: codedotorg.atlassian.net/browse/STAR-987
+    And I wait for 1.5 seconds
+
     Then I press "runButton"
     And I wait until element "#successLabel" is visible within element "#divApplab"


### PR DESCRIPTION
Temporary fix for a race condition in `applab/data_blocks.feature` where the "Run" button is clicked before tables have loaded. I couldn't reproduce this manually, so I feel confident that this is an issue that won't affect users.

![Screen Shot 2020-02-19 at 10 19 51 AM](https://user-images.githubusercontent.com/9812299/74865849-a0bef600-5306-11ea-9997-df00f7fe1553.png)

## Links

- [Slack thread w/ context](https://codedotorg.slack.com/archives/CN4T89YP8/p1582137424011300)
- [Jira](https://codedotorg.atlassian.net/browse/STAR-987)
