### PR TITLE
Add unit tests for Foorm

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -343,5 +343,5 @@ namespace :seed do
   task incremental: [:videos, :concepts, :scripts_incremental, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :courses, :ap_school_codes, :ap_cs_offerings, :ib_school_codes, :ib_cs_offerings, :state_cs_offerings, :donors, :donor_schools, :foorms]
 
   desc "seed only dashboard data required for tests"
-  task test: [:videos, :games, :concepts, :secret_words, :secret_pictures, :school_districts, :schools]
+  task test: [:videos, :games, :concepts, :secret_words, :secret_pictures, :school_districts, :schools, :foorms]
 end

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class Api::V1::Pd::WorkshopSurveyFoormSubmissionsControllerTest < ::ActionController::TestCase
+  self.use_transactional_test_case = true
+  setup_all do
+    @user = create :user
+    @pd_summer_workshop = create :csp_summer_workshop
+    @foorm_form = create :foorm_form
+  end
+
+  test 'can create and save survey submission' do
+    params = {
+      answers: {
+        question1: 'answer1'
+      },
+      user_id: @user.id,
+      pd_workshop_id: @pd_summer_workshop.id,
+      pd_session_id: nil,
+      day: 0,
+      form_name: @foorm_form.name,
+      form_version: @foorm_form.version
+    }
+
+    response = post :create, params: params
+    assert_response :created
+    response_body = JSON.parse(response.body)
+    assert_not_nil response_body['submission_id']
+    assert_not_nil response_body['survey_submission_id']
+  end
+end

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -52,6 +52,16 @@ module Pd
       assert_response :not_found
     end
 
+    test 'daily summer workshop foorm survey returns 404 for days outside of range 0-4' do
+      setup_summer_workshop
+      sign_in @enrolled_summer_teacher
+      get '/pd/workshop_survey/foorm/day/-1'
+      assert_response :not_found
+
+      get '/pd/workshop_survey/foorm/day/5'
+      assert_response :not_found
+    end
+
     test 'daily academic year workshop survey results 404 for days outside of 1' do
       setup_academic_year_workshop
       sign_in @enrolled_academic_year_teacher
@@ -70,6 +80,13 @@ module Pd
       assert_not_enrolled
     end
 
+    test 'pre-workshop foorm survey displays not enrolled message when not enrolled' do
+      sign_in unenrolled_teacher
+      get '/pd/workshop_survey/foorm/day/0'
+      assert_response :success
+      assert_not_enrolled
+    end
+
     test 'pre-workshop survey redirects to thanks when a response exists' do
       setup_summer_workshop
       create :pd_workshop_daily_survey, pd_workshop: @summer_workshop, user: @enrolled_summer_teacher,
@@ -77,6 +94,16 @@ module Pd
 
       sign_in @enrolled_summer_teacher
       get '/pd/workshop_survey/day/0'
+      assert_redirected_to action: 'thanks'
+    end
+
+    test 'pre-workshop foorm survey redirects to thanks when a response exists' do
+      setup_summer_workshop
+      create :pd_workshop_survey_foorm_submission, pd_workshop: @summer_workshop, user: @enrolled_summer_teacher,
+             day: 0
+
+      sign_in @enrolled_summer_teacher
+      get '/pd/workshop_survey/foorm/day/0'
       assert_redirected_to action: 'thanks'
     end
 
@@ -105,6 +132,14 @@ module Pd
 
       sign_in @enrolled_summer_teacher
       get '/pd/workshop_survey/day/0'
+      assert_response :success
+    end
+
+    test 'pre-workshop foorm survey displays foorm when enrolled' do
+      setup_summer_workshop
+
+      sign_in @enrolled_summer_teacher
+      get '/pd/workshop_survey/foorm/day/0'
       assert_response :success
     end
 

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -1433,4 +1433,23 @@ FactoryGirl.define do
     application_status 'confirmation'
     to {application.user.email}
   end
