### PR TITLE
Extract 'Form2' to its own file

### DIFF
--- a/lib/cdo/form.rb
+++ b/lib/cdo/form.rb
@@ -1,0 +1,15 @@
+require 'json'
+
+class Form2 < OpenStruct
+  def initialize(params={})
+    params = params.dup
+    params[:data] = JSON.load(params[:data])
+    params[:processed_data] = JSON.load(params[:processed_data])
+    super params
+  end
+
+  def self.from_row(row)
+    return nil unless row
+    new row
+  end
+end

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'cdo/db'
+require 'cdo/form'
 require 'cdo/parse_email_address_string'
 require 'cdo/pegasus/text_render'
 require 'digest/md5'

--- a/pegasus/src/database.rb
+++ b/pegasus/src/database.rb
@@ -1,7 +1,7 @@
 require 'cdo/db'
 require 'cdo/geocoder'
 require 'cdo/properties'
-require 'json'
+require 'cdo/form'
 require 'securerandom'
 require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/object/deep_dup'
@@ -130,18 +130,4 @@ def geocode_address(address)
   return nil unless location
   return nil unless location.latitude && location.longitude
   "#{location.latitude},#{location.longitude}"
-end
-
-class Form2 < OpenStruct
-  def initialize(params={})
-    params = params.dup
-    params[:data] = JSON.load(params[:data])
-    params[:processed_data] = JSON.load(params[:processed_data])
-    super params
-  end
-
-  def self.from_row(row)
-    return nil unless row
-    new row
-  end
 end


### PR DESCRIPTION
So it can be explicitly required by poste without requiring the whole pegasus/src/database file

Required for https://github.com/code-dot-org/code-dot-org/pull/33362

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
