### PR TITLE
"My Libraries" tab - server changes

### DIFF
--- a/apps/src/sites/studio/pages/projects/index.js
+++ b/apps/src/sites/studio/pages/projects/index.js
@@ -26,10 +26,18 @@ $(document).ready(() => {
   });
   const store = getStore();
 
-  const initialState = projectsData.isPublic
-    ? Galleries.PUBLIC
-    : Galleries.PRIVATE;
-  store.dispatch(selectGallery(initialState));
+  // Default to private gallery if no tab is specified.
+  const currentTab = (
+    projectsData.currentTab || Galleries.PRIVATE
+  ).toUpperCase();
+
+  if (!Object.values(Galleries).includes(currentTab)) {
+    console.error(
+      `Unknown /projects tab '${currentTab}'. Make sure to add this tab to the Galleries constant.`
+    );
+  }
+
+  store.dispatch(selectGallery(currentTab));
   store.dispatch(setPersonalProjects());
   store.dispatch(setPublicProjects());
 

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -129,7 +129,7 @@ class ProjectsController < ApplicationController
   @@project_level_cache = {}
 
   # GET /projects/:tab_name
-  # Where a valid :tab_name is (nil|public|library)
+  # Where a valid :tab_name is (nil|public|libraries)
   def index
     unless params[:tab_name] == 'public'
       return redirect_to '/projects/public' unless current_user
@@ -198,7 +198,7 @@ class ProjectsController < ApplicationController
       combine_projects_and_featured_projects_data
       render template: 'projects/featured'
     else
-      redirect_to projects_public_path, flash: {alert: 'Only project validators can feature projects.'}
+      redirect_to '/projects/public', flash: {alert: 'Only project validators can feature projects.'}
     end
   end
 

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -132,7 +132,7 @@ class ProjectsController < ApplicationController
   # Where a valid :tab_name is (nil|public|library)
   def index
     unless params[:tab_name] == 'public'
-      return redirect_to projects_public_path unless current_user
+      return redirect_to '/projects/public' unless current_user
       return redirect_to '/', flash: {alert: 'Labs not allowed for admins.'} if current_user.admin
     end
 

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -128,19 +128,16 @@ class ProjectsController < ApplicationController
 
   @@project_level_cache = {}
 
-  # GET /projects
+  # GET /projects/:tab_name
+  # Where a valid :tab_name is (nil|public|library)
   def index
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
+    unless params[:tab_name] == 'public'
+      return redirect_to projects_public_path unless current_user
+      return redirect_to '/', flash: {alert: 'Labs not allowed for admins.'} if current_user.admin
     end
 
-    return redirect_to projects_public_path unless current_user
-  end
-
-  # GET /projects/public
-  def public
-    render template: 'projects/index', locals: {is_public: true, limited_gallery: limited_gallery?}
+    @limited_gallery = limited_gallery?
+    @current_tab = params[:tab_name]
   end
 
   def project_and_featured_project_fields

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -99,7 +99,7 @@
 - elsif request.path == "/courses"
   #header-banner.header-banner-courses{class: user_type ? "header-banner-short" : "", style: "background-image: url(\"/shared/images/banners/#{@header_banner_image_filename}.jpg\")"}
 
-- if request.path == "/projects" || request.path == "/projects/public"
+- if ["/projects", "/projects/public", "/projects/libraries"].include? request.path
   #header-banner.header-banner-short{style: 'background-image: url("/shared/images/banners/project-banner.jpg")'}
 
 - if should_show_progress

--- a/dashboard/app/views/projects/index.html.haml
+++ b/dashboard/app/views/projects/index.html.haml
@@ -1,9 +1,9 @@
 :ruby
   @page_title = t('project.project_gallery')
   projects_data = {}
-  projects_data[:limitedGallery] = local_assigns[:limited_gallery]
+  projects_data[:limitedGallery] = @limited_gallery
+  projects_data[:currentTab] = @current_tab
   projects_data[:projectCount] = fetch_project_count['total_projects']
-  projects_data[:isPublic] = local_assigns[:is_public]
 
   if current_user
     projects_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -203,7 +203,7 @@ Dashboard::Application.routes.draw do
         get "/#{key}/:channel_id/export_config", to: 'projects#export_config', key: key.to_s, as: "#{key}_project_export_config"
       end
 
