### PR TITLE
don't escape manually-added linebreak

### DIFF
--- a/pegasus/sites.v3/code.org/public/certificates.haml
+++ b/pegasus/sites.v3/code.org/public/certificates.haml
@@ -29,7 +29,7 @@ theme: responsive
     -if request.params['names']
       - request.params['names'].each do |name|
         =CGI::unescape(name)
-        ="&#x000A;"
+        !="&#x000A;"
   %br
   %br
   != I18n.t(:landscape_recommended_certificates, markdown: true)


### PR DESCRIPTION
Broken by https://github.com/code-dot-org/code-dot-org/pull/33246; this wasn't caught by testing because it only manifests if you POST to the page, not on a simple GET.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
