### PR TITLE
don't translate encrypted levels

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -99,6 +99,10 @@ def localize_level_content
       script_strings = {}
       script.script_levels.each do |script_level|
         level = script_level.oldest_active_level
+        # Don't localize encrypted levels; the whole point of encryption is to
+        # keep the contents of certain levels secret.
+        next if level.encrypted?
+
         url = I18nScriptUtils.get_level_url_key(script, level)
         script_strings[url] = get_i18n_strings(level)
 


### PR DESCRIPTION
Currently, there are only nine levels in the intersection of "encrypted levels" and "levels we translate":

- OPD-K5 Celebrate (https://studio.code.org/s/K5-OnlinePD/stage/11/puzzle/5)
- Social Sleuth_2018 (https://studio.code.org/s/csd2-2018/stage/5/puzzle/2)
- CSD U3 Collision Detection (https://studio.code.org/s/csd3-2017/stage/16/puzzle/1)
- CSD U3 complex sprite movement SFLP (https://studio.code.org/s/csd3-2017/stage/17/puzzle/1)
- CSD U3 Entertainment_2018 (https://studio.code.org/s/csd3-2018/stage/1/puzzle/2)
- Terminology Recap (https://studio.code.org/s/hoc-encryption/stage/1/puzzle/2)
- Social Sleuth_2018_2019 (https://studio.code.org/s/csd2-2019/stage/5/puzzle/2)
- CSD U2 image debug match (https://studio.code.org/s/csd2-2019/stage/7/puzzle/4)
- CSD U3 Entertainment_2018_2019 (https://studio.code.org/s/csd3-2019/stage/1/puzzle/2)

We've confirmed that the seven CSD levels and the one hoc-encryption do not actually need to be encrypted, and are updating them to indicate as much. The K5-OnlinePD script as a whole is removed from the i18n sync (https://github.com/code-dot-org/code-dot-org/pull/33292). So this change should not actually result in any change to the set of levels that are currently being translated.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack thread](https://codedotorg.slack.com/archives/CA3KCSGTD/p1582242545292900)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
