### PR TITLE
Translate the word video in standalone video levels

### DIFF
--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -12,7 +12,7 @@
   - @slides = get_slides_by_video_key(@level.video_key)
 
   - unless @level.video_full_width
-    %h1= "#{t('video.video')}: #{video.localized_name}"
+    %h1= "#{t('video.label')}: #{video.localized_name}"
   %div= render(inline: @level.long_instructions, type: :md) if @level.long_instructions
 
   .video-content

--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -12,7 +12,7 @@
   - @slides = get_slides_by_video_key(@level.video_key)
 
   - unless @level.video_full_width
-    %h1= "Video: #{video.localized_name}"
+    %h1= "#{t('video.video')}: #{video.localized_name}"
   %div= render(inline: @level.long_instructions, type: :md) if @level.long_instructions
 
   .video-content

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -578,6 +578,7 @@ en:
     download: 'Download Video'
     show_notes: 'Show Notes'
     show_video: 'Show Video'
+    video: 'Video'
   compatibility:
     upgrade:
       unsupported_message: "Your browser is not supported. Please upgrade your browser to [one of our supported browsers](%{supported_browsers_url}). You can try viewing the page, but expect functionality to be broken."

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -578,7 +578,7 @@ en:
     download: 'Download Video'
     show_notes: 'Show Notes'
     show_video: 'Show Video'
-    video: 'Video'
+    label: 'Video'
   compatibility:
     upgrade:
       unsupported_message: "Your browser is not supported. Please upgrade your browser to [one of our supported browsers](%{supported_browsers_url}). You can try viewing the page, but expect functionality to be broken."


### PR DESCRIPTION
Currently the word "Video" is not translateable in standalone video levels. This PR allows "Video" to be translated. (Side note: happy for suggestions on the key for this string...`video.video` is a bit weird...)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
