### PR TITLE
[Applab Design Mode] Fix hex code auto-complete bug

### DIFF
--- a/apps/src/applab/designElements/ColorPickerPropertyRow.jsx
+++ b/apps/src/applab/designElements/ColorPickerPropertyRow.jsx
@@ -12,7 +12,7 @@ export default class ColorPickerPropertyRow extends React.Component {
   };
 
   state = {
-    value: this.props.initialValue,
+    colorPickerText: this.props.initialValue,
     displayColorPicker: false
   };
 
@@ -27,9 +27,7 @@ export default class ColorPickerPropertyRow extends React.Component {
   componentWillReceiveProps(nextProps) {
     const {initialValue} = nextProps;
     if (this.props.initialValue !== initialValue) {
-      this.setState({
-        value: initialValue
-      });
+      this.setState({colorPickerText: initialValue});
     }
   }
 
@@ -43,24 +41,20 @@ export default class ColorPickerPropertyRow extends React.Component {
     }
   };
 
-  handleChangeInternal = event => {
-    this.changeColor(event.target.value);
-  };
-
   handleColorChange = color => {
     if (color.rgb.a === 1) {
       // no transparency set
-      this.changeColor(color.hex);
+      this.changeElementColor(color.hex);
     } else {
-      this.changeColor(
+      this.changeElementColor(
         `rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`
       );
     }
   };
 
-  changeColor(color) {
+  changeElementColor(color) {
     this.props.handleChange(color);
-    this.setState({value: color});
+    this.setState({colorPickerText: color});
   }
 
   toggleColorPicker = () => {
@@ -69,13 +63,13 @@ export default class ColorPickerPropertyRow extends React.Component {
 
   render() {
     const buttonStyle = {
-      backgroundColor: this.state.value,
+      backgroundColor: this.state.colorPickerText,
       verticalAlign: 'top'
     };
     let colorPicker = this.state.displayColorPicker ? (
       <ColorPicker
         ref="colorPicker"
-        color={this.state.value}
+        color={this.state.colorPickerText}
         onChangeComplete={this.handleColorChange}
       />
     ) : null;
@@ -84,14 +78,17 @@ export default class ColorPickerPropertyRow extends React.Component {
         <div style={rowStyle.description}>{this.props.desc}</div>
         <div>
           <input
-            value={this.state.value}
-            onChange={this.handleChangeInternal}
+            value={this.state.colorPickerText}
+            onChange={e => this.setState({colorPickerText: e.target.value})}
+            onBlur={e => this.changeElementColor(e.target.value)}
             style={rowStyle.input}
           />
           <button
             ref="button"
             type="button"
-            className={this.state.value === '' ? 'rainbow-gradient' : undefined}
+            className={
+              this.state.colorPickerText === '' ? 'rainbow-gradient' : undefined
+            }
             style={buttonStyle}
             onClick={this.toggleColorPicker}
           />


### PR DESCRIPTION
The issue here ended up being that our change handler in the `ColorPickerPropertyRow` input was calling `this.props.handleChange`, which set the color on the actual design element. This then caused a re-render of the design element, which re-rendered the `ColorPickerPropertyRow`. However, the issue is that each design mode element was calling `rgb2hex` on its color, which was causing the erratic behavior observed.

The solution is to not update the color of the design element until the user's focus has left the `ColorPickerPropertyRow` input area.  

I've also made a couple small naming changes to make it more clear what's happening:
1. `value` -> `colorPickerText` (this is the internal state of the `ColorPickerPropertyRow` component which controls what is in the input HTML element)
1. `changeColor` -> `changeElementColor` (this changes the color property of the design element.)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-418)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
