### PR TITLE
[Maze] Don't allow action sounds to overlap

### DIFF
--- a/apps/src/Sounds.js
+++ b/apps/src/Sounds.js
@@ -329,11 +329,11 @@ Sounds.prototype.playURL = function(url, playbackOptions) {
 };
 
 /**
- * @param {!string} url
+ * @param {!string} id of the sound. This is a URL for sounds played via playURL.
  * @returns {boolean} whether the given sound is currently playing.
  */
-Sounds.prototype.isPlayingURL = function(url) {
-  var sound = this.soundsById[url];
+Sounds.prototype.isPlaying = function(id) {
+  var sound = this.soundsById[id];
   if (sound) {
     return sound.isPlaying();
   }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -973,9 +973,13 @@ StudioApp.prototype.loadAudio = function(filenames, name) {
  * @param {string} name sound ID
  * @param {Object} options for sound playback
  * @param {number} options.volume value between 0.0 and 1.0 specifying volume
+ * @param {boolean} options.noOverlap if true, will not start playing if the sound is already playing
  * @param {function} [options.onEnded]
  */
 StudioApp.prototype.playAudio = function(name, options) {
+  if (options && options.noOverlap && Sounds.getSingleton().isPlaying(name)) {
+    return;
+  }
   options = options || {};
   var defaultOptions = {volume: 0.5};
   var newOptions = utils.extend(defaultOptions, options);

--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -53,7 +53,7 @@ export const commands = {
     );
 
     const url = assetPrefix.fixPath(opts.url);
-    if (Sounds.getSingleton().isPlayingURL(url)) {
+    if (Sounds.getSingleton().isPlaying(url)) {
       if (opts.callback) {
         opts.callback(false);
       }
@@ -103,7 +103,7 @@ export const commands = {
 
     if (opts.url) {
       const url = assetPrefix.fixPath(opts.url);
-      if (Sounds.getSingleton().isPlayingURL(url)) {
+      if (Sounds.getSingleton().isPlaying(url)) {
         Sounds.getSingleton().stopLoopingAudio(url);
       }
     } else {

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -89,7 +89,9 @@ module.exports = class Maze {
 
     this.controller = new MazeController(level, skin, config, {
       methods: {
-        playAudio: studioApp().playAudio.bind(studioApp()),
+        playAudio: (sound, options) => {
+          studioApp().playAudio(sound, {...options, noOverlap: true});
+        },
         playAudioOnFailure: studioApp().playAudioOnFailure.bind(studioApp()),
         loadAudio: studioApp().loadAudio.bind(studioApp()),
         getTestResults: studioApp().getTestResults.bind(studioApp())

--- a/apps/test/unit/StudioAppTest.js
+++ b/apps/test/unit/StudioAppTest.js
@@ -7,6 +7,7 @@ import {
   restoreStudioApp,
   makeFooterMenuItems
 } from '@cdo/apps/StudioApp';
+import Sounds from '@cdo/apps/Sounds';
 import {assets as assetsApi} from '@cdo/apps/clientApi';
 import {listStore} from '@cdo/apps/code-studio/assets';
 import * as commonReducers from '@cdo/apps/redux/commonReducers';
@@ -179,6 +180,36 @@ describe('StudioApp', () => {
       var footItems = makeFooterMenuItems();
       var itemKeys = footItems.map(item => item.key);
       expect(itemKeys).to.include('try-hoc');
+    });
+  });
+
+  describe('playAudio', () => {
+    let playStub, isPlayingStub;
+    beforeEach(() => {
+      playStub = sinon.stub(Sounds.getSingleton(), 'play');
+      isPlayingStub = sinon.stub(Sounds.getSingleton(), 'isPlaying');
+    });
+
+    afterEach(() => {
+      playStub.restore();
+      isPlayingStub.restore();
+    });
+
+    it('does not play audio over itself when noOverlap is true', () => {
+      isPlayingStub.onCall(0).returns(true);
+      studioApp().playAudio('testAudio', {noOverlap: true});
+      expect(playStub).not.to.have.been.called;
+
+      isPlayingStub.onCall(1).returns(false);
+      studioApp().playAudio('testAudio', {noOverlap: true});
+      expect(playStub).to.have.been.calledOnce;
+    });
+
+    it('does play audio over itself when noOverlap is false or unspecified', () => {
+      isPlayingStub.returns(true);
+      studioApp().playAudio('testAudio', {noOverlap: false});
+      studioApp().playAudio('testAudio');
+      expect(playStub).to.have.been.calledTwice;
     });
   });
 

--- a/apps/test/unit/code-studio/components/SoundListEntryTest.js
+++ b/apps/test/unit/code-studio/components/SoundListEntryTest.js
@@ -61,7 +61,7 @@ describe('SoundListEntry', () => {
     sinon.stub(sounds, 'stopPlayingURL');
     wrapper.setProps({isSelected: false});
 
-    assert.equal(sounds.isPlayingURL(sourceURL), false);
+    assert.equal(sounds.isPlaying(sourceURL), false);
     expect(sounds.stopPlayingURL).to.have.been.calledOnce;
 
     sounds.stopPlayingURL.restore();


### PR DESCRIPTION
Sample repro: `s/express-2019/stage/12/puzzle/10`
![image](https://user-images.githubusercontent.com/8787187/74994142-13f96280-5402-11ea-92c7-2270353e1adc.png)
Plays a truly horrible sound which is the result of trying to play the dig sound over and over itself.

The solution is to prevent a new instance of sound from starting while the previous instance is still playing. The result for the infinite loop case is that you hear the dig sound looping because a new instance of the sound starts as soon as one instance finishes playing.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-156)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
