### PR TITLE
Hide lesson status dialog button if no unplugged lessons

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1473,6 +1473,7 @@
   "standardsHowToDetailsForPrint": "This report shows how Code.org's [{courseName}]({courseLink}) maps to [CSTA Standards]({cstaLink}) and how many lessons in {courseName} this class has completed. Completing all lessons for a standard does not automatically indicate mastery of that standard - please check with your teacher to get specific information about how well the class or individual students have learned the course material. For reference, a Code.org lesson is approximately 45 - 65 minutes of instructional time. A lesson is considered \"complete\" when either (1) indicated by the teacher or (2) at least 80% of the enrolled students have finished 60% of the online levels (online lesson)",
   "standardsReminder": "**Remember:** Completing all lessons for a standard **does not automatically indicate mastery** of that standard - please use your best judgement to determine how well your students have learned course material.",
   "standardsReportHeader": "Class Standards Report",
+  "standardsReportNoUnpluggedLessons": "There are no unplugged lessons in this course.",
   "standardsReportLessonLengthInfo": "*Lessons in this course offer between 45 and 65 minutes of instruction",
   "startLearning": "Start learning",
   "startOver": "Start Over",

--- a/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.jsx
+++ b/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.jsx
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import BaseDialog from '../../BaseDialog';
-import {CreateStandardsReportStep1} from './CreateStandardsReportStep1';
+import CreateStandardsReportStep1 from './CreateStandardsReportStep1';
 import CreateStandardsReportStep2 from './CreateStandardsReportStep2';
 
 const styles = {

--- a/apps/src/templates/sectionProgress/standards/CreateStandardsReportStep1.jsx
+++ b/apps/src/templates/sectionProgress/standards/CreateStandardsReportStep1.jsx
@@ -4,10 +4,22 @@ import i18n from '@cdo/locale';
 import LessonStatusList from './LessonStatusList';
 import Button from '../../Button';
 import DialogFooter from '../../teacherDashboard/DialogFooter';
+import {connect} from 'react-redux';
+import {getUnpluggedLessonsForScript} from '@cdo/apps/templates/sectionProgress/standards/sectionStandardsProgressRedux';
 
-export class CreateStandardsReportStep1 extends Component {
+const styles = {
+  noUnplugged: {
+    fontStyle: 'italic',
+    fontWeight: 'bold',
+    marginTop: 20,
+    marginBottom: 30
+  }
+};
+
+class CreateStandardsReportStep1 extends Component {
   static propTypes = {
-    onNext: PropTypes.func.isRequired
+    onNext: PropTypes.func.isRequired,
+    unpluggedLessons: PropTypes.array.isRequired
   };
 
   render() {
@@ -18,7 +30,12 @@ export class CreateStandardsReportStep1 extends Component {
           {i18n.createStandardsReportStep1() + ' '}
           {i18n.completedUnpluggedLessons()}
         </h3>
-        <LessonStatusList />
+        {this.props.unpluggedLessons.length > 0 && <LessonStatusList />}
+        {this.props.unpluggedLessons.length === 0 && (
+          <p style={styles.noUnplugged}>
+            {i18n.standardsReportNoUnpluggedLessons()}
+          </p>
+        )}
         <p>{i18n.pluggedLessonsNote()}</p>
         <DialogFooter rightAlign>
           <Button
@@ -34,3 +51,7 @@ export class CreateStandardsReportStep1 extends Component {
 }
 
 export const UnconnectedCreateStandardsReportStep1 = CreateStandardsReportStep1;
+
+export default connect(state => ({
+  unpluggedLessons: getUnpluggedLessonsForScript(state)
+}))(CreateStandardsReportStep1);

--- a/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
@@ -116,17 +116,21 @@ class StandardsViewHeaderButtons extends Component {
   render() {
     return (
       <div style={styles.buttonsGroup}>
-        <Button
-          onClick={this.openLessonStatusDialog}
-          color={Button.ButtonColor.gray}
-          text={i18n.updateUnpluggedProgress()}
-          size={'narrow'}
-          style={styles.button}
-        />
-        <LessonStatusDialog
-          isOpen={this.state.isLessonStatusDialogOpen}
-          handleConfirm={this.onSaveUnpluggedLessonStatus}
-        />
+        {this.props.unpluggedLessons.length > 0 && (
+          <div>
+            <Button
+              onClick={this.openLessonStatusDialog}
+              color={Button.ButtonColor.gray}
+              text={i18n.updateUnpluggedProgress()}
+              size={'narrow'}
+              style={styles.button}
+            />
+            <LessonStatusDialog
+              isOpen={this.state.isLessonStatusDialogOpen}
+              handleConfirm={this.onSaveUnpluggedLessonStatus}
+            />
+          </div>
+        )}
         <Button
           onClick={this.openCreateReportDialog}
           color={Button.ButtonColor.gray}

--- a/apps/test/unit/templates/sectionProgress/StandardsViewHeaderButtonsTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/StandardsViewHeaderButtonsTest.jsx
@@ -4,7 +4,7 @@ import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedStandardsViewHeaderButtons as StandardsViewHeaderButtons} from '@cdo/apps/templates/sectionProgress/standards/StandardsViewHeaderButtons';
 
 describe('StandardsViewHeaderButtons', () => {
-  it('opens lesson status dialog', () => {
+  it('does not show update unplugged progress button if no unplugged lessons', () => {
     const wrapper = shallow(
       <StandardsViewHeaderButtons
         sectionId={1}
@@ -12,6 +12,25 @@ describe('StandardsViewHeaderButtons', () => {
         scriptId={100}
         selectedLessons={[]}
         unpluggedLessons={[]}
+      />
+    );
+    expect(wrapper.find('Button')).to.have.lengthOf(1);
+  });
+  it('opens lesson status dialog', () => {
+    const wrapper = shallow(
+      <StandardsViewHeaderButtons
+        sectionId={1}
+        setTeacherCommentForReport={() => {}}
+        scriptId={100}
+        selectedLessons={[]}
+        unpluggedLessons={[
+          {
+            id: 2,
+            name: 'Lesson Name',
+            number: 1,
+            url: 'fakeurl.com'
+          }
+        ]}
       />
     );
 
@@ -28,7 +47,14 @@ describe('StandardsViewHeaderButtons', () => {
         setTeacherCommentForReport={() => {}}
         scriptId={100}
         selectedLessons={[]}
-        unpluggedLessons={[]}
+        unpluggedLessons={[
+          {
+            id: 2,
+            name: 'Lesson Name',
+            number: 1,
+            url: 'fakeurl.com'
+          }
+        ]}
       />
     );
 


### PR DESCRIPTION
## Course with Unplugged Lessons
<img width="996" alt="Screen Shot 2020-03-05 at 9 00 39 PM" src="https://user-images.githubusercontent.com/208083/76043345-45574f80-5f25-11ea-843f-113a5e858c2d.png">

## Course with NO Unplugged Lessons
<img width="998" alt="Screen Shot 2020-03-05 at 9 00 24 PM" src="https://user-images.githubusercontent.com/208083/76043347-45efe600-5f25-11ea-8f2b-e772ac32552a.png">

## 1st Part of Create Report Dialog for Course with NO Unplugged Lessons
<img width="731" alt="Screen Shot 2020-03-05 at 9 00 11 PM" src="https://user-images.githubusercontent.com/208083/76043348-45efe600-5f25-11ea-9bd8-e20f57be7efc.png">


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1233)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Added a test to check that the button is not rendered when there is no unplugged lessons.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
