### PR TITLE
Improve the image path on hourofcode.com carousels

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/learn_carousel.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/learn_carousel.haml
@@ -31,7 +31,7 @@
             .slide.clear{:style=>styling}
               .slide-img<
                 %a{:href=>url, :target=>'_blank'}<
-                  %img{:src=>tutorial[:image].sub("/images/", "https://code.org/images/fit-520/").sub(".png", ".jpg")}
+                  %img{:src=>tutorial[:image].sub("/images/", CDO.code_org_url("/images/fit-520/")).sub(".png", ".jpg")}
               .slide-text
                 %a{:href=>url, :target=>'_blank'}<
                   -unless international_layout


### PR DESCRIPTION
The "learn carousels" on https://hourofcode.com/beyond were always retrieving images from production https://code.org, even when running on environments such as staging and localhost, where new images would not yet exist.

This improves the image path to use the local-environment's version of code.org.
