### PR TITLE
Update name of express 2019 lesson 24

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -10402,7 +10402,7 @@ en:
               description_student: ''
               description_teacher: ''
             Learning Sprites with Sprite Lab:
-              name: Learning Sprite Lab
+              name: Swimming Fish in Sprite Lab
               description_student: ''
               description_teacher: ''
             Alien Dance Party with Sprite Lab:


### PR DESCRIPTION
There is an inconsistency between lesson name in the Express 2019 course on the lesson plan on curriculum.code.org and the lesson on Code Studio. 

On the Lesson Plan: 
<img width="1128" alt="Screen Shot 2020-02-19 at 11 25 32 AM" src="https://user-images.githubusercontent.com/12300669/74868476-2d6bb300-530b-11ea-9932-b0ae951cc72f.png">

On Code Studio: 
<img width="890" alt="Screen Shot 2020-02-19 at 11 26 00 AM" src="https://user-images.githubusercontent.com/12300669/74868504-36f51b00-530b-11ea-8213-179005dc84f3.png">

I discovered this because when importing standards associations we match Code Studio and Curriculum Builder stages by localized_name. 
<img width="1049" alt="Screen Shot 2020-02-19 at 11 25 43 AM" src="https://user-images.githubusercontent.com/12300669/74868510-39f00b80-530b-11ea-8bb9-fb0197157215.png">

This change puts the lesson names back in sync.