### PR TITLE
Making code.org/csforgood translatable

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -74,3 +74,7 @@ loc_dir=i18n/locales/source/markdown/public/educate/curriculum/
 mkdir -p $loc_dir
 orig_file=pegasus/sites.v3/code.org/public/educate/curriculum/csf-transition-guide.md
 cp_in $orig_file $loc_dir
+loc_dir=i18n/locales/source/markdown/public/
+mkdir -p $loc_dir
+orig_file=pegasus/sites.v3/code.org/public/csforgood.md
+cp_in $orig_file $loc_dir


### PR DESCRIPTION
As a student or teacher, when I visit https://code.org/csforgood , I want to see the page in my native language.
* Updated i18n scripts to include the csforgood.md document.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1046)

## Testing story
* locally ran `./bin/i18n/syncin.rb`
  * confirmed the new entry of `i18n/locales/source/markdown/public/csforgood.md`

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
