### PR TITLE
Refactor CloudFormation stack template

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -21,7 +21,6 @@ else
 end
 
 commit = ENV['COMMIT'] || `git ls-remote origin #{branch}`.split.first
-ami = commit[0..4]
 
 frontends = @frontends = rack_env?(:production) || ENV['FRONTENDS']
 database = @database = [:staging, :test, :levelbuilder].include?(rack_env) || ENV['DATABASE']
@@ -154,76 +153,7 @@ Resources:
             Action: 's3:*'
             Resource: '*'
 <% if frontends -%>
-  FrontendRole:
-    Type: AWS::IAM::Role
-    Properties:
-      <%=service_role 'ec2'%>
-      Policies:
-        - PolicyName: LifecycleHook
-          PolicyDocument:
-            Statement:
-              - Effect: Allow
-                Action: 'autoscaling:CompleteLifecycleAction'
-                Resource: !Sub "arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/Frontends-${AWS::StackName}"
-      ManagedPolicyArns: [!Ref CDOPolicy]
-      PermissionsBoundary: !ImportValue IAM-DevPermissions
-  FrontendInstanceProfile:
-    Type: AWS::IAM::InstanceProfile
-    Properties: {Roles: [!Ref FrontendRole]}
-  # Signal when the instance is fully provisioned and ready for AMI creation.
-  AMICreate<%=ami%>:
-    Type: AWS::CloudFormation::WaitCondition
-    DependsOn: WebServerAMI
-    CreationPolicy:
-      ResourceSignal:
-        Timeout: PT120M
-        Count: 1
-  WebServerAMI:
-    Type: AWS::EC2::Instance
-    DependsOn: <%=[daemon].compact.to_json%>
-    Properties:
-      ImageId: <%=IMAGE_ID%>
-      InstanceType: !Ref InstanceType
-      IamInstanceProfile: !Ref FrontendInstanceProfile
-      SecurityGroupIds: [!ImportValue VPC-FrontendSecurityGroup]
-      SubnetId: !ImportValue VPC-Subnet<%=azs.first%>
-      KeyName: <%=SSH_KEY_NAME%>
-      BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            VolumeSize: 64
-            VolumeType: gp2
-      UserData:
-        Fn::Base64: <%=file('bootstrap_chef_stack.sh.erb',
-          resource_id: "AMICreate#{ami}",
-          node_name: 'ami-$INSTANCE_ID',
-          run_list: [
-            local_mode ? 'recipe[cdo-apps]' : 'role[unmonitored-frontend]'
-          ],
-          commit: commit,
-          shutdown: true,
-          daemon: false,
-          chef_version: chef_version
-        )%>
-  AMI<%=ami%>: <%= lambda_fn.call 'AMIManager',
-    DependsOn: "AMICreate#{ami}",
-    InstanceId: {Ref: "WebServerAMI" } %>
-  FastSnapshotRestore: <%= lambda_fn.call 'FastSnapshotRestore',
-    ImageIds: [{Ref: "AMI#{ami}" }],
-    AvailabilityZones: AVAILABILITY_ZONES
-  %>
-  ASGCount: <%= lambda_fn.call 'CountASG',
-    Default: {
-      MinSize: 2,
-      MaxSize: 20,
-      DesiredCapacity: 2
-    },
-    AutoScalingGroupTags: [
-      {Key: 'aws:cloudformation:stack-id', Value: {Ref: 'AWS::StackId'}},
-      {Key: 'aws:cloudformation:logical-id', Value: 'Frontends'}
-    ],
-    LaunchConfiguration: {Ref: 'FrontendLaunchConfig'}
-  %>
+<%=  component 'ami', commit: commit, chef_version: chef_version%>
 <% end -%>
 <% if load_balancer -%>
   # TODO hourofcode.com and csedweek.org load balancers should be added to this template.
@@ -298,158 +228,11 @@ Resources:
 <% end -%>
 
 <% if frontends -%>
