### PR TITLE
AFE: Audit school ids submitted to external form

### DIFF
--- a/apps/src/templates/DonorTeacherBanner.jsx
+++ b/apps/src/templates/DonorTeacherBanner.jsx
@@ -5,6 +5,7 @@ import Button from './Button';
 import color from '@cdo/apps/util/color';
 import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import {putRecord} from '../lib/util/firehose';
 
 const styles = {
   heading: {
@@ -115,6 +116,12 @@ export default class DonorTeacherBanner extends Component {
 
   handleSubmit = event => {
     if (this.state.permission && this.state.participate) {
+      putRecord({
+        study: 'afe-schools',
+        event: 'submit',
+        data_string: $('input[name="nces-id"]').val()
+      });
+
       // Post to the external endpoint in a new tab.
       $('#hidden_form').submit();
     }


### PR DESCRIPTION
Uses firehose to write a metrics event anytime someone submits the AFE banner, allowing us to check whether we're sending invalid NCES ids to the external form.

We had some reports last year that NCES id was being dropped between our system and theirs.  We've been asked to double-check whether our system is dropping NCES id before the POST request.

I don't know if we're actually seeing traffic to this feature anymore, but figured it'd be worth checking this way.

## Testing story

No tests integrated here.  I did some manual testing to check that the call to `putRecord` is working.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