-      get '/:tab_name', to: 'projects#index', constraints: {tab_name: /(public|library)/}
+      get '/:tab_name', to: 'projects#index', constraints: {tab_name: /(public|libraries)/}
     end
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -189,7 +189,6 @@ Dashboard::Application.routes.draw do
   put '/featured_projects/:project_id/unfeature', to: 'featured_projects#unfeature'
   put '/featured_projects/:project_id/feature', to: 'featured_projects#feature'
 
-  get '/projects/public', to: 'projects#public'
   resources :projects, path: '/projects/', only: [:index] do
     collection do
       ProjectsController::STANDALONE_PROJECTS.each do |key, _|
@@ -203,6 +202,8 @@ Dashboard::Application.routes.draw do
         get "/#{key}/:channel_id/export_create_channel", to: 'projects#export_create_channel', key: key.to_s, as: "#{key}_project_export_create_channel"
         get "/#{key}/:channel_id/export_config", to: 'projects#export_config', key: key.to_s, as: "#{key}_project_export_config"
       end
+
+      get '/:tab_name', to: 'projects#index', constraints: {tab_name: /(public|library)/}
     end
   end
 

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -37,7 +37,6 @@ module ProjectsList
         project_data = get_project_row_data(project, channel_id, nil, true)
         personal_projects_list << project_data if project_data
       end
-
       personal_projects_list
     end
 

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -224,7 +224,11 @@ module ProjectsList
         updatedAt: project_value['updatedAt'],
         publishedAt: project[:published_at]
       }
-      row_data[:library] = get_library_row_data(project, channel_id) if with_library
+
+      if with_library
+        row_data[:libraryName] = project_value['libraryName']
+        row_data[:libraryDescription] = project_value['libraryDescription']
+      end
 
       row_data.with_indifferent_access
     end

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -34,9 +34,10 @@ module ProjectsList
       storage_id = storage_id_for_user_id(user_id)
       PEGASUS_DB[:storage_apps].where(storage_id: storage_id, state: 'active').each do |project|
         channel_id = storage_encrypt_channel_id(storage_id, project[:id])
-        project_data = get_project_row_data(project, channel_id)
+        project_data = get_project_row_data(project, channel_id, nil, true)
         personal_projects_list << project_data if project_data
       end
+
       personal_projects_list
     end
 
@@ -210,18 +211,22 @@ module ProjectsList
     # pull various fields out of the student and project records to populate
     # a data structure that can be used to populate a UI component displaying a
     # single project.
-    def get_project_row_data(project, channel_id, student = nil)
+    def get_project_row_data(project, channel_id, student = nil, with_library = false)
       project_value = project[:value] ? JSON.parse(project[:value]) : {}
       return nil if project_value['hidden'] == true || project_value['hidden'] == 'true'
-      {
+
+      row_data = {
         channel: channel_id,
         name: project_value['name'],
         studentName: student&.name,
         thumbnailUrl: project_value['thumbnailUrl'],
         type: project_type(project_value['level']),
         updatedAt: project_value['updatedAt'],
-        publishedAt: project[:published_at],
-      }.with_indifferent_access
+        publishedAt: project[:published_at]
+      }
+      row_data[:library] = get_library_row_data(project, channel_id) if with_library
+
+      row_data.with_indifferent_access
     end
 
     # pull various fields out of the user and project records to populate

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -228,6 +228,7 @@ module ProjectsList
       if with_library
         row_data[:libraryName] = project_value['libraryName']
         row_data[:libraryDescription] = project_value['libraryDescription']
+        row_data[:libraryPublishedAt] = project_value['libraryPublishedAt']
       end
 
       row_data.with_indifferent_access

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -23,8 +23,42 @@ class ProjectsControllerTest < ActionController::TestCase
     section.add_student @navigator
   end
 
-  test "get index" do
+  test "index" do
     get :index
