### PR TITLE
Only fetch standards data if experiment is enabled

### DIFF
--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -89,11 +89,13 @@ class SectionProgress extends Component {
 
   componentDidMount() {
     this.props.loadScript(this.props.scriptId);
-    this.props.fetchStandardsCoveredForScript(this.props.scriptId);
-    this.props.fetchStudentLevelScores(
-      this.props.scriptId,
-      this.props.section.id
-    );
+    if (experiments.isEnabled(experiments.STANDARDS_REPORT)) {
+      this.props.fetchStandardsCoveredForScript(this.props.scriptId);
+      this.props.fetchStudentLevelScores(
+        this.props.scriptId,
+        this.props.section.id
+      );
+    }
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
The queries I'm using to get information for the standards tab are currently inefficient and causing all kinds of [mayhem](https://codedotorg.slack.com/archives/C0T0PNTM3/p1583418074176700). In the very short term, I'd like to limit querying for the standards tab to only scenarios where the experiment flag is turned on to buy time to improve the efficiency of those queries.  
