### PR TITLE
Refactor cloudformation glue code and stack template

### DIFF
--- a/aws/cloudformation/README.md
+++ b/aws/cloudformation/README.md
@@ -1,0 +1,15 @@
+# /cloudformation
+
+This directory contains CloudFormation stack templates, associated Custom Resource Lambda functions, and some other related scripts and configuration.
+
+- [`cloud_formation_stack.yml.erb`](cloud_formation_stack.yml.erb) - Stack template for the monolithic Code.org application.
+- `*.yml`, `*.yml.erb` (e.g., [vpc.yml.erb](vpc.yml.erb), [iam.yml.erb](iam.yml.erb), [data.yml.erb](data.yml.erb), [lambda.yml.erb](lambda.yml.erb), [alerting.yml.erb](alerting.yml.erb), [`geocoder.yml`](geocoder.yml), [`drone-stack.yml`](drone-stack.yml)) - Various other standalone or service-oriented stack templates.
+- `*.js, *.rb` (e.g., [`ami-manager.js`](ami-manager.js), [`count_asg.js`](count_asg.js), [`vpcClassicLink.js`](vpcClassicLink.js), [`fast_snapshot_restore.rb`](fast_snapshot_restore.rb)) - Custom Resource Lambda function code.
+- `package.json`, `yarn.lock`, `test/*` -  Package definitions and test files related to Custom Resource Lambda functions.
+
+### See also
+
+- [`stack.rake`](../../lib/rake/stack.rake), [`adhoc.rake`](../../lib/rake/adhoc.rake) - Rakefiles implementing `stack:*` / `adhoc:*` commands for managing various CloudFormation stacks.
+- [`AWS::CloudFormation`](../../lib/cdo/aws/cloud_formation.rb) - Class managing configuration and deployment of AWS CloudFormation stacks.
+- [`Cdo::CloudFormation::StackTemplate`](../../lib/cdo/cloud_formation/stack_template.rb) - Controller class providing the ERB binding context for CloudFormation stack templates.
+- [`Cdo::CloudFormation::CdoApp`](../../lib/cdo/cloud_formation/cdo_app.rb) - Stack-template controller specific to the monolithic Code.org application stack.

--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -5,10 +5,10 @@ apt-get -y install python3-pip curl
 test "$(pip3 show awscli)" || pip3 install awscli
 
 STACK=${AWS::StackName}
-CHEF_VERSION=<%=chef_version%>
+CHEF_VERSION=<%=CHEF_VERSION%>
 REGION=${AWS::Region}
 BRANCH=${Branch}
-S3_BUCKET=<%=s3_bucket%>
+S3_BUCKET=<%=S3_BUCKET%>
 ENVIRONMENT=<%=environment%>
 RUN_LIST='<%=run_list.to_json%>'
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
@@ -19,9 +19,9 @@ RESOURCE_ID=<%=resource_id%>
 export AWS_METADATA_SERVICE_TIMEOUT=30
 export AWS_METADATA_SERVICE_NUM_ATTEMPTS=30
 
-<% if environment == 'adhoc' -%>
+<% if environment == :adhoc -%>
 # Redirect copy of stdout/stderr to a log file for later auditing.
-LOG=<%=log_name%>
+LOG=<%=TailLogs::LOG_NAME%>
 exec >> >(tee -i $LOG)
 exec 2>&1
 
@@ -47,11 +47,11 @@ aws logs put-retention-policy \
   --retention-in-days 1 \
   --region $REGION
 <% end -%>
-<% unless @load_balancer -%>
+<% unless load_balancer -%>
 # Fetch acmesmith-provisioned SSL certificate and key from S3
 aws configure set s3.signature_version s3v4
 SUBDOMAIN=<%=subdomain%>
