### PR TITLE
[Applab Datasets] Scroll data library pane

### DIFF
--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -19,7 +19,7 @@ const styles = {
     width: 270,
     boxSizing: 'border-box',
     borderRight: '1px solid gray',
-    overflowY: 'hidden',
+    overflowY: 'auto',
     padding: 10
   },
   divider: {

--- a/apps/src/storage/dataBrowser/LibraryTable.jsx
+++ b/apps/src/storage/dataBrowser/LibraryTable.jsx
@@ -26,7 +26,7 @@ const styles = {
     fontSize: '14px',
     padding: '1px 7px 2px',
     height: '30px',
-    width: '95px',
+    width: '90px',
     margin: 10,
     marginLeft: 0
   },
@@ -38,7 +38,7 @@ const styles = {
     color: color.white,
     padding: '1px 7px 2px',
     height: '30px',
-    width: '95px',
+    width: '90px',
     margin: 10,
     marginRight: 0
   },


### PR DESCRIPTION
Tiny fix to show a scroll bar if needed in the library pane
![image](https://user-images.githubusercontent.com/8787187/74976046-e2ba6b80-53dc-11ea-8253-7c0ddf9a5302.png)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
