### PR TITLE
Move "how to read standards report"

### DIFF
--- a/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
@@ -163,14 +163,6 @@ class StandardsReport extends Component {
                   </div>
                 )}
                 <h2 style={styles.headerColor}>
-                  {i18n.CSTAStandardsPracticed()}
-                </h2>
-                <StandardsProgressTable
-                  style={styles.table}
-                  isViewingReport={true}
-                />
-                <StandardsLegendForPrint />
-                <h2 style={styles.headerColor}>
                   {i18n.standardsHowToForPrint()}
                 </h2>
                 <SafeMarkdown
@@ -181,6 +173,14 @@ class StandardsReport extends Component {
                     cstaLink: cstaStandardsURL
                   })}
                 />
+                <h2 style={styles.headerColor}>
+                  {i18n.CSTAStandardsPracticed()}
+                </h2>
+                <StandardsProgressTable
+                  style={styles.table}
+                  isViewingReport={true}
+                />
+                <StandardsLegendForPrint />
                 <h2 style={styles.headerColor}>
                   {i18n.standardsGetInvolved()}
                 </h2>


### PR DESCRIPTION
Previously the "How to read this report" section was at the bottom of the standards report, but it will likely be more relevant at the top where it will be seen by admin/parents who are encountering the report for the first time. 

BEFORE: 
<img width="1042" alt="Screen Shot 2020-03-12 at 5 25 01 PM" src="https://user-images.githubusercontent.com/12300669/76578652-8819aa00-6486-11ea-8b4c-0867272da78c.png">

AFTER with comment: 

<img width="1026" alt="Screen Shot 2020-03-12 at 5 08 52 PM" src="https://user-images.githubusercontent.com/12300669/76578073-9f579800-6484-11ea-8bc6-9b776a7ba5d1.png">


AFTER without comment: 

![Screen Shot 2020-03-12 at 5 07 21 PM](https://user-images.githubusercontent.com/12300669/76578101-c1e9b100-6484-11ea-9933-0cdad5c554c3.png)


