### PR TITLE
DOTD improvements: manual re-run warning

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -185,6 +185,7 @@ def main
 
       if CDO.test_system?
         DevelopersTopic.set_dtt 'no (robo-DTT failed)'
+        ChatClient.log "*** Before you manually re-run a test, please ensure that the cabal who owns that test is actively tracking de-flaking. ***", color: 'yellow'
       end
     end
 


### PR DESCRIPTION
[LP-1271](https://codedotorg.atlassian.net/browse/LP-1271)

 Following a recent investigation into flaky UI tests ([COE](https://docs.google.com/document/d/1JhQ5TeNFt51qz_8fGgbW9GkksAPjeaPMEVbNn2kcfjw/edit#)), we'd like to implement a few process changes to hopefully prevent similar future situations. Part of that effort includes discouraging Developers of the Day from manually re-running failed tests without first understanding the severity and frequency of the failure, as well as which cabal owns the failed test. 

As a lightweight step in that direction, I added a little reminder "_Before you manually re-run a test, please ensure that the cabal who owns that test is actively tracking de-flaking._" that will be displayed in the #infra-test Slack channel when a test build fails.  