### PR TITLE
Remove Litmus tracking

### DIFF
--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -339,7 +339,6 @@ class Deliverer
       params.merge(
         {
           recipient: OpenStruct.new(recipient),
-          encrypted_id: encrypted_id,
           unsubscribe_link: unsubscribe_url,
           tracking_pixel: poste_url("/o/#{encrypted_id}"),
         }

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2014_receipt/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2014_receipt/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Thanks for signing up to host an Hour of Code!
-litmus_tracking_id: 5g5lyi1a

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2015_receipt/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2015_receipt/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Thanks for signing up to host an Hour of Code!
-litmus_tracking_id: 5g5lyi1a

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2017_receipt_en/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2017_receipt_en/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Get ready for the Hour of Code
-litmus_tracking_id: 5g5lyi1a

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_en/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_en/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Get ready for the Hour of Code
-litmus_tracking_id: 5g5lyi1a

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_es/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_es/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
-litmus_tracking_id: 5g5lyi1a

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_pt/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_pt/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!
-litmus_tracking_id: 5g5lyi1a

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_en/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_en/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Get ready for the Hour of Code
-litmus_tracking_id: 5g5lyi1a

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_es/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_es/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
-litmus_tracking_id: 5g5lyi1a

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_pt/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_pt/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!
-litmus_tracking_id: 5g5lyi1a

--- a/lib/test/fixtures/deliverer/expected/petition_receipt/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/petition_receipt/header.yaml
@@ -1,4 +1,3 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Thanks!
-litmus_tracking_id: sfgaovfs

--- a/pegasus/emails/hoc_signup_2014_receipt.md
+++ b/pegasus/emails/hoc_signup_2014_receipt.md
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
-litmus_tracking_id: "5g5lyi1a"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>
 

--- a/pegasus/emails/hoc_signup_2015_receipt.md
+++ b/pegasus/emails/hoc_signup_2015_receipt.md
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
-litmus_tracking_id: "5g5lyi1a"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>
 

--- a/pegasus/emails/hoc_signup_2017_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2017_receipt_en.md
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Get ready for the Hour of Code"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_en.md
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Get ready for the Hour of Code"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_es.md
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_pt.md
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_en.md
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Get ready for the Hour of Code"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_es.md
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_pt.md
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/petition_receipt.md
+++ b/pegasus/emails/petition_receipt.md
@@ -1,7 +1,6 @@
 ---
 from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
 subject: 'Thanks!'
-litmus_tracking_id: 'sfgaovfs'
 ---
 
 ## Thank you for signing your name to support computer science!


### PR DESCRIPTION
[PLC-792](https://codedotorg.atlassian.net/browse/PLC-792): Remove litmus tracking code from our Poste mail system.

We noticed that we no longer use this service in [this discussion on February 28th](https://github.com/code-dot-org/code-dot-org/pull/33380#discussion_r385979912).  Since there are some other changes going on in the email system right now, this seems like a good time to remove the related code.

## Testing story

Strictly removing behavior here, so leaning on existing tests to cover this change.  I've updated a set of fixtures to remove the relevant litmus ids.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
