### PR TITLE
Revert "Revert "Projects page cleanup""

### DIFF
--- a/apps/src/sites/studio/pages/projects/index.js
+++ b/apps/src/sites/studio/pages/projects/index.js
@@ -3,123 +3,52 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {getStore, registerReducers} from '@cdo/apps/redux';
+import getScriptData from '@cdo/apps/util/getScriptData';
 import PublishDialog from '@cdo/apps/templates/projects/publishDialog/PublishDialog';
 import DeleteProjectDialog from '@cdo/apps/templates/projects/deleteDialog/DeleteProjectDialog';
-import PublicGallery from '@cdo/apps/templates/projects/PublicGallery';
 import GallerySwitcher from '@cdo/apps/templates/projects/GallerySwitcher';
 import ProjectHeader from '@cdo/apps/templates/projects/ProjectHeader';
-import PersonalProjectsTable from '@cdo/apps/templates/projects/PersonalProjectsTable';
-import {
-  MAX_PROJECTS_PER_CATEGORY,
-  Galleries
-} from '@cdo/apps/templates/projects/projectConstants';
+import {Galleries} from '@cdo/apps/templates/projects/projectConstants';
 import projects, {
   selectGallery,
-  setProjectLists,
-  setPersonalProjectsList
+  setPersonalProjects,
+  setPublicProjects
 } from '@cdo/apps/templates/projects/projectsRedux';
 import publishDialogReducer from '@cdo/apps/templates/projects/publishDialog/publishDialogRedux';
 import deleteDialogReducer from '@cdo/apps/templates/projects/deleteDialog/deleteProjectDialogRedux';
 
 $(document).ready(() => {
-  const script = document.querySelector('script[data-projects]');
-  const projectsData = JSON.parse(script.dataset.projects);
-
+  const projectsData = getScriptData('projects');
   registerReducers({
     projects,
     publishDialog: publishDialogReducer,
     deleteDialog: deleteDialogReducer
   });
   const store = getStore();
-  setupReduxSubscribers(store);
-  ReactDOM.render(
-    <Provider store={store}>
-      <GallerySwitcher />
-    </Provider>,
-    document.getElementById('gallery-navigation')
-  );
 
-  ReactDOM.render(
-    <Provider store={store}>
-      <ProjectHeader
-        canViewAdvancedTools={projectsData.canViewAdvancedTools}
-        projectCount={projectsData.projectCount}
-      />
-    </Provider>,
-    document.getElementById('projects-header')
-  );
-
-  const isPublic = window.location.pathname.startsWith('/projects/public');
-  const initialState = isPublic ? Galleries.PUBLIC : Galleries.PRIVATE;
+  const initialState = projectsData.isPublic
+    ? Galleries.PUBLIC
+    : Galleries.PRIVATE;
   store.dispatch(selectGallery(initialState));
-  const url = `/api/v1/projects/gallery/public/all/${MAX_PROJECTS_PER_CATEGORY}`;
-
-  $.ajax({
-    method: 'GET',
-    url: url,
-    dataType: 'json'
-  }).done(projectLists => {
-    store.dispatch(setProjectLists(projectLists));
-    const publicGallery = document.getElementById('public-gallery');
-    ReactDOM.render(
-      <Provider store={store}>
-        <PublicGallery limitedGallery={projectsData.limitedGallery} />
-      </Provider>,
-      publicGallery
-    );
-  });
-
-  const personalProjectsUrl = `/api/v1/projects/personal`;
-
-  $.ajax({
-    method: 'GET',
-    url: personalProjectsUrl,
-    dataType: 'json'
-  }).done(personalProjectsList => {
-    store.dispatch(setPersonalProjectsList(personalProjectsList));
-    ReactDOM.render(
-      <Provider store={store}>
-        <PersonalProjectsTable canShare={projectsData.canShare} />
-      </Provider>,
-      document.getElementById('react-personal-projects')
-    );
-  });
-
-  const publishConfirm = document.getElementById('publish-confirm');
+  store.dispatch(setPersonalProjects());
+  store.dispatch(setPublicProjects());
 
   ReactDOM.render(
     <Provider store={store}>
-      <PublishDialog />
+      <div>
+        <ProjectHeader
+          canViewAdvancedTools={projectsData.canViewAdvancedTools}
+          projectCount={projectsData.projectCount}
+        />
+        <GallerySwitcher
+          limitedGallery={projectsData.limitedGallery}
+          canShare={projectsData.canShare}
+        />
+        {/* TODO: Move components below into <PersonalProjectsTable/>? */}
+        <PublishDialog />
+        <DeleteProjectDialog />
+      </div>
     </Provider>,
-    publishConfirm
-  );
-
-  const deleteConfirm = document.getElementById('delete-confirm');
-
-  ReactDOM.render(
-    <Provider store={store}>
-      <DeleteProjectDialog />
-    </Provider>,
-    deleteConfirm
+    document.querySelector('#projects-page')
   );
 });
