### PR TITLE
Hide tooltip for progress bubble on sublevels in bubble choice

### DIFF
--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -153,7 +153,11 @@ export default class BubbleChoice extends React.Component {
             )}
             <div style={styles.column}>
               <div style={styles.bubbleAndTitle}>
-                <ProgressBubble level={sublevel} disabled={false} />
+                <ProgressBubble
+                  level={sublevel}
+                  disabled={false}
+                  hideToolTips={true}
+                />
                 <a href={sublevel.url + location.search} style={styles.title}>
                   {sublevel.display_name}
                 </a>


### PR DESCRIPTION
The sublevel ProgressBubbles on a bubble choice parent level were showing tooltips with the sublevel name instead of display name. Since the display name for the sublevel is right next to the ProgressBubble I don't think we need the tooltip at all so this turns it off

<img width="1043" alt="Screen Shot 2020-02-24 at 12 33 03 PM" src="https://user-images.githubusercontent.com/208083/75176250-cf234380-5701-11ea-8991-390b76229937.png">
