### PR TITLE
Remove scholarship validation from application model

### DIFF
--- a/dashboard/app/models/pd/application/teacher_application_base.rb
+++ b/dashboard/app/models/pd/application/teacher_application_base.rb
@@ -54,7 +54,6 @@ module Pd::Application
       *(1..12).map {|n| "Grade #{n}".freeze}
     ].freeze
 
-    validate :scholarship_status_valid
     validates :status, exclusion: {in: ['interview'], message: '%{value} is reserved for facilitator applications.'}
     validates :course, presence: true, inclusion: {in: VALID_COURSES}
 
@@ -64,12 +63,6 @@ module Pd::Application
     serialized_attrs %w(
       pd_workshop_id
     )
-
-    def scholarship_status_valid
-      unless scholarship_status.nil? || Pd::ScholarshipInfoConstants::SCHOLARSHIP_STATUSES.include?(scholarship_status)
-        errors.add(:scholarship_status, 'is not included in the list.')
-      end
-    end
 
     # Updates the associated user's school info with the info from this teacher application
     # based on these rules in order:

--- a/dashboard/test/models/pd/application/teacher2021_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher2021_application_test.rb
@@ -901,16 +901,22 @@ module Pd::Application
 
       application.update_scholarship_status(Pd::ScholarshipInfoConstants::YES_OTHER)
       assert_equal Pd::ScholarshipInfoConstants::YES_OTHER, application.scholarship_status
-
-      application.update_scholarship_status(Pd::ScholarshipInfoConstants::YES_EIR)
-      assert_equal Pd::ScholarshipInfoConstants::YES_EIR, application.scholarship_status
     end
 
-    test 'course-specific scholarship statuses' do
+    test 'course-specific scholarship status valid for CSP application' do
+      application = create :pd_teacher2021_application
+      assert_nil application.scholarship_status
+
+      application.update_scholarship_status(Pd::ScholarshipInfoConstants::YES_EIR)
+      application.valid?
+    end
+
+    test 'course-specific scholarship statuses invalid for CSD application' do
       application = create :pd_teacher2021_application, course: 'csd'
       assert_nil application.scholarship_status
 
       # This application status is only valid for CSP applications
+      # Asserting this application status can't be assigned to a CSD application
       application.update_scholarship_status(Pd::ScholarshipInfoConstants::YES_EIR)
       assert_nil application.scholarship_status
     end

--- a/dashboard/test/models/pd/application/teacher2021_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher2021_application_test.rb
@@ -908,7 +908,7 @@ module Pd::Application
       assert_nil application.scholarship_status
 
       application.update_scholarship_status(Pd::ScholarshipInfoConstants::YES_EIR)
-      application.valid?
+      assert application.valid?
     end
 
     test 'course-specific scholarship statuses invalid for CSD application' do

--- a/dashboard/test/models/pd/application/teacher2021_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher2021_application_test.rb
@@ -889,7 +889,7 @@ module Pd::Application
       end
     end
 
-    test 'test update scholarship status' do
+    test 'update scholarship status' do
       application = create :pd_teacher2021_application
       assert_nil application.scholarship_status
 
@@ -901,6 +901,18 @@ module Pd::Application
 
       application.update_scholarship_status(Pd::ScholarshipInfoConstants::YES_OTHER)
       assert_equal Pd::ScholarshipInfoConstants::YES_OTHER, application.scholarship_status
+
+      application.update_scholarship_status(Pd::ScholarshipInfoConstants::YES_EIR)
+      assert_equal Pd::ScholarshipInfoConstants::YES_EIR, application.scholarship_status
+    end
+
+    test 'course-specific scholarship statuses' do
+      application = create :pd_teacher2021_application, course: 'csd'
+      assert_nil application.scholarship_status
+
+      # This application status is only valid for CSP applications
+      application.update_scholarship_status(Pd::ScholarshipInfoConstants::YES_EIR)
+      assert_nil application.scholarship_status
     end
 
     test 'associated models cache prefetch' do

--- a/dashboard/test/models/pd/scholarship_info_test.rb
+++ b/dashboard/test/models/pd/scholarship_info_test.rb
@@ -44,24 +44,24 @@ class Pd::ScholarshipInfoTest < ActiveSupport::TestCase
   end
 
   test 'cannot create CSF scholarship info with CSP-specific scholarship status' do
-    csf_scholarship_info = build :pd_scholarship_info, course: COURSE_KEY_MAP[COURSE_CSF], scholarship_status: Pd::ScholarshipInfo::YES_EIR
+    csf_scholarship_info = build :pd_scholarship_info, course: COURSE_KEY_MAP[COURSE_CSF], scholarship_status: Pd::ScholarshipInfoConstants::YES_EIR
     assert_not_nil csf_scholarship_info.errors[:scholarship_status]
   end
 
   test 'can create CSP scholarship info with CSP-specific scholarship status' do
-    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfo::YES_EIR
+    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfoConstants::YES_EIR
     assert csp_scholarship_info.valid?
   end
 
   # Test confirms that we can get a friendly scholarship status (without error)
   test 'can get friendly scholarship name with CSP-specific scholarship status' do
-    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfo::YES_EIR
+    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfoConstants::YES_EIR
     csp_scholarship_info.friendly_status_name
   end
 
   # Test confirms that we can get a friendly scholarship status (without error)
   test 'can get friendly scholarship name with non-course specific scholarship status' do
-    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfo::NO
+    csp_scholarship_info = build :pd_scholarship_info, scholarship_status: Pd::ScholarshipInfoConstants::NO
     csp_scholarship_info.friendly_status_name
   end
 end


### PR DESCRIPTION
Education team noticed a bug where no updates (of any kind) could be made to CSP scholarships with the new EIR scholarship status.

Problem is a validation on the application that I missed, which validates the scholarship status. My approach here was to remove this validation -- I _think_ it is redundant because:
- an application [retrieves its scholarship status](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/pd/application/teacher_application_base.rb#L89) (or lack thereof) from the `scholarshipInfo` model,
- which has [its own validation](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/pd/scholarship_info.rb#L36) for whether the scholarship is in the list of possible scholarship options.

## Testing story

[manual] After reproducing the original issue locally, I've tested that it no longer occurs on an existing CSP or CSD application. Also checked that I can create an application (via factory), and update the scholarship status via the application dashboard.

[automated, per Clare's suggestion] added test that failed prior to this change, and passes with it.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
