### PR TITLE
Remove specifying ltr on the fish app

### DIFF
--- a/apps/src/fish/FishView.jsx
+++ b/apps/src/fish/FishView.jsx
@@ -61,11 +61,7 @@ class FishView extends React.Component {
     return (
       <StudioAppWrapper rotateContainerWidth={this.props.mobilePortraitWidth}>
         <CodeWorkspaceContainer topMargin={0}>
-          <ProtectedStatefulDiv
-            id="container"
-            style={styles.container}
-            dir="ltr"
-          >
+          <ProtectedStatefulDiv id="container" style={styles.container}>
             <div id="container-react" style={styles.containerReact} />
             <canvas id="background-canvas" style={styles.backgroundCanvas} />
             <canvas id="activity-canvas" style={styles.activityCanvas} />


### PR DESCRIPTION
Most of the major bugs were fixed in https://github.com/code-dot-org/ml-activities/pull/352 and now that oceans is translated into Arabic we should allow the page to be rendered rtl.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
