### PR TITLE
Extract email preferences into contact_rollups_raw

### DIFF
--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require_relative('../../dashboard/config/environment')
+require 'cdo/contact_rollups_v2'
+require 'cdo/only_one'
+require 'cdo/log_collector'
+
+def main
+  log_collector = LogCollector.new "Build contact rollups"
+
+  # Build new daily table of contact rollups
+  ContactRollupsV2.build_contact_rollups(log_collector)
+  puts log_collector.to_s
+end
+
+main if only_one_running?(__FILE__)

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -18,8 +18,8 @@
 class ContactRollupsRaw < ApplicationRecord
   self.table_name = 'contact_rollups_raw'
 
-  def self.truncate_raw_contacts
-    ActiveRecord::Base.connection.execute("TRUNCATE TABLE contact_rollups_raw")
+  def self.truncate_table
+    ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name}")
   end
 
   def self.extract_email_preferences
@@ -28,7 +28,7 @@ class ContactRollupsRaw < ApplicationRecord
       email_preference_batch.each do |email_preference|
         raw_contact = {
           email: email_preference.email,
-          sources: 'dashboard_production.email_preferences',
+          sources: EmailPreference.table_name,
           data: {opt_in: email_preference.opt_in}.to_json,
           data_updated_at: email_preference.updated_at
         }

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -17,4 +17,27 @@
 
 class ContactRollupsRaw < ApplicationRecord
   self.table_name = 'contact_rollups_raw'
+
+  def self.truncate_raw_contacts
+    ActiveRecord::Base.connection.execute("TRUNCATE TABLE contact_rollups_raw")
+  end
+
+  def self.extract_email_preferences
+    EmailPreference.all.find_in_batches(batch_size: 1000) do |email_preference_batch|
+      raw_contacts = []
+      email_preference_batch.each do |email_preference|
+        raw_contact = {
+          email: email_preference.email,
+          sources: 'dashboard_production.email_preferences',
+          data: {opt_in: email_preference.opt_in}.to_json,
+          data_updated_at: email_preference.updated_at
+        }
+        raw_contacts << raw_contact
+      end
+
+      # ben to do: handle if required fields are missing, or if there's a duplicate?
+      # currently will fail if any required fields are missing
+      import! raw_contacts
+    end
+  end
 end

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -28,8 +28,8 @@ class ContactRollupsRaw < ApplicationRecord
       email_preference_batch.each do |email_preference|
         raw_contact = {
           email: email_preference.email,
-          sources: EmailPreference.table_name,
-          data: {opt_in: email_preference.opt_in}.to_json,
+          sources: "dashboard.#{EmailPreference.table_name}",
+          data: {opt_in: email_preference.opt_in},
           data_updated_at: email_preference.updated_at
         }
         raw_contacts << raw_contact

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1233,4 +1233,11 @@ FactoryGirl.define do
   end
 
   factory :donor_school
+
+  factory :contact_rollups_raw do
+    sequence(:email) {|n| "contact_#{n}@example.domain"}
+    sequence(:sources) {|n| "dashboard.table_#{n}"}
+    data {{opt_in: 1}}
+    data_updated_at {Time.now}
+  end
 end

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -6,7 +6,10 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
     ContactRollupsRaw.extract_email_preferences
 
     expected_data = {opt_in: email_preference.opt_in}
