### PR TITLE
Can unselect a lesson that was previously marked as complete

### DIFF
--- a/apps/src/templates/sectionProgress/standards/LessonStatusDialog.jsx
+++ b/apps/src/templates/sectionProgress/standards/LessonStatusDialog.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import i18n from '@cdo/locale';
-import {connect} from 'react-redux';
 import BaseDialog from '../../BaseDialog';
 import DialogFooter from '../../teacherDashboard/DialogFooter';
 import Button from '../../Button';
@@ -16,12 +15,10 @@ const styles = {
   }
 };
 
-class LessonStatusDialog extends Component {
+export default class LessonStatusDialog extends Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
-    handleConfirm: PropTypes.func.isRequired,
-    // redux
-    selectedLessons: PropTypes.array.isRequired
+    handleConfirm: PropTypes.func.isRequired
   };
 
   render() {
@@ -48,7 +45,3 @@ class LessonStatusDialog extends Component {
     );
   }
 }
-
-export default connect(state => ({
-  selectedLessons: state.sectionStandardsProgress.selectedLessons
-}))(LessonStatusDialog);

--- a/apps/src/templates/sectionProgress/standards/LessonStatusList.jsx
+++ b/apps/src/templates/sectionProgress/standards/LessonStatusList.jsx
@@ -28,9 +28,7 @@ class LessonStatusList extends Component {
     const completedLessons = _.filter(unpluggedLessonList, function(lesson) {
       return lesson.completed;
     });
-    const alreadySelected = this.props.selectedLessons;
-    const displayAsSelected = alreadySelected.concat(completedLessons);
-    this.props.setSelectedLessons(displayAsSelected);
+    this.props.setSelectedLessons(completedLessons);
   }
 
   handleChange = selectedLessons => {

--- a/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
@@ -8,7 +8,8 @@ import LessonStatusDialog from './LessonStatusDialog';
 import {CreateStandardsReportDialog} from './CreateStandardsReportDialog';
 import {
   setTeacherCommentForReport,
-  getUnpluggedLessonsForScript
+  getUnpluggedLessonsForScript,
+  fetchStudentLevelScores
 } from './sectionStandardsProgressRedux';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import {TeacherScores} from './standardsConstants';
@@ -31,7 +32,8 @@ class StandardsViewHeaderButtons extends Component {
     setTeacherCommentForReport: PropTypes.func.isRequired,
     scriptId: PropTypes.number,
     selectedLessons: PropTypes.array.isRequired,
-    unpluggedLessons: PropTypes.array.isRequired
+    unpluggedLessons: PropTypes.array.isRequired,
+    fetchStudentLevelScores: PropTypes.func
   };
 
   state = {
@@ -109,6 +111,10 @@ class StandardsViewHeaderButtons extends Component {
         stage_scores: selectedStageScores.concat(unselectedStageScores)
       })
     }).done(() => {
+      this.props.fetchStudentLevelScores(
+        this.props.scriptId,
+        this.props.sectionId
+      );
       this.closeLessonStatusDialog();
     });
   };
@@ -162,6 +168,9 @@ export default connect(
   dispatch => ({
     setTeacherCommentForReport(comment) {
       dispatch(setTeacherCommentForReport(comment));
+    },
+    fetchStudentLevelScores(scriptId, sectionId) {
+      dispatch(fetchStudentLevelScores(scriptId, sectionId));
     }
   })
 )(StandardsViewHeaderButtons);

--- a/apps/test/unit/templates/sectionProgress/StandardsViewHeaderButtonsTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/StandardsViewHeaderButtonsTest.jsx
@@ -38,7 +38,7 @@ describe('StandardsViewHeaderButtons', () => {
       .find('Button')
       .at(0)
       .simulate('click');
-    expect(wrapper.find('Connect(LessonStatusDialog)')).to.have.lengthOf(1);
+    expect(wrapper.find('LessonStatusDialog')).to.have.lengthOf(1);
   });
   it('opens create report dialog', () => {
     const wrapper = shallow(


### PR DESCRIPTION
In testing the unplugged lesson status dialog yesterday we noticed that something that was marked as completed previously and saved could not be unmarked in a future time of opening the dialog. This makes it so that you can now uncheck previously completed lessons and it will save the result.

![uncheck-unplugged](https://user-images.githubusercontent.com/208083/76432008-c0d35980-6388-11ea-882e-ad4fa5956729.gif)

