### PR TITLE
Standards: migration to change user_level_id on teacher_score to bigint

### DIFF
--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -3,7 +3,7 @@
 # Table name: teacher_scores
 #
 #  id            :integer          not null, primary key
-#  user_level_id :integer
+#  user_level_id :integer          unsigned
 #  teacher_id    :integer
 #  score         :integer
 #  created_at    :datetime         not null

--- a/dashboard/db/migrate/20200304010927_change_user_level_id_to_bigint.rb
+++ b/dashboard/db/migrate/20200304010927_change_user_level_id_to_bigint.rb
@@ -1,0 +1,9 @@
+class ChangeUserLevelIdToBigint < ActiveRecord::Migration[5.0]
+  def up
+    change_column :teacher_scores, :user_level_id, 'BIGINT(11) UNSIGNED'
+  end
+
+  def down
+    change_column :teacher_scores, :user_level_id, :int
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200221223130) do
+ActiveRecord::Schema.define(version: 20200304010927) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1469,7 +1469,7 @@ ActiveRecord::Schema.define(version: 20200221223130) do
   end
 
   create_table "teacher_scores", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer  "user_level_id"
+    t.bigint   "user_level_id",              unsigned: true
     t.integer  "teacher_id"
     t.integer  "score"
     t.datetime "created_at",    null: false

--- a/dashboard/test/factories/teacher_scores.rb
+++ b/dashboard/test/factories/teacher_scores.rb
@@ -3,7 +3,7 @@
 # Table name: teacher_scores
 #
 #  id            :integer          not null, primary key
-#  user_level_id :integer
+#  user_level_id :integer          unsigned
 #  teacher_id    :integer
 #  score         :integer
 #  created_at    :datetime         not null


### PR DESCRIPTION
TeacherScores have a user_level_id field.  The UserLevels table on production has ids than exceed the allowed values for MySQL integer. This caused [HoneyBadger errors ](https://app.honeybadger.io/projects/3240/faults/61471127). To fix the issue, I ran a migration to change the user_level_id field to bigint.