### PR TITLE
Move HoC activity and project count cronjobs to reader

### DIFF
--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -51,8 +51,8 @@ def main
   # https://docs.google.com/document/d/1RTTCpkDYZjqZxfVehkZRkk1HckYMvFdFGs6SEZnK1I8
   total_started += 14_861_327
 
-  today = Date.strptime('2020/02/01', '%Y/%m/%d')
-  day = Date.strptime('2020/02/01', '%Y/%m/%d')
+  today = Date.new(2020, 2, 2)
+  day = Date.new(2020, 2, 1)
 
   while day < today
     cache_path = pegasus_dir("cache/HourOfActivity_Results_#{day.strftime('%Y-%m-%d')}.json")
@@ -80,14 +80,10 @@ def main
   hoc_year = DCDO.get("hoc_year", 2017)
 
   # Compute the number of hoc events (the grand total and broken down by company and country).
-  # Note that these queries use the "DB" connection, which is set in lib/cdo/properties.rb to PEGASUS_DB
-  # PEGASUS_DB is defined in lib/cdo/db.rb using sequel with connections to the pegasus writer and reader.
-  # So, even though most of the script uses the reader connections (eg, DASHBOARD_DB_READER),
-  # the "DB" connection used here does include a connection to the writer.
   hoc_country_totals = Hash.new(0)
   hoc_company_totals = Hash.new(0)
-  unique_hoc_events = DB[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:name, :email, :processed_data, :data)
-  total_hoc_count = DB[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:email, :name).count
+  unique_hoc_events = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:name, :email, :processed_data, :data)
+  total_hoc_count = PEGASUS_DB_READER[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:email, :name).count
 
   unique_hoc_events.each do |row|
     data = JSON.parse(row[:data])

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -19,7 +19,7 @@ require 'cdo/properties'
 require 'dynamic_config/dcdo'
 
 # Provides helper methods (analyze_day_fast and add_hashes) as well as the
-# *_DB_READONLY constants.
+# *_DB_READER constants.
 require_relative '../../lib/analyze_hoc_activity_helper'
 
 # This default number of lines of code is from 2016-11-23.
@@ -51,8 +51,8 @@ def main
   # https://docs.google.com/document/d/1RTTCpkDYZjqZxfVehkZRkk1HckYMvFdFGs6SEZnK1I8
   total_started += 14_861_327
 
-  today = DateTime.now.to_date
-  day = Date.strptime('2014/12/06', '%Y/%m/%d')
+  today = Date.strptime('2020/02/01', '%Y/%m/%d')
+  day = Date.strptime('2020/02/01', '%Y/%m/%d')
 
   while day <= today
     cache_path = pegasus_dir("cache/HourOfActivity_Results_#{day.strftime('%Y-%m-%d')}.json")
@@ -140,7 +140,7 @@ def main
   existing_lines_of_code = metrics['lines_of_code']
   lines_of_code = [lines_of_code, existing_lines_of_code].max
 
-  petition_signatures = PEGASUS_REPORTING_DB_READONLY[:forms].where(kind: 'Petition').group_by(:hashed_email).count
+  petition_signatures = PEGASUS_DB_READER[:forms].where(kind: 'Petition').group_by(:hashed_email).count
 
   existing_project_count = metrics['project_count']
 
@@ -157,8 +157,8 @@ def main
   }
 
   Properties.set :about_stats, {
-    number_students: DASHBOARD_REPORTING_DB_READONLY[:users].where(user_type: 'student').exclude(last_sign_in_at: nil).count,
-    number_teachers: DASHBOARD_REPORTING_DB_READONLY[:users].where(user_type: 'teacher').exclude(last_sign_in_at: nil).count,
+    number_students: DASHBOARD_DB_READER[:users].where(user_type: 'student').exclude(last_sign_in_at: nil).count,
+    number_teachers: DASHBOARD_DB_READER[:users].where(user_type: 'teacher').exclude(last_sign_in_at: nil).count,
   }
 end
 

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -54,7 +54,7 @@ def main
   today = Date.strptime('2020/02/01', '%Y/%m/%d')
   day = Date.strptime('2020/02/01', '%Y/%m/%d')
 
-  while day <= today
+  while day < today
     cache_path = pegasus_dir("cache/HourOfActivity_Results_#{day.strftime('%Y-%m-%d')}.json")
     if (day != today) && File.file?(cache_path)
       day_data = JSON.load(IO.read(cache_path))

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -80,6 +80,10 @@ def main
   hoc_year = DCDO.get("hoc_year", 2017)
 
   # Compute the number of hoc events (the grand total and broken down by company and country).