+
+  factory :foorm_form, class: 'Foorm::Form' do
+    sequence(:name) {|n| "FormName#{n}"}
+    version 0
+    questions '{}'
+  end
+
+  factory :daily_workshop_day_0_foorm_submission, class: 'Foorm::Submission' do
+    form_name "surveys/pd/workshop_daily_survey_day_0"
+    form_version 0
+    answers "{'question1':'answer1'}"
+  end
+
+  factory :pd_workshop_survey_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
+    association :foorm_submission, factory: :daily_workshop_day_0_foorm_submission
+    association :pd_workshop, factory: :csp_summer_workshop
+    association :user, factory: :teacher
+    day 0
+  end
 end

--- a/dashboard/test/models/foorm/form_test.rb
+++ b/dashboard/test/models/foorm/form_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class Foorm::FormTest < ActiveSupport::TestCase
+  test 'get latest form and version gets correct form' do
+    form1 = create :foorm_form
+    form2 = create :foorm_form, name: form1.name, version: form1.version + 1
+
+    form, version = Foorm::Form.get_form_and_latest_version_for_name(form1.name)
+    assert_equal form2.name, form.name
+    assert_equal form2.version, version
+  end
+end

--- a/dashboard/test/models/pd/workshop_survey_foorm_submission_test.rb
+++ b/dashboard/test/models/pd/workshop_survey_foorm_submission_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+module Pd
+  class WorkshopSurveyFoormSubmissionTest < ActiveSupport::TestCase
+    self.use_transactional_test_case = true
+    setup_all do
+      @user = create :user
+      @pd_summer_workshop = create :csp_summer_workshop
+      @foorm_form = create :foorm_form
+    end
+
+    test 'save workshop with submission' do
+      workshop_survey = Pd::WorkshopSurveyFoormSubmission.new(user_id: @user.id, pd_workshop_id: @pd_summer_workshop.id, day: 0)
+      workshop_survey.save_with_foorm_submission({'question1': 'answer1'}, @foorm_form.name, @foorm_form.version)
+      assert_equal @foorm_form.name, workshop_survey.foorm_submission.form_name
+    end
+
+    test 'can check that survey has already been submitted' do
+      workshop_survey = Pd::WorkshopSurveyFoormSubmission.new(user_id: @user.id, pd_workshop_id: @pd_summer_workshop.id, day: 0)
+      workshop_survey.save_with_foorm_submission({'question1': 'answer1'}, @foorm_form.name, @foorm_form.version)
+
+      assert Pd::WorkshopSurveyFoormSubmission.has_submitted_form?(@user.id, @pd_summer_workshop.id, nil, 0, @foorm_form.name)
+    end
+
+    test 'can check that survey has already been submitted without form name' do
+      workshop_survey = Pd::WorkshopSurveyFoormSubmission.new(user_id: @user.id, pd_workshop_id: @pd_summer_workshop.id, day: 0)
+      workshop_survey.save_with_foorm_submission({'question1': 'answer1'}, @foorm_form.name, @foorm_form.version)
+
+      assert Pd::WorkshopSurveyFoormSubmission.has_submitted_form?(@user.id, @pd_summer_workshop.id, nil, 0, nil)
+    end
+
+    test 'can check that survey has not already been submitted' do
+      refute Pd::WorkshopSurveyFoormSubmission.has_submitted_form?(@user.id, @pd_summer_workshop.id, nil, nil, @foorm_form.name)
+    end
+  end
+end


### PR DESCRIPTION
Follow up to [33278](https://github.com/code-dot-org/code-dot-org/pull/33278), added unit tests for the following:
- workshop_survey_foorm_submissions_controller
- foorm functionality in workshop_daily_survey_controller
- Foorm::foorm
- workshop_survey_foorm_submission
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Validated new tests pass. Also added foorm seeding to test environment seeding so that we can test against real forms.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