+    assert_response :success
+
+    get :index, params: {tab_name: 'libraries'}
+    assert_response :success
+
+    get :index, params: {tab_name: 'public'}
+    assert_response :success
+  end
+
+  test "index: redirect to public tab if no user" do
+    sign_out :user
+
+    get :index
+    assert_redirected_to '/projects/public'
+
+    get :index, params: {tab_name: 'libraries'}
+    assert_redirected_to '/projects/public'
+
+    # Don't redirect if we're already on /projects/public
+    get :index, params: {tab_name: 'public'}
+    assert_response :success
+  end
+
+  test "index: redirect to '/' if user is admin" do
+    sign_in create(:admin)
+
+    get :index
+    assert_redirected_to '/'
+
+    get :index, params: {tab_name: 'libraries'}
+    assert_redirected_to '/'
+
+    # Don't redirect if we're already on /projects/public
+    get :index, params: {tab_name: 'public'}
     assert_response :success
   end
 

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -13,7 +13,10 @@ class ProjectsListTest < ActionController::TestCase
       name: 'Bobs App',
       level: '/projects/applab',
       createdAt: '2017-01-24T16:41:08.000-08:00',
-      updatedAt: '2017-01-25T17:48:12.358-08:00'
+      updatedAt: '2017-01-25T17:48:12.358-08:00',
+      libraryName: 'bobsLibrary',
+      libraryDescription: 'A library by Bob.',
+      libraryPublishedAt: '2020-01-25T17:48:12.358-08:00'
     }.to_json
     @student_project = {id: 22, value: student_project_value}
 
@@ -46,6 +49,18 @@ class ProjectsListTest < ActionController::TestCase
     assert_equal 'Bobs App', project_row['name']
     assert_equal 'applab', project_row['type']
     assert_equal '2017-01-25T17:48:12.358-08:00', project_row['updatedAt']
+  end
+
+  test 'get_project_row_data includes library data if with_library is true' do
+    project_row = ProjectsList.send(:get_project_row_data, @student_project, @channel_id, nil, false)
+    assert_nil project_row['libraryName']
+    assert_nil project_row['libraryDescription']
+    assert_nil project_row['libraryPublishedAt']
+
+    project_row = ProjectsList.send(:get_project_row_data, @student_project, @channel_id, nil, true)
+    assert_equal 'bobsLibrary', project_row['libraryName']
+    assert_equal 'A library by Bob.', project_row['libraryDescription']
+    assert_equal '2020-01-25T17:48:12.358-08:00', project_row['libraryPublishedAt']
   end
 
   test 'get_published_project_and_user_data returns nil for App Lab project with sharing_disabled' do

--- a/shared/middleware/channels_api.rb
+++ b/shared/middleware/channels_api.rb
@@ -155,6 +155,7 @@ class ChannelsApi < Sinatra::Base
     end
     bad_request unless value.is_a? Hash
     value = value.merge('updatedAt' => Time.now)
+    value = value.merge('libraryPublishedAt' => Time.now) if value['publishLibrary']
 
     # Channels for project-backed levels are created without a project_type. The
     # type is then determined by client-side logic when the project is updated.

--- a/shared/test/test_channels.rb
+++ b/shared/test/test_channels.rb
@@ -99,6 +99,35 @@ class ChannelsTest < Minitest::Test
     Timecop.return
   end
 
+  def test_update_channel_and_publish_library
+    # Create channel
+    post '/v3/channels', {}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    channel_id = last_response.location.split('/').last
+
+    get "/v3/channels/#{channel_id}"
+    assert last_response.ok?
+    result = JSON.parse(last_response.body)
+    assert_nil result['libraryPublishedAt']
+
+    # Update channel where publishLibrary is false
+    post "/v3/channels/#{channel_id}", {publishLibrary: false}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    assert last_response.successful?
+
+    get "/v3/channels/#{channel_id}"
+    assert last_response.ok?
+    result = JSON.parse(last_response.body)
+    assert_nil result['libraryPublishedAt']
+
+    # Update channel where publishLibrary is true
+    post "/v3/channels/#{channel_id}", {publishLibrary: true}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    assert last_response.successful?
+
+    get "/v3/channels/#{channel_id}"
+    assert last_response.ok?
+    result = JSON.parse(last_response.body)
+    refute_nil result['libraryPublishedAt']
+  end
+
   def test_delete_channel
     post '/v3/channels', {}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     channel_id = last_response.location.split('/').last


### PR DESCRIPTION
Server-side changes to allow for:
1. Setting `libraryPublishedAt` field on a project in the pegasus db
2. Route for `/projects/libraries` + cleaning up the existing routes for other tabs (`/projects` and `/projects/public`)

## Links

- [STAR-960](https://codedotorg.atlassian.net/browse/STAR-960)
- [STAR-748](https://codedotorg.atlassian.net/browse/STAR-748)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
