### PR TITLE
Bring back teacher only markdown preview in editor on DSl levels

### DIFF
--- a/dashboard/app/views/levels/editors/_curriculum_reference.haml
+++ b/dashboard/app/views/levels/editors/_curriculum_reference.haml
@@ -1,12 +1,3 @@
-:scss
-  $cyan: #0094ca;
-  $lightest_cyan: #d9eff7;
-
-  #level_teacher_markdown_preview {
-    border: 5px solid $cyan;
-    background-color: $lightest_cyan;
-    padding: 10px;
-  }
 
 .field
   = f.label :reference, 'Curriculum Reference'

--- a/dashboard/app/views/levels/editors/_dsl.html.haml
+++ b/dashboard/app/views/levels/editors/_dsl.html.haml
@@ -11,14 +11,15 @@
     padding: 10px;
   }
 
-  .markdown.teacher {
-    border: 5px solid $cyan;
-    background-color: $lightest_cyan;
-  }
-
   .field.teacher-only-markdown {
     border: 5px solid gray;
     border-radius: 5px;
+    padding: 10px;
+  }
+
+  #level_teacher_markdown_textarea_preview {
+    border: 5px solid $cyan;
+    background-color: $lightest_cyan;
     padding: 10px;
   }
 
@@ -48,4 +49,4 @@
   .field.teacher-only-markdown
 
     %textarea#level_teacher_markdown_textarea
-    #level_teacher_markdown_preview
+    #level_teacher_markdown_textarea_preview

--- a/dashboard/app/views/levels/editors/fields/_teacher_only_markdown.haml
+++ b/dashboard/app/views/levels/editors/fields/_teacher_only_markdown.haml
@@ -1,4 +1,13 @@
 :scss
+  $cyan: #0094ca;
+  $lightest_cyan: #d9eff7;
+
+  #level_teacher_markdown_preview {
+    border: 5px solid $cyan;
+    background-color: $lightest_cyan;
+    padding: 10px;
+  }
+
   .field.teacher-only-markdown {
     border: 5px solid gray;
     border-radius: 5px;


### PR DESCRIPTION
When we shipped https://github.com/code-dot-org/code-dot-org/pull/33332 we lost the preview of Teacher Only Markdown in the DSL level editor. This bring that functionality back.

<img width="1004" alt="Screen Shot 2020-03-02 at 10 32 33 AM" src="https://user-images.githubusercontent.com/208083/75692014-ea96cd00-5c72-11ea-8b9c-b97b4c0375d9.png">


I also removed/moved some CSS styling of the Teacher Only Markdown preview to clean up.