### PR TITLE
Change DNS records to point to ALB [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -506,8 +506,8 @@ Resources:
             HostedZoneId: Z2FDTNDATAQYW2 # static ID for cloudfront aliases
 <%   elsif load_balancer -%>
           AliasTarget:
-            DNSName: !GetAtt [LoadBalancer, CanonicalHostedZoneName]
-            HostedZoneId: !GetAtt [LoadBalancer, CanonicalHostedZoneNameID]
+            DNSName: !GetAtt [ALB, DNSName]
+            HostedZoneId: !GetAtt [ALB, CanonicalHostedZoneID]
 <%   else -%>
           TTL: <%= DNS_TTL %>
           ResourceRecords: [!GetAtt <%=daemon%>.PublicIp]
@@ -540,8 +540,8 @@ Resources:
           Type: A
 <%   if load_balancer -%>
           AliasTarget:
-            HostedZoneId: !GetAtt [LoadBalancer, CanonicalHostedZoneNameID]
-            DNSName: !GetAtt [LoadBalancer, CanonicalHostedZoneName]
+            HostedZoneId: !GetAtt [ALB, CanonicalHostedZoneID]
+            DNSName: !GetAtt [ALB, DNSName]
 <%   else -%>
           TTL: <%= DNS_TTL %>
           ResourceRecords: [!GetAtt <%=daemon%>.PublicIp]


### PR DESCRIPTION
We manually changed the DNS record for `origin-autoscale-prod.code.org` to point to the new ALB on friday afternoon, causing production traffic to shift completely from the ELB classic to the ALB, with no observed issues. This change just adds that change to the cloudformation template - this should be a no-op when deployed.

validate:
```
Winters-MBP:code-dot-org winterdong$ RAILS_ENV=test bundle exec rake stack:validate
AWS CloudFormation Template for Code.org application
Parameters:
DatabaseUsername: master
Listing changes to existing stack `test`:
Modify OriginDNS [AWS::Route53::RecordSetGroup] Properties (RecordSets)
```

