### PR TITLE
Standards: teacher_scores query optimizations

### DIFF
--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -86,12 +86,14 @@ class TeacherScore < ApplicationRecord
     stage = Stage.find(stage_id)
     script_id = stage.script.id
     level_ids = stage.script_levels.map(&:level_id)
-    user_levels = UserLevel.where(user_id: student_id, level_id: level_ids, script_id: script_id)
+    user_levels = UserLevel.select(:id, :level_id).where(user_id: student_id, level_id: level_ids, script_id: script_id)
+    teacher_scores = TeacherScore.select(:score, :created_at, :user_level_id).where(
+      user_level_id: user_levels.pluck(:id)
+    )
+
     level_scores = {}
     user_levels.each do |user_level|
-      teacher_score = TeacherScore.where(
-        user_level_id: user_level.id
-      )&.order("created_at")&.last&.score
+      teacher_score = teacher_scores.select {|t_s| t_s.user_level_id == user_level.id}.sort_by(&:created_at).last&.score
       if teacher_score
         level_scores[user_level.level_id] = teacher_score
       end

--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -84,7 +84,7 @@ class TeacherScore < ApplicationRecord
 
   def self.get_level_scores_for_stage_for_student(stage_id, student_id)
     stage = Stage.find(stage_id)
-    script_id = stage.script.id
+    script_id = stage.script_id
     level_ids = stage.script_levels.map(&:level_id)
     user_levels = UserLevel.select(:id, :level_id).where(user_id: student_id, level_id: level_ids, script_id: script_id)
     teacher_scores = TeacherScore.select(:score, :created_at, :user_level_id).where(

--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -58,23 +58,23 @@ class TeacherScore < ApplicationRecord
 
   def self.get_level_scores_for_script_for_section(script_id, section_id)
     level_scores_by_student_by_stage_by_script = {}
-    stage_ids = Script.find(script_id).stages.pluck(:id)
+    stages = Script.find(script_id).stages
     stage_student_level_scores = {}
-    stage_ids.each do |stage_id|
-      level_scores = get_level_scores_for_stage_for_section(stage_id, section_id)
+    stages.each do |stage|
+      level_scores = get_level_scores_for_stage_for_section(stage, section_id)
       unless level_scores.empty?
-        stage_student_level_scores[stage_id] = level_scores
+        stage_student_level_scores[stage.id] = level_scores
       end
     end
     level_scores_by_student_by_stage_by_script[script_id] = stage_student_level_scores
     level_scores_by_student_by_stage_by_script
   end
 
-  def self.get_level_scores_for_stage_for_section(stage_id, section_id)
+  def self.get_level_scores_for_stage_for_section(stage, section_id)
     student_ids = Section.find(section_id).students.pluck(:id)
     student_level_scores = {}
     student_ids.each do |student_id|
-      level_scores = get_level_scores_for_stage_for_student(stage_id, student_id)
+      level_scores = get_level_scores_for_stage_for_student(stage, student_id)
       unless level_scores.empty?
         student_level_scores[student_id] = level_scores
       end
@@ -82,15 +82,13 @@ class TeacherScore < ApplicationRecord
     student_level_scores
   end
 
-  def self.get_level_scores_for_stage_for_student(stage_id, student_id)
-    stage = Stage.find(stage_id)
+  def self.get_level_scores_for_stage_for_student(stage, student_id)
     script_id = stage.script_id
     level_ids = stage.script_levels.map(&:level_id)
     user_levels = UserLevel.select(:id, :level_id).where(user_id: student_id, level_id: level_ids, script_id: script_id)
     teacher_scores = TeacherScore.select(:score, :created_at, :user_level_id).where(
       user_level_id: user_levels.pluck(:id)
     )
-
     level_scores = {}
     user_levels.each do |user_level|
       teacher_score = teacher_scores.select {|t_s| t_s.user_level_id == user_level.id}.sort_by(&:created_at).last&.score

--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -76,28 +76,24 @@ class TeacherScore < ApplicationRecord
     level_ids = stage.script_levels.map(&:level_id)
     user_levels = UserLevel.select(:id, :level_id, :user_id).where(user_id: student_ids, level_id: level_ids, script_id: script_id)
 
-    student_level_scores = {}
+    teacher_scores = TeacherScore.select(:score, :created_at, :user_level_id).where(
+      user_level_id: user_levels.pluck(:id)
+    )
+
+    level_scores_by_student = {}
     student_ids.each do |student_id|
       student_user_levels = user_levels.select {|u_l| u_l.user_id == student_id}
-      level_scores = get_level_scores_for_stage_for_student(stage, student_user_levels)
-      unless level_scores.empty?
-        student_level_scores[student_id] = level_scores
+      student_level_score = {}
+      student_user_levels.each do |u_l|
+        teacher_score = teacher_scores.select {|t_s| t_s.user_level_id == u_l.id}.sort_by(&:created_at).last&.score
+        if teacher_score
+          student_level_score[u_l.level_id] = teacher_score
+        end
+      end
+      unless student_level_score.empty?
+        level_scores_by_student[student_id] = student_level_score
       end
     end
-    student_level_scores
-  end
-
-  def self.get_level_scores_for_stage_for_student(stage, student_user_levels)
-    teacher_scores = TeacherScore.select(:score, :created_at, :user_level_id).where(
-      user_level_id: student_user_levels.pluck(:id)
-    )
-    level_scores = {}
-    student_user_levels.each do |u_l|
-      teacher_score = teacher_scores.select {|t_s| t_s.user_level_id == u_l.id}.sort_by(&:created_at).last&.score
-      if teacher_score
-        level_scores[u_l.level_id] = teacher_score
-      end
-    end
-    level_scores
+    level_scores_by_student
   end
 end

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -141,7 +141,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, stage_scores: [{stage_id: stage.id, score: score}]}
 
