### PR TITLE
add ability to render inline markdown in pegasus

### DIFF
--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -62,7 +62,8 @@ module Cdo
       # source strings that include HTML
       def translate(locale, key, options = ::I18n::EMPTY_HASH)
         translation = super(locale, key, options.except(:markdown))
-        if options.fetch(:markdown, false)
+        markdown = options.fetch(:markdown, false)
+        if markdown == true
           # The safe_links_only just makes sure that the URL is a "safe" web
           # one which starts with: "#", "/", "http://", "https://", "ftp://",
           # "mailto:" However, it isn't good enough because it ignores URLS
@@ -76,6 +77,9 @@ module Cdo
           # redacting all URLs in strings given to outside translators.
           @renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::Safe.new(safe_links_only: false))
           @renderer.render(translation)
+        elsif markdown == :inline
+          @inline_renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::Inline.new(filter_html: true))
+          @inline_renderer.render(translation)
         else
           translation
         end

--- a/lib/cdo/markdown_handler.rb
+++ b/lib/cdo/markdown_handler.rb
@@ -19,4 +19,8 @@ class MarkdownHandler
   def self.register_html_safe(*args)
     ActionView::Template.register_template_handler :safe_md, MarkdownHandler.new(*args)
   end
+
+  def self.register_inline(*args)
+    ActionView::Template.register_template_handler :inline_md, MarkdownHandler.new(*args)
+  end
 end

--- a/lib/cdo/pegasus/actionview_sinatra.rb
+++ b/lib/cdo/pegasus/actionview_sinatra.rb
@@ -1,5 +1,6 @@
 require 'action_view'
 require 'cdo/markdown_handler'
+require 'cdo/redcarpet/inline'
 require 'haml'
 require 'haml/template'
 require 'redcarpet'
@@ -51,6 +52,7 @@ module ActionViewSinatra
 
       MarkdownHandler.register(MarkdownRenderer, MarkdownRenderer::OPTIONS)
       MarkdownHandler.register_html_safe(Redcarpet::Render::Safe)
+      MarkdownHandler.register_inline(Redcarpet::Render::Inline.new({filter_html: true}))
     end
 
     def response

--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -39,9 +39,6 @@ def hoc_s(id, markdown: false, locals: nil)
 
   if markdown
     type = markdown == :inline ? :inline_md : :safe_md
-    if type == :inline_md
-      puts "rendering #{string.inspect} inline"
-    end
     string = @actionview.render(inline: string, type: type)
   end
 

--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -22,6 +22,9 @@ HOC_I18N = hoc_load_i18n
 # When called from the other sites, it uses request.locale and converts that XX-XX
 # locale code into a two-letter language code which notably involves a database hit to
 # do that conversion using information in the cdo-languages gsheet.
+#
+# Can be called with markdown: true to render the string as (HTML-safe)
+# markdown, or with markdown: :inline to render as inline markdown.
 def hoc_s(id, markdown: false, locals: nil)
   id = id.to_s
   language = @language || Languages.get_hoc_unique_language_by_locale(request.locale)
@@ -34,7 +37,13 @@ def hoc_s(id, markdown: false, locals: nil)
     end
   end
 
-  string = @actionview.render(inline: string, type: :safe_md) if markdown
+  if markdown
+    type = markdown == :inline ? :inline_md : :safe_md
+    if type == :inline_md
+      puts "rendering #{string.inspect} inline"
+    end
+    string = @actionview.render(inline: string, type: type)
+  end
 
   string
 end

--- a/pegasus/test/fixtures/sites/code.org/public/hoc_s/inline_markdown.haml
+++ b/pegasus/test/fixtures/sites/code.org/public/hoc_s/inline_markdown.haml
@@ -1,0 +1,1 @@
+%h1= hoc_s(:test, markdown: :inline)

--- a/pegasus/test/test_hoc_s.rb
+++ b/pegasus/test/test_hoc_s.rb
@@ -65,4 +65,21 @@ class HocI18nTest < Minitest::Test
     assert_equal 200, resp.status
     assert_match "<h1><p>string with an <a href=\"http://test.com\">interpolated link</a></p>\n</h1>", resp.body
   end
+
+  def test_inline_markdown
+    HOC_I18N['en']['test'] = "basic string"
+    resp = get('/hoc_s/inline_markdown')
+    assert_equal 200, resp.status
+    assert_match "<h1>basic string</h1>", resp.body
+
+    HOC_I18N['en']['test'] = "string with\n\n- some\n- block\n\nmarkdown"
+    resp = get('/hoc_s/inline_markdown')
+    assert_equal 200, resp.status
+    assert_match "<h1>string withsome\nblock\nmarkdown</h1>", resp.body
+
+    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    resp = get('/hoc_s/inline_markdown')
+    assert_equal 200, resp.status
+    assert_match "<h1>string with embedded html</h1>", resp.body
+  end
 end


### PR DESCRIPTION
In both the hourofcode and pegasus strings.

Will be used to update several strings that are currently using raw HTML. See for example [these strings that need to be rendered as list items, not as paragraphs](https://github.com/code-dot-org/code-dot-org/blob/c803e00ec2d328d57e74280b7b2e0de559e797b9/pegasus/sites.v3/code.org/public/athletes.haml#L83-L84)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