-S3_PATH=s3://$S3_BUCKET/ssl/certs/$SUBDOMAIN
+S3_PATH=<%=ssl_certs_path%>
 CURRENT=$S3_PATH/$(aws s3 cp $S3_PATH/current -)
 function replace_newline() {
   sed 's/$/\\n/' | tr -d '\n'
@@ -61,7 +61,7 @@ CHAIN=$(aws s3 cp $CURRENT/chain.pem - | replace_newline)
 KEY=$(aws s3 cp $CURRENT/key.pem - | replace_newline)
 <% end -%>
 
-<% if TEMPLATE == 'cloud_formation_stack.yml.erb' && @database -%>
+<% if database -%>
 apt-get install -y  jq
 DB_SECRET_NAME=${DatabaseSecret}
 DB_SECRET=$(aws --region $REGION secretsmanager get-secret-value --secret-id $DB_SECRET_NAME --version-stage AWSCURRENT | jq -r ".SecretString")
@@ -74,7 +74,7 @@ FIRST_BOOT=/etc/chef/first-boot.json
 mkdir -p $(dirname $FIRST_BOOT)
 cat <<JSON > $FIRST_BOOT
 {
-<% unless @load_balancer -%>
+<% unless load_balancer -%>
   "cdo-nginx": {
     "ssl_cert": {
       "content": "$CERT"
@@ -95,13 +95,13 @@ cat <<JSON > $FIRST_BOOT
     "sync": true
   },
   "cdo-secrets": {
-<% if @frontends -%>
+<% if frontends -%>
     "memcached_endpoint": "${Memcached.ConfigurationEndpoint.Address}:${Memcached.ConfigurationEndpoint.Port}",
     "redis_primary": "${GeocoderGroup.PrimaryEndPoint.Address}:${GeocoderGroup.PrimaryEndPoint.Port}",
     "redis_read_addresses": "${GeocoderGroup.ReadEndPoint.Addresses}",
     "redis_read_ports": "${GeocoderGroup.ReadEndPoint.Ports}",
 <% end -%>
-<% if TEMPLATE == 'cloud_formation_stack.yml.erb' && @database -%>
+<% if database -%>
     "db_writer": "mysql://$DB_USERNAME:$DB_PASSWORD@${AuroraCluster.Endpoint.Address}:${AuroraCluster.Endpoint.Port}/",
     "db_reader": "mysql://$DB_USERNAME:$DB_PASSWORD@${AuroraCluster.ReadEndpoint.Address}:${AuroraCluster.Endpoint.Port}/",
     "db_cluster_id": "${AuroraCluster}",
@@ -116,7 +116,7 @@ cat <<JSON > $FIRST_BOOT
 <% end -%>
     "stack_name": "$STACK"
   },
-<% if local_mode -%>
+<% if CDO.chef_local_mode -%>
   "omnibus_updater": {
     "version": "$CHEF_VERSION"
   },
@@ -131,8 +131,8 @@ cat <<JSON > $FIRST_BOOT
 JSON
 
 # Provision via Chef.
-OPTIONS="<%=local_mode ? '-z ' : ''%> -b $BRANCH -n $NODE_NAME -r '$RUN_LIST' -e $ENVIRONMENT -v $CHEF_VERSION"
-sudo -u ubuntu bash -c "aws s3 cp s3://$S3_BUCKET/<%=CHEF_KEY%>/bootstrap-$STACK.sh - | sudo bash -s -- $OPTIONS"
+OPTIONS="<%=cookbooks_path ? '-z ' : ''%> -b $BRANCH -n $NODE_NAME -r '$RUN_LIST' -e $ENVIRONMENT -v $CHEF_VERSION"
+sudo -u ubuntu bash -c "aws s3 cp <%=bootstrap_script_path%> - | sudo bash -s -- $OPTIONS"
 [ $? -eq 0 ] && STATUS=SUCCESS || STATUS=<%=daemon ? 'SUCCESS' : 'FAILURE'%>
 
 <% unless daemon -%>

--- a/aws/cloudformation/bootstrap_frontend.sh.erb
+++ b/aws/cloudformation/bootstrap_frontend.sh.erb
@@ -1,4 +1,4 @@
-CHEF_CACHE=<%=local_mode ? '/etc/chef/local-mode-cache/cache' : '/var/chef/cache' %>
+CHEF_CACHE=<%=CDO.chef_local_mode ? '/etc/chef/local-mode-cache/cache' : '/var/chef/cache' %>
 
 # This line causes the LaunchConfiguration to be replaced on each new commit.
 COMMIT=<%=commit%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -1,61 +1,3 @@
-<%
-require 'active_support/core_ext/numeric/bytes'
-require 'cdo/aws/cloudfront'
-
-origin = "'https://github.com/code-dot-org/code-dot-org.git'"
-
-if rack_env?(:adhoc) && RakeUtils.git_branch == branch
-  # Current branch is the one we're deploying to the adhoc server,
-  # so check whether it's up-to-date with the remote before we get any further.
-  unless `git remote show #{origin} 2>&1 | grep \"(up to date)\" | grep \"#{branch}\" | wc -l`.strip.to_i > 0
-    raise 'Current adhoc branch needs to be up-to-date with GitHub branch of the same name, otherwise deploy will fail.
-To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`.'
-  end
-else
-  # Either not adhoc or deploying a different branch than the current local one;
-  # simply check that the branch exists on GitHub before deploying.
-  unless system("git ls-remote --exit-code #{origin} #{branch} > /dev/null")
-    raise 'Current branch needs to be pushed to GitHub with the same name, otherwise deploy will fail.
-  To specify an alternate branch name, run `rake stack:start branch=BRANCH`.'
-  end
-end
-
-commit = ENV['COMMIT'] || `git ls-remote origin #{branch}`.split.first
-ami = commit[0..4]
-
-frontends = @frontends = rack_env?(:production) || ENV['FRONTENDS']
-database = @database = [:staging, :test, :levelbuilder].include?(rack_env) || ENV['DATABASE']
-load_balancer = @load_balancer = !rack_env?(:adhoc) || ENV['FRONTENDS'] || ENV['LOAD_BALANCER']
-alarms = @alarms = !rack_env?(:adhoc) || ENV['ALARMS']
-chef_version = '15.2.20'
-
-unless dry_run
-  update_certs.call unless load_balancer
-  update_cookbooks.call
-  update_bootstrap_script.call
-end
-
-require 'cdo/cron'
-
-self.log_resource_filter.push 'FrontendLaunchConfig', 'ASGCount'
-
-# Don't provision daemon where manually-provisioned daemon instances already exist.
-# Track Instance ID of manually-provisioned daemon instances that already exist and can't be referenced dynamically
-# TODO migrate stacks to cloudformation-provisioned instances.
-if %w(autoscale-prod test staging levelbuilder).include? stack_name
-  self.daemon_instance_id = {
-    'autoscale-prod' => 'i-08f5f8ace0a473b8d',
-    'test' => 'i-004727200191f3251',
-    'staging' => 'i-02e6cdc765421ab34',
-    'levelbuilder' => 'i-0907b146f7e6503f6'
-  }[stack_name]
-else
-  self.daemon = 'Daemon'
-end
-
-# Use alternate legacy EC2 instance resource name for standalone-adhoc stack.
-self.daemon = 'WebServer' if rack_env?(:adhoc) && !frontends
--%>
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: AWS CloudFormation Template for Code.org application
@@ -153,22 +95,19 @@ Resources:
             Action: 's3:*'
             Resource: '*'
 <% if frontends -%>
-<%=  component 'ami', ami: ami,
+<%=  component 'ami', ami: (ami = commit[0..4]),
+  image_id: IMAGE_ID,
+  ssh_key_name: SSH_KEY_NAME,
   frontend_policies: [Ref: 'CDOPolicy'],
-  frontend_properties: {
-    TargetGroupARNs: [Ref: 'ALBTargetGroup']
-  },
+  frontend_properties: {TargetGroupARNs: [Ref: 'ALBTargetGroup']},
   frontend_volume_size: 64,
   ami_timeout: 'PT120M',
   build_ami: erb_file(aws_dir('cloudformation/bootstrap_chef_stack.sh.erb'),
     resource_id: "AMICreate#{ami}",
     node_name: 'ami-$INSTANCE_ID',
-    run_list: [
-      local_mode ? 'recipe[cdo-apps]' : 'role[unmonitored-frontend]'
-    ],
+    run_list: [CDO.chef_local_mode ? 'recipe[cdo-apps]' : 'role[unmonitored-frontend]'],
     commit: commit,
-    daemon: false,
-    chef_version: chef_version
+    daemon: false
   ),
   frontend_timeout: 'PT50M',
   build_frontend: erb_file(aws_dir('cloudformation/bootstrap_frontend.sh.erb'),
@@ -285,18 +224,7 @@ Resources:
   <%=app%>CDN:
     Type: AWS::CloudFront::Distribution
     Properties:
-      DistributionConfig: <%= AWS::CloudFront.distribution_config(
-        app.downcase.to_sym,
-        subdomain('origin'),
-        app == 'Dashboard' ?
-          [studio_subdomain] :
-          [subdomain] + (CDO.partners + ['advocacy']).map{|x| subdomain(nil, x)},
-        {
-          AcmCertificateArn: certificate_arn,
-          MinimumProtocolVersion: 'TLSv1',
-          SslSupportMethod: domain == 'code.org' ? 'vip' : 'sni-only'
-        }
-      )%>
+      DistributionConfig: <%= cloudfront_config(app) %>
 <%   end -%>
 <% end -%>
 <% if cdn_enabled -%>
@@ -451,11 +379,9 @@ Resources:
           <%=indent(erb_file(aws_dir('cloudformation', 'bootstrap_chef_stack.sh.erb'),
             resource_id: daemon,
             node_name: '$STACK',
-            run_list: local_mode ? ['recipe[cdo-apps]', 'recipe[cdo-home-ubuntu]'] : ['role[daemon]'],
+            run_list: CDO.chef_local_mode ? ['recipe[cdo-apps]', 'recipe[cdo-home-ubuntu]'] : ['role[daemon]'],
             commit: nil, # track branch
-            shutdown: false,
-            daemon: true,
-            chef_version: chef_version
+            daemon: true
           ), 10)%>
           # Signal CloudFormation resource.
           aws cloudformation signal-resource \

--- a/aws/cloudformation/components/README.md
+++ b/aws/cloudformation/components/README.md
@@ -1,0 +1,3 @@
+# /components
+
+This directory contains partial-template chunks that can be included in a CloudFormation template via `StackTemplate#component` within an ERB snippet (e.g., `<%=component 'my_component' [...] %>`). This provides a lightweight layer of organization to large templates without depending on CloudFormation Nested Stacks or other heavier constructs.

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -25,8 +25,8 @@ frontend_policies ||= []
 # Array of properties to append to the frontend AutoScalingGroup resource.
 frontend_properties ||= {}
 
-image_id ||= IMAGE_ID
-ssh_key_name ||= SSH_KEY_NAME
+image_id ||= {Ref: 'ImageId'}.to_json
+ssh_key_name ||= {Ref: 'SSHKeyName'}.to_json
 instance_type ||= {Ref: 'InstanceType'}.to_json
 
 ami_timeout ||= 'PT10M'
@@ -92,14 +92,14 @@ frontend_device_name ||= '/dev/sda1'
             || true
 
           shutdown -h now
-  AMI<%=ami%>: <%= lambda_fn.call 'AMIManager',
+  AMI<%=ami%>: <%= lambda_fn 'AMIManager',
     DependsOn: "AMICreate#{ami}",
     InstanceId: {Ref: "WebServerAMI" } %>
-  FastSnapshotRestore: <%= lambda_fn.call 'FastSnapshotRestore',
+  FastSnapshotRestore: <%= lambda_fn 'FastSnapshotRestore',
     ImageIds: [{Ref: "AMI#{ami}" }],
     AvailabilityZones: AVAILABILITY_ZONES
   %>
-  ASGCount: <%= lambda_fn.call 'CountASG',
+  ASGCount: <%= lambda_fn 'CountASG',
     Default: {
       MinSize: 2,
       MaxSize: 20,

--- a/aws/cloudformation/components/cache.yml.erb
+++ b/aws/cloudformation/components/cache.yml.erb
@@ -34,5 +34,5 @@
       EngineVersion: 1.4
       NumCacheNodes: 2
       AZMode: cross-az
-      PreferredAvailabilityZones: <%= availability_zones.first(2).to_json %>
+      PreferredAvailabilityZones: <%= AVAILABILITY_ZONES.first(2).to_json %>
       VpcSecurityGroupIds: [!ImportValue VPC-MemcachedSecurityGroup]

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -2,6 +2,8 @@
 require 'cdo/aws/dms'
 require 'active_support/core_ext/numeric/bytes'
 require 'active_support/core_ext/numeric/time'
+
+self.tags.push key: 'environment', value: rack_env
 -%>
 ---
 AWSTemplateFormatVersion: 2010-09-09

--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -1,7 +1,3 @@
-<%
-require 'cdo/cloud_formation/lambda'
-self.class.include Lambda
--%>
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-

--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -1,3 +1,7 @@
+<%
+require 'cdo/cloud_formation/lambda'
+self.class.include Lambda
+-%>
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-

--- a/aws/cloudformation/test_stack.yml.erb
+++ b/aws/cloudformation/test_stack.yml.erb
@@ -30,5 +30,5 @@ Resources:
     ami: ami,
     frontend_device_name: '/dev/xvda',
     frontend_policies: [Ref: 'CDOPolicy'],
-    image_id: {Ref: 'ImageId'}.to_json
+    ssh_key_name: SSH_KEY_NAME
 -%>

--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -1,3 +1,7 @@
+<%
+require 'cdo/cloud_formation/vpc'
+self.class.include VPC
+-%>
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: VPC layer including all Subnets, NAT Gateway and Security Groups for Code.org infrastructure.
@@ -7,7 +11,7 @@ Resources:
     Properties:
       CidrBlock: 10.0.0.0/16
       EnableDnsHostnames: true
-  VpcClassicLink: <%= lambda_fn.call 'VpcClassicLink',
+  VpcClassicLink: <%= lambda_fn 'VpcClassicLink',
     VpcId: {Ref: 'VPC'},
     DnsSupport: true %>
   S3Endpoint:
@@ -100,7 +104,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
-          CidrIp: <%=ssh_ip%>
+          CidrIp: <%=SSH_IP%>
   DaemonSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -1,656 +1,283 @@
-require_relative '../../../deployment'
 require 'active_support/core_ext/string/inflections'
-require 'active_support/core_ext/object/blank'
-require 'cdo/rake_utils'
 require 'aws-sdk-cloudformation'
-require 'aws-sdk-acm'
 require 'aws-sdk-s3'
-require 'aws-sdk-ec2'
-require 'aws-sdk-cloudwatchlogs'
 require 'json'
 require 'yaml'
 require 'erb'
-require 'tempfile'
-require 'base64'
-require 'uglifier'
 require 'digest'
 
-# Manages application-specific configuration and deployment of AWS CloudFront distributions.
 module AWS
+  # Manages configuration and deployment of AWS CloudFormation stacks.
   class CloudFormation
-    # Hard-coded values for our CloudFormation template.
-    TEMPLATE = ENV['TEMPLATE'] || raise('Stack template not provided in environment (TEMPLATE=[stack].yml.erb)')
-    TEMPLATE_POLICY = TEMPLATE.split('.').tap {|s| s.first << '-policy'}.join('.')
-    TEMP_BUCKET = ENV['TEMP_S3_BUCKET'] || 'cf-templates-p9nfb0gyyrpf-us-east-1'
-    # number of seconds to configure as Time To Live for DNS record
-    DNS_TTL = 60
+    # @return [Logger]
+    attr_accessor :log
 
-    DOMAIN = ENV['DOMAIN'] || 'cdn-code.org'
+    # @return [Cdo::CloudFormation::StackTemplate]
+    attr_reader :stack
+    delegate :stack_name, to: :stack
+
+    # @return [Hash]
+    attr_reader :options
+
+    # Default S3 bucket for uploading temporary template files.
+    TEMP_S3_BUCKET = 'cf-templates-p9nfb0gyyrpf-us-east-1'
 
     # A stack name can contain only alphanumeric characters (case sensitive) and hyphens.
     # Ref: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html
-    STACK_NAME_INVALID_REGEX = /[^[:alnum:]-]/
+    STACK_NAME_INVALID_REGEX = /[^[[:alnum:]-]]/
 
-    SSH_KEY_NAME = 'server_access_key'.freeze
-    IMAGE_ID = ENV['IMAGE_ID'] || 'ami-07d0cf3af28718ef8' # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1
-    INSTANCE_TYPE = rack_env?(:production) ? 'm4.10xlarge' : 't2.2xlarge'
-    SSH_IP = '0.0.0.0/0'.freeze
-    S3_BUCKET = 'cdo-dist'.freeze
-    CHEF_KEY = rack_env?(:adhoc) ? 'adhoc/chef' : 'chef'
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
+    # Max size of template body you can pass directly to the CloudFormation API.
+    TEMPLATE_MAX = 51_200
+    # Max size of template body you can pass in an S3 object with a template URL.
+    TEMPLATE_S3_MAX = 460_800
 
-    AVAILABILITY_ZONES = ('b'..'e').map {|i| "us-east-1#{i}"}
+    # @param [Cdo::CloudFormation::StackTemplate] stack
+    # @param [Logger] log
+    def initialize(stack:, log: Logger.new(STDOUT), **options)
+      @stack = stack
+      @log = log
+      @options = options
+      @stack_resource = nil
 
-    STACK_ERROR_LINES = 250
-    LOG_NAME = '/var/log/bootstrap.log'.freeze
+      options[:policy] ||= stack.filename.split('.').tap {|s| s.first << '-policy'}.join('.')
+      options[:temp_bucket] ||= TEMP_S3_BUCKET
+      stack_name.gsub!(STACK_NAME_INVALID_REGEX, '-')
+    end
 
-    class << self
-      attr_accessor :daemon
-      attr_accessor :daemon_instance_id
-      attr_accessor :log_resource_filter
-      CloudFormation.log_resource_filter = []
-
-      def branch
-        ENV['branch'] || (rack_env?(:adhoc) ? RakeUtils.git_branch : rack_env)
+    # Validates that the template is valid CloudFormation syntax.
+    # Does not check validity of the resource properties, just the base syntax.
+    # First prints the JSON-formatted template (if verbose), then either raises an error (if invalid)
+    # or prints the template description (if valid) and stack changes (if it already exists).
+    def validate
+      stack.dry_run = true
+      template = stack.render
+      if options[:verbose]
+        log.info template.lines.map.with_index(1) {|line, i| format("[%3d] %s", i, line)}.join
       end
+      template_info = string_or_url(template)
+      log.info cfn.validate_template(template_info).description
+      stack_options = stack_options(template)
+      params = stack_options[:parameters].reject {|x| x[:parameter_value].nil?}
+      log.info "Parameters:\n#{params.map {|p| "#{p[:parameter_key]}: #{p[:parameter_value]}"}.join("\n")}" unless params.empty?
 
-      def stack_name
-        name = ENV['STACK_NAME'] || CDO.stack_name
-        name += "-#{branch}" if name == 'adhoc'
-        name.gsub(STACK_NAME_INVALID_REGEX, '-')
+      if stack_exists?
+        validate_changes(stack_options, "#{stack_name}-#{Digest::MD5.hexdigest(template)}")
       end
+    end
 
-      # CNAME prefix to use for this stack.
-      def cname
-        stack_name
+    # Creates a new stack, or updates an existing stack if it already exists.
+    def create_or_update
+      $stdout.sync = true
+      template = stack.render
+      action = stack_exists? ? :update : :create
+      log.info "#{action} stack: #{stack_name}..."
+      stack_options = stack_options(template)
+      if File.file?(options[:policy])
+        stack_policy = JSON.pretty_generate(YAML.load(stack.render(filename: options[:policy])))
+        stack_options[:stack_policy_body] = stack_policy
+        stack_options[:stack_policy_during_update_body] = stack_policy if action == :update
       end
+      stack_options[:on_failure] = 'DO_NOTHING' if action == :create
 
-      # Fully qualified domain name, with optional pre/postfix.
-      def subdomain(prefix = nil, postfix = nil)
-        subdomain = [prefix, cname, postfix].compact.join('-')
-        [subdomain.presence, DOMAIN].compact.join('.').downcase
-      end
+      stack_action(action, stack_options)
 
-      def studio_subdomain
-        subdomain nil, 'studio'
-      end
-
-      def adhoc_image_id
-        cfn.describe_stacks(stack_name: 'AMI-adhoc').
-          stacks.first.outputs.
-          find {|o| o.output_key == 'AMI'}.
-          output_value
-      end
-
-      # Lookup ACM certificate for ELB and CloudFront SSL.
-      # Choose latest expiration among multiple active matching certificates.
-      ACM_REGION = 'us-east-1'.freeze
-      def certificate_arn
-        acm = Aws::ACM::Client.new(region: ACM_REGION)
-        wildcard = "*.#{DOMAIN}"
-        acm.
-          list_certificates(certificate_statuses: ['ISSUED']).
-          certificate_summary_list.
-          select {|cert| cert.domain_name == wildcard || cert.domain_name == DOMAIN}.
-          map {|cert| acm.describe_certificate(certificate_arn: cert.certificate_arn).certificate}.
-          select {|cert| cert.subject_alternative_names.include? wildcard}.
-          max_by(&:not_after).
-          certificate_arn
-      end
-
-      # Validates that the template is valid CloudFormation syntax.
-      # Does not check validity of the resource properties, just the base syntax.
-      # First prints the JSON-formatted template, then either raises an error (if invalid)
-      # or prints the template description (if valid).
-      def validate
-        template = render_template(dry_run: true)
-        if ENV['VERBOSE']
-          CDO.log.info template.lines.map.with_index(1) {|line, i| format("[%3d] %s", i, line)}.join
-        end
-        template_info = string_or_url(template)
-        CDO.log.info cfn.validate_template(template_info).description
-        options = stack_options(template)
-        params = options[:parameters].reject {|x| x[:parameter_value].nil?}
-        CDO.log.info "Parameters:\n#{params.map {|p| "#{p[:parameter_key]}: #{p[:parameter_value]}"}.join("\n")}" unless params.empty?
-
-        if stack_exists?
-          CDO.log.info "Listing changes to existing stack `#{stack_name}`:"
-          change_set_id = cfn.create_change_set(
-            options.merge(
-              change_set_name: "#{stack_name}-#{Digest::MD5.hexdigest(template)}"
-            )
-          ).id
-
-          begin
-            change_set = {changes: []}
-            loop do
-              sleep 1
-              change_set = cfn.describe_change_set(
-                change_set_name: change_set_id,
-                stack_name: stack_name
-              )
-              break unless %w(CREATE_PENDING CREATE_IN_PROGRESS).include?(change_set.status)
-            end
-            change_set.changes.each do |change|
-              c = change.resource_change
-              str = "#{c.action} #{c.logical_resource_id} [#{c.resource_type}] #{c.scope.join(', ')}"
-              str += " Replacement: #{c.replacement}" if %w(True Conditional).include?(c.replacement)
-              str += " (#{c.details.map {|d| d.target.name}.join(', ')})" if c.details.any?
-              CDO.log.info str
-            end
-            CDO.log.info 'No changes' if change_set.changes.empty?
-
-          ensure
-            cfn.delete_change_set(
-              change_set_name: change_set_id,
-              stack_name: stack_name
-            )
-          end
+      unless options[:quiet]
+        log.info 'Outputs:'
+        cfn.describe_stacks(stack_name: @stack_id).stacks.first.outputs.each do |output|
+          log.info "#{output.output_key}: #{output.output_value}"
         end
       end
+    end
 
-      # Returns an inline string or S3 URL depending on the size of the template.
-      def string_or_url(template)
-        # Upload the template to S3 if it's too large to be passed directly.
-        if template.length < 51200
-          {template_body: template}
-        elsif template.length < 460800
-          CDO.log.debug 'Uploading template to S3...'
-          key = AWS::S3.upload_to_bucket(TEMP_BUCKET, "#{stack_name}-#{Digest::MD5.hexdigest(template)}-cfn.json", template, no_random: true)
-          {template_url: "https://s3.amazonaws.com/#{TEMP_BUCKET}/#{key}"}
-        else
-          raise 'Template is too large'
-        end
+    # Deletes a stack if it already exists.
+    def delete
+      if stack_exists?
+        log.info "Shutting down #{stack_name}..."
+        stack_action(:delete, base_options)
+      else
+        warn "Stack #{stack_name} does not exist."
       end
+    end
 
-      def parameters(template)
-        params = YAML.load(template)['Parameters']
-        return [] unless params
-        params.map do |key, properties|
-          value = CDO[key.underscore] || ENV[key.underscore.upcase]
-          param = {parameter_key: key}
-          if value
-            param[:parameter_value] = value
-          elsif stack_exists? && @@stack.parameters.any? {|p| p.parameter_key == key}
-            param[:use_previous_value] = true
-          elsif properties['Default']
-            next # use default param
-          else
-            # Required parameter value not found in environment, existing stack or default.
-            # Ask for input directly.
-            require 'highline'
-            param[:parameter_value] = HighLine.new.ask("Enter value for Parameter #{key}:", String)
-          end
-          param
-        end.compact
-      end
+    private
 
-      def base_options
-        # All stacks use the same shared Service Role for CloudFormation resource-management permissions.
-        # Pass `ADMIN=1` to update admin resources with a privileged Service Role.
-        role_name = "CloudFormation#{ENV['ADMIN'] ? 'Admin' : 'Service'}"
-        account = Aws::STS::Client.new.get_caller_identity.account
-        {
-          stack_name: stack_name,
-          role_arn: "arn:aws:iam::#{account}:role/admin/#{role_name}"
-        }
-      end
+    def cfn
+      @cfn ||= Aws::CloudFormation::Client.new
+    end
 
-      def stack_options(template)
-        base_options.merge(
-          {
-            parameters: parameters(template),
-            tags: [],
-          }
-        ).merge(string_or_url(template)).tap do |options|
-          options[:capabilities] = %w[
-            CAPABILITY_IAM
-            CAPABILITY_NAMED_IAM
-          ]
-          if %w[cloud_formation_stack.yml.erb data.yml.erb].include?(TEMPLATE)
-            options[:tags].push(
-              key: 'environment',
-              value: rack_env
-            )
-          end
-          if rack_env?(:adhoc)
-            options[:tags].push(
-              key: 'owner',
-              value: Aws::STS::Client.new.get_caller_identity.arn
-            )
-          end
-        end
-      end
+    # Log potential changes to an existing stack using a temporary change set.
+    def validate_changes(stack_options, name)
+      log.info "Listing changes to existing stack `#{stack_name}`:"
+      change_set_id = cfn.create_change_set(
+        stack_options.merge(change_set_name: name)
+      ).id
 
-      def create_or_update
-        $stdout.sync = true
-        template = render_template
-        action = stack_exists? ? :update : :create
-        CDO.log.info "#{action} stack: #{stack_name}..."
-        start_time = Time.now
-        options = stack_options(template)
-        if File.file?(aws_dir('cloudformation', TEMPLATE_POLICY))
-          stack_policy = JSON.pretty_generate(YAML.load(render_template(template: TEMPLATE_POLICY)))
-          options[:stack_policy_body] = stack_policy
-          options[:stack_policy_during_update_body] = stack_policy if action == :update
-        end
-        options[:on_failure] = 'DO_NOTHING' if action == :create
-
-        begin
-          updated_stack_id = cfn.method("#{action}_stack").call(options).stack_id
-        rescue Aws::CloudFormation::Errors::ValidationError => e
-          if e.message == 'No updates are to be performed.'
-            CDO.log.info e.message
-            return
-          else
-            raise e
-          end
-        end
-        wait_for_stack(action, start_time)
-        unless ENV['QUIET']
-          CDO.log.info 'Outputs:'
-          cfn.describe_stacks(stack_name: updated_stack_id).stacks.first.outputs.each do |output|
-            CDO.log.info "#{output.output_key}: #{output.output_value}"
-          end
-        end
-      end
-
-      def start_inactive_instance
-        cloudformation_resource = Aws::CloudFormation::Resource.new
-        stack = cloudformation_resource.stack(stack_name)
-        instance = Aws::EC2::Instance.new(id: stack.resource('WebServer').physical_resource_id)
-        if instance.state.code != 80
-          CDO.log.info "Instance #{instance.id} in Stack #{stack_name} can't be started because it is not" \
-          " currently stopped.  Current state - #{instance.state.code}:#{instance.state.name}"
-        else
-          CDO.log.info "Starting Instance #{instance.id} ..."
-          instance.start
-          instance.wait_until_running
-          CDO.log.info "Instance #{instance.id} is started."
-
-          public_ip_address = instance.reload.public_ip_address
-          dashboard_url = stack.outputs.detect {|output| output.output_key == 'DashboardURL'}.output_value
-          pegasus_url = stack.outputs.detect {|output| output.output_key == 'PegasusURL'}.output_value
-
-          # suffix period to construct fully qualified domain name
-          pegasus_domain_name = URI.parse(pegasus_url).host + '.'
-          dashboard_domain_name = URI.parse(dashboard_url).host + '.'
-
-          route53_client = Aws::Route53::Client.new
-
-          # this lookup may stop working if/when there are more than 100 zones
-          # prefix zone name with a period to prevent partial match (don't let zone "code.org." match "foo.cdn-code.org.")
-          hosted_zone_id = route53_client.
-            list_hosted_zones.
-            hosted_zones.
-            select {|zone| pegasus_domain_name.end_with?('.' + zone.name)}.
-            first.
-            id
-
-          change_resource_response = route53_client.change_resource_record_sets(
-            {
-              change_batch: {
-                changes: [
-                  {
-                    action: "UPSERT",
-                    resource_record_set: {
-                      name: pegasus_domain_name,
-                      resource_records: [
-                        {
-                          value: public_ip_address,
-                        },
-                      ],
-                      ttl: DNS_TTL,
-                      type: "A",
-                    },
-                  },
-                  {
-                    action: "UPSERT",
-                    resource_record_set: {
-                      name: dashboard_domain_name,
-                      resource_records: [
-                        {
-                          value: public_ip_address,
-                        },
-                      ],
-                      ttl: DNS_TTL,
-                      type: "A",
-                    }
-                  }
-                ],
-                comment: "Web server for adhoc environment #{pegasus_domain_name}",
-              },
-              hosted_zone_id: hosted_zone_id
-            }
+      begin
+        change_set = {changes: []}
+        loop do
+          sleep 1
+          change_set = cfn.describe_change_set(
+            change_set_name: change_set_id,
+            stack_name: stack_name
           )
+          break unless %w(CREATE_PENDING CREATE_IN_PROGRESS).include?(change_set.status)
         end
-
-        change_status = change_resource_response.change_info.status
-        change_id = change_resource_response.change_info.id
-        CDO.log.info "DNS update status - #{change_status}"
-        CDO.log.info "Waiting for AWS Route53 to apply updated DNS records to all of its servers."
-        route53_client.wait_until(:resource_record_sets_changed, {id: change_id})
-        change_status = route53_client.get_change({id: change_id}).change_info.status
-        CDO.log.info "DNS update status - #{change_status}"
-        CDO.log.info "Wait up to the configured Time To Live (#{DNS_TTL} seconds) to lookup new IP address."
-        stack.outputs.each do |output|
-          CDO.log.info "#{output.output_key}: #{output.output_value}"
+        change_set.changes.each do |change|
+          c = change.resource_change
+          str = "#{c.action} #{c.logical_resource_id} [#{c.resource_type}] #{c.scope.join(', ')}"
+          str += " Replacement: #{c.replacement}" if %w(True Conditional).include?(c.replacement)
+          str += " (#{c.details.map {|d| d.target.name}.join(', ')})" if c.details.any?
+          log.info str
         end
+        log.info 'No changes' if change_set.changes.empty?
+
+      ensure
+        cfn.delete_change_set(
+          change_set_name: change_set_id,
+          stack_name: stack_name
+        )
       end
+    end
 
-      def stop
-        if stack_exists?
-          CDO.log.info "Finding EC2 Instance for CloudFormation Stack #{stack_name} ..."
-          cloudformation_resource = Aws::CloudFormation::Resource.new
-          stack = cloudformation_resource.stack(stack_name)
-          instance_id = stack.resource('WebServer').physical_resource_id
-          instance = Aws::EC2::Instance.new(id: instance_id)
-          if instance.nil?
-            CDO.log.info "Instance #{instance_id} does not exist or has been terminated."\
-              "Delete this unrecoverable CloudFormation stack: rake adhoc:delete STACK_NAME=#{stack_name}"
-          elsif instance.state.code == 80 # already Stopped
-            CDO.log.info "Instance #{instance.id} is already Stopped."
-          elsif instance.state.code == 16 # Running
-            CDO.log.info "Stopping Instance #{instance.id} ..."
-            stop_result = instance.stop
-            CDO.log.info "Instance Status - #{stop_result.stopping_instances[0].current_state.name}"
-            CDO.log.info "Waiting until Stopped ..."
-            instance.wait_until_stopped
-            CDO.log.info "Instance Status - #{instance.reload.state.name}"
-            CDO.log.info "To start instance: rake adhoc:start_inactive_instance STACK_NAME=#{stack_name}"
-          else
-            CDO.log.info "Cannot stop Instance because its state is #{instance.state.name}"
-          end
-        else
-          CDO.log.warn "Stack #{stack_name} does not exist."
-        end
-      end
-
-      def delete
-        if stack_exists?
-          CDO.log.info "Shutting down #{stack_name}..."
-          start_time = Time.now
-          cfn.delete_stack(base_options)
-          wait_for_stack(:delete, start_time)
-        else
-          CDO.log.warn "Stack #{stack_name} does not exist."
-        end
-      end
-
-      private
-
-      def cfn
-        @@cfn ||= Aws::CloudFormation::Client.new
-      end
-
-      def logs
-        @@logs ||= Aws::CloudWatchLogs::Client.new
-      end
-
-      # Only way to determine whether a given stack exists using the Ruby API.
-      def stack_exists?
-        !!@@stack ||= begin
-          cfn.describe_stacks(stack_name: stack_name).stacks.first
-        rescue Aws::CloudFormation::Errors::ValidationError => e
-          raise e unless e.message == "Stack with id #{stack_name} does not exist"
-          false
-        end
-      end
-
-      def update_certs
-        Dir.chdir(aws_dir('cloudformation')) do
-          RakeUtils.bundle_exec './update_certs',
-            subdomain,
-            studio_subdomain,
-            subdomain('origin')
-        end
-      end
-
-      def update_cookbooks
-        if CDO.chef_local_mode
-          RakeUtils.with_bundle_dir(cookbooks_dir) do
-            Tempfile.open('berks') do |tmp|
-              RakeUtils.bundle_exec 'berks', 'package', tmp.path
-              Aws::S3::Client.new.put_object(
-                bucket: S3_BUCKET,
-                key: "#{CHEF_KEY}/#{branch}.tar.gz",
-                body: tmp.read
-              )
-            end
-          end
-        end
-      end
-
-      def update_bootstrap_script
+    # Returns an inline string or S3 URL depending on the size of the template.
+    def string_or_url(template)
+      # Upload the template to S3 if it's too large to be passed directly.
+      if template.length < TEMPLATE_MAX
+        {template_body: template}
+      elsif template.length < TEMPLATE_S3_MAX
+        log.debug 'Uploading template to S3...'
+        bucket = options[:temp_bucket]
+        key = "#{stack_name}-#{Digest::MD5.hexdigest(template)}-cfn.json"
         Aws::S3::Client.new.put_object(
-          bucket: S3_BUCKET,
-          key: "#{CHEF_KEY}/bootstrap-#{stack_name}.sh",
-          body: File.read(aws_dir('chef-bootstrap.sh'))
+          bucket: bucket,
+          key: key,
+          body: template
         )
+        {template_url: "https://s3.amazonaws.com/#{bucket}/#{key}"}
+      else
+        raise 'Template is too large'
       end
+    end
 
-      # Prints the latest output from a CloudWatch Logs log stream, if present.
-      def tail_log(quiet: false)
-        log_config = {
-          log_group_name: stack_name,
-          log_stream_name: LOG_NAME
-        }
-        log_config[:next_token] = @@log_token unless @@log_token.nil?
-        # Return silently if we can't get the log events for any reason.
-        resp = logs.get_log_events(log_config) rescue return
-        resp.events.each do |event|
-          CDO.log.info(event.message) unless quiet
+    def parameters(template)
+      params = YAML.load(template)['Parameters']
+      return [] unless params
+      params.map do |key, properties|
+        value = CDO[key.underscore] || ENV[key.underscore.upcase]
+        param = {parameter_key: key}
+        if value
+          param[:parameter_value] = value
+        elsif stack_exists? && @stack_resource&.parameters&.any? {|p| p.parameter_key == key}
+          param[:use_previous_value] = true
+        elsif properties['Default']
+          next # use default param
+        else
+          # Required parameter value not found in environment, existing stack or default.
+          # Ask for input directly.
+          require 'highline'
+          param[:parameter_value] = stack.dry_run ?
+            '!Required' :
+            HighLine.new.ask("Enter value for Parameter #{key}:", String)
         end
-        @@log_token = resp.next_forward_token
+        param
+      end.compact
+    end
+
+    def base_options
+      # All stacks use the same shared Service Role for CloudFormation resource-management permissions.
+      # Pass `ADMIN=1` to update admin resources with a privileged Service Role.
+      role_name = "CloudFormation#{ENV['ADMIN'] ? 'Admin' : 'Service'}"
+      account = Aws::STS::Client.new.get_caller_identity.account
+      {
+        stack_name: stack_name,
+        role_arn: "arn:aws:iam::#{account}:role/admin/#{role_name}"
+      }
+    end
+
+    def stack_options(template)
+      base_options.merge(string_or_url(template)).merge(
+        parameters: parameters(template),
+        tags: stack.tags,
+        capabilities: %w[
+          CAPABILITY_IAM
+          CAPABILITY_NAMED_IAM
+        ]
+      )
+    end
+
+    def stack_action(method, stack_options)
+      start = Time.now
+      begin
+        result = cfn.method("#{method}_stack").call(stack_options)
+        @stack_id ||= result.stack_id if result.respond_to?(:stack_id)
+      rescue Aws::CloudFormation::Errors::ValidationError => e
+        if e.message == 'No updates are to be performed.'
+          log.info e.message
+          return
+        else
+          raise
+        end
       end
+      wait_for_stack(method) do
+        tail_events(start)
+      end
+    end
 
-      # Prints the latest CloudFormation stack events.
-      def tail_events(stack_id, resource_filter = [])
-        stack_events = cfn.describe_stack_events(stack_name: stack_id).stack_events
-        stack_events.reject! do |event|
-          event.timestamp <= @@event_timestamp ||
-            resource_filter.include?(event.logical_resource_id)
+    # Only way to determine whether a given stack exists using the Ruby API.
+    def stack_exists?
+      !!@stack_resource ||= begin
+        cfn.describe_stacks(stack_name: stack_name).stacks.first.tap do |stack|
+          @stack_id = stack.stack_id
         end
-        stack_events.sort_by(&:timestamp).each do |event|
-          str = "#{event.logical_resource_id} [#{event.resource_status}]"
-          str = "#{str}: #{event.resource_status_reason}" if event.resource_status_reason
-          str = "#{event.timestamp}- #{str}" unless ENV['QUIET']
-          CDO.log.info str
-          if event.resource_status == 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS'
-            throw :success
+      rescue Aws::CloudFormation::Errors::ValidationError => e
+        raise e unless e.message == "Stack with id #{stack_name} does not exist"
+        false
+      end
+    end
+
+    # Prints the latest CloudFormation stack events.
+    def tail_events(start)
+      @last_event ||= start
+      stack_events = cfn.describe_stack_events(stack_name: @stack_id).stack_events
+      stack_events.reject! do |event|
+        event.timestamp <= @last_event ||
+          stack.log_resource_filter.include?(event.logical_resource_id)
+      end
+      stack_events.sort_by(&:timestamp).each do |event|
+        str = "#{event.logical_resource_id} [#{event.resource_status}]"
+        str = "#{str}: #{event.resource_status_reason}" if event.resource_status_reason
+        str = "#{event.timestamp}- #{str}" unless options[:quiet]
+        log.info str
+        if event.resource_status == 'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS'
+          throw :success
+        end
+      end
+      @last_event = ([@last_event] + stack_events.map(&:timestamp)).max
+    end
+
+    def wait_for_stack(action)
+      log.info "Stack #{action} requested, waiting for provisioning to complete..."
+      yield rescue nil
+      begin
+        cfn.wait_until("stack_#{action}_complete".to_sym, stack_name: @stack_id) do |w|
+          w.delay = 5 # seconds
+          w.max_attempts = 540 # = 1.5 hours
+          w.before_wait do
+            yield
+            print '.' unless options[:quiet]
           end
         end
-        @@event_timestamp = ([@@event_timestamp] + stack_events.map(&:timestamp)).max
-      end
-
-      def wait_for_stack(action, start_time)
-        CDO.log.info "Stack #{action} requested, waiting for provisioning to complete..."
-        stack_id = stack_name
-        begin
-          @@event_timestamp = start_time
-          @@log_token = nil
-          tail_log(quiet: true)
-          stack_id = cfn.describe_stacks(stack_name: stack_id).stacks.first.stack_id
-          cfn.wait_until("stack_#{action}_complete".to_sym, stack_name: stack_id) do |w|
-            w.delay = 10 # seconds
-            w.max_attempts = 540 # = 1.5 hours
-            w.before_wait do
-              tail_events(stack_id, log_resource_filter)
-              tail_log
-              print '.' unless ENV['QUIET']
-            end
-          end
-          tail_events(stack_id, log_resource_filter) rescue nil
-          tail_log
-        rescue Aws::Waiters::Errors::FailureStateError
-          tail_events(stack_id)
-          tail_log
-          if action == :create
-            CDO.log.info 'Stack will remain in its half-created state for debugging. To delete, run `rake adhoc:stop`.'
-          end
-          raise "\nError on #{action}."
+      rescue Aws::Waiters::Errors::FailureStateError
+        yield rescue nil
+        if action == :create
+          log.info 'Stack will remain in its half-created state for debugging. To delete, run `rake adhoc:stop`.'
         end
-        CDO.log.info "\nStack #{action} complete." unless ENV['QUIET']
-        CDO.log.info "Don't forget to remove AWS resources by running `rake adhoc:delete` after you're done testing your instance!" if action == :create
+        raise "\nError on #{action}."
       end
-
-      def render_template(template: TEMPLATE, dry_run: false)
-        filename = aws_dir('cloudformation', template)
-        template_string = File.read(filename)
-        azs = AVAILABILITY_ZONES.map {|zone| zone[-1].upcase}
-        @@local_variables = OpenStruct.new(
-          dry_run: dry_run,
-          local_mode: !!CDO.chef_local_mode,
-          stack_name: stack_name,
-          branch: branch,
-          region: CDO.aws_region,
-          environment: rack_env,
-          ssh_ip: SSH_IP,
-          cdn_enabled: !!ENV['CDN_ENABLED'],
-          domain: DOMAIN,
-          cname: cname,
-          availability_zone: AVAILABILITY_ZONES.first,
-          availability_zones: AVAILABILITY_ZONES,
-          azs: azs,
-          s3_bucket: S3_BUCKET,
-          subnets: azs.map {|az| {'Fn::ImportValue': "VPC-Subnet#{az}"}},
-          public_subnets: azs.map {|az| {'Fn::ImportValue': "VPC-PublicSubnet#{az}"}},
-          lambda_fn: method(:lambda),
-          update_certs: method(:update_certs),
-          update_cookbooks: method(:update_cookbooks),
-          update_bootstrap_script: method(:update_bootstrap_script),
-          log_name: LOG_NAME
-        )
-        erb_eval(template_string, filename)
-      end
-
-      # Inline a file into a CloudFormation template.
-      def file(filename, vars={})
-        str = File.read(filename.start_with?('/') ? filename : aws_dir('cloudformation', filename))
-        vars = @@local_variables.dup.to_h.merge(vars)
-        {'Fn::Sub': erb_eval(str, filename, vars)}.to_json
-      end
-
-      def erb_file(filename, vars={})
-        file = File.expand_path filename
-        str = File.read(file)
-        vars = @@local_variables.dup.to_h.merge(vars)
-        erb_eval(str, file, vars)
-      end
-
-      # Ref: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-zipfile
-      LAMBDA_ZIPFILE_MAX = 4096
-
-      # Inline a single javascript file into a CloudFormation template for a Lambda function resource.
-      # Raises an error if the minified file is too large.
-      # Use UglifyJS to compress code if `uglify` parameter is set.
-      def js(filename, uglify=true)
-        str = File.read(aws_dir('cloudformation', filename))
-        if uglify
-          str = Dir.chdir(aws_dir('cloudformation')) do
-            RakeUtils.npm_install
-            `$(npm bin)/uglifyjs --compress --mangle -- #{filename}`
-          end
-        end
-        if str.length > LAMBDA_ZIPFILE_MAX
-          raise "Length of JavaScript file '#{filename}' (#{str.length}) cannot exceed #{LAMBDA_ZIPFILE_MAX} characters."
-        end
-        erb_eval(str, filename).to_json
-      end
-
-      # Zip a Lambda package of files and upload to S3.
-      def lambda_zip(*files, key_prefix: 'lambda')
-        hash = nil
-        code_zip = Dir.chdir(aws_dir('cloudformation')) do
-          # Zip files contain non-deterministic timestamps, so calculate a deterministic hash based on file contents.
-          globs = files.map do |file|
-            file += '/**/*' if File.directory?(file)
-            file
-          end
-          hash = Digest::MD5.hexdigest(
-            Dir[*globs].
-              select(&File.method(:file?)).
-              sort.
-              map(&Digest::MD5.method(:file)).
-              join
-          )
-          `zip -qr - #{files.join(' ')}`
-        end
-        key = "#{key_prefix}-#{hash}.zip"
-        object_exists = Aws::S3::Client.new.head_object(bucket: S3_BUCKET, key: key) rescue nil
-        unless object_exists
-          CDO.log.info("Uploading Lambda zip package to S3 (#{code_zip.length} bytes)...")
-          Aws::S3::Client.new(http_read_timeout: 30).
-              put_object({bucket: S3_BUCKET, key: key, body: code_zip})
-        end
-        {
-          S3Bucket: S3_BUCKET,
-          S3Key: key
-        }.to_json
-      end
-
-      # Zip an array of JS files (along with the `node_modules` folder), and upload to S3.
-      def js_zip(files)
-        Dir.chdir(aws_dir('cloudformation')) do
-          RakeUtils.npm_install '--production'
-        end
-        lambda_zip(*files, 'node_modules', key_prefix: 'lambdajs')
-      end
-
-      # Helper function to call a Lambda-function-based AWS::CloudFormation::CustomResource.
-      # Ref: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html
-      def lambda(function_name, properties={})
-        custom_type = properties.delete(:CustomType)
-        depends_on = properties.delete(:DependsOn)
-        custom_resource = {
-          Type: properties.delete('Type') || "Custom::#{custom_type || function_name}",
-          Properties: {
-            ServiceToken: {'Fn::Join' => [':', [
-              'arn:aws:lambda',
-              {Ref: 'AWS::Region'},
-              {Ref: 'AWS::AccountId'},
-              'function',
-              function_name
-            ]]}
-          }.merge(properties)
-        }
-        custom_resource['DependsOn'] = depends_on if depends_on
-        custom_resource.to_json
-      end
-
-      def erb_eval(str, filename=nil, local_vars=nil)
-        local_vars ||= @@local_variables
-        local_binding = binding
-        local_vars.each_pair do |key, value|
-          local_binding.local_variable_set(key, value)
-        end
-        ERB.new(str, nil, '-').tap {|erb| erb.filename = filename}.result(local_binding)
-      end
-
-      # Generate boilerplate Trust Policy for an AWS Service Role.
-      def service_role(service)
-        document = {
-          Statement: [
-            Effect: 'Allow',
-            Action: 'sts:AssumeRole',
-            Principal: {Service: ["#{service}.amazonaws.com"]}
-          ]
-        }
-        "AssumeRolePolicyDocument: #{document.to_json}"
-      end
-
-      def component(name, vars = {})
-        erb_file(aws_dir("cloudformation/components/#{name}.yml.erb"), vars)
-      end
-
-      # Adds the specified properties to a YAML document.
-      def add_properties(properties)
-        properties.transform_values(&:to_json).map {|p| p.join(': ')}.join
-      end
-
-      # Indent all lines in the string by the specified number of characters.
-      def indent(string, chars)
-        string.gsub(/\n/, "\n#{' ' * chars}")
-      end
+      yield rescue nil
+      log.info "\nStack #{action} complete." unless options[:quiet]
+      log.info "Don't forget to remove AWS resources by running `rake adhoc:delete` after you're done testing your instance!" if action == :create
     end
   end
 end

--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/numeric/time'
 require 'aws-sdk-cloudformation'
 require 'aws-sdk-s3'
 require 'json'
@@ -262,7 +263,7 @@ module AWS
       begin
         cfn.wait_until("stack_#{action}_complete".to_sym, stack_name: @stack_id) do |w|
           w.delay = 5 # seconds
-          w.max_attempts = 540 # = 1.5 hours
+          w.max_attempts = 1.5.hours / w.delay
           w.before_wait do
             yield
             print '.' unless options[:quiet]

--- a/lib/cdo/cloud_formation/README.md
+++ b/lib/cdo/cloud_formation/README.md
@@ -1,0 +1,12 @@
+# `Cdo::CloudFormation` module
+
+Classes and modules related to managing CloudFormation templates.
+
+[`AWS::CloudFormation`](../../../lib/cdo/aws/cloud_formation.rb) uses a [`StackTemplate`](stack_template.rb) to render a template document to a string, which is used to create/update a CloudFormation stack.
+
+## [`StackTemplate`](stack_template.rb)
+Controller class that provides the ERB binding context for a CloudFormation stack template.
+Includes helper methods for rendering CloudFormation stack templates.
+
+## [`CdoApp < StackTemplate`](cdo_app.rb)
+Stack-template context with constants and helper-methods specific to the monolithic Code.org application stack.

--- a/lib/cdo/cloud_formation/adhoc.rb
+++ b/lib/cdo/cloud_formation/adhoc.rb
@@ -1,0 +1,99 @@
+require 'aws-sdk-ec2'
+require 'aws-sdk-route53'
+
+module Cdo::CloudFormation
+  # Helper functions related to adhoc instances of CdoApp,
+  # included AWS::CloudFormation in adhoc environment.
+  module Adhoc
+    def start_inactive_instance
+      cloudformation_resource = Aws::CloudFormation::Resource.new
+      stack = cloudformation_resource.stack(stack_name)
+      instance = Aws::EC2::Instance.new(id: stack.resource('WebServer').physical_resource_id)
+      if instance.state.code != 80
+        log.info "Instance #{instance.id} in Stack #{stack_name} can't be started because it is not" \
+            " currently stopped.  Current state - #{instance.state.code}:#{instance.state.name}"
+      else
+        log.info "Starting Instance #{instance.id} ..."
+        instance.start
+        instance.wait_until_running
+        log.info "Instance #{instance.id} is started."
+
+        public_ip_address = instance.reload.public_ip_address
+        dashboard_url = stack.outputs.detect {|output| output.output_key == 'DashboardURL'}.output_value
+        pegasus_url = stack.outputs.detect {|output| output.output_key == 'PegasusURL'}.output_value
+
+        # suffix period to construct fully qualified domain name
+        pegasus_domain_name = URI.parse(pegasus_url).host + '.'
+        dashboard_domain_name = URI.parse(dashboard_url).host + '.'
+
+        route53_client = Aws::Route53::Client.new
+
+        # this lookup may stop working if/when there are more than 100 zones
+        # prefix zone name with a period to prevent partial match (don't let zone "code.org." match "foo.cdn-code.org.")
+        hosted_zone_id = route53_client.
+          list_hosted_zones.
+          hosted_zones.
+          select {|zone| pegasus_domain_name.end_with?('.' + zone.name)}.
+          first.
+          id
+
+        change_resource_response = route53_client.change_resource_record_sets(
+          hosted_zone_id: hosted_zone_id,
+          change_batch: {
+            changes: [pegasus_domain_name, dashboard_domain_name].map do |domain_name|
+              {
+                action: "UPSERT",
+                resource_record_set: {
+                  name: domain_name,
+                  resource_records: [{value: public_ip_address}],
+                  ttl: DNS_TTL,
+                  type: "A"
+                }
+              }
+            end,
+            comment: "Web server for adhoc environment #{pegasus_domain_name}",
+          }
+        )
+        change_status = change_resource_response.change_info.status
+        change_id = change_resource_response.change_info.id
+        log.info "DNS update status - #{change_status}"
+        log.info "Waiting for AWS Route53 to apply updated DNS records to all of its servers."
+        route53_client.wait_until(:resource_record_sets_changed, {id: change_id})
+        change_status = route53_client.get_change({id: change_id}).change_info.status
+        log.info "DNS update status - #{change_status}"
+        log.info "Wait up to the configured Time To Live (#{DNS_TTL} seconds) to lookup new IP address."
+      end
+      stack.outputs.each do |output|
+        log.info "#{output.output_key}: #{output.output_value}"
+      end
+    end
+
+    def stop
+      if stack_exists?
+        log.info "Finding EC2 Instance for CloudFormation Stack #{stack_name} ..."
+        cloudformation_resource = Aws::CloudFormation::Resource.new
+        stack = cloudformation_resource.stack(stack_name)
+        instance_id = stack.resource('WebServer').physical_resource_id
+        instance = Aws::EC2::Instance.new(id: instance_id)
+        if instance.nil?
+          log.info "Instance #{instance_id} does not exist or has been terminated."\
+                "Delete this unrecoverable CloudFormation stack: rake adhoc:delete STACK_NAME=#{stack_name}"
+        elsif instance.state.code == 80 # already Stopped
+          log.info "Instance #{instance.id} is already Stopped."
+        elsif instance.state.code == 16 # Running
+          log.info "Stopping Instance #{instance.id} ..."
+          stop_result = instance.stop
+          log.info "Instance Status - #{stop_result.stopping_instances[0].current_state.name}"
+          log.info "Waiting until Stopped ..."
+          instance.wait_until_stopped
+          log.info "Instance Status - #{instance.reload.state.name}"
+          log.info "To start instance: rake adhoc:start_inactive_instance STACK_NAME=#{stack_name}"
+        else
+          log.info "Cannot stop Instance because its state is #{instance.state.name}"
+        end
+      else
+        log.warn "Stack #{stack_name} does not exist."
+      end
+    end
+  end
+end

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -1,0 +1,206 @@
+require_relative './stack_template'
+require_relative './vpc'
+
+require 'aws-sdk-acm'
+
+require 'active_support/core_ext/numeric/bytes'
+require 'ostruct'
+require 'tempfile'
+
+require 'cdo/aws/cloudfront'
+require 'cdo/cron'
+require 'cdo/rake_utils'
+
+module Cdo::CloudFormation
+  # Stack-template context with logic specific to the monolithic Code.org application stack.
+  class CdoApp < StackTemplate
+    include VPC
+
+    if rack_env?(:adhoc)
+      require_relative './adhoc'
+      AWS::CloudFormation.include Adhoc
+      require_relative './tail_logs'
+      AWS::CloudFormation.prepend TailLogs
+    end
+
+    # Hard-coded constants and default values.
+    CHEF_KEY = rack_env?(:adhoc) ? 'adhoc/chef' : 'chef'
+    IMAGE_ID = ENV['IMAGE_ID'] || 'ami-07d0cf3af28718ef8' # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1
+    INSTANCE_TYPE = rack_env?(:production) ? 'm4.10xlarge' : 't2.2xlarge'
+    ORIGIN = "https://github.com/code-dot-org/code-dot-org.git"
+    CHEF_VERSION = '15.2.20'
+    DOMAIN = 'cdn-code.org'
+    SSH_KEY_NAME = 'server_access_key'.freeze
+    S3_BUCKET = 'cdo-dist'.freeze
+
+    # number of seconds to configure as Time To Live for DNS record
+    DNS_TTL = 60
+
+    attr_reader :daemon, :daemon_instance_id
+
+    # Struct providing arbitrary configuration options used by the template.
+    # @return [OpenStruct]
+    attr_reader :options
+    delegate :commit, :frontends, :database, :load_balancer, :alarms, :cdn_enabled, :branch, :domain,
+      to: :options
+
+    def initialize(**options)
+      options[:stack_name]  ||= CDO.stack_name
+      options[:filename]    ||= 'cloud_formation_stack.yml.erb'
+      super(options)
+      options = @options = OpenStruct.new(options)
+
+      # Various option defaults.
+      options.commit        ||= `git ls-remote origin #{branch}`.split.first
+      options.frontends     ||= rack_env?(:production)
+      options.database      ||= [:staging, :test, :levelbuilder].include?(rack_env)
+      options.load_balancer ||= !rack_env?(:adhoc) || options.frontends
+      options.alarms        ||= !rack_env?(:adhoc)
+      options.cdn_enabled   ||= !rack_env?(:adhoc)
+      options.branch        ||= (rack_env?(:adhoc) ? RakeUtils.git_branch : rack_env)
+      options.domain        ||= DOMAIN
+
+      stack_name << "-#{branch}" if stack_name == 'adhoc'
+      raise "Stack name must not include 'dashboard'" if stack_name.include?('dashboard')
+
+      check_branch!
+
+      # Don't provision daemon where manually-provisioned daemon instances already exist.
+      # Track Instance ID of manually-provisioned daemon instances that already exist and can't be referenced dynamically
+      # TODO import manually-provisioned instances into cloudformation stacks.
+      if %w(autoscale-prod test staging levelbuilder).include? stack_name
+        @daemon_instance_id = {
+          'autoscale-prod' => 'i-08f5f8ace0a473b8d',
+          'test' => 'i-004727200191f3251',
+          'staging' => 'i-02e6cdc765421ab34',
+          'levelbuilder' => 'i-0907b146f7e6503f6'
+        }[stack_name]
+      else
+        @daemon = 'Daemon'
+      end
+      # Use alternate legacy EC2 instance resource name for standalone-adhoc stack.
+      @daemon = 'WebServer' if rack_env?(:adhoc) && !frontends
+
+      log_resource_filter.push 'FrontendLaunchConfig', 'ASGCount'
+      tags.push(key: 'environment', value: rack_env)
+      tags.push(key: 'owner', value: Aws::STS::Client.new.get_caller_identity.arn) if rack_env?(:adhoc)
+    end
+
+    def check_branch!
+      if rack_env?(:adhoc) && RakeUtils.git_branch == branch
+        # Current branch is the one we're deploying to the adhoc server,
+        # so check whether it's up-to-date with the remote before we get any further.
+        unless `git remote show '#{ORIGIN}' 2>&1 | grep '(up to date)' | grep '#{branch}' | wc -l`.strip.to_i > 0
+          raise 'Current adhoc branch needs to be up-to-date with GitHub branch of the same name, otherwise deploy will fail.
+To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`.'
+        end
+      else
+        # Either not adhoc or deploying a different branch than the current local one;
+        # simply check that the branch exists on GitHub before deploying.
+        unless system("git ls-remote --exit-code '#{ORIGIN}' #{branch} > /dev/null")
+          raise 'Current branch needs to be pushed to GitHub with the same name, otherwise deploy will fail.
+  To specify an alternate branch name, run `rake stack:start branch=BRANCH`.'
+        end
+      end
+    end
+
+    # Fully qualified domain name, with optional pre/postfix.
+    def subdomain(prefix = nil, postfix = nil)
+      subdomain = [prefix, stack_name, postfix].compact.join('-')
+      [subdomain.presence, options.domain].compact.join('.').downcase
+    end
+
+    def studio_subdomain
+      subdomain nil, 'studio'
+    end
+
+    # Lookup ACM certificate for ELB and CloudFront SSL.
+    # Choose latest expiration among multiple active matching certificates.
+    ACM_REGION = 'us-east-1'.freeze
+    def certificate_arn
+      acm = Aws::ACM::Client.new(region: ACM_REGION)
+      wildcard = "*.#{domain}"
+      acm.
+        list_certificates(certificate_statuses: ['ISSUED']).
+        certificate_summary_list.
+        select {|cert| cert.domain_name == wildcard || cert.domain_name == domain}.
+        map {|cert| acm.describe_certificate(certificate_arn: cert.certificate_arn).certificate}.
+        select {|cert| cert.subject_alternative_names.include? wildcard}.
+        max_by(&:not_after).
+        certificate_arn
+    end
+
+    # S3 path to bootstrap script.
+    # Note: Uploads bootstrap script to S3 as a side effect.
+    def bootstrap_script_path
+      @bootstrap_script ||= begin
+        unless dry_run
+          Aws::S3::Client.new.put_object(
+            bucket: S3_BUCKET,
+            key: "#{CHEF_KEY}/bootstrap-#{stack_name}.sh",
+            body: File.read(aws_dir('chef-bootstrap.sh'))
+          )
+        end
+        "s3://$S3_BUCKET/#{CHEF_KEY}/bootstrap-$STACK.sh"
+      end
+    end
+
+    # S3 path to subdomain SSL certificate.
+    # Note: uploads certificate to S3 as a side effect.
+    def ssl_certs_path
+      @certs_path ||= begin
+        unless dry_run
+          Dir.chdir(aws_dir('cloudformation')) do
+            RakeUtils.bundle_exec './update_certs',
+              subdomain,
+              studio_subdomain,
+              subdomain('origin')
+          end
+        end
+        "s3://#{S3_BUCKET}/ssl/certs/#{subdomain}"
+      end
+    end
+
+    # S3 path to cookbook package.
+    # Note: uploads cookbooks to S3 as a side effect.
+    def cookbooks_path
+      return nil unless CDO.chef_local_mode
+      @cookbooks_path ||= begin
+        unless dry_run
+          RakeUtils.with_bundle_dir(cookbooks_dir) do
+            Tempfile.open('berks') do |tmp|
+              RakeUtils.bundle_exec 'berks', 'package', tmp.path
+              Aws::S3::Client.new.put_object(
+                bucket: S3_BUCKET,
+                key: "#{CHEF_KEY}/#{branch}.tar.gz",
+                body: tmp.read
+              )
+            end
+          end
+        end
+        "s3://#{S3_BUCKET}/#{CHEF_KEY}/#{branch}.tar.gz"
+      end
+    end
+
+    def cloudfront_config(app)
+      AWS::CloudFront.distribution_config(
+        app.downcase.to_sym,
+        subdomain('origin'),
+        app == 'Dashboard' ?
+          [studio_subdomain] :
+          [subdomain] + (CDO.partners + ['advocacy']).map {|x| subdomain(nil, x)},
+        {
+          AcmCertificateArn: certificate_arn,
+          MinimumProtocolVersion: 'TLSv1',
+          SslSupportMethod: domain == 'code.org' ? 'vip' : 'sni-only'
+        }
+      )
+    end
+
+    private
+
+    def get_binding
+      binding
+    end
+  end
+end

--- a/lib/cdo/cloud_formation/lambda.rb
+++ b/lib/cdo/cloud_formation/lambda.rb
@@ -1,0 +1,84 @@
+module Cdo::CloudFormation
+  # Helper functions related to use of Lambda functions in CloudFormation stacks.
+  module Lambda
+    # S3 bucket containing uploaded Lambda zip packages.
+    S3_LAMBDA_BUCKET = 'cdo-dist'.freeze
+
+    # Ref: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-zipfile
+    ZIPFILE_MAX = 4096
+
+    # Inline a single javascript file into a CloudFormation template for a Lambda function resource.
+    # Raises an error if the minified file is too large.
+    # Use UglifyJS to compress code if `uglify` parameter is set.
+    def js(filename, uglify=true)
+      str =
+        if uglify
+          RakeUtils.npm_install
+          `$(npm bin)/uglifyjs --compress --mangle -- #{filename}`
+        else
+          File.read(filename)
+        end
+      if str.length > ZIPFILE_MAX
+        raise "Length of JavaScript file '#{filename}' (#{str.length}) cannot exceed #{ZIPFILE_MAX} characters."
+      end
+      str.to_json
+    end
+
+    # Zip a Lambda package of files and upload to S3.
+    def lambda_zip(*files, key_prefix: 'lambda')
+      # Zip files contain non-deterministic timestamps, so calculate a deterministic hash based on file contents.
+      globs = files.map do |file|
+        file += '/**/*' if File.directory?(file)
+        file
+      end
+      hash = Digest::MD5.hexdigest(
+        Dir[*globs].
+          select(&File.method(:file?)).
+          sort.
+          map(&Digest::MD5.method(:file)).
+          join
+      )
+      code_zip = `zip -qr - #{files.join(' ')}`
+      key = "#{key_prefix}-#{hash}.zip"
+      s3_client = Aws::S3::Client.new(http_read_timeout: 30)
+      object_exists = s3_client.head_object(bucket: S3_LAMBDA_BUCKET, key: key) rescue nil
+      unless object_exists
+        CDO.log.info("Uploading Lambda zip package to S3 (#{code_zip.length} bytes)...")
+        s3_client.put_object({bucket: S3_LAMBDA_BUCKET, key: key, body: code_zip})
+      end
+      {
+        S3Bucket: S3_LAMBDA_BUCKET,
+        S3Key: key
+      }.to_json
+    end
+
+    # Zip an array of JS files (along with the `node_modules` folder), and upload to S3.
+    def js_zip(files)
+      Dir.chdir(aws_dir('cloudformation')) do
+        RakeUtils.npm_install '--production'
+      end
+      lambda_zip(*files, 'node_modules', key_prefix: 'lambdajs')
+    end
+
+    # Helper function to call a Lambda-function-based AWS::CloudFormation::CustomResource.
+    # Ref: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html
+    def lambda_fn(function_name, properties={})
+      custom_type = properties.delete(:CustomType)
+      depends_on = properties.delete(:DependsOn)
+      custom_resource = {
+        Type: properties.delete('Type') || "Custom::#{custom_type || function_name}",
+        Properties: {
+          ServiceToken: {'Fn::Join' => [':', [
+            'arn:aws:lambda',
+            {Ref: 'AWS::Region'},
+            {Ref: 'AWS::AccountId'},
+            'function',
+            function_name
+          ]]}
+        }.merge(properties)
+      }
+      custom_resource['DependsOn'] = depends_on if depends_on
+      custom_resource.to_json
+    end
+  end
+end

--- a/lib/cdo/cloud_formation/stack_template.rb
+++ b/lib/cdo/cloud_formation/stack_template.rb
@@ -4,6 +4,8 @@ module Cdo::CloudFormation
   # Controller class that provides the ERB binding context for CloudFormation stack templates.
   # Includes helper methods for rendering CloudFormation stack templates.
   class StackTemplate
+    include Lambda
+
     # Array preventing specified Logical Resource IDs from having their events logged by `#tail_events`.
     attr_reader :log_resource_filter
 

--- a/lib/cdo/cloud_formation/stack_template.rb
+++ b/lib/cdo/cloud_formation/stack_template.rb
@@ -1,0 +1,94 @@
+require_relative './lambda'
+
+module Cdo::CloudFormation
+  # Controller class that provides the ERB binding context for CloudFormation stack templates.
+  # Includes helper methods for rendering CloudFormation stack templates.
+  class StackTemplate
+    # Array preventing specified Logical Resource IDs from having their events logged by `#tail_events`.
+    attr_reader :log_resource_filter
+
+    # Array adding specified tags to the CloudFormation stack update.
+    attr_reader :tags
+
+    # True when the rendered template won't actually be used to update a stack ('validate').
+    # Templates with side-effects coupled to stack updates may execute them only when dry_run is false.
+    attr_accessor :dry_run
+
+    # Name of the CloudFormation stack instance to be created.
+    attr_reader :stack_name
+
+    # Filename of the ERB template to be rendered to create a CloudFormation stack template.
+    attr_reader :filename
+
+    def initialize(filename:, stack_name:, **_options)
+      @stack_name = stack_name
+      @filename = filename
+      @log_resource_filter = []
+      @tags = []
+    end
+
+    # Returns the fully-rendered template as a string.
+    def render(filename: self.filename)
+      erb_file(filename)
+    end
+
+    private
+
+    def environment
+      rack_env
+    end
+
+    # Generate boilerplate Trust Policy for an AWS Service Role.
+    def service_role(service)
+      document = {
+        Statement: [
+          Effect: 'Allow',
+          Action: 'sts:AssumeRole',
+          Principal: {Service: ["#{service}.amazonaws.com"]}
+        ]
+      }
+      "AssumeRolePolicyDocument: #{document.to_json}"
+    end
+
+    def erb_file(filename, vars={})
+      file = File.expand_path filename
+      erb_eval(File.read(file), file, vars)
+    end
+
+    # Inline a file into a CloudFormation template.
+    def file(filename, vars={})
+      {'Fn::Sub': erb_file(filename, vars)}.to_json
+    end
+
+    def erb_eval(str, filename=nil, local_vars={})
+      binding = get_binding
+      local_vars.each_pair do |key, value|
+        binding.local_variable_set(key, value)
+      end
+      Dir.chdir(File.dirname(filename)) do
+        ERB.new(str, nil, '-').tap {|erb| erb.filename = filename}.result(binding)
+      end
+    end
+
+    # Inline a component file into the stack template using local variables as parameters.
+    def component(name, vars = {})
+      erb_file(aws_dir("cloudformation/components/#{name}.yml.erb"), vars)
+    end
+
+    # Adds the specified properties to a YAML document.
+    def add_properties(properties)
+      properties.transform_values(&:to_json).map {|p| p.join(': ')}.join
+    end
+
+    # Indent all lines in the string by the specified number of characters.
+    def indent(string, chars)
+      string.gsub(/\n/, "\n#{' ' * chars}")
+    end
+
+    # Creates Binding object used for ERB template context.
+    # Must be overridden in subclasses.
+    def get_binding
+      binding
+    end
+  end
+end

--- a/lib/cdo/cloud_formation/tail_logs.rb
+++ b/lib/cdo/cloud_formation/tail_logs.rb
@@ -1,0 +1,31 @@
+require 'aws-sdk-cloudwatchlogs'
+
+module Cdo::CloudFormation
+  # Overrides tail_events to monitor a specific CloudWatch Log during stack update.
+  module TailLogs
+    LOG_NAME = '/var/log/bootstrap.log'.freeze
+
+    # Print the latest output from a CloudWatch Logs log stream, if present.
+    def tail_events(start)
+      super
+      log_config = {
+        log_group_name: stack_name,
+        log_stream_name: LOG_NAME,
+        start_from_head: true
+      }
+      if @log_token
+        log_config[:next_token] = @log_token
+      else
+        log_config[:start_time] = start
+      end
+      # Return silently if we can't get the log events for any reason.
+      resp = cw_logs.get_log_events(log_config) rescue return
+      resp.events.map(&:message).each {|message| log.info(message)}
+      @log_token = resp.next_forward_token
+    end
+
+    def cw_logs
+      @cw_logs ||= Aws::CloudWatchLogs::Client.new
+    end
+  end
+end

--- a/lib/cdo/cloud_formation/vpc.rb
+++ b/lib/cdo/cloud_formation/vpc.rb
@@ -1,0 +1,19 @@
+module Cdo::CloudFormation
+  # Helper functions related to VPC subnets.
+  module VPC
+    AVAILABILITY_ZONES = ('b'..'e').map {|i| "us-east-1#{i}"}
+    SSH_IP = '0.0.0.0/0'.freeze
+
+    def azs
+      AVAILABILITY_ZONES.map {|zone| zone[-1].upcase}
+    end
+
+    def subnets
+      azs.map {|az| {'Fn::ImportValue': "VPC-Subnet#{az}"}}
+    end
+
+    def public_subnets
+      azs.map {|az| {'Fn::ImportValue': "VPC-PublicSubnet#{az}"}}
+    end
+  end
+end

--- a/lib/rake/adhoc.rake
+++ b/lib/rake/adhoc.rake
@@ -1,38 +1,46 @@
 namespace :adhoc do
   task :environment do
     require_relative '../../deployment'
-    ENV['TEMPLATE'] ||= 'cloud_formation_stack.yml.erb'
-    unless ENV['CHEF_SERVER']
-      raise "RAILS_ENV=adhoc required to deploy adhoc instance." unless rack_env?(:adhoc)
-    end
+    raise "RAILS_ENV=adhoc required to deploy adhoc instance." unless rack_env?(:adhoc)
+    Dir.chdir aws_dir('cloudformation')
     require 'cdo/aws/cloud_formation'
+    require 'cdo/cloud_formation/cdo_app'
+    @cfn = AWS::CloudFormation.new(
+      stack_name: ENV['STACK_NAME'],
+      template: ENV['TEMPLATE'] || 'cloud_formation_stack.yml.erb',
+      stack: (@template = Cdo::CloudFormation::CdoApp.new(
+        frontends: ENV['FRONTENDS']
+      )),
+      log: CDO.log,
+      verbose: ENV['VERBOSE'],
+      quiet: ENV['QUIET'],
+    )
   end
 
   desc 'Launch/update an adhoc server.
 Note: Consumes AWS resources until `adhoc:stop` is called.'
   task start: :environment do
-    raise "adhoc name must not include 'dashboard'" if AWS::CloudFormation.stack_name.include?('dashboard')
-    AWS::CloudFormation.create_or_update
+    @cfn.create_or_update
   end
 
   desc 'Start an inactive adhoc server'
   task start_inactive_instance: :environment do
-    AWS::CloudFormation.start_inactive_instance
+    @cfn.start_inactive_instance
   end
 
   desc 'Stop an adhoc environment\'s EC2 Instance '
   task stop: :environment do
-    AWS::CloudFormation.stop
+    @cfn.stop
   end
 
   desc 'Delete an adhoc environment and all of its AWS Resources.  '
   task delete: :environment do
-    AWS::CloudFormation.delete
+    @cfn.delete
   end
 
   desc 'Validate adhoc CloudFormation template.'
   task validate: :environment do
-    AWS::CloudFormation.validate
+    @cfn.validate
   end
 
   namespace :full_stack do

--- a/lib/rake/stack.rake
+++ b/lib/rake/stack.rake
@@ -1,22 +1,34 @@
 namespace :stack do
   task :environment do
-    require_relative '../../deployment'
-    ENV['TEMPLATE'] ||= 'cloud_formation_stack.yml.erb'
     ENV['CDN_ENABLED'] ||= '1' unless rack_env?(:adhoc)
     ENV['DOMAIN'] ||= rack_env?(:adhoc) ? 'cdn-code.org' : 'code.org'
+    Dir.chdir aws_dir('cloudformation')
     require 'cdo/aws/cloud_formation'
+    require 'cdo/cloud_formation/cdo_app'
+    @cfn = AWS::CloudFormation.new(
+      stack: (@stack = Cdo::CloudFormation::CdoApp.new(
+        filename: ENV['TEMPLATE'],
+        stack_name: ENV['STACK_NAME'],
+        frontends: ENV['FRONTENDS'],
+        domain: ENV['DOMAIN'],
+        cdn_enabled: ENV['CDN_ENABLED']
+      )),
+      log: CDO.log,
+      verbose: ENV['VERBOSE'],
+      quiet: ENV['QUIET'],
+    )
   end
 
   namespace :start do
     task default: :environment do
-      AWS::CloudFormation.create_or_update
+      @cfn.create_or_update
     end
 
     desc 'Launch/update a full-stack deployment with CloudFront CDN disabled.
 Note: Consumes AWS resources until `stack:stop` is called.'
     task no_cdn: :environment do
-      ENV['CDN_ENABLED'] = nil
-      AWS::CloudFormation.create_or_update
+      @stack.options[:cdn_enabled] = false
+      @cfn.create_or_update
     end
   end
 
@@ -28,27 +40,39 @@ Note: Consumes AWS resources until `adhoc:stop` is called.'
 
   desc 'Validate CloudFormation template.'
   task validate: :environment do
-    AWS::CloudFormation.validate
+    @cfn.validate
   end
 
+  # Managed resource stacks other than the Code.org application.
   %I(vpc iam ami data lambda alerting).each do |stack|
     namespace stack do
       task :environment do
-        require_relative '../../deployment'
-        ENV['TEMPLATE'] ||= "#{stack}.yml.erb"
-        ENV['STACK_NAME'] ||= stack.to_s if [:lambda, :alerting].include? stack
-        ENV['STACK_NAME'] ||= "#{stack.upcase}#{"-#{rack_env}" if [:ami, :data].include? stack}"
+        stack_name = ENV['STACK_NAME']
+        stack_name ||= stack.to_s if [:lambda, :alerting].include? stack
+        stack_name ||= "#{stack.upcase}#{"-#{rack_env}" if [:ami, :data].include? stack}"
+
+        Dir.chdir aws_dir('cloudformation')
         require 'cdo/aws/cloud_formation'
+        require 'cdo/cloud_formation/stack_template'
+        @cfn = AWS::CloudFormation.new(
+          stack: Cdo::CloudFormation::StackTemplate.new(
+            filename: ENV['TEMPLATE'] || "#{stack}.yml.erb",
+            stack_name: stack_name
+          ),
+          log: CDO.log,
+          verbose: ENV['VERBOSE'],
+          quiet: ENV['QUIET'],
+        )
       end
 
       desc "Launch/update #{stack} stack component."
       task start: :environment do
-        AWS::CloudFormation.create_or_update
+        @cfn.create_or_update
       end
 
       desc "Validate #{stack} stack template."
       task validate: :environment do
-        AWS::CloudFormation.validate
+        @cfn.validate
       end
 
       # `stop` command intentionally removed. Use AWS console to manually delete stacks.


### PR DESCRIPTION
## Summary
This PR refactors CloudFormation glue code separating the monolithic `AWS::CloudFormation` class into separate classes/modules to provide a bit more organization.

## Details

The `AWS::CloudFormation` Ruby class was becoming a dense mix of cloudformation client-specific functions, convenience helpers related to manipulating CloudFormation stacks in general, and logic and constants specific to how our cdo-application generates its stack template from various options and constants in our environment. The refactoring splits these different concerns out into several modules/classes, so that the related parts can be grouped (and eventually tested) separately:

`AWS::CloudFormation`: This class now contains only code specific to managing configuration and deployment of AWS CloudFormation stacks.

`Cdo::CloudFormation::StackTemplate`: This provides the basic ERB context for rendering a CloudFormation stack template.

`Cdo::CloudFormation::CdoApp`: Extends `StackTemplate`, adding constants, methods, and options specific to the monolithic Code.org application stack.

This class also includes a bunch of Ruby code moved from the `cloud_formation_stack.yml.erb` template header into the constructor and other helper methods to make the template file easier to read.

`Cdo::CloudFormation::Adhoc`: Module (mixed in only when current environment is `adhoc`) containing methods related to managing adhoc instances of `CdoApp`.

## Links

## Testing story

Manually verified `No changes` CFN diff against all existing stacks:
- cdo stack in each environment:
  - [x] production
  - [x] test
  - [x] staging
  - [x] levelbuilder
- service-oriented stacks:
  - [x] vpc
  - [x] iam
  - [x] data
  - [x] lambda
  - [x] alerting

Also verify all adhoc stack configurations validate properly:
  - [x] base
  - [x] frontends
  - [x] database
  - [x] cdn

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
