### PR TITLE
Standards: reset instead of add standards associations on import

### DIFF
--- a/dashboard/app/controllers/admin_standards_controller.rb
+++ b/dashboard/app/controllers/admin_standards_controller.rb
@@ -21,9 +21,12 @@ class AdminStandardsController < ApplicationController
 
     curriculum_builder_lessons&.each do |lesson|
       stage = code_studio_stages[lesson["title"]]
+
       unless stage
         missing_stages << lesson["title"]
       end
+
+      updated_standards = []
 
       lesson["standards"].each do |standard|
         code_studio_standard = Standard.find_by(
@@ -37,11 +40,12 @@ class AdminStandardsController < ApplicationController
           missing_standards << standard["shortcode"]
         end
 
-        if code_studio_standard && stage && !stage.standards.include?(code_studio_standard)
-          stage.standards << code_studio_standard
-          stage.save!
+        if code_studio_standard && stage
+          updated_standards << code_studio_standard
         end
       end
+      stage.standards = updated_standards
+      stage.save!
     end
 
     if !missing_standards.empty? || !missing_stages.empty?


### PR DESCRIPTION
[LP-1157](https://codedotorg.atlassian.net/browse/LP-1157)

Previously, when importing standards we added any new associations to those that currently existed.  This could pose a problem if a standard association was removed from a lesson in Curriculum Builder; on re-import there would still be the removed association on Code Studio.  

To fix, I just re-set all of the standards associations for a stage on import rather than adding. 