### PR TITLE
[Applab Data] Restrict record data types entered through API

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -801,6 +801,7 @@
   "inProgress": "In progress",
   "inspireStudents": "Inspire students",
   "instructions": "Instructions",
+  "invalidRecordTypeError": "You attempted to add a record to the table that included a list or object. The data table can only store booleans, numbers, strings, null, and undefined.",
   "joinASection": "Join a section",
   "joinInstructions": "Joining Instructions",
   "joinSection": "Join section",

--- a/apps/src/lib/util/javascriptMode.js
+++ b/apps/src/lib/util/javascriptMode.js
@@ -1,6 +1,7 @@
 /** @file Utility methods common to toolkits that use the Droplet editor to let
  * students write and execute JavaScript. */
 import RGBColor from './rgbcolor.js';
+import i18n from '@cdo/locale';
 
 export const OPTIONAL = true;
 
@@ -84,6 +85,16 @@ export function apiValidateType(
         // Validate that we have a data record. These must be objects, and
         // not arrays
         properType = typeof varValue === 'object' && !Array.isArray(varValue);
+        if (properType) {
+          // Records must contain only strings, numbers, booleans, undefined, or null.
+          const isValidRecord = Object.values(varValue).every(val =>
+            isPrimitiveType(val)
+          );
+          if (!isValidRecord) {
+            outputError(i18n.invalidRecordTypeError());
+            return false;
+          }
+        }
         break;
       default:
         properType = typeof varValue === expectedType;


### PR DESCRIPTION
Values in a record must all be primitive types (string, number, boolean, `null`, `undefined`)
![image](https://user-images.githubusercontent.com/8787187/75924714-4781b700-5e1c-11ea-844d-0d83bc674b3d.png)

![image](https://user-images.githubusercontent.com/8787187/75924652-30db6000-5e1c-11ea-9a8d-ebd030f01eb6.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1w3J2tVaFpxQpFloAbn50X-XAeatCId7fMS-qdJCce9U/edit)
- [jira](https://codedotorg.atlassian.net/browse/STAR-979)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