+  # Note that these queries use the "DB" connection, which is set in lib/cdo/properties.rb to PEGASUS_DB
+  # PEGASUS_DB is defined in lib/cdo/db.rb using sequel with connections to the pegasus writer and reader.
+  # So, even though most of the script uses the reader connections (eg, DASHBOARD_DB_READER),
+  # the "DB" connection used here does include a connection to the writer.
   hoc_country_totals = Hash.new(0)
   hoc_company_totals = Hash.new(0)
   unique_hoc_events = DB[:forms].where(kind: "HocSignup#{hoc_year}").group(:email, :name).select(:name, :email, :processed_data, :data)

--- a/bin/cron/update_project_count
+++ b/bin/cron/update_project_count
@@ -20,9 +20,9 @@ MAX_EXECUTION_TIME = 1_200_000
 MAX_EXECUTION_TIME_SEC = MAX_EXECUTION_TIME / 1000
 
 # Connection to read from Pegasus reporting database.
-PEGASUS_REPORTING_DB_READER = sequel_connect(
-  CDO.pegasus_reporting_db_reader,
-  CDO.pegasus_reporting_db_reader,
+PEGASUS_DB_READER = sequel_connect(
+  CDO.pegasus_db_reader,
+  CDO.pegasus_db_reader,
   query_timeout: MAX_EXECUTION_TIME_SEC
 )
 
@@ -33,7 +33,7 @@ NUMBER_PROJECTS_SIGNIFICANT_DECREASE = 10_000
 
 def main
   # Get the current amount of projects.
-  project_count = PEGASUS_REPORTING_DB_READER[:storage_apps].where(standalone: true).count
+  project_count = PEGASUS_DB_READER[:storage_apps].where(standalone: true).count
 
   existing_project_count = Properties.get(:metrics)['project_count'] || 0
   if (existing_project_count - project_count) >= NUMBER_PROJECTS_SIGNIFICANT_DECREASE

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -113,14 +113,16 @@
     # background tasks that adhoc instances don't need to run.
     unless node.chef_environment == 'adhoc'
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'process_forms')
-      cronjob at:'35 * * * *', do:deploy_dir('bin', 'cron', 'analyze_hoc_activity')
+      # temporarily commenting out to test this script manually
+      # cronjob at:'35 * * * *', do:deploy_dir('bin', 'cron', 'analyze_hoc_activity')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'deliver_poste_messages')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'geocode_hoc_activity')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'form_geos')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'user_geos')
       cronjob at:'0 9 * * 5', do:deploy_dir('bin', 'cron', 'create_rollup_tables')
       cronjob at:"0 8 * * *", do:deploy_dir('bin', 'cron', 'purge_expired_deleted_accounts')
-      cronjob at:'0 4 * * 0', do:deploy_dir('bin', 'cron', 'update_project_count')
+      # temporarily commenting out to test this script manually
+      #cronjob at:'0 4 * * 0', do:deploy_dir('bin', 'cron', 'update_project_count')
     end
   end
 

--- a/lib/analyze_hoc_activity_helper.rb
+++ b/lib/analyze_hoc_activity_helper.rb
@@ -6,8 +6,8 @@ require File.expand_path('../../pegasus/src/env', __FILE__)
 require src_dir 'database'
 require 'cdo/properties'
 
-DASHBOARD_REPORTING_DB_READONLY = sequel_connect(CDO.dashboard_reporting_db_reader, CDO.dashboard_reporting_db_reader, query_timeout: 1200)
-PEGASUS_REPORTING_DB_READONLY = sequel_connect(CDO.pegasus_reporting_db_reader, CDO.pegasus_reporting_db_reader, query_timeout: 1200)
+DASHBOARD_DB_READER = sequel_connect(CDO.dashboard_db_reader, CDO.dashboard_db_reader, query_timeout: 1200)
+PEGASUS_DB_READER = sequel_connect(CDO.pegasus_db_reader, CDO.pegasus_db_reader, query_timeout: 1200)
 
 WEIGHTED_COUNT = "SUM(" \
   " IF(session REGEXP '^_.*_'," +
@@ -62,7 +62,7 @@ def rank_tutorials(end_date)
     key = "#{num_days} days"
     memo[key] = {}
     start_date = end_date - num_days.days
