### PR TITLE
Add latestLibraryVersion field to projects db

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -245,28 +245,22 @@ export class LibraryPublisher extends React.Component {
   };
 
   unpublish = () => {
-    const {unpublishProjectLibrary, libraryClientApi} = this.props;
-
-    unpublishProjectLibrary(
-      libraryClientApi.channelId,
-      libraryClientApi,
-      this.onUnpublishComplete
+    const {libraryClientApi, onUnpublishSuccess} = this.props;
+    libraryClientApi.delete(
+      () => {
+        dashboard.project.setLibraryDetails({
+          newName: undefined,
+          newDescription: undefined,
+          publishing: false,
+          newVersionId: -1
+        });
+        onUnpublishSuccess();
+      },
+      error => {
+        console.warn(`Error unpublishing library: ${error}`);
+        this.setState({publishState: PublishState.ERROR_UNPUBLISH});
+      }
     );
-  };
-
-  onUnpublishComplete = (error, _) => {
-    if (error) {
-      console.warn(`Error unpublishing library: ${error}`);
-      this.setState({publishState: PublishState.ERROR_UNPUBLISH});
-    } else {
-      this.props.onUnpublishSuccess();
-      dashboard.project.setLibraryDetails({
-        newName: undefined,
-        newDescription: undefined,
-        publishing: false,
-        newVersionId: -1
-      });
-    }
   };
 
   render() {

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -263,7 +263,8 @@ export class LibraryPublisher extends React.Component {
       dashboard.project.setLibraryDetails({
         newName: undefined,
         newDescription: undefined,
-        publishing: false
+        publishing: false,
+        newVersionId: -1
       });
     }
   };

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -115,16 +115,15 @@ export class LibraryPublisher extends React.Component {
         console.warn(`Error publishing library: ${error}`);
         this.setState({publishState: PublishState.ERROR_PUBLISH});
       },
-      () => {
+      data => {
+        // Write to projects database
+        dashboard.project.setLibraryDetails({
+          newName: libraryName,
+          newDescription: libraryDescription,
+          publishing: true
+        });
         onPublishSuccess(libraryName);
       }
-    );
-
-    // Write to projects database
-    dashboard.project.setLibraryDetails(
-      libraryName,
-      libraryDescription,
-      true /* publishing */
     );
   };
 
