### PR TITLE
Revert "Revert "[Cleanup][Applab Data] Coerce Firebase response to consistent type""

### DIFF
--- a/apps/src/storage/dataBrowser/DataBrowser.jsx
+++ b/apps/src/storage/dataBrowser/DataBrowser.jsx
@@ -101,8 +101,6 @@ class DataBrowser extends React.Component {
     // from redux state
     tableListMap: PropTypes.object.isRequired,
     view: PropTypes.oneOf(Object.keys(DataView)),
-    keyValueData: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
 
     // from redux dispatch
     onShowWarning: PropTypes.func.isRequired,
@@ -223,8 +221,7 @@ DataBrowser.TabType = TabType;
 export default connect(
   state => ({
     view: state.data.view,
-    tableListMap: state.data.tableListMap || {},
-    keyValueData: state.data.keyValueData || {}
+    tableListMap: state.data.tableListMap || {}
   }),
   dispatch => ({
     onShowWarning(warningMsg, warningTitle) {

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -62,12 +62,7 @@ class DataTable extends React.Component {
     // from redux state
     tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     tableName: PropTypes.string.isRequired,
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    tableRecords: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
+    tableRecords: PropTypes.array.isRequired,
 
     // from redux dispatch
     onShowWarning: PropTypes.func.isRequired
@@ -196,13 +191,10 @@ class DataTable extends React.Component {
   };
 
   getRowsForCurrentPage(rowsPerPage) {
-    if (this.props.tableRecords['slice']) {
-      return this.props.tableRecords.slice(
-        this.state.currentPage * rowsPerPage,
-        (this.state.currentPage + 1) * rowsPerPage
-      );
-    }
-    return this.props.tableRecords;
+    return this.props.tableRecords.slice(
+      this.state.currentPage * rowsPerPage,
+      (this.state.currentPage + 1) * rowsPerPage
+    );
   }
 
   render() {
@@ -212,7 +204,7 @@ class DataTable extends React.Component {
     let rowsPerPage = this.props.rowsPerPage || MAX_ROWS_PER_PAGE;
     let numPages = Math.max(
       1,
-      Math.ceil(Object.keys(this.props.tableRecords).length / rowsPerPage)
+      Math.ceil(this.props.tableRecords.length / rowsPerPage)
     );
     let rows = this.getRowsForCurrentPage(rowsPerPage);
 
@@ -303,7 +295,7 @@ class DataTable extends React.Component {
 export default connect(
   state => ({
     tableColumns: state.data.tableColumns || [],
-    tableRecords: state.data.tableRecords || {},
+    tableRecords: state.data.tableRecords || [],
     tableName: state.data.tableName || ''
   }),
   dispatch => ({

--- a/apps/src/storage/dataBrowser/DataTableView.jsx
+++ b/apps/src/storage/dataBrowser/DataTableView.jsx
@@ -68,12 +68,7 @@ class DataTableView extends React.Component {
     tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     tableName: PropTypes.string.isRequired,
     tableListMap: PropTypes.object.isRequired,
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    tableRecords: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
+    tableRecords: PropTypes.array.isRequired,
     view: PropTypes.oneOf(Object.keys(DataView)),
 
     // from redux dispatch
@@ -132,12 +127,7 @@ class DataTableView extends React.Component {
   };
 
   getTableJson() {
-    const records = [];
-    // Cast Array to Object
-    const tableRecords = Object.assign({}, this.props.tableRecords);
-    for (const id in tableRecords) {
-      records.push(JSON.parse(tableRecords[id]));
-    }
+    const records = this.props.tableRecords.map(record => JSON.parse(record));
     return JSON.stringify(records, null, 2);
   }
 
@@ -199,7 +189,7 @@ export default connect(
   state => ({
     view: state.data.view,
     tableColumns: state.data.tableColumns || [],
-    tableRecords: state.data.tableRecords || {},
+    tableRecords: state.data.tableRecords || [],
     tableName: state.data.tableName || '',
     tableListMap: state.data.tableListMap || {}
   }),

--- a/apps/src/storage/dataBrowser/DataTableView.jsx
+++ b/apps/src/storage/dataBrowser/DataTableView.jsx
@@ -127,7 +127,8 @@ class DataTableView extends React.Component {
   };
 
   getTableJson() {
-    const records = this.props.tableRecords.map(record => JSON.parse(record));
+    const records = [];
+    this.props.tableRecords.forEach(record => records.push(JSON.parse(record)));
     return JSON.stringify(records, null, 2);
   }
 
@@ -185,6 +186,7 @@ class DataTableView extends React.Component {
   }
 }
 
+export const UnconnectedDataTableView = DataTableView;
 export default connect(
   state => ({
     view: state.data.view,

--- a/apps/src/storage/dataBrowser/KVPairs.jsx
+++ b/apps/src/storage/dataBrowser/KVPairs.jsx
@@ -30,12 +30,7 @@ class KVPairs extends React.Component {
   static propTypes = {
     // from redux state
     view: PropTypes.oneOf(Object.keys(DataView)),
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    keyValueData: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
+    keyValueData: PropTypes.object.isRequired,
 
     // from redux dispatch
     onShowWarning: PropTypes.func.isRequired,

--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -56,12 +56,7 @@ class VisualizerModal extends React.Component {
     // from redux state
     tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     tableName: PropTypes.string.isRequired,
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    tableRecords: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired
+    tableRecords: PropTypes.array.isRequired
   };
 
   state = {...INITIAL_STATE};
@@ -143,13 +138,7 @@ class VisualizerModal extends React.Component {
   }
 
   render() {
-    // this.props.tableRecords is either an object or an array (see propTypes comment). If it's an object, we want to
-    // convert it to an array before trying to parse the records.
-    const parsedRecords = this.parseRecords(
-      Array.isArray(this.props.tableRecords)
-        ? this.props.tableRecords
-        : Object.values(this.props.tableRecords)
-    );
+    const parsedRecords = this.parseRecords(this.props.tableRecords);
     let filteredRecords = parsedRecords;
     if (this.state.filterColumn !== '' && this.state.filterValue !== '') {
       filteredRecords = this.filterRecords(
@@ -341,6 +330,6 @@ class VisualizerModal extends React.Component {
 export const UnconnectedVisualizerModal = VisualizerModal;
 export default connect(state => ({
   tableColumns: state.data.tableColumns || [],
-  tableRecords: state.data.tableRecords || {},
+  tableRecords: state.data.tableRecords || [],
   tableName: state.data.tableName || ''
 }))(VisualizerModal);

--- a/apps/src/storage/levelbuilder/Dataset.jsx
+++ b/apps/src/storage/levelbuilder/Dataset.jsx
@@ -30,14 +30,7 @@ class Dataset extends React.Component {
   static propTypes = {
     isLive: PropTypes.bool.isRequired,
     // Provided via Redux
-    tableColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     tableName: PropTypes.string.isRequired,
-    // "if all of the keys are integers, and more than half of the keys between 0 and
-    // the maximum key in the object have non-empty values, then Firebase will render
-    // it as an array."
-    // https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html
-    tableRecords: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
     onUploadComplete: PropTypes.func.isRequired
   };
 
@@ -90,8 +83,6 @@ class Dataset extends React.Component {
 
 export default connect(
   state => ({
-    tableColumns: state.data.tableColumns || [],
-    tableRecords: state.data.tableRecords || {},
     tableName: state.data.tableName || ''
   }),
   dispatch => ({

--- a/apps/test/unit/storage/dataBrowser/DataTableViewTest.js
+++ b/apps/test/unit/storage/dataBrowser/DataTableViewTest.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import {UnconnectedDataTableView as DataTableView} from '@cdo/apps/storage/dataBrowser/DataTableView';
+
+const DEFAULT_PROPS = {
+  tableColumns: [],
+  tableName: 'testTable',
+  tableListMap: {},
+  view: DataView.TABLE,
+  tableRecords: [],
+  onShowWarning: () => {},
+  onViewChange: () => {}
+};
+
+describe('DataTableView', () => {
+  it('can show the table as JSON', () => {
+    let records = [];
+    // records[0] is empty
+    records[1] = '{"column1":"foo","column2":"bar","id":1}';
+    let expectedJSON = `[
+  {
+    "column1": "foo",
+    "column2": "bar",
+    "id": 1
+  }
+]`;
+    let wrapper = shallow(<DataTableView {...DEFAULT_PROPS} />);
+    wrapper.setProps({tableRecords: records});
+    expect(wrapper.instance().getTableJson()).to.equal(expectedJSON);
+  });
+});


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#33575, Restoring https://github.com/code-dot-org/code-dot-org/pull/33553

The issue was that the 0-index of the tableRecords array is often `empty`, which was resulting in `null` showing in the JSON view (caught via eyes test see [slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1583966569140500)). 

This PR handles the empty index issue by using `forEach` instead of `map` so that the resulting array does not have empty indices. Also adds a unit test to cover this.

cc @wjordan 