### PR TITLE
Preventing duplicate accounts from being created.

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -178,6 +178,13 @@ class User < ActiveRecord::Base
     end
   end
 
+  # Validate that a user with the same authentication credentials does not already exist.
+  validate on: :create, if: -> {uid.present?} do |user|
+    # If the user has a unique authentication ID, fail if there is an existing User with that ID.
+    other = User.find_by_credential(type: user.provider, id: user.uid)
+    user.errors.add(:uid, "User already exists with uid: #{user.uid} and provider: #{user.provider}") unless other.nil?
+  end
+
   has_many :teacher_feedbacks, foreign_key: 'teacher_id', dependent: :destroy
 
   belongs_to :school_info

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -22,7 +22,13 @@ class UserTest < ActiveSupport::TestCase
       user_type: User::TYPE_STUDENT,
       age: 8
     }
-
+    @good_data_google_classroom_import = {
+      name: 'tester',
+      user_type: User::TYPE_STUDENT,
+      age: 8,
+      provider: AuthenticationOption::GOOGLE,
+      uid: '110879982140384463192',
+    }
     @admin = create :admin
     @user = create :user
     @teacher = create :teacher
@@ -364,6 +370,20 @@ class UserTest < ActiveSupport::TestCase
     # Now create second user with duplicate username with different case
     user = User.create(@good_data_young.merge(hashed_email: User.hash_email(@good_data_young[:email].upcase)))
     assert_equal ['Email has already been taken'], user.errors.full_messages
+  end
+
+  test 'cannot create user when a user with the same credentials exists' do
+    User.create(@good_data_google_classroom_import)
+    duplicate_user = User.create(@good_data_google_classroom_import)
+    assert_not_empty(duplicate_user.errors)
+    assert(duplicate_user.errors[:uid])
+  end
+
+  test 'cannot create user when an non-migrated user with the same credentials exists' do
+    User.create(@good_data_google_classroom_import).demigrate_from_multi_auth
+    duplicate_user = User.create(@good_data_google_classroom_import)
+    assert_not_empty(duplicate_user.errors)
+    assert(duplicate_user.errors[:uid])
   end
 
   #


### PR DESCRIPTION
We discovered that duplicate User accounts were getting created when
looking at our database of Users. Although we couldn't find why
duplicate accounts were being created, we did verify that our User model
was not validating that an account already existed before trying to
create it.
* Validates the unique authentication ID for a User is unique.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1050)

## Testing story
* Verified the new unit test fail if the change is absent.
* Manually tested on localhost and successfully created a new user using my Google account.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