-
-function showGallery(gallery) {
-  $('#personal-projects-wrapper').toggle(gallery === Galleries.PRIVATE);
-  $('#public-gallery-wrapper').toggle(gallery === Galleries.PUBLIC);
-}
-
-function setupReduxSubscribers(store) {
-  let state = {};
-  store.subscribe(() => {
-    let lastState = state;
-    state = store.getState();
-
-    if (
-      (lastState.projects && lastState.projects.selectedGallery) !==
-      (state.projects && state.projects.selectedGallery)
-    ) {
-      showGallery(state.projects.selectedGallery);
-    }
-  });
-}

--- a/apps/src/templates/projects/GallerySwitcher.jsx
+++ b/apps/src/templates/projects/GallerySwitcher.jsx
@@ -3,9 +3,11 @@ import i18n from '@cdo/locale';
 import color from '../../util/color';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
-import {selectGallery} from './projectsRedux.js';
+import {selectGallery} from './projectsRedux';
 import {connect} from 'react-redux';
 import {Galleries} from './projectConstants';
+import PublicGallery from '@cdo/apps/templates/projects/PublicGallery';
+import PersonalProjectsTable from '@cdo/apps/templates/projects/PersonalProjectsTable';
 
 const styles = {
   container: {
@@ -47,6 +49,10 @@ const styles = {
 
 class GallerySwitcher extends Component {
   static propTypes = {
+    limitedGallery: PropTypes.bool,
+    canShare: PropTypes.bool.isRequired,
+
+    // Provided by Redux
     selectedGallery: PropTypes.string.isRequired,
     selectGallery: PropTypes.func.isRequired
   };
@@ -70,29 +76,37 @@ class GallerySwitcher extends Component {
 
   render() {
     return (
-      <div style={styles.container} id="uitest-gallery-switcher">
-        <div
-          key={'private'}
-          style={[
-            styles.pill,
-            this.props.selectedGallery === Galleries.PRIVATE &&
-              styles.selectedPill
-          ]}
-          onClick={this.toggleToMyProjects}
-        >
-          {i18n.myProjects()}
+      <div>
+        <div style={styles.container} id="uitest-gallery-switcher">
+          <div
+            key={'private'}
+            style={[
+              styles.pill,
+              this.props.selectedGallery === Galleries.PRIVATE &&
+                styles.selectedPill
+            ]}
+            onClick={this.toggleToMyProjects}
+          >
+            {i18n.myProjects()}
+          </div>
+          <div
+            key={'public'}
+            style={[
+              styles.pill,
+              this.props.selectedGallery === Galleries.PUBLIC &&
+                styles.selectedPill
+            ]}
+            onClick={this.toggleToGallery}
+          >
+            {i18n.publicProjects()}
+          </div>
         </div>
-        <div
-          key={'public'}
-          style={[
-            styles.pill,
-            this.props.selectedGallery === Galleries.PUBLIC &&
-              styles.selectedPill
-          ]}
-          onClick={this.toggleToGallery}
-        >
-          {i18n.publicProjects()}
-        </div>
+        {this.props.selectedGallery === Galleries.PUBLIC && (
+          <PublicGallery limitedGallery={this.props.limitedGallery} />
+        )}
+        {this.props.selectedGallery === Galleries.PRIVATE && (
+          <PersonalProjectsTable canShare={this.props.canShare} />
+        )}
       </div>
     );
   }

--- a/apps/src/templates/projects/GallerySwitcher.story.jsx
+++ b/apps/src/templates/projects/GallerySwitcher.story.jsx
@@ -4,10 +4,13 @@ import {Galleries} from './projectConstants';
 import projects, {selectGallery} from './projectsRedux';
 import {createStore, combineReducers} from 'redux';
 import {Provider} from 'react-redux';
-import {action} from '@storybook/addon-actions';
 
 const createProjectsStore = function() {
   return createStore(combineReducers({projects}));
+};
+
+const DEFAULT_PROPS = {
+  canShare: true
 };
 
 export default storybook => {
@@ -20,7 +23,7 @@ export default storybook => {
         store.dispatch(selectGallery(Galleries.PRIVATE));
         return (
           <Provider store={store}>
-            <GallerySwitcher showGallery={action('showGallery')} />
+            <GallerySwitcher {...DEFAULT_PROPS} />
           </Provider>
         );
       }
@@ -33,7 +36,7 @@ export default storybook => {
         store.dispatch(selectGallery(Galleries.PUBlIC));
         return (
           <Provider store={store}>
-            <GallerySwitcher showGallery={action('showGallery')} />
+            <GallerySwitcher {...DEFAULT_PROPS} />
           </Provider>
         );
       }

--- a/apps/src/templates/projects/PersonalProjectsTable.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTable.jsx
@@ -121,9 +121,10 @@ const dateFormatter = function(time) {
 
 class PersonalProjectsTable extends React.Component {
   static propTypes = {
+    canShare: PropTypes.bool.isRequired,
+
+    // Provided by Redux
     personalProjectsList: PropTypes.arrayOf(personalProjectDataPropType)
-      .isRequired,
-    canShare: PropTypes.bool.isRequired
   };
 
   state = {
@@ -302,6 +303,10 @@ class PersonalProjectsTable extends React.Component {
   };
 
   render() {
+    if (!this.props.personalProjectsList) {
+      return null;
+    }
+
     // Define a sorting transform that can be applied to each column
     const sortable = wrappedSortable(
       this.getSortingColumns,
@@ -320,7 +325,7 @@ class PersonalProjectsTable extends React.Component {
     const noProjects = this.props.personalProjectsList.length === 0;
 
     return (
-      <div style={styles.bottomMargin}>
+      <div id="uitest-personal-projects" style={styles.bottomMargin}>
         {!noProjects && (
           <Table.Provider
             columns={columns}

--- a/apps/src/templates/projects/PublicGallery.jsx
+++ b/apps/src/templates/projects/PublicGallery.jsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import ProjectCardGrid from './ProjectCardGrid';
 import _ from 'lodash';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
+import ProjectCardGrid from './ProjectCardGrid';
 
 const styles = {
   clear: {
@@ -31,7 +31,11 @@ export const publishedProjectPropType = PropTypes.shape({
 
 class PublicGallery extends Component {
   static propTypes = {
-    // from redux state
+    // Controls hiding/showing view more links for App Lab and Game Lab.
+    limitedGallery: PropTypes.bool,
+    includeDanceParty: PropTypes.bool,
+
+    // Provided by Redux
     projectLists: PropTypes.shape({
       applab: PropTypes.arrayOf(publishedProjectPropType),
       spritelab: PropTypes.arrayOf(publishedProjectPropType),
@@ -40,10 +44,7 @@ class PublicGallery extends Component {
       artist: PropTypes.arrayOf(publishedProjectPropType),
       minecraft: PropTypes.arrayOf(publishedProjectPropType),
       dance: PropTypes.arrayOf(publishedProjectPropType)
-    }),
-    // Controls hiding/showing view more links for App Lab and Game Lab.
-    limitedGallery: PropTypes.bool,
-    includeDanceParty: PropTypes.bool
+    })
   };
 
   /**
@@ -70,7 +71,7 @@ class PublicGallery extends Component {
     const {projectLists, limitedGallery, includeDanceParty} = this.props;
 
     return (
-      <div>
+      <div id="uitest-public-projects">
         <ProjectCardGrid
           projectLists={this.mapProjectData(projectLists)}
           galleryType="public"

--- a/apps/src/templates/projects/projectsRedux.js
+++ b/apps/src/templates/projects/projectsRedux.js
@@ -1,7 +1,7 @@
 /** @file Redux actions and reducer for the Projects Gallery */
 import {combineReducers} from 'redux';
 import _ from 'lodash';
-import {Galleries} from './projectConstants';
+import {Galleries, MAX_PROJECTS_PER_CATEGORY} from './projectConstants';
 import {PUBLISH_SUCCESS} from './publishDialog/publishDialogRedux';
 import {DELETE_SUCCESS} from './deleteDialog/deleteProjectDialogRedux';
 import {channels as channelsApi} from '../../clientApi';
@@ -387,6 +387,30 @@ const reducer = combineReducers({
   personalProjectsList
 });
 export default reducer;
+
+export const setPublicProjects = () => {
+  return dispatch => {
+    $.ajax({
+      method: 'GET',
+      url: `/api/v1/projects/gallery/public/all/${MAX_PROJECTS_PER_CATEGORY}`,
+      dataType: 'json'
+    }).done(projectLists => {
+      dispatch(setProjectLists(projectLists));
+    });
+  };
+};
+
+export const setPersonalProjects = () => {
+  return dispatch => {
+    $.ajax({
+      method: 'GET',
+      url: '/api/v1/projects/personal',
+      dataType: 'json'
+    }).done(personalProjectsList => {
+      dispatch(setPersonalProjectsList(personalProjectsList));
+    });
+  };
+};
 
 const fetchProjectToUpdate = (projectId, onComplete) => {
   $.ajax({

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -135,12 +135,12 @@ class ProjectsController < ApplicationController
       return
     end
 
-    redirect_to projects_public_path unless current_user
+    return redirect_to projects_public_path unless current_user
   end
 
   # GET /projects/public
   def public
-    render template: 'projects/index', locals: {is_public: current_user&.present?, limited_gallery: limited_gallery?}
+    render template: 'projects/index', locals: {is_public: true, limited_gallery: limited_gallery?}
   end
 
   def project_and_featured_project_fields

--- a/dashboard/app/views/projects/index.html.haml
+++ b/dashboard/app/views/projects/index.html.haml
@@ -6,7 +6,7 @@
   projects_data[:isPublic] = local_assigns[:is_public]
 
   if current_user
-    projects_data[:canViewAdvancedTools] = !current_user.under_13? && current_user.terms_version.present?
+    projects_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)
     projects_data[:canShare] = !current_user.sharing_disabled?
   end
 

--- a/dashboard/app/views/projects/index.html.haml
+++ b/dashboard/app/views/projects/index.html.haml
@@ -1,27 +1,16 @@
 :ruby
   @page_title = t('project.project_gallery')
-  is_public = local_assigns[:is_public]
   projects_data = {}
   projects_data[:limitedGallery] = local_assigns[:limited_gallery]
   projects_data[:projectCount] = fetch_project_count['total_projects']
+  projects_data[:isPublic] = local_assigns[:is_public]
 
   if current_user
-    projects_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)
+    projects_data[:canViewAdvancedTools] = !current_user.under_13? && current_user.terms_version.present?
     projects_data[:canShare] = !current_user.sharing_disabled?
   end
 
-%script{src: webpack_asset_path("js/#{js_locale}/common_locale.js"), data: {projects: projects_data.to_json}}
-%script{src: webpack_asset_path('js/projects/index.js')}
+%script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
+%script{src: webpack_asset_path('js/projects/index.js'), data: {projects: projects_data.to_json}}
 
-.projects-page
-  #projects-header
-
-  #gallery-navigation
-
-  #personal-projects-wrapper{'style' => ('display: none;' if is_public)}
-    #react-personal-projects
-
-  #public-gallery-wrapper{'style' => ('display: none;' unless is_public)}
-    #public-gallery
-  #publish-confirm
-  #delete-confirm
+#projects-page

--- a/dashboard/test/ui/features/projects/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/projects/personal_project_gallery.feature
@@ -7,14 +7,14 @@ Background:
 
 Scenario: Can Toggle to the Public Project Gallery
   Given I am on "http://studio.code.org/projects"
-  And I wait until element "#react-personal-projects" is visible
-  And element "#public-gallery" is not visible
+  And I wait until element "#uitest-personal-projects" is visible
+  And element "#uitest-public-projects" is not visible
   Then I navigate to the public gallery via the gallery switcher
 
 Scenario: Can Publish and Unpublish a Project (Button Version)
   Given I make a "playlab" project named "Publishable Project"
   Given I am on "http://studio.code.org/projects"
-  And I wait until element "#react-personal-projects" is visible
+  And I wait until element "#uitest-personal-projects" is visible
   And I wait until element ".ui-personal-projects-table" is visible
   And the project table contains 1 row
   And the first project in the table is named "Publishable Project"
@@ -27,7 +27,7 @@ Scenario: Can Publish and Unpublish a Project (Button Version)
 Scenario: Can Rename a Project
   Given I make a "playlab" project named "Old Name"
   Given I am on "http://studio.code.org/projects"
-  And I wait until element "#react-personal-projects" is visible
+  And I wait until element "#uitest-personal-projects" is visible
   And I wait until element ".ui-personal-projects-table" is visible
   And the project table contains 1 row
   And the first project in the table is named "Old Name"
@@ -42,7 +42,7 @@ Scenario: Can Rename a Project
 Scenario: Can Remix a Project
   Given I make a "playlab" project named "Remix Template"
   Given I am on "http://studio.code.org/projects"
-  And I wait until element "#react-personal-projects" is visible
+  And I wait until element "#uitest-personal-projects" is visible
   And I wait until element ".ui-personal-projects-table" is visible
   And the project table contains 1 row
   And the first project in the table is named "Remix Template"
@@ -53,7 +53,7 @@ Scenario: Can Remix a Project
 Scenario: Can Delete a Project
   Given I make a "playlab" project named "To Be Deleted"
   Given I am on "http://studio.code.org/projects"
-  And I wait until element "#react-personal-projects" is visible
+  And I wait until element "#uitest-personal-projects" is visible
   And I wait until element ".ui-personal-projects-table" is visible
   And the project table contains 1 row
   And the first project in the table is named "To Be Deleted"

--- a/dashboard/test/ui/features/projects/projects.feature
+++ b/dashboard/test/ui/features/projects/projects.feature
@@ -9,7 +9,7 @@ Scenario: My Projects
   And I wait until element "#uitest-view-full-list" is visible
   And element "a[href='/projects/artist/new']" is visible
   And element "a[href='/projects/gumball/new']" is not visible
-  And I wait until element "#react-personal-projects" contains text "You currently have no projects."
+  And I wait until element "#uitest-personal-projects" contains text "You currently have no projects."
   Then I see no difference for "page load"
 
   When I press "uitest-view-full-list"

--- a/dashboard/test/ui/features/projects/public_project_gallery_project_validator.feature
+++ b/dashboard/test/ui/features/projects/public_project_gallery_project_validator.feature
@@ -65,16 +65,17 @@ Scenario: UnPublished, Featured Projects Do Not Show
 
 Scenario: Can Toggle to the Personal Project Gallery
   Given I am on "http://studio.code.org/projects/public"
-  And I wait until element "#public-gallery" is visible
-  And element "#react-personal-projects" is not visible
+  And I wait until element "#projects-page" is visible
+  And I wait until element "#uitest-public-projects" is visible
+  And element "#uitest-personal-projects" is not visible
   Then I click selector "#uitest-gallery-switcher div:contains(My Projects)"
   Then check that I am on "http://studio.code.org/projects"
-  And I wait until element "#react-personal-projects" is visible
-  And element "#public-gallery" is not visible
+  And I wait until element "#uitest-personal-projects" is visible
+  And element "#uitest-public-projects" is not visible
 
 Scenario: Can See App Lab/Game Lab View More Links
   Given I am on "http://studio.code.org/projects/public"
-  Then I wait until element "#public-gallery" is visible
+  And I wait until element "#projects-page" is visible
   Then I wait until element ".ui-project-app-type-area" is in the DOM
   And the project gallery contains 9 project types
   And the project gallery contains 9 view more links

--- a/dashboard/test/ui/features/projects/public_project_gallery_signed_out.feature
+++ b/dashboard/test/ui/features/projects/public_project_gallery_signed_out.feature
@@ -5,10 +5,10 @@ Background:
 
 Scenario: Public Gallery Shows Expected Elements
   Then I wait until element "#header-banner" is visible
-  Then I wait until element "#public-gallery" is visible
+  Then I wait until element "#uitest-public-projects" is visible
 
 Scenario: Public Gallery Shows Expected Project Types
-  Then I wait until element "#public-gallery" is visible
+  Then I wait until element "#uitest-public-projects" is visible
   Then I wait until element ".ui-project-app-type-area" is in the DOM
   And the project gallery contains 9 project types
   And element ".ui-dance" contains text "Dance Party"

--- a/dashboard/test/ui/features/sharepage.feature
+++ b/dashboard/test/ui/features/sharepage.feature
@@ -61,7 +61,7 @@ Scenario: Share and save an artist level to the project gallery
   # Make sure the published project shows up in the public gallery
 
   Then I click selector "#uitest-gallery-switcher div:contains(Public Projects)"
-  And I wait until element "#public-gallery" is visible
+  And I wait until element "#projects-page" is visible
   And I wait until element ".project_card:contains(Artist Project)" is visible
   And I sign out
 
@@ -92,7 +92,7 @@ Scenario: Share and save a playlab level to the project gallery
   # Make sure the published project shows up in the public gallery
 
   Then I click selector "#uitest-gallery-switcher div:contains(Public Projects)"
-  And I wait until element "#public-gallery" is visible
+  And I wait until element "#projects-page" is visible
   And I wait until element ".project_card:contains(Play Lab Project)" is visible
   And I sign out
 

--- a/dashboard/test/ui/features/step_definitions/projects.rb
+++ b/dashboard/test/ui/features/step_definitions/projects.rb
@@ -116,8 +116,8 @@ Then /^I navigate to the public gallery via the gallery switcher$/ do
   steps <<-STEPS
     Then I click selector "#uitest-gallery-switcher div:contains(Public Projects)"
     Then check that I am on "http://studio.code.org/projects/public"
-    And I wait until element "#public-gallery" is visible
-    And element "#react-personal-projects" is not visible
+    And I wait until element "#uitest-public-projects" is visible
+    And element "#uitest-personal-projects" is not visible
   STEPS
 end
 
@@ -125,8 +125,8 @@ Then /^I navigate to the personal gallery via the gallery switcher$/ do
   steps <<-STEPS
     Then I click selector "#uitest-gallery-switcher div:contains(My Projects)"
     Then check that I am on "http://studio.code.org/projects"
-    And I wait until element "#public-gallery" is not visible
-    And element "#react-personal-projects" is visible
+    And I wait until element "#uitest-personal-projects" is visible
+    And element "#uitest-public-projects" is not visible
   STEPS
 end
 


### PR DESCRIPTION
Reverts #33230, reimplementing #33117

In the original PR (#33117), I "simplified" a boolean calculation in error 😅 This is fixed in commit [3621117](https://github.com/code-dot-org/code-dot-org/pull/33232/commits/3621117db52ef7e02b7e0b88e516f9b7d8a38e88) ("fixed" by reverting the boolean to its original state)

This error was caught by an eyes test ([Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1582156837286200)). Yay, tests!