-  Frontends:
-    DependsOn: [ASGCount]
-    Type: AWS::AutoScaling::AutoScalingGroup
-    CreationPolicy:
-      ResourceSignal:
-        Timeout: PT50M
-        Count: !GetAtt [ASGCount, DesiredCapacity]
-      AutoScalingCreationPolicy:
-        MinSuccessfulInstancesPercent: 80
-    UpdatePolicy:
-      AutoScalingRollingUpdate:
-        MaxBatchSize: 20
-        MinInstancesInService: !GetAtt [ASGCount, DesiredCapacity]
-        MinSuccessfulInstancesPercent: 80
-        PauseTime: PT50M
-        SuspendProcesses: [ScheduledActions]
-        WaitOnResourceSignals: true
-    Properties:
-      AutoScalingGroupName: !Sub "Frontends-${AWS::StackName}"
-      VPCZoneIdentifier: <%= subnets.to_json %>
-      LaunchConfigurationName: !Ref FrontendLaunchConfig
-      MinSize: !GetAtt [ASGCount, MinSize]
-      MaxSize: !GetAtt [ASGCount, MaxSize]
-      DesiredCapacity: !GetAtt [ASGCount, DesiredCapacity]
-      HealthCheckType: EC2 # TODO: use ELB health check that returns healthy even when fully loaded.
-      HealthCheckGracePeriod: 2000
-      TargetGroupARNs: [Ref: ALBTargetGroup]
-      MetricsCollection:
-        - Granularity: 1Minute
-  FrontendLaunchConfig:
-    Type: AWS::AutoScaling::LaunchConfiguration
-    DependsOn: FastSnapshotRestore
-    Properties:
-      ImageId: !GetAtt [AMI<%=ami%>, ImageId]
-      InstanceType: !Ref InstanceType
-      IamInstanceProfile: !Ref FrontendInstanceProfile
-      SecurityGroups: [!ImportValue VPC-FrontendSecurityGroup]
-      KeyName: <%=SSH_KEY_NAME%>
-      BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            VolumeSize: 64
-            VolumeType: gp2
-      UserData:
-        Fn::Base64: <%=file('bootstrap_frontend.sh.erb',
-          resource_id: 'Frontends',
-          hook: 'WebServerHook-${AWS::StackName}',
-          auto_scaling_group: 'Frontends-${AWS::StackName}',
-          node_name: 'fe-$INSTANCE_ID',
-          commit: commit)%>
-  CPUScalingPolicy:
-    Type: AWS::AutoScaling::ScalingPolicy
-    Properties:
-      AutoScalingGroupName: !Ref Frontends
-      EstimatedInstanceWarmup: 300
-      PolicyType: TargetTrackingScaling
-      TargetTrackingConfiguration:
-        PredefinedMetricSpecification:
-          PredefinedMetricType: ASGAverageCPUUtilization
-        TargetValue: 50
-  WebServerHook:
-    Type: AWS::AutoScaling::LifecycleHook
-    Properties:
-      LifecycleHookName: !Sub "WebServerHook-${AWS::StackName}"
-      AutoScalingGroupName: !Ref Frontends
-      LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING'
-      DefaultResult: ABANDON
-      HeartbeatTimeout: 1200 # seconds = 20 minutes
-      NotificationTargetARN: !Ref WebServerHookTopicNew
-      RoleARN: !GetAtt WebServerHookRole.Arn
-  WebServerHookEventRule:
-    Type: AWS::Events::Rule
-    Properties:
-      Description: !Sub "Auto Scaling Events for ${AWS::StackName}."
-      EventPattern:
-        source: [aws.autoscaling]
-        detail-type:
-        - EC2 Instance Launch Successful
-        - EC2 Instance Terminate Successful
-        - EC2 Instance Launch Unsuccessful
-        - EC2 Instance Terminate Unsuccessful
-        - EC2 Instance-launch Lifecycle Action
-        - EC2 Instance-terminate Lifecycle Action
-        detail:
-          AutoScalingGroupName: [!Ref Frontends]
-      State: ENABLED
-      Targets:
-      - Arn: !ImportValue SlackEvent
-        Id: WebServerHookTarget
-  WebServerHookEventPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !ImportValue SlackEvent
-      Action: 'lambda:InvokeFunction'
-      Principal: events.amazonaws.com
-      SourceArn: !GetAtt WebServerHookEventRule.Arn
-  WebServerHookTopicNew: {Type: 'AWS::SNS::Topic'}
-  WebServerHookRole:
-    Type: AWS::IAM::Role
-    Properties:
-      <%=service_role 'autoscaling'%>
-      Policies:
-        - PolicyName: snsPublish
-          PolicyDocument:
-            Statement:
-              - Effect: Allow
-                Action: 'sns:Publish'
-                Resource: !Ref WebServerHookTopicNew
-      PermissionsBoundary: !ImportValue IAM-DevPermissions
+<%= component 'slack_scaling_events' -%>
 <%  if environment == :production -%>
