### PR TITLE
Use level.try in _content to accomodate views with a nil level

### DIFF
--- a/dashboard/app/views/levels/_content.html.haml
+++ b/dashboard/app/views/levels/_content.html.haml
@@ -27,6 +27,6 @@
       %p.content.content3!= render_multi_or_match_content(level.localized_property('content3'))
   / Markdown will be rendered clientside by _content.js
   - if data['markdown'].present?
-    - level_markdown = level.try(:localized_replaced_markdown, current_user) || level.localized_property('markdown')
+    - level_markdown = level.try(:localized_replaced_markdown, current_user) || level.try(:localized_property, 'markdown')
     .markdown-container{data: {markdown: level_markdown}}
   = postcontent


### PR DESCRIPTION
The script instructions overview page in particular is fragile in this way.

Before this change, https://levelbuilder-studio.code.org/s/coursea-2019/instructions was throwing:

    NoMethodError in Scripts#instructions:

    Showing
    /home/ubuntu/levelbuilder/dashboard/app/views/levels/_content.html.haml
    where line #30 raised:

    undefined method `localized_property' for nil:NilClass

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story


tracking follow-up work to add tests for this view [here](https://codedotorg.atlassian.net/browse/LP-1231)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
