### PR TITLE
[Applab Datasets] Add new dataset link on levelbuilder page

### DIFF
--- a/apps/src/storage/levelbuilder/DatasetList.jsx
+++ b/apps/src/storage/levelbuilder/DatasetList.jsx
@@ -32,7 +32,6 @@ class DatasetList extends React.Component {
         <br />
         <p> Add a dataset </p>
         <input
-          ref="nameInput"
           type="text"
           onChange={e => this.setState({newTableName: e.target.value})}
         />

--- a/apps/src/storage/levelbuilder/DatasetList.jsx
+++ b/apps/src/storage/levelbuilder/DatasetList.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Button from '@cdo/apps/templates/Button';
 
 class DatasetList extends React.Component {
   static propTypes = {
     datasets: PropTypes.arrayOf(PropTypes.string).isRequired,
     liveDatasets: PropTypes.arrayOf(PropTypes.string).isRequired
   };
+
+  state = {
+    newTableName: ''
+  };
+
   render() {
+    const isValidTableName =
+      this.state.newTableName &&
+      this.props.datasets.indexOf(this.state.newTableName) === -1;
     return (
       <div>
         <h1>Datasets</h1>
@@ -20,6 +29,21 @@ class DatasetList extends React.Component {
             </li>
           ))}
         </ul>
+        <br />
+        <p> Add a dataset </p>
+        <input
+          ref="nameInput"
+          type="text"
+          onChange={e => this.setState({newTableName: e.target.value})}
+        />
+        <br />
+        <Button
+          text="New Dataset"
+          href={`/datasets/${this.state.newTableName}`}
+          disabled={!isValidTableName}
+          color={Button.ButtonColor.blue}
+          size={Button.ButtonSize.large}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Add a text box and button to make a new dataset. This doesn't actually add any functionality, it just links to `/datasets/<newTableName>` but makes it so you don't have to type the exact URL
![image](https://user-images.githubusercontent.com/8787187/75495425-588d7c80-5973-11ea-8dd3-6ed6d84b4044.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