-  HealthEventRule:
-    Type: AWS::Events::Rule
-    Properties:
-      Description: !Sub "Health Events for ${AWS::StackName}."
-      EventPattern:
-        source: [aws.health]
-      State: ENABLED
-      Targets:
-      - Arn: !ImportValue SlackEvent
-        Id: HealthEventRuleTarget
-  HealthEventPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !ImportValue SlackEvent
-      Action: 'lambda:InvokeFunction'
-      Principal: events.amazonaws.com
-      SourceArn: !GetAtt HealthEventRule.Arn
-  ClassroomScaleUp:
-    Type: AWS::AutoScaling::ScheduledAction
-    Properties:
-      AutoScalingGroupName: !Ref Frontends
-      MinSize: 4
-      Recurrence: <%= Cdo::Cron.weekdays_at '4am' %>
-  ClassroomScaleDown:
-    Type: AWS::AutoScaling::ScheduledAction
-    Properties:
-      AutoScalingGroupName: !Ref Frontends
-      MinSize: 3
-      Recurrence: <%= Cdo::Cron.weekdays_at '1pm' %>
-  WeekendScaleDown:
-    Type: AWS::AutoScaling::ScheduledAction
-    Properties:
-      AutoScalingGroupName: !Ref Frontends
-      MinSize: 2
-      Recurrence: <%= Cdo::Cron.weekly_at '8pm Friday' %>
-  WeekendScaleUp:
-    Type: AWS::AutoScaling::ScheduledAction
-    Properties:
-      AutoScalingGroupName: !Ref Frontends
-      MinSize: 3
-      Recurrence: <%= Cdo::Cron.weekly_at '4am Monday', time_zone: 'London' %>
-<%   end -%>
+<%=   component 'slack_health_events' -%>
+<%=   component 'scaling_schedule' -%>
+<%  end -%>
 <% end -%>
 # Route53 (DNS) and CloudFront (CDN) resources:
 # TODO hourofcode.com and csedweek.org DNS/CDN resources should be added to this template.
@@ -511,45 +294,8 @@ Resources:
           ResourceRecords: [!GetAtt <%=daemon%>.PublicIp]
 <%   end -%>
 <% end -%>
