### PR TITLE
Add additional variant to teacher dashboard header A/B test

### DIFF
--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeaderWithButtons.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeaderWithButtons.jsx
@@ -13,6 +13,7 @@ import {ReloadAfterEditSectionDialog} from './EditSectionDialog';
 import {beginEditingSection} from './teacherSectionsRedux';
 import Button from '../Button';
 import DropdownButton from '../DropdownButton';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   shortH1: {
@@ -52,7 +53,27 @@ class TeacherDashboardHeaderWithButtons extends React.Component {
     this.selectedSection = this.props.sections[this.props.selectedSectionId];
   }
 
-  getDropdownOptions() {
+  experimentDropdownButton() {
+    if (
+      experiments.isEnabled(
+        experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT
+      )
+    ) {
+      return (
+        <DropdownButton size="narrow" color="gray" text={i18n.switchSection()}>
+          {this.getDropdownOptions('from_button_switch_section')}
+        </DropdownButton>
+      );
+    } else {
+      return (
+        <DropdownButton size="narrow" color="gray" text={i18n.selectSection()}>
+          {this.getDropdownOptions('from_button_select_section')}
+        </DropdownButton>
+      );
+    }
+  }
+
+  getDropdownOptions(optionMetricName) {
     let self = this;
     let sections = this.props.sections;
     let options = Object.keys(sections).map(function(key, i) {
@@ -62,7 +83,7 @@ class TeacherDashboardHeaderWithButtons extends React.Component {
         recordSwitchToSection(
           section.id,
           self.selectedSection.id,
-          'from_button'
+          optionMetricName
         );
       };
       let icon = undefined;
@@ -111,13 +132,7 @@ class TeacherDashboardHeaderWithButtons extends React.Component {
                 text={i18n.editSectionDetails()}
                 style={styles.buttonWithMargin}
               />
-              <DropdownButton
-                size="narrow"
-                text={i18n.selectSection()}
-                color="gray"
-              >
-                {this.getDropdownOptions()}
-              </DropdownButton>
+              {this.experimentDropdownButton()}
             </div>
           </div>
         </div>

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -28,6 +28,8 @@ experiments.STANDARDS_REPORT = 'standardsReport';
 experiments.BETT_DEMO = 'bett-demo';
 experiments.TEACHER_DASHBOARD_SECTION_BUTTONS =
   'teacher-dashboard-section-buttons';
+experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
+  'teacher-dashboard-section-buttons-alternate-text';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.


### PR DESCRIPTION
Add additional variant where the text of the button to change sections reads
'switch section' rather than 'select section'. The A/B test is now technically
an A / (B|C) test: 50% of our users are in a control group, and the other 50%
is evenly split between two differerent variants of the teacher dashboard
header, one with text reading 'switch section' and the other with text reading
'select section'

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
