### PR TITLE
ActionView in Poste

### DIFF
--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -126,8 +126,19 @@ module Poste
       # alongside the given one; we will use this to help build confidence that
       # switching our templates over to actionview can be done without changing
       # the resulting rendered HTML
-      if File.exists?(path + ".actionview")
-        @actionview_header, @actionview_html, @actionview_text = parse_template(IO.read(path + ".actionview"))
+      actionview_path = path + ".actionview"
+      if File.exists?(actionview_path)
+        @actionview_header, @actionview_html, @actionview_text = parse_template(IO.read(actionview_path))
+      else
+        # Warn if there is no such path, in case a new email template gets
+        # added to our system before this experiment has concluded.
+        Honeybadger.notify(
+          error_class: 'No email template to render with ActionView',
+          error_message: "Could not find actionview-specific #{actionview_path.inspect} email template",
+          context: {
+            path: path
+          }
+        )
       end
     end
 

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -119,6 +119,7 @@ module Poste
         '.html' => TextRender::ErbEngine,
         '.md' => TextRender::MarkdownEngine,
       }[File.extname(path).downcase]
+      @template_type = File.extname(path)[1..-1]
 
       @header, @html, @text = parse_template(IO.read(path))
 
@@ -240,10 +241,6 @@ module Poste
       end
 
       html = @engine.new(@html).result(bound)
-      # Parse the html into a DOM and then re-serialize back to html text in case we were depending on that
-      # logic in the click tracking method to clean up or canonicalize the HTML.
-      html = Nokogiri::HTML(html).to_html
-      html = inject_litmus_tracking html, tracking_id, encrypted_id
 
       if html && actionview_result && html != actionview_result
         Honeybadger.notify(
@@ -255,6 +252,11 @@ module Poste
           }
         )
       end
+
+      # Parse the html into a DOM and then re-serialize back to html text in case we were depending on that
+      # logic in the click tracking method to clean up or canonicalize the HTML.
+      html = Nokogiri::HTML(html).to_html
+      html = inject_litmus_tracking html, tracking_id, encrypted_id
 
       html
     end

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -7,6 +7,7 @@ require 'digest/md5'
 require_relative 'email_validator'
 require 'mail'
 require 'openssl'
+require 'cdo/honeybadger'
 
 module Poste
   def self.logger
@@ -111,7 +112,7 @@ module Poste
 
   class Template
     def initialize(path)
-      body = IO.read(path)
+      @path = path
 
       @engine = {
         '.haml' => TextRender::HamlEngine,
@@ -119,15 +120,14 @@ module Poste
         '.md' => TextRender::MarkdownEngine,
       }[File.extname(path).downcase]
 
-      if match = body.match(/^---\s*\n(?<header>.*?\n?)^(---\s*$\n?)(?<html>\s*\n.*?\n?)^(---\s*$\n?)(?<text>\s*\n.*?\n?\z)/m)
-        @header = match[:header].strip
-        @html = match[:html].strip
-        @text = match[:text].strip
-      elsif match = body.match(/^---\s*\n(?<header>.*?\n?)^(---\s*$\n?)(?<html>\s*\n.*?\n?\z)/m)
-        @header = match[:header].strip
-        @html = match[:html].strip
-      else
-        @html = body.strip
+      @header, @html, @text = parse_template(IO.read(path))
+
+      # Temporarily also load in a new 'actionview' template and render it
+      # alongside the given one; we will use this to help build confidence that
+      # switching our templates over to actionview can be done without changing
+      # the resulting rendered HTML
+      if File.exists?(path + ".actionview")
+        @actionview_header, @actionview_html, @actionview_text = parse_template(IO.read(path + ".actionview"))
       end
     end
 
@@ -138,38 +138,150 @@ module Poste
         params.merge! form.processed_data
         params['form'] = form
       end
-      locals = OpenStruct.new(params).instance_eval {binding}
+      bound = OpenStruct.new(params).instance_eval {binding}
+      locals = params.symbolize_keys
 
-      header = render_header(locals)
-      html = render_html(locals, header['litmus_tracking_id'], params[:encrypted_id])
-      text = render_text(locals)
+      header = render_header(bound, locals)
+      html = render_html(bound, locals, header['litmus_tracking_id'], params[:encrypted_id])
+      text = render_text(bound, locals)
 
       [header, html, text]
     end
 
     private
 
-    def render_header(locals={})
-      return {} unless @header.present?
+    def parse_template(content)
+      header = nil
+      html = nil
+      text = nil
 
-      TextRender::YamlEngine.new(@header).result(locals)
+      if match = content.match(/^---\s*\n(?<header>.*?\n?)^(---\s*$\n?)(?<html>\s*\n.*?\n?)^(---\s*$\n?)(?<text>\s*\n.*?\n?\z)/m)
+        header = match[:header].strip
+        html = match[:html].strip
+        text = match[:text].strip
+      elsif match = content.match(/^---\s*\n(?<header>.*?\n?)^(---\s*$\n?)(?<html>\s*\n.*?\n?\z)/m)
+        header = match[:header].strip
+        html = match[:html].strip
+      else
+        html = content.strip
+      end
+
+      [header, html, text]
     end
 
-    def render_html(locals={}, tracking_id=nil, encrypted_id=nil)
+    def render_header(bound, locals={})
+      return {} unless @header.present?
+
+      if @actionview_header
+        begin
+          actionview_result = YAML.safe_load(renderer.render(inline: @actionview_header, type: :erb, locals: locals))
+        rescue => e
+          Honeybadger.notify(
+            error_class: 'Error rendering email with ActionView',
+            error_message: "Email template #{@path} could not render header",
+            context: {
+              locals: locals,
+              error: e
+            }
+          )
+          puts @path
+          puts e
+        end
+      end
+
+      result = TextRender::YamlEngine.new(@header).result(bound)
+
+      if result && actionview_result && result != actionview_result
+        Honeybadger.notify(
+          error_class: 'Incorrectly rendered email with ActionView',
+          error_message: "Email template #{@path} rendered the header incorrectly",
+          context: {
+            expected: result,
+            actual: actionview_result
+          }
+        )
+      end
+      
+      result
+    end
+
+    def render_html(bound, locals={}, tracking_id=nil, encrypted_id=nil)
       return nil unless @html.present?
 
-      html = @engine.new(@html).result(locals)
+      if @actionview_html
+        begin
+          # All our emails regardless of the extension they use are parsed as ERB
+          # in addition to their regular template type.
+          html = renderer.render(inline: @actionview_html, type: :erb, locals: locals)
+          actionview_result = renderer.render(inline: html, type: @template_type)
+        rescue => e
+          Honeybadger.notify(
+            error_class: 'Error rendering email with ActionView',
+            error_message: "Email template #{@path} could not render html",
+            context: {
+              locals: locals,
+              error: e
+            }
+          )
+          puts @path
+          puts e
+        end
+      end
+
+      html = @engine.new(@html).result(bound)
       # Parse the html into a DOM and then re-serialize back to html text in case we were depending on that
       # logic in the click tracking method to clean up or canonicalize the HTML.
       html = Nokogiri::HTML(html).to_html
       html = inject_litmus_tracking html, tracking_id, encrypted_id
 
