### PR TITLE
Standards: selected lessons in the dialog should appear as completed in the table

### DIFF
--- a/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
+++ b/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
@@ -91,10 +91,7 @@ export function getUnpluggedLessonsForScript(state) {
 
   unpluggedStages.forEach(stage => {
     const lessonCompletionStatus = getLessonCompletionStatus(state, stage.id);
-    const selected = _.map(
-      state.sectionStandardsProgress.selectedLessons,
-      'id'
-    ).includes(stage.id);
+    const selected = getLessonSelectionStatus(state, stage.id);
     stage['selected'] = selected;
     stage['completed'] = lessonCompletionStatus.completed;
   });
@@ -204,6 +201,14 @@ export function getLessonCompletionStatus(state, stageId) {
   }
 }
 
+export function getLessonSelectionStatus(state, stageId) {
+  const selected = _.map(
+    state.sectionStandardsProgress.selectedLessons,
+    'id'
+  ).includes(stageId);
+  return selected;
+}
+
 export function getUnpluggedLessonCompletionStatus(state, scriptId, stageId) {
   let completionByLesson = {};
   completionByLesson['completed'] = false;
@@ -236,7 +241,11 @@ export function getUnpluggedLessonCompletionStatus(state, scriptId, stageId) {
     // it's marked complete for all students in the section.
     const completed = numStudentCompleted >= 1;
 
-    completionByLesson['completed'] = completed;
+    // If a teacher selects an unplugged lesson in one of the
+    // dialogs, it should display as completed.
+    const selected = getLessonSelectionStatus(state, stageId);
+
+    completionByLesson['completed'] = completed || selected;
     completionByLesson['numStudentsCompleted'] = numStudentCompleted;
   }
   return completionByLesson;


### PR DESCRIPTION
[LP-1263](https://codedotorg.atlassian.net/browse/LP-1263)

Follow up to #33478

 Extracted `getLessonSelectionStatus` and used it to show a green box on the standards table if the lesson is selected in one of the dialogs. 
![selected-updates-table](https://user-images.githubusercontent.com/12300669/76050239-9b26fa00-5f1b-11ea-91cf-4ae230292031.gif)

