### PR TITLE
Standards Report: adjust legend spacing 

### DIFF
--- a/apps/src/templates/sectionProgress/standards/StandardsLegendForPrint.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsLegendForPrint.jsx
@@ -6,7 +6,8 @@ const styles = {
   key: {
     display: 'flex',
     flexDirection: 'row',
-    alignItems: 'center'
+    alignItems: 'center',
+    marginTop: 10
   },
   keyItems: {
     display: 'flex',


### PR DESCRIPTION
Tiny polish item to give the legend a little top margin on the CSF Standards Report. 

BEFORE:
<img width="1053" alt="Screen Shot 2020-03-09 at 3 14 32 PM" src="https://user-images.githubusercontent.com/12300669/76262437-8f884b80-6219-11ea-9d14-daf0bb07a268.png">

AFTER:
<img width="650" alt="Screen Shot 2020-03-09 at 3 17 57 PM" src="https://user-images.githubusercontent.com/12300669/76262444-91520f00-6219-11ea-99b2-437991056fa5.png">
