### PR TITLE
hoc overview: Show Oceans for non-en users

### DIFF
--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -30,51 +30,38 @@ social:
   %br/
   = view :professional_learning_apply_banner, use_sign_up_text: true
   %br/
-  .tile-container-responsive{style: "margin-top: 20px;"}
-    .col-50
-      .tutorial-tile
-        %a{href: "/dance"}
-          %img.tutorial-tile-img{src: "/images/dance_party_2019.gif"}
-        .tutorial-info
-          %span
-            %h3.tutorial-info-h= I18n.t(:hoc_overview_dance_title)
-            .smalltext= I18n.t(:hoc_overview_dance_2019_subtitle)
-          %span
-            %a{href: "/dance"}
-              %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
-            .tutorial-info-guide
-              %a{href: "https://curriculum.code.org/hoc/plugged/8/"}
-                = I18n.t(:hoc_overview_view_teacher_guide)
 
-    .col-50
-      .tutorial-tile
-        %a{href: "/oceans"}
-          %img.tutorial-tile-img{src: "/images/fill-485x235/oceans/oceans-overview.png"}
-        .tutorial-info
-          %span
-            %h3.tutorial-info-h=hoc_s(:hoc_overview_oceans_tutorial_header)
-            .smalltext=hoc_s(:hoc_overview_oceans_tutorial_desc)
-          %span
-            %a{href: "/oceans"}
-              %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
-            .tutorial-info-guide
-              %a{href: "https://curriculum.code.org/hoc/plugged/9/"}
-                = I18n.t(:hoc_overview_view_teacher_guide)
 
-- else
-  .full-resource-block{style: "margin-top: 20px; margin-bottom: 20px;"}
-    %a{href: "/dance"}
-      %img.full-resource-image{src: "/images/dance_party_2019.gif"}
-    .tutorial-info{style: "padding: 30px;"}
-      %span
-        %h2.resource-title= I18n.t(:hoc_overview_dance_title)
-        = I18n.t(:hoc_overview_dance_2019_subtitle)
-      %span
-        %a{href: "/dance"}
-          %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
-        .tutorial-info-guide
-          %a{href: "https://curriculum.code.org/hoc/plugged/8/"}
-            = I18n.t(:hoc_overview_view_teacher_guide)
+.tile-container-responsive{style: "margin-top: 20px;"}
+  .col-50
+    .tutorial-tile
+      %a{href: "/dance"}
+        %img.tutorial-tile-img{src: "/images/dance_party_2019.gif"}
+      .tutorial-info
+        %span
+          %h3.tutorial-info-h= I18n.t(:hoc_overview_dance_title)
+          .smalltext= I18n.t(:hoc_overview_dance_2019_subtitle)
+        %span
+          %a{href: "/dance"}
+            %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
+          .tutorial-info-guide
+            %a{href: "https://curriculum.code.org/hoc/plugged/8/"}
+              = I18n.t(:hoc_overview_view_teacher_guide)
+
+  .col-50
+    .tutorial-tile
+      %a{href: "/oceans"}
+        %img.tutorial-tile-img{src: "/images/fill-485x235/oceans/oceans-overview.png"}
+      .tutorial-info
+        %span
+          %h3.tutorial-info-h=hoc_s(:hoc_overview_oceans_tutorial_header)
+          .smalltext=hoc_s(:hoc_overview_oceans_tutorial_desc)
+        %span
+          %a{href: "/oceans"}
+            %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
+          .tutorial-info-guide
+            %a{href: "https://curriculum.code.org/hoc/plugged/9/"}
+              = I18n.t(:hoc_overview_view_teacher_guide)
 
 .tile-container-responsive
   = view :top_hoc_tutorials


### PR DESCRIPTION
Now that the Oceans for AI tutorial has been localised into a bunch of languages, show it for non-en users at https://code.org/hourofcode/overview.

### before, en

![Screenshot 2020-03-11 15 41 32](https://user-images.githubusercontent.com/2205926/76472629-5edc1980-63b3-11ea-89b3-81b818cc3250.png)

### before, non-en

![Screenshot 2020-03-11 16 15 45](https://user-images.githubusercontent.com/2205926/76472709-93e86c00-63b3-11ea-9f3f-c05d7d1401ff.png)

### after, en

![Screenshot 2020-03-11 15 42 51](https://user-images.githubusercontent.com/2205926/76472604-4f5cd080-63b3-11ea-9fa5-b7cbb7e40041.png)

### after, non-en

![Screenshot 2020-03-11 16 06 10](https://user-images.githubusercontent.com/2205926/76472592-4409a500-63b3-11ea-8e30-3863bf030ddb.png)
