### PR TITLE
Standards: fix link, administrator -> administrators

### DIFF
--- a/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
@@ -186,7 +186,7 @@ class StandardsReport extends Component {
                 </h2>
                 <SafeMarkdown
                   markdown={i18n.standardsGetInvolvedDetailsForPrint({
-                    adminLink: pegasus('/administrator'),
+                    adminLink: pegasus('/administrators'),
                     parentLink: pegasus('/help'),
                     teacherLink: '/courses'
                   })}

--- a/apps/src/templates/sectionProgress/standards/StandardsView.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsView.jsx
@@ -50,7 +50,7 @@ class StandardsView extends Component {
           <h3>{i18n.standardsGetInvolved()}</h3>
           <SafeMarkdown
             markdown={i18n.standardsGetInvolvedDetails({
-              adminLink: pegasus('/administrator'),
+              adminLink: pegasus('/administrators'),
               parentLink: pegasus('/help'),
               teacherLink: '/courses'
             })}


### PR DESCRIPTION
We had a typo; fixed it! 

BEFORE: 
<img width="920" alt="Screen Shot 2020-03-09 at 3 30 45 PM" src="https://user-images.githubusercontent.com/12300669/76263359-e8f17a00-621b-11ea-92de-9161edf5892b.png">

AFTER: 
![correct-admin-link](https://user-images.githubusercontent.com/12300669/76263363-eb53d400-621b-11ea-86dc-e5ef54f34793.gif)
