### PR TITLE
escape 'disabledTutorials' json

### DIFF
--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -131,7 +131,7 @@ style_min: false
       locale: "#{request.locale}",
       roboticsButtonUrl: "/learn/robotics",
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},
-      disabledTutorials: #{DCDO.get('learn_hide_tutorials', [])},
+      disabledTutorials: #{raw DCDO.get('learn_hide_tutorials', [])},
       defaultSortByPopularity: #{Tutorials.sort_by_popularity?(request.site, DCDO.get("hoc_mode", CDO.default_hoc_mode))}
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));

--- a/pegasus/sites.v3/code.org/public/learn/robotics.haml
+++ b/pegasus/sites.v3/code.org/public/learn/robotics.haml
@@ -96,7 +96,7 @@ social:
       locale: "#{request.locale}",
       robotics: true,
       backButton: true,
-      disabledTutorials: #{DCDO.get('learn_hide_tutorials', [])}
+      disabledTutorials: #{raw DCDO.get('learn_hide_tutorials', [])}
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));
   });

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -125,7 +125,7 @@ social:
       locale: "#{locale_code}",
       roboticsButtonUrl: "#{resolve_url('/learn/robotics')}",
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},
-      disabledTutorials: #{DCDO.get('learn_hide_tutorials', [])},
+      disabledTutorials: #{raw DCDO.get('learn_hide_tutorials', [])},
       defaultSortByPopularity: #{Tutorials.sort_by_popularity?(request.site, DCDO.get("hoc_mode", CDO.default_hoc_mode))}
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));

--- a/pegasus/sites.v3/hourofcode.com/public/learn/robotics.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/robotics.haml
@@ -99,7 +99,7 @@ social:
       locale: "#{locale_code}",
       robotics: true,
       backButton: true,
-      disabledTutorials: #{DCDO.get('learn_hide_tutorials', [])}
+      disabledTutorials: #{raw DCDO.get('learn_hide_tutorials', [])}
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));
   });


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/33295; this wasn't caught by tests because we don't have this environment variable set anywhere in our tests

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
