### PR TITLE
Index start_at and end_at columns for experiments tables

### DIFF
--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -19,10 +19,12 @@
 #
 # Indexes
 #
+#  index_experiments_on_end_at                (end_at)
 #  index_experiments_on_max_user_id           (max_user_id)
 #  index_experiments_on_min_user_id           (min_user_id)
 #  index_experiments_on_overflow_max_user_id  (overflow_max_user_id)
 #  index_experiments_on_section_id            (section_id)
+#  index_experiments_on_start_at              (start_at)
 #
 
 MAX_CACHE_AGE = Rails.application.config.experiment_cache_time_seconds.seconds

--- a/dashboard/app/models/experiments/single_section_experiment.rb
+++ b/dashboard/app/models/experiments/single_section_experiment.rb
@@ -19,10 +19,12 @@
 #
 # Indexes
 #
+#  index_experiments_on_end_at                (end_at)
 #  index_experiments_on_max_user_id           (max_user_id)
 #  index_experiments_on_min_user_id           (min_user_id)
 #  index_experiments_on_overflow_max_user_id  (overflow_max_user_id)
 #  index_experiments_on_section_id            (section_id)
+#  index_experiments_on_start_at              (start_at)
 #
 
 class SingleSectionExperiment < Experiment

--- a/dashboard/app/models/experiments/single_user_experiment.rb
+++ b/dashboard/app/models/experiments/single_user_experiment.rb
@@ -19,10 +19,12 @@
 #
 # Indexes
 #
+#  index_experiments_on_end_at                (end_at)
 #  index_experiments_on_max_user_id           (max_user_id)
 #  index_experiments_on_min_user_id           (min_user_id)
 #  index_experiments_on_overflow_max_user_id  (overflow_max_user_id)
 #  index_experiments_on_section_id            (section_id)
+#  index_experiments_on_start_at              (start_at)
 #
 
 class SingleUserExperiment < Experiment

--- a/dashboard/app/models/experiments/teacher_based_experiment.rb
+++ b/dashboard/app/models/experiments/teacher_based_experiment.rb
@@ -19,10 +19,12 @@
 #
 # Indexes
 #
+#  index_experiments_on_end_at                (end_at)
 #  index_experiments_on_max_user_id           (max_user_id)
 #  index_experiments_on_min_user_id           (min_user_id)
 #  index_experiments_on_overflow_max_user_id  (overflow_max_user_id)
 #  index_experiments_on_section_id            (section_id)
+#  index_experiments_on_start_at              (start_at)
 #
 
 class TeacherBasedExperiment < Experiment

--- a/dashboard/app/models/experiments/user_based_experiment.rb
+++ b/dashboard/app/models/experiments/user_based_experiment.rb
@@ -19,10 +19,12 @@
 #
 # Indexes
 #
+#  index_experiments_on_end_at                (end_at)
 #  index_experiments_on_max_user_id           (max_user_id)
 #  index_experiments_on_min_user_id           (min_user_id)
 #  index_experiments_on_overflow_max_user_id  (overflow_max_user_id)
 #  index_experiments_on_section_id            (section_id)
+#  index_experiments_on_start_at              (start_at)
 #
 
 class UserBasedExperiment < Experiment

--- a/dashboard/db/migrate/20200306044716_add_indexes_to_experiments.rb
+++ b/dashboard/db/migrate/20200306044716_add_indexes_to_experiments.rb
@@ -1,0 +1,6 @@
+class AddIndexesToExperiments < ActiveRecord::Migration[5.0]
+  def change
+    add_index :experiments, :start_at
+    add_index :experiments, :end_at
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200304032242) do
+ActiveRecord::Schema.define(version: 20200306044716) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -354,10 +354,12 @@ ActiveRecord::Schema.define(version: 20200304032242) do
     t.datetime "earliest_section_at"
     t.datetime "latest_section_at"
     t.integer  "script_id"
+    t.index ["end_at"], name: "index_experiments_on_end_at", using: :btree
     t.index ["max_user_id"], name: "index_experiments_on_max_user_id", using: :btree
     t.index ["min_user_id"], name: "index_experiments_on_min_user_id", using: :btree
     t.index ["overflow_max_user_id"], name: "index_experiments_on_overflow_max_user_id", using: :btree
     t.index ["section_id"], name: "index_experiments_on_section_id", using: :btree
+    t.index ["start_at"], name: "index_experiments_on_start_at", using: :btree
   end
 
   create_table "featured_projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
[COE](https://docs.google.com/document/d/1JhQ5TeNFt51qz_8fGgbW9GkksAPjeaPMEVbNn2kcfjw/edit#)
[LP-1218](https://codedotorg.atlassian.net/browse/LP-1218)

Recent test failures uncovered inefficient querying of the SingleUserExperiments table, partially because we query by the `start_at` and `end_at` fields, which did not have indexes. Now they do. 
