### PR TITLE
Mark certain projects as translateable and sync the associated levels

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -133,8 +133,14 @@ class I18nScriptUtils
 
       hash[new_url] =
         if matches.nil?
-          STDERR.puts "could not find level for url: #{new_url}"
-          nil
+          project_url_regex = %r{https://studio.code.org/p/(?<project_name>[A-Za-z0-9\s\-_]+)}
+          project_matches = new_url.match(project_url_regex)
+          if project_matches.nil?
+            STDERR.puts "could not find level for url: #{new_url}"
+            nil
+          else
+            Level.find_by_name(ProjectsController::STANDALONE_PROJECTS[project_matches[:project_name]]['name'])
+          end
         elsif matches[:level_info].starts_with?("extras")
           level_info_regex = %r{extras\?level_name=(?<level_name>.+)}
           level_name = matches[:level_info].match(level_info_regex)[:level_name]

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -18,22 +18,28 @@ class ProjectsController < ApplicationController
   # @option {Boolean|nil} :login_required Whether you must be logged in to
   #   access this project type. Default: false.
   # @option {String|nil} :default_image_url If present, set this as the
+  # @option {Boolean|nil} :i18n If present, include this level in the i18n sync
   # thumbnail image url when creating a project of this type.
   STANDALONE_PROJECTS = {
     artist: {
-      name: 'New Artist Project'
+      name: 'New Artist Project',
+      i18n: true
     },
     artist_k1: {
-      name: 'New K1 Artist Project'
+      name: 'New K1 Artist Project',
+      i18n: true
     },
     frozen: {
-      name: 'New Frozen Project'
+      name: 'New Frozen Project',
+      i18n: true
     },
     playlab: {
-      name: 'New Play Lab Project'
+      name: 'New Play Lab Project',
+      i18n: true
     },
     playlab_k1: {
-      name: 'New K1 Play Lab Project'
+      name: 'New K1 Play Lab Project',
+      i18n: true
     },
     starwars: {
       name: 'New Star Wars Project'
@@ -42,16 +48,20 @@ class ProjectsController < ApplicationController
       name: 'New Star Wars Blocks Project'
     },
     starwarsblocks: {
-      name: 'New Star Wars Expanded Blocks Project'
+      name: 'New Star Wars Expanded Blocks Project',
+      i18n: true
     },
     iceage: {
-      name: 'New Ice Age Project'
+      name: 'New Ice Age Project',
+      i18n: true
     },
     infinity: {
-      name: 'New Infinity Project'
+      name: 'New Infinity Project',
+      i18n: true
     },
     gumball: {
-      name: 'New Gumball Project'
+      name: 'New Gumball Project',
+      i18n: true
     },
     flappy: {
       name: 'New Flappy Project',
@@ -68,16 +78,20 @@ class ProjectsController < ApplicationController
       name: 'New Minecraft Code Connection Project'
     },
     minecraft_adventurer: {
-      name: 'New Minecraft Adventurer Project'
+      name: 'New Minecraft Adventurer Project',
+      i18n: true
     },
     minecraft_designer: {
-      name: 'New Minecraft Designer Project'
+      name: 'New Minecraft Designer Project',
+      i18n: true
     },
     minecraft_hero: {
-      name: 'New Minecraft Hero Project'
+      name: 'New Minecraft Hero Project',
+      i18n: true
     },
     minecraft_aquatic: {
-      name: 'New Minecraft Aquatic Project'
+      name: 'New Minecraft Aquatic Project',
+      i18n: true
     },
     applab: {
       name: 'New App Lab Project',
@@ -93,10 +107,12 @@ class ProjectsController < ApplicationController
     },
     spritelab: {
       name: 'New Sprite Lab Project',
+      i18n: true
     },
     dance: {
       name: 'New Dance Lab Project',
       default_image_url: '/blockly/media/dance/placeholder.png',
+      i18n: true
     },
     makerlab: {
       name: 'New Maker Lab Project',
@@ -108,12 +124,15 @@ class ProjectsController < ApplicationController
     },
     bounce: {
       name: 'New Bounce Project',
+      i18n: true
     },
     sports: {
       name: 'New Sports Project',
+      i18n: true
     },
     basketball: {
       name: 'New Basketball Project',
+      i18n: true
     },
     algebra_game: {
       name: 'New Algebra Project'


### PR DESCRIPTION
The [jira task](https://codedotorg.atlassian.net/browse/FND-1045) just referred to Artist functions but it wasn't much more work to simply sync all project levels that seemed like they should be translated.

This PR adds a field `i18n` to each project in STANDALONE_PROJECTS (defaults to nil/false). I tried my best to add this field to only projects that I thought were reasonable to translate.

The source strings are added to a `projects.json` file in `i18n/locales/source/course_content`. Because the file is in `course_content`, our out step pulls those strings in when distributing course content.


## Testing story

Manually ran the in step, everything looked good. Copied `projects.json` to the `i18n/locales/es-MX/course_content` and ran the out step. I also ran `crowdin --config bin/i18n/codeorg_crowdin.yml --identity bin/i18n/CROWDIN_CODEORGG_PRODUCTION_CREDENTIALS.yml upload sources --dryrun` and `course_content/projects.json` was included.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
