### PR TITLE
Reapply ActionView in Sinatra

### DIFF
--- a/lib/cdo/pegasus.rb
+++ b/lib/cdo/pegasus.rb
@@ -8,5 +8,4 @@ require_relative './pegasus/hash'
 require_relative './pegasus/object'
 require_relative './pegasus/string'
 
-require_relative './pegasus/text_render'
 require_relative './pegasus/screencap'

--- a/lib/cdo/pegasus/actionview_sinatra.rb
+++ b/lib/cdo/pegasus/actionview_sinatra.rb
@@ -1,0 +1,78 @@
+require 'action_view'
+require 'haml'
+require 'haml/template'
+require 'redcarpet'
+
+module ActionViewSinatra
+  class MarkdownHandler
+    class HTMLWithDivBrackets < Redcarpet::Render::HTML
+      def preprocess(full_document)
+        full_document.gsub(/```/, "```\n")
+      end
+
+      def postprocess(full_document)
+        process_div_brackets(full_document)
+      end
+
+      private
+
+      # CDO-Markdown div_brackets extension.
+      # Convert `[tag]...[/tag]` to `<div class='tag'>...</div>`.
+      def process_div_brackets(full_document)
+        full_document.
+          gsub(/<p>\[\/(.*)\]<\/p>/, '</div>').
+          gsub(/<p>\[(.*)\]<\/p>/) do
+          value = $1
+          if value[0] == '#'
+            attribute = 'id'
+            value = value[1..-1]
+          else
+            attribute = 'class'
+          end
+
+          "<div #{attribute}='#{value}'>"
+        end
+      end
+    end
+
+    def self.call(template)
+      @renderer ||= Redcarpet::Markdown.new(
+        HTMLWithDivBrackets,
+        autolink: true,
+        tables: true,
+        space_after_headers: true,
+        fenced_code_blocks: true,
+        lax_spacing: true
+      )
+      "#{@renderer.render(template.source).inspect}.html_safe"
+    end
+  end
+
+  class Base < ActionView::Base
+    def initialize(sinatra, *args)
+      @sinatra = sinatra
+      super(*args)
+    end
+
+    def response
+      @sinatra.response
+    end
+
+    def params
+      {}
+    end
+
+    # allow templates to throw a Sinatra::NotFound error to trigger a 404
+    def render(*args)
+      super(*args)
+    rescue ActionView::Template::Error => e
+      raise e.cause if e.cause.is_a?(Sinatra::NotFound)
+      raise e
+    end
+
+    # Our templates currently use a bunch of sinatra methods like resolve_static, redirect, etc.
+    def method_missing(name, *args, &block)
+      @sinatra.send(name, *args)
+    end
+  end
+end

--- a/lib/cdo/pegasus/actionview_sinatra.rb
+++ b/lib/cdo/pegasus/actionview_sinatra.rb
@@ -62,10 +62,21 @@ module ActionViewSinatra
       {}
     end
 
-    # allow templates to throw a Sinatra::NotFound error to trigger a 404
-    def render(*args)
-      super(*args)
+    # make locals hash directly accessible from templates; our old renderer
+    # supported this and some templates rely on this functionality (see
+    # views/pd_survey_controls/multi_select.haml for an example).
+    #
+    # TODO: update templates to no longer rely on this and remove.
+    def locals
+      @locals || {}
+    end
+
+    def render(options = {}, locals = {})
+      # save locals hash for access by the locals method
+      @locals = locals
+      super(options, locals)
     rescue ActionView::Template::Error => e
+      # allow templates to throw a Sinatra::NotFound error to trigger a 404
       raise e.cause if e.cause.is_a?(Sinatra::NotFound)
       raise e
     end

--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'cdo/erb'
+require 'cdo/pegasus/text_render'
 
 module Cdo
   # Extend YAML with customizations.

--- a/pegasus/helpers/page_helpers.rb
+++ b/pegasus/helpers/page_helpers.rb
@@ -41,7 +41,7 @@ def inline_css(css)
     $log.warn "Too much inlined CSS in page! [#{@total_css} bytes]" if @total_css > max_inline_css
   end
 
-  <<-HTML
+  <<-HTML.html_safe
 <style>
 #{css_string.indent(2)}
 </style>
@@ -86,5 +86,5 @@ def youtube_embed(youtube_url)
     youtube_id = $5
   end
 
-  %Q{<iframe title="YouTube video player" width="250" height="141" src="http://www.youtube.com/embed/#{youtube_id}" frameborder="0" allowfullscreen></iframe>}
+  %Q{<iframe title="YouTube video player" width="250" height="141" src="http://www.youtube.com/embed/#{youtube_id}" frameborder="0" allowfullscreen></iframe>}.html_safe
 end

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -110,13 +110,6 @@ class Documents < Sinatra::Base
       settings.template_extnames +
       settings.exclude_extnames +
       ['.fetch']
-    set :markdown,
-      renderer: ::TextRender::MarkdownEngine::HTMLWithDivBrackets,
-      autolink: true,
-      tables: true,
-      space_after_headers: true,
-      fenced_code_blocks: true,
-      lax_spacing: true
     Sass::Plugin.options[:cache_location] = pegasus_dir('cache', '.sass-cache')
     Sass::Plugin.options[:css_location] = pegasus_dir('cache', 'css')
     Sass::Plugin.options[:template_location] = shared_dir('css')
@@ -161,6 +154,41 @@ class Documents < Sinatra::Base
         base = settings.configs[base][:base]
       end
     end
+
+    @actionview ||= begin
+      # Lazily require actionview_sinatra here, because it it turn will require
+      # ActionView::Base, which will in turn run the ActiveSupport load hooks for
+      # the class.
+      #
+      # This can cause some issues for environments that want to load both
+      # Pegasus and Dashboard, since if ActionView is loaded outside the context
+      # of Rails it won't load all functionality, and ActionView won't be
+      # re-initialized when it _does_ get loaded by Rails.
+      #
+      # This is similar to the lazy loading we need to do for Haml:
+      # https://github.com/code-dot-org/code-dot-org/blob/8a49e0f39e1bc98aac462a3eb049d0eeb6af3e06/lib/cdo/pegasus/text_render.rb#L82-L97
+      require 'cdo/pegasus/actionview_sinatra'
+      ActionView::Template.register_template_handler :md, ActionViewSinatra::MarkdownHandler
+      ActionViewSinatra::Base.new(self)
+    end
+
+    update_actionview_assigns
+    @actionview.instance_variable_set("@_request", request)
+  end
+
+  # This will make all instance variables on our sinatra controller also
+  # available from our views. Inspired by similar behavior in Rails' controller
+  # logic:
+  # https://github.com/rails/rails/blob/c4d3e202e10ae627b3b9c34498afb45450652421/actionpack/lib/abstract_controller/rendering.rb#L66-L77
+  #
+  # If in the future Sinatra's controller functionality is replaced by Rails,
+  # this can probably go away.
+  def update_actionview_assigns
+    view_assigns = {}
+    instance_variables.each do |name|
+      view_assigns[name[1..-1]] = instance_variable_get(name)
+    end
+    @actionview.assign(view_assigns)
   end
 
   # Language selection
@@ -254,14 +282,14 @@ class Documents < Sinatra::Base
     unless ['', 'none'].include?(layout)
       template = resolve_template('layouts', settings.template_extnames, layout)
       raise Exception, "'#{layout}' layout not found." unless template
-      body render_template(template, {body: body.join('')})
+      body render_template(template, {body: body.join('').html_safe})
     end
 
     theme = @header['theme'] || 'default'
     unless ['', 'none'].include?(theme)
       template = resolve_template('themes', settings.template_extnames, theme)
       raise Exception, "'#{theme}' theme not found." unless template
-      body render_template(template, {body: body.join('')})
+      body render_template(template, {body: body.join('').html_safe})
     end
   end
 
@@ -363,10 +391,6 @@ class Documents < Sinatra::Base
         rescue
           ''
         end
-    end
-
-    def preprocess_markdown(markdown_content)
-      markdown_content.gsub(/```/, "```\n")
     end
 
     def resolve_static(subdir, uri)
@@ -481,8 +505,6 @@ class Documents < Sinatra::Base
     end
 
     def render_(body, path=nil, line=0, locals={})
-      options = {locals: locals, line: line, path: path}
-
       extensions = MultipleExtnameFileUtils.all_extnames(path)
 
       # Now, apply the processing operations implied by each extension to the
@@ -492,10 +514,8 @@ class Documents < Sinatra::Base
       result = body
       extensions.reverse.each do |extension|
         case extension
-        when '.erb', '.html'
-          result = erb result, options
-        when '.haml'
-          result = haml result, options
+        when '.erb', '.html', '.haml', '.md'
+          result = @actionview.render(inline: result, type: extension[1..-1], locals: locals)
         when '.fetch'
           cache_file = cache_dir('fetch', request.site, request.path_info)
           unless File.file?(cache_file) && File.mtime(cache_file) > settings.launched_at
@@ -506,9 +526,6 @@ class Documents < Sinatra::Base
 
           cache :static
           result = send_file(cache_file)
-        when '.md'
-          preprocessed = preprocess_markdown result
-          result = markdown preprocessed, options
         when '.partial'
           result = render_partials(result)
         when '.redirect', '.moved', '.301'

--- a/pegasus/routes/hourofcode_routes.rb
+++ b/pegasus/routes/hourofcode_routes.rb
@@ -9,5 +9,12 @@ get '*' do |uri|
   only_for 'hourofcode.com'
   dont_cache unless rack_env == :production
   env['PATH_INFO'] = hoc_canonicalized_i18n_path(uri, request.query_string) unless resolve_static('public', uri)
+  # hoc_canonicalized_i18n_path has a side effect of setting some important
+  # instance variables like country, language, etc., so we need to re-assign
+  # them to actionview here.
+  #
+  # These values should ideally be directly inferred from request rather than
+  # managed as volatile instance variables.
+  update_actionview_assigns
   pass
 end

--- a/pegasus/sites.v3/code.org/public/certificates/splat.haml
+++ b/pegasus/sites.v3/code.org/public/certificates/splat.haml
@@ -45,9 +45,9 @@ social:
           -count_string = I18n.t(:n_have_learned_an_hoc).gsub("#", format_integer_with_commas(fetch_hoc_metrics['started']).to_s)
           -if request.locale == 'en-US'
             %a{:href=>'/leaderboards', :style=>'text-decoration:none'}
-              =count_string
+              !=count_string
           -else
-            =count_string
+            !=count_string
           %h4.desktop-feature=I18n.t(:anybody_can_learn)
         %br
 

--- a/pegasus/sites.v3/code.org/public/congrats.haml
+++ b/pegasus/sites.v3/code.org/public/congrats.haml
@@ -52,7 +52,7 @@ max_age: 60
 
     #additional_actions.ee_markdown
       -if company['additional_actions_copy_t']
-        =TextRender.safe_markdown company['additional_actions_copy_t']
+        = @actionview.render(inline: company['additional_actions_copy_t'], type: :md)
       -else
         =view :company_profile_additional_actions
       = I18n.t :congratulations_volunteer

--- a/pegasus/sites.v3/code.org/public/curriculum/concepts/index.md.erb
+++ b/pegasus/sites.v3/code.org/public/curriculum/concepts/index.md.erb
@@ -86,14 +86,14 @@ Each of these activities can either be used alone or with other computer science
     <tr>
       <td rowspan="2" style="color: white; border:1px solid white; text-align: center;"><%= lesson[:mainConcept_s] %></td>
       <td style="border:1px solid #999999;"> <h3><a href="<%= lesson[:lessonURL_t] %>" target="_new"><%= lesson[:name_t] %></a></h3>
-        <div style="font-size: 11px; line-height: 120%;"><b><%= theCourse %><br/> <%= "(age #{lesson[:age_s]})" %> </b><br/><br/></div>
+        <div style="font-size: 11px; line-height: 120%;"><b><%= theCourse.html_safe %><br/> <%= "(age #{lesson[:age_s]})" %> </b><br/><br/></div>
      	<div style="font-size: 12px; line-height: 110%;"><%= lesson[:overview_t] %><br/><br/></div>
         <a href="<%= lesson[:lessonPlan_t] %>" target="_new">Lesson Plan</a>
         <%	if lesson[:teacherVid_t].present? %>
 		  | <a href="<%= lesson[:teacherVid_t] %>">Teacher Video</a><br/>
 		<% end %>
 		 <%	if lesson[:answers_t].present? %>
-		   <%= lesson[:answers_t] %>
+		   <%= lesson[:answers_t].html_safe %>
 		<% end %>
 
       </td>
@@ -109,7 +109,7 @@ Each of these activities can either be used alone or with other computer science
           <%= youtube_embed(lesson[:sampleTeachingVid_t])%>
 		  <a href="<%= lesson[:sampleTeachingVid_t] %>">See Lesson in Action</a>
 		<% end %>
-      <%= lesson[:additional_t] %></td>
+      <%= lesson[:additional_t].html_safe if lesson[:additional_t].present? %></td>
     </tr>
     <% end %>
 </table>

--- a/pegasus/sites.v3/code.org/public/employees/splat.haml
+++ b/pegasus/sites.v3/code.org/public/employees/splat.haml
@@ -42,7 +42,7 @@ max_age: 60
 
 #intro_top.ee_markdown
   -if company['intro_top_copy_t']
-    =TextRender.safe_markdown company['intro_top_copy_t']
+    = @actionview.render(inline: company['intro_top_copy_t'], type: :md)
   -else
     =view :company_profile_intro_top
 

--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -127,7 +127,7 @@ style_min: false
   $(document).ready(function() {
     // Send through some values that the JavaScript will need.
     var tutorialExplorerManager = new window.TutorialExplorerManager({
-      tutorials: #{tutorials_contents.to_json},
+      tutorials: #{tutorials_contents.to_json.html_safe},
       locale: "#{request.locale}",
       roboticsButtonUrl: "/learn/robotics",
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},

--- a/pegasus/sites.v3/code.org/public/learn/robotics.haml
+++ b/pegasus/sites.v3/code.org/public/learn/robotics.haml
@@ -92,7 +92,7 @@ social:
   $(document).ready(function() {
     // Send through some values that the JavaScript will need.
     var tutorialExplorerManager = new window.TutorialExplorerManager({
-      tutorials: #{tutorials_contents.to_json},
+      tutorials: #{tutorials_contents.to_json.html_safe},
       locale: "#{request.locale}",
       robotics: true,
       backButton: true,

--- a/pegasus/sites.v3/code.org/views/display_chart.haml
+++ b/pegasus/sites.v3/code.org/views/display_chart.haml
@@ -6,7 +6,7 @@
 
   // Callback function to fetch data from a spreadsheet.
   window["getChartData_#{id}"] = function() {
-    var query = new google.visualization.Query("#{query_url}");
+    var query = new google.visualization.Query("#{query_url.html_safe}");
     query.send(window["handleQueryResponse_#{id}"]);
   };
 

--- a/pegasus/sites.v3/code.org/views/stats_carousel.haml
+++ b/pegasus/sites.v3/code.org/views/stats_carousel.haml
@@ -36,7 +36,7 @@
 :javascript
   $(document).ready(function() {
 
-    var statistics = #{JSON.pretty_generate(statistics)};
+    var statistics = #{JSON.pretty_generate(statistics).html_safe};
 
     var id = '#stats-carousel';
     // Define the carousel using the ID.

--- a/pegasus/sites.v3/code.org/views/stats_impact_carousel.haml
+++ b/pegasus/sites.v3/code.org/views/stats_impact_carousel.haml
@@ -32,7 +32,7 @@
 :javascript
   $(document).ready(function() {
 
-    var statistics = #{JSON.pretty_generate(statistics)};
+    var statistics = #{JSON.pretty_generate(statistics).html_safe};
 
     var id = '#stats-impact-carousel';
     // Define the carousel using the ID.

--- a/pegasus/sites.v3/code.org/views/unsupported_browser.haml
+++ b/pegasus/sites.v3/code.org/views/unsupported_browser.haml
@@ -1,4 +1,4 @@
 #warning-banner{style: 'display: none;'}
   %i.fa.fa-warning.warning-sign
   &nbsp;
-  = I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true)
+  = I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true).html_safe

--- a/pegasus/sites.v3/codeprojects.org/views/footer.haml
+++ b/pegasus/sites.v3/codeprojects.org/views/footer.haml
@@ -10,4 +10,4 @@
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;
     %a.codeprojects_pagefooter_link{:href=>code_org_url("privacy")} Privacy Policy
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;
-    %a.codeprojects_pagefooter_link="&copy; Code.org, #{Time.now.year}."
+    %a.codeprojects_pagefooter_link="&copy; Code.org, #{Time.now.year}.".html_safe

--- a/pegasus/sites.v3/csedweek.org/views/stats_carousel.haml
+++ b/pegasus/sites.v3/csedweek.org/views/stats_carousel.haml
@@ -24,7 +24,7 @@
 %script{:src=>'/js/jquery.touchSwipe.min.js'}
 :javascript
   $(document).ready(function() {
-    var statistics = #{JSON.pretty_generate(statistics)};
+    var statistics = #{raw JSON.pretty_generate(statistics)};
     var id = '#stats-carousel';
 
     // Define the carousel using the ID.

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -121,7 +121,7 @@ social:
   $(document).ready(function() {
     // Send through some values that the JavaScript will need.
     var tutorialExplorerManager = new window.TutorialExplorerManager({
-      tutorials: #{tutorials_contents.to_json},
+      tutorials: #{raw tutorials_contents.to_json},
       locale: "#{locale_code}",
       roboticsButtonUrl: "#{resolve_url('/learn/robotics')}",
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},

--- a/pegasus/sites.v3/hourofcode.com/public/learn/robotics.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/robotics.haml
@@ -95,7 +95,7 @@ social:
   $(document).ready(function() {
     // Send through some values that the JavaScript will need.
     var tutorialExplorerManager = new window.TutorialExplorerManager({
-      tutorials: #{tutorials_contents.to_json},
+      tutorials: #{raw tutorials_contents.to_json},
       locale: "#{locale_code}",
       robotics: true,
       backButton: true,

--- a/pegasus/sites.v3/hourofcode.com/views/stats_carousel.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/stats_carousel.haml
@@ -24,7 +24,7 @@
 %script{:src=>'/js/jquery.touchSwipe.min.js'}
 :javascript
   $(document).ready(function() {
-    var statistics = #{JSON.pretty_generate(statistics)};
+    var statistics = #{raw JSON.pretty_generate(statistics)};
     var id = '#stats-carousel';
 
     // Define the carousel using the ID.

--- a/pegasus/sites.v3/hourofcode.com/views/unsupported_browser.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/unsupported_browser.haml
@@ -1,4 +1,4 @@
 #warning-banner{style: 'display: none;'}
   %i.fa.fa-warning.warning-sign
   &nbsp;
-  = I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true)
+  = I18n.t("compatibility_unsupported_browser_markdown", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true).html_safe

--- a/pegasus/test/test_router.rb
+++ b/pegasus/test/test_router.rb
@@ -1,3 +1,5 @@
+require 'action_view'
+
 require_relative './test_helper'
 require_relative '../router'
 
@@ -33,21 +35,17 @@ class RouterTest < Minitest::Test
   end
 
   def test_erb_error_body
-    err = assert_raises(RuntimeError) do
+    err = assert_raises(ActionView::Template::Error) do
       get('/erb_error_body')
     end
-    file, line = err.backtrace.first.split(':')
-    assert_equal file, app.helpers.content_dir('code.org/public/erb_error_body.md.erb')
-    assert_equal 8, line.to_i
+    assert_equal app.helpers.content_dir('code.org/public/erb_error_body.md.erb'), err.backtrace.first
   end
 
   def test_haml_error
-    err = assert_raises(Haml::Error) do
+    err = assert_raises(ActionView::Template::Error) do
       get('/haml_error')
     end
-    file, line = err.backtrace.first.split(':')
-    assert_equal file, app.helpers.content_dir('code.org/public/haml_error.haml')
-    assert_equal 10, line.to_i
+    assert_equal app.helpers.content_dir('code.org/public/haml_error.haml'), err.backtrace.first
   end
 
   def test_markdown_partial
@@ -114,6 +112,6 @@ class RouterTest < Minitest::Test
     # functionality.
     resp = get('/test_no_erb_in_yaml')
     refute_match "<title>1,2,3</title>", resp.body
-    assert_match "<title><%= (1..3).to_a.join(',').inspect %></title>", resp.body
+    assert_match "<title>&lt;%= (1..3).to_a.join(&#39;,&#39;).inspect %&gt;</title>", resp.body
   end
 end


### PR DESCRIPTION
Reverts https://github.com/code-dot-org/code-dot-org/pull/33228, reapplying https://github.com/code-dot-org/code-dot-org/pull/33192

The last PR caused a template rendering error on production, because some views rely on being able to access the `locals` hash directly. Rather than try to identify all views with this dependency and update them, I chose to [make the locals hash accessible](https://github.com/code-dot-org/code-dot-org/commit/aa8b14650884089738369826c5761e30eb6e4d11). Tracking longer-term work [here](https://codedotorg.atlassian.net/browse/FND-1033) to look through all the templates and remove this functionality.

I also chose not to add a UI test for the routes that failed, because they are in the process of being deprecated. Relevant slack thread [here](https://codedotorg.slack.com/archives/CC4U03GA0/p1582231497051600).

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [honeybadger error](https://app.honeybadger.io/projects/34365/faults/61013904)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