-<% if frontends -%>
-<%   cache_node_type = rack_env?(:production) ? 'cache.r3.large' : 'cache.t2.micro' -%>
-  GeocoderSubnetGroup:
-    Type: AWS::ElastiCache::SubnetGroup
-    Properties:
-      Description: Geocoder Cache Subnet Group
-      SubnetIds: <%= subnets.to_json %>
-  GeocoderGroup:
-    Type: AWS::ElastiCache::ReplicationGroup
-    Properties:
-      ReplicationGroupDescription: Geocoder Replication Group
-      NumCacheClusters: 3
-<%  if cache_node_type.include? 'cache.t2' %>
-      AutomaticFailoverEnabled: false
-<%  end-%>
-      Engine: redis
-      CacheNodeType: <%= cache_node_type %>
-      SecurityGroupIds: [!ImportValue VPC-RedisSecurityGroup]
-      CacheSubnetGroupName: !Ref GeocoderSubnetGroup
-  MemcachedParameterGroup:
-    Type: AWS::ElastiCache::ParameterGroup
-    Properties:
-      CacheParameterGroupFamily: memcached1.4
-      Description: Memcached modified max_item_size.
-      Properties:
-        max_item_size: <%=64.megabytes%>
-  Memcached:
-    Type: AWS::ElastiCache::CacheCluster
-    Properties:
-      CacheNodeType: <%= cache_node_type %>
-      CacheParameterGroupName: !Ref MemcachedParameterGroup
-      CacheSubnetGroupName: !Ref GeocoderSubnetGroup
-      ClusterName: <%=stack_name[0..19]%> # Max 20 chars
-      Engine: memcached
-      EngineVersion: 1.4
-      NumCacheNodes: 2
-      AZMode: cross-az
-      PreferredAvailabilityZones: <%= availability_zones.first(2).to_json %>
-      VpcSecurityGroupIds: [!ImportValue VPC-MemcachedSecurityGroup]
+<% if frontends-%>
+<%=  component 'cache'%>
 <% end -%>
   DaemonRole:
     Type: AWS::IAM::Role
@@ -701,91 +447,11 @@ Resources:
     DependsOn: Aurora1
 <% end -%>
 <%end-%>
-<% if alarms %>
-  DaemonStorageUtilizationAlarm:
-    Type: "AWS::CloudWatch::Alarm"
-    Properties:
-      AlarmActions:
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
-      AlarmDescription: Send page if daemon storage utilization exceeds 80% for an hour
-      AlarmName: <%="#{stack_name}_daemon_high_storage_utilization" %>
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: Filesystem
-          Value: '/dev/xvda1'
-        - Name: MountPath
-          Value: '/'
-        - Name: InstanceId
-          Value: <%= daemon_instance_id || "!Ref #{daemon}" %>
-      EvaluationPeriods: 60
-      MetricName: DiskSpaceUtilization
-      Namespace: 'System/Linux'
-      Period: 60
-      Statistic: Average
-      Threshold: 80
-      TreatMissingData: missing
-  DaemonMemoryUtilizationAlarm:
-    Type: "AWS::CloudWatch::Alarm"
-    Properties:
-      AlarmActions:
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
-      AlarmDescription: Send page if daemon memory utilization exceeds 87% for 5 minutes
-      AlarmName: <%="#{stack_name}_daemon_high_memory_utilization" %>
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: InstanceId
-          Value: <%= daemon_instance_id || "!Ref #{daemon}" %>
-      EvaluationPeriods: 5
-      MetricName: MemoryUtilization
-      Namespace: 'System/Linux'
-      Period: 60
-      Statistic: Maximum
-      Threshold: 87
-      TreatMissingData: missing
+<% if alarms-%>
+<%=  component 'alarms'%>
 <% end -%>
