### PR TITLE
Export MySQL Pegasus tables to Redshift staging tables

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -121,13 +121,13 @@ Resources:
          # Default value: 1000 KB (1 MB)
          writeBufferSize: 8.megabytes / 1.kilobyte
       }.map{|x|x.join('=')}.join(';')%>
-<% Cdo::DMS.tasks(aws_dir('dms/tasks.yml')).each do |task_name, table_mappings| -%>
-  DMS<%=task_name.underscore.camelize%>FullLoad:
+<% Cdo::DMS.tasks(aws_dir('dms/tasks.yml')).each do |task_name, table_mappings, schedule| -%>
+  DMS<%=task_name.underscore.camelize%>:
     Type: AWS::DMS::ReplicationTask
     Properties:
       MigrationType: full-load
       ReplicationInstanceArn: !Ref TableauSync
-      ReplicationTaskIdentifier: <%= task_name %>-full-load-no-cdc
+      ReplicationTaskIdentifier: <%= task_name %>
       SourceEndpointArn: !Ref AuroraReaderEndpoint
       TargetEndpointArn: !Ref RedshiftEndpoint
       ReplicationTaskSettings: !Sub |
@@ -136,8 +136,8 @@ Resources:
           <%= table_mappings.to_json %>
       Tags:
         -
-          Key: environment
-          Value: <%=rack_env.to_s%>
+          Key: schedule
+          Value: <%=schedule%>
 <% end -%>
   DMSS3Role:
     Type: AWS::IAM::Role

--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -112,4 +112,6 @@ cron-user-hierarchy-pii:
 cron-user-levels:
 - dashboard.user_levels
 cron-level-sources-pii:
-- dashboard.level_sources
+- dashboard.level_sources:
+    skip_staging_table: true
+    schedule: 'weekly'


### PR DESCRIPTION
Configure DMS Replication Tasks to export all MySQL tables to temporary / staging (`_import_`) tables, unless `tasks.yml` explicitly states that the staging table should be skipped.  Previously only MySQL dashboard tables were being loaded into temp tables.

In practice, the `level_sources` table will utilize the `skip_staging_table` configuration setting because it takes longer than 24 hours to load and is not queried frequently by data analysts.

Also, tag the Replication Tasks to indicate which ones should be run daily and which ones (level sources) should be run weekly.  This tag will be used by the [scheduled export process](https://github.com/code-dot-org/code-dot-org/pull/31524) to identify which tasks it should start.

### Background

Epic - https://codedotorg.atlassian.net/browse/INF-242


## Testing story

```
suresh$ bundle exec rake stack:data:validate RAILS_ENV=production
Data layer including RedShift cluster configuration and synchronization with RDS instance.
Listing changes to existing stack `DATA-production`:
Remove DMSCronFullLoad [AWS::DMS::ReplicationTask]
Remove DMSCronLevelSourcesPiiFullLoad [AWS::DMS::ReplicationTask]
Add DMSCronLevelSourcesPii [AWS::DMS::ReplicationTask]
Remove DMSCronPiiFullLoad [AWS::DMS::ReplicationTask]
Add DMSCronPii [AWS::DMS::ReplicationTask]
Remove DMSCronUserHierarchyFullLoad [AWS::DMS::ReplicationTask]
Remove DMSCronUserHierarchyPiiFullLoad [AWS::DMS::ReplicationTask]
Add DMSCronUserHierarchyPii [AWS::DMS::ReplicationTask]
Add DMSCronUserHierarchy [AWS::DMS::ReplicationTask]
Remove DMSCronUserLevelsFullLoad [AWS::DMS::ReplicationTask]
Add DMSCronUserLevels [AWS::DMS::ReplicationTask]
Add DMSCron [AWS::DMS::ReplicationTask]
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
