### PR TITLE
[student-libraries] Fixed library creation code so libraries that end in comments don't break things.

### DIFF
--- a/apps/src/code-studio/components/libraries/libraryParser.js
+++ b/apps/src/code-studio/components/libraries/libraryParser.js
@@ -71,7 +71,7 @@ export function createLibraryClosure(json) {
   let functionsInClosure = exportedFunctions.join(',');
   return `var ${json.name} = (function() {${
     json.source
-  }; return {${functionsInClosure}}})();`;
+  };\nreturn {${functionsInClosure}}})();`;
 }
 
 /**

--- a/apps/test/unit/code-studio/components/libraries/libraryParserTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryParserTest.js
@@ -249,7 +249,7 @@ describe('Library parser', () => {
     let emptyFunctions = [];
 
     function closureCreator(libraryName = '', code = '', functions = '') {
-      return `var ${libraryName} = (function() {${code}; return {${functions}}})();`;
+      return `var ${libraryName} = (function() {${code};\nreturn {${functions}}})();`;
     }
 
     it('is able to parse code with quotes', () => {
@@ -261,6 +261,18 @@ describe('Library parser', () => {
       };
       let newJson = parser.createLibraryClosure(originalJson);
       expect(newJson).to.deep.equal(closureCreator(emptyLibraryName, code));
+    });
+
+    // This is especially important when the user code ends with a comment
+    it('adds a newline to the end of the user code', () => {
+      let code = '// comment';
+      let originalJson = {
+        name: emptyLibraryName,
+        functions: emptyFunctions,
+        source: code
+      };
+      let newJson = parser.createLibraryClosure(originalJson);
+      expect(newJson).to.include('// comment;\nreturn');
     });
 
     it('is able to parse functions', () => {


### PR DESCRIPTION
In the past, if the last line of a library was a comment, importing the library would cause a syntax error because the closure wouldn't close. 

![image](https://user-images.githubusercontent.com/8324574/75936266-80c72080-5e36-11ea-86b1-a7585d4d7105.png)


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
