### PR TITLE
Create cron job to auto sync from dropbox with our git repo on staging.

### DIFF
--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -48,9 +48,9 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
       # they are sub-paths of the code.org folder on git.
       command << " -ignore \"Path */public/applab/docs\" -ignore \"Path */public/applab/docs1\""
     end
-    stdout, _, _ = Open3.capture3(command)
-    if stdout != ""
-      error_message = error_message + "Dropbox #{key}. staging #{value}. " + stdout + "\n"
+    stdout, stderr, _ = Open3.capture3(command)
+    if stdout != "" || stderr != ""
+      error_message = "#{error_message}Dropbox directory: #{key}. staging directory: #{value}. \n#{stdout}#{stderr}\n"
     end
   end
   current_time = Time.now

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -6,7 +6,10 @@
 
 SCRIPT_START = Time.now
 
-require_relative '../../lib/cdo/only_one'
+require_relative "../../lib/cdo/only_one"
+require_relative "../../deployment"
+require "cdo/slack"
+require "open3"
 exit unless only_one_running?(__FILE__)
 
 FOLDERS = {
@@ -32,6 +35,8 @@ FOLDERS = {
 
 INTERVAL_SECONDS = 5
 TOTAL_SECONDS = 60 - INTERVAL_SECONDS
+error_message = ""
+alert_slack = true
 while (Time.now - SCRIPT_START) < TOTAL_SECONDS
   attempt_start = Time.now
   FOLDERS.each do |key, value|
@@ -43,10 +48,16 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
       # they are sub-paths of the code.org folder on git.
       command << " -ignore \"Path */public/applab/docs\" -ignore \"Path */public/applab/docs1\""
     end
-    success = system(command)
-    throw "Error syncing Dropbox #{key} and staging #{value} with the sync_dropbox cron job. Check job output for more details." unless success
+    stdout, _, _ = Open3.capture3(command)
+    if stdout != ""
+      error_message = error_message + stdout + "\n"
+    end
   end
   current_time = Time.now
+  if alert_slack && error_message != ""
+    Slack.message("@here Error syncing Dropbox #{key} and staging #{value} \n" + error_message, {channel: "sync-dropbox-staging"})
+    alert_slack = false
+  end
   while current_time - attempt_start < INTERVAL_SECONDS && (current_time - SCRIPT_START) < TOTAL_SECONDS
     sleep 0.1
     current_time = Time.now

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -4,6 +4,8 @@
 # on the staging machine. This is required for contents changes from dropbox to
 # be deployed.
 
+SCRIPT_START = Time.now
+
 require_relative '../../lib/cdo/only_one'
 exit unless only_one_running?(__FILE__)
 
@@ -28,15 +30,25 @@ FOLDERS = {
   "hourofcode.com" => "sites.v3/hourofcode.com"
 }.freeze
 
-FOLDERS.each do |key, value|
-  # 'unison' will sync the two folders. It will return true on success and false on failure.
-  # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
-  command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod"
-  if key == "code.org"
-    # The applab-docs and applab-docs-1 folders on dropbox are synced separately even though
-    # they are sub-paths of the code.org folder on git.
-    command << " -ignore \"Path */public/applab/docs\" -ignore \"Path */public/applab/docs1\""
+INTERVAL_SECONDS = 5
+TOTAL_SECONDS = 60 - INTERVAL_SECONDS
+while (Time.now - SCRIPT_START) < TOTAL_SECONDS
+  attempt_start = Time.now
+  FOLDERS.each do |key, value|
+    # 'unison' will sync the two folders. It will return true on success and false on failure.
+    # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
+    command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod"
+    if key == "code.org"
+      # The applab-docs and applab-docs-1 folders on dropbox are synced separately even though
+      # they are sub-paths of the code.org folder on git.
+      command << " -ignore \"Path */public/applab/docs\" -ignore \"Path */public/applab/docs1\""
+    end
+    success = system(command)
+    throw "Error syncing Dropbox #{key} and staging #{value} with the sync_dropbox cron job. Check job output for more details." unless success
   end
-  success = system(command)
-  throw "Error syncing Dropbox #{key} and staging #{value} with the sync_dropbox cron job. Check job output for more details." unless success
+  current_time = Time.now
+  while current_time - attempt_start < INTERVAL_SECONDS && (current_time - SCRIPT_START) < TOTAL_SECONDS
+    sleep 0.1
+    current_time = Time.now
+  end
 end

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -50,12 +50,12 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     end
     stdout, _, _ = Open3.capture3(command)
     if stdout != ""
-      error_message = error_message + stdout + "\n"
+      error_message = error_message + "Dropbox #{key}. staging #{value}. " + stdout + "\n"
     end
   end
   current_time = Time.now
   if alert_slack && error_message != ""
-    Slack.message("@here Error syncing Dropbox #{key} and staging #{value} \n" + error_message, {channel: "sync-dropbox-staging"})
+    Slack.message("@here Error syncing Dropbox and staging\n" + error_message, {channel: "sync-dropbox-staging"})
     alert_slack = false
   end
   while current_time - attempt_start < INTERVAL_SECONDS && (current_time - SCRIPT_START) < TOTAL_SECONDS

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -6,8 +6,6 @@
 
 require_relative '../../lib/cdo/only_one'
 exit unless only_one_running?(__FILE__)
-require_relative '../../dashboard/config/environment'
-exit unless rack_env?(:staging) && CDO.dashboard_hostname == 'staging-studio.code.org'
 
 FOLDERS = {
   "advocacy.code.org" => "sites.v3/advocacy.code.org",
@@ -32,9 +30,11 @@ FOLDERS = {
 
 FOLDERS.each do |key, value|
   # 'unison' will sync the two folders. It will return true on success and false on failure.
-  # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierceg/unison/
-  command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignoreinodenumbers -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod"
+  # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
+  command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod"
   if key == "code.org"
+    # The applab-docs and applab-docs-1 folders on dropbox are synced separately even though
+    # they are sub-paths of the code.org folder on git.
     command << " -ignore \"Path */public/applab/docs\" -ignore \"Path */public/applab/docs1\""
   end
   success = system(command)

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -32,7 +32,11 @@ FOLDERS = {
 
 FOLDERS.each do |key, value|
   # 'unison' will sync the two folders. It will return true on success and false on failure.
-  # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/
-  success = system("unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent")
+  # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierceg/unison/
+  command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignoreinodenumbers -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod"
+  if key == "code.org"
+    command << " -ignore \"Path */public/applab/docs\" -ignore \"Path */public/applab/docs1\""
+  end
+  success = system(command)
   throw "Error syncing Dropbox and staging with the sync_dropbox cron job. Check job output for more details." unless success
 end

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -9,8 +9,6 @@ exit unless only_one_running?(__FILE__)
 require_relative '../../dashboard/config/environment'
 exit unless rack_env?(:staging) && CDO.dashboard_hostname == 'staging-studio.code.org'
 
-system("sudo apt-get install -y unison")
-
 FOLDERS = {
   "advocacy.code.org" => "sites.v3/advocacy.code.org",
   "applab-docs-1" => "sites.v3/code.org/public/applab/docs1",

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -38,5 +38,5 @@ FOLDERS.each do |key, value|
     command << " -ignore \"Path */public/applab/docs\" -ignore \"Path */public/applab/docs1\""
   end
   success = system(command)
-  throw "Error syncing Dropbox and staging with the sync_dropbox cron job. Check job output for more details." unless success
+  throw "Error syncing Dropbox #{key} and staging #{value} with the sync_dropbox cron job. Check job output for more details." unless success
 end

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+# This syncs content changes from the shared dropbox folder to our github repo
+# on the staging machine. This is required for contents changes from dropbox to
+# be deployed.
+
+system("sudo apt-get install -y unison")
+
+FOLDERS = {
+  "advocacy.code.org" => "/home/ubuntu/staging/pegasus/sites.v3/advocacy.code.org",
+  "applab-docs-1" => "/home/ubuntu/staging/pegasus/sites.v3/code.org/public/applab/docs1",
+  "applab-docs" => "/home/ubuntu/staging/pegasus/sites.v3/code.org/public/applab/docs",
+  "code.org" => "/home/ubuntu/staging/pegasus/sites.v3/code.org",
+  "csedweek.org" => "/home/ubuntu/staging/pegasus/sites.v3/csedweek.org",
+  "curriculum-6-8" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-6-8",
+  "curriculum-algebra" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-algebra",
+  "curriculum-course1" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-course1",
+  "curriculum-course2" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-course2",
+  "curriculum-course3" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-course3",
+  "curriculum-course4" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-course4",
+  "curriculum-csp" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-csp",
+  "curriculum-docs" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-docs",
+  "curriculum-misc" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-misc",
+  "curriculum-science" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-science",
+  "curriculum-unplugged" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-unplugged",
+  "emails" => "/home/ubuntu/staging/pegasus/emails",
+  "hourofcode.com" => "/home/ubuntu/staging/pegasus/sites.v3/hourofcode.com"
+}
+
+FOLDERS.each do |key, value|
+  system("unison ~/Dropbox/Shared/#{key} #{value} -silent")
+end

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -4,29 +4,37 @@
 # on the staging machine. This is required for contents changes from dropbox to
 # be deployed.
 
+require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
+require_relative '../../dashboard/config/environment'
+exit unless rack_env?(:staging) && CDO.dashboard_hostname == 'staging-studio.code.org'
+
 system("sudo apt-get install -y unison")
 
 FOLDERS = {
-  "advocacy.code.org" => "/home/ubuntu/staging/pegasus/sites.v3/advocacy.code.org",
-  "applab-docs-1" => "/home/ubuntu/staging/pegasus/sites.v3/code.org/public/applab/docs1",
-  "applab-docs" => "/home/ubuntu/staging/pegasus/sites.v3/code.org/public/applab/docs",
-  "code.org" => "/home/ubuntu/staging/pegasus/sites.v3/code.org",
-  "csedweek.org" => "/home/ubuntu/staging/pegasus/sites.v3/csedweek.org",
-  "curriculum-6-8" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-6-8",
-  "curriculum-algebra" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-algebra",
-  "curriculum-course1" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-course1",
-  "curriculum-course2" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-course2",
-  "curriculum-course3" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-course3",
-  "curriculum-course4" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-course4",
-  "curriculum-csp" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-csp",
-  "curriculum-docs" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-docs",
-  "curriculum-misc" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-misc",
-  "curriculum-science" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-science",
-  "curriculum-unplugged" => "/home/ubuntu/staging/pegasus/sites/virtual/curriculum-unplugged",
-  "emails" => "/home/ubuntu/staging/pegasus/emails",
-  "hourofcode.com" => "/home/ubuntu/staging/pegasus/sites.v3/hourofcode.com"
-}
+  "advocacy.code.org" => "sites.v3/advocacy.code.org",
+  "applab-docs-1" => "sites.v3/code.org/public/applab/docs1",
+  "applab-docs" => "sites.v3/code.org/public/applab/docs",
+  "code.org" => "sites.v3/code.org",
+  "csedweek.org" => "sites.v3/csedweek.org",
+  "curriculum-6-8" => "sites/virtual/curriculum-6-8",
+  "curriculum-algebra" => "sites/virtual/curriculum-algebra",
+  "curriculum-course1" => "sites/virtual/curriculum-course1",
+  "curriculum-course2" => "sites/virtual/curriculum-course2",
+  "curriculum-course3" => "sites/virtual/curriculum-course3",
+  "curriculum-course4" => "sites/virtual/curriculum-course4",
+  "curriculum-csp" => "sites/virtual/curriculum-csp",
+  "curriculum-docs" => "sites/virtual/curriculum-docs",
+  "curriculum-misc" => "sites/virtual/curriculum-misc",
+  "curriculum-science" => "sites/virtual/curriculum-science",
+  "curriculum-unplugged" => "sites/virtual/curriculum-unplugged",
+  "emails" => "emails",
+  "hourofcode.com" => "sites.v3/hourofcode.com"
+}.freeze
 
 FOLDERS.each do |key, value|
-  system("unison ~/Dropbox/Shared/#{key} #{value} -silent")
+  # 'unison' will sync the two folders. It will return true on success and false on failure.
+  # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/
+  success = system("unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent")
+  throw "Error syncing Dropbox and staging with the sync_dropbox cron job. Check job output for more details." unless success
 end

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -50,7 +50,7 @@
     if node.chef_environment == 'staging' && node.name == 'staging' # 'real' staging only
       cronjob at:'@reboot', do:home_dir('.dropbox-dist', 'dropboxd')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'import_google_sheets')
-      cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'sync_dropbox')
+      cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'sync_dropbox')
       cronjob at:'*/2 * * * *', do:deploy_dir('bin', 'cron', 'run_server_generate_pdfs')
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','run_server_generate_curriculum_pdfs')
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','collate_pdfs')

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -50,6 +50,7 @@
     if node.chef_environment == 'staging' && node.name == 'staging' # 'real' staging only
       cronjob at:'@reboot', do:home_dir('.dropbox-dist', 'dropboxd')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'import_google_sheets')
+      cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'sync_dropbox')
       cronjob at:'*/2 * * * *', do:deploy_dir('bin', 'cron', 'run_server_generate_pdfs')
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','run_server_generate_curriculum_pdfs')
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','collate_pdfs')


### PR DESCRIPTION
In the past, we used used symlinks to keep dropbox and our staging environment in sync. Dropbox has deprecated this type of usage of symlinks. Now, we need to manage this syncing ourselves. Full details on this issue are in the COE (linked)

This PR creates a cronjob to sync dropbox and our staging environment every 5 minutes. This will allow content editors to add content to staging again.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [COE](https://docs.google.com/document/d/1E7g7N8PKwQ0PGFj4DxjtvfOEeLVeiqNAt_RVdf16eMc/edit#)
- [Slack Thread 1](https://codedotorg.slack.com/archives/C0T0PNTM3/p1582676249019500)
- [Slack Thread 2](https://codedotorg.slack.com/archives/C0T0PNTM3/p1582746599044000)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