@@ -259,11 +258,11 @@ export class LibraryPublisher extends React.Component {
       this.setState({publishState: PublishState.ERROR_UNPUBLISH});
     } else {
       this.props.onUnpublishSuccess();
-      dashboard.project.setLibraryDetails(
-        undefined,
-        undefined,
-        false /* publishing */
-      );
+      dashboard.project.setLibraryDetails({
+        newName: undefined,
+        newDescription: undefined,
+        publishing: false
+      });
     }
   };
 

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -113,10 +113,10 @@ export default class LibraryPublisher extends React.Component {
       data => {
         // Write to projects database
         dashboard.project.setLibraryDetails({
-          newName: libraryName,
-          newDescription: libraryDescription,
+          libraryName,
+          libraryDescription,
           publishing: true,
-          newVersionId: data && data.versionId
+          latestLibraryVersion: data && data.versionId
         });
 
         onPublishSuccess(libraryName);
@@ -244,10 +244,10 @@ export default class LibraryPublisher extends React.Component {
     libraryClientApi.delete(
       () => {
         dashboard.project.setLibraryDetails({
-          newName: undefined,
-          newDescription: undefined,
+          libraryName: undefined,
+          libraryDescription: undefined,
           publishing: false,
-          newVersionId: -1
+          latestLibraryVersion: -1
         });
         onUnpublishSuccess();
       },

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -1,13 +1,11 @@
 /*global dashboard*/
 import React from 'react';
 import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
 import libraryParser from './libraryParser';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import {Heading2} from '@cdo/apps/lib/ui/Headings';
 import Button from '@cdo/apps/templates/Button';
-import {unpublishProjectLibrary} from '@cdo/apps/templates/projects/projectsRedux';
 
 const styles = {
   alert: {
@@ -59,15 +57,12 @@ export const PublishState = {
  * An interactive page for a dialog that can be used to publish or unpublish
  * a library from a source project.
  */
-export class LibraryPublisher extends React.Component {
+export default class LibraryPublisher extends React.Component {
   static propTypes = {
     onPublishSuccess: PropTypes.func.isRequired,
     onUnpublishSuccess: PropTypes.func.isRequired,
     libraryDetails: PropTypes.object.isRequired,
-    libraryClientApi: PropTypes.object.isRequired,
-
-    // Provided by Redux
-    unpublishProjectLibrary: PropTypes.func.isRequired
+    libraryClientApi: PropTypes.object.isRequired
   };
 
   state = {
@@ -121,7 +116,7 @@ export class LibraryPublisher extends React.Component {
           newName: libraryName,
           newDescription: libraryDescription,
           publishing: true,
-          newVersionId: data.versionId
+          newVersionId: data && data.versionId
         });
 
         onPublishSuccess(libraryName);
@@ -295,12 +290,3 @@ export class LibraryPublisher extends React.Component {
     );
   }
 }
-
-export default connect(
-  state => ({}),
-  dispatch => ({
-    unpublishProjectLibrary(channelId, libraryApi, onComplete) {
-      dispatch(unpublishProjectLibrary(channelId, libraryApi, onComplete));
-    }
-  })
-)(LibraryPublisher);

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -120,8 +120,10 @@ export class LibraryPublisher extends React.Component {
         dashboard.project.setLibraryDetails({
           newName: libraryName,
           newDescription: libraryDescription,
-          publishing: true
+          publishing: true,
+          newVersionId: data.versionId
         });
+
         onPublishSuccess(libraryName);
       }
     );

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -587,40 +587,39 @@ var projects = (module.exports = {
     }
   },
   /**
+   * Updates the current channel's library details.
    *
    * @param {Object} config - Object containing library details.
    * @param {string} config.newName
    * @param {string} config.newDescription
+   * @param {string} config.newVersionId - S3 version ID for the current library version.
    * @param {boolean} config.publishing - true if library is being published, false if library is being unpublished, undefined otherwise.
-   * @param {string} config.versionId - S3 version ID for the current library version.
-   *
-   * NOTE: One of the following must be true or the library channel will not be updated:
-   *  1. config.newName !== current.libraryName
-   *  2. config.newDescription !== current.libraryDescription
-   *  3. config.publishing is present
    */
   setLibraryDetails(config = {}) {
     current = current || {};
-    const {newName, newDescription, publishing} = config;
+    const {newName, newDescription, newVersionId, publishing} = config;
 
-    if (
-      current.libraryName !== newName ||
-      current.libraryDescription !== newDescription ||
-      publishing !== undefined
-    ) {
+    if (newName) {
       current.libraryName = newName;
-      current.libraryDescription = newDescription;
-
-      if (publishing) {
-        // Tells the server to set libraryPublishedAt timestamp.
-        current.publishLibrary = true;
-      } else if (publishing === false) {
-        // Unpublishing, so nullify libraryPublishedAt timestamp.
-        current.libraryPublishedAt = null;
-      }
-
-      this.updateChannels_();
     }
+
+    if (newDescription) {
+      current.libraryDescription = newDescription;
+    }
+
+    if (newVersionId) {
+      current.latestLibraryVersion = newVersionId;
+    }
+
+    if (publishing) {
+      // Tells the server to set libraryPublishedAt timestamp.
+      current.publishLibrary = true;
+    } else if (publishing === false) {
+      // Unpublishing, so nullify libraryPublishedAt timestamp.
+      current.libraryPublishedAt = null;
+    }
+
+    this.updateChannels_();
   },
   setTitle(newName) {
     if (newName && appOptions.gameDisplayName) {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -590,27 +590,32 @@ var projects = (module.exports = {
    * Updates the current channel's library details.
    *
    * @param {Object} config - Object containing library details.
-   * @param {string} config.newName
-   * @param {string} config.newDescription
-   * @param {string} config.newVersionId - S3 version ID for the current library version. Passing this value as -1 will nullify libraryLatestVersion.
+   * @param {string} config.libraryName
+   * @param {string} config.libraryDescription
+   * @param {string} config.latestLibraryVersion - S3 version ID for the current library version. Passing this value as -1 will nullify libraryLatestVersion.
    * @param {boolean} config.publishing - true if library is being published, false if library is being unpublished, undefined otherwise.
    */
   setLibraryDetails(config = {}) {
     current = current || {};
-    const {newName, newDescription, newVersionId, publishing} = config;
+    const {
+      libraryName,
+      libraryDescription,
+      latestLibraryVersion,
+      publishing
+    } = config;
 
     if (
-      current.libraryName !== newName ||
-      current.libraryDescription !== newDescription ||
-      current.latestLibraryVersion !== newVersionId ||
+      current.libraryName !== libraryName ||
+      current.libraryDescription !== libraryDescription ||
+      current.latestLibraryVersion !== latestLibraryVersion ||
       publishing !== undefined
     ) {
-      current.libraryName = newName;
-      current.libraryDescription = newDescription;
+      current.libraryName = libraryName;
+      current.libraryDescription = libraryDescription;
 
-      if (newVersionId) {
+      if (latestLibraryVersion) {
         current.latestLibraryVersion =
-          newVersionId === -1 ? null : newVersionId;
+          latestLibraryVersion === -1 ? null : latestLibraryVersion;
       }
 
       if (publishing) {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -586,8 +586,23 @@ var projects = (module.exports = {
       this.updateChannels_(callback);
     }
   },
-  setLibraryDetails(newName, newDescription, publishing = undefined) {
+  /**
+   *
+   * @param {Object} config - Object containing library details.
+   * @param {string} config.newName
+   * @param {string} config.newDescription
+   * @param {boolean} config.publishing - true if library is being published, false if library is being unpublished, undefined otherwise.
+   * @param {string} config.versionId - S3 version ID for the current library version.
+   *
+   * NOTE: One of the following must be true or the library channel will not be updated:
+   *  1. config.newName !== current.libraryName
+   *  2. config.newDescription !== current.libraryDescription
+   *  3. config.publishing is present
+   */
+  setLibraryDetails(config = {}) {
     current = current || {};
+    const {newName, newDescription, publishing} = config;
+
     if (
       current.libraryName !== newName ||
       current.libraryDescription !== newDescription ||

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -592,34 +592,37 @@ var projects = (module.exports = {
    * @param {Object} config - Object containing library details.
    * @param {string} config.newName
    * @param {string} config.newDescription
-   * @param {string} config.newVersionId - S3 version ID for the current library version.
+   * @param {string} config.newVersionId - S3 version ID for the current library version. Passing this value as -1 will nullify libraryLatestVersion.
    * @param {boolean} config.publishing - true if library is being published, false if library is being unpublished, undefined otherwise.
    */
   setLibraryDetails(config = {}) {
     current = current || {};
     const {newName, newDescription, newVersionId, publishing} = config;
 
-    if (newName) {
+    if (
+      current.libraryName !== newName ||
+      current.libraryDescription !== newDescription ||
+      current.latestLibraryVersion !== newVersionId ||
+      publishing !== undefined
+    ) {
       current.libraryName = newName;
-    }
-
-    if (newDescription) {
       current.libraryDescription = newDescription;
-    }
 
-    if (newVersionId) {
-      current.latestLibraryVersion = newVersionId;
-    }
+      if (newVersionId) {
+        current.latestLibraryVersion =
+          newVersionId === -1 ? null : newVersionId;
+      }
 
-    if (publishing) {
-      // Tells the server to set libraryPublishedAt timestamp.
-      current.publishLibrary = true;
-    } else if (publishing === false) {
-      // Unpublishing, so nullify libraryPublishedAt timestamp.
-      current.libraryPublishedAt = null;
-    }
+      if (publishing) {
+        // Tells the server to set libraryPublishedAt timestamp.
+        current.publishLibrary = true;
+      } else if (publishing === false) {
+        // Unpublishing, so nullify libraryPublishedAt timestamp.
+        current.libraryPublishedAt = null;
+      }
 
-    this.updateChannels_();
+      this.updateChannels_();
+    }
   },
   setTitle(newName) {
     if (newName && appOptions.gameDisplayName) {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -604,31 +604,29 @@ var projects = (module.exports = {
       publishing
     } = config;
 
-    if (
-      current.libraryName !== libraryName ||
-      current.libraryDescription !== libraryDescription ||
-      current.latestLibraryVersion !== latestLibraryVersion ||
-      publishing !== undefined
-    ) {
+    if (libraryName !== current.libraryName) {
       current.libraryName = libraryName;
-      current.libraryDescription = libraryDescription;
-
-      if (latestLibraryVersion) {
-        current.latestLibraryVersion =
-          latestLibraryVersion === -1 ? null : latestLibraryVersion;
-      }
-
-      if (publishing) {
-        // Tells the server to set libraryPublishedAt timestamp.
-        current.publishLibrary = true;
-      } else if (publishing === false) {
-        // Unpublishing, so nullify libraryPublishedAt timestamp.
-        current.libraryPublishedAt = null;
-        current.publishLibrary = false;
-      }
-
-      this.updateChannels_();
     }
+
+    if (libraryDescription !== current.libraryDescription) {
+      current.libraryDescription = libraryDescription;
+    }
+
+    if (latestLibraryVersion !== current.latestLibraryVersion) {
+      current.latestLibraryVersion =
+        latestLibraryVersion === -1 ? null : latestLibraryVersion;
+    }
+
+    if (publishing) {
+      // Tells the server to set libraryPublishedAt timestamp.
+      current.publishLibrary = true;
+    } else if (publishing === false) {
+      // Unpublishing, so nullify libraryPublishedAt timestamp.
+      current.libraryPublishedAt = null;
+      current.publishLibrary = false;
+    }
+
+    this.updateChannels_();
   },
   setTitle(newName) {
     if (newName && appOptions.gameDisplayName) {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -619,6 +619,7 @@ var projects = (module.exports = {
       } else if (publishing === false) {
         // Unpublishing, so nullify libraryPublishedAt timestamp.
         current.libraryPublishedAt = null;
+        current.publishLibrary = false;
       }
 
       this.updateChannels_();

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -1,8 +1,7 @@
 import {expect} from '../../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow} from 'enzyme';
-import {
-  LibraryPublisher,
+import LibraryPublisher, {
   PublishState
 } from '@cdo/apps/code-studio/components/libraries/LibraryPublisher';
 import LibraryClientApi from '@cdo/apps/code-studio/components/libraries/LibraryClientApi';
@@ -240,7 +239,7 @@ describe('LibraryPublisher', () => {
     libraryParser.createLibraryJson.restore();
   });
 
-  describe('onUnpublishComplete', () => {
+  describe('unpublish', () => {
     let wrapper, deleteSpy;
     beforeEach(() => {
       deleteSpy = sinon.stub(libraryClientApi, 'delete');
@@ -256,14 +255,14 @@ describe('LibraryPublisher', () => {
 
     it('calls onUnpublishSuccess when it succeeds', () => {
       deleteSpy.callsArg(0);
-      wrapper.instance().onUnpublishComplete(null, {});
+      wrapper.instance().unpublish();
       expect(onUnpublishSuccess.called).to.be.true;
     });
 
     it('sets ERROR_UNPUBLISH when it fails', () => {
       sinon.stub(console, 'warn');
       deleteSpy.callsArg(1);
-      wrapper.instance().onUnpublishComplete(new Error(), {});
+      wrapper.instance().unpublish();
       wrapper.update();
       expect(wrapper.state().publishState).to.equal(
         PublishState.ERROR_UNPUBLISH

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -580,6 +580,36 @@ describe('project.js', () => {
       currentProject = project.__TestInterface.getCurrent();
       expect(currentProject.libraryPublishedAt).to.be.null;
     });
+
+    it('does not call updateChannels_ if library details are unchanged', () => {
+      const lib = {
+        libraryName: 'my name',
+        libraryDescription: 'my description',
+        latestLibraryVersion: '123456',
+        libraryPublishedAt: new Date()
+      };
+      setData(lib);
+      let currentProject = project.__TestInterface.getCurrent();
+      expect(currentProject.libraryName).to.equal(lib.libraryName);
+      expect(currentProject.libraryDescription).to.equal(
+        lib.libraryDescription
+      );
+      expect(currentProject.latestLibraryVersion).to.equal(
+        lib.latestLibraryVersion
+      );
+      expect(currentProject.libraryPublishedAt).to.equal(
+        lib.libraryPublishedAt
+      );
+
+      project.setLibraryDetails({
+        newName: lib.libraryName,
+        newDescription: lib.libraryDescription,
+        newVersionId: lib.latestLibraryVersion,
+        publishing: undefined
+      });
+
+      expect(project.updateChannels_).not.to.have.been.called;
+    });
   });
 
   describe('setProjectLibraries()', () => {

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -506,7 +506,7 @@ describe('project.js', () => {
     });
   });
 
-  describe('setLibraryDetails()', () => {
+  describe('setLibraryDetails(config)', () => {
     beforeEach(() => {
       sinon.stub(project, 'updateChannels_');
     });
@@ -524,7 +524,7 @@ describe('project.js', () => {
 
       expect(project.getCurrentLibraryName()).to.equal(oldName);
       expect(project.getCurrentLibraryDescription()).to.equal(oldDescription);
-      project.setLibraryDetails(newName, newDescription);
+      project.setLibraryDetails({newName, newDescription});
       expect(project.getCurrentLibraryName()).to.equal(newName);
       expect(project.getCurrentLibraryDescription()).to.equal(newDescription);
       expect(project.updateChannels_).to.have.been.called;
@@ -555,7 +555,11 @@ describe('project.js', () => {
       });
 
       it('sets publishLibrary if true', () => {
-        project.setLibraryDetails(libraryName, libraryDescription, true);
+        project.setLibraryDetails({
+          newName: libraryName,
+          newDescription: libraryDescription,
+          publishing: true
+        });
         const currentProject = project.__TestInterface.getCurrent();
 
         expect(currentProject.publishLibrary).to.be.true;
@@ -567,7 +571,11 @@ describe('project.js', () => {
       });
 
       it('nullifies libraryPublishedAt if false', () => {
-        project.setLibraryDetails(libraryName, libraryDescription, false);
+        project.setLibraryDetails({
+          newName: libraryName,
+          newDescription: libraryDescription,
+          publishing: false
+        });
         const currentProject = project.__TestInterface.getCurrent();
 
         expect(currentProject.libraryPublishedAt).to.be.null;
@@ -579,7 +587,10 @@ describe('project.js', () => {
       });
 
       it('does nothing if undefined', () => {
-        project.setLibraryDetails(libraryName, libraryDescription);
+        project.setLibraryDetails({
+          newName: libraryName,
+          newDescription: libraryDescription
+        });
         const currentProject = project.__TestInterface.getCurrent();
 
         expect(currentProject.libraryName).to.equal(libraryName);

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -551,6 +551,11 @@ describe('project.js', () => {
 
       currentProject = project.__TestInterface.getCurrent();
       expect(currentProject.latestLibraryVersion).to.equal(newVersion);
+
+      project.setLibraryDetails({newVersionId: -1});
+
+      currentProject = project.__TestInterface.getCurrent();
+      expect(currentProject.latestLibraryVersion).to.be.null;
     });
 
     it('updates current publishLibrary if publishing is true', () => {

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {expect} from '../../../util/reconfiguredChai';
+import {expect, assert} from '../../../util/reconfiguredChai';
 import sinon from 'sinon';
 import {replaceOnWindow, restoreOnWindow} from '../../../util/testUtils';
 import * as utils from '@cdo/apps/utils';
@@ -581,7 +581,7 @@ describe('project.js', () => {
       expect(currentProject.libraryPublishedAt).to.be.null;
     });
 
-    it('does not call updateChannels_ if library details are unchanged', () => {
+    it('does not overwrite current with undefined/missing config properties', () => {
       const lib = {
         libraryName: 'my name',
         libraryDescription: 'my description',
@@ -590,23 +590,22 @@ describe('project.js', () => {
       };
       setData(lib);
       let currentProject = project.__TestInterface.getCurrent();
+      assert.deepEqual(currentProject, lib);
+
+      project.setLibraryDetails({
+        libraryDescription: 'new description',
+        latestLibraryVersion: undefined
+      });
+
+      currentProject = project.__TestInterface.getCurrent();
       expect(currentProject.libraryName).to.equal(lib.libraryName);
-      expect(currentProject.libraryDescription).to.equal(
-        lib.libraryDescription
-      );
+      expect(currentProject.libraryDescription).to.equal('new description');
       expect(currentProject.latestLibraryVersion).to.equal(
         lib.latestLibraryVersion
       );
       expect(currentProject.libraryPublishedAt).to.equal(
         lib.libraryPublishedAt
       );
-
-      project.setLibraryDetails({
-        ...lib,
-        publishing: undefined
-      });
-
-      expect(project.updateChannels_).not.to.have.been.called;
     });
   });
 

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -516,43 +516,43 @@ describe('project.js', () => {
       setData({});
     });
 
-    it('updates current library name if newName provided', () => {
+    it('updates current library name if libraryName provided', () => {
       let oldName = 'initialLibrary';
       let newName = 'newLibraryName';
       setData({libraryName: oldName});
       expect(project.getCurrentLibraryName()).to.equal(oldName);
 
-      project.setLibraryDetails({newName});
+      project.setLibraryDetails({libraryName: newName});
 
       expect(project.getCurrentLibraryName()).to.equal(newName);
       expect(project.updateChannels_).to.have.been.called;
     });
 
-    it('updates current library description if newDescription provided', () => {
+    it('updates current library description if libraryDescription provided', () => {
       let oldDescription = 'initialDescription';
       let newDescription = 'newLibraryDescription';
       setData({libraryDescription: oldDescription});
       expect(project.getCurrentLibraryDescription()).to.equal(oldDescription);
 
-      project.setLibraryDetails({newDescription});
+      project.setLibraryDetails({libraryDescription: newDescription});
 
       expect(project.getCurrentLibraryDescription()).to.equal(newDescription);
       expect(project.updateChannels_).to.have.been.called;
     });
 
-    it('updates current latestLibraryVersion if newVersionId provided', () => {
+    it('updates current latestLibraryVersion if latestLibraryVersion provided', () => {
       let oldVersion = '123456';
       let newVersion = '654321';
       setData({latestLibraryVersion: oldVersion});
       let currentProject = project.__TestInterface.getCurrent();
       expect(currentProject.latestLibraryVersion).to.equal(oldVersion);
 
-      project.setLibraryDetails({newVersionId: newVersion});
+      project.setLibraryDetails({latestLibraryVersion: newVersion});
 
       currentProject = project.__TestInterface.getCurrent();
       expect(currentProject.latestLibraryVersion).to.equal(newVersion);
 
-      project.setLibraryDetails({newVersionId: -1});
+      project.setLibraryDetails({latestLibraryVersion: -1});
 
       currentProject = project.__TestInterface.getCurrent();
       expect(currentProject.latestLibraryVersion).to.be.null;
@@ -602,9 +602,7 @@ describe('project.js', () => {
       );
 
       project.setLibraryDetails({
-        newName: lib.libraryName,
-        newDescription: lib.libraryDescription,
-        newVersionId: lib.latestLibraryVersion,
+        ...lib,
         publishing: undefined
       });
 

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -506,98 +506,74 @@ describe('project.js', () => {
     });
   });
 
-  describe('setLibraryDetails(config)', () => {
+  describe('setLibraryDetails()', () => {
     beforeEach(() => {
       sinon.stub(project, 'updateChannels_');
     });
 
     afterEach(() => {
       project.updateChannels_.restore();
-    });
-
-    it('updates the current library name and description', () => {
-      let oldName = 'initialLibrary';
-      let oldDescription = 'initialDescription';
-      let newName = 'newLibraryName';
-      let newDescription = 'newLibraryDescription';
-      setData({libraryName: oldName, libraryDescription: oldDescription});
-
-      expect(project.getCurrentLibraryName()).to.equal(oldName);
-      expect(project.getCurrentLibraryDescription()).to.equal(oldDescription);
-      project.setLibraryDetails({newName, newDescription});
-      expect(project.getCurrentLibraryName()).to.equal(newName);
-      expect(project.getCurrentLibraryDescription()).to.equal(newDescription);
-      expect(project.updateChannels_).to.have.been.called;
-
       setData({});
     });
 
-    it('does nothing if name and description are unchanged', () => {
-      expect(project.getCurrentLibraryName()).to.be.undefined;
-      expect(project.getCurrentLibraryDescription()).to.be.undefined;
-      project.setLibraryDetails();
-      expect(project.getCurrentLibraryName()).to.be.undefined;
-      expect(project.getCurrentLibraryDescription()).to.be.undefined;
-      expect(project.updateChannels_).to.have.not.been.called;
+    it('updates current library name if newName provided', () => {
+      let oldName = 'initialLibrary';
+      let newName = 'newLibraryName';
+      setData({libraryName: oldName});
+      expect(project.getCurrentLibraryName()).to.equal(oldName);
+
+      project.setLibraryDetails({newName});
+
+      expect(project.getCurrentLibraryName()).to.equal(newName);
+      expect(project.updateChannels_).to.have.been.called;
     });
 
-    describe('publishing param', () => {
-      const libraryName = 'myLib';
-      const libraryDescription = 'a cool library!';
-      const libraryPublishedAt = new Date();
+    it('updates current library description if newDescription provided', () => {
+      let oldDescription = 'initialDescription';
+      let newDescription = 'newLibraryDescription';
+      setData({libraryDescription: oldDescription});
+      expect(project.getCurrentLibraryDescription()).to.equal(oldDescription);
 
-      beforeEach(() => {
-        setData({libraryName, libraryDescription, libraryPublishedAt});
-      });
+      project.setLibraryDetails({newDescription});
 
-      afterEach(() => {
-        setData({});
-      });
+      expect(project.getCurrentLibraryDescription()).to.equal(newDescription);
+      expect(project.updateChannels_).to.have.been.called;
+    });
 
-      it('sets publishLibrary if true', () => {
-        project.setLibraryDetails({
-          newName: libraryName,
-          newDescription: libraryDescription,
-          publishing: true
-        });
-        const currentProject = project.__TestInterface.getCurrent();
+    it('updates current latestLibraryVersion if newVersionId provided', () => {
+      let oldVersion = '123456';
+      let newVersion = '654321';
+      setData({latestLibraryVersion: oldVersion});
+      let currentProject = project.__TestInterface.getCurrent();
+      expect(currentProject.latestLibraryVersion).to.equal(oldVersion);
 
-        expect(currentProject.publishLibrary).to.be.true;
+      project.setLibraryDetails({newVersionId: newVersion});
 
-        // Make sure other properties are unaffected
-        expect(currentProject.libraryName).to.equal(libraryName);
-        expect(currentProject.libraryDescription).to.equal(libraryDescription);
-        expect(currentProject.libraryPublishedAt).to.equal(libraryPublishedAt);
-      });
+      currentProject = project.__TestInterface.getCurrent();
+      expect(currentProject.latestLibraryVersion).to.equal(newVersion);
+    });
 
-      it('nullifies libraryPublishedAt if false', () => {
-        project.setLibraryDetails({
-          newName: libraryName,
-          newDescription: libraryDescription,
-          publishing: false
-        });
-        const currentProject = project.__TestInterface.getCurrent();
+    it('updates current publishLibrary if publishing is true', () => {
+      setData({publishLibrary: false});
+      let currentProject = project.__TestInterface.getCurrent();
+      expect(currentProject.publishLibrary).to.be.false;
 
-        expect(currentProject.libraryPublishedAt).to.be.null;
+      project.setLibraryDetails({publishing: true});
 
-        // Make sure other properties are unaffected
-        expect(currentProject.libraryName).to.equal(libraryName);
-        expect(currentProject.libraryDescription).to.equal(libraryDescription);
-        expect(currentProject.publishLibrary).to.be.undefined;
-      });
+      currentProject = project.__TestInterface.getCurrent();
+      expect(currentProject.publishLibrary).to.be.true;
+    });
 
-      it('does nothing if undefined', () => {
-        project.setLibraryDetails({
-          newName: libraryName,
-          newDescription: libraryDescription
-        });
-        const currentProject = project.__TestInterface.getCurrent();
+    it('nullifies current libraryPublishedAt if publishing is false', () => {
+      const oldPublishedAt = new Date();
+      setData({libraryPublishedAt: oldPublishedAt});
+      let currentProject = project.__TestInterface.getCurrent();
+      expect(currentProject.libraryPublishedAt).to.equal(oldPublishedAt);
 
-        expect(currentProject.libraryName).to.equal(libraryName);
-        expect(currentProject.libraryDescription).to.equal(libraryDescription);
-        expect(currentProject.publishLibrary).to.be.undefined;
-        expect(currentProject.libraryPublishedAt).to.equal(libraryPublishedAt);
-      });
+      project.setLibraryDetails({publishing: false});
+
+      currentProject = project.__TestInterface.getCurrent();
+      expect(currentProject.libraryPublishedAt).to.be.null;
     });
   });
 


### PR DESCRIPTION
## Description

1. After a library is published to S3, we take the `versionId` returned from the server and save that in the projects db as `latestLibraryVersion`
2. `setLibraryDetails` now accepts a `config` option as its parameter (for cleanliness -- I didn't want to keep adding params to this method)
3. Fixed a bug I introduced in #33374 where `POST /v3/channels/:channel_id` was being called twice on unpublish (more details in [comment](https://github.com/code-dot-org/code-dot-org/pull/33552/files#r390689047))
4. Fixed a bug I introduced in #33330 where publishing/unpublishing a library without a pageload in-between resulted in `libraryPublishedAt` not being cleared on the server because `current.publishLibrary === true` (more details in [comment](https://github.com/code-dot-org/code-dot-org/pull/33552/files#r390689389))

## Links

- [STAR-707](https://codedotorg.atlassian.net/browse/STAR-707) (this PR corresponds to part 1 in the task description)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
