### PR TITLE
Teacher Application Export updates

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -22,25 +22,37 @@ end
 def update_sheets(drive)
   # Update application sheet
   applications = [%w(course regional_partner status scholarship_status school_type pay_fee email created_at
-                     meets_minimum_requirements meets_scholarship_criteria registered_for_workshop rural_status free_reduced_lunch_percent
-                     urm_percent)]
+                     meets_minimum_requirements meets_scholarship_criteria registered_for_workshop rural_status
+                     free_reduced_lunch_percent urm_percent accepted_at)]
   Pd::Application::Teacher2021Application.find_each do |app|
     stats = app.get_latest_school_stats(app.school_id)
+    pay_fee = app.sanitize_form_data_hash[:principal_pay_fee] || app.sanitize_form_data_hash[:pay_fee]
+    frl_percent = stats&.frl_eligible_percent
+    # principal data is stored as a string with % at the end. Convert to float
+    if app.sanitize_form_data_hash[:principal_free_lunch_percent]
+      frl_percent = app.sanitize_form_data_hash[:principal_free_lunch_percent].to_f
+    end
+    urm_percent = stats&.urm_percent
+    if app.sanitize_form_data_hash[:principal_underrepresented_minority_percent]
+      urm_percent = app.sanitize_form_data_hash[:principal_underrepresented_minority_percent].to_f
+    end
+
     applications << [
       app.course,
       app.regional_partner.try(:name),
       app.status,
       app.scholarship_status,
       app.school_type,
-      app.sanitize_form_data_hash[:pay_fee],
+      pay_fee,
       app.email,
       app.created_at,
       app.meets_criteria,
       app.meets_scholarship_criteria,
       app.friendly_registered_workshop,
       stats&.rural_school?,
-      stats&.frl_eligible_percent,
-      stats&.urm_percent
+      frl_percent,
+      urm_percent,
+      app.accepted_at
     ]
   end
 


### PR DESCRIPTION
[PLC-769](https://codedotorg.atlassian.net/browse/PLC-769)
Do the following updates to teacher application export:
- pay_fee field should fall back to teacher response if principal response is not found
- free_reduced_lunch_percent and urm_percent should use principal response first, and fall back to nces data if principal response is not found
- add accepted_at column

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/PLC-769)

## Testing story
Tested similarly to previous updates to the application summary sheet by creating a private spreadsheet and testing manually, see details [here](https://github.com/code-dot-org/code-dot-org/pull/32609). Verified that data uses principal data first and falls back if principal data is not found (and has no errors if there is no data). Also verified new accepted_at field shows up as expected.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
