### PR TITLE
rewrite parse_yaml_header to implement parsing manually rather than with TextRender

### DIFF
--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -1,7 +1,6 @@
 require 'yaml'
 require 'cdo/erb'
 require 'cdo/pegasus/text_render'
-#require 'dynamic_config/dcdo'
 
 module Cdo
   # Extend YAML with customizations.

--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -1,14 +1,15 @@
 require 'yaml'
 require 'cdo/erb'
-require 'cdo/pegasus/text_render'
 
 module Cdo
   # Extend YAML with customizations.
   module YAMLExtension
-    def parse_yaml_header(content, locals={})
+    def parse_yaml_header(content, locals=nil)
       match = content.match(/\A\s*^(?<yaml>---\s*\n.*?\n?)^(---\s*$\n?)/m)
       return [{}, content] unless match
-      [TextRender.yaml(match[:yaml], locals), match.post_match]
+      yaml = match[:yaml]
+      yaml = ERB.new(yaml).result_with_hash(locals) if locals.present?
+      [YAML.safe_load(yaml), match.post_match]
     end
 
     # Return +nil+ if file not found.

--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -4,11 +4,11 @@ require 'cdo/erb'
 module Cdo
   # Extend YAML with customizations.
   module YAMLExtension
-    def parse_yaml_header(content, locals=nil)
+    def parse_yaml_header(content, locals={})
       match = content.match(/\A\s*^(?<yaml>---\s*\n.*?\n?)^(---\s*$\n?)/m)
       return [{}, content] unless match
       yaml = match[:yaml]
-      yaml = ERB.new(yaml).result_with_hash(locals) if locals.present?
+      yaml = ERB.new(yaml).result_with_hash(locals)
       [YAML.safe_load(yaml), match.post_match]
     end
 

--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -1,5 +1,7 @@
 require 'yaml'
 require 'cdo/erb'
+require 'cdo/pegasus/text_render'
+#require 'dynamic_config/dcdo'
 
 module Cdo
   # Extend YAML with customizations.
@@ -7,9 +9,17 @@ module Cdo
     def parse_yaml_header(content, locals={})
       match = content.match(/\A\s*^(?<yaml>---\s*\n.*?\n?)^(---\s*$\n?)/m)
       return [{}, content] unless match
-      yaml = match[:yaml]
-      yaml = ERB.new(yaml).result_with_hash(locals)
-      [YAML.safe_load(yaml), match.post_match]
+
+      # Implement new, TextRender-less parsing behind a DCDO flag so we can
+      # verify it doesn't have any unexpected side effects before switching
+      # over entirely.
+      if DCDO.get('parse_yaml_header-manually', true)
+        yaml = match[:yaml]
+        yaml = ERB.new(yaml).result_with_hash(locals)
+        [YAML.safe_load(yaml), match.post_match]
+      else
+        [TextRender.yaml(match[:yaml], locals), match.post_match]
+      end
     end
 
     # Return +nil+ if file not found.

--- a/lib/test/cdo/test_yaml.rb
+++ b/lib/test/cdo/test_yaml.rb
@@ -1,0 +1,36 @@
+require_relative '../test_helper'
+require 'cdo/yaml'
+
+class YamlTest < Minitest::Test
+  def test_parse_yaml_header
+    content = <<~CONTENT
+      ---
+      key: value
+      ---
+
+      body content
+    CONTENT
+
+    header, body = YAML.parse_yaml_header(content)
+    assert_equal({"key" => "value"}, header)
+    assert_equal "body content\n", body
+  end
+
+  def test_parse_yaml_header_erb_support
+    content = <<~CONTENT
+      ---
+      key: <%= value %>
+      ---
+
+      body content
+    CONTENT
+
+    header, body = YAML.parse_yaml_header(content)
+    assert_equal({"key" => "<%= value %>"}, header)
+    assert_equal "body content\n", body
+
+    header, body = YAML.parse_yaml_header(content, {value: "foo"})
+    assert_equal({"key" => "foo"}, header)
+    assert_equal "body content\n", body
+  end
+end

--- a/lib/test/cdo/test_yaml.rb
+++ b/lib/test/cdo/test_yaml.rb
@@ -25,9 +25,10 @@ class YamlTest < Minitest::Test
       body content
     CONTENT
 
-    header, body = YAML.parse_yaml_header(content)
-    assert_equal({"key" => "<%= value %>"}, header)
-    assert_equal "body content\n", body
+    # undefined local variables will throw an error
+    assert_raises NameError do
+      YAML.parse_yaml_header(content)
+    end
 
     header, body = YAML.parse_yaml_header(content, {value: "foo"})
     assert_equal({"key" => "foo"}, header)


### PR DESCRIPTION
Since we plan to remove TextRender soon

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1027)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
