### PR TITLE
Fix skipping of seeding encrypted levels

### DIFF
--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -45,7 +45,7 @@ class LevelLoader
 
       if [:development, :adhoc].include?(rack_env) && !CDO.properties_encryption_key
         puts "WARNING: skipping seeding encrypted levels because CDO.properties_encryption_key is not defined"
-        changed_levels.reject!(&:encrypted)
+        changed_levels.reject!(&:encrypted?)
       end
 
       # activerecord-import (with MySQL, anyway) doesn't save associated


### PR DESCRIPTION
<!-- ### Background -->
Fixes bug introduced in: https://github.com/code-dot-org/code-dot-org/pull/33077

with question mark it returns boolean, without it returns a string:
```
[39] pry(LevelLoader)> changed_levels[0].encrypted?
=> false
[40] pry(LevelLoader)> changed_levels[0].encrypted
=> "false"
```

and the string value is "truthy" for the `reject`, so everything is rejected.

## Testing story
Tested the change on an adhoc for a single level, which fixed the issue for that level. Currently waiting on testing the entire seeding process on a new adhoc.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
