### PR TITLE
Standardize registration of an ActionView Markdown handler

### DIFF
--- a/dashboard/config/initializers/markdown_handler.rb
+++ b/dashboard/config/initializers/markdown_handler.rb
@@ -1,43 +1,38 @@
 require 'nokogiri'
+require 'cdo/markdown_handler'
+
 # Add Markdown .md support to the ActionView template system.
-module MarkdownHandler
-  MARKDOWN_OPTIONS = {
-    autolink: true,
-    tables: true,
-    space_after_headers: true
-  }.freeze
+MARKDOWN_OPTIONS = {
+  autolink: true,
+  tables: true,
+  space_after_headers: true
+}.freeze
 
-  class CustomRewriter < Redcarpet::Render::HTML
-    # Rewrite YouTube iframe elements to use the fallback-player iframe instead.
-    def block_html(html)
-      doc = ::Nokogiri::HTML(html)
-      nodes = doc.xpath(%w(youtube youtubeeducation youtube-nocookie).map {|x| "//iframe[@src[contains(.,'#{x}.com/embed')]]"}.join(' | '))
-      nodes.each do |node|
-        next unless node['src']
-        id = node['src'].match(Video::EMBED_URL_REGEX)[:id]
-        node['src'] = node['src'].sub(
-          Video::EMBED_URL_REGEX,
-          Video.embed_url(id)
-        )
-      end
-      doc.css('body').children.to_html
+class CustomRewriter < Redcarpet::Render::HTML
+  # Rewrite YouTube iframe elements to use the fallback-player iframe instead.
+  def block_html(html)
+    doc = ::Nokogiri::HTML(html)
+    nodes = doc.xpath(%w(youtube youtubeeducation youtube-nocookie).map {|x| "//iframe[@src[contains(.,'#{x}.com/embed')]]"}.join(' | '))
+    nodes.each do |node|
+      next unless node['src']
+      id = node['src'].match(Video::EMBED_URL_REGEX)[:id]
+      node['src'] = node['src'].sub(
+        Video::EMBED_URL_REGEX,
+        Video.embed_url(id)
+      )
     end
-
-    # Open links in a new tab by default.
-    def link(link, title, content)
-      # `content` is already escaped by Redcarpet.
-      "<a target='_blank' href='#{Rack::Utils.escape_html(link)}' title='#{Rack::Utils.escape_html(title)}'>#{content}</a>"
-    end
-
-    def autolink(link, _)
-      link(link, nil, link)
-    end
+    doc.css('body').children.to_html
   end
 
-  def self.call(template)
-    @markdown ||= Redcarpet::Markdown.new(CustomRewriter, MARKDOWN_OPTIONS)
-    "#{@markdown.render(template.source).inspect}.html_safe"
+  # Open links in a new tab by default.
+  def link(link, title, content)
+    # `content` is already escaped by Redcarpet.
+    "<a target='_blank' href='#{Rack::Utils.escape_html(link)}' title='#{Rack::Utils.escape_html(title)}'>#{content}</a>"
+  end
+
+  def autolink(link, _)
+    link(link, nil, link)
   end
 end
 
-ActionView::Template.register_template_handler :md, MarkdownHandler
+MarkdownHandler.register(CustomRewriter, MARKDOWN_OPTIONS)

--- a/dashboard/test/config/initializers/markdown_handler_test.rb
+++ b/dashboard/test/config/initializers/markdown_handler_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class MarkdownHandlerTest < ActionView::TestCase
+  def setup
+    @actionview = ActionView::Base.new
+  end
+
+  test 'links open in new tabs by default' do
+    markdown = "[test](link)"
+    expected = "<p><a target='_blank' href='link' title=''>test</a></p>\n"
+    assert_equal expected, @actionview.render(inline: markdown, type: :md)
+  end
+
+  test 'autolinks open in new tabs by default' do
+    markdown = "http://example.com"
+    expected = "<p><a target='_blank' href='http:&#x2F;&#x2F;example.com' title=''>http://example.com</a></p>\n"
+    assert_equal expected, @actionview.render(inline: markdown, type: :md)
+  end
+
+  test 'youtube iframe elements use fallback player' do
+    markdown = "<iframe src='http://youtube.com/embed/samplevideo'></iframe>"
+    expected = "<iframe src=\"//test-studio.code.org/videos/embed/samplevideo\"></iframe>\n"
+    assert_equal expected, @actionview.render(inline: markdown, type: :md)
+  end
+end