-    PEGASUS_REPORTING_DB_READONLY.fetch(
+    PEGASUS_DB_READER.fetch(
       "SELECT tutorial, SUM(weight) AS count
         FROM hoc_learn_activity
         WHERE (
@@ -89,7 +89,7 @@ def analyze_day_fast(date)
   # Generate a list of Code.org tutorials so that we can generate the count for
   # Code.org hosted tutorials below.
   codedotorg_tutorials = []
-  PEGASUS_REPORTING_DB_READONLY.fetch(
+  PEGASUS_DB_READER.fetch(
     "SELECT code FROM tutorials WHERE orgname = 'Code.org'"
   ).each do |row|
     codedotorg_tutorials.push(row[:code])
@@ -97,7 +97,7 @@ def analyze_day_fast(date)
 
   codedotorg_tutorial_count = 0
   tutorials = Hash.new(0)
-  PEGASUS_REPORTING_DB_READONLY.fetch(
+  PEGASUS_DB_READER.fetch(
     "SELECT tutorial, #{WEIGHTED_COUNT} #{from_where} GROUP BY tutorial ORDER BY count DESC"
   ).each do |row|
     next if row[:tutorial].nil_or_empty?
@@ -108,7 +108,7 @@ def analyze_day_fast(date)
   end
 
   countries = Hash.new(0)
-  PEGASUS_REPORTING_DB_READONLY.fetch(
+  PEGASUS_DB_READER.fetch(
     "SELECT country, #{WEIGHTED_COUNT} #{from_where} GROUP BY country ORDER BY count DESC"
   ).each do |row|
     row[:country] = 'Other' if row[:country].nil_or_empty? || row[:country] == 'Reserved'
@@ -116,7 +116,7 @@ def analyze_day_fast(date)
   end
 
   states = Hash.new(0)
-  PEGASUS_REPORTING_DB_READONLY.fetch(
+  PEGASUS_DB_READER.fetch(
     "SELECT state, #{WEIGHTED_COUNT} #{from_where} GROUP BY state ORDER BY count DESC"
   ).each do |row|
     row[:state] = 'Other' if row[:state].nil_or_empty? || row[:state] == 'Reserved'
@@ -124,16 +124,15 @@ def analyze_day_fast(date)
   end
 
   cities = Hash.new(0)
-  PEGASUS_REPORTING_DB_READONLY.fetch(
+  PEGASUS_DB_READER.fetch(
     "SELECT city, #{WEIGHTED_COUNT} #{from_where} GROUP BY city ORDER BY count DESC"
   ).each do |row|
     row[:city] = 'Other' if row[:city].nil_or_empty? || row[:city] == 'Reserved'
     cities[row[:city]] += row[:count].to_i
   end
 
-  started = PEGASUS_REPORTING_DB_READONLY.fetch("SELECT #{WEIGHTED_COUNT} #{from_where}").first[:count].to_i
-
-  finished = PEGASUS_REPORTING_DB_READONLY.fetch("SELECT #{WEIGHTED_COUNT} #{finished_from_where}").first[:count].to_i
+  started = PEGASUS_DB_READER.fetch("SELECT #{WEIGHTED_COUNT} #{from_where}").first[:count].to_i
+  finished = PEGASUS_DB_READER.fetch("SELECT #{WEIGHTED_COUNT} #{finished_from_where}").first[:count].to_i
 
   {
     'started' => started,


### PR DESCRIPTION
[update: I ended up running the script on our production clone to generate data for the past 4 months. I can move those JSON files (generated daily) to `production-daemon` if that seems sensible to others? In any case, the contents of this PR still stand.]

High level approach proposed:

1. Copy four months of backfilled data from adhoc to production-daemon.
2. Manually execute `analyze_hoc_activity` for single day on production-daemon.
3. If no problems with #2, manually execute remaining 2 weeks (March 3-present) of `analyze_hoc_activity` on production-daemon.
4. Confirm that the total # of hours served is sensible, and turn off manual override if so.
5. Uncomment cron tasks that run these scripts daily.

Details:

The `analyze_hoc_activity` and `update_project_count` scripts that produce high level stats that appear on our website (eg, # of projects created and number of hours of code started) have been broken for several months.

After much research, I've pointed the `analyze_hoc_activity` script and `update_project_count` scripts to our reader connection (which, in my understanding, [may actually be routed back to the writer](https://github.com/code-dot-org/code-dot-org/blob/staging/config.yml.erb#L523) on `production-daemon`).

The whole `analyze_hoc_activity` script (consists of 10 or so pretty large SQL queries) took between 10 and 60 seconds to run on a production clone (depending if covering a weekday or weekend -- could be as high as 5 minutes for days during CSEdWeek). I am pretty confident we could run these queries safely in production, at least for a single day of data (even if it's the writer connection).

I think the speediness is a function of the comprehensive indexes on tables / columns used in this script, particularly `hoc_activities` and `forms` in pegasus. Try out `select index from hoc_activity`, for example, to check out all the indexes on that table.

I've commented out the cron entries that run these scripts so that we can run this manually for a single day (currently set up to run just for February 1 2020 for testing purposes) before running it for more days (we'll need to backfill several months of data, have a couple ideas on how we could do that).

Other notes:
- there's some code that [uses "milestone logs" to get total "lines of code written"](https://github.com/code-dot-org/code-dot-org/blob/staging/bin/cron/analyze_hoc_activity#L114-L136). I looked at the folder on production-daemon where that happens, and it looks incomplete. My guess is we should deprecate those counts from our website, but would need to check with stakeholders first.

## Testing story

Tested this manually on an adhoc connected to a production clone. Note that I overrode the `db_reader` config entry so that the queries were pointed at the reader endpoint, although I am not sure if this will be possible by default on production-daemon currently.