-<% if database -%>
-  AuroraCluster:
-    Type: AWS::RDS::DBCluster
-    Properties:
-      DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
-      DBClusterParameterGroupName: !Ref AuroraClusterDBParameters
-      Engine: aurora-mysql
-      # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with cluster.
-      EngineVersion: 5.7.12
-      MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:username}}"
-      MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:password}}"
-      VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
-      DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
-
-<% 2.times do |i| %>
-  Aurora<%=i%>:
-    Type: AWS::RDS::DBInstance
-    Properties:
-      DBInstanceIdentifier: !Sub "${AWS::StackName}-<%=i%>"
-      DBClusterIdentifier: !Ref AuroraCluster
-      DBInstanceClass: db.r4.large
-      DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
-      Engine: aurora-mysql
-      # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.
-<% end -%>
-
-  AuroraClusterDBParameters:
-    Type: AWS::RDS::DBClusterParameterGroup
-    Properties:
-      Description: !Sub "Aurora DB Cluster Parameters for ${AWS::StackName}."
-      Family: aurora-mysql5.7
-      Parameters: {'innodb_monitor_enable': 'all'}
-
-  DatabaseSecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: !Sub "Secrets for accessing database from ${AWS::StackName} CloudFormation stack"
-      GenerateSecretString:
-        SecretStringTemplate: !Sub '{"username": "${DatabaseUsername}"}'
-        GenerateStringKey: password
-        PasswordLength: 10
-        ExcludePunctuation: True
-      Name: !Sub "CfnStack/${AWS::StackName}/database-secret"
+<% if database-%>
+<%=  component 'database'%>
 <% end -%>
 Outputs:
   DashboardURL:

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -1,0 +1,40 @@
+  DaemonStorageUtilizationAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
+      AlarmDescription: Send page if daemon storage utilization exceeds 80% for an hour
+      AlarmName: <%="#{stack_name}_daemon_high_storage_utilization" %>
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Filesystem
+          Value: '/dev/xvda1'
+        - Name: MountPath
+          Value: '/'
+        - Name: InstanceId
+          Value: <%= daemon_instance_id || "!Ref #{daemon}" %>
+      EvaluationPeriods: 60
+      MetricName: DiskSpaceUtilization
+      Namespace: 'System/Linux'
+      Period: 60
+      Statistic: Average
+      Threshold: 80
+      TreatMissingData: missing
+  DaemonMemoryUtilizationAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
+      AlarmDescription: Send page if daemon memory utilization exceeds 87% for 5 minutes
+      AlarmName: <%="#{stack_name}_daemon_high_memory_utilization" %>
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: InstanceId
+          Value: <%= daemon_instance_id || "!Ref #{daemon}" %>
+      EvaluationPeriods: 5
+      MetricName: MemoryUtilization
+      Namespace: 'System/Linux'
+      Period: 60
+      Statistic: Maximum
+      Threshold: 87
+      TreatMissingData: missing

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -1,0 +1,154 @@
+<% ami = commit[0..4] -%>
+  FrontendRole:
+    Type: AWS::IAM::Role
+    Properties:
+      <%=service_role 'ec2'%>
+      Policies:
+        - PolicyName: LifecycleHook
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: 'autoscaling:CompleteLifecycleAction'
+                Resource: !Sub "arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/Frontends-${AWS::StackName}"
+      ManagedPolicyArns: [!Ref CDOPolicy]
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
+  FrontendInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties: {Roles: [!Ref FrontendRole]}
+  # Signal when the instance is fully provisioned and ready for AMI creation.
+  AMICreate<%=ami%>:
+    Type: AWS::CloudFormation::WaitCondition
+    DependsOn: WebServerAMI
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT120M
+        Count: 1
+  WebServerAMI:
+    Type: AWS::EC2::Instance
+    DependsOn: <%=[daemon].compact.to_json%>
+    Properties:
+      ImageId: <%=IMAGE_ID%>
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref FrontendInstanceProfile
+      SecurityGroupIds: [!ImportValue VPC-FrontendSecurityGroup]
+      SubnetId: !ImportValue VPC-Subnet<%=azs.first%>
+      KeyName: <%=SSH_KEY_NAME%>
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 64
+            VolumeType: gp2
+      UserData:
+        Fn::Base64: <%=file('bootstrap_chef_stack.sh.erb',
+          resource_id: "AMICreate#{ami}",
+          node_name: 'ami-$INSTANCE_ID',
+          run_list: [
+            local_mode ? 'recipe[cdo-apps]' : 'role[unmonitored-frontend]'
+          ],
+          commit: commit,
+          shutdown: true,
+          daemon: false,
+          chef_version: chef_version
+        )%>
+  AMI<%=ami%>: <%= lambda_fn.call 'AMIManager',
+    DependsOn: "AMICreate#{ami}",
+    InstanceId: {Ref: "WebServerAMI" } %>
+  FastSnapshotRestore: <%= lambda_fn.call 'FastSnapshotRestore',
+    ImageIds: [{Ref: "AMI#{ami}" }],
+    AvailabilityZones: AVAILABILITY_ZONES
+  %>
+  ASGCount: <%= lambda_fn.call 'CountASG',
+    Default: {
+      MinSize: 2,
+      MaxSize: 20,
+      DesiredCapacity: 2
+    },
+    AutoScalingGroupTags: [
+      {Key: 'aws:cloudformation:stack-id', Value: {Ref: 'AWS::StackId'}},
+      {Key: 'aws:cloudformation:logical-id', Value: 'Frontends'}
+    ],
+    LaunchConfiguration: {Ref: 'FrontendLaunchConfig'}
+  %>
+  Frontends:
+    DependsOn: [ASGCount]
+    Type: AWS::AutoScaling::AutoScalingGroup
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT50M
+        Count: !GetAtt [ASGCount, DesiredCapacity]
+      AutoScalingCreationPolicy:
+        MinSuccessfulInstancesPercent: 80
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 20
+        MinInstancesInService: !GetAtt [ASGCount, DesiredCapacity]
+        MinSuccessfulInstancesPercent: 80
+        PauseTime: PT50M
+        SuspendProcesses: [ScheduledActions]
+        WaitOnResourceSignals: true
+    Properties:
+      AutoScalingGroupName: !Sub "Frontends-${AWS::StackName}"
+      VPCZoneIdentifier: <%= subnets.to_json %>
+      LaunchConfigurationName: !Ref FrontendLaunchConfig
+      MinSize: !GetAtt [ASGCount, MinSize]
+      MaxSize: !GetAtt [ASGCount, MaxSize]
+      DesiredCapacity: !GetAtt [ASGCount, DesiredCapacity]
+      HealthCheckType: EC2 # TODO: use ELB health check that returns healthy even when fully loaded.
+      HealthCheckGracePeriod: 2000
+      TargetGroupARNs: [Ref: ALBTargetGroup]
+      MetricsCollection:
+        - Granularity: 1Minute
+  FrontendLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    DependsOn: FastSnapshotRestore
+    Properties:
+      ImageId: !GetAtt [AMI<%=ami%>, ImageId]
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref FrontendInstanceProfile
+      SecurityGroups: [!ImportValue VPC-FrontendSecurityGroup]
+      KeyName: <%=SSH_KEY_NAME%>
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 64
+            VolumeType: gp2
+      UserData:
+        Fn::Base64: <%=file('bootstrap_frontend.sh.erb',
+          resource_id: 'Frontends',
+          hook: 'WebServerHook-${AWS::StackName}',
+          auto_scaling_group: 'Frontends-${AWS::StackName}',
+          node_name: 'fe-$INSTANCE_ID',
+          commit: commit)%>
+  CPUScalingPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AutoScalingGroupName: !Ref Frontends
+      EstimatedInstanceWarmup: 300
+      PolicyType: TargetTrackingScaling
+      TargetTrackingConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ASGAverageCPUUtilization
+        TargetValue: 50
+  WebServerHook:
+    Type: AWS::AutoScaling::LifecycleHook
+    Properties:
+      LifecycleHookName: !Sub "WebServerHook-${AWS::StackName}"
+      AutoScalingGroupName: !Ref Frontends
+      LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING'
+      DefaultResult: ABANDON
+      HeartbeatTimeout: 1200 # seconds = 20 minutes
+      NotificationTargetARN: !Ref WebServerHookTopicNew
+      RoleARN: !GetAtt WebServerHookRole.Arn
+  WebServerHookTopicNew: {Type: 'AWS::SNS::Topic'}
+  WebServerHookRole:
+    Type: AWS::IAM::Role
+    Properties:
+      <%=service_role 'autoscaling'%>
+      Policies:
+        - PolicyName: snsPublish
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: 'sns:Publish'
+                Resource: !Ref WebServerHookTopicNew
+      PermissionsBoundary: !ImportValue IAM-DevPermissions

