### PR TITLE
[Applab Data] Restrict data entry types entered through UI

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -801,6 +801,7 @@
   "inProgress": "In progress",
   "inspireStudents": "Inspire students",
   "instructions": "Instructions",
+  "invalidDataEntryTypeError": "Value must be boolean, number, string, `undefined`, or `null`. Make sure to include quotes for strings like \"this\". ",
   "invalidRecordTypeError": "You attempted to add a record to the table that included a list or object. The data table can only store booleans, numbers, strings, null, and undefined.",
   "joinASection": "Join a section",
   "joinInstructions": "Joining Instructions",

--- a/apps/src/storage/dataBrowser/AddKeyRow.jsx
+++ b/apps/src/storage/dataBrowser/AddKeyRow.jsx
@@ -24,6 +24,8 @@ class AddKeyRow extends React.Component {
 
   state = {...INITIAL_STATE};
 
+  inExperiment = experiments.isEnabled(experiments.APPLAB_DATASETS);
+
   handleKeyChange = event => {
     this.setState({key: event.target.value});
   };
@@ -34,7 +36,7 @@ class AddKeyRow extends React.Component {
 
   handleAdd = () => {
     if (this.state.key) {
-      if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      if (this.inExperiment) {
         this.props.hideError();
       }
       try {
@@ -60,7 +62,7 @@ class AddKeyRow extends React.Component {
           }
         );
       } catch (e) {
-        if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+        if (this.inExperiment) {
           this.setState({isAdding: false});
           this.props.showError();
         }

--- a/apps/src/storage/dataBrowser/AddTableRow.jsx
+++ b/apps/src/storage/dataBrowser/AddTableRow.jsx
@@ -24,6 +24,8 @@ class AddTableRow extends React.Component {
 
   state = {...INITIAL_STATE};
 
+  inExperiment = experiments.isEnabled(experiments.APPLAB_DATASETS);
+
   handleChange(columnName, event) {
     const newInput = Object.assign({}, this.state.newInput, {
       [columnName]: event.target.value
@@ -33,7 +35,7 @@ class AddTableRow extends React.Component {
 
   handleAdd = () => {
     try {
-      if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      if (this.inExperiment) {
         this.props.hideError();
       }
       const record = _.mapValues(this.state.newInput, inputString =>
@@ -47,7 +49,7 @@ class AddTableRow extends React.Component {
         msg => console.warn(msg)
       );
     } catch (e) {
-      if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      if (this.inExperiment) {
         this.setState({isSaving: false});
         this.props.showError();
       }

--- a/apps/src/storage/dataBrowser/AddTableRow.jsx
+++ b/apps/src/storage/dataBrowser/AddTableRow.jsx
@@ -1,5 +1,6 @@
 import FirebaseStorage from '../firebaseStorage';
 import PendingButton from '../../templates/PendingButton';
+import experiments from '@cdo/apps/util/experiments';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import React from 'react';
@@ -16,7 +17,9 @@ const INITIAL_STATE = {
 class AddTableRow extends React.Component {
   static propTypes = {
     columnNames: PropTypes.array.isRequired,
-    tableName: PropTypes.string.isRequired
+    tableName: PropTypes.string.isRequired,
+    showError: PropTypes.func.isRequired,
+    hideError: PropTypes.func.isRequired
   };
 
   state = {...INITIAL_STATE};
@@ -29,13 +32,26 @@ class AddTableRow extends React.Component {
   }
 
   handleAdd = () => {
-    this.setState({isAdding: true});
-    FirebaseStorage.createRecord(
-      this.props.tableName,
-      _.mapValues(this.state.newInput, castValue),
-      () => this.setState(INITIAL_STATE),
-      msg => console.warn(msg)
-    );
+    try {
+      if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+        this.props.hideError();
+      }
+      const record = _.mapValues(this.state.newInput, inputString =>
+        castValue(inputString, /* allowUnquotedStrings */ false)
+      );
+      this.setState({isAdding: true});
+      FirebaseStorage.createRecord(
+        this.props.tableName,
+        record,
+        () => this.setState(INITIAL_STATE),
+        msg => console.warn(msg)
+      );
+    } catch (e) {
+      if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+        this.setState({isSaving: false});
+        this.props.showError();
+      }
+    }
   };
 
   handleKeyUp = event => {

--- a/apps/src/storage/dataBrowser/DataEntryError.jsx
+++ b/apps/src/storage/dataBrowser/DataEntryError.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import msg from '@cdo/locale';
+import color from '../../util/color';
 import SafeMarkdown from '../../templates/SafeMarkdown';
 
 const styles = {
@@ -13,7 +14,7 @@ const styles = {
   }
 };
 
-class DataEntryWarning extends React.Component {
+class DataEntryError extends React.Component {
   static propTypes = {
     isVisible: PropTypes.bool.isRequired
   };
@@ -21,13 +22,13 @@ class DataEntryWarning extends React.Component {
   render() {
     return this.props.isVisible ? (
       <div style={styles.visible}>
-        <SafeMarkdown markdown={msg.invalidDataEntryTypeWarning()} />
+        <SafeMarkdown markdown={msg.invalidDataEntryTypeError()} />
       </div>
     ) : (
-      // Blank space so layout stays the same whether or not warning is visible.
+      // Blank space so layout stays the same whether or not error is visible.
       <div style={styles.hidden} />
     );
   }
 }
 
-export default DataEntryWarning;
+export default DataEntryError;

--- a/apps/src/storage/dataBrowser/DataEntryWarning.jsx
+++ b/apps/src/storage/dataBrowser/DataEntryWarning.jsx
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import msg from '@cdo/locale';
+import SafeMarkdown from '../../templates/SafeMarkdown';
+
+const styles = {
+  visible: {
+    background: color.lighter_yellow,
+    padding: '1em'
+  },
+  hidden: {
+    height: '3em'
+  }
+};
+
+class DataEntryWarning extends React.Component {
+  static propTypes = {
+    isVisible: PropTypes.bool.isRequired
+  };
+
+  render() {
+    return this.props.isVisible ? (
+      <div style={styles.visible}>
+        <SafeMarkdown markdown={msg.invalidDataEntryTypeWarning()} />
+      </div>
+    ) : (
+      // Blank space so layout stays the same whether or not warning is visible.
+      <div style={styles.hidden} />
+    );
+  }
+}
+
+export default DataEntryWarning;

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -4,6 +4,7 @@
 import AddTableRow from './AddTableRow';
 import EditTableRow from './EditTableRow';
 import ColumnHeader from './ColumnHeader';
+import DataEntryError from './DataEntryError';
 import FirebaseStorage from '../firebaseStorage';
 import FontAwesome from '../../templates/FontAwesome';
 import PropTypes from 'prop-types';
@@ -52,7 +53,8 @@ const INITIAL_STATE = {
   pendingAdd: false,
   // The old name of the column currently being renamed or deleted.
   pendingColumn: null,
-  currentPage: 0
+  currentPage: 0,
+  showError: false
 };
 
 class DataTable extends React.Component {
@@ -81,6 +83,9 @@ class DataTable extends React.Component {
       this.setState(INITIAL_STATE);
     }
   }
+
+  showError = () => this.setState({showError: true});
+  hideError = () => this.setState({showError: false});
 
   addColumn = () => {
     const columnName = this.getNextColumnName();
@@ -224,6 +229,7 @@ class DataTable extends React.Component {
 
     return (
       <div>
+        <DataEntryError isVisible={this.state.showError} />
         <div style={styles.pagination}>
           <PaginationWrapper
             totalPages={numPages}
@@ -281,6 +287,8 @@ class DataTable extends React.Component {
               <AddTableRow
                 tableName={this.props.tableName}
                 columnNames={columnNames}
+                showError={this.showError}
+                hideError={this.hideError}
               />
             )}
 
@@ -291,6 +299,8 @@ class DataTable extends React.Component {
                 record={JSON.parse(rows[id])}
                 key={id}
                 readOnly={this.props.readOnly}
+                showError={this.showError}
+                hideError={this.hideError}
               />
             ))}
           </tbody>

--- a/apps/src/storage/dataBrowser/EditKeyRow.jsx
+++ b/apps/src/storage/dataBrowser/EditKeyRow.jsx
@@ -3,6 +3,7 @@ import FirebaseStorage from '../firebaseStorage';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import React from 'react';
+import experiments from '@cdo/apps/util/experiments';
 import PendingButton from '../../templates/PendingButton';
 import {castValue, displayableValue, editableValue} from './dataUtils';
 import * as dataStyles from './dataStyles';
@@ -17,7 +18,9 @@ const INITIAL_STATE = {
 class EditKeyRow extends React.Component {
   static propTypes = {
     keyName: PropTypes.string.isRequired,
-    value: PropTypes.any
+    value: PropTypes.any,
+    showError: PropTypes.func.isRequired,
+    hideError: PropTypes.func.isRequired
   };
 
   state = {...INITIAL_STATE};
@@ -39,13 +42,27 @@ class EditKeyRow extends React.Component {
     });
 
   handleSave = () => {
-    this.setState({isSaving: true});
-    FirebaseStorage.setKeyValue(
-      this.props.keyName,
-      castValue(this.state.newValue),
-      this.resetState,
-      msg => console.warn(msg)
-    );
+    if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      this.props.hideError();
+    }
+    try {
+      this.setState({isSaving: true});
+      const newValue = castValue(
+        this.state.newValue,
+        /* allowUnquotedStrings */ false
+      );
+      FirebaseStorage.setKeyValue(
+        this.props.keyName,
+        newValue,
+        this.resetState,
+        msg => console.warn(msg)
+      );
+    } catch (e) {
+      if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+        this.setState({isSaving: false});
+        this.props.showError();
+      }
+    }
   };
 
   resetState = () => {

--- a/apps/src/storage/dataBrowser/EditKeyRow.jsx
+++ b/apps/src/storage/dataBrowser/EditKeyRow.jsx
@@ -25,6 +25,8 @@ class EditKeyRow extends React.Component {
 
   state = {...INITIAL_STATE};
 
+  inExperiment = experiments.isEnabled(experiments.APPLAB_DATASETS);
+
   componentDidMount() {
     this.isMounted_ = true;
   }
@@ -42,7 +44,7 @@ class EditKeyRow extends React.Component {
     });
 
   handleSave = () => {
-    if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+    if (this.inExperiment) {
       this.props.hideError();
     }
     try {
@@ -58,7 +60,7 @@ class EditKeyRow extends React.Component {
         msg => console.warn(msg)
       );
     } catch (e) {
-      if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      if (this.inExperiment) {
         this.setState({isSaving: false});
         this.props.showError();
       }

--- a/apps/src/storage/dataBrowser/EditTableRow.jsx
+++ b/apps/src/storage/dataBrowser/EditTableRow.jsx
@@ -36,6 +36,8 @@ class EditTableRow extends React.Component {
 
   state = {...INITIAL_STATE};
 
+  inExperiment = experiments.isEnabled(experiments.APPLAB_DATASETS);
+
   // Optimization: skip rendering when nothing has changed.
   shouldComponentUpdate(nextProps, nextState) {
     const propsChanged = !_.isEqual(this.props, nextProps);
@@ -51,7 +53,7 @@ class EditTableRow extends React.Component {
   }
 
   handleSave = () => {
-    if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+    if (this.inExperiment) {
       this.props.hideError();
     }
     try {
@@ -66,7 +68,7 @@ class EditTableRow extends React.Component {
         msg => console.warn(msg)
       );
     } catch (e) {
-      if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+      if (this.inExperiment) {
         this.setState({isSaving: false});
         this.props.showError();
       }

--- a/apps/src/storage/dataBrowser/KVPairs.jsx
+++ b/apps/src/storage/dataBrowser/KVPairs.jsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import AddKeyRow from './AddKeyRow';
 import {DataView} from '../constants';
 import EditKeyRow from './EditKeyRow';
+import DataEntryError from './DataEntryError';
 import FontAwesome from '../../templates/FontAwesome';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
@@ -43,8 +44,12 @@ class KVPairs extends React.Component {
   };
 
   state = {
-    showDebugView: false
+    showDebugView: false,
+    showError: false
   };
+
+  showError = () => this.setState({showError: true});
+  hideError = () => this.setState({showError: false});
 
   toggleDebugView = () => {
     const showDebugView = !this.state.showDebugView;
@@ -83,13 +88,19 @@ class KVPairs extends React.Component {
             <th style={dataStyles.headerCell}>Actions</th>
           </tr>
 
-          <AddKeyRow onShowWarning={this.props.onShowWarning} />
+          <AddKeyRow
+            onShowWarning={this.props.onShowWarning}
+            showError={this.showError}
+            hideError={this.hideError}
+          />
 
           {Object.keys(this.props.keyValueData).map(key => (
             <EditKeyRow
               key={key}
               keyName={key}
               value={JSON.parse(this.props.keyValueData[key])}
+              showError={this.showError}
+              hideError={this.hideError}
             />
           ))}
         </tbody>
@@ -97,7 +108,12 @@ class KVPairs extends React.Component {
     );
 
     if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
-      return kvTable;
+      return (
+        <div>
+          <DataEntryError isVisible={this.state.showError} />
+          {kvTable}
+        </div>
+      );
     }
     return (
       <div id="dataProperties" style={containerStyle}>

--- a/apps/src/storage/dataBrowser/dataUtils.js
+++ b/apps/src/storage/dataBrowser/dataUtils.js
@@ -82,7 +82,11 @@ export function castValue(inputString, allowUnquotedStrings) {
   if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
     // 1. Remove leading and trailing whitespace
     inputString = inputString.trim();
-    // 2. Check for undefined and null
+    // 2. Check for '', undefined, and null
+    if (inputString === '') {
+      // This happens when the text area is blank, so interpret as undefined.
+      return undefined;
+    }
     if (inputString === 'undefined') {
       return undefined;
     } else if (inputString === 'null') {

--- a/apps/src/storage/dataBrowser/dataUtils.js
+++ b/apps/src/storage/dataBrowser/dataUtils.js
@@ -1,3 +1,4 @@
+import experiments from '@cdo/apps/util/experiments';
 /** @file Utility functions for the data browser. */
 
 /**
@@ -74,17 +75,41 @@ export function toBoolean(val) {
 
 /**
  * Convert a string to a boolean or number if possible.
- * @param val
+ * @param inputString
  * @returns {string|number|boolean}
  */
-export function castValue(val) {
-  try {
-    return JSON.parse(val);
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      return val;
+export function castValue(inputString, allowUnquotedStrings) {
+  if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+    // 1. Remove leading and trailing whitespace
+    inputString = inputString.trim();
+    // 2. Check for undefined and null
+    if (inputString === 'undefined') {
+      return undefined;
+    } else if (inputString === 'null') {
+      return null;
     }
-    throw new Error(`Unexpected error parsing JSON: ${e}`);
+    // 3. Attempt to parse as number, string, or boolean
+    try {
+      const parsed = JSON.parse(inputString);
+      if (typeof parsed === 'object') {
+        throw new Error('Invalid entry type: object');
+      }
+      return parsed;
+    } catch (e) {
+      if (e instanceof SyntaxError && allowUnquotedStrings) {
+        return inputString;
+      }
+      throw e;
+    }
+  } else {
+    try {
+      return JSON.parse(inputString);
+    } catch (e) {
+      if (e instanceof SyntaxError) {
+        return inputString;
+      }
+      throw new Error(`Unexpected error parsing JSON: ${e}`);
+    }
   }
 }
 
@@ -94,21 +119,28 @@ export function castValue(val) {
  * @returns {string}
  */
 export function editableValue(val) {
-  if (val === null || val === undefined) {
-    return '';
-  }
-  if (typeof val === 'string') {
-    try {
-      JSON.parse(val);
-    } catch (e) {
-      // The value is a string which is not parseable as JSON (e.g. 'foo' but not 'true'
-      // or '1'). Therefore, it is safe to return it without stringifying it, and
-      // calling castValue on the result will return the original input.
-      return val;
+  if (experiments.isEnabled(experiments.APPLAB_DATASETS)) {
+    if (val === undefined) {
+      return 'undefined';
     }
-  }
+    return JSON.stringify(val);
+  } else {
+    if (val === null || val === undefined) {
+      return '';
+    }
+    if (typeof val === 'string') {
+      try {
+        JSON.parse(val);
+      } catch (e) {
+        // The value is a string which is not parseable as JSON (e.g. 'foo' but not 'true'
+        // or '1'). Therefore, it is safe to return it without stringifying it, and
+        // calling castValue on the result will return the original input.
+        return val;
+      }
+    }
 
-  return JSON.stringify(val);
+    return JSON.stringify(val);
+  }
 }
 
 /**

--- a/apps/src/storage/firebaseStorage.js
+++ b/apps/src/storage/firebaseStorage.js
@@ -975,7 +975,7 @@ function parseRecordsDataFromCsv(csvData) {
     records.forEach((record, index) => {
       const id = index + 1;
       for (const key in record) {
-        record[key] = castValue(record[key]);
+        record[key] = castValue(record[key], /* allowUnquotedStrings */ true);
       }
       record.id = id;
       recordsData[id] = JSON.stringify(record);

--- a/apps/test/unit/storage/dataUtilsTest.js
+++ b/apps/test/unit/storage/dataUtilsTest.js
@@ -9,6 +9,7 @@ import {
   isBoolean,
   toBoolean
 } from '@cdo/apps/storage/dataBrowser/dataUtils';
+import experiments from '@cdo/apps/util/experiments';
 
 describe('isBlank', () => {
   it('counts null, undefined, and empty string as blank', () => {
@@ -202,6 +203,34 @@ describe('castValue', () => {
     expect(castValue('"foo')).to.equal('"foo');
     expect(castValue('""foo""')).to.equal('""foo""');
   });
+
+  describe('with applabDatasets experiment enabled', () => {
+    beforeEach(() => {
+      experiments.setEnabled(experiments.APPLAB_DATASETS, true);
+    });
+    afterEach(() => {
+      experiments.setEnabled(experiments.APPLAB_DATASETS, false);
+    });
+    it('does not allow objects or arrays', () => {
+      expect(() => castValue('[1, 2, 3]')).to.throw(
+        /Invalid entry type: object/
+      );
+      expect(() => castValue('{"a": 1, "b": 2, "c": 3}')).to.throw(
+        /Invalid entry type: object/
+      );
+    });
+
+    it('converts "undefined" to undefined', () => {
+      expect(castValue('undefined')).to.equal(undefined);
+    });
+
+    it('only allows unquoted strings if allowUnquotedStrings is true', () => {
+      expect(castValue('abc', /* allowUnquotedStrings */ true)).to.equal('abc');
+      expect(() => castValue('abc', /* allowUnquotedStrings */ false)).to.throw(
+        /JSON Parse error/
+      );
+    });
+  });
 });
 
 describe('editableValue', () => {
@@ -220,6 +249,18 @@ describe('editableValue', () => {
   it('stringifies objects and arrays', () => {
     expect(editableValue({a: 1})).to.equal('{"a":1}');
     expect(editableValue([1, 2])).to.equal('[1,2]');
+  });
+
+  describe('with applabDatasets experiment enabled', () => {
+    beforeEach(() => {
+      experiments.setEnabled(experiments.APPLAB_DATASETS, true);
+    });
+    afterEach(() => {
+      experiments.setEnabled(experiments.APPLAB_DATASETS, false);
+    });
+    it('shows undefined', () => {
+      expect(editableValue(undefined)).to.equal('undefined');
+    });
   });
 });
 


### PR DESCRIPTION
New restrictions on the type of data that can be stored in the data tab, behind `applabDatasets` experiment flag.

In tables and key/value pairs, values must be strings, numbers, booleans, `null`, or `undefined`. If an invalid type is entered, an error message is shown:

![image](https://user-images.githubusercontent.com/8787187/75911129-eea62480-5e03-11ea-9ab1-cce288ad2885.png)
![image](https://user-images.githubusercontent.com/8787187/75911197-0bdaf300-5e04-11ea-9ccb-037a68392ea1.png)
![image](https://user-images.githubusercontent.com/8787187/76338617-2c002b80-62b6-11ea-87ad-9ba72d824672.png)

With experiment turned off:
![image](https://user-images.githubusercontent.com/8787187/76338674-40dcbf00-62b6-11ea-9672-e5c0a8121502.png)
![image](https://user-images.githubusercontent.com/8787187/76338719-5520bc00-62b6-11ea-864c-fb41cd389bf3.png)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1w3J2tVaFpxQpFloAbn50X-XAeatCId7fMS-qdJCce9U/edit)
- [jira](https://codedotorg.atlassian.net/browse/STAR-979)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
