### PR TITLE
Disable exporting functions with duplicate names

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -861,6 +861,7 @@
   "libraryCodeError": "We can't publish your library because there is an error in the code. Go look for the square red error indicator and fix the errors.",
   "libraryCreatorError": "There was an error creating your library. Contact support@code.org to resolve the issue.",
   "libraryDescriptionPlaceholder": "Write a description of your library",
+  "libraryExportDuplicationFunctionError": "This function cannot be exported because there are multiple functions with this name.",
   "libraryExportNoCommentError": "This function cannot be exported until you add a comment to it.",
   "libraryExportSubtitle": "Share functions in your project to others in your class or to anyone with the project's ID. Others can import your functions into their projects by going to \"Manage Libraries\" in the gear icon at the top of the toolbox.",
   "libraryExportTitle": "Export Functions as a Library",

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -190,7 +190,12 @@ export class LibraryPublisher extends React.Component {
     const {sourceFunctionList} = this.props.libraryDetails;
     return sourceFunctionList.map(sourceFunction => {
       const {functionName, comment} = sourceFunction;
-      const shouldDisable = comment.length === 0;
+      const noComment = comment.length === 0;
+      const duplicateFunction =
+        sourceFunctionList.filter(
+          source => source.functionName === functionName
+        ).length > 1;
+      const shouldDisable = noComment || duplicateFunction;
       let checked = selectedFunctions[functionName] || false;
       if (shouldDisable && checked) {
         checked = false;
@@ -211,8 +216,13 @@ export class LibraryPublisher extends React.Component {
           />
           <span>{functionName}</span>
           <br />
-          {shouldDisable && (
+          {noComment && (
             <p style={styles.alert}>{i18n.libraryExportNoCommentError()}</p>
+          )}
+          {duplicateFunction && (
+            <p style={styles.alert}>
+              {i18n.libraryExportDuplicationFunctionError()}
+            </p>
           )}
           <pre style={styles.textInput}>{comment}</pre>
         </div>

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -104,6 +104,22 @@ describe('LibraryPublisher', () => {
       expect(checkboxes.last().prop('disabled')).to.be.true;
     });
 
+    it('disables checkbox for functions with duplicate names', () => {
+      libraryDetails.sourceFunctionList = libraryDetails.sourceFunctionList.concat(
+        [
+          {functionName: 'duplicate', comment: 'first dup!'},
+          {functionName: 'duplicate', comment: 'another dup!'}
+        ]
+      );
+      let wrapper = shallow(
+        <LibraryPublisher {...DEFAULT_PROPS} libraryDetails={libraryDetails} />
+      );
+
+      let checkboxes = wrapper.find(CHECKBOX_SELECTOR);
+      expect(checkboxes.at(0).prop('disabled')).to.be.false;
+      expect(checkboxes.at(1).prop('disabled')).to.be.true;
+    });
+
     it('checks checkboxes of selected functions', () => {
       libraryDetails.sourceFunctionList.push({
         functionName: 'bar',


### PR DESCRIPTION
Disables exporting functions with duplicate names in libraries.

[Video](https://drive.google.com/open?id=1NLOtocMgF2fTVqKVtpMW9NoVm2lsOtNi)

**Screenshot:**
![Screen Shot 2020-03-09 at 4 34 04 PM](https://user-images.githubusercontent.com/9812299/76267345-af267080-6227-11ea-8789-ea890f3e1d6a.png)


## Links

- [STAR-962](https://codedotorg.atlassian.net/browse/STAR-962)

## Testing story

Added a unit test for this case.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
