### PR TITLE
Allow customized background color for announcements

### DIFF
--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -23,12 +23,6 @@ const styles = {
     minHeight: 281,
     boxSizing: 'border-box'
   },
-  textItemCyan: {
-    backgroundColor: color.light_cyan,
-    padding: 25,
-    minHeight: 281,
-    boxSizing: 'border-box'
-  },
   subHeading: {
     paddingRight: 0,
     paddingBottom: 20,
@@ -75,7 +69,6 @@ export class UnconnectedTwoColumnActionBlock extends Component {
     responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']).isRequired,
     imageUrl: PropTypes.string.isRequired,
     imageExtra: PropTypes.node,
-    teacherStyle: PropTypes.bool,
     heading: PropTypes.string,
     subHeading: PropTypes.string,
     subHeadingSmallFont: PropTypes.bool,
@@ -87,7 +80,8 @@ export class UnconnectedTwoColumnActionBlock extends Component {
         target: PropTypes.string,
         id: PropTypes.string
       })
-    )
+    ),
+    backgroundColor: PropTypes.string
   };
 
   render() {
@@ -101,10 +95,16 @@ export class UnconnectedTwoColumnActionBlock extends Component {
       subHeading,
       subHeadingSmallFont,
       description,
-      buttons
+      buttons,
+      backgroundColor
     } = this.props;
     const float = isRtl ? 'right' : 'left';
     const width = responsiveSize === 'lg' ? '50%' : '100%';
+
+    const textItemCustomBackgroundColor = {
+      ...styles.textItem,
+      backgroundColor: backgroundColor || styles.textItem.backgroundColor
+    };
 
     return (
       <div id={id} style={styles.container}>
@@ -117,11 +117,7 @@ export class UnconnectedTwoColumnActionBlock extends Component {
             </div>
           )}
           <div style={{float, width}}>
-            <div
-              style={
-                this.props.teacherStyle ? styles.textItemCyan : styles.textItem
-              }
-            >
+            <div style={textItemCustomBackgroundColor}>
               {subHeading && (
                 <div
                   style={
@@ -253,6 +249,7 @@ export class SpecialAnnouncementActionBlock extends Component {
         subHeading={announcement.title}
         description={announcement.body}
         buttons={this.state.buttonList}
+        backgroundColor={announcement.backgroundColor}
       />
     );
   }

--- a/apps/src/templates/studioHomepages/shapes.jsx
+++ b/apps/src/templates/studioHomepages/shapes.jsx
@@ -50,7 +50,8 @@ const shapes = {
     buttonText: PropTypes.string.isRequired,
     buttonId2: PropTypes.string,
     buttonUrl2: PropTypes.string,
-    buttonText2: PropTypes.string
+    buttonText2: PropTypes.string,
+    backgroundColor: PropTypes.string
   })
 };
 

--- a/pegasus/sites.v3/code.org/announcements.json
+++ b/pegasus/sites.v3/code.org/announcements.json
@@ -26,7 +26,8 @@
       "body": "Let them know how amazing they are by nominating them for a Professional Learning Scholarship today!",
       "buttonText": "Nominate a Teacher",
       "buttonUrl": "https://code.org/nominate",
-      "buttonId": "teacher-apps-nominate-2020-button"
+      "buttonId": "teacher-apps-nominate-2020-button",
+      "backgroundColor": "#59b9dc"
     }
   }
 }


### PR DESCRIPTION
Allows customization of background color on announcements via JSON control, and updates current teacher announcement to be a better color.

Also removes the `teacherStyle` prop, which was [added for this announcement last year](https://github.com/code-dot-org/code-dot-org/pull/27306/files) and appears redundant now.

One concern is that this approach will result in white text on a white background in the case of an incorrectly formatted hex code or invalid HTML color. That said, people creating these banners should be able to check their work on staging, and we don't actively prevent things like broken links in the banner either currently.

I see an [approach for checking whether a color is a valid CSS color here](https://stackoverflow.com/questions/48484767/javascript-check-if-string-is-valid-css-color), which I could implement.

**Old**

![image](https://user-images.githubusercontent.com/25372625/75574976-1e27ec00-5a14-11ea-8dd3-372a48af0257.png)

**New**

![image](https://user-images.githubusercontent.com/25372625/75574936-0ea8a300-5a14-11ea-93b9-a2505a09a278.png)

## Testing story

Tested locally -- we don't have much in the way of automated testing for this banner.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
