### PR TITLE
break up the Poste::Template.render and .initialize methods to make it more composable

### DIFF
--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -110,8 +110,13 @@ module Poste
   end
 
   class Template
-    def initialize(body, engine=TextRender::MarkdownEngine)
-      @engine = engine
+    def initialize(path)
+      body = IO.read(path)
+
+      @engine = {
+        '.html' => TextRender::ErbEngine,
+        '.md' => TextRender::MarkdownEngine,
+      }[File.extname(path).downcase]
 
       if match = body.match(/^---\s*\n(?<header>.*?\n?)^(---\s*$\n?)(?<html>\s*\n.*?\n?)^(---\s*$\n?)(?<text>\s*\n.*?\n?\z)/m)
         @header = match[:header].strip
@@ -302,15 +307,7 @@ class Deliverer
     path = Poste.resolve_template(name)
     raise ArgumentError, "[Poste] '#{name}' template wasn't found." unless path
 
-    engine = {
-      '.haml' => TextRender::HamlEngine,
-      '.html' => TextRender::ErbEngine,
-      '.md' => TextRender::MarkdownEngine,
-      '.txt' => TextRender::MarkdownEngine,
-      '.yml' => TextRender::YamlEngine,
-    }[File.extname(path).downcase]
-
-    @templates[name] = Poste::Template.new IO.read(path), engine
+    @templates[name] = Poste::Template.new path
   end
 
   private

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -114,6 +114,7 @@ module Poste
       body = IO.read(path)
 
       @engine = {
+        '.haml' => TextRender::HamlEngine,
         '.html' => TextRender::ErbEngine,
         '.md' => TextRender::MarkdownEngine,
       }[File.extname(path).downcase]

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -141,11 +141,7 @@ module Poste
       locals = OpenStruct.new(params).instance_eval {binding}
 
       header = render_header(locals)
-
-      # TODO(andrew): Fix this so that we get a signal as to how often this is happening.
-      # For more information, see https://www.pivotaltracker.com/story/show/104750788.
-      tracking_id = header['litmus_tracking_id']
-      html = render_html(locals, tracking_id, params[:encrypted_id])
+      html = render_html(locals, header['litmus_tracking_id'], params[:encrypted_id])
       text = render_text(locals)
 
       [header, html, text]


### PR DESCRIPTION
In preparation for switching it over to use ActionView for the rendering logic.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1020)

## Testing story

I'm relying on our [new email rendering test](https://github.com/code-dot-org/code-dot-org/pull/33362) to ensure this refactor doesn't change anything.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