--- a/aws/cloudformation/components/cache.yml.erb
+++ b/aws/cloudformation/components/cache.yml.erb
@@ -1,0 +1,38 @@
+<% cache_node_type = rack_env?(:production) ? 'cache.r3.large' : 'cache.t2.micro' -%>
+  GeocoderSubnetGroup:
+    Type: AWS::ElastiCache::SubnetGroup
+    Properties:
+      Description: Geocoder Cache Subnet Group
+      SubnetIds: <%= subnets.to_json %>
+  GeocoderGroup:
+    Type: AWS::ElastiCache::ReplicationGroup
+    Properties:
+      ReplicationGroupDescription: Geocoder Replication Group
+      NumCacheClusters: 3
+<%  if cache_node_type.include? 'cache.t2' -%>
+      AutomaticFailoverEnabled: false
+<%  end-%>
+      Engine: redis
+      CacheNodeType: <%= cache_node_type %>
+      SecurityGroupIds: [!ImportValue VPC-RedisSecurityGroup]
+      CacheSubnetGroupName: !Ref GeocoderSubnetGroup
+  MemcachedParameterGroup:
+    Type: AWS::ElastiCache::ParameterGroup
+    Properties:
+      CacheParameterGroupFamily: memcached1.4
+      Description: Memcached modified max_item_size.
+      Properties:
+        max_item_size: <%=64.megabytes%>
+  Memcached:
+    Type: AWS::ElastiCache::CacheCluster
+    Properties:
+      CacheNodeType: <%= cache_node_type %>
+      CacheParameterGroupName: !Ref MemcachedParameterGroup
+      CacheSubnetGroupName: !Ref GeocoderSubnetGroup
+      ClusterName: <%=stack_name[0..19]%> # Max 20 chars
+      Engine: memcached
+      EngineVersion: 1.4
+      NumCacheNodes: 2
+      AZMode: cross-az
+      PreferredAvailabilityZones: <%= availability_zones.first(2).to_json %>
+      VpcSecurityGroupIds: [!ImportValue VPC-MemcachedSecurityGroup]

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -1,0 +1,42 @@
+  AuroraCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
+      DBClusterParameterGroupName: !Ref AuroraClusterDBParameters
+      Engine: aurora-mysql
+      # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with cluster.
+      EngineVersion: 5.7.12
+      MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:username}}"
+      MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:password}}"
+      VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
+      DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
+
+<% 2.times do |i| %>
+  Aurora<%=i%>:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier: !Sub "${AWS::StackName}-<%=i%>"
+      DBClusterIdentifier: !Ref AuroraCluster
+      DBInstanceClass: db.r4.large
+      DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
+      Engine: aurora-mysql
+      # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.
+<% end -%>
+
+  AuroraClusterDBParameters:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Properties:
+      Description: !Sub "Aurora DB Cluster Parameters for ${AWS::StackName}."
+      Family: aurora-mysql5.7
+      Parameters: {'innodb_monitor_enable': 'all'}
+
+  DatabaseSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: !Sub "Secrets for accessing database from ${AWS::StackName} CloudFormation stack"
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{"username": "${DatabaseUsername}"}'
+        GenerateStringKey: password
+        PasswordLength: 10
+        ExcludePunctuation: True
+      Name: !Sub "CfnStack/${AWS::StackName}/database-secret"

