### PR TITLE
CloudFormation: Print line numbers in verbose template output

### DIFF
--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -103,7 +103,9 @@ module AWS
       # or prints the template description (if valid).
       def validate
         template = render_template(dry_run: true)
-        CDO.log.info template if ENV['VERBOSE']
+        if ENV['VERBOSE']
+          CDO.log.info template.lines.map.with_index(1) {|line, i| format("[%3d] %s", i, line)}.join
+        end
         template_info = string_or_url(template)
         CDO.log.info cfn.validate_template(template_info).description
         options = stack_options(template)


### PR DESCRIPTION
Small change to CloudFormation glue code to print line numbers in verbose template output. This is helpful for debugging errors in YAML validation on a specific line number in the rendered template.