### PR TITLE
Add cloudformation template for devel curriculumbuilder bucket

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -258,6 +258,23 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+  CurriculumbuilderDevRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: curriculumBuilderDevRole
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: 'Allow'
+            Principal: !Sub "arn:aws:iam::${AWS::AccountId}:role/Developer"
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Action:
+            - s3:*
+          Resource:
+            - 'arn:aws:s3:::cdo-curriculum-devel'
+            - 'arn:aws:s3:::cdo-curriculum-devel/*'
 Outputs:
   DevPermissions:
     Description: Developer Permissions

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -258,23 +258,6 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
-  CurriculumbuilderDevRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: curriculumBuilderDevRole
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: 'Allow'
-            Principal: !Sub "arn:aws:iam::${AWS::AccountId}:role/Developer"
-      PolicyDocument:
-        Statement:
-        - Effect: Allow
-          Action:
-            - s3:*
-          Resource:
-            - 'arn:aws:s3:::cdo-curriculum-devel'
-            - 'arn:aws:s3:::cdo-curriculum-devel/*'
 Outputs:
   DevPermissions:
     Description: Developer Permissions

--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -52,3 +52,29 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: 'cdo-logs'
         LogFilePrefix: 's3/cdo-curriculum-devel'
+      PolicyDocument: {
+        "Version": "2008-10-17",
+        "Statement": [
+            {
+                "Sid": "PublicReadForGetBucketObjects",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "*"
+                },
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cdo-curriculum-devel/*"
+            },
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn:aws:iam::475661607190:user/josh@code.org"
+                },
+                "Action": "s3:*",
+                "Resource": [
+                    "arn:aws:s3:::cdo-curriculum-devel/*",
+                    "arn:aws:s3:::cdo-curriculum-devel"
+                ]
+            }
+        ]
+      }

--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -38,3 +38,43 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+  # for curriculumbuilder
+  CurriculumBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: 'cdo-curriculum-devel'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: 'aws:kms'
+      VersioningConfiguration:
+        Status: 'Enabled'
+      LoggingConfiguration:
+        DestinationBucketName: 'cdo-logs'
+        LogFilePrefix: 's3/cdo-curriculum-devel'
+      PolicyDocument: {
+        "Version": "2008-10-17",
+        "Statement": [
+            {
+                "Sid": "PublicReadForGetBucketObjects",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "*"
+                },
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::cdo-curriculum-devel/*"
+            },
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn:aws:iam::475661607190:user/josh@code.org"
+                },
+                "Action": "s3:*",
+                "Resource": [
+                    "arn:aws:s3:::cdo-curriculum-devel/*",
+                    "arn:aws:s3:::cdo-curriculum-devel"
+                ]
+            }
+        ]
+      }

--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -52,29 +52,3 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: 'cdo-logs'
         LogFilePrefix: 's3/cdo-curriculum-devel'
-      PolicyDocument: {
-        "Version": "2008-10-17",
-        "Statement": [
-            {
-                "Sid": "PublicReadForGetBucketObjects",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "*"
-                },
-                "Action": "s3:GetObject",
-                "Resource": "arn:aws:s3:::cdo-curriculum-devel/*"
-            },
-            {
-                "Sid": "",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "arn:aws:iam::475661607190:user/josh@code.org"
-                },
-                "Action": "s3:*",
-                "Resource": [
-                    "arn:aws:s3:::cdo-curriculum-devel/*",
-                    "arn:aws:s3:::cdo-curriculum-devel"
-                ]
-            }
-        ]
-      }


### PR DESCRIPTION
This configuration is for an S3 bucket for curriculumbuilder to use for local
development. Currently, it is impossible to safley test features that publish
content to S3, since the app is only configured to push to the prod S3 bucket.


There will be a followup pr to add configuration for the prod bucket as well after we verify this configuration is in fact accurate

Edit for revision 2:
Summary of additions - Offline, it was agreed that it is a best practice to scope down permissions of services as much as possible. Added an IAM role to the PR. with what we think is the minimal permissions needed for curriculumbuilder to run in a development environment (being able to access the development S3 bucket). The plan is we will write a script that assumes this role on startup when launching curriculumbuilder locally

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


- [jira](https://codedotorg.atlassian.net/browse/LP-891?atlOrigin=eyJpIjoiMDExODE1MDAwNTc2NGVlZTliMjEyMzM1ZWZmNWIxZDEiLCJwIjoiaiJ9)

## Testing story
Tested by running `aws cloudformation validate-template` on this template

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
