### PR TITLE
PL: Fix pegasus forms' scroll-to-top

### DIFF
--- a/apps/src/sites/code.org/pages/public/pd-workshop-survey/splat.js
+++ b/apps/src/sites/code.org/pages/public/pd-workshop-survey/splat.js
@@ -107,7 +107,7 @@ function processError(data) {
     )
     .show();
 
-  $('body').scrollTop(0);
+  window.scrollTo(0, 0);
   $('#btn-submit').removeAttr('disabled');
   $('#btn-submit')
     .removeClass('button_disabled')

--- a/pegasus/sites.v3/code.org/public/js/pd-workshop-survey-counselor-admin.js
+++ b/pegasus/sites.v3/code.org/public/js/pd-workshop-survey-counselor-admin.js
@@ -1,72 +1,93 @@
 /* jshint globals: $ */
 
-$(document).ready(function () {
-  $('#pd-workshop-survey-form').find("select").selectize();
+$(document).ready(function() {
+  $("#pd-workshop-survey-form")
+    .find("select")
+    .selectize();
 
-  $('#pd-workshop-survey-form').submit(function (event) {
+  $("#pd-workshop-survey-form").submit(function(event) {
     PdWorkshopSurveyFormSubmit(event);
   });
 
-  $("input[name='how_heard_ss[]']:checkbox").change(function () {
+  $("input[name='how_heard_ss[]']:checkbox").change(function() {
     if ($("input[name='how_heard_ss[]'][value='Other']").is(":checked")) {
-      $('#how-heard-other-wrapper').show();
+      $("#how-heard-other-wrapper").show();
     } else {
-      $('#how-heard-other-wrapper').hide();
+      $("#how-heard-other-wrapper").hide();
     }
   });
 
-  $("input[name='attendee_type_s']").change(function () {
+  $("input[name='attendee_type_s']").change(function() {
     // These button groups are shared between the admin and counselor sections. Make sure
     // we never submit a hidden answer after switching between Counselor and Admin.
-    $("input[name='understand_curricular_offerings_s']").prop('checked', false);
-    $("input[name='understand_professional_experiences_s']").prop('checked', false);
+    $("input[name='understand_curricular_offerings_s']").prop("checked", false);
+    $("input[name='understand_professional_experiences_s']").prop(
+      "checked",
+      false
+    );
 
-    if ($("input[name='attendee_type_s'][value='Administrator']").is(':checked')) {
-      $('.counselor-section').hide();
-      $('.admin-section').show();
+    if (
+      $("input[name='attendee_type_s'][value='Administrator']").is(":checked")
+    ) {
+      $(".counselor-section").hide();
+      $(".admin-section").show();
     } else {
-      $('.admin-section').hide();
-      $('.counselor-section').show();
+      $(".admin-section").hide();
+      $(".counselor-section").show();
     }
   });
 });
 
 function processResponse() {
-  $("#btn-submit").removeAttr('disabled');
-  $("#btn-submit").removeClass("button_disabled").addClass("button_enabled");
-  $('#pd-workshop-survey-form').hide();
-  $('#thanks').show();
+  $("#btn-submit").removeAttr("disabled");
+  $("#btn-submit")
+    .removeClass("button_disabled")
+    .addClass("button_enabled");
+  $("#pd-workshop-survey-form").hide();
+  $("#thanks").show();
 }
 
 function processError(data) {
-  $('.has-error').removeClass('has-error');
+  $(".has-error").removeClass("has-error");
 
   var error_field_names = Object.keys(data.responseJSON);
   var errors_count = error_field_names.length;
 
   for (var i = 0; i < errors_count; ++i) {
-    var error_field_name = error_field_names[i].replace(/_ss$/,'_ss[]');
+    var error_field_name = error_field_names[i].replace(/_ss$/, "_ss[]");
     var query = ".control-label[for='" + error_field_name + "']";
-    $(query).parents('.form-group').addClass('has-error');
+    $(query)
+      .parents(".form-group")
+      .addClass("has-error");
   }
 
-  $('#error-message').text('An error occurred. Please check to make sure all required fields have been filled out.').show();
+  $("#error-message")
+    .text(
+      "An error occurred. Please check to make sure all required fields have been filled out."
+    )
+    .show();
 
-  $('body').scrollTop(0);
-  $("#btn-submit").removeAttr('disabled');
-  $("#btn-submit").removeClass("button_disabled").addClass("button_enabled");
+  window.scrollTo(0, 0);
+  $("#btn-submit").removeAttr("disabled");
+  $("#btn-submit")
+    .removeClass("button_disabled")
+    .addClass("button_enabled");
 }
 
 function PdWorkshopSurveyFormSubmit(event) {
-  $("#btn-submit").attr('disabled','disabled');
-  $("#btn-submit").removeClass("button_enabled").addClass("button_disabled");
+  $("#btn-submit").attr("disabled", "disabled");
+  $("#btn-submit")
+    .removeClass("button_enabled")
+    .addClass("button_disabled");
 
   $.ajax({
     url: "/forms/PdWorkshopSurveyCounselorAdmin",
     type: "post",
     dataType: "json",
-    data: $('#pd-workshop-survey-form').serialize()
-  }).done(processResponse).fail(processError);
+    data: $("#pd-workshop-survey-form").serialize()
+  })
+    .done(processResponse)
+    .fail(processError);
 
   event.preventDefault();
 }

--- a/pegasus/sites.v3/code.org/public/js/volunteer-unsubscribe.js
+++ b/pegasus/sites.v3/code.org/public/js/volunteer-unsubscribe.js
@@ -1,6 +1,6 @@
 function processVolunteerUnsubscribeResponse(data) {
-  $('form').hide();
-  $('#unsubscribe-volunteer-thanks').show();
+  $("form").hide();
+  $("#unsubscribe-volunteer-thanks").show();
 }
 
 function processVolunteerUnsubscribeError(data) {
@@ -10,36 +10,44 @@ function processVolunteerUnsubscribeError(data) {
 
   for (var i = 0; i < errors.length; i++) {
     if (errors[i] === "age_18_plus_b") {
-      errorMessage = 'An error occurred. You must be 18 to volunteer. ' +
-      'Please certify that you are at least 18 years old to update your preferences. ' +
-      'If you are not yet 18, please request to remove yourself from the volunteer list by ' +
-      '<a href="https://support.code.org/hc/en-us/requests/new" target="_blank">contacting support</a>.';
+      errorMessage =
+        "An error occurred. You must be 18 to volunteer. " +
+        "Please certify that you are at least 18 years old to update your preferences. " +
+        "If you are not yet 18, please request to remove yourself from the volunteer list by " +
+        '<a href="https://support.code.org/hc/en-us/requests/new" target="_blank">contacting support</a>.';
     } else if (errors[i] === "email_preference_opt_in_s") {
-      errorMessage = 'Please select an email preference below.';
+      errorMessage = "Please select an email preference below.";
     }
   }
 
   if (!errorMessage) {
-    errorMessage = 'An error occurred. Please try again or ' +
+    errorMessage =
+      "An error occurred. Please try again or " +
       '<a href="https://support.code.org/hc/en-us/requests/new" target="_blank">' +
-      'contact us</a> if you continue to receive this error.';
+      "contact us</a> if you continue to receive this error.";
   }
 
-  $('#unsubscribe-volunteer-form .error-message').html(errorMessage).show();
-  $('body').scrollTop(0);
-  $('#btn-submit').removeAttr('disabled');
-  $('#btn-submit').removeClass('button_disabled').addClass('button_enabled');
+  $("#unsubscribe-volunteer-form .error-message")
+    .html(errorMessage)
+    .show();
+  window.scrollTo(0, 0);
+  $("#btn-submit").removeAttr("disabled");
+  $("#btn-submit")
+    .removeClass("button_disabled")
+    .addClass("button_enabled");
 }
 
-window.unsubscribeVolunteerList = function () {
-  $('#btn-submit').attr('disabled','disabled');
-  $('#btn-submit').removeClass('button_enabled').addClass('button_disabled');
+window.unsubscribeVolunteerList = function() {
+  $("#btn-submit").attr("disabled", "disabled");
+  $("#btn-submit")
+    .removeClass("button_enabled")
+    .addClass("button_disabled");
 
-  var secret = $('#volunteer-secret').text();
-  var formResults = $('#unsubscribe-volunteer-form').serializeArray();
+  var secret = $("#volunteer-secret").text();
+  var formResults = $("#unsubscribe-volunteer-form").serializeArray();
 
   var data = {};
-  $(formResults).each(function (index, obj) {
+  $(formResults).each(function(index, obj) {
     data[obj.name] = obj.value;
   });
 
@@ -48,7 +56,9 @@ window.unsubscribeVolunteerList = function () {
     method: "post",
     contentType: "application/json; charset=utf-8",
     data: JSON.stringify(data)
-  }).done(processVolunteerUnsubscribeResponse).fail(processVolunteerUnsubscribeError);
+  })
+    .done(processVolunteerUnsubscribeResponse)
+    .fail(processVolunteerUnsubscribeError);
 
   return false;
 };


### PR DESCRIPTION
Three pegasus forms used
```
$('body').scrollTop(0);
```
but it no longer works, so we're replacing it with
```
window.scrollTo(0, 0);
```

The other changes are just `JsPrettier`.