### PR TITLE
Adhoc / managed envs vimrc [ci skip]

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -717,9 +717,7 @@ Resources:
         Fn::Base64: <%=file('bootstrap_chef_stack.sh.erb',
           resource_id: daemon,
           node_name: '$STACK',
-          run_list: [
-            local_mode ? 'recipe[cdo-apps]' : 'role[daemon]'
-          ],
+          run_list: local_mode ? ['recipe[cdo-apps]', 'recipe[cdo-home-ubuntu]'] : ['role[daemon]'],
           commit: nil, # track branch
           shutdown: false,
           daemon: true,

--- a/cookbooks/cdo-home-ubuntu/recipes/default.rb
+++ b/cookbooks/cdo-home-ubuntu/recipes/default.rb
@@ -7,11 +7,19 @@
   '.bashrc',
   '.inputrc',
   '.profile',
+  '.vimrc'
 ].each do |file|
   template "/home/#{node[:current_user]}/#{file}" do
     source "#{file[1..-1]}.erb"
     mode '0644'
     user node[:current_user]
     group node[:current_user]
+  end
+
+  template "/root/#{file}" do
+    source "#{file[1..-1]}.erb"
+    mode '0644'
+    user 'root'
+    group 'root'
   end
 end

--- a/cookbooks/cdo-home-ubuntu/templates/default/vimrc.erb
+++ b/cookbooks/cdo-home-ubuntu/templates/default/vimrc.erb
@@ -1,0 +1,10 @@
+# Sets defaults for the vim editor.
+
+# tab width of 2
+set tabstop=2
+
+# indented blocks are indented at a width of 2
+set shiftwidth=2
+
+# use spaces instead of tabs
+set expandtab

--- a/cookbooks/cdo-home-ubuntu/templates/default/vimrc.erb
+++ b/cookbooks/cdo-home-ubuntu/templates/default/vimrc.erb
@@ -1,10 +1,10 @@
-# Sets defaults for the vim editor.
+"Sets defaults for the vim editor.
 
-# tab width of 2
+"tab width of 2
 set tabstop=2
 
-# indented blocks are indented at a width of 2
+"indented blocks are indented at a width of 2
 set shiftwidth=2
 
-# use spaces instead of tabs
+"use spaces instead of tabs
 set expandtab


### PR DESCRIPTION
Sets sensible defaults for vim on adhocs and managed environments daemons instances. (Vim defaults to tab width/indent of 8.)

## Testing story

Tested on an adhoc.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
