### PR TITLE
Add CSF 2020 scripts to script constants

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -57,6 +57,16 @@ module ScriptConstants
       EXPRESS_2019_NAME = 'express-2019'.freeze,
       PRE_READER_EXPRESS_2019_NAME = 'pre-express-2019'.freeze,
     ],
+    csf_2020: [
+      COURSEA_2020_NAME = 'coursea-2020'.freeze,
+      COURSEB_2020_NAME = 'courseb-2020'.freeze,
+      COURSEC_2020_NAME = 'coursec-2020'.freeze,
+      COURSED_2020_NAME = 'coursed-2020'.freeze,
+      COURSEE_2020_NAME = 'coursee-2020'.freeze,
+      COURSEF_2020_NAME = 'coursef-2020'.freeze,
+      EXPRESS_2020_NAME = 'express-2020'.freeze,
+      PRE_READER_EXPRESS_2020_NAME = 'pre-express-2020'.freeze,
+    ],
     hoc: [
       # Note that now multiple scripts can be an 'hour of code' script.
       # If adding a script here,

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -63,8 +63,8 @@ class ScriptConstantsTest < Minitest::Test
 
   def test_category_priority
     assert_equal 0, ScriptConstants.category_priority(:full_course)
-    assert_equal 5, ScriptConstants.category_priority(:csf_international)
-    assert_equal 7, ScriptConstants.category_priority(:research_studies)
+    assert_equal 6, ScriptConstants.category_priority(:csf_international)
+    assert_equal 8, ScriptConstants.category_priority(:research_studies)
   end
 
   def test_assignable_info


### PR DESCRIPTION
Yesterday we cloned all the CSF 2020 scripts. This adds them to the script_constants file. 