--- a/aws/cloudformation/components/scaling_schedule.yml.erb
+++ b/aws/cloudformation/components/scaling_schedule.yml.erb
@@ -1,0 +1,24 @@
+  ClassroomScaleUp:
+    Type: AWS::AutoScaling::ScheduledAction
+    Properties:
+      AutoScalingGroupName: !Ref Frontends
+      MinSize: 4
+      Recurrence: <%= Cdo::Cron.weekdays_at '4am' %>
+  ClassroomScaleDown:
+    Type: AWS::AutoScaling::ScheduledAction
+    Properties:
+      AutoScalingGroupName: !Ref Frontends
+      MinSize: 3
+      Recurrence: <%= Cdo::Cron.weekdays_at '1pm' %>
+  WeekendScaleDown:
+    Type: AWS::AutoScaling::ScheduledAction
+    Properties:
+      AutoScalingGroupName: !Ref Frontends
+      MinSize: 2
+      Recurrence: <%= Cdo::Cron.weekly_at '8pm Friday' %>
+  WeekendScaleUp:
+    Type: AWS::AutoScaling::ScheduledAction
+    Properties:
+      AutoScalingGroupName: !Ref Frontends
+      MinSize: 3
+      Recurrence: <%= Cdo::Cron.weekly_at '4am Monday', time_zone: 'London' %>

