### PR TITLE
Sort the scripts with standards for dropdown on admin/standards

### DIFF
--- a/dashboard/app/controllers/admin_standards_controller.rb
+++ b/dashboard/app/controllers/admin_standards_controller.rb
@@ -3,7 +3,7 @@ class AdminStandardsController < ApplicationController
   before_action :require_admin
 
   def index
-    @scripts_for_standards = Script.scripts_with_standards
+    @scripts_with_standards = Script.scripts_with_standards.sort
   end
 
   def import_standards

--- a/dashboard/app/views/admin_standards/index.html.haml
+++ b/dashboard/app/views/admin_standards/index.html.haml
@@ -17,7 +17,7 @@
 
 %h3 Select a Course
 = form_tag url_for(action: 'import_standards'), id: 'standards-form', method: 'post', class: 'form-inline', enforce_utf8: false, remote: true do
-  = select_tag(:script, options_for_select(@scripts_for_standards), id: "select")
+  = select_tag(:script, options_for_select(@scripts_with_standards), id: "select")
   %br
   %br
   %button.primary.padded-button#import-standards="Import Standards"


### PR DESCRIPTION
A little tidying....

- made the variable names consistent with the method name (`scripts_for_standards` -> `scripts_with_standards`) 
- sort the dropdown options

BEFORE: 
<img width="282" alt="Screen Shot 2020-02-19 at 11 46 30 AM" src="https://user-images.githubusercontent.com/12300669/74870008-d5827b80-530d-11ea-968f-00be1a2186f5.png">

AFTER:
<img width="320" alt="Screen Shot 2020-02-19 at 11 46 50 AM" src="https://user-images.githubusercontent.com/12300669/74870013-d74c3f00-530d-11ea-9b78-c521c897fce1.png">