--- a/lib/cdo/markdown_handler.rb
+++ b/lib/cdo/markdown_handler.rb
@@ -1,0 +1,18 @@
+require 'action_view'
+require 'redcarpet'
+
+# A simple helper to capture the logic of registering a markdown handler with
+# ActionView
+class MarkdownHandler
+  def initialize(renderer=Redcarpet::Render::HTML, options={})
+    @parser = Redcarpet::Markdown.new(renderer, options)
+  end
+
+  def call(template)
+    "#{@parser.render(template.source).inspect}.html_safe"
+  end
+
+  def self.register(*args)
+    ActionView::Template.register_template_handler :md, MarkdownHandler.new(*args)
+  end
+end

--- a/lib/cdo/pegasus/actionview_sinatra.rb
+++ b/lib/cdo/pegasus/actionview_sinatra.rb
@@ -1,8 +1,9 @@
 require 'action_view'
+require 'cdo/markdown_handler'
 require 'haml'
 require 'haml/template'
 require 'redcarpet'
-require 'cdo/markdown_handler'
+require 'sinatra/base'
 
 module ActionViewSinatra
   class MarkdownRenderer < Redcarpet::Render::HTML

--- a/lib/test/cdo/pegasus/test_actionview_sinatra.rb
+++ b/lib/test/cdo/pegasus/test_actionview_sinatra.rb
@@ -1,0 +1,27 @@
+require_relative '../../test_helper'
+require 'cdo/pegasus/actionview_sinatra'
+
+class ActionViewSinatraTest < Minitest::Test
+  def setup
+    @actionview = ActionViewSinatra::Base.new(self)
+    @locals = {variable: 'headline'}
+  end
+
+  def test_erb
+    assert_equal "<h1>headline</h1>", @actionview.render(inline: '<h1><%= variable %></h1>', type: :erb, locals: @locals)
+  end
+
+  def test_haml
+    assert_equal "<h1>headline</h1>\n", @actionview.render(inline: '%h1= variable', type: :haml, locals: @locals)
+  end
+
+  def test_markdown
+    assert_equal "<h1>headline</h1>\n", @actionview.render(inline: '# headline', type: :md)
+  end
+
+  def test_markdown_brackets_to_div_classes
+    markdown = "[classname]\n\nMy Text\n\n[/classname]"
+    expected = "<div class='classname'>\n\n<p>My Text</p>\n\n</div>\n"
+    assert_equal expected, @actionview.render(inline: markdown, type: :md)
+  end
+end

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -168,7 +168,6 @@ class Documents < Sinatra::Base
       # This is similar to the lazy loading we need to do for Haml:
       # https://github.com/code-dot-org/code-dot-org/blob/8a49e0f39e1bc98aac462a3eb049d0eeb6af3e06/lib/cdo/pegasus/text_render.rb#L82-L97
       require 'cdo/pegasus/actionview_sinatra'
-      ActionView::Template.register_template_handler :md, ActionViewSinatra::MarkdownHandler
       ActionViewSinatra::Base.new(self)
     end
 


### PR DESCRIPTION
We have a couple of different places where we are initializing ActionView now, so I'm adding a helper at `lib/cdo/markdown_handler.rb` to make it easier to hook up a redcarpet renderer.

We still do use two different redcarpet renderers in Dashboard vs Pegasus, so it's only the process of connecting the renderer to ActionView that can be standardized, not the process of declaring the renderer. Still, better than nothing.

I recommend reviewing [with whitespace changes ignored](https://github.com/code-dot-org/code-dot-org/pull/33414/files?w=1)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
