### PR TITLE
Remove ELB classic from CFN template [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -227,42 +227,7 @@ Resources:
 <% end -%>
 <% if load_balancer -%>
   # TODO hourofcode.com and csedweek.org load balancers should be added to this template.
-  LoadBalancer:
-    Type: AWS::ElasticLoadBalancing::LoadBalancer
-    Properties:
 <% raise "LoadBalancer name [#{stack_name}] cannot be longer than 32 characters" if stack_name.length > 32 -%>
-      LoadBalancerName: !Ref AWS::StackName
-      CrossZone: true
-      SecurityGroups: [!ImportValue VPC-ELBSecurityGroup]
-      Subnets: <%= public_subnets.to_json %>
-      LBCookieStickinessPolicy:
-        - PolicyName: CookieBasedPolicy
-          CookieExpirationPeriod: 30
-      Listeners:
-        - LoadBalancerPort: 80
-          InstancePort: 80
-          Protocol: HTTP
-          PolicyNames: [CookieBasedPolicy]
-        - LoadBalancerPort: 443
-          InstancePort: 80
-          Protocol: HTTPS
-          SSLCertificateId: <%=certificate_arn%>
-          PolicyNames: [CookieBasedPolicy]
-      HealthCheck:
-        Target: HTTP:80/health_check
-        HealthyThreshold: 2
-        UnhealthyThreshold: 5
-        Interval: 10
-        Timeout: 5
-      ConnectionDrainingPolicy:
-        Enabled: true
-        Timeout: 300
-<%   if !frontends && daemon_instance_id -%>
-      Instances: [<%=daemon_instance_id%>]
-<%   elsif daemon %>
-      Instances:
-        - !Ref <%=daemon%>
-<%   end -%>
 
   ALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -359,7 +324,6 @@ Resources:
       DesiredCapacity: !GetAtt [ASGCount, DesiredCapacity]
       HealthCheckType: EC2 # TODO: use ELB health check that returns healthy even when fully loaded.
       HealthCheckGracePeriod: 2000
-      LoadBalancerNames: [Ref: LoadBalancer]
       TargetGroupARNs: [Ref: ALBTargetGroup]
       MetricsCollection:
         - Granularity: 1Minute


### PR DESCRIPTION
Final part of migration to ALB started here: https://github.com/code-dot-org/code-dot-org/pull/33248

## Testing story

* Successfully created `adhoc-remove-elb-classic` full stack
* Validated production stack changes:
```
Winters-MBP:code-dot-org winterdong$ RAILS_ENV=production bundle exec rake stack:validate
GetSecretValue: production/cdo/db_writer
AWS CloudFormation Template for Code.org application
Listing changes to existing stack `autoscale-prod`:
Modify Frontends [AWS::AutoScaling::AutoScalingGroup] Properties (LoadBalancerNames)
Remove LoadBalancer [AWS::ElasticLoadBalancing::LoadBalancer] 
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