--- a/aws/cloudformation/components/slack_health_events.yml.erb
+++ b/aws/cloudformation/components/slack_health_events.yml.erb
@@ -1,0 +1,17 @@
+  HealthEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: !Sub "Health Events for ${AWS::StackName}."
+      EventPattern:
+        source: [aws.health]
+      State: ENABLED
+      Targets:
+        - Arn: !ImportValue SlackEvent
+          Id: HealthEventRuleTarget
+  HealthEventPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !ImportValue SlackEvent
+      Action: 'lambda:InvokeFunction'
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt HealthEventRule.Arn

--- a/aws/cloudformation/components/slack_scaling_events.yml.erb
+++ b/aws/cloudformation/components/slack_scaling_events.yml.erb
@@ -1,0 +1,26 @@
+  WebServerHookEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: !Sub "Auto Scaling Events for ${AWS::StackName}."
+      EventPattern:
+        source: [aws.autoscaling]
+        detail-type:
+          - EC2 Instance Launch Successful
+          - EC2 Instance Terminate Successful
+          - EC2 Instance Launch Unsuccessful
+          - EC2 Instance Terminate Unsuccessful
+          - EC2 Instance-launch Lifecycle Action
+          - EC2 Instance-terminate Lifecycle Action
+        detail:
+          AutoScalingGroupName: [!Ref Frontends]
+      State: ENABLED
+      Targets:
+        - Arn: !ImportValue SlackEvent
+          Id: WebServerHookTarget
+  WebServerHookEventPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !ImportValue SlackEvent
+      Action: 'lambda:InvokeFunction'
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt WebServerHookEventRule.Arn

--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -635,6 +635,10 @@ module AWS
         }
         "AssumeRolePolicyDocument: #{document.to_json}"
       end
+
+      def component(name, vars = {})
+        erb_file(aws_dir("cloudformation/components/#{name}.yml.erb"), vars)
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary
This refactor breaks apart the monolithic CloudFormation stack template into partial components located in separate files. Mostly just for better organization (extracts ~350 lines from this ~800-line template file), but this also opens up the possibility of independently testing individual partial components moving forward. This is a first step towards more 'modular' composition of our application stack.

No changes to the actual template code were made beyond what was necessary to extract into separate files.

### Details
 The large `cloud_formation_stack.yml.erb` template is extracted into separate partials in the `components/` subfolder:

- `alarms` - `AWS::CloudWatch::Alarm` resources (2) for daemon storage/memory
- `ami` - The most complex component (13 resources), containing the core of the immutable-server deployment strategy leveraging AMI-backed AutoScalingGroup with rolling updates.
- `cache` - `AWS::ElastiCache` resources (4) for the Memcached and Redis Elasticache deployments.
- `database` - `AWS::RDS` resources (3, plus one `AWS::SecretsManager::Secret`) for the RDS database cluster.
- `scaling_schedule`- `AWS::AutoScaling::ScheduledAction` resources (4).
- `slack_health_events`- `AWS::Events::Rule` and corresponding `AWS::Lambda::Permission` hooking up AWS health events to post Slack notifications.
- `slack_scaling_events`- `AWS::Events::Rule` and corresponding `AWS::Lambda::Permission` hooking up AWS autoscaling events to post Slack notifications.

## Testing story

Manually verified this change doesn't create any diff on existing stacks:

```
$ RAILS_ENV=staging bundle exec rake stack:validate
AWS CloudFormation Template for Code.org application
Listing changes to existing stack `staging`:
No changes
$ RAILS_ENV=production bundle exec rake stack:validate
AWS CloudFormation Template for Code.org application
Listing changes to existing stack `autoscale-prod`:
No changes
```