### PR TITLE
Fix linter violation

### DIFF
--- a/pegasus/sites.v3/code.org/views/about_advisors.haml
+++ b/pegasus/sites.v3/code.org/views/about_advisors.haml
@@ -6,6 +6,6 @@
       -else
         = i[:name_s]
     -unless i[:role_s].nil_or_empty?
-      %p!= "#{i[:role_s]}"
+      %p!= i[:role_s]
     -unless i[:description_t].nil_or_empty?
-      %p!= "#{i[:description_t]}"
+      %p!= i[:description_t]


### PR DESCRIPTION
I updated an old branch by merging staging into it, and as part of resolving the merge conflicts, I'm now getting a linter error for some code that's already committed to staging:
```
/Users/winterdong/CDO/code-dot-org/pegasus/sites.v3/code.org/views/about_advisors.haml:9 [W] UnnecessaryInterpolation: `%... \#{expression}` can be written without interpolation as `%...= expression`
/Users/winterdong/CDO/code-dot-org/pegasus/sites.v3/code.org/views/about_advisors.haml:11 [W] UnnecessaryInterpolation: `%... \#{expression}` can be written without interpolation as `%...= expression`
```

## Testing story

Tested locally and the page renders the same after the change.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
