### PR TITLE
[Cleanup][Applab Data] Coerce Firebase response to consistent type

### DIFF
--- a/apps/src/storage/dataBrowser/DataBrowser.jsx
+++ b/apps/src/storage/dataBrowser/DataBrowser.jsx
@@ -101,8 +101,6 @@ class DataBrowser extends React.Component {
     // from redux state
     tableListMap: PropTypes.object.isRequired,
     view: PropTypes.oneOf(Object.keys(DataView)),
-    keyValueData: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
 
     // from redux dispatch
     onShowWarning: PropTypes.func.isRequired,
@@ -223,8 +221,7 @@ DataBrowser.TabType = TabType;
 export default connect(
   state => ({
     view: state.data.view,
-    tableListMap: state.data.tableListMap || {},
-    keyValueData: state.data.keyValueData || {}
+    tableListMap: state.data.tableListMap || {}
   }),
   dispatch => ({
     onShowWarning(warningMsg, warningTitle) {

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -62,12 +62,7 @@ class DataTable extends React.Component {
     // from redux state
     tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     tableName: PropTypes.string.isRequired,
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    tableRecords: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
+    tableRecords: PropTypes.array.isRequired,
 
     // from redux dispatch
     onShowWarning: PropTypes.func.isRequired
@@ -196,13 +191,10 @@ class DataTable extends React.Component {
   };
 
   getRowsForCurrentPage(rowsPerPage) {
-    if (this.props.tableRecords['slice']) {
-      return this.props.tableRecords.slice(
-        this.state.currentPage * rowsPerPage,
-        (this.state.currentPage + 1) * rowsPerPage
-      );
-    }
-    return this.props.tableRecords;
+    return this.props.tableRecords.slice(
+      this.state.currentPage * rowsPerPage,
+      (this.state.currentPage + 1) * rowsPerPage
+    );
   }
 
   render() {
@@ -212,7 +204,7 @@ class DataTable extends React.Component {
     let rowsPerPage = this.props.rowsPerPage || MAX_ROWS_PER_PAGE;
     let numPages = Math.max(
       1,
-      Math.ceil(Object.keys(this.props.tableRecords).length / rowsPerPage)
+      Math.ceil(this.props.tableRecords.length / rowsPerPage)
     );
     let rows = this.getRowsForCurrentPage(rowsPerPage);
 
@@ -303,7 +295,7 @@ class DataTable extends React.Component {
 export default connect(
   state => ({
     tableColumns: state.data.tableColumns || [],
-    tableRecords: state.data.tableRecords || {},
+    tableRecords: state.data.tableRecords || [],
     tableName: state.data.tableName || ''
   }),
   dispatch => ({

--- a/apps/src/storage/dataBrowser/DataTableView.jsx
+++ b/apps/src/storage/dataBrowser/DataTableView.jsx
@@ -68,12 +68,7 @@ class DataTableView extends React.Component {
     tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     tableName: PropTypes.string.isRequired,
     tableListMap: PropTypes.object.isRequired,
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    tableRecords: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
+    tableRecords: PropTypes.array.isRequired,
     view: PropTypes.oneOf(Object.keys(DataView)),
 
     // from redux dispatch
@@ -132,12 +127,7 @@ class DataTableView extends React.Component {
   };
 
   getTableJson() {
-    const records = [];
-    // Cast Array to Object
-    const tableRecords = Object.assign({}, this.props.tableRecords);
-    for (const id in tableRecords) {
-      records.push(JSON.parse(tableRecords[id]));
-    }
+    const records = this.props.tableRecords.map(record => JSON.parse(record));
     return JSON.stringify(records, null, 2);
   }
 
@@ -199,7 +189,7 @@ export default connect(
   state => ({
     view: state.data.view,
     tableColumns: state.data.tableColumns || [],
-    tableRecords: state.data.tableRecords || {},
+    tableRecords: state.data.tableRecords || [],
     tableName: state.data.tableName || '',
     tableListMap: state.data.tableListMap || {}
   }),

--- a/apps/src/storage/dataBrowser/KVPairs.jsx
+++ b/apps/src/storage/dataBrowser/KVPairs.jsx
@@ -30,12 +30,7 @@ class KVPairs extends React.Component {
   static propTypes = {
     // from redux state
     view: PropTypes.oneOf(Object.keys(DataView)),
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    keyValueData: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
+    keyValueData: PropTypes.object.isRequired,
 
     // from redux dispatch
     onShowWarning: PropTypes.func.isRequired,

--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -56,12 +56,7 @@ class VisualizerModal extends React.Component {
     // from redux state
     tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     tableName: PropTypes.string.isRequired,
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    tableRecords: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired
+    tableRecords: PropTypes.array.isRequired
   };
 
   state = {...INITIAL_STATE};
@@ -143,13 +138,7 @@ class VisualizerModal extends React.Component {
   }
 
   render() {
-    // this.props.tableRecords is either an object or an array (see propTypes comment). If it's an object, we want to
-    // convert it to an array before trying to parse the records.
-    const parsedRecords = this.parseRecords(
-      Array.isArray(this.props.tableRecords)
-        ? this.props.tableRecords
-        : Object.values(this.props.tableRecords)
-    );
+    const parsedRecords = this.parseRecords(this.props.tableRecords);
     let filteredRecords = parsedRecords;
     if (this.state.filterColumn !== '' && this.state.filterValue !== '') {
       filteredRecords = this.filterRecords(
@@ -341,6 +330,6 @@ class VisualizerModal extends React.Component {
 export const UnconnectedVisualizerModal = VisualizerModal;
 export default connect(state => ({
   tableColumns: state.data.tableColumns || [],
-  tableRecords: state.data.tableRecords || {},
+  tableRecords: state.data.tableRecords || [],
   tableName: state.data.tableName || ''
 }))(VisualizerModal);

--- a/apps/src/storage/levelbuilder/Dataset.jsx
+++ b/apps/src/storage/levelbuilder/Dataset.jsx
@@ -30,14 +30,7 @@ class Dataset extends React.Component {
   static propTypes = {
     isLive: PropTypes.bool.isRequired,
     // Provided via Redux
-    tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     tableName: PropTypes.string.isRequired,
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    tableRecords: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
     onUploadComplete: PropTypes.func.isRequired
   };
 
@@ -90,8 +83,6 @@ class Dataset extends React.Component {
 
 export default connect(
   state => ({
-    tableColumns: state.data.tableColumns || [],
-    tableRecords: state.data.tableRecords || {},
     tableName: state.data.tableName || ''
   }),
   dispatch => ({

--- a/apps/src/storage/redux/data.js
+++ b/apps/src/storage/redux/data.js
@@ -65,7 +65,12 @@ export default function(state = initialState, action) {
       return state.set('tableListMap', map);
     }
     case UPDATE_KEY_VALUE_DATA:
-      return state.set('keyValueData', action.keyValueData);
+      // "if all of the keys are integers, and more than half of the keys between 0 and
+      // the maximum key in the object have non-empty values, then Firebase will render
+      // it as an array."
+      // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
+      // For simplicity, always coerce it to an object.
+      return state.set('keyValueData', Object.assign({}, action.keyValueData));
     case UPDATE_TABLE_COLUMNS:
       if (state.tableName === action.tableName) {
         return state.set('tableColumns', action.tableColumns);

--- a/apps/src/storage/redux/data.js
+++ b/apps/src/storage/redux/data.js
@@ -83,6 +83,9 @@ export default function(state = initialState, action) {
         // it as an array."
         // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
         // For simplicity, always coerce it to an array (list of records).
+        if (!action.tableRecords) {
+          return state.set('tableRecords', []);
+        }
         const records = Array.isArray(action.tableRecords)
           ? action.tableRecords
           : Object.values(action.tableRecords);

--- a/apps/src/storage/redux/data.js
+++ b/apps/src/storage/redux/data.js
@@ -32,7 +32,7 @@ const DataState = Record({
   tableListMap: {},
   tableName: '',
   tableColumns: [],
-  tableRecords: {},
+  tableRecords: [],
   keyValueData: {},
   warningTitle: '',
   warningMsg: '',
@@ -56,7 +56,7 @@ export default function(state = initialState, action) {
       // Discard table data when not viewing a table, so that we don't momentarily
       // show data for the wrong table when we return to the table view.
       if (action.view !== DataView.TABLE) {
-        state = state.set('tableRecords', {});
+        state = state.set('tableRecords', []);
       }
       return state.set('view', action.view).set('tableName', action.tableName);
     case DELETE_TABLE_NAME: {
@@ -78,7 +78,15 @@ export default function(state = initialState, action) {
       return state;
     case UPDATE_TABLE_RECORDS:
       if (state.tableName === action.tableName) {
-        return state.set('tableRecords', action.tableRecords);
+        // "if all of the keys are integers, and more than half of the keys between 0 and
+        // the maximum key in the object have non-empty values, then Firebase will render
+        // it as an array."
+        // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
+        // For simplicity, always coerce it to an array (list of records).
+        const records = Array.isArray(action.tableRecords)
+          ? action.tableRecords
+          : Object.values(action.tableRecords);
+        return state.set('tableRecords', records);
       }
       return state;
     case SHOW_WARNING:
@@ -99,7 +107,7 @@ export default function(state = initialState, action) {
       return state
         .set('isPreviewOpen', false)
         .set('tableName', '')
-        .set('tableRecords', {})
+        .set('tableRecords', [])
         .set('tableColumns', []);
     case SET_LIBRARY_MANIFEST:
       return state.set('libraryManifest', action.libraryManifest);


### PR DESCRIPTION
From the [firebase docs](https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html):
> If all of the keys are integers, and more than half of the keys between 0 and the maximum key in the object have non-empty values, then Firebase will render it as an array.

This is kind of tricky for our use-case because we're ending up with data that is sometimes returned as an array and sometimes an object.

For key value pairs, we should *always* coerce the data to an object.
For data tables, we should *always* coerce the data to an array (it's a list of records, and we don't really actually care what the ids of the records are).

---
More detailed explanation of why the way this works currently is confusing:

For example,
![image](https://user-images.githubusercontent.com/8787187/76368603-0abb3180-62ee-11ea-8401-ee1ac9d2431e.png)
returns `[empty, "2", empty, 4]`
while 
![image](https://user-images.githubusercontent.com/8787187/76368638-2d4d4a80-62ee-11ea-8562-1e92bd66b4c3.png)
returns `{1: "2", 10: "100", 3: "4"} `

Similarly for tables:
![image](https://user-images.githubusercontent.com/8787187/76368733-73a2a980-62ee-11ea-82b0-3b34df1e523f.png)
returns ` [empty, "{"column1":1,"id":1}", "{"column1":2,"id":2}", "{"column1":3,"id":3}"]`
but
![image](https://user-images.githubusercontent.com/8787187/76368794-959c2c00-62ee-11ea-82d1-0f51dcacce66.png)
returns `{4: "{"column1":4,"id":4}", 5: "{"column1":5,"id":5}", 6: "{"column1":6,"id":6}"}`

This leads to some hard-to-catch bugs.
For example, the first example shown, where the key/value data is returned as an array, is currently broken on production.
![image](https://user-images.githubusercontent.com/8787187/76368937-10654700-62ef-11ea-87b1-ff127803eb28.png)
![image](https://user-images.githubusercontent.com/8787187/76368949-165b2800-62ef-11ea-87d1-2fafa505cd74.png)

Another example: pagination doesn't work in the data tab if the data is returned as an object, not an array.



<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
