### PR TITLE
Keep the code moving the pegasus files in the correct order

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -60,6 +60,8 @@ cp_in apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json i18n/locale
 orig_dir=pegasus/cache/i18n
 loc_dir=i18n/locales/source/pegasus
 mkdir -p $loc_dir
+perl -i ./bin/i18n-codeorg/lib/fix-ruby-yml.pl $orig_dir/en-US.yml
+cp_in $orig_dir/en-US.yml $loc_dir/mobile.yml
 
 ### Markdown
 mkdir -p i18n/locales/source/markdown
@@ -72,7 +74,3 @@ loc_dir=i18n/locales/source/markdown/public/educate/curriculum/
 mkdir -p $loc_dir
 orig_file=pegasus/sites.v3/code.org/public/educate/curriculum/csf-transition-guide.md
 cp_in $orig_file $loc_dir
-
-
-perl -i ./bin/i18n-codeorg/lib/fix-ruby-yml.pl $orig_dir/en-US.yml
-cp_in $orig_dir/en-US.yml $loc_dir/mobile.yml


### PR DESCRIPTION
In #33127 I added some new code to deal with the pegasus markdown files but I put it in the wrong place and it broke the pegasus sync.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