-    assert_queries 39 do
+    assert_queries 38 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -144,6 +144,18 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
     assert_queries 11 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
+
+    assert_equal section.students.count, 10
+
+    student = create :student
+    section.students << student
+    create :user_level, user: student, level: level, script: script
+
+    assert_equal section.students.count, 11
+
+    assert_queries 11 do
+      get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
+    end
   end
 
   private

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -141,7 +141,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, stage_scores: [{stage_id: stage.id, score: score}]}
 
-    assert_queries 38 do
+    assert_queries 19 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -141,7 +141,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, stage_scores: [{stage_id: stage.id, score: score}]}
 
-    assert_queries 19 do
+    assert_queries 11 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/models/teacher_score_test.rb
+++ b/dashboard/test/models/teacher_score_test.rb
@@ -93,15 +93,7 @@ class TeacherScoreTest < ActiveSupport::TestCase
     assert_equal(teacher_scores_count_after, teacher_scores_count_before + student_count)
   end
 
-  test 'get scores for stage for student' do
-    TeacherScore.score_level_for_student(
-      @teacher.id, @student_1.id, @level_1.id, @script.id, @score
-    )
-
-    assert_equal(TeacherScore.get_level_scores_for_stage_for_student(@stage.id, @student_1.id), {@level_1.id => @score})
-  end
-
-  test 'get scores for stage for student looks at most recent score' do
+  test 'get scores for stage looks at most recent score' do
     Timecop.freeze do
       TeacherScore.score_level_for_student(
         @teacher.id, @student_1.id, @level_1.id, @script.id, @score
@@ -114,7 +106,7 @@ class TeacherScoreTest < ActiveSupport::TestCase
       )
     end
 
-    assert_equal(TeacherScore.get_level_scores_for_stage_for_student(@stage.id, @student_1.id), {@level_1.id => @score_2})
+    assert_equal(TeacherScore.get_level_scores_for_stage_for_section(@stage, @section.id), {@student_1.id => {@level_1.id => @score_2}})
   end
 
   test 'get scores for stage for section' do
@@ -124,7 +116,7 @@ class TeacherScoreTest < ActiveSupport::TestCase
 
     assert_equal(
       TeacherScore.get_level_scores_for_stage_for_section(
-        @stage.id,
+        @stage,
         @section.id
       ),
       {


### PR DESCRIPTION
Querying for the progress tab is inefficient, particularly new queries for the standards tab related to TeacherScores. This causes performance problems, particularly for large sections. After [issues were discovered in production](https://codedotorg.slack.com/archives/C0T0PNTM3/p1583418074176700), I temporarily stopped fetching standards data unless the `standardsReport` flag is on (#33467). 

In this PR, to improve performance of the problematic queries : 

-  Extracted content from`get_level_scores_for_stage_for_student` and then deleted it to move database hits to TeacherScores out of loops so we only hit that table once instead of on every iteration. 
- Pass stage instead of stage.id as an argument to `get_level_scores_for_stage_for_section` so we don't have an additional database hit to re-fetch the stage. 

I also added a test to ensure that increasing the number of students in a section doesn't increase the number of database hits and updated the TeacherScores model tests accordingly. 