### PR TITLE
Render teacher_markdown clientside

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -542,6 +542,7 @@ describe('entry tests', () => {
     'levels/_bubble_choice':
       './src/sites/studio/pages/levels/_bubble_choice.js',
     'levels/_content': './src/sites/studio/pages/levels/_content.js',
+    'levels/_teacher_markdown': './src/sites/studio/pages/levels/_teacher_markdown.js',
     'levels/_contract_match':
       './src/sites/studio/pages/levels/_contract_match.js',
     'levels/_curriculum_reference':

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -542,7 +542,6 @@ describe('entry tests', () => {
     'levels/_bubble_choice':
       './src/sites/studio/pages/levels/_bubble_choice.js',
     'levels/_content': './src/sites/studio/pages/levels/_content.js',
-    'levels/_teacher_markdown': './src/sites/studio/pages/levels/_teacher_markdown.js',
     'levels/_contract_match':
       './src/sites/studio/pages/levels/_contract_match.js',
     'levels/_curriculum_reference':
@@ -558,6 +557,7 @@ describe('entry tests', () => {
     'levels/_multi': './src/sites/studio/pages/levels/_multi.js',
     'levels/_standalone_video':
       './src/sites/studio/pages/levels/_standalone_video.js',
+    'levels/_teacher_markdown': './src/sites/studio/pages/levels/_teacher_markdown.js',
     'levels/_teacher_panel':
       './src/sites/studio/pages/levels/_teacher_panel.js',
     'levels/_text_match': './src/sites/studio/pages/levels/_text_match.js',

--- a/apps/src/sites/studio/pages/levels/_teacher_markdown.js
+++ b/apps/src/sites/studio/pages/levels/_teacher_markdown.js
@@ -1,0 +1,18 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDom from 'react-dom';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+
+$(document).ready(() => {
+  $('#markdown.teacher.hide-as-student > .markdown-container').each(function() {
+    const container = this;
+    if (!container.dataset.markdown) {
+      return;
+    }
+
+    ReactDom.render(
+      React.createElement(SafeMarkdown, container.dataset, null),
+      container
+    );
+  });
+});

--- a/dashboard/app/views/levels/_teacher_markdown.html.haml
+++ b/dashboard/app/views/levels/_teacher_markdown.html.haml
@@ -1,7 +1,9 @@
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/levels/_teacher_markdown.js')}
+
 / Teacher only markdown
 - if data['teacher_markdown'].present? && can_view_teacher_markdown?
   #markdown.teacher.hide-as-student
     %h3= t('teacher.for_teachers_only')
-    / Render markdown text through the ActionView template engine.
-    .content
-      = ActionView::Base.new.render(inline: data['teacher_markdown'], type: :md)
+    / Render markdown text clientside via _teacher_markdown.js
+    .content.markdown-container{data: {markdown: data['teacher_markdown']}}

--- a/dashboard/app/views/levels/_teacher_markdown.html.haml
+++ b/dashboard/app/views/levels/_teacher_markdown.html.haml
@@ -1,5 +1,8 @@
 - content_for(:head) do
-  %script{src: webpack_asset_path('js/levels/_teacher_markdown.js')}
+  - # only add a single script time, even if this view is included multiple times in the page
+  - js_path = webpack_asset_path('js/levels/_teacher_markdown.js')
+  - unless content_for(:head) && content_for(:head).include?(js_path)
+    %script{src: js_path}
 
 / Teacher only markdown
 - if data['teacher_markdown'].present? && can_view_teacher_markdown?

--- a/dashboard/app/views/levels/_teacher_markdown.html.haml
+++ b/dashboard/app/views/levels/_teacher_markdown.html.haml
@@ -1,5 +1,5 @@
 - content_for(:head) do
-  - # only add a single script time, even if this view is included multiple times in the page
+  - # only add a single script, even if this view is included multiple times in the page
   - js_path = webpack_asset_path('js/levels/_teacher_markdown.js')
   - unless content_for(:head) && content_for(:head).include?(js_path)
     %script{src: js_path}

--- a/dashboard/app/views/levels/instructions.haml
+++ b/dashboard/app/views/levels/instructions.haml
@@ -10,23 +10,6 @@
       border: 1px dashed black;
       padding: 10px;
     }
-    .teacher_markdown {
-      border: 5px solid #0094ca;
-      border-radius: 5px;
-      background: #d9eff7;
-
-      > h3 {
-        background: #0094ca;
-        color: white;
-        font-family: "Gotham 7r", sans-serif;
-        font-size: 18;
-        padding: 5px;
-        margin: 0px;
-      }
-      .content {
-        padding: 10px;
-      }
-    }
   }
 
 - stages = local_assigns[:stages]
@@ -56,12 +39,7 @@
           - if level.properties['long_instructions']
             - markdown = level.properties['long_instructions']
             =ActionView::Base.new.render(inline: markdown, type: :md) unless markdown.blank?
-          - if level.properties['teacher_markdown']
-            .teacher_markdown
-              %h3 For Teachers Only
-              .content
-                - markdown = level.properties['teacher_markdown']
-                =ActionView::Base.new.render(inline: markdown, type: :md) unless markdown.blank?
+          = render partial: 'levels/teacher_markdown', locals: {data: level.properties}
           - if level.properties['questions']
             %div= "Questions: #{level.properties['questions']}"
           - if level.properties['answers']


### PR DESCRIPTION
So we can render it with our SafeMarkdown component.

Prerequisite to opening this field up for translations.

Because this is switching the renderer from redcarpet to remark, it also requires content updates for many of the affected levels; that work is being tracked [here](https://docs.google.com/spreadsheets/d/1p-KP5RMQn3d-aNuagCCyGKyUfC7L8893gPoT2e3fCmA/edit#gid=153934544).

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-730)
- [content updates](https://docs.google.com/spreadsheets/d/1p-KP5RMQn3d-aNuagCCyGKyUfC7L8893gPoT2e3fCmA/edit#gid=153934544)

## Testing story

As with other renderer switches, the testing pattern for this is to:

- Output all affected markdown to a `markdown.json` file
- Render all markdown with Redcarpet, output to `redcarpet.json`
- Render all markdown with Remark, output to `remark.json`
- Use https://github.com/Hamms/html-equivalency to compare `redcarpet.json` and `remark.json` and identify the levels for which there is an html change

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
