### PR TITLE
Add COVID-19 information to workshop reminder emails

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_covid_19.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_covid_19.html.haml
@@ -1,0 +1,32 @@
+%h3 COVID-19 precautions
+
+%p
+  In light of the global situation surrounding the COVID-19 virus, we understand that traveling and
+  gathering for a workshop may be cause for anxiety or concern for teachers registered for upcoming
+  Code.org workshops. We encourage you to refer to the
+  = link_to 'Centers for Disease Control and Prevention', 'https://www.cdc.gov/', target: '_blank'
+  (CDC) for the most up to date recommendations, as is your Regional Partner in evaluating whether
+  to host your workshops as planned. If you have returned from a
+  = link_to 'Level 3 country', 'https://www.cdc.gov/coronavirus/2019-ncov/travelers/index.html', target: '_blank'
+  within the past 14-days, are feeling ill or show any flu-like symptoms such as a fever or cough,
+  please inform your Regional Partner.
+
+%p
+  Our workshops are highly interactive. At time of this update, the CDC suggests all individuals
+  = link_to 'follow this guidance', 'https://www.cdc.gov/coronavirus/2019-ncov/about/prevention-treatment.html', target: '_blank'
+  during flu season and to prevent the spread of the COVID-19 virus, including:
+  %ul
+    %li
+      Avoid contact with sick people.
+    %li
+      Avoid touching your eyes, nose, or mouth with unwashed hands.
+    %li
+      Clean your hands often by washing them with soap and water for at least 20 seconds or using
+      an alcohol-based hand sanitizer that contains at least 60% alcohol.
+    %li
+      It is especially important to clean hands after going to the bathroom; before eating; and
+      after coughing, sneezing or blowing your nose.
+
+%p
+  More information about the virus can also be found on the
+  = link_to('CDC’s COVID-19 Factsheet', 'https://www.cdc.gov/coronavirus/2019-ncov/about/share-facts.html', target: '_blank') + '.'

--- a/dashboard/app/views/pd/workshop_mailer/_covid_19.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_covid_19.html.haml
@@ -5,14 +5,14 @@
   gathering for a workshop may be cause for anxiety or concern for teachers registered for upcoming
   Code.org workshops. We encourage you to refer to the
   = link_to 'Centers for Disease Control and Prevention', 'https://www.cdc.gov/', target: '_blank'
-  (CDC) for the most up to date recommendations, as is your Regional Partner in evaluating whether
-  to host your workshops as planned. If you have returned from a
+  (CDC) for the most up-to-date recommendations. Your regional partner will do the same when
+  evaluating whether to host your workshops as planned. If you have returned from a
   = link_to 'Level 3 country', 'https://www.cdc.gov/coronavirus/2019-ncov/travelers/index.html', target: '_blank'
-  within the past 14-days, are feeling ill or show any flu-like symptoms such as a fever or cough,
+  within the past 14-days, are feeling ill, or show any flu-like symptoms such as a fever or cough,
   please inform your Regional Partner.
 
 %p
-  Our workshops are highly interactive. At time of this update, the CDC suggests all individuals
+  Our workshops are highly interactive. At the time of this update, the CDC suggests all individuals
   = link_to 'follow this guidance', 'https://www.cdc.gov/coronavirus/2019-ncov/about/prevention-treatment.html', target: '_blank'
   during flu season and to prevent the spread of the COVID-19 virus, including:
   %ul
@@ -24,7 +24,7 @@
       Clean your hands often by washing them with soap and water for at least 20 seconds or using
       an alcohol-based hand sanitizer that contains at least 60% alcohol.
     %li
-      It is especially important to clean hands after going to the bathroom; before eating; and
+      It is especially important to clean hands: After going to the bathroom; before eating; and
       after coughing, sneezing or blowing your nose.
 
 %p

--- a/dashboard/app/views/pd/workshop_mailer/_covid_19.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_covid_19.html.haml
@@ -24,7 +24,7 @@
       Clean your hands often by washing them with soap and water for at least 20 seconds or using
       an alcohol-based hand sanitizer that contains at least 60% alcohol.
     %li
-      It is especially important to clean hands: After going to the bathroom; before eating; and
+      It is especially important to clean hands: after going to the bathroom; before eating; and
       after coughing, sneezing or blowing your nose.
 
 %p

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -18,6 +18,8 @@
 
 = render partial: 'how_to_cancel'
 
+= render partial: 'covid_19'
+
 - if @is_reminder && @workshop.course == Pd::Workshop::COURSE_CSD && @workshop.subject == Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
   %h3
     Pre-Workshop Tech Setup


### PR DESCRIPTION
[PLC-798](https://codedotorg.atlassian.net/browse/PLC-798) Adds COVID-19 copy to our workshop reminder emails, helping teachers and regional partners prepare appropriately.

Here's the new copy, as rendered by our mailer preview system:

![image](https://user-images.githubusercontent.com/1615761/76672440-eebbc800-6559-11ea-8544-9b09bb3d672c.png)


Copy was drafted [in this doc (internal)](https://docs.google.com/document/d/1nEe2fW1FkoVoJTV0oaKvQ7DqrgzlOdWUHXgazFW3yHE/edit#).

This new copy appears in the following WorkshopMailer templates, for all workshop types except Admin/Counselor:

- Teacher-facing:
  - teacher_enrollment_receipt
  - teacher_enrollment_reminder
  - detail_change_notification
- Facilitator-facing
  - facilitator_enrollment_reminder
  - facilitator_detail_change_notification
- Organizer-facing
  - organizer_enrollment_reminder
  - organizer_detail_change_notification

## Testing story

Tested manually using mailer previews at `/rails/mailers/pd/workshop_mailer`.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