+      if html && actionview_result && html != actionview_result
+        Honeybadger.notify(
+          error_class: 'Incorrectly rendered email with ActionView',
+          error_message: "Email template #{@path} rendered the html incorrectly",
+          context: {
+            expected: html,
+            actual: actionview_result
+          }
+        )
+      end
+
       html
     end
 
-    def render_text(locals={})
+    def render_text(bound, locals={})
       return nil unless @text.present?
-      TextRender::ErbEngine.new(@text).result(locals)
+
+      if @actionview_text
+        begin
+          actionview_result = renderer.render(inline: @actionview_text, type: :erb, locals: locals)
+        rescue => e
+          Honeybadger.notify(
+            error_class: 'Error rendering email with ActionView',
+            error_message: "Email template #{@path} could not render text",
+            context: {
+              locals: locals,
+              error: e
+            }
+          )
+          puts @path
+          puts e
+        end
+      end
+
+      result = TextRender::ErbEngine.new(@text).result(bound)
+
+      if result && actionview_result && result != actionview_result
+        Honeybadger.notify(
+          error_class: 'Incorrectly rendered email with ActionView',
+          error_message: "Email template #{@path} rendered the text incorrectly",
+          context: {
+            expected: result,
+            actual: actionview_result
+          }
+        )
+      end
+
+      result
     end
 
     def inject_litmus_tracking(html, tracking_id, unique_id)
@@ -179,6 +291,14 @@ module Poste
 <img src="https://#{tracking_id}.emltrk.com/#{tracking_id}?d=#{unique_id}" width="1" height="1" border="0" />
 eos
       html.gsub("</body>", litmus_blob + "\n</body>")
+    end
+
+    def renderer
+      @@renderer ||= begin
+        require 'cdo/pegasus/actionview_sinatra'
+        ActionView::Template.register_template_handler :md, ActionViewSinatra::MarkdownHandler
+        ActionView::Base.new
+      end
     end
   end
 end

--- a/lib/test/fixtures/deliverer/expected/volunteer_contact_2015_receipt/body.html
+++ b/lib/test/fixtures/deliverer/expected/volunteer_contact_2015_receipt/body.html
@@ -5,9 +5,7 @@
 <p>Fake Name is a teacher at Fabricated Elementary. They found you on the <a href="https://code.org/volunteer/local">volunteer site</a> and after reviewing your profile specifically requested if you could help their class. They would like it if you could:</p>
 
 <ul>
-
-  <li> visit the classroom for technical help and inspiration
-
+<li> visit the classroom for technical help and inspiration
 
 
 </li>

--- a/lib/test/test_deliverer.rb
+++ b/lib/test/test_deliverer.rb
@@ -78,6 +78,10 @@ class DelivererTest < Minitest::Test
   #       - body.txt
   def test_deliverer_render_all
     Dir.each_child(Poste.emails_dir) do |email|
+      # skip over 'actionview' templates; those are being used alongside the
+      # un-suffixed templates of the same name
+      next if email.end_with?("actionview")
+
       name = File.basename(email, ".*")
       template = @deliverer.load_template(name)
 

