### PR TITLE
PL: Remove survey constant

### DIFF
--- a/dashboard/lib/pd/workshop_survey_constants.rb
+++ b/dashboard/lib/pd/workshop_survey_constants.rb
@@ -79,7 +79,6 @@ module Pd
     }
 
     CSF_SURVEY_NAMES = [
-      POST_INTRO_SURVEY = 'post101',
       PRE_DEEPDIVE_SURVEY = 'pre201',
       POST_DEEPDIVE_SURVEY = 'post201',
     ]


### PR DESCRIPTION
A constant added in https://github.com/code-dot-org/code-dot-org/pull/33272 was not actually used, and in fact caused a `Mising jotform form: csf.post101 (KeyError)` error in `sync_jotforms`.