-    result = ContactRollupsRaw.find_by(email: email_preference.email, sources: "dashboard.#{email_preference.class.table_name}")
+    result = ContactRollupsRaw.find_by(
+      email: email_preference.email,
+      sources: "dashboard.#{email_preference.class.table_name}"
+    )
 
     assert_equal expected_data, result.data.symbolize_keys
   end

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ContactRollupsRawTest < ActiveSupport::TestCase
+  test 'truncate_table removes all rows' do
+    create :email_preference
+    assert_equal 1, EmailPreference.count
+
+    ContactRollupsRaw.truncate_table
+    assert_equal 0, EmailPreference.count
+  end
+
+  test 'extract_email_preferences adds all email preferences' do
+    @email_preference = create :email_preference
+    ContactRollupsRaw.extract_email_preferences
+    assert ContactRollupsRaw.exists? email: @email_preference.email, sources: @email_preference.class.table_name
+  end
+end

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class ContactRollupsRawTest < ActiveSupport::TestCase
-  test 'extract_email_preferences adds all email preferences' do
+  test 'extract_email_preferences creates records as we would expect' do
     email_preference = create :email_preference
     ContactRollupsRaw.extract_email_preferences
 
@@ -14,7 +14,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
     assert_equal expected_data, result.data.symbolize_keys
   end
 
-  test 'bunch of email prefences works' do
+  test 'extract_email_preferences can import many email preferences' do
     3.times {|i| create :email_preference, email: "contact_#{i}@rollups.com"}
     ContactRollupsRaw.extract_email_preferences
     assert 3, ContactRollupsRaw.count

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -1,17 +1,19 @@
 require 'test_helper'
 
 class ContactRollupsRawTest < ActiveSupport::TestCase
-  test 'truncate_table removes all rows' do
-    create :email_preference
-    assert_equal 1, EmailPreference.count
+  test 'extract_email_preferences adds all email preferences' do
+    email_preference = create :email_preference
+    ContactRollupsRaw.extract_email_preferences
 
-    ContactRollupsRaw.truncate_table
-    assert_equal 0, EmailPreference.count
+    expected_data = {opt_in: email_preference.opt_in}
+    result = ContactRollupsRaw.find_by(email: email_preference.email, sources: "dashboard.#{email_preference.class.table_name}")
+
+    assert_equal expected_data, result.data.symbolize_keys
   end
 
-  test 'extract_email_preferences adds all email preferences' do
-    @email_preference = create :email_preference
+  test 'bunch of email prefences works' do
+    3.times {|i| create :email_preference, email: "contact_#{i}@rollups.com"}
     ContactRollupsRaw.extract_email_preferences
-    assert ContactRollupsRaw.exists? email: @email_preference.email, sources: @email_preference.class.table_name
+    assert 3, ContactRollupsRaw.count
   end
 end

--- a/lib/cdo/contact_rollups_v2.rb
+++ b/lib/cdo/contact_rollups_v2.rb
@@ -1,0 +1,9 @@
+require_relative('../../dashboard/config/environment')
+
+class ContactRollupsV2
+  def self.build_contact_rollups(log_collector)
+    # Set opt_in based on information collected in Dashboard Email Preference.
+    log_collector.time!("truncate_raw_contacts") {ContactRollupsRaw.truncate_raw_contacts}
+    log_collector.time!("extract_email_preferences") {ContactRollupsRaw.extract_email_preferences}
+  end
+end


### PR DESCRIPTION
Basic logic to extract email preferences into contact_rollups_raw by executing `bin/cron/build_contact_rollups_v2`.

## Testing story

Tested locally and on a newly created ad hoc connected to a production clone. `email_preferences` has close to a million rows in production -- some interesting findings:

- using `truncate` in raw SQL (in this PR) instead of `delete_all` in ActiveRecord (not in this PR) takes .3 seconds instead of 14 seconds.
- changing `find_in_batches` batch size from 1000 to 10000 has minimal impact on execution time (actually was 7 seconds slower, 337 vs 330)
- using a raw SQL query for inserts (not in this PR) instead of batched active record queries (in this PR) significantly reduces run time (17 seconds vs. 5.5 minutes) -- here is SQL query that was used:

```
  insert into contact_rollups_raw(email, sources, data, data_updated_at, created_at, updated_at)
  select email, 'dashboard.email_preferences', json_object('opt_in', opt_in), updated_at, now(), now() 
  from email_preferences
```

General finding is raw SQL dramatically outperforming ActiveRecord.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
