### PR TITLE
Add migration to create contact_rollups_processed table

### DIFF
--- a/dashboard/db/migrate/20200309213913_create_contact_rollups_processed.rb
+++ b/dashboard/db/migrate/20200309213913_create_contact_rollups_processed.rb
@@ -1,0 +1,9 @@
+class CreateContactRollupsProcessed < ActiveRecord::Migration[5.0]
+  def change
+    create_table :contact_rollups_processed do |t|
+      t.string :email, null: false, index: {unique: true}
+      t.json :data, null: false
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -278,6 +278,14 @@ ActiveRecord::Schema.define(version: 20200310000601) do
     t.index ["email", "sources"], name: "index_contact_rollups_raw_on_email_and_sources", unique: true, using: :btree
   end
 
+  create_table "contact_rollups_processed", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string   "email",      null: false
+    t.json     "data",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_contact_rollups_processed_on_email", unique: true, using: :btree
+  end
+
   create_table "contained_level_answers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false


### PR DESCRIPTION
Creates `contact_rollups_processed` table that contains processed data for all contacts.
Details are in [CRv1.5 plan](https://docs.google.com/document/d/1dMO8-cGQjtX1jZ32XIfPuk5Y20dYU_dSU8_7i7Vzcp8/edit#) -> Table schemas and data structures.

## Links
[PLC-784](https://codedotorg.atlassian.net/browse/PLC-784)

## Testing story
* Ran `rails db:migrate` locally.
* Will test on adhoc with a cloned db.

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