--- a/pegasus/emails/census_form_receipt.md.actionview
+++ b/pegasus/emails/census_form_receipt.md.actionview
@@ -1,0 +1,32 @@
+---
+from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
+subject: "Your local school’s computer science program"
+---
+Thank you for sharing information about your school’s computer science program and your continued support of our mission to give every student the opportunity to learn computer science.
+
+Here are steps that you can take to expand computer science access to more students in your local region:
+
+
+- If you’re a district or school administrator, see our [Administrator guide](https://code.org/administrators) for expanding access in your school or district.
+
+- If you’re a teacher, view our curriculum options for [teaching computer science](https://code.org/teach) to your students - no computer science experience necessary.
+
+- If you’re a parent or community member, [take an action](https://code.org/help) to encourage your local school to offer computer science.
+
+In just a few years, support for computer science has impacted hundreds of thousands of classrooms and tens of millions of students. Many school districts, U.S. states, and even entire countries have joined the movement.
+
+Please follow our progress on [Facebook](https://www.facebook.com/Code.org) or on [Twitter](https://twitter.com/codeorg) to stay in touch.
+
+Thank you so much for your support,
+
+Hadi Partovi<br />
+Founder, [Code.org](https://code.org/) <br />
+
+
+
+<hr/>
+<small>
+You’re receiving this email because you provided information about your local school on [Code.org](https://code.org/). [Code.org](https://code.org/) is a 501c3 non-profit. Our address is [1501 4th Avenue, Suite 900, Seattle, WA 98101](https://www.google.com/maps/place/1501+4th+Ave+%23900,+Seattle,+WA+98101/@47.6101003,-122.3396487,17z/data=!3m1!4b1!4m5!3m4!1s0x54906ab36ff44f0f:0xbce135aa1bb96835!8m2!3d47.6101003!4d-122.33746). <br />Don't like these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/class_submission_receipt.md.actionview
+++ b/pegasus/emails/class_submission_receipt.md.actionview
@@ -1,0 +1,18 @@
+---
+from: '"Hadi Partovi (Code.org)" <hadi_partovi@code.org>'
+subject: Submission Received
+---
+<% edit_link = "http://#{CDO.canonical_hostname('code.org')}/schools/edit/#{form.secret}" %>
+
+Thank you for submitting a school/activity. After review, it will appear on our site. If necessary, you can make changes by clicking here: [<%= edit_link %>](<%= edit_link %>).
+
+Thanks again for your support,
+
+Hadi Partovi,<br/>
+Founder, Code.org
+
+<hr/>
+
+Code.org is a 501c3 non-profit. Our address is 1501 4th Avenue, Suite 900, Seattle, WA 98101. Don't like these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/dashboard.html.actionview
+++ b/pegasus/emails/dashboard.html.actionview
@@ -1,0 +1,20 @@
+---
+<%
+formatted_from = "Code.org <noreply@code.org>"
+if defined?(from) && from != nil
+  if from.include? '<'
+    formatted_from = from
+  else
+    formatted_from = "Code.org <#{from}>"
+  end
+end
+%>
+from: <%= formatted_from.inspect.html_safe %>
+subject: <%= local_assigns.fetch(:subject, nil).inspect&.html_safe %>
+reply-to: <%= local_assigns.fetch(:reply_to, nil)&.inspect&.html_safe%>
+cc: <%= local_assigns.fetch(:cc, nil)&.inspect&.html_safe%>
+bcc: <%= local_assigns.fetch(:bcc, nil)&.inspect&.html_safe %>
+---
+<%= local_assigns.fetch(:body, "").html_safe %>
+
+<img src="<%= local_assigns.fetch(:tracking_pixel, "") %>"/>

--- a/pegasus/emails/hoc_census_2017_pledge_receipt.md.actionview
+++ b/pegasus/emails/hoc_census_2017_pledge_receipt.md.actionview
@@ -1,0 +1,36 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Go beyond an hour!"
+---
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+  <% studiodotcodedotorg = CDO.canonical_hostname('studio.code.org') %>
+
+### Yes! You pledged to go beyond an hour to expand computer science at your school.
+
+Thank you for joining the movement! We want to help you go further.
+
+### Administrators
+If you’re a district or school administrator, see our [Administrator Guide](https://<%= codedotorg %>/administrators) for expanding access in your school or district.
+
+### Teachers
+If you’re a teacher, view our curriculum and professional learning options for [teaching computer science](https://<%= studiodotcodedotorg %>/courses?view=teacher) to your students - no computer science experience necessary.
+
+We also have [resources to help you advocate](https://<%= codedotorg %>/promote) for the need for computer science in your area.
+
+Thank you for being a leader in pledging to expand offerings at your school. You will make real lasting change in students’ lives by giving them the opportunity to take these courses. 
+ 
+Please follow our progress on [Facebook](https://www.facebook.com/Code.org) or on [Twitter](https://twitter.com/codeorg) to stay in touch.
+ 
+Thank you so much for your support,
+
+Hadi Partovi<br />
+Founder, Code.org<br />
+
+<hr/>
+<small>
+You're receiving this email because you pledged to expand computer science offerings at your school when you provided information to Code.org about your school on HourOfCode.com.  Code.org is a 501c3 non-profit. Our address is [1501 4th Avenue, Suite 900, Seattle, WA 98101](https://maps.google.com/?q=1501+4th+Avenue,+Suite+900,+Seattle,+WA+98101&entry=gmail&source=g). Don't want these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)
+
+ 

--- a/pegasus/emails/hoc_hardware_prizes_2015_receipt.md.actionview
+++ b/pegasus/emails/hoc_hardware_prizes_2015_receipt.md.actionview
@@ -1,0 +1,29 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Thanks for signing up for a chance to win the $10,000 Hardware Prize"
+---
+<% hostname = CDO.canonical_hostname('hourofcode.com') %>
+
+# Thanks for signing up for a chance to win the $10,000 Hardware Prize
+
+Your whole school is now entered to win a class-set of laptops (or $10,000 for other technology). We'll be reviewing your application and announcing the winners in December.
+
+## 1. Spread the word
+Tell your friends about the #HourOfCode.
+
+## 2. Ask your whole school to offer an Hour of Code
+[Send this email](http://<%= hostname %>/resources#email) to your principal.
+
+## 3. Ask your employer to get involved
+[Send this email](http://<%= hostname %>/resources#email) to your manager, or the CEO.
+
+## 4. Promote the Hour of Code in your community
+Recruit a local group — boy/girl scouts club, church, university, veterans group or labor union. Or host an Hour of Code "block party" for your neighborhood. [Send this email](http://<%= hostname %>/resources#email).
+
+## 5. Ask a local elected official to support the Hour of Code
+[Send this email](http://<%= hostname %>/resources#politicians) to your mayor, city council, or school board and invite them to visit your school.
+
+<hr/>
+
+Code.org is a 501c3 non-profit. Our address is 1301 5th Ave, Suite 1225, Seattle, WA, 98101. Don't like these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+

--- a/pegasus/emails/hoc_signup_2014_receipt.md.actionview
+++ b/pegasus/emails/hoc_signup_2014_receipt.md.actionview
@@ -1,0 +1,40 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Thanks for signing up to host an Hour of Code!"
+litmus_tracking_id: "5g5lyi1a"
+---
+<% hostname = CDO.canonical_hostname('hourofcode.com') %>
+
+<% if @country == 'ro' %>
+
+Va multumim pentru inregistrare. Daca aveti nevoie de ajutor sau aveti orice intrebare contactati Echipa Hour of Code Romania la adresa: hoc@adfaber.org.
+
+<% end %>
+
+# Thanks for signing up to host an Hour of Code!
+
+**EVERY** Hour of Code organizer will receive 10 GB of Dropbox space or $10 of Skype credit as a thank you. [Details](http://<%= hostname %>/prizes)
+
+## 1. Spread the word
+Tell your friends about the #HourOfCode.
+
+<% if @country == 'us' %>
+
+## 2. Ask your whole school to offer an Hour of Code
+[Send this email](http://<%= hostname %>/resources#email) or give [this handout](http://<%= hostname %>/files/schools-handout.pdf) to your principal.
+
+<% end %>
+
+## 3. Ask your employer to get involved
+[Send this email](http://<%= hostname %>/resources#email) to your manager, or the CEO. Or [give them this handout](http://<%= hostname %>/resources/hoc-one-pager.pdf).
+
+## 4. Promote Hour of Code within your community
+Recruit a local group — boy/girl scouts club, church, university, veterans group or labor union. Or host an Hour of Code "block party" for your neighborhood.
+
+## 5. Ask a local elected official to support the Hour of Code
+[Send this email](http://<%= hostname %>/resources#politicians) to your mayor, city council, or school board. Or [give them this handout](http://<%= hostname %>/resources/hoc-one-pager.pdf) and invite them to visit your school.
+
+<hr/>
+
+Code.org is a 501c3 non-profit. Our address is 1301 5th Ave, Suite 1225, Seattle, WA, 98101. Don't like these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+

--- a/pegasus/emails/hoc_signup_2015_receipt.md.actionview
+++ b/pegasus/emails/hoc_signup_2015_receipt.md.actionview
@@ -1,0 +1,42 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Thanks for signing up to host an Hour of Code!"
+litmus_tracking_id: "5g5lyi1a"
+---
+<% hostname = CDO.canonical_hostname('hourofcode.com') %>
+
+# Thanks for signing up to host an Hour of Code!
+
+You're making it possible for students all around the world to learn one Hour of Code that can change the rest of their lives, during Dec. 7-13. 
+
+*Every* Hour of Code organizer worldwide will receive a gift card to Amazon, iTunes, or Windows Store as a thank-you gift while supplies last. [And there are more awesome prizes](https://<%= hostname %>/prizes).
+
+#### We'll be in touch about new tutorials and other exciting updates. What can you do now?
+
+## 1. Find a local volunteer to help you with your event.
+[Search our volunteer map](https://code.org/volunteer/local) for volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.
+
+## 2. Spread the word
+We need your help to reach organizers worldwide. Tell your friends about the #HourOfCode. [Use these helpful resources](https://<%= hostname %>/promote/resources) to promote your event.
+
+## 3. Recruit your whole school for the Hour of Code
+[Send this email](https://<%= hostname %>/promote/resources#sample-emails) to your principal or [share these handouts](https://<%= hostname %>/promote/resources).
+
+## 4. Ask your employer to get involved
+[Send this email](https://<%= hostname %>/promote/resources#sample-emails) to your manager, or the CEO.
+
+## 5. Promote the Hour of Code in your community
+Recruit a local group or even some friends. [Send this email](https://<%= hostname %>/resources#sample-emails).
+
+Thank you for leading the movement to give every student the chance to learn foundational computer science skills. 
+
+Hadi Partovi<br />
+Founder, Code.org
+
+<hr/>
+<small>
+You're receiving this email because you signed up for the Hour of Code, supported by more than 200 partners and organized by Code.org. Code.org is a 501c3 non-profit. Our address is 1301 5th Ave, Suite 1225, Seattle, WA, 98101. Don't want these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)
+

--- a/pegasus/emails/hoc_signup_2017_receipt_en.md.actionview
+++ b/pegasus/emails/hoc_signup_2017_receipt_en.md.actionview
@@ -1,0 +1,51 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Get ready for the Hour of Code"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+  <% storedotcodedotorg = CDO.canonical_hostname('store.code.org') %>
+
+### Thanks for signing up to host an Hour of Code!
+As a thank you for helping make it possible for students to start learning computer science, we'd like to give you a [free set of 12 professionally printed posters featuring diverse role models for your classroom](https://<%= storedotcodedotorg %>/products/code-org-posters-set-of-12). Use offer code FREEPOSTERS at checkout. (This code is good through 12/31 while supplies last. Since these posters ship from the United States, shipping costs can be quite high if shipping to Canada and internationally. We understand that this may not be in your budget, and we encourage you to print the [PDF files](https://<%= hourofcode %>/promote/resources#posters) for your classroom.)
+
+<% if form.data["hoc_event_country_s"] == 'US' %>
+Thanks to the generosity of Ozobot, Dexter Industries, littleBits, and Wonder Workshop, over 100 classrooms will be selected to receive robots or circuits for their class! To be eligible to receive a set, make sure to complete the survey sent from Code.org after the Hour of Code. Code.org will select the winning classrooms. Please note that this is only open for US schools.
+
+<% end %>
+Hour of Code runs December 4-10. We'll be in touch about new tutorials and other exciting updates as they come out. **In the meantime, what can you do now?**
+
+### 1. Find a local volunteer to help you with your event.
+[Search our volunteer map](https://<%= codedotorg %>/volunteer/local) for volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.
+
+### 2. Spread the word & recruit your whole school
+We need your help to reach organizers worldwide. Tell your friends about the #HourOfCode. [Use these helpful resources](https://<%= hourofcode %>/promote/resources) to promote your event.
+
+Help recruit more people from your school and community by [sending our sample emails](https://<%= hourofcode %>/promote/resources#sample-emails) to your principal, a local group, or even some friends.
+
+### 3. Start planning your event
+Choose an [Hour of Code activity](https://<%= hourofcode %>/learn) for your classroom and [review this how-to guide](https://<%= hourofcode %>/how-to).
+
+### From an Hour of Code to years of computer science
+<% if form.data["hoc_event_country_s"] == 'US' %>
+An Hour of Code is just the beginning. Whether you are an administrator, teacher, or advocate, we have [professional learning, curriculum, and resources to help you bring computer science classes to your school or expand your offerings.](https://<%= codedotorg %>/yourschool) If you already teach computer science, use these resources during CS Education Week to rally support from your administration, parents, and community.
+
+You have many choices to fit your school. Most of the organizations offering Hour of Code tutorials also have curriculum and professional learning available. If you find a lesson you like, ask about going further. To help you get started, we've highlighted a number of [curriculum providers that will help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond)
+<% else %>
+An Hour of Code is just the beginning. Most of the organizations offering Hour of Code lessons also have curriculum available to go further. To help you get started, we've highlighted a number of [curriculum providers that will help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond) 
+
+Code.org also offers full [introductory computer science courses](https://<%= codedotorg %>/educate/curriculum/cs-fundamentals-international) translated into over 25 languages at no cost to you or your school.
+<% end %>
+ 
+Thank you for leading the movement to give every student the chance to learn foundational computer science skills.
+ 
+Hadi Partovi<br />
+Founder, Code.org<br />
+
+<hr/>
+<small>
+You're receiving this email because you signed up for the Hour of Code, supported by more than 200 partners and organized by Code.org. Code.org is a 501c3 non-profit. Our address is [1501 4th Avenue, Suite 900, Seattle, WA 98101](https://maps.google.com/?q=1501+4th+Avenue,+Suite+900,+Seattle,+WA+98101&entry=gmail&source=g). Don't want these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/hoc_signup_2018_receipt_en.md.actionview
+++ b/pegasus/emails/hoc_signup_2018_receipt_en.md.actionview
@@ -1,0 +1,47 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Get ready for the Hour of Code"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+  <% storedotcodedotorg = CDO.canonical_hostname('store.code.org') %>
+
+### Thanks for signing up to host an Hour of Code!
+Thank you for helping make it possible for students to start learning computer science! Computer Science Education Week and the Hour of Code run from December 3-9, and we couldn't be more excited. 
+
+As a special thank you to Hour of Code organizers, we have a new poster set featuring Malala, Stephen Curry, Shakira and more available to order at a [50% discount from Amazon](https://www.amazon.com/promocode/A3QAYNZUZTSSNQ). This year, each set comes with 6 posters and 126 "I did the Hour of Code" stickers. With the discount you'll get them for less than our cost to make them. Supplies are limited, so order your posters soon. If you're not in the United States, you can [download and print all posters](https://hourofcode.com/promote/resources#posters).
+
+In the meantime, what can you do now?
+
+### 1. Find a local volunteer to help you with your event.
+[Search our volunteer map](https://<%= codedotorg %>/volunteer/local) to find volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.
+
+### 2. Spread the word & recruit your whole school
+We need your help to reach organizers worldwide. Tell your friends about the #HourOfCode. [Use these helpful resources](https://<%= hourofcode %>/promote/resources) to promote your event.
+
+Help recruit more people from your school and community by [sending our sample emails](https://<%= hourofcode %>/promote/resources#sample-emails) to your principal, a local group, or even some friends.
+
+### 3. Start planning your event
+Choose an [Hour of Code activity](https://<%= hourofcode %>/learn) for your classroom and [review this how-to guide](https://<%= hourofcode %>/how-to) for more information on getting started.
+
+### 4. Stock up on swag
+Order materials to help get students excited about your event by heading to the Code.org [Amazon store](https://www.amazon.com/stores/page/8557B2A6-EBF2-4C9F-95C5-C3256FBA0220). [Order posters](https://www.amazon.com/promocode/A3QAYNZUZTSSNQ) (and get an extra 50% off), Hour of Code kits, stickers, and more! But hurry, supplies are limited.   
+
+### From an Hour of Code to years of computer science
+<% if form.data["hoc_event_country_s"] == 'US' %> An Hour of Code is just the beginning. Whether you’re an administrator, teacher, or advocate, we have [professional learning, curriculum, and resources to help you bring computer science classes to your school or expand your offerings.](https://<%= codedotorg %>/yourschool) If you already teach computer science, use these resources during CS Education Week to rally support!
+
+If you find an Hour of Code activity you like, ask about going further. Most of the organizations offering activities have curriculum and professional learning available as well. To help you get started, we've highlighted [curriculum providers that can help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond) <% else %> An Hour of Code is just the beginning. Most of the organizations offering Hour of Code lessons also have curriculum available to go further. To help you get started, we've highlighted a number of [curriculum providers that will help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond)
+
+Code.org also offers full [introductory computer science courses](https://<%= codedotorg %>/educate/curriculum/cs-fundamentals-international) translated into over 25 languages at no cost to you or your school. <% end %>
+Thank you for leading the movement to give every student the chance to learn foundational computer science skills.
+
+Hadi Partovi<br />
+Founder, Code.org<br />
+
+<hr/>
+<small>
+You're receiving this email because you signed up for the Hour of Code, supported by more than 200 partners and organized by Code.org. Code.org is a 501c3 non-profit. Our address is [1501 4th Avenue, Suite 900, Seattle, WA 98101](https://maps.google.com/?q=1501+4th+Avenue,+Suite+900,+Seattle,+WA+98101&entry=gmail&source=g). Don't want these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/hoc_signup_2018_receipt_es.md.actionview
+++ b/pegasus/emails/hoc_signup_2018_receipt_es.md.actionview
@@ -1,0 +1,37 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hostname = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+
+# ¡Gracias por inscribirte para ser anfitrión de una Hora de Código!
+Usted está haciendo posible para que los estudiantes de todo el mundo aprendan una Hora de Código que puede cambiar el resto de sus vidas, durante los días del 1 al 7 de octubre. Estaremos en contacto sobre nuevos tutoriales y otras noticias interesantes. ¿Qué puede usted hacer ahora?
+
+## 1. Encuentre a un voluntario local para ayudarle con su evento.
+[Buscar en nuestro mapa del voluntariado](https://<%= codedotorg %>/volunteer/local) para que los voluntarios puedan visitar tu aula o hagan un videochat remotamente para inspirar a tus estudiantes acerca de la amplitud de posibilidades con las Ciencias de la Computación.
+
+## 2. Corre la voz
+Necesitamos su ayuda para llegar a los organizadores en todo el mundo. ¡Habla a tus amigos de la #HoraDeCódigo! [Use estos recursos útiles](https://<%= hostname %>/promote/resources) para promocionar tu evento.
+
+## 3. Pídele a tu escuela que ofrezca una Hora de Código
+[Envíe este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails) o [comparte estos folletos](https://<%= hostname %>/promote/resources) a su director y desafíe a cada clase de su escuela para que se inscriba.
+
+## 4. Pídele a tu compañía que se involucre
+[Envia este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails) a tu gerente o director general.
+
+## 5. Promociona la Hora de Código en tu comunidad
+Recluta a un grupo local o incluso algunos amigos. [Enviar este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails).
+
+Gracias por dirigir el movimiento para dar a cada estudiante la oportunidad de aprender habilidades informáticas fundacionales.
+
+Hadi Partovi<br />
+Fundador, Code.org
+
+<hr/>
+<small>
+Estás recibiendo este correo electrónico porque usted se registro para la Hora de Código, apoyado por más de 200 socios y organizado por Code.org. Code.org es una 501c3 sin fines de lucro. Nuestra dirección es 1501 4th Avenue, Suite 900, Seattle, WA 98101. ¿No quieres estos correos? [Darse de baja](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/hoc_signup_2018_receipt_pt.md.actionview
+++ b/pegasus/emails/hoc_signup_2018_receipt_pt.md.actionview
@@ -1,0 +1,37 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Obrigado por se inscrever para sediar a Hora do Código!"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hostname = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+
+# Obrigado por se inscrever para organizar um evento da Hora do Código!
+Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, no período de 2 a 8 de outubro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
+
+## 1. Encontre um voluntário para ajudá-lo no evento.
+[Busque em nosso mapa de voluntários](https://<%= codedotorg %>/volunteer/local) voluntários que possam visitar sua sala de aula ou fazer um chat de vídeo remotamente para inspirar seus alunos, falando sobre a imensidão de possibilidades que a Ciência da Computação proporciona.
+
+## 2. Divulgue
+Precisamos da sua ajuda para alcançar organizadores do mundo todo. Fale para os seus amigos sobre a #HoraDoCodigo. [Use estes recursos](https://<%= hostname %>/promote/resources) para promover seu evento.
+
+## 3. Convide sua escola inteira para participar da Hora do Código
+[Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails) para o diretor ou [compartilhe estes materiais](https://<%= hostname %>/promote/resources).
+
+## 4. Peça para que sua empresa participe
+[Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails) para seu gerente ou CEO.
+
+## 5. Promova a Hora do Código na sua comunidade
+Reúna um grupo da sua região ou mesmo alguns amigos. [Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails).
+
+Obrigado por participar deste movimento e por dar aos alunos a chance de aprender as habilidades básicas da Ciência da Computação.
+
+Hadi Partovi<br />
+Fundador da Code.org
+
+<hr/>
+<small>
+Você está recebendo este e-mail porque você se cadastrou na Hora do Código, apoiada por mais de 200 parceiros e organizada pela Code.org. A Code.org é uma organização sem fins lucrativos. Nosso endereço é: 1501 4th Avenue, Suite 900, Seattle, WA 98101. Não quer receber esses e-mails? [Cancele sua assinatura](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/hoc_signup_2019_receipt_en.md.actionview
+++ b/pegasus/emails/hoc_signup_2019_receipt_en.md.actionview
@@ -1,0 +1,45 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Get ready for the Hour of Code"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+  <% storedotcodedotorg = CDO.canonical_hostname('store.code.org') %>
+
+### Thanks for signing up to host an Hour of Code!
+Thank you for helping make it possible for students to start learning computer science! Computer Science Education Week and the Hour of Code run from December 9-15, and we couldn't be more excited.
+
+In the meantime, what can you do now?
+
+### 1. Find a local volunteer to help you with your event.
+[Search our volunteer map](https://<%= codedotorg %>/volunteer/local) to find volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.
+
+### 2. Spread the word & recruit your whole school
+We need your help to reach organizers worldwide. Tell your friends about the #HourOfCode. [Use these helpful resources](https://<%= hourofcode %>/promote/resources) to promote your event.
+
+Help recruit more people from your school and community by [sending our sample emails](https://<%= hourofcode %>/promote/resources#sample-emails) to your principal, a local group, or even some friends.
+
+### 3. Start planning your event
+Choose an [Hour of Code activity](https://<%= hourofcode %>/learn) for your classroom and [review this how-to guide](https://<%= hourofcode %>/how-to) for more information on getting started.
+
+### 4. Stock up on swag
+Order materials to help get students excited about your event by heading to the Code.org [Amazon store](https://www.amazon.com/stores/page/8557B2A6-EBF2-4C9F-95C5-C3256FBA0220). [Order posters](https://www.amazon.com/dp/B07J6T18DH?m=A2ZEA2ORKPFEVK), Hour of Code kits, stickers, and more! But hurry, supplies are limited.
+
+### From an Hour of Code to years of computer science
+<% if form.data["hoc_event_country_s"] == 'US' %> An Hour of Code is just the beginning. Whether you’re an administrator, teacher, or advocate, we have [professional learning, curriculum, and resources to help you bring computer science classes to your school or expand your offerings.](https://<%= codedotorg %>/yourschool) If you already teach computer science, use these resources during CS Education Week to rally support!
+
+If you find an Hour of Code activity you like, ask about going further. Most of the organizations offering activities have curriculum and professional learning available as well. To help you get started, we've highlighted [curriculum providers that can help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond) <% else %> An Hour of Code is just the beginning. Most of the organizations offering Hour of Code lessons also have curriculum available to go further. To help you get started, we've highlighted a number of [curriculum providers that will help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond)
+
+Code.org also offers full [introductory computer science courses](https://<%= codedotorg %>/educate/curriculum/cs-fundamentals-international) translated into over 25 languages at no cost to you or your school. <% end %>
+Thank you for leading the movement to give every student the chance to learn foundational computer science skills.
+
+Hadi Partovi<br />
+Founder, Code.org<br />
+
+<hr/>
+<small>
+You're receiving this email because you signed up for the Hour of Code, supported by more than 200 partners and organized by Code.org. Code.org is a 501c3 non-profit. Our address is [1501 4th Avenue, Suite 900, Seattle, WA 98101](https://maps.google.com/?q=1501+4th+Avenue,+Suite+900,+Seattle,+WA+98101&entry=gmail&source=g). Don't want these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/hoc_signup_2019_receipt_es.md.actionview
+++ b/pegasus/emails/hoc_signup_2019_receipt_es.md.actionview
@@ -1,0 +1,37 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hostname = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+
+# ¡Gracias por inscribirte para ser anfitrión de una Hora de Código!
+Usted está haciendo posible para que los estudiantes de todo el mundo aprendan una Hora de Código que puede cambiar el resto de sus vidas, durante los días del 7 al 13 de octubre. Estaremos en contacto sobre nuevos tutoriales y otras noticias interesantes. ¿Qué puede usted hacer ahora?
+
+## 1. Encuentre a un voluntario local para ayudarle con su evento.
+[Buscar en nuestro mapa del voluntariado](https://<%= codedotorg %>/volunteer/local) para que los voluntarios puedan visitar tu aula o hagan un videochat remotamente para inspirar a tus estudiantes acerca de la amplitud de posibilidades con las Ciencias de la Computación.
+
+## 2. Corre la voz
+Necesitamos su ayuda para llegar a los organizadores en todo el mundo. ¡Habla a tus amigos de la #HoraDeCódigo! [Use estos recursos útiles](https://<%= hostname %>/promote/resources) para promocionar tu evento.
+
+## 3. Pídele a tu escuela que ofrezca una Hora de Código
+[Envíe este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails) o [comparte estos folletos](https://<%= hostname %>/promote/resources) a su director y desafíe a cada clase de su escuela para que se inscriba.
+
+## 4. Pídele a tu compañía que se involucre
+[Envia este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails) a tu gerente o director general.
+
+## 5. Promociona la Hora de Código en tu comunidad
+Recluta a un grupo local o incluso algunos amigos. [Enviar este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails).
+
+Gracias por dirigir el movimiento para dar a cada estudiante la oportunidad de aprender habilidades informáticas fundacionales.
+
+Hadi Partovi<br />
+Fundador, Code.org
+
+<hr/>
+<small>
+Estás recibiendo este correo electrónico porque usted se registro para la Hora de Código, apoyado por más de 200 socios y organizado por Code.org. Code.org es una 501c3 sin fines de lucro. Nuestra dirección es 1501 4th Avenue, Suite 900, Seattle, WA 98101. ¿No quieres estos correos? [Darse de baja](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/hoc_signup_2019_receipt_pt.md.actionview
+++ b/pegasus/emails/hoc_signup_2019_receipt_pt.md.actionview
@@ -1,0 +1,37 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Obrigado por se inscrever para sediar a Hora do Código!"
+litmus_tracking_id: "5g5lyi1a"
+---
+  <% hostname = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+
+# Obrigado por se inscrever para organizar um evento da Hora do Código!
+Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, no período de 9 a 15 de dezembro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
+
+## 1. Encontre um voluntário para ajudá-lo no evento.
+[Busque em nosso mapa de voluntários](https://<%= codedotorg %>/volunteer/local) voluntários que possam visitar sua sala de aula ou fazer um chat de vídeo remotamente para inspirar seus alunos, falando sobre a imensidão de possibilidades que a Ciência da Computação proporciona.
+
+## 2. Divulgue
+Precisamos da sua ajuda para alcançar organizadores do mundo todo. Fale para os seus amigos sobre a #HoraDoCodigo. [Use estes recursos](https://<%= hostname %>/promote/resources) para promover seu evento.
+
+## 3. Convide sua escola inteira para participar da Hora do Código
+[Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails) para o diretor ou [compartilhe estes materiais](https://<%= hostname %>/promote/resources).
+
+## 4. Peça para que sua empresa participe
+[Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails) para seu gerente ou CEO.
+
+## 5. Promova a Hora do Código na sua comunidade
+Reúna um grupo da sua região ou mesmo alguns amigos. [Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails).
+
+Obrigado por participar deste movimento e por dar aos alunos a chance de aprender as habilidades básicas da Ciência da Computação.
+
+Hadi Partovi<br />
+Fundador da Code.org
+
+<hr/>
+<small>
+Você está recebendo este e-mail porque você se cadastrou na Hora do Código, apoiada por mais de 200 parceiros e organizada pela Code.org. A Code.org é uma organização sem fins lucrativos. Nosso endereço é: 1501 4th Avenue, Suite 900, Seattle, WA 98101. Não quer receber esses e-mails? [Cancele sua assinatura](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/hoc_survey_2014_receipt.md.actionview
+++ b/pegasus/emails/hoc_survey_2014_receipt.md.actionview
@@ -1,0 +1,69 @@
+---
+from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
+subject: "Your gift code"
+---
+## Thank you! Use this code to redeem your gift:
+
+- Gift Type: <%= local_assigns.fetch(:prize_choice_s, "") %>
+- Gift Code: `<%= local_assigns.fetch(:prize_code_s, "") %>`
+
+<% if defined?(prize_choice_s) && prize_choice_s == "Dropbox" %>
+Note: Dropbox space expires 1 year after it's applied to your account. Limit one redemption per organizer. Redeem your gift at [https://www.dropbox.com/coupons](https://www.dropbox.com/coupons).
+<% end %>
+
+<% if defined?(prize_choice_s) && prize_choice_s == "Skype" %>
+
+**To redeem your Skype gift code:**
+1. Sign into your Skype account [on your browser](http://www.skype.com/go/myaccount).
+2. Scroll down to "Billing and Payments" and click "Redeem Voucher."
+
+![image](https://code.org/images/email/fit-200/skype_redeem_voucher.jpg)
+
+3. Enter your voucher number and submit.
+
+<% end %>
+
+## If you enjoyed the Hour of Code, consider going beyond
+
+<% if defined?(event_country_s) && event_country_s == 'United States' && ((['Pre-kindergarten','Kindergarten','1st','2nd','3rd','4th','5th','6th'] & students_grade_levels_ss).first) %>
+
+Our learning platform Code Studio offers [multiple 20-lesson courses for elementary grades](https://code.org/k5).  We offer high-quality one day weekend-workshops with computer science experts to help you get started. [Find a workshop near you](https://code.org/k5). 
+
+<% else %>
+
+Across all grade levels, find [student-guided learning options](https://code.org/learn/beyond) and [educational/curriculum resources for teachers](https://code.org/educate/3rdparty). Our own Code Studio offers [courses for elementary grades](https://code.org/k5). Please, recruit more teachers to help expose the youngest students to computer science at an early age. 
+
+<% end %>
+
+<% if defined?(event_location_type_s) && ['Public school','Public charter school','Private school','Parochial/Religious school','After school'].include?(event_location_type_s) %>
+
+## Ask us to visit your school
+While we get asked often, we’re usually not able to speak at school assemblies, but we'd love to help *when* we can. If you’re interested in hosting a Code.org ambassador, [let us know here](http://code.org/visit) and we’ll reach out if a visit becomes possible.
+
+<% end %>
+
+<% if local_assigns.fetch(:teacher_description_s, "") == 'Computer Science teacher' || local_assigns.fetch(:teacher_plan_teach_cs_s, "") == 'Yes' %>
+
+## Add your classroom to the Code.org map
+
+If you’re teaching computer science or computer programming, we’d love to include your class in our classroom database for students and parents. 
+
+Step 1) Check if your classroom or course is [already listed on the map](http://code.org/learn/local).  
+Step 2) If it’s not, please [add it by submitting information on your class](http://code.org/schools/new).
+
+<% end %>
+
+<% if local_assigns.fetch(:event_country_s, "") != 'United States' %>
+## Want to get more involved in <%= local_assigns.fetch(:event_country_s, 'your country') %>?
+[Join our international mailing list](https://docs.google.com/forms/d/1qYJFBjXRRiCchqtYunTUy7qyYwNHpUIZKAxh1T-bGL8/viewform) to be updated by our international partners, and find out how you can promote computer science education near you.
+<% end %>
+
+
+
+<p><br/>
+<hr/></p>
+
+You’re receiving this email because you signed up to host an Hour of Code at [hourofcode.com](https://hourofcode.com/). We’ll send you only a few updates a year on new ways to learn or help. Don’t like these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)
+

--- a/pegasus/emails/petition_receipt.md.actionview
+++ b/pegasus/emails/petition_receipt.md.actionview
@@ -1,0 +1,68 @@
+---
+from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
+subject: 'Thanks!'
+litmus_tracking_id: 'sfgaovfs'
+---
+
+## Thank you for signing your name to support computer science!
+
+[<button>Like us on Facebook](https://facebook.com/Codeorg)[<button>Follow us on Twitter](https://twitter.com/codeorg)
+
+#### Help the world learn how to code:
+
+## 1) Learn yourself (or have your child learn)
+
+[Learn online](https://code.org/learn) or [find local schools, camps, or workshops](https://code.org/learn/local) that teach coding.
+
+<% if defined?(role_s) && ['educator'].include?(role_s) %>
+
+## 2) [Host an Hour of Code](https://hourofcode.com) during Computer Science Education Week
+
+Help students worldwide learn their first Hour of Code, to show that anyone can learn the basics. Help us celebrate this year's Computer Science Education Week by leading your students through one Hour of Code!
+
+<% else %>
+
+## 2) [Host an Hour of Code](https://hourofcode.com) at work, in your community, or local school
+
+During this year's Computer Science Education Week in December, help students worldwide learn their first Hour of Code. Organize an Hour of Code event at your office, a local school, or anywhere in your community. Or [try it yourself](https://code.org/learn).
+
+<% end %>
+
+<% if defined?(role_s) && ['educator'].include?(role_s) %>
+
+## 3) Teach computer science
+
+You can teach these self-serve [intro courses](https://studio.code.org), with professional development included, inspire students with [these videos](https://code.org/educate/inspire), or partner with us to bring computer science [to your district or region](https://code.org/educate/partner). 
+
+<% else %>
+
+## 3) Ask your local school to [teach computer science](https://code.org/educate)
+
+Here's a [sample letter](https://code.org/promote/letter) to send to your school! Your local school can teach these [intro courses](https://studio.code.org), partner with us to bring computer science [to your entire district or region](https://code.org/educate/partner), and inspire students with [these videos](https://code.org/educate/inspire). Check [our map](https://code.org/learn/local) to see if your school teaches computer science. If not, ask them to.
+
+<% end %>
+
+## 4) Support our work
+
+[Make a generous donation](https://code.org/donate) or [buy a t-shirt or hat](https://store.code.org). We're working to give every student the opportunity to learn computer science. One child learns for every dollar you donate.
+
+## 5) Not in the United States? Sign up to receive updates about Code.org's International Program
+
+Code.org partners with dozens of organizations around the world to promote computer science education. [Get the latest news](http://go.pardot.com/l/153401/2018-07-20/lfw71d) about newsletters, webinars, and updates specifically for Code.org's international community. 
+
+In just a few years, support for computer science has impacted hundreds of thousands of classrooms and tens of millions of students. Many school districts, U.S. states, and even entire countries have joined the movement. 
+
+I won't email this list too often. Please follow our progress [on Facebook](https://facebook.com/Code.org) or [on Twitter](https://twitter.com/codeorg) to stay in touch.
+
+Thank you so much for your support,<br/>
+Hadi Partovi <br/>
+Founder, Code.org
+
+<hr>
+
+<small>You’re receiving this email because you signed the petition on <a href="https://Code.org/">Code.org</a>. Code.org is a 501c3 non-profit. Our address is 1501 4th Avenue, Suite 900, Seattle, WA 98101.</small> <br />
+<small><strong>Don't like these emails? [Unsubscribe here](<%= local_assigns.fetch(:unsubscribe_link, "") %>).</strong></small>
+
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)
+

--- a/pegasus/emails/student_nomination_notice.md.actionview
+++ b/pegasus/emails/student_nomination_notice.md.actionview
@@ -1,0 +1,20 @@
+---
+from: '"Pegasus (Code.org)" <pegasus@code.org>'
+to: '"Marketing" <marketing@code.org>'
+subject: Student Nominated
+---
+## Student Nominated
+
+- Nominator: <%= name_s %> [<%= email_s %>](<%= email_s %>)
+- Relationship: <%= local_assigns.fetch(:relationship_s, "") %>
+- Student: <%= local_assigns.fetch(:student_name_s, "") %> [<%= local_assigns.fetch(:student_email_s, "") %>](<%= local_assigns.fetch(:student_email_s, "") %>)
+- Student Link: [<%= local_assigns.fetch(:student_link_s, "") %>](<%= local_assigns.fetch(:student_link_s, "") %>)
+- Grade: <%= local_assigns.fetch(:student_grade_i, "") %>
+- School: <%= local_assigns.fetch(:school_name_s, "") %>
+- School Zip Code: <%= local_assigns.fetch(:school_zip_code_s, "") %>.
+
+### Message
+
+<pre><%= local_assigns.fetch(:message_s, "") %></pre>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/teacher_nomination_notice.md.actionview
+++ b/pegasus/emails/teacher_nomination_notice.md.actionview
@@ -1,0 +1,20 @@
+---
+from: '"Pegasus (Code.org)" <pegasus@code.org>'
+to: '"Marketing" <marketing@code.org>'
+subject: Teacher Nominated
+---
+## Teacher Nominated
+
+- Nominator: <%= name_s %> [<%= email_s %>](<%= email_s %>)
+- Relationship: <%= relationship_s %>
+- Teacher: <%= teacher_name_s %> [<%= teacher_email_s %>](<%= teacher_email_s %>)
+- Teacher Subject: <%= teacher_subject_s %>
+- Teacher Link: [<%= teacher_link_s %>](<%= teacher_link_s %>)
+- School: <%= school_name_s %>
+- School Zip Code: <%= school_zip_code_s %>.
+
+### Message
+
+<pre><%= message_s %></pre>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/volunteer_contact_2015_receipt.md.actionview
+++ b/pegasus/emails/volunteer_contact_2015_receipt.md.actionview
@@ -5,9 +5,9 @@ def format_email_address(email, name='')
   "#{name} <#{email}>".strip
 end
 %>
-to: <%= format_email_address(volunteer_email_s, volunteer_name_s).inspect %>
+to: <%= format_email_address(volunteer_email_s, volunteer_name_s).inspect.html_safe %>
 from: 'Code.org Volunteers <volunteers@code.org>'
-reply-to: <%= format_email_address(email_s, name_s).inspect %>
+reply-to: <%= format_email_address(email_s, name_s).inspect.html_safe %>
 subject: "A teacher is requesting your help"
 ---
 
@@ -54,6 +54,6 @@ Getting too many email requests? It means there aren't enough volunteers in your
 
 - [Unsubscribe from additional teacher requests **this year**](<%= update_preferences %>)
 - [Unsubscribe from teacher requests **forever**](<%= update_preferences %>)
-- [Unsubscribe from all Code.org emails](<%= unsubscribe_link %>)
+- [Unsubscribe from all Code.org emails](<%= local_assigns.fetch(:unsubscribe_link, "") %>)
 
-![](<%= tracking_pixel %>)
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/volunteer_engineer_submission_receipt.md.actionview
+++ b/pegasus/emails/volunteer_engineer_submission_receipt.md.actionview
@@ -1,0 +1,28 @@
+---
+from: 'Code.org Volunteers <volunteers@code.org>'
+subject: Volunteer Submission Received
+---
+<% hostname = CDO.canonical_hostname('hourofcode.com') %>
+<% update_preferences = "http://#{CDO.canonical_hostname('code.org')}/volunteer/engineer/edit/#{form.secret}/" %>
+
+Thank you for submitting your information to help local teachers. Teachers will be using this [map of volunteers](https://code.org/volunteer/local) to find and contact volunteers like you. You can review [this guide](https://code.org/volunteer/guide) to get a better idea of what your volunteer experience will be like and to review tips for connecting with students.
+
+If you need to update your information or want to unsubscribe from teacher requests, use this link:
+
+<%= "https://#{CDO.canonical_hostname('code.org')}/volunteer/engineer/edit/#{form.secret}/" %>
+
+Thanks again for your support,
+
+Alice Steinglass<br/>
+President, Code.org
+
+<hr/>
+
+Code.org is a 501c3 non-profit. Our address is 1501 4th Avenue, Suite 900, Seattle, WA 98101. You can update your email preferences and edit your submitted information at any time.
+
+- [Edit my information](<%= update_preferences %>)
+- [Unsubscribe from additional teacher requests **this year**](<%= update_preferences %>)
+- [Unsubscribe from teacher requests **forever**](<%= update_preferences %>)
+- [Unsubscribe from all Code.org emails](<%= local_assigns.fetch(:unsubscribe_link, "") %>)
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/volunteer_translator_notice.md.actionview
+++ b/pegasus/emails/volunteer_translator_notice.md.actionview
@@ -1,0 +1,13 @@
+---
+from: '"Pegasus (Code.org)" <pegasus@code.org>'
+to: '"Tanya Parker" <translations@code.org>'
+subject: New Translation Volunteer
+---
+## New Translation Volunteer
+
+- First Name: <%= first_name_s %>
+- Last Name: <%= last_name_s %> 
+- Email [<%= email_s %>](<%= email_s %>)
+- See database for languages
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/32607, this is a proposal to switch our Poste emails over to also use the ActionView renderer.

Specifically, this PR contains the work to add a parallel, ActionView-compatible set of templates alongside our existing email templates. Whenever we would send an email, we render both the old template with the old renderer and the new template with the new renderer, and log any errors or rendering differences to Honeybadger.

Once this has been live for long enough for us to be confident that a switch will result in no user-visible differences, we can remove the old rendering logic and switch entirely to ActionView.

This is perhaps an overcautious approach to the switchover, but given the amount of minor issues that came out of the earlier switchover and our relative lack of visibility into emails, I think it's justified.

## Why not ...

### ... render the same template in both renderers?

One of the big differences that comes with the switchover to ActionView is the "unescaped by default" logic laid out in the "ActionView in Sinatra" PR. In order to render the same template in both engines and get the same result, we'd either need to modify ActionView to no longer require `.html_safe` or update our own engine to define `html_safe` on the String class.

### ... have fewer Honeybadger reports?

Another big difference between the renderers is their treatment of undefined local variables; our existing renderer will silently default to `nil` if we try to use an undefined variable in the templates, while ActionView will throw an error. It's difficult to determine which local variables we can actually count on being passed to the view for our emails, so I expect a lot of attempts to render with ActionView to fail outright because of that.

With the `Error rendering email with ActionView` errors, we can track down which variables are optional for each template and update the corresponding template to be explicit about this optionality.

Then, once the templates are rendering without errors, I expect there to be a few places where we'll need to add `.html_safe` or implement other small rendering tweaks to get the exact same result; the `Incorrectly rendered email with ActionView` error will help with that.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1020)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